### PR TITLE
Adding option for enabling/disabling -march=native

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,13 @@ endif()
 set(CPACK_SOURCE_GENERATOR "TGZ" CACHE STRING "CPack Default Source Generator")
 set(CPACK_GENERATOR        "TGZ" CACHE STRING "CPack Default Binary Generator")
 
+option(GTSAM_BUILD_WITH_MARCH_NATIVE     "Enable/Disable building with native architecture" ON)
+
+# Set march=native if enabled
+if(GTSAM_BUILD_WITH_MARCH_NATIVE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+endif()
+
 ###############################################################################
 # Find boost
 


### PR DESCRIPTION
I am using gtsam along with rtabmap, g2o and pcl. Since g2o and pcl builds with march=native it creates segfault if gtsam is not built with this flag. Rtabmap github has [issues](https://github.com/introlab/rtabmap/issues/368) regarding this. It would be great to have this option so that downstream can decide if they want -march=native enabled or not.  