### PR TITLE
Fixes for clang on Mac

### DIFF
--- a/gtsam_unstable/nonlinear/BatchFixedLagSmoother.cpp
+++ b/gtsam_unstable/nonlinear/BatchFixedLagSmoother.cpp
@@ -52,7 +52,7 @@ Matrix BatchFixedLagSmoother::marginalCovariance(Key key) const {
 /* ************************************************************************* */
 FixedLagSmoother::Result BatchFixedLagSmoother::update(
     const NonlinearFactorGraph& newFactors, const Values& newTheta,
-    const KeyTimestampMap& timestamps, const FastVector<size_t>& factorsToRemove) {
+    const KeyTimestampMap& timestamps, const FactorIndices& factorsToRemove) {
 
   // Update all of the internal variables with the new information
   gttic(augment_system);

--- a/gtsam_unstable/nonlinear/BatchFixedLagSmoother.h
+++ b/gtsam_unstable/nonlinear/BatchFixedLagSmoother.h
@@ -41,22 +41,22 @@ public:
   virtual ~BatchFixedLagSmoother() { };
 
   /** Print the factor for debugging and testing (implementing Testable) */
-  virtual void print(const std::string& s = "BatchFixedLagSmoother:\n", const KeyFormatter& keyFormatter = DefaultKeyFormatter) const;
+  virtual void print(const std::string& s = "BatchFixedLagSmoother:\n", const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override;
 
   /** Check if two IncrementalFixedLagSmoother Objects are equal */
-  virtual bool equals(const FixedLagSmoother& rhs, double tol = 1e-9) const;
+  virtual bool equals(const FixedLagSmoother& rhs, double tol = 1e-9) const override;
 
   /** Add new factors, updating the solution and relinearizing as needed. */
   Result update(const NonlinearFactorGraph& newFactors = NonlinearFactorGraph(),
                 const Values& newTheta = Values(),
                 const KeyTimestampMap& timestamps = KeyTimestampMap(),
-                const FastVector<size_t>& factorsToRemove = FastVector<size_t>());
+                const FactorIndices& factorsToRemove = FactorIndices()) override;
 
   /** Compute an estimate from the incomplete linear delta computed during the last update.
    * This delta is incomplete because it was not updated below wildfire_threshold.  If only
    * a single variable is needed, it is faster to call calculateEstimate(const KEY&).
    */
-  Values calculateEstimate() const {
+  Values calculateEstimate() const override {
     return theta_.retract(delta_);
   }
 

--- a/gtsam_unstable/nonlinear/FixedLagSmoother.h
+++ b/gtsam_unstable/nonlinear/FixedLagSmoother.h
@@ -93,7 +93,7 @@ public:
   virtual Result update(const NonlinearFactorGraph& newFactors = NonlinearFactorGraph(),
                         const Values& newTheta = Values(),
                         const KeyTimestampMap& timestamps = KeyTimestampMap(),
-                        const FastVector<size_t>& factorsToRemove = FastVector<size_t>()) = 0;
+                        const FactorIndices& factorsToRemove = FactorIndices()) = 0;
 
   /** Compute an estimate from the incomplete linear delta computed during the last update.
    * This delta is incomplete because it was not updated below wildfire_threshold.  If only

--- a/gtsam_unstable/nonlinear/IncrementalFixedLagSmoother.cpp
+++ b/gtsam_unstable/nonlinear/IncrementalFixedLagSmoother.cpp
@@ -65,7 +65,7 @@ bool IncrementalFixedLagSmoother::equals(const FixedLagSmoother& rhs,
 /* ************************************************************************* */
 FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
     const NonlinearFactorGraph& newFactors, const Values& newTheta,
-    const KeyTimestampMap& timestamps, const FastVector<size_t>& factorsToRemove) {
+    const KeyTimestampMap& timestamps, const FactorIndices& factorsToRemove) {
 
   const bool debug = ISDEBUG("IncrementalFixedLagSmoother update");
 

--- a/gtsam_unstable/nonlinear/IncrementalFixedLagSmoother.h
+++ b/gtsam_unstable/nonlinear/IncrementalFixedLagSmoother.h
@@ -49,10 +49,10 @@ public:
 
   /** Print the factor for debugging and testing (implementing Testable) */
   virtual void print(const std::string& s = "IncrementalFixedLagSmoother:\n",
-      const KeyFormatter& keyFormatter = DefaultKeyFormatter) const;
+      const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override;
 
   /** Check if two IncrementalFixedLagSmoother Objects are equal */
-  virtual bool equals(const FixedLagSmoother& rhs, double tol = 1e-9) const;
+  virtual bool equals(const FixedLagSmoother& rhs, double tol = 1e-9) const override;
 
   /**
    * Add new factors, updating the solution and re-linearizing as needed.
@@ -64,13 +64,13 @@ public:
   Result update(const NonlinearFactorGraph& newFactors = NonlinearFactorGraph(),
                 const Values& newTheta = Values(), //
                 const KeyTimestampMap& timestamps = KeyTimestampMap(),
-                const FastVector<size_t>& factorsToRemove = FactorIndices());
+                const FactorIndices& factorsToRemove = FactorIndices()) override;
 
   /** Compute an estimate from the incomplete linear delta computed during the last update.
    * This delta is incomplete because it was not updated below wildfire_threshold.  If only
    * a single variable is needed, it is faster to call calculateEstimate(const KEY&).
    */
-  Values calculateEstimate() const {
+  Values calculateEstimate() const override {
     return isam_.calculateEstimate();
   }
 


### PR DESCRIPTION
Change FastVector<size_t> to FactorIndices to make clang happy.

This went undetected by Jenkins because https://bitbucket.org/gtborg/gtsam/pull-requests/355 did not have changes from https://bitbucket.org/gtborg/gtsam/pull-requests/409, and gcc did not seem to mind.