### PR TITLE
Fix build for GTSAM_ALLOW_DEPRECATED_SINCE_V4=OFF

### DIFF
--- a/gtsam/navigation/tests/testImuFactor.cpp
+++ b/gtsam/navigation/tests/testImuFactor.cpp
@@ -106,7 +106,7 @@ TEST(ImuFactor, Accelerating) {
       Vector3(a, 0, 0));
 
   const double T = 3.0; // seconds
-  ScenarioRunner runner(&scenario, testing::Params(), T / 10);
+  ScenarioRunner runner(scenario, testing::Params(), T / 10);
 
   PreintegratedImuMeasurements pim = runner.integrate(T);
   EXPECT(assert_equal(scenario.pose(T), runner.predict(pim).pose(), 1e-9));
@@ -494,7 +494,7 @@ TEST(ImuFactor, ErrorWithBiasesAndSensorBodyDisplacement) {
   Bias biasHat(Vector3(0.2, 0.0, 0.0), Vector3(0.0, 0.0, 0.0));
 
   const double T = 3.0; // seconds
-  ScenarioRunner runner(&scenario, p, T / 10);
+  ScenarioRunner runner(scenario, p, T / 10);
 
   //  PreintegratedImuMeasurements pim = runner.integrate(T);
   //  EXPECT(assert_equal(scenario.pose(T), runner.predict(pim).pose, 1e-9));
@@ -630,7 +630,7 @@ TEST(ImuFactor, PredictArbitrary) {
       Vector3(0.1, 0.2, 0), Vector3(M_PI / 10, M_PI / 10, M_PI / 10));
 
   const double T = 3.0; // seconds
-  ScenarioRunner runner(&scenario, testing::Params(), T / 10);
+  ScenarioRunner runner(scenario, testing::Params(), T / 10);
   //
   //  PreintegratedImuMeasurements pim = runner.integrate(T);
   //  EXPECT(assert_equal(scenario.pose(T), runner.predict(pim).pose, 1e-9));
@@ -827,7 +827,7 @@ struct ImuFactorMergeTest {
     PreintegratedImuMeasurements pim02_expected(p_, bias01);
 
     double deltaT = 0.01;
-    ScenarioRunner runner(&scenario, p_, deltaT);
+    ScenarioRunner runner(scenario, p_, deltaT);
     // TODO(frank) can this loop just go into runner ?
     for (int i = 0; i < 100; i++) {
       double t = i * deltaT;


### PR DESCRIPTION
Remove usage of deprecated pointer constructor from testIMUFactor. 
Trivial fix - will merge once Jenkins is happy.