### PR TITLE
Expression wrapper for rotation

### DIFF
--- a/gtsam/slam/expressions.h
+++ b/gtsam/slam/expressions.h
@@ -40,6 +40,16 @@ inline Point3_ transformFrom(const Pose3_& x, const Point3_& p) {
   return Point3_(x, &Pose3::transformFrom, p);
 }
 
+namespace internal {
+Rot3 rotation(const Pose3& pose, OptionalJacobian<3, 6> H) {
+  return pose.rotation(H);
+}
+}  // namespace internal
+
+inline Rot3_ rotation(const Pose3_& pose) {
+  return Rot3_(internal::rotation, pose);
+}
+
 inline Point3_ rotate(const Rot3_& x, const Point3_& p) {
   return Point3_(x, &Rot3::rotate, p);
 }

--- a/gtsam/slam/tests/testSlamExpressions.cpp
+++ b/gtsam/slam/tests/testSlamExpressions.cpp
@@ -46,6 +46,19 @@ TEST(SlamExpressions, project2) {
 }
 
 /* ************************************************************************* */
+TEST(SlamExpressions, rotation) {
+  Pose3_ T_(0);
+  const Rot3_ R_ = rotation(T_);
+}
+
+/* ************************************************************************* */
+TEST(SlamExpressions, unrotate) {
+  Rot3_ R_(0);
+  Point3_ p_(1);
+  const Point3_ q_ = unrotate(R_, p_);
+}
+
+/* ************************************************************************* */
 int main() {
   TestResult tr;
   return TestRegistry::runAllTests(tr);


### PR DESCRIPTION
Fixes issue #13 by adding a wrapper for `rotation()` that returns a value and not a const reference. Also added a unit test.