### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -24,14 +24,14 @@ function build_and_test ()
 
   # gcc is too slow and we have a time limit in Travis CI: selective builds.
   if [ "$BUILD_EXAMPLES" == "1" ]; then
-    GTSAM_BUILD_EXAMPLES_ALWAYS=FALSE
+    GTSAM_BUILD_EXAMPLES_ALWAYS=ON
   else
-    GTSAM_BUILD_EXAMPLES_ALWAYS=TRUE
+    GTSAM_BUILD_EXAMPLES_ALWAYS=OFF
   fi
   if [ "$RUN_TESTS" == "1" ]; then
-    GTSAM_BUILD_TESTS=FALSE
+    GTSAM_BUILD_TESTS=ON
   else
-    GTSAM_BUILD_TESTS=TRUE
+    GTSAM_BUILD_TESTS=OFF
   fi
 
   cmake $SOURCE_DIR \

--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -e   # Make sure any error makes the script to return an error code
+set -x   # echo
+
+SOURCE_DIR=`pwd`
+BUILD_DIR=build
+
+#CMAKE_C_FLAGS="-Wall -Wextra -Wabi -O2"
+#CMAKE_CXX_FLAGS="-Wall -Wextra -Wabi -O2"
+
+function build_and_test ()
+{
+  #env
+  git clean -fd || true
+  rm -fr $BUILD_DIR || true
+  mkdir $BUILD_DIR && cd $BUILD_DIR
+
+  if [ ! -z "$GCC_VERSION" ]; then
+    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$GCC_VERSION 60 \
+                         --slave /usr/bin/g++ g++ /usr/bin/g++-$GCC_VERSION
+    sudo update-alternatives --set gcc /usr/bin/gcc-$GCC_VERSION
+  fi
+
+  # gcc is too slow and we have a time limit in Travis CI: selective builds.
+  if [ "$BUILD_EXAMPLES" == "1" ]; then
+    GTSAM_BUILD_EXAMPLES_ALWAYS=FALSE
+  else
+    GTSAM_BUILD_EXAMPLES_ALWAYS=TRUE
+  fi
+  if [ "$RUN_TESTS" == "1" ]; then
+    GTSAM_BUILD_TESTS=FALSE
+  else
+    GTSAM_BUILD_TESTS=TRUE
+  fi
+
+  cmake $SOURCE_DIR \
+      -DGTSAM_BUILD_EXAMPLES_ALWAYS=$GTSAM_BUILD_EXAMPLES_ALWAYS \
+      -DGTSAM_BUILD_TESTS=$GTSAM_BUILD_TESTS
+
+  # Actual build:
+  make -j2
+
+  # Run tests:
+  if [ "$RUN_TESTS" == "1" ]; then
+    make check
+  fi
+
+  cd $SOURCE_DIR
+}
+
+build_and_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,49 @@
+language: cpp
+cache: ccache
+sudo: required
+dist: xenial
+
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-8
+    - clang-3.8
+    - build-essential
+    - pkg-config
+    - cmake
+    - libpython-dev python-numpy
+    - libboost-all-dev
+
+before_install:
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update          ; fi
+
+script:
+  - bash .travis.sh
+
+env:
+  global:
+    - MAKEFLAGS="-j 2"
+    - CCACHE_SLOPPINESS=pch_defines,time_macros
+
+matrix:
+  include:
+  - compiler: gcc
+    os: linux
+    env: BUILD_EXAMPLES=1
+  - compiler: gcc
+    os: linux
+    env: RUN_TESTS=1
+  - compiler: gcc
+    os: linux
+    env: BUILD_EXAMPLES=1 GCC_VERSION="8"
+  - compiler: clang
+    os: linux
+    env: BUILD_EXAMPLES=1
+  - compiler: gcc
+    os: osx
+    env: BUILD_EXAMPLES=1
+  - compiler: clang
+    os: osx
+    env: RUN_TESTS=1

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/borglab/gtsam.svg?branch=develop)](https://travis-ci.org/borglab/gtsam)
+
 README - Georgia Tech Smoothing and Mapping library
 ===================================================
 


### PR DESCRIPTION
This adds Travis CI support. It builds gtsam, gtsam_unstable, all examples, all tests, and run them, for: 
* Ubuntu Xenial, with default gcc version.
* Ubuntu Xenial, with default clang version.
* Ubuntu Xenial, with gcc-8
* OSX with gcc.
* OSX with clang.

Due to build time limitations in the free version of Travis, it has been split into different jobs, some build only examples, other tests. 

Example output (from my fork): https://travis-ci.org/jlblancoc/gtsam/builds/539620367

Please, enable the GitHub App "Travis CI" to allow TravisCI to actually run the tests here (admins should have received a request email earlier today).