### PR TITLE
Feature/stage travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,16 @@ stages:
 # Compile stage without building examples/tests to populate the caches.
 jobs:
   include:
+# on Mac, GCC
+  - stage: compile
+    os: osx
+    compiler: gcc
+    env: GTSAM_ALLOW_DEPRECATED_SINCE_V4=OFF GTSAM_BUILD_TESTS=OFF GTSAM_BUILD_UNSTABLE=ON GTSAM_BUILD_EXAMPLES_ALWAYS=OFF
+# on Mac, CLANG
+  - stage: compile
+    os: osx
+    compiler: clang
+    env: GTSAM_ALLOW_DEPRECATED_SINCE_V4=OFF GTSAM_BUILD_TESTS=OFF GTSAM_BUILD_UNSTABLE=ON GTSAM_BUILD_EXAMPLES_ALWAYS=OFF
 # on Linux, GCC
   - stage: compile
     os: linux
@@ -52,8 +62,8 @@ jobs:
 
 # Matrix configuration:
 os:
-  - linux
   - osx
+  - linux
 compiler:
   - gcc
   - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,17 +43,17 @@ jobs:
   - stage: compile
     os: linux
     compiler: clang
-    env: GTSAM_ALLOW_DEPRECATED_SINCE_V4=OFF GTSAM_BUILD_TESTS=OFF GTSAM_BUILD_UNSTABLE=ON GTSAM_BUILD_EXAMPLES_ALWAYS=ON
+    env: GTSAM_ALLOW_DEPRECATED_SINCE_V4=OFF GTSAM_BUILD_TESTS=OFF GTSAM_BUILD_UNSTABLE=ON GTSAM_BUILD_EXAMPLES_ALWAYS=OFF
 # on Linux, with deprecated ON to make sure that path still compiles
   - stage: compile
     os: linux
     compiler: clang
-    env: GTSAM_ALLOW_DEPRECATED_SINCE_V4=ON GTSAM_BUILD_TESTS=OFF GTSAM_BUILD_UNSTABLE=ON GTSAM_BUILD_EXAMPLES_ALWAYS=ON
+    env: GTSAM_ALLOW_DEPRECATED_SINCE_V4=ON GTSAM_BUILD_TESTS=OFF GTSAM_BUILD_UNSTABLE=ON GTSAM_BUILD_EXAMPLES_ALWAYS=OFF
 
 # Matrix configuration:
 os:
   - linux
-  # - osx
+  - osx
 compiler:
   - gcc
   - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,32 +26,42 @@ install:
 script:
   - bash .travis.sh
 
+# We first do the compile stage specified below, then the matrix expansion specified after.
+stages:
+  - compile
+  - test
+
+# Compile stage without building examples/tests to populate the caches.
+jobs:
+  include:
+# on Linux, GCC
+  - stage: compile
+    os: linux
+    compiler: gcc
+    env: GTSAM_ALLOW_DEPRECATED_SINCE_V4=OFF GTSAM_BUILD_TESTS=OFF GTSAM_BUILD_UNSTABLE=ON GTSAM_BUILD_EXAMPLES_ALWAYS=OFF
+# on Linux, CLANG
+  - stage: compile
+    os: linux
+    compiler: clang
+    env: GTSAM_ALLOW_DEPRECATED_SINCE_V4=OFF GTSAM_BUILD_TESTS=OFF GTSAM_BUILD_UNSTABLE=ON GTSAM_BUILD_EXAMPLES_ALWAYS=ON
+# on Linux, with deprecated ON to make sure that path still compiles
+  - stage: compile
+    os: linux
+    compiler: clang
+    env: GTSAM_ALLOW_DEPRECATED_SINCE_V4=ON GTSAM_BUILD_TESTS=OFF GTSAM_BUILD_UNSTABLE=ON GTSAM_BUILD_EXAMPLES_ALWAYS=ON
+
+# Matrix configuration:
+os:
+  - linux
+  # - osx
+compiler:
+  - gcc
+  - clang
 env:
   global:
     - MAKEFLAGS="-j 2"
     - CCACHE_SLOPPINESS=pch_defines,time_macros
+  matrix:
+    - GTSAM_ALLOW_DEPRECATED_SINCE_V4=OFF GTSAM_BUILD_TESTS=OFF GTSAM_BUILD_UNSTABLE=ON GTSAM_BUILD_EXAMPLES_ALWAYS=ON
+    - GTSAM_ALLOW_DEPRECATED_SINCE_V4=OFF GTSAM_BUILD_TESTS=ON GTSAM_BUILD_UNSTABLE=ON GTSAM_BUILD_EXAMPLES_ALWAYS=OFF
 
-# gcc is too slow and we have a time limit in Travis CI: selective builds.
-matrix:
-  include:
-  - compiler: gcc
-    os: linux
-    env: GTSAM_ALLOW_DEPRECATED_SINCE_V4=OFF GTSAM_BUILD_TESTS=OFF GTSAM_BUILD_UNSTABLE=ON GTSAM_BUILD_EXAMPLES_ALWAYS=ON
-  - compiler: gcc
-    os: linux
-    env: GTSAM_ALLOW_DEPRECATED_SINCE_V4=OFF GTSAM_BUILD_TESTS=ON GTSAM_BUILD_UNSTABLE=OFF GTSAM_BUILD_EXAMPLES_ALWAYS=OFF  # gcc too slow for all tests
-  - compiler: gcc
-    os: linux
-    env: GTSAM_ALLOW_DEPRECATED_SINCE_V4=OFF GTSAM_BUILD_TESTS=OFF GTSAM_BUILD_UNSTABLE=ON GTSAM_BUILD_EXAMPLES_ALWAYS=ON GCC_VERSION="8"
-  - compiler: clang
-    os: linux
-    env: GTSAM_ALLOW_DEPRECATED_SINCE_V4=OFF GTSAM_BUILD_TESTS=ON GTSAM_BUILD_UNSTABLE=ON GTSAM_BUILD_EXAMPLES_ALWAYS=ON
-  - compiler: clang
-    os: linux
-    env: GTSAM_ALLOW_DEPRECATED_SINCE_V4=ON GTSAM_BUILD_TESTS=ON GTSAM_BUILD_UNSTABLE=ON GTSAM_BUILD_EXAMPLES_ALWAYS=ON
-# - compiler: gcc
-#   os: osx
-#   env: GTSAM_ALLOW_DEPRECATED_SINCE_V4=OFF GTSAM_BUILD_TESTS=OFF GTSAM_BUILD_UNSTABLE=ON GTSAM_BUILD_EXAMPLES_ALWAYS=ON
-  - compiler: clang
-    os: osx
-    env: GTSAM_ALLOW_DEPRECATED_SINCE_V4=OFF GTSAM_BUILD_TESTS=ON GTSAM_BUILD_UNSTABLE=ON GTSAM_BUILD_EXAMPLES_ALWAYS=OFF 


### PR DESCRIPTION
Added a compile stage before the matrix of features is built, to populate the ccache. Works well for Linux, does *still* not seem to work for OSX. Somehow, even though the cache is written by the compile stage, the filenames do not match when the test stage tries to read.

I will cancel the branch build for now, let's see how the CI fares on this PR. But if it still does not work, I have no idea how to fix.