### PR TITLE
Inline keyword for navigation expression functions

### DIFF
--- a/gtsam/slam/expressions.h
+++ b/gtsam/slam/expressions.h
@@ -42,7 +42,7 @@ inline Point3_ transformFrom(const Pose3_& x, const Point3_& p) {
 
 namespace internal {
 // define getter that returns value rather than reference
-Rot3 rotation(const Pose3& pose, OptionalJacobian<3, 6> H) {
+inline Rot3 rotation(const Pose3& pose, OptionalJacobian<3, 6> H) {
   return pose.rotation(H);
 }
 }  // namespace internal
@@ -70,12 +70,12 @@ inline Unit3_ unrotate(const Rot3_& x, const Unit3_& p) {
 #ifndef GTSAM_TYPEDEF_POINTS_TO_VECTORS
 namespace internal {
 // define a rotate and unrotate for Vector3
-Vector3 rotate(const Rot3& R, const Vector3& v,
+inline Vector3 rotate(const Rot3& R, const Vector3& v,
                OptionalJacobian<3, 3> H1 = boost::none,
                OptionalJacobian<3, 3> H2 = boost::none) {
   return R.rotate(v, H1, H2);
 }
-Vector3 unrotate(const Rot3& R, const Vector3& v,
+inline Vector3 unrotate(const Rot3& R, const Vector3& v,
                  OptionalJacobian<3, 3> H1 = boost::none,
                  OptionalJacobian<3, 3> H2 = boost::none) {
   return R.unrotate(v, H1, H2);


### PR DESCRIPTION
Adds `inline` keyword to functions introduced in PR #32 to avoid `multiple declaration` conflicts during linking as well as keep all declarations in the file consistent.