### PR TITLE
Cython wrapper for all release modes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,11 +75,22 @@ option(GTSAM_WITH_EIGEN_MKL              "Eigen will use Intel MKL if available"
 option(GTSAM_WITH_EIGEN_MKL_OPENMP       "Eigen, when using Intel MKL, will also use OpenMP for multithreading if available" OFF)
 option(GTSAM_THROW_CHEIRALITY_EXCEPTION "Throw exception when a triangulated point is behind a camera" ON)
 option(GTSAM_ALLOW_DEPRECATED_SINCE_V4   "Allow use of methods/functions deprecated in GTSAM 4" ON)
-option(GTSAM_TYPEDEF_POINTS_TO_VECTORS   "Typdef Point2 and Point3 to Eigen::Vector equivalents" OFF)
+option(GTSAM_TYPEDEF_POINTS_TO_VECTORS   "Typedef Point2 and Point3 to Eigen::Vector equivalents" OFF)
 option(GTSAM_SUPPORT_NESTED_DISSECTION   "Support Metis-based nested dissection" ON)
 option(GTSAM_TANGENT_PREINTEGRATION      "Use new ImuFactor with integration on tangent space" ON)
 if(NOT MSVC AND NOT XCODE_VERSION)
     option(GTSAM_BUILD_WITH_CCACHE           "Use ccache compiler cache" ON)
+endif()
+
+# Set the build type to upper case for downstream use
+string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_UPPER)
+
+# Set the GTSAM_BUILD_TAG variable.
+# If build type is Release, set to blank (""), else set to the build type.
+if(${CMAKE_BUILD_TYPE_UPPER} STREQUAL "RELEASE")
+	set(GTSAM_BUILD_TAG "") # Don't create release mode tag on installed directory
+else()
+	set(GTSAM_BUILD_TAG "${CMAKE_BUILD_TYPE}")
 endif()
 
 # Options relating to MATLAB wrapper
@@ -94,10 +105,7 @@ if((GTSAM_INSTALL_MATLAB_TOOLBOX OR GTSAM_INSTALL_CYTHON_TOOLBOX) AND NOT GTSAM_
 	message(FATAL_ERROR "GTSAM_INSTALL_MATLAB_TOOLBOX or GTSAM_INSTALL_CYTHON_TOOLBOX is enabled, please also enable GTSAM_BUILD_WRAP")
 endif()
 if((GTSAM_INSTALL_MATLAB_TOOLBOX OR GTSAM_INSTALL_CYTHON_TOOLBOX) AND GTSAM_BUILD_TYPE_POSTFIXES)
-    set(CURRENT_POSTFIX ${CMAKE_${CMAKE_BUILD_TYPE}_POSTFIX})
-    if(NOT "${CURRENT_POSTFIX}" STREQUAL "")
-        message(FATAL_ERROR "Cannot use executable postfixes with the matlab or cython wrappers. Please disable GTSAM_BUILD_TYPE_POSTFIXES")
-    endif()
+		set(CURRENT_POSTFIX ${CMAKE_${CMAKE_BUILD_TYPE_UPPER}_POSTFIX})
 endif()
 if(GTSAM_INSTALL_WRAP AND NOT GTSAM_BUILD_WRAP)
 	message(FATAL_ERROR "GTSAM_INSTALL_WRAP is enabled, please also enable GTSAM_BUILD_WRAP")
@@ -528,11 +536,13 @@ print_config_flag(${GTSAM_BUILD_TYPE_POSTFIXES}        "Put build type in librar
 if(GTSAM_UNSTABLE_AVAILABLE)
     print_config_flag(${GTSAM_BUILD_UNSTABLE}          "Build libgtsam_unstable        ")
 endif()
-string(TOUPPER "${CMAKE_BUILD_TYPE}" cmake_build_type_toupper)
+
+print_config_flag(${GTSAM_BUILD_WITH_MARCH_NATIVE}     "Build for native architecture  ")
 if(NOT MSVC AND NOT XCODE_VERSION)
     print_config_flag(${GTSAM_BUILD_WITH_MARCH_NATIVE}     "Build for native architecture  ")
     message(STATUS "  Build type                     : ${CMAKE_BUILD_TYPE}")
-    message(STATUS "  C++ compilation flags          : ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${cmake_build_type_toupper}}")
+    message(STATUS "  C compilation flags            : ${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${CMAKE_BUILD_TYPE_UPPER}}")
+    message(STATUS "  C++ compilation flags          : ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE_UPPER}}")
 endif()
 
 print_build_options_for_target(gtsam)

--- a/cmake/GtsamCythonWrap.cmake
+++ b/cmake/GtsamCythonWrap.cmake
@@ -86,8 +86,13 @@ function(build_cythonized_cpp target cpp_file output_lib_we output_dir)
   if(APPLE)
     set(link_flags "-undefined dynamic_lookup")
   endif()
-  set_target_properties(${target} PROPERTIES COMPILE_FLAGS "-w" LINK_FLAGS "${link_flags}"
-    OUTPUT_NAME ${output_lib_we} PREFIX "" LIBRARY_OUTPUT_DIRECTORY ${output_dir})
+  set_target_properties(${target}
+      PROPERTIES COMPILE_FLAGS "-w"
+      LINK_FLAGS "${link_flags}"
+      OUTPUT_NAME ${output_lib_we}
+      PREFIX ""
+      ${CMAKE_BUILD_TYPE_UPPER}_POSTFIX ""
+      LIBRARY_OUTPUT_DIRECTORY ${output_dir})
 endfunction()
 
 # Cythonize a pyx from the command line as described at
@@ -161,9 +166,13 @@ endfunction()
 function(install_cython_wrapped_library interface_header generated_files_path install_path)
   get_filename_component(module_name "${interface_header}" NAME_WE)
 
-    # NOTE: only installs .pxd and .pyx and binary files (not .cpp) - the trailing slash on the directory name
+  # NOTE: only installs .pxd and .pyx and binary files (not .cpp) - the trailing slash on the directory name
   # here prevents creating the top-level module name directory in the destination.
-  message(STATUS "Installing Cython Toolbox to ${install_path}") #${GTSAM_CYTHON_INSTALL_PATH}")
+  # Split up filename to strip trailing '/' in GTSAM_CYTHON_INSTALL_PATH/subdirectory if there is one
+  get_filename_component(location "${install_path}" PATH)
+  get_filename_component(name "${install_path}" NAME)
+  message(STATUS "Installing Cython Toolbox to ${location}${GTSAM_BUILD_TAG}/${name}") #${GTSAM_CYTHON_INSTALL_PATH}"
+
   if(GTSAM_BUILD_TYPE_POSTFIXES)
     foreach(build_type ${CMAKE_CONFIGURATION_TYPES})
       string(TOUPPER "${build_type}" build_type_upper)
@@ -172,10 +181,8 @@ function(install_cython_wrapped_library interface_header generated_files_path in
       else()
         set(build_type_tag "${build_type}")
       endif()
-      # Split up filename to strip trailing '/' in GTSAM_CYTHON_INSTALL_PATH if there is one
-      get_filename_component(location "${install_path}" PATH)
-      get_filename_component(name "${install_path}" NAME)
-      install(DIRECTORY "${generated_files_path}/" DESTINATION "${location}/${name}${build_type_tag}"
+
+      install(DIRECTORY "${generated_files_path}/" DESTINATION "${location}${build_type_tag}/${name}"
           CONFIGURATIONS "${build_type}"
           PATTERN "build" EXCLUDE
           PATTERN "CMakeFiles" EXCLUDE

--- a/cython/gtsam_eigency/CMakeLists.txt
+++ b/cython/gtsam_eigency/CMakeLists.txt
@@ -39,11 +39,11 @@ add_dependencies(cythonize_eigency cythonize_eigency_conversions cythonize_eigen
 
 # install
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        DESTINATION ${GTSAM_CYTHON_INSTALL_PATH}
+        DESTINATION "${GTSAM_CYTHON_INSTALL_PATH}${GTSAM_BUILD_TAG}"
         PATTERN "CMakeLists.txt" EXCLUDE
         PATTERN "__init__.py.in" EXCLUDE)
 install(TARGETS cythonize_eigency_core cythonize_eigency_conversions
-        DESTINATION "${GTSAM_CYTHON_INSTALL_PATH}/gtsam_eigency")
-install(FILES ${OUTPUT_DIR}/conversions_api.h DESTINATION ${GTSAM_CYTHON_INSTALL_PATH}/gtsam_eigency)
+        DESTINATION "${GTSAM_CYTHON_INSTALL_PATH}${GTSAM_BUILD_TAG}/gtsam_eigency")
+install(FILES ${OUTPUT_DIR}/conversions_api.h DESTINATION ${GTSAM_CYTHON_INSTALL_PATH}${GTSAM_BUILD_TAG}/gtsam_eigency)
 configure_file(__init__.py.in ${OUTPUT_DIR}/__init__.py)
-install(FILES ${OUTPUT_DIR}/__init__.py DESTINATION ${GTSAM_CYTHON_INSTALL_PATH}/gtsam_eigency)
+install(FILES ${OUTPUT_DIR}/__init__.py DESTINATION ${GTSAM_CYTHON_INSTALL_PATH}${GTSAM_BUILD_TAG}/gtsam_eigency)

--- a/cython/setup.py.in
+++ b/cython/setup.py.in
@@ -7,7 +7,7 @@ except ImportError:
 
 if 'SETUP_PY_NO_CHECK' not in os.environ:
     script_path = os.path.abspath(os.path.realpath(__file__))
-    install_path = os.path.abspath(os.path.realpath(os.path.join('${GTSAM_CYTHON_INSTALL_PATH}', 'setup.py')))
+    install_path = os.path.abspath(os.path.realpath(os.path.join('${GTSAM_CYTHON_INSTALL_PATH}${GTSAM_BUILD_TAG}', 'setup.py')))
     if script_path != install_path:
         print('setup.py is being run from an unexpected location: "{}"'.format(script_path))
         print('please run `make install` and run the script from there')

--- a/gtsam.h
+++ b/gtsam.h
@@ -248,6 +248,9 @@ class FactorIndices {
 
 /** gtsam namespace functions */
 
+#include <gtsam/base/debug.h>
+bool isDebugVersion();
+
 #include <gtsam/base/DSFMap.h>
 class IndexPair { 
   IndexPair(); 

--- a/gtsam/base/debug.cpp
+++ b/gtsam/base/debug.cpp
@@ -47,4 +47,15 @@ void guardedSetDebug(const std::string& s, const bool v) {
   gtsam::debugFlags[s] = v;
 }
 
+bool isDebugVersion() {
+#ifdef NDEBUG
+  // nondebug
+  return false;
+#else
+  // debug
+  return true;
+#endif
+
+}
+
 }

--- a/gtsam/base/debug.h
+++ b/gtsam/base/debug.h
@@ -47,6 +47,7 @@ namespace gtsam {
   // Non-guarded use led to crashes, and solved in commit cd35db2
   bool GTSAM_EXPORT guardedIsDebug(const std::string& s);
   void GTSAM_EXPORT guardedSetDebug(const std::string& s, const bool v);
+  bool GTSAM_EXPORT isDebugVersion();
 }
 
 #undef ISDEBUG

--- a/gtsam/base/debug.h
+++ b/gtsam/base/debug.h
@@ -47,6 +47,8 @@ namespace gtsam {
   // Non-guarded use led to crashes, and solved in commit cd35db2
   bool GTSAM_EXPORT guardedIsDebug(const std::string& s);
   void GTSAM_EXPORT guardedSetDebug(const std::string& s, const bool v);
+
+  // function to check if compiled version has debug information
   bool GTSAM_EXPORT isDebugVersion();
 }
 


### PR DESCRIPTION
This PR upates the CMake files so that the generated cython wrapper only appends the build type postfix to the top-level `cython` directory in the install path, rather than appending it to the sub-directories or `.so` files since that would cause import issues when using the cython wrapper in any mode other than `Release`.

This was a doozy, but it works and should be a huge step forward with respect to improvements in the python wrapper.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/63)
<!-- Reviewable:end -->
