### PR TITLE
C++ to Python Exceptions

### DIFF
--- a/wrap/GlobalFunction.cpp
+++ b/wrap/GlobalFunction.cpp
@@ -143,6 +143,7 @@ void GlobalFunction::emit_cython_pxd(FileWriter& file) const {
                     "\"(";
     argumentList(i).emit_cython_pxd(file, "", vector<string>());
     file.oss << ")";
+    file.oss << " except +";
     file.oss << "\n";
   }
 }
@@ -206,16 +207,18 @@ void GlobalFunction::emit_cython_pyx(FileWriter& file) const {
 
     /// Call corresponding cython function
     file.oss << argumentList(i).pyx_convertEigenTypeAndStorageOrder("        ");
-    string call = pyx_functionCall("", pxdName(), i);
-    if (!returnVals_[i].isVoid()) {
-      file.oss << "        return_value = " << call << "\n";
-      file.oss << "        return True, " << returnVals_[i].pyx_casting("return_value") << "\n";
-    } else {
-      file.oss << "        " << call << "\n";
-      file.oss << "        return True, None\n";
-    }
+    // catch exception which indicates the parameters passed are incorrect.
     file.oss << "    except:\n";
     file.oss << "        return False, None\n\n";
+
+    string call = pyx_functionCall("", pxdName(), i);
+    if (!returnVals_[i].isVoid()) {
+      file.oss << "    return_value = " << call << "\n";
+      file.oss << "    return True, " << returnVals_[i].pyx_casting("return_value") << "\n";
+    } else {
+      file.oss << "    " << call << "\n";
+      file.oss << "    return True, None\n";
+    }
   }
 }
 /* ************************************************************************* */

--- a/wrap/tests/expected-cython/geometry.pxd
+++ b/wrap/tests/expected-cython/geometry.pxd
@@ -145,7 +145,7 @@ cdef extern from "folder/path/to/Test.h":
 
 
 cdef extern from "folder/path/to/Test.h" namespace "":
-        VectorXd pxd_aGlobalFunction "aGlobalFunction"()
+        VectorXd pxd_aGlobalFunction "aGlobalFunction"() except +
 cdef extern from "folder/path/to/Test.h" namespace "":
-        VectorXd pxd_overloadedGlobalFunction "overloadedGlobalFunction"(int a)
-        VectorXd pxd_overloadedGlobalFunction "overloadedGlobalFunction"(int a, double b)
+        VectorXd pxd_overloadedGlobalFunction "overloadedGlobalFunction"(int a) except +
+        VectorXd pxd_overloadedGlobalFunction "overloadedGlobalFunction"(int a, double b) except +

--- a/wrap/tests/expected-cython/geometry.pyx
+++ b/wrap/tests/expected-cython/geometry.pyx
@@ -464,11 +464,11 @@ def overloadedGlobalFunction_0(args, kwargs):
     try:
         __params = process_args(['a'], args, kwargs)
         a = <int>(__params[0])
-        return_value = pxd_overloadedGlobalFunction(a)
-        return True, ndarray_copy(return_value).squeeze()
     except:
         return False, None
 
+    return_value = pxd_overloadedGlobalFunction(a)
+    return True, ndarray_copy(return_value).squeeze()
 def overloadedGlobalFunction_1(args, kwargs):
     cdef list __params
     cdef VectorXd return_value
@@ -476,8 +476,8 @@ def overloadedGlobalFunction_1(args, kwargs):
         __params = process_args(['a', 'b'], args, kwargs)
         a = <int>(__params[0])
         b = <double>(__params[1])
-        return_value = pxd_overloadedGlobalFunction(a, b)
-        return True, ndarray_copy(return_value).squeeze()
     except:
         return False, None
 
+    return_value = pxd_overloadedGlobalFunction(a, b)
+    return True, ndarray_copy(return_value).squeeze()


### PR DESCRIPTION
This PR gives global functions the ability to propagate exceptions up to python.
Now things like `CheiralityExceptions` can be caught in Python rather than the process just exiting with a message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/83)
<!-- Reviewable:end -->
