### PR TITLE
Changes to get gtsam to compile in Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,20 +179,18 @@ option(GTSAM_DISABLE_NEW_TIMERS "Disables using Boost.chrono for timing" OFF)
 # so we downgraded this to classic filenames-based variables, and manually adding
 # the target_include_directories(xxx ${Boost_INCLUDE_DIR})
 set(GTSAM_BOOST_LIBRARIES
-  optimized
-    ${Boost_SERIALIZATION_LIBRARY_RELEASE}
-    ${Boost_SYSTEM_LIBRARY_RELEASE}
-    ${Boost_FILESYSTEM_LIBRARY_RELEASE}
-    ${Boost_THREAD_LIBRARY_RELEASE}
-    ${Boost_DATE_TIME_LIBRARY_RELEASE}
-    ${Boost_REGEX_LIBRARY_RELEASE}
-  debug
-    ${Boost_SERIALIZATION_LIBRARY_DEBUG}
-    ${Boost_SYSTEM_LIBRARY_DEBUG}
-    ${Boost_FILESYSTEM_LIBRARY_DEBUG}
-    ${Boost_THREAD_LIBRARY_DEBUG}
-    ${Boost_DATE_TIME_LIBRARY_DEBUG}
-    ${Boost_REGEX_LIBRARY_DEBUG}
+  optimized ${Boost_SERIALIZATION_LIBRARY_RELEASE}
+  optimized ${Boost_SYSTEM_LIBRARY_RELEASE}
+  optimized ${Boost_FILESYSTEM_LIBRARY_RELEASE}
+  optimized ${Boost_THREAD_LIBRARY_RELEASE}
+  optimized ${Boost_DATE_TIME_LIBRARY_RELEASE}
+  optimized ${Boost_REGEX_LIBRARY_RELEASE}
+  debug ${Boost_SERIALIZATION_LIBRARY_DEBUG}
+  debug ${Boost_SYSTEM_LIBRARY_DEBUG}
+  debug ${Boost_FILESYSTEM_LIBRARY_DEBUG}
+  debug ${Boost_THREAD_LIBRARY_DEBUG}
+  debug ${Boost_DATE_TIME_LIBRARY_DEBUG}
+  debug ${Boost_REGEX_LIBRARY_DEBUG}
 )
 message(STATUS "GTSAM_BOOST_LIBRARIES: ${GTSAM_BOOST_LIBRARIES}")
 if (GTSAM_DISABLE_NEW_TIMERS)
@@ -201,12 +199,10 @@ if (GTSAM_DISABLE_NEW_TIMERS)
 else()
     if(Boost_TIMER_LIBRARY)
       list(APPEND GTSAM_BOOST_LIBRARIES
-        optimized
-          ${Boost_TIMER_LIBRARY_RELEASE}
-          ${Boost_CHRONO_LIBRARY_RELEASE}
-        debug
-          ${Boost_TIMER_LIBRARY_DEBUG}
-          ${Boost_CHRONO_LIBRARY_DEBUG}
+        optimized ${Boost_TIMER_LIBRARY_RELEASE}
+        optimized ${Boost_CHRONO_LIBRARY_RELEASE}
+        debug ${Boost_TIMER_LIBRARY_DEBUG}
+        debug ${Boost_CHRONO_LIBRARY_DEBUG}
         )
     else()
       list(APPEND GTSAM_BOOST_LIBRARIES rt) # When using the header-only boost timer library, need -lrt

--- a/cmake/GtsamMatlabWrap.cmake
+++ b/cmake/GtsamMatlabWrap.cmake
@@ -35,7 +35,11 @@ mark_as_advanced(FORCE MEX_COMMAND)
 # Now that we have mex, trace back to find the Matlab installation root
 get_filename_component(MEX_COMMAND "${MEX_COMMAND}" REALPATH)
 get_filename_component(mex_path "${MEX_COMMAND}" PATH)
-get_filename_component(MATLAB_ROOT "${mex_path}/.." ABSOLUTE)
+if(mex_path MATCHES ".*/win64$")
+	get_filename_component(MATLAB_ROOT "${mex_path}/../.." ABSOLUTE)
+else()
+	get_filename_component(MATLAB_ROOT "${mex_path}/.." ABSOLUTE)
+endif()
 set(MATLAB_ROOT "${MATLAB_ROOT}" CACHE PATH "Path to MATLAB installation root (e.g. /usr/local/MATLAB/R2012a)")
 
 
@@ -97,9 +101,9 @@ function(wrap_library_internal interfaceHeader linkLibraries extraIncludeDirs ex
 	set(compiled_mex_modules_root "${PROJECT_BINARY_DIR}/wrap/${moduleName}_mex")
 	
 	message(STATUS "Building wrap module ${moduleName}")
-	
+
 	# Find matlab.h in GTSAM
-	if("${PROJECT_NAME}" STREQUAL "GTSAM")
+	if("${PROJECT_NAME}" STREQUAL "gtsam")
 		set(matlab_h_path "${PROJECT_SOURCE_DIR}")
 	else()
 		if(NOT GTSAM_INCLUDE_DIR)
@@ -115,14 +119,15 @@ function(wrap_library_internal interfaceHeader linkLibraries extraIncludeDirs ex
 	set(automaticDependencies "")
 	foreach(lib ${moduleName} ${linkLibraries})
 	  #message("MODULE NAME: ${moduleName}")
+	  #message("lib: ${lib}")
 		if(TARGET "${lib}")
             get_target_property(dependentLibraries ${lib} INTERFACE_LINK_LIBRARIES)
-           # message("DEPENDENT LIBRARIES:  ${dependentLibraries}")
-            if(dependentLibraries)
-               list(APPEND automaticDependencies ${dependentLibraries})
+            #message("DEPENDENT LIBRARIES:  ${dependentLibraries}")
+			if(dependentLibraries)
+			   list(APPEND automaticDependencies ${dependentLibraries})
             endif()
         endif()
-    endforeach()
+	endforeach()
     
     ## CHRIS: Temporary fix. On my system the get_target_property above returned Not-found for gtsam module
     ## This needs to be fixed!!

--- a/gtsam/geometry/CalibratedCamera.h
+++ b/gtsam/geometry/CalibratedCamera.h
@@ -18,6 +18,10 @@
 
 #pragma once
 
+//Needed if windows.h is included somehow.  
+//It defines min and max, which conflicts with numeric_limits::max()
+#define NOMINMAX  
+
 #include <gtsam/geometry/BearingRange.h>
 #include <gtsam/geometry/Point2.h>
 #include <gtsam/geometry/Pose3.h>
@@ -29,8 +33,7 @@
 
 namespace gtsam {
 
-class GTSAM_EXPORT CheiralityException: public ThreadsafeException<
-    CheiralityException> {
+class GTSAM_EXPORT CheiralityException: public ThreadsafeException<CheiralityException> {
 public:
   CheiralityException()
     : CheiralityException(std::numeric_limits<Key>::max()) {}


### PR DESCRIPTION
These changes were required on my Windows machine to get the gtsam library to compile.  Using Boost 1.67, and VS 2017 (Community)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/84)
<!-- Reviewable:end -->
