### PR TITLE
Testing performance of SLOW_BUT_CORRECT_BETWEENFACTOR

### DIFF
--- a/gtsam/slam/tests/testBetweenFactor.cpp
+++ b/gtsam/slam/tests/testBetweenFactor.cpp
@@ -5,11 +5,15 @@
  * @date    Aug 2, 2013
  */
 
+// #define SLOW_BUT_CORRECT_BETWEENFACTOR
+
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/geometry/Rot3.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/slam/BetweenFactor.h>
 #include <CppUnitLite/TestHarness.h>
+
+#include <chrono>
 
 using namespace gtsam;
 using namespace gtsam::symbol_shorthand;
@@ -42,6 +46,57 @@ TEST(BetweenFactor, Rot3) {
           &BetweenFactor<Rot3>::evaluateError, factor, _1, _2, boost::none,
           boost::none)), R1, R2, 1e-5);
   EXPECT(assert_equal(numericalH2,actualH2, 1E-5));
+}
+
+/* ************************************************************************* *
+
+// Timing and error evaluation for evaluate error 
+ 
+TEST(BetweenFactor, SlowButCorrectCompare) {
+  Rot3 R1 = Rot3::Rodrigues(0.1, 0.2, 0.3);
+  Rot3 R2 = Rot3::Rodrigues(0.4, 0.5, 0.6);
+  Rot3 noise = Rot3::Rodrigues(0.01, 0.01, 0.01); // Uncomment to make unit test fail
+  Rot3 measured = R1.between(R2)*noise  ;
+  BetweenFactor<Rot3> factor(R(1), R(2), measured, Isotropic::Sigma(3, 0.05));
+
+  Vector3 actual;
+  Matrix actualH1 = Eigen::MatrixXd::Zero(3,3);
+  Matrix actualH2 = Eigen::MatrixXd::Zero(3,3);
+  double duration = 0.0;
+
+  size_t sample_size = 100; 
+  for (size_t i = 0; i < sample_size; i++) {
+    Matrix H1, H2;
+    auto start = std::chrono::high_resolution_clock::now();
+    Vector3 error = factor.evaluateError(R1, R2, H1, H2);
+    auto finish = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> elapsed = finish - start;
+    duration = duration + elapsed.count();
+    actual = actual + error;
+    actualH1 = actualH1 + H1; 
+    actualH2 = actualH2 + H2;
+  }
+  
+  actual = actual / sample_size;
+  actualH1 = actualH1 / sample_size;
+  actualH2 = actualH2 / sample_size;
+  duration = duration / sample_size;
+
+  Vector expected = Rot3::Logmap(measured.inverse() * R1.between(R2));
+  Matrix numericalH1 = numericalDerivative21<Vector3,Rot3,Rot3>(
+      boost::function<Vector(const Rot3&, const Rot3&)>(boost::bind(
+          &BetweenFactor<Rot3>::evaluateError, factor, _1, _2, boost::none,
+          boost::none)), R1, R2, 1e-5);
+
+  Matrix numericalH2 = numericalDerivative22<Vector3,Rot3,Rot3>(
+      boost::function<Vector(const Rot3&, const Rot3&)>(boost::bind(
+          &BetweenFactor<Rot3>::evaluateError, factor, _1, _2, boost::none,
+          boost::none)), R1, R2, 1e-5);
+
+  std::cout << "measurement error: \n" << (expected - actual).array().abs() << std::endl;
+  std::cout << "H1 error: \n" << (numericalH1 - actualH1).array().abs() << std::endl;
+  std::cout << "H2 error: \n" << (numericalH2 - actualH2).array().abs() << std::endl;
+  std::cout << "Average runtime for evaluaterError: " << duration << std::endl;
 }
 
 /* ************************************************************************* */

--- a/gtsam/slam/tests/testBetweenFactor.cpp
+++ b/gtsam/slam/tests/testBetweenFactor.cpp
@@ -55,8 +55,8 @@ TEST(BetweenFactor, Rot3) {
 TEST(BetweenFactor, SlowButCorrectCompare) {
   Rot3 R1 = Rot3::Rodrigues(0.1, 0.2, 0.3);
   Rot3 R2 = Rot3::Rodrigues(0.4, 0.5, 0.6);
-  Rot3 noise = Rot3::Rodrigues(0.01, 0.01, 0.01); // Uncomment to make unit test fail
-  Rot3 measured = R1.between(R2)*noise  ;
+  Rot3 noise = Rot3::Rodrigues(0.01, 0.01, 0.01);
+  Rot3 measured = R1.between(R2)*noise  ; // Some noisy measurement
   BetweenFactor<Rot3> factor(R(1), R(2), measured, Isotropic::Sigma(3, 0.05));
 
   Vector3 actual;
@@ -81,7 +81,7 @@ TEST(BetweenFactor, SlowButCorrectCompare) {
   actualH1 = actualH1 / sample_size;
   actualH2 = actualH2 / sample_size;
   duration = duration / sample_size;
-
+  // Comparing calculated Jacobian to numerically obtained Jacobian 
   Vector expected = Rot3::Logmap(measured.inverse() * R1.between(R2));
   Matrix numericalH1 = numericalDerivative21<Vector3,Rot3,Rot3>(
       boost::function<Vector(const Rot3&, const Rot3&)>(boost::bind(

--- a/gtsam/slam/tests/testBetweenFactor.cpp
+++ b/gtsam/slam/tests/testBetweenFactor.cpp
@@ -63,7 +63,7 @@ TEST(BetweenFactor, SlowButCorrectCompare) {
   Matrix actualH1 = Eigen::MatrixXd::Zero(3,3);
   Matrix actualH2 = Eigen::MatrixXd::Zero(3,3);
   double duration = 0.0;
-
+  // Running samples to get the timing of evaluateError
   size_t sample_size = 100; 
   for (size_t i = 0; i < sample_size; i++) {
     Matrix H1, H2;


### PR DESCRIPTION
Hi, 
Looking at the performance of BetweenFactors and wrote this extra test. @dellaert @lucacarlone told me to ping you about this. The current default does not define the `SLOW_BUT_CORRECT_BETWEENFACTOR` and for the test example gave an error (compared with the numerical result) with magnitude of around 0.01 with an average runtime on my laptop of around 2e-7 seconds. If we do define `SLOW_BUT_CORRECT_BETWEENFACTOR` and enable the exponential maps, the error magnitude goes down to around 1e-12 and runtime increased to around 3e-7. 
Perhaps, since the runtime does not increase by much, `SLOW_BUT_CORRECT_BETWEENFACTOR` and `GTSAM_ROT3_EXP` should be made default? Or at least documented in readme and allow the user to set it as a cmake option? (Note that if we set `SLOW_BUT_CORRECT_BETWEENFACTOR` but not `GTSAM_ROT3_EXP` gtsam would crash due to the cayley derivatives being unimplemented currently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/88)
<!-- Reviewable:end -->
