### PR TITLE
[CMake][Bugfix] Fixed matlab wrapper based on new project names

### DIFF
--- a/cmake/GtsamMatlabWrap.cmake
+++ b/cmake/GtsamMatlabWrap.cmake
@@ -99,7 +99,7 @@ function(wrap_library_internal interfaceHeader linkLibraries extraIncludeDirs ex
 	message(STATUS "Building wrap module ${moduleName}")
 	
 	# Find matlab.h in GTSAM
-	if("${PROJECT_NAME}" STREQUAL "GTSAM")
+	if("${PROJECT_NAME}" STREQUAL "GTSAM" OR "${PROJECT_NAME}" STREQUAL "gtsam" OR "${PROJECT_NAME}" STREQUAL "gtsam_unstable")
 		set(matlab_h_path "${PROJECT_SOURCE_DIR}")
 	else()
 		if(NOT GTSAM_INCLUDE_DIR)


### PR DESCRIPTION
Seems like there is some issue with the new project names introduced in [this pull request](https://github.com/borglab/gtsam/pull/65). I tried to maintain backward compatibility here, but I'll happily change it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/89)
<!-- Reviewable:end -->
