### PR TITLE
Fixed spelling for Welsch and added to gtsam.h

### DIFF
--- a/gtsam.h
+++ b/gtsam.h
@@ -252,9 +252,9 @@ class FactorIndices {
 bool isDebugVersion();
 
 #include <gtsam/base/DSFMap.h>
-class IndexPair { 
-  IndexPair(); 
-  IndexPair(size_t i, size_t j); 
+class IndexPair {
+  IndexPair();
+  IndexPair(size_t i, size_t j);
   size_t i() const;
   size_t j() const;
 };
@@ -1387,6 +1387,15 @@ virtual class Tukey: gtsam::noiseModel::mEstimator::Base {
   // enabling serialization functionality
   void serializable() const;
 };
+
+virtual class Welsch: gtsam::noiseModel::mEstimator::Base {
+  Welsch(double k);
+  static gtsam::noiseModel::mEstimator::Welsch* Create(double k);
+
+  // enabling serialization functionality
+  void serializable() const;
+};
+
 
 }///\namespace mEstimator
 

--- a/gtsam/linear/NoiseModel.cpp
+++ b/gtsam/linear/NoiseModel.cpp
@@ -808,22 +808,22 @@ Tukey::shared_ptr Tukey::Create(double c, const ReweightScheme reweight) {
 }
 
 /* ************************************************************************* */
-// Welsh
+// Welsch
 /* ************************************************************************* */
-Welsh::Welsh(double c, const ReweightScheme reweight) : Base(reweight), c_(c), csquared_(c * c) {}
+Welsch::Welsch(double c, const ReweightScheme reweight) : Base(reweight), c_(c), csquared_(c * c) {}
 
-void Welsh::print(const std::string &s="") const {
-  std::cout << s << ": Welsh (" << c_ << ")" << std::endl;
+void Welsch::print(const std::string &s="") const {
+  std::cout << s << ": Welsch (" << c_ << ")" << std::endl;
 }
 
-bool Welsh::equals(const Base &expected, double tol) const {
-  const Welsh* p = dynamic_cast<const Welsh*>(&expected);
+bool Welsch::equals(const Base &expected, double tol) const {
+  const Welsch* p = dynamic_cast<const Welsch*>(&expected);
   if (p == NULL) return false;
   return std::abs(c_ - p->c_) < tol;
 }
 
-Welsh::shared_ptr Welsh::Create(double c, const ReweightScheme reweight) {
-  return shared_ptr(new Welsh(c, reweight));
+Welsch::shared_ptr Welsch::Create(double c, const ReweightScheme reweight) {
+  return shared_ptr(new Welsch(c, reweight));
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/NoiseModel.cpp
+++ b/gtsam/linear/NoiseModel.cpp
@@ -826,6 +826,24 @@ Welsch::shared_ptr Welsch::Create(double c, const ReweightScheme reweight) {
   return shared_ptr(new Welsch(c, reweight));
 }
 
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V4
+Welsh::Welsh(double c, const ReweightScheme reweight) : Base(reweight), c_(c), csquared_(c * c) {}
+
+void Welsh::print(const std::string &s="") const {
+  std::cout << s << ": Welsh (" << c_ << ")" << std::endl;
+}
+
+bool Welsh::equals(const Base &expected, double tol) const {
+  const Welsh* p = dynamic_cast<const Welsh*>(&expected);
+  if (p == NULL) return false;
+  return std::abs(c_ - p->c_) < tol;
+}
+
+Welsh::shared_ptr Welsh::Create(double c, const ReweightScheme reweight) {
+  return shared_ptr(new Welsh(c, reweight));
+}
+#endif
+
 /* ************************************************************************* */
 // GemanMcClure
 /* ************************************************************************* */

--- a/gtsam/linear/NoiseModel.h
+++ b/gtsam/linear/NoiseModel.h
@@ -878,6 +878,38 @@ namespace gtsam {
           ar & BOOST_SERIALIZATION_NVP(c_);
         }
       };
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V4
+      /// @name Deprecated
+      /// @{
+      // Welsh implements the "Welsch" robust error model (Zhang97ivc)
+      // This was misspelled in previous versions of gtsam and should be
+      // removed in the future.
+      class GTSAM_EXPORT Welsh : public Base {
+      protected:
+        double c_, csquared_;
+
+      public:
+        typedef boost::shared_ptr<Welsh> shared_ptr;
+
+        Welsh(double c = 2.9846, const ReweightScheme reweight = Block);
+        double weight(double error) const {
+          double xc2 = (error*error)/csquared_;
+          return std::exp(-xc2);
+        }
+        void print(const std::string &s) const;
+        bool equals(const Base& expected, double tol=1e-8) const;
+        static shared_ptr Create(double k, const ReweightScheme reweight = Block) ;
+
+      private:
+        /** Serialization function */
+        friend class boost::serialization::access;
+        template<class ARCHIVE>
+        void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
+          ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
+          ar & BOOST_SERIALIZATION_NVP(c_);
+        }
+      };
+#endif
 
       /// GemanMcClure implements the "Geman-McClure" robust error model
       /// (Zhang97ivc).

--- a/gtsam/linear/NoiseModel.h
+++ b/gtsam/linear/NoiseModel.h
@@ -852,15 +852,15 @@ namespace gtsam {
         }
       };
 
-      /// Welsh implements the "Welsh" robust error model (Zhang97ivc)
-      class GTSAM_EXPORT Welsh : public Base {
+      /// Welsch implements the "Welsch" robust error model (Zhang97ivc)
+      class GTSAM_EXPORT Welsch : public Base {
       protected:
         double c_, csquared_;
 
       public:
-        typedef boost::shared_ptr<Welsh> shared_ptr;
+        typedef boost::shared_ptr<Welsch> shared_ptr;
 
-        Welsh(double c = 2.9846, const ReweightScheme reweight = Block);
+        Welsch(double c = 2.9846, const ReweightScheme reweight = Block);
         double weight(double error) const {
           double xc2 = (error*error)/csquared_;
           return std::exp(-xc2);


### PR DESCRIPTION
Welsch is spelled inconsistently with the citation: https://members.loria.fr/MOBerger/Enseignement/Master2/Documents/ZhangIVC-97-01.pdf

I am also hoping to use this from Python, so I added it to gtsam.h

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/107)
<!-- Reviewable:end -->
