### PR TITLE
boost libraries fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,32 +178,49 @@ option(GTSAM_DISABLE_NEW_TIMERS "Disables using Boost.chrono for timing" OFF)
 # problems with Boost versions newer than FindBoost.cmake was prepared to handle,
 # so we downgraded this to classic filenames-based variables, and manually adding
 # the target_include_directories(xxx ${Boost_INCLUDE_DIR})
-set(GTSAM_BOOST_LIBRARIES
-  optimized ${Boost_SERIALIZATION_LIBRARY_RELEASE}
-  optimized ${Boost_SYSTEM_LIBRARY_RELEASE}
-  optimized ${Boost_FILESYSTEM_LIBRARY_RELEASE}
-  optimized ${Boost_THREAD_LIBRARY_RELEASE}
-  optimized ${Boost_DATE_TIME_LIBRARY_RELEASE}
-  optimized ${Boost_REGEX_LIBRARY_RELEASE}
-  debug ${Boost_SERIALIZATION_LIBRARY_DEBUG}
-  debug ${Boost_SYSTEM_LIBRARY_DEBUG}
-  debug ${Boost_FILESYSTEM_LIBRARY_DEBUG}
-  debug ${Boost_THREAD_LIBRARY_DEBUG}
-  debug ${Boost_DATE_TIME_LIBRARY_DEBUG}
-  debug ${Boost_REGEX_LIBRARY_DEBUG}
-)
+set(GTSAM_BOOST_LIBRARIES "")
+foreach(TMP
+        ${Boost_SERIALIZATION_LIBRARY_RELEASE}
+        ${Boost_SYSTEM_LIBRARY_RELEASE}
+        ${Boost_FILESYSTEM_LIBRARY_RELEASE}
+        ${Boost_THREAD_LIBRARY_RELEASE}
+        ${Boost_DATE_TIME_LIBRARY_RELEASE}
+        ${Boost_REGEX_LIBRARY_RELEASE})
+    if(NOT "${TMP}" STREQUAL "")
+        list(APPEND GTSAM_BOOST_LIBRARIES optimized "${TMP}")
+    endif()
+endforeach(TMP)
+foreach(TMP
+        ${Boost_SERIALIZATION_LIBRARY_DEBUG}
+        ${Boost_SYSTEM_LIBRARY_DEBUG}
+        ${Boost_FILESYSTEM_LIBRARY_DEBUG}
+        ${Boost_THREAD_LIBRARY_DEBUG}
+        ${Boost_DATE_TIME_LIBRARY_DEBUG}
+        ${Boost_REGEX_LIBRARY_DEBUG})
+    if(NOT "${TMP}" STREQUAL "")
+        list(APPEND GTSAM_BOOST_LIBRARIES debug "${TMP}")
+    endif()
+endforeach(TMP)
 message(STATUS "GTSAM_BOOST_LIBRARIES: ${GTSAM_BOOST_LIBRARIES}")
 if (GTSAM_DISABLE_NEW_TIMERS)
     message("WARNING:  GTSAM timing instrumentation manually disabled")
     list_append_cache(GTSAM_COMPILE_DEFINITIONS_PUBLIC DGTSAM_DISABLE_NEW_TIMERS)
 else()
     if(Boost_TIMER_LIBRARY)
-      list(APPEND GTSAM_BOOST_LIBRARIES
-        optimized ${Boost_TIMER_LIBRARY_RELEASE}
-        optimized ${Boost_CHRONO_LIBRARY_RELEASE}
-        debug ${Boost_TIMER_LIBRARY_DEBUG}
-        debug ${Boost_CHRONO_LIBRARY_DEBUG}
-        )
+        foreach(TMP
+                ${Boost_TIMER_LIBRARY_RELEASE}
+                ${Boost_CHRONO_LIBRARY_RELEASE})
+            if(NOT "${TMP}" STREQUAL "")
+                list(APPEND GTSAM_BOOST_LIBRARIES optimized "${TMP}")
+            endif()
+        endforeach(TMP)
+        foreach(TMP
+                ${Boost_TIMER_LIBRARY_DEBUG}
+                ${Boost_CHRONO_LIBRARY_DEBUG})
+            if(NOT "${TMP}" STREQUAL "")
+                list(APPEND GTSAM_BOOST_LIBRARIES debug "${TMP}")
+            endif()
+        endforeach(TMP)
     else()
       list(APPEND GTSAM_BOOST_LIBRARIES rt) # When using the header-only boost timer library, need -lrt
       message("WARNING:  GTSAM timing instrumentation will use the older, less accurate, Boost timer library because boost older than 1.48 was found.")

--- a/wrap/CMakeLists.txt
+++ b/wrap/CMakeLists.txt
@@ -1,15 +1,23 @@
 # Build/install Wrap
 
-set(WRAP_BOOST_LIBRARIES
-  optimized
-    ${Boost_FILESYSTEM_LIBRARY_RELEASE}
-    ${Boost_SYSTEM_LIBRARY_RELEASE}
-    ${Boost_THREAD_LIBRARY_RELEASE}
-  debug
-    ${Boost_FILESYSTEM_LIBRARY_DEBUG}
-    ${Boost_SYSTEM_LIBRARY_DEBUG}
-    ${Boost_THREAD_LIBRARY_DEBUG}
-)
+set(WRAP_BOOST_LIBRARIES "")
+foreach(TMP
+        ${Boost_FILESYSTEM_LIBRARY_RELEASE}
+        ${Boost_SYSTEM_LIBRARY_RELEASE}
+        ${Boost_THREAD_LIBRARY_RELEASE})
+    if(NOT "${TMP}" STREQUAL "")
+        list(APPEND WRAP_BOOST_LIBRARIES optimized "${TMP}")
+    endif()
+endforeach(TMP)
+foreach(TMP
+        ${Boost_FILESYSTEM_LIBRARY_DEBUG}
+        ${Boost_SYSTEM_LIBRARY_DEBUG}
+        ${Boost_THREAD_LIBRARY_DEBUG})
+    if(NOT "${TMP}" STREQUAL "")
+        list(APPEND WRAP_BOOST_LIBRARIES debug "${TMP}")
+    endif()
+endforeach(TMP)
+
 
 # Allow for disabling serialization to handle errors related to Clang's linker
 option(GTSAM_WRAP_SERIALIZATION "If enabled, allows for wrapped objects to be saved via boost.serialization" ON)


### PR DESCRIPTION
I encountered a problem when building gtsam and linking with boost installed through anaconda, because it seems that none of the debug libraries were available in that package. This was OK because I was building in release mode, however because the `Boost_*_LIBRARY_DEBUG` symbols were all empty, the `GTSAM_BOOST_LIBRARIES` variable ended up being `optimized;<library>;optimized;<library>......;debug;debug;debug;debug` which is invalid syntax because `debug` and `optimized` has to immediately be followed by a path. It is also invalid to have a dangling `debug` or `optimized` at the end of the string.

I don't think my fix is optimal, but it does work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/131)
<!-- Reviewable:end -->
