### PR TITLE
Fix Metis ordering for empty graph and single node

### DIFF
--- a/gtsam/inference/Ordering.cpp
+++ b/gtsam/inference/Ordering.cpp
@@ -213,11 +213,21 @@ Ordering Ordering::Metis(const MetisIndex& met) {
 #ifdef GTSAM_SUPPORT_NESTED_DISSECTION
   gttic(Ordering_METIS);
 
+  idx_t size = met.nValues();
+  if (size == 0)
+  {
+    return Ordering();
+  }
+
+  if (size == 1)
+  {
+    return Ordering(KeyVector(1, met.intToKey(0)));
+  }
+
   vector<idx_t> xadj = met.xadj();
   vector<idx_t> adj = met.adj();
   vector<idx_t> perm, iperm;
 
-  idx_t size = met.nValues();
   for (idx_t i = 0; i < size; i++) {
     perm.push_back(0);
     iperm.push_back(0);

--- a/gtsam/inference/Ordering.h
+++ b/gtsam/inference/Ordering.h
@@ -191,7 +191,10 @@ public:
 
   template<class FACTOR_GRAPH>
   static Ordering Metis(const FACTOR_GRAPH& graph) {
-    return Metis(MetisIndex(graph));
+    if (graph.empty())
+      return Ordering();
+    else
+      return Metis(MetisIndex(graph));
   }
 
   /// @}

--- a/gtsam/inference/tests/testOrdering.cpp
+++ b/gtsam/inference/tests/testOrdering.cpp
@@ -294,6 +294,28 @@ TEST(Ordering, MetisLoop) {
 }
 #endif
 /* ************************************************************************* */
+#ifdef GTSAM_SUPPORT_NESTED_DISSECTION
+TEST(Ordering, MetisEmptyGraph) {
+  SymbolicFactorGraph symbolicGraph;
+
+  Ordering actual = Ordering::Create(Ordering::METIS, symbolicGraph);
+  Ordering expected;
+  EXPECT(assert_equal(expected, actual));
+}
+#endif
+/* ************************************************************************* */
+#ifdef GTSAM_SUPPORT_NESTED_DISSECTION
+TEST(Ordering, MetisSingleNode) {
+  // create graph with a single node
+  SymbolicFactorGraph symbolicGraph;
+  symbolicGraph.push_factor(7);
+
+  Ordering actual = Ordering::Create(Ordering::METIS, symbolicGraph);
+  Ordering expected = Ordering(list_of(7));
+  EXPECT(assert_equal(expected, actual));
+}
+#endif
+/* ************************************************************************* */
 TEST(Ordering, Create) {
 
   // create chain graph


### PR DESCRIPTION
This fixes an edge case in generating a Metis ordering for factor graphs involving a single node. Without this fix we crash in Metis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/140)
<!-- Reviewable:end -->
