### PR TITLE
Fix/clang warnings

### DIFF
--- a/gtsam/linear/GaussianBayesNet.cpp
+++ b/gtsam/linear/GaussianBayesNet.cpp
@@ -187,16 +187,16 @@ namespace gtsam {
   }
 
   /* ************************************************************************* */
-  double GaussianBayesNet::logDeterminant() const
-  {
+  double GaussianBayesNet::logDeterminant() const {
     double logDet = 0.0;
-    for(const sharedConditional& cg: *this) {
-      if(cg->get_model()) {
+    for (const sharedConditional& cg : *this) {
+      if (cg->get_model()) {
         Vector diag = cg->R().diagonal();
         cg->get_model()->whitenInPlace(diag);
-        logDet += diag.unaryExpr(ptr_fun<double,double>(log)).sum();
+        logDet += diag.unaryExpr([](double x) { return log(x); }).sum();
       } else {
-        logDet += cg->R().diagonal().unaryExpr(ptr_fun<double,double>(log)).sum();
+        logDet +=
+            cg->R().diagonal().unaryExpr([](double x) { return log(x); }).sum();
       }
     }
     return logDet;

--- a/gtsam/linear/GaussianBayesTree.cpp
+++ b/gtsam/linear/GaussianBayesTree.cpp
@@ -40,11 +40,11 @@ namespace gtsam {
     parentSum += clique->conditional()
                      ->R()
                      .diagonal()
-                     .unaryExpr(std::ptr_fun<double, double>(log))
+                     .unaryExpr([](double x) { return log(x); })
                      .sum();
     return 0;
   }
-  }
+  }  // namespace internal
 
   /* ************************************************************************* */
   bool GaussianBayesTree::equals(const This& other, double tol) const

--- a/gtsam/linear/NoiseModel.h
+++ b/gtsam/linear/NoiseModel.h
@@ -752,8 +752,8 @@ namespace gtsam {
         Fair(double c = 1.3998, const ReweightScheme reweight = Block);
         double weight(double error) const override;
         double residual(double error) const override;
-        void print(const std::string &s) const;
-        bool equals(const Base& expected, double tol=1e-8) const;
+        void print(const std::string &s) const override;
+        bool equals(const Base& expected, double tol = 1e-8) const override;
         static shared_ptr Create(double c, const ReweightScheme reweight = Block) ;
 
       private:
@@ -777,8 +777,8 @@ namespace gtsam {
         Huber(double k = 1.345, const ReweightScheme reweight = Block);
         double weight(double error) const override;
         double residual(double error) const override;
-        void print(const std::string &s) const;
-        bool equals(const Base& expected, double tol=1e-8) const;
+        void print(const std::string &s) const override;
+        bool equals(const Base& expected, double tol = 1e-8) const override;
         static shared_ptr Create(double k, const ReweightScheme reweight = Block) ;
 
       private:
@@ -806,8 +806,8 @@ namespace gtsam {
         Cauchy(double k = 0.1, const ReweightScheme reweight = Block);
         double weight(double error) const override;
         double residual(double error) const override;
-        void print(const std::string &s) const;
-        bool equals(const Base& expected, double tol=1e-8) const;
+        void print(const std::string &s) const override;
+        bool equals(const Base& expected, double tol = 1e-8) const override;
         static shared_ptr Create(double k, const ReweightScheme reweight = Block) ;
 
       private:
@@ -831,8 +831,8 @@ namespace gtsam {
         Tukey(double c = 4.6851, const ReweightScheme reweight = Block);
         double weight(double error) const override;
         double residual(double error) const override;
-        void print(const std::string &s) const;
-        bool equals(const Base& expected, double tol=1e-8) const;
+        void print(const std::string &s) const override;
+        bool equals(const Base& expected, double tol = 1e-8) const override;
         static shared_ptr Create(double k, const ReweightScheme reweight = Block) ;
 
       private:
@@ -856,8 +856,8 @@ namespace gtsam {
         Welsch(double c = 2.9846, const ReweightScheme reweight = Block);
         double weight(double error) const override;
         double residual(double error) const override;
-        void print(const std::string &s) const;
-        bool equals(const Base& expected, double tol=1e-8) const;
+        void print(const std::string &s) const override;
+        bool equals(const Base& expected, double tol = 1e-8) const override;
         static shared_ptr Create(double k, const ReweightScheme reweight = Block) ;
 
       private:
@@ -892,8 +892,8 @@ namespace gtsam {
         ~GemanMcClure() {}
         double weight(double error) const override;
         double residual(double error) const override;
-        void print(const std::string &s) const;
-        bool equals(const Base& expected, double tol=1e-8) const;
+        void print(const std::string &s) const override;
+        bool equals(const Base& expected, double tol=1e-8) const override;
         static shared_ptr Create(double k, const ReweightScheme reweight = Block) ;
 
       protected:
@@ -922,8 +922,8 @@ namespace gtsam {
         ~DCS() {}
         double weight(double error) const override;
         double residual(double error) const override;
-        void print(const std::string &s) const;
-        bool equals(const Base& expected, double tol=1e-8) const;
+        void print(const std::string &s) const override;
+        bool equals(const Base& expected, double tol = 1e-8) const override;
         static shared_ptr Create(double k, const ReweightScheme reweight = Block) ;
 
       protected:
@@ -954,8 +954,8 @@ namespace gtsam {
           L2WithDeadZone(double k = 1.0, const ReweightScheme reweight = Block);
           double weight(double error) const override;
           double residual(double error) const override;
-          void print(const std::string &s) const;
-          bool equals(const Base& expected, double tol=1e-8) const;
+          void print(const std::string &s) const override;
+          bool equals(const Base& expected, double tol = 1e-8) const override;
           static shared_ptr Create(double k, const ReweightScheme reweight = Block);
 
       private:


### PR DESCRIPTION
Fix warnings on clang. Most are missing overrides from @varunagrawal 's last PR. Probably warnings did not show up on Linux. But I also resolved calls to `ptr_fun` which was deprecated in c++11.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/146)
<!-- Reviewable:end -->
