### PR TITLE
Fix bug when constructing VariableSlots

### DIFF
--- a/gtsam/inference/VariableSlots.h
+++ b/gtsam/inference/VariableSlots.h
@@ -99,7 +99,9 @@ VariableSlots::VariableSlots(const FG& factorGraph)
   // factor does not involve that variable.
   size_t jointFactorPos = 0;
   for(const typename FG::sharedFactor& factor: factorGraph) {
-    assert(factor);
+    if (!factor) {
+      continue;
+    }
     size_t factorVarSlot = 0;
     for(const Key involvedVariable: *factor) {
       // Set the slot in this factor for this variable.  If the
@@ -111,7 +113,7 @@ VariableSlots::VariableSlots(const FG& factorGraph)
       iterator thisVarSlots; bool inserted;
         boost::tie(thisVarSlots, inserted) = this->insert(std::make_pair(involvedVariable, FastVector<size_t>()));
       if(inserted)
-        thisVarSlots->second.resize(factorGraph.size(), Empty);
+        thisVarSlots->second.resize(factorGraph.nrFactors(), Empty);
       thisVarSlots->second[jointFactorPos] = factorVarSlot;
       if(debug) std::cout << "  var " << involvedVariable << " rowblock " << jointFactorPos << " comes from factor's slot " << factorVarSlot << std::endl;
       ++ factorVarSlot;

--- a/gtsam_unstable/examples/FixedLagSmootherExample.cpp
+++ b/gtsam_unstable/examples/FixedLagSmootherExample.cpp
@@ -145,5 +145,18 @@ int main(int argc, char** argv) {
     cout << setprecision(5) << "    Key: " << key_timestamp.first << "  Time: " << key_timestamp.second << endl;
   }
 
+  // get the linearization point
+  Values result = smootherISAM2.calculateEstimate();
+
+  // create the factor graph
+  auto &factor_graph = smootherISAM2.getFactors();
+
+  // linearize to a Gaussian factor graph
+  boost::shared_ptr<GaussianFactorGraph> linear_graph = factor_graph.linearize(result);
+
+  // this is where the segmentation fault occurs
+  Matrix A = linear_graph->jacobian().first;
+  cout << " A = " << A << endl;
+
   return 0;
 }

--- a/gtsam_unstable/examples/FixedLagSmootherExample.cpp
+++ b/gtsam_unstable/examples/FixedLagSmootherExample.cpp
@@ -145,18 +145,19 @@ int main(int argc, char** argv) {
     cout << setprecision(5) << "    Key: " << key_timestamp.first << "  Time: " << key_timestamp.second << endl;
   }
 
-  // get the linearization point
+  // Here is an example of how to get the full Jacobian of the problem.
+  // First, get the linearization point.
   Values result = smootherISAM2.calculateEstimate();
 
-  // create the factor graph
-  auto &factor_graph = smootherISAM2.getFactors();
+  // Get the factor graph
+  auto &factorGraph = smootherISAM2.getFactors();
 
-  // linearize to a Gaussian factor graph
-  boost::shared_ptr<GaussianFactorGraph> linear_graph = factor_graph.linearize(result);
+  // Linearize to a Gaussian factor graph
+  boost::shared_ptr<GaussianFactorGraph> linearGraph = factorGraph.linearize(result);
 
-  // this is where the segmentation fault occurs
-  Matrix A = linear_graph->jacobian().first;
-  cout << " A = " << A << endl;
+  // Converts the linear graph into a Jacobian factor and extracts the Jacobian matrix
+  Matrix jacobian = linearGraph->jacobian().first;
+  cout << " Jacobian: " << jacobian << endl;
 
   return 0;
 }


### PR DESCRIPTION
VariableSlots were not constructable from GaussianFactorGraphs that contained null factors.
This caused seg faults when generating Jacobian factors from such graphs.

This bug was discovered by Guillermo Dueas Arana <gdueasar@hawk.iit.edu>:
https://groups.google.com/d/msgid/gtsam-users/5d7b05a9-2200-43e2-8f1d-ddc878d6ab5e%40googlegroups.com.

This fix was developed by myself and Francesco Papi <fpapi@zoox.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/163)
<!-- Reviewable:end -->
