### PR TITLE
Fix potential infinite loop in GTSAM's nonlinear optimizer.

### DIFF
--- a/gtsam/nonlinear/NonlinearOptimizer.cpp
+++ b/gtsam/nonlinear/NonlinearOptimizer.cpp
@@ -101,7 +101,7 @@ void NonlinearOptimizer::defaultOptimize() {
       cout << "newError: " << error() << endl;
   } while (iterations() < params.maxIterations &&
            !checkConvergence(params.relativeErrorTol, params.absoluteErrorTol, params.errorTol,
-                             currentError, error(), params.verbosity));
+                             currentError, error(), params.verbosity) && std::isfinite(currentError));
 
   // Printing if verbose
   if (params.verbosity >= NonlinearOptimizerParams::TERMINATION) {


### PR DESCRIPTION
This PR fixes a possible infinite loop within the NonlinearOptimizer class.

To reproduce the issue:
1) Build a factor graph with at least one factor whose error evaluates to inf or NaN on a given set of values (for example, I made a fake factor that always returns inf error).
2) Build a `LevenbergMarquardtOptimizer`
3) Run `LevenbergMarquardtOptimizer::optimize()`

The `optimize()` function will get stuck in [this loop](https://github.com/borglab/gtsam/blob/develop/gtsam/nonlinear/NonlinearOptimizer.cpp#L91) indefinitely.

While this is not a common use case and should be avoided at the user level, it is better to break out of `optimize()` and still return that the optimization did not converge than to hang the program in an infinite loop.

I have only verified that this bug occurs when using `LevenbergMarquardOptimizer`, but I would imagine that this fix is generally a good thing to have. The reason that the issue occurs in `LevenbergMarquardtOptimizer` specifically is that we do not increase the state's `iteration` field unless `decreaseLambda` succeeds ([this](https://github.com/borglab/gtsam/blob/develop/gtsam/nonlinear/internal/LevenbergMarquardtState.h#L93) is the only location in the LM optimizer where iteration number is increased). 

There are likely other ways to fix this issue specifically for LM, such as increasing `state_.iteration` in at least one other location, but this PR blanket fixes the issue for all optimizers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/170)
<!-- Reviewable:end -->
