### PR TITLE
Add missing boost::shared_ptr include to Values.h

### DIFF
--- a/gtsam/nonlinear/Values.h
+++ b/gtsam/nonlinear/Values.h
@@ -39,6 +39,7 @@
 #pragma GCC diagnostic pop
 #endif
 #include <boost/ptr_container/serialize_ptr_map.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <string>
 #include <utility>


### PR DESCRIPTION
This include was previously missing, causing link errors when `#include`ing and using `gtsam/nonlinear/Values.h` directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/171)
<!-- Reviewable:end -->
