### PR TITLE
Make AttitudeFactor copy and move assignable.

### DIFF
--- a/gtsam/navigation/AttitudeFactor.h
+++ b/gtsam/navigation/AttitudeFactor.h
@@ -35,7 +35,7 @@ class AttitudeFactor {
 
 protected:
 
-  const Unit3 nZ_, bRef_; ///< Position measurement in
+  Unit3 nZ_, bRef_; ///< Position measurement in
 
 public:
 
@@ -56,12 +56,19 @@ public:
   Vector attitudeError(const Rot3& p,
       OptionalJacobian<2,3> H = boost::none) const;
 
+  const Unit3& nZ() const {
+    return nZ_;
+  }
+  const Unit3& bRef() const {
+    return bRef_;
+  }
+
   /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
-    ar & boost::serialization::make_nvp("nZ_", const_cast<Unit3&>(nZ_));
-    ar & boost::serialization::make_nvp("bRef_", const_cast<Unit3&>(bRef_));
+    ar & boost::serialization::make_nvp("nZ_",  nZ_);
+    ar & boost::serialization::make_nvp("bRef_", bRef_);
   }
 };
 
@@ -117,12 +124,6 @@ public:
   virtual Vector evaluateError(const Rot3& nRb, //
       boost::optional<Matrix&> H = boost::none) const {
     return attitudeError(nRb, H);
-  }
-  Unit3 nZ() const {
-    return nZ_;
-  }
-  Unit3 bRef() const {
-    return bRef_;
   }
 
 private:
@@ -203,12 +204,6 @@ public:
       H->block<2,3>(0,0) = H23;
     }
     return e;
-  }
-  Unit3 nZ() const {
-    return nZ_;
-  }
-  Unit3 bRef() const {
-    return bRef_;
   }
 
 private:

--- a/gtsam/navigation/tests/testAttitudeFactor.cpp
+++ b/gtsam/navigation/tests/testAttitudeFactor.cpp
@@ -82,10 +82,12 @@ TEST(Rot3AttitudeFactor, CopyAndMove) {
   Rot3AttitudeFactor factor(0, nDown, model);
 
   // Copy assignable.
+  EXPECT(std::is_copy_assignable<Rot3AttitudeFactor>::value);
   Rot3AttitudeFactor factor_copied = factor;
   EXPECT(assert_equal(factor, factor_copied));
 
   // Move assignable.
+  EXPECT(std::is_move_assignable<Rot3AttitudeFactor>::value);
   Rot3AttitudeFactor factor_moved = std::move(factor_copied);
   EXPECT(assert_equal(factor, factor_moved));
 }
@@ -141,10 +143,12 @@ TEST(Pose3AttitudeFactor, CopyAndMove) {
   Pose3AttitudeFactor factor(0, nDown, model);
 
   // Copy assignable.
+  EXPECT(std::is_copy_assignable<Pose3AttitudeFactor>::value);
   Pose3AttitudeFactor factor_copied = factor;
   EXPECT(assert_equal(factor, factor_copied));
 
   // Move assignable.
+  EXPECT(std::is_move_assignable<Pose3AttitudeFactor>::value);
   Pose3AttitudeFactor factor_moved = std::move(factor_copied);
   EXPECT(assert_equal(factor, factor_moved));
 }

--- a/gtsam/navigation/tests/testAttitudeFactor.cpp
+++ b/gtsam/navigation/tests/testAttitudeFactor.cpp
@@ -75,6 +75,21 @@ TEST(Rot3AttitudeFactor, Serialization) {
   EXPECT(serializationTestHelpers::equalsBinary(factor));
 }
 
+/* ************************************************************************* */
+TEST(Rot3AttitudeFactor, CopyAndMove) {
+  Unit3 nDown(0, 0, -1);
+  SharedNoiseModel model = noiseModel::Isotropic::Sigma(2, 0.25);
+  Rot3AttitudeFactor factor(0, nDown, model);
+
+  // Copy assignable.
+  Rot3AttitudeFactor factor_copied = factor;
+  EXPECT(assert_equal(factor, factor_copied));
+
+  // Move assignable.
+  Rot3AttitudeFactor factor_moved = std::move(factor_copied);
+  EXPECT(assert_equal(factor, factor_moved));
+}
+
 // *************************************************************************
 TEST( Pose3AttitudeFactor, Constructor ) {
 
@@ -117,6 +132,21 @@ TEST(Pose3AttitudeFactor, Serialization) {
   EXPECT(serializationTestHelpers::equalsObj(factor));
   EXPECT(serializationTestHelpers::equalsXML(factor));
   EXPECT(serializationTestHelpers::equalsBinary(factor));
+}
+
+/* ************************************************************************* */
+TEST(Pose3AttitudeFactor, CopyAndMove) {
+  Unit3 nDown(0, 0, -1);
+  SharedNoiseModel model = noiseModel::Isotropic::Sigma(2, 0.25);
+  Pose3AttitudeFactor factor(0, nDown, model);
+
+  // Copy assignable.
+  Pose3AttitudeFactor factor_copied = factor;
+  EXPECT(assert_equal(factor, factor_copied));
+
+  // Move assignable.
+  Pose3AttitudeFactor factor_moved = std::move(factor_copied);
+  EXPECT(assert_equal(factor, factor_moved));
 }
 
 // *************************************************************************


### PR DESCRIPTION
To my knowledge `AttitudeFactor` is the only non copy and move assignable factor in the codebase because we mark its members as `const` on construction. This prevents users from writing generic template utilities that attempt to copy or move templated factor types.

It seems like we were previously getting around this within `AttitudeFactor::serialize` by const casting to a normal reference.

I also pulled the getters `nZ()` and `bRef()` into the base class, rather than duplicating them in derived classes (the members these getters return are owned by the base class), and made them return a const ref to avoid an output copy.

This PR is a strawman; happy to close if we favor this type of const correctness more (although if we do close it, we should also change e.g. [GPSFactor](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/GPSFactor.h#L41) and others, which differ from AttitudeFactor in this respect).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/172)
<!-- Reviewable:end -->
