### PR TITLE
Declare build dependencies in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -8,6 +8,11 @@
   <license>BSD</license>
 
   <buildtool_depend>cmake</buildtool_depend>
+  
+  <build_depend>boost</build_depend>
+  <build_depend>eigen</build_depend>
+  <build_depend>tbb</build_depend>
+  
   <export>
     <!-- Specify that this is not really a Catkin package-->
     <build_type>cmake</build_type>


### PR DESCRIPTION
This adds the missing `libboost-all-dev` build dependency for this Cmake package.

I've also added `libeigen3-dev`, given it was installed in this repo's Dockerfile. I'm guessing copy of eigen in the 3rd-party folder is only built if eigen is not found to be pre installed in the system?

Also, Intel Thread Building Blocks (TBB) was listed as an optional dependency, so I'm not sure if we'd like to declare that here; we could leave that line commented it out if you think it's uncommon to use.

FYI, here is the source reference for library to key names used for package manifests:
https://github.com/ros/rosdistro/blob/master/rosdep/base.yaml

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/173)
<!-- Reviewable:end -->
