### PR TITLE
Install GtsamPrinting.cmake

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -20,6 +20,7 @@ install(FILES
   GtsamPythonWrap.cmake
   GtsamCythonWrap.cmake
   GtsamTesting.cmake
+  GtsamPrinting.cmake
   FindCython.cmake
   FindNumPy.cmake
   README.html


### PR DESCRIPTION
This PR installs `GtsamPrinting.cmake` as part of the GTSAM installation to allow the use of build configuration printing functions in downstream applications.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/176)
<!-- Reviewable:end -->
