### PR TITLE
Eigen alignment fix in ExpressionNode and RotateFactor

### DIFF
--- a/gtsam/nonlinear/internal/ExpressionNode.h
+++ b/gtsam/nonlinear/internal/ExpressionNode.h
@@ -149,6 +149,8 @@ public:
       ExecutionTraceStorage* traceStorage) const {
     return constant_;
   }
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 //-----------------------------------------------------------------------------

--- a/gtsam/slam/RotateFactor.h
+++ b/gtsam/slam/RotateFactor.h
@@ -112,6 +112,8 @@ public:
     }
     return error;
   }
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 }  // namespace gtsam
 


### PR DESCRIPTION
This fixes alignment warnings in `ExpressionNode` and `RotateFactor` when compiling with gcc 7.4  (and higher) on Ubuntu 18.04, as described in https://github.com/borglab/gtsam/issues/21

I was able to reproduce (and then fix) the warnings on my own machine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/185)
<!-- Reviewable:end -->
