### PR TITLE
Fix LM linearizedCostChange for robust noise models

### DIFF
--- a/gtsam/linear/JacobianFactor.cpp
+++ b/gtsam/linear/JacobianFactor.cpp
@@ -513,8 +513,10 @@ Vector JacobianFactor::error_vector(const VectorValues& c) const {
 
 /* ************************************************************************* */
 double JacobianFactor::error(const VectorValues& c) const {
-  Vector weighted = error_vector(c);
-  return 0.5 * weighted.dot(weighted);
+  Vector e = unweighted_error(c);
+  // Use the noise model distance function to get the correct error if available.
+  if (model_) return 0.5 * model_->distance(e);
+  return 0.5 * e.dot(e);
 }
 
 /* ************************************************************************* */

--- a/gtsam/nonlinear/LevenbergMarquardtOptimizer.cpp
+++ b/gtsam/nonlinear/LevenbergMarquardtOptimizer.cpp
@@ -152,18 +152,18 @@ bool LevenbergMarquardtOptimizer::tryLambda(const GaussianFactorGraph& linear,
     systemSolvedSuccessfully = false;
   }
 
-  // Compute the old linearized error as it is not the same
-  // as the nonlinear error when robust noise models are used.
-  double oldLinearizedError = linear.error(VectorValues::Zero(delta));
   if (systemSolvedSuccessfully) {
     if (verbose)
       cout << "linear delta norm = " << delta.norm() << endl;
     if (params_.verbosityLM >= LevenbergMarquardtParams::TRYDELTA)
       delta.print("delta");
 
-    // cost change in the linearized system (old - new)
+    // Compute the old linearized error as it is not the same
+    // as the nonlinear error when robust noise models are used.
+    double oldLinearizedError = linear.error(VectorValues::Zero(delta));
     double newlinearizedError = linear.error(delta);
 
+    // cost change in the linearized system (old - new)
     double linearizedCostChange = oldLinearizedError - newlinearizedError;
     if (verbose)
       cout << "newlinearizedError = " << newlinearizedError


### PR DESCRIPTION
When robust noise models are used, the linearized error is not
the same as the nonlinear error even at zero delta.

In the L2 loss case, the rho(error) = 0.5 * error^2
which is the same as 0.5 *(sqrt(weight)*error)^2
since weight is always 1.0;

However this is not the case with other loss functions since in general,
rho(error) != 0.5 * weight * error^2

This PR fixes the LevenbergMarquardtOptimizer to explicityly compute
the linear cost change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/187)
<!-- Reviewable:end -->
