### PR TITLE
Travis: upgrade to use clang-9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,12 @@ addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
+    - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main'
+      key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
     packages:
-    - g++-8
-    - clang-3.8
-    - build-essential
-    - pkg-config
+    - g++-9
+    - clang-9
+    - build-essential pkg-config
     - cmake
     - libpython-dev python-numpy
     - libboost-all-dev
@@ -28,8 +29,14 @@ stages:
   - compile
   - test
 
+env:
+  global:
+    - MAKEFLAGS="-j2"
+    - CCACHE_SLOPPINESS=pch_defines,time_macros
+
 # Compile stage without building examples/tests to populate the caches.
 jobs:
+# -------- STAGE 1: COMPILE -----------
   include:
 # on Mac, GCC
   - stage: compile
@@ -68,46 +75,45 @@ jobs:
   - stage: compile
     os: linux
     compiler: clang
-    env: CMAKE_BUILD_TYPE=Debug GTSAM_BUILD_UNSTABLE=OFF
+    env: CC=clang-9 CXX=clang++-9 CMAKE_BUILD_TYPE=Debug GTSAM_BUILD_UNSTABLE=OFF
     script: bash .travis.sh -b
   - stage: compile
     os: linux
     compiler: clang
-    env: CMAKE_BUILD_TYPE=Release
+    env: CC=clang-9 CXX=clang++-9 CMAKE_BUILD_TYPE=Release
     script: bash .travis.sh -b
 # on Linux, with deprecated ON to make sure that path still compiles
   - stage: compile
     os: linux
     compiler: clang
-    env: CMAKE_BUILD_TYPE=Debug GTSAM_BUILD_UNSTABLE=OFF GTSAM_ALLOW_DEPRECATED_SINCE_V4=ON
+    env: CC=clang-9 CXX=clang++-9 CMAKE_BUILD_TYPE=Debug GTSAM_BUILD_UNSTABLE=OFF GTSAM_ALLOW_DEPRECATED_SINCE_V4=ON
     script: bash .travis.sh -b
-
-# Matrix configuration:
-os:
-  - osx
-  - linux
-compiler:
-  - gcc
-  - clang
-env:
-  global:
-    - MAKEFLAGS="-j2"
-    - CCACHE_SLOPPINESS=pch_defines,time_macros
-    - GTSAM_ALLOW_DEPRECATED_SINCE_V4=OFF
-    - GTSAM_BUILD_UNSTABLE=ON
-  matrix:
-    - CMAKE_BUILD_TYPE=Debug GTSAM_BUILD_UNSTABLE=OFF
-    - CMAKE_BUILD_TYPE=Release
-script:
-  - bash .travis.sh -t
-
-matrix:
-  exclude:
-    # Exclude g++ debug on Linux as it consistently times out
-    - os: linux
-      compiler: gcc
-      env : CMAKE_BUILD_TYPE=Debug GTSAM_BUILD_UNSTABLE=OFF
-    # Exclude clang on Linux/clang in release until issue #57 is solved
-    - os: linux
-      compiler: clang
-      env : CMAKE_BUILD_TYPE=Release
+# -------- STAGE 2: TESTS -----------
+# on Mac, GCC
+  - stage: test
+    os: osx
+    compiler: clang
+    env: CMAKE_BUILD_TYPE=Release
+    script: bash .travis.sh -t
+  - stage: test
+    os: osx
+    compiler: clang
+    env: CMAKE_BUILD_TYPE=Debug GTSAM_BUILD_UNSTABLE=OFF
+    script: bash .travis.sh -t
+  - stage: test
+    os: linux
+    compiler: gcc
+    env: CMAKE_BUILD_TYPE=Release
+    script: bash .travis.sh -t
+# Exclude g++ debug on Linux as it consistently times out
+#  - stage: test
+#    os: linux
+#    compiler: gcc
+#    env: CMAKE_BUILD_TYPE=Debug GTSAM_BUILD_UNSTABLE=OFF
+#    script: bash .travis.sh -t
+# Exclude clang on Linux/clang in release until issue #57 is solved
+#  - stage: test
+#    os: linux
+#    compiler: clang
+#    env: CC=clang-9 CXX=clang++-9 CMAKE_BUILD_TYPE=Release
+#    script: bash .travis.sh -t

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -434,7 +434,7 @@ add_subdirectory(timing)
 # Build gtsam_unstable
 if (GTSAM_BUILD_UNSTABLE)
     add_subdirectory(gtsam_unstable)
-endif(GTSAM_BUILD_UNSTABLE)
+endif()
 
 # Matlab toolbox
 if (GTSAM_INSTALL_MATLAB_TOOLBOX)


### PR DESCRIPTION
This is done to workaround apparent compiler internal errors, e.g. [here](https://travis-ci.com/borglab/gtsam/jobs/265834977).

Also, it seems it would be beneficial to #73. cc: @ProfFan . 

If you prefer an older clang version, let me know...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/189)
<!-- Reviewable:end -->
