### PR TITLE
Fix GenericValue copy

### DIFF
--- a/gtsam/base/GenericValue.h
+++ b/gtsam/base/GenericValue.h
@@ -89,12 +89,9 @@ public:
 
     /**
      * Create a duplicate object returned as a pointer to the generic Value interface.
-     * For the sake of performance, this function use singleton pool allocator instead of the normal heap allocator.
-     * The result must be deleted with Value::deallocate_, not with the 'delete' operator.
      */
     virtual Value* clone_() const {
-      void *place = boost::singleton_pool<PoolTag, sizeof(GenericValue)>::malloc();
-      GenericValue* ptr = new (place) GenericValue(*this); // calls copy constructor to fill in
+      GenericValue* ptr = new GenericValue(*this); // calls copy constructor to fill in
       return ptr;
     }
 
@@ -102,8 +99,7 @@ public:
      * Destroy and deallocate this object, only if it was originally allocated using clone_().
      */
     virtual void deallocate_() const {
-      this->~GenericValue(); // Virtual destructor cleans up the derived object
-      boost::singleton_pool<PoolTag, sizeof(GenericValue)>::free((void*) this); // Release memory from pool
+      delete this;
     }
 
     /**
@@ -118,10 +114,7 @@ public:
       // Call retract on the derived class using the retract trait function
       const T retractResult = traits<T>::Retract(GenericValue<T>::value(), delta);
 
-      // Create a Value pointer copy of the result
-      void* resultAsValuePlace =
-          boost::singleton_pool<PoolTag, sizeof(GenericValue)>::malloc();
-      Value* resultAsValue = new (resultAsValuePlace) GenericValue(retractResult);
+      Value* resultAsValue = new GenericValue(retractResult);
 
       // Return the pointer to the Value base class
       return resultAsValue;
@@ -171,12 +164,6 @@ public:
       value_ = rhs.value_;
       return *this;
     }
-
-  private:
-
-    /// Fake Tag struct for singleton pool allocator. In fact, it is never used!
-    struct PoolTag {
-    };
 
   private:
 


### PR DESCRIPTION
`GenericValue` correctly handles alignment when constructing objects but fails to do so when copying objects.

This is currently based on `feature/rotation_group`, but can also rebase on `develop` if that is preferred :)

CI passes for branch, let's hope that it pass for PR as well :smile:

Link to `GenericValue.h`: https://github.com/borglab/gtsam/pull/190/files#diff-12d727d01bcb063ba1996d3d58ed26c4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/190)
<!-- Reviewable:end -->
