### PR TITLE
Fixing the test for merging two sets in the DSF

### DIFF
--- a/cython/gtsam/tests/test_dsf_map.py
+++ b/cython/gtsam/tests/test_dsf_map.py
@@ -30,8 +30,10 @@ class TestDSFMap(GtsamTestCase):
         pair1 = gtsam.IndexPair(1, 18)
         self.assertEqual(key(dsf.find(pair1)), key(pair1))
         pair2 = gtsam.IndexPair(2, 2)
+        
+        # testing the merge feature of dsf
         dsf.merge(pair1, pair2)
-        self.assertTrue(dsf.find(pair1), dsf.find(pair1))
+        self.assertEquals(key(dsf.find(pair1)), key(dsf.find(pair2)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I am not super sure with the code, but I think the intention behind the test is to check pair1 with pair2 after it has been merged. Hence changing it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/202)
<!-- Reviewable:end -->
