### PR TITLE
add "Information" constructor to python wrapper

### DIFF
--- a/gtsam.h
+++ b/gtsam.h
@@ -1364,6 +1364,7 @@ virtual class Base {
 };
 
 virtual class Gaussian : gtsam::noiseModel::Base {
+  static gtsam::noiseModel::Gaussian* Information(Matrix R);
   static gtsam::noiseModel::Gaussian* SqrtInformation(Matrix R);
   static gtsam::noiseModel::Gaussian* Covariance(Matrix R);
 


### PR DESCRIPTION
This constructor was inexplicably missing from the Python wrapper.

I use it for LQR since unary cost factors are of the form

|x^TQx|

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/211)
<!-- Reviewable:end -->
