### PR TITLE
python wrapper: access to gaussian conditional matrices

### DIFF
--- a/gtsam.h
+++ b/gtsam.h
@@ -1799,6 +1799,9 @@ virtual class GaussianConditional : gtsam::GaussianFactor {
   gtsam::VectorValues solveOtherRHS(const gtsam::VectorValues& parents, const gtsam::VectorValues& rhs) const;
   void solveTransposeInPlace(gtsam::VectorValues& gy) const;
   void scaleFrontalsBySigma(gtsam::VectorValues& gy) const;
+  Matrix R() const;
+  Matrix S() const;
+  Vector d() const;
 
   // enabling serialization functionality
   void serialize() const;


### PR DESCRIPTION
Just exposing some functions that already exist in C++ to the python wrapper

These are the matrices in a GaussianConditional, which is a node in a BayesNet.  The probability distribution for the node is given by

$$ \frac{1}{2} |Rx - (d - Sy - Tz - ...)|^2 $$

thus to infer x given its parents, we would solve $Rx = d - Sy$

I use this for LQR local control laws / gain scheduling

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/212)
<!-- Reviewable:end -->
