### PR TITLE
Replace c++17 removed classes with c++11 replacements

### DIFF
--- a/gtsam/base/Testable.h
+++ b/gtsam/base/Testable.h
@@ -107,7 +107,7 @@ namespace gtsam {
    * Template to create a binary predicate
    */
   template<class V>
-  struct equals : public std::binary_function<const V&, const V&, bool> {
+  struct equals : public std::function<bool(const V&, const V&)> {
     double tol_;
     equals(double tol = 1e-9) : tol_(tol) {}
     bool operator()(const V& expected, const V& actual) {
@@ -119,7 +119,7 @@ namespace gtsam {
    * Binary predicate on shared pointers
    */
   template<class V>
-  struct equals_star : public std::binary_function<const boost::shared_ptr<V>&, const boost::shared_ptr<V>&, bool> {
+  struct equals_star : public std::function<bool(const boost::shared_ptr<V>&, const boost::shared_ptr<V>&)> {
     double tol_;
     equals_star(double tol = 1e-9) : tol_(tol) {}
     bool operator()(const boost::shared_ptr<V>& expected, const boost::shared_ptr<V>& actual) {

--- a/gtsam/linear/Errors.cpp
+++ b/gtsam/linear/Errors.cpp
@@ -43,7 +43,7 @@ void Errors::print(const std::string& s) const {
 }
 
 /* ************************************************************************* */
-struct equalsVector : public std::binary_function<const Vector&, const Vector&, bool> {
+struct equalsVector : public std::function<bool(const Vector&, const Vector&)> {
   double tol_;
   equalsVector(double tol = 1e-9) : tol_(tol) {}
   bool operator()(const Vector& expected, const Vector& actual) {


### PR DESCRIPTION
This fixes building 3rd party programs with C++17, while still being compatible with "older" C++11; let's see how it goes in the CI...

PS: The failure reason is that `binary_function` was deprecated in c++11, **removed** in c++17.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/214)
<!-- Reviewable:end -->
