### PR TITLE
Minor updates to wrapper

### DIFF
--- a/gtsam.h
+++ b/gtsam.h
@@ -875,6 +875,7 @@ class Cal3_S2 {
   gtsam::Point2 principalPoint() const;
   Vector vector() const;
   Matrix K() const;
+  Matrix matrix() const;
   Matrix matrix_inverse() const;
 
   // enabling serialization functionality

--- a/gtsam.h
+++ b/gtsam.h
@@ -874,7 +874,7 @@ class Cal3_S2 {
   double py() const;
   gtsam::Point2 principalPoint() const;
   Vector vector() const;
-  Matrix matrix() const;
+  Matrix K() const;
   Matrix matrix_inverse() const;
 
   // enabling serialization functionality
@@ -1162,6 +1162,9 @@ class StereoCamera {
 // Templates appear not yet supported for free functions
 gtsam::Point3 triangulatePoint3(const gtsam::Pose3Vector& poses,
     gtsam::Cal3_S2* sharedCal, const gtsam::Point2Vector& measurements,
+    double rank_tol, bool optimize);
+gtsam::Point3 triangulatePoint3(const gtsam::Pose3Vector& poses,
+    gtsam::Cal3DS2* sharedCal, const gtsam::Point2Vector& measurements,
     double rank_tol, bool optimize);
 gtsam::Point3 triangulatePoint3(const gtsam::Pose3Vector& poses,
     gtsam::Cal3Bundler* sharedCal, const gtsam::Point2Vector& measurements,


### PR DESCRIPTION
Replace Cal3_S2 deprecated matrix() with K(), add Cal3DS2 support to triangulation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/219)
<!-- Reviewable:end -->
