### PR TITLE
Improved floating point comparison for better numerical stability

### DIFF
--- a/gtsam/base/Matrix.h
+++ b/gtsam/base/Matrix.h
@@ -88,10 +88,9 @@ bool equal_with_abs_tol(const Eigen::DenseBase<MATRIX>& A, const Eigen::DenseBas
 
   for(size_t i=0; i<m1; i++)
     for(size_t j=0; j<n1; j++) {
-      if(boost::math::isnan(A(i,j)) ^ boost::math::isnan(B(i,j)))
+      if(!fp_isequal(A(i,j), B(i,j), tol)) {
         return false;
-      else if(std::abs(A(i,j) - B(i,j)) > tol)
-        return false;
+      }
     }
   return true;
 }

--- a/gtsam/base/Matrix.h
+++ b/gtsam/base/Matrix.h
@@ -88,7 +88,7 @@ bool equal_with_abs_tol(const Eigen::DenseBase<MATRIX>& A, const Eigen::DenseBas
 
   for(size_t i=0; i<m1; i++)
     for(size_t j=0; j<n1; j++) {
-      if(!fp_isequal(A(i,j), B(i,j), tol)) {
+      if(!fpEqual(A(i,j), B(i,j), tol)) {
         return false;
       }
     }

--- a/gtsam/base/Matrix.h
+++ b/gtsam/base/Matrix.h
@@ -17,6 +17,7 @@
  * @author  Frank Dellaert
  * @author  Alex Cunningham
  * @author  Alex Hagiopol
+ * @author  Varun Agrawal
  */
 
 // \callgraph

--- a/gtsam/base/Vector.cpp
+++ b/gtsam/base/Vector.cpp
@@ -35,26 +35,38 @@ using namespace std;
 namespace gtsam {
 
 /* ************************************************************************* */
-bool fp_isequal(double a, double b, double epsilon) {
-  double DOUBLE_MIN_NORMAL = std::numeric_limits<double>::min() + 1.0;
+bool fpEqual(double a, double b, double tol) {
+  using std::abs;
+  using std::isnan;
+  using std::isinf;
+
+  double DOUBLE_MIN_NORMAL = numeric_limits<double>::min() + 1.0;
+  double larger = (abs(b) > abs(a)) ? abs(b) : abs(a);
 
   // handle NaNs
-  if(std::isnan(a) ^ std::isnan(b)) {
-    return false;
+  if(std::isnan(a) || isnan(b)) {
+    return isnan(a) && isnan(b);
   }
   // handle inf
-  else if(std::isinf(a) ^ std::isinf(b)) {
-    return false;
+  else if(isinf(a) || isinf(b)) {
+    return isinf(a) && isinf(b);
   }
   // If the two values are zero or both are extremely close to it
   // relative error is less meaningful here
-  else if(a == 0 || b == 0 || (std::abs(a) + std::abs(b)) < DOUBLE_MIN_NORMAL) {
-    return std::abs(a-b) < epsilon * DOUBLE_MIN_NORMAL;
+  else if(a == 0 || b == 0 || (abs(a) + abs(b)) < DOUBLE_MIN_NORMAL) {
+    return abs(a-b) <= tol * DOUBLE_MIN_NORMAL;
+  }
+  // Check if the numbers are really close
+  // Needed when comparing numbers near zero or tol is in vicinity
+  else if(abs(a-b) <= tol) {
+    return true;
   }
   // Use relative error
-  else {
-    return std::abs(a-b) < epsilon * std::min((std::abs(a) + std::abs(b)), std::numeric_limits<double>::max());
+  else if(abs(a-b) <= tol * min(larger, std::numeric_limits<double>::max())) {
+    return true;
   }
+
+  return false;
 }
 
 /* ************************************************************************* */
@@ -106,7 +118,7 @@ bool equal_with_abs_tol(const Vector& vec1, const Vector& vec2, double tol) {
   if (vec1.size()!=vec2.size()) return false;
   size_t m = vec1.size();
   for(size_t i=0; i<m; ++i) {
-    if (!fp_isequal(vec1[i], vec2[i], tol))
+    if (!fpEqual(vec1[i], vec2[i], tol))
       return false;
   }
   return true;
@@ -117,7 +129,7 @@ bool equal_with_abs_tol(const SubVector& vec1, const SubVector& vec2, double tol
   if (vec1.size()!=vec2.size()) return false;
   size_t m = vec1.size();
   for(size_t i=0; i<m; ++i) {
-    if (!fp_isequal(vec1[i], vec2[i], tol))
+    if (!fpEqual(vec1[i], vec2[i], tol))
       return false;
   }
   return true;

--- a/gtsam/base/Vector.cpp
+++ b/gtsam/base/Vector.cpp
@@ -34,7 +34,11 @@ using namespace std;
 
 namespace gtsam {
 
-/* ************************************************************************* */
+/* *************************************************************************
+ * References:
+ * 1. https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
+ * 2. https://floating-point-gui.de/errors/comparison/
+ * ************************************************************************* */
 bool fpEqual(double a, double b, double tol) {
   using std::abs;
   using std::isnan;

--- a/gtsam/base/Vector.cpp
+++ b/gtsam/base/Vector.cpp
@@ -14,6 +14,7 @@
  * @brief   typedef and functions to augment Eigen's Vectors
  * @author  Kai Ni
  * @author  Frank Dellaert
+ * @author  Varun Agrawal
  */
 
 #include <gtsam/base/Vector.h>
@@ -32,6 +33,29 @@
 using namespace std;
 
 namespace gtsam {
+
+/* ************************************************************************* */
+bool fp_isequal(double a, double b, double epsilon) {
+  double DOUBLE_MIN_NORMAL = std::numeric_limits<double>::min() + 1.0;
+
+  // handle NaNs
+  if(std::isnan(a) ^ std::isnan(b)) {
+    return false;
+  }
+  // handle inf
+  else if(std::isinf(a) ^ std::isinf(b)) {
+    return false;
+  }
+  // If the two values are zero or both are extremely close to it
+  // relative error is less meaningful here
+  else if(a == 0 || b == 0 || (std::abs(a) + std::abs(b)) < DOUBLE_MIN_NORMAL) {
+    return std::abs(a-b) < epsilon * DOUBLE_MIN_NORMAL;
+  }
+  // Use relative error
+  else {
+    return std::abs(a-b) < epsilon * std::min((std::abs(a) + std::abs(b)), std::numeric_limits<double>::max());
+  }
+}
 
 /* ************************************************************************* */
 //3 argument call
@@ -82,9 +106,7 @@ bool equal_with_abs_tol(const Vector& vec1, const Vector& vec2, double tol) {
   if (vec1.size()!=vec2.size()) return false;
   size_t m = vec1.size();
   for(size_t i=0; i<m; ++i) {
-    if(std::isnan(vec1[i]) ^ std::isnan(vec2[i]))
-      return false;
-    if(std::abs(vec1[i] - vec2[i]) > tol)
+    if (!fp_isequal(vec1[i], vec2[i], tol))
       return false;
   }
   return true;
@@ -95,9 +117,7 @@ bool equal_with_abs_tol(const SubVector& vec1, const SubVector& vec2, double tol
   if (vec1.size()!=vec2.size()) return false;
   size_t m = vec1.size();
   for(size_t i=0; i<m; ++i) {
-    if(std::isnan(vec1[i]) ^ std::isnan(vec2[i]))
-      return false;
-    if(std::abs(vec1[i] - vec2[i]) > tol)
+    if (!fp_isequal(vec1[i], vec2[i], tol))
       return false;
   }
   return true;

--- a/gtsam/base/Vector.h
+++ b/gtsam/base/Vector.h
@@ -27,9 +27,7 @@
 
 #include <gtsam/global_includes.h>
 #include <Eigen/Core>
-#include <cmath>
 #include <iosfwd>
-#include <limits>
 #include <list>
 
 namespace gtsam {

--- a/gtsam/base/Vector.h
+++ b/gtsam/base/Vector.h
@@ -80,9 +80,6 @@ static_assert(
  * Numerically stable function for comparing if floating point values are equal
  * within epsilon tolerance.
  * Used for vector and matrix comparison with C++11 compatible functions.
- * References:
- * 1. https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
- * 2. https://floating-point-gui.de/errors/comparison/
  * Return true if two numbers are close wrt epsilon.
  */
 GTSAM_EXPORT bool fpEqual(double a, double b, double epsilon);

--- a/gtsam/base/Vector.h
+++ b/gtsam/base/Vector.h
@@ -15,6 +15,7 @@
  * @author  Kai Ni
  * @author  Frank Dellaert
  * @author  Alex Hagiopol
+ * @author  Varun Agrawal
  */
 
 // \callgraph
@@ -24,6 +25,8 @@
 #define MKL_BLAS MKL_DOMAIN_BLAS
 #endif
 
+#include <cmath>
+#include <limits>
 #include <gtsam/global_includes.h>
 #include <Eigen/Core>
 #include <iosfwd>
@@ -74,6 +77,15 @@ static_assert(
     GTSAM_EIGEN_VERSION_MAJOR==EIGEN_MAJOR_VERSION,
   "Error: GTSAM was built against a different version of Eigen");
 #endif
+
+/**
+ * Numerically stable function for comparing if floating point values are equal
+ * within epsilon tolerance.
+ * Used for vector and matrix comparison with C++11 compatible functions.
+ * Reference : https://floating-point-gui.de/errors/comparison/
+ * Return true if two numbers are close wrt epsilon.
+ */
+GTSAM_EXPORT bool fp_isequal(double a, double b, double epsilon);
 
 /**
  * print without optional string, must specify cout yourself

--- a/gtsam/base/Vector.h
+++ b/gtsam/base/Vector.h
@@ -25,11 +25,11 @@
 #define MKL_BLAS MKL_DOMAIN_BLAS
 #endif
 
-#include <cmath>
-#include <limits>
 #include <gtsam/global_includes.h>
 #include <Eigen/Core>
+#include <cmath>
 #include <iosfwd>
+#include <limits>
 #include <list>
 
 namespace gtsam {
@@ -82,10 +82,12 @@ static_assert(
  * Numerically stable function for comparing if floating point values are equal
  * within epsilon tolerance.
  * Used for vector and matrix comparison with C++11 compatible functions.
- * Reference : https://floating-point-gui.de/errors/comparison/
+ * References:
+ * 1. https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
+ * 2. https://floating-point-gui.de/errors/comparison/
  * Return true if two numbers are close wrt epsilon.
  */
-GTSAM_EXPORT bool fp_isequal(double a, double b, double epsilon);
+GTSAM_EXPORT bool fpEqual(double a, double b, double epsilon);
 
 /**
  * print without optional string, must specify cout yourself

--- a/gtsam/base/Vector.h
+++ b/gtsam/base/Vector.h
@@ -80,9 +80,14 @@ static_assert(
  * Numerically stable function for comparing if floating point values are equal
  * within epsilon tolerance.
  * Used for vector and matrix comparison with C++11 compatible functions.
- * Return true if two numbers are close wrt epsilon.
+ *
+ * If either value is NaN or Inf, we check for both values to be NaN or Inf
+ * respectively for the comparison to be true.
+ * If one is NaN/Inf and the other is not, returns false.
+ *
+ * Return true if two numbers are close wrt tol.
  */
-GTSAM_EXPORT bool fpEqual(double a, double b, double epsilon);
+GTSAM_EXPORT bool fpEqual(double a, double b, double tol);
 
 /**
  * print without optional string, must specify cout yourself


### PR DESCRIPTION
Using [this](https://floating-point-gui.de/errors/comparison/) as a reference, this PR adds a new function `fpEqual` to check if floating point numbers are equal in a numerically stable way.

This function is then used as in `Matrix` and `Vector` equality (with absolute tolerance) functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/245)
<!-- Reviewable:end -->
