### PR TITLE
Add triggering for python build

### DIFF
--- a/.github/workflows/trigger-python.yml
+++ b/.github/workflows/trigger-python.yml
@@ -1,0 +1,13 @@
+name: Trigger Python Builds
+on: push
+jobs:
+  triggerCython:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: ProfFan/repository-dispatch@master
+        with:
+          token: ${{ secrets.PYTHON_CI_REPO_ACCESS_TOKEN }}
+          repository: borglab/gtsam-manylinux-build
+          event-type: cython-wrapper
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/trigger-python.yml
+++ b/.github/workflows/trigger-python.yml
@@ -1,3 +1,4 @@
+# This triggers Cython builds on `gtsam-manylinux-build`
 name: Trigger Python Builds
 on: push
 jobs:


### PR DESCRIPTION
This adds a GitHub Actions based trigger to trigger the building for the python wheels each time `develop` is updated. However this currently does not work as we need to have an access token for the action (`PYTHON_CI_REPO_ACCESS_TOKEN` in the source). This token is a **personal access token** so the best practice would be:
- We create a new GitHub user (for example `borgbot`)
- Give it access to the borglab org and the `gtsam-manylinux-build` repo
- Create an access token for that bot
- Profit

CC @dellaert @jlblancoc @varunagrawal for comments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/247)
<!-- Reviewable:end -->
