### PR TITLE
Fix Unit Test when GTSAM_DEFINE_POINTS_AS_VECTORS is defined

### DIFF
--- a/gtsam/geometry/tests/testPose3.cpp
+++ b/gtsam/geometry/tests/testPose3.cpp
@@ -1008,7 +1008,14 @@ TEST(Pose3, print) {
   // Generate the expected output
   std::stringstream expected;
   Point3 translation(1, 2, 3);
+
+#ifdef GTSAM_TYPEDEF_POINTS_TO_VECTORS
+  expected << "1\n"
+              "2\n"
+              "3;\n";
+#else
   expected << '[' << translation.x() << ", " << translation.y() << ", " << translation.z() << "]\';";
+#endif
 
   // reset cout to the original stream
   std::cout.rdbuf(oldbuf);


### PR DESCRIPTION
When `GTSAM_TYPEDEF_POINTS_TO_VECTORS` is defined the output format will change because it is now an Eigen vector.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/264)
<!-- Reviewable:end -->
