### PR TITLE
printError(): allow custom factor filter

### DIFF
--- a/gtsam/nonlinear/NonlinearFactorGraph.cpp
+++ b/gtsam/nonlinear/NonlinearFactorGraph.cpp
@@ -61,19 +61,26 @@ void NonlinearFactorGraph::print(const std::string& str, const KeyFormatter& key
 
 /* ************************************************************************* */
 void NonlinearFactorGraph::printErrors(const Values& values, const std::string& str,
-                                       const KeyFormatter& keyFormatter) const {
+    const KeyFormatter& keyFormatter,
+    const std::function<bool(const Factor* /*factor*/, double /*whitenedError*/, size_t /*index*/)>& printCondition) const
+{
   cout << str << "size: " << size() << endl
        << endl;
   for (size_t i = 0; i < factors_.size(); i++) {
+    const sharedFactor& factor = factors_[i];
+    const double errorValue = (factor != nullptr ? factors_[i]->error(values) : .0);
+    if (!printCondition(factor.get(),errorValue,i))
+      continue; // User-provided filter did not pass
+
     stringstream ss;
     ss << "Factor " << i << ": ";
-    if (factors_[i] == nullptr) {
-      cout << "nullptr" << endl;
+    if (factor == nullptr) {
+      cout << "nullptr" << "\n";
     } else {
-      factors_[i]->print(ss.str(), keyFormatter);
-      cout << "error = " << factors_[i]->error(values) << endl;
+      factor->print(ss.str(), keyFormatter);
+      cout << "error = " << errorValue << "\n";
     }
-    cout << endl;
+    cout << endl; // only one "endl" at end might be faster, \n for each factor
   }
 }
 

--- a/gtsam/nonlinear/NonlinearFactorGraph.h
+++ b/gtsam/nonlinear/NonlinearFactorGraph.h
@@ -103,7 +103,9 @@ namespace gtsam {
 
     /** print errors along with factors*/
     void printErrors(const Values& values, const std::string& str = "NonlinearFactorGraph: ",
-                     const KeyFormatter& keyFormatter = DefaultKeyFormatter) const;
+      const KeyFormatter& keyFormatter = DefaultKeyFormatter,
+      const std::function<bool(const Factor* /*factor*/, double /*whitenedError*/, size_t /*index*/)>&
+        printCondition = [](const Factor *,double, size_t) {return true;}) const;
 
     /** Test equality */
     bool equals(const NonlinearFactorGraph& other, double tol = 1e-9) const;

--- a/tests/testNonlinearFactorGraph.cpp
+++ b/tests/testNonlinearFactorGraph.cpp
@@ -243,5 +243,30 @@ TEST(testNonlinearFactorGraph, eliminate) {
 }
 
 /* ************************************************************************* */
+TEST(NonlinearFactorGraph, printErrors)
+{
+  const NonlinearFactorGraph fg = createNonlinearFactorGraph();
+  const Values c = createValues();
+
+  // Test that it builds with default parameters.
+  // We cannot check the output since (at present) output is fixed to std::cout.
+  fg.printErrors(c);
+
+  // Second round: using callback filter to check that we actually visit all factors:
+  std::vector<bool> visited;
+  visited.assign(fg.size(), false);
+  const auto testFilter =
+      [&](const gtsam::Factor *f, double error, size_t index) {
+        EXPECT(f!=nullptr);
+        EXPECT(error>=.0);
+        visited.at(index)=true;
+        return false; // do not print
+      };
+  fg.printErrors(c,"Test graph: ", gtsam::DefaultKeyFormatter,testFilter);
+
+  for (bool visit : visited) EXPECT(visit==true);
+}
+
+/* ************************************************************************* */
 int main() { TestResult tr; return TestRegistry::runAllTests(tr); }
 /* ************************************************************************* */


### PR DESCRIPTION
I found this feature really useful while debugging whether one or a few factors were not honored as well as the rest, i.e. outliers. 

Please, check and let me know if you would prefer alternative signatures... or defining a named type for the optional functor, etc. There are just too many ways of doing even the simplest thing ;-)

At the beginning I tried implementing a "relative filter", with two passes: one to collect stats on all factor errors, then decide based on some statistic. But that requires dynamic memory allocation (for the stats), doing the two passes, etc. so it's probably not worth. Having the option to use individual whitened errors to decide whether to print or not seems to me a good trade-off.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/274)
<!-- Reviewable:end -->
