### PR TITLE
Fix/find mkl

### DIFF
--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -231,6 +231,7 @@ ELSEIF(MKL_ROOT_DIR) # UNIX and macOS
                         FIND_LIBRARY(MKL_IOMP5_LIBRARY
                           iomp5
                           PATHS
+                                ${MKL_ROOT_DIR}/lib/intel64
                                 ${MKL_ROOT_DIR}/../lib/intel64
                         )
                 ELSE()

--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -115,7 +115,7 @@ IF(WIN32 AND MKL_ROOT_DIR)
         IF (MKL_INCLUDE_DIR MATCHES "10.3")
                 SET(MKL_LIBS ${MKL_LIBS} libiomp5md)
         ENDIF()
-        
+
         FOREACH (LIB ${MKL_LIBS})
                 FIND_LIBRARY(${LIB}_PATH ${LIB} PATHS ${MKL_LIB_SEARCHPATH} ENV LIBRARY_PATH)
                 IF(${LIB}_PATH)
@@ -147,7 +147,7 @@ ELSEIF(MKL_ROOT_DIR) # UNIX and macOS
                 ${MKL_ROOT_DIR}/lib/${MKL_ARCH_DIR}
                 ${MKL_ROOT_DIR}/lib/
         )
-        
+
         # MKL on Mac OS doesn't ship with GNU thread versions, only Intel versions (see above)
         IF(NOT APPLE)
             FIND_LIBRARY(MKL_GNUTHREAD_LIBRARY
@@ -254,7 +254,7 @@ ELSEIF(MKL_ROOT_DIR) # UNIX and macOS
         ELSE()
             SET(MKL_LIBRARIES ${MKL_LP_GNUTHREAD_LIBRARIES})
         ENDIF()
-        
+
         MARK_AS_ADVANCED(MKL_CORE_LIBRARY MKL_LP_LIBRARY MKL_ILP_LIBRARY
                 MKL_SEQUENTIAL_LIBRARY MKL_INTELTHREAD_LIBRARY MKL_GNUTHREAD_LIBRARY)
 ENDIF()


### PR DESCRIPTION
Resolves #299 

I added the appropriate path to find a missing library `libiomp5.so` which was causing MKL_LIBRARIES to remain incorrectly defined.

The path I added works on Arch Linux, and it makes me believe that maybe the previous path (`../lib/intel64`) might not even work on Ubuntu. If anyone could confirm this, then we could also delete that path. But for right now adding the new path fixes the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/300)
<!-- Reviewable:end -->
