### PR TITLE
allow users to use upstream metis, instead of vendored metis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,6 +350,41 @@ if (APPLE AND BUILD_SHARED_LIBS)
 endif()
 
 ###############################################################################
+# Option for using system Metis or GTSAM-bundled Metis
+option(GTSAM_USE_SYSTEM_METIS "Find and use system-installed Metis. If 'off', use the one bundled with GTSAM" OFF)
+
+# Switch for using system Metis or GTSAM-bundled Metis
+if(GTSAM_USE_SYSTEM_METIS)
+    find_package(METIS REQUIRED)
+
+    # Use generic Metis include paths e.g. <metis.h>
+    set(GTSAM_METIS_INCLUDE_FOR_INSTALL "${METIS_INCLUDE_DIRS}")
+
+    # The actual include directory (for BUILD cmake target interface):
+    set(GTSAM_METIS_INCLUDE_FOR_BUILD "${METIS_INCLUDE_DIRS}")
+
+else()
+    # Use bundled Metis include path.
+    # Clear any variables set by FindMETIS
+    if(METIS_INCLUDE_DIRS)
+        set(METIS_INCLUDE_DIRS NOTFOUND CACHE STRING "" FORCE)
+    endif()
+    if(METIS_LIBRARIES)
+        set(METIS_LIBRARIES NOTFOUND CACHE STRING "" FORCE)
+    endif()
+
+    # set full path to be used by external projects
+    # this will be added to GTSAM_INCLUDE_DIR by gtsam_extra.cmake.in
+    set(GTSAM_METIS_INCLUDE_FOR_INSTALL "include/gtsam/3rdparty/metis/")
+
+    # The actual include directory (for BUILD cmake target interface):
+    #set(GTSAM_METIS_INCLUDE_FOR_BUILD
+    #    ${CMAKE_SOURCE_DIR}/gtsam/3rdparty/metis/include
+    #    ${CMAKE_SOURCE_DIR}/gtsam/3rdparty/metis/libmetis
+    #    ${CMAKE_SOURCE_DIR}/gtsam/3rdparty/metis/GKlib)
+endif()
+
+###############################################################################
 # Global compile options
 
 # Build list of possible allocators
@@ -537,6 +572,10 @@ endif()
 print_build_options_for_target(gtsam)
 
 message(STATUS "  Use System Eigen               : ${GTSAM_USE_SYSTEM_EIGEN} (Using version: ${GTSAM_EIGEN_VERSION})")
+
+if(GTSAM_SUPPORT_NESTED_DISSECTION)
+    message(STATUS "  Use System Metis               : ${GTSAM_USE_SYSTEM_METIS}")
+endif()
 
 if(GTSAM_USE_TBB)
 	message(STATUS "  Use Intel TBB                  : Yes")

--- a/cmake/FindMETIS.cmake
+++ b/cmake/FindMETIS.cmake
@@ -1,0 +1,23 @@
+# This module will try to find METIS and define the following:
+#  METIS_FOUND - True iff METIS was found
+#  METIS_INCLUDE_DIRS - METIS include directories
+#  METIS_LIBRARIES - METIS library paths
+
+find_path(METIS_INCLUDE_DIR metis.h
+          PATHS /usr/include /usr/local/include
+          DOC "METIS include directory")
+
+find_library(METIS_LIBRARY metis
+             PATHS /usr/lib /usr/local/lib ${PROJECT_SOURCE_DIR}/metis
+             DOC "Path to METIS library")
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set METIS_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(METIS  DEFAULT_MSG
+                                  METIS_LIBRARY METIS_INCLUDE_DIR)
+
+mark_as_advanced(METIS_INCLUDE_DIR METIS_LIBRARY)
+
+set(METIS_LIBRARIES ${METIS_LIBRARY})
+set(METIS_INCLUDE_DIRS ${METIS_INCLUDE_DIR})

--- a/gtsam/3rdparty/CMakeLists.txt
+++ b/gtsam/3rdparty/CMakeLists.txt
@@ -48,9 +48,11 @@ if(NOT GTSAM_USE_SYSTEM_EIGEN)
 
 endif()
 
-option(GTSAM_BUILD_METIS_EXECUTABLES "Build metis library executables" OFF)
-if(GTSAM_SUPPORT_NESTED_DISSECTION)
-	add_subdirectory(metis)
+if(NOT GTSAM_USE_SYSTEM_METIS)
+    option(GTSAM_BUILD_METIS_EXECUTABLES "Build metis library executables" OFF)
+    if(GTSAM_SUPPORT_NESTED_DISSECTION)
+        add_subdirectory(metis)
+    endif()
 endif()
 
 add_subdirectory(ceres)

--- a/gtsam/CMakeLists.txt
+++ b/gtsam/CMakeLists.txt
@@ -89,7 +89,11 @@ list(APPEND gtsam_srcs "${PROJECT_BINARY_DIR}/config.h" "${PROJECT_BINARY_DIR}/d
 install(FILES "${PROJECT_BINARY_DIR}/config.h" "${PROJECT_BINARY_DIR}/dllexport.h" DESTINATION include/gtsam)
 
 if(GTSAM_SUPPORT_NESTED_DISSECTION)
-    list(APPEND GTSAM_ADDITIONAL_LIBRARIES metis)
+    if(GTSAM_USE_SYSTEM_METIS)
+        list(APPEND GTSAM_ADDITIONAL_LIBRARIES ${METIS_LIBRARIES})
+    else()
+        list(APPEND GTSAM_ADDITIONAL_LIBRARIES metis)
+    endif()
 endif()
 
 # Versions
@@ -130,6 +134,24 @@ if(GTSAM_USE_TBB)
   target_include_directories(gtsam PUBLIC ${TBB_INCLUDE_DIRS})
 endif()
 
+# Append Metis include path, set in top-level CMakeLists.txt to either
+# system-metis, or GTSAM metis path
+if(GTSAM_SUPPORT_NESTED_DISSECTION)
+    if(GTSAM_USE_SYSTEM_METIS)
+        target_include_directories(gtsam PUBLIC
+          $<BUILD_INTERFACE:${GTSAM_METIS_INCLUDE_FOR_BUILD}>
+          $<INSTALL_INTERFACE:${GTSAM_METIS_INCLUDE_FOR_INSTALL}>
+        )
+    else()
+        target_include_directories(gtsam PUBLIC
+          $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/gtsam/3rdparty/metis/include>
+          $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/gtsam/3rdparty/metis/libmetis>
+          $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/gtsam/3rdparty/metis/GKlib>
+          $<INSTALL_INTERFACE:${GTSAM_METIS_INCLUDE_FOR_INSTALL}>
+        )
+    endif()
+endif()
+
 # Add includes for source directories 'BEFORE' boost and any system include
 # paths so that the compiler uses GTSAM headers in our source directory instead
 # of any previously installed GTSAM headers.
@@ -148,16 +170,6 @@ target_include_directories(gtsam BEFORE PUBLIC
   # unit tests:
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/CppUnitLite>
 )
-if(GTSAM_SUPPORT_NESTED_DISSECTION)
-  target_include_directories(gtsam BEFORE PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/gtsam/3rdparty/metis/include>
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/gtsam/3rdparty/metis/libmetis>
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/gtsam/3rdparty/metis/GKlib>
-    $<INSTALL_INTERFACE:include/gtsam/3rdparty/metis/>
-  )
-endif()
-
-
 
 if(WIN32) # Add 'lib' prefix to static library to avoid filename collision with shared library
 	if (NOT BUILD_SHARED_LIBS)

--- a/gtsam/inference/Ordering.cpp
+++ b/gtsam/inference/Ordering.cpp
@@ -25,7 +25,7 @@
 #include <gtsam/3rdparty/CCOLAMD/Include/ccolamd.h>
 
 #ifdef GTSAM_SUPPORT_NESTED_DISSECTION
-#include <gtsam/3rdparty/metis/include/metis.h>
+#include <metis.h>
 #endif
 
 using namespace std;

--- a/gtsam_unstable/partition/FindSeparator-inl.h
+++ b/gtsam_unstable/partition/FindSeparator-inl.h
@@ -22,7 +22,7 @@
 
 extern "C" {
 #include <metis.h>
-#include "metislib.h"
+#include <metislib.h>
 }
 
 


### PR DESCRIPTION
Resolves #220 by allowing the user to use the system metis so as to prevent conflicts from GTSAM's metis and other libraries using the system metis.

Also partially addresses #292 

Note: This PR is based on a patch of upstream METIS that has yet to be merged and released in a new METIS version (https://github.com/KarypisLab/METIS/pull/9). Since I went ahead and did this work, I thought I would at least make a PR so that others can see it. When upstream METIS releases a new version, we can then properly merge this in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/309)
<!-- Reviewable:end -->
