### PR TITLE
More precise use of setZero() and add comments

### DIFF
--- a/gtsam/base/SymmetricBlockMatrix.h
+++ b/gtsam/base/SymmetricBlockMatrix.h
@@ -71,6 +71,7 @@ namespace gtsam {
     }
 
     /// Construct from a container of the sizes of each block.
+    /// Uninitialized blocks are filled with zeros.
     template<typename CONTAINER>
     SymmetricBlockMatrix(const CONTAINER& dimensions, bool appendOneDimension = false) :
       blockStart_(0)
@@ -81,6 +82,7 @@ namespace gtsam {
     }
 
     /// Construct from iterator over the sizes of each vertical block.
+    /// Uninitialized blocks are filled with zeros.
     template<typename ITERATOR>
     SymmetricBlockMatrix(ITERATOR firstBlockDim, ITERATOR lastBlockDim, bool appendOneDimension = false) :
       blockStart_(0)
@@ -95,7 +97,7 @@ namespace gtsam {
     SymmetricBlockMatrix(const CONTAINER& dimensions, const Matrix& matrix, bool appendOneDimension = false) :
       blockStart_(0)
     {
-      matrix_.setZero(matrix.rows(), matrix.cols());
+      matrix_.resize(matrix.rows(), matrix.cols());
       matrix_.triangularView<Eigen::Upper>() = matrix.triangularView<Eigen::Upper>();
       fillOffsets(dimensions.begin(), dimensions.end(), appendOneDimension);
       if(matrix_.rows() != matrix_.cols())

--- a/gtsam/base/SymmetricBlockMatrix.h
+++ b/gtsam/base/SymmetricBlockMatrix.h
@@ -71,24 +71,22 @@ namespace gtsam {
     }
 
     /// Construct from a container of the sizes of each block.
-    /// Uninitialized blocks are filled with zeros.
     template<typename CONTAINER>
     SymmetricBlockMatrix(const CONTAINER& dimensions, bool appendOneDimension = false) :
       blockStart_(0)
     {
       fillOffsets(dimensions.begin(), dimensions.end(), appendOneDimension);
-      matrix_.setZero(variableColOffsets_.back(), variableColOffsets_.back());
+      matrix_.resize(variableColOffsets_.back(), variableColOffsets_.back());
       assertInvariants();
     }
 
     /// Construct from iterator over the sizes of each vertical block.
-    /// Uninitialized blocks are filled with zeros.
     template<typename ITERATOR>
     SymmetricBlockMatrix(ITERATOR firstBlockDim, ITERATOR lastBlockDim, bool appendOneDimension = false) :
       blockStart_(0)
     {
       fillOffsets(firstBlockDim, lastBlockDim, appendOneDimension);
-      matrix_.setZero(variableColOffsets_.back(), variableColOffsets_.back());
+      matrix_.resize(variableColOffsets_.back(), variableColOffsets_.back());
       assertInvariants();
     }
 
@@ -418,4 +416,3 @@ namespace gtsam {
   class CholeskyFailed;
 
 }
-


### PR DESCRIPTION
This is a follow up of #310 , trying to minimize the changes wrt former behavior and improve the docs. 
cc: @dellaert 

Mainly, the idea is that constructors taking lists of blocks **could** fill with zeros so if a block is not provided, it's taken for granted that it will be filled with zeros (this is now documented, and also fixes the original x32 bug, by the way), while the third constructor modified in the former PR, taking as input a `Matrix`, doesn't actually need the `setZero()` since it will be immediately after that overwritten, so it's a potential waste of time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/314)
<!-- Reviewable:end -->
