### PR TITLE
added email parameter to ubuntu/debian packaging scripts

### DIFF
--- a/package_scripts/README.md
+++ b/package_scripts/README.md
@@ -1,14 +1,43 @@
+# Handling of gpg PPA keys
+
+Packages must be signed with a GPG key. First have a look of the keys
+you have available:
+
+    gpg --list-secret-keys
+
+If you don't have one, create one, then list again.
+
+Pick a secret key you like from the listed keys, for instance
+"Your Name <your.email@yourprovider.com>". Then unlock that key by
+signing a dummy file. The following line should pop up a window to
+enter the passphrase:
+
+    echo | gpg --local-user "Your Name <your.email@yourprovider.com>" -s >/dev/null
+
+Now you can run the below scripts. Without this step they will fail
+with "No secret key" or similar messages.
+
 
 # How to generate Debian packages
 
+Run the package script, providing a name/email that matches your PGP key.
+
     cd [GTSAM_SOURCE_ROOT]
-    bash package_scripts/prepare_debian.sh
+    bash package_scripts/prepare_debian.sh -e "Your Name <your.email@yourprovider.com>"
 
 
 # How to generate Ubuntu packages for a PPA
 
-    cd [GTSAM_SOURCE_ROOT]
-    bash package_scripts/prepare_ubuntu_pkgs_for_ppa.sh
-    cd ~/gtsam_ubuntu
-    bash [GTSAM_SOURCE_ROOT]/upload_all_gtsam_ppa.sh
+Run the packaging script, passing the name of the gpg key
+(see above) with the "-e" option:
 
+    cd [GTSAM_SOURCE_ROOT]
+    bash package_scripts/prepare_ubuntu_pkgs_for_ppa.sh -e "Your Name <your.email@yourprovider.com>"
+
+Check that you have uploaded this key to the ubuntu key server, and
+have added the key to your account.
+
+Upload the package to your ppa:
+
+    cd ~/gtsam_ubuntu
+    bash [GTSAM_SOURCE_ROOT]/package_scripts/upload_all_gtsam_ppa.sh -p "ppa:your-name/ppa-name"

--- a/package_scripts/prepare_debian.sh
+++ b/package_scripts/prepare_debian.sh
@@ -3,6 +3,38 @@
 # Jose Luis Blanco Claraco, 2019 (for GTSAM)
 # Jose Luis Blanco Claraco, 2008-2018 (for MRPT)
 
+function show_help {
+    echo "USAGE:"
+    echo ""
+    echo "- to display this help: "
+    echo "prepare_debian.sh -h or -?"
+    echo ""
+    echo "- to package to your PPA: "
+    echo "prepare_debian.sh -e email_of_your_gpg_key"
+    echo ""
+    echo "to pass custom config for GTSAM, set the following"
+    echo "environment variable beforehand: "
+    echo ""
+    echo "GTSAM_PKG_CUSTOM_CMAKE_PARAMS=\"\"-DDISABLE_SSE3=ON\"\""
+    echo ""
+}
+
+while getopts "h?e:" opt; do
+    case "$opt" in
+    h|\?)
+        show_help
+        exit 0
+        ;;
+    e)  packager_email=$OPTARG
+        ;;
+    esac
+done
+
+if [ -z ${packager_email+x} ]; then
+    show_help
+    exit -1
+fi
+
 set -e   # end on error
 #set -x  # for debugging
 
@@ -162,7 +194,7 @@ fi
 
 echo "Adding a new entry to debian/changelog..."
 
-DEBEMAIL="Jose Luis Blanco Claraco <joseluisblancoc@gmail.com>" debchange $DEBCHANGE_CMD -b --distribution unstable --force-distribution New version of upstream sources.
+DEBEMAIL="${packager_email}" debchange $DEBCHANGE_CMD -b --distribution unstable --force-distribution New version of upstream sources.
 
 echo "Copying back the new changelog to a temporary file in: ${GTSAM_EXTERN_DEBIAN_DIR}changelog.new"
 cp debian/changelog ${GTSAM_EXTERN_DEBIAN_DIR}changelog.new

--- a/package_scripts/prepare_ubuntu_pkgs_for_ppa.sh
+++ b/package_scripts/prepare_ubuntu_pkgs_for_ppa.sh
@@ -1,20 +1,55 @@
 #!/bin/bash
 # Creates a set of packages for each different Ubuntu distribution, with the
-# intention of uploading them to:
-#   https://launchpad.net/~joseluisblancoc/
+# intention of uploading them to a PPA on launchpad
 #
 # JLBC, 2010
 # [Addition 2012:]
 #
 # You can declare a variable (in the caller shell) with extra flags for the
 # CMake in the final ./configure like:
+#
 #  GTSAM_PKG_CUSTOM_CMAKE_PARAMS="\"-DDISABLE_SSE3=ON\""
 #
+
+
+function show_help {
+    echo "USAGE:"
+    echo ""
+    echo "- to display this help: "
+    echo "prepare_ubuntu_packages_for_ppa.sh -h or -?"
+    echo ""
+    echo "- to package to your PPA: "
+    echo "prepare_ubuntu_packages_for_ppa.sh -e email_of_your_gpg_key"
+    echo ""
+    echo "to pass custom config for GTSAM, set the following"
+    echo "environment variable beforehand: "
+    echo ""
+    echo "GTSAM_PKG_CUSTOM_CMAKE_PARAMS=\"\"-DDISABLE_SSE3=ON\"\""
+    echo ""
+}
+
+while getopts "h?e:" opt; do
+    case "$opt" in
+    h|\?)
+        show_help
+        exit 0
+        ;;
+    e)  packager_email=$OPTARG
+        ;;
+    esac
+done
+
+if [ -z ${packager_email+x} ]; then
+    show_help
+    exit -1
+fi
+
 
 set -e
 
 # List of distributions to create PPA packages for:
-LST_DISTROS=(xenial bionic eoan focal)
+LST_DISTROS=(xenial bionic disco eoan focal)
+#LST_DISTROS=(bionic)
 
 # Checks
 # --------------------------------
@@ -35,7 +70,7 @@ if [ -z "${GTSAM_DEB_DIR}" ]; then
        export GTSAM_DEB_DIR="$HOME/gtsam_debian"
 fi
 GTSAM_EXTERN_DEBIAN_DIR="$GTSAMSRC/debian/"
-EMAIL4DEB="Jose Luis Blanco (University of Malaga) <joseluisblancoc@gmail.com>"
+EMAIL4DEB="${packager_email}"
 
 # Clean out dirs:
 rm -fr $gtsam_ubuntu_OUT_DIR/
@@ -68,7 +103,7 @@ do
 	DEBCHANGE_CMD="--newversion ${GTSAM_VERSION_STR}~snapshot${GTSAM_SNAPSHOT_VERSION}${DEBIAN_DIST}-1"
 	echo "Changing to a new Debian version: ${DEBCHANGE_CMD}"
 	echo "Adding a new entry to debian/changelog for distribution ${DEBIAN_DIST}"
-	DEBEMAIL="Jose Luis Blanco Claraco <joseluisblancoc@gmail.com>" debchange $DEBCHANGE_CMD -b --distribution ${DEBIAN_DIST} --force-distribution New version of upstream sources.
+	DEBEMAIL="${packager_email}" debchange $DEBCHANGE_CMD -b --distribution ${DEBIAN_DIST} --force-distribution New version of upstream sources.
 
 	cp changelog /tmp/my_changelog
 

--- a/package_scripts/upload_all_gtsam_ppa.sh
+++ b/package_scripts/upload_all_gtsam_ppa.sh
@@ -1,3 +1,31 @@
 #!/bin/bash
 
-find . -name '*.changes' | xargs -I FIL dput ppa:joseluisblancoc/gtsam-develop FIL
+function show_help {
+    echo "USAGE:"
+    echo ""
+    echo "- to display this help: "
+    echo "upload_all_gtsam_ppa.sh -h or -?"
+    echo ""
+    echo "- to upload to your PPA: "
+    echo "upload_all_gtsam_ppa.sh -p ppa:your_name/name_of_ppa"
+    echo ""
+}
+
+while getopts "h?p:" opt; do
+    case "$opt" in
+    h|\?)
+        show_help
+        exit 0
+        ;;
+    p)  ppa_name=$OPTARG
+        ;;
+    esac
+done
+
+if [ -z ${ppa_name+x} ]; then
+    show_help
+    exit -1
+fi
+
+
+find . -name '*.changes' | xargs -I FIL dput ${ppa_name} FIL


### PR DESCRIPTION
This PR adds a parameter to the packaging scripts such that they can be used without having to be edited.
The documentation is adjusted accordingly, and also expanded to cover the handling of keys used for signing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/316)
<!-- Reviewable:end -->
