### PR TITLE
Fix Cython build on Windows/MSVC

### DIFF
--- a/cmake/GtsamCythonWrap.cmake
+++ b/cmake/GtsamCythonWrap.cmake
@@ -87,6 +87,12 @@ endfunction()
 #    - output_dir:   The output directory
 function(build_cythonized_cpp target cpp_file output_lib_we output_dir)
   add_library(${target} MODULE ${cpp_file})
+  
+  # Use .pyd extension instead of .dll on Windows
+  if(WIN32)
+    set_target_properties(${target} PROPERTIES SUFFIX ".pyd")
+  endif()
+  
   if(APPLE)
     set(link_flags "-undefined dynamic_lookup")
   endif()

--- a/cython/CMakeLists.txt
+++ b/cython/CMakeLists.txt
@@ -7,6 +7,11 @@ if (GTSAM_INSTALL_CYTHON_TOOLBOX)
   add_subdirectory(gtsam_eigency)
   include_directories(${PROJECT_BINARY_DIR}/cython/gtsam_eigency)
 
+  # Fix for error "C1128: number of sections exceeded object file format limit"
+  if(MSVC)
+    add_compile_options(/bigobj)
+  endif()
+
   # wrap gtsam
   add_custom_target(gtsam_header DEPENDS "../gtsam.h")
   wrap_and_install_library_cython("../gtsam.h" # interface_header

--- a/cython/setup.py.in
+++ b/cython/setup.py.in
@@ -35,7 +35,7 @@ setup(
 
     packages=packages,
     package_data={package:
-        [f for f in os.listdir(package.replace('.', os.path.sep)) if os.path.splitext(f)[1] in ('.so', '.dll')]
+        [f for f in os.listdir(package.replace('.', os.path.sep)) if os.path.splitext(f)[1] in ('.so', '.pyd')]
         for package in packages
     },
     install_requires=[line.strip() for line in '''


### PR DESCRIPTION
This fixes two issues with the Cython build on Windows/MSVC:
1. Fail compiling `gtsam.pyx` due to error [`C1128: number of sections exceeded object file format limit`](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/fatal-error-c1128?view=vs-2019). This is solved by adding the compile option `/bigobj`, as suggested in the above link.
2. Fail loading the module `gtsam` in Python after successful install. The error was:
```
Python 3.7.3 (default, Mar 27 2019, 17:13:21) [MSC v.1915 64 bit (AMD64)] :: Anaconda, Inc. on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import gtsam
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\ProgramData\Anaconda3\lib\site-packages\gtsam-4.0.2-py3.7.egg\gtsam\__init__.py", line 1, in <module>
    from .gtsam import *
ModuleNotFoundError: No module named 'gtsam.gtsam'
>>>
```
This is solved by renaming the compiled file extension from `.dll` to `.pyd`. 

Tested on MSVC 2019 x64 compiler (cl.exe v. 19.25.28614), Python 3.7.3, CMake 3.16.4, Ninja 1.9.0, Windows 10 Pro (1909).