### PR TITLE
added email parameter to ubuntu/debian packaging scripts

### DIFF
--- a/package_scripts/README.md
+++ b/package_scripts/README.md
@@ -1,14 +1,44 @@
+# How to build Debian and Ubuntu Packages
 
-# How to generate Debian packages
+## Preparations
+
+Packages must be signed with a GPG key. First have a look of the keys
+you have available:
+
+    gpg --list-secret-keys
+
+If you don't have one, create one, then list again.
+
+Pick a secret key you like from the listed keys, for instance
+"Your Name <your.email@yourprovider.com>". Then unlock that key by
+signing a dummy file. The following line should pop up a window to
+enter the passphrase:
+
+    echo | gpg --local-user "Your Name <your.email@yourprovider.com>" -s >/dev/null
+
+Now you can run the below scripts. Without this step they will fail
+with "No secret key" or similar messages.
+
+## How to generate a Debian package
+
+Run the package script, providing a name/email that matches your PGP key.
 
     cd [GTSAM_SOURCE_ROOT]
-    bash package_scripts/prepare_debian.sh
+    bash package_scripts/prepare_debian.sh -e "Your Name <your.email@yourprovider.com>"
 
 
-# How to generate Ubuntu packages for a PPA
+## How to generate Ubuntu packages for a PPA
+
+Run the packaging script, passing the name of the gpg key
+(see above) with the "-e" option:
 
     cd [GTSAM_SOURCE_ROOT]
-    bash package_scripts/prepare_ubuntu_pkgs_for_ppa.sh
+    bash package_scripts/prepare_ubuntu_pkgs_for_ppa.sh -e "Your Name <your.email@yourprovider.com>"
+
+Check that you have uploaded this key to the ubuntu key server, and
+have added the key to your account.
+
+Upload the package to your ppa:
+
     cd ~/gtsam_ubuntu
-    bash [GTSAM_SOURCE_ROOT]/upload_all_gtsam_ppa.sh
-
+    bash [GTSAM_SOURCE_ROOT]/package_scripts/upload_all_gtsam_ppa.sh -p "ppa:your-name/ppa-name"

--- a/package_scripts/prepare_debian.sh
+++ b/package_scripts/prepare_debian.sh
@@ -10,7 +10,7 @@ APPEND_SNAPSHOT_NUM=0
 IS_FOR_UBUNTU=0
 APPEND_LINUX_DISTRO=""
 VALUE_EXTRA_CMAKE_PARAMS=""
-while getopts "sud:c:" OPTION
+while getopts "sud:c:e:" OPTION
 do
      case $OPTION in
          s)
@@ -25,12 +25,20 @@ do
          c)
              VALUE_EXTRA_CMAKE_PARAMS=$OPTARG
              ;;
+         e)
+             PACKAGER_EMAIL=$OPTARG
+             ;;
          ?)
              echo "Unknown command line argument!"
              exit 1
              ;;
      esac
 done
+
+if [ -z ${PACKAGER_EMAIL+x} ]; then
+    echo "must specify packager email via -e option!"
+    exit -1
+fi
 
 if [ -f CMakeLists.txt ];
 then
@@ -162,7 +170,7 @@ fi
 
 echo "Adding a new entry to debian/changelog..."
 
-DEBEMAIL="Jose Luis Blanco Claraco <joseluisblancoc@gmail.com>" debchange $DEBCHANGE_CMD -b --distribution unstable --force-distribution New version of upstream sources.
+DEBEMAIL=${PACKAGER_EMAIL} debchange $DEBCHANGE_CMD -b --distribution unstable --force-distribution New version of upstream sources.
 
 echo "Copying back the new changelog to a temporary file in: ${GTSAM_EXTERN_DEBIAN_DIR}changelog.new"
 cp debian/changelog ${GTSAM_EXTERN_DEBIAN_DIR}changelog.new

--- a/package_scripts/upload_all_gtsam_ppa.sh
+++ b/package_scripts/upload_all_gtsam_ppa.sh
@@ -1,3 +1,31 @@
 #!/bin/bash
 
-find . -name '*.changes' | xargs -I FIL dput ppa:joseluisblancoc/gtsam-develop FIL
+function show_help {
+    echo "USAGE:"
+    echo ""
+    echo "- to display this help: "
+    echo "upload_all_gtsam_ppa.sh -h or -?"
+    echo ""
+    echo "- to upload to your PPA: "
+    echo "upload_all_gtsam_ppa.sh -p ppa:your_name/name_of_ppa"
+    echo ""
+}
+
+while getopts "h?p:" opt; do
+    case "$opt" in
+    h|\?)
+        show_help
+        exit 0
+        ;;
+    p)  ppa_name=$OPTARG
+        ;;
+    esac
+done
+
+if [ -z ${ppa_name+x} ]; then
+    show_help
+    exit -1
+fi
+
+
+find . -name '*.changes' | xargs -I FIL dput ${ppa_name} FIL


### PR DESCRIPTION
Modify the Debian and Ubuntu packaging scripts such that the email/key of the package maintainer can be specified on the command line.
Added documentation regarding GPG key handling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/320)
<!-- Reviewable:end -->
