### PR TITLE
Fix problem introduced in #255.

### DIFF
--- a/cython/gtsam/utils/plot.py
+++ b/cython/gtsam/utils/plot.py
@@ -153,7 +153,7 @@ def plot_3d_points(fignum, values, linespec="g*", marginals=None):
             # I guess it's not a Point3
 
 
-def plot_pose3_on_axes(axes, pose, P=None, scale=1, axis_length=0.1):
+def plot_pose3_on_axes(axes, pose, axis_length=0.1, P=None, scale=1):
     """Plot a 3D pose on given axis 'axes' with given 'axis_length'."""
     # get rotation and translation (center)
     gRp = pose.rotation().matrix()  # rotation from pose to global
@@ -181,7 +181,7 @@ def plot_pose3_on_axes(axes, pose, P=None, scale=1, axis_length=0.1):
         plot_covariance_ellipse_3d(axes, origin, gPp)
 
 
-def plot_pose3(fignum, pose, P, axis_length=0.1):
+def plot_pose3(fignum, pose, axis_length=0.1, P=None):
     """Plot a 3D pose on given figure with given 'axis_length'."""
     # get figure object
     fig = plt.figure(fignum)


### PR DESCRIPTION
The api plot_pose3 and plot_pose3_on_axes has been changed, breaking
backward compatibility by adding arguments in the middle. The newly
introduced arguments have been moved to the end of the argument list to
mitigate the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/326)
<!-- Reviewable:end -->
