### PR TITLE
Fix Unit3 copy assign

### DIFF
--- a/gtsam/geometry/Unit3.h
+++ b/gtsam/geometry/Unit3.h
@@ -90,6 +90,8 @@ public:
   /// Copy assignment
   Unit3& operator=(const Unit3 & u) {
     p_ = u.p_;
+    B_ = u.B_;
+    H_B_ = u.H_B_;
     return *this;
   }
 

--- a/gtsam/geometry/tests/testUnit3.cpp
+++ b/gtsam/geometry/tests/testUnit3.cpp
@@ -484,7 +484,7 @@ TEST(Unit3, ErrorBetweenFactor) {
   }
 }
 
-TEST(Unit3, copy_assign) {
+TEST(Unit3, CopyAssign) {
   Unit3 p{1, 0.2, 0.3};
 
   EXPECT(p.error(p).isZero());

--- a/gtsam/geometry/tests/testUnit3.cpp
+++ b/gtsam/geometry/tests/testUnit3.cpp
@@ -484,6 +484,15 @@ TEST(Unit3, ErrorBetweenFactor) {
   }
 }
 
+TEST(Unit3, copy_assign) {
+  Unit3 p{1, 0.2, 0.3};
+
+  EXPECT(p.error(p).isZero());
+
+  p = Unit3{-1, 2, 8};
+  EXPECT(p.error(p).isZero());
+}
+
 /* ************************************************************************* */
 TEST(actualH, Serialization) {
   Unit3 p(0, 1, 0);


### PR DESCRIPTION
`Unit3::operator=` doesn't properly handle setting the cached basis and Jacobian. If `B_` and/or `H_B_` was calculated prior to calling `Unit3::operator=` then they are not reset, which causes subsequent calls to `basis()` to return the previous basis and Jacobian.

This PR fixes `Unit3::operator=(const Unit3& u)` so that `B_` and `H_B_` are set to the cached values of `u` if they exist, and reset otherwise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/334)
<!-- Reviewable:end -->
