### PR TITLE
Switched to in-place update of the diagonal Hessian

### DIFF
--- a/gtsam/config.h.in
+++ b/gtsam/config.h.in
@@ -42,6 +42,9 @@
 // Whether we are using TBB (if TBB was found and GTSAM_WITH_TBB is enabled in CMake)
 #cmakedefine GTSAM_USE_TBB
 
+// Whether we are using a TBB version higher than 2020
+#cmakedefine TBB_GREATER_EQUAL_2020
+
 // Whether we are using system-Eigen or our own patched version
 #cmakedefine GTSAM_USE_SYSTEM_EIGEN
 

--- a/gtsam/linear/GaussianFactor.cpp
+++ b/gtsam/linear/GaussianFactor.cpp
@@ -1,0 +1,35 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file    GaussianFactor.cpp
+ * @brief   A factor with a quadratic error function - a Gaussian
+ * @brief   GaussianFactor
+ * @author  Fan Jiang
+ */
+
+// \callgraph
+
+#pragma once
+
+#include <gtsam/linear/GaussianFactor.h>
+#include <gtsam/linear/VectorValues.h>
+
+namespace gtsam {
+
+/* ************************************************************************* */
+  VectorValues GaussianFactor::hessianDiagonal() const {
+    VectorValues d;
+    hessianDiagonalAdd(d);
+    return d;
+  }
+
+}

--- a/gtsam/linear/GaussianFactor.h
+++ b/gtsam/linear/GaussianFactor.h
@@ -102,6 +102,9 @@ namespace gtsam {
     /// Return the diagonal of the Hessian for this factor
     virtual VectorValues hessianDiagonal() const = 0;
 
+    /// Add the current diagonal to a VectorValues instance
+    virtual void hessianDiagonalAdd(VectorValues& d) const = 0;
+
     /// Raw memory access version of hessianDiagonal
     virtual void hessianDiagonal(double* d) const = 0;
 

--- a/gtsam/linear/GaussianFactor.h
+++ b/gtsam/linear/GaussianFactor.h
@@ -100,7 +100,7 @@ namespace gtsam {
     virtual Matrix information() const = 0;
 
     /// Return the diagonal of the Hessian for this factor
-    virtual VectorValues hessianDiagonal() const = 0;
+    VectorValues hessianDiagonal() const;
 
     /// Add the current diagonal to a VectorValues instance
     virtual void hessianDiagonalAdd(VectorValues& d) const = 0;

--- a/gtsam/linear/GaussianFactorGraph.cpp
+++ b/gtsam/linear/GaussianFactorGraph.cpp
@@ -255,8 +255,7 @@ namespace gtsam {
     VectorValues d;
     for (const sharedFactor& factor : *this) {
       if(factor){
-        VectorValues di = factor->hessianDiagonal();
-        d.addInPlace_(di);
+        factor->hessianDiagonalAdd(d);
       }
     }
     return d;

--- a/gtsam/linear/HessianFactor.cpp
+++ b/gtsam/linear/HessianFactor.cpp
@@ -302,15 +302,6 @@ Matrix HessianFactor::information() const {
 }
 
 /* ************************************************************************* */
-VectorValues HessianFactor::hessianDiagonal() const {
-  VectorValues d;
-  for (DenseIndex j = 0; j < (DenseIndex)size(); ++j) {
-    d.emplace(keys_[j], info_.diagonal(j));
-  }
-  return d;
-}
-
-/* ************************************************************************* */
 void HessianFactor::hessianDiagonalAdd(VectorValues &d) const {
   for (DenseIndex j = 0; j < (DenseIndex)size(); ++j) {
     auto result = d.emplace(keys_[j], info_.diagonal(j));

--- a/gtsam/linear/HessianFactor.cpp
+++ b/gtsam/linear/HessianFactor.cpp
@@ -311,6 +311,17 @@ VectorValues HessianFactor::hessianDiagonal() const {
 }
 
 /* ************************************************************************* */
+void HessianFactor::hessianDiagonalAdd(VectorValues &d) const {
+  for (DenseIndex j = 0; j < (DenseIndex)size(); ++j) {
+    if(d.exists(keys_[j])) {
+      d.at(keys_[j]) += info_.diagonal(j);
+    } else {
+      d.emplace(keys_[j], info_.diagonal(j));
+    }
+  }
+}
+
+/* ************************************************************************* */
 // Raw memory access version should be called in Regular Factors only currently
 void HessianFactor::hessianDiagonal(double* d) const {
   throw std::runtime_error(

--- a/gtsam/linear/HessianFactor.cpp
+++ b/gtsam/linear/HessianFactor.cpp
@@ -315,6 +315,7 @@ void HessianFactor::hessianDiagonalAdd(VectorValues &d) const {
   for (DenseIndex j = 0; j < (DenseIndex)size(); ++j) {
     auto result = d.emplace(keys_[j], info_.diagonal(j));
     if(!result.second) {
+      // if emplace fails, it returns an iterator to the existing element, which we add to:
       result.first->second += info_.diagonal(j);
     }
   }

--- a/gtsam/linear/HessianFactor.cpp
+++ b/gtsam/linear/HessianFactor.cpp
@@ -313,8 +313,9 @@ VectorValues HessianFactor::hessianDiagonal() const {
 /* ************************************************************************* */
 void HessianFactor::hessianDiagonalAdd(VectorValues &d) const {
   for (DenseIndex j = 0; j < (DenseIndex)size(); ++j) {
-    if(d.exists(keys_[j])) {
-      d.at(keys_[j]) += info_.diagonal(j);
+    auto item = d.find(keys_[j]);
+    if(item != d.end()) {
+      item->second += info_.diagonal(j);
     } else {
       d.emplace(keys_[j], info_.diagonal(j));
     }

--- a/gtsam/linear/HessianFactor.cpp
+++ b/gtsam/linear/HessianFactor.cpp
@@ -313,11 +313,9 @@ VectorValues HessianFactor::hessianDiagonal() const {
 /* ************************************************************************* */
 void HessianFactor::hessianDiagonalAdd(VectorValues &d) const {
   for (DenseIndex j = 0; j < (DenseIndex)size(); ++j) {
-    auto item = d.find(keys_[j]);
-    if(item != d.end()) {
-      item->second += info_.diagonal(j);
-    } else {
-      d.emplace(keys_[j], info_.diagonal(j));
+    auto result = d.emplace(keys_[j], info_.diagonal(j));
+    if(!result.second) {
+      result.first->second += info_.diagonal(j);
     }
   }
 }

--- a/gtsam/linear/HessianFactor.h
+++ b/gtsam/linear/HessianFactor.h
@@ -296,6 +296,9 @@ namespace gtsam {
     /// Return the diagonal of the Hessian for this factor
     VectorValues hessianDiagonal() const override;
 
+    /// Add the current diagonal to a VectorValues instance
+    void hessianDiagonalAdd(VectorValues& d) const override;
+
     /// Raw memory access version of hessianDiagonal
     void hessianDiagonal(double* d) const override;
 

--- a/gtsam/linear/HessianFactor.h
+++ b/gtsam/linear/HessianFactor.h
@@ -293,11 +293,11 @@ namespace gtsam {
      */
     Matrix information() const override;
 
-    /// Return the diagonal of the Hessian for this factor
-    VectorValues hessianDiagonal() const override;
-
     /// Add the current diagonal to a VectorValues instance
     void hessianDiagonalAdd(VectorValues& d) const override;
+
+    /// Using the base method
+    using Base::hessianDiagonal;
 
     /// Raw memory access version of hessianDiagonal
     void hessianDiagonal(double* d) const override;

--- a/gtsam/linear/JacobianFactor.cpp
+++ b/gtsam/linear/JacobianFactor.cpp
@@ -560,8 +560,9 @@ void JacobianFactor::hessianDiagonalAdd(VectorValues& d) const {
         model_->whitenInPlace(column_k);
       dj(k) = dot(column_k, column_k);
     }
-    if(d.exists(j)) {
-      d.at(j) += dj;
+    auto item = d.find(j);
+    if(item != d.end()) {
+      item->second += dj;
     } else {
       d.emplace(j, dj);
     }

--- a/gtsam/linear/JacobianFactor.cpp
+++ b/gtsam/linear/JacobianFactor.cpp
@@ -556,11 +556,15 @@ void JacobianFactor::hessianDiagonalAdd(VectorValues& d) const {
     auto result = d.emplace(j, nj);
 
     Vector& dj = result.first->second;
+
     for (size_t k = 0; k < nj; ++k) {
       Vector column_k = Ab_(pos).col(k);
       if (model_)
         model_->whitenInPlace(column_k);
-      dj(k) += dot(column_k, column_k);
+      if(!result.second)
+        dj(k) += dot(column_k, column_k);
+      else
+        dj(k) = dot(column_k, column_k);
     }
   }
 }

--- a/gtsam/linear/JacobianFactor.cpp
+++ b/gtsam/linear/JacobianFactor.cpp
@@ -558,13 +558,20 @@ void JacobianFactor::hessianDiagonalAdd(VectorValues& d) const {
     Vector& dj = result.first->second;
 
     for (size_t k = 0; k < nj; ++k) {
-      Vector column_k = Ab_(pos).col(k);
-      if (model_)
-        model_->whitenInPlace(column_k);
-      if(!result.second)
-        dj(k) += dot(column_k, column_k);
-      else
-        dj(k) = dot(column_k, column_k);
+      Eigen::Ref<const Vector> column_k = Ab_(pos).col(k);
+      if (model_) {
+        Vector column_k_copy = column_k;
+        model_->whitenInPlace(column_k_copy);
+        if(!result.second)
+          dj(k) += dot(column_k_copy, column_k_copy);
+        else
+          dj(k) = dot(column_k_copy, column_k_copy);
+      } else {
+        if (!result.second)
+          dj(k) += dot(column_k, column_k);
+        else
+          dj(k) = dot(column_k, column_k);
+      }
     }
   }
 }

--- a/gtsam/linear/JacobianFactor.cpp
+++ b/gtsam/linear/JacobianFactor.cpp
@@ -542,13 +542,6 @@ Matrix JacobianFactor::information() const {
 }
 
 /* ************************************************************************* */
-VectorValues JacobianFactor::hessianDiagonal() const {
-  VectorValues d;
-  hessianDiagonalAdd(d);
-  return d;
-}
-
-/* ************************************************************************* */
 void JacobianFactor::hessianDiagonalAdd(VectorValues& d) const {
   for (size_t pos = 0; pos < size(); ++pos) {
     Key j = keys_[pos];

--- a/gtsam/linear/JacobianFactor.cpp
+++ b/gtsam/linear/JacobianFactor.cpp
@@ -552,28 +552,15 @@ VectorValues JacobianFactor::hessianDiagonal() const {
 void JacobianFactor::hessianDiagonalAdd(VectorValues& d) const {
   for (size_t pos = 0; pos < size(); ++pos) {
     Key j = keys_[pos];
-    auto item = d.find(j);
+    size_t nj = Ab_(pos).cols();
+    auto result = d.emplace(j, nj);
 
-    if(item != d.end()) {
-      size_t nj = Ab_(pos).cols();
-      Vector& dj = item->second;
-      for (size_t k = 0; k < nj; ++k) {
-        Vector column_k = Ab_(pos).col(k);
-        if (model_)
-          model_->whitenInPlace(column_k);
-        dj(k) += dot(column_k, column_k);
-      }
-    } else {
-      size_t nj = Ab_(pos).cols();
-      Vector dj(nj);
-      for (size_t k = 0; k < nj; ++k) {
-        Vector column_k = Ab_(pos).col(k);
-        if (model_)
-          model_->whitenInPlace(column_k);
-        dj(k) = dot(column_k, column_k);
-      }
-
-      d.emplace(j, dj);
+    Vector& dj = result.first->second;
+    for (size_t k = 0; k < nj; ++k) {
+      Vector column_k = Ab_(pos).col(k);
+      if (model_)
+        model_->whitenInPlace(column_k);
+      dj(k) += dot(column_k, column_k);
     }
   }
 }

--- a/gtsam/linear/JacobianFactor.cpp
+++ b/gtsam/linear/JacobianFactor.cpp
@@ -544,6 +544,12 @@ Matrix JacobianFactor::information() const {
 /* ************************************************************************* */
 VectorValues JacobianFactor::hessianDiagonal() const {
   VectorValues d;
+  hessianDiagonalAdd(d);
+  return d;
+}
+
+/* ************************************************************************* */
+void JacobianFactor::hessianDiagonalAdd(VectorValues& d) const {
   for (size_t pos = 0; pos < size(); ++pos) {
     Key j = keys_[pos];
     size_t nj = Ab_(pos).cols();
@@ -554,9 +560,12 @@ VectorValues JacobianFactor::hessianDiagonal() const {
         model_->whitenInPlace(column_k);
       dj(k) = dot(column_k, column_k);
     }
-    d.emplace(j, dj);
+    if(d.exists(j)) {
+      d.at(j) += dj;
+    } else {
+      d.emplace(j, dj);
+    }
   }
-  return d;
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/JacobianFactor.cpp
+++ b/gtsam/linear/JacobianFactor.cpp
@@ -552,18 +552,27 @@ VectorValues JacobianFactor::hessianDiagonal() const {
 void JacobianFactor::hessianDiagonalAdd(VectorValues& d) const {
   for (size_t pos = 0; pos < size(); ++pos) {
     Key j = keys_[pos];
-    size_t nj = Ab_(pos).cols();
-    Vector dj(nj);
-    for (size_t k = 0; k < nj; ++k) {
-      Vector column_k = Ab_(pos).col(k);
-      if (model_)
-        model_->whitenInPlace(column_k);
-      dj(k) = dot(column_k, column_k);
-    }
     auto item = d.find(j);
+
     if(item != d.end()) {
-      item->second += dj;
+      size_t nj = Ab_(pos).cols();
+      Vector& dj = item->second;
+      for (size_t k = 0; k < nj; ++k) {
+        Vector column_k = Ab_(pos).col(k);
+        if (model_)
+          model_->whitenInPlace(column_k);
+        dj(k) += dot(column_k, column_k);
+      }
     } else {
+      size_t nj = Ab_(pos).cols();
+      Vector dj(nj);
+      for (size_t k = 0; k < nj; ++k) {
+        Vector column_k = Ab_(pos).col(k);
+        if (model_)
+          model_->whitenInPlace(column_k);
+        dj(k) = dot(column_k, column_k);
+      }
+
       d.emplace(j, dj);
     }
   }

--- a/gtsam/linear/JacobianFactor.h
+++ b/gtsam/linear/JacobianFactor.h
@@ -218,6 +218,9 @@ namespace gtsam {
     /// Return the diagonal of the Hessian for this factor
     VectorValues hessianDiagonal() const override;
 
+    /// Add the current diagonal to a VectorValues instance
+    void hessianDiagonalAdd(VectorValues& d) const override;
+
     /// Raw memory access version of hessianDiagonal
     void hessianDiagonal(double* d) const override;
 

--- a/gtsam/linear/JacobianFactor.h
+++ b/gtsam/linear/JacobianFactor.h
@@ -215,8 +215,8 @@ namespace gtsam {
      */
     Matrix information() const override;
 
-    /// Return the diagonal of the Hessian for this factor
-    VectorValues hessianDiagonal() const override;
+    /// Using the base method
+    using Base::hessianDiagonal;
 
     /// Add the current diagonal to a VectorValues instance
     void hessianDiagonalAdd(VectorValues& d) const override;

--- a/gtsam/linear/RegularJacobianFactor.h
+++ b/gtsam/linear/RegularJacobianFactor.h
@@ -102,10 +102,8 @@ public:
       DMap(y + D * keys_[pos]) += Ab_(pos).transpose() * Ax;
   }
 
-  /// Expose base class hessianDiagonal
-  virtual VectorValues hessianDiagonal() const {
-    return JacobianFactor::hessianDiagonal();
-  }
+  /// Using the base method
+  using GaussianFactor::hessianDiagonal;
 
   /// Raw memory access version of hessianDiagonal
   void hessianDiagonal(double* d) const {

--- a/gtsam/linear/VectorValues.cpp
+++ b/gtsam/linear/VectorValues.cpp
@@ -97,17 +97,13 @@ namespace gtsam {
   }
 
   /* ************************************************************************* */
-  VectorValues::iterator VectorValues::emplace(Key j, const Vector& value) {
+  std::pair<VectorValues::iterator, bool> VectorValues::emplace(Key j, const Vector& value) {
 #ifdef TBB_GREATER_EQUAL_2020
     std::pair<iterator, bool> result = values_.emplace(j, value);
 #else
     std::pair<iterator, bool> result = values_.insert(std::make_pair(j, value));
 #endif
-    if(!result.second)
-      throw std::invalid_argument(
-      "Requested to emplace variable '" + DefaultKeyFormatter(j)
-      + "' already in this VectorValues.");
-    return result.first;
+    return result;
   }
 
   /* ************************************************************************* */

--- a/gtsam/linear/VectorValues.cpp
+++ b/gtsam/linear/VectorValues.cpp
@@ -97,16 +97,6 @@ namespace gtsam {
   }
 
   /* ************************************************************************* */
-  std::pair<VectorValues::iterator, bool> VectorValues::emplace(Key j, const Vector& value) {
-#ifdef TBB_GREATER_EQUAL_2020
-    std::pair<iterator, bool> result = values_.emplace(j, value);
-#else
-    std::pair<iterator, bool> result = values_.insert(std::make_pair(j, value));
-#endif
-    return result;
-  }
-
-  /* ************************************************************************* */
   void VectorValues::update(const VectorValues& values)
   {
     iterator hint = begin();

--- a/gtsam/linear/VectorValues.h
+++ b/gtsam/linear/VectorValues.h
@@ -179,7 +179,13 @@ namespace gtsam {
      *  j is already used.
      * @param value The vector to be inserted.
      * @param j The index with which the value will be associated. */
-    std::pair<VectorValues::iterator, bool> emplace(Key j, const Vector& value);
+    std::pair<VectorValues::iterator, bool> emplace(Key j, const Vector& value) {
+#if ! defined(GTSAM_USE_TBB) || defined (TBB_GREATER_EQUAL_2020)
+      return values_.emplace(j, value);
+#else
+      return values_.insert(std::make_pair(j, value));
+#endif
+    }
 
     /** Insert a vector \c value with key \c j.  Throws an invalid_argument exception if the key \c
      *  j is already used.
@@ -197,7 +203,7 @@ namespace gtsam {
      *  and an iterator to the existing value is returned, along with 'false'.  If the value did not
      *  exist, it is inserted and an iterator pointing to the new element, along with 'true', is
      *  returned. */
-    std::pair<iterator, bool> tryInsert(Key j, const Vector& value) {
+    inline std::pair<iterator, bool> tryInsert(Key j, const Vector& value) {
 #ifdef TBB_GREATER_EQUAL_2020
       return values_.emplace(j, value);
 #else

--- a/gtsam/linear/VectorValues.h
+++ b/gtsam/linear/VectorValues.h
@@ -179,7 +179,7 @@ namespace gtsam {
      *  j is already used.
      * @param value The vector to be inserted.
      * @param j The index with which the value will be associated. */
-    iterator emplace(Key j, const Vector& value);
+    std::pair<VectorValues::iterator, bool> emplace(Key j, const Vector& value);
 
     /** Insert a vector \c value with key \c j.  Throws an invalid_argument exception if the key \c
      *  j is already used.

--- a/gtsam/linear/VectorValues.h
+++ b/gtsam/linear/VectorValues.h
@@ -179,11 +179,12 @@ namespace gtsam {
      *  j is already used.
      * @param value The vector to be inserted.
      * @param j The index with which the value will be associated. */
-    std::pair<VectorValues::iterator, bool> emplace(Key j, const Vector& value) {
+    template<class... Args>
+    inline std::pair<VectorValues::iterator, bool> emplace(Key j, Args&&... args) {
 #if ! defined(GTSAM_USE_TBB) || defined (TBB_GREATER_EQUAL_2020)
-      return values_.emplace(j, value);
+      return values_.emplace(j, std::forward<Args>(args)...);
 #else
-      return values_.insert(std::make_pair(j, value));
+      return values_.insert(std::make_pair(j, Vector(std::forward<Args>(args)...)));
 #endif
     }
 

--- a/gtsam/linear/VectorValues.h
+++ b/gtsam/linear/VectorValues.h
@@ -182,7 +182,7 @@ namespace gtsam {
     template<class... Args>
     inline std::pair<VectorValues::iterator, bool> emplace(Key j, Args&&... args) {
 #if ! defined(GTSAM_USE_TBB) || defined (TBB_GREATER_EQUAL_2020)
-      return values_.emplace(j, std::forward<Args>(args)...);
+      return values_.emplace(std::piecewise_construct, std::forward_as_tuple(j), std::forward_as_tuple(args...));
 #else
       return values_.insert(std::make_pair(j, Vector(std::forward<Args>(args)...)));
 #endif

--- a/gtsam/linear/linearAlgorithms-inst.h
+++ b/gtsam/linear/linearAlgorithms-inst.h
@@ -100,9 +100,9 @@ namespace gtsam
             for(GaussianConditional::const_iterator frontal = c.beginFrontals(); frontal != c.endFrontals(); ++frontal) {
               auto result = collectedResult.emplace(*frontal, solution.segment(vectorPosition, c.getDim(frontal)));
               if(!result.second)
-                  throw std::invalid_argument(
-                      "Requested to emplace variable '" + DefaultKeyFormatter(*frontal)
-                      + "' already in this VectorValues.");
+                  throw std::runtime_error(
+                      "Internal error while optimizing clique. Trying to insert key '" + DefaultKeyFormatter(*frontal)
+                      + "' that exists.");
 
               VectorValues::const_iterator r = result.first;
               myData.cliqueResults.emplace(r->first, r);

--- a/gtsam/linear/linearAlgorithms-inst.h
+++ b/gtsam/linear/linearAlgorithms-inst.h
@@ -103,7 +103,7 @@ namespace gtsam
                   throw std::invalid_argument(
                       "Requested to emplace variable '" + DefaultKeyFormatter(*frontal)
                       + "' already in this VectorValues.");
-              
+
               VectorValues::const_iterator r = result.first;
               myData.cliqueResults.emplace(r->first, r);
               vectorPosition += c.getDim(frontal);

--- a/gtsam/linear/linearAlgorithms-inst.h
+++ b/gtsam/linear/linearAlgorithms-inst.h
@@ -98,8 +98,13 @@ namespace gtsam
             // Insert solution into a VectorValues
             DenseIndex vectorPosition = 0;
             for(GaussianConditional::const_iterator frontal = c.beginFrontals(); frontal != c.endFrontals(); ++frontal) {
-              VectorValues::const_iterator r =
-                collectedResult.emplace(*frontal, solution.segment(vectorPosition, c.getDim(frontal)));
+              auto result = collectedResult.emplace(*frontal, solution.segment(vectorPosition, c.getDim(frontal)));
+              if(!result.second)
+                  throw std::invalid_argument(
+                      "Requested to emplace variable '" + DefaultKeyFormatter(*frontal)
+                      + "' already in this VectorValues.");
+              
+              VectorValues::const_iterator r = result.first;
               myData.cliqueResults.emplace(r->first, r);
               vectorPosition += c.getDim(frontal);
             }

--- a/gtsam/slam/RegularImplicitSchurFactor.h
+++ b/gtsam/slam/RegularImplicitSchurFactor.h
@@ -172,11 +172,9 @@ public:
         dj(k) -= FtE.row(k) * PointCovariance_ * FtE.row(k).transpose();
       }
 
-      auto item = d.find(j);
-      if(item != d.end()) {
-        item->second += dj;
-      } else {
-        d.emplace(j, dj);
+      auto result = d.emplace(j, dj);
+      if(!result.second) {
+        result.first->second += dj;
       }
     }
   }

--- a/gtsam/slam/RegularImplicitSchurFactor.h
+++ b/gtsam/slam/RegularImplicitSchurFactor.h
@@ -151,7 +151,7 @@ public:
     return d;
   }
 
-  /// Return the diagonal of the Hessian for this factor
+  /// Add the diagonal of the Hessian for this factor to existing VectorValues
   virtual void hessianDiagonalAdd(VectorValues &d) const override {
     // diag(Hessian) = diag(F' * (I - E * PointCov * E') * F);
     for (size_t k = 0; k < size(); ++k) { // for each camera

--- a/gtsam/slam/RegularImplicitSchurFactor.h
+++ b/gtsam/slam/RegularImplicitSchurFactor.h
@@ -147,7 +147,7 @@ public:
     VectorValues d;
 
     hessianDiagonalAdd(d);
-    
+
     return d;
   }
 

--- a/gtsam/slam/RegularImplicitSchurFactor.h
+++ b/gtsam/slam/RegularImplicitSchurFactor.h
@@ -141,15 +141,8 @@ public:
     return augmented.block(0, 0, M, M);
   }
 
-  /// Return the diagonal of the Hessian for this factor
-  virtual VectorValues hessianDiagonal() const {
-    // diag(Hessian) = diag(F' * (I - E * PointCov * E') * F);
-    VectorValues d;
-
-    hessianDiagonalAdd(d);
-
-    return d;
-  }
+  /// Using the base method
+  using GaussianFactor::hessianDiagonal;
 
   /// Add the diagonal of the Hessian for this factor to existing VectorValues
   virtual void hessianDiagonalAdd(VectorValues &d) const override {


### PR DESCRIPTION
Benchmark with `SEQUENTIAL_CHOLESKY`

Warmed-up timing
================

Before:
```
Initial error: 4.18566e+06, values: 22122
iter      cost      cost_change    lambda  success iter_time
   0  1.030608e+05    4.08e+06    1.00e-04     1    7.43e+00
   1  6.149065e+04    4.16e+04    3.33e-05     1    7.27e+00
   2  1.956166e+04    4.19e+04    3.33e-05     1    7.28e+00
   3  1.814774e+04    1.41e+03    1.11e-05     1    7.31e+00
   4  1.803417e+04    1.14e+02    3.98e-06     1    7.34e+00
   5  1.803390e+04    2.62e-01    1.33e-06     1    7.35e+00
   6  1.803390e+04    8.14e-05    4.42e-07     1    7.36e+00
-Total: 0 CPU (0 times, 0 wall, 74.61 children, min: 0 max: 0)
|   -optimize: 74.61 CPU (1 times, 74.7746 wall, 74.61 children, min: 74.61 max: 74.61)
LD_LIBRARY_PATH=/opt/intel/lib ../gtsam_build/timing/timeSFMBAL  74.23s user 0.88s system 99% cpu 1:15.27 total
```

After:
```
Initial error: 4.18566e+06, values: 22122
iter      cost      cost_change    lambda  success iter_time
   0  1.030608e+05    4.08e+06    1.00e-04     1    7.47e+00
   1  6.149065e+04    4.16e+04    3.33e-05     1    7.30e+00
   2  1.956166e+04    4.19e+04    3.33e-05     1    7.29e+00
   3  1.814774e+04    1.41e+03    1.11e-05     1    7.29e+00
   4  1.803417e+04    1.14e+02    3.98e-06     1    7.32e+00
   5  1.803390e+04    2.62e-01    1.33e-06     1    7.35e+00
   6  1.803390e+04    8.14e-05    4.42e-07     1    7.37e+00
-Total: 0 CPU (0 times, 0 wall, 71.2 children, min: 0 max: 0)
|   -optimize: 71.2 CPU (1 times, 71.3531 wall, 71.2 children, min: 71.2 max: 71.2)
LD_LIBRARY_PATH=/opt/intel/lib ../gtsam_build/timing/timeSFMBAL  70.95s user 0.74s system 99% cpu 1:11.84 total
```

Cold timing
===============

Before:
```
Initial error: 4.18566e+06, values: 22122
iter      cost      cost_change    lambda  success iter_time
   0  1.030608e+05    4.08e+06    1.00e-04     1    1.03e+01
   1  6.149065e+04    4.16e+04    3.33e-05     1    8.06e+00
   2  1.956166e+04    4.19e+04    3.33e-05     1    8.07e+00
   3  1.814774e+04    1.41e+03    1.11e-05     1    7.77e+00
   4  1.803417e+04    1.14e+02    3.98e-06     1    8.16e+00
   5  1.803390e+04    2.62e-01    1.33e-06     1    7.77e+00
   6  1.803390e+04    8.14e-05    4.42e-07     1    7.80e+00
-Total: 0 CPU (0 times, 0 wall, 82.97 children, min: 0 max: 0)
|   -optimize: 82.97 CPU (1 times, 85.3366 wall, 82.97 children, min: 82.97 max: 82.97)
LD_LIBRARY_PATH=/opt/intel/lib ../gtsam_build/timing/timeSFMBAL  81.95s user 1.64s system 97% cpu 1:26.04 total
```

After:

```
Initial error: 4.18566e+06, values: 22122
iter      cost      cost_change    lambda  success iter_time
   0  1.030608e+05    4.08e+06    1.00e-04     1    8.29e+00
   1  6.149065e+04    4.16e+04    3.33e-05     1    8.29e+00
   2  1.956166e+04    4.19e+04    3.33e-05     1    7.48e+00
   3  1.814774e+04    1.41e+03    1.11e-05     1    7.69e+00
   4  1.803417e+04    1.14e+02    3.98e-06     1    7.83e+00
   5  1.803390e+04    2.62e-01    1.33e-06     1    7.48e+00
   6  1.803390e+04    8.14e-05    4.42e-07     1    7.58e+00
-Total: 0 CPU (0 times, 0 wall, 75.98 children, min: 0 max: 0)
|   -optimize: 75.98 CPU (1 times, 76.699 wall, 75.98 children, min: 75.98 max: 75.98)
LD_LIBRARY_PATH=/opt/intel/lib ../gtsam_build/timing/timeSFMBAL  75.47s user 1.07s system 98% cpu 1:17.34 total
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/337)
<!-- Reviewable:end -->
