### PR TITLE
Improved Python IMU example 

### DIFF
--- a/cython/gtsam/examples/ImuFactorExample.py
+++ b/cython/gtsam/examples/ImuFactorExample.py
@@ -76,8 +76,14 @@ class ImuFactorExample(PreintegrationExample):
         initial.insert(BIAS_KEY, self.actualBias)
         for i in range(num_poses):
             state_i = self.scenario.navState(float(i))
-            initial.insert(X(i), state_i.pose())
-            initial.insert(V(i), state_i.velocity())
+
+            poseNoise = gtsam.Pose3.Expmap(np.random.randn(3)*0.1)
+            pose = state_i.pose().compose(poseNoise)
+
+            velocity = state_i.velocity() + np.random.randn(3)*0.1
+
+            initial.insert(X(i), pose)
+            initial.insert(V(i), velocity)
 
         # simulate the loop
         i = 0  # state index
@@ -87,6 +93,12 @@ class ImuFactorExample(PreintegrationExample):
             measuredOmega = self.runner.measuredAngularVelocity(t)
             measuredAcc = self.runner.measuredSpecificForce(t)
             pim.integrateMeasurement(measuredAcc, measuredOmega, self.dt)
+
+            poseNoise = gtsam.Pose3.Expmap(np.random.randn(3)*0.1)
+
+            actual_state_i = gtsam.NavState(
+                actual_state_i.pose().compose(poseNoise),
+                actual_state_i.velocity() + np.random.randn(3)*0.1)
 
             # Plot IMU many times
             if k % 10 == 0:
@@ -133,6 +145,9 @@ class ImuFactorExample(PreintegrationExample):
             pose_i = result.atPose3(X(i))
             plot_pose3(POSES_FIG, pose_i, 0.1)
             i += 1
+
+        gtsam.utils.plot.set_axes_equal(POSES_FIG)
+
         print(result.atimuBias_ConstantBias(BIAS_KEY))
 
         plt.ioff()

--- a/gtsam.h
+++ b/gtsam.h
@@ -2913,6 +2913,8 @@ class PreintegratedImuMeasurements {
   void integrateMeasurement(Vector measuredAcc, Vector measuredOmega,
       double deltaT);
   void resetIntegration();
+  void resetIntegrationAndSetBias(const gtsam::imuBias::ConstantBias& biasHat);
+
   Matrix preintMeasCov() const;
   double deltaTij() const;
   gtsam::Rot3 deltaRij() const;
@@ -2972,6 +2974,8 @@ class PreintegratedCombinedMeasurements {
   void integrateMeasurement(Vector measuredAcc, Vector measuredOmega,
       double deltaT);
   void resetIntegration();
+  void resetIntegrationAndSetBias(const gtsam::imuBias::ConstantBias& biasHat);
+
   Matrix preintMeasCov() const;
   double deltaTij() const;
   gtsam::Rot3 deltaRij() const;


### PR DESCRIPTION
As part of a longer term plan of improving the examples for `ImuFactor` and `CombinedImuFactor`, this PR updates the wrapper and adds random gaussian noise to the initial estimates to better simulate "real" scenarios.

Output visualizations looks sane and pretty much like the previous version.
![imufactors](https://user-images.githubusercontent.com/975964/84207918-10085380-aa78-11ea-86c9-b10a19bba258.png)
