### PR TITLE
Fix OrientedPlane3Factor jacobian

### DIFF
--- a/gtsam/geometry/OrientedPlane3.h
+++ b/gtsam/geometry/OrientedPlane3.h
@@ -114,6 +114,10 @@ public:
    */
   Vector3 error(const OrientedPlane3& plane) const;
 
+  static Vector3 Error(const OrientedPlane3& plane1, const OrientedPlane3& plane2) {
+    return plane1.error(plane2);
+  }
+
   /** Computes the error between the two planes, with derivatives.
    *  This uses Unit3::errorVector, as opposed to the other .error() in this class, which uses
    *  Unit3::localCoordinates. This one has correct derivatives.

--- a/gtsam/slam/tests/testOrientedPlane3Factor.cpp
+++ b/gtsam/slam/tests/testOrientedPlane3Factor.cpp
@@ -83,7 +83,7 @@ TEST (OrientedPlane3Factor, lm_rotation_error) {
   // Tests one pose, two measurements of the landmark that differ in angle only.
   // Normal along -x, 3m away
   Symbol lm_sym('p', 0);
-  OrientedPlane3 test_lm0(-1.0, 0.0, 0.0, 3.0);
+  OrientedPlane3 test_lm0(-1.0/sqrt(1.01), 0.1/sqrt(1.01), 0.0, 3.0);
 
   ISAM2 isam2;
   Values new_values;
@@ -153,8 +153,8 @@ TEST( OrientedPlane3Factor, Derivatives ) {
     factor.evaluateError(poseLin, pLin, actualH1, actualH2);
 
     // Verify we get the expected error
-    EXPECT(assert_equal(numericalH1, actualH1, 1e-8));
-    EXPECT(assert_equal(numericalH2, actualH2, 1e-8));
+    EXPECT(assert_equal(numericalH1, actualH1, 1e-7));
+    EXPECT(assert_equal(numericalH2, actualH2, 1e-7));
   }
 }
 


### PR DESCRIPTION
See #283.

This PR fixes the derivative of the `OrientedPlane3Factor`. Previously, the calculated Jacobians didn't account for the second function in `evaluateError` which meant that the Jacobian was not correct.

I have added a `numericalDerivative` to calculate the Jacobian of the second calculation and then applied the chain rule. I have also added a unit test to check that this is correct.

TODO: Ideally `OrientedPlane3::error()` should calculate analytical derivatives itself instead of using `numericalDerivatives`. Would anyone be able to help with this?

@mcamurri