### PR TITLE
Fix memory leak in Expressions

### DIFF
--- a/gtsam/nonlinear/internal/ExecutionTrace.h
+++ b/gtsam/nonlinear/internal/ExecutionTrace.h
@@ -169,6 +169,12 @@ class ExecutionTrace {
       content.ptr->reverseAD2(dTdA, jacobians);
   }
 
+  ~ExecutionTrace() {
+    if (kind == Function) {
+      content.ptr->~CallRecord<Dim>();
+    }
+  }
+
   /// Define type so we can apply it as a meta-function
   typedef ExecutionTrace<T> type;
 };

--- a/gtsam/nonlinear/tests/testExecutionTrace.cpp
+++ b/gtsam/nonlinear/tests/testExecutionTrace.cpp
@@ -16,6 +16,7 @@
  * @brief unit tests for Expression internals
  */
 
+#include <gtsam/nonlinear/internal/CallRecord.h>
 #include <gtsam/nonlinear/internal/ExecutionTrace.h>
 #include <gtsam/geometry/Point2.h>
 


### PR DESCRIPTION
There is a memory leak in expressions when the expression involves an object that is not functionally constructed (`StereoCamera` here in `testTriangulation.cpp`, which involves incrementing the reference count of a `shared_ptr` pointing to the `Cal3_S2Stereo` object).

Thus, each time `valueAndJacobianMap` is called, the RC is incremented, but never decreased because of a raw placement new in `ExpressionNode.h`:
```cpp
    // Create a Record in the memory pointed to by ptr
    // Calling the constructor will record the traces for all arguments
    // Write an Expression<A> execution trace in record->trace
    // Iff Constant or Leaf, this will not write to traceStorage, only to trace.
    // Iff the expression is functional, write all Records in traceStorage buffer
    // Return value of type T is recorded in record->value
    // NOTE(frank, abe): The destructor on this record is never called due to this placement new
    // Records must only contain statically sized objects!
    Record* record = new (ptr) Record(values, *expression1_, ptr);
```

I only ran this on the unit tests, could someone test it on a real demo or application? Thanks :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/373)
<!-- Reviewable:end -->
