### PR TITLE
Fix TranslationFactor with Vector3 as Point3

### DIFF
--- a/gtsam/sfm/TranslationFactor.h
+++ b/gtsam/sfm/TranslationFactor.h
@@ -67,8 +67,7 @@ class TranslationFactor : public NoiseModelFactor2<Point3, Point3> {
       boost::optional<Matrix&> H2 = boost::none) const override {
     const Point3 dir = Tb - Ta;
     Matrix33 H_predicted_dir;
-    const Point3 predicted =
-        dir.normalized(H1 || H2 ? &H_predicted_dir : nullptr);
+    const Point3 predicted = normalize(dir, H1 || H2 ? &H_predicted_dir : nullptr);
     if (H1) *H1 = -H_predicted_dir;
     if (H2) *H2 = H_predicted_dir;
     return predicted - measured_w_aZb_;


### PR DESCRIPTION
Fix compilation when the vector3 as point3 flag is enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/374)
<!-- Reviewable:end -->
