### PR TITLE
Fix/matlab wrapper

### DIFF
--- a/gtsam.h
+++ b/gtsam.h
@@ -2836,33 +2836,33 @@ virtual class KarcherMeanFactor : gtsam::NonlinearFactor {
   KarcherMeanFactor(const gtsam::KeyVector& keys);
 };
 
-#include <gtsam/slam/FrobeniusFactor.h>
-gtsam::noiseModel::Isotropic* ConvertPose3NoiseModel(
-    gtsam::noiseModel::Base* model, size_t d);
-
-template<T = {gtsam::SO3, gtsam::SO4}>
-virtual class FrobeniusFactor : gtsam::NoiseModelFactor {
-  FrobeniusFactor(size_t key1, size_t key2);
-  FrobeniusFactor(size_t key1, size_t key2, gtsam::noiseModel::Base* model);
-
-  Vector evaluateError(const T& R1, const T& R2);
-};
-
-template<T = {gtsam::SO3, gtsam::SO4}>
-virtual class FrobeniusBetweenFactor : gtsam::NoiseModelFactor {
-  FrobeniusBetweenFactor(size_t key1, size_t key2, const T& R12);
-  FrobeniusBetweenFactor(size_t key1, size_t key2, const T& R12, gtsam::noiseModel::Base* model);
-
-  Vector evaluateError(const T& R1, const T& R2);
-};
-
-virtual class FrobeniusWormholeFactor : gtsam::NoiseModelFactor {
-  FrobeniusWormholeFactor(size_t key1, size_t key2, const gtsam::Rot3& R12,
-                          size_t p);
-  FrobeniusWormholeFactor(size_t key1, size_t key2, const gtsam::Rot3& R12,
-                          size_t p, gtsam::noiseModel::Base* model);
-  Vector evaluateError(const gtsam::SOn& Q1, const gtsam::SOn& Q2);
-};
+//#include <gtsam/slam/FrobeniusFactor.h>
+//gtsam::noiseModel::Isotropic* ConvertPose3NoiseModel(
+//    gtsam::noiseModel::Base* model, size_t d);
+//
+//template<T = {gtsam::SO3, gtsam::SO4}>
+//virtual class FrobeniusFactor : gtsam::NoiseModelFactor {
+//  FrobeniusFactor(size_t key1, size_t key2);
+//  FrobeniusFactor(size_t key1, size_t key2, gtsam::noiseModel::Base* model);
+//
+//  Vector evaluateError(const T& R1, const T& R2);
+//};
+//
+//template<T = {gtsam::SO3, gtsam::SO4}>
+//virtual class FrobeniusBetweenFactor : gtsam::NoiseModelFactor {
+//  FrobeniusBetweenFactor(size_t key1, size_t key2, const T& R12);
+//  FrobeniusBetweenFactor(size_t key1, size_t key2, const T& R12, gtsam::noiseModel::Base* model);
+//
+//  Vector evaluateError(const T& R1, const T& R2);
+//};
+//
+//virtual class FrobeniusWormholeFactor : gtsam::NoiseModelFactor {
+//  FrobeniusWormholeFactor(size_t key1, size_t key2, const gtsam::Rot3& R12,
+//                          size_t p);
+//  FrobeniusWormholeFactor(size_t key1, size_t key2, const gtsam::Rot3& R12,
+//                          size_t p, gtsam::noiseModel::Base* model);
+//  Vector evaluateError(const gtsam::SOn& Q1, const gtsam::SOn& Q2);
+//};
 
 //*************************************************************************
 // Navigation

--- a/gtsam/geometry/SOn.h
+++ b/gtsam/geometry/SOn.h
@@ -30,6 +30,9 @@
 #include <vector>
 #include <random>
 
+ // For save/load
+#include <boost/serialization/split_member.hpp>
+
 namespace gtsam {
 
 namespace internal {
@@ -293,6 +296,11 @@ class SO : public LieGroup<SO<N>, internal::DimensionSO(N)> {
   /// @}
 
   template <class Archive>
+  friend void save(Archive&, SO&, const unsigned int);
+  template <class Archive>
+  friend void load(Archive&, SO&, const unsigned int);
+  template <class Archive>
+  template <class Archive>
   friend void serialize(Archive&, SO&, const unsigned int);
   friend class boost::serialization::access;
   friend class Rot3;  // for serialize
@@ -328,6 +336,16 @@ SOn LieGroup<SOn, Eigen::Dynamic>::compose(const SOn& g, DynamicJacobian H1,
 template <>
 SOn LieGroup<SOn, Eigen::Dynamic>::between(const SOn& g, DynamicJacobian H1,
                                            DynamicJacobian H2) const;
+
+/** Serialization function */
+template<class Archive>
+void serialize(
+  Archive& ar, SOn& Q,
+  const unsigned int file_version
+) {
+  Matrix& M = Q.matrix_;
+  ar& M;
+}
 
 /*
  * Define the traits. internal::LieGroup provides both Lie group and Testable


### PR DESCRIPTION
Quick changes to get the MATLAB wrapper building.

@jlblancoc Per #377 , I think something is up with CMake and the FrobeniusFactor. You seem to be the CMake wizard, do you know why the Frobenius factor files might not turn up in a solution? I would have assumed that all of the files in `slam` were just added together automatically.

@ProfFan Also per #377 , the changes to `SOn.h` were just grabbed from `feature/new_wrapper`. Could you confirm that porting them over like this is appropriate?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/378)
<!-- Reviewable:end -->
