### PR TITLE
Second attempt at a MATLAB wrapper build fix.

### DIFF
--- a/gtsam/geometry/SOn.h
+++ b/gtsam/geometry/SOn.h
@@ -30,6 +30,9 @@
 #include <vector>
 #include <random>
 
+ // For save/load
+#include <boost/serialization/split_member.hpp>
+
 namespace gtsam {
 
 namespace internal {
@@ -293,6 +296,10 @@ class SO : public LieGroup<SO<N>, internal::DimensionSO(N)> {
   /// @}
 
   template <class Archive>
+  friend void save(Archive&, SO&, const unsigned int);
+  template <class Archive>
+  friend void load(Archive&, SO&, const unsigned int);
+  template <class Archive>
   friend void serialize(Archive&, SO&, const unsigned int);
   friend class boost::serialization::access;
   friend class Rot3;  // for serialize
@@ -328,6 +335,16 @@ SOn LieGroup<SOn, Eigen::Dynamic>::compose(const SOn& g, DynamicJacobian H1,
 template <>
 SOn LieGroup<SOn, Eigen::Dynamic>::between(const SOn& g, DynamicJacobian H1,
                                            DynamicJacobian H2) const;
+
+/** Serialization function */
+template<class Archive>
+void serialize(
+  Archive& ar, SOn& Q,
+  const unsigned int file_version
+) {
+  Matrix& M = Q.matrix_;
+  ar& M;
+}
 
 /*
  * Define the traits. internal::LieGroup provides both Lie group and Testable

--- a/gtsam/slam/FrobeniusFactor.h
+++ b/gtsam/slam/FrobeniusFactor.h
@@ -33,7 +33,7 @@ namespace gtsam {
  * isotropic. If it is, we extend to 'Dim' dimensions, otherwise we throw an
  * error. If defaultToUnit == false throws an exception on unexepcted input.
  */
-boost::shared_ptr<noiseModel::Isotropic> ConvertPose3NoiseModel(
+  GTSAM_EXPORT boost::shared_ptr<noiseModel::Isotropic> ConvertPose3NoiseModel(
     const SharedNoiseModel& model, size_t d, bool defaultToUnit = true);
 
 /**
@@ -125,7 +125,7 @@ class FrobeniusBetweenFactor : public NoiseModelFactor2<Rot, Rot> {
  * the SO(p) matrices down to a Stiefel manifold of p*d matrices.
  * TODO(frank): template on D=2 or 3
  */
-class FrobeniusWormholeFactor : public NoiseModelFactor2<SOn, SOn> {
+class GTSAM_EXPORT FrobeniusWormholeFactor : public NoiseModelFactor2<SOn, SOn> {
   Matrix M_;                   ///< measured rotation between R1 and R2
   size_t p_, pp_, dimension_;  ///< dimensionality constants
   Matrix G_;                   ///< matrix of vectorized generators


### PR DESCRIPTION
1) Some serialization code was missing from `SOn.h` (not sure why this wouldn't have been a problem before building the MATLAB toolbox ...). I grabbed the added code from the `feature/new_wrapper` branch.

2) FrobeniusFactor stuff needed a couple `GTSAM_EXPORT` statements

Passes Windows building (don't have access to my Linux box at the moment)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/borglab/gtsam/381)
<!-- Reviewable:end -->
