### PR TITLE
Suppress 3rd Party Warnings in Release mode

### DIFF
--- a/gtsam/CMakeLists.txt
+++ b/gtsam/CMakeLists.txt
@@ -106,7 +106,7 @@ add_library(gtsam ${gtsam_srcs})
 target_link_libraries(gtsam PUBLIC ${GTSAM_BOOST_LIBRARIES})
 target_link_libraries(gtsam PUBLIC ${GTSAM_ADDITIONAL_LIBRARIES})
 
-if(${CMAKE_BUILD_TYPE} STREQUAL "Release")
+if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
   # Suppress warnings if Release build
   target_compile_options(gtsam PRIVATE -w)
 endif()

--- a/gtsam/CMakeLists.txt
+++ b/gtsam/CMakeLists.txt
@@ -189,7 +189,7 @@ set(GTSAM_EXPORTED_TARGETS "${GTSAM_EXPORTED_TARGETS}" PARENT_SCOPE)
 # Make sure that ccolamd compiles even in face of warnings
 # and suppress all warnings from 3rd party code if Release build
 if(WIN32)
-  set_source_files_properties(${3rdparty_srcs} PROPERTIES COMPILE_FLAGS "-w")
+  set_source_files_properties(${3rdparty_srcs} PROPERTIES COMPILE_FLAGS "/w")
 else()
   if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
     # Suppress all warnings from 3rd party sources.

--- a/gtsam/CMakeLists.txt
+++ b/gtsam/CMakeLists.txt
@@ -15,7 +15,7 @@ set (gtsam_subdirs
     sfm
     slam
     smart
-	navigation
+	  navigation
 )
 
 set(gtsam_srcs)
@@ -106,11 +106,6 @@ add_library(gtsam ${gtsam_srcs})
 target_link_libraries(gtsam PUBLIC ${GTSAM_BOOST_LIBRARIES})
 target_link_libraries(gtsam PUBLIC ${GTSAM_ADDITIONAL_LIBRARIES})
 
-if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
-  # Suppress warnings if Release build
-  target_compile_options(gtsam PRIVATE -w)
-endif()
-
 # Apply build flags:
 gtsam_apply_build_flags(gtsam)
 
@@ -191,11 +186,17 @@ install(
 list(APPEND GTSAM_EXPORTED_TARGETS gtsam)
 set(GTSAM_EXPORTED_TARGETS "${GTSAM_EXPORTED_TARGETS}" PARENT_SCOPE)
 
-# make sure that ccolamd compiles even in face of warnings
+# Make sure that ccolamd compiles even in face of warnings
+# and suppress all warnings from 3rd party code if Release build
 if(WIN32)
-    set_source_files_properties(${3rdparty_srcs} PROPERTIES COMPILE_FLAGS "-w")
+  set_source_files_properties(${3rdparty_srcs} PROPERTIES COMPILE_FLAGS "-w")
 else()
+  if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+    # Suppress all warnings from 3rd party sources.
+    set_source_files_properties(${3rdparty_srcs} PROPERTIES COMPILE_FLAGS "-w")
+  else()
     set_source_files_properties(${3rdparty_srcs} PROPERTIES COMPILE_FLAGS "-Wno-error")
+  endif()
 endif()
 
 # Create the matlab toolbox for the gtsam library

--- a/gtsam/CMakeLists.txt
+++ b/gtsam/CMakeLists.txt
@@ -106,6 +106,11 @@ add_library(gtsam ${gtsam_srcs})
 target_link_libraries(gtsam PUBLIC ${GTSAM_BOOST_LIBRARIES})
 target_link_libraries(gtsam PUBLIC ${GTSAM_ADDITIONAL_LIBRARIES})
 
+if(${CMAKE_BUILD_TYPE} STREQUAL "Release")
+  # Suppress warnings if Release build
+  target_compile_options(gtsam PRIVATE -w)
+endif()
+
 # Apply build flags:
 gtsam_apply_build_flags(gtsam)
 


### PR DESCRIPTION
Some of GTSAM's users have complained about GTSAM emitting warnings which are harmless but spam their logging system.

This PR suppresses the warnings on release build (only!) for 3rd party code to fix this issue.

Warnings from primarily GTSAM code will still show as is the best practice.
