### PR TITLE
CombinedImuParams Equality Comparison

### DIFF
--- a/gtsam/navigation/CombinedImuFactor.cpp
+++ b/gtsam/navigation/CombinedImuFactor.cpp
@@ -44,7 +44,7 @@ void PreintegrationCombinedParams::print(const string& s) const {
 }
 
 //------------------------------------------------------------------------------
-bool PreintegrationCombinedParams::equals(const PreintegrationParams& other,
+bool PreintegrationCombinedParams::equals(const PreintegratedRotationParams& other,
                                   double tol) const {
   auto e = dynamic_cast<const PreintegrationCombinedParams*>(&other);
   return e != nullptr && PreintegrationParams::equals(other, tol) &&

--- a/gtsam/navigation/CombinedImuFactor.h
+++ b/gtsam/navigation/CombinedImuFactor.h
@@ -88,7 +88,7 @@ struct GTSAM_EXPORT PreintegrationCombinedParams : PreintegrationParams {
   }
 
   void print(const std::string& s="") const;
-  bool equals(const PreintegrationParams& other, double tol) const;
+  bool equals(const PreintegratedRotationParams& other, double tol) const;
 
   void setBiasAccCovariance(const Matrix3& cov) { biasAccCovariance=cov; }
   void setBiasOmegaCovariance(const Matrix3& cov) { biasOmegaCovariance=cov; }


### PR DESCRIPTION
Fix the equality comparison of CombinedImuParams by performing it with PreintegratedRotationParams class types.
This tackles any warnings issues of "hiding" of the equals method.