### PR TITLE
Travis timeout fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: cpp
 cache: ccache
-sudo: required
 dist: xenial
 
 addons:
@@ -33,7 +32,7 @@ stages:
 
 env:
   global:
-    - MAKEFLAGS="-j2"
+    - MAKEFLAGS="-j3"
     - CCACHE_SLOPPINESS=pch_defines,time_macros
 
 # Compile stage without building examples/tests to populate the caches.


### PR DESCRIPTION
Travis has been timing out a lot recently due to the increase in unit tests (especially for DEBUG builds).

This PR increases the number of make cores from 2 to 3.
I also removed the `sudo` requirement since travis has deprecated that.