### PR TITLE
remove empty smart folder

### DIFF
--- a/gtsam/CMakeLists.txt
+++ b/gtsam/CMakeLists.txt
@@ -14,7 +14,6 @@ set (gtsam_subdirs
     sam
     sfm
     slam
-    smart
 	  navigation
 )
 

--- a/gtsam/smart/CMakeLists.txt
+++ b/gtsam/smart/CMakeLists.txt
@@ -1,6 +1,0 @@
-# Install headers
-file(GLOB smart_headers "*.h")
-install(FILES ${smart_headers} DESTINATION include/gtsam/smart)
-
-# Build tests
-add_subdirectory(tests)

--- a/gtsam/smart/tests/CMakeLists.txt
+++ b/gtsam/smart/tests/CMakeLists.txt
@@ -1,1 +1,0 @@
-gtsamAddTestsGlob(smart "test*.cpp" "" "gtsam")


### PR DESCRIPTION
I was wondering if we can remove the `gtsam/smart/` folder? It's been empty for 6 years.