### PR TITLE
Allow factors to be disabled manually

### DIFF
--- a/gtsam/inference/Factor.h
+++ b/gtsam/inference/Factor.h
@@ -71,10 +71,13 @@ typedef FastSet<FactorIndex> FactorIndexSet;
     /// The keys involved in this factor
     KeyVector keys_;
 
+    /// Whether this factor is active (default=true) and should be included in optimizations.
+    bool active_ = true;
+
     /// @name Standard Constructors
     /// @{
 
-    /** Default constructor for I/O */
+    /** Default constructor for serialization */
     Factor() {}
 
     /** Construct factor from container of keys.  This constructor is used internally from derived factor
@@ -128,6 +131,13 @@ typedef FastSet<FactorIndex> FactorIndexSet;
     */
     size_t size() const { return keys_.size(); }
 
+    /// See NonLinearFactor::active().
+    bool active() const { return active_; }
+
+    /// Changes the default "active" status of this factor.
+    void active(bool newActiveValue) { active_ = newActiveValue; }
+
+
     /// @}
 
 
@@ -163,8 +173,9 @@ typedef FastSet<FactorIndex> FactorIndexSet;
     /** Serialization function */
     friend class boost::serialization::access;
     template<class Archive>
-    void serialize(Archive & ar, const unsigned int /*version*/) {
+    void serialize(Archive & ar, const unsigned int version) {
       ar & BOOST_SERIALIZATION_NVP(keys_);
+      if (version>=1) ar & BOOST_SERIALIZATION_NVP(active_);
     }
 
     /// @}
@@ -172,3 +183,5 @@ typedef FastSet<FactorIndex> FactorIndexSet;
   };
 
 }
+
+BOOST_CLASS_VERSION(gtsam::Factor, 1)

--- a/gtsam/nonlinear/NonlinearFactor.h
+++ b/gtsam/nonlinear/NonlinearFactor.h
@@ -102,15 +102,19 @@ public:
 
   /**
    * Checks whether a factor should be used based on a set of values.
-   * This is primarily used to implment inequality constraints that
+   * This is primarily used to implement inequality constraints that
    * require a variable active set. For all others, the default implementation
-   * returning true solves this problem.
+   * returns the base Factor's active status, which defaults to true but
+   * can be manually overriden with Factor::active(bool).
    *
    * In an inequality/bounding constraint, this active() returns true
    * when the constraint is *NOT* fulfilled.
-   * @return true if the constraint is active
+   * @return true if the factor/constraint is active
    */
-  virtual bool active(const Values& /*c*/) const { return true; }
+  virtual bool active(const Values& /*c*/) const { return Factor::active(); }
+
+  /// Changes the default "active" status of this factor.
+  void active(bool newActiveValue) { Factor::active(newActiveValue); }
 
   /** linearize to a GaussianFactor */
   virtual boost::shared_ptr<GaussianFactor>


### PR DESCRIPTION
`NonLinearFactor::active()` always returned true by default. This PR allows this to be overriden via a new `Factor::active(bool)`. 

Why the implementation has been moved down to Factor instead of NonLinearFactor since?
- Factor already had a serializable state, whose version has been bumped. Introducing serialize in NonLinearFactor would have implied way more code changes in derived classes.
- Conceptually, it's a generic status that applied to plain linear factor (doesn't need the "Values").

See new unit tests for usage example.