### PR TITLE
Update plot_pose2 to stop trying to set zlabel on axes with no z-axis

### DIFF
--- a/cython/gtsam/utils/plot.py
+++ b/cython/gtsam/utils/plot.py
@@ -155,7 +155,6 @@ def plot_pose2(fignum, pose, axis_length=0.1, covariance=None,
 
     axes.set_xlabel(axis_labels[0])
     axes.set_ylabel(axis_labels[1])
-    axes.set_zlabel(axis_labels[2])
 
     return fig
 


### PR DESCRIPTION
Currently, the python util `plot_pose2` tries to call `set_zlabel` on an Axes object with no z-axis.

This causes
```
AttributeError: 'AxesSubplot' object has no attribute 'set_zlabel'
```
and breaks at least the `Pose2SLAMExample.py` example.