### PR TITLE
Fix pose2 align bug.

### DIFF
--- a/gtsam/geometry/Pose2.cpp
+++ b/gtsam/geometry/Pose2.cpp
@@ -322,10 +322,10 @@ boost::optional<Pose2> align(const vector<Point2Pair>& pairs) {
   // calculate cos and sin
   double c=0,s=0;
   for(const Point2Pair& pair: pairs) {
-    Point2 dq = pair.first  - cp;
-    Point2 dp = pair.second - cq;
-    c +=  dp.x() * dq.x() + dp.y() * dq.y();
-    s +=  dp.y() * dq.x() - dp.x() * dq.y(); // this works but is negative from formula above !! :-(
+    Point2 dp = pair.first - cp;
+    Point2 dq = pair.second - cq;
+    c += dp.x() * dq.x() + dp.y() * dq.y();
+    s += -dp.y() * dq.x() + dp.x() * dq.y();
   }
 
   // calculate angle and translation


### PR DESCRIPTION
In pose2 align function, the code does not align with the formula:
    cos ~ sum(dpx*dqx + dpy*dqy) and sin ~ sum(-dpy*dqx + dpx*dqy)

This is clearly due to an incorrect variable declaration as **dp** should generate from **cp** and **dq** should generate from **cq**. To correct the code, I just switch the **dp** and **dq** variable.