### PR TITLE
New readBal function

### DIFF
--- a/gtsam/slam/dataset.cpp
+++ b/gtsam/slam/dataset.cpp
@@ -1130,6 +1130,13 @@ bool readBAL(const string &filename, SfmData &data) {
 }
 
 /* ************************************************************************* */
+SfmData readBAL(const string &filename) {
+  SfmData data;
+  readBAL(filename, data);
+  return data;
+}
+
+/* ************************************************************************* */
 bool writeBAL(const string &filename, SfmData &data) {
   // Open the output file
   ofstream os;

--- a/gtsam/slam/dataset.cpp
+++ b/gtsam/slam/dataset.cpp
@@ -1130,7 +1130,7 @@ bool readBAL(const string &filename, SfmData &data) {
 }
 
 /* ************************************************************************* */
-SfmData readBAL(const string &filename) {
+SfmData readBal(const string &filename) {
   SfmData data;
   readBAL(filename, data);
   return data;

--- a/gtsam/slam/dataset.h
+++ b/gtsam/slam/dataset.h
@@ -278,6 +278,14 @@ GTSAM_EXPORT bool readBundler(const std::string& filename, SfmData &data);
 GTSAM_EXPORT bool readBAL(const std::string& filename, SfmData &data);
 
 /**
+ * @brief This function parses a "Bundle Adjustment in the Large" (BAL) file and returns the data
+ * as a SfmData structure. Mainly used by wrapped code.
+ * @param filename The name of the BAL file.
+ * @return SfM structure where the data is stored.
+ */
+GTSAM_EXPORT SfmData readBAL(const std::string& filename);
+
+/**
  * @brief This function writes a "Bundle Adjustment in the Large" (BAL) file from a
  * SfmData structure
  * @param filename The name of the BAL file to write

--- a/gtsam/slam/dataset.h
+++ b/gtsam/slam/dataset.h
@@ -283,7 +283,7 @@ GTSAM_EXPORT bool readBAL(const std::string& filename, SfmData &data);
  * @param filename The name of the BAL file.
  * @return SfM structure where the data is stored.
  */
-GTSAM_EXPORT SfmData readBAL(const std::string& filename);
+GTSAM_EXPORT SfmData readBal(const std::string& filename);
 
 /**
  * @brief This function writes a "Bundle Adjustment in the Large" (BAL) file from a


### PR DESCRIPTION
This PR adds a new function readBal which returns the SfmData object, allowing for single line calling.

This function is particularly useful with the wrapper.

E.g.
```cpp
SfmData data = readBal("example.bal")
```
rather than
```
SfmData data;
readBAL("example.bal", data);
```

*Note* I followed Google style when naming the function.