### PR TITLE
Automatically find Python3 version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,11 @@ if(GTSAM_BUILD_PYTHON)
     endif()
 
     if(${GTSAM_PYTHON_VERSION} STREQUAL "Default")
-        set(GTSAM_PYTHON_VERSION "${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}" CACHE STRING "The version of Python to build the wrappers against." FORCE)
+        set(GTSAM_PYTHON_VERSION "${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}"
+                CACHE
+                STRING
+                "The version of Python to build the wrappers against."
+                FORCE)
     endif()
 
     if(GTSAM_UNSTABLE_BUILD_PYTHON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,11 @@ set (GTSAM_VERSION_PATCH 0)
 math (EXPR GTSAM_VERSION_NUMERIC "10000 * ${GTSAM_VERSION_MAJOR} + 100 * ${GTSAM_VERSION_MINOR} + ${GTSAM_VERSION_PATCH}")
 set (GTSAM_VERSION_STRING "${GTSAM_VERSION_MAJOR}.${GTSAM_VERSION_MINOR}.${GTSAM_VERSION_PATCH}")
 
+set (CMAKE_PROJECT_VERSION ${GTSAM_VERSION_STRING})
+set (CMAKE_PROJECT_VERSION_MAJOR ${GTSAM_VERSION_MAJOR})
+set (CMAKE_PROJECT_VERSION_MINOR ${GTSAM_VERSION_MINOR})
+set (CMAKE_PROJECT_VERSION_PATCH ${GTSAM_VERSION_PATCH})
+
 ###############################################################################
 # Gather information, perform checks, set defaults
 
@@ -113,6 +118,18 @@ if(GTSAM_INSTALL_MATLAB_TOOLBOX AND NOT BUILD_SHARED_LIBS)
 endif()
 
 if(GTSAM_BUILD_PYTHON)
+    # Get info about the Python3 interpreter
+    # https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3
+    find_package(Python3 COMPONENTS Interpreter Development)
+
+    if(NOT ${Python3_FOUND})
+        message(FATAL_ERROR "Cannot find Python3 interpreter. Please install Python >= 3.6.")
+    endif()
+
+    if(${GTSAM_PYTHON_VERSION} STREQUAL "Default")
+        set(GTSAM_PYTHON_VERSION "${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}" CACHE STRING "The version of Python to build the wrappers against." FORCE)
+    endif()
+
     if(GTSAM_UNSTABLE_BUILD_PYTHON)
         if (NOT GTSAM_BUILD_UNSTABLE)
             message(WARNING "GTSAM_UNSTABLE_BUILD_PYTHON requires the unstable module to be enabled.")

--- a/cmake/FindNumPy.cmake
+++ b/cmake/FindNumPy.cmake
@@ -40,17 +40,9 @@
 
 # Finding NumPy involves calling the Python interpreter
 if(NumPy_FIND_REQUIRED)
-  if(GTSAM_PYTHON_VERSION STREQUAL "Default")
-    find_package(PythonInterp REQUIRED)
-  else()
-      find_package(PythonInterp ${GTSAM_PYTHON_VERSION} EXACT REQUIRED)
-  endif()
+  find_package(PythonInterp ${GTSAM_PYTHON_VERSION} EXACT REQUIRED)
 else()
-  if(GTSAM_PYTHON_VERSION STREQUAL "Default")
-    find_package(PythonInterp)
-  else()
-    find_package(PythonInterp ${GTSAM_PYTHON_VERSION} EXACT)
-  endif()
+  find_package(PythonInterp ${GTSAM_PYTHON_VERSION} EXACT)
 endif()
 
 if(NOT PYTHONINTERP_FOUND)

--- a/cmake/GtsamMatlabWrap.cmake
+++ b/cmake/GtsamMatlabWrap.cmake
@@ -215,19 +215,15 @@ function(wrap_library_internal interfaceHeader linkLibraries extraIncludeDirs ex
 	# Set up generation of module source file
 	file(MAKE_DIRECTORY "${generated_files_path}")
 
-	if(GTSAM_PYTHON_VERSION STREQUAL "Default")
-		find_package(PythonInterp REQUIRED)
-		find_package(PythonLibs REQUIRED)
-	else()
-		find_package(PythonInterp
-				${GTSAM_PYTHON_VERSION}
-				EXACT
-				REQUIRED)
-		find_package(PythonLibs
-				${GTSAM_PYTHON_VERSION}
-				EXACT
-				REQUIRED)
-	endif()
+    find_package(PythonInterp
+            ${GTSAM_PYTHON_VERSION}
+            EXACT
+            REQUIRED)
+    find_package(PythonLibs
+            ${GTSAM_PYTHON_VERSION}
+            EXACT
+            REQUIRED)
+
 
 	set(_ignore gtsam::Point2
 			gtsam::Point3)


### PR DESCRIPTION
Use CMake to identify best Python3 version if `Default` requested.
Note that the CMake code looks specifically for Python3 as we shouldn't be supporting the EOL'd Python2.

This also helps get rid of a bunch of checks for the `Default` value.

Fixes #519 and #522.