### PR TITLE
Normalize rotations after composition

### DIFF
--- a/gtsam/geometry/Rot3.h
+++ b/gtsam/geometry/Rot3.h
@@ -435,7 +435,7 @@ namespace gtsam {
      * This means either re-orthogonalizing the Matrix representation or
      * normalizing the quaternion representation.
      */
-    Rot3 normalize(const Rot3& R) const;
+    Rot3 normalized() const;
 
     /// @deprecated, this is base 1, and was just confusing
     Point3 column(int index) const;

--- a/gtsam/geometry/Rot3.h
+++ b/gtsam/geometry/Rot3.h
@@ -430,6 +430,13 @@ namespace gtsam {
      */
     Matrix3 transpose() const;
 
+    /**
+     * Normalize rotation so that its determinant is 1.
+     * This means either re-orthogonalizing the Matrix representation or
+     * normalizing the quaternion representation.
+     */
+    Rot3 normalize(const Rot3& R) const;
+
     /// @deprecated, this is base 1, and was just confusing
     Point3 column(int index) const;
 

--- a/gtsam/geometry/Rot3.h
+++ b/gtsam/geometry/Rot3.h
@@ -262,8 +262,28 @@ namespace gtsam {
     static Rot3 AlignTwoPairs(const Unit3& a_p, const Unit3& b_p,  //
                               const Unit3& a_q, const Unit3& b_q);
 
-    /// Static, named constructor that finds Rot3 element closest to M in Frobenius norm.
+    /**
+     * Static, named constructor that finds Rot3 element closest to M in Frobenius norm.
+     * 
+     * Uses Full SVD to compute the orthogonal matrix, thus is highly accurate and robust.
+     * 
+     * N. J. Higham. Matrix nearness problems and applications.
+     * In M. J. C. Gover and S. Barnett, editors, Applications of Matrix Theory, pages 1–27.
+     * Oxford University Press, 1989.
+     */
     static Rot3 ClosestTo(const Matrix3& M) { return Rot3(SO3::ClosestTo(M)); }
+
+    /**
+     * Normalize rotation so that its determinant is 1.
+     * This means either re-orthogonalizing the Matrix representation or
+     * normalizing the quaternion representation.
+     *
+     * This method is akin to `ClosestTo` but uses a computationally cheaper
+     * algorithm.
+     * 
+     * Ref: https://drive.google.com/file/d/0B9rLLz1XQKmaZTlQdV81QjNoZTA/view
+     */
+    Rot3 normalized() const;
 
     /// @}
     /// @name Testable
@@ -429,13 +449,6 @@ namespace gtsam {
      * Return 3*3 transpose (inverse) rotation matrix
      */
     Matrix3 transpose() const;
-
-    /**
-     * Normalize rotation so that its determinant is 1.
-     * This means either re-orthogonalizing the Matrix representation or
-     * normalizing the quaternion representation.
-     */
-    Rot3 normalized() const;
 
     /// @deprecated, this is base 1, and was just confusing
     Point3 column(int index) const;

--- a/gtsam/geometry/Rot3M.cpp
+++ b/gtsam/geometry/Rot3M.cpp
@@ -111,7 +111,6 @@ Rot3 Rot3::RzRyRx(double x, double y, double z, OptionalJacobian<3, 1> Hx,
 /* ************************************************************************* */
 Rot3 Rot3::normalized() const {
   /// Implementation from here: https://stackoverflow.com/a/23082112/1236990
-  /// Theory: https://drive.google.com/file/d/0B9rLLz1XQKmaZTlQdV81QjNoZTA/view
 
   /// Essentially, this computes the orthogonalization error, distributes the
   /// error to the x and y rows, and then performs a Taylor expansion to

--- a/gtsam/geometry/Rot3M.cpp
+++ b/gtsam/geometry/Rot3M.cpp
@@ -109,7 +109,7 @@ Rot3 Rot3::RzRyRx(double x, double y, double z, OptionalJacobian<3, 1> Hx,
 }
 
 /* ************************************************************************* */
-Rot3 Rot3::normalize(const Rot3& R) const {
+Rot3 Rot3::normalized() const {
   /// Implementation from here: https://stackoverflow.com/a/23082112/1236990
   /// Theory: https://drive.google.com/file/d/0B9rLLz1XQKmaZTlQdV81QjNoZTA/view
 
@@ -117,9 +117,11 @@ Rot3 Rot3::normalize(const Rot3& R) const {
   /// error to the x and y rows, and then performs a Taylor expansion to
   /// orthogonalize.
 
-  Matrix3 rot = R.matrix(), rot_new;
+  Matrix3 rot = rot_.matrix(), rot_orth;
 
-  if (std::fabs(rot.determinant()-1) < 1e-12) return R;
+  // Check if determinant is already 1.
+  // If yes, then return the current Rot3.
+  if (std::fabs(rot.determinant()-1) < 1e-12) return Rot3(rot_);
 
   Vector3 x = rot.block<1, 3>(0, 0), y = rot.block<1, 3>(1, 0);
   double error = x.dot(y);
@@ -127,16 +129,16 @@ Rot3 Rot3::normalize(const Rot3& R) const {
   Vector3 x_ort = x - (error / 2) * y, y_ort = y - (error / 2) * x;
   Vector3 z_ort = x_ort.cross(y_ort);
 
-  rot_new.block<1, 3>(0, 0) = 0.5 * (3 - x_ort.dot(x_ort)) * x_ort;
-  rot_new.block<1, 3>(1, 0) = 0.5 * (3 - y_ort.dot(y_ort)) * y_ort;
-  rot_new.block<1, 3>(2, 0) = 0.5 * (3 - z_ort.dot(z_ort)) * z_ort;
+  rot_orth.block<1, 3>(0, 0) = 0.5 * (3 - x_ort.dot(x_ort)) * x_ort;
+  rot_orth.block<1, 3>(1, 0) = 0.5 * (3 - y_ort.dot(y_ort)) * y_ort;
+  rot_orth.block<1, 3>(2, 0) = 0.5 * (3 - z_ort.dot(z_ort)) * z_ort;
 
-  return Rot3(rot_new);
+  return Rot3(rot_orth);
 }
 
 /* ************************************************************************* */
 Rot3 Rot3::operator*(const Rot3& R2) const {
-  return normalize(Rot3(rot_*R2.rot_));
+  return Rot3(rot_*R2.rot_);
 }
 
 /* ************************************************************************* */

--- a/gtsam/geometry/Rot3M.cpp
+++ b/gtsam/geometry/Rot3M.cpp
@@ -109,8 +109,34 @@ Rot3 Rot3::RzRyRx(double x, double y, double z, OptionalJacobian<3, 1> Hx,
 }
 
 /* ************************************************************************* */
+Rot3 Rot3::normalize(const Rot3& R) const {
+  /// Implementation from here: https://stackoverflow.com/a/23082112/1236990
+  /// Theory: https://drive.google.com/file/d/0B9rLLz1XQKmaZTlQdV81QjNoZTA/view
+
+  /// Essentially, this computes the orthogonalization error, distributes the
+  /// error to the x and y rows, and then performs a Taylor expansion to
+  /// orthogonalize.
+
+  Matrix3 rot = R.matrix(), rot_new;
+
+  if (std::fabs(rot.determinant()-1) < 1e-12) return R;
+
+  Vector3 x = rot.block<1, 3>(0, 0), y = rot.block<1, 3>(1, 0);
+  double error = x.dot(y);
+
+  Vector3 x_ort = x - (error / 2) * y, y_ort = y - (error / 2) * x;
+  Vector3 z_ort = x_ort.cross(y_ort);
+
+  rot_new.block<1, 3>(0, 0) = 0.5 * (3 - x_ort.dot(x_ort)) * x_ort;
+  rot_new.block<1, 3>(1, 0) = 0.5 * (3 - y_ort.dot(y_ort)) * y_ort;
+  rot_new.block<1, 3>(2, 0) = 0.5 * (3 - z_ort.dot(z_ort)) * z_ort;
+
+  return Rot3(rot_new);
+}
+
+/* ************************************************************************* */
 Rot3 Rot3::operator*(const Rot3& R2) const {
-  return Rot3(rot_*R2.rot_);
+  return normalize(Rot3(rot_*R2.rot_));
 }
 
 /* ************************************************************************* */

--- a/gtsam/geometry/Rot3Q.cpp
+++ b/gtsam/geometry/Rot3Q.cpp
@@ -87,8 +87,12 @@ namespace gtsam {
   }
 
   /* ************************************************************************* */
+  Rot3 Rot3::normalize(const Rot3& R) const {
+    return Rot3(R.quaternion_.normalized());
+  }
+  /* ************************************************************************* */
   Rot3 Rot3::operator*(const Rot3& R2) const {
-    return Rot3(quaternion_ * R2.quaternion_);
+    return normalize(Rot3(quaternion_ * R2.quaternion_));
   }
 
   /* ************************************************************************* */

--- a/gtsam/geometry/Rot3Q.cpp
+++ b/gtsam/geometry/Rot3Q.cpp
@@ -87,12 +87,12 @@ namespace gtsam {
   }
 
   /* ************************************************************************* */
-  Rot3 Rot3::normalize(const Rot3& R) const {
-    return Rot3(R.quaternion_.normalized());
+  Rot3 Rot3::normalized() const {
+    return Rot3(quaternion_.normalized());
   }
   /* ************************************************************************* */
   Rot3 Rot3::operator*(const Rot3& R2) const {
-    return normalize(Rot3(quaternion_ * R2.quaternion_));
+    return Rot3(quaternion_ * R2.quaternion_);
   }
 
   /* ************************************************************************* */

--- a/gtsam/geometry/tests/testRot3.cpp
+++ b/gtsam/geometry/tests/testRot3.cpp
@@ -911,6 +911,26 @@ TEST(Rot3, yaw_derivative) {
 }
 
 /* ************************************************************************* */
+TEST(Rot3, determinant) {
+  size_t degree = 1;
+  Rot3 R_w0;  // Zero rotation
+  Rot3 R_w1 = Rot3::Ry(degree * M_PI / 180);
+
+  Rot3 R_01, R_w2;
+  double actual, expected = 1.0;
+
+  for (size_t i = 2; i < 360; ++i) {
+    R_01 = R_w0.between(R_w1);
+    R_w2 = R_w1 * R_01;
+    R_w0 = R_w1;
+    R_w1 = R_w2;
+    actual = R_w2.matrix().determinant();
+
+    EXPECT_DOUBLES_EQUAL(expected, actual, 1e-7);
+  }
+}
+
+/* ************************************************************************* */
 int main() {
   TestResult tr;
   return TestRegistry::runAllTests(tr);

--- a/gtsam/geometry/tests/testRot3.cpp
+++ b/gtsam/geometry/tests/testRot3.cpp
@@ -923,7 +923,7 @@ TEST(Rot3, determinant) {
     R_01 = R_w0.between(R_w1);
     R_w2 = R_w1 * R_01;
     R_w0 = R_w1;
-    R_w1 = R_w2;
+    R_w1 = R_w2.normalized();
     actual = R_w2.matrix().determinant();
 
     EXPECT_DOUBLES_EQUAL(expected, actual, 1e-7);


### PR DESCRIPTION
This PR fixes #372 

I added `normalize` function to orthogonalize the rotation after composition for the matrix representation and I used the `normalized` method for the quaternion representation.

I added a test case based on #372 and while it initially failed, it now succeeds, validating this approach.

The idea is from [here](https://drive.google.com/file/d/0B9rLLz1XQKmaZTlQdV81QjNoZTA/view).