### PR TITLE
Add alternativeName() for symbols

### DIFF
--- a/gtsam/inference/Symbol.h
+++ b/gtsam/inference/Symbol.h
@@ -165,13 +165,15 @@ inline Key Z(std::uint64_t j) { return Symbol('z', j); }
 
 /** Generates symbol shorthands with alternative names different than the
  * one-letter predefined ones. */
-inline std::function<Key(std::uint64_t)> alternativeName(const char c) {
-	return [c](std::uint64_t j) { return gtsam::Symbol(c, j); };
-}
+class SymbolGenerator {
+  const char c_;
+public:
+  SymbolGenerator(const char c) : c_(c) {}
+  Symbol operator()(const std::uint64_t j) const { return Symbol(c_, j); }
+};
 }
 
 /// traits
 template<> struct traits<Symbol> : public Testable<Symbol> {};
 
 } // \ namespace gtsam
-

--- a/gtsam/inference/Symbol.h
+++ b/gtsam/inference/Symbol.h
@@ -162,6 +162,12 @@ inline Key W(std::uint64_t j) { return Symbol('w', j); }
 inline Key X(std::uint64_t j) { return Symbol('x', j); }
 inline Key Y(std::uint64_t j) { return Symbol('y', j); }
 inline Key Z(std::uint64_t j) { return Symbol('z', j); }
+
+/** Generates symbol shorthands with alternative names different than the
+ * one-letter predefined ones. */
+inline std::function<Key(std::uint64_t)> alternativeName(const char c) {
+	return [c](std::uint64_t j) { return gtsam::Symbol(c, j); };
+}
 }
 
 /// traits

--- a/gtsam/inference/Symbol.h
+++ b/gtsam/inference/Symbol.h
@@ -162,6 +162,7 @@ inline Key W(std::uint64_t j) { return Symbol('w', j); }
 inline Key X(std::uint64_t j) { return Symbol('x', j); }
 inline Key Y(std::uint64_t j) { return Symbol('y', j); }
 inline Key Z(std::uint64_t j) { return Symbol('z', j); }
+}
 
 /** Generates symbol shorthands with alternative names different than the
  * one-letter predefined ones. */
@@ -171,7 +172,6 @@ public:
   SymbolGenerator(const char c) : c_(c) {}
   Symbol operator()(const std::uint64_t j) const { return Symbol(c_, j); }
 };
-}
 
 /// traits
 template<> struct traits<Symbol> : public Testable<Symbol> {};

--- a/gtsam/inference/tests/testKey.cpp
+++ b/gtsam/inference/tests/testKey.cpp
@@ -41,14 +41,14 @@ TEST(Key, KeySymbolConversion) {
 }
 
 /* ************************************************************************* */
-TEST(Key, SymbolAlternativeNames) {
+TEST(Key, SymbolGenerator) {
   const auto x1 = gtsam::symbol_shorthand::X(1);
   const auto v1 = gtsam::symbol_shorthand::V(1);
   const auto a1 = gtsam::symbol_shorthand::A(1);
 
-  const auto Z = gtsam::symbol_shorthand::alternativeName('x');
-  const auto DZ = gtsam::symbol_shorthand::alternativeName('v');
-  const auto DDZ = gtsam::symbol_shorthand::alternativeName('a');
+  const auto Z = gtsam::symbol_shorthand::SymbolGenerator('x');
+  const auto DZ = gtsam::symbol_shorthand::SymbolGenerator('v');
+  const auto DDZ = gtsam::symbol_shorthand::SymbolGenerator('a');
 
   const auto z1 = Z(1);
   const auto dz1 = DZ(1);
@@ -125,4 +125,3 @@ int main() {
   return TestRegistry::runAllTests(tr);
 }
 /* ************************************************************************* */
-

--- a/gtsam/inference/tests/testKey.cpp
+++ b/gtsam/inference/tests/testKey.cpp
@@ -41,6 +41,25 @@ TEST(Key, KeySymbolConversion) {
 }
 
 /* ************************************************************************* */
+TEST(Key, SymbolAlternativeNames) {
+  const auto x1 = gtsam::symbol_shorthand::X(1);
+  const auto v1 = gtsam::symbol_shorthand::V(1);
+  const auto a1 = gtsam::symbol_shorthand::A(1);
+
+  const auto Z = gtsam::symbol_shorthand::alternativeName('x');
+  const auto DZ = gtsam::symbol_shorthand::alternativeName('v');
+  const auto DDZ = gtsam::symbol_shorthand::alternativeName('a');
+
+  const auto z1 = Z(1);
+  const auto dz1 = DZ(1);
+  const auto ddz1 = DDZ(1);
+
+  EXPECT(assert_equal(x1, z1));
+  EXPECT(assert_equal(v1, dz1));
+  EXPECT(assert_equal(a1, ddz1));
+}
+
+/* ************************************************************************* */
 template<int KeySize>
 Key KeyTestValue();
 

--- a/gtsam/inference/tests/testKey.cpp
+++ b/gtsam/inference/tests/testKey.cpp
@@ -46,9 +46,9 @@ TEST(Key, SymbolGenerator) {
   const auto v1 = gtsam::symbol_shorthand::V(1);
   const auto a1 = gtsam::symbol_shorthand::A(1);
 
-  const auto Z = gtsam::symbol_shorthand::SymbolGenerator('x');
-  const auto DZ = gtsam::symbol_shorthand::SymbolGenerator('v');
-  const auto DDZ = gtsam::symbol_shorthand::SymbolGenerator('a');
+  const auto Z = gtsam::SymbolGenerator('x');
+  const auto DZ = gtsam::SymbolGenerator('v');
+  const auto DDZ = gtsam::SymbolGenerator('a');
 
   const auto z1 = Z(1);
   const auto dz1 = DZ(1);


### PR DESCRIPTION
What do you think of this feature? 

It allows writing code with symbol named according to their physical meaning. Check the example in the new unit test. 

Of course, the default KeyFormatter would still return the underlying one-character symbol name, but if someone want to have custom names printed, a custom KeyFormatter would be required.
