### PR TITLE
Avoid redundant calls to error() in NonLinearOptimizer

### DIFF
--- a/gtsam/nonlinear/NonlinearOptimizer.cpp
+++ b/gtsam/nonlinear/NonlinearOptimizer.cpp
@@ -88,20 +88,24 @@ void NonlinearOptimizer::defaultOptimize() {
   }
 
   // Iterative loop
+  double newError = currentError; // used to avoid repeated calls to error()
   do {
     // Do next iteration
-    currentError = error(); // TODO(frank): don't do this twice at first !? Computed above!
+    currentError = newError;
     iterate();
     tictoc_finishedIteration();
 
+    // Update newError for either printouts or conditional-end checks:
+    newError = error();
+    
     // Maybe show output
     if (params.verbosity >= NonlinearOptimizerParams::VALUES)
       values().print("newValues");
     if (params.verbosity >= NonlinearOptimizerParams::ERROR)
-      cout << "newError: " << error() << endl;
+      cout << "newError: " << newError << endl;
   } while (iterations() < params.maxIterations &&
            !checkConvergence(params.relativeErrorTol, params.absoluteErrorTol, params.errorTol,
-                             currentError, error(), params.verbosity) && std::isfinite(currentError));
+                             currentError, newError, params.verbosity) && std::isfinite(currentError));
 
   // Printing if verbose
   if (params.verbosity >= NonlinearOptimizerParams::TERMINATION) {


### PR DESCRIPTION
A simple fix. `error()` was called two times in each iteration (or 3 times if verbose-level was high enough). 
Surely not a huge efficient loss, haven't measured it, but for large graphs it might be noticeable.