### PR TITLE
Ubuntu+GCC9 CI stage

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -19,7 +19,7 @@ jobs:
         # See https://help.github.com/en/articles/workflow-syntax-for-github-actions.
         name: [
           ubuntu-18.04-gcc-5,
-          # ubuntu-18.04-gcc-9,  # TODO Disabled for now because of timeouts
+          ubuntu-18.04-gcc-9,
           ubuntu-18.04-clang-9,
           macOS-10.15-xcode-11.3.1,
           ubuntu-18.04-gcc-5-tbb,
@@ -33,11 +33,10 @@ jobs:
             compiler: gcc
             version: "5"
 
-          # TODO Disabled for now because of timeouts
-          # - name: ubuntu-18.04-gcc-9
-          #   os: ubuntu-18.04
-          #   compiler: gcc
-          #   version: "9"
+          - name: ubuntu-18.04-gcc-9
+            os: ubuntu-18.04
+            compiler: gcc
+            version: "9"
 
           - name: ubuntu-18.04-clang-9
             os: ubuntu-18.04


### PR DESCRIPTION
Github Actions has improved its performance and this particular stage no longer times out, so reintroducing it.