### PR TITLE
Fix issues with maths in docs at gtsam.org

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1188,7 +1188,7 @@ USE_MATHJAX            = YES
 # MathJax, but it is strongly recommended to install a local copy of MathJax 
 # before deployment.
 
-MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
+MATHJAX_RELPATH        = https://cdn.mathjax.org/mathjax/latest
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or MathJax extension 
 # names that should be enabled during MathJax rendering.


### PR DESCRIPTION
The GTSAM docs hosted at gtsam.org do not render equations properly in Chromium (and probably most other browsers). See for instance [JacobianFactor](https://gtsam.org/doxygen/a03183.html).

The reason for this is that gtsam.org uses HTTPS, while the mathjax script is loaded from `http://cdn.mathjax.org`, which makes Chromium give the following error:
```
Mixed Content: The page at 'https://gtsam.org/doxygen/a03183.html' was loaded over HTTPS, but requested an insecure script 'http://cdn.mathjax.org/mathjax/latest/MathJax.js'. This request has been blocked; the content must be served over HTTPS.
```

This patch makes Doxygen use HTTPS against the mathjax CDN instead, which resolves this error for gtsam.org. Needless to say the HTTPS mathjax endpoint also works fine when the gtsam docs are hosted over HTTP.