### PR TITLE
Publish GTSAM artifacts

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -83,3 +83,8 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           bash .github/scripts/unix.sh -t
+      - name: Upload build directory
+        uses: actions/upload-artifact@v2
+          with:
+            name: gtsam-${{ matrix.name }}
+            path: $GITHUB_WORKSPACE/build/

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -85,6 +85,6 @@ jobs:
           bash .github/scripts/unix.sh -t
       - name: Upload build directory
         uses: actions/upload-artifact@v2
-          with:
-            name: gtsam-${{ matrix.name }}
-            path: $GITHUB_WORKSPACE/build/
+        with:
+          name: gtsam-${{ matrix.name }}
+          path: $GITHUB_WORKSPACE/build/

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -85,7 +85,7 @@ jobs:
           bash .github/scripts/unix.sh -t
       - name: Upload build directory
         uses: actions/upload-artifact@v2
-        if: ${{ matrix.build_type }} == "Release"
+        if: ${{ matrix.build_type  == "Release" }}
         with:
           name: gtsam-${{ matrix.name }}-${{ matrix.build_type }}
           path: ${{ github.workspace }}/build/

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -86,5 +86,5 @@ jobs:
       - name: Upload build directory
         uses: actions/upload-artifact@v2
         with:
-          name: gtsam-${{ matrix.name }}
+          name: gtsam-${{ matrix.name }}-${{ matrix.build_type }}
           path: ${{ github.workspace }}/build/

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -87,4 +87,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: gtsam-${{ matrix.name }}
-          path: $GITHUB_WORKSPACE/build/
+          path: ${{ github.workspace }}/build/

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -85,7 +85,7 @@ jobs:
           bash .github/scripts/unix.sh -t
       - name: Upload build directory
         uses: actions/upload-artifact@v2
-        if: ${{ matrix.build_type  == "Release" }}
+        if: matrix.build_type  == 'Release'
         with:
           name: gtsam-${{ matrix.name }}-${{ matrix.build_type }}
           path: ${{ github.workspace }}/build/

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -85,6 +85,7 @@ jobs:
           bash .github/scripts/unix.sh -t
       - name: Upload build directory
         uses: actions/upload-artifact@v2
+        if: ${{ matrix.build_type }} == "Release"
         with:
           name: gtsam-${{ matrix.name }}-${{ matrix.build_type }}
           path: ${{ github.workspace }}/build/

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -51,3 +51,8 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           bash .github/scripts/unix.sh -t
+      - name: Upload build directory
+        uses: actions/upload-artifact@v2
+          with:
+            name: gtsam-${{ matrix.name }}
+            path: $GITHUB_WORKSPACE/build/

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -53,7 +53,7 @@ jobs:
           bash .github/scripts/unix.sh -t
       - name: Upload build directory
         uses: actions/upload-artifact@v2
-        if: ${{ matrix.build_type == "Release" }}
+        if: matrix.build_type == 'Release'
         with:
           name: gtsam-${{ matrix.name }}-${{ matrix.build_type }}
           path: ${{ github.workspace }}/build/

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -55,4 +55,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: gtsam-${{ matrix.name }}
-          path: $GITHUB_WORKSPACE/build/
+          path: ${{ github.workspace }}/build/

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -53,7 +53,7 @@ jobs:
           bash .github/scripts/unix.sh -t
       - name: Upload build directory
         uses: actions/upload-artifact@v2
-        if: ${{ matrix.build_type }} == "Release"
+        if: ${{ matrix.build_type == "Release" }}
         with:
           name: gtsam-${{ matrix.name }}-${{ matrix.build_type }}
           path: ${{ github.workspace }}/build/

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -54,5 +54,5 @@ jobs:
       - name: Upload build directory
         uses: actions/upload-artifact@v2
         with:
-          name: gtsam-${{ matrix.name }}
+          name: gtsam-${{ matrix.name }}-${{ matrix.build_type }}
           path: ${{ github.workspace }}/build/

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -53,6 +53,7 @@ jobs:
           bash .github/scripts/unix.sh -t
       - name: Upload build directory
         uses: actions/upload-artifact@v2
+        if: ${{ matrix.build_type }} == "Release"
         with:
           name: gtsam-${{ matrix.name }}-${{ matrix.build_type }}
           path: ${{ github.workspace }}/build/

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -53,6 +53,6 @@ jobs:
           bash .github/scripts/unix.sh -t
       - name: Upload build directory
         uses: actions/upload-artifact@v2
-          with:
-            name: gtsam-${{ matrix.name }}
-            path: $GITHUB_WORKSPACE/build/
+        with:
+          name: gtsam-${{ matrix.name }}
+          path: $GITHUB_WORKSPACE/build/

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -78,7 +78,7 @@ jobs:
           cmake --build build --config ${{ matrix.build_type }} --target check.linear
       - name: Upload build directory
         uses: actions/upload-artifact@v2
-        if: ${{ matrix.build_type == "Release" }}
+        if: matrix.build_type == 'Release'
         with:
           name: gtsam-${{ matrix.name }}-${{ matrix.build_type }}
           path: ${{ github.workspace }}/build/

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -78,6 +78,7 @@ jobs:
           cmake --build build --config ${{ matrix.build_type }} --target check.linear
       - name: Upload build directory
         uses: actions/upload-artifact@v2
+        if: ${{ matrix.build_type }} == "Release"
         with:
           name: gtsam-${{ matrix.name }}-${{ matrix.build_type }}
           path: ${{ github.workspace }}/build/

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -79,5 +79,5 @@ jobs:
       - name: Upload build directory
         uses: actions/upload-artifact@v2
         with:
-          name: gtsam-${{ matrix.name }}
+          name: gtsam-${{ matrix.name }}-${{ matrix.build_type }}
           path: ${{ github.workspace }}/build/

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -76,3 +76,8 @@ jobs:
           cmake --build build --config ${{ matrix.build_type }} --target check.base
           cmake --build build --config ${{ matrix.build_type }} --target check.base_unstable
           cmake --build build --config ${{ matrix.build_type }} --target check.linear
+      - name: Upload build directory
+        uses: actions/upload-artifact@v2
+        with:
+          name: gtsam-${{ matrix.name }}
+          path: $GITHUB_WORKSPACE/build/

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -80,4 +80,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: gtsam-${{ matrix.name }}
-          path: $GITHUB_WORKSPACE/build/
+          path: ${{ github.workspace }}/build/

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -78,7 +78,7 @@ jobs:
           cmake --build build --config ${{ matrix.build_type }} --target check.linear
       - name: Upload build directory
         uses: actions/upload-artifact@v2
-        if: ${{ matrix.build_type }} == "Release"
+        if: ${{ matrix.build_type == "Release" }}
         with:
           name: gtsam-${{ matrix.name }}-${{ matrix.build_type }}
           path: ${{ github.workspace }}/build/


### PR DESCRIPTION
Updated the Actions workflow to upload the corresponding build directories, so we can use the latest version of GTSAM in CI pipelines for other repos (e.g. GTDynamics).