### PR TITLE
Use KeyVector for proper wrapping with TBB

### DIFF
--- a/gtsam/sfm/MFAS.cpp
+++ b/gtsam/sfm/MFAS.cpp
@@ -121,8 +121,8 @@ MFAS::MFAS(const TranslationEdges& relativeTranslations,
   }
 }
 
-vector<Key> MFAS::computeOrdering() const {
-  vector<Key> ordering;  // Nodes in MFAS order (result).
+KeyVector MFAS::computeOrdering() const {
+  KeyVector ordering;  // Nodes in MFAS order (result).
 
   // A graph is an unordered map from keys to nodes. Each node contains a list
   // of its adjacent nodes. Create the graph from the edgeWeights.
@@ -140,7 +140,7 @@ vector<Key> MFAS::computeOrdering() const {
 
 map<MFAS::KeyPair, double> MFAS::computeOutlierWeights() const {
   // Find the ordering.
-  vector<Key> ordering = computeOrdering();
+  KeyVector ordering = computeOrdering();
 
   // Create a map from the node key to its position in the ordering. This makes
   // it easier to lookup positions of different nodes.

--- a/gtsam/sfm/MFAS.h
+++ b/gtsam/sfm/MFAS.h
@@ -84,7 +84,7 @@ class MFAS {
    * @brief Computes the 1D MFAS ordering of nodes in the graph
    * @return orderedNodes: vector of nodes in the obtained order
    */
-  std::vector<Key> computeOrdering() const;
+  KeyVector computeOrdering() const;
 
   /**
    * @brief Computes the outlier weights of the graph. We define the outlier

--- a/gtsam/sfm/tests/testMFAS.cpp
+++ b/gtsam/sfm/tests/testMFAS.cpp
@@ -25,7 +25,7 @@ using namespace gtsam;
 vector<MFAS::KeyPair> edges = {make_pair(3, 2), make_pair(0, 1), make_pair(3, 1),
                          make_pair(1, 2), make_pair(0, 2), make_pair(3, 0)};
 // nodes in the graph
-vector<Key> nodes = {Key(0), Key(1), Key(2), Key(3)};
+KeyVector nodes = {Key(0), Key(1), Key(2), Key(3)};
 // weights from projecting in direction-1 (bad direction, outlier accepted)
 vector<double> weights1 = {2, 1.5, 0.5, 0.25, 1, 0.75};
 // weights from projecting in direction-2 (good direction, outlier rejected)
@@ -47,10 +47,10 @@ map<MFAS::KeyPair, double> getEdgeWeights(const vector<MFAS::KeyPair> &edges,
 TEST(MFAS, OrderingWeights2) {
   MFAS mfas_obj(getEdgeWeights(edges, weights2));
 
-  vector<Key> ordered_nodes = mfas_obj.computeOrdering();
+  KeyVector ordered_nodes = mfas_obj.computeOrdering();
 
   // ground truth (expected) ordering in this example
-  vector<Key> gt_ordered_nodes = {0, 1, 3, 2};
+  KeyVector gt_ordered_nodes = {0, 1, 3, 2};
 
   // check if the expected ordering is obtained
   for (size_t i = 0; i < ordered_nodes.size(); i++) {
@@ -77,10 +77,10 @@ TEST(MFAS, OrderingWeights2) {
 TEST(MFAS, OrderingWeights1) {
   MFAS mfas_obj(getEdgeWeights(edges, weights1));
 
-  vector<Key> ordered_nodes = mfas_obj.computeOrdering();
+  KeyVector ordered_nodes = mfas_obj.computeOrdering();
 
   // "ground truth" expected ordering in this example
-  vector<Key> gt_ordered_nodes = {3, 0, 1, 2};
+  KeyVector gt_ordered_nodes = {3, 0, 1, 2};
 
   // check if the expected ordering is obtained
   for (size_t i = 0; i < ordered_nodes.size(); i++) {


### PR DESCRIPTION
This fixes #598. All I had to do was replace `vector<Key>` with `KeyVector` since the latter supports allocator overloading (which is needed for TBB).

@tmcg0 