### PR TITLE
SymbolGenerator: add chr() and made constexpr-capable

### DIFF
--- a/gtsam/inference/Symbol.h
+++ b/gtsam/inference/Symbol.h
@@ -167,10 +167,11 @@ inline Key Z(std::uint64_t j) { return Symbol('z', j); }
 /** Generates symbol shorthands with alternative names different than the
  * one-letter predefined ones. */
 class SymbolGenerator {
-  const char c_;
+  const unsigned char c_;
 public:
-  SymbolGenerator(const char c) : c_(c) {}
+  constexpr SymbolGenerator(const unsigned char c) : c_(c) {}
   Symbol operator()(const std::uint64_t j) const { return Symbol(c_, j); }
+  constexpr unsigned char chr() const { return c_; }
 };
 
 /// traits

--- a/gtsam/inference/tests/testKey.cpp
+++ b/gtsam/inference/tests/testKey.cpp
@@ -60,6 +60,12 @@ TEST(Key, SymbolGenerator) {
 }
 
 /* ************************************************************************* */
+TEST(Key, SymbolGeneratorConstexpr) {
+  constexpr auto Z = gtsam::SymbolGenerator('x');
+  EXPECT(assert_equal(Z.chr(), 'x'));
+}
+
+/* ************************************************************************* */
 template<int KeySize>
 Key KeyTestValue();
 


### PR DESCRIPTION
That it is: 
- add a `chr()` method to recover the underlying char symbol, and
- Make possible to write things like:

```cpp
constexpr auto sQpp = gtsam::SymbolGenerator('a');
//...

    for (const auto &kv : values) {
      gtsam::Symbol s(kv.key);
      switch (s.chr()) {
      case sQpp.chr():    // this requires SymbolGenerator to be constexpr
        // ...
      }
   }


```