### PR TITLE
Adding serialization support to be used for GT-SFM

### DIFF
--- a/gtsam/gtsam.i
+++ b/gtsam/gtsam.i
@@ -2768,6 +2768,9 @@ class SfmTrack {
   pair<size_t, gtsam::Point2> measurement(size_t idx) const;
   pair<size_t, size_t> siftIndex(size_t idx) const;
   void add_measurement(size_t idx, const gtsam::Point2& m);
+
+  // enabling serialization functionality
+  void serialize() const;
 };
 
 class SfmData {
@@ -2778,6 +2781,9 @@ class SfmData {
   gtsam::SfmTrack track(size_t idx) const;
   void add_track(const gtsam::SfmTrack& t) ;
   void add_camera(const gtsam::SfmCamera& cam);
+
+  // enabling serialization functionality
+  void serialize() const;
 };
 
 gtsam::SfmData readBal(string filename);

--- a/gtsam/gtsam.i
+++ b/gtsam/gtsam.i
@@ -2771,6 +2771,9 @@ class SfmTrack {
 
   // enabling serialization functionality
   void serialize() const;
+
+  // enabling function to compare objects
+  bool equals(const gtsam::SfmTrack& expected, double tol) const;
 };
 
 class SfmData {
@@ -2784,6 +2787,9 @@ class SfmData {
 
   // enabling serialization functionality
   void serialize() const;
+
+  // enabling function to compare objects
+  bool equals(const gtsam::SfmData& expected, double tol) const;
 };
 
 gtsam::SfmData readBal(string filename);

--- a/gtsam/slam/dataset.h
+++ b/gtsam/slam/dataset.h
@@ -303,7 +303,8 @@ struct SfmTrack {
 
   /// print
   void print(const std::string& s = "") const {
-    cout << "Track with " << measurements.size() << "measurements\n";
+    cout << "Track with " << measurements.size();
+    cout << " measurements of point " << p << "\n";
   }
 };
 

--- a/gtsam/slam/dataset.h
+++ b/gtsam/slam/dataset.h
@@ -29,11 +29,10 @@
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/Values.h>
 #include <gtsam/linear/NoiseModel.h>
+#include <gtsam/base/serialization.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/types.h>
 
-
-#include <boost/serialization/vector.hpp>
 #include <boost/smart_ptr/shared_ptr.hpp>
 #include <string>
 #include <utility> // for pair
@@ -218,94 +217,95 @@ typedef std::pair<size_t, Point2> SfmMeasurement;
 typedef std::pair<size_t, size_t> SiftIndex;
 
 /// Define the structure for the 3D points
-struct SfmTrack {
-  SfmTrack(): p(0,0,0) {}
-  SfmTrack(const gtsam::Point3& pt) : p(pt) {}
-  Point3 p; ///< 3D position of the point
-  float r, g, b; ///< RGB color of the 3D point
-  std::vector<SfmMeasurement> measurements; ///< The 2D image projections (id,(u,v))
-  std::vector<SiftIndex> siftIndices;
+class GTSAM_EXPORT SfmTrack {
+  public:
+    SfmTrack(): p(0,0,0) {}
+    SfmTrack(const gtsam::Point3& pt) : p(pt) {}
+    Point3 p; ///< 3D position of the point
+    float r, g, b; ///< RGB color of the 3D point
+    std::vector<SfmMeasurement> measurements; ///< The 2D image projections (id,(u,v))
+    std::vector<SiftIndex> siftIndices;
 
-  /// Total number of measurements in this track
-  size_t number_measurements() const {
-    return measurements.size();
-  }
-  /// Get the measurement (camera index, Point2) at pose index `idx`
-  SfmMeasurement measurement(size_t idx) const {
-    return measurements[idx];
-  }
-  /// Get the SIFT feature index corresponding to the measurement at `idx`
-  SiftIndex siftIndex(size_t idx) const {
-    return siftIndices[idx];
-  }
-  /// Get 3D point
-  const Point3& point3() const {
-    return p;
-  }
-  /// Add measurement (camera_idx, Point2) to track
-  void add_measurement(size_t idx, const gtsam::Point2& m) {
-    measurements.emplace_back(idx, m);
-  }
-
-  /** Serialization function */
-  friend class boost::serialization::access;
-  template<class ARCHIVE>
-  void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
-    ar & p;
-    ar & r;
-    ar & g;
-    ar & b;
-    ar & measurements;
-    ar & siftIndices;
-  }
-
-  /// assert equality up to a tolerance
-  bool equals(const SfmTrack &sfmTrack, double tol = 1e-9) const {
-    // check the 3D point
-    if (!p.isApprox(sfmTrack.p)) {
-      return false;
+    /// Total number of measurements in this track
+    size_t number_measurements() const {
+      return measurements.size();
+    }
+    /// Get the measurement (camera index, Point2) at pose index `idx`
+    SfmMeasurement measurement(size_t idx) const {
+      return measurements[idx];
+    }
+    /// Get the SIFT feature index corresponding to the measurement at `idx`
+    SiftIndex siftIndex(size_t idx) const {
+      return siftIndices[idx];
+    }
+    /// Get 3D point
+    const Point3& point3() const {
+      return p;
+    }
+    /// Add measurement (camera_idx, Point2) to track
+    void add_measurement(size_t idx, const gtsam::Point2& m) {
+      measurements.emplace_back(idx, m);
     }
 
-    // check the RGB values
-    if (r!=sfmTrack.r || g!=sfmTrack.g || b!=sfmTrack.b) {
-      return false;
+    /** Serialization function */
+    friend class boost::serialization::access;
+    template<class ARCHIVE>
+    void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
+      ar & BOOST_SERIALIZATION_NVP(p);
+      ar & BOOST_SERIALIZATION_NVP(r);
+      ar & BOOST_SERIALIZATION_NVP(g);
+      ar & BOOST_SERIALIZATION_NVP(b);
+      ar & BOOST_SERIALIZATION_NVP(measurements);
+      ar & BOOST_SERIALIZATION_NVP(siftIndices);
     }
 
-    // compare size of vectors for measurements and siftIndices
-    if (number_measurements() != sfmTrack.number_measurements() ||
-        siftIndices.size() != sfmTrack.siftIndices.size()) {
-      return false;
-    }
-
-    // compare measurements (order sensitive)
-    for (size_t idx = 0; idx < number_measurements(); ++idx) {
-      SfmMeasurement measurement = measurements[idx];
-      SfmMeasurement otherMeasurement = sfmTrack.measurements[idx];
-
-      if (measurement.first != otherMeasurement.first ||
-          !measurement.second.isApprox(otherMeasurement.second)) {
+    /// assert equality up to a tolerance
+    bool equals(const SfmTrack &sfmTrack, double tol = 1e-9) const {
+      // check the 3D point
+      if (!p.isApprox(sfmTrack.p)) {
         return false;
       }
-    }
 
-    // compare sift indices (order sensitive)
-    for (size_t idx = 0; idx < siftIndices.size(); ++idx) {
-      SiftIndex index = siftIndices[idx];
-      SiftIndex otherIndex = sfmTrack.siftIndices[idx];
-
-      if (index.first != otherIndex.first ||
-          index.second != otherIndex.second) {
+      // check the RGB values
+      if (r!=sfmTrack.r || g!=sfmTrack.g || b!=sfmTrack.b) {
         return false;
       }
+
+      // compare size of vectors for measurements and siftIndices
+      if (number_measurements() != sfmTrack.number_measurements() ||
+          siftIndices.size() != sfmTrack.siftIndices.size()) {
+        return false;
+      }
+
+      // compare measurements (order sensitive)
+      for (size_t idx = 0; idx < number_measurements(); ++idx) {
+        SfmMeasurement measurement = measurements[idx];
+        SfmMeasurement otherMeasurement = sfmTrack.measurements[idx];
+
+        if (measurement.first != otherMeasurement.first ||
+            !measurement.second.isApprox(otherMeasurement.second)) {
+          return false;
+        }
+      }
+
+      // compare sift indices (order sensitive)
+      for (size_t idx = 0; idx < siftIndices.size(); ++idx) {
+        SiftIndex index = siftIndices[idx];
+        SiftIndex otherIndex = sfmTrack.siftIndices[idx];
+
+        if (index.first != otherIndex.first ||
+            index.second != otherIndex.second) {
+          return false;
+        }
+      }
+
+      return true;
     }
 
-    return true;
-  }
-
-  /// print
-  void print(const std::string& s = "") const {
-    cout << "Track with " << measurements.size() << "measurements\n";
-  }
+    /// print
+    void print(const std::string& s = "") const {
+      cout << "Track with " << measurements.size() << "measurements\n";
+    }
 };
 
 /* ************************************************************************* */
@@ -350,8 +350,8 @@ struct SfmData {
   friend class boost::serialization::access;
   template<class Archive>
   void serialize(Archive & ar, const unsigned int /*version*/) {
-    ar & cameras;
-    ar & tracks;
+    ar & BOOST_SERIALIZATION_NVP(cameras);
+    ar & BOOST_SERIALIZATION_NVP(tracks);
   }
 
   /// @}

--- a/gtsam/slam/tests/testSerializationDataset.cpp
+++ b/gtsam/slam/tests/testSerializationDataset.cpp
@@ -1,0 +1,44 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file testSerializationDataset.cpp
+ * @brief serialization tests for dataset.cpp
+ * @author Ayush Baid
+ * @date Jan 1, 2021
+ */
+
+#include <gtsam/slam/dataset.h>
+
+#include <CppUnitLite/TestHarness.h>
+
+#include <gtsam/base/serializationTestHelpers.h>
+#include <CppUnitLite/TestHarness.h>
+
+using namespace std;
+using namespace gtsam;
+using namespace gtsam::serializationTestHelpers;
+
+/* ************************************************************************* */
+TEST(dataSet, sfmDataSerialization){
+  // Test the serialization of SfmData
+  const string filename = findExampleDataFile("dubrovnik-3-7-pre");
+  SfmData mydata;
+  CHECK(readBAL(filename, mydata));
+
+  EXPECT(equalsObj(mydata));
+  // EXPECT(equalsXML(mydata));
+  // EXPECT(equalsBinary(mydata));
+}
+
+/* ************************************************************************* */
+int main() { TestResult tr; return TestRegistry::runAllTests(tr); }
+/* ************************************************************************* */

--- a/gtsam/slam/tests/testSerializationDataset.cpp
+++ b/gtsam/slam/tests/testSerializationDataset.cpp
@@ -26,19 +26,19 @@ using namespace gtsam;
 using namespace gtsam::serializationTestHelpers;
 
 /* ************************************************************************* */
-TEST(dataSet, sfmDataSerialization){
+TEST(dataSet, sfmDataSerialization) {
   // Test the serialization of SfmData
   const string filename = findExampleDataFile("dubrovnik-3-7-pre");
   SfmData mydata;
   CHECK(readBAL(filename, mydata));
 
   EXPECT(equalsObj(mydata));
-  // EXPECT(equalsXML(mydata));
-  // EXPECT(equalsBinary(mydata));
+  EXPECT(equalsXML(mydata));
+  EXPECT(equalsBinary(mydata));
 }
 
 /* ************************************************************************* */
-TEST(dataSet, sfmTrackSerialization){
+TEST(dataSet, sfmTrackSerialization) {
   // Test the serialization of SfmTrack
   const string filename = findExampleDataFile("dubrovnik-3-7-pre");
   SfmData mydata;
@@ -47,8 +47,8 @@ TEST(dataSet, sfmTrackSerialization){
   SfmTrack track = mydata.track(0);
 
   EXPECT(equalsObj(track));
-  // EXPECT(equalsXML(track));
-  // EXPECT(equalsBinary(track));
+  EXPECT(equalsXML(track));
+  EXPECT(equalsBinary(track));
 }
 
 /* ************************************************************************* */

--- a/gtsam/slam/tests/testSerializationDataset.cpp
+++ b/gtsam/slam/tests/testSerializationDataset.cpp
@@ -39,7 +39,7 @@ TEST(dataSet, sfmDataSerialization){
 
 /* ************************************************************************* */
 TEST(dataSet, sfmTrackSerialization){
-  // Test the serialization of SfmData
+  // Test the serialization of SfmTrack
   const string filename = findExampleDataFile("dubrovnik-3-7-pre");
   SfmData mydata;
   CHECK(readBAL(filename, mydata));
@@ -47,8 +47,8 @@ TEST(dataSet, sfmTrackSerialization){
   SfmTrack track = mydata.track(0);
 
   EXPECT(equalsObj(track));
-  // EXPECT(equalsXML(mydata));
-  // EXPECT(equalsBinary(mydata));
+  // EXPECT(equalsXML(track));
+  // EXPECT(equalsBinary(track));
 }
 
 /* ************************************************************************* */

--- a/gtsam/slam/tests/testSerializationDataset.cpp
+++ b/gtsam/slam/tests/testSerializationDataset.cpp
@@ -32,6 +32,7 @@ TEST(dataSet, sfmDataSerialization) {
   SfmData mydata;
   CHECK(readBAL(filename, mydata));
 
+  // round-trip equality check on serialization and subsequent deserialization
   EXPECT(equalsObj(mydata));
   EXPECT(equalsXML(mydata));
   EXPECT(equalsBinary(mydata));
@@ -46,6 +47,7 @@ TEST(dataSet, sfmTrackSerialization) {
 
   SfmTrack track = mydata.track(0);
 
+  // round-trip equality check on serialization and subsequent deserialization
   EXPECT(equalsObj(track));
   EXPECT(equalsXML(track));
   EXPECT(equalsBinary(track));

--- a/gtsam/slam/tests/testSerializationDataset.cpp
+++ b/gtsam/slam/tests/testSerializationDataset.cpp
@@ -18,8 +18,6 @@
 
 #include <gtsam/slam/dataset.h>
 
-#include <CppUnitLite/TestHarness.h>
-
 #include <gtsam/base/serializationTestHelpers.h>
 #include <CppUnitLite/TestHarness.h>
 
@@ -35,6 +33,20 @@ TEST(dataSet, sfmDataSerialization){
   CHECK(readBAL(filename, mydata));
 
   EXPECT(equalsObj(mydata));
+  // EXPECT(equalsXML(mydata));
+  // EXPECT(equalsBinary(mydata));
+}
+
+/* ************************************************************************* */
+TEST(dataSet, sfmTrackSerialization){
+  // Test the serialization of SfmData
+  const string filename = findExampleDataFile("dubrovnik-3-7-pre");
+  SfmData mydata;
+  CHECK(readBAL(filename, mydata));
+
+  SfmTrack track = mydata.track(0);
+
+  EXPECT(equalsObj(track));
   // EXPECT(equalsXML(mydata));
   // EXPECT(equalsBinary(mydata));
 }


### PR DESCRIPTION
GT-SFM project uses the `SfmData` and `SfmTrack` structures. Hence, this PR adds serialization support to these two structures.