### PR TITLE
Remove Build Upload

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -83,9 +83,3 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           bash .github/scripts/unix.sh -t
-      - name: Upload build directory
-        uses: actions/upload-artifact@v2
-        if: matrix.build_type  == 'Release'
-        with:
-          name: gtsam-${{ matrix.name }}-${{ matrix.build_type }}
-          path: ${{ github.workspace }}/build/

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -51,9 +51,3 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           bash .github/scripts/unix.sh -t
-      - name: Upload build directory
-        uses: actions/upload-artifact@v2
-        if: matrix.build_type == 'Release'
-        with:
-          name: gtsam-${{ matrix.name }}-${{ matrix.build_type }}
-          path: ${{ github.workspace }}/build/

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -76,9 +76,3 @@ jobs:
           cmake --build build --config ${{ matrix.build_type }} --target check.base
           cmake --build build --config ${{ matrix.build_type }} --target check.base_unstable
           cmake --build build --config ${{ matrix.build_type }} --target check.linear
-      - name: Upload build directory
-        uses: actions/upload-artifact@v2
-        if: matrix.build_type == 'Release'
-        with:
-          name: gtsam-${{ matrix.name }}-${{ matrix.build_type }}
-          path: ${{ github.workspace }}/build/


### PR DESCRIPTION
The build upload as part of Github Actions can't be used downstream by other applications in their CI directly.

A better way to do this would be to create a nightly binary release via another Action such as [deploy-nightly](https://github.com/marketplace/actions/deploy-nightly).