### PR TITLE
add robust shonan updates to python wrapper

### DIFF
--- a/gtsam/gtsam.i
+++ b/gtsam/gtsam.i
@@ -2933,9 +2933,14 @@ class ShonanAveragingParameters2 {
   void setAnchorWeight(double value);
   double getAnchorWeight() const;
   void setKarcherWeight(double value);
-  double getKarcherWeight();
+  double getKarcherWeight() const;
   void setGaugesWeight(double value);
-  double getGaugesWeight();
+  double getGaugesWeight() const;
+  void setUseHuber(bool value);
+  bool getUseHuber() const;
+  void setCertifyOptimality(bool value);
+  bool getCertifyOptimality() const;
+  void print() const;
 };
 
 class ShonanAveragingParameters3 {
@@ -2949,9 +2954,14 @@ class ShonanAveragingParameters3 {
   void setAnchorWeight(double value);
   double getAnchorWeight() const;
   void setKarcherWeight(double value);
-  double getKarcherWeight();
+  double getKarcherWeight() const;
   void setGaugesWeight(double value);
-  double getGaugesWeight();
+  double getGaugesWeight() const;
+  void setUseHuber(bool value);
+  bool getUseHuber() const;
+  void setCertifyOptimality(bool value);
+  bool getCertifyOptimality() const;
+  void print() const;
 };
 
 class ShonanAveraging2 {


### PR DESCRIPTION
The [robust Shonan PR](https://github.com/borglab/gtsam/pull/547/files#diff-d32ec5e827de8b7213ffbdd73328d7b107cad1395ee778884fdef04555222fcdR83) introduces new attributes and methods in the `ShonanAveragingParameters` struct.

In this PR, we port these new methods to the Python wrapper (via .i file).