### PR TITLE
Fix GTSAM_EXPORT

### DIFF
--- a/gtsam/geometry/Point3.h
+++ b/gtsam/geometry/Point3.h
@@ -61,7 +61,7 @@ GTSAM_EXPORT double dot(const Point3& p, const Point3& q,
 
 /// mean
 template <class CONTAINER>
-GTSAM_EXPORT Point3 mean(const CONTAINER& points) {
+Point3 mean(const CONTAINER& points) {
   if (points.size() == 0) throw std::invalid_argument("Point3::mean input container is empty");
   Point3 sum(0, 0, 0);
   sum = std::accumulate(points.begin(), points.end(), sum);

--- a/gtsam/sfm/ShonanAveraging.h
+++ b/gtsam/sfm/ShonanAveraging.h
@@ -414,7 +414,7 @@ class GTSAM_EXPORT ShonanAveraging {
 // Subclasses for d=2 and d=3 that explicitly instantiate, as well as provide a
 // convenience interface with file access.
 
-class ShonanAveraging2 : public ShonanAveraging<2> {
+class GTSAM_EXPORT ShonanAveraging2 : public ShonanAveraging<2> {
  public:
   ShonanAveraging2(const Measurements &measurements,
                    const Parameters &parameters = Parameters());
@@ -422,7 +422,7 @@ class ShonanAveraging2 : public ShonanAveraging<2> {
                             const Parameters &parameters = Parameters());
 };
 
-class ShonanAveraging3 : public ShonanAveraging<3> {
+class GTSAM_EXPORT ShonanAveraging3 : public ShonanAveraging<3> {
  public:
   ShonanAveraging3(const Measurements &measurements,
                    const Parameters &parameters = Parameters());


### PR DESCRIPTION
Fix GTSAM_EXPORT for some classes and function

- Remove GTSAM_EXPORT from template function because its must be implmented in header and so there is nothing to export
- Add GTSAM_EXPORT to Shanon Averaging2/3 to export these classes that are used in examples 
