### PR TITLE
CMake scripts compatible with gtsam as git submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ include(GtsamTesting)
 include(GtsamPrinting)
 
 # guard against in-source builds
-if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+if(${GTSAM_SOURCE_DIR} STREQUAL ${GTSAM_BINARY_DIR})
   message(FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there. You may need to remove CMakeCache.txt. ")
 endif()
 

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -6,7 +6,7 @@
 get_filename_component(OUR_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 if(EXISTS "${OUR_CMAKE_DIR}/CMakeCache.txt")
   # In build tree
-  set(@PACKAGE_NAME@_INCLUDE_DIR @CMAKE_SOURCE_DIR@ CACHE PATH "@PACKAGE_NAME@ include directory")
+  set(@PACKAGE_NAME@_INCLUDE_DIR @GTSAM_SOURCE_DIR@ CACHE PATH "@PACKAGE_NAME@ include directory")
 else()
   # Find installed library
   set(@PACKAGE_NAME@_INCLUDE_DIR "${OUR_CMAKE_DIR}/@CONF_REL_INCLUDE_DIR@" CACHE PATH "@PACKAGE_NAME@ include directory")
@@ -15,7 +15,7 @@ endif()
 # Find dependencies, required by cmake exported targets:
 include(CMakeFindDependencyMacro)
 # Allow using cmake < 3.8
-if(${CMAKE_VERSION} VERSION_LESS "3.8.0") 
+if(${CMAKE_VERSION} VERSION_LESS "3.8.0")
 find_package(Boost @BOOST_FIND_MINIMUM_VERSION@ COMPONENTS @BOOST_FIND_MINIMUM_COMPONENTS@)
 else()
 find_dependency(Boost @BOOST_FIND_MINIMUM_VERSION@ COMPONENTS @BOOST_FIND_MINIMUM_COMPONENTS@)

--- a/cmake/GtsamBuildTypes.cmake
+++ b/cmake/GtsamBuildTypes.cmake
@@ -204,9 +204,9 @@ endif()
 
 # Make common binary output directory when on Windows
 if(WIN32)
-  set(RUNTIME_OUTPUT_PATH "${CMAKE_BINARY_DIR}/bin")
-  set(EXECUTABLE_OUTPUT_PATH "${CMAKE_BINARY_DIR}/bin")
-  set(LIBRARY_OUTPUT_PATH "${CMAKE_BINARY_DIR}/lib")
+  set(RUNTIME_OUTPUT_PATH "${GTSAM_BINARY_DIR}/bin")
+  set(EXECUTABLE_OUTPUT_PATH "${GTSAM_BINARY_DIR}/bin")
+  set(LIBRARY_OUTPUT_PATH "${GTSAM_BINARY_DIR}/lib")
 endif()
 
 # Set up build type list for cmake-gui

--- a/cmake/GtsamMatlabWrap.cmake
+++ b/cmake/GtsamMatlabWrap.cmake
@@ -146,7 +146,7 @@ function(wrap_library_internal interfaceHeader linkLibraries extraIncludeDirs ex
             endif()
         endif()
     endforeach()
-    
+
     ## CHRIS: Temporary fix. On my system the get_target_property above returned Not-found for gtsam module
     ## This needs to be fixed!!
     if(UNIX AND NOT APPLE)
@@ -159,7 +159,7 @@ function(wrap_library_internal interfaceHeader linkLibraries extraIncludeDirs ex
         endif()
       endif()
     endif()
-    
+
     #message("AUTOMATIC DEPENDENCIES:  ${automaticDependencies}")
     ## CHRIS: End temporary fix
 
@@ -213,7 +213,7 @@ function(wrap_library_internal interfaceHeader linkLibraries extraIncludeDirs ex
             endif()
 		endif()
 	endforeach()
-    
+
     # Check libraries for conflicting versions built-in to MATLAB
     set(dependentLibraries "")
     if(NOT "${otherLibraryTargets}" STREQUAL "")
@@ -257,7 +257,7 @@ function(wrap_library_internal interfaceHeader linkLibraries extraIncludeDirs ex
 			--ignore ${_ignore}
 		VERBATIM
 		WORKING_DIRECTORY ${generated_files_path})
-		
+
 	# Set up building of mex module
 	string(REPLACE ";" " " extraMexFlagsSpaced "${extraMexFlags}")
 	string(REPLACE ";" " " mexFlagsSpaced "${GTSAM_BUILD_MEX_BINARY_FLAGS}")
@@ -295,8 +295,8 @@ function(wrap_library_internal interfaceHeader linkLibraries extraIncludeDirs ex
 	endif()
 
     # Hacking around output issue with custom command
-    # Deletes generated build folder 
-    add_custom_target(wrap_${moduleName}_matlab_distclean 
+    # Deletes generated build folder
+    add_custom_target(wrap_${moduleName}_matlab_distclean
 	    COMMAND cmake -E remove_directory ${generated_files_path}
 		COMMAND cmake -E remove_directory ${compiled_mex_modules_root})
 endfunction()
@@ -347,17 +347,17 @@ function(check_conflicting_libraries_internal libraries)
                 set(mxLibPath "${MATLAB_ROOT}/bin/glnx86")
             endif()
         endif()
-        
+
         # List matlab's built-in libraries
         file(GLOB matlabLibs RELATIVE "${mxLibPath}" "${mxLibPath}/lib*")
-        
+
         # Convert to base names
         set(matlabLibNames "")
         foreach(lib ${matlabLibs})
             get_filename_component(libName "${lib}" NAME_WE)
             list(APPEND matlabLibNames "${libName}")
         endforeach()
-        
+
         # Get names of link libraries
         set(linkLibNames "")
         foreach(lib ${libraries})
@@ -379,10 +379,10 @@ function(check_conflicting_libraries_internal libraries)
                 endif()
             endif()
         endforeach()
-        
+
         # Remove duplicates
         list(REMOVE_DUPLICATES linkLibNames)
-        
+
         set(conflictingLibs "")
         foreach(lib ${linkLibNames})
             list(FIND matlabLibNames "${lib}" libPos)
@@ -393,7 +393,7 @@ function(check_conflicting_libraries_internal libraries)
                 set(conflictingLibs "${conflictingLibs}${lib}")
             endif()
         endforeach()
-        
+
         if(NOT "${conflictingLibs}" STREQUAL "")
             message(WARNING "GTSAM links to the libraries [ ${conflictingLibs} ] on your system, but "
                 "MATLAB is distributed with its own versions of these libraries which may conflict. "
@@ -435,4 +435,3 @@ function(install_matlab_scripts source_directory patterns)
 	endif()
 
 endfunction()
-

--- a/cmake/HandleEigen.cmake
+++ b/cmake/HandleEigen.cmake
@@ -42,7 +42,7 @@ else()
     set(GTSAM_EIGEN_INCLUDE_FOR_INSTALL "include/gtsam/3rdparty/Eigen/")
 
     # The actual include directory (for BUILD cmake target interface):
-    set(GTSAM_EIGEN_INCLUDE_FOR_BUILD "${CMAKE_SOURCE_DIR}/gtsam/3rdparty/Eigen/")
+    set(GTSAM_EIGEN_INCLUDE_FOR_BUILD "${GTSAM_SOURCE_DIR}/gtsam/3rdparty/Eigen/")
 endif()
 
 # Detect Eigen version:

--- a/gtsam/CMakeLists.txt
+++ b/gtsam/CMakeLists.txt
@@ -134,15 +134,15 @@ endif()
 # of any previously installed GTSAM headers.
 target_include_directories(gtsam BEFORE PUBLIC
   # main gtsam includes:
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+  $<BUILD_INTERFACE:${GTSAM_SOURCE_DIR}>
   $<INSTALL_INTERFACE:include/>
   # config.h
-  $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
+  $<BUILD_INTERFACE:${GTSAM_BINARY_DIR}>
   # unit tests:
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/CppUnitLite>
+  $<BUILD_INTERFACE:${GTSAM_SOURCE_DIR}/CppUnitLite>
 )
 # 3rdparty libraries: use the "system" flag so they are included via "-isystem"
-# and warnings (and warnings-considered-errors) in those headers are not 
+# and warnings (and warnings-considered-errors) in those headers are not
 # reported as warnings/errors in our targets:
 target_include_directories(gtsam SYSTEM BEFORE PUBLIC
   # SuiteSparse_config
@@ -156,9 +156,9 @@ target_include_directories(gtsam SYSTEM BEFORE PUBLIC
 )
 if(GTSAM_SUPPORT_NESTED_DISSECTION)
   target_include_directories(gtsam BEFORE PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/gtsam/3rdparty/metis/include>
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/gtsam/3rdparty/metis/libmetis>
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/gtsam/3rdparty/metis/GKlib>
+    $<BUILD_INTERFACE:${GTSAM_SOURCE_DIR}/gtsam/3rdparty/metis/include>
+    $<BUILD_INTERFACE:${GTSAM_SOURCE_DIR}/gtsam/3rdparty/metis/libmetis>
+    $<BUILD_INTERFACE:${GTSAM_SOURCE_DIR}/gtsam/3rdparty/metis/GKlib>
     $<INSTALL_INTERFACE:include/gtsam/3rdparty/metis/>
   )
 endif()


### PR DESCRIPTION
Minor changes to make cmake scripts not to assume `CMAKE_SOURCE_DIR` is identical to `GTSAM_SOURCE_DIR` (and the same for `*_BINARY_DIR`). 

PS: The `GTSAM_` prefix comes from the `project(GTSAM)` in the root `CMakeLists.txt`.
