### PR TITLE
Fix/plane factor dwisth

### DIFF
--- a/gtsam/slam/tests/testOrientedPlane3Factor.cpp
+++ b/gtsam/slam/tests/testOrientedPlane3Factor.cpp
@@ -239,7 +239,7 @@ TEST(OrientedPlane3Factor, Issue561) {
     Values result = optimizer.optimize();
     EXPECT_DOUBLES_EQUAL(0, graph.error(result), 0.1);
   } catch (const IndeterminantLinearSystemException &e) {
-    std::cerr << "CAPTURED THE EXCEPTION: " << e.nearbyVariable() << std::endl;
+    std::cerr << "CAPTURED THE EXCEPTION: " << DefaultKeyFormatter(e.nearbyVariable()) << std::endl;
     EXPECT(false); // fail if this happens
   }
 }
@@ -287,6 +287,42 @@ TEST(OrientedPlane3Factor, Issue561Simplified) {
   initialEstimate.insert(P(2), p2);
   initialEstimate.insert(X(0), x0);
 
+  // For testing only
+  HessianFactor::shared_ptr hessianFactor = graph.linearizeToHessianFactor(initialEstimate);
+  const auto hessian = hessianFactor->hessianBlockDiagonal();
+
+  Matrix hessianP1 = hessian.at(P(1)),
+         hessianP2 = hessian.at(P(2)),
+	 hessianX0 = hessian.at(X(0));
+
+  Eigen::JacobiSVD<Matrix> svdP1(hessianP1, Eigen::ComputeThinU),
+	                   svdP2(hessianP2, Eigen::ComputeThinU),
+			   svdX0(hessianX0, Eigen::ComputeThinU);
+
+  double conditionNumberP1 = svdP1.singularValues()[0] / svdP1.singularValues()[2],
+         conditionNumberP2 = svdP2.singularValues()[0] / svdP2.singularValues()[2],
+	 conditionNumberX0 = svdX0.singularValues()[0] / svdX0.singularValues()[5];
+
+  std::cout << "Hessian P1:\n" << hessianP1 << "\n"
+	    << "Condition number:\n" << conditionNumberP1 << "\n"
+	    << "Singular values:\n" << svdP1.singularValues().transpose() << "\n"
+	    << "SVD U:\n" << svdP1.matrixU() << "\n" << std::endl;
+
+  std::cout << "Hessian P2:\n" << hessianP2 << "\n"
+	    << "Condition number:\n" << conditionNumberP2 << "\n"
+	    << "Singular values:\n" << svdP2.singularValues().transpose() << "\n"
+	    << "SVD U:\n" << svdP2.matrixU() << "\n" << std::endl;
+
+  std::cout << "Hessian X0:\n" << hessianX0 << "\n"
+	    << "Condition number:\n" << conditionNumberX0 << "\n"
+	    << "Singular values:\n" << svdX0.singularValues().transpose() << "\n"
+	    << "SVD U:\n" << svdX0.matrixU() << "\n" << std::endl;
+
+  // std::cout << "Hessian P2:\n" << hessianP2 << std::endl;
+  // std::cout << "Hessian X0:\n" << hessianX0 << std::endl;
+  
+  // For testing only
+
   // Optimize
   try {
     GaussNewtonParams params;
@@ -302,7 +338,7 @@ TEST(OrientedPlane3Factor, Issue561Simplified) {
     EXPECT(p1.equals(result.at<Plane>(P(1))));
     EXPECT(p2.equals(result.at<Plane>(P(2))));
   } catch (const IndeterminantLinearSystemException &e) {
-    std::cerr << "CAPTURED THE EXCEPTION: " << e.nearbyVariable() << std::endl;
+    std::cerr << "CAPTURED THE EXCEPTION: " << DefaultKeyFormatter(e.nearbyVariable()) << std::endl;
     EXPECT(false); // fail if this happens
   }
 }


### PR DESCRIPTION
This adds another simplified unit test of related to PR #564 and Issue #561.

The unit test situation is very simple - there are two horizontal planes, p1 and p2, connected to a pose, x0. All the variables have priors on them.

![image](https://user-images.githubusercontent.com/6793487/105092390-109aab00-5a99-11eb-99c3-8d047ff79e31.png)

In this toy example, all the factors are "perfect" (i.e. the optimal solution should have zero error), and the initial condition on the planes are "perfect" (the same as their optimal value). The only thing the optimizer needs to do is solve a pose offset - the initial condition is at (100,0,0) and the optimal solution is at (99,0,0).
![image](https://user-images.githubusercontent.com/6793487/105092066-ac77e700-5a98-11eb-82a0-897c06c1057a.png)

The Gauss Newton optimizer throws an `IndeterminantSystemError` exception.

The Hessians associated to each variable are below. It seems that the plane variables are very poorly conditioned.
```
Hessian P1:
       401          0          0
         0 4.0004e+06     -40000
         0     -40000     400.04
Condition number:
4.99551e+07
Singular values:
4.0008e+06        401   0.080088
SVD U:
         0          1          0
   0.99995          0  0.0099985
-0.0099985          0    0.99995

Hessian P2:
       401          0          0
         0 4.0004e+06     -40000
         0     -40000     400.04
Condition number:
4.99551e+07
Singular values:
4.0008e+06        401   0.080088
SVD U:
         0          1          0
   0.99995          0  0.0099985
-0.0099985          0    0.99995

Hessian X0:
10800     0     0     0     0     0
    0 10800     0     0     0     0
    0     0 10000     0     0     0
    0     0     0 10000     0     0
    0     0     0     0 10000     0
    0     0     0     0     0 10800
Condition number:
1.08
Singular values:
10800 10800 10800 10000 10000 10000
SVD U:
1 0 0 0 0 0
0 1 0 0 0 0
0 0 0 0 0 1
0 0 0 1 0 0
0 0 0 0 1 0
0 0 1 0 0 0
```

I think there may be a problem with the second element in the `OrientedPlane3Factor` residual but I don't know enough about how gtsam works out the Hessian to be sure.

Any thoughts on the next step for debugging this?