### PR TITLE
Update CMake Variables and TBB build type

### DIFF
--- a/cmake/FindTBB.cmake
+++ b/cmake/FindTBB.cmake
@@ -99,11 +99,8 @@ if(NOT TBB_FOUND)
   ##################################
 
   if(NOT DEFINED TBB_USE_DEBUG_BUILD)
-    if(CMAKE_BUILD_TYPE MATCHES "(Debug|DEBUG|debug|RelWithDebInfo|RELWITHDEBINFO|relwithdebinfo)")
-      set(TBB_BUILD_TYPE DEBUG)
-    else()
-      set(TBB_BUILD_TYPE RELEASE)
-    endif()
+    # Set build type to RELEASE by default for optimization.
+    set(TBB_BUILD_TYPE RELEASE)
   elseif(TBB_USE_DEBUG_BUILD)
     set(TBB_BUILD_TYPE DEBUG)
   else()

--- a/cmake/GtsamBuildTypes.cmake
+++ b/cmake/GtsamBuildTypes.cmake
@@ -59,10 +59,10 @@ endif()
 option(GTSAM_BUILD_TYPE_POSTFIXES        "Enable/Disable appending the build type to the name of compiled libraries" ON)
 
 # Define all cache variables, to be populated below depending on the OS/compiler:
-set(GTSAM_COMPILE_OPTIONS_PRIVATE        "" CACHE STRING "(Do not edit) Private compiler flags for all build configurations." FORCE)
-set(GTSAM_COMPILE_OPTIONS_PUBLIC         "" CACHE STRING "(Do not edit) Public compiler flags (exported to user projects) for all build configurations."  FORCE)
-set(GTSAM_COMPILE_DEFINITIONS_PRIVATE    "" CACHE STRING "(Do not edit) Private preprocessor macros for all build configurations." FORCE)
-set(GTSAM_COMPILE_DEFINITIONS_PUBLIC     "" CACHE STRING "(Do not edit) Public preprocessor macros for all build configurations." FORCE)
+set(GTSAM_COMPILE_OPTIONS_PRIVATE        "" CACHE INTERNAL "(Do not edit) Private compiler flags for all build configurations." FORCE)
+set(GTSAM_COMPILE_OPTIONS_PUBLIC         "" CACHE INTERNAL "(Do not edit) Public compiler flags (exported to user projects) for all build configurations."  FORCE)
+set(GTSAM_COMPILE_DEFINITIONS_PRIVATE    "" CACHE INTERNAL "(Do not edit) Private preprocessor macros for all build configurations." FORCE)
+set(GTSAM_COMPILE_DEFINITIONS_PUBLIC     "" CACHE INTERNAL "(Do not edit) Public preprocessor macros for all build configurations." FORCE)
 mark_as_advanced(GTSAM_COMPILE_OPTIONS_PRIVATE)
 mark_as_advanced(GTSAM_COMPILE_OPTIONS_PUBLIC)
 mark_as_advanced(GTSAM_COMPILE_DEFINITIONS_PRIVATE)
@@ -71,7 +71,7 @@ mark_as_advanced(GTSAM_COMPILE_DEFINITIONS_PUBLIC)
 foreach(build_type ${GTSAM_CMAKE_CONFIGURATION_TYPES})
   string(TOUPPER "${build_type}" build_type_toupper)
 
-  # Define empty cache variables for "public". "private" are creaed below.
+  # Define empty cache variables for "public". "private" are created below.
   set(GTSAM_COMPILE_OPTIONS_PUBLIC_${build_type_toupper}      "" CACHE STRING "(User editable) Public compiler flags (exported to user projects) for `${build_type_toupper}` configuration.")
   set(GTSAM_COMPILE_DEFINITIONS_PUBLIC_${build_type_toupper}  "" CACHE STRING "(User editable) Public preprocessor macros for `${build_type_toupper}` configuration.")
 endforeach()


### PR DESCRIPTION
1. Update non-user-editable CMake variables to be `INTERNAL`.
2. TBB should be in Release mode by default unless `TBB_USE_DEBUG_BUILD=ON` is specified. This fixes #661.