### PR TITLE
changed barcsq to a vector to allow each factor to have a different inlier threshold

### DIFF
--- a/gtsam/nonlinear/GncOptimizer.h
+++ b/gtsam/nonlinear/GncOptimizer.h
@@ -54,7 +54,7 @@ class GncOptimizer {
   Values state_; ///< Initial values to be used at each iteration by GNC.
   GncParameters params_; ///< GNC parameters.
   Vector weights_;  ///< Weights associated to each factor in GNC (this could be a local variable in optimize, but it is useful to make it accessible from outside).
-  Vector barcSq_;  ///< Inlier thresholds. A factor is considered an inlier if factor.error() < barcSq. Note that factor.error() whitens by the covariance. Also note the code allows a threshold for each factor.
+  Vector barcSq_;  ///< Inlier thresholds. A factor is considered an inlier if factor.error() < barcSq_[i] (where i is the position of the factor in the factor graph. Note that factor.error() whitens by the covariance.
 
  public:
   /// Constructor.
@@ -84,7 +84,7 @@ class GncOptimizer {
   /** Set the maximum weighted residual error for an inlier (same for all factors). For a factor in the form f(x) = 0.5 * || r(x) ||^2_Omega,
    * the inlier threshold is the largest value of f(x) for the corresponding measurement to be considered an inlier.
    * In other words, an inlier at x is such that 0.5 * || r(x) ||^2_Omega <= barcSq.
-   * Assuming a isotropic measurement covariance sigma^2 * Identity, the cost becomes: 0.5 * 1/sigma^2 || r(x) ||^2 <= barcSq.
+   * Assuming an isotropic measurement covariance sigma^2 * Identity, the cost becomes: 0.5 * 1/sigma^2 || r(x) ||^2 <= barcSq.
    * Hence || r(x) ||^2 <= 2 * barcSq * sigma^2.
    * */
   void setInlierCostThresholds(const double inth) {
@@ -94,8 +94,6 @@ class GncOptimizer {
   /** Set the maximum weighted residual error for an inlier (one for each factor). For a factor in the form f(x) = 0.5 * || r(x) ||^2_Omega,
    * the inlier threshold is the largest value of f(x) for the corresponding measurement to be considered an inlier.
    * In other words, an inlier at x is such that 0.5 * || r(x) ||^2_Omega <= barcSq.
-   * Assuming a isotropic measurement covariance sigma^2 * Identity, the cost becomes: 0.5 * 1/sigma^2 || r(x) ||^2 <= barcSq.
-   * Hence || r(x) ||^2 <= 2 * barcSq * sigma^2.
    * */
   void setInlierCostThresholds(const Vector& inthVec) {
     barcSq_ = inthVec;
@@ -105,7 +103,7 @@ class GncOptimizer {
    * alpha that the inlier residuals are smaller than that threshold
    * */
   void setInlierCostThresholdsAtProbability(const double alpha) {
-    barcSq_  = Vector::Ones(nfg_.size());
+    barcSq_  = Vector::Ones(nfg_.size()); // initialize
     for (size_t k = 0; k < nfg_.size(); k++) {
       if (nfg_[k]) {
         barcSq_[k] = 0.5 * Chi2inv(alpha, nfg_[k]->dim()); // 0.5 derives from the error definition in gtsam
@@ -214,10 +212,12 @@ class GncOptimizer {
   double initializeMu() const {
 
     double mu_init = 0.0;
-    // set initial mu
+    // initialize mu to the value specified in Remark 5 in GNC paper.
     switch (params_.lossType) {
       case GncLossType::GM:
-        // surrogate cost is convex for large mu. initialize as in remark 5 in GNC paper
+        /* surrogate cost is convex for large mu. initialize as in remark 5 in GNC paper.
+         Since barcSq_ can be different for each factor, we compute the max of the quantity in remark 5 in GNC paper
+         */
         for (size_t k = 0; k < nfg_.size(); k++) {
           if (nfg_[k]) {
             mu_init = std::max(mu_init, 2 * nfg_[k]->error(state_) / barcSq_[k]);
@@ -225,11 +225,11 @@ class GncOptimizer {
         }
         return mu_init;  // initial mu
       case GncLossType::TLS:
-        /* initialize mu to the value specified in Remark 5 in GNC paper.
-         surrogate cost is convex for mu close to zero
+        /* surrogate cost is convex for mu close to zero. initialize as in remark 5 in GNC paper.
          degenerate case: 2 * rmax_sq - params_.barcSq < 0 (handled in the main loop)
          according to remark mu = params_.barcSq / (2 * rmax_sq - params_.barcSq) = params_.barcSq/ excessResidual
-         however, if the denominator is 0 or negative, we return mu = -1 which leads to termination of the main GNC loop
+         however, if the denominator is 0 or negative, we return mu = -1 which leads to termination of the main GNC loop.
+         Since barcSq_ can be different for each factor, we look for the minimimum (positive) quantity in remark 5 in GNC paper
          */
         mu_init = std::numeric_limits<double>::infinity();
         for (size_t k = 0; k < nfg_.size(); k++) {
@@ -239,7 +239,9 @@ class GncOptimizer {
                 std::min(mu_init, barcSq_[k] / (2 * rk - barcSq_[k]) ) : mu_init;
           }
         }
-        return mu_init > 0 && !isinf(mu_init) ? mu_init : -1;
+        return mu_init > 0 && !isinf(mu_init) ? mu_init : -1; // if mu <= 0 or mu = inf, return -1,
+        // which leads to termination of the main gnc loop. In this case, all residuals are already below the threshold
+        // and there is no need to robustify (TLS = least squares)
       default:
         throw std::runtime_error(
             "GncOptimizer::initializeMu: called with unknown loss type.");

--- a/gtsam/nonlinear/GncOptimizer.h
+++ b/gtsam/nonlinear/GncOptimizer.h
@@ -28,8 +28,6 @@
 
 #include <gtsam/nonlinear/GncParams.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
-
-//#include <boost/math/distributions/inverse_chi_squared.hpp>
 #include <boost/math/distributions/chi_squared.hpp>
 
 namespace gtsam {

--- a/gtsam/nonlinear/GncOptimizer.h
+++ b/gtsam/nonlinear/GncOptimizer.h
@@ -67,13 +67,6 @@ class GncOptimizer {
     nfg_.resize(graph.size());
     barcSq_ = Vector::Ones(graph.size());
 
-    boost::math::chi_squared_distribution<double> chi2inv(3.0);
-
-    std::cout << "chi2inv.degrees_of_freedom() = " << chi2inv.degrees_of_freedom() << std::endl;
-
-    double a = boost::math::quantile(chi2inv, 0.997);
-    std::cout << " a " << a << std::endl;
-
     double alpha = 0.99; // with this (default) probability, inlier residuals are smaller than barcSq_
 
     for (size_t i = 0; i < graph.size(); i++) {

--- a/gtsam/nonlinear/GncOptimizer.h
+++ b/gtsam/nonlinear/GncOptimizer.h
@@ -237,7 +237,7 @@ class GncOptimizer {
                 std::min(mu_init, barcSq_[k] / (2 * rk - barcSq_[k]) ) : mu_init;
           }
         }
-        return mu_init > 0 && !isinf(mu_init) ? mu_init : -1; // if mu <= 0 or mu = inf, return -1,
+        return mu_init > 0 && !std::isinf(mu_init) ? mu_init : -1; // if mu <= 0 or mu = inf, return -1,
         // which leads to termination of the main gnc loop. In this case, all residuals are already below the threshold
         // and there is no need to robustify (TLS = least squares)
       default:

--- a/gtsam/nonlinear/GncParams.h
+++ b/gtsam/nonlinear/GncParams.h
@@ -66,7 +66,6 @@ class GncParams {
   /// any other specific GNC parameters:
   GncLossType lossType = TLS;  ///< Default loss
   size_t maxIterations = 100;  ///<  Maximum number of iterations
-  double barcSq = 1.0;  ///< A factor is considered an inlier if factor.error() < barcSq. Note that factor.error() whitens by the covariance
   double muStep = 1.4;  ///< Multiplicative factor to reduce/increase the mu in gnc
   double relativeCostTol = 1e-5;  ///< If relative cost change is below this threshold, stop iterating
   double weightsTol = 1e-4;  ///< If the weights are within weightsTol from being binary, stop iterating (only for TLS)
@@ -84,16 +83,6 @@ class GncParams {
         << "setMaxIterations: changing the max nr of iters might lead to less accurate solutions and is not recommended! "
         << std::endl;
     maxIterations = maxIter;
-  }
-
-  /** Set the maximum weighted residual error for an inlier. For a factor in the form f(x) = 0.5 * || r(x) ||^2_Omega,
-   * the inlier threshold is the largest value of f(x) for the corresponding measurement to be considered an inlier.
-   * In other words, an inlier at x is such that 0.5 * || r(x) ||^2_Omega <= barcSq.
-   * Assuming a isotropic measurement covariance sigma^2 * Identity, the cost becomes: 0.5 * 1/sigma^2 || r(x) ||^2 <= barcSq.
-   * Hence || r(x) ||^2 <= 2 * barcSq * sigma^2.
-   * */
-  void setInlierCostThreshold(const double inth) {
-    barcSq = inth;
   }
 
   /// Set the graduated non-convexity step: at each GNC iteration, mu is updated as mu <- mu * muStep.
@@ -131,7 +120,6 @@ class GncParams {
   bool equals(const GncParams& other, double tol = 1e-9) const {
     return baseOptimizerParams.equals(other.baseOptimizerParams)
         && lossType == other.lossType && maxIterations == other.maxIterations
-        && std::fabs(barcSq - other.barcSq) <= tol
         && std::fabs(muStep - other.muStep) <= tol
         && verbosity == other.verbosity && knownInliers == other.knownInliers;
   }
@@ -150,7 +138,6 @@ class GncParams {
         throw std::runtime_error("GncParams::print: unknown loss type.");
     }
     std::cout << "maxIterations: " << maxIterations << "\n";
-    std::cout << "barcSq: " << barcSq << "\n";
     std::cout << "muStep: " << muStep << "\n";
     std::cout << "relativeCostTol: " << relativeCostTol << "\n";
     std::cout << "weightsTol: " << weightsTol << "\n";

--- a/tests/testGncOptimizer.cpp
+++ b/tests/testGncOptimizer.cpp
@@ -128,6 +128,7 @@ TEST(GncOptimizer, initializeMu) {
   gncParams.setLossType(GncLossType::GM);
   auto gnc_gm = GncOptimizer<GncParams<LevenbergMarquardtParams>>(fg, initial,
                                                                   gncParams);
+  gnc_gm.setInlierCostThresholds(1.0);
   // according to rmk 5 in the gnc paper: m0 = 2 rmax^2 / barcSq
   // (barcSq=1 in this example)
   EXPECT_DOUBLES_EQUAL(gnc_gm.initializeMu(), 2 * 198.999, 1e-3);
@@ -136,6 +137,7 @@ TEST(GncOptimizer, initializeMu) {
   gncParams.setLossType(GncLossType::TLS);
   auto gnc_tls = GncOptimizer<GncParams<LevenbergMarquardtParams>>(fg, initial,
                                                                    gncParams);
+  gnc_tls.setInlierCostThresholds(1.0);
   // according to rmk 5 in the gnc paper: m0 =  barcSq / (2 * rmax^2 - barcSq)
   // (barcSq=1 in this example)
   EXPECT_DOUBLES_EQUAL(gnc_tls.initializeMu(), 1 / (2 * 198.999 - 1), 1e-3);
@@ -339,6 +341,7 @@ TEST(GncOptimizer, calculateWeightsGM) {
   GncParams<GaussNewtonParams> gncParams(gnParams);
   gncParams.setLossType(GncLossType::GM);
   auto gnc = GncOptimizer<GncParams<GaussNewtonParams>>(fg, initial, gncParams);
+  gnc.setInlierCostThresholds(1.0);
   double mu = 1.0;
   Vector weights_actual = gnc.calculateWeights(initial, mu);
   CHECK(assert_equal(weights_expected, weights_actual, tol));
@@ -550,7 +553,7 @@ TEST(GncOptimizer, optimizeWithKnownInliers) {
     //gncParams.setVerbosityGNC(GncParams<GaussNewtonParams>::Verbosity::SUMMARY);
     auto gnc = GncOptimizer<GncParams<GaussNewtonParams>>(fg, initial,
                                                           gncParams);
-
+    gnc.setInlierCostThresholds(1.0);
     Values gnc_result = gnc.optimize();
     CHECK(assert_equal(Point2(0.0, 0.0), gnc_result.at<Point2>(X(1)), 1e-3));
 


### PR DESCRIPTION
I realized that having a default inlier threshold equal to 1 does not make sense for the gtsam user since:
1) "1" is not a reasonable error threshold (for Gaussian noise, we should use the chi2inv to establish a reasonable maximum error) and 
2) the factors can have different dimensions, hence it is desirable to be able to set a different threshold for each factor.

The PR involves:

- [x] making barcsq into a vector
- [x] adding/adjusting the unit tests accordingly
- [x] initializing barcsq using chi2inv