### PR TITLE
Avoid target collision if gtsam used as submodule

### DIFF
--- a/cmake/HandleUninstall.cmake
+++ b/cmake/HandleUninstall.cmake
@@ -6,5 +6,11 @@ configure_file(
   "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
   IMMEDIATE @ONLY)
 
-add_custom_target(uninstall
-  "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
+if (NOT TARGET uninstall) # avoid duplicating this target
+  add_custom_target(uninstall
+    "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
+else()
+    add_custom_target(uninstall_gtsam
+      "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
+    add_dependencies(uninstall uninstall_gtsam)
+endif()


### PR DESCRIPTION
CMake ends with an error if gtsam is used as a git submodule in another project also having an `uninstall()` target. 

This PR simply defines another target and makes the top-level one to depend on it, or fallback to the usual way if no other top-level `uninstall` exists.