### PR TITLE
Constant Velocity Constraint between NavStates

### DIFF
--- a/gtsam/navigation/ConstantVelocityFactor.h
+++ b/gtsam/navigation/ConstantVelocityFactor.h
@@ -52,20 +52,11 @@ class ConstantVelocityFactor : public NoiseModelFactor2<NavState, NavState> {
         static const Vector3 b_accel{0.0, 0.0, 0.0};
         static const Vector3 b_omega{0.0, 0.0, 0.0};
 
-        NavState predicted;
-        Matrix predicted_H_x1;
+        Matrix99 predicted_H_x1;
+        NavState predicted = x1.update(b_accel, b_omega, dt_, H1 ? &predicted_H_x1 : nullptr, {}, {});
 
-        if (H1)
-            predicted = x1.update(b_accel, b_omega, dt_, predicted_H_x1, {}, {});
-        else
-            predicted = x1.update(b_accel, b_omega, dt_, boost::none, {}, {});
-
-        Matrix error_H_predicted;
-        Vector9 error;
-        if (H1)
-            error = predicted.localCoordinates(x2, error_H_predicted, H2);
-        else
-            error = predicted.localCoordinates(x2, boost::none, H2);
+        Matrix99 error_H_predicted;
+        Vector9 error = predicted.localCoordinates(x2, H1 ? &error_H_predicted : nullptr, H2);
 
         if (H1) {
             *H1 = error_H_predicted * predicted_H_x1;

--- a/gtsam/navigation/ConstantVelocityFactor.h
+++ b/gtsam/navigation/ConstantVelocityFactor.h
@@ -35,8 +35,8 @@ class ConstantVelocityFactor : public NoiseModelFactor2<NavState, NavState> {
                                 boost::optional<gtsam::Matrix &> H1 = boost::none,
                                 boost::optional<gtsam::Matrix &> H2 = boost::none) const override {
         // only used to use update() below
-        const Vector3 b_accel{0.0, 0.0, 0.0};
-        const Vector3 b_omega{0.0, 0.0, 0.0};
+        static const Vector3 b_accel{0.0, 0.0, 0.0};
+        static const Vector3 b_omega{0.0, 0.0, 0.0};
 
         Matrix predicted_H_x1;
         NavState predicted = x1.update(b_accel, b_omega, dt_, predicted_H_x1, {}, {});

--- a/gtsam/navigation/ConstantVelocityFactor.h
+++ b/gtsam/navigation/ConstantVelocityFactor.h
@@ -1,6 +1,20 @@
-#include <gtsam/base/numericalDerivative.h>
-#include <gtsam/geometry/Pose3.h>
-#include <gtsam/inference/Symbol.h>
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file    NonlinearFactor.h
+ * @brief   Non-linear factor base classes
+ * @author  Asa Hammond
+ */
+
 #include <gtsam/navigation/NavState.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 

--- a/gtsam/navigation/ConstantVelocityFactor.h
+++ b/gtsam/navigation/ConstantVelocityFactor.h
@@ -20,35 +20,33 @@ class ConstantVelocityFactor : public NoiseModelFactor2<NavState, NavState> {
     gtsam::Vector evaluateError(const NavState &x1, const NavState &x2,
                                 boost::optional<gtsam::Matrix &> H1 = boost::none,
                                 boost::optional<gtsam::Matrix &> H2 = boost::none) const override {
+        // so we can reuse this calculation below
+        auto evaluateErrorInner = [dt = dt_](const NavState &x1, const NavState &x2) -> gtsam::Vector {
+            const Velocity3 &v1 = x1.v();
+            const Velocity3 &v2 = x2.v();
+            const Point3 &p1 = x1.t();
+            const Point3 &p2 = x2.t();
+
+            // trapezoidal integration constant accelleration
+            // const Point3 hx = p1 + Point3((v1 + v2) * dt / 2.0);
+
+            // euler start
+            // const Point3 hx = p1 + Point3(v1 * dt);
+
+            // euler end
+            const Point3 hx = p1 + Point3(v2 * dt);
+
+            return p2 - hx;
+        };
+
         if (H1) {
-            (*H1) = numericalDerivative21<gtsam::Vector, NavState, NavState>(
-                boost::bind(ConstantVelocityFactor::evaluateError_, _1, _2, dt_), x1, x2, 1e-5);
+            (*H1) = numericalDerivative21<gtsam::Vector, NavState, NavState>(evaluateErrorInner, x1, x2, 1e-5);
         }
         if (H2) {
-            (*H2) = numericalDerivative22<gtsam::Vector, NavState, NavState>(
-                boost::bind(ConstantVelocityFactor::evaluateError_, _1, _2, dt_), x1, x2, 1e-5);
+            (*H2) = numericalDerivative22<gtsam::Vector, NavState, NavState>(evaluateErrorInner, x1, x2, 1e-5);
         }
 
-        return evaluateError_(x1, x2, dt_);
-    }
-
-   private:
-    static gtsam::Vector evaluateError_(const NavState &x1, const NavState &x2, double dt) {
-        const Velocity3 &v1 = x1.v();
-        const Velocity3 &v2 = x2.v();
-        const Point3 &p1 = x1.t();
-        const Point3 &p2 = x2.t();
-
-        // trapezoidal integration constant accelleration
-        // const Point3 hx = p1 + Point3((v1 + v2) * dt / 2.0);
-
-        // euler start
-        // const Point3 hx = p1 + Point3(v1 * dt);
-
-        // euler end
-        const Point3 hx = p1 + Point3(v2 * dt);
-
-        return p2 - hx;
+        return evaluateErrorInner(x1, x2);
     }
 };
 

--- a/gtsam/navigation/ConstantVelocityFactor.h
+++ b/gtsam/navigation/ConstantVelocityFactor.h
@@ -52,11 +52,20 @@ class ConstantVelocityFactor : public NoiseModelFactor2<NavState, NavState> {
         static const Vector3 b_accel{0.0, 0.0, 0.0};
         static const Vector3 b_omega{0.0, 0.0, 0.0};
 
+        NavState predicted;
         Matrix predicted_H_x1;
-        NavState predicted = x1.update(b_accel, b_omega, dt_, predicted_H_x1, {}, {});
+
+        if (H1)
+            predicted = x1.update(b_accel, b_omega, dt_, predicted_H_x1, {}, {});
+        else
+            predicted = x1.update(b_accel, b_omega, dt_, boost::none, {}, {});
 
         Matrix error_H_predicted;
-        Vector9 error = predicted.localCoordinates(x2, error_H_predicted, H2);
+        Vector9 error;
+        if (H1)
+            error = predicted.localCoordinates(x2, error_H_predicted, H2);
+        else
+            error = predicted.localCoordinates(x2, boost::none, H2);
 
         if (H1) {
             *H1 = error_H_predicted * predicted_H_x1;

--- a/gtsam/navigation/ConstantVelocityFactor.h
+++ b/gtsam/navigation/ConstantVelocityFactor.h
@@ -4,12 +4,7 @@
 #include <gtsam/navigation/NavState.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 
-using gtsam::Key;
-using gtsam::NavState;
-using gtsam::NoiseModelFactor2;
-using gtsam::Point3;
-using gtsam::SharedNoiseModel;
-using gtsam::Velocity3;
+namespace gtsam {
 
 class ConstantVelocityFactor : public NoiseModelFactor2<NavState, NavState> {
     double dt_;
@@ -57,3 +52,4 @@ class ConstantVelocityFactor : public NoiseModelFactor2<NavState, NavState> {
     }
 };
 
+}  // namespace gtsam

--- a/gtsam/navigation/ConstantVelocityFactor.h
+++ b/gtsam/navigation/ConstantVelocityFactor.h
@@ -10,8 +10,8 @@
  * -------------------------------------------------------------------------- */
 
 /**
- * @file    NonlinearFactor.h
- * @brief   Non-linear factor base classes
+ * @file    ConstantVelocityFactor.h
+ * @brief   Maintain a constant velocity motion model between two NavStates
  * @author  Asa Hammond
  */
 

--- a/gtsam/navigation/ConstantVelocityFactor.h
+++ b/gtsam/navigation/ConstantVelocityFactor.h
@@ -1,0 +1,59 @@
+#include <gtsam/base/numericalDerivative.h>
+#include <gtsam/geometry/Pose3.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/navigation/NavState.h>
+#include <gtsam/nonlinear/NonlinearFactor.h>
+
+using gtsam::Key;
+using gtsam::NavState;
+using gtsam::NoiseModelFactor2;
+using gtsam::Point3;
+using gtsam::SharedNoiseModel;
+using gtsam::Velocity3;
+
+class ConstantVelocityFactor : public NoiseModelFactor2<NavState, NavState> {
+    double dt_;
+
+   public:
+    using Base = NoiseModelFactor2<NavState, NavState>;
+
+   public:
+    ConstantVelocityFactor(Key i, Key j, double dt, const SharedNoiseModel &model)
+        : NoiseModelFactor2<NavState, NavState>(model, i, j), dt_(dt) {}
+    ~ConstantVelocityFactor() override{};
+
+    gtsam::Vector evaluateError(const NavState &x1, const NavState &x2,
+                                boost::optional<gtsam::Matrix &> H1 = boost::none,
+                                boost::optional<gtsam::Matrix &> H2 = boost::none) const override {
+        if (H1) {
+            (*H1) = numericalDerivative21<gtsam::Vector, NavState, NavState>(
+                boost::bind(ConstantVelocityFactor::evaluateError_, _1, _2, dt_), x1, x2, 1e-5);
+        }
+        if (H2) {
+            (*H2) = numericalDerivative22<gtsam::Vector, NavState, NavState>(
+                boost::bind(ConstantVelocityFactor::evaluateError_, _1, _2, dt_), x1, x2, 1e-5);
+        }
+
+        return evaluateError_(x1, x2, dt_);
+    }
+
+   private:
+    static gtsam::Vector evaluateError_(const NavState &x1, const NavState &x2, double dt) {
+        const Velocity3 &v1 = x1.v();
+        const Velocity3 &v2 = x2.v();
+        const Point3 &p1 = x1.t();
+        const Point3 &p2 = x2.t();
+
+        // trapezoidal integration constant accelleration
+        // const Point3 hx = p1 + Point3((v1 + v2) * dt / 2.0);
+
+        // euler start
+        // const Point3 hx = p1 + Point3(v1 * dt);
+
+        // euler end
+        const Point3 hx = p1 + Point3(v2 * dt);
+
+        return p2 - hx;
+    }
+};
+

--- a/gtsam/navigation/NavState.cpp
+++ b/gtsam/navigation/NavState.cpp
@@ -136,12 +136,12 @@ Vector9 NavState::localCoordinates(const NavState& g, //
     OptionalJacobian<9, 9> H1, OptionalJacobian<9, 9> H2) const {
   Matrix3 D_dR_R, D_dt_R, D_dv_R;
   const Rot3 dR = R_.between(g.R_, H1 ? &D_dR_R : 0);
-  const Point3 dt = R_.unrotate(g.t_ - t_, H1 ? &D_dt_R : 0);
-  const Vector dv = R_.unrotate(g.v_ - v_, H1 ? &D_dv_R : 0);
+  const Point3 dP = R_.unrotate(g.t_ - t_, H1 ? &D_dt_R : 0);
+  const Vector dV = R_.unrotate(g.v_ - v_, H1 ? &D_dv_R : 0);
 
   Vector9 xi;
   Matrix3 D_xi_R;
-  xi << Rot3::Logmap(dR, (H1 || H2) ? &D_xi_R : 0), dt, dv;
+  xi << Rot3::Logmap(dR, (H1 || H2) ? &D_xi_R : 0), dP, dV;
   if (H1) {
     *H1 << D_xi_R * D_dR_R, Z_3x3, Z_3x3, //
     D_dt_R, -I_3x3, Z_3x3, //

--- a/gtsam/navigation/tests/testConstantVelocityFactor.cpp
+++ b/gtsam/navigation/tests/testConstantVelocityFactor.cpp
@@ -1,0 +1,74 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file    testConstantVelocityFactor.cpp
+ * @brief   Unit test for ConstantVelocityFactor
+ * @author  Alex Cunningham
+ * @author  Asa Hammond
+ */
+
+#include <gtsam/base/TestableAssertions.h>
+#include <gtsam/base/numericalDerivative.h>
+#include <gtsam/geometry/Pose3.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/navigation/ConstantVelocityFactor.h>
+#include <gtsam/nonlinear/Values.h>
+
+#include <CppUnitLite/TestHarness.h>
+
+#include <boost/bind.hpp>
+#include <list>
+
+/* ************************************************************************* */
+TEST(ConstantVelocityFactor, VelocityFactor) {
+    using namespace gtsam;
+
+    const auto tol = double{1e-5};
+
+    const auto x1 = Key{1};
+    const auto x2 = Key{2};
+
+    const auto dt = double{1.0};
+    const auto mu = double{1000};
+
+    // moving upward with groundtruth velocity"
+    const auto origin = NavState{Pose3{Rot3::Yaw(0), Point3{0.0, 0.0, 0.0}}, Velocity3{0.0, 0.0, 0.0}};
+
+    const auto state0 = NavState{Pose3{Rot3::Yaw(0), Point3{0.0, 0.0, 0.0}}, Velocity3{0.0, 0.0, 1.0}};
+
+    const auto state1 = NavState{Pose3{Rot3::Yaw(0), Point3{0.0, 0.0, 1.0}}, Velocity3{0.0, 0.0, 1.0}};
+
+    const auto state2 = NavState{Pose3{Rot3::Yaw(0), Point3{0.0, 0.0, 2.0}}, Velocity3{0.0, 0.0, 1.0}};
+
+    const auto noise_model = noiseModel::Constrained::All(3, mu);
+
+    const auto factor = ConstantVelocityFactor(x1, x2, dt, noise_model);
+
+    // positions are the same, secondary state has velocity 1.0 ,
+    EXPECT(assert_equal(Unit3{0.0, 0.0, -1.0}.unitVector(), factor.evaluateError(origin, state0), tol));
+
+    // same velocities, different position
+    // second state agrees with initial state + velocity * dt
+    EXPECT(assert_equal(Unit3{0.0, 0.0, 0.0}.unitVector(), factor.evaluateError(state0, state1), tol));
+
+    // both bodies have the same velocity,
+    // but state2.pose() != state0.pose() + state0.velocity * dt
+    // error comes from this pose difference
+    EXPECT(assert_equal(Unit3{0.0, 0.0, 1.0}.unitVector(), factor.evaluateError(state0, state2), tol));
+}
+
+/* ************************************************************************* */
+int main() {
+    TestResult tr;
+    return TestRegistry::runAllTests(tr);
+}
+/* ************************************************************************* */

--- a/gtsam/navigation/tests/testConstantVelocityFactor.cpp
+++ b/gtsam/navigation/tests/testConstantVelocityFactor.cpp
@@ -43,51 +43,34 @@ TEST(ConstantVelocityFactor, VelocityFactor) {
 
     const auto state2 = NavState{Pose3{Rot3::Yaw(0), Point3{0.0, 0.0, 2.0}}, Velocity3{0.0, 0.0, 1.0}};
 
+    const auto state3 = NavState{Pose3{Rot3::Yaw(M_PI_2), Point3{0.0, 0.0, 2.0}}, Velocity3{0.0, 0.0, 1.0}};
+
     const double mu{1000};
     const auto noise_model = noiseModel::Constrained::All(9, mu);
 
     const auto factor = ConstantVelocityFactor(x1, x2, dt, noise_model);
 
-    // TODO make these tests way less verbose!
-    // ideally I could find an initializer for Vector9 like: Vector9{0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0}'
     // positions are the same, secondary state has velocity 1.0 in z,
     const auto state0_err_origin = factor.evaluateError(origin, state0);
-    EXPECT(assert_equal(0.0, NavState::dP(state0_err_origin).x(), tol));
-    EXPECT(assert_equal(0.0, NavState::dP(state0_err_origin).y(), tol));
-    EXPECT(assert_equal(0.0, NavState::dP(state0_err_origin).z(), tol));
-    EXPECT(assert_equal(0.0, NavState::dR(state0_err_origin).x(), tol));
-    EXPECT(assert_equal(0.0, NavState::dR(state0_err_origin).y(), tol));
-    EXPECT(assert_equal(0.0, NavState::dR(state0_err_origin).z(), tol));
-    EXPECT(assert_equal(0.0, NavState::dV(state0_err_origin).x(), tol));
-    EXPECT(assert_equal(0.0, NavState::dV(state0_err_origin).y(), tol));
-    EXPECT(assert_equal(1.0, NavState::dV(state0_err_origin).z(), tol));
+    EXPECT(assert_equal((Vector9() << 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0).finished(), state0_err_origin, tol));
 
     // same velocities, different position
     // second state agrees with initial state + velocity * dt
     const auto state1_err_state0 = factor.evaluateError(state0, state1);
-    EXPECT(assert_equal(0.0, NavState::dP(state1_err_state0).x(), tol));
-    EXPECT(assert_equal(0.0, NavState::dP(state1_err_state0).y(), tol));
-    EXPECT(assert_equal(0.0, NavState::dP(state1_err_state0).z(), tol));
-    EXPECT(assert_equal(0.0, NavState::dR(state1_err_state0).x(), tol));
-    EXPECT(assert_equal(0.0, NavState::dR(state1_err_state0).y(), tol));
-    EXPECT(assert_equal(0.0, NavState::dR(state1_err_state0).z(), tol));
-    EXPECT(assert_equal(0.0, NavState::dV(state1_err_state0).x(), tol));
-    EXPECT(assert_equal(0.0, NavState::dV(state1_err_state0).y(), tol));
-    EXPECT(assert_equal(0.0, NavState::dV(state1_err_state0).z(), tol));
+    EXPECT(assert_equal((Vector9() << 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0).finished(), state1_err_state0, tol));
+
+    // same velocities, same position, different rotations
+    // second state agrees with initial state + velocity * dt
+    // as we assume that omega is 0.0 this is the same as the above case
+    //  TODO: this should respect omega and actually fail in this case
+    const auto state3_err_state2 = factor.evaluateError(state0, state1);
+    EXPECT(assert_equal((Vector9() << 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0).finished(), state3_err_state2, tol));
 
     // both bodies have the same velocity,
-    // but state2.pose() does not agree with .update()
-    // error comes from this pose difference
+    // but state2.pose() does not agree with state0.update()
+    // error comes from this position difference
     const auto state2_err_state0 = factor.evaluateError(state0, state2);
-    EXPECT(assert_equal(0.0, NavState::dP(state2_err_state0).x(), tol));
-    EXPECT(assert_equal(0.0, NavState::dP(state2_err_state0).y(), tol));
-    EXPECT(assert_equal(1.0, NavState::dP(state2_err_state0).z(), tol));
-    EXPECT(assert_equal(0.0, NavState::dR(state2_err_state0).x(), tol));
-    EXPECT(assert_equal(0.0, NavState::dR(state2_err_state0).y(), tol));
-    EXPECT(assert_equal(0.0, NavState::dR(state2_err_state0).z(), tol));
-    EXPECT(assert_equal(0.0, NavState::dV(state2_err_state0).x(), tol));
-    EXPECT(assert_equal(0.0, NavState::dV(state2_err_state0).y(), tol));
-    EXPECT(assert_equal(0.0, NavState::dV(state2_err_state0).z(), tol));
+    EXPECT(assert_equal((Vector9() << 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0).finished(), state2_err_state0, tol));
 }
 
 /* ************************************************************************* */

--- a/gtsam/navigation/tests/testConstantVelocityFactor.cpp
+++ b/gtsam/navigation/tests/testConstantVelocityFactor.cpp
@@ -12,20 +12,15 @@
 /**
  * @file    testConstantVelocityFactor.cpp
  * @brief   Unit test for ConstantVelocityFactor
- * @author  Alex Cunningham
  * @author  Asa Hammond
  */
 
 #include <gtsam/base/TestableAssertions.h>
-#include <gtsam/base/numericalDerivative.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/navigation/ConstantVelocityFactor.h>
-#include <gtsam/nonlinear/Values.h>
 
 #include <CppUnitLite/TestHarness.h>
-
-#include <boost/bind.hpp>
 #include <list>
 
 /* ************************************************************************* */

--- a/gtsam/navigation/tests/testConstantVelocityFactor.cpp
+++ b/gtsam/navigation/tests/testConstantVelocityFactor.cpp
@@ -53,17 +53,46 @@ TEST(ConstantVelocityFactor, VelocityFactor) {
 
     const auto factor = ConstantVelocityFactor(x1, x2, dt, noise_model);
 
-    // positions are the same, secondary state has velocity 1.0 ,
-    EXPECT(assert_equal(Unit3{0.0, 0.0, -1.0}.unitVector(), factor.evaluateError(origin, state0), tol));
+    // TODO make these tests way less verbose!
+    // ideally I could find an initializer for Vector9 like: Vector9{0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0}'
+    // positions are the same, secondary state has velocity 1.0 in z,
+    const auto state0_err_origin = factor.evaluateError(origin, state0);
+    EXPECT(assert_equal(0.0, NavState::dP(state0_err_origin).x(), tol));
+    EXPECT(assert_equal(0.0, NavState::dP(state0_err_origin).y(), tol));
+    EXPECT(assert_equal(0.0, NavState::dP(state0_err_origin).z(), tol));
+    EXPECT(assert_equal(0.0, NavState::dR(state0_err_origin).x(), tol));
+    EXPECT(assert_equal(0.0, NavState::dR(state0_err_origin).y(), tol));
+    EXPECT(assert_equal(0.0, NavState::dR(state0_err_origin).z(), tol));
+    EXPECT(assert_equal(0.0, NavState::dV(state0_err_origin).x(), tol));
+    EXPECT(assert_equal(0.0, NavState::dV(state0_err_origin).y(), tol));
+    EXPECT(assert_equal(1.0, NavState::dV(state0_err_origin).z(), tol));
 
     // same velocities, different position
     // second state agrees with initial state + velocity * dt
-    EXPECT(assert_equal(Unit3{0.0, 0.0, 0.0}.unitVector(), factor.evaluateError(state0, state1), tol));
+    const auto state1_err_state0 = factor.evaluateError(state0, state1);
+    EXPECT(assert_equal(0.0, NavState::dP(state1_err_state0).x(), tol));
+    EXPECT(assert_equal(0.0, NavState::dP(state1_err_state0).y(), tol));
+    EXPECT(assert_equal(0.0, NavState::dP(state1_err_state0).z(), tol));
+    EXPECT(assert_equal(0.0, NavState::dR(state1_err_state0).x(), tol));
+    EXPECT(assert_equal(0.0, NavState::dR(state1_err_state0).y(), tol));
+    EXPECT(assert_equal(0.0, NavState::dR(state1_err_state0).z(), tol));
+    EXPECT(assert_equal(0.0, NavState::dV(state1_err_state0).x(), tol));
+    EXPECT(assert_equal(0.0, NavState::dV(state1_err_state0).y(), tol));
+    EXPECT(assert_equal(0.0, NavState::dV(state1_err_state0).z(), tol));
 
     // both bodies have the same velocity,
-    // but state2.pose() != state0.pose() + state0.velocity * dt
+    // but state2.pose() does not agree with .update()
     // error comes from this pose difference
-    EXPECT(assert_equal(Unit3{0.0, 0.0, 1.0}.unitVector(), factor.evaluateError(state0, state2), tol));
+    const auto state2_err_state0 = factor.evaluateError(state0, state2);
+    EXPECT(assert_equal(0.0, NavState::dP(state2_err_state0).x(), tol));
+    EXPECT(assert_equal(0.0, NavState::dP(state2_err_state0).y(), tol));
+    EXPECT(assert_equal(1.0, NavState::dP(state2_err_state0).z(), tol));
+    EXPECT(assert_equal(0.0, NavState::dR(state2_err_state0).x(), tol));
+    EXPECT(assert_equal(0.0, NavState::dR(state2_err_state0).y(), tol));
+    EXPECT(assert_equal(0.0, NavState::dR(state2_err_state0).z(), tol));
+    EXPECT(assert_equal(0.0, NavState::dV(state2_err_state0).x(), tol));
+    EXPECT(assert_equal(0.0, NavState::dV(state2_err_state0).y(), tol));
+    EXPECT(assert_equal(0.0, NavState::dV(state2_err_state0).z(), tol));
 }
 
 /* ************************************************************************* */

--- a/gtsam/navigation/tests/testConstantVelocityFactor.cpp
+++ b/gtsam/navigation/tests/testConstantVelocityFactor.cpp
@@ -49,7 +49,7 @@ TEST(ConstantVelocityFactor, VelocityFactor) {
     const auto state2 = NavState{Pose3{Rot3::Yaw(0), Point3{0.0, 0.0, 2.0}}, Velocity3{0.0, 0.0, 1.0}};
 
     const double mu{1000};
-    const auto noise_model = noiseModel::Constrained::All(3, mu);
+    const auto noise_model = noiseModel::Constrained::All(9, mu);
 
     const auto factor = ConstantVelocityFactor(x1, x2, dt, noise_model);
 

--- a/gtsam/navigation/tests/testConstantVelocityFactor.cpp
+++ b/gtsam/navigation/tests/testConstantVelocityFactor.cpp
@@ -32,13 +32,12 @@
 TEST(ConstantVelocityFactor, VelocityFactor) {
     using namespace gtsam;
 
-    const auto tol = double{1e-5};
+    const double tol{1e-5};
 
-    const auto x1 = Key{1};
-    const auto x2 = Key{2};
+    const Key x1 = Key{1};
+    const Key x2 = Key{2};
 
-    const auto dt = double{1.0};
-    const auto mu = double{1000};
+    const double dt{1.0};
 
     // moving upward with groundtruth velocity"
     const auto origin = NavState{Pose3{Rot3::Yaw(0), Point3{0.0, 0.0, 0.0}}, Velocity3{0.0, 0.0, 0.0}};
@@ -49,6 +48,7 @@ TEST(ConstantVelocityFactor, VelocityFactor) {
 
     const auto state2 = NavState{Pose3{Rot3::Yaw(0), Point3{0.0, 0.0, 2.0}}, Velocity3{0.0, 0.0, 1.0}};
 
+    const double mu{1000};
     const auto noise_model = noiseModel::Constrained::All(3, mu);
 
     const auto factor = ConstantVelocityFactor(x1, x2, dt, noise_model);


### PR DESCRIPTION
Here is a first pass at a Constant Velocity Constraint between two NavStates.

It is much cribbed from the VelocityConstraint in gtsam_unstable/dynamics. Hopefully along the way we can improve this to be usable in external state tracking problems.

I am using almost always auto style here, let me know if that is discouraged, or how else I can tailor this back to being more in line with the rest of the library.