### PR TITLE
Fixing translation averaging for the panorama case

### DIFF
--- a/gtsam/sfm/TranslationRecovery.cpp
+++ b/gtsam/sfm/TranslationRecovery.cpp
@@ -81,6 +81,7 @@ void TranslationRecovery::addPrior(
     const double scale, NonlinearFactorGraph *graph,
     const SharedNoiseModel &priorNoiseModel) const {
   auto edge = relativeTranslations_.begin();
+  if(edge == relativeTranslations_.end()) return;
   graph->emplace_shared<PriorFactor<Point3> >(edge->key1(), Point3(0, 0, 0),
                                               priorNoiseModel);
   graph->emplace_shared<PriorFactor<Point3> >(
@@ -101,6 +102,15 @@ Values TranslationRecovery::initalizeRandomly() const {
   for (auto edge : relativeTranslations_) {
     insert(edge.key1());
     insert(edge.key2());
+  }
+
+  // If there are no valid edges, but zero-distance edges exist, initialize one of 
+  // the nodes in a connected component of zero-distance edges. 
+  if(initial.empty() && !sameTranslationNodes_.empty()){
+    for(const auto &optimizedAndDuplicateKeys : sameTranslationNodes_) {
+      Key optimizedKey = optimizedAndDuplicateKeys.first;
+      initial.insert<Point3>(optimizedKey, Point3(0, 0, 0));
+    }
   }
   return initial;
 }

--- a/gtsam/sfm/TranslationRecovery.cpp
+++ b/gtsam/sfm/TranslationRecovery.cpp
@@ -81,7 +81,7 @@ void TranslationRecovery::addPrior(
     const double scale, NonlinearFactorGraph *graph,
     const SharedNoiseModel &priorNoiseModel) const {
   auto edge = relativeTranslations_.begin();
-  if(edge == relativeTranslations_.end()) return;
+  if (edge == relativeTranslations_.end()) return;
   graph->emplace_shared<PriorFactor<Point3> >(edge->key1(), Point3(0, 0, 0),
                                               priorNoiseModel);
   graph->emplace_shared<PriorFactor<Point3> >(
@@ -104,10 +104,10 @@ Values TranslationRecovery::initalizeRandomly() const {
     insert(edge.key2());
   }
 
-  // If there are no valid edges, but zero-distance edges exist, initialize one of 
-  // the nodes in a connected component of zero-distance edges. 
-  if(initial.empty() && !sameTranslationNodes_.empty()){
-    for(const auto &optimizedAndDuplicateKeys : sameTranslationNodes_) {
+  // If there are no valid edges, but zero-distance edges exist, initialize one
+  // of the nodes in a connected component of zero-distance edges.
+  if (initial.empty() && !sameTranslationNodes_.empty()) {
+    for (const auto &optimizedAndDuplicateKeys : sameTranslationNodes_) {
       Key optimizedKey = optimizedAndDuplicateKeys.first;
       initial.insert<Point3>(optimizedKey, Point3(0, 0, 0));
     }

--- a/tests/testTranslationRecovery.cpp
+++ b/tests/testTranslationRecovery.cpp
@@ -17,7 +17,6 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
-
 #include <gtsam/sfm/TranslationRecovery.h>
 #include <gtsam/slam/dataset.h>
 
@@ -185,7 +184,7 @@ TEST(TranslationRecovery, ThreePosesIncludingZeroTranslation) {
   TranslationRecovery algorithm(relativeTranslations);
   const auto graph = algorithm.buildGraph();
   // There is only 1 non-zero translation edge.
-  EXPECT_LONGS_EQUAL(1, graph.size()); 
+  EXPECT_LONGS_EQUAL(1, graph.size());
 
   // Run translation recovery
   const auto result = algorithm.run(/*scale=*/3.0);
@@ -244,28 +243,28 @@ TEST(TranslationRecovery, ThreePosesWithZeroTranslation) {
   poses.insert<Pose3>(1, Pose3(Rot3(), Point3(0, 0, 0)));
   poses.insert<Pose3>(2, Pose3(Rot3::RzRyRx(M_PI / 6, 0, 0), Point3(0, 0, 0)));
 
-  auto relativeTranslations = TranslationRecovery::SimulateMeasurements(poses, {{0, 1}, {1, 2}, {2, 0}});
+  auto relativeTranslations = TranslationRecovery::SimulateMeasurements(
+      poses, {{0, 1}, {1, 2}, {2, 0}});
 
   // Check simulated measurements.
   for (auto& unitTranslation : relativeTranslations) {
-    EXPECT(assert_equal(GetDirectionFromPoses(poses, unitTranslation), 
-			    unitTranslation.measured()));
+    EXPECT(assert_equal(GetDirectionFromPoses(poses, unitTranslation),
+                        unitTranslation.measured()));
   }
 
   TranslationRecovery algorithm(relativeTranslations);
   const auto graph = algorithm.buildGraph();
-  // Graph size will be zero as there no 'non-zero distance' edges. 
+  // Graph size will be zero as there no 'non-zero distance' edges.
   EXPECT_LONGS_EQUAL(0, graph.size());
-  
+
   // Run translation recovery
   const auto result = algorithm.run(/*scale=*/4.0);
-  
+
   // Check result
   EXPECT(assert_equal(Point3(0, 0, 0), result.at<Point3>(0)));
   EXPECT(assert_equal(Point3(0, 0, 0), result.at<Point3>(1)));
   EXPECT(assert_equal(Point3(0, 0, 0), result.at<Point3>(2)));
 }
-                                                   
 
 /* ************************************************************************* */
 int main() {


### PR DESCRIPTION
When the translation recovery class was used with unit translations that are all zero (all cameras at the same point), it would cause a segmentation fault. 
This PR adds a unit test for this case and fixes the segmentation fault. 