### PR TITLE
Enabling pickle support to python types generated by the pybind wrapper

### DIFF
--- a/gtsam/gtsam.i
+++ b/gtsam/gtsam.i
@@ -797,6 +797,12 @@ class Unit3 {
   size_t dim() const;
   gtsam::Unit3 retract(Vector v) const;
   Vector localCoordinates(const gtsam::Unit3& s) const;
+
+  // enabling serialization functionality
+  void serialize() const;
+
+  // enabling function to compare objects
+  bool equals(const gtsam::Unit3& expected, double tol) const;
 };
 
 #include <gtsam/geometry/EssentialMatrix.h>

--- a/python/gtsam/tests/test_pickle.py
+++ b/python/gtsam/tests/test_pickle.py
@@ -44,5 +44,3 @@ class TestPickle(GtsamTestCase):
     def test_unit3_roundtrip(self):
         obj = Unit3(Point3(1, 1, 0))
         self.assertEqualityOnPickleRoundtrip(obj)
-
-    

--- a/python/gtsam/tests/test_pickle.py
+++ b/python/gtsam/tests/test_pickle.py
@@ -1,0 +1,48 @@
+"""
+GTSAM Copyright 2010-2020, Georgia Tech Research Corporation,
+Atlanta, Georgia 30332-0415
+All Rights Reserved
+
+See LICENSE for the license information
+
+Unit tests to check pickling.
+
+Author: Ayush Baid
+"""
+from gtsam import Cal3Bundler, PinholeCameraCal3Bundler, Point2, Point3, Pose3, Rot3, SfmTrack, Unit3 
+
+from gtsam.utils.test_case import GtsamTestCase
+
+class TestPickle(GtsamTestCase):
+    """Tests pickling of types where it has been configured."""
+
+    def test_cal3Bundler_roundtrip(self):
+        obj = Cal3Bundler(fx=100, k1=0.1, k2=0.2, u0=100, v0=70)
+        self.assertEqualityOnPickleRoundtrip(obj)
+    
+    def test_pinholeCameraCal3Bundler_roundtrip(self):
+        obj = PinholeCameraCal3Bundler(
+            Pose3(Rot3.RzRyRx(0, 0.1, -0.05), Point3(1, 1, 0)),
+            Cal3Bundler(fx=100, k1=0.1, k2=0.2, u0=100, v0=70),
+        )
+        self.assertEqualityOnPickleRoundtrip(obj)
+    
+    def test_rot3_roundtrip(self):
+        obj = Rot3.RzRyRx(0, 0.05, 0.1)
+        self.assertEqualityOnPickleRoundtrip(obj)
+
+    def test_pose3_roundtrip(self):
+        obj = Pose3(Rot3.Ypr(0.0, 1.0, 0.0), Point3(1, 1, 0))
+        self.assertEqualityOnPickleRoundtrip(obj)
+
+    def test_sfmTrack_roundtrip(self):
+        obj = SfmTrack(Point3(1, 1, 0))
+        obj.add_measurement(0, Point2(-1, 5))
+        obj.add_measurement(1, Point2(6, 2))
+        self.assertEqualityOnPickleRoundtrip(obj)
+
+    def test_unit3_roundtrip(self):
+        obj = Unit3(Point3(1, 1, 0))
+        self.assertEqualityOnPickleRoundtrip(obj)
+
+    

--- a/python/gtsam/utils/test_case.py
+++ b/python/gtsam/utils/test_case.py
@@ -8,6 +8,7 @@ See LICENSE for the license information
 TestCase class with GTSAM assert utils.
 Author: Frank Dellaert
 """
+import pickle
 import unittest
 
 
@@ -29,3 +30,14 @@ class GtsamTestCase(unittest.TestCase):
         if not equal:
             raise self.failureException(
                 "Values are not equal:\n{}!={}".format(actual, expected))
+
+    def assertEqualityOnPickleRoundtrip(self, obj: object, tol=1e-9) -> None:
+        """ Performs a round-trip using pickle and asserts equality.
+
+            Usage:
+                self.assertEqualityOnPickleRoundtrip(obj)
+            Keyword Arguments:
+                tol {float} -- tolerance passed to 'equals', default 1e-9
+        """
+        roundTripObj = pickle.loads(pickle.dumps(obj))
+        self.gtsamAssertEquals(roundTripObj, obj)

--- a/wrap/gtwrap/pybind_wrapper.py
+++ b/wrap/gtwrap/pybind_wrapper.py
@@ -75,7 +75,17 @@ class PybindWrapper(object):
                         []({class_inst} self, string serialized){{
                             gtsam::deserialize(serialized, *self);
                         }}, py::arg("serialized"))
-                    '''.format(class_inst=cpp_class + '*'))
+                    .def(py::pickle(
+                        [](const {cpp_class} &a){{ // __getstate__
+                            /* Returns a string that encodes the state of the object */
+                            return py::make_tuple(gtsam::serialize(a));
+                        }},
+                        [](py::tuple t){{ // __setstate__
+                            {cpp_class} obj;
+                            gtsam::deserialize(t[0].cast<std::string>(), obj);
+                            return obj;
+                        }}))
+                    '''.format(class_inst=cpp_class + '*', cpp_class=cpp_class))
 
         is_method = isinstance(method, instantiator.InstantiatedMethod)
         is_static = isinstance(method, parser.StaticMethod)
@@ -353,3 +363,4 @@ class PybindWrapper(object):
             wrapped_namespace=wrapped_namespace,
             boost_class_export=boost_class_export,
         )
+

--- a/wrap/gtwrap/pybind_wrapper.py
+++ b/wrap/gtwrap/pybind_wrapper.py
@@ -305,10 +305,10 @@ class PybindWrapper(object):
         """
         if cpp_class not in [
             "gtsam::Cal3Bundler",
-            "gtsam::PinholeCameraCal3Bundler", 
+            "gtsam::PinholeCamera<gtsam::Cal3Bundler>", 
             "gtsam::Pose3", 
             "gtsam::Rot3", 
-            "gtsam::SfmTrack"
+            "gtsam::SfmTrack",
             "gtsam::Unit3", 
         ]:
             # TODO: fix this check by just checking if serialization is supported.

--- a/wrap/gtwrap/pybind_wrapper.py
+++ b/wrap/gtwrap/pybind_wrapper.py
@@ -182,6 +182,7 @@ class PybindWrapper(object):
                 '{wrapped_ctors}'
                 '{wrapped_methods}'
                 '{wrapped_static_methods}'
+                '{wrapped_pickle}'
                 '{wrapped_properties};\n'.format(
                     shared_ptr_type=('boost' if self.use_boost else 'std'),
                     cpp_class=cpp_class,
@@ -192,6 +193,7 @@ class PybindWrapper(object):
                     wrapped_ctors=self.wrap_ctors(instantiated_class),
                     wrapped_methods=self.wrap_methods(instantiated_class.methods, cpp_class),
                     wrapped_static_methods=self.wrap_methods(instantiated_class.static_methods, cpp_class),
+                    wrapped_pickle=self.wrap_pickle(cpp_class),
                     wrapped_properties=self.wrap_properties(instantiated_class.properties, cpp_class),
                 ))
 
@@ -206,6 +208,7 @@ class PybindWrapper(object):
                 '{wrapped_ctors}'
                 '{wrapped_methods}'
                 '{wrapped_static_methods}'
+                '{wrapped_pickle}'
                 '{wrapped_properties};\n'.format(
                     shared_ptr_type=('boost' if self.use_boost else 'std'),
                     cpp_class=cpp_class,
@@ -215,6 +218,7 @@ class PybindWrapper(object):
                     wrapped_ctors=self.wrap_ctors(stl_class),
                     wrapped_methods=self.wrap_methods(stl_class.methods, cpp_class),
                     wrapped_static_methods=self.wrap_methods(stl_class.static_methods, cpp_class),
+                    wrapped_pickle=self.wrap_pickle(cpp_class),
                     wrapped_properties=self.wrap_properties(stl_class.properties, cpp_class),
                 ))
 
@@ -291,6 +295,37 @@ class PybindWrapper(object):
                 suffix=';',
             )
         return wrapped, includes
+
+    def wrap_pickle(self, cpp_class):
+        """Wrap to enable pickling on the generated Python class.
+        
+        Pickling is supported by reusing the serialization functionality already build in to many GTSAM types.
+
+        Ref: https://pybind11.readthedocs.io/en/stable/advanced/classes.html#pickling-support
+        """
+        if cpp_class not in [
+            "gtsam::Cal3Bundler",
+            "gtsam::PinholeCameraCal3Bundler", 
+            "gtsam::Pose3", 
+            "gtsam::Rot3", 
+            "gtsam::SfmTrack"
+            "gtsam::Unit3", 
+        ]:
+            # TODO: fix this check by just checking if serialization is supported.
+            return ""
+        return textwrap.dedent('''
+                .def(py::pickle(
+                    [](const {cpp_class} &a){{ // __getstate__
+                        /* Returns a string that encodes the state of the object */
+                        return py::make_tuple(gtsam::serialize(a));
+                    }},
+                    [](py::tuple t){{ // __setstate__
+                        {cpp_class} obj;
+                        gtsam::deserialize(t[0].cast<std::string>(), obj);
+                        return obj;
+                    }}
+                ))
+                ''').format(cpp_class=cpp_class)
 
     def wrap(self):
         wrapped_namespace, includes = self.wrap_namespace(self.module)

--- a/wrap/gtwrap/pybind_wrapper.py
+++ b/wrap/gtwrap/pybind_wrapper.py
@@ -328,4 +328,3 @@ class PybindWrapper(object):
             wrapped_namespace=wrapped_namespace,
             boost_class_export=boost_class_export,
         )
-

--- a/wrap/tests/expected-python/geometry_pybind.cpp
+++ b/wrap/tests/expected-python/geometry_pybind.cpp
@@ -47,6 +47,16 @@ PYBIND11_MODULE(geometry_py, m_) {
     [](gtsam::Point2* self, string serialized){
         gtsam::deserialize(serialized, *self);
     }, py::arg("serialized"))
+.def(py::pickle(
+    [](const gtsam::Point2 &a){ // __getstate__
+        /* Returns a string that encodes the state of the object */
+        return py::make_tuple(gtsam::serialize(a));
+    },
+    [](py::tuple t){ // __setstate__
+        gtsam::Point2 obj;
+        gtsam::deserialize(t[0].cast<std::string>(), obj);
+        return obj;
+    }))
 ;
 
     py::class_<gtsam::Point3, std::shared_ptr<gtsam::Point3>>(m_gtsam, "Point3")
@@ -61,6 +71,16 @@ PYBIND11_MODULE(geometry_py, m_) {
     [](gtsam::Point3* self, string serialized){
         gtsam::deserialize(serialized, *self);
     }, py::arg("serialized"))
+.def(py::pickle(
+    [](const gtsam::Point3 &a){ // __getstate__
+        /* Returns a string that encodes the state of the object */
+        return py::make_tuple(gtsam::serialize(a));
+    },
+    [](py::tuple t){ // __setstate__
+        gtsam::Point3 obj;
+        gtsam::deserialize(t[0].cast<std::string>(), obj);
+        return obj;
+    }))
 
         .def_static("staticFunction",[](){return gtsam::Point3::staticFunction();})
         .def_static("StaticFunctionRet",[]( double z){return gtsam::Point3::StaticFunctionRet(z);}, py::arg("z"));


### PR DESCRIPTION
This PR will enable some python types for GTSAM to be [pickled](https://docs.python.org/3/library/pickle.html). Popular frameworks like numpy and pytorch already support pickling. This addition will enable better compatibility with multi-processing in Python and direct use in frameworks like Dask.