### PR TITLE
Fix numpy deprecation warnings

### DIFF
--- a/python/gtsam/examples/ImuFactorISAM2Example.py
+++ b/python/gtsam/examples/ImuFactorISAM2Example.py
@@ -24,7 +24,7 @@ from gtsam.utils import plot
 
 def vector3(x, y, z):
     """Create 3d double numpy array."""
-    return np.array([x, y, z], dtype=np.float)
+    return np.array([x, y, z], dtype=float)
 
 
 g = 9.81

--- a/python/gtsam/examples/PlanarManipulatorExample.py
+++ b/python/gtsam/examples/PlanarManipulatorExample.py
@@ -29,7 +29,7 @@ from gtsam.utils.test_case import GtsamTestCase
 
 def vector3(x, y, z):
     """Create 3D double numpy array."""
-    return np.array([x, y, z], dtype=np.float)
+    return np.array([x, y, z], dtype=float)
 
 
 def compose(*poses):
@@ -94,7 +94,7 @@ class ThreeLinkArm(object):
                          [-self.L1*math.sin(q[0]) - self.L2*math.sin(a)-self.L3*math.sin(b),
                           -self.L1*math.sin(a)-self.L3*math.sin(b),
                           - self.L3*math.sin(b)],
-                         [1, 1, 1]], np.float)
+                         [1, 1, 1]], float)
 
     def poe(self, q):
         """ Forward kinematics.
@@ -230,12 +230,12 @@ class TestPose2SLAMExample(GtsamTestCase):
     def test_jacobian(self):
         """Test Jacobian calculation."""
         # at rest
-        expected = np.array([[-9.5, -6, -2.5], [0, 0, 0], [1, 1, 1]], np.float)
+        expected = np.array([[-9.5, -6, -2.5], [0, 0, 0], [1, 1, 1]], float)
         J = self.arm.jacobian(Q0)
         np.testing.assert_array_almost_equal(J, expected)
 
         # at -90, 90, 0
-        expected = np.array([[-6, -6, -2.5], [3.5, 0, 0], [1, 1, 1]], np.float)
+        expected = np.array([[-6, -6, -2.5], [3.5, 0, 0], [1, 1, 1]], float)
         J = self.arm.jacobian(Q2)
         np.testing.assert_array_almost_equal(J, expected)
 
@@ -280,13 +280,13 @@ class TestPose2SLAMExample(GtsamTestCase):
     def test_manipulator_jacobian(self):
         """Test Jacobian calculation."""
         # at rest
-        expected = np.array([[0, 3.5, 7], [0, 0, 0], [1, 1, 1]], np.float)
+        expected = np.array([[0, 3.5, 7], [0, 0, 0], [1, 1, 1]], float)
         J = self.arm.manipulator_jacobian(Q0)
         np.testing.assert_array_almost_equal(J, expected)
 
         # at -90, 90, 0
         expected = np.array(
-            [[0, 0, 3.5], [0, -3.5, -3.5], [1, 1, 1]], np.float)
+            [[0, 0, 3.5], [0, -3.5, -3.5], [1, 1, 1]], float)
         J = self.arm.manipulator_jacobian(Q2)
         np.testing.assert_array_almost_equal(J, expected)
 

--- a/python/gtsam/examples/Pose2SLAMExample.py
+++ b/python/gtsam/examples/Pose2SLAMExample.py
@@ -25,7 +25,7 @@ import gtsam.utils.plot as gtsam_plot
 
 def vector3(x, y, z):
     """Create 3d double numpy array."""
-    return np.array([x, y, z], dtype=np.float)
+    return np.array([x, y, z], dtype=float)
 
 # Create noise models
 PRIOR_NOISE = gtsam.noiseModel.Diagonal.Sigmas(vector3(0.3, 0.3, 0.1))

--- a/python/gtsam/examples/Pose2SLAMExample_g2o.py
+++ b/python/gtsam/examples/Pose2SLAMExample_g2o.py
@@ -23,7 +23,7 @@ from gtsam.utils import plot
 
 def vector3(x, y, z):
     """Create 3d double numpy array."""
-    return np.array([x, y, z], dtype=np.float)
+    return np.array([x, y, z], dtype=float)
 
 
 parser = argparse.ArgumentParser(

--- a/python/gtsam/examples/Pose3SLAMExample_g2o.py
+++ b/python/gtsam/examples/Pose3SLAMExample_g2o.py
@@ -19,7 +19,7 @@ from gtsam.utils import plot
 
 def vector6(x, y, z, a, b, c):
     """Create 6d double numpy array."""
-    return np.array([x, y, z, a, b, c], dtype=np.float)
+    return np.array([x, y, z, a, b, c], dtype=float)
 
 
 parser = argparse.ArgumentParser(

--- a/python/gtsam/examples/PreintegrationExample.py
+++ b/python/gtsam/examples/PreintegrationExample.py
@@ -29,11 +29,11 @@ class PreintegrationExample(object):
         kGyroSigma = math.radians(0.5) / 60  # 0.5 degree ARW
         kAccelSigma = 0.1 / 60  # 10 cm VRW
         params.setGyroscopeCovariance(
-            kGyroSigma ** 2 * np.identity(3, np.float))
+            kGyroSigma ** 2 * np.identity(3, float))
         params.setAccelerometerCovariance(
-            kAccelSigma ** 2 * np.identity(3, np.float))
+            kAccelSigma ** 2 * np.identity(3, float))
         params.setIntegrationCovariance(
-            0.0000001 ** 2 * np.identity(3, np.float))
+            0.0000001 ** 2 * np.identity(3, float))
         return params
 
     def __init__(self, twist=None, bias=None, dt=1e-2):

--- a/python/gtsam/tests/test_SO4.py
+++ b/python/gtsam/tests/test_SO4.py
@@ -32,13 +32,13 @@ class TestSO4(unittest.TestCase):
 
     def test_retract(self):
         """Test retraction to manifold."""
-        v = np.zeros((6,), np.float)
+        v = np.zeros((6,), float)
         actual = I4.retract(v)
         self.assertTrue(actual.equals(I4, 1e-9))
 
     def test_local(self):
         """Check localCoordinates for trivial case."""
-        v0 = np.zeros((6,), np.float)
+        v0 = np.zeros((6,), float)
         actual = I4.localCoordinates(I4)
         np.testing.assert_array_almost_equal(actual, v0)
 

--- a/python/gtsam/tests/test_SOn.py
+++ b/python/gtsam/tests/test_SOn.py
@@ -32,13 +32,13 @@ class TestSO4(unittest.TestCase):
 
     def test_retract(self):
         """Test retraction to manifold."""
-        v = np.zeros((6,), np.float)
+        v = np.zeros((6,), float)
         actual = I4.retract(v)
         self.assertTrue(actual.equals(I4, 1e-9))
 
     def test_local(self):
         """Check localCoordinates for trivial case."""
-        v0 = np.zeros((6,), np.float)
+        v0 = np.zeros((6,), float)
         actual = I4.localCoordinates(I4)
         np.testing.assert_array_almost_equal(actual, v0)
 


### PR DESCRIPTION
Numpy has deprecated `np.float` in favor of the built-in `float`.

This PR updates the `dtype`s so that the deprecation warnings are resolved.