### PR TITLE
Fix/boost issue #713 again

### DIFF
--- a/gtsam/base/FastList.h
+++ b/gtsam/base/FastList.h
@@ -22,6 +22,8 @@
 #include <list>
 #include <boost/utility/enable_if.hpp>
 #include <boost/serialization/nvp.hpp>
+#include <boost/serialization/version.hpp>
+#include <boost/serialization/optional.hpp>
 #include <boost/serialization/list.hpp>
 
 namespace gtsam {

--- a/gtsam/linear/LossFunctions.h
+++ b/gtsam/linear/LossFunctions.h
@@ -25,10 +25,10 @@
 
 #include <boost/serialization/extended_type_info.hpp>
 #include <boost/serialization/nvp.hpp>
+#include <boost/serialization/version.hpp>
 #include <boost/serialization/optional.hpp>
 #include <boost/serialization/shared_ptr.hpp>
 #include <boost/serialization/singleton.hpp>
-#include <boost/serialization/version.hpp>
 
 namespace gtsam {
 namespace noiseModel {

--- a/gtsam/linear/SubgraphBuilder.h
+++ b/gtsam/linear/SubgraphBuilder.h
@@ -22,8 +22,9 @@
 #include <gtsam/dllexport.h>
 
 #include <boost/serialization/nvp.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/serialization/version.hpp>
+#include <boost/serialization/optional.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <vector>
 

--- a/gtsam/linear/SubgraphBuilder.h
+++ b/gtsam/linear/SubgraphBuilder.h
@@ -21,6 +21,7 @@
 #include <gtsam/base/types.h>
 #include <gtsam/dllexport.h>
 
+#include <boost/serialization/version.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <boost/shared_ptr.hpp>
 

--- a/gtsam/linear/SubgraphBuilder.h
+++ b/gtsam/linear/SubgraphBuilder.h
@@ -22,8 +22,6 @@
 #include <gtsam/dllexport.h>
 
 #include <boost/serialization/nvp.hpp>
-#include <boost/serialization/version.hpp>
-#include <boost/serialization/optional.hpp>
 #include <boost/shared_ptr.hpp>
 
 #include <vector>


### PR DESCRIPTION
Fixes issue #634
Fixes order of  #include <boost/serialization/version.hpp> headers 

My compilation on Ubuntu failed with the same error as in issue #634
Changing order of includes fixed my compilation.

`<boost/serialization/version.hpp>` should be included before `<boost/serialization/list.hpp>` and before `<boost/shared_ptr.hpp>`, not after.

Also it was needed to add includes to `FastList.h` to avoid the same compilation errors.

boost version: 1.74.0
gcc version 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04)

Probably this issue will not appear in boost version 1.75, but I tested only with 1.74 