### PR TITLE
Disable Wrapper CI for GCC 5 until we optimize the wrapper

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -19,7 +19,7 @@ jobs:
         # Github Actions requires a single row to be added to the build matrix.
         # See https://help.github.com/en/articles/workflow-syntax-for-github-actions.
         name: [
-          ubuntu-18.04-gcc-5,
+          # ubuntu-18.04-gcc-5,  #TODO Enable once the Python wrapper is optimized for memory
           ubuntu-18.04-gcc-9,
           ubuntu-18.04-clang-9,
           macOS-10.15-xcode-11.3.1,
@@ -31,10 +31,10 @@ jobs:
         build_type: [Release]
         python_version: [3]
         include:
-          - name: ubuntu-18.04-gcc-5
-            os: ubuntu-18.04
-            compiler: gcc
-            version: "5"
+          # - name: ubuntu-18.04-gcc-5
+          #   os: ubuntu-18.04
+          #   compiler: gcc
+          #   version: "5"
 
           - name: ubuntu-18.04-gcc-9
             os: ubuntu-18.04


### PR DESCRIPTION
We can enable it once https://github.com/borglab/wrap/issues/44 is resolved.