### PR TITLE
KeyFormatter - boost::function to std::function

### DIFF
--- a/gtsam/inference/Key.h
+++ b/gtsam/inference/Key.h
@@ -25,7 +25,6 @@
 #include <gtsam/base/types.h>
 #include <gtsam/dllexport.h>
 
-#include <boost/function.hpp>
 #include <functional>
 
 #include <iosfwd>

--- a/gtsam/inference/Key.h
+++ b/gtsam/inference/Key.h
@@ -26,13 +26,14 @@
 #include <gtsam/dllexport.h>
 
 #include <boost/function.hpp>
+#include <functional>
 
 #include <iosfwd>
 
 namespace gtsam {
 
 /// Typedef for a function to format a key, i.e. to convert it to a string
-typedef boost::function<std::string(Key)> KeyFormatter;
+typedef std::function<std::string(Key)> KeyFormatter;
 
 // Helper function for DefaultKeyFormatter
 GTSAM_EXPORT std::string _defaultKeyFormatter(Key key);

--- a/gtsam/inference/LabeledSymbol.h
+++ b/gtsam/inference/LabeledSymbol.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <gtsam/inference/Symbol.h>
+#include <boost/function.hpp>
 
 namespace gtsam {
 

--- a/gtsam/inference/Symbol.h
+++ b/gtsam/inference/Symbol.h
@@ -21,6 +21,7 @@
 #include <gtsam/inference/Key.h>
 #include <gtsam/base/Testable.h>
 #include <boost/serialization/nvp.hpp>
+#include <boost/function.hpp>
 #include <cstdint>
 
 namespace gtsam {


### PR DESCRIPTION
This PR updates the KeyFormatter typedef from `boost::function` to `std::function`.

@gchenfc and I discovered that the pybind11 wrapper plays well with std::function but not with boost::function. So this change will enable the direct use of `gtsam::KeyFormatter` in the wrapped code without any major modifications or hacks.

The best part is that std::function is a drop-in replacement to boost::function for this particular use case, so there should be no breaking change.