### PR TITLE
Wrapper Update

### DIFF
--- a/gtsam/gtsam.i
+++ b/gtsam/gtsam.i
@@ -47,7 +47,7 @@ class KeySet {
   KeySet(const gtsam::KeyList& list);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::KeySet& other) const;
 
   // common STL methods
@@ -221,7 +221,7 @@ virtual class Value {
   // No constructors because this is an abstract class
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
 
   // Manifold
   size_t dim() const;
@@ -245,7 +245,7 @@ class Point2 {
   Point2(Vector v);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::Point2& point, double tol) const;
 
   // Group
@@ -298,7 +298,7 @@ class StereoPoint2 {
   StereoPoint2(double uL, double uR, double v);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::StereoPoint2& point, double tol) const;
 
   // Group
@@ -342,7 +342,7 @@ class Point3 {
   Point3(Vector v);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::Point3& p, double tol) const;
 
   // Group
@@ -379,7 +379,7 @@ class Rot2 {
   static gtsam::Rot2 fromCosSin(double c, double s);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::Rot2& rot, double tol) const;
 
   // Group
@@ -430,7 +430,7 @@ class SO3 {
   static gtsam::SO3 ClosestTo(const Matrix M);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::SO3& other, double tol) const;
 
   // Group
@@ -460,7 +460,7 @@ class SO4 {
   static gtsam::SO4 FromMatrix(Matrix R);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::SO4& other, double tol) const;
 
   // Group
@@ -490,7 +490,7 @@ class SOn {
   static gtsam::SOn Lift(size_t n, Matrix R);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::SOn& other, double tol) const;
 
   // Group
@@ -551,7 +551,7 @@ class Rot3 {
   static gtsam::Rot3 ClosestTo(const Matrix M);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::Rot3& rot, double tol) const;
 
   // Group
@@ -608,7 +608,7 @@ class Pose2 {
   Pose2(Vector v);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::Pose2& pose, double tol) const;
 
   // Group
@@ -668,7 +668,7 @@ class Pose3 {
   Pose3(Matrix mat);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::Pose3& pose, double tol) const;
 
   // Group
@@ -744,7 +744,7 @@ class Unit3 {
   Unit3(const gtsam::Point3& pose);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::Unit3& pose, double tol) const;
 
   // Other functionality
@@ -774,7 +774,7 @@ class EssentialMatrix {
   EssentialMatrix(const gtsam::Rot3& aRb, const gtsam::Unit3& aTb);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::EssentialMatrix& pose, double tol) const;
 
   // Manifold
@@ -799,7 +799,7 @@ class Cal3_S2 {
   Cal3_S2(double fov, int w, int h);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::Cal3_S2& rhs, double tol) const;
 
   // Manifold
@@ -836,7 +836,7 @@ virtual class Cal3DS2_Base {
   Cal3DS2_Base();
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
 
   // Standard Interface
   double fx() const;
@@ -922,7 +922,7 @@ class Cal3_S2Stereo {
   Cal3_S2Stereo(Vector v);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::Cal3_S2Stereo& K, double tol) const;
 
   // Standard Interface
@@ -943,7 +943,7 @@ class Cal3Bundler {
   Cal3Bundler(double fx, double k1, double k2, double u0, double v0, double tol);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::Cal3Bundler& rhs, double tol) const;
 
   // Manifold
@@ -983,7 +983,7 @@ class CalibratedCamera {
   static gtsam::CalibratedCamera Level(const gtsam::Pose2& pose2, double height);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::CalibratedCamera& camera, double tol) const;
 
   // Manifold
@@ -1022,7 +1022,7 @@ class PinholeCamera {
       const gtsam::Point3& upVector, const CALIBRATION& K);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const This& camera, double tol) const;
 
   // Standard Interface
@@ -1097,7 +1097,7 @@ class StereoCamera {
   StereoCamera(const gtsam::Pose3& pose, const gtsam::Cal3_S2Stereo* K);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::StereoCamera& camera, double tol) const;
 
   // Standard Interface
@@ -1160,7 +1160,7 @@ virtual class SymbolicFactor {
 
   // From Factor
   size_t size() const;
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::SymbolicFactor& other, double tol) const;
   gtsam::KeyVector keys();
 };
@@ -1173,7 +1173,7 @@ virtual class SymbolicFactorGraph {
 
   // From FactorGraph
   void push_back(gtsam::SymbolicFactor* factor);
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::SymbolicFactorGraph& rhs, double tol) const;
   size_t size() const;
   bool exists(size_t idx) const;
@@ -1223,7 +1223,7 @@ virtual class SymbolicConditional : gtsam::SymbolicFactor {
   static gtsam::SymbolicConditional FromKeys(const gtsam::KeyVector& keys, size_t nrFrontals);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::SymbolicConditional& other, double tol) const;
 
   // Standard interface
@@ -1236,7 +1236,7 @@ class SymbolicBayesNet {
   SymbolicBayesNet();
   SymbolicBayesNet(const gtsam::SymbolicBayesNet& other);
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::SymbolicBayesNet& other, double tol) const;
 
   // Standard interface
@@ -1257,7 +1257,7 @@ class SymbolicBayesTree {
     SymbolicBayesTree(const gtsam::SymbolicBayesTree& other);
 
     // Testable
-    void print(string s);
+    void print(string s="");
     bool equals(const gtsam::SymbolicBayesTree& other, double tol) const;
 
     //Standard Interface
@@ -1279,7 +1279,7 @@ class SymbolicBayesTree {
 //   SymbolicBayesTreeClique(const pair<typename ConditionalType::shared_ptr, typename ConditionalType::FactorType::shared_ptr>& result) : Base(result) {}
 //
 //   bool equals(const This& other, double tol) const;
-//   void print(string s) const;
+//   void print(string s="") const;
 //   void printTree() const; // Default indent of ""
 //   void printTree(string indent) const;
 //   size_t numCachedSeparatorMarginals() const;
@@ -1313,7 +1313,7 @@ class VariableIndex {
 
   // Testable
   bool equals(const gtsam::VariableIndex& other, double tol) const;
-  void print(string s) const;
+  void print(string s="") const;
 
   // Standard interface
   size_t size() const;
@@ -1328,7 +1328,7 @@ class VariableIndex {
 namespace noiseModel {
 #include <gtsam/linear/NoiseModel.h>
 virtual class Base {
-  void print(string s) const;
+  void print(string s="") const;
   // Methods below are available for all noise models. However, can't add them
   // because wrap (incorrectly) thinks robust classes derive from this Base as well.
   // bool isConstrained() const;
@@ -1411,7 +1411,7 @@ virtual class Unit : gtsam::noiseModel::Isotropic {
 
 namespace mEstimator {
 virtual class Base {
-  void print(string s) const;
+  void print(string s="") const;
 };
 
 virtual class Null: gtsam::noiseModel::mEstimator::Base {
@@ -1551,7 +1551,7 @@ class VectorValues {
   size_t size() const;
   size_t dim(size_t j) const;
   bool exists(size_t j) const;
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::VectorValues& expected, double tol) const;
   void insert(size_t j, Vector value);
   Vector vector() const;
@@ -1582,7 +1582,7 @@ class VectorValues {
 #include <gtsam/linear/GaussianFactor.h>
 virtual class GaussianFactor {
   gtsam::KeyVector keys() const;
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::GaussianFactor& lf, double tol) const;
   double error(const gtsam::VectorValues& c) const;
   gtsam::GaussianFactor* clone() const;
@@ -1610,7 +1610,7 @@ virtual class JacobianFactor : gtsam::GaussianFactor {
   JacobianFactor(const gtsam::GaussianFactorGraph& graph);
 
   //Testable
-  void print(string s) const;
+  void print(string s="") const;
   void printKeys(string s) const;
   bool equals(const gtsam::GaussianFactor& lf, double tol) const;
   size_t size() const;
@@ -1659,7 +1659,7 @@ virtual class HessianFactor : gtsam::GaussianFactor {
 
   //Testable
   size_t size() const;
-  void print(string s) const;
+  void print(string s="") const;
   void printKeys(string s) const;
   bool equals(const gtsam::GaussianFactor& lf, double tol) const;
   double error(const gtsam::VectorValues& c) const;
@@ -1684,7 +1684,7 @@ class GaussianFactorGraph {
   GaussianFactorGraph(const gtsam::GaussianBayesTree& bayesTree);
 
   // From FactorGraph
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::GaussianFactorGraph& lfgraph, double tol) const;
   size_t size() const;
   gtsam::GaussianFactor* at(size_t idx) const;
@@ -1775,7 +1775,7 @@ virtual class GaussianConditional : gtsam::JacobianFactor {
         size_t name2, Matrix T);
 
   //Standard Interface
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::GaussianConditional &cg, double tol) const;
 
   //Advanced Interface
@@ -1797,7 +1797,7 @@ virtual class GaussianDensity : gtsam::GaussianConditional {
   GaussianDensity(size_t key, Vector d, Matrix R, const gtsam::noiseModel::Diagonal* sigmas);
 
   //Standard Interface
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::GaussianDensity &cg, double tol) const;
   Vector mean() const;
   Matrix covariance() const;
@@ -1810,7 +1810,7 @@ virtual class GaussianBayesNet {
   GaussianBayesNet(const gtsam::GaussianConditional* conditional);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::GaussianBayesNet& other, double tol) const;
   size_t size() const;
 
@@ -1845,7 +1845,7 @@ virtual class GaussianBayesTree {
   GaussianBayesTree();
   GaussianBayesTree(const gtsam::GaussianBayesTree& other);
   bool equals(const gtsam::GaussianBayesTree& other, double tol) const;
-  void print(string s);
+  void print(string s="");
   size_t size() const;
   bool empty() const;
   size_t numCachedSeparatorMarginals() const;
@@ -1871,7 +1871,7 @@ class Errors {
     Errors(const gtsam::VectorValues& V);
 
     //Testable
-    void print(string s);
+    void print(string s="");
     bool equals(const gtsam::Errors& expected, double tol) const;
 };
 
@@ -1927,7 +1927,7 @@ virtual class DummyPreconditionerParameters : gtsam::PreconditionerParameters {
 #include <gtsam/linear/PCGSolver.h>
 virtual class PCGSolverParameters : gtsam::ConjugateGradientParameters {
   PCGSolverParameters();
-  void print(string s);
+  void print(string s="");
   void setPreconditionerParams(gtsam::PreconditionerParameters* preconditioner);
 };
 
@@ -1948,7 +1948,7 @@ class KalmanFilter {
   KalmanFilter(size_t n);
   // gtsam::GaussianDensity* init(Vector x0, const gtsam::SharedDiagonal& P0);
   gtsam::GaussianDensity* init(Vector x0, Matrix P0);
-  void print(string s) const;
+  void print(string s="") const;
   static size_t step(gtsam::GaussianDensity* p);
   gtsam::GaussianDensity* predict(gtsam::GaussianDensity* p, Matrix F,
       Matrix B, Vector u, const gtsam::noiseModel::Diagonal* modelQ);
@@ -2039,7 +2039,7 @@ class LabeledSymbol {
   gtsam::LabeledSymbol newChr(unsigned char c) const;
   gtsam::LabeledSymbol newLabel(unsigned char label) const;
 
-  void print(string s) const;
+  void print(string s="") const;
 };
 
 size_t mrsymbol(unsigned char c, unsigned char label, size_t j);
@@ -2054,7 +2054,7 @@ class Ordering {
   Ordering(const gtsam::Ordering& other);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::Ordering& ord, double tol) const;
 
   // Standard interface
@@ -2075,7 +2075,7 @@ class NonlinearFactorGraph {
   NonlinearFactorGraph(const gtsam::NonlinearFactorGraph& graph);
 
   // FactorGraph
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::NonlinearFactorGraph& fg, double tol) const;
   size_t size() const;
   bool empty() const;
@@ -2123,7 +2123,7 @@ virtual class NonlinearFactor {
   // Factor base class
   size_t size() const;
   gtsam::KeyVector keys() const;
-  void print(string s) const;
+  void print(string s="") const;
   void printKeys(string s) const;
   // NonlinearFactor
   bool equals(const gtsam::NonlinearFactor& other, double tol) const;
@@ -2153,7 +2153,7 @@ class Values {
   void clear();
   size_t dim() const;
 
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::Values& other, double tol) const;
 
   void insert(const gtsam::Values& values);
@@ -2242,7 +2242,7 @@ class Marginals {
   Marginals(const gtsam::GaussianFactorGraph& gfgraph,
       const gtsam::VectorValues& solutionvec);
 
-  void print(string s) const;
+  void print(string s="") const;
   Matrix marginalCovariance(size_t variable) const;
   Matrix marginalInformation(size_t variable) const;
   gtsam::JointMarginal jointMarginalCovariance(const gtsam::KeyVector& variables) const;
@@ -2252,7 +2252,7 @@ class Marginals {
 class JointMarginal {
   Matrix at(size_t iVariable, size_t jVariable) const;
   Matrix fullMatrix() const;
-  void print(string s) const;
+  void print(string s="") const;
   void print() const;
 };
 
@@ -2296,7 +2296,7 @@ virtual class LinearContainerFactor : gtsam::NonlinearFactor {
 #include <gtsam/nonlinear/NonlinearOptimizerParams.h>
 virtual class NonlinearOptimizerParams {
   NonlinearOptimizerParams();
-  void print(string s) const;
+  void print(string s="") const;
 
   int getMaxIterations() const;
   double getRelativeErrorTol() const;
@@ -2490,7 +2490,7 @@ class ISAM2Clique {
 
     //Standard Interface
     Vector gradientContribution() const;
-    void print(string s);
+    void print(string s="");
 };
 
 class ISAM2Result {
@@ -2512,7 +2512,7 @@ class ISAM2 {
   ISAM2(const gtsam::ISAM2& other);
 
   bool equals(const gtsam::ISAM2& other, double tol) const;
-  void print(string s) const;
+  void print(string s="") const;
   void printStats() const;
   void saveGraph(string s) const;
 
@@ -2544,7 +2544,7 @@ class ISAM2 {
 class NonlinearISAM {
   NonlinearISAM();
   NonlinearISAM(int reorderInterval);
-  void print(string s) const;
+  void print(string s="") const;
   void printStats() const;
   void saveGraph(string s) const;
   gtsam::Values estimate() const;
@@ -2679,7 +2679,7 @@ class BearingRange {
   static This Measure(const POSE& pose, const POINT& point);
   static BEARING MeasureBearing(const POSE& pose, const POINT& point);
   static RANGE MeasureRange(const POSE& pose, const POINT& point);
-  void print(string s) const;
+  void print(string s="") const;
 };
 
 typedef gtsam::BearingRange<gtsam::Pose2, gtsam::Point2, gtsam::Rot2, double> BearingRange2D;
@@ -3167,7 +3167,7 @@ class ConstantBias {
   ConstantBias(Vector biasAcc, Vector biasGyro);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::imuBias::ConstantBias& expected, double tol) const;
 
   // Group
@@ -3207,7 +3207,7 @@ class NavState {
   NavState(const gtsam::Pose3& pose, Vector v);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::NavState& expected, double tol) const;
 
   // Access
@@ -3225,7 +3225,7 @@ virtual class PreintegratedRotationParams {
   PreintegratedRotationParams();
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::PreintegratedRotationParams& expected, double tol);
 
   void setGyroscopeCovariance(Matrix cov);
@@ -3248,7 +3248,7 @@ virtual class PreintegrationParams : gtsam::PreintegratedRotationParams {
   static gtsam::PreintegrationParams* MakeSharedU();  // default g = 9.81
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::PreintegrationParams& expected, double tol);
 
   void setAccelerometerCovariance(Matrix cov);
@@ -3268,7 +3268,7 @@ class PreintegratedImuMeasurements {
       const gtsam::imuBias::ConstantBias& bias);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::PreintegratedImuMeasurements& expected, double tol);
 
   // Standard Interface
@@ -3311,7 +3311,7 @@ virtual class PreintegrationCombinedParams : gtsam::PreintegrationParams {
   static gtsam::PreintegrationCombinedParams* MakeSharedU();  // default g = 9.81
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::PreintegrationCombinedParams& expected, double tol);
 
   void setBiasAccCovariance(Matrix cov);
@@ -3330,7 +3330,7 @@ class PreintegratedCombinedMeasurements {
   PreintegratedCombinedMeasurements(const gtsam::PreintegrationCombinedParams* params,
 				    const gtsam::imuBias::ConstantBias& bias);
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::PreintegratedCombinedMeasurements& expected,
       double tol);
 
@@ -3371,7 +3371,7 @@ class PreintegratedAhrsMeasurements {
   PreintegratedAhrsMeasurements(const gtsam::PreintegratedAhrsMeasurements& rhs);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::PreintegratedAhrsMeasurements& expected, double tol);
 
   // get Data
@@ -3410,7 +3410,7 @@ virtual class Rot3AttitudeFactor : gtsam::NonlinearFactor{
       const gtsam::Unit3& bRef);
   Rot3AttitudeFactor(size_t key, const gtsam::Unit3& nZ, const gtsam::noiseModel::Diagonal* model);
   Rot3AttitudeFactor();
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::NonlinearFactor& expected, double tol) const;
   gtsam::Unit3 nZ() const;
   gtsam::Unit3 bRef() const;
@@ -3423,7 +3423,7 @@ virtual class Pose3AttitudeFactor : gtsam::NonlinearFactor {
   Pose3AttitudeFactor(size_t key, const gtsam::Unit3& nZ,
                       const gtsam::noiseModel::Diagonal* model);
   Pose3AttitudeFactor();
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::NonlinearFactor& expected, double tol) const;
   gtsam::Unit3 nZ() const;
   gtsam::Unit3 bRef() const;
@@ -3435,7 +3435,7 @@ virtual class GPSFactor : gtsam::NonlinearFactor{
             const gtsam::noiseModel::Base* model);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::GPSFactor& expected, double tol);
 
   // Standard Interface
@@ -3447,7 +3447,7 @@ virtual class GPSFactor2 : gtsam::NonlinearFactor {
             const gtsam::noiseModel::Base* model);
 
   // Testable
-  void print(string s) const;
+  void print(string s="") const;
   bool equals(const gtsam::GPSFactor2& expected, double tol);
 
   // Standard Interface

--- a/wrap/README.md
+++ b/wrap/README.md
@@ -109,3 +109,15 @@ Arguments:
   include_directories. Again, normally, leave this empty.
 - `extraMexFlags`: Any _additional_ flags to pass to the compiler when building
   the wrap code. Normally, leave this empty.
+
+## Git subtree and Contributing
+
+**\*WARNING\*: Running the ./update_wrap.sh script from the GTSAM repo creates 2 new commits in GTSAM.  Be sure to _NOT_ push these directly to master/develop.  Preferably, open up a new PR with these updates (see below).**
+
+The [wrap library](https://github.com/borglab/wrap) is included in GTSAM as a git subtree.  This means that sometimes the wrap library can have new features or changes that are not yet reflected in GTSAM.  There are two options to get the most up-to-date versions of wrap:
+  1. Clone and install the [wrap repository](https://github.com/borglab/wrap).  For external projects, make sure cmake is using the external `wrap` rather than the one pre-packaged with GTSAM.
+  2. Run `./update_wrap.sh` from the root of GTSAM's repository to pull in the newest version of wrap to your local GTSAM installation.  See the warning above about this script automatically creating commits.
+
+To make a PR on GTSAM with the most recent wrap updates, create a new branch/fork then pull in the most recent wrap changes using `./update_wrap.sh`.  You should find that two new commits have been made: a squash and a merge from master.  You can push these (to the non-develop branch) and open a PR.
+
+For any code contributions to the wrap project, please make them on the [wrap repository](https://github.com/borglab/wrap).

--- a/wrap/tests/expected/python/enum_pybind.cpp
+++ b/wrap/tests/expected/python/enum_pybind.cpp
@@ -21,13 +21,23 @@ namespace py = pybind11;
 PYBIND11_MODULE(enum_py, m_) {
     m_.doc() = "pybind11 wrapper of enum_py";
 
+    py::enum_<Color>(m_, "Color", py::arithmetic())
+        .value("Red", Color::Red)
+        .value("Green", Color::Green)
+        .value("Blue", Color::Blue);
 
-    py::enum_<Kind>(m_, "Kind", py::arithmetic())
-        .value("Dog", Kind::Dog)
-        .value("Cat", Kind::Cat);
+
+    py::class_<Pet, std::shared_ptr<Pet>> pet(m_, "Pet");
+    pet
+        .def(py::init<const string&, Kind>(), py::arg("name"), py::arg("type"))
+        .def_readwrite("name", &Pet::name)
+        .def_readwrite("type", &Pet::type);
+
+    py::enum_<Pet::Kind>(pet, "Kind", py::arithmetic())
+        .value("Dog", Pet::Kind::Dog)
+        .value("Cat", Pet::Kind::Cat);
 
     pybind11::module m_gtsam = m_.def_submodule("gtsam", "gtsam submodule");
-
     py::enum_<gtsam::VerbosityLM>(m_gtsam, "VerbosityLM", py::arithmetic())
         .value("SILENT", gtsam::VerbosityLM::SILENT)
         .value("SUMMARY", gtsam::VerbosityLM::SUMMARY)
@@ -39,10 +49,25 @@ PYBIND11_MODULE(enum_py, m_) {
         .value("TRYDELTA", gtsam::VerbosityLM::TRYDELTA);
 
 
-    py::class_<gtsam::Pet, std::shared_ptr<gtsam::Pet>>(m_gtsam, "Pet")
-        .def(py::init<const string&, Kind>(), py::arg("name"), py::arg("type"))
-        .def_readwrite("name", &gtsam::Pet::name)
-        .def_readwrite("type", &gtsam::Pet::type);
+    py::class_<gtsam::MCU, std::shared_ptr<gtsam::MCU>> mcu(m_gtsam, "MCU");
+    mcu
+        .def(py::init<>());
+
+    py::enum_<gtsam::MCU::Avengers>(mcu, "Avengers", py::arithmetic())
+        .value("CaptainAmerica", gtsam::MCU::Avengers::CaptainAmerica)
+        .value("IronMan", gtsam::MCU::Avengers::IronMan)
+        .value("Hulk", gtsam::MCU::Avengers::Hulk)
+        .value("Hawkeye", gtsam::MCU::Avengers::Hawkeye)
+        .value("Thor", gtsam::MCU::Avengers::Thor);
+
+
+    py::enum_<gtsam::MCU::GotG>(mcu, "GotG", py::arithmetic())
+        .value("Starlord", gtsam::MCU::GotG::Starlord)
+        .value("Gamorra", gtsam::MCU::GotG::Gamorra)
+        .value("Rocket", gtsam::MCU::GotG::Rocket)
+        .value("Drax", gtsam::MCU::GotG::Drax)
+        .value("Groot", gtsam::MCU::GotG::Groot);
+
 
 
 #include "python/specializations.h"

--- a/wrap/tests/fixtures/enum.i
+++ b/wrap/tests/fixtures/enum.i
@@ -1,4 +1,13 @@
-enum Kind { Dog, Cat };
+enum Color { Red, Green, Blue };
+
+class Pet {
+  enum Kind { Dog, Cat };
+
+  Pet(const string &name, Kind type);
+
+  string name;
+  Kind type;
+};
 
 namespace gtsam {
 enum VerbosityLM {
@@ -12,12 +21,25 @@ enum VerbosityLM {
   TRYDELTA
 };
 
-class Pet {
-  enum Kind { Dog, Cat };
+class MCU {
+  MCU();
 
-  Pet(const string &name, Kind type);
+  enum Avengers {
+    CaptainAmerica,
+    IronMan,
+    Hulk,
+    Hawkeye,
+    Thor
+  };
 
-  string name;
-  Kind type;
+  enum GotG {
+    Starlord,
+    Gamorra,
+    Rocket,
+    Drax,
+    Groot
+  };
+
 };
+
 }  // namespace gtsam


### PR DESCRIPTION
1. Fix global variable assignment.
2. Wrap enums defined inside classes.
3. Added default values for `print()` so that `__repr__` works.