### PR TITLE
Fix printing of preintegration params

### DIFF
--- a/gtsam/navigation/PreintegrationBase.cpp
+++ b/gtsam/navigation/PreintegrationBase.cpp
@@ -17,6 +17,7 @@
  *  @author Vadim Indelman
  *  @author David Jensen
  *  @author Frank Dellaert
+ *  @author Varun Agrawal
  **/
 
 #include "PreintegrationBase.h"
@@ -35,12 +36,12 @@ PreintegrationBase::PreintegrationBase(const boost::shared_ptr<Params>& p,
 
 //------------------------------------------------------------------------------
 ostream& operator<<(ostream& os, const PreintegrationBase& pim) {
-  os << "    deltaTij " << pim.deltaTij_ << endl;
+  os << "    deltaTij = " << pim.deltaTij_ << endl;
   os << "    deltaRij.ypr = (" << pim.deltaRij().ypr().transpose() << ")" << endl;
-  os << "    deltaPij " << Point3(pim.deltaPij()) << endl;
-  os << "    deltaVij " << Point3(pim.deltaVij()) << endl;
-  os << "    gyrobias " << Point3(pim.biasHat_.gyroscope()) << endl;
-  os << "    acc_bias " << Point3(pim.biasHat_.accelerometer()) << endl;
+  os << "    deltaPij = " << pim.deltaPij().transpose() << endl;
+  os << "    deltaVij = " << pim.deltaVij().transpose() << endl;
+  os << "    gyrobias = " << pim.biasHat_.gyroscope().transpose() << endl;
+  os << "    acc_bias = " << pim.biasHat_.accelerometer().transpose() << endl;
   return os;
 }
 


### PR DESCRIPTION
Use `.transpose` to print vectors horizontally and save time by not casting to Point3 redundantly.