### PR TITLE
Avoid potential wrong memory access

### DIFF
--- a/gtsam/inference/FactorGraph.h
+++ b/gtsam/inference/FactorGraph.h
@@ -355,7 +355,7 @@ class FactorGraph {
 
   /** delete factor without re-arranging indexes by inserting a nullptr pointer
    */
-  void remove(size_t i) { factors_[i].reset(); }
+  void remove(size_t i) { factors_.at(i).reset(); }
 
   /** replace a factor by index */
   void replace(size_t index, sharedFactor factor) { at(index) = factor; }


### PR DESCRIPTION
(Spotted while randomly browsing the code)

If the user uses an invalid index, the [] operator won't check it and the program will access invalid memory. Using at() would throw instead.