### PR TITLE
Update boost download link

### DIFF
--- a/.github/scripts/boost.sh
+++ b/.github/scripts/boost.sh
@@ -2,7 +2,7 @@
 BOOST_FOLDER=boost_${BOOST_VERSION//./_}
 
 # Download Boost
-wget https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/${BOOST_FOLDER}.tar.gz
+wget https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/${BOOST_FOLDER}.tar.gz
 
 # Unzip
 tar -zxf ${BOOST_FOLDER}.tar.gz


### PR DESCRIPTION
As per [this notice](https://www.boost.org/users/news/boost_has_moved_downloads_to_jfr.html), the download link for boost has changed since Bintray has been retired. This is causing the CI to fail, which this PR fixes.