### PR TITLE
Custom Factors in Python

### DIFF
--- a/gtsam/gtsam.i
+++ b/gtsam/gtsam.i
@@ -2170,6 +2170,21 @@ virtual class NoiseModelFactor: gtsam::NonlinearFactor {
 virtual class CustomFactor: gtsam::NoiseModelFactor {
   // Note CustomFactor will not be wrapped for MATLAB, as there is no supporting machinery there.
   CustomFactor();
+  /*
+   * Example:
+   * ```
+   * def error_func(this: CustomFactor, v: gtsam.Values, H: List[np.ndarray]):
+   *    <calculated error>
+   *    if not H is None:
+   *        <calculate the Jacobian>
+   *        H[0] = J1 # 2-d numpy array for a Jacobian block
+   *        H[1] = J2
+   *        ...
+   *    return error # 1-d numpy array
+   *
+   * cf = CustomFactor(noise_model, keys, error_func)
+   * ```
+   */
   CustomFactor(const gtsam::SharedNoiseModel& noiseModel, const gtsam::KeyVector& keys, const gtsam::CustomErrorFunction& errorFunction);
 };
 

--- a/gtsam/gtsam.i
+++ b/gtsam/gtsam.i
@@ -2166,6 +2166,12 @@ virtual class NoiseModelFactor: gtsam::NonlinearFactor {
   Vector whitenedError(const gtsam::Values& x) const;
 };
 
+#include <gtsam/nonlinear/CustomFactor.h>
+virtual class CustomFactor: gtsam::NoiseModelFactor {
+  CustomFactor();
+  CustomFactor(const gtsam::SharedNoiseModel& noiseModel, const gtsam::KeyVector& keys, const gtsam::CustomErrorFunction& errorFunction);
+};
+
 #include <gtsam/nonlinear/Values.h>
 class Values {
   Values();

--- a/gtsam/gtsam.i
+++ b/gtsam/gtsam.i
@@ -2168,6 +2168,7 @@ virtual class NoiseModelFactor: gtsam::NonlinearFactor {
 
 #include <gtsam/nonlinear/CustomFactor.h>
 virtual class CustomFactor: gtsam::NoiseModelFactor {
+  // Note CustomFactor will not be wrapped for MATLAB, as there is no supporting machinery there.
   CustomFactor();
   CustomFactor(const gtsam::SharedNoiseModel& noiseModel, const gtsam::KeyVector& keys, const gtsam::CustomErrorFunction& errorFunction);
 };

--- a/gtsam/gtsam.i
+++ b/gtsam/gtsam.i
@@ -2185,7 +2185,10 @@ virtual class CustomFactor: gtsam::NoiseModelFactor {
    * cf = CustomFactor(noise_model, keys, error_func)
    * ```
    */
-  CustomFactor(const gtsam::SharedNoiseModel& noiseModel, const gtsam::KeyVector& keys, const gtsam::CustomErrorFunction& errorFunction);
+  CustomFactor(const gtsam::SharedNoiseModel& noiseModel, const gtsam::KeyVector& keys,
+               const gtsam::CustomErrorFunction& errorFunction);
+
+  void print(string s = "", gtsam::KeyFormatter keyFormatter = gtsam::DefaultKeyFormatter);
 };
 
 #include <gtsam/nonlinear/Values.h>

--- a/gtsam/gtsam.i
+++ b/gtsam/gtsam.i
@@ -2168,7 +2168,10 @@ virtual class NoiseModelFactor: gtsam::NonlinearFactor {
 
 #include <gtsam/nonlinear/CustomFactor.h>
 virtual class CustomFactor: gtsam::NoiseModelFactor {
-  // Note CustomFactor will not be wrapped for MATLAB, as there is no supporting machinery there.
+  /*
+   * Note CustomFactor will not be wrapped for MATLAB, as there is no supporting machinery there.
+   * This is achieved by adding `gtsam::CustomFactor` to the ignore list in `matlab/CMakeLists.txt`.
+   */
   CustomFactor();
   /*
    * Example:

--- a/gtsam/nonlinear/CustomFactor.cpp
+++ b/gtsam/nonlinear/CustomFactor.cpp
@@ -24,6 +24,7 @@ namespace gtsam {
  */
 Vector CustomFactor::unwhitenedError(const Values& x, boost::optional<std::vector<Matrix>&> H) const {
   if(this->active(x)) {
+
     if(H) {
       /*
        * In this case, we pass the raw pointer to the `std::vector<Matrix>` object directly to pybind.
@@ -45,7 +46,7 @@ Vector CustomFactor::unwhitenedError(const Values& x, boost::optional<std::vecto
       return this->error_function_(*this, x, H.get_ptr());
     } else {
       /*
-       * In this case, we pass the a `nullptr` to pybind, and it will translated to `None` in Python.
+       * In this case, we pass the a `nullptr` to pybind, and it will translate to `None` in Python.
        * Users can check for `None` in their callback to determine if the Jacobian is requested.
        */
       return this->error_function_(*this, x, nullptr);

--- a/gtsam/nonlinear/CustomFactor.cpp
+++ b/gtsam/nonlinear/CustomFactor.cpp
@@ -1,0 +1,35 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file    CustomFactor.cpp
+ * @brief   Class to enable arbitrary factors with runtime swappable error function.
+ * @author  Fan Jiang
+ */
+
+#include <gtsam/nonlinear/CustomFactor.h>
+
+namespace gtsam {
+
+Vector CustomFactor::unwhitenedError(const Values& x, boost::optional<std::vector<Matrix>&> H) const {
+  if(this->active(x)) {
+    if(H) {
+      return this->errorFunction(*this, x, H.get_ptr());
+    } else {
+      JacobianVector dummy;
+      return this->errorFunction(*this, x, &dummy);
+    }
+  } else {
+    return Vector::Zero(this->dim());
+  }
+}
+
+}

--- a/gtsam/nonlinear/CustomFactor.cpp
+++ b/gtsam/nonlinear/CustomFactor.cpp
@@ -42,17 +42,34 @@ Vector CustomFactor::unwhitenedError(const Values& x, boost::optional<std::vecto
        *    return error
        * ```
        */
-      return this->errorFunction(*this, x, H.get_ptr());
+      return this->error_function_(*this, x, H.get_ptr());
     } else {
       /*
        * In this case, we pass the a `nullptr` to pybind, and it will translated to `None` in Python.
        * Users can check for `None` in their callback to determine if the Jacobian is requested.
        */
-      return this->errorFunction(*this, x, nullptr);
+      return this->error_function_(*this, x, nullptr);
     }
   } else {
     return Vector::Zero(this->dim());
   }
+}
+
+void CustomFactor::print(const std::string &s, const KeyFormatter &keyFormatter) const {
+  std::cout << s << "CustomFactor on ";
+  auto keys_ = this->keys();
+  bool f = false;
+  for (const Key &k: keys_) {
+    if (f)
+      std::cout << ", ";
+    std::cout << keyFormatter(k);
+    f = true;
+  }
+  std::cout << "\n";
+  if (this->noiseModel_)
+    this->noiseModel_->print("  noise model: ");
+  else
+    std::cout << "no noise model" << std::endl;
 }
 
 }

--- a/gtsam/nonlinear/CustomFactor.h
+++ b/gtsam/nonlinear/CustomFactor.h
@@ -35,7 +35,7 @@ class CustomFactor;
  * This is safe because this is passing a const pointer, and pybind11 will maintain the `std::vector` memory layout.
  * Thus the pointer will never be invalidated.
  */
-using CustomErrorFunction = std::function<Vector(const CustomFactor&, const Values&, const JacobianVector*)>;
+using CustomErrorFunction = std::function<Vector(const CustomFactor &, const Values &, const JacobianVector *)>;
 
 /**
  * @brief Custom factor that takes a std::function as the error
@@ -46,7 +46,7 @@ using CustomErrorFunction = std::function<Vector(const CustomFactor&, const Valu
  */
 class CustomFactor: public NoiseModelFactor {
 protected:
-   CustomErrorFunction error_function_;
+  CustomErrorFunction error_function_;
 
 protected:
 
@@ -66,7 +66,7 @@ public:
    * @param keys keys of the variables
    * @param errorFunction the error functional
    */
-  CustomFactor(const SharedNoiseModel& noiseModel, const KeyVector& keys, const CustomErrorFunction& errorFunction) :
+  CustomFactor(const SharedNoiseModel &noiseModel, const KeyVector &keys, const CustomErrorFunction &errorFunction) :
       Base(noiseModel, keys) {
     this->error_function_ = errorFunction;
   }
@@ -80,16 +80,22 @@ public:
   Vector unwhitenedError(const Values &x, boost::optional<std::vector<Matrix> &> H = boost::none) const override;
 
   /** print */
-  void print(const std::string& s,
-             const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override;
+  void print(const std::string &s,
+             const KeyFormatter &keyFormatter = DefaultKeyFormatter) const override;
 
+  /**
+   * Mark not sendable
+   */
+  bool sendable() const override {
+    return false;
+  }
 
 private:
 
   /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
-  void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
+  void serialize(ARCHIVE &ar, const unsigned int /*version*/) {
     ar & boost::serialization::make_nvp("CustomFactor",
                                         boost::serialization::base_object<Base>(*this));
   }

--- a/gtsam/nonlinear/CustomFactor.h
+++ b/gtsam/nonlinear/CustomFactor.h
@@ -45,13 +45,13 @@ using CustomErrorFunction = std::function<Vector(const CustomFactor&, const Valu
  * This factor is mainly for creating a custom factor in Python.
  */
 class CustomFactor: public NoiseModelFactor {
-public:
-   CustomErrorFunction errorFunction;
+protected:
+   CustomErrorFunction error_function_;
 
 protected:
 
-  typedef NoiseModelFactor Base;
-  typedef CustomFactor This;
+  using Base = NoiseModelFactor;
+  using This = CustomFactor;
 
 public:
 
@@ -68,7 +68,7 @@ public:
    */
   CustomFactor(const SharedNoiseModel& noiseModel, const KeyVector& keys, const CustomErrorFunction& errorFunction) :
       Base(noiseModel, keys) {
-    this->errorFunction = errorFunction;
+    this->error_function_ = errorFunction;
   }
 
   ~CustomFactor() override = default;
@@ -81,22 +81,7 @@ public:
 
   /** print */
   void print(const std::string& s,
-             const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override {
-    std::cout << s << "CustomFactor on ";
-    auto keys_ = this->keys();
-    bool f = false;
-    for (const Key& k: keys_) {
-      if (f)
-        std::cout << ", ";
-      std::cout << keyFormatter(k);
-      f = true;
-    }
-    std::cout << "\n";
-    if (this->noiseModel_)
-      this->noiseModel_->print("  noise model: ");
-    else
-      std::cout << "no noise model" << std::endl;
-  }
+             const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override;
 
 
 private:

--- a/gtsam/nonlinear/CustomFactor.h
+++ b/gtsam/nonlinear/CustomFactor.h
@@ -1,0 +1,84 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file    CustomFactor.h
+ * @brief   Class to enable arbitrary factors with runtime swappable error function.
+ * @author  Fan Jiang
+ */
+
+#pragma once
+
+#include <gtsam/nonlinear/NonlinearFactor.h>
+
+using namespace gtsam;
+
+namespace gtsam {
+
+typedef std::vector<Matrix> JacobianVector;
+
+class CustomFactor;
+
+typedef std::function<Vector(const CustomFactor&, const Values&, const JacobianVector*)> CustomErrorFunction;
+
+/**
+ * @brief Custom factor that takes a std::function as the error
+ * @addtogroup nonlinear
+ * \nosubgrouping
+ *
+ * This factor is mainly for creating a custom factor in Python.
+ */
+class CustomFactor: public NoiseModelFactor {
+public:
+   CustomErrorFunction errorFunction;
+
+protected:
+
+  typedef NoiseModelFactor Base;
+  typedef CustomFactor This;
+
+public:
+
+  /**
+   * Default Constructor for I/O
+   */
+  CustomFactor() = default;
+
+  /**
+   * Constructor
+   * @param noiseModel shared pointer to noise model
+   * @param keys keys of the variables
+   * @param errorFunction the error functional
+   */
+  CustomFactor(const SharedNoiseModel& noiseModel, const KeyVector& keys, const CustomErrorFunction& errorFunction) :
+      Base(noiseModel, keys) {
+    this->errorFunction = errorFunction;
+  }
+
+  ~CustomFactor() override = default;
+
+  /** Calls the errorFunction closure, which is a std::function object
+    * One can check if a derivative is needed in the errorFunction by checking the length of Jacobian array
+  */
+  Vector unwhitenedError(const Values& x, boost::optional<std::vector<Matrix>&> H = boost::none) const override;
+
+private:
+
+  /** Serialization function */
+  friend class boost::serialization::access;
+  template<class ARCHIVE>
+  void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
+    ar & boost::serialization::make_nvp("CustomFactor",
+                                        boost::serialization::base_object<Base>(*this));
+  }
+};
+
+};

--- a/gtsam/nonlinear/CustomFactor.h
+++ b/gtsam/nonlinear/CustomFactor.h
@@ -27,6 +27,14 @@ typedef std::vector<Matrix> JacobianVector;
 
 class CustomFactor;
 
+/*
+ * NOTE
+ * ==========
+ * pybind11 will invoke a copy if this is `JacobianVector &`, and modifications in Python will not be reflected.
+ *
+ * This is safe because this is passing a const pointer, and pybind11 will maintain the `std::vector` memory layout.
+ * Thus the pointer will never be invalidated.
+ */
 typedef std::function<Vector(const CustomFactor&, const Values&, const JacobianVector*)> CustomErrorFunction;
 
 /**

--- a/gtsam/nonlinear/CustomFactor.h
+++ b/gtsam/nonlinear/CustomFactor.h
@@ -23,7 +23,7 @@ using namespace gtsam;
 
 namespace gtsam {
 
-typedef std::vector<Matrix> JacobianVector;
+using JacobianVector = std::vector<Matrix>;
 
 class CustomFactor;
 
@@ -35,7 +35,7 @@ class CustomFactor;
  * This is safe because this is passing a const pointer, and pybind11 will maintain the `std::vector` memory layout.
  * Thus the pointer will never be invalidated.
  */
-typedef std::function<Vector(const CustomFactor&, const Values&, const JacobianVector*)> CustomErrorFunction;
+using CustomErrorFunction = std::function<Vector(const CustomFactor&, const Values&, const JacobianVector*)>;
 
 /**
  * @brief Custom factor that takes a std::function as the error
@@ -73,10 +73,31 @@ public:
 
   ~CustomFactor() override = default;
 
-  /** Calls the errorFunction closure, which is a std::function object
+  /**
+    * Calls the errorFunction closure, which is a std::function object
     * One can check if a derivative is needed in the errorFunction by checking the length of Jacobian array
-  */
-  Vector unwhitenedError(const Values& x, boost::optional<std::vector<Matrix>&> H = boost::none) const override;
+    */
+  Vector unwhitenedError(const Values &x, boost::optional<std::vector<Matrix> &> H = boost::none) const override;
+
+  /** print */
+  void print(const std::string& s,
+             const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override {
+    std::cout << s << "CustomFactor on ";
+    auto keys_ = this->keys();
+    bool f = false;
+    for (const Key& k: keys_) {
+      if (f)
+        std::cout << ", ";
+      std::cout << keyFormatter(k);
+      f = true;
+    }
+    std::cout << "\n";
+    if (this->noiseModel_)
+      this->noiseModel_->print("  noise model: ");
+    else
+      std::cout << "no noise model" << std::endl;
+  }
+
 
 private:
 

--- a/gtsam/nonlinear/NonlinearFactor.h
+++ b/gtsam/nonlinear/NonlinearFactor.h
@@ -95,7 +95,7 @@ public:
 
   /**
    * Checks whether a factor should be used based on a set of values.
-   * This is primarily used to implment inequality constraints that
+   * This is primarily used to implement inequality constraints that
    * require a variable active set. For all others, the default implementation
    * returning true solves this problem.
    *
@@ -133,6 +133,14 @@ public:
    * @param new_keys is the full replacement set of keys
    */
   shared_ptr rekey(const KeyVector& new_keys) const;
+
+  /**
+   * Should the factor be evaluated in the same thread as the caller
+   * This is to enable factors that has shared states (like the Python GIL lock)
+   */
+   virtual bool sendable() const {
+    return true;
+  }
 
 }; // \class NonlinearFactor
 

--- a/gtsam/nonlinear/NonlinearFactorGraph.cpp
+++ b/gtsam/nonlinear/NonlinearFactorGraph.cpp
@@ -325,7 +325,7 @@ public:
   // Operator that linearizes a given range of the factors
   void operator()(const tbb::blocked_range<size_t>& blocked_range) const {
     for (size_t i = blocked_range.begin(); i != blocked_range.end(); ++i) {
-      if (nonlinearGraph_[i])
+      if (nonlinearGraph_[i] && nonlinearGraph_[i]->sendable())
         result_[i] = nonlinearGraph_[i]->linearize(linearizationPoint_);
       else
         result_[i] = GaussianFactor::shared_ptr();
@@ -348,8 +348,18 @@ GaussianFactorGraph::shared_ptr NonlinearFactorGraph::linearize(const Values& li
 
   linearFG->resize(size());
   TbbOpenMPMixedScope threadLimiter; // Limits OpenMP threads since we're mixing TBB and OpenMP
+
+  // First linearize all sendable factors
   tbb::parallel_for(tbb::blocked_range<size_t>(0, size()),
     _LinearizeOneFactor(*this, linearizationPoint, *linearFG));
+
+  // Linearize all non-sendable factors
+  for(int i = 0; i < size(); i++) {
+    auto& factor = (*this)[i];
+    if(factor && !(factor->sendable())) {
+      (*linearFG)[i] = factor->linearize(linearizationPoint);
+    }
+  }
 
 #else
 

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -61,7 +61,8 @@ endif()
 # ignoring the non-concrete types (type aliases)
 set(ignore
     gtsam::Point2
-    gtsam::Point3)
+    gtsam::Point3
+    gtsam::CustomFactor)
 
 # Wrap
 matlab_wrap(${GTSAM_SOURCE_DIR}/gtsam/gtsam.i "${GTSAM_ADDITIONAL_LIBRARIES}"

--- a/python/CustomFactors.md
+++ b/python/CustomFactors.md
@@ -40,24 +40,25 @@ import gtsam
 import numpy as np
 from typing import List
 
-def error_func(this: gtsam.CustomFactor, v: gtsam.Values, H: List[np.ndarray]):
-    # Get the variable values from `v`
+expected = Pose2(2, 2, np.pi / 2)
+
+def error_func(this: CustomFactor, v: gtsam.Values, H: List[np.ndarray]):
+    """
+    Error function that mimics a BetweenFactor
+    :param this: reference to the current CustomFactor being evaluated
+    :param v: Values object
+    :param H: list of references to the Jacobian arrays
+    :return: the non-linear error
+    """
     key0 = this.keys()[0]
     key1 = this.keys()[1]
-    
-    # Calculate non-linear error
     gT1, gT2 = v.atPose2(key0), v.atPose2(key1)
-    error = gtsam.Pose2(0, 0, 0).localCoordinates(gT1.between(gT2))
+    error = expected.localCoordinates(gT1.between(gT2))
 
-    # If we need Jacobian
     if H is not None:
-        # Fill the Jacobian arrays
-        # Note we have two vars, so two entries
         result = gT1.between(gT2)
         H[0] = -result.inverse().AdjointMap()
         H[1] = np.eye(3)
-    
-    # Return the error
     return error
 
 noise_model = gtsam.noiseModel.Unit.Create(3)

--- a/python/FACTORS.md
+++ b/python/FACTORS.md
@@ -1,0 +1,78 @@
+# GTSAM Python-based factors
+
+One now can build factors purely in Python using the `CustomFactor` factor.
+
+## Theory
+
+`CustomFactor` is a `NonlinearFactor` that has a `std::function` as its callback.
+This callback can be translated to a Python function call, thanks to `pybind11`'s functional support.
+
+## Usage
+
+In order to use a Python-based factor, one needs to have a Python function with the following signature:
+
+```python
+import gtsam
+import numpy as np
+from typing import List
+
+def error_func(this: gtsam.CustomFactor, v: gtsam.Values, H: List[np.ndarray]):
+    ...
+```
+
+`this` is a reference to the `CustomFactor` object. This is required because one can reuse the same
+`error_func` for multiple factors. `v` is a reference to the current set of values, and `H` is a list of
+**references** to the list of required Jacobians (see the corresponding C++ documentation).
+
+If `H` is `None`, it means the current factor evaluation does not need Jacobians. For example, the `error`
+method on a factor does not need Jacobians, so we don't evaluate them to save CPU. If `H` is not `None`,
+each entry of `H` can be assigned a `numpy` array, as the Jacobian for the corresponding variable.
+
+After defining `error_func`, one can create a `CustomFactor` just like any other factor in GTSAM:
+
+```python
+noise_model = gtsam.noiseModel.Unit.Create(3)
+# constructor(<noise model>, <list of keys>, <error callback>)
+cf = gtsam.CustomFactor(noise_model, [X(0), X(1)], error_func)
+```
+
+## Example
+
+The following is a simple `BetweenFactor` implemented in Python.
+
+```python
+import gtsam
+import numpy as np
+from typing import List
+
+def error_func(this: gtsam.CustomFactor, v: gtsam.Values, H: List[np.ndarray]):
+    # Get the variable values from `v`
+    key0 = this.keys()[0]
+    key1 = this.keys()[1]
+    
+    # Calculate non-linear error
+    gT1, gT2 = v.atPose2(key0), v.atPose2(key1)
+    error = gtsam.Pose2(0, 0, 0).localCoordinates(gT1.between(gT2))
+
+    # If we need Jacobian
+    if H is not None:
+        # Fill the Jacobian arrays
+        # Note we have two vars, so two entries
+        result = gT1.between(gT2)
+        H[0] = -result.inverse().AdjointMap()
+        H[1] = np.eye(3)
+    
+    # Return the error
+    return error
+
+noise_model = gtsam.noiseModel.Unit.Create(3)
+cf = gtsam.CustomFactor(noise_model, gtsam.KeyVector([0, 1]), error_func)
+```
+
+In general, the Python-based factor works just like their C++ counterparts.
+
+## Known Issues
+
+Because of the `pybind11`-based translation, the performance of `CustomFactor` is not guaranteed.
+Also, because `pybind11` needs to lock the Python GIL lock for evaluation of each factor, parallel
+evaluation of `CustomFactor` is not possible.

--- a/python/gtsam/preamble.h
+++ b/python/gtsam/preamble.h
@@ -1,5 +1,13 @@
-// Please refer to: https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html
-// These are required to save one copy operation on Python calls
+/* Please refer to: https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html
+ * These are required to save one copy operation on Python calls.
+ *
+ * NOTES
+ * =================
+ *
+ * `PYBIND11_MAKE_OPAQUE` will mark the type as "opaque" for the pybind11 automatic STL binding,
+ * such that the raw objects can be accessed in Python. Without this they will be automatically
+ * converted to a Python object, and all mutations on Python side will not be reflected on C++.
+ */
 #ifdef GTSAM_ALLOCATOR_TBB
 PYBIND11_MAKE_OPAQUE(std::vector<gtsam::Key, tbb::tbb_allocator<gtsam::Key>>);
 #else

--- a/python/gtsam/preamble.h
+++ b/python/gtsam/preamble.h
@@ -6,9 +6,17 @@ PYBIND11_MAKE_OPAQUE(std::vector<gtsam::Key, tbb::tbb_allocator<gtsam::Key>>);
 PYBIND11_MAKE_OPAQUE(std::vector<gtsam::Key>);
 #endif
 PYBIND11_MAKE_OPAQUE(std::vector<gtsam::Point2, Eigen::aligned_allocator<gtsam::Point2> >);
+PYBIND11_MAKE_OPAQUE(gtsam::Point3Pairs);
+PYBIND11_MAKE_OPAQUE(gtsam::Pose3Pairs);
 PYBIND11_MAKE_OPAQUE(std::vector<gtsam::Pose3>);
 PYBIND11_MAKE_OPAQUE(std::vector<boost::shared_ptr<gtsam::BetweenFactor<gtsam::Pose3> > >);
 PYBIND11_MAKE_OPAQUE(std::vector<boost::shared_ptr<gtsam::BetweenFactor<gtsam::Pose2> > >);
 PYBIND11_MAKE_OPAQUE(std::vector<gtsam::IndexPair>);
 PYBIND11_MAKE_OPAQUE(gtsam::CameraSet<gtsam::PinholeCamera<gtsam::Cal3Bundler> >);
 PYBIND11_MAKE_OPAQUE(gtsam::CameraSet<gtsam::PinholeCamera<gtsam::Cal3_S2> >);
+PYBIND11_MAKE_OPAQUE(std::vector<gtsam::Matrix>); // JacobianVector
+
+// TODO(fan): This is to fix the Argument-dependent lookup (ADL) of std::pair. We should find a way to NOT do this.
+namespace std {
+  using gtsam::operator<<;
+}

--- a/python/gtsam/specializations.h
+++ b/python/gtsam/specializations.h
@@ -1,5 +1,17 @@
-// Please refer to: https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html
-// These are required to save one copy operation on Python calls
+/* Please refer to: https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html
+ * These are required to save one copy operation on Python calls.
+ *
+ * NOTES
+ * =================
+ *
+ * `PYBIND11_MAKE_OPAQUE` will mark the type as "opaque" for the pybind11 automatic STL binding,
+ * such that the raw objects can be accessed in Python. Without this they will be automatically
+ * converted to a Python object, and all mutations on Python side will not be reflected on C++.
+ *
+ * `py::bind_vector` and similar machinery gives the std container a Python-like interface, but
+ * without the `<pybind11/stl.h>` copying mechanism. Combined with `PYBIND11_MAKE_OPAQUE` this
+ * allows the types to be modified with Python, and saves one copy operation.
+ */
 #ifdef GTSAM_ALLOCATOR_TBB
 py::bind_vector<std::vector<gtsam::Key, tbb::tbb_allocator<gtsam::Key> > >(m_, "KeyVector");
 py::implicitly_convertible<py::list, std::vector<gtsam::Key, tbb::tbb_allocator<gtsam::Key> > >();

--- a/python/gtsam/specializations.h
+++ b/python/gtsam/specializations.h
@@ -2,9 +2,12 @@
 // These are required to save one copy operation on Python calls
 #ifdef GTSAM_ALLOCATOR_TBB
 py::bind_vector<std::vector<gtsam::Key, tbb::tbb_allocator<gtsam::Key> > >(m_, "KeyVector");
+py::implicitly_convertible<py::list, std::vector<gtsam::Key, tbb::tbb_allocator<gtsam::Key> > >();
 #else
 py::bind_vector<std::vector<gtsam::Key> >(m_, "KeyVector");
+py::implicitly_convertible<py::list, std::vector<gtsam::Key> >();
 #endif
+
 py::bind_vector<std::vector<gtsam::Point2, Eigen::aligned_allocator<gtsam::Point2> > >(m_, "Point2Vector");
 py::bind_vector<std::vector<gtsam::Point3Pair> >(m_, "Point3Pairs");
 py::bind_vector<std::vector<gtsam::Pose3Pair> >(m_, "Pose3Pairs");

--- a/python/gtsam/specializations.h
+++ b/python/gtsam/specializations.h
@@ -17,3 +17,4 @@ py::bind_vector<gtsam::IndexPairVector>(m_, "IndexPairVector");
 py::bind_map<gtsam::KeyPairDoubleMap>(m_, "KeyPairDoubleMap");
 py::bind_vector<gtsam::CameraSet<gtsam::PinholeCamera<gtsam::Cal3_S2> > >(m_, "CameraSetCal3_S2");
 py::bind_vector<gtsam::CameraSet<gtsam::PinholeCamera<gtsam::Cal3Bundler> > >(m_, "CameraSetCal3Bundler");
+py::bind_vector<std::vector<gtsam::Matrix> >(m_, "JacobianVector");

--- a/python/gtsam/tests/test_custom_factor.py
+++ b/python/gtsam/tests/test_custom_factor.py
@@ -23,6 +23,7 @@ class TestCustomFactor(GtsamTestCase):
         """Test the creation of a new CustomFactor"""
 
         def error_func(this: CustomFactor, v: gtsam.Values, H: List[np.ndarray]):
+            """Minimal error function stub"""
             return np.array([1, 0, 0])
 
         noise_model = gtsam.noiseModel.Unit.Create(3)
@@ -32,6 +33,7 @@ class TestCustomFactor(GtsamTestCase):
         """Test the creation of a new CustomFactor"""
 
         def error_func(this: CustomFactor, v: gtsam.Values, H: List[np.ndarray]):
+            """Minimal error function stub"""
             return np.array([1, 0, 0])
 
         noise_model = gtsam.noiseModel.Unit.Create(3)
@@ -42,6 +44,7 @@ class TestCustomFactor(GtsamTestCase):
         expected_pose = Pose2(1, 1, 0)
 
         def error_func(this: CustomFactor, v: gtsam.Values, H: List[np.ndarray]) -> np.ndarray:
+            """Minimal error function with no Jacobian"""
             key0 = this.keys()[0]
             error = -v.atPose2(key0).localCoordinates(expected_pose)
             return error
@@ -102,11 +105,8 @@ class TestCustomFactor(GtsamTestCase):
         gT2 = Pose2(-1, 4, np.pi)
 
         def error_func(this: CustomFactor, v: gtsam.Values, _: List[np.ndarray]):
-            key0 = this.keys()[0]
-            key1 = this.keys()[1]
-            gT1, gT2 = v.atPose2(key0), v.atPose2(key1)
-            error = Pose2(0, 0, 0).localCoordinates(gT1.between(gT2))
-            return error
+            """Minimal error function stub"""
+            return np.array([1, 0, 0])
 
         noise_model = gtsam.noiseModel.Unit.Create(3)
         from gtsam.symbol_shorthand import X
@@ -126,6 +126,13 @@ class TestCustomFactor(GtsamTestCase):
         expected = Pose2(2, 2, np.pi / 2)
 
         def error_func(this: CustomFactor, v: gtsam.Values, H: List[np.ndarray]):
+            """
+            Error function that mimics a BetweenFactor
+            :param this: reference to the current CustomFactor being evaluated
+            :param v: Values object
+            :param H: list of references to the Jacobian arrays
+            :return: the non-linear error
+            """
             key0 = this.keys()[0]
             key1 = this.keys()[1]
             gT1, gT2 = v.atPose2(key0), v.atPose2(key1)

--- a/python/gtsam/tests/test_custom_factor.py
+++ b/python/gtsam/tests/test_custom_factor.py
@@ -17,10 +17,9 @@ import numpy as np
 import gtsam
 from gtsam.utils.test_case import GtsamTestCase
 
-
 class TestCustomFactor(GtsamTestCase):
-
     def test_new(self):
+        """Test the creation of a new CustomFactor"""
         def error_func(this: CustomFactor, v: gtsam.Values, H: List[np.ndarray]):
             return np.array([1, 0, 0])
         
@@ -28,7 +27,7 @@ class TestCustomFactor(GtsamTestCase):
         cf = CustomFactor(noise_model, gtsam.KeyVector([0]), error_func)
 
     def test_call(self):
-
+        """Test if calling the factor works (only error)"""
         expected_pose = Pose2(1, 1, 0)
 
         def error_func(this: CustomFactor, v: gtsam.Values, H: List[np.ndarray]) -> np.ndarray:
@@ -53,14 +52,18 @@ class TestCustomFactor(GtsamTestCase):
         expected = Pose2(2, 2, np.pi/2)
 
         def error_func(this: CustomFactor, v: gtsam.Values, H: List[np.ndarray]):
-            # print(f"{this = },\n{v = },\n{len(H) = }")
+            """
+            the custom error function. One can freely use variables captured
+            from the outside scope. Or the variables can be acquired by indexing `v`.
+            Jacobian is passed by modifying the H array of numpy matrices.
+            """
 
             key0 = this.keys()[0]
             key1 = this.keys()[1]
             gT1, gT2 = v.atPose2(key0), v.atPose2(key1)
             error = Pose2(0, 0, 0).localCoordinates(gT1.between(gT2))
             
-            if len(H) > 0:
+            if not H is None:
                 result = gT1.between(gT2)
                 H[0] = -result.inverse().AdjointMap()
                 H[1] = np.eye(3)
@@ -81,6 +84,42 @@ class TestCustomFactor(GtsamTestCase):
         J_bf, b_bf = gf_b.jacobian()
         np.testing.assert_allclose(J_cf, J_bf)
         np.testing.assert_allclose(b_cf, b_bf)
+
+    def test_no_jacobian(self):
+        """Tests that we will not calculate the Jacobian if not requested"""
+
+        gT1 = Pose2(1, 2, np.pi/2)
+        gT2 = Pose2(-1, 4, np.pi)
+
+        expected = Pose2(2, 2, np.pi/2)
+
+        def error_func(this: CustomFactor, v: gtsam.Values, H: List[np.ndarray]):
+            # print(f"{this = },\n{v = },\n{len(H) = }")
+
+            key0 = this.keys()[0]
+            key1 = this.keys()[1]
+            gT1, gT2 = v.atPose2(key0), v.atPose2(key1)
+            error = Pose2(0, 0, 0).localCoordinates(gT1.between(gT2))
+
+            self.assertTrue(H is None) # Should be true if we only request the error
+
+            if not H is None:
+                result = gT1.between(gT2)
+                H[0] = -result.inverse().AdjointMap()
+                H[1] = np.eye(3)
+            return error
+
+        noise_model = gtsam.noiseModel.Unit.Create(3)
+        cf = CustomFactor(noise_model, gtsam.KeyVector([0, 1]), error_func)
+        v = Values()
+        v.insert(0, gT1)
+        v.insert(1, gT2)
+
+        bf = gtsam.BetweenFactorPose2(0, 1, Pose2(0, 0, 0), noise_model)
+
+        e_cf = cf.error(v)
+        e_bf = bf.error(v)
+        np.testing.assert_allclose(e_cf, e_bf)
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/gtsam/tests/test_custom_factor.py
+++ b/python/gtsam/tests/test_custom_factor.py
@@ -1,0 +1,86 @@
+"""
+GTSAM Copyright 2010-2019, Georgia Tech Research Corporation,
+Atlanta, Georgia 30332-0415
+All Rights Reserved
+
+See LICENSE for the license information
+
+CustomFactor unit tests.
+Author: Fan Jiang
+"""
+from typing import List
+import unittest
+from gtsam import Values, Pose2, CustomFactor
+
+import numpy as np
+
+import gtsam
+from gtsam.utils.test_case import GtsamTestCase
+
+
+class TestCustomFactor(GtsamTestCase):
+
+    def test_new(self):
+        def error_func(this: CustomFactor, v: gtsam.Values, H: List[np.ndarray]):
+            return np.array([1, 0, 0])
+        
+        noise_model = gtsam.noiseModel.Unit.Create(3)
+        cf = CustomFactor(noise_model, gtsam.KeyVector([0]), error_func)
+
+    def test_call(self):
+
+        expected_pose = Pose2(1, 1, 0)
+
+        def error_func(this: CustomFactor, v: gtsam.Values, H: List[np.ndarray]) -> np.ndarray:
+            key0 = this.keys()[0]
+            error = -v.atPose2(key0).localCoordinates(expected_pose)
+            return error
+        
+        noise_model = gtsam.noiseModel.Unit.Create(3)
+        cf = CustomFactor(noise_model, gtsam.KeyVector([0]), error_func)
+        v = Values()
+        v.insert(0, Pose2(1, 0, 0))
+        e = cf.error(v)
+        
+        self.assertEqual(e, 0.5)
+    
+    def test_jacobian(self):
+        """Tests if the factor result matches the GTSAM Pose2 unit test"""
+
+        gT1 = Pose2(1, 2, np.pi/2)
+        gT2 = Pose2(-1, 4, np.pi)
+
+        expected = Pose2(2, 2, np.pi/2)
+
+        def error_func(this: CustomFactor, v: gtsam.Values, H: List[np.ndarray]):
+            # print(f"{this = },\n{v = },\n{len(H) = }")
+
+            key0 = this.keys()[0]
+            key1 = this.keys()[1]
+            gT1, gT2 = v.atPose2(key0), v.atPose2(key1)
+            error = Pose2(0, 0, 0).localCoordinates(gT1.between(gT2))
+            
+            if len(H) > 0:
+                result = gT1.between(gT2)
+                H[0] = -result.inverse().AdjointMap()
+                H[1] = np.eye(3)
+            return error
+        
+        noise_model = gtsam.noiseModel.Unit.Create(3)
+        cf = CustomFactor(noise_model, gtsam.KeyVector([0, 1]), error_func)
+        v = Values()
+        v.insert(0, gT1)
+        v.insert(1, gT2)
+        
+        bf = gtsam.BetweenFactorPose2(0, 1, Pose2(0, 0, 0), noise_model)
+
+        gf = cf.linearize(v)
+        gf_b = bf.linearize(v)
+
+        J_cf, b_cf = gf.jacobian()
+        J_bf, b_bf = gf_b.jacobian()
+        np.testing.assert_allclose(J_cf, J_bf)
+        np.testing.assert_allclose(b_cf, b_bf)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/gtsam/tests/test_custom_factor.py
+++ b/python/gtsam/tests/test_custom_factor.py
@@ -126,8 +126,6 @@ class TestCustomFactor(GtsamTestCase):
         expected = Pose2(2, 2, np.pi / 2)
 
         def error_func(this: CustomFactor, v: gtsam.Values, H: List[np.ndarray]):
-            # print(f"{this = },\n{v = },\n{len(H) = }")
-
             key0 = this.keys()[0]
             key1 = this.keys()[1]
             gT1, gT2 = v.atPose2(key0), v.atPose2(key1)

--- a/python/gtsam/tests/test_custom_factor.py
+++ b/python/gtsam/tests/test_custom_factor.py
@@ -36,7 +36,7 @@ class TestCustomFactor(GtsamTestCase):
             return error
         
         noise_model = gtsam.noiseModel.Unit.Create(3)
-        cf = CustomFactor(noise_model, gtsam.KeyVector([0]), error_func)
+        cf = CustomFactor(noise_model, [0], error_func)
         v = Values()
         v.insert(0, Pose2(1, 0, 0))
         e = cf.error(v)


### PR DESCRIPTION
Per #748 and #764, this is a factor that allow one to create the evaluateError function in Python.

The unit tests document the usage.

It also contains a fix for the proper binding of `Point3Pairs`. @johnwlambert 
