### PR TITLE
Bugfix: correct SO(3) logmap when theta small

### DIFF
--- a/gtsam/geometry/SO3.cpp
+++ b/gtsam/geometry/SO3.cpp
@@ -278,7 +278,8 @@ Vector3 SO3::Logmap(const SO3& Q, ChartJacobian H) {
     } else {
       // when theta near 0, +-2pi, +-4pi, etc. (trace near 3.0)
       // use Taylor expansion: theta \approx 1/2-(t-3)/12 + O((t-3)^2)
-      magnitude = 0.5 - tr_3 * tr_3 / 12.0;
+      // see https://github.com/borglab/gtsam/issues/746 for details
+      magnitude = 0.5 - tr_3 / 12.0;
     }
     omega = magnitude * Vector3(R32 - R23, R13 - R31, R21 - R12);
   }


### PR DESCRIPTION
This PR fixes https://github.com/borglab/gtsam/issues/746. 

When mod(theta, 2pi) is small, the SO(3) logmap has to be handled specially (to avoid numerical problems) using the Taylor series expansion. Previously the code which implemented this first-order Taylor series expansion was incorrect (although the comment above it was correct). This PR corrects the line of code, as well as adds a comment above directing the user to the related issue (https://github.com/borglab/gtsam/issues/746), where the user can find the derivation of the equation.