### PR TITLE
Switching to squared sampson point-line error

### DIFF
--- a/gtsam/geometry/EssentialMatrix.cpp
+++ b/gtsam/geometry/EssentialMatrix.cpp
@@ -101,17 +101,15 @@ EssentialMatrix EssentialMatrix::rotate(const Rot3& cRb,
 }
 
 /* ************************************************************************* */
-double EssentialMatrix::error(const Vector3& vA, const Vector3& vB, //
-    OptionalJacobian<1, 5> H) const {
-
+double EssentialMatrix::error(const Vector3& vA, const Vector3& vB,  //
+                              OptionalJacobian<1, 5> H) const {
   // compute the epipolar lines
   Point3 lB = E_ * vB;
   Point3 lA = E_.transpose() * vA;
 
-
   // compute the algebraic error as a simple dot product.
-  double algebraic_error = dot(vA, lB); 
-  
+  double algebraic_error = dot(vA, lB);
+
   // compute the line-norms for the two lines
   Matrix23 I;
   I.setIdentity();
@@ -128,9 +126,9 @@ double EssentialMatrix::error(const Vector3& vA, const Vector3& vB, //
     // See math.lyx
     // computing the derivatives of the numerator w.r.t. E
     Matrix13 numerator_H_R = vA.transpose() * E_ * skewSymmetric(-vB);
-    Matrix12 numerator_H_D = vA.transpose() * skewSymmetric(-rotation().matrix() * vB)
-        * direction().basis();
-
+    Matrix12 numerator_H_D = vA.transpose() *
+                             skewSymmetric(-rotation().matrix() * vB) *
+                             direction().basis();
 
     // computing the derivatives of the denominator w.r.t. E
     Matrix12 denominator_H_nA = nA.transpose() / denominator;
@@ -138,20 +136,24 @@ double EssentialMatrix::error(const Vector3& vA, const Vector3& vB, //
     Matrix13 denominator_H_lA = denominator_H_nA * I;
     Matrix13 denominator_H_lB = denominator_H_nB * I;
     Matrix33 lB_H_R = E_ * skewSymmetric(-vB);
-    Matrix32 lB_H_D = skewSymmetric(-rotation().matrix() * vB) * direction().basis();
-    Matrix33 lA_H_R = skewSymmetric(E_.matrix().transpose() * vA) * 
-      rotation().matrix().transpose();
-    Matrix32 lA_H_D = rotation().inverse().matrix() * skewSymmetric(vA) * direction().basis();
+    Matrix32 lB_H_D =
+        skewSymmetric(-rotation().matrix() * vB) * direction().basis();
+    Matrix33 lA_H_R = skewSymmetric(E_.matrix().transpose() * vA);
+    Matrix32 lA_H_D =
+        rotation().inverse().matrix() * skewSymmetric(vA) * direction().basis();
 
-    Matrix13 denominator_H_R = denominator_H_lA * lA_H_R + denominator_H_lB * lB_H_R;
-    Matrix12 denominator_H_D = denominator_H_lA * lA_H_D + denominator_H_lB * lB_H_D;
+    Matrix13 denominator_H_R =
+        denominator_H_lA * lA_H_R + denominator_H_lB * lB_H_R;
+    Matrix12 denominator_H_D =
+        denominator_H_lA * lA_H_D + denominator_H_lB * lB_H_D;
 
     Matrix15 denominator_H;
     denominator_H << denominator_H_R, denominator_H_D;
     Matrix15 numerator_H;
     numerator_H << numerator_H_R, numerator_H_D;
 
-    *H  = numerator_H / denominator - algebraic_error * denominator_H / (denominator * denominator);
+    *H = numerator_H / denominator -
+         algebraic_error * denominator_H / (denominator * denominator);
   }
   return sampson_error;
 }

--- a/gtsam/geometry/EssentialMatrix.cpp
+++ b/gtsam/geometry/EssentialMatrix.cpp
@@ -154,25 +154,27 @@ double EssentialMatrix::error(const Vector3& vA, const Vector3& vB,
     Matrix15 numerator_H;
     numerator_H << numerator_H_R, numerator_H_D;
 
-    *HE = numerator_H / denominator -
-         algebraic_error * denominator_H / (denominator * denominator);
+    *HE = 2 * sampson_error * (numerator_H / denominator -
+         algebraic_error * denominator_H / (denominator * denominator));
   }
 
   if (HvA){
     Matrix13 numerator_H_vA = vB.transpose() * matrix().transpose();
     Matrix13 denominator_H_vA = nA.transpose() * I * matrix().transpose() / denominator;
 
-    *HvA = numerator_H_vA / denominator - algebraic_error * denominator_H_vA / (denominator * denominator);
+    *HvA = 2 * sampson_error * (numerator_H_vA / denominator - 
+        algebraic_error * denominator_H_vA / (denominator * denominator));
   }
 
   if (HvB){
     Matrix13 numerator_H_vB = vA.transpose() * matrix();
     Matrix13 denominator_H_vB = nB.transpose() * I * matrix() / denominator;
 
-    *HvB = numerator_H_vB / denominator - algebraic_error * denominator_H_vB / (denominator * denominator);
+    *HvB = 2 * sampson_error * (numerator_H_vB / denominator - 
+        algebraic_error * denominator_H_vB / (denominator * denominator));
   }
 
-  return sampson_error;
+  return sampson_error * sampson_error;
 }
 
 /* ************************************************************************* */

--- a/gtsam/geometry/EssentialMatrix.h
+++ b/gtsam/geometry/EssentialMatrix.h
@@ -159,7 +159,7 @@ class EssentialMatrix {
     return E.rotate(cRb);
   }
 
-  /// epipolar error, sampson
+  /// epipolar error, sampson squared
   GTSAM_EXPORT double error(const Vector3& vA, const Vector3& vB,
       OptionalJacobian<1, 5> HE = boost::none, 
       OptionalJacobian<1, 3> HvA = boost::none,

--- a/gtsam/geometry/EssentialMatrix.h
+++ b/gtsam/geometry/EssentialMatrix.h
@@ -161,7 +161,9 @@ class EssentialMatrix {
 
   /// epipolar error, sampson
   GTSAM_EXPORT double error(const Vector3& vA, const Vector3& vB,
-      OptionalJacobian<1, 5> H = boost::none) const;
+      OptionalJacobian<1, 5> HE = boost::none, 
+      OptionalJacobian<1, 3> HvA = boost::none,
+      OptionalJacobian<1, 3> HvB = boost::none) const;
 
   /// @}
 

--- a/gtsam/geometry/EssentialMatrix.h
+++ b/gtsam/geometry/EssentialMatrix.h
@@ -159,7 +159,7 @@ class EssentialMatrix {
     return E.rotate(cRb);
   }
 
-  /// epipolar error, algebraic
+  /// epipolar error, sampson
   GTSAM_EXPORT double error(const Vector3& vA, const Vector3& vB,
       OptionalJacobian<1, 5> H = boost::none) const;
 

--- a/gtsam/geometry/tests/testEssentialMatrix.cpp
+++ b/gtsam/geometry/tests/testEssentialMatrix.cpp
@@ -254,8 +254,8 @@ TEST(EssentialMatrix, errorValue) {
   // algebraic error = 5
   // norm of line for b = 1
   // norm of line for a = 1
-  // sampson error = 5 / sqrt(1^2 + 1^2)
-  double expected = 3.535533906;
+  // sampson error = 5^2 / 1^2 + 1^2
+  double expected = 12.5;
 
   // check the error
   double actual = trueE.error(a, b);

--- a/gtsam/geometry/tests/testEssentialMatrix.cpp
+++ b/gtsam/geometry/tests/testEssentialMatrix.cpp
@@ -263,18 +263,14 @@ TEST(EssentialMatrix, errorValue) {
 }
 
 //*************************************************************************
-double error_(const Rot3& R, const Unit3& t) {
-  // Use two points to get error
-  Point3 a(1, -2, 1);
-  Point3 b(3, 1, 1);
-
+double error_(const Rot3& R, const Unit3& t, const Point3& a, const Point3& b) {
   EssentialMatrix E = EssentialMatrix::FromRotationAndDirection(R, t);
   return E.error(a, b);
 }
 TEST(EssentialMatrix, errorJacobians) {
   // Use two points to get error
-  Point3 a(1, -2, 1);
-  Point3 b(3, 1, 1);
+  Point3 vA(1, -2, 1);
+  Point3 vB(3, 1, 1);
 
   Rot3 c1Rc2 = Rot3::Ypr(0.1, -0.2, 0.3);
   Point3 c1Tc2(0.4, 0.5, 0.6);
@@ -283,18 +279,27 @@ TEST(EssentialMatrix, errorJacobians) {
   // Use numerical derivatives to calculate the expected Jacobian
   Matrix13 HRexpected;
   Matrix12 HDexpected;
-  HRexpected = numericalDerivative21<double, Rot3, Unit3>(error_, E.rotation(),
-                                                          E.direction());
-  HDexpected = numericalDerivative22<double, Rot3, Unit3>(error_, E.rotation(),
-                                                          E.direction());
+  Matrix13 HvAexpected;
+  Matrix13 HvBexpected;
+  HRexpected = numericalDerivative41<double, Rot3, Unit3, Point3, Point3>(error_, E.rotation(),
+                                                          E.direction(), vA, vB);
+  HDexpected = numericalDerivative42<double, Rot3, Unit3, Point3, Point3>(error_, E.rotation(),
+                                                          E.direction(), vA, vB);
+  HvAexpected = numericalDerivative43<double, Rot3, Unit3, Point3, Point3>(error_, E.rotation(),
+                                                          E.direction(), vA, vB);
+  HvBexpected = numericalDerivative44<double, Rot3, Unit3, Point3, Point3>(error_, E.rotation(),
+                                                          E.direction(), vA, vB);
   Matrix15 HEexpected;
   HEexpected << HRexpected, HDexpected;
 
   Matrix15 HEactual;
-  E.error(a, b, HEactual);
+  Matrix13 HvAactual, HvBactual;
+  E.error(vA, vB, HEactual, HvAactual, HvBactual);
 
   // Verify the Jacobian is correct
   EXPECT(assert_equal(HEexpected, HEactual, 1e-5));
+  EXPECT(assert_equal(HvAexpected, HvAactual, 1e-5));
+  EXPECT(assert_equal(HvBexpected, HvBactual, 1e-5));
 }
 
 /* ************************************************************************* */

--- a/gtsam/geometry/tests/testEssentialMatrix.cpp
+++ b/gtsam/geometry/tests/testEssentialMatrix.cpp
@@ -242,7 +242,7 @@ TEST (EssentialMatrix, epipoles) {
 }
 
 //*************************************************************************
-TEST (EssentialMatrix, errorValue) {
+TEST(EssentialMatrix, errorValue) {
   // Use two points to get error
   Point3 a(1, -2, 1);
   Point3 b(3, 1, 1);
@@ -254,7 +254,7 @@ TEST (EssentialMatrix, errorValue) {
   // algebraic error = 5
   // norm of line for b = 1
   // norm of line for a = 1
-  // sampson error = 5 / sqrt(1^2 + 1^2) 
+  // sampson error = 5 / sqrt(1^2 + 1^2)
   double expected = 3.535533906;
 
   // check the error
@@ -263,7 +263,7 @@ TEST (EssentialMatrix, errorValue) {
 }
 
 //*************************************************************************
-double error_(const Rot3& R, const Unit3& t){
+double error_(const Rot3& R, const Unit3& t) {
   // Use two points to get error
   Point3 a(1, -2, 1);
   Point3 b(3, 1, 1);
@@ -271,7 +271,7 @@ double error_(const Rot3& R, const Unit3& t){
   EssentialMatrix E = EssentialMatrix::FromRotationAndDirection(R, t);
   return E.error(a, b);
 }
-TEST (EssentialMatrix, errorJacobians) {
+TEST(EssentialMatrix, errorJacobians) {
   // Use two points to get error
   Point3 a(1, -2, 1);
   Point3 b(3, 1, 1);
@@ -283,10 +283,10 @@ TEST (EssentialMatrix, errorJacobians) {
   // Use numerical derivatives to calculate the expected Jacobian
   Matrix13 HRexpected;
   Matrix12 HDexpected;
-  HRexpected = numericalDerivative21<double, Rot3, Unit3>(
-      error_, E.rotation(), E.direction(), 1e-8);
-  HDexpected = numericalDerivative22<double, Rot3, Unit3>(
-      error_, E.rotation(), E.direction(), 1e-8);
+  HRexpected = numericalDerivative21<double, Rot3, Unit3>(error_, E.rotation(),
+                                                          E.direction());
+  HDexpected = numericalDerivative22<double, Rot3, Unit3>(error_, E.rotation(),
+                                                          E.direction());
   Matrix15 HEexpected;
   HEexpected << HRexpected, HDexpected;
 
@@ -294,7 +294,7 @@ TEST (EssentialMatrix, errorJacobians) {
   E.error(a, b, HEactual);
 
   // Verify the Jacobian is correct
-  EXPECT(assert_equal(HEexpected, HEactual, 1e-8));
+  EXPECT(assert_equal(HEexpected, HEactual, 1e-5));
 }
 
 /* ************************************************************************* */
@@ -303,4 +303,3 @@ int main() {
   return TestRegistry::runAllTests(tr);
 }
 /* ************************************************************************* */
-

--- a/gtsam/slam/tests/testEssentialMatrixFactor.cpp
+++ b/gtsam/slam/tests/testEssentialMatrixFactor.cpp
@@ -192,7 +192,7 @@ TEST (EssentialMatrixFactor, minimization) {
       (Vector(5) << 0.1, -0.1, 0.1, 0.1, -0.1).finished());
   initial.insert(1, initialE);
 #if defined(GTSAM_ROT3_EXPMAP) || defined(GTSAM_USE_QUATERNIONS)
-  EXPECT_DOUBLES_EQUAL(643.26, graph.error(initial), 1e-2);
+  EXPECT_DOUBLES_EQUAL(313.85, graph.error(initial), 1e-2);
 #else
   EXPECT_DOUBLES_EQUAL(639.84, graph.error(initial), 1e-2);
 #endif
@@ -406,7 +406,7 @@ TEST (EssentialMatrixFactor, extraMinimization) {
   initial.insert(1, initialE);
 
 #if defined(GTSAM_ROT3_EXPMAP) || defined(GTSAM_USE_QUATERNIONS)
-  EXPECT_DOUBLES_EQUAL(643.26, graph.error(initial), 1e-2);
+  EXPECT_DOUBLES_EQUAL(313.85, graph.error(initial), 1e-2);
 #else
   EXPECT_DOUBLES_EQUAL(639.84, graph.error(initial), 1e-2);
 #endif

--- a/gtsam/slam/tests/testEssentialMatrixFactor.cpp
+++ b/gtsam/slam/tests/testEssentialMatrixFactor.cpp
@@ -24,7 +24,7 @@ using namespace gtsam;
 
 // Noise model for first type of factor is evaluating algebraic error
 noiseModel::Isotropic::shared_ptr model1 = noiseModel::Isotropic::Sigma(1,
-    0.01);
+    1e-4);
 // Noise model for second type of factor is evaluating pixel coordinates
 noiseModel::Unit::shared_ptr model2 = noiseModel::Unit::Create(2);
 
@@ -196,9 +196,9 @@ TEST (EssentialMatrixFactor, minimization) {
       (Vector(5) << 0.1, -0.1, 0.1, 0.1, -0.1).finished());
   initial.insert(1, initialE);
 #if defined(GTSAM_ROT3_EXPMAP) || defined(GTSAM_USE_QUATERNIONS)
-  EXPECT_DOUBLES_EQUAL(313.85, graph.error(initial), 1e-2);
+  EXPECT_DOUBLES_EQUAL(59403.51, graph.error(initial), 1e-2);
 #else
-  EXPECT_DOUBLES_EQUAL(639.84, graph.error(initial), 1e-2);
+  EXPECT_DOUBLES_EQUAL(639.84, graph.error(initial), 1e-2); # TODO: redo this error
 #endif
 
   // Optimize
@@ -410,7 +410,7 @@ TEST (EssentialMatrixFactor, extraMinimization) {
   initial.insert(1, initialE);
 
 #if defined(GTSAM_ROT3_EXPMAP) || defined(GTSAM_USE_QUATERNIONS)
-  EXPECT_DOUBLES_EQUAL(313.85, graph.error(initial), 1e-2);
+  EXPECT_DOUBLES_EQUAL(59403.51, graph.error(initial), 1e-2);
 #else
   EXPECT_DOUBLES_EQUAL(639.84, graph.error(initial), 1e-2);
 #endif

--- a/gtsam/slam/tests/testEssentialMatrixFactor.cpp
+++ b/gtsam/slam/tests/testEssentialMatrixFactor.cpp
@@ -117,7 +117,8 @@ TEST(EssentialMatrixFactor, ExpressionFactor) {
   Key key(1);
   for (size_t i = 0; i < 5; i++) {
     boost::function<double(const EssentialMatrix&, OptionalJacobian<1, 5>)> f =
-        boost::bind(&EssentialMatrix::error, _1, vA(i), vB(i), _2);
+        boost::bind(&EssentialMatrix::error, _1, vA(i), vB(i), _2, boost::none,
+                    boost::none);
     Expression<EssentialMatrix> E_(key); // leaf expression
     Expression<double> expr(f, E_); // unary expression
 
@@ -143,9 +144,12 @@ TEST(EssentialMatrixFactor, ExpressionFactorRotationOnly) {
   Key key(1);
   for (size_t i = 0; i < 5; i++) {
     boost::function<double(const EssentialMatrix&, OptionalJacobian<1, 5>)> f =
-        boost::bind(&EssentialMatrix::error, _1, vA(i), vB(i), _2);
-    boost::function<EssentialMatrix(const Rot3&, const Unit3&, OptionalJacobian<5, 3>,
-                                    OptionalJacobian<5, 2>)> g;
+        boost::bind(&EssentialMatrix::error, _1, vA(i), vB(i), _2, boost::none,
+                    boost::none);
+    boost::function<EssentialMatrix(const Rot3&, const Unit3&,
+                                    OptionalJacobian<5, 3>,
+                                    OptionalJacobian<5, 2>)>
+        g;
     Expression<Rot3> R_(key);
     Expression<Unit3> d_(trueDirection);
     Expression<EssentialMatrix> E_(&EssentialMatrix::FromRotationAndDirection, R_, d_);


### PR DESCRIPTION
The squared sampson error is the first order approximation of the gold-standard reprojection error. 

This is a work-in-progress PR, and I'll see if the switch actually improves performance. I will clean up the PR and add more documentation if we want to merge this.