### PR TITLE
Remove separate function for double in wrapper

### DIFF
--- a/gtsam/gtsam.i
+++ b/gtsam/gtsam.i
@@ -2257,6 +2257,7 @@ class Values {
   void insert(size_t j, const gtsam::PinholeCamera<gtsam::Cal3Bundler>& camera);
   void insert(size_t j, const gtsam::imuBias::ConstantBias& constant_bias);
   void insert(size_t j, const gtsam::NavState& nav_state);
+  void insert(size_t j, double c);
 
   void update(size_t j, const gtsam::Point2& point2);
   void update(size_t j, const gtsam::Point3& point3);
@@ -2278,13 +2279,31 @@ class Values {
   void update(size_t j, const gtsam::NavState& nav_state);
   void update(size_t j, Vector vector);
   void update(size_t j, Matrix matrix);
+  void update(size_t j, double c);
 
-  template<T = {gtsam::Point2, gtsam::Point3, gtsam::Rot2, gtsam::Pose2, gtsam::SO3, gtsam::SO4, gtsam::SOn, gtsam::Rot3, gtsam::Pose3, gtsam::Unit3, gtsam::Cal3_S2, gtsam::Cal3DS2, gtsam::Cal3Bundler, gtsam::EssentialMatrix, gtsam::PinholeCameraCal3_S2, gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::imuBias::ConstantBias, gtsam::NavState, Vector, Matrix}>
+  template <T = {gtsam::Point2,
+                 gtsam::Point3,
+                 gtsam::Rot2,
+                 gtsam::Pose2,
+                 gtsam::SO3,
+                 gtsam::SO4,
+                 gtsam::SOn,
+                 gtsam::Rot3,
+                 gtsam::Pose3,
+                 gtsam::Unit3,
+                 gtsam::Cal3_S2,
+                 gtsam::Cal3DS2,
+                 gtsam::Cal3Bundler,
+                 gtsam::EssentialMatrix,
+                 gtsam::PinholeCameraCal3_S2,
+                 gtsam::PinholeCamera<gtsam::Cal3Bundler>,
+                 gtsam::imuBias::ConstantBias,
+                 gtsam::NavState,
+                 Vector,
+                 Matrix,
+                 double}>
   T at(size_t j);
 
-  /// version for double
-  void insertDouble(size_t j, double c);
-  double atDouble(size_t j) const;
 };
 
 #include <gtsam/nonlinear/Marginals.h>

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -142,3 +142,13 @@ add_custom_target(${GTSAM_PYTHON_INSTALL_TARGET}
         COMMAND ${PYTHON_EXECUTABLE} ${GTSAM_PYTHON_BUILD_DIRECTORY}/setup.py install
         DEPENDS ${GTSAM_PYTHON_DEPENDENCIES}
         WORKING_DIRECTORY ${GTSAM_PYTHON_BUILD_DIRECTORY})
+
+# Custom make command to run all GTSAM Python tests
+add_custom_target(
+        python-test
+        COMMAND
+          ${CMAKE_COMMAND} -E env # add package to python path so no need to install
+          "PYTHONPATH=${GTSAM_PYTHON_BUILD_DIRECTORY}/$ENV{PYTHONPATH}"
+          ${PYTHON_EXECUTABLE} -m unittest discover
+          DEPENDS ${GTSAM_PYTHON_DEPENDENCIES}
+        WORKING_DIRECTORY ${GTSAM_PYTHON_BUILD_DIRECTORY}/gtsam/tests)

--- a/python/README.md
+++ b/python/README.md
@@ -35,12 +35,8 @@ For instructions on updating the version of the [wrap library](https://github.co
 ## Unit Tests
 
 The Python toolbox also has a small set of unit tests located in the
-test directory. To run them:
-
-  ```bash
-  cd <GTSAM_SOURCE_DIRECTORY>/python/gtsam/tests
-  python -m unittest discover
-  ```
+test directory.
+To run them, use `make python-test`.
 
 ## Utils
 


### PR DESCRIPTION
After understanding the semantics of the wrapper, there is no need for a separate function `atDouble` in `gtsam::Values`, thus this PR adds it to the template list.

I tested this for both Python and Matlab!