### PR TITLE
use size_t variable type

### DIFF
--- a/gtsam/nonlinear/NonlinearFactorGraph.cpp
+++ b/gtsam/nonlinear/NonlinearFactorGraph.cpp
@@ -354,7 +354,7 @@ GaussianFactorGraph::shared_ptr NonlinearFactorGraph::linearize(const Values& li
     _LinearizeOneFactor(*this, linearizationPoint, *linearFG));
 
   // Linearize all non-sendable factors
-  for(int i = 0; i < size(); i++) {
+  for(size_t i = 0; i < size(); i++) {
     auto& factor = (*this)[i];
     if(factor && !(factor->sendable())) {
       (*linearFG)[i] = factor->linearize(linearizationPoint);


### PR DESCRIPTION
Super small fix

Warning this PR fixes:
```
/home/acxz/vcs/git/github/borglab/gtsam/gtsam/nonlinear/NonlinearFactorGraph.cpp: In member function ‘gtsam::GaussianFactorGr     aph::shared_ptr gtsam::NonlinearFactorGraph::linearize(const gtsam::Values&) const’:
/home/acxz/vcs/git/github/borglab/gtsam/gtsam/nonlinear/NonlinearFactorGraph.cpp:357:20: warning: comparison of integer expre     ssions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
 357 |   for(int i = 0; i < size(); i++) {                                                                                  
     |                  ~~^~~~~~~~            
```