### PR TITLE
update timeLago.cpp with newer Sampler interface

### DIFF
--- a/timing/timeLago.cpp
+++ b/timing/timeLago.cpp
@@ -41,11 +41,11 @@ int main(int argc, char *argv[]) {
 
   // add noise to create initial estimate
   Values initial;
-  Sampler sampler(42u);
   Values::ConstFiltered<Pose2> poses = solution->filter<Pose2>();
   SharedDiagonal noise = noiseModel::Diagonal::Sigmas((Vector(3) << 0.5, 0.5, 15.0 * M_PI / 180.0).finished());
+  Sampler sampler(noise);
   for(const Values::ConstFiltered<Pose2>::KeyValuePair& it: poses)
-    initial.insert(it.key, it.value.retract(sampler.sampleNewModel(noise)));
+    initial.insert(it.key, it.value.retract(sampler.sample()));
 
   // Add prior on the pose having index (key) = 0
   noiseModel::Diagonal::shared_ptr priorModel = //


### PR DESCRIPTION
Had an error when compiling some of the timing code.

```
/home/acxz/vcs/git/github/acxz/gtsam/timing/timeLago.cpp: In function ‘int main(int, char**)’:
/home/acxz/vcs/git/github/acxz/gtsam/timing/timeLago.cpp:44:22: error: no matching function for call to ‘gtsam::Sampler::Sampler(unsigned int)’
   44 |   Sampler sampler(42u);
      |                      ^
In file included from /home/acxz/vcs/git/github/acxz/gtsam/timing/timeLago.cpp:23:
/home/acxz/vcs/git/github/acxz/gtsam/gtsam/linear/Sampler.h:60:12: note: candidate: ‘gtsam::Sampler::Sampler(const Vector&, uint_fast64_t)’
   60 |   explicit Sampler(const Vector& sigmas, uint_fast64_t seed = 42u);
      |            ^~~~~~~
/home/acxz/vcs/git/github/acxz/gtsam/gtsam/linear/Sampler.h:60:34: note:   no known conversion for argument 1 from ‘unsigned int’ to ‘const Vector&’ {aka ‘const Eigen::Matrix<double, -1, 1>&’}
   60 |   explicit Sampler(const Vector& sigmas, uint_fast64_t seed = 42u);
      |                    ~~~~~~~~~~~~~~^~~~~~
/home/acxz/vcs/git/github/acxz/gtsam/gtsam/linear/Sampler.h:51:12: note: candidate: ‘gtsam::Sampler::Sampler(const shared_ptr&, uint_fast64_t)’
   51 |   explicit Sampler(const noiseModel::Diagonal::shared_ptr& model,
      |            ^~~~~~~
/home/acxz/vcs/git/github/acxz/gtsam/gtsam/linear/Sampler.h:51:60: note:   no known conversion for argument 1 from ‘unsigned int’ to ‘const shared_ptr&’ {aka ‘const boost::shared_ptr<gtsam::noiseModel::Diagonal>&’}
   51 |   explicit Sampler(const noiseModel::Diagonal::shared_ptr& model,
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/home/acxz/vcs/git/github/acxz/gtsam/gtsam/linear/Sampler.h:31:20: note: candidate: ‘gtsam::Sampler::Sampler(const gtsam::Sampler&)’
   31 | class GTSAM_EXPORT Sampler {
      |                    ^~~~~~~
/home/acxz/vcs/git/github/acxz/gtsam/gtsam/linear/Sampler.h:31:20: note:   no known conversion for argument 1 from ‘unsigned int’ to ‘const gtsam::Sampler&’
/home/acxz/vcs/git/github/acxz/gtsam/gtsam/linear/Sampler.h:31:20: note: candidate: ‘gtsam::Sampler::Sampler(gtsam::Sampler&&)’
/home/acxz/vcs/git/github/acxz/gtsam/gtsam/linear/Sampler.h:31:20: note:   no known conversion for argument 1 from ‘unsigned int’ to ‘gtsam::Sampler&&’
/home/acxz/vcs/git/github/acxz/gtsam/timing/timeLago.cpp:48:53: error: ‘class gtsam::Sampler’ has no member named ‘sampleNewModel’
   48 |     initial.insert(it.key, it.value.retract(sampler.sampleNewModel(noise)));
      |                                                     ^~~~~~~~~~~~~~
```