### PR TITLE
use size_t variable type

### DIFF
--- a/gtsam_unstable/timing/timeShonanAveraging.cpp
+++ b/gtsam_unstable/timing/timeShonanAveraging.cpp
@@ -52,7 +52,7 @@ void saveResult(string name, const Values& values) {
     myfile.open("shonan_result_of_" + name + ".dat");
     size_t nrSO3 = values.count<SO3>();
     myfile << "#Type SO3 Number " << nrSO3 << "\n";
-    for (int i = 0; i < nrSO3; ++i) {
+    for (size_t i = 0; i < nrSO3; ++i) {
         Matrix R = values.at<SO3>(i).matrix();
         // Check if the result of R.Transpose*R satisfy orthogonal constraint
         checkR(R);
@@ -72,7 +72,7 @@ void saveG2oResult(string name, const Values& values, std::map<Key, Pose3> poses
     ofstream myfile;
     myfile.open("shonan_result_of_" + name + ".g2o");
     size_t nrSO3 = values.count<SO3>();
-    for (int i = 0; i < nrSO3; ++i) {
+    for (size_t i = 0; i < nrSO3; ++i) {
         Matrix R = values.at<SO3>(i).matrix();
         // Check if the result of R.Transpose*R satisfy orthogonal constraint
         checkR(R);
@@ -92,7 +92,7 @@ void saveResultQuat(const Values& values) {
     ofstream myfile;
     myfile.open("shonan_result.dat");
     size_t nrSOn = values.count<SOn>();
-    for (int i = 0; i < nrSOn; ++i) {
+    for (size_t i = 0; i < nrSOn; ++i) {
         GTSAM_PRINT(values.at<SOn>(i));
         Rot3 R = Rot3(values.at<SOn>(i).matrix());
         float x = R.toQuaternion().x();


### PR DESCRIPTION
```
/home/acxz/vcs/git/github/acxz/gtsam/gtsam_unstable/timing/timeShonanAveraging.cpp: In function ‘void saveResult(std::string, const gtsam::Values&)’:
/home/acxz/vcs/git/github/acxz/gtsam/gtsam_unstable/timing/timeShonanAveraging.cpp:55:23: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
   55 |     for (int i = 0; i < nrSO3; ++i) {
      |                     ~~^~~~~~~
/home/acxz/vcs/git/github/acxz/gtsam/gtsam_unstable/timing/timeShonanAveraging.cpp: In function ‘void saveG2oResult(std::string, const gtsam::Values&, std::map<long unsigned int, gtsam::Pose3>)’:
/home/acxz/vcs/git/github/acxz/gtsam/gtsam_unstable/timing/timeShonanAveraging.cpp:75:23: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
   75 |     for (int i = 0; i < nrSO3; ++i) {
      |                     ~~^~~~~~~
/home/acxz/vcs/git/github/acxz/gtsam/gtsam_unstable/timing/timeShonanAveraging.cpp: In function ‘void saveResultQuat(const gtsam::Values&)’:
/home/acxz/vcs/git/github/acxz/gtsam/gtsam_unstable/timing/timeShonanAveraging.cpp:95:23: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
   95 |     for (int i = 0; i < nrSOn; ++i) {
      |                     ~~^~~~~~~
```