### PR TITLE
Add ShonanAveraging2 interface to wrapper with BetweenFactorPose2s, that does not require g2o files

### DIFF
--- a/gtsam/gtsam.i
+++ b/gtsam/gtsam.i
@@ -3123,6 +3123,8 @@ class ShonanAveraging2 {
   ShonanAveraging2(string g2oFile);
   ShonanAveraging2(string g2oFile,
                    const gtsam::ShonanAveragingParameters2 &parameters);
+  ShonanAveraging2(const gtsam::BetweenFactorPose2s &factors,
+                   const gtsam::ShonanAveragingParameters2 &parameters);
 
   // Query properties
   size_t nrUnknowns() const;

--- a/gtsam/sfm/ShonanAveraging.cpp
+++ b/gtsam/sfm/ShonanAveraging.cpp
@@ -944,6 +944,20 @@ ShonanAveraging2::ShonanAveraging2(string g2oFile, const Parameters &parameters)
                                      parameters.getUseHuber()),
                          parameters) {}
 
+static ShonanAveraging2::Measurements extractRot2Measurements(
+    const BetweenFactorPose2s &factors) {
+  ShonanAveraging2::Measurements result;
+  result.reserve(factors.size());
+  for (auto f : factors) result.push_back(convert(f));
+  return result;
+}
+
+ShonanAveraging2::ShonanAveraging2(const BetweenFactorPose2s &factors,
+                                   const Parameters &parameters)
+    : ShonanAveraging<3>(maybeRobust(extractRot2Measurements(factors),
+                                     parameters.getUseHuber()),
+                         parameters) {}    
+    
 /* ************************************************************************* */
 // Explicit instantiation for d=3
 template class ShonanAveraging<3>;

--- a/gtsam/sfm/ShonanAveraging.cpp
+++ b/gtsam/sfm/ShonanAveraging.cpp
@@ -944,11 +944,27 @@ ShonanAveraging2::ShonanAveraging2(string g2oFile, const Parameters &parameters)
                                      parameters.getUseHuber()),
                          parameters) {}
 
+// Extract Rot2 measurement from Pose2 betweenfactors
+// Modeled after similar function in dataset.cpp
+static BinaryMeasurement<Rot2> convertPose2ToBinaryMeasurementRot2(
+    const BetweenFactor<Pose2>::shared_ptr &f) {
+  auto gaussian =
+      boost::dynamic_pointer_cast<noiseModel::Gaussian>(f->noiseModel());
+  if (!gaussian)
+    throw std::invalid_argument(
+        "parseMeasurements<Rot2> can only convert Pose2 measurements "
+        "with Gaussian noise models.");
+  const Matrix6 M = gaussian->covariance();
+  auto model = noiseModel::Gaussian::Covariance(M.block<2, 2>(2, 2));
+  return BinaryMeasurement<Rot2>(f->key1(), f->key2(), f->measured().rotation(),
+                                 model);
+}
+    
 static ShonanAveraging2::Measurements extractRot2Measurements(
     const BetweenFactorPose2s &factors) {
   ShonanAveraging2::Measurements result;
   result.reserve(factors.size());
-  for (auto f : factors) result.push_back(convert(f));
+  for (auto f : factors) result.push_back(convertPose2ToBinaryMeasurementRot2(f));
   return result;
 }
 

--- a/gtsam/sfm/ShonanAveraging.cpp
+++ b/gtsam/sfm/ShonanAveraging.cpp
@@ -954,7 +954,7 @@ static ShonanAveraging2::Measurements extractRot2Measurements(
 
 ShonanAveraging2::ShonanAveraging2(const BetweenFactorPose2s &factors,
                                    const Parameters &parameters)
-    : ShonanAveraging<3>(maybeRobust(extractRot2Measurements(factors),
+    : ShonanAveraging<2>(maybeRobust(extractRot2Measurements(factors),
                                      parameters.getUseHuber()),
                          parameters) {}    
     

--- a/gtsam/sfm/ShonanAveraging.cpp
+++ b/gtsam/sfm/ShonanAveraging.cpp
@@ -954,7 +954,7 @@ static BinaryMeasurement<Rot2> convertPose2ToBinaryMeasurementRot2(
     throw std::invalid_argument(
         "parseMeasurements<Rot2> can only convert Pose2 measurements "
         "with Gaussian noise models.");
-  const Matrix6 M = gaussian->covariance();
+  const Matrix3 M = gaussian->covariance();
   auto model = noiseModel::Gaussian::Covariance(M.block<2, 2>(2, 2));
   return BinaryMeasurement<Rot2>(f->key1(), f->key2(), f->measured().rotation(),
                                  model);

--- a/gtsam/sfm/ShonanAveraging.cpp
+++ b/gtsam/sfm/ShonanAveraging.cpp
@@ -955,7 +955,7 @@ static BinaryMeasurement<Rot2> convertPose2ToBinaryMeasurementRot2(
         "parseMeasurements<Rot2> can only convert Pose2 measurements "
         "with Gaussian noise models.");
   const Matrix3 M = gaussian->covariance();
-  auto model = noiseModel::Gaussian::Covariance(M.block<2, 2>(2, 2));
+  auto model = noiseModel::Gaussian::Covariance(M.block<1, 1>(2, 2));
   return BinaryMeasurement<Rot2>(f->key1(), f->key2(), f->measured().rotation(),
                                  model);
 }

--- a/gtsam/sfm/ShonanAveraging.h
+++ b/gtsam/sfm/ShonanAveraging.h
@@ -430,6 +430,8 @@ class GTSAM_EXPORT ShonanAveraging2 : public ShonanAveraging<2> {
                    const Parameters &parameters = Parameters());
   explicit ShonanAveraging2(std::string g2oFile,
                             const Parameters &parameters = Parameters());
+  ShonanAveraging2(const gtsam::BetweenFactorPose2s &factors,
+                   const gtsam::ShonanAveragingParameters2 &parameters);
 };
 
 class GTSAM_EXPORT ShonanAveraging3 : public ShonanAveraging<3> {

--- a/gtsam/sfm/ShonanAveraging.h
+++ b/gtsam/sfm/ShonanAveraging.h
@@ -430,8 +430,8 @@ class GTSAM_EXPORT ShonanAveraging2 : public ShonanAveraging<2> {
                    const Parameters &parameters = Parameters());
   explicit ShonanAveraging2(std::string g2oFile,
                             const Parameters &parameters = Parameters());
-  ShonanAveraging2(const gtsam::BetweenFactorPose2s &factors,
-                   const gtsam::ShonanAveragingParameters2 &parameters);
+  ShonanAveraging2(const BetweenFactorPose2s &factors,
+                   const Parameters &parameters = Parameters());
 };
 
 class GTSAM_EXPORT ShonanAveraging3 : public ShonanAveraging<3> {

--- a/python/gtsam/tests/test_ShonanAveraging.py
+++ b/python/gtsam/tests/test_ShonanAveraging.py
@@ -196,11 +196,13 @@ class TestShonanAveraging(GtsamTestCase):
 
         wRi_list = [result_values.atRot2(i) for i in range(num_images)]
         thetas_deg = np.array([wRi.degrees() for wRi in wRi_list])
-        thetas_deg -= max(thetas_deg)
+        
         # map all angles to [0,360)
         thetas_deg = thetas_deg % 360
+        thetas_deg -= max(thetas_deg)
+        
         expected_thetas_deg = np.array([0.0, 90.0, 0.0])
-        np.testing.assert_allclose(thetas_deg, expected_thetas_deg)
+        np.testing.assert_allclose(thetas_deg, expected_thetas_deg, atol=0.1)
 
 
 if __name__ == "__main__":

--- a/python/gtsam/tests/test_ShonanAveraging.py
+++ b/python/gtsam/tests/test_ShonanAveraging.py
@@ -13,6 +13,7 @@ Author: Frank Dellaert
 import unittest
 
 import gtsam
+import numpy as np
 from gtsam import (
     BetweenFactorPose2,
     LevenbergMarquardtParams,

--- a/python/gtsam/tests/test_ShonanAveraging.py
+++ b/python/gtsam/tests/test_ShonanAveraging.py
@@ -193,7 +193,8 @@ class TestShonanAveraging(GtsamTestCase):
         
         obj = ShonanAveraging2(between_factors, shonan_params)
         initial = obj.initializeRandomly()
-        result_values, _ = obj.run(initial, min_p=2, max_p=10)
+        min
+        result_values, _ = obj.run(initial, min_p=2, max_p=40)
         
         for i in range(num_images):
             wRi = result_values.atRot2(i)

--- a/python/gtsam/tests/test_ShonanAveraging.py
+++ b/python/gtsam/tests/test_ShonanAveraging.py
@@ -197,7 +197,9 @@ class TestShonanAveraging(GtsamTestCase):
         wRi_list = [result_values.atRot2(i) for i in range(num_images)]
         thetas_deg = np.array([wRi.degrees() for wRi in wRi_list])
         thetas_deg -= max(thetas_deg)
-        expected_thetas_deg = np.array([0.0, -270.0, 0.0])
+        # map all angles to [0,360)
+        thetas_deg = thetas_deg % 360
+        expected_thetas_deg = np.array([0.0, 90.0, 0.0])
         np.testing.assert_allclose(thetas_deg, expected_thetas_deg)
 
 

--- a/python/gtsam/tests/test_ShonanAveraging.py
+++ b/python/gtsam/tests/test_ShonanAveraging.py
@@ -148,6 +148,7 @@ class TestShonanAveraging(GtsamTestCase):
     
     def test_constructorBetweenFactorPose2s(self) -> None:
         """Check if ShonanAveraging2 constructor works when not initialized from g2o file."""
+        num_images = 11
         # map (i1,i2) pair to theta in degrees that parameterizes Rot2 object i2Ri1
         i2Ri1_dict = {
             (1, 2):  -43.86342,
@@ -192,9 +193,9 @@ class TestShonanAveraging(GtsamTestCase):
         
         obj = ShonanAveraging2(between_factors, shonan_params)
         initial = obj.initializeRandomly()
-        result_values, _ = obj.run(initial, p_min, self._p_max)
+        result_values, _ = obj.run(initial, min_p=2, max_p=10)
         
-        for i in range(11):
+        for i in range(num_images):
             wRi = result_values.atRot2(i)
 
 

--- a/python/gtsam/tests/test_ShonanAveraging.py
+++ b/python/gtsam/tests/test_ShonanAveraging.py
@@ -193,7 +193,6 @@ class TestShonanAveraging(GtsamTestCase):
         
         obj = ShonanAveraging2(between_factors, shonan_params)
         initial = obj.initializeRandomly()
-        min
         result_values, _ = obj.run(initial, min_p=2, max_p=40)
         
         for i in range(num_images):

--- a/python/gtsam/tests/test_ShonanAveraging.py
+++ b/python/gtsam/tests/test_ShonanAveraging.py
@@ -199,7 +199,7 @@ class TestShonanAveraging(GtsamTestCase):
         
         # map all angles to [0,360)
         thetas_deg = thetas_deg % 360
-        thetas_deg -= max(thetas_deg)
+        thetas_deg -= thetas_deg[0]
         
         expected_thetas_deg = np.array([0.0, 90.0, 0.0])
         np.testing.assert_allclose(thetas_deg, expected_thetas_deg, atol=0.1)


### PR DESCRIPTION
Currently, the python wrapper includes an interface to `ShonanAveraging2`, but only accepts g2o files as input
```c++
  ShonanAveraging2(string g2oFile);
  ShonanAveraging2(string g2oFile,
                   const gtsam::ShonanAveragingParameters2 &parameters);
```

This PR adds support so that optimization over `Rot2` is a first-class citizen in the wrapper with `Rot3`, since `Rot3` has the following additional support:
```c++
  ShonanAveraging3(string g2oFile);
  ShonanAveraging3(string g2oFile,
                   const gtsam::ShonanAveragingParameters3 &parameters);

  // TODO(frank): deprecate once we land pybind wrapper
  ShonanAveraging3(const gtsam::BetweenFactorPose3s &factors);
  ShonanAveraging3(const gtsam::BetweenFactorPose3s &factors,
                   const gtsam::ShonanAveragingParameters3 &parameters);
```

@dellaert I see a line here about deprecating something after the pybind wrapper is landed -- could you give a bit more context about that? It seems relevant to this PR (in case I'm extending something that was supposed to be deprecated). Thanks!
```c++
ShonanAveraging3::ShonanAveraging3(string g2oFile, const Parameters &parameters)
    : ShonanAveraging<3>(maybeRobust(parseMeasurements<Rot3>(g2oFile),
                                     parameters.getUseHuber()),
                         parameters) {}
// TODO(frank): Deprecate after we land pybind wrapper
// Extract Rot3 measurement from Pose3 betweenfactors
// Modeled after similar function in dataset.cpp
static BinaryMeasurement<Rot3> convert(
    const BetweenFactor<Pose3>::shared_ptr &f) {
  auto gaussian =
      boost::dynamic_pointer_cast<noiseModel::Gaussian>(f->noiseModel());
  if (!gaussian)
    throw std::invalid_argument(
        "parseMeasurements<Rot3> can only convert Pose3 measurements "
        "with Gaussian noise models.");
  const Matrix6 M = gaussian->covariance();
  auto model = noiseModel::Gaussian::Covariance(M.block<3, 3>(3, 3));
  return BinaryMeasurement<Rot3>(f->key1(), f->key2(), f->measured().rotation(),
                                 model);
}
```