### PR TITLE
Replace boost with std

### DIFF
--- a/gtsam/base/Matrix.h
+++ b/gtsam/base/Matrix.h
@@ -29,7 +29,7 @@
 #include <gtsam/config.h>
 
 #include <boost/format.hpp>
-#include <boost/function.hpp>
+#include <functional>
 #include <boost/tuple/tuple.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 
@@ -489,7 +489,7 @@ struct MultiplyWithInverseFunction {
 
   // The function phi should calculate f(a)*b, with derivatives in a and b.
   // Naturally, the derivative in b is f(a).
-  typedef boost::function<VectorN(
+  typedef std::function<VectorN(
       const T&, const VectorN&, OptionalJacobian<N, M>, OptionalJacobian<N, N>)>
       Operator;
 

--- a/gtsam/base/Testable.h
+++ b/gtsam/base/Testable.h
@@ -34,8 +34,9 @@
 #pragma once
 
 #include <boost/concept_check.hpp>
-#include <boost/shared_ptr.hpp>
+#include <functional>
 #include <iostream>
+#include <memory>
 #include <string>
 
 #define GTSAM_PRINT(x)((x).print(#x))
@@ -119,10 +120,10 @@ namespace gtsam {
    * Binary predicate on shared pointers
    */
   template<class V>
-  struct equals_star : public std::function<bool(const boost::shared_ptr<V>&, const boost::shared_ptr<V>&)> {
+  struct equals_star : public std::function<bool(const std::shared_ptr<V>&, const std::shared_ptr<V>&)> {
     double tol_;
     equals_star(double tol = 1e-9) : tol_(tol) {}
-    bool operator()(const boost::shared_ptr<V>& expected, const boost::shared_ptr<V>& actual) {
+    bool operator()(const std::shared_ptr<V>& expected, const std::shared_ptr<V>& actual) {
       if (!actual && !expected) return true;
       return actual && expected && traits<V>::Equals(*actual,*expected, tol_);
     }

--- a/gtsam/base/lieProxies.h
+++ b/gtsam/base/lieProxies.h
@@ -24,7 +24,7 @@
  *
  * These should not be used outside of tests, as they are just remappings
  * of the original functions.  We use these to avoid needing to do
- * too much boost::bind magic or writing a bunch of separate proxy functions.
+ * too much std::bind magic or writing a bunch of separate proxy functions.
  *
  * Don't expect all classes to work for all of these functions.
  */

--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -450,7 +450,7 @@ namespace gtsam {
   template<typename L, typename Y>
   template<typename M, typename X>
   DecisionTree<L, Y>::DecisionTree(const DecisionTree<M, X>& other,
-      const std::map<M, L>& map, boost::function<Y(const X&)> op)  {
+      const std::map<M, L>& map, std::function<Y(const X&)> op)  {
     root_ = convert(other.root_, map, op);
   }
 
@@ -568,7 +568,7 @@ namespace gtsam {
   template<typename M, typename X>
   typename DecisionTree<L, Y>::NodePtr DecisionTree<L, Y>::convert(
       const typename DecisionTree<M, X>::NodePtr& f, const std::map<M, L>& map,
-      boost::function<Y(const X&)> op) {
+      std::function<Y(const X&)> op) {
 
     typedef DecisionTree<M, X> MX;
     typedef typename MX::Leaf MXLeaf;

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -20,10 +20,12 @@
 #pragma once
 
 #include <gtsam/discrete/Assignment.h>
+
 #include <boost/function.hpp>
+#include <functional>
 #include <iostream>
-#include <vector>
 #include <map>
+#include <vector>
 
 namespace gtsam {
 
@@ -38,8 +40,8 @@ namespace gtsam {
   public:
 
     /** Handy typedefs for unary and binary function types */
-    typedef boost::function<Y(const Y&)> Unary;
-    typedef boost::function<Y(const Y&, const Y&)> Binary;
+    typedef std::function<Y(const Y&)> Unary;
+    typedef std::function<Y(const Y&, const Y&)> Binary;
 
     /** A label annotated with cardinality */
     typedef std::pair<L,size_t> LabelC;
@@ -107,7 +109,7 @@ namespace gtsam {
     /** Convert to a different type */
     template<typename M, typename X> NodePtr
     convert(const typename DecisionTree<M, X>::NodePtr& f, const std::map<M,
-        L>& map, boost::function<Y(const X&)> op);
+        L>& map, std::function<Y(const X&)> op);
 
     /** Default constructor */
     DecisionTree();
@@ -143,7 +145,7 @@ namespace gtsam {
     /** Convert from a different type */
     template<typename M, typename X>
     DecisionTree(const DecisionTree<M, X>& other,
-        const std::map<M, L>& map, boost::function<Y(const X&)> op);
+        const std::map<M, L>& map, std::function<Y(const X&)> op);
 
     /// @}
     /// @name Testable

--- a/gtsam/discrete/tests/testAlgebraicDecisionTree.cpp
+++ b/gtsam/discrete/tests/testAlgebraicDecisionTree.cpp
@@ -54,7 +54,7 @@ void dot(const T&f, const string& filename) {
 }
 
 /** I can't get this to work !
- class Mul: boost::function<double(const double&, const double&)> {
+ class Mul: std::function<double(const double&, const double&)> {
  inline double operator()(const double& a, const double& b) {
  return a * b;
  }

--- a/gtsam/discrete/tests/testDecisionTree.cpp
+++ b/gtsam/discrete/tests/testDecisionTree.cpp
@@ -196,7 +196,7 @@ TEST(DT, conversion)
   map<string, Label> ordering;
   ordering[A] = X;
   ordering[B] = Y;
-  boost::function<bool(const int&)> op = convert;
+  std::function<bool(const int&)> op = convert;
   BDT f2(f1, ordering, op);
   //  f1.print("f1");
   //  f2.print("f2");

--- a/gtsam/geometry/Cyclic.h
+++ b/gtsam/geometry/Cyclic.h
@@ -17,7 +17,9 @@
 
 #include <gtsam/base/Group.h>
 #include <gtsam/base/Testable.h>
-#include <iostream> // for cout :-(
+
+#include <cassert>
+#include <iostream>  // for cout :-(
 
 namespace gtsam {
 

--- a/gtsam/geometry/tests/testCalibratedCamera.cpp
+++ b/gtsam/geometry/tests/testCalibratedCamera.cpp
@@ -20,12 +20,11 @@
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/numericalDerivative.h>
 
-#include <boost/bind/bind.hpp>
 #include <CppUnitLite/TestHarness.h>
 
 #include <iostream>
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -54,8 +53,8 @@ TEST(CalibratedCamera, Create) {
   EXPECT(assert_equal(camera, CalibratedCamera::Create(kDefaultPose, actualH)));
 
   // Check derivative
-  boost::function<CalibratedCamera(Pose3)> f =  //
-      boost::bind(CalibratedCamera::Create, _1, boost::none);
+  std::function<CalibratedCamera(Pose3)> f =  //
+      std::bind(CalibratedCamera::Create, std::placeholders::_1, boost::none);
   Matrix numericalH = numericalDerivative11<CalibratedCamera, Pose3>(f, kDefaultPose);
   EXPECT(assert_equal(numericalH, actualH, 1e-9));
 }

--- a/gtsam/geometry/tests/testEssentialMatrix.cpp
+++ b/gtsam/geometry/tests/testEssentialMatrix.cpp
@@ -5,16 +5,15 @@
  * @date December 17, 2013
  */
 
-#include <gtsam/geometry/EssentialMatrix.h>
-#include <gtsam/geometry/CalibratedCamera.h>
-#include <gtsam/base/numericalDerivative.h>
-#include <gtsam/base/Testable.h>
-
-#include <boost/bind/bind.hpp>
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/Testable.h>
+#include <gtsam/base/numericalDerivative.h>
+#include <gtsam/geometry/CalibratedCamera.h>
+#include <gtsam/geometry/EssentialMatrix.h>
+
 #include <sstream>
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -42,15 +41,15 @@ TEST(EssentialMatrix, FromRotationAndDirection) {
       1e-8));
 
   Matrix expectedH1 = numericalDerivative11<EssentialMatrix, Rot3>(
-      boost::bind(EssentialMatrix::FromRotationAndDirection, _1, trueDirection, boost::none,
-                  boost::none),
+      std::bind(EssentialMatrix::FromRotationAndDirection,
+                std::placeholders::_1, trueDirection, boost::none, boost::none),
       trueRotation);
   EXPECT(assert_equal(expectedH1, actualH1, 1e-7));
 
   Matrix expectedH2 = numericalDerivative11<EssentialMatrix, Unit3>(
-      boost::bind(EssentialMatrix::FromRotationAndDirection, trueRotation, _1, boost::none,
-                  boost::none),
-                  trueDirection);
+      std::bind(EssentialMatrix::FromRotationAndDirection, trueRotation,
+                std::placeholders::_1, boost::none, boost::none),
+      trueDirection);
   EXPECT(assert_equal(expectedH2, actualH2, 1e-7));
 }
 
@@ -176,7 +175,7 @@ TEST (EssentialMatrix, FromPose3_a) {
   Pose3 pose(trueRotation, trueTranslation); // Pose between two cameras
   EXPECT(assert_equal(trueE, EssentialMatrix::FromPose3(pose, actualH), 1e-8));
   Matrix expectedH = numericalDerivative11<EssentialMatrix, Pose3>(
-      boost::bind(EssentialMatrix::FromPose3, _1, boost::none), pose);
+      std::bind(EssentialMatrix::FromPose3, std::placeholders::_1, boost::none), pose);
   EXPECT(assert_equal(expectedH, actualH, 1e-7));
 }
 
@@ -189,7 +188,7 @@ TEST (EssentialMatrix, FromPose3_b) {
   Pose3 pose(c1Rc2, c1Tc2); // Pose between two cameras
   EXPECT(assert_equal(E, EssentialMatrix::FromPose3(pose, actualH), 1e-8));
   Matrix expectedH = numericalDerivative11<EssentialMatrix, Pose3>(
-      boost::bind(EssentialMatrix::FromPose3, _1, boost::none), pose);
+      std::bind(EssentialMatrix::FromPose3, std::placeholders::_1, boost::none), pose);
   EXPECT(assert_equal(expectedH, actualH, 1e-5));
 }
 

--- a/gtsam/geometry/tests/testOrientedPlane3.cpp
+++ b/gtsam/geometry/tests/testOrientedPlane3.cpp
@@ -21,10 +21,9 @@
 #include <gtsam/base/numericalDerivative.h>
 #include <CppUnitLite/TestHarness.h>
 #include <boost/assign/std/vector.hpp>
-#include <boost/bind/bind.hpp>
 
 using namespace boost::assign;
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace gtsam;
 using namespace std;
 using boost::none;
@@ -138,8 +137,9 @@ TEST(OrientedPlane3, errorVector) {
                       Vector2(actual[0], actual[1])));
   EXPECT(assert_equal(plane1.distance() - plane2.distance(), actual[2]));
 
-  boost::function<Vector3(const OrientedPlane3&, const OrientedPlane3&)> f =
-      boost::bind(&OrientedPlane3::errorVector, _1, _2, boost::none, boost::none);
+  std::function<Vector3(const OrientedPlane3&, const OrientedPlane3&)> f =
+      std::bind(&OrientedPlane3::errorVector, std::placeholders::_1,
+                std::placeholders::_2, boost::none, boost::none);
   expectedH1 = numericalDerivative21(f, plane1, plane2);
   expectedH2 = numericalDerivative22(f, plane1, plane2);
   EXPECT(assert_equal(expectedH1, actualH1, 1e-5));
@@ -150,8 +150,8 @@ TEST(OrientedPlane3, errorVector) {
 TEST(OrientedPlane3, jacobian_retract) {
   OrientedPlane3 plane(-1, 0.1, 0.2, 5);
   Matrix33 H_actual;
-  boost::function<OrientedPlane3(const Vector3&)> f =
-      boost::bind(&OrientedPlane3::retract, plane, _1, boost::none);
+  std::function<OrientedPlane3(const Vector3&)> f = std::bind(
+      &OrientedPlane3::retract, plane, std::placeholders::_1, boost::none);
   {
       Vector3 v(-0.1, 0.2, 0.3);
       plane.retract(v, H_actual);

--- a/gtsam/geometry/tests/testPinholeCamera.cpp
+++ b/gtsam/geometry/tests/testPinholeCamera.cpp
@@ -22,13 +22,12 @@
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/numericalDerivative.h>
 
-#include <boost/bind/bind.hpp>
 #include <CppUnitLite/TestHarness.h>
 
 #include <cmath>
 #include <iostream>
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -66,8 +65,9 @@ TEST(PinholeCamera, Create) {
   EXPECT(assert_equal(camera, Camera::Create(pose,K, actualH1, actualH2)));
 
   // Check derivative
-  boost::function<Camera(Pose3,Cal3_S2)> f = //
-      boost::bind(Camera::Create,_1,_2,boost::none,boost::none);
+  std::function<Camera(Pose3, Cal3_S2)> f =  //
+      std::bind(Camera::Create, std::placeholders::_1, std::placeholders::_2,
+                boost::none, boost::none);
   Matrix numericalH1 = numericalDerivative21<Camera,Pose3,Cal3_S2>(f,pose,K);
   EXPECT(assert_equal(numericalH1, actualH1, 1e-9));
   Matrix numericalH2 = numericalDerivative22<Camera,Pose3,Cal3_S2>(f,pose,K);
@@ -81,8 +81,8 @@ TEST(PinholeCamera, Pose) {
   EXPECT(assert_equal(pose, camera.getPose(actualH)));
 
   // Check derivative
-  boost::function<Pose3(Camera)> f = //
-      boost::bind(&Camera::getPose,_1,boost::none);
+  std::function<Pose3(Camera)> f =  //
+      std::bind(&Camera::getPose, std::placeholders::_1, boost::none);
   Matrix numericalH = numericalDerivative11<Pose3,Camera>(f,camera);
   EXPECT(assert_equal(numericalH, actualH, 1e-9));
 }

--- a/gtsam/geometry/tests/testPinholePose.cpp
+++ b/gtsam/geometry/tests/testPinholePose.cpp
@@ -65,8 +65,8 @@ TEST(PinholeCamera, Pose) {
   EXPECT(assert_equal(pose, camera.getPose(actualH)));
 
   // Check derivative
-  boost::function<Pose3(Camera)> f = //
-      boost::bind(&Camera::getPose,_1,boost::none);
+  std::function<Pose3(Camera)> f = //
+      std::bind(&Camera::getPose,_1,boost::none);
   Matrix numericalH = numericalDerivative11<Pose3,Camera>(f,camera);
   EXPECT(assert_equal(numericalH, actualH, 1e-9));
 }

--- a/gtsam/geometry/tests/testPoint3.cpp
+++ b/gtsam/geometry/tests/testPoint3.cpp
@@ -14,14 +14,14 @@
  * @brief  Unit tests for Point3 class
  */
 
-#include <gtsam/geometry/Point3.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/numericalDerivative.h>
+#include <gtsam/geometry/Point3.h>
 
-#include <boost/bind/bind.hpp>
-#include <CppUnitLite/TestHarness.h>
+#include <boost/function.hpp>
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace gtsam;
 
 GTSAM_CONCEPT_TESTABLE_INST(Point3)
@@ -101,7 +101,7 @@ TEST( Point3, dot) {
 
   // Use numerical derivatives to calculate the expected Jacobians
   Matrix H1, H2;
-  boost::function<double(const Point3&, const Point3&)> f =
+  std::function<double(const Point3&, const Point3&)> f =
       [](const Point3& p, const Point3& q) { return gtsam::dot(p, q); };
   {
     gtsam::dot(p, q, H1, H2);
@@ -123,8 +123,9 @@ TEST( Point3, dot) {
 /* ************************************************************************* */
 TEST(Point3, cross) {
   Matrix aH1, aH2;
-  boost::function<Point3(const Point3&, const Point3&)> f =
-      boost::bind(&gtsam::cross, _1, _2, boost::none, boost::none);
+  std::function<Point3(const Point3&, const Point3&)> f =
+      std::bind(&gtsam::cross, std::placeholders::_1, std::placeholders::_2,
+                boost::none, boost::none);
   const Point3 omega(0, 1, 0), theta(4, 6, 8);
   cross(omega, theta, aH1, aH2);
   EXPECT(assert_equal(numericalDerivative21(f, omega, theta), aH1));
@@ -142,8 +143,9 @@ TEST( Point3, cross2) {
 
   // Use numerical derivatives to calculate the expected Jacobians
   Matrix H1, H2;
-  boost::function<Point3(const Point3&, const Point3&)> f = boost::bind(&gtsam::cross, _1, _2,  //
-                                                                      boost::none, boost::none);
+  std::function<Point3(const Point3&, const Point3&)> f =
+      std::bind(&gtsam::cross, std::placeholders::_1, std::placeholders::_2,  //
+                boost::none, boost::none);
   {
     gtsam::cross(p, q, H1, H2);
     EXPECT(assert_equal(numericalDerivative21<Point3,Point3>(f, p, q), H1, 1e-9));
@@ -163,7 +165,7 @@ TEST (Point3, normalize) {
   Point3 expected(point / sqrt(14.0));
   EXPECT(assert_equal(expected, normalize(point, actualH), 1e-8));
   Matrix expectedH = numericalDerivative11<Point3, Point3>(
-      boost::bind(gtsam::normalize, _1, boost::none), point);
+      std::bind(gtsam::normalize, std::placeholders::_1, boost::none), point);
   EXPECT(assert_equal(expectedH, actualH, 1e-8));
 }
 

--- a/gtsam/geometry/tests/testPose3.cpp
+++ b/gtsam/geometry/tests/testPose3.cpp
@@ -22,8 +22,7 @@
 
 #include <boost/assign/std/vector.hpp> // for operator +=
 using namespace boost::assign;
-#include <boost/bind/bind.hpp>
-using namespace boost::placeholders;
+using namespace std::placeholders;
 
 #include <CppUnitLite/TestHarness.h>
 #include <cmath>
@@ -215,7 +214,7 @@ TEST(Pose3, translation) {
   EXPECT(assert_equal(Point3(3.5, -8.2, 4.2), T.translation(actualH), 1e-8));
 
   Matrix numericalH = numericalDerivative11<Point3, Pose3>(
-      boost::bind(&Pose3::translation, _1, boost::none), T);
+      std::bind(&Pose3::translation, std::placeholders::_1, boost::none), T);
   EXPECT(assert_equal(numericalH, actualH, 1e-6));
 }
 
@@ -226,7 +225,7 @@ TEST(Pose3, rotation) {
   EXPECT(assert_equal(R, T.rotation(actualH), 1e-8));
 
   Matrix numericalH = numericalDerivative11<Rot3, Pose3>(
-      boost::bind(&Pose3::rotation, _1, boost::none), T);
+      std::bind(&Pose3::rotation, std::placeholders::_1, boost::none), T);
   EXPECT(assert_equal(numericalH, actualH, 1e-6));
 }
 
@@ -1052,7 +1051,9 @@ TEST(Pose3, Create) {
   Matrix63 actualH1, actualH2;
   Pose3 actual = Pose3::Create(R, P2, actualH1, actualH2);
   EXPECT(assert_equal(T, actual));
-  boost::function<Pose3(Rot3,Point3)> create = boost::bind(Pose3::Create,_1,_2,boost::none,boost::none);
+  std::function<Pose3(Rot3, Point3)> create =
+      std::bind(Pose3::Create, std::placeholders::_1, std::placeholders::_2,
+                boost::none, boost::none);
   EXPECT(assert_equal(numericalDerivative21<Pose3,Rot3,Point3>(create, R, P2), actualH1, 1e-9));
   EXPECT(assert_equal(numericalDerivative22<Pose3,Rot3,Point3>(create, R, P2), actualH2, 1e-9));
 }

--- a/gtsam/geometry/tests/testSO3.cpp
+++ b/gtsam/geometry/tests/testSO3.cpp
@@ -15,15 +15,12 @@
  * @author Frank Dellaert
  **/
 
-#include <gtsam/geometry/SO3.h>
-
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/testLie.h>
+#include <gtsam/geometry/SO3.h>
 
-#include <boost/bind/bind.hpp>
-#include <CppUnitLite/TestHarness.h>
-
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -211,7 +208,7 @@ TEST(SO3, ExpmapDerivative) {
 TEST(SO3, ExpmapDerivative2) {
   const Vector3 theta(0.1, 0, 0.1);
   const Matrix Jexpected = numericalDerivative11<SO3, Vector3>(
-      boost::bind(&SO3::Expmap, _1, boost::none), theta);
+      std::bind(&SO3::Expmap, std::placeholders::_1, boost::none), theta);
 
   CHECK(assert_equal(Jexpected, SO3::ExpmapDerivative(theta)));
   CHECK(assert_equal(Matrix3(Jexpected.transpose()),
@@ -222,7 +219,7 @@ TEST(SO3, ExpmapDerivative2) {
 TEST(SO3, ExpmapDerivative3) {
   const Vector3 theta(10, 20, 30);
   const Matrix Jexpected = numericalDerivative11<SO3, Vector3>(
-      boost::bind(&SO3::Expmap, _1, boost::none), theta);
+      std::bind(&SO3::Expmap, std::placeholders::_1, boost::none), theta);
 
   CHECK(assert_equal(Jexpected, SO3::ExpmapDerivative(theta)));
   CHECK(assert_equal(Matrix3(Jexpected.transpose()),
@@ -277,7 +274,7 @@ TEST(SO3, ExpmapDerivative5) {
 TEST(SO3, ExpmapDerivative6) {
   const Vector3 thetahat(0.1, 0, 0.1);
   const Matrix Jexpected = numericalDerivative11<SO3, Vector3>(
-      boost::bind(&SO3::Expmap, _1, boost::none), thetahat);
+      std::bind(&SO3::Expmap, std::placeholders::_1, boost::none), thetahat);
   Matrix3 Jactual;
   SO3::Expmap(thetahat, Jactual);
   EXPECT(assert_equal(Jexpected, Jactual));
@@ -288,7 +285,7 @@ TEST(SO3, LogmapDerivative) {
   const Vector3 thetahat(0.1, 0, 0.1);
   const SO3 R = SO3::Expmap(thetahat);  // some rotation
   const Matrix Jexpected = numericalDerivative11<Vector, SO3>(
-      boost::bind(&SO3::Logmap, _1, boost::none), R);
+      std::bind(&SO3::Logmap, std::placeholders::_1, boost::none), R);
   const Matrix3 Jactual = SO3::LogmapDerivative(thetahat);
   EXPECT(assert_equal(Jexpected, Jactual));
 }
@@ -298,7 +295,7 @@ TEST(SO3, JacobianLogmap) {
   const Vector3 thetahat(0.1, 0, 0.1);
   const SO3 R = SO3::Expmap(thetahat);  // some rotation
   const Matrix Jexpected = numericalDerivative11<Vector, SO3>(
-      boost::bind(&SO3::Logmap, _1, boost::none), R);
+      std::bind(&SO3::Logmap, std::placeholders::_1, boost::none), R);
   Matrix3 Jactual;
   SO3::Logmap(R, Jactual);
   EXPECT(assert_equal(Jexpected, Jactual));
@@ -308,7 +305,7 @@ TEST(SO3, JacobianLogmap) {
 TEST(SO3, ApplyDexp) {
   Matrix aH1, aH2;
   for (bool nearZeroApprox : {true, false}) {
-    boost::function<Vector3(const Vector3&, const Vector3&)> f =
+    std::function<Vector3(const Vector3&, const Vector3&)> f =
         [=](const Vector3& omega, const Vector3& v) {
           return so3::DexpFunctor(omega, nearZeroApprox).applyDexp(v);
         };
@@ -331,7 +328,7 @@ TEST(SO3, ApplyDexp) {
 TEST(SO3, ApplyInvDexp) {
   Matrix aH1, aH2;
   for (bool nearZeroApprox : {true, false}) {
-    boost::function<Vector3(const Vector3&, const Vector3&)> f =
+    std::function<Vector3(const Vector3&, const Vector3&)> f =
         [=](const Vector3& omega, const Vector3& v) {
           return so3::DexpFunctor(omega, nearZeroApprox).applyInvDexp(v);
         };
@@ -357,7 +354,7 @@ TEST(SO3, vec) {
   Matrix actualH;
   const Vector9 actual = R2.vec(actualH);
   CHECK(assert_equal(expected, actual));
-  boost::function<Vector9(const SO3&)> f = [](const SO3& Q) { return Q.vec(); };
+  std::function<Vector9(const SO3&)> f = [](const SO3& Q) { return Q.vec(); };
   const Matrix numericalH = numericalDerivative11(f, R2, 1e-5);
   CHECK(assert_equal(numericalH, actualH));
 }
@@ -371,7 +368,7 @@ TEST(Matrix, compose) {
   Matrix actualH;
   const Matrix3 actual = so3::compose(M, R, actualH);
   CHECK(assert_equal(expected, actual));
-  boost::function<Matrix3(const Matrix3&)> f = [R](const Matrix3& M) {
+  std::function<Matrix3(const Matrix3&)> f = [R](const Matrix3& M) {
     return so3::compose(M, R);
   };
   Matrix numericalH = numericalDerivative11(f, M, 1e-2);

--- a/gtsam/geometry/tests/testSO4.cpp
+++ b/gtsam/geometry/tests/testSO4.cpp
@@ -166,7 +166,7 @@ TEST(SO4, vec) {
   Matrix actualH;
   const Vector16 actual = Q2.vec(actualH);
   EXPECT(assert_equal(expected, actual));
-  boost::function<Vector16(const SO4&)> f = [](const SO4& Q) {
+  std::function<Vector16(const SO4&)> f = [](const SO4& Q) {
     return Q.vec();
   };
   const Matrix numericalH = numericalDerivative11(f, Q2, 1e-5);
@@ -179,7 +179,7 @@ TEST(SO4, topLeft) {
   Matrix actualH;
   const Matrix3 actual = topLeft(Q3, actualH);
   EXPECT(assert_equal(expected, actual));
-  boost::function<Matrix3(const SO4&)> f = [](const SO4& Q3) {
+  std::function<Matrix3(const SO4&)> f = [](const SO4& Q3) {
     return topLeft(Q3);
   };
   const Matrix numericalH = numericalDerivative11(f, Q3, 1e-5);
@@ -192,7 +192,7 @@ TEST(SO4, stiefel) {
   Matrix actualH;
   const Matrix43 actual = stiefel(Q3, actualH);
   EXPECT(assert_equal(expected, actual));
-  boost::function<Matrix43(const SO4&)> f = [](const SO4& Q3) {
+  std::function<Matrix43(const SO4&)> f = [](const SO4& Q3) {
     return stiefel(Q3);
   };
   const Matrix numericalH = numericalDerivative11(f, Q3, 1e-5);

--- a/gtsam/geometry/tests/testSOn.cpp
+++ b/gtsam/geometry/tests/testSOn.cpp
@@ -189,7 +189,7 @@ Matrix RetractJacobian(size_t n) { return SOn::VectorizedGenerators(n); }
 /// Test Jacobian of Retract at origin
 TEST(SOn, RetractJacobian) {
   Matrix actualH = RetractJacobian(3);
-  boost::function<Matrix(const Vector &)> h = [](const Vector &v) {
+  std::function<Matrix(const Vector &)> h = [](const Vector &v) {
     return SOn::ChartAtOrigin::Retract(v).matrix();
   };
   Vector3 v;
@@ -205,7 +205,7 @@ TEST(SOn, vec) {
   SOn Q = SOn::ChartAtOrigin::Retract(v);
   Matrix actualH;
   const Vector actual = Q.vec(actualH);
-  boost::function<Vector(const SOn &)> h = [](const SOn &Q) { return Q.vec(); };
+  std::function<Vector(const SOn &)> h = [](const SOn &Q) { return Q.vec(); };
   const Matrix H = numericalDerivative11<Vector, SOn, 10>(h, Q, 1e-5);
   CHECK(assert_equal(H, actualH));
 }

--- a/gtsam/geometry/tests/testSimilarity3.cpp
+++ b/gtsam/geometry/tests/testSimilarity3.cpp
@@ -16,24 +16,22 @@
  * @author Zhaoyang Lv
  */
 
-#include <gtsam/geometry/Similarity3.h>
-#include <gtsam/slam/BetweenFactor.h>
-#include <gtsam/nonlinear/NonlinearFactorGraph.h>
-#include <gtsam/nonlinear/ExpressionFactorGraph.h>
-#include <gtsam/nonlinear/Values.h>
-#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
-#include <gtsam/geometry/Pose3.h>
-#include <gtsam/inference/Symbol.h>
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/Testable.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/base/testLie.h>
-#include <gtsam/base/Testable.h>
+#include <gtsam/geometry/Pose3.h>
+#include <gtsam/geometry/Similarity3.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/nonlinear/ExpressionFactorGraph.h>
+#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
+#include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <gtsam/nonlinear/Values.h>
+#include <gtsam/slam/BetweenFactor.h>
 
-#include <CppUnitLite/TestHarness.h>
+#include <functional>
 
-#include <boost/bind/bind.hpp>
-#include <boost/function.hpp>
-
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace gtsam;
 using namespace std;
 using symbol_shorthand::X;
@@ -243,8 +241,9 @@ TEST(Similarity3, GroupAction) {
   EXPECT(assert_equal(Point3(2, 6, 6), Td.transformFrom(pa)));
 
   // Test derivative
-  boost::function<Point3(Similarity3, Point3)> f = boost::bind(
-      &Similarity3::transformFrom, _1, _2, boost::none, boost::none);
+  // Use lambda to resolve overloaded method
+  std::function<Point3(const Similarity3&, const Point3&)>
+      f = [](const Similarity3& S, const Point3& p){ return S.transformFrom(p); };
 
   Point3 q(1, 2, 3);
   for (const auto& T : { T1, T2, T3, T4, T5, T6 }) {

--- a/gtsam/geometry/tests/testUnit3.cpp
+++ b/gtsam/geometry/tests/testUnit3.cpp
@@ -32,13 +32,12 @@
 #include <CppUnitLite/TestHarness.h>
 
 #include <boost/assign/std/vector.hpp>
-#include <boost/bind/bind.hpp>
 
 #include <cmath>
 #include <random>
 
 using namespace boost::assign;
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace gtsam;
 using namespace std;
 using gtsam::symbol_shorthand::U;
@@ -127,8 +126,9 @@ TEST(Unit3, dot) {
 
   // Use numerical derivatives to calculate the expected Jacobians
   Matrix H1, H2;
-  boost::function<double(const Unit3&, const Unit3&)> f = boost::bind(&Unit3::dot, _1, _2,  //
-                                                                      boost::none, boost::none);
+  std::function<double(const Unit3&, const Unit3&)> f =
+      std::bind(&Unit3::dot, std::placeholders::_1, std::placeholders::_2,  //
+                boost::none, boost::none);
   {
     p.dot(q, H1, H2);
     EXPECT(assert_equal(numericalDerivative21<double,Unit3>(f, p, q), H1, 1e-5));
@@ -158,13 +158,13 @@ TEST(Unit3, error) {
   // Use numerical derivatives to calculate the expected Jacobian
   {
     expected = numericalDerivative11<Vector2,Unit3>(
-        boost::bind(&Unit3::error, &p, _1, boost::none), q);
+        std::bind(&Unit3::error, &p, std::placeholders::_1, boost::none), q);
     p.error(q, actual);
     EXPECT(assert_equal(expected.transpose(), actual, 1e-5));
   }
   {
     expected = numericalDerivative11<Vector2,Unit3>(
-        boost::bind(&Unit3::error, &p, _1, boost::none), r);
+        std::bind(&Unit3::error, &p, std::placeholders::_1, boost::none), r);
     p.error(r, actual);
     EXPECT(assert_equal(expected.transpose(), actual, 1e-5));
   }
@@ -185,25 +185,33 @@ TEST(Unit3, error2) {
   // Use numerical derivatives to calculate the expected Jacobian
   {
     expected = numericalDerivative21<Vector2, Unit3, Unit3>(
-        boost::bind(&Unit3::errorVector, _1, _2, boost::none, boost::none), p, q);
+        std::bind(&Unit3::errorVector, std::placeholders::_1,
+                  std::placeholders::_2, boost::none, boost::none),
+        p, q);
     p.errorVector(q, actual, boost::none);
     EXPECT(assert_equal(expected, actual, 1e-5));
   }
   {
     expected = numericalDerivative21<Vector2, Unit3, Unit3>(
-        boost::bind(&Unit3::errorVector, _1, _2, boost::none, boost::none), p, r);
+        std::bind(&Unit3::errorVector, std::placeholders::_1,
+                  std::placeholders::_2, boost::none, boost::none),
+        p, r);
     p.errorVector(r, actual, boost::none);
     EXPECT(assert_equal(expected, actual, 1e-5));
   }
   {
     expected = numericalDerivative22<Vector2, Unit3, Unit3>(
-        boost::bind(&Unit3::errorVector, _1, _2, boost::none, boost::none), p, q);
+        std::bind(&Unit3::errorVector, std::placeholders::_1,
+                  std::placeholders::_2, boost::none, boost::none),
+        p, q);
     p.errorVector(q, boost::none, actual);
     EXPECT(assert_equal(expected, actual, 1e-5));
   }
   {
     expected = numericalDerivative22<Vector2, Unit3, Unit3>(
-        boost::bind(&Unit3::errorVector, _1, _2, boost::none, boost::none), p, r);
+        std::bind(&Unit3::errorVector, std::placeholders::_1,
+                  std::placeholders::_2, boost::none, boost::none),
+        p, r);
     p.errorVector(r, boost::none, actual);
     EXPECT(assert_equal(expected, actual, 1e-5));
   }
@@ -221,13 +229,13 @@ TEST(Unit3, distance) {
   // Use numerical derivatives to calculate the expected Jacobian
   {
     expected = numericalGradient<Unit3>(
-        boost::bind(&Unit3::distance, &p, _1, boost::none), q);
+        std::bind(&Unit3::distance, &p, std::placeholders::_1, boost::none), q);
     p.distance(q, actual);
     EXPECT(assert_equal(expected.transpose(), actual, 1e-5));
   }
   {
     expected = numericalGradient<Unit3>(
-        boost::bind(&Unit3::distance, &p, _1, boost::none), r);
+        std::bind(&Unit3::distance, &p, std::placeholders::_1, boost::none), r);
     p.distance(r, actual);
     EXPECT(assert_equal(expected.transpose(), actual, 1e-5));
   }
@@ -319,7 +327,7 @@ TEST(Unit3, basis) {
 
   Matrix62 actualH;
   Matrix62 expectedH = numericalDerivative11<Vector6, Unit3>(
-      boost::bind(BasisTest, _1, boost::none), p);
+      std::bind(BasisTest, std::placeholders::_1, boost::none), p);
 
   // without H, first time
   EXPECT(assert_equal(expected, p.basis(), 1e-6));
@@ -348,7 +356,7 @@ TEST(Unit3, basis_derivatives) {
     p.basis(actualH);
 
     Matrix62 expectedH = numericalDerivative11<Vector6, Unit3>(
-                           boost::bind(BasisTest, _1, boost::none), p);
+        std::bind(BasisTest, std::placeholders::_1, boost::none), p);
     EXPECT(assert_equal(expectedH, actualH, 1e-5));
   }
 }
@@ -376,8 +384,8 @@ TEST(Unit3, retract) {
 TEST (Unit3, jacobian_retract) {
   Matrix22 H;
   Unit3 p;
-  boost::function<Unit3(const Vector2&)> f =
-      boost::bind(&Unit3::retract, p, _1, boost::none);
+  std::function<Unit3(const Vector2&)> f =
+      std::bind(&Unit3::retract, p, std::placeholders::_1, boost::none);
   {
       Vector2 v (-0.2, 0.1);
       p.retract(v, H);
@@ -440,7 +448,7 @@ TEST (Unit3, FromPoint3) {
   Unit3 expected(point);
   EXPECT(assert_equal(expected, Unit3::FromPoint3(point, actualH), 1e-5));
   Matrix expectedH = numericalDerivative11<Unit3, Point3>(
-      boost::bind(Unit3::FromPoint3, _1, boost::none), point);
+      std::bind(Unit3::FromPoint3, std::placeholders::_1, boost::none), point);
   EXPECT(assert_equal(expectedH, actualH, 1e-5));
 }
 

--- a/gtsam/inference/EliminateableFactorGraph.h
+++ b/gtsam/inference/EliminateableFactorGraph.h
@@ -19,7 +19,7 @@
 #pragma once
 
 #include <boost/shared_ptr.hpp>
-#include <boost/function.hpp>
+#include <functional>
 #include <boost/variant.hpp>
 #include <boost/optional.hpp>
 
@@ -86,7 +86,7 @@ namespace gtsam {
     typedef std::pair<boost::shared_ptr<ConditionalType>, boost::shared_ptr<_FactorType> > EliminationResult;
 
     /// The function type that does a single dense elimination step on a subgraph.
-    typedef boost::function<EliminationResult(const FactorGraphType&, const Ordering&)> Eliminate;
+    typedef std::function<EliminationResult(const FactorGraphType&, const Ordering&)> Eliminate;
 
     /// Typedef for an optional variable index as an argument to elimination functions
     typedef boost::optional<const VariableIndex&> OptionalVariableIndex;

--- a/gtsam/inference/LabeledSymbol.cpp
+++ b/gtsam/inference/LabeledSymbol.cpp
@@ -15,14 +15,11 @@
  * @author: Alex Cunningham
  */
 
-#include <iostream>
-
-#include <boost/bind/bind.hpp>
-#include <boost/format.hpp>
-
-#include <boost/lexical_cast.hpp>
-
 #include <gtsam/inference/LabeledSymbol.h>
+
+#include <boost/format.hpp>
+#include <boost/lexical_cast.hpp>
+#include <iostream>
 
 namespace gtsam {
 
@@ -109,17 +106,37 @@ bool LabeledSymbol::operator!=(gtsam::Key comp) const {
 /* ************************************************************************* */
 static LabeledSymbol make(gtsam::Key key) { return LabeledSymbol(key);}
 
-boost::function<bool(gtsam::Key)> LabeledSymbol::TypeTest(unsigned char c) {
-  return boost::bind(&LabeledSymbol::chr, boost::bind(make, boost::placeholders::_1)) == c;
+std::function<bool(gtsam::Key)> LabeledSymbol::TypeTest(unsigned char c) {
+  // Use lambda function to check equality
+  auto equals = [](unsigned char s, unsigned char c) { return s == c; };
+  return std::bind(
+      equals,
+      std::bind(&LabeledSymbol::chr, std::bind(make, std::placeholders::_1)),
+      c);
 }
 
-boost::function<bool(gtsam::Key)> LabeledSymbol::LabelTest(unsigned char label) {
-  return boost::bind(&LabeledSymbol::label, boost::bind(make, boost::placeholders::_1)) == label;
+std::function<bool(gtsam::Key)> LabeledSymbol::LabelTest(unsigned char label) {
+  // Use lambda function to check equality
+  auto equals = [](unsigned char s, unsigned char c) { return s == c; };
+  return std::bind(
+      equals,
+      std::bind(&LabeledSymbol::label, std::bind(make, std::placeholders::_1)),
+      label);
 }
 
-boost::function<bool(gtsam::Key)> LabeledSymbol::TypeLabelTest(unsigned char c, unsigned char label) {
-  return boost::bind(&LabeledSymbol::chr,   boost::bind(make, boost::placeholders::_1)) == c &&
-      boost::bind(&LabeledSymbol::label, boost::bind(make, boost::placeholders::_1)) == label;
+std::function<bool(gtsam::Key)> LabeledSymbol::TypeLabelTest(unsigned char c, unsigned char label) {
+  // Use lambda functions for && and ==
+  auto logical_and = [](bool is_type, bool is_label) { return is_type == is_label; };
+  auto equals = [](unsigned char s, unsigned char c) { return s == c; };
+  return std::bind(logical_and,
+                   std::bind(equals,
+                             std::bind(&LabeledSymbol::chr,
+                                       std::bind(make, std::placeholders::_1)),
+                             c),
+                   std::bind(equals,
+                             std::bind(&LabeledSymbol::label,
+                                       std::bind(make, std::placeholders::_1)),
+                             label));
 }
 
 /* ************************************************************************* */

--- a/gtsam/inference/LabeledSymbol.h
+++ b/gtsam/inference/LabeledSymbol.h
@@ -19,8 +19,8 @@
 
 #pragma once
 
+#include <functional>
 #include <gtsam/inference/Symbol.h>
-#include <boost/function.hpp>
 
 namespace gtsam {
 
@@ -89,13 +89,13 @@ public:
    */
 
   // Checks only the type
-  static boost::function<bool(gtsam::Key)> TypeTest(unsigned char c);
+  static std::function<bool(gtsam::Key)> TypeTest(unsigned char c);
 
   // Checks only the robot ID (label_)
-  static boost::function<bool(gtsam::Key)> LabelTest(unsigned char label);
+  static std::function<bool(gtsam::Key)> LabelTest(unsigned char label);
 
   // Checks both type and the robot ID
-  static boost::function<bool(gtsam::Key)> TypeLabelTest(unsigned char c, unsigned char label);
+  static std::function<bool(gtsam::Key)> TypeLabelTest(unsigned char c, unsigned char label);
 
   // Converts to upper/lower versions of labels
   LabeledSymbol upper() const { return LabeledSymbol(c_, toupper(label_), j_); }

--- a/gtsam/inference/Symbol.cpp
+++ b/gtsam/inference/Symbol.cpp
@@ -62,8 +62,11 @@ Symbol::operator std::string() const {
 
 static Symbol make(gtsam::Key key) { return Symbol(key);}
 
-boost::function<bool(Key)> Symbol::ChrTest(unsigned char c) {
-  return boost::bind(&Symbol::chr, boost::bind(make, boost::placeholders::_1)) == c;
+std::function<bool(Key)> Symbol::ChrTest(unsigned char c) {
+  auto equals = [](unsigned char s, unsigned char c) { return s == c; };
+  return std::bind(
+      equals, std::bind(&Symbol::chr, std::bind(make, std::placeholders::_1)),
+      c);
 }
 
 GTSAM_EXPORT std::ostream &operator<<(std::ostream &os, const Symbol &symbol) {

--- a/gtsam/inference/Symbol.h
+++ b/gtsam/inference/Symbol.h
@@ -18,11 +18,12 @@
 
 #pragma once
 
-#include <gtsam/inference/Key.h>
 #include <gtsam/base/Testable.h>
+#include <gtsam/inference/Key.h>
+
 #include <boost/serialization/nvp.hpp>
-#include <boost/function.hpp>
 #include <cstdint>
+#include <functional>
 
 namespace gtsam {
 
@@ -114,7 +115,7 @@ public:
    * Values::filter() function to retrieve all key-value pairs with the
    * requested character.
    */
-  static boost::function<bool(Key)> ChrTest(unsigned char c);
+  static std::function<bool(Key)> ChrTest(unsigned char c);
 
   /// Output stream operator that can be used with key_formatter (see Key.h).
   GTSAM_EXPORT friend std::ostream &operator<<(std::ostream &, const Symbol &);

--- a/gtsam/linear/VectorValues.cpp
+++ b/gtsam/linear/VectorValues.cpp
@@ -38,8 +38,8 @@ namespace gtsam {
   {
     // Merge using predicate for comparing first of pair
     merge(first.begin(), first.end(), second.begin(), second.end(), inserter(values_, values_.end()),
-      boost::bind(&less<Key>::operator(), less<Key>(), boost::bind(&KeyValuePair::first, boost::placeholders::_1),
-          boost::bind(&KeyValuePair::first, boost::placeholders::_2)));
+      std::bind(&less<Key>::operator(), less<Key>(), std::bind(&KeyValuePair::first, std::placeholders::_1),
+          std::bind(&KeyValuePair::first, std::placeholders::_2)));
     if(size() != first.size() + second.size())
       throw invalid_argument("Requested to merge two VectorValues that have one or more variables in common.");
   }

--- a/gtsam/linear/tests/testGaussianBayesNet.cpp
+++ b/gtsam/linear/tests/testGaussianBayesNet.cpp
@@ -32,7 +32,7 @@
 #include <sstream>
 
 using namespace boost::assign;
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -270,11 +270,11 @@ TEST(GaussianBayesNet, ComputeSteepestDescentPoint) {
 
   // Compute the Hessian numerically
   Matrix hessian = numericalHessian<Vector10>(
-      boost::bind(&computeError, gbn, _1), Vector10::Zero());
+      std::bind(&computeError, gbn, std::placeholders::_1), Vector10::Zero());
 
   // Compute the gradient numerically
   Vector gradient = numericalGradient<Vector10>(
-      boost::bind(&computeError, gbn, _1), Vector10::Zero());
+      std::bind(&computeError, gbn, std::placeholders::_1), Vector10::Zero());
 
   // Compute the gradient using dense matrices
   Matrix augmentedHessian = GaussianFactorGraph(gbn).augmentedHessian();

--- a/gtsam/linear/tests/testGaussianBayesTree.cpp
+++ b/gtsam/linear/tests/testGaussianBayesTree.cpp
@@ -21,7 +21,6 @@
 #include <boost/assign/list_of.hpp>
 #include <boost/assign/std/list.hpp> // for operator +=
 #include <boost/assign/std/set.hpp> // for operator +=
-#include <boost/bind/bind.hpp>
 
 #include <gtsam/base/debug.h>
 #include <gtsam/base/numericalDerivative.h>
@@ -30,7 +29,7 @@
 #include <gtsam/linear/GaussianConditional.h>
 
 using namespace boost::assign;
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -260,11 +259,11 @@ TEST(GaussianBayesTree, ComputeSteepestDescentPointBT) {
 
   // Compute the Hessian numerically
   Matrix hessian = numericalHessian<Vector10>(
-      boost::bind(&computeError, bt, _1), Vector10::Zero());
+      std::bind(&computeError, bt, std::placeholders::_1), Vector10::Zero());
 
   // Compute the gradient numerically
   Vector gradient = numericalGradient<Vector10>(
-      boost::bind(&computeError, bt, _1), Vector10::Zero());
+      std::bind(&computeError, bt, std::placeholders::_1), Vector10::Zero());
 
   // Compute the gradient using dense matrices
   Matrix augmentedHessian = GaussianFactorGraph(bt).augmentedHessian();

--- a/gtsam/navigation/tests/testAHRSFactor.cpp
+++ b/gtsam/navigation/tests/testAHRSFactor.cpp
@@ -25,10 +25,9 @@
 #include <gtsam/base/debug.h>
 #include <CppUnitLite/TestHarness.h>
 
-#include <boost/bind/bind.hpp>
 #include <list>
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -175,17 +174,17 @@ TEST(AHRSFactor, Error) {
 
   // Expected Jacobians
   Matrix H1e = numericalDerivative11<Vector3, Rot3>(
-      boost::bind(&callEvaluateError, factor, _1, x2, bias), x1);
+      std::bind(&callEvaluateError, factor, std::placeholders::_1, x2, bias), x1);
   Matrix H2e = numericalDerivative11<Vector3, Rot3>(
-      boost::bind(&callEvaluateError, factor, x1, _1, bias), x2);
+      std::bind(&callEvaluateError, factor, x1, std::placeholders::_1, bias), x2);
   Matrix H3e = numericalDerivative11<Vector3, Vector3>(
-      boost::bind(&callEvaluateError, factor, x1, x2, _1), bias);
+      std::bind(&callEvaluateError, factor, x1, x2, std::placeholders::_1), bias);
 
   // Check rotation Jacobians
   Matrix RH1e = numericalDerivative11<Rot3, Rot3>(
-      boost::bind(&evaluateRotationError, factor, _1, x2, bias), x1);
+      std::bind(&evaluateRotationError, factor, std::placeholders::_1, x2, bias), x1);
   Matrix RH2e = numericalDerivative11<Rot3, Rot3>(
-      boost::bind(&evaluateRotationError, factor, x1, _1, bias), x2);
+      std::bind(&evaluateRotationError, factor, x1, std::placeholders::_1, bias), x2);
 
   // Actual Jacobians
   Matrix H1a, H2a, H3a;
@@ -234,19 +233,19 @@ TEST(AHRSFactor, ErrorWithBiases) {
 
   // Expected Jacobians
   Matrix H1e = numericalDerivative11<Vector, Rot3>(
-      boost::bind(&callEvaluateError, factor, _1, x2, bias), x1);
+      std::bind(&callEvaluateError, factor, std::placeholders::_1, x2, bias), x1);
   Matrix H2e = numericalDerivative11<Vector, Rot3>(
-      boost::bind(&callEvaluateError, factor, x1, _1, bias), x2);
+      std::bind(&callEvaluateError, factor, x1, std::placeholders::_1, bias), x2);
   Matrix H3e = numericalDerivative11<Vector, Vector3>(
-      boost::bind(&callEvaluateError, factor, x1, x2, _1), bias);
+      std::bind(&callEvaluateError, factor, x1, x2, std::placeholders::_1), bias);
 
   // Check rotation Jacobians
   Matrix RH1e = numericalDerivative11<Rot3, Rot3>(
-      boost::bind(&evaluateRotationError, factor, _1, x2, bias), x1);
+      std::bind(&evaluateRotationError, factor, std::placeholders::_1, x2, bias), x1);
   Matrix RH2e = numericalDerivative11<Rot3, Rot3>(
-      boost::bind(&evaluateRotationError, factor, x1, _1, bias), x2);
+      std::bind(&evaluateRotationError, factor, x1, std::placeholders::_1, bias), x2);
   Matrix RH3e = numericalDerivative11<Rot3, Vector3>(
-      boost::bind(&evaluateRotationError, factor, x1, x2, _1), bias);
+      std::bind(&evaluateRotationError, factor, x1, x2, std::placeholders::_1), bias);
 
   // Actual Jacobians
   Matrix H1a, H2a, H3a;
@@ -269,7 +268,7 @@ TEST( AHRSFactor, PartialDerivativeExpmap ) {
 
   // Compute numerical derivatives
   Matrix expectedDelRdelBiasOmega = numericalDerivative11<Rot3, Vector3>(
-      boost::bind(&evaluateRotation, measuredOmega, _1, deltaT), biasOmega);
+      std::bind(&evaluateRotation, measuredOmega, std::placeholders::_1, deltaT), biasOmega);
 
   const Matrix3 Jr = Rot3::ExpmapDerivative(
       (measuredOmega - biasOmega) * deltaT);
@@ -294,7 +293,7 @@ TEST( AHRSFactor, PartialDerivativeLogmap ) {
 
   // Compute numerical derivatives
   Matrix expectedDelFdeltheta = numericalDerivative11<Vector3, Vector3>(
-      boost::bind(&evaluateLogRotation, thetahat, _1), deltatheta);
+      std::bind(&evaluateLogRotation, thetahat, std::placeholders::_1), deltatheta);
 
   const Vector3 x = thetahat; // parametrization of so(3)
   const Matrix3 X = skewSymmetric(x); // element of Lie algebra so(3): X = x^
@@ -368,7 +367,7 @@ TEST( AHRSFactor, FirstOrderPreIntegratedMeasurements ) {
   // Compute numerical derivatives
   Matrix expectedDelRdelBias =
       numericalDerivative11<Rot3, Vector3>(
-          boost::bind(&evaluatePreintegratedMeasurementsRotation, _1,
+          std::bind(&evaluatePreintegratedMeasurementsRotation, std::placeholders::_1,
               measuredOmegas, deltaTs, Vector3(M_PI / 100.0, 0.0, 0.0)), bias);
   Matrix expectedDelRdelBiasOmega = expectedDelRdelBias.rightCols(3);
 
@@ -410,19 +409,19 @@ TEST( AHRSFactor, ErrorWithBiasesAndSensorBodyDisplacement ) {
 
   // Expected Jacobians
   Matrix H1e = numericalDerivative11<Vector, Rot3>(
-      boost::bind(&callEvaluateError, factor, _1, x2, bias), x1);
+      std::bind(&callEvaluateError, factor, std::placeholders::_1, x2, bias), x1);
   Matrix H2e = numericalDerivative11<Vector, Rot3>(
-      boost::bind(&callEvaluateError, factor, x1, _1, bias), x2);
+      std::bind(&callEvaluateError, factor, x1, std::placeholders::_1, bias), x2);
   Matrix H3e = numericalDerivative11<Vector, Vector3>(
-      boost::bind(&callEvaluateError, factor, x1, x2, _1), bias);
+      std::bind(&callEvaluateError, factor, x1, x2, std::placeholders::_1), bias);
 
   // Check rotation Jacobians
   Matrix RH1e = numericalDerivative11<Rot3, Rot3>(
-      boost::bind(&evaluateRotationError, factor, _1, x2, bias), x1);
+      std::bind(&evaluateRotationError, factor, std::placeholders::_1, x2, bias), x1);
   Matrix RH2e = numericalDerivative11<Rot3, Rot3>(
-      boost::bind(&evaluateRotationError, factor, x1, _1, bias), x2);
+      std::bind(&evaluateRotationError, factor, x1, std::placeholders::_1, bias), x2);
   Matrix RH3e = numericalDerivative11<Rot3, Vector3>(
-      boost::bind(&evaluateRotationError, factor, x1, x2, _1), bias);
+      std::bind(&evaluateRotationError, factor, x1, x2, std::placeholders::_1), bias);
 
   // Actual Jacobians
   Matrix H1a, H2a, H3a;
@@ -459,8 +458,8 @@ TEST (AHRSFactor, predictTest) {
 
   // AHRSFactor::PreintegratedMeasurements::predict
   Matrix expectedH = numericalDerivative11<Vector3, Vector3>(
-      boost::bind(&AHRSFactor::PreintegratedMeasurements::predict,
-          &pim, _1, boost::none), bias);
+      std::bind(&AHRSFactor::PreintegratedMeasurements::predict,
+          &pim, std::placeholders::_1, boost::none), bias);
 
   // Actual Jacobians
   Matrix H;

--- a/gtsam/navigation/tests/testAttitudeFactor.cpp
+++ b/gtsam/navigation/tests/testAttitudeFactor.cpp
@@ -25,7 +25,7 @@
 #include <boost/bind/bind.hpp>
 #include <CppUnitLite/TestHarness.h>
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -50,8 +50,9 @@ TEST( Rot3AttitudeFactor, Constructor ) {
   EXPECT(assert_equal((Vector) Z_2x1,factor.evaluateError(nRb),1e-5));
 
   // Calculate numerical derivatives
-  Matrix expectedH = numericalDerivative11<Vector,Rot3>(
-      boost::bind(&Rot3AttitudeFactor::evaluateError, &factor, _1, boost::none),
+  Matrix expectedH = numericalDerivative11<Vector, Rot3>(
+      std::bind(&Rot3AttitudeFactor::evaluateError, &factor,
+                std::placeholders::_1, boost::none),
       nRb);
 
   // Use the factor to calculate the derivative
@@ -117,7 +118,7 @@ TEST( Pose3AttitudeFactor, Constructor ) {
 
   // Calculate numerical derivatives
   Matrix expectedH = numericalDerivative11<Vector,Pose3>(
-      boost::bind(&Pose3AttitudeFactor::evaluateError, &factor, _1,
+      std::bind(&Pose3AttitudeFactor::evaluateError, &factor, std::placeholders::_1,
           boost::none), T);
 
   // Use the factor to calculate the derivative

--- a/gtsam/navigation/tests/testGPSFactor.cpp
+++ b/gtsam/navigation/tests/testGPSFactor.cpp
@@ -27,7 +27,7 @@
 #include <GeographicLib/Config.h>
 #include <GeographicLib/LocalCartesian.hpp>
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 using namespace GeographicLib;
@@ -72,7 +72,7 @@ TEST( GPSFactor, Constructor ) {
 
   // Calculate numerical derivatives
   Matrix expectedH = numericalDerivative11<Vector,Pose3>(
-      boost::bind(&GPSFactor::evaluateError, &factor, _1, boost::none), T);
+      std::bind(&GPSFactor::evaluateError, &factor, _1, boost::none), T);
 
   // Use the factor to calculate the derivative
   Matrix actualH;
@@ -101,7 +101,7 @@ TEST( GPSFactor2, Constructor ) {
 
   // Calculate numerical derivatives
   Matrix expectedH = numericalDerivative11<Vector,NavState>(
-      boost::bind(&GPSFactor2::evaluateError, &factor, _1, boost::none), T);
+      std::bind(&GPSFactor2::evaluateError, &factor, _1, boost::none), T);
 
   // Use the factor to calculate the derivative
   Matrix actualH;

--- a/gtsam/navigation/tests/testImuBias.cpp
+++ b/gtsam/navigation/tests/testImuBias.cpp
@@ -19,9 +19,8 @@
 #include <gtsam/base/numericalDerivative.h>
 
 #include <CppUnitLite/TestHarness.h>
-#include <boost/bind/bind.hpp>
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -128,8 +127,9 @@ TEST(ImuBias, operatorSubB) {
 TEST(ImuBias, Correct1) {
   Matrix aH1, aH2;
   const Vector3 measurement(1, 2, 3);
-  boost::function<Vector3(const Bias&, const Vector3&)> f = boost::bind(
-      &Bias::correctAccelerometer, _1, _2, boost::none, boost::none);
+  std::function<Vector3(const Bias&, const Vector3&)> f =
+      std::bind(&Bias::correctAccelerometer, std::placeholders::_1,
+                std::placeholders::_2, boost::none, boost::none);
   bias1.correctAccelerometer(measurement, aH1, aH2);
   EXPECT(assert_equal(numericalDerivative21(f, bias1, measurement), aH1));
   EXPECT(assert_equal(numericalDerivative22(f, bias1, measurement), aH2));
@@ -139,8 +139,9 @@ TEST(ImuBias, Correct1) {
 TEST(ImuBias, Correct2) {
   Matrix aH1, aH2;
   const Vector3 measurement(1, 2, 3);
-  boost::function<Vector3(const Bias&, const Vector3&)> f =
-      boost::bind(&Bias::correctGyroscope, _1, _2, boost::none, boost::none);
+  std::function<Vector3(const Bias&, const Vector3&)> f =
+      std::bind(&Bias::correctGyroscope, std::placeholders::_1,
+                std::placeholders::_2, boost::none, boost::none);
   bias1.correctGyroscope(measurement, aH1, aH2);
   EXPECT(assert_equal(numericalDerivative21(f, bias1, measurement), aH1));
   EXPECT(assert_equal(numericalDerivative22(f, bias1, measurement), aH2));

--- a/gtsam/navigation/tests/testImuFactor.cpp
+++ b/gtsam/navigation/tests/testImuFactor.cpp
@@ -146,9 +146,9 @@ TEST(ImuFactor, PreintegratedMeasurements) {
   Matrix9 aH1, aH2;
   Matrix96 aH3;
   actual.computeError(x1, x2, bias, aH1, aH2, aH3);
-  boost::function<Vector9(const NavState&, const NavState&, const Bias&)> f =
-      boost::bind(&PreintegrationBase::computeError, actual,
-                  boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3,
+  std::function<Vector9(const NavState&, const NavState&, const Bias&)> f =
+      std::bind(&PreintegrationBase::computeError, actual,
+                  std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
                   boost::none, boost::none, boost::none);
   EXPECT(assert_equal(numericalDerivative31(f, x1, x2, bias), aH1, 1e-9));
   EXPECT(assert_equal(numericalDerivative32(f, x1, x2, bias), aH2, 1e-9));
@@ -204,20 +204,20 @@ TEST(ImuFactor, PreintegrationBaseMethods) {
   Matrix96 actualH;
   pim.biasCorrectedDelta(kZeroBias, actualH);
   Matrix expectedH = numericalDerivative11<Vector9, Bias>(
-      boost::bind(&PreintegrationBase::biasCorrectedDelta, pim,
-          boost::placeholders::_1, boost::none), kZeroBias);
+      std::bind(&PreintegrationBase::biasCorrectedDelta, pim,
+          std::placeholders::_1, boost::none), kZeroBias);
   EXPECT(assert_equal(expectedH, actualH));
 
   Matrix9 aH1;
   Matrix96 aH2;
   NavState predictedState = pim.predict(state1, kZeroBias, aH1, aH2);
   Matrix eH1 = numericalDerivative11<NavState, NavState>(
-      boost::bind(&PreintegrationBase::predict, pim, boost::placeholders::_1,
+      std::bind(&PreintegrationBase::predict, pim, std::placeholders::_1,
           kZeroBias, boost::none, boost::none), state1);
   EXPECT(assert_equal(eH1, aH1));
   Matrix eH2 = numericalDerivative11<NavState, Bias>(
-      boost::bind(&PreintegrationBase::predict, pim, state1,
-          boost::placeholders::_1, boost::none, boost::none), kZeroBias);
+      std::bind(&PreintegrationBase::predict, pim, state1,
+          std::placeholders::_1, boost::none, boost::none), kZeroBias);
   EXPECT(assert_equal(eH2, aH2));
 }
 
@@ -278,12 +278,12 @@ TEST(ImuFactor, ErrorAndJacobians) {
   // Make sure rotation part is correct when error is interpreted as axis-angle
   // Jacobians are around zero, so the rotation part is the same as:
   Matrix H1Rot3 = numericalDerivative11<Rot3, Pose3>(
-      boost::bind(&evaluateRotationError, factor, boost::placeholders::_1, v1, x2, v2, kZeroBias),
+      std::bind(&evaluateRotationError, factor, std::placeholders::_1, v1, x2, v2, kZeroBias),
       x1);
   EXPECT(assert_equal(H1Rot3, H1a.topRows(3)));
 
   Matrix H3Rot3 = numericalDerivative11<Rot3, Pose3>(
-      boost::bind(&evaluateRotationError, factor, x1, v1, boost::placeholders::_1, v2, kZeroBias),
+      std::bind(&evaluateRotationError, factor, x1, v1, std::placeholders::_1, v2, kZeroBias),
       x2);
   EXPECT(assert_equal(H3Rot3, H3a.topRows(3)));
 
@@ -333,8 +333,8 @@ TEST(ImuFactor, ErrorAndJacobianWithBiases) {
   Matrix96 actualH;
   pim.biasCorrectedDelta(bias, actualH);
   Matrix expectedH = numericalDerivative11<Vector9, Bias>(
-      boost::bind(&PreintegrationBase::biasCorrectedDelta, pim,
-          boost::placeholders::_1, boost::none), bias);
+      std::bind(&PreintegrationBase::biasCorrectedDelta, pim,
+          std::placeholders::_1, boost::none), bias);
   EXPECT(assert_equal(expectedH, actualH));
 
   // Create factor
@@ -522,7 +522,7 @@ TEST(ImuFactor, ErrorWithBiasesAndSensorBodyDisplacement) {
   pim.correctMeasurementsBySensorPose(measuredAcc, measuredOmega,
       boost::none, D_correctedAcc_measuredOmega, boost::none);
   Matrix3 expectedD = numericalDerivative11<Vector3, Vector3>(
-      boost::bind(correctedAcc, pim, measuredAcc, boost::placeholders::_1),
+      std::bind(correctedAcc, pim, measuredAcc, std::placeholders::_1),
       measuredOmega, 1e-6);
   EXPECT(assert_equal(expectedD, D_correctedAcc_measuredOmega, 1e-5));
 
@@ -534,15 +534,15 @@ TEST(ImuFactor, ErrorWithBiasesAndSensorBodyDisplacement) {
 //      pim.updatedDeltaXij(measuredAcc, measuredOmega, dt, boost::none, G1, G2);
 //
 //  Matrix93 expectedG1 = numericalDerivative21<NavState, Vector3, Vector3>(
-//      boost::bind(&PreintegratedImuMeasurements::updatedDeltaXij, pim,
-//          boost::placeholders::_1, boost::placeholders::_2,
+//      std::bind(&PreintegratedImuMeasurements::updatedDeltaXij, pim,
+//          std::placeholders::_1, std::placeholders::_2,
 //          dt, boost::none, boost::none, boost::none), measuredAcc,
 //      measuredOmega, 1e-6);
 //  EXPECT(assert_equal(expectedG1, G1, 1e-5));
 //
 //  Matrix93 expectedG2 = numericalDerivative22<NavState, Vector3, Vector3>(
-//      boost::bind(&PreintegratedImuMeasurements::updatedDeltaXij, pim,
-//          boost::placeholders::_1, boost::placeholders::_2,
+//      std::bind(&PreintegratedImuMeasurements::updatedDeltaXij, pim,
+//          std::placeholders::_1, std::placeholders::_2,
 //          dt, boost::none, boost::none, boost::none), measuredAcc,
 //      measuredOmega, 1e-6);
 //  EXPECT(assert_equal(expectedG2, G2, 1e-5));

--- a/gtsam/navigation/tests/testMagFactor.cpp
+++ b/gtsam/navigation/tests/testMagFactor.cpp
@@ -26,7 +26,7 @@
 
 #include <GeographicLib/LocalCartesian.hpp>
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 using namespace GeographicLib;
@@ -64,7 +64,7 @@ TEST( MagFactor, unrotate ) {
   Point3 expected(22735.5, 314.502, 44202.5);
   EXPECT( assert_equal(expected, MagFactor::unrotate(theta,nM,H),1e-1));
   EXPECT( assert_equal(numericalDerivative11<Point3,Rot2> //
-      (boost::bind(&MagFactor::unrotate, _1, nM, none), theta), H, 1e-6));
+      (std::bind(&MagFactor::unrotate, _1, nM, none), theta), H, 1e-6));
 }
 
 // *************************************************************************
@@ -76,35 +76,35 @@ TEST( MagFactor, Factors ) {
   MagFactor f(1, measured, s, dir, bias, model);
   EXPECT( assert_equal(Z_3x1,f.evaluateError(theta,H1),1e-5));
   EXPECT( assert_equal((Matrix)numericalDerivative11<Vector,Rot2> //
-      (boost::bind(&MagFactor::evaluateError, &f, _1, none), theta), H1, 1e-7));
+      (std::bind(&MagFactor::evaluateError, &f, _1, none), theta), H1, 1e-7));
 
 // MagFactor1
   MagFactor1 f1(1, measured, s, dir, bias, model);
   EXPECT( assert_equal(Z_3x1,f1.evaluateError(nRb,H1),1e-5));
   EXPECT( assert_equal(numericalDerivative11<Vector,Rot3> //
-      (boost::bind(&MagFactor1::evaluateError, &f1, _1, none), nRb), H1, 1e-7));
+      (std::bind(&MagFactor1::evaluateError, &f1, _1, none), nRb), H1, 1e-7));
 
 // MagFactor2
   MagFactor2 f2(1, 2, measured, nRb, model);
   EXPECT( assert_equal(Z_3x1,f2.evaluateError(scaled,bias,H1,H2),1e-5));
   EXPECT( assert_equal(numericalDerivative11<Vector,Point3> //
-      (boost::bind(&MagFactor2::evaluateError, &f2, _1, bias, none, none), scaled),//
+      (std::bind(&MagFactor2::evaluateError, &f2, _1, bias, none, none), scaled),//
       H1, 1e-7));
   EXPECT( assert_equal(numericalDerivative11<Vector,Point3> //
-      (boost::bind(&MagFactor2::evaluateError, &f2, scaled, _1, none, none), bias),//
+      (std::bind(&MagFactor2::evaluateError, &f2, scaled, _1, none, none), bias),//
       H2, 1e-7));
 
 // MagFactor2
   MagFactor3 f3(1, 2, 3, measured, nRb, model);
   EXPECT(assert_equal(Z_3x1,f3.evaluateError(s,dir,bias,H1,H2,H3),1e-5));
   EXPECT(assert_equal((Matrix)numericalDerivative11<Vector,double> //
-      (boost::bind(&MagFactor3::evaluateError, &f3, _1, dir, bias, none, none, none), s),//
+      (std::bind(&MagFactor3::evaluateError, &f3, _1, dir, bias, none, none, none), s),//
       H1, 1e-7));
   EXPECT(assert_equal(numericalDerivative11<Vector,Unit3> //
-      (boost::bind(&MagFactor3::evaluateError, &f3, s, _1, bias, none, none, none), dir),//
+      (std::bind(&MagFactor3::evaluateError, &f3, s, _1, bias, none, none, none), dir),//
       H2, 1e-7));
   EXPECT(assert_equal(numericalDerivative11<Vector,Point3> //
-      (boost::bind(&MagFactor3::evaluateError, &f3, s, dir, _1, none, none, none), bias),//
+      (std::bind(&MagFactor3::evaluateError, &f3, s, dir, _1, none, none, none), bias),//
       H3, 1e-7));
 }
 

--- a/gtsam/navigation/tests/testMagPoseFactor.cpp
+++ b/gtsam/navigation/tests/testMagPoseFactor.cpp
@@ -17,9 +17,7 @@
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/navigation/MagPoseFactor.h>
 
-#include <boost/bind/bind.hpp>
-
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace gtsam;
 
 // *****************************************************************************
@@ -78,8 +76,11 @@ TEST(MagPoseFactor, JacobianPose2) {
   // Error should be zero at the groundtruth pose.
   MagPoseFactor<Pose2> f(Symbol('X', 0), measured2, scale, dir2, bias2, model2, boost::none);
   CHECK(gtsam::assert_equal(Z_2x1, f.evaluateError(n_P2_b, H2), 1e-5));
-  CHECK(gtsam::assert_equal(gtsam::numericalDerivative11<Vector, Pose2> //
-      (boost::bind(&MagPoseFactor<Pose2>::evaluateError, &f, _1, boost::none), n_P2_b), H2, 1e-7));
+  CHECK(gtsam::assert_equal(gtsam::numericalDerivative11<Vector, Pose2>  //
+                            (std::bind(&MagPoseFactor<Pose2>::evaluateError, &f,
+                                       std::placeholders::_1, boost::none),
+                             n_P2_b),
+                            H2, 1e-7));
 }
 
 // *****************************************************************************
@@ -89,8 +90,11 @@ TEST(MagPoseFactor, JacobianPose3) {
   // Error should be zero at the groundtruth pose.
   MagPoseFactor<Pose3> f(Symbol('X', 0), measured3, scale, dir3, bias3, model3, boost::none);
   CHECK(gtsam::assert_equal(Z_3x1, f.evaluateError(n_P3_b, H3), 1e-5));
-  CHECK(gtsam::assert_equal(gtsam::numericalDerivative11<Vector, Pose3> //
-      (boost::bind(&MagPoseFactor<Pose3>::evaluateError, &f, _1, boost::none), n_P3_b), H3, 1e-7));
+  CHECK(gtsam::assert_equal(gtsam::numericalDerivative11<Vector, Pose3>  //
+                            (std::bind(&MagPoseFactor<Pose3>::evaluateError, &f,
+                                       std::placeholders::_1, boost::none),
+                             n_P3_b),
+                            H3, 1e-7));
 }
 
 // *****************************************************************************
@@ -104,7 +108,7 @@ TEST(MagPoseFactor, body_P_sensor2) {
   MagPoseFactor<Pose2> f = MagPoseFactor<Pose2>(Symbol('X', 0), sM, scale, dir2, bias2, model2, body_P2_sensor);
   CHECK(gtsam::assert_equal(Z_2x1, f.evaluateError(n_P2_b, H2), 1e-5));
   CHECK(gtsam::assert_equal(gtsam::numericalDerivative11<Vector, Pose2> //
-      (boost::bind(&MagPoseFactor<Pose2>::evaluateError, &f, _1, boost::none), n_P2_b), H2, 1e-7));
+      (std::bind(&MagPoseFactor<Pose2>::evaluateError, &f, std::placeholders::_1, boost::none), n_P2_b), H2, 1e-7));
 }
 
 // *****************************************************************************
@@ -118,7 +122,7 @@ TEST(MagPoseFactor, body_P_sensor3) {
   MagPoseFactor<Pose3> f = MagPoseFactor<Pose3>(Symbol('X', 0), sM, scale, dir3, bias3, model3, body_P3_sensor);
   CHECK(gtsam::assert_equal(Z_3x1, f.evaluateError(n_P3_b, H3), 1e-5));
   CHECK(gtsam::assert_equal(gtsam::numericalDerivative11<Vector, Pose3> //
-      (boost::bind(&MagPoseFactor<Pose3>::evaluateError, &f, _1, boost::none), n_P3_b), H3, 1e-7));
+      (std::bind(&MagPoseFactor<Pose3>::evaluateError, &f, std::placeholders::_1, boost::none), n_P3_b), H3, 1e-7));
 }
 
 // *****************************************************************************

--- a/gtsam/navigation/tests/testManifoldPreintegration.cpp
+++ b/gtsam/navigation/tests/testManifoldPreintegration.cpp
@@ -22,11 +22,10 @@
 #include <gtsam/nonlinear/expressionTesting.h>
 
 #include <CppUnitLite/TestHarness.h>
-#include <boost/bind/bind.hpp>
 
 #include "imuFactorTesting.h"
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 
 namespace testing {
 // Create default parameters with Z-down and above noise parameters
@@ -43,21 +42,21 @@ static boost::shared_ptr<PreintegrationParams> Params() {
 TEST(ManifoldPreintegration, BiasCorrectionJacobians) {
   testing::SomeMeasurements measurements;
 
-  boost::function<Rot3(const Vector3&, const Vector3&)> deltaRij =
+  std::function<Rot3(const Vector3&, const Vector3&)> deltaRij =
       [=](const Vector3& a, const Vector3& w) {
         ManifoldPreintegration pim(testing::Params(), Bias(a, w));
         testing::integrateMeasurements(measurements, &pim);
         return pim.deltaRij();
       };
 
-  boost::function<Point3(const Vector3&, const Vector3&)> deltaPij =
+  std::function<Point3(const Vector3&, const Vector3&)> deltaPij =
       [=](const Vector3& a, const Vector3& w) {
         ManifoldPreintegration pim(testing::Params(), Bias(a, w));
         testing::integrateMeasurements(measurements, &pim);
         return pim.deltaPij();
       };
 
-  boost::function<Vector3(const Vector3&, const Vector3&)> deltaVij =
+  std::function<Vector3(const Vector3&, const Vector3&)> deltaVij =
       [=](const Vector3& a, const Vector3& w) {
         ManifoldPreintegration pim(testing::Params(), Bias(a, w));
         testing::integrateMeasurements(measurements, &pim);
@@ -98,10 +97,12 @@ TEST(ManifoldPreintegration, computeError) {
   Matrix9 aH1, aH2;
   Matrix96 aH3;
   pim.computeError(x1, x2, bias, aH1, aH2, aH3);
-  boost::function<Vector9(const NavState&, const NavState&,
-                          const imuBias::ConstantBias&)> f =
-      boost::bind(&ManifoldPreintegration::computeError, pim, _1, _2, _3,
-                  boost::none, boost::none, boost::none);
+  std::function<Vector9(const NavState&, const NavState&,
+                        const imuBias::ConstantBias&)>
+      f = std::bind(&ManifoldPreintegration::computeError, pim,
+                    std::placeholders::_1, std::placeholders::_2,
+                    std::placeholders::_3, boost::none, boost::none,
+                    boost::none);
   // NOTE(frank): tolerance of 1e-3 on H1 because approximate away from 0
   EXPECT(assert_equal(numericalDerivative31(f, x1, x2, bias), aH1, 1e-9));
   EXPECT(assert_equal(numericalDerivative32(f, x1, x2, bias), aH2, 1e-9));

--- a/gtsam/navigation/tests/testNavState.cpp
+++ b/gtsam/navigation/tests/testNavState.cpp
@@ -23,7 +23,7 @@
 #include <boost/bind/bind.hpp>
 #include <CppUnitLite/TestHarness.h>
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -39,9 +39,9 @@ static const Vector9 kZeroXi = Vector9::Zero();
 
 /* ************************************************************************* */
 TEST(NavState, Constructor) {
-  boost::function<NavState(const Rot3&, const Point3&, const Vector3&)> create =
-      boost::bind(&NavState::Create, _1, _2, _3, boost::none, boost::none,
-          boost::none);
+  std::function<NavState(const Rot3&, const Point3&, const Vector3&)> create =
+      std::bind(&NavState::Create, std::placeholders::_1, std::placeholders::_2,
+                std::placeholders::_3, boost::none, boost::none, boost::none);
   Matrix aH1, aH2, aH3;
   EXPECT(
       assert_equal(kState1,
@@ -59,9 +59,9 @@ TEST(NavState, Constructor) {
 
 /* ************************************************************************* */
 TEST(NavState, Constructor2) {
-  boost::function<NavState(const Pose3&, const Vector3&)> construct =
-      boost::bind(&NavState::FromPoseVelocity, _1, _2, boost::none,
-          boost::none);
+  std::function<NavState(const Pose3&, const Vector3&)> construct =
+      std::bind(&NavState::FromPoseVelocity, std::placeholders::_1,
+                std::placeholders::_2, boost::none, boost::none);
   Matrix aH1, aH2;
   EXPECT(
       assert_equal(kState1,
@@ -76,7 +76,7 @@ TEST( NavState, Attitude) {
   Rot3 actual = kState1.attitude(aH);
   EXPECT(assert_equal(actual, kAttitude));
   eH = numericalDerivative11<Rot3, NavState>(
-      boost::bind(&NavState::attitude, _1, boost::none), kState1);
+      std::bind(&NavState::attitude, std::placeholders::_1, boost::none), kState1);
   EXPECT(assert_equal((Matrix )eH, aH));
 }
 
@@ -86,7 +86,8 @@ TEST( NavState, Position) {
   Point3 actual = kState1.position(aH);
   EXPECT(assert_equal(actual, kPosition));
   eH = numericalDerivative11<Point3, NavState>(
-      boost::bind(&NavState::position, _1, boost::none), kState1);
+      std::bind(&NavState::position, std::placeholders::_1, boost::none),
+      kState1);
   EXPECT(assert_equal((Matrix )eH, aH));
 }
 
@@ -96,7 +97,8 @@ TEST( NavState, Velocity) {
   Velocity3 actual = kState1.velocity(aH);
   EXPECT(assert_equal(actual, kVelocity));
   eH = numericalDerivative11<Velocity3, NavState>(
-      boost::bind(&NavState::velocity, _1, boost::none), kState1);
+      std::bind(&NavState::velocity, std::placeholders::_1, boost::none),
+      kState1);
   EXPECT(assert_equal((Matrix )eH, aH));
 }
 
@@ -106,7 +108,8 @@ TEST( NavState, BodyVelocity) {
   Velocity3 actual = kState1.bodyVelocity(aH);
   EXPECT(assert_equal<Velocity3>(actual, kAttitude.unrotate(kVelocity)));
   eH = numericalDerivative11<Velocity3, NavState>(
-      boost::bind(&NavState::bodyVelocity, _1, boost::none), kState1);
+      std::bind(&NavState::bodyVelocity, std::placeholders::_1, boost::none),
+      kState1);
   EXPECT(assert_equal((Matrix )eH, aH));
 }
 
@@ -137,8 +140,9 @@ TEST( NavState, Manifold ) {
   // Check retract derivatives
   Matrix9 aH1, aH2;
   kState1.retract(xi, aH1, aH2);
-  boost::function<NavState(const NavState&, const Vector9&)> retract =
-      boost::bind(&NavState::retract, _1, _2, boost::none, boost::none);
+  std::function<NavState(const NavState&, const Vector9&)> retract =
+      std::bind(&NavState::retract, std::placeholders::_1,
+                std::placeholders::_2, boost::none, boost::none);
   EXPECT(assert_equal(numericalDerivative21(retract, kState1, xi), aH1));
   EXPECT(assert_equal(numericalDerivative22(retract, kState1, xi), aH2));
 
@@ -149,9 +153,9 @@ TEST( NavState, Manifold ) {
   EXPECT(assert_equal(numericalDerivative22(retract, state2, xi2), aH2));
 
   // Check localCoordinates derivatives
-  boost::function<Vector9(const NavState&, const NavState&)> local =
-      boost::bind(&NavState::localCoordinates, _1, _2, boost::none,
-          boost::none);
+  std::function<Vector9(const NavState&, const NavState&)> local =
+      std::bind(&NavState::localCoordinates, std::placeholders::_1,
+                std::placeholders::_2, boost::none, boost::none);
   // from state1 to state2
   kState1.localCoordinates(state2, aH1, aH2);
   EXPECT(assert_equal(numericalDerivative21(local, kState1, state2), aH1));
@@ -168,8 +172,9 @@ TEST( NavState, Manifold ) {
 
 /* ************************************************************************* */
 static const double dt = 2.0;
-boost::function<Vector9(const NavState&, const bool&)> coriolis = boost::bind(
-    &NavState::coriolis, _1, dt, kOmegaCoriolis, _2, boost::none);
+std::function<Vector9(const NavState&, const bool&)> coriolis =
+    std::bind(&NavState::coriolis, std::placeholders::_1, dt, kOmegaCoriolis,
+              std::placeholders::_2, boost::none);
 
 TEST(NavState, Coriolis) {
   Matrix9 aH;
@@ -244,9 +249,10 @@ TEST(NavState, CorrectPIM) {
   xi << 0.1, 0.1, 0.1, 0.2, 0.3, 0.4, -0.1, -0.2, -0.3;
   double dt = 0.5;
   Matrix9 aH1, aH2;
-  boost::function<Vector9(const NavState&, const Vector9&)> correctPIM =
-      boost::bind(&NavState::correctPIM, _1, _2, dt, kGravity, kOmegaCoriolis,
-          false, boost::none, boost::none);
+  std::function<Vector9(const NavState&, const Vector9&)> correctPIM =
+      std::bind(&NavState::correctPIM, std::placeholders::_1,
+                std::placeholders::_2, dt, kGravity, kOmegaCoriolis, false,
+                boost::none, boost::none);
   kState1.correctPIM(xi, dt, kGravity, kOmegaCoriolis, false, aH1, aH2);
   EXPECT(assert_equal(numericalDerivative21(correctPIM, kState1, xi), aH1));
   EXPECT(assert_equal(numericalDerivative22(correctPIM, kState1, xi), aH2));

--- a/gtsam/navigation/tests/testScenario.cpp
+++ b/gtsam/navigation/tests/testScenario.cpp
@@ -19,10 +19,9 @@
 #include <gtsam/navigation/Scenario.h>
 
 #include <CppUnitLite/TestHarness.h>
-#include <boost/bind/bind.hpp>
 #include <cmath>
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -148,7 +147,7 @@ TEST(Scenario, Accelerating) {
   {
     // Check acceleration in nav
     Matrix expected = numericalDerivative11<Vector3, double>(
-        boost::bind(&Scenario::velocity_n, scenario, _1), T);
+        std::bind(&Scenario::velocity_n, scenario, std::placeholders::_1), T);
     EXPECT(assert_equal(Vector3(expected), scenario.acceleration_n(T), 1e-9));
   }
 

--- a/gtsam/navigation/tests/testTangentPreintegration.cpp
+++ b/gtsam/navigation/tests/testTangentPreintegration.cpp
@@ -22,11 +22,10 @@
 #include <gtsam/nonlinear/expressionTesting.h>
 
 #include <CppUnitLite/TestHarness.h>
-#include <boost/bind/bind.hpp>
 
 #include "imuFactorTesting.h"
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 
 static const double kDt = 0.1;
 
@@ -78,7 +77,7 @@ TEST(TangentPreintegration, UpdateEstimate2) {
 TEST(ImuFactor, BiasCorrectionJacobians) {
   testing::SomeMeasurements measurements;
 
-  boost::function<Vector9(const Vector3&, const Vector3&)> preintegrated =
+  std::function<Vector9(const Vector3&, const Vector3&)> preintegrated =
       [=](const Vector3& a, const Vector3& w) {
         TangentPreintegration pim(testing::Params(), Bias(a, w));
         testing::integrateMeasurements(measurements, &pim);
@@ -105,10 +104,12 @@ TEST(TangentPreintegration, computeError) {
   Matrix9 aH1, aH2;
   Matrix96 aH3;
   pim.computeError(x1, x2, bias, aH1, aH2, aH3);
-  boost::function<Vector9(const NavState&, const NavState&,
-                          const imuBias::ConstantBias&)> f =
-      boost::bind(&TangentPreintegration::computeError, pim, _1, _2, _3,
-                  boost::none, boost::none, boost::none);
+  std::function<Vector9(const NavState&, const NavState&,
+                        const imuBias::ConstantBias&)>
+      f = std::bind(&TangentPreintegration::computeError, pim,
+                    std::placeholders::_1, std::placeholders::_2,
+                    std::placeholders::_3, boost::none, boost::none,
+                    boost::none);
   // NOTE(frank): tolerance of 1e-3 on H1 because approximate away from 0
   EXPECT(assert_equal(numericalDerivative31(f, x1, x2, bias), aH1, 1e-9));
   EXPECT(assert_equal(numericalDerivative32(f, x1, x2, bias), aH2, 1e-9));
@@ -121,7 +122,7 @@ TEST(TangentPreintegration, Compose) {
   TangentPreintegration pim(testing::Params());
   testing::integrateMeasurements(measurements, &pim);
 
-  boost::function<Vector9(const Vector9&, const Vector9&)> f =
+  std::function<Vector9(const Vector9&, const Vector9&)> f =
       [pim](const Vector9& zeta01, const Vector9& zeta12) {
         return TangentPreintegration::Compose(zeta01, zeta12, pim.deltaTij());
       };

--- a/gtsam/nonlinear/Expression-inl.h
+++ b/gtsam/nonlinear/Expression-inl.h
@@ -83,8 +83,8 @@ template<typename A>
 Expression<T>::Expression(const Expression<A>& expression,
     T (A::*method)(typename MakeOptionalJacobian<T, A>::type) const) :
     root_(
-        new internal::UnaryExpression<T, A>(boost::bind(method,
-                boost::placeholders::_1, boost::placeholders::_2),
+        new internal::UnaryExpression<T, A>(std::bind(method,
+                std::placeholders::_1, std::placeholders::_2),
             expression)) {
 }
 
@@ -97,9 +97,9 @@ Expression<T>::Expression(const Expression<A1>& expression1,
     const Expression<A2>& expression2) :
     root_(
         new internal::BinaryExpression<T, A1, A2>(
-            boost::bind(method, boost::placeholders::_1,
-                boost::placeholders::_2, boost::placeholders::_3,
-                boost::placeholders::_4),
+            std::bind(method, std::placeholders::_1,
+                std::placeholders::_2, std::placeholders::_3,
+                std::placeholders::_4),
             expression1, expression2)) {
 }
 
@@ -114,10 +114,10 @@ Expression<T>::Expression(const Expression<A1>& expression1,
     const Expression<A2>& expression2, const Expression<A3>& expression3) :
     root_(
         new internal::TernaryExpression<T, A1, A2, A3>(
-            boost::bind(method, boost::placeholders::_1,
-                boost::placeholders::_2, boost::placeholders::_3,
-                boost::placeholders::_4, boost::placeholders::_5,
-                boost::placeholders::_6),
+            std::bind(method, std::placeholders::_1,
+                std::placeholders::_2, std::placeholders::_3,
+                std::placeholders::_4, std::placeholders::_5,
+                std::placeholders::_6),
             expression1, expression2, expression3)) {
 }
 
@@ -255,9 +255,9 @@ template<typename T>
 Expression<T> operator*(const Expression<T>& expression1,
     const Expression<T>& expression2) {
   return Expression<T>(
-      boost::bind(internal::apply_compose<T>(), boost::placeholders::_1,
-          boost::placeholders::_2, boost::placeholders::_3,
-          boost::placeholders::_4),
+      std::bind(internal::apply_compose<T>(), std::placeholders::_1,
+          std::placeholders::_2, std::placeholders::_3,
+          std::placeholders::_4),
       expression1, expression2);
 }
 

--- a/gtsam/nonlinear/Expression.h
+++ b/gtsam/nonlinear/Expression.h
@@ -68,20 +68,20 @@ public:
   //   Expression<Point2>::BinaryFunction<PinholeCamera<Cal3_S2>,Point3>::type
   template<class A1>
   struct UnaryFunction {
-    typedef boost::function<
+    typedef std::function<
         T(const A1&, typename MakeOptionalJacobian<T, A1>::type)> type;
   };
 
   template<class A1, class A2>
   struct BinaryFunction {
-    typedef boost::function<
+    typedef std::function<
         T(const A1&, const A2&, typename MakeOptionalJacobian<T, A1>::type,
             typename MakeOptionalJacobian<T, A2>::type)> type;
   };
 
   template<class A1, class A2, class A3>
   struct TernaryFunction {
-    typedef boost::function<
+    typedef std::function<
         T(const A1&, const A2&, const A3&,
             typename MakeOptionalJacobian<T, A1>::type,
             typename MakeOptionalJacobian<T, A2>::type,
@@ -239,7 +239,7 @@ class BinarySumExpression : public Expression<T> {
  */
 template <typename T, typename A>
 Expression<T> linearExpression(
-    const boost::function<T(A)>& f, const Expression<A>& expression,
+    const std::function<T(A)>& f, const Expression<A>& expression,
     const Eigen::Matrix<double, traits<T>::dimension, traits<A>::dimension>& dTdA) {
   // Use lambda to endow f with a linear Jacobian
   typename Expression<T>::template UnaryFunction<A>::type g =

--- a/gtsam/nonlinear/NonlinearEquality.h
+++ b/gtsam/nonlinear/NonlinearEquality.h
@@ -69,7 +69,7 @@ public:
   /**
    * Function that compares two values
    */
-  typedef boost::function<bool(const T&, const T&)> CompareFunction;
+  typedef std::function<bool(const T&, const T&)> CompareFunction;
   CompareFunction compare_;
 //  bool (*compare_)(const T& a, const T& b);
 
@@ -87,8 +87,8 @@ public:
    * Constructor - forces exact evaluation
    */
   NonlinearEquality(Key j, const T& feasible,
-      const CompareFunction &_compare = boost::bind(traits<T>::Equals,
-          boost::placeholders::_1, boost::placeholders::_2, 1e-9)) :
+      const CompareFunction &_compare = std::bind(traits<T>::Equals,
+          std::placeholders::_1, std::placeholders::_2, 1e-9)) :
       Base(noiseModel::Constrained::All(traits<T>::GetDimension(feasible)),
           j), feasible_(feasible), allow_error_(false), error_gain_(0.0), //
       compare_(_compare) {
@@ -98,8 +98,8 @@ public:
    * Constructor - allows inexact evaluation
    */
   NonlinearEquality(Key j, const T& feasible, double error_gain,
-      const CompareFunction &_compare = boost::bind(traits<T>::Equals,
-          boost::placeholders::_1, boost::placeholders::_2, 1e-9)) :
+      const CompareFunction &_compare = std::bind(traits<T>::Equals,
+          std::placeholders::_1, std::placeholders::_2, 1e-9)) :
       Base(noiseModel::Constrained::All(traits<T>::GetDimension(feasible)),
           j), feasible_(feasible), allow_error_(true), error_gain_(error_gain), //
       compare_(_compare) {

--- a/gtsam/nonlinear/Values-inl.h
+++ b/gtsam/nonlinear/Values-inl.h
@@ -103,7 +103,7 @@ namespace gtsam {
       boost::transform_iterator<
       KeyValuePair(*)(Values::KeyValuePair),
       boost::filter_iterator<
-      boost::function<bool(const Values::ConstKeyValuePair&)>,
+      std::function<bool(const Values::ConstKeyValuePair&)>,
       Values::iterator> >
       iterator;
 
@@ -113,7 +113,7 @@ namespace gtsam {
       boost::transform_iterator<
       ConstKeyValuePair(*)(Values::ConstKeyValuePair),
       boost::filter_iterator<
-      boost::function<bool(const Values::ConstKeyValuePair&)>,
+      std::function<bool(const Values::ConstKeyValuePair&)>,
       Values::const_iterator> >
       const_const_iterator;
 
@@ -134,7 +134,7 @@ namespace gtsam {
 
   private:
     Filtered(
-        const boost::function<bool(const Values::ConstKeyValuePair&)>& filter,
+        const std::function<bool(const Values::ConstKeyValuePair&)>& filter,
         Values& values) :
         begin_(
             boost::make_transform_iterator(
@@ -205,7 +205,7 @@ namespace gtsam {
     const_iterator begin_;
     const_iterator end_;
     ConstFiltered(
-        const boost::function<bool(const Values::ConstKeyValuePair&)>& filter,
+        const std::function<bool(const Values::ConstKeyValuePair&)>& filter,
         const Values& values) {
       // We remove the const from values to create a non-const Filtered
       // view, then pull the const_iterators out of it.
@@ -236,35 +236,35 @@ namespace gtsam {
 
   /* ************************************************************************* */
   Values::Filtered<Value>
-  inline Values::filter(const boost::function<bool(Key)>& filterFcn) {
+  inline Values::filter(const std::function<bool(Key)>& filterFcn) {
     return filter<Value>(filterFcn);
   }
 
   /* ************************************************************************* */
   template<class ValueType>
   Values::Filtered<ValueType>
-  Values::filter(const boost::function<bool(Key)>& filterFcn) {
-    return Filtered<ValueType>(boost::bind(&filterHelper<ValueType>, filterFcn,
-      boost::placeholders::_1), *this);
+  Values::filter(const std::function<bool(Key)>& filterFcn) {
+    return Filtered<ValueType>(std::bind(&filterHelper<ValueType>, filterFcn,
+      std::placeholders::_1), *this);
   }
 
   /* ************************************************************************* */
   Values::ConstFiltered<Value>
-  inline Values::filter(const boost::function<bool(Key)>& filterFcn) const {
+  inline Values::filter(const std::function<bool(Key)>& filterFcn) const {
     return filter<Value>(filterFcn);
   }
 
   /* ************************************************************************* */
   template<class ValueType>
   Values::ConstFiltered<ValueType>
-  Values::filter(const boost::function<bool(Key)>& filterFcn) const {
-    return ConstFiltered<ValueType>(boost::bind(&filterHelper<ValueType>,
-      filterFcn, boost::placeholders::_1), *this);
+  Values::filter(const std::function<bool(Key)>& filterFcn) const {
+    return ConstFiltered<ValueType>(std::bind(&filterHelper<ValueType>,
+      filterFcn, std::placeholders::_1), *this);
   }
 
   /* ************************************************************************* */
    template<>
-   inline bool Values::filterHelper<Value>(const boost::function<bool(Key)> filter,
+   inline bool Values::filterHelper<Value>(const std::function<bool(Key)> filter,
        const ConstKeyValuePair& key_value) {
      // Filter and check the type
      return filter(key_value.key);

--- a/gtsam/nonlinear/Values.h
+++ b/gtsam/nonlinear/Values.h
@@ -108,19 +108,19 @@ namespace gtsam {
 
     /// Mutable forward iterator, with value type KeyValuePair
     typedef boost::transform_iterator<
-        boost::function1<KeyValuePair, const KeyValuePtrPair&>, KeyValueMap::iterator> iterator;
+        std::function<KeyValuePair(const KeyValuePtrPair&)>, KeyValueMap::iterator> iterator;
 
     /// Const forward iterator, with value type ConstKeyValuePair
     typedef boost::transform_iterator<
-        boost::function1<ConstKeyValuePair, const ConstKeyValuePtrPair&>, KeyValueMap::const_iterator> const_iterator;
+        std::function<ConstKeyValuePair(const ConstKeyValuePtrPair&)>, KeyValueMap::const_iterator> const_iterator;
 
     /// Mutable reverse iterator, with value type KeyValuePair
     typedef boost::transform_iterator<
-        boost::function1<KeyValuePair, const KeyValuePtrPair&>, KeyValueMap::reverse_iterator> reverse_iterator;
+        std::function<KeyValuePair(const KeyValuePtrPair&)>, KeyValueMap::reverse_iterator> reverse_iterator;
 
     /// Const reverse iterator, with value type ConstKeyValuePair
     typedef boost::transform_iterator<
-        boost::function1<ConstKeyValuePair, const ConstKeyValuePtrPair&>, KeyValueMap::const_reverse_iterator> const_reverse_iterator;
+        std::function<ConstKeyValuePair(const ConstKeyValuePtrPair&)>, KeyValueMap::const_reverse_iterator> const_reverse_iterator;
 
     typedef KeyValuePair value_type;
 
@@ -321,7 +321,7 @@ namespace gtsam {
      * the original Values class.
      */
     Filtered<Value>
-    filter(const boost::function<bool(Key)>& filterFcn);
+    filter(const std::function<bool(Key)>& filterFcn);
 
     /**
      * Return a filtered view of this Values class, without copying any data.
@@ -344,7 +344,7 @@ namespace gtsam {
      */
     template<class ValueType>
     Filtered<ValueType>
-    filter(const boost::function<bool(Key)>& filterFcn = &_truePredicate<Key>);
+    filter(const std::function<bool(Key)>& filterFcn = &_truePredicate<Key>);
 
     /**
      * Return a filtered view of this Values class, without copying any data.
@@ -360,7 +360,7 @@ namespace gtsam {
      * the original Values class.
      */
     ConstFiltered<Value>
-    filter(const boost::function<bool(Key)>& filterFcn) const;
+    filter(const std::function<bool(Key)>& filterFcn) const;
 
     /**
      * Return a filtered view of this Values class, without copying any data.
@@ -382,7 +382,7 @@ namespace gtsam {
      */
     template<class ValueType>
     ConstFiltered<ValueType>
-    filter(const boost::function<bool(Key)>& filterFcn = &_truePredicate<Key>) const;
+    filter(const std::function<bool(Key)>& filterFcn = &_truePredicate<Key>) const;
 
     // Count values of given type \c ValueType
     template<class ValueType>
@@ -399,7 +399,7 @@ namespace gtsam {
     // Filters based on ValueType (if not Value) and also based on the user-
     // supplied \c filter function.
     template<class ValueType>
-    static bool filterHelper(const boost::function<bool(Key)> filter, const ConstKeyValuePair& key_value) {
+    static bool filterHelper(const std::function<bool(Key)> filter, const ConstKeyValuePair& key_value) {
       BOOST_STATIC_ASSERT((!boost::is_same<ValueType, Value>::value));
       // Filter and check the type
       return filter(key_value.key) && (dynamic_cast<const GenericValue<ValueType>*>(&key_value.value));

--- a/gtsam/nonlinear/internal/ExpressionNode.h
+++ b/gtsam/nonlinear/internal/ExpressionNode.h
@@ -57,7 +57,7 @@ T upAligned(T value, unsigned requiredAlignment = TraceAlignment) {
  * Expression node. The superclass for objects that do the heavy lifting
  * An Expression<T> has a pointer to an ExpressionNode<T> underneath
  * allowing Expressions to have polymorphic behaviour even though they
- * are passed by value. This is the same way boost::function works.
+ * are passed by value. This is the same way std::function works.
  * http://loki-lib.sourceforge.net/html/a00652.html
  */
 template<class T>

--- a/gtsam/nonlinear/tests/testExpression.cpp
+++ b/gtsam/nonlinear/tests/testExpression.cpp
@@ -495,7 +495,7 @@ TEST(Expression, Subtract) {
 /* ************************************************************************* */
 TEST(Expression, LinearExpression) {
   const Key key(67);
-  const boost::function<Vector3(Point3)> f = [](const Point3& p) { return (Vector3)p; };
+  const std::function<Vector3(Point3)> f = [](const Point3& p) { return (Vector3)p; };
   const Matrix3 kIdentity = I_3x3;
   const Expression<Vector3> linear_ = linearExpression(f, Point3_(key), kIdentity);
 

--- a/gtsam/nonlinear/tests/testValues.cpp
+++ b/gtsam/nonlinear/tests/testValues.cpp
@@ -34,7 +34,7 @@
 #include <type_traits>
 
 using namespace boost::assign;
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace gtsam;
 using namespace std;
 static double inf = std::numeric_limits<double>::infinity();
@@ -336,7 +336,7 @@ TEST(Values, filter) {
 
   // Filter by key
   int i = 0;
-  Values::Filtered<Value> filtered = values.filter(boost::bind(std::greater_equal<Key>(), _1, 2));
+  Values::Filtered<Value> filtered = values.filter(std::bind(std::greater_equal<Key>(), std::placeholders::_1, 2));
   EXPECT_LONGS_EQUAL(2, (long)filtered.size());
   for(const auto key_value: filtered) {
     if(i == 0) {
@@ -364,7 +364,7 @@ TEST(Values, filter) {
   EXPECT(assert_equal(expectedSubValues1, actualSubValues1));
 
   // ConstFilter by Key
-  Values::ConstFiltered<Value> constfiltered = values.filter(boost::bind(std::greater_equal<Key>(), _1, 2));
+  Values::ConstFiltered<Value> constfiltered = values.filter(std::bind(std::greater_equal<Key>(), std::placeholders::_1, 2));
   EXPECT_LONGS_EQUAL(2, (long)constfiltered.size());
   Values fromconstfiltered(constfiltered);
   EXPECT(assert_equal(expectedSubValues1, fromconstfiltered));

--- a/gtsam/sam/tests/testRangeFactor.cpp
+++ b/gtsam/sam/tests/testRangeFactor.cpp
@@ -28,7 +28,7 @@
 #include <CppUnitLite/TestHarness.h>
 #include <boost/bind/bind.hpp>
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -265,9 +265,9 @@ TEST( RangeFactor, Jacobian2D ) {
   // Use numerical derivatives to calculate the Jacobians
   Matrix H1Expected, H2Expected;
   H1Expected = numericalDerivative11<Vector, Pose2>(
-      boost::bind(&factorError2D, _1, point, factor), pose);
+      std::bind(&factorError2D, std::placeholders::_1, point, factor), pose);
   H2Expected = numericalDerivative11<Vector, Point2>(
-      boost::bind(&factorError2D, pose, _1, factor), point);
+      std::bind(&factorError2D, pose, std::placeholders::_1, factor), point);
 
   // Verify the Jacobians are correct
   CHECK(assert_equal(H1Expected, H1Actual, 1e-9));
@@ -296,9 +296,9 @@ TEST( RangeFactor, Jacobian2DWithTransform ) {
   // Use numerical derivatives to calculate the Jacobians
   Matrix H1Expected, H2Expected;
   H1Expected = numericalDerivative11<Vector, Pose2>(
-      boost::bind(&factorErrorWithTransform2D, _1, point, factor), pose);
+      std::bind(&factorErrorWithTransform2D, std::placeholders::_1, point, factor), pose);
   H2Expected = numericalDerivative11<Vector, Point2>(
-      boost::bind(&factorErrorWithTransform2D, pose, _1, factor), point);
+      std::bind(&factorErrorWithTransform2D, pose, std::placeholders::_1, factor), point);
 
   // Verify the Jacobians are correct
   CHECK(assert_equal(H1Expected, H1Actual, 1e-9));
@@ -323,9 +323,9 @@ TEST( RangeFactor, Jacobian3D ) {
   // Use numerical derivatives to calculate the Jacobians
   Matrix H1Expected, H2Expected;
   H1Expected = numericalDerivative11<Vector, Pose3>(
-      boost::bind(&factorError3D, _1, point, factor), pose);
+      std::bind(&factorError3D, std::placeholders::_1, point, factor), pose);
   H2Expected = numericalDerivative11<Vector, Point3>(
-      boost::bind(&factorError3D, pose, _1, factor), point);
+      std::bind(&factorError3D, pose, std::placeholders::_1, factor), point);
 
   // Verify the Jacobians are correct
   CHECK(assert_equal(H1Expected, H1Actual, 1e-9));
@@ -355,9 +355,9 @@ TEST( RangeFactor, Jacobian3DWithTransform ) {
   // Use numerical derivatives to calculate the Jacobians
   Matrix H1Expected, H2Expected;
   H1Expected = numericalDerivative11<Vector, Pose3>(
-      boost::bind(&factorErrorWithTransform3D, _1, point, factor), pose);
+      std::bind(&factorErrorWithTransform3D, std::placeholders::_1, point, factor), pose);
   H2Expected = numericalDerivative11<Vector, Point3>(
-      boost::bind(&factorErrorWithTransform3D, pose, _1, factor), point);
+      std::bind(&factorErrorWithTransform3D, pose, std::placeholders::_1, factor), point);
 
   // Verify the Jacobians are correct
   CHECK(assert_equal(H1Expected, H1Actual, 1e-9));

--- a/gtsam/sfm/tests/testTranslationFactor.cpp
+++ b/gtsam/sfm/tests/testTranslationFactor.cpp
@@ -20,10 +20,9 @@
 #include <gtsam/geometry/Point3.h>
 #include <gtsam/sfm/TranslationFactor.h>
 
-#include <boost/bind/bind.hpp>
 #include <CppUnitLite/TestHarness.h>
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -91,9 +90,9 @@ TEST(TranslationFactor, Jacobian) {
   // Use numerical derivatives to calculate the Jacobians
   Matrix H1Expected, H2Expected;
   H1Expected = numericalDerivative11<Vector, Point3>(
-      boost::bind(&factorError, _1, T2, factor), T1);
+      std::bind(&factorError, std::placeholders::_1, T2, factor), T1);
   H2Expected = numericalDerivative11<Vector, Point3>(
-      boost::bind(&factorError, T1, _1, factor), T2);
+      std::bind(&factorError, T1, std::placeholders::_1, factor), T2);
 
   // Verify the Jacobians are correct
   EXPECT(assert_equal(H1Expected, H1Actual, 1e-9));

--- a/gtsam/slam/tests/testBetweenFactor.cpp
+++ b/gtsam/slam/tests/testBetweenFactor.cpp
@@ -14,7 +14,7 @@
 #include <gtsam/nonlinear/factorTesting.h>
 #include <gtsam/slam/BetweenFactor.h>
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace gtsam;
 using namespace gtsam::symbol_shorthand;
 using namespace gtsam::noiseModel;
@@ -35,15 +35,16 @@ TEST(BetweenFactor, Rot3) {
   Vector expected = Rot3::Logmap(measured.inverse() * R1.between(R2));
   EXPECT(assert_equal(expected,actual/*, 1e-100*/)); // Uncomment to make unit test fail
 
-  Matrix numericalH1 = numericalDerivative21<Vector3,Rot3,Rot3>(
-      boost::function<Vector(const Rot3&, const Rot3&)>(boost::bind(
-          &BetweenFactor<Rot3>::evaluateError, factor, _1, _2, boost::none,
-          boost::none)), R1, R2, 1e-5);
+  Matrix numericalH1 = numericalDerivative21<Vector3, Rot3, Rot3>(
+      std::function<Vector(const Rot3&, const Rot3&)>(std::bind(
+          &BetweenFactor<Rot3>::evaluateError, factor, std::placeholders::_1,
+          std::placeholders::_2, boost::none, boost::none)),
+      R1, R2, 1e-5);
   EXPECT(assert_equal(numericalH1,actualH1, 1E-5));
 
   Matrix numericalH2 = numericalDerivative22<Vector3,Rot3,Rot3>(
-      boost::function<Vector(const Rot3&, const Rot3&)>(boost::bind(
-          &BetweenFactor<Rot3>::evaluateError, factor, _1, _2, boost::none,
+      std::function<Vector(const Rot3&, const Rot3&)>(std::bind(
+          &BetweenFactor<Rot3>::evaluateError, factor, std::placeholders::_1, std::placeholders::_2, boost::none,
           boost::none)), R1, R2, 1e-5);
   EXPECT(assert_equal(numericalH2,actualH2, 1E-5));
 }

--- a/gtsam/slam/tests/testEssentialMatrixConstraint.cpp
+++ b/gtsam/slam/tests/testEssentialMatrixConstraint.cpp
@@ -23,10 +23,9 @@
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/base/TestableAssertions.h>
 
-#include <boost/bind/bind.hpp>
 #include <CppUnitLite/TestHarness.h>
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -53,12 +52,14 @@ TEST( EssentialMatrixConstraint, test ) {
   CHECK(assert_equal(expected, actual, 1e-8));
 
   // Calculate numerical derivatives
-  Matrix expectedH1 = numericalDerivative11<Vector5,Pose3>(
-      boost::bind(&EssentialMatrixConstraint::evaluateError, &factor, _1, pose2,
-          boost::none, boost::none), pose1);
-  Matrix expectedH2 = numericalDerivative11<Vector5,Pose3>(
-      boost::bind(&EssentialMatrixConstraint::evaluateError, &factor, pose1, _1,
-          boost::none, boost::none), pose2);
+  Matrix expectedH1 = numericalDerivative11<Vector5, Pose3>(
+      std::bind(&EssentialMatrixConstraint::evaluateError, &factor,
+                std::placeholders::_1, pose2, boost::none, boost::none),
+      pose1);
+  Matrix expectedH2 = numericalDerivative11<Vector5, Pose3>(
+      std::bind(&EssentialMatrixConstraint::evaluateError, &factor, pose1,
+                std::placeholders::_1, boost::none, boost::none),
+      pose2);
 
   // Use the factor to calculate the derivative
   Matrix actualH1;

--- a/gtsam/slam/tests/testEssentialMatrixFactor.cpp
+++ b/gtsam/slam/tests/testEssentialMatrixFactor.cpp
@@ -17,9 +17,7 @@
 #include <gtsam/slam/EssentialMatrixFactor.h>
 #include <gtsam/slam/dataset.h>
 
-#include <boost/bind/bind.hpp>
-
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -104,8 +102,8 @@ TEST(EssentialMatrixFactor, factor) {
 TEST(EssentialMatrixFactor, ExpressionFactor) {
   Key key(1);
   for (size_t i = 0; i < 5; i++) {
-    boost::function<double(const EssentialMatrix &, OptionalJacobian<1, 5>)> f =
-        boost::bind(&EssentialMatrix::error, _1, vA(i), vB(i), _2);
+    std::function<double(const EssentialMatrix &, OptionalJacobian<1, 5>)> f =
+        std::bind(&EssentialMatrix::error, std::placeholders::_1, vA(i), vB(i), std::placeholders::_2);
     Expression<EssentialMatrix> E_(key);  // leaf expression
     Expression<double> expr(f, E_);       // unary expression
 
@@ -130,9 +128,9 @@ TEST(EssentialMatrixFactor, ExpressionFactor) {
 TEST(EssentialMatrixFactor, ExpressionFactorRotationOnly) {
   Key key(1);
   for (size_t i = 0; i < 5; i++) {
-    boost::function<double(const EssentialMatrix &, OptionalJacobian<1, 5>)> f =
-        boost::bind(&EssentialMatrix::error, _1, vA(i), vB(i), _2);
-    boost::function<EssentialMatrix(const Rot3 &, const Unit3 &,
+    std::function<double(const EssentialMatrix &, OptionalJacobian<1, 5>)> f =
+        std::bind(&EssentialMatrix::error, std::placeholders::_1, vA(i), vB(i), std::placeholders::_2);
+    std::function<EssentialMatrix(const Rot3 &, const Unit3 &,
                                     OptionalJacobian<5, 3>,
                                     OptionalJacobian<5, 2>)>
         g;

--- a/gtsam/slam/tests/testOrientedPlane3Factor.cpp
+++ b/gtsam/slam/tests/testOrientedPlane3Factor.cpp
@@ -27,10 +27,9 @@
 
 #include <boost/assign/std/vector.hpp>
 #include <boost/assign/std.hpp>
-#include <boost/bind/bind.hpp>
 
 using namespace boost::assign;
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace gtsam;
 using namespace std;
 
@@ -145,8 +144,9 @@ TEST( OrientedPlane3Factor, Derivatives ) {
   OrientedPlane3Factor factor(p.planeCoefficients(), noise, poseKey, planeKey);
 
   // Calculate numerical derivatives
-  boost::function<Vector(const Pose3&, const OrientedPlane3&)> f = boost::bind(
-      &OrientedPlane3Factor::evaluateError, factor, _1, _2, boost::none, boost::none);
+  std::function<Vector(const Pose3 &, const OrientedPlane3 &)> f = std::bind(
+      &OrientedPlane3Factor::evaluateError, factor, std::placeholders::_1,
+      std::placeholders::_2, boost::none, boost::none);
   Matrix numericalH1 = numericalDerivative21<Vector, Pose3, OrientedPlane3>(f, poseLin, pLin);
   Matrix numericalH2 = numericalDerivative22<Vector, Pose3, OrientedPlane3>(f, poseLin, pLin);
 
@@ -184,15 +184,15 @@ TEST( OrientedPlane3DirectionPrior, Constructor ) {
 
   // Calculate numerical derivatives
   Matrix expectedH1 = numericalDerivative11<Vector, OrientedPlane3>(
-      boost::bind(&OrientedPlane3DirectionPrior::evaluateError, &factor, _1,
+      std::bind(&OrientedPlane3DirectionPrior::evaluateError, &factor, std::placeholders::_1,
           boost::none), T1);
 
   Matrix expectedH2 = numericalDerivative11<Vector, OrientedPlane3>(
-      boost::bind(&OrientedPlane3DirectionPrior::evaluateError, &factor, _1,
+      std::bind(&OrientedPlane3DirectionPrior::evaluateError, &factor, std::placeholders::_1,
           boost::none), T2);
 
   Matrix expectedH3 = numericalDerivative11<Vector, OrientedPlane3>(
-      boost::bind(&OrientedPlane3DirectionPrior::evaluateError, &factor, _1,
+      std::bind(&OrientedPlane3DirectionPrior::evaluateError, &factor, std::placeholders::_1,
           boost::none), T3);
 
   // Use the factor to calculate the derivative

--- a/gtsam/slam/tests/testReferenceFrameFactor.cpp
+++ b/gtsam/slam/tests/testReferenceFrameFactor.cpp
@@ -16,8 +16,6 @@
 
 #include <iostream>
 
-#include <boost/bind/bind.hpp>
-
 #include <CppUnitLite/TestHarness.h>
 
 #include <gtsam/base/Testable.h>
@@ -32,7 +30,7 @@
 
 using namespace std;
 using namespace boost;
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace gtsam;
 
 typedef gtsam::ReferenceFrameFactor<gtsam::Point2, gtsam::Pose2> PointReferenceFrameFactor;
@@ -70,13 +68,13 @@ TEST( ReferenceFrameFactor, jacobians ) {
 
   Matrix numericalDT, numericalDL, numericalDF;
   numericalDF = numericalDerivative31<Vector,Point2,Pose2,Point2>(
-      boost::bind(evaluateError_, tc, _1, _2, _3),
+      std::bind(evaluateError_, tc, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3),
       global, trans, local, 1e-5);
   numericalDT = numericalDerivative32<Vector,Point2,Pose2,Point2>(
-      boost::bind(evaluateError_, tc, _1, _2, _3),
+      std::bind(evaluateError_, tc, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3),
       global, trans, local, 1e-5);
   numericalDL = numericalDerivative33<Vector,Point2,Pose2,Point2>(
-      boost::bind(evaluateError_, tc, _1, _2, _3),
+      std::bind(evaluateError_, tc, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3),
       global, trans, local, 1e-5);
 
   EXPECT(assert_equal(numericalDF, actualDF));
@@ -102,13 +100,13 @@ TEST( ReferenceFrameFactor, jacobians_zero ) {
 
   Matrix numericalDT, numericalDL, numericalDF;
   numericalDF = numericalDerivative31<Vector,Point2,Pose2,Point2>(
-      boost::bind(evaluateError_, tc, _1, _2, _3),
+      std::bind(evaluateError_, tc, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3),
       global, trans, local, 1e-5);
   numericalDT = numericalDerivative32<Vector,Point2,Pose2,Point2>(
-      boost::bind(evaluateError_, tc, _1, _2, _3),
+      std::bind(evaluateError_, tc, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3),
       global, trans, local, 1e-5);
   numericalDL = numericalDerivative33<Vector,Point2,Pose2,Point2>(
-      boost::bind(evaluateError_, tc, _1, _2, _3),
+      std::bind(evaluateError_, tc, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3),
       global, trans, local, 1e-5);
 
   EXPECT(assert_equal(numericalDF, actualDF));

--- a/gtsam/slam/tests/testRotateFactor.cpp
+++ b/gtsam/slam/tests/testRotateFactor.cpp
@@ -13,12 +13,11 @@
 #include <CppUnitLite/TestHarness.h>
 
 #include <boost/assign/std/vector.hpp>
-#include <boost/bind/bind.hpp>
 #include <vector>
 
 using namespace std;
 using namespace boost::assign;
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace gtsam;
 
 static const double kDegree = M_PI / 180;
@@ -73,13 +72,13 @@ TEST (RotateFactor, test) {
   // Use numerical derivatives to calculate the expected Jacobian
   {
     expected = numericalDerivative11<Vector3,Rot3>(
-        boost::bind(&RotateFactor::evaluateError, &f, _1, boost::none), iRc);
+        std::bind(&RotateFactor::evaluateError, &f, std::placeholders::_1, boost::none), iRc);
     f.evaluateError(iRc, actual);
     EXPECT(assert_equal(expected, actual, 1e-9));
   }
   {
     expected = numericalDerivative11<Vector3,Rot3>(
-        boost::bind(&RotateFactor::evaluateError, &f, _1, boost::none), R);
+        std::bind(&RotateFactor::evaluateError, &f, std::placeholders::_1, boost::none), R);
     f.evaluateError(R, actual);
     EXPECT(assert_equal(expected, actual, 1e-9));
   }
@@ -144,14 +143,14 @@ TEST (RotateDirectionsFactor, test) {
   // Use numerical derivatives to calculate the expected Jacobian
   {
     expected = numericalDerivative11<Vector,Rot3>(
-        boost::bind(&RotateDirectionsFactor::evaluateError, &f, _1,
+        std::bind(&RotateDirectionsFactor::evaluateError, &f, std::placeholders::_1,
             boost::none), iRc);
     f.evaluateError(iRc, actual);
     EXPECT(assert_equal(expected, actual, 1e-9));
   }
   {
     expected = numericalDerivative11<Vector,Rot3>(
-        boost::bind(&RotateDirectionsFactor::evaluateError, &f, _1,
+        std::bind(&RotateDirectionsFactor::evaluateError, &f, std::placeholders::_1,
             boost::none), R);
     f.evaluateError(R, actual);
     EXPECT(assert_equal(expected, actual, 1e-9));

--- a/gtsam/slam/tests/testSmartProjectionPoseFactor.cpp
+++ b/gtsam/slam/tests/testSmartProjectionPoseFactor.cpp
@@ -27,11 +27,10 @@
 #include <gtsam/base/serializationTestHelpers.h>
 #include <CppUnitLite/TestHarness.h>
 #include <boost/assign/std/map.hpp>
-#include <boost/bind/bind.hpp>
 #include <iostream>
 
 using namespace boost::assign;
-using namespace boost::placeholders;
+using namespace std::placeholders;
 
 static const double rankTol = 1.0;
 // Create a noise model for the pixel error
@@ -132,8 +131,8 @@ TEST( SmartProjectionPoseFactor, noiseless ) {
   EXPECT_DOUBLES_EQUAL(expectedError, actualError2, 1e-7);
 
   // Calculate expected derivative for point (easiest to check)
-  boost::function<Vector(Point3)> f = //
-      boost::bind(&SmartFactor::whitenedError<Point3>, factor, cameras, _1);
+  std::function<Vector(Point3)> f = //
+      std::bind(&SmartFactor::whitenedError<Point3>, factor, cameras, std::placeholders::_1);
 
   // Calculate using computeEP
   Matrix actualE;

--- a/gtsam/slam/tests/testTriangulationFactor.cpp
+++ b/gtsam/slam/tests/testTriangulationFactor.cpp
@@ -32,7 +32,7 @@
 using namespace std;
 using namespace gtsam;
 using namespace boost::assign;
-using namespace boost::placeholders;
+using namespace std::placeholders;
 
 // Some common constants
 static const boost::shared_ptr<Cal3_S2> sharedCal = //
@@ -62,7 +62,7 @@ TEST( triangulation, TriangulationFactor ) {
   factor.evaluateError(landmark, HActual);
 
   Matrix HExpected = numericalDerivative11<Vector,Point3>(
-      boost::bind(&Factor::evaluateError, &factor, _1, boost::none), landmark);
+      std::bind(&Factor::evaluateError, &factor, std::placeholders::_1, boost::none), landmark);
 
   // Verify the Jacobians are correct
   CHECK(assert_equal(HExpected, HActual, 1e-3));
@@ -86,13 +86,15 @@ TEST( triangulation, TriangulationFactorStereo ) {
   factor.evaluateError(landmark, HActual);
 
   Matrix HExpected = numericalDerivative11<Vector,Point3>(
-      boost::bind(&Factor::evaluateError, &factor, _1, boost::none), landmark);
+      std::bind(&Factor::evaluateError, &factor, std::placeholders::_1, boost::none), landmark);
 
   // Verify the Jacobians are correct
   CHECK(assert_equal(HExpected, HActual, 1e-3));
 
   // compare same problem against expression factor
-  Expression<StereoPoint2>::UnaryFunction<Point3>::type f = boost::bind(&StereoCamera::project2, camera2, _1, boost::none, _2);
+  Expression<StereoPoint2>::UnaryFunction<Point3>::type f =
+      std::bind(&StereoCamera::project2, camera2, std::placeholders::_1,
+                boost::none, std::placeholders::_2);
   Expression<Point3> point_(pointKey);
   Expression<StereoPoint2> project2_(f, point_);
 

--- a/gtsam_unstable/base/BTree.h
+++ b/gtsam_unstable/base/BTree.h
@@ -20,7 +20,7 @@
 #include <stack>
 #include <sstream>
 #include <boost/shared_ptr.hpp>
-#include <boost/function.hpp>
+#include <functional>
 
 namespace gtsam {
 
@@ -260,7 +260,7 @@ namespace gtsam {
     }
 
     /** iterate over tree */
-    void iter(boost::function<void(const KEY&, const VALUE&)> f) const {
+    void iter(std::function<void(const KEY&, const VALUE&)> f) const {
       if (!root_) return;
       left().iter(f);
       f(key(), value());
@@ -269,7 +269,7 @@ namespace gtsam {
 
     /** map key-values in tree over function f that computes a new value */
     template<class TO>
-    BTree<KEY, TO> map(boost::function<TO(const KEY&, const VALUE&)> f) const {
+    BTree<KEY, TO> map(std::function<TO(const KEY&, const VALUE&)> f) const {
       if (empty()) return BTree<KEY, TO> ();
       std::pair<KEY, TO> xd(key(), f(key(), value()));
       return BTree<KEY, TO> (left().map(f), xd, right().map(f));
@@ -282,7 +282,7 @@ namespace gtsam {
      * The associated values are passed to [f] in reverse sort order
      */
     template<class ACC>
-    ACC fold(boost::function<ACC(const KEY&, const VALUE&, const ACC&)> f,
+    ACC fold(std::function<ACC(const KEY&, const VALUE&, const ACC&)> f,
         const ACC& a) const {
       if (!root_) return a;
       ACC ar = right().fold(f, a); // fold over right subtree

--- a/gtsam_unstable/base/DSF.h
+++ b/gtsam_unstable/base/DSF.h
@@ -122,7 +122,7 @@ public:
   }
 
   // maps f over all keys, must be invertible
-  DSF map(boost::function<KEY(const KEY&)> func) const {
+  DSF map(std::function<KEY(const KEY&)> func) const {
     DSF t;
     for(const KeyLabel& pair: (Tree)*this)
       t = t.add(func(pair.first), func(pair.second));

--- a/gtsam_unstable/dynamics/FullIMUFactor.h
+++ b/gtsam_unstable/dynamics/FullIMUFactor.h
@@ -91,9 +91,9 @@ public:
     z.segment(3, 3).operator=(gyro_); // Strange syntax to work around ambiguous operator error with clang
     z.tail(3).operator=(x2.t()); // Strange syntax to work around ambiguous operator error with clang
     if (H1) *H1 = numericalDerivative21<Vector9, PoseRTV, PoseRTV>(
-        boost::bind(This::predict_proxy, boost::placeholders::_1, boost::placeholders::_2, dt_), x1, x2, 1e-5);
+        std::bind(This::predict_proxy, std::placeholders::_1, std::placeholders::_2, dt_), x1, x2, 1e-5);
     if (H2) *H2 = numericalDerivative22<Vector9, PoseRTV, PoseRTV>(
-        boost::bind(This::predict_proxy, boost::placeholders::_1, boost::placeholders::_2, dt_), x1, x2, 1e-5);
+        std::bind(This::predict_proxy, std::placeholders::_1, std::placeholders::_2, dt_), x1, x2, 1e-5);
     return z - predict_proxy(x1, x2, dt_);
   }
 

--- a/gtsam_unstable/dynamics/IMUFactor.h
+++ b/gtsam_unstable/dynamics/IMUFactor.h
@@ -81,9 +81,9 @@ public:
       boost::optional<Matrix&> H2 = boost::none) const override {
     const Vector6 meas = z();
     if (H1) *H1 = numericalDerivative21<Vector6, PoseRTV, PoseRTV>(
-        boost::bind(This::predict_proxy, boost::placeholders::_1, boost::placeholders::_2, dt_, meas), x1, x2, 1e-5);
+        std::bind(This::predict_proxy, std::placeholders::_1, std::placeholders::_2, dt_, meas), x1, x2, 1e-5);
     if (H2) *H2 = numericalDerivative22<Vector6, PoseRTV, PoseRTV>(
-        boost::bind(This::predict_proxy, boost::placeholders::_1, boost::placeholders::_2, dt_, meas), x1, x2, 1e-5);
+        std::bind(This::predict_proxy, std::placeholders::_1, std::placeholders::_2, dt_, meas), x1, x2, 1e-5);
     return predict_proxy(x1, x2, dt_, meas);
   }
 

--- a/gtsam_unstable/dynamics/SimpleHelicopter.h
+++ b/gtsam_unstable/dynamics/SimpleHelicopter.h
@@ -166,24 +166,24 @@ public:
       boost::optional<Matrix&> H3 = boost::none) const {
     if (H1) {
       (*H1) = numericalDerivative31(
-          boost::function<Vector(const Vector6&, const Vector6&, const Pose3&)>(
-              boost::bind(&DiscreteEulerPoincareHelicopter::computeError, *this, _1, _2, _3)
+          std::function<Vector(const Vector6&, const Vector6&, const Pose3&)>(
+              std::bind(&DiscreteEulerPoincareHelicopter::computeError, *this, _1, _2, _3)
           ),
           xik, xik_1, gk, 1e-5
       );
     }
     if (H2) {
       (*H2) = numericalDerivative32(
-          boost::function<Vector(const Vector6&, const Vector6&, const Pose3&)>(
-              boost::bind(&DiscreteEulerPoincareHelicopter::computeError, *this, _1, _2, _3)
+          std::function<Vector(const Vector6&, const Vector6&, const Pose3&)>(
+              std::bind(&DiscreteEulerPoincareHelicopter::computeError, *this, _1, _2, _3)
           ),
           xik, xik_1, gk, 1e-5
       );
     }
     if (H3) {
       (*H3) = numericalDerivative33(
-          boost::function<Vector(const Vector6&, const Vector6&, const Pose3&)>(
-              boost::bind(&DiscreteEulerPoincareHelicopter::computeError, *this, _1, _2, _3)
+          std::function<Vector(const Vector6&, const Vector6&, const Pose3&)>(
+              std::bind(&DiscreteEulerPoincareHelicopter::computeError, *this, _1, _2, _3)
           ),
           xik, xik_1, gk, 1e-5
       );

--- a/gtsam_unstable/dynamics/VelocityConstraint.h
+++ b/gtsam_unstable/dynamics/VelocityConstraint.h
@@ -86,11 +86,11 @@ public:
       boost::optional<gtsam::Matrix&> H1=boost::none,
       boost::optional<gtsam::Matrix&> H2=boost::none) const override {
     if (H1) *H1 = gtsam::numericalDerivative21<gtsam::Vector,PoseRTV,PoseRTV>(
-        boost::bind(VelocityConstraint::evaluateError_, boost::placeholders::_1,
-            boost::placeholders::_2, dt_, integration_mode_), x1, x2, 1e-5);
+        std::bind(VelocityConstraint::evaluateError_, std::placeholders::_1,
+            std::placeholders::_2, dt_, integration_mode_), x1, x2, 1e-5);
     if (H2) *H2 = gtsam::numericalDerivative22<gtsam::Vector,PoseRTV,PoseRTV>(
-        boost::bind(VelocityConstraint::evaluateError_, boost::placeholders::_1,
-            boost::placeholders::_2, dt_, integration_mode_), x1, x2, 1e-5);
+        std::bind(VelocityConstraint::evaluateError_, std::placeholders::_1,
+            std::placeholders::_2, dt_, integration_mode_), x1, x2, 1e-5);
     return evaluateError_(x1, x2, dt_, integration_mode_);
   }
 

--- a/gtsam_unstable/dynamics/tests/testSimpleHelicopter.cpp
+++ b/gtsam_unstable/dynamics/tests/testSimpleHelicopter.cpp
@@ -3,14 +3,13 @@
  * @author Duy-Nguyen Ta
  */
 
-#include <boost/bind/bind.hpp>
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam_unstable/dynamics/SimpleHelicopter.h>
 
 /* ************************************************************************* */
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace gtsam;
 using namespace gtsam::symbol_shorthand;
 
@@ -58,19 +57,28 @@ TEST( Reconstruction, evaluateError) {
       assert_equal(Z_6x1, constraint.evaluateError(g2, g1, V1_g1, H1, H2, H3), tol));
 
   Matrix numericalH1 = numericalDerivative31(
-      boost::function<Vector(const Pose3&, const Pose3&, const Vector6&)>(
-          boost::bind(&Reconstruction::evaluateError, constraint, _1, _2, _3,
-              boost::none, boost::none, boost::none)), g2, g1, V1_g1, 1e-5);
+      std::function<Vector(const Pose3&, const Pose3&, const Vector6&)>(
+          std::bind(&Reconstruction::evaluateError, constraint,
+                    std::placeholders::_1, std::placeholders::_2,
+                    std::placeholders::_3, boost::none, boost::none,
+                    boost::none)),
+      g2, g1, V1_g1, 1e-5);
 
   Matrix numericalH2 = numericalDerivative32(
-      boost::function<Vector(const Pose3&, const Pose3&, const Vector6&)>(
-          boost::bind(&Reconstruction::evaluateError, constraint, _1, _2, _3,
-              boost::none, boost::none, boost::none)), g2, g1, V1_g1, 1e-5);
+      std::function<Vector(const Pose3&, const Pose3&, const Vector6&)>(
+          std::bind(&Reconstruction::evaluateError, constraint,
+                    std::placeholders::_1, std::placeholders::_2,
+                    std::placeholders::_3, boost::none, boost::none,
+                    boost::none)),
+      g2, g1, V1_g1, 1e-5);
 
   Matrix numericalH3 = numericalDerivative33(
-      boost::function<Vector(const Pose3&, const Pose3&, const Vector6&)>(
-          boost::bind(&Reconstruction::evaluateError, constraint, _1, _2, _3,
-              boost::none, boost::none, boost::none)), g2, g1, V1_g1, 1e-5);
+      std::function<Vector(const Pose3&, const Pose3&, const Vector6&)>(
+          std::bind(&Reconstruction::evaluateError, constraint,
+                    std::placeholders::_1, std::placeholders::_2,
+                    std::placeholders::_3, boost::none, boost::none,
+                    boost::none)),
+      g2, g1, V1_g1, 1e-5);
 
   EXPECT(assert_equal(numericalH1,H1,1e-5));
   EXPECT(assert_equal(numericalH2,H2,1e-5));
@@ -111,22 +119,22 @@ TEST( DiscreteEulerPoincareHelicopter, evaluateError) {
   EXPECT(assert_equal(Z_6x1, constraint.evaluateError(expectedv2, V1_g1, g2, H1, H2, H3), 1e0));
 
   Matrix numericalH1 = numericalDerivative31(
-      boost::function<Vector(const Vector6&, const Vector6&, const Pose3&)>(
-          boost::bind(&DiscreteEulerPoincareHelicopter::evaluateError, constraint, _1, _2, _3, boost::none, boost::none, boost::none)
+      std::function<Vector(const Vector6&, const Vector6&, const Pose3&)>(
+          std::bind(&DiscreteEulerPoincareHelicopter::evaluateError, constraint, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, boost::none, boost::none, boost::none)
           ),
           expectedv2, V1_g1, g2, 1e-5
       );
 
   Matrix numericalH2 = numericalDerivative32(
-      boost::function<Vector(const Vector6&, const Vector6&, const Pose3&)>(
-          boost::bind(&DiscreteEulerPoincareHelicopter::evaluateError, constraint, _1, _2, _3, boost::none, boost::none, boost::none)
+      std::function<Vector(const Vector6&, const Vector6&, const Pose3&)>(
+          std::bind(&DiscreteEulerPoincareHelicopter::evaluateError, constraint, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, boost::none, boost::none, boost::none)
           ),
           expectedv2, V1_g1, g2, 1e-5
       );
 
   Matrix numericalH3 = numericalDerivative33(
-      boost::function<Vector(const Vector6&, const Vector6&, const Pose3&)>(
-          boost::bind(&DiscreteEulerPoincareHelicopter::evaluateError, constraint, _1, _2, _3, boost::none, boost::none, boost::none)
+      std::function<Vector(const Vector6&, const Vector6&, const Pose3&)>(
+          std::bind(&DiscreteEulerPoincareHelicopter::evaluateError, constraint, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, boost::none, boost::none, boost::none)
           ),
           expectedv2, V1_g1, g2, 1e-5
       );

--- a/gtsam_unstable/geometry/tests/testEvent.cpp
+++ b/gtsam_unstable/geometry/tests/testEvent.cpp
@@ -23,9 +23,7 @@
 
 #include <CppUnitLite/TestHarness.h>
 
-#include <boost/bind/bind.hpp>
-
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -67,11 +65,11 @@ TEST(Event, Derivatives) {
   Matrix13 actualH2;
   kToa(exampleEvent, microphoneAt0, actualH1, actualH2);
   Matrix expectedH1 = numericalDerivative11<double, Event>(
-      boost::bind(kToa, _1, microphoneAt0, boost::none, boost::none),
+      std::bind(kToa, std::placeholders::_1, microphoneAt0, boost::none, boost::none),
       exampleEvent);
   EXPECT(assert_equal(expectedH1, actualH1, 1e-8));
   Matrix expectedH2 = numericalDerivative11<double, Point3>(
-      boost::bind(kToa, exampleEvent, _1, boost::none, boost::none),
+      std::bind(kToa, exampleEvent, std::placeholders::_1, boost::none, boost::none),
       microphoneAt0);
   EXPECT(assert_equal(expectedH2, actualH2, 1e-8));
 }

--- a/gtsam_unstable/linear/QPSParser.cpp
+++ b/gtsam_unstable/linear/QPSParser.cpp
@@ -24,7 +24,6 @@
 #include <gtsam_unstable/linear/QPSParser.h>
 #include <gtsam_unstable/linear/QPSParserException.h>
 
-#include <boost/bind/bind.hpp>
 #include <boost/fusion/include/vector.hpp>
 #include <boost/fusion/sequence.hpp>
 #include <boost/lambda/lambda.hpp>
@@ -40,7 +39,7 @@
 #include <vector>
 
 using boost::fusion::at_c;
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 
 namespace bf = boost::fusion;
@@ -412,50 +411,50 @@ typedef qi::grammar<boost::spirit::basic_istream_iterator<char>> base_grammar;
 struct QPSParser::MPSGrammar : base_grammar {
   typedef std::vector<char> Chars;
   QPSVisitor *rqp_;
-  boost::function<void(bf::vector<Chars, Chars, Chars> const &)> setName;
-  boost::function<void(bf::vector<Chars, char, Chars, Chars, Chars> const &)>
+  std::function<void(bf::vector<Chars, Chars, Chars> const &)> setName;
+  std::function<void(bf::vector<Chars, char, Chars, Chars, Chars> const &)>
       addRow;
-  boost::function<void(
+  std::function<void(
       bf::vector<Chars, Chars, Chars, Chars, Chars, double, Chars> const &)>
       rhsSingle;
-  boost::function<void(bf::vector<Chars, Chars, Chars, Chars, Chars, double,
+  std::function<void(bf::vector<Chars, Chars, Chars, Chars, Chars, double,
                                   Chars, Chars, Chars, double>)>
       rhsDouble;
-  boost::function<void(
+  std::function<void(
       bf::vector<Chars, Chars, Chars, Chars, Chars, double, Chars> const &)>
       rangeSingle;
-  boost::function<void(bf::vector<Chars, Chars, Chars, Chars, Chars, double,
+  std::function<void(bf::vector<Chars, Chars, Chars, Chars, Chars, double,
                                   Chars, Chars, Chars, double>)>
       rangeDouble;
-  boost::function<void(
+  std::function<void(
       bf::vector<Chars, Chars, Chars, Chars, Chars, double, Chars>)>
       colSingle;
-  boost::function<void(bf::vector<Chars, Chars, Chars, Chars, double, Chars,
+  std::function<void(bf::vector<Chars, Chars, Chars, Chars, double, Chars,
                                   Chars, Chars, double> const &)>
       colDouble;
-  boost::function<void(
+  std::function<void(
       bf::vector<Chars, Chars, Chars, Chars, Chars, double, Chars> const &)>
       addQuadTerm;
-  boost::function<void(bf::vector<Chars, Chars, Chars, Chars, Chars, Chars,
+  std::function<void(bf::vector<Chars, Chars, Chars, Chars, Chars, Chars,
                                   Chars, double> const &)>
       addBound;
-  boost::function<void(
+  std::function<void(
       bf::vector<Chars, Chars, Chars, Chars, Chars, Chars, Chars> const &)>
       addFreeBound;
   MPSGrammar(QPSVisitor *rqp)
       : base_grammar(start),
         rqp_(rqp),
-        setName(boost::bind(&QPSVisitor::setName, rqp, ::_1)),
-        addRow(boost::bind(&QPSVisitor::addRow, rqp, ::_1)),
-        rhsSingle(boost::bind(&QPSVisitor::addRHS, rqp, ::_1)),
-        rhsDouble(boost::bind(&QPSVisitor::addRHSDouble, rqp, ::_1)),
-        rangeSingle(boost::bind(&QPSVisitor::addRangeSingle, rqp, ::_1)),
-        rangeDouble(boost::bind(&QPSVisitor::addRangeDouble, rqp, ::_1)),
-        colSingle(boost::bind(&QPSVisitor::addColumn, rqp, ::_1)),
-        colDouble(boost::bind(&QPSVisitor::addColumnDouble, rqp, ::_1)),
-        addQuadTerm(boost::bind(&QPSVisitor::addQuadTerm, rqp, ::_1)),
-        addBound(boost::bind(&QPSVisitor::addBound, rqp, ::_1)),
-        addFreeBound(boost::bind(&QPSVisitor::addFreeBound, rqp, ::_1)) {
+        setName(std::bind(&QPSVisitor::setName, rqp, std::placeholders::_1)),
+        addRow(std::bind(&QPSVisitor::addRow, rqp, std::placeholders::_1)),
+        rhsSingle(std::bind(&QPSVisitor::addRHS, rqp, std::placeholders::_1)),
+        rhsDouble(std::bind(&QPSVisitor::addRHSDouble, rqp, std::placeholders::_1)),
+        rangeSingle(std::bind(&QPSVisitor::addRangeSingle, rqp, std::placeholders::_1)),
+        rangeDouble(std::bind(&QPSVisitor::addRangeDouble, rqp, std::placeholders::_1)),
+        colSingle(std::bind(&QPSVisitor::addColumn, rqp, std::placeholders::_1)),
+        colDouble(std::bind(&QPSVisitor::addColumnDouble, rqp, std::placeholders::_1)),
+        addQuadTerm(std::bind(&QPSVisitor::addQuadTerm, rqp, std::placeholders::_1)),
+        addBound(std::bind(&QPSVisitor::addBound, rqp, std::placeholders::_1)),
+        addFreeBound(std::bind(&QPSVisitor::addFreeBound, rqp, std::placeholders::_1)) {
     using namespace boost::spirit;
     using namespace boost::spirit::qi;
     character = lexeme[alnum | '_' | '-' | '.'];

--- a/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel.h
+++ b/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel.h
@@ -309,12 +309,12 @@ public:
     // Jacobian w.r.t. Pose1
     if (H1){
       Matrix H1_Pose = numericalDerivative11<POSE, POSE>(
-          boost::bind(&EquivInertialNavFactor_GlobalVel::evaluatePoseError,
-                      this, boost::placeholders::_1, Vel1, Bias1, Pose2, Vel2),
+          std::bind(&EquivInertialNavFactor_GlobalVel::evaluatePoseError,
+                      this, std::placeholders::_1, Vel1, Bias1, Pose2, Vel2),
           Pose1);
       Matrix H1_Vel = numericalDerivative11<VELOCITY, POSE>(
-          boost::bind(&EquivInertialNavFactor_GlobalVel::evaluateVelocityError,
-                      this, boost::placeholders::_1, Vel1, Bias1, Pose2, Vel2),
+          std::bind(&EquivInertialNavFactor_GlobalVel::evaluateVelocityError,
+                      this, std::placeholders::_1, Vel1, Bias1, Pose2, Vel2),
           Pose1);
       *H1 = stack(2, &H1_Pose, &H1_Vel);
     }
@@ -323,12 +323,12 @@ public:
     if (H2){
       if (Vel1.size()!=3) throw std::runtime_error("Frank's hack to make this compile will not work if size != 3");
       Matrix H2_Pose = numericalDerivative11<POSE, Vector3>(
-          boost::bind(&EquivInertialNavFactor_GlobalVel::evaluatePoseError,
-                      this, Pose1, boost::placeholders::_1, Bias1, Pose2, Vel2),
+          std::bind(&EquivInertialNavFactor_GlobalVel::evaluatePoseError,
+                      this, Pose1, std::placeholders::_1, Bias1, Pose2, Vel2),
           Vel1);
       Matrix H2_Vel = numericalDerivative11<Vector3, Vector3>(
-          boost::bind(&EquivInertialNavFactor_GlobalVel::evaluateVelocityError,
-                      this, Pose1, boost::placeholders::_1, Bias1, Pose2, Vel2),
+          std::bind(&EquivInertialNavFactor_GlobalVel::evaluateVelocityError,
+                      this, Pose1, std::placeholders::_1, Bias1, Pose2, Vel2),
           Vel1);
       *H2 = stack(2, &H2_Pose, &H2_Vel);
     }
@@ -336,12 +336,12 @@ public:
     // Jacobian w.r.t. IMUBias1
     if (H3){
       Matrix H3_Pose = numericalDerivative11<POSE, IMUBIAS>(
-          boost::bind(&EquivInertialNavFactor_GlobalVel::evaluatePoseError,
-                      this, Pose1, Vel1, boost::placeholders::_1, Pose2, Vel2),
+          std::bind(&EquivInertialNavFactor_GlobalVel::evaluatePoseError,
+                      this, Pose1, Vel1, std::placeholders::_1, Pose2, Vel2),
           Bias1);
       Matrix H3_Vel = numericalDerivative11<VELOCITY, IMUBIAS>(
-          boost::bind(&EquivInertialNavFactor_GlobalVel::evaluateVelocityError,
-                      this, Pose1, Vel1, boost::placeholders::_1, Pose2, Vel2),
+          std::bind(&EquivInertialNavFactor_GlobalVel::evaluateVelocityError,
+                      this, Pose1, Vel1, std::placeholders::_1, Pose2, Vel2),
           Bias1);
       *H3 = stack(2, &H3_Pose, &H3_Vel);
     }
@@ -349,12 +349,12 @@ public:
     // Jacobian w.r.t. Pose2
     if (H4){
       Matrix H4_Pose = numericalDerivative11<POSE, POSE>(
-          boost::bind(&EquivInertialNavFactor_GlobalVel::evaluatePoseError,
-                      this, Pose1, Vel1, Bias1, boost::placeholders::_1, Vel2),
+          std::bind(&EquivInertialNavFactor_GlobalVel::evaluatePoseError,
+                      this, Pose1, Vel1, Bias1, std::placeholders::_1, Vel2),
           Pose2);
       Matrix H4_Vel = numericalDerivative11<VELOCITY, POSE>(
-          boost::bind(&EquivInertialNavFactor_GlobalVel::evaluateVelocityError,
-                      this, Pose1, Vel1, Bias1, boost::placeholders::_1, Vel2),
+          std::bind(&EquivInertialNavFactor_GlobalVel::evaluateVelocityError,
+                      this, Pose1, Vel1, Bias1, std::placeholders::_1, Vel2),
           Pose2);
       *H4 = stack(2, &H4_Pose, &H4_Vel);
     }
@@ -363,12 +363,12 @@ public:
     if (H5){
       if (Vel2.size()!=3) throw std::runtime_error("Frank's hack to make this compile will not work if size != 3");
       Matrix H5_Pose = numericalDerivative11<POSE, Vector3>(
-          boost::bind(&EquivInertialNavFactor_GlobalVel::evaluatePoseError,
-                      this, Pose1, Vel1, Bias1, Pose2, boost::placeholders::_1),
+          std::bind(&EquivInertialNavFactor_GlobalVel::evaluatePoseError,
+                      this, Pose1, Vel1, Bias1, Pose2, std::placeholders::_1),
           Vel2);
       Matrix H5_Vel = numericalDerivative11<Vector3, Vector3>(
-          boost::bind(&EquivInertialNavFactor_GlobalVel::evaluateVelocityError,
-                      this, Pose1, Vel1, Bias1, Pose2, boost::placeholders::_1),
+          std::bind(&EquivInertialNavFactor_GlobalVel::evaluateVelocityError,
+                      this, Pose1, Vel1, Bias1, Pose2, std::placeholders::_1),
           Vel2);
       *H5 = stack(2, &H5_Pose, &H5_Vel);
     }
@@ -469,43 +469,43 @@ public:
     Matrix I_3x3 = I_3x3;
 
     Matrix H_pos_pos = numericalDerivative11<Vector3, Vector3>(
-        boost::bind(&PreIntegrateIMUObservations_delta_pos, msr_dt,
-                    boost::placeholders::_1, delta_vel_in_t0),
+        std::bind(&PreIntegrateIMUObservations_delta_pos, msr_dt,
+                    std::placeholders::_1, delta_vel_in_t0),
         delta_pos_in_t0);
     Matrix H_pos_vel = numericalDerivative11<Vector3, Vector3>(
-        boost::bind(&PreIntegrateIMUObservations_delta_pos, msr_dt,
-                    delta_pos_in_t0, boost::placeholders::_1),
+        std::bind(&PreIntegrateIMUObservations_delta_pos, msr_dt,
+                    delta_pos_in_t0, std::placeholders::_1),
         delta_vel_in_t0);
     Matrix H_pos_angles = Z_3x3;
     Matrix H_pos_bias = collect(2, &Z_3x3, &Z_3x3);
 
     Matrix H_vel_vel = numericalDerivative11<Vector3, Vector3>(
-        boost::bind(&PreIntegrateIMUObservations_delta_vel, msr_gyro_t,
-                    msr_acc_t, msr_dt, delta_angles, boost::placeholders::_1,
+        std::bind(&PreIntegrateIMUObservations_delta_vel, msr_gyro_t,
+                    msr_acc_t, msr_dt, delta_angles, std::placeholders::_1,
                     flag_use_body_P_sensor, body_P_sensor, Bias_t0),
         delta_vel_in_t0);
     Matrix H_vel_angles = numericalDerivative11<Vector3, Vector3>(
-        boost::bind(&PreIntegrateIMUObservations_delta_vel, msr_gyro_t,
-                    msr_acc_t, msr_dt, boost::placeholders::_1, delta_vel_in_t0,
+        std::bind(&PreIntegrateIMUObservations_delta_vel, msr_gyro_t,
+                    msr_acc_t, msr_dt, std::placeholders::_1, delta_vel_in_t0,
                     flag_use_body_P_sensor, body_P_sensor, Bias_t0),
         delta_angles);
     Matrix H_vel_bias = numericalDerivative11<Vector3, IMUBIAS>(
-        boost::bind(&PreIntegrateIMUObservations_delta_vel, msr_gyro_t,
+        std::bind(&PreIntegrateIMUObservations_delta_vel, msr_gyro_t,
                     msr_acc_t, msr_dt, delta_angles, delta_vel_in_t0,
                     flag_use_body_P_sensor, body_P_sensor,
-                    boost::placeholders::_1),
+                    std::placeholders::_1),
         Bias_t0);
     Matrix H_vel_pos = Z_3x3;
 
     Matrix H_angles_angles = numericalDerivative11<Vector3, Vector3>(
-        boost::bind(&PreIntegrateIMUObservations_delta_angles, msr_gyro_t,
-                    msr_dt, boost::placeholders::_1, flag_use_body_P_sensor,
+        std::bind(&PreIntegrateIMUObservations_delta_angles, msr_gyro_t,
+                    msr_dt, std::placeholders::_1, flag_use_body_P_sensor,
                     body_P_sensor, Bias_t0),
         delta_angles);
     Matrix H_angles_bias = numericalDerivative11<Vector3, IMUBIAS>(
-        boost::bind(&PreIntegrateIMUObservations_delta_angles, msr_gyro_t,
+        std::bind(&PreIntegrateIMUObservations_delta_angles, msr_gyro_t,
                     msr_dt, delta_angles, flag_use_body_P_sensor, body_P_sensor,
-                    boost::placeholders::_1),
+                    std::placeholders::_1),
         Bias_t0);
     Matrix H_angles_pos = Z_3x3;
     Matrix H_angles_vel = Z_3x3;

--- a/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel_NoBias.h
+++ b/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel_NoBias.h
@@ -278,29 +278,29 @@ public:
     // TODO: Write analytical derivative calculations
     // Jacobian w.r.t. Pose1
     if (H1){
-      Matrix H1_Pose = numericalDerivative11<POSE, POSE>(boost::bind(&EquivInertialNavFactor_GlobalVel_NoBias::evaluatePoseError, this, _1, Vel1, Pose2, Vel2), Pose1);
-      Matrix H1_Vel = numericalDerivative11<VELOCITY, POSE>(boost::bind(&EquivInertialNavFactor_GlobalVel_NoBias::evaluateVelocityError, this, _1, Vel1, Pose2, Vel2), Pose1);
+      Matrix H1_Pose = numericalDerivative11<POSE, POSE>(std::bind(&EquivInertialNavFactor_GlobalVel_NoBias::evaluatePoseError, this, _1, Vel1, Pose2, Vel2), Pose1);
+      Matrix H1_Vel = numericalDerivative11<VELOCITY, POSE>(std::bind(&EquivInertialNavFactor_GlobalVel_NoBias::evaluateVelocityError, this, _1, Vel1, Pose2, Vel2), Pose1);
       *H1 = stack(2, &H1_Pose, &H1_Vel);
     }
 
     // Jacobian w.r.t. Vel1
     if (H2){
-      Matrix H2_Pose = numericalDerivative11<POSE, VELOCITY>(boost::bind(&EquivInertialNavFactor_GlobalVel_NoBias::evaluatePoseError, this, Pose1, _1, Pose2, Vel2), Vel1);
-      Matrix H2_Vel = numericalDerivative11<VELOCITY, VELOCITY>(boost::bind(&EquivInertialNavFactor_GlobalVel_NoBias::evaluateVelocityError, this, Pose1, _1, Pose2, Vel2), Vel1);
+      Matrix H2_Pose = numericalDerivative11<POSE, VELOCITY>(std::bind(&EquivInertialNavFactor_GlobalVel_NoBias::evaluatePoseError, this, Pose1, _1, Pose2, Vel2), Vel1);
+      Matrix H2_Vel = numericalDerivative11<VELOCITY, VELOCITY>(std::bind(&EquivInertialNavFactor_GlobalVel_NoBias::evaluateVelocityError, this, Pose1, _1, Pose2, Vel2), Vel1);
       *H2 = stack(2, &H2_Pose, &H2_Vel);
     }
 
     // Jacobian w.r.t. Pose2
     if (H3){
-      Matrix H3_Pose = numericalDerivative11<POSE, POSE>(boost::bind(&EquivInertialNavFactor_GlobalVel_NoBias::evaluatePoseError, this, Pose1, Vel1, _1, Vel2), Pose2);
-      Matrix H3_Vel = numericalDerivative11<VELOCITY, POSE>(boost::bind(&EquivInertialNavFactor_GlobalVel_NoBias::evaluateVelocityError, this, Pose1, Vel1, _1, Vel2), Pose2);
+      Matrix H3_Pose = numericalDerivative11<POSE, POSE>(std::bind(&EquivInertialNavFactor_GlobalVel_NoBias::evaluatePoseError, this, Pose1, Vel1, _1, Vel2), Pose2);
+      Matrix H3_Vel = numericalDerivative11<VELOCITY, POSE>(std::bind(&EquivInertialNavFactor_GlobalVel_NoBias::evaluateVelocityError, this, Pose1, Vel1, _1, Vel2), Pose2);
       *H3 = stack(2, &H3_Pose, &H3_Vel);
     }
 
     // Jacobian w.r.t. Vel2
     if (H4){
-      Matrix H4_Pose = numericalDerivative11<POSE, VELOCITY>(boost::bind(&EquivInertialNavFactor_GlobalVel_NoBias::evaluatePoseError, this, Pose1, Vel1, Pose2, _1), Vel2);
-      Matrix H4_Vel = numericalDerivative11<VELOCITY, VELOCITY>(boost::bind(&EquivInertialNavFactor_GlobalVel_NoBias::evaluateVelocityError, this, Pose1, Vel1, Pose2, _1), Vel2);
+      Matrix H4_Pose = numericalDerivative11<POSE, VELOCITY>(std::bind(&EquivInertialNavFactor_GlobalVel_NoBias::evaluatePoseError, this, Pose1, Vel1, Pose2, _1), Vel2);
+      Matrix H4_Vel = numericalDerivative11<VELOCITY, VELOCITY>(std::bind(&EquivInertialNavFactor_GlobalVel_NoBias::evaluateVelocityError, this, Pose1, Vel1, Pose2, _1), Vel2);
       *H4 = stack(2, &H4_Pose, &H4_Vel);
     }
 
@@ -372,15 +372,15 @@ public:
     Matrix Z_3x3 = Z_3x3;
     Matrix I_3x3 = I_3x3;
 
-    Matrix H_pos_pos = numericalDerivative11<LieVector, LieVector>(boost::bind(&PreIntegrateIMUObservations_delta_pos, msr_dt, _1, delta_vel_in_t0), delta_pos_in_t0);
-    Matrix H_pos_vel = numericalDerivative11<LieVector, LieVector>(boost::bind(&PreIntegrateIMUObservations_delta_pos, msr_dt, delta_pos_in_t0, _1), delta_vel_in_t0);
+    Matrix H_pos_pos = numericalDerivative11<LieVector, LieVector>(std::bind(&PreIntegrateIMUObservations_delta_pos, msr_dt, _1, delta_vel_in_t0), delta_pos_in_t0);
+    Matrix H_pos_vel = numericalDerivative11<LieVector, LieVector>(std::bind(&PreIntegrateIMUObservations_delta_pos, msr_dt, delta_pos_in_t0, _1), delta_vel_in_t0);
     Matrix H_pos_angles = Z_3x3;
 
-    Matrix H_vel_vel = numericalDerivative11<LieVector, LieVector>(boost::bind(&PreIntegrateIMUObservations_delta_vel, msr_gyro_t, msr_acc_t, msr_dt, delta_angles, _1, flag_use_body_P_sensor, body_P_sensor), delta_vel_in_t0);
-    Matrix H_vel_angles = numericalDerivative11<LieVector, LieVector>(boost::bind(&PreIntegrateIMUObservations_delta_vel, msr_gyro_t, msr_acc_t, msr_dt, _1, delta_vel_in_t0, flag_use_body_P_sensor, body_P_sensor), delta_angles);
+    Matrix H_vel_vel = numericalDerivative11<LieVector, LieVector>(std::bind(&PreIntegrateIMUObservations_delta_vel, msr_gyro_t, msr_acc_t, msr_dt, delta_angles, _1, flag_use_body_P_sensor, body_P_sensor), delta_vel_in_t0);
+    Matrix H_vel_angles = numericalDerivative11<LieVector, LieVector>(std::bind(&PreIntegrateIMUObservations_delta_vel, msr_gyro_t, msr_acc_t, msr_dt, _1, delta_vel_in_t0, flag_use_body_P_sensor, body_P_sensor), delta_angles);
     Matrix H_vel_pos = Z_3x3;
 
-    Matrix H_angles_angles = numericalDerivative11<LieVector, LieVector>(boost::bind(&PreIntegrateIMUObservations_delta_angles, msr_gyro_t, msr_dt, _1, flag_use_body_P_sensor, body_P_sensor), delta_angles);
+    Matrix H_angles_angles = numericalDerivative11<LieVector, LieVector>(std::bind(&PreIntegrateIMUObservations_delta_angles, msr_gyro_t, msr_dt, _1, flag_use_body_P_sensor, body_P_sensor), delta_angles);
     Matrix H_angles_pos = Z_3x3;
     Matrix H_angles_vel = Z_3x3;
 

--- a/gtsam_unstable/slam/InertialNavFactor_GlobalVelocity.h
+++ b/gtsam_unstable/slam/InertialNavFactor_GlobalVelocity.h
@@ -236,12 +236,12 @@ public:
     // Jacobian w.r.t. Pose1
     if (H1){
       Matrix H1_Pose = gtsam::numericalDerivative11<POSE, POSE>(
-          boost::bind(&InertialNavFactor_GlobalVelocity::evaluatePoseError,
-                      this, boost::placeholders::_1, Vel1, Bias1, Pose2, Vel2),
+          std::bind(&InertialNavFactor_GlobalVelocity::evaluatePoseError,
+                      this, std::placeholders::_1, Vel1, Bias1, Pose2, Vel2),
           Pose1);
       Matrix H1_Vel = gtsam::numericalDerivative11<VELOCITY, POSE>(
-          boost::bind(&InertialNavFactor_GlobalVelocity::evaluateVelocityError,
-                      this, boost::placeholders::_1, Vel1, Bias1, Pose2, Vel2),
+          std::bind(&InertialNavFactor_GlobalVelocity::evaluateVelocityError,
+                      this, std::placeholders::_1, Vel1, Bias1, Pose2, Vel2),
           Pose1);
       *H1 = stack(2, &H1_Pose, &H1_Vel);
     }
@@ -250,12 +250,12 @@ public:
     if (H2){
       if (Vel1.size()!=3) throw std::runtime_error("Frank's hack to make this compile will not work if size != 3");
       Matrix H2_Pose = gtsam::numericalDerivative11<POSE, Vector3>(
-          boost::bind(&InertialNavFactor_GlobalVelocity::evaluatePoseError,
-                      this, Pose1, boost::placeholders::_1, Bias1, Pose2, Vel2),
+          std::bind(&InertialNavFactor_GlobalVelocity::evaluatePoseError,
+                      this, Pose1, std::placeholders::_1, Bias1, Pose2, Vel2),
           Vel1);
       Matrix H2_Vel = gtsam::numericalDerivative11<Vector3, Vector3>(
-          boost::bind(&InertialNavFactor_GlobalVelocity::evaluateVelocityError,
-                      this, Pose1, boost::placeholders::_1, Bias1, Pose2, Vel2),
+          std::bind(&InertialNavFactor_GlobalVelocity::evaluateVelocityError,
+                      this, Pose1, std::placeholders::_1, Bias1, Pose2, Vel2),
           Vel1);
       *H2 = stack(2, &H2_Pose, &H2_Vel);
     }
@@ -263,12 +263,12 @@ public:
     // Jacobian w.r.t. IMUBias1
     if (H3){
       Matrix H3_Pose = gtsam::numericalDerivative11<POSE, IMUBIAS>(
-          boost::bind(&InertialNavFactor_GlobalVelocity::evaluatePoseError,
-                      this, Pose1, Vel1, boost::placeholders::_1, Pose2, Vel2),
+          std::bind(&InertialNavFactor_GlobalVelocity::evaluatePoseError,
+                      this, Pose1, Vel1, std::placeholders::_1, Pose2, Vel2),
           Bias1);
       Matrix H3_Vel = gtsam::numericalDerivative11<VELOCITY, IMUBIAS>(
-          boost::bind(&InertialNavFactor_GlobalVelocity::evaluateVelocityError,
-                      this, Pose1, Vel1, boost::placeholders::_1, Pose2, Vel2),
+          std::bind(&InertialNavFactor_GlobalVelocity::evaluateVelocityError,
+                      this, Pose1, Vel1, std::placeholders::_1, Pose2, Vel2),
           Bias1);
       *H3 = stack(2, &H3_Pose, &H3_Vel);
     }
@@ -276,12 +276,12 @@ public:
     // Jacobian w.r.t. Pose2
     if (H4){
       Matrix H4_Pose = gtsam::numericalDerivative11<POSE, POSE>(
-          boost::bind(&InertialNavFactor_GlobalVelocity::evaluatePoseError,
-                      this, Pose1, Vel1, Bias1, boost::placeholders::_1, Vel2),
+          std::bind(&InertialNavFactor_GlobalVelocity::evaluatePoseError,
+                      this, Pose1, Vel1, Bias1, std::placeholders::_1, Vel2),
           Pose2);
       Matrix H4_Vel = gtsam::numericalDerivative11<VELOCITY, POSE>(
-          boost::bind(&InertialNavFactor_GlobalVelocity::evaluateVelocityError,
-                      this, Pose1, Vel1, Bias1, boost::placeholders::_1, Vel2),
+          std::bind(&InertialNavFactor_GlobalVelocity::evaluateVelocityError,
+                      this, Pose1, Vel1, Bias1, std::placeholders::_1, Vel2),
           Pose2);
       *H4 = stack(2, &H4_Pose, &H4_Vel);
     }
@@ -290,12 +290,12 @@ public:
     if (H5){
       if (Vel2.size()!=3) throw std::runtime_error("Frank's hack to make this compile will not work if size != 3");
       Matrix H5_Pose = gtsam::numericalDerivative11<POSE, Vector3>(
-          boost::bind(&InertialNavFactor_GlobalVelocity::evaluatePoseError,
-                      this, Pose1, Vel1, Bias1, Pose2, boost::placeholders::_1),
+          std::bind(&InertialNavFactor_GlobalVelocity::evaluatePoseError,
+                      this, Pose1, Vel1, Bias1, Pose2, std::placeholders::_1),
           Vel2);
       Matrix H5_Vel = gtsam::numericalDerivative11<Vector3, Vector3>(
-          boost::bind(&InertialNavFactor_GlobalVelocity::evaluateVelocityError,
-                      this, Pose1, Vel1, Bias1, Pose2, boost::placeholders::_1),
+          std::bind(&InertialNavFactor_GlobalVelocity::evaluateVelocityError,
+                      this, Pose1, Vel1, Bias1, Pose2, std::placeholders::_1),
           Vel2);
       *H5 = stack(2, &H5_Pose, &H5_Vel);
     }

--- a/gtsam_unstable/slam/InvDepthFactorVariant1.h
+++ b/gtsam_unstable/slam/InvDepthFactorVariant1.h
@@ -108,14 +108,14 @@ public:
 
     if (H1) {
       (*H1) = numericalDerivative11<Vector, Pose3>(
-          boost::bind(&InvDepthFactorVariant1::inverseDepthError, this,
-                      boost::placeholders::_1, landmark),
+          std::bind(&InvDepthFactorVariant1::inverseDepthError, this,
+                      std::placeholders::_1, landmark),
           pose);
     }
     if (H2) {
       (*H2) = numericalDerivative11<Vector, Vector6>(
-          boost::bind(&InvDepthFactorVariant1::inverseDepthError, this, pose,
-              boost::placeholders::_1), landmark);
+          std::bind(&InvDepthFactorVariant1::inverseDepthError, this, pose,
+              std::placeholders::_1), landmark);
     }
 
     return inverseDepthError(pose, landmark);

--- a/gtsam_unstable/slam/InvDepthFactorVariant2.h
+++ b/gtsam_unstable/slam/InvDepthFactorVariant2.h
@@ -111,13 +111,13 @@ public:
 
     if (H1) {
       (*H1) = numericalDerivative11<Vector, Pose3>(
-          boost::bind(&InvDepthFactorVariant2::inverseDepthError, this,
-              boost::placeholders::_1, landmark), pose);
+          std::bind(&InvDepthFactorVariant2::inverseDepthError, this,
+              std::placeholders::_1, landmark), pose);
     }
     if (H2) {
       (*H2) = numericalDerivative11<Vector, Vector3>(
-          boost::bind(&InvDepthFactorVariant2::inverseDepthError, this, pose,
-              boost::placeholders::_1), landmark);
+          std::bind(&InvDepthFactorVariant2::inverseDepthError, this, pose,
+              std::placeholders::_1), landmark);
     }
 
     return inverseDepthError(pose, landmark);

--- a/gtsam_unstable/slam/InvDepthFactorVariant3.h
+++ b/gtsam_unstable/slam/InvDepthFactorVariant3.h
@@ -111,14 +111,14 @@ public:
 
     if(H1) {
       (*H1) = numericalDerivative11<Vector, Pose3>(
-          boost::bind(&InvDepthFactorVariant3a::inverseDepthError, this,
-                      boost::placeholders::_1, landmark),
+          std::bind(&InvDepthFactorVariant3a::inverseDepthError, this,
+                      std::placeholders::_1, landmark),
           pose);
     }
     if(H2) {
       (*H2) = numericalDerivative11<Vector, Vector3>(
-          boost::bind(&InvDepthFactorVariant3a::inverseDepthError, this, pose,
-                      boost::placeholders::_1),
+          std::bind(&InvDepthFactorVariant3a::inverseDepthError, this, pose,
+                      std::placeholders::_1),
           landmark);
     }
 
@@ -238,20 +238,20 @@ public:
 
     if(H1)
       (*H1) = numericalDerivative11<Vector, Pose3>(
-          boost::bind(&InvDepthFactorVariant3b::inverseDepthError, this,
-                      boost::placeholders::_1, pose2, landmark),
+          std::bind(&InvDepthFactorVariant3b::inverseDepthError, this,
+                      std::placeholders::_1, pose2, landmark),
           pose1);
 
     if(H2)
       (*H2) = numericalDerivative11<Vector, Pose3>(
-          boost::bind(&InvDepthFactorVariant3b::inverseDepthError, this, pose1,
-                      boost::placeholders::_1, landmark),
+          std::bind(&InvDepthFactorVariant3b::inverseDepthError, this, pose1,
+                      std::placeholders::_1, landmark),
           pose2);
 
     if(H3)
       (*H3) = numericalDerivative11<Vector, Vector3>(
-          boost::bind(&InvDepthFactorVariant3b::inverseDepthError, this, pose1,
-                      pose2, boost::placeholders::_1),
+          std::bind(&InvDepthFactorVariant3b::inverseDepthError, this, pose1,
+                      pose2, std::placeholders::_1),
           landmark);
 
     return inverseDepthError(pose1, pose2, landmark);

--- a/gtsam_unstable/slam/tests/testBetweenFactorEM.cpp
+++ b/gtsam_unstable/slam/tests/testBetweenFactorEM.cpp
@@ -190,12 +190,12 @@ TEST (BetweenFactorEM, jacobian ) {
 //  CHECK( assert_equal(H2_actual_stnd, H2_actual, 1e-8));
 
   double stepsize = 1.0e-9;
-  Matrix H1_expected = gtsam::numericalDerivative11<LieVector, Pose2>(boost::bind(&predictionError, _1, p2, key1, key2, f), p1, stepsize);
-  Matrix H2_expected = gtsam::numericalDerivative11<LieVector, Pose2>(boost::bind(&predictionError, p1, _1, key1, key2, f), p2, stepsize);
+  Matrix H1_expected = gtsam::numericalDerivative11<LieVector, Pose2>(std::bind(&predictionError, _1, p2, key1, key2, f), p1, stepsize);
+  Matrix H2_expected = gtsam::numericalDerivative11<LieVector, Pose2>(std::bind(&predictionError, p1, _1, key1, key2, f), p2, stepsize);
 
 
   // try to check numerical derivatives of a standard between factor
-  Matrix H1_expected_stnd = gtsam::numericalDerivative11<LieVector, Pose2>(boost::bind(&predictionError_standard, _1, p2, key1, key2, h), p1, stepsize);
+  Matrix H1_expected_stnd = gtsam::numericalDerivative11<LieVector, Pose2>(std::bind(&predictionError_standard, _1, p2, key1, key2, h), p1, stepsize);
 //  CHECK( assert_equal(H1_expected_stnd, H1_actual_stnd, 1e-5));
 //
 //

--- a/gtsam_unstable/slam/tests/testBiasedGPSFactor.cpp
+++ b/gtsam_unstable/slam/tests/testBiasedGPSFactor.cpp
@@ -10,10 +10,9 @@
 #include <gtsam/inference/Symbol.h>
 #include <gtsam_unstable/slam/BiasedGPSFactor.h>
 
-#include <boost/bind/bind.hpp>
 #include <CppUnitLite/TestHarness.h>
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace gtsam;
 using namespace gtsam::symbol_shorthand;
 using namespace gtsam::noiseModel;
@@ -68,15 +67,17 @@ TEST(BiasedGPSFactor, jacobian) {
   factor.evaluateError(pose,bias, actualH1, actualH2);
 
   Matrix numericalH1 = numericalDerivative21(
-      boost::function<Vector(const Pose3&, const Point3&)>(boost::bind(
-          &BiasedGPSFactor::evaluateError, factor, _1, _2, boost::none,
-          boost::none)), pose, bias, 1e-5);
+      std::function<Vector(const Pose3&, const Point3&)>(std::bind(
+          &BiasedGPSFactor::evaluateError, factor, std::placeholders::_1,
+          std::placeholders::_2, boost::none, boost::none)),
+      pose, bias, 1e-5);
   EXPECT(assert_equal(numericalH1,actualH1, 1E-5));
 
   Matrix numericalH2 = numericalDerivative22(
-      boost::function<Vector(const Pose3&, const Point3&)>(boost::bind(
-          &BiasedGPSFactor::evaluateError, factor, _1, _2, boost::none,
-          boost::none)), pose, bias, 1e-5);
+      std::function<Vector(const Pose3&, const Point3&)>(std::bind(
+          &BiasedGPSFactor::evaluateError, factor, std::placeholders::_1,
+          std::placeholders::_2, boost::none, boost::none)),
+      pose, bias, 1e-5);
   EXPECT(assert_equal(numericalH2,actualH2, 1E-5));
 }
 

--- a/gtsam_unstable/slam/tests/testEquivInertialNavFactor_GlobalVel.cpp
+++ b/gtsam_unstable/slam/tests/testEquivInertialNavFactor_GlobalVel.cpp
@@ -26,7 +26,7 @@
 #include <CppUnitLite/TestHarness.h>
 #include <iostream>
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 

--- a/gtsam_unstable/slam/tests/testGaussMarkov1stOrderFactor.cpp
+++ b/gtsam_unstable/slam/tests/testGaussMarkov1stOrderFactor.cpp
@@ -23,9 +23,7 @@
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/deprecated/LieVector.h>
 
-#include <boost/bind/bind.hpp>
-
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -108,9 +106,13 @@ TEST (GaussMarkovFactor, jacobian ) {
   // Calculate the Jacobian matrices H1 and H2 using the numerical derivative function
   Matrix numerical_H1, numerical_H2;
   numerical_H1 = numericalDerivative21<Vector3, Vector3, Vector3>(
-      boost::bind(&predictionError, _1, _2, factor), v1_upd, v2_upd);
+      std::bind(&predictionError, std::placeholders::_1, std::placeholders::_2,
+                factor),
+      v1_upd, v2_upd);
   numerical_H2 = numericalDerivative22<Vector3, Vector3, Vector3>(
-      boost::bind(&predictionError, _1, _2, factor), v1_upd, v2_upd);
+      std::bind(&predictionError, std::placeholders::_1, std::placeholders::_2,
+                factor),
+      v1_upd, v2_upd);
 
   // Verify they are equal for this choice of state
   CHECK( assert_equal(numerical_H1, computed_H1, 1e-9));

--- a/gtsam_unstable/slam/tests/testInertialNavFactor_GlobalVelocity.cpp
+++ b/gtsam_unstable/slam/tests/testInertialNavFactor_GlobalVelocity.cpp
@@ -16,7 +16,6 @@
  */
 
 #include <iostream>
-#include <boost/bind/bind.hpp>
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/navigation/ImuBias.h>
 #include <gtsam_unstable/slam/InertialNavFactor_GlobalVelocity.h>
@@ -26,7 +25,7 @@
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/base/TestableAssertions.h>
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -251,7 +250,7 @@ Vector predictionErrorVel(const Pose3& p1, const Vector3& v1,
 //
 //  Vector3 v(predictionRq(angles, q));
 //
-//  J_expected = numericalDerivative11<Vector3, Vector3>(boost::bind(&predictionRq, _1, q), angles);
+//  J_expected = numericalDerivative11<Vector3, Vector3>(std::bind(&predictionRq, std::placeholders::_1, q), angles);
 //
 //  cout<<"J_hyp"<<J_hyp<<endl;
 //  cout<<"J_expected"<<J_expected<<endl;
@@ -312,19 +311,19 @@ Vector predictionErrorVel(const Pose3& p1, const Vector3& v1,
   Matrix H1_expectedPose, H2_expectedPose, H3_expectedPose, H4_expectedPose,
       H5_expectedPose;
   H1_expectedPose = numericalDerivative11<Pose3, Pose3>(
-      boost::bind(&predictionErrorPose, _1, Vel1, Bias1, Pose2, Vel2, factor),
+      std::bind(&predictionErrorPose, std::placeholders::_1, Vel1, Bias1, Pose2, Vel2, factor),
       Pose1);
   H2_expectedPose = numericalDerivative11<Pose3, Vector3>(
-      boost::bind(&predictionErrorPose, Pose1, _1, Bias1, Pose2, Vel2, factor),
+      std::bind(&predictionErrorPose, Pose1, std::placeholders::_1, Bias1, Pose2, Vel2, factor),
       Vel1);
   H3_expectedPose = numericalDerivative11<Pose3, imuBias::ConstantBias>(
-      boost::bind(&predictionErrorPose, Pose1, Vel1, _1, Pose2, Vel2, factor),
+      std::bind(&predictionErrorPose, Pose1, Vel1, std::placeholders::_1, Pose2, Vel2, factor),
       Bias1);
   H4_expectedPose = numericalDerivative11<Pose3, Pose3>(
-      boost::bind(&predictionErrorPose, Pose1, Vel1, Bias1, _1, Vel2, factor),
+      std::bind(&predictionErrorPose, Pose1, Vel1, Bias1, std::placeholders::_1, Vel2, factor),
       Pose2);
   H5_expectedPose = numericalDerivative11<Pose3, Vector3>(
-      boost::bind(&predictionErrorPose, Pose1, Vel1, Bias1, Pose2, _1, factor),
+      std::bind(&predictionErrorPose, Pose1, Vel1, Bias1, Pose2, std::placeholders::_1, factor),
       Vel2);
 
   // Verify they are equal for this choice of state
@@ -346,19 +345,19 @@ Vector predictionErrorVel(const Pose3& p1, const Vector3& v1,
   Matrix H1_expectedVel, H2_expectedVel, H3_expectedVel, H4_expectedVel,
       H5_expectedVel;
   H1_expectedVel = numericalDerivative11<Vector, Pose3>(
-      boost::bind(&predictionErrorVel, _1, Vel1, Bias1, Pose2, Vel2, factor),
+      std::bind(&predictionErrorVel, std::placeholders::_1, Vel1, Bias1, Pose2, Vel2, factor),
       Pose1);
   H2_expectedVel = numericalDerivative11<Vector, Vector3>(
-      boost::bind(&predictionErrorVel, Pose1, _1, Bias1, Pose2, Vel2, factor),
+      std::bind(&predictionErrorVel, Pose1, std::placeholders::_1, Bias1, Pose2, Vel2, factor),
       Vel1);
   H3_expectedVel = numericalDerivative11<Vector, imuBias::ConstantBias>(
-      boost::bind(&predictionErrorVel, Pose1, Vel1, _1, Pose2, Vel2, factor),
+      std::bind(&predictionErrorVel, Pose1, Vel1, std::placeholders::_1, Pose2, Vel2, factor),
       Bias1);
   H4_expectedVel = numericalDerivative11<Vector, Pose3>(
-      boost::bind(&predictionErrorVel, Pose1, Vel1, Bias1, _1, Vel2, factor),
+      std::bind(&predictionErrorVel, Pose1, Vel1, Bias1, std::placeholders::_1, Vel2, factor),
       Pose2);
   H5_expectedVel = numericalDerivative11<Vector, Vector3>(
-      boost::bind(&predictionErrorVel, Pose1, Vel1, Bias1, Pose2, _1, factor),
+      std::bind(&predictionErrorVel, Pose1, Vel1, Bias1, Pose2, std::placeholders::_1, factor),
       Vel2);
 
   // Verify they are equal for this choice of state
@@ -644,19 +643,19 @@ Vector predictionErrorVel(const Pose3& p1, const Vector3& v1,
   Matrix H1_expectedPose, H2_expectedPose, H3_expectedPose, H4_expectedPose,
       H5_expectedPose;
   H1_expectedPose = numericalDerivative11<Pose3, Pose3>(
-      boost::bind(&predictionErrorPose, _1, Vel1, Bias1, Pose2, Vel2, factor),
+      std::bind(&predictionErrorPose, std::placeholders::_1, Vel1, Bias1, Pose2, Vel2, factor),
       Pose1);
   H2_expectedPose = numericalDerivative11<Pose3, Vector3>(
-      boost::bind(&predictionErrorPose, Pose1, _1, Bias1, Pose2, Vel2, factor),
+      std::bind(&predictionErrorPose, Pose1, std::placeholders::_1, Bias1, Pose2, Vel2, factor),
       Vel1);
   H3_expectedPose = numericalDerivative11<Pose3, imuBias::ConstantBias>(
-      boost::bind(&predictionErrorPose, Pose1, Vel1, _1, Pose2, Vel2, factor),
+      std::bind(&predictionErrorPose, Pose1, Vel1, std::placeholders::_1, Pose2, Vel2, factor),
       Bias1);
   H4_expectedPose = numericalDerivative11<Pose3, Pose3>(
-      boost::bind(&predictionErrorPose, Pose1, Vel1, Bias1, _1, Vel2, factor),
+      std::bind(&predictionErrorPose, Pose1, Vel1, Bias1, std::placeholders::_1, Vel2, factor),
       Pose2);
   H5_expectedPose = numericalDerivative11<Pose3, Vector3>(
-      boost::bind(&predictionErrorPose, Pose1, Vel1, Bias1, Pose2, _1, factor),
+      std::bind(&predictionErrorPose, Pose1, Vel1, Bias1, Pose2, std::placeholders::_1, factor),
       Vel2);
 
   // Verify they are equal for this choice of state
@@ -678,19 +677,19 @@ Vector predictionErrorVel(const Pose3& p1, const Vector3& v1,
   Matrix H1_expectedVel, H2_expectedVel, H3_expectedVel, H4_expectedVel,
       H5_expectedVel;
   H1_expectedVel = numericalDerivative11<Vector, Pose3>(
-      boost::bind(&predictionErrorVel, _1, Vel1, Bias1, Pose2, Vel2, factor),
+      std::bind(&predictionErrorVel, std::placeholders::_1, Vel1, Bias1, Pose2, Vel2, factor),
       Pose1);
   H2_expectedVel = numericalDerivative11<Vector, Vector3>(
-      boost::bind(&predictionErrorVel, Pose1, _1, Bias1, Pose2, Vel2, factor),
+      std::bind(&predictionErrorVel, Pose1, std::placeholders::_1, Bias1, Pose2, Vel2, factor),
       Vel1);
   H3_expectedVel = numericalDerivative11<Vector, imuBias::ConstantBias>(
-      boost::bind(&predictionErrorVel, Pose1, Vel1, _1, Pose2, Vel2, factor),
+      std::bind(&predictionErrorVel, Pose1, Vel1, std::placeholders::_1, Pose2, Vel2, factor),
       Bias1);
   H4_expectedVel = numericalDerivative11<Vector, Pose3>(
-      boost::bind(&predictionErrorVel, Pose1, Vel1, Bias1, _1, Vel2, factor),
+      std::bind(&predictionErrorVel, Pose1, Vel1, Bias1, std::placeholders::_1, Vel2, factor),
       Pose2);
   H5_expectedVel = numericalDerivative11<Vector, Vector3>(
-      boost::bind(&predictionErrorVel, Pose1, Vel1, Bias1, Pose2, _1, factor),
+      std::bind(&predictionErrorVel, Pose1, Vel1, Bias1, Pose2, std::placeholders::_1, factor),
       Vel2);
 
   // Verify they are equal for this choice of state

--- a/gtsam_unstable/slam/tests/testLocalOrientedPlane3Factor.cpp
+++ b/gtsam_unstable/slam/tests/testLocalOrientedPlane3Factor.cpp
@@ -24,9 +24,7 @@
 
 #include <CppUnitLite/TestHarness.h>
 
-#include <boost/bind/bind.hpp>
-
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace gtsam;
 using namespace std;
 
@@ -143,8 +141,10 @@ TEST(LocalOrientedPlane3Factor, Derivatives) {
   LocalOrientedPlane3Factor factor(p, noise, poseKey, anchorPoseKey, planeKey);
 
   // Calculate numerical derivatives
-  auto f = boost::bind(&LocalOrientedPlane3Factor::evaluateError, factor,
-    _1, _2, _3, boost::none, boost::none, boost::none);
+  auto f =
+      std::bind(&LocalOrientedPlane3Factor::evaluateError, factor,
+                std::placeholders::_1, std::placeholders::_2,
+                std::placeholders::_3, boost::none, boost::none, boost::none);
   Matrix numericalH1 = numericalDerivative31<Vector3, Pose3, Pose3,
     OrientedPlane3>(f, poseLin, anchorPoseLin, pLin);
   Matrix numericalH2 = numericalDerivative32<Vector3, Pose3, Pose3,

--- a/gtsam_unstable/slam/tests/testPartialPriorFactor.cpp
+++ b/gtsam_unstable/slam/tests/testPartialPriorFactor.cpp
@@ -16,10 +16,9 @@
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/base/TestableAssertions.h>
 
-#include <boost/bind/bind.hpp>
 #include <CppUnitLite/TestHarness.h>
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -83,7 +82,9 @@ TEST(PartialPriorFactor, JacobianPartialTranslation2) {
 
   // Calculate numerical derivatives.
   Matrix expectedH1 = numericalDerivative11<Vector, Pose2>(
-      boost::bind(&TestPartialPriorFactor2::evaluateError, &factor, _1, boost::none), pose);
+      std::bind(&TestPartialPriorFactor2::evaluateError, &factor,
+                std::placeholders::_1, boost::none),
+      pose);
 
   // Use the factor to calculate the derivative.
   Matrix actualH1;
@@ -99,13 +100,16 @@ TEST(PartialPriorFactor, JacobianFullTranslation2) {
   Pose2 measurement(-6.0, 3.5, 0.123);
 
   // Prior on x component of translation.
-  TestPartialPriorFactor2 factor(poseKey, { 0, 1 }, measurement.translation(), NM::Isotropic::Sigma(2, 0.25));
+  TestPartialPriorFactor2 factor(poseKey, {0, 1}, measurement.translation(),
+                                 NM::Isotropic::Sigma(2, 0.25));
 
   Pose2 pose = measurement; // Zero-error linearization point.
 
   // Calculate numerical derivatives.
   Matrix expectedH1 = numericalDerivative11<Vector, Pose2>(
-      boost::bind(&TestPartialPriorFactor2::evaluateError, &factor, _1, boost::none), pose);
+      std::bind(&TestPartialPriorFactor2::evaluateError, &factor,
+                std::placeholders::_1, boost::none),
+      pose);
 
   // Use the factor to calculate the derivative.
   Matrix actualH1;
@@ -127,7 +131,7 @@ TEST(PartialPriorFactor, JacobianTheta) {
 
   // Calculate numerical derivatives.
   Matrix expectedH1 = numericalDerivative11<Vector, Pose2>(
-      boost::bind(&TestPartialPriorFactor2::evaluateError, &factor, _1, boost::none), pose);
+      std::bind(&TestPartialPriorFactor2::evaluateError, &factor, std::placeholders::_1, boost::none), pose);
 
   // Use the factor to calculate the derivative.
   Matrix actualH1;
@@ -178,7 +182,7 @@ TEST(PartialPriorFactor, JacobianAtIdentity3) {
 
   // Calculate numerical derivatives.
   Matrix expectedH1 = numericalDerivative11<Vector, Pose3>(
-      boost::bind(&TestPartialPriorFactor3::evaluateError, &factor, _1, boost::none), pose);
+      std::bind(&TestPartialPriorFactor3::evaluateError, &factor, std::placeholders::_1, boost::none), pose);
 
   // Use the factor to calculate the derivative.
   Matrix actualH1;
@@ -200,7 +204,7 @@ TEST(PartialPriorFactor, JacobianPartialTranslation3) {
 
   // Calculate numerical derivatives.
   Matrix expectedH1 = numericalDerivative11<Vector, Pose3>(
-      boost::bind(&TestPartialPriorFactor3::evaluateError, &factor, _1, boost::none), pose);
+      std::bind(&TestPartialPriorFactor3::evaluateError, &factor, std::placeholders::_1, boost::none), pose);
 
   // Use the factor to calculate the derivative.
   Matrix actualH1;
@@ -224,7 +228,7 @@ TEST(PartialPriorFactor, JacobianFullTranslation3) {
 
   // Calculate numerical derivatives.
   Matrix expectedH1 = numericalDerivative11<Vector, Pose3>(
-      boost::bind(&TestPartialPriorFactor3::evaluateError, &factor, _1, boost::none), pose);
+      std::bind(&TestPartialPriorFactor3::evaluateError, &factor, std::placeholders::_1, boost::none), pose);
 
   // Use the factor to calculate the derivative.
   Matrix actualH1;
@@ -248,7 +252,7 @@ TEST(PartialPriorFactor, JacobianTxTz3) {
 
   // Calculate numerical derivatives.
   Matrix expectedH1 = numericalDerivative11<Vector, Pose3>(
-      boost::bind(&TestPartialPriorFactor3::evaluateError, &factor, _1, boost::none), pose);
+      std::bind(&TestPartialPriorFactor3::evaluateError, &factor, std::placeholders::_1, boost::none), pose);
 
   // Use the factor to calculate the derivative.
   Matrix actualH1;
@@ -271,7 +275,7 @@ TEST(PartialPriorFactor, JacobianFullRotation3) {
 
   // Calculate numerical derivatives.
   Matrix expectedH1 = numericalDerivative11<Vector, Pose3>(
-      boost::bind(&TestPartialPriorFactor3::evaluateError, &factor, _1, boost::none), pose);
+      std::bind(&TestPartialPriorFactor3::evaluateError, &factor, std::placeholders::_1, boost::none), pose);
 
   // Use the factor to calculate the derivative.
   Matrix actualH1;

--- a/gtsam_unstable/slam/tests/testPoseBetweenFactor.cpp
+++ b/gtsam_unstable/slam/tests/testPoseBetweenFactor.cpp
@@ -22,10 +22,9 @@
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/base/TestableAssertions.h>
 
-#include <boost/bind/bind.hpp>
 #include <CppUnitLite/TestHarness.h>
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -199,8 +198,14 @@ TEST( PoseBetweenFactor, Jacobian ) {
               Point3(-3.37493895, 6.14660244, -8.93650986));
 
   // Calculate numerical derivatives
-  Matrix expectedH1 = numericalDerivative11<Vector,Pose3>(boost::bind(&TestPoseBetweenFactor::evaluateError, &factor, _1, pose2, boost::none, boost::none), pose1);
-  Matrix expectedH2 = numericalDerivative11<Vector,Pose3>(boost::bind(&TestPoseBetweenFactor::evaluateError, &factor, pose1, _1, boost::none, boost::none), pose2);
+  Matrix expectedH1 = numericalDerivative11<Vector, Pose3>(
+      std::bind(&TestPoseBetweenFactor::evaluateError, &factor,
+                std::placeholders::_1, pose2, boost::none, boost::none),
+      pose1);
+  Matrix expectedH2 = numericalDerivative11<Vector, Pose3>(
+      std::bind(&TestPoseBetweenFactor::evaluateError, &factor, pose1,
+                std::placeholders::_1, boost::none, boost::none),
+      pose2);
 
   // Use the factor to calculate the derivative
   Matrix actualH1;
@@ -228,8 +233,14 @@ TEST( PoseBetweenFactor, JacobianWithTransform ) {
               Point3(-3.5257579, 6.02637531, -8.98382384));
 
   // Calculate numerical derivatives
-  Matrix expectedH1 = numericalDerivative11<Vector,Pose3>(boost::bind(&TestPoseBetweenFactor::evaluateError, &factor, _1, pose2, boost::none, boost::none), pose1);
-  Matrix expectedH2 = numericalDerivative11<Vector,Pose3>(boost::bind(&TestPoseBetweenFactor::evaluateError, &factor, pose1, _1, boost::none, boost::none), pose2);
+  Matrix expectedH1 = numericalDerivative11<Vector, Pose3>(
+      std::bind(&TestPoseBetweenFactor::evaluateError, &factor,
+                std::placeholders::_1, pose2, boost::none, boost::none),
+      pose1);
+  Matrix expectedH2 = numericalDerivative11<Vector, Pose3>(
+      std::bind(&TestPoseBetweenFactor::evaluateError, &factor, pose1,
+                std::placeholders::_1, boost::none, boost::none),
+      pose2);
 
   // Use the factor to calculate the derivative
   Matrix actualH1;

--- a/gtsam_unstable/slam/tests/testPosePriorFactor.cpp
+++ b/gtsam_unstable/slam/tests/testPosePriorFactor.cpp
@@ -22,10 +22,9 @@
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/base/TestableAssertions.h>
 
-#include <boost/bind/bind.hpp>
 #include <CppUnitLite/TestHarness.h>
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -188,7 +187,10 @@ TEST( PosePriorFactor, Jacobian ) {
   Pose3 pose(Rot3::RzRyRx(0.15, -0.30, 0.45), Point3(-5.0, 8.0, -11.0));
 
   // Calculate numerical derivatives
-  Matrix expectedH1 = numericalDerivative11<Vector,Pose3>(boost::bind(&TestPosePriorFactor::evaluateError, &factor, _1, boost::none), pose);
+  Matrix expectedH1 = numericalDerivative11<Vector, Pose3>(
+      std::bind(&TestPosePriorFactor::evaluateError, &factor,
+                std::placeholders::_1, boost::none),
+      pose);
 
   // Use the factor to calculate the derivative
   Matrix actualH1;
@@ -212,7 +214,10 @@ TEST( PosePriorFactor, JacobianWithTransform ) {
              Point3(-4.74767676, 7.67044942, -11.00985));
 
   // Calculate numerical derivatives
-  Matrix expectedH1 = numericalDerivative11<Vector,Pose3>(boost::bind(&TestPosePriorFactor::evaluateError, &factor, _1, boost::none), pose);
+  Matrix expectedH1 = numericalDerivative11<Vector, Pose3>(
+      std::bind(&TestPosePriorFactor::evaluateError, &factor,
+                std::placeholders::_1, boost::none),
+      pose);
 
   // Use the factor to calculate the derivative
   Matrix actualH1;

--- a/gtsam_unstable/slam/tests/testPoseToPointFactor.h
+++ b/gtsam_unstable/slam/tests/testPoseToPointFactor.h
@@ -63,7 +63,7 @@ TEST(PoseToPointFactor, jacobian) {
   PoseToPointFactor factor(pose_key, point_key, l_meas, noise);
 
   // Calculate numerical derivatives
-  auto f = boost::bind(&PoseToPointFactor::evaluateError, factor, _1, _2,
+  auto f = std::bind(&PoseToPointFactor::evaluateError, factor, _1, _2,
                        boost::none, boost::none);
   Matrix numerical_H1 = numericalDerivative21<Vector, Pose3, Point3>(f, p, l);
   Matrix numerical_H2 = numericalDerivative22<Vector, Pose3, Point3>(f, p, l);

--- a/gtsam_unstable/slam/tests/testProjectionFactorPPP.cpp
+++ b/gtsam_unstable/slam/tests/testProjectionFactorPPP.cpp
@@ -28,9 +28,7 @@
 
 #include <CppUnitLite/TestHarness.h>
 
-#include <boost/bind/bind.hpp>
-
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -178,10 +176,13 @@ TEST( ProjectionFactorPPP, Jacobian ) {
   CHECK(assert_equal(H3Expected, H3Actual, 1e-3));
 
   // Verify H2 with numerical derivative
-  Matrix H2Expected = numericalDerivative32<Vector,Pose3, Pose3, Point3>(
-      boost::function<Vector(const Pose3&, const Pose3&, const Point3&)>(
-      boost::bind(&TestProjectionFactor::evaluateError, &factor, _1, _2, _3,
-          boost::none, boost::none, boost::none)), pose, Pose3(), point);
+  Matrix H2Expected = numericalDerivative32<Vector, Pose3, Pose3, Point3>(
+      std::function<Vector(const Pose3&, const Pose3&, const Point3&)>(
+          std::bind(&TestProjectionFactor::evaluateError, &factor,
+                    std::placeholders::_1, std::placeholders::_2,
+                    std::placeholders::_3, boost::none, boost::none,
+                    boost::none)),
+      pose, Pose3(), point);
 
   CHECK(assert_equal(H2Expected, H2Actual, 1e-5));
 }
@@ -214,9 +215,12 @@ TEST( ProjectionFactorPPP, JacobianWithTransform ) {
 
   // Verify H2 with numerical derivative
   Matrix H2Expected = numericalDerivative32<Vector, Pose3, Pose3, Point3>(
-      boost::function<Vector(const Pose3&, const Pose3&, const Point3&)>(
-      boost::bind(&TestProjectionFactor::evaluateError, &factor, _1, _2, _3,
-          boost::none, boost::none, boost::none)), pose, body_P_sensor, point);
+      std::function<Vector(const Pose3&, const Pose3&, const Point3&)>(
+          std::bind(&TestProjectionFactor::evaluateError, &factor,
+                    std::placeholders::_1, std::placeholders::_2,
+                    std::placeholders::_3, boost::none, boost::none,
+                    boost::none)),
+      pose, body_P_sensor, point);
 
   CHECK(assert_equal(H2Expected, H2Actual, 1e-5));
 

--- a/gtsam_unstable/slam/tests/testProjectionFactorPPPC.cpp
+++ b/gtsam_unstable/slam/tests/testProjectionFactorPPPC.cpp
@@ -28,9 +28,7 @@
 
 #include <CppUnitLite/TestHarness.h>
 
-#include <boost/bind/bind.hpp>
-
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -138,12 +136,16 @@ TEST( ProjectionFactorPPPC, Jacobian ) {
 
   // Verify H2 and H4 with numerical derivatives
   Matrix H2Expected = numericalDerivative11<Vector, Pose3>(
-      boost::bind(&TestProjectionFactor::evaluateError, &factor, pose, _1, point,
-          *K1, boost::none, boost::none, boost::none, boost::none), Pose3());
+      std::bind(&TestProjectionFactor::evaluateError, &factor, pose,
+                std::placeholders::_1, point, *K1, boost::none, boost::none,
+                boost::none, boost::none),
+      Pose3());
 
   Matrix H4Expected = numericalDerivative11<Vector, Cal3_S2>(
-      boost::bind(&TestProjectionFactor::evaluateError, &factor, pose, Pose3(), point,
-          _1, boost::none, boost::none, boost::none, boost::none), *K1);
+      std::bind(&TestProjectionFactor::evaluateError, &factor, pose, Pose3(),
+                point, std::placeholders::_1, boost::none, boost::none,
+                boost::none, boost::none),
+      *K1);
 
   CHECK(assert_equal(H2Expected, H2Actual, 1e-5));
   CHECK(assert_equal(H4Expected, H4Actual, 1e-5));
@@ -174,12 +176,12 @@ TEST( ProjectionFactorPPPC, JacobianWithTransform ) {
 
   // Verify H2 and H4 with numerical derivatives
   Matrix H2Expected = numericalDerivative11<Vector, Pose3>(
-      boost::bind(&TestProjectionFactor::evaluateError, &factor, pose, _1, point,
+      std::bind(&TestProjectionFactor::evaluateError, &factor, pose, std::placeholders::_1, point,
           *K1, boost::none, boost::none, boost::none, boost::none), body_P_sensor);
 
   Matrix H4Expected = numericalDerivative11<Vector, Cal3_S2>(
-      boost::bind(&TestProjectionFactor::evaluateError, &factor, pose, body_P_sensor, point,
-          _1, boost::none, boost::none, boost::none, boost::none), *K1);
+      std::bind(&TestProjectionFactor::evaluateError, &factor, pose, body_P_sensor, point,
+          std::placeholders::_1, boost::none, boost::none, boost::none, boost::none), *K1);
 
   CHECK(assert_equal(H2Expected, H2Actual, 1e-5));
   CHECK(assert_equal(H4Expected, H4Actual, 1e-5));

--- a/gtsam_unstable/slam/tests/testRelativeElevationFactor.cpp
+++ b/gtsam_unstable/slam/tests/testRelativeElevationFactor.cpp
@@ -5,14 +5,13 @@
  * @author Alex Cunningham
  */
 
-#include <boost/bind/bind.hpp>
 #include <CppUnitLite/TestHarness.h>
 
 #include <gtsam_unstable/slam/RelativeElevationFactor.h>
 
 #include <gtsam/base/numericalDerivative.h>
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace gtsam;
 
 SharedNoiseModel model1 = noiseModel::Unit::Create(1);
@@ -37,10 +36,14 @@ TEST( testRelativeElevationFactor, level_zero_error ) {
   RelativeElevationFactor factor(poseKey, pointKey, measured, model1);
   Matrix actH1, actH2;
   EXPECT(assert_equal(Z_1x1, factor.evaluateError(pose1, point1, actH1, actH2)));
-  Matrix expH1 = numericalDerivative21<Vector,Pose3,Point3>(
-      boost::bind(evalFactorError, factor, _1, _2), pose1, point1, 1e-5);
-  Matrix expH2 = numericalDerivative22<Vector,Pose3,Point3>(
-      boost::bind(evalFactorError, factor, _1, _2), pose1, point1, 1e-5);
+  Matrix expH1 = numericalDerivative21<Vector, Pose3, Point3>(
+      std::bind(evalFactorError, factor, std::placeholders::_1,
+                std::placeholders::_2),
+      pose1, point1, 1e-5);
+  Matrix expH2 = numericalDerivative22<Vector, Pose3, Point3>(
+      std::bind(evalFactorError, factor, std::placeholders::_1,
+                std::placeholders::_2),
+      pose1, point1, 1e-5);
   EXPECT(assert_equal(expH1, actH1, tol));
   EXPECT(assert_equal(expH2, actH2, tol));
 }
@@ -52,10 +55,14 @@ TEST( testRelativeElevationFactor, level_positive ) {
   RelativeElevationFactor factor(poseKey, pointKey, measured, model1);
   Matrix actH1, actH2;
   EXPECT(assert_equal((Vector(1) << 2.0).finished(), factor.evaluateError(pose1, point1, actH1, actH2)));
-  Matrix expH1 = numericalDerivative21<Vector,Pose3,Point3>(
-      boost::bind(evalFactorError, factor, _1, _2), pose1, point1, 1e-5);
-  Matrix expH2 = numericalDerivative22<Vector,Pose3,Point3>(
-      boost::bind(evalFactorError, factor, _1, _2), pose1, point1, 1e-5);
+  Matrix expH1 = numericalDerivative21<Vector, Pose3, Point3>(
+      std::bind(evalFactorError, factor, std::placeholders::_1,
+                std::placeholders::_2),
+      pose1, point1, 1e-5);
+  Matrix expH2 = numericalDerivative22<Vector, Pose3, Point3>(
+      std::bind(evalFactorError, factor, std::placeholders::_1,
+                std::placeholders::_2),
+      pose1, point1, 1e-5);
   EXPECT(assert_equal(expH1, actH1, tol));
   EXPECT(assert_equal(expH2, actH2, tol));
 }
@@ -67,10 +74,14 @@ TEST( testRelativeElevationFactor, level_negative ) {
   RelativeElevationFactor factor(poseKey, pointKey, measured, model1);
   Matrix actH1, actH2;
   EXPECT(assert_equal((Vector(1) << 3.0).finished(), factor.evaluateError(pose1, point1, actH1, actH2)));
-  Matrix expH1 = numericalDerivative21<Vector,Pose3,Point3>(
-      boost::bind(evalFactorError, factor, _1, _2), pose1, point1, 1e-5);
-  Matrix expH2 = numericalDerivative22<Vector,Pose3,Point3>(
-      boost::bind(evalFactorError, factor, _1, _2), pose1, point1, 1e-5);
+  Matrix expH1 = numericalDerivative21<Vector, Pose3, Point3>(
+      std::bind(evalFactorError, factor, std::placeholders::_1,
+                std::placeholders::_2),
+      pose1, point1, 1e-5);
+  Matrix expH2 = numericalDerivative22<Vector, Pose3, Point3>(
+      std::bind(evalFactorError, factor, std::placeholders::_1,
+                std::placeholders::_2),
+      pose1, point1, 1e-5);
   EXPECT(assert_equal(expH1, actH1, tol));
   EXPECT(assert_equal(expH2, actH2, tol));
 }
@@ -82,10 +93,14 @@ TEST( testRelativeElevationFactor, rotated_zero_error ) {
   RelativeElevationFactor factor(poseKey, pointKey, measured, model1);
   Matrix actH1, actH2;
   EXPECT(assert_equal(Z_1x1, factor.evaluateError(pose2, point1, actH1, actH2)));
-  Matrix expH1 = numericalDerivative21<Vector,Pose3,Point3>(
-      boost::bind(evalFactorError, factor, _1, _2), pose2, point1, 1e-5);
-  Matrix expH2 = numericalDerivative22<Vector,Pose3,Point3>(
-      boost::bind(evalFactorError, factor, _1, _2), pose2, point1, 1e-5);
+  Matrix expH1 = numericalDerivative21<Vector, Pose3, Point3>(
+      std::bind(evalFactorError, factor, std::placeholders::_1,
+                std::placeholders::_2),
+      pose2, point1, 1e-5);
+  Matrix expH2 = numericalDerivative22<Vector, Pose3, Point3>(
+      std::bind(evalFactorError, factor, std::placeholders::_1,
+                std::placeholders::_2),
+      pose2, point1, 1e-5);
   EXPECT(assert_equal(expH1, actH1, tol));
   EXPECT(assert_equal(expH2, actH2, tol));
 }
@@ -97,10 +112,14 @@ TEST( testRelativeElevationFactor, rotated_positive ) {
   RelativeElevationFactor factor(poseKey, pointKey, measured, model1);
   Matrix actH1, actH2;
   EXPECT(assert_equal((Vector(1) << 2.0).finished(), factor.evaluateError(pose2, point1, actH1, actH2)));
-  Matrix expH1 = numericalDerivative21<Vector,Pose3,Point3>(
-      boost::bind(evalFactorError, factor, _1, _2), pose2, point1, 1e-5);
-  Matrix expH2 = numericalDerivative22<Vector,Pose3,Point3>(
-      boost::bind(evalFactorError, factor, _1, _2), pose2, point1, 1e-5);
+  Matrix expH1 = numericalDerivative21<Vector, Pose3, Point3>(
+      std::bind(evalFactorError, factor, std::placeholders::_1,
+                std::placeholders::_2),
+      pose2, point1, 1e-5);
+  Matrix expH2 = numericalDerivative22<Vector, Pose3, Point3>(
+      std::bind(evalFactorError, factor, std::placeholders::_1,
+                std::placeholders::_2),
+      pose2, point1, 1e-5);
   EXPECT(assert_equal(expH1, actH1, tol));
   EXPECT(assert_equal(expH2, actH2, tol));
 }
@@ -112,10 +131,14 @@ TEST( testRelativeElevationFactor, rotated_negative1 ) {
   RelativeElevationFactor factor(poseKey, pointKey, measured, model1);
   Matrix actH1, actH2;
   EXPECT(assert_equal((Vector(1) << 3.0).finished(), factor.evaluateError(pose2, point1, actH1, actH2)));
-  Matrix expH1 = numericalDerivative21<Vector,Pose3,Point3>(
-      boost::bind(evalFactorError, factor, _1, _2), pose2, point1, 1e-5);
-  Matrix expH2 = numericalDerivative22<Vector,Pose3,Point3>(
-      boost::bind(evalFactorError, factor, _1, _2), pose2, point1, 1e-5);
+  Matrix expH1 = numericalDerivative21<Vector, Pose3, Point3>(
+      std::bind(evalFactorError, factor, std::placeholders::_1,
+                std::placeholders::_2),
+      pose2, point1, 1e-5);
+  Matrix expH2 = numericalDerivative22<Vector, Pose3, Point3>(
+      std::bind(evalFactorError, factor, std::placeholders::_1,
+                std::placeholders::_2),
+      pose2, point1, 1e-5);
   EXPECT(assert_equal(expH1, actH1, tol));
   EXPECT(assert_equal(expH2, actH2, tol));
 }
@@ -127,10 +150,14 @@ TEST( testRelativeElevationFactor, rotated_negative2 ) {
   RelativeElevationFactor factor(poseKey, pointKey, measured, model1);
   Matrix actH1, actH2;
   EXPECT(assert_equal((Vector(1) << 3.0).finished(), factor.evaluateError(pose3, point1, actH1, actH2)));
-  Matrix expH1 = numericalDerivative21<Vector,Pose3,Point3>(
-      boost::bind(evalFactorError, factor, _1, _2), pose3, point1, 1e-5);
-  Matrix expH2 = numericalDerivative22<Vector,Pose3,Point3>(
-      boost::bind(evalFactorError, factor, _1, _2), pose3, point1, 1e-5);
+  Matrix expH1 = numericalDerivative21<Vector, Pose3, Point3>(
+      std::bind(evalFactorError, factor, std::placeholders::_1,
+                std::placeholders::_2),
+      pose3, point1, 1e-5);
+  Matrix expH2 = numericalDerivative22<Vector, Pose3, Point3>(
+      std::bind(evalFactorError, factor, std::placeholders::_1,
+                std::placeholders::_2),
+      pose3, point1, 1e-5);
   EXPECT(assert_equal(expH1, actH1, tol));
   EXPECT(assert_equal(expH2, actH2, tol));
 }

--- a/gtsam_unstable/slam/tests/testTSAMFactors.cpp
+++ b/gtsam_unstable/slam/tests/testTSAMFactors.cpp
@@ -19,10 +19,9 @@
 #include <gtsam_unstable/slam/TSAMFactors.h>
 #include <gtsam/base/numericalDerivative.h>
 
-#include <boost/bind/bind.hpp>
 #include <CppUnitLite/TestHarness.h>
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -48,10 +47,10 @@ TEST( DeltaFactor, all ) {
   // Use numerical derivatives to calculate the Jacobians
   Matrix H1Expected, H2Expected;
   H1Expected = numericalDerivative11<Vector2, Pose2>(
-      boost::bind(&DeltaFactor::evaluateError, &factor, _1, point, boost::none,
+      std::bind(&DeltaFactor::evaluateError, &factor, std::placeholders::_1, point, boost::none,
           boost::none), pose);
   H2Expected = numericalDerivative11<Vector2, Point2>(
-      boost::bind(&DeltaFactor::evaluateError, &factor, pose, _1, boost::none,
+      std::bind(&DeltaFactor::evaluateError, &factor, pose, std::placeholders::_1, boost::none,
           boost::none), point);
 
   // Verify the Jacobians are correct
@@ -82,17 +81,17 @@ TEST( DeltaFactorBase, all ) {
   // Use numerical derivatives to calculate the Jacobians
   Matrix H1Expected, H2Expected, H3Expected, H4Expected;
   H1Expected = numericalDerivative11<Vector2, Pose2>(
-      boost::bind(&DeltaFactorBase::evaluateError, &factor, _1, pose, base2,
+      std::bind(&DeltaFactorBase::evaluateError, &factor, std::placeholders::_1, pose, base2,
           point, boost::none, boost::none, boost::none, boost::none), base1);
   H2Expected = numericalDerivative11<Vector2, Pose2>(
-      boost::bind(&DeltaFactorBase::evaluateError, &factor, base1, _1, base2,
+      std::bind(&DeltaFactorBase::evaluateError, &factor, base1, std::placeholders::_1, base2,
           point, boost::none, boost::none, boost::none, boost::none), pose);
   H3Expected = numericalDerivative11<Vector2, Pose2>(
-      boost::bind(&DeltaFactorBase::evaluateError, &factor, base1, pose, _1,
+      std::bind(&DeltaFactorBase::evaluateError, &factor, base1, pose, std::placeholders::_1,
           point, boost::none, boost::none, boost::none, boost::none), base2);
   H4Expected = numericalDerivative11<Vector2, Point2>(
-      boost::bind(&DeltaFactorBase::evaluateError, &factor, base1, pose, base2,
-          _1, boost::none, boost::none, boost::none, boost::none), point);
+      std::bind(&DeltaFactorBase::evaluateError, &factor, base1, pose, base2,
+          std::placeholders::_1, boost::none, boost::none, boost::none, boost::none), point);
 
   // Verify the Jacobians are correct
   EXPECT(assert_equal(H1Expected, H1Actual, 1e-9));
@@ -123,17 +122,17 @@ TEST( OdometryFactorBase, all ) {
   // Use numerical derivatives to calculate the Jacobians
   Matrix H1Expected, H2Expected, H3Expected, H4Expected;
   H1Expected = numericalDerivative11<Vector3, Pose2>(
-      boost::bind(&OdometryFactorBase::evaluateError, &factor, _1, pose1, base2,
+      std::bind(&OdometryFactorBase::evaluateError, &factor, std::placeholders::_1, pose1, base2,
           pose2, boost::none, boost::none, boost::none, boost::none), base1);
   H2Expected = numericalDerivative11<Vector3, Pose2>(
-      boost::bind(&OdometryFactorBase::evaluateError, &factor, base1, _1, base2,
+      std::bind(&OdometryFactorBase::evaluateError, &factor, base1, std::placeholders::_1, base2,
           pose2, boost::none, boost::none, boost::none, boost::none), pose1);
   H3Expected = numericalDerivative11<Vector3, Pose2>(
-      boost::bind(&OdometryFactorBase::evaluateError, &factor, base1, pose1, _1,
+      std::bind(&OdometryFactorBase::evaluateError, &factor, base1, pose1, std::placeholders::_1,
           pose2, boost::none, boost::none, boost::none, boost::none), base2);
   H4Expected = numericalDerivative11<Vector3, Pose2>(
-      boost::bind(&OdometryFactorBase::evaluateError, &factor, base1, pose1,
-          base2, _1, boost::none, boost::none, boost::none, boost::none),
+      std::bind(&OdometryFactorBase::evaluateError, &factor, base1, pose1,
+          base2, std::placeholders::_1, boost::none, boost::none, boost::none, boost::none),
       pose2);
 
   // Verify the Jacobians are correct

--- a/gtsam_unstable/slam/tests/testTransformBtwRobotsUnaryFactor.cpp
+++ b/gtsam_unstable/slam/tests/testTransformBtwRobotsUnaryFactor.cpp
@@ -18,9 +18,7 @@
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/GaussNewtonOptimizer.h>
 
-#include <boost/bind/bind.hpp>
-
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -233,7 +231,7 @@ TEST( TransformBtwRobotsUnaryFactor, Jacobian)
   Matrix H1_actual = H_actual[0];
 
   double stepsize = 1.0e-9;
-  Matrix H1_expected = gtsam::numericalDerivative11<Vector, Pose2>(boost::bind(&predictionError, _1,  key, g), orgA_T_orgB, stepsize);
+  Matrix H1_expected = gtsam::numericalDerivative11<Vector, Pose2>(std::bind(&predictionError, std::placeholders::_1,  key, g), orgA_T_orgB, stepsize);
 //  CHECK( assert_equal(H1_expected, H1_actual, 1e-5));
 }
 
@@ -287,12 +285,12 @@ TEST( TransformBtwRobotsUnaryFactor, Jacobian)
 ////  CHECK( assert_equal(H2_actual_stnd, H2_actual, 1e-8));
 //
 //  double stepsize = 1.0e-9;
-//  Matrix H1_expected = gtsam::numericalDerivative11<Vector, Pose2>(boost::bind(&predictionError, _1, p2, keyA, keyB, f), p1, stepsize);
-//  Matrix H2_expected = gtsam::numericalDerivative11<Vector, Pose2>(boost::bind(&predictionError, p1, _1, keyA, keyB, f), p2, stepsize);
+//  Matrix H1_expected = gtsam::numericalDerivative11<Vector, Pose2>(std::bind(&predictionError, std::placeholders::_1, p2, keyA, keyB, f), p1, stepsize);
+//  Matrix H2_expected = gtsam::numericalDerivative11<Vector, Pose2>(std::bind(&predictionError, p1, std::placeholders::_1, keyA, keyB, f), p2, stepsize);
 //
 //
 //  // try to check numerical derivatives of a standard between factor
-//  Matrix H1_expected_stnd = gtsam::numericalDerivative11<Vector, Pose2>(boost::bind(&predictionError_standard, _1, p2, keyA, keyB, h), p1, stepsize);
+//  Matrix H1_expected_stnd = gtsam::numericalDerivative11<Vector, Pose2>(std::bind(&predictionError_standard, std::placeholders::_1, p2, keyA, keyB, h), p1, stepsize);
 //  CHECK( assert_equal(H1_expected_stnd, H1_actual_stnd, 1e-5));
 //
 //

--- a/gtsam_unstable/slam/tests/testTransformBtwRobotsUnaryFactorEM.cpp
+++ b/gtsam_unstable/slam/tests/testTransformBtwRobotsUnaryFactorEM.cpp
@@ -18,9 +18,7 @@
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/GaussNewtonOptimizer.h>
 
-#include <boost/bind/bind.hpp>
-
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -262,8 +260,10 @@ TEST( TransformBtwRobotsUnaryFactorEM, Jacobian)
   Matrix H1_actual = H_actual[0];
 
   double stepsize = 1.0e-9;
-  Matrix H1_expected = gtsam::numericalDerivative11<Vector, Pose2>(boost::bind(&predictionError, _1,  key, g), orgA_T_orgB, stepsize);
-//  CHECK( assert_equal(H1_expected, H1_actual, 1e-5));
+  Matrix H1_expected = gtsam::numericalDerivative11<Vector, Pose2>(
+      std::bind(&predictionError, std::placeholders::_1, key, g), orgA_T_orgB,
+      stepsize);
+  //  CHECK( assert_equal(H1_expected, H1_actual, 1e-5));
 }
 /////* ************************************************************************** */
 //TEST (TransformBtwRobotsUnaryFactorEM, jacobian ) {
@@ -312,12 +312,12 @@ TEST( TransformBtwRobotsUnaryFactorEM, Jacobian)
 ////  CHECK( assert_equal(H2_actual_stnd, H2_actual, 1e-8));
 //
 //  double stepsize = 1.0e-9;
-//  Matrix H1_expected = gtsam::numericalDerivative11<Vector, Pose2>(boost::bind(&predictionError, _1, p2, keyA, keyB, f), p1, stepsize);
-//  Matrix H2_expected = gtsam::numericalDerivative11<Vector, Pose2>(boost::bind(&predictionError, p1, _1, keyA, keyB, f), p2, stepsize);
+//  Matrix H1_expected = gtsam::numericalDerivative11<Vector, Pose2>(std::bind(&predictionError, std::placeholders::_1, p2, keyA, keyB, f), p1, stepsize);
+//  Matrix H2_expected = gtsam::numericalDerivative11<Vector, Pose2>(std::bind(&predictionError, p1, std::placeholders::_1, keyA, keyB, f), p2, stepsize);
 //
 //
 //  // try to check numerical derivatives of a standard between factor
-//  Matrix H1_expected_stnd = gtsam::numericalDerivative11<Vector, Pose2>(boost::bind(&predictionError_standard, _1, p2, keyA, keyB, h), p1, stepsize);
+//  Matrix H1_expected_stnd = gtsam::numericalDerivative11<Vector, Pose2>(std::bind(&predictionError_standard, std::placeholders::_1, p2, keyA, keyB, h), p1, stepsize);
 //  CHECK( assert_equal(H1_expected_stnd, H1_actual_stnd, 1e-5));
 //
 //

--- a/tests/testExpressionFactor.cpp
+++ b/tests/testExpressionFactor.cpp
@@ -17,22 +17,19 @@
  * @brief unit tests for Block Automatic Differentiation
  */
 
-#include <gtsam/slam/expressions.h>
-#include <gtsam/slam/GeneralSFMFactor.h>
-#include <gtsam/slam/ProjectionFactor.h>
-#include <gtsam/nonlinear/PriorFactor.h>
-#include <gtsam/nonlinear/expressionTesting.h>
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/Testable.h>
 #include <gtsam/nonlinear/ExpressionFactor.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <gtsam/nonlinear/PriorFactor.h>
 #include <gtsam/nonlinear/expressionTesting.h>
-#include <gtsam/base/Testable.h>
-
-#include <CppUnitLite/TestHarness.h>
+#include <gtsam/slam/GeneralSFMFactor.h>
+#include <gtsam/slam/ProjectionFactor.h>
+#include <gtsam/slam/expressions.h>
 
 #include <boost/assign/list_of.hpp>
 using boost::assign::list_of;
-#include <boost/bind/bind.hpp>
-using namespace boost::placeholders;
+using namespace std::placeholders;
 
 using namespace std;
 using namespace gtsam;
@@ -621,9 +618,10 @@ TEST(ExpressionFactor, MultiplyWithInverseFunction) {
   Matrix3 A;
   const Vector Ab = f(a, b, H1, A);
   CHECK(assert_equal(A * b, Ab));
-  CHECK(assert_equal(numericalDerivative11<Vector3, Point2>(
-                         boost::bind(f, _1, b, boost::none, boost::none), a),
-                     H1));
+  CHECK(assert_equal(
+      numericalDerivative11<Vector3, Point2>(
+          std::bind(f, std::placeholders::_1, b, boost::none, boost::none), a),
+      H1));
 
   Values values;
   values.insert<Point2>(0, a);

--- a/tests/testSimulated3D.cpp
+++ b/tests/testSimulated3D.cpp
@@ -26,7 +26,7 @@
 
 #include <iostream>
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 using namespace gtsam;
 
 // Convenience for named keys
@@ -46,7 +46,7 @@ TEST( simulated3D, Values )
 TEST( simulated3D, Dprior )
 {
   Point3 x(1,-9, 7);
-  Matrix numerical = numericalDerivative11<Point3, Point3>(boost::bind(simulated3D::prior, _1, boost::none),x);
+  Matrix numerical = numericalDerivative11<Point3, Point3>(std::bind(simulated3D::prior, std::placeholders::_1, boost::none),x);
   Matrix computed;
   simulated3D::prior(x,computed);
   EXPECT(assert_equal(numerical,computed,1e-9));
@@ -55,13 +55,19 @@ TEST( simulated3D, Dprior )
 /* ************************************************************************* */
 TEST( simulated3D, DOdo )
 {
-  Point3 x1(1,-9,7),x2(-5,6,7);
-  Matrix H1,H2;
-  simulated3D::odo(x1,x2,H1,H2);
-  Matrix A1 = numericalDerivative21<Point3, Point3, Point3>(boost::bind(simulated3D::odo, _1, _2, boost::none, boost::none),x1,x2);
-  EXPECT(assert_equal(A1,H1,1e-9));
-  Matrix A2 = numericalDerivative22<Point3, Point3, Point3>(boost::bind(simulated3D::odo, _1, _2, boost::none, boost::none),x1,x2);
-  EXPECT(assert_equal(A2,H2,1e-9));
+  Point3 x1(1, -9, 7), x2(-5, 6, 7);
+  Matrix H1, H2;
+  simulated3D::odo(x1, x2, H1, H2);
+  Matrix A1 = numericalDerivative21<Point3, Point3, Point3>(
+      std::bind(simulated3D::odo, std::placeholders::_1, std::placeholders::_2,
+                boost::none, boost::none),
+      x1, x2);
+  EXPECT(assert_equal(A1, H1, 1e-9));
+  Matrix A2 = numericalDerivative22<Point3, Point3, Point3>(
+      std::bind(simulated3D::odo, std::placeholders::_1, std::placeholders::_2,
+                boost::none, boost::none),
+      x1, x2);
+  EXPECT(assert_equal(A2, H2, 1e-9));
 }
 
 


### PR DESCRIPTION
Fixes #812

1. Use `std::placeholders` instead of `boost::placeholders`.
2. Use `std::bind` instead of `boost::bind`.
3. Use `std::function` instead of `boost::function`.

Had to make edits to functionals in some places (used lambdas instead) to get things to work. Also the tests can't seem to disambiguate the placeholder variables (guess this is because some other boost library is importing `boost/bind` internally), so I just made them have the full namespace.

@ToniRV FYI