### PR TITLE
ShonanAveraging Covariance fixes

### DIFF
--- a/gtsam/sfm/ShonanAveraging.cpp
+++ b/gtsam/sfm/ShonanAveraging.cpp
@@ -955,7 +955,7 @@ static BinaryMeasurement<Rot2> convertPose2ToBinaryMeasurementRot2(
         "parseMeasurements<Rot2> can only convert Pose2 measurements "
         "with Gaussian noise models.");
   const Matrix3 M = gaussian->covariance();
-  auto model = noiseModel::Gaussian::Covariance(M.block<1, 1>(2, 2));
+  auto model = noiseModel::Isotropic::Variance(1, M(2, 2));
   return BinaryMeasurement<Rot2>(f->key1(), f->key2(), f->measured().rotation(),
                                  model);
 }
@@ -1001,7 +1001,7 @@ static BinaryMeasurement<Rot3> convert(
         "parseMeasurements<Rot3> can only convert Pose3 measurements "
         "with Gaussian noise models.");
   const Matrix6 M = gaussian->covariance();
-  auto model = noiseModel::Gaussian::Covariance(M.block<3, 3>(3, 3));
+  auto model = noiseModel::Gaussian::Covariance(M.block<3, 3>(0, 0));
   return BinaryMeasurement<Rot3>(f->key1(), f->key2(), f->measured().rotation(),
                                  model);
 }

--- a/gtsam/sfm/ShonanAveraging.cpp
+++ b/gtsam/sfm/ShonanAveraging.cpp
@@ -955,6 +955,8 @@ static BinaryMeasurement<Rot2> convertPose2ToBinaryMeasurementRot2(
         "parseMeasurements<Rot2> can only convert Pose2 measurements "
         "with Gaussian noise models.");
   const Matrix3 M = gaussian->covariance();
+  // the (2,2) entry of Pose2's covariance corresponds to Rot2's covariance
+  // because the tangent space of Pose2 is ordered as (vx, vy, w)
   auto model = noiseModel::Isotropic::Variance(1, M(2, 2));
   return BinaryMeasurement<Rot2>(f->key1(), f->key2(), f->measured().rotation(),
                                  model);
@@ -1001,6 +1003,8 @@ static BinaryMeasurement<Rot3> convert(
         "parseMeasurements<Rot3> can only convert Pose3 measurements "
         "with Gaussian noise models.");
   const Matrix6 M = gaussian->covariance();
+  // the upper-left 3x3 sub-block of Pose3's covariance corresponds to Rot3's covariance
+  // because the tangent space of Pose3 is ordered as (w,T) where w and T are both Vector3's
   auto model = noiseModel::Gaussian::Covariance(M.block<3, 3>(0, 0));
   return BinaryMeasurement<Rot3>(f->key1(), f->key2(), f->measured().rotation(),
                                  model);


### PR DESCRIPTION
- use upper 3x3 sub-block of covariance matrix for converting BetweenFactor to BinaryMeasurement, instead of erroneous lower 3x3 sub-block, as the tangent space of SE(3) is ordered as (R,t)
- Use Isotropic in ShonanAveraging2, instead of taking a 1x1 subblock of a matrix

In GTSFM, we use the erroneous 3x3 lower-right sub-block, but it doesn't matter currently because we set each dimension to a unit Gaussian, as follows:
```python
        noise_model = gtsam.noiseModel.Unit.Create(6)

        between_factors = gtsam.BetweenFactorPose3s()

        for (i1, i2), i2Ri1 in i2Ri1_dict.items():
            if i2Ri1 is not None:
                # ignore translation during rotation averaging
                i2Ti1 = Pose3(i2Ri1, np.zeros(3))
                between_factors.append(BetweenFactorPose3(i2, i1, i2Ti1, noise_model))

        obj = ShonanAveraging3(between_factors, shonan_params)
```