### PR TITLE
Add getters to GenericProjectionFactor

### DIFF
--- a/gtsam/slam/ProjectionFactor.h
+++ b/gtsam/slam/ProjectionFactor.h
@@ -99,17 +99,6 @@ namespace gtsam {
     /** Virtual destructor */
     ~GenericProjectionFactor() override {}
 
-    /// @return the measured pixel coordinates
-    auto measured() const -> const Point2 & { return measured_; }
-
-    /// @return the camera calibration
-    auto K() const -> const boost::shared_ptr<CALIBRATION> & { return K_; }
-
-    /// @return the (optional) sensor pose with respect to the vehicle frame
-    auto body_P_sensor() const -> const boost::optional<POSE> & {
-      return body_P_sensor_;
-    }
-
     /// @return a deep copy of this factor
     gtsam::NonlinearFactor::shared_ptr clone() const override {
       return boost::static_pointer_cast<gtsam::NonlinearFactor>(
@@ -170,13 +159,18 @@ namespace gtsam {
     }
 
     /** return the measurement */
-    const Point2& measured() const {
+    auto measured() const -> const Point2& {
       return measured_;
     }
 
     /** return the calibration object */
-    inline const boost::shared_ptr<CALIBRATION> calibration() const {
+    auto calibration() const -> const boost::shared_ptr<CALIBRATION>& {
       return K_;
+    }
+
+    /** return the (optional) sensor pose with respect to the vehicle frame */
+    auto body_P_sensor() const -> const boost::optional<POSE>& {
+      return body_P_sensor_;
     }
 
     /** return verbosity */

--- a/gtsam/slam/ProjectionFactor.h
+++ b/gtsam/slam/ProjectionFactor.h
@@ -99,6 +99,17 @@ namespace gtsam {
     /** Virtual destructor */
     ~GenericProjectionFactor() override {}
 
+    /// @return the measured pixel coordinates
+    auto measured() const -> const Point2 & { return measured_; }
+
+    /// @return the camera calibration
+    auto K() const -> const boost::shared_ptr<CALIBRATION> & { return K_; }
+
+    /// @return the (optional) sensor pose with respect to the vehicle frame
+    auto body_P_sensor() const -> const boost::optional<POSE> & {
+      return body_P_sensor_;
+    }
+
     /// @return a deep copy of this factor
     gtsam::NonlinearFactor::shared_ptr clone() const override {
       return boost::static_pointer_cast<gtsam::NonlinearFactor>(


### PR DESCRIPTION
This trivial PR adds getters to GenericProjectionFactor so one can inspect the fixed variables after construction, e.g. while iterating over a FG.