### PR TITLE
Small clarification and md cleanup

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -51,13 +51,13 @@ The directory **vSLAMexample** includes 2 simple examples using GTSAM:
 
 See the separate README file there.
 
-##Undirected Graphical Models (UGM)
+## Undirected Graphical Models (UGM)
 The best representation for a Markov Random Field is a factor graph :-) This is illustrated with some discrete examples from the UGM MATLAB toolbox, which
 can be found at <http://www.di.ens.fr/~mschmidt/Software/UGM>
 
 
-##Building and Running
-To build, cd into the directory and do:
+## Building and Running
+To build, cd into the top-level gtsam directory and do:
 
 ```
 mkdir build


### PR DESCRIPTION
1. Added the small "top-level gtsam directory" clarification because for a few minutes I thought it was saying to do this build process inside of the `examples` directory, which didn't work.
2. Cleaned up the ## because without the space between icon and text it does not make a heading as intended. What the README looks like on `develop` at the moment:
 
![Screenshot from 2021-08-21 17-02-11](https://user-images.githubusercontent.com/3709527/130334769-7b0e8aa2-b209-4628-9cec-08f91716f666.png)
