### PR TITLE
make templates for smart projection factors uniform (all templated on cameras)

### DIFF
--- a/gtsam/base/Lie.h
+++ b/gtsam/base/Lie.h
@@ -17,6 +17,7 @@
  * @author Frank Dellaert
  * @author Mike Bosse
  * @author Duy Nguyen Ta
+ * @author Yotam Stern
  */
 
 
@@ -319,11 +320,27 @@ T expm(const Vector& x, int K=7) {
 }
 
 /**
- * Linear interpolation between X and Y by coefficient t in [0, 1].
+ * Linear interpolation between X and Y by coefficient t (typically t \in [0,1],
+ * but can also be used to extrapolate before pose X or after pose Y), with optional jacobians.
  */
 template <typename T>
-T interpolate(const T& X, const T& Y, double t) {
-  assert(t >= 0 && t <= 1);
+T interpolate(const T& X, const T& Y, double t,
+              typename MakeOptionalJacobian<T, T>::type Hx = boost::none,
+              typename MakeOptionalJacobian<T, T>::type Hy = boost::none) {
+
+  if (Hx || Hy) {
+    typename traits<T>::TangentVector log_Xinv_Y;
+    typename MakeJacobian<T, T>::type between_H_x, log_H, exp_H, compose_H_x;
+
+    T Xinv_Y = traits<T>::Between(X, Y, between_H_x); // between_H_y = identity
+    log_Xinv_Y = traits<T>::Logmap(Xinv_Y, log_H);
+    Xinv_Y = traits<T>::Expmap(t * log_Xinv_Y, exp_H);
+    Xinv_Y = traits<T>::Compose(X, Xinv_Y, compose_H_x); // compose_H_xinv_y = identity
+
+    if(Hx) *Hx = compose_H_x + t * exp_H * log_H * between_H_x;
+    if(Hy) *Hy = t * exp_H * log_H;
+    return Xinv_Y;
+  }
   return traits<T>::Compose(X, traits<T>::Expmap(t * traits<T>::Logmap(traits<T>::Between(X, Y))));
 }
 

--- a/gtsam/geometry/CameraSet.h
+++ b/gtsam/geometry/CameraSet.h
@@ -294,6 +294,19 @@ public:
   }
 
   /**
+   * non-templated version of function above
+   */
+  static SymmetricBlockMatrix SchurComplementAndRearrangeBlocks_3_6_6(
+      const std::vector<Eigen::Matrix<double,ZDim, 6>,
+          Eigen::aligned_allocator<Eigen::Matrix<double,ZDim,6> > >& Fs,
+      const Matrix& E, const Eigen::Matrix<double,3,3>& P, const Vector& b,
+      const KeyVector jacobianKeys, const KeyVector hessianKeys) {
+    return SchurComplementAndRearrangeBlocks<3,6,6>(Fs, E, P, b,
+                                                       jacobianKeys,
+                                                       hessianKeys);
+  }
+
+  /**
    * Do Schur complement, given Jacobian as Fs,E,P, return SymmetricBlockMatrix
    * G = F' * F - F' * E * P * E' * F
    * g = F' * (b - E * P * E' * b)

--- a/gtsam/geometry/tests/testCameraSet.cpp
+++ b/gtsam/geometry/tests/testCameraSet.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <gtsam/geometry/CameraSet.h>
+#include <gtsam/geometry/Cal3_S2.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <CppUnitLite/TestHarness.h>
@@ -123,6 +124,90 @@ TEST(CameraSet, Pinhole) {
   EXPECT(assert_equal(F1, Fs[0]));
   EXPECT(assert_equal(F1, Fs[1]));
   EXPECT(assert_equal(actualE, E));
+}
+
+/* ************************************************************************* */
+TEST(CameraSet, SchurComplementAndRearrangeBlocks) {
+  typedef PinholePose<Cal3Bundler> Camera;
+  typedef CameraSet<Camera> Set;
+
+  // this is the (block) Jacobian with respect to the nonuniqueKeys
+  std::vector<Eigen::Matrix<double, 2, 12>,
+      Eigen::aligned_allocator<Eigen::Matrix<double, 2, 12> > > Fs;
+  Fs.push_back(1 * Matrix::Ones(2, 12));  // corresponding to key pair (0,1)
+  Fs.push_back(2 * Matrix::Ones(2, 12));  // corresponding to key pair (1,2)
+  Fs.push_back(3 * Matrix::Ones(2, 12));  // corresponding to key pair (2,0)
+  Matrix E = 4 * Matrix::Identity(6, 3) + Matrix::Ones(6, 3);
+  E(0, 0) = 3;
+  E(1, 1) = 2;
+  E(2, 2) = 5;
+  Matrix Et = E.transpose();
+  Matrix P = (Et * E).inverse();
+  Vector b = 5 * Vector::Ones(6);
+
+  {  // SchurComplement
+     // Actual
+    SymmetricBlockMatrix augmentedHessianBM = Set::SchurComplement<3, 12>(Fs, E,
+                                                                          P, b);
+    Matrix actualAugmentedHessian = augmentedHessianBM.selfadjointView();
+
+    // Expected
+    Matrix F = Matrix::Zero(6, 3 * 12);
+    F.block<2, 12>(0, 0) = 1 * Matrix::Ones(2, 12);
+    F.block<2, 12>(2, 12) = 2 * Matrix::Ones(2, 12);
+    F.block<2, 12>(4, 24) = 3 * Matrix::Ones(2, 12);
+
+    Matrix Ft = F.transpose();
+    Matrix H = Ft * F - Ft * E * P * Et * F;
+    Vector v = Ft * (b - E * P * Et * b);
+    Matrix expectedAugmentedHessian = Matrix::Zero(3 * 12 + 1, 3 * 12 + 1);
+    expectedAugmentedHessian.block<36, 36>(0, 0) = H;
+    expectedAugmentedHessian.block<36, 1>(0, 36) = v;
+    expectedAugmentedHessian.block<1, 36>(36, 0) = v.transpose();
+    expectedAugmentedHessian(36, 36) = b.squaredNorm();
+
+    EXPECT(assert_equal(expectedAugmentedHessian, actualAugmentedHessian));
+  }
+
+  {  // SchurComplementAndRearrangeBlocks
+    KeyVector nonuniqueKeys;
+    nonuniqueKeys.push_back(0);
+    nonuniqueKeys.push_back(1);
+    nonuniqueKeys.push_back(1);
+    nonuniqueKeys.push_back(2);
+    nonuniqueKeys.push_back(2);
+    nonuniqueKeys.push_back(0);
+
+    KeyVector uniqueKeys;
+    uniqueKeys.push_back(0);
+    uniqueKeys.push_back(1);
+    uniqueKeys.push_back(2);
+
+    // Actual
+    SymmetricBlockMatrix augmentedHessianBM =
+        Set::SchurComplementAndRearrangeBlocks_3_12_6(Fs, E, P, b,
+                                                         nonuniqueKeys,
+                                                         uniqueKeys);
+    Matrix actualAugmentedHessian = augmentedHessianBM.selfadjointView();
+
+    // Expected
+    // we first need to build the Jacobian F according to unique keys
+    Matrix F = Matrix::Zero(6, 18);
+    F.block<2, 6>(0, 0) = Fs[0].block<2, 6>(0, 0);
+    F.block<2, 6>(0, 6) = Fs[0].block<2, 6>(0, 6);
+    F.block<2, 6>(2, 6) = Fs[1].block<2, 6>(0, 0);
+    F.block<2, 6>(2, 12) = Fs[1].block<2, 6>(0, 6);
+    F.block<2, 6>(4, 12) = Fs[2].block<2, 6>(0, 0);
+    F.block<2, 6>(4, 0) = Fs[2].block<2, 6>(0, 6);
+
+    Matrix Ft = F.transpose();
+    Vector v = Ft * (b - E * P * Et * b);
+    Matrix H = Ft * F - Ft * E * P * Et * F;
+    Matrix expectedAugmentedHessian(19, 19);
+    expectedAugmentedHessian << H, v, v.transpose(), b.squaredNorm();
+
+    EXPECT(assert_equal(expectedAugmentedHessian, actualAugmentedHessian));
+  }
 }
 
 /* ************************************************************************* */

--- a/gtsam/geometry/tests/testPose3.cpp
+++ b/gtsam/geometry/tests/testPose3.cpp
@@ -1047,6 +1047,68 @@ TEST(Pose3, interpolate) {
 }
 
 /* ************************************************************************* */
+Pose3 testing_interpolate(const Pose3& t1, const Pose3& t2, double gamma) { return interpolate(t1,t2,gamma); }
+
+TEST(Pose3, interpolateJacobians) {
+  {
+    Pose3 X = Pose3::identity();
+    Pose3 Y(Rot3::Rz(M_PI_2), Point3(1, 0, 0));
+    double t = 0.5;
+    Pose3 expectedPoseInterp(Rot3::Rz(M_PI_4), Point3(0.5, -0.207107, 0)); // note: different from test above: this is full Pose3 interpolation
+    Matrix actualJacobianX, actualJacobianY;
+    EXPECT(assert_equal(expectedPoseInterp, interpolate(X, Y, t, actualJacobianX, actualJacobianY), 1e-5));
+
+    Matrix expectedJacobianX = numericalDerivative31<Pose3,Pose3,Pose3,double>(testing_interpolate, X, Y, t);
+    EXPECT(assert_equal(expectedJacobianX,actualJacobianX,1e-6));
+
+    Matrix expectedJacobianY = numericalDerivative32<Pose3,Pose3,Pose3,double>(testing_interpolate, X, Y, t);
+    EXPECT(assert_equal(expectedJacobianY,actualJacobianY,1e-6));
+  }
+  {
+    Pose3 X = Pose3::identity();
+    Pose3 Y(Rot3::identity(), Point3(1, 0, 0));
+    double t = 0.3;
+    Pose3 expectedPoseInterp(Rot3::identity(), Point3(0.3, 0, 0));
+    Matrix actualJacobianX, actualJacobianY;
+    EXPECT(assert_equal(expectedPoseInterp, interpolate(X, Y, t, actualJacobianX, actualJacobianY), 1e-5));
+
+    Matrix expectedJacobianX = numericalDerivative31<Pose3,Pose3,Pose3,double>(testing_interpolate, X, Y, t);
+    EXPECT(assert_equal(expectedJacobianX,actualJacobianX,1e-6));
+
+    Matrix expectedJacobianY = numericalDerivative32<Pose3,Pose3,Pose3,double>(testing_interpolate, X, Y, t);
+    EXPECT(assert_equal(expectedJacobianY,actualJacobianY,1e-6));
+  }
+  {
+    Pose3 X = Pose3::identity();
+    Pose3 Y(Rot3::Rz(M_PI_2), Point3(0, 0, 0));
+    double t = 0.5;
+    Pose3 expectedPoseInterp(Rot3::Rz(M_PI_4), Point3(0, 0, 0));
+    Matrix actualJacobianX, actualJacobianY;
+    EXPECT(assert_equal(expectedPoseInterp, interpolate(X, Y, t, actualJacobianX, actualJacobianY), 1e-5));
+
+    Matrix expectedJacobianX = numericalDerivative31<Pose3,Pose3,Pose3,double>(testing_interpolate, X, Y, t);
+    EXPECT(assert_equal(expectedJacobianX,actualJacobianX,1e-6));
+
+    Matrix expectedJacobianY = numericalDerivative32<Pose3,Pose3,Pose3,double>(testing_interpolate, X, Y, t);
+    EXPECT(assert_equal(expectedJacobianY,actualJacobianY,1e-6));
+  }
+  {
+    Pose3 X(Rot3::Ypr(0.1,0.2,0.3), Point3(10, 5, -2));
+    Pose3 Y(Rot3::Ypr(1.1,-2.2,-0.3), Point3(-5, 1, 1));
+    double t = 0.3;
+    Pose3 expectedPoseInterp(Rot3::Rz(M_PI_4), Point3(0, 0, 0));
+    Matrix actualJacobianX, actualJacobianY;
+    interpolate(X, Y, t, actualJacobianX, actualJacobianY);
+
+    Matrix expectedJacobianX = numericalDerivative31<Pose3,Pose3,Pose3,double>(testing_interpolate, X, Y, t);
+    EXPECT(assert_equal(expectedJacobianX,actualJacobianX,1e-6));
+
+    Matrix expectedJacobianY = numericalDerivative32<Pose3,Pose3,Pose3,double>(testing_interpolate, X, Y, t);
+    EXPECT(assert_equal(expectedJacobianY,actualJacobianY,1e-6));
+  }
+}
+
+/* ************************************************************************* */
 TEST(Pose3, Create) {
   Matrix63 actualH1, actualH2;
   Pose3 actual = Pose3::Create(R, P2, actualH1, actualH2);

--- a/gtsam/slam/SmartFactorBase.h
+++ b/gtsam/slam/SmartFactorBase.h
@@ -178,7 +178,7 @@ protected:
       DefaultKeyFormatter) const override {
     std::cout << s << "SmartFactorBase, z = \n";
     for (size_t k = 0; k < measured_.size(); ++k) {
-      std::cout << "measurement, p = " << measured_[k] << "\t";
+      std::cout << "measurement " << k<<", px = \n" << measured_[k] << "\n";
       noiseModel_->print("noise model = ");
     }
     if(body_P_sensor_)

--- a/gtsam/slam/SmartFactorBase.h
+++ b/gtsam/slam/SmartFactorBase.h
@@ -393,7 +393,6 @@ protected:
       F.block<ZDim, Dim>(ZDim * i, Dim * i) = Fs.at(i);
   }
 
-
   Pose3 body_P_sensor() const{
     if(body_P_sensor_)
       return *body_P_sensor_;

--- a/gtsam/slam/SmartProjectionFactor.h
+++ b/gtsam/slam/SmartProjectionFactor.h
@@ -101,7 +101,7 @@ public:
   void print(const std::string& s = "", const KeyFormatter& keyFormatter =
       DefaultKeyFormatter) const override {
     std::cout << s << "SmartProjectionFactor\n";
-    std::cout << "linearizationMode:\n" << params_.linearizationMode
+    std::cout << "linearizationMode: " << params_.linearizationMode
         << std::endl;
     std::cout << "triangulationParameters:\n" << params_.triangulation
         << std::endl;

--- a/gtsam/slam/SmartProjectionFactorP.h
+++ b/gtsam/slam/SmartProjectionFactorP.h
@@ -90,6 +90,9 @@ class SmartProjectionFactorP : public SmartProjectionFactor<CAMERA> {
                          const SmartProjectionParams& params =
                              SmartProjectionParams())
       : Base(sharedNoiseModel, params) {
+    // use only configuration that works with this factor
+    Base::params_.degeneracyMode = gtsam::ZERO_ON_DEGENERACY;
+    Base::params_.linearizationMode = gtsam::HESSIAN;
   }
 
   /** Virtual destructor */

--- a/gtsam/slam/SmartProjectionFactorP.h
+++ b/gtsam/slam/SmartProjectionFactorP.h
@@ -1,0 +1,216 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file   SmartProjectionFactorP.h
+ * @brief  Smart factor on poses, assuming camera calibration is fixed.
+ *         Same as SmartProjectionPoseFactor, except:
+ *         - it is templated on CAMERA (i.e., it allows cameras beyond pinhole)
+ *         - it admits a different calibration for each measurement (i.e., it can model a multi-camera system)
+ * @author Luca Carlone
+ * @author Chris Beall
+ * @author Zsolt Kira
+ */
+
+#pragma once
+
+#include <gtsam/slam/SmartProjectionFactor.h>
+
+namespace gtsam {
+/**
+ *
+ * @addtogroup SLAM
+ *
+ * If you are using the factor, please cite:
+ * L. Carlone, Z. Kira, C. Beall, V. Indelman, F. Dellaert, Eliminating conditionally
+ * independent sets in factor graphs: a unifying perspective based on smart factors,
+ * Int. Conf. on Robotics and Automation (ICRA), 2014.
+ *
+ */
+
+/**
+ * This factor assumes that camera calibration is fixed (but each camera
+ * measurement can have a different extrinsic and intrinsic calibration).
+ * The factor only constrains poses (variable dimension is 6).
+ * This factor requires that values contains the involved poses (Pose3).
+ * If all measurements share the same calibration (i.e., are from the same camera), use SmartProjectionPoseFactor instead!
+ * If the calibration should be optimized, as well, use SmartProjectionFactor instead!
+ * @addtogroup SLAM
+ */
+template<class CAMERA>
+class SmartProjectionFactorP: public SmartProjectionFactor<CAMERA> {
+
+private:
+  typedef SmartProjectionFactor<CAMERA> Base;
+  typedef SmartProjectionFactorP<CAMERA> This;
+  typedef CAMERA Camera;
+  typedef typename CAMERA::CalibrationType CALIBRATION;
+
+protected:
+
+  /// shared pointer to calibration object (one for each observation)
+  std::vector<boost::shared_ptr<CALIBRATION> > K_all_;
+
+  /// Pose of the camera in the body frame (one for each observation)
+  std::vector<Pose3> body_P_sensors_;
+
+public:
+
+  /// shorthand for a smart pointer to a factor
+  typedef boost::shared_ptr<This> shared_ptr;
+
+  /// Default constructor, only for serialization
+  SmartProjectionFactorP() {}
+
+  /**
+   * Constructor
+   * @param sharedNoiseModel isotropic noise model for the 2D feature measurements
+   * @param params parameters for the smart projection factors
+   */
+  SmartProjectionFactorP(
+      const SharedNoiseModel& sharedNoiseModel,
+      const SmartProjectionParams& params = SmartProjectionParams())
+      : Base(sharedNoiseModel, params) {
+  }
+
+  /** Virtual destructor */
+  ~SmartProjectionFactorP() override {
+  }
+
+  /**
+   * add a new measurement, corresponding to an observation from pose "poseKey" whose camera
+   * has intrinsic calibration K and extrinsic calibration body_P_sensor.
+   * @param measured 2-dimensional location of the projection of a
+   * single landmark in a single view (the measurement)
+   * @param poseKey key corresponding to the body pose of the camera taking the measurement
+   * @param K (fixed) camera intrinsic calibration
+   * @param body_P_sensor (fixed) camera extrinsic calibration
+   */
+  void add(const Point2& measured, const Key& poseKey,
+           const boost::shared_ptr<CALIBRATION>& K, const Pose3 body_P_sensor = Pose3::identity()) {
+    // store measurement and key
+    this->measured_.push_back(measured);
+    this->keys_.push_back(key);
+    // store fixed intrinsic calibration
+    K_all_.push_back(K);
+    // store fixed extrinsics of the camera
+    body_P_sensors_.push_back(body_P_sensor);
+  }
+
+  /**
+   * Variant of the previous "add" function in which we include multiple measurements
+   * @param measurements vector of the 2m dimensional location of the projection
+   * of a single landmark in the m views (the measurements)
+   * @param poseKeys keys corresponding to the body poses of the cameras taking the measurements
+   * @param Ks vector of (fixed) intrinsic calibration objects
+   * @param body_P_sensors vector of (fixed) extrinsic calibration objects
+   */
+  void add(const Point2Vector& measurements,
+           const std::vector<Key>& poseKeys,
+           const std::vector<boost::shared_ptr<CALIBRATION>>& Ks,
+           const std::vector<Pose3> body_P_sensors) {
+    assert(poseKeys.size() == measurements.size());
+    assert(poseKeys.size() == Ks.size());
+    assert(poseKeys.size() == body_P_sensors.size());
+    for (size_t i = 0; i < measurements.size(); i++) {
+      add(measurements[i], poseKeys[i], Ks[i], body_P_sensors[i]);
+    }
+  }
+
+  /// return the calibration object
+  inline std::vector<boost::shared_ptr<CALIBRATION>> calibration() const {
+    return K_all_;
+  }
+
+  /// return the extrinsic camera calibration body_P_sensors
+  const std::vector<Pose3> body_P_sensors() const {
+    return body_P_sensors_;
+  }
+
+  /**
+   * print
+   * @param s optional string naming the factor
+   * @param keyFormatter optional formatter useful for printing Symbols
+   */
+  void print(const std::string& s = "", const KeyFormatter& keyFormatter =
+      DefaultKeyFormatter) const override {
+    std::cout << s << "SmartProjectionFactorP: \n ";
+    for (size_t i = 0; i < K_all_.size(); i++) {
+      std::cout << "-- Measurement nr " << i << std::endl;
+      body_P_sensors_[i].print("extrinsic calibration:\n");
+      K_all_[i]->print("intrinsic calibration = ");
+    }
+    Base::print("", keyFormatter);
+  }
+
+  /// equals
+  bool equals(const NonlinearFactor& p, double tol = 1e-9) const override {
+    const This *e = dynamic_cast<const This*>(&p);
+    double extrinsicCalibrationEqual = true;
+    if(this->body_P_sensors_.size() == e->body_P_sensors().size()){
+      for(size_t i=0; i< this->body_P_sensors_.size(); i++){
+        if (!body_P_sensors_[i].equals(e->body_P_sensors()[i])){
+          extrinsicCalibrationEqual = false; break;
+        }
+      }
+    }else{ extrinsicCalibrationEqual = false; }
+
+    return e && Base::equals(p, tol) && K_all_ == e->calibration()
+        && extrinsicCalibrationEqual;
+  }
+
+  /**
+   * error calculates the error of the factor.
+   */
+  double error(const Values& values) const override {
+    if (this->active(values)) {
+      return this->totalReprojectionError(cameras(values));
+    } else { // else of active flag
+      return 0.0;
+    }
+  }
+
+  /**
+   * Collect all cameras involved in this factor
+   * @param values Values structure which must contain camera poses corresponding
+   * to keys involved in this factor
+   * @return vector of cameras
+   */
+  typename Base::Cameras cameras(const Values& values) const override {
+    typename Base::Cameras cameras;
+    for (const Key& k : this->keys_) {
+      const Pose3& body_P_cam = body_P_sensors_[i];
+      const Pose3 world_P_sensor_k = values.at<Pose3>(k) * body_P_cam;
+      cameras.emplace_back(world_P_sensor_k, K_all_[i]);
+    }
+    return cameras;
+  }
+
+ private:
+
+  /// Serialization function
+  friend class boost::serialization::access;
+  template<class ARCHIVE>
+  void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
+    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
+    ar & BOOST_SERIALIZATION_NVP(K_);
+  }
+
+};
+// end of class declaration
+
+/// traits
+template<class CAMERA>
+struct traits<SmartProjectionFactorP<CAMERA> > : public Testable<
+    SmartProjectionFactorP<CAMERA> > {
+};
+
+} // \ namespace gtsam

--- a/gtsam/slam/SmartProjectionFactorP.h
+++ b/gtsam/slam/SmartProjectionFactorP.h
@@ -340,6 +340,7 @@ class SmartProjectionFactorP : public SmartProjectionFactor<CAMERA> {
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
     ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     ar & BOOST_SERIALIZATION_NVP(K_all_);
+    ar & BOOST_SERIALIZATION_NVP(nonUniqueKeys_);
     ar & BOOST_SERIALIZATION_NVP(body_P_sensors_);
   }
 

--- a/gtsam/slam/SmartProjectionFactorP.h
+++ b/gtsam/slam/SmartProjectionFactorP.h
@@ -98,7 +98,7 @@ public:
            const boost::shared_ptr<CALIBRATION>& K, const Pose3 body_P_sensor = Pose3::identity()) {
     // store measurement and key
     this->measured_.push_back(measured);
-    this->keys_.push_back(key);
+    this->keys_.push_back(poseKey);
     // store fixed intrinsic calibration
     K_all_.push_back(K);
     // store fixed extrinsics of the camera
@@ -186,9 +186,9 @@ public:
    */
   typename Base::Cameras cameras(const Values& values) const override {
     typename Base::Cameras cameras;
-    for (const Key& k : this->keys_) {
+    for (const Key& i : this->keys_) {
       const Pose3& body_P_cam = body_P_sensors_[i];
-      const Pose3 world_P_sensor_k = values.at<Pose3>(k) * body_P_cam;
+      const Pose3 world_P_sensor_k = values.at<Pose3>(i) * body_P_cam;
       cameras.emplace_back(world_P_sensor_k, K_all_[i]);
     }
     return cameras;
@@ -201,7 +201,8 @@ public:
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
     ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
-    ar & BOOST_SERIALIZATION_NVP(K_);
+    ar & BOOST_SERIALIZATION_NVP(K_all_);
+    ar & BOOST_SERIALIZATION_NVP(body_P_sensors_);
   }
 
 };

--- a/gtsam/slam/SmartProjectionFactorP.h
+++ b/gtsam/slam/SmartProjectionFactorP.h
@@ -51,7 +51,6 @@ class SmartProjectionFactorP : public SmartProjectionFactor<CAMERA> {
  private:
   typedef SmartProjectionFactor<CAMERA> Base;
   typedef SmartProjectionFactorP<CAMERA> This;
-  typedef CAMERA Camera;
   typedef typename CAMERA::CalibrationType CALIBRATION;
 
  protected:
@@ -63,6 +62,8 @@ class SmartProjectionFactorP : public SmartProjectionFactor<CAMERA> {
   std::vector<Pose3> body_P_sensors_;
 
  public:
+  typedef CAMERA Camera;
+  typedef CameraSet<CAMERA> Cameras;
 
   /// shorthand for a smart pointer to a factor
   typedef boost::shared_ptr<This> shared_ptr;

--- a/gtsam/slam/SmartProjectionFactorP.h
+++ b/gtsam/slam/SmartProjectionFactorP.h
@@ -186,10 +186,11 @@ public:
    */
   typename Base::Cameras cameras(const Values& values) const override {
     typename Base::Cameras cameras;
-    for (const Key& i : this->keys_) {
-      const Pose3& body_P_cam = body_P_sensors_[i];
-      const Pose3 world_P_sensor_k = values.at<Pose3>(i) * body_P_cam;
-      cameras.emplace_back(world_P_sensor_k, K_all_[i]);
+    for (size_t i = 0; i < this->keys_.size(); i++) {
+      const Pose3& body_P_cam_i = body_P_sensors_[i];
+      const Pose3 world_P_sensor_i = values.at<Pose3>(this->keys_[i])
+          * body_P_cam_i;
+      cameras.emplace_back(world_P_sensor_i, K_all_[i]);
     }
     return cameras;
   }

--- a/gtsam/slam/SmartProjectionPoseFactor.h
+++ b/gtsam/slam/SmartProjectionPoseFactor.h
@@ -41,7 +41,7 @@ namespace gtsam {
  * If the calibration should be optimized, as well, use SmartProjectionFactor instead!
  * @addtogroup SLAM
  */
-template<class CALIBRATION>
+template<class CAMERA>
 class SmartProjectionPoseFactor: public SmartProjectionFactor<
     PinholePose<CALIBRATION> > {
 

--- a/gtsam/slam/SmartProjectionPoseFactor.h
+++ b/gtsam/slam/SmartProjectionPoseFactor.h
@@ -10,7 +10,7 @@
  * -------------------------------------------------------------------------- */
 
 /**
- * @file   SmartProjectionPoseFactor.h
+ * @file   SmartProjectionPoseFactorC.h
  * @brief  Smart factor on poses, assuming camera calibration is fixed
  * @author Luca Carlone
  * @author Chris Beall
@@ -42,13 +42,13 @@ namespace gtsam {
  * @addtogroup SLAM
  */
 template<class CAMERA>
-class SmartProjectionPoseFactor: public SmartProjectionFactor<
-    PinholePose<CALIBRATION> > {
+class SmartProjectionPoseFactorC: public SmartProjectionFactor<CAMERA> {
 
 private:
-  typedef PinholePose<CALIBRATION> Camera;
-  typedef SmartProjectionFactor<Camera> Base;
-  typedef SmartProjectionPoseFactor<CALIBRATION> This;
+  typedef SmartProjectionFactor<CAMERA> Base;
+  typedef SmartProjectionPoseFactorC<CAMERA> This;
+  typedef CAMERA Camera;
+  typedef typename CAMERA::CalibrationType CALIBRATION;
 
 protected:
 
@@ -62,7 +62,7 @@ public:
   /**
    * Default constructor, only for serialization
    */
-  SmartProjectionPoseFactor() {}
+  SmartProjectionPoseFactorC() {}
 
   /**
    * Constructor
@@ -70,7 +70,7 @@ public:
    * @param K (fixed) calibration, assumed to be the same for all cameras
    * @param params parameters for the smart projection factors
    */
-  SmartProjectionPoseFactor(
+  SmartProjectionPoseFactorC(
       const SharedNoiseModel& sharedNoiseModel,
       const boost::shared_ptr<CALIBRATION> K,
       const SmartProjectionParams& params = SmartProjectionParams())
@@ -84,17 +84,17 @@ public:
    * @param body_P_sensor pose of the camera in the body frame (optional)
    * @param params parameters for the smart projection factors
    */
-  SmartProjectionPoseFactor(
+  SmartProjectionPoseFactorC(
       const SharedNoiseModel& sharedNoiseModel,
       const boost::shared_ptr<CALIBRATION> K,
       const boost::optional<Pose3> body_P_sensor,
       const SmartProjectionParams& params = SmartProjectionParams())
-      : SmartProjectionPoseFactor(sharedNoiseModel, K, params) {
+      : SmartProjectionPoseFactorC(sharedNoiseModel, K, params) {
     this->body_P_sensor_ = body_P_sensor;
   }
 
   /** Virtual destructor */
-  ~SmartProjectionPoseFactor() override {
+  ~SmartProjectionPoseFactorC() override {
   }
 
   /**
@@ -104,7 +104,7 @@ public:
    */
   void print(const std::string& s = "", const KeyFormatter& keyFormatter =
       DefaultKeyFormatter) const override {
-    std::cout << s << "SmartProjectionPoseFactor, z = \n ";
+    std::cout << s << "SmartProjectionPoseFactorC, z = \n ";
     Base::print("", keyFormatter);
   }
 
@@ -161,9 +161,33 @@ public:
 // end of class declaration
 
 /// traits
-template<class CALIBRATION>
-struct traits<SmartProjectionPoseFactor<CALIBRATION> > : public Testable<
-    SmartProjectionPoseFactor<CALIBRATION> > {
+template<class CAMERA>
+struct traits<SmartProjectionPoseFactorC<CAMERA> > : public Testable<
+    SmartProjectionPoseFactorC<CAMERA> > {
 };
+
+// legacy smart factor class, only templated on calibration and assuming pinhole
+template <class CALIBRATION> using SmartProjectionPoseFactor = SmartProjectionPoseFactorC< PinholePose<CALIBRATION> >;
+
+//template <class CALIBRATION>
+//using SmartProjectionPoseFactor = SmartProjectionPoseFactorC< PinholePose<CALIBRATION> >;
+
+//template<class CALIBRATION>
+//struct SmartProjectionPoseFactor{
+//    typedef SmartProjectionPoseFactorC< PinholePose<CALIBRATION> >;
+//};
+
+//template<class CALIBRATION>
+//class SmartProjectionPoseFactor{
+//    typedef SmartProjectionPoseFactorC< PinholePose<CALIBRATION> >;
+//};
+
+//typedef typename CAMERA::CalibrationType CALIBRATION;
+//template<class CALIBRATION>
+//class SmartProjectionPoseFactor: public SmartProjectionPoseFactorC< <PinholePose<CALIBRATION> > {
+// public:
+// private:
+//};
+// end
 
 } // \ namespace gtsam

--- a/gtsam/slam/SmartProjectionPoseFactor.h
+++ b/gtsam/slam/SmartProjectionPoseFactor.h
@@ -10,7 +10,7 @@
  * -------------------------------------------------------------------------- */
 
 /**
- * @file   SmartProjectionPoseFactorC.h
+ * @file   SmartProjectionFactorP.h
  * @brief  Smart factor on poses, assuming camera calibration is fixed
  * @author Luca Carlone
  * @author Chris Beall
@@ -42,11 +42,11 @@ namespace gtsam {
  * @addtogroup SLAM
  */
 template<class CAMERA>
-class SmartProjectionPoseFactorC: public SmartProjectionFactor<CAMERA> {
+class SmartProjectionFactorP: public SmartProjectionFactor<CAMERA> {
 
 private:
   typedef SmartProjectionFactor<CAMERA> Base;
-  typedef SmartProjectionPoseFactorC<CAMERA> This;
+  typedef SmartProjectionFactorP<CAMERA> This;
   typedef CAMERA Camera;
   typedef typename CAMERA::CalibrationType CALIBRATION;
 
@@ -62,7 +62,7 @@ public:
   /**
    * Default constructor, only for serialization
    */
-  SmartProjectionPoseFactorC() {}
+  SmartProjectionFactorP() {}
 
   /**
    * Constructor
@@ -70,7 +70,7 @@ public:
    * @param K (fixed) calibration, assumed to be the same for all cameras
    * @param params parameters for the smart projection factors
    */
-  SmartProjectionPoseFactorC(
+  SmartProjectionFactorP(
       const SharedNoiseModel& sharedNoiseModel,
       const boost::shared_ptr<CALIBRATION> K,
       const SmartProjectionParams& params = SmartProjectionParams())
@@ -84,17 +84,17 @@ public:
    * @param body_P_sensor pose of the camera in the body frame (optional)
    * @param params parameters for the smart projection factors
    */
-  SmartProjectionPoseFactorC(
+  SmartProjectionFactorP(
       const SharedNoiseModel& sharedNoiseModel,
       const boost::shared_ptr<CALIBRATION> K,
       const boost::optional<Pose3> body_P_sensor,
       const SmartProjectionParams& params = SmartProjectionParams())
-      : SmartProjectionPoseFactorC(sharedNoiseModel, K, params) {
+      : SmartProjectionFactorP(sharedNoiseModel, K, params) {
     this->body_P_sensor_ = body_P_sensor;
   }
 
   /** Virtual destructor */
-  ~SmartProjectionPoseFactorC() override {
+  ~SmartProjectionFactorP() override {
   }
 
   /**
@@ -104,7 +104,7 @@ public:
    */
   void print(const std::string& s = "", const KeyFormatter& keyFormatter =
       DefaultKeyFormatter) const override {
-    std::cout << s << "SmartProjectionPoseFactorC, z = \n ";
+    std::cout << s << "SmartProjectionFactorP, z = \n ";
     Base::print("", keyFormatter);
   }
 
@@ -162,32 +162,11 @@ public:
 
 /// traits
 template<class CAMERA>
-struct traits<SmartProjectionPoseFactorC<CAMERA> > : public Testable<
-    SmartProjectionPoseFactorC<CAMERA> > {
+struct traits<SmartProjectionFactorP<CAMERA> > : public Testable<
+    SmartProjectionFactorP<CAMERA> > {
 };
 
 // legacy smart factor class, only templated on calibration and assuming pinhole
-template <class CALIBRATION> using SmartProjectionPoseFactor = SmartProjectionPoseFactorC< PinholePose<CALIBRATION> >;
-
-//template <class CALIBRATION>
-//using SmartProjectionPoseFactor = SmartProjectionPoseFactorC< PinholePose<CALIBRATION> >;
-
-//template<class CALIBRATION>
-//struct SmartProjectionPoseFactor{
-//    typedef SmartProjectionPoseFactorC< PinholePose<CALIBRATION> >;
-//};
-
-//template<class CALIBRATION>
-//class SmartProjectionPoseFactor{
-//    typedef SmartProjectionPoseFactorC< PinholePose<CALIBRATION> >;
-//};
-
-//typedef typename CAMERA::CalibrationType CALIBRATION;
-//template<class CALIBRATION>
-//class SmartProjectionPoseFactor: public SmartProjectionPoseFactorC< <PinholePose<CALIBRATION> > {
-// public:
-// private:
-//};
-// end
+template <class CALIBRATION> using SmartProjectionPoseFactor = SmartProjectionFactorP< PinholePose<CALIBRATION> >;
 
 } // \ namespace gtsam

--- a/gtsam/slam/SmartProjectionPoseFactor.h
+++ b/gtsam/slam/SmartProjectionPoseFactor.h
@@ -10,7 +10,7 @@
  * -------------------------------------------------------------------------- */
 
 /**
- * @file   SmartProjectionFactorP.h
+ * @file   SmartProjectionPoseFactor.h
  * @brief  Smart factor on poses, assuming camera calibration is fixed
  * @author Luca Carlone
  * @author Chris Beall
@@ -41,14 +41,14 @@ namespace gtsam {
  * If the calibration should be optimized, as well, use SmartProjectionFactor instead!
  * @addtogroup SLAM
  */
-template<class CAMERA>
-class SmartProjectionFactorP: public SmartProjectionFactor<CAMERA> {
+template<class CALIBRATION>
+class SmartProjectionPoseFactor: public SmartProjectionFactor<
+    PinholePose<CALIBRATION> > {
 
 private:
-  typedef SmartProjectionFactor<CAMERA> Base;
-  typedef SmartProjectionFactorP<CAMERA> This;
-  typedef CAMERA Camera;
-  typedef typename CAMERA::CalibrationType CALIBRATION;
+  typedef PinholePose<CALIBRATION> Camera;
+  typedef SmartProjectionFactor<Camera> Base;
+  typedef SmartProjectionPoseFactor<CALIBRATION> This;
 
 protected:
 
@@ -62,7 +62,7 @@ public:
   /**
    * Default constructor, only for serialization
    */
-  SmartProjectionFactorP() {}
+  SmartProjectionPoseFactor() {}
 
   /**
    * Constructor
@@ -70,7 +70,7 @@ public:
    * @param K (fixed) calibration, assumed to be the same for all cameras
    * @param params parameters for the smart projection factors
    */
-  SmartProjectionFactorP(
+  SmartProjectionPoseFactor(
       const SharedNoiseModel& sharedNoiseModel,
       const boost::shared_ptr<CALIBRATION> K,
       const SmartProjectionParams& params = SmartProjectionParams())
@@ -84,17 +84,17 @@ public:
    * @param body_P_sensor pose of the camera in the body frame (optional)
    * @param params parameters for the smart projection factors
    */
-  SmartProjectionFactorP(
+  SmartProjectionPoseFactor(
       const SharedNoiseModel& sharedNoiseModel,
       const boost::shared_ptr<CALIBRATION> K,
       const boost::optional<Pose3> body_P_sensor,
       const SmartProjectionParams& params = SmartProjectionParams())
-      : SmartProjectionFactorP(sharedNoiseModel, K, params) {
+      : SmartProjectionPoseFactor(sharedNoiseModel, K, params) {
     this->body_P_sensor_ = body_P_sensor;
   }
 
   /** Virtual destructor */
-  ~SmartProjectionFactorP() override {
+  ~SmartProjectionPoseFactor() override {
   }
 
   /**
@@ -104,7 +104,7 @@ public:
    */
   void print(const std::string& s = "", const KeyFormatter& keyFormatter =
       DefaultKeyFormatter) const override {
-    std::cout << s << "SmartProjectionFactorP, z = \n ";
+    std::cout << s << "SmartProjectionPoseFactor, z = \n ";
     Base::print("", keyFormatter);
   }
 
@@ -161,12 +161,9 @@ public:
 // end of class declaration
 
 /// traits
-template<class CAMERA>
-struct traits<SmartProjectionFactorP<CAMERA> > : public Testable<
-    SmartProjectionFactorP<CAMERA> > {
+template<class CALIBRATION>
+struct traits<SmartProjectionPoseFactor<CALIBRATION> > : public Testable<
+    SmartProjectionPoseFactor<CALIBRATION> > {
 };
-
-// legacy smart factor class, only templated on calibration and assuming pinhole
-template <class CALIBRATION> using SmartProjectionPoseFactor = SmartProjectionFactorP< PinholePose<CALIBRATION> >;
 
 } // \ namespace gtsam

--- a/gtsam/slam/tests/smartFactorScenarios.h
+++ b/gtsam/slam/tests/smartFactorScenarios.h
@@ -18,6 +18,7 @@
 
 #pragma once
 #include <gtsam/slam/SmartProjectionPoseFactor.h>
+#include <gtsam/slam/SmartProjectionFactorP.h>
 #include <gtsam/slam/SmartProjectionFactor.h>
 #include <gtsam/slam/GeneralSFMFactor.h>
 #include <gtsam/geometry/Cal3_S2.h>

--- a/gtsam/slam/tests/smartFactorScenarios.h
+++ b/gtsam/slam/tests/smartFactorScenarios.h
@@ -84,6 +84,7 @@ Camera cam3(pose_above, sharedK);
 namespace vanillaPose2 {
 typedef PinholePose<Cal3_S2> Camera;
 typedef SmartProjectionPoseFactor<Cal3_S2> SmartFactor;
+typedef SmartProjectionFactorP<Camera> SmartFactorP;
 static Cal3_S2::shared_ptr sharedK2(new Cal3_S2(1500, 1200, 0, 640, 480));
 Camera level_camera(level_pose, sharedK2);
 Camera level_camera_right(pose_right, sharedK2);
@@ -113,6 +114,7 @@ typedef GeneralSFMFactor<Camera, Point3> SFMFactor;
 namespace bundlerPose {
 typedef PinholePose<Cal3Bundler> Camera;
 typedef SmartProjectionPoseFactor<Cal3Bundler> SmartFactor;
+typedef SmartProjectionFactorP<Camera> SmartFactorP;
 static boost::shared_ptr<Cal3Bundler> sharedBundlerK(
     new Cal3Bundler(500, 1e-3, 1e-3, 1000, 2000));
 Camera level_camera(level_pose, sharedBundlerK);

--- a/gtsam/slam/tests/smartFactorScenarios.h
+++ b/gtsam/slam/tests/smartFactorScenarios.h
@@ -70,6 +70,7 @@ SmartProjectionParams params;
 namespace vanillaPose {
 typedef PinholePose<Cal3_S2> Camera;
 typedef SmartProjectionPoseFactor<Cal3_S2> SmartFactor;
+typedef SmartProjectionFactorP<Camera> SmartFactorP;
 static Cal3_S2::shared_ptr sharedK(new Cal3_S2(fov, w, h));
 Camera level_camera(level_pose, sharedK);
 Camera level_camera_right(pose_right, sharedK);

--- a/gtsam/slam/tests/testSmartProjectionFactorP.cpp
+++ b/gtsam/slam/tests/testSmartProjectionFactorP.cpp
@@ -1,0 +1,1382 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ *  @file  testSmartProjectionPoseFactor.cpp
+ *  @brief Unit tests for ProjectionFactor Class
+ *  @author Chris Beall
+ *  @author Luca Carlone
+ *  @author Zsolt Kira
+ *  @author Frank Dellaert
+ *  @date   Sept 2013
+ */
+
+#include "smartFactorScenarios.h"
+#include <gtsam/slam/ProjectionFactor.h>
+#include <gtsam/slam/PoseTranslationPrior.h>
+#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
+#include <gtsam/base/numericalDerivative.h>
+#include <gtsam/base/serializationTestHelpers.h>
+#include <CppUnitLite/TestHarness.h>
+#include <boost/assign/std/map.hpp>
+#include <iostream>
+
+using namespace boost::assign;
+using namespace std::placeholders;
+
+static const double rankTol = 1.0;
+// Create a noise model for the pixel error
+static const double sigma = 0.1;
+static SharedIsotropic model(noiseModel::Isotropic::Sigma(2, sigma));
+
+// Convenience for named keys
+using symbol_shorthand::X;
+using symbol_shorthand::L;
+
+// tests data
+static Symbol x1('X', 1);
+static Symbol x2('X', 2);
+static Symbol x3('X', 3);
+
+static Point2 measurement1(323.0, 240.0);
+
+LevenbergMarquardtParams lmParams;
+// Make more verbose like so (in tests):
+// params.verbosityLM = LevenbergMarquardtParams::SUMMARY;
+
+/* ************************************************************************* */
+TEST( SmartProjectionPoseFactor, Constructor) {
+  using namespace vanillaPose;
+  SmartFactor::shared_ptr factor1(new SmartFactor(model, sharedK));
+}
+
+/* ************************************************************************* */
+TEST( SmartProjectionPoseFactor, Constructor2) {
+  using namespace vanillaPose;
+  SmartProjectionParams params;
+  params.setRankTolerance(rankTol);
+  SmartFactor factor1(model, sharedK, params);
+}
+
+/* ************************************************************************* */
+TEST( SmartProjectionPoseFactor, Constructor3) {
+  using namespace vanillaPose;
+  SmartFactor::shared_ptr factor1(new SmartFactor(model, sharedK));
+  factor1->add(measurement1, x1);
+}
+
+/* ************************************************************************* */
+TEST( SmartProjectionPoseFactor, Constructor4) {
+  using namespace vanillaPose;
+  SmartProjectionParams params;
+  params.setRankTolerance(rankTol);
+  SmartFactor factor1(model, sharedK, params);
+  factor1.add(measurement1, x1);
+}
+
+/* ************************************************************************* */
+TEST( SmartProjectionPoseFactor, params) {
+  using namespace vanillaPose;
+  SmartProjectionParams params;
+  double rt = params.getRetriangulationThreshold();
+  EXPECT_DOUBLES_EQUAL(1e-5, rt, 1e-7);
+  params.setRetriangulationThreshold(1e-3);
+  rt = params.getRetriangulationThreshold();
+  EXPECT_DOUBLES_EQUAL(1e-3, rt, 1e-7);
+}
+
+/* ************************************************************************* */
+TEST( SmartProjectionPoseFactor, Equals ) {
+  using namespace vanillaPose;
+  SmartFactor::shared_ptr factor1(new SmartFactor(model, sharedK));
+  factor1->add(measurement1, x1);
+
+  SmartFactor::shared_ptr factor2(new SmartFactor(model,sharedK));
+  factor2->add(measurement1, x1);
+
+  CHECK(assert_equal(*factor1, *factor2));
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactor, noiseless ) {
+
+  using namespace vanillaPose;
+
+  // Project two landmarks into two cameras
+  Point2 level_uv = level_camera.project(landmark1);
+  Point2 level_uv_right = level_camera_right.project(landmark1);
+
+  SmartFactor factor(model, sharedK);
+  factor.add(level_uv, x1);
+  factor.add(level_uv_right, x2);
+
+  Values values; // it's a pose factor, hence these are poses
+  values.insert(x1, cam1.pose());
+  values.insert(x2, cam2.pose());
+
+  double actualError = factor.error(values);
+  double expectedError = 0.0;
+  EXPECT_DOUBLES_EQUAL(expectedError, actualError, 1e-7);
+
+  SmartFactor::Cameras cameras = factor.cameras(values);
+  double actualError2 = factor.totalReprojectionError(cameras);
+  EXPECT_DOUBLES_EQUAL(expectedError, actualError2, 1e-7);
+
+  // Calculate expected derivative for point (easiest to check)
+  std::function<Vector(Point3)> f = //
+      std::bind(&SmartFactor::whitenedError<Point3>, factor, cameras, std::placeholders::_1);
+
+  // Calculate using computeEP
+  Matrix actualE;
+  factor.triangulateAndComputeE(actualE, values);
+
+  // get point
+  boost::optional<Point3> point = factor.point();
+  CHECK(point);
+
+  // calculate numerical derivative with triangulated point
+  Matrix expectedE = sigma * numericalDerivative11<Vector, Point3>(f, *point);
+  EXPECT(assert_equal(expectedE, actualE, 1e-7));
+
+  // Calculate using reprojectionError
+  SmartFactor::Cameras::FBlocks F;
+  Matrix E;
+  Vector actualErrors = factor.unwhitenedError(cameras, *point, F, E);
+  EXPECT(assert_equal(expectedE, E, 1e-7));
+
+  EXPECT(assert_equal(Z_4x1, actualErrors, 1e-7));
+
+  // Calculate using computeJacobians
+  Vector b;
+  SmartFactor::FBlocks Fs;
+  factor.computeJacobians(Fs, E, b, cameras, *point);
+  double actualError3 = b.squaredNorm();
+  EXPECT(assert_equal(expectedE, E, 1e-7));
+  EXPECT_DOUBLES_EQUAL(expectedError, actualError3, 1e-6);
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactor, noisy ) {
+
+  using namespace vanillaPose;
+
+  // Project two landmarks into two cameras
+  Point2 pixelError(0.2, 0.2);
+  Point2 level_uv = level_camera.project(landmark1) + pixelError;
+  Point2 level_uv_right = level_camera_right.project(landmark1);
+
+  Values values;
+  values.insert(x1, cam1.pose());
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 10, 0., -M_PI / 10),
+      Point3(0.5, 0.1, 0.3));
+  values.insert(x2, pose_right.compose(noise_pose));
+
+  SmartFactor::shared_ptr factor(new SmartFactor(model, sharedK));
+  factor->add(level_uv, x1);
+  factor->add(level_uv_right, x2);
+
+  double actualError1 = factor->error(values);
+
+  SmartFactor::shared_ptr factor2(new SmartFactor(model, sharedK));
+  Point2Vector measurements;
+  measurements.push_back(level_uv);
+  measurements.push_back(level_uv_right);
+
+  KeyVector views {x1, x2};
+
+  factor2->add(measurements, views);
+  double actualError2 = factor2->error(values);
+  DOUBLES_EQUAL(actualError1, actualError2, 1e-7);
+}
+
+/* *************************************************************************/
+TEST(SmartProjectionPoseFactor, smartFactorWithSensorBodyTransform) {
+  using namespace vanillaPose;
+
+  // create arbitrary body_T_sensor (transforms from sensor to body)
+  Pose3 body_T_sensor = Pose3(Rot3::Ypr(-M_PI / 2, 0., -M_PI / 2), Point3(1, 1, 1));
+
+  // These are the poses we want to estimate, from camera measurements
+  const Pose3 sensor_T_body = body_T_sensor.inverse();
+  Pose3 wTb1 = cam1.pose() * sensor_T_body;
+  Pose3 wTb2 = cam2.pose() * sensor_T_body;
+  Pose3 wTb3 = cam3.pose() * sensor_T_body;
+
+  // three landmarks ~5 meters infront of camera
+  Point3 landmark1(5, 0.5, 1.2), landmark2(5, -0.5, 1.2), landmark3(5, 0, 3.0);
+
+  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+
+  // Project three landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+
+  // Create smart factors
+  KeyVector views {x1, x2, x3};
+
+  SmartProjectionParams params;
+  params.setRankTolerance(1.0);
+  params.setDegeneracyMode(IGNORE_DEGENERACY);
+  params.setEnableEPI(false);
+
+  SmartFactor smartFactor1(model, sharedK, body_T_sensor, params);
+  smartFactor1.add(measurements_cam1, views);
+
+  SmartFactor smartFactor2(model, sharedK, body_T_sensor, params);
+  smartFactor2.add(measurements_cam2, views);
+
+  SmartFactor smartFactor3(model, sharedK, body_T_sensor, params);
+  smartFactor3.add(measurements_cam3, views);
+
+  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+
+  // Put all factors in factor graph, adding priors
+  NonlinearFactorGraph graph;
+  graph.push_back(smartFactor1);
+  graph.push_back(smartFactor2);
+  graph.push_back(smartFactor3);
+  graph.addPrior(x1, wTb1, noisePrior);
+  graph.addPrior(x2, wTb2, noisePrior);
+
+  // Check errors at ground truth poses
+  Values gtValues;
+  gtValues.insert(x1, wTb1);
+  gtValues.insert(x2, wTb2);
+  gtValues.insert(x3, wTb3);
+  double actualError = graph.error(gtValues);
+  double expectedError = 0.0;
+  DOUBLES_EQUAL(expectedError, actualError, 1e-7)
+
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+                           Point3(0.1, 0.1, 0.1));
+  Values values;
+  values.insert(x1, wTb1);
+  values.insert(x2, wTb2);
+  // initialize third pose with some noise, we expect it to move back to
+  // original pose3
+  values.insert(x3, wTb3 * noise_pose);
+
+  LevenbergMarquardtParams lmParams;
+  Values result;
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  result = optimizer.optimize();
+  EXPECT(assert_equal(wTb3, result.at<Pose3>(x3)));
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactor, 3poses_smart_projection_factor ) {
+
+  using namespace vanillaPose2;
+  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+
+  // Project three landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+
+  KeyVector views;
+  views.push_back(x1);
+  views.push_back(x2);
+  views.push_back(x3);
+
+  SmartFactor::shared_ptr smartFactor1(new SmartFactor(model, sharedK2));
+  smartFactor1->add(measurements_cam1, views);
+
+  SmartFactor::shared_ptr smartFactor2(new SmartFactor(model, sharedK2));
+  smartFactor2->add(measurements_cam2, views);
+
+  SmartFactor::shared_ptr smartFactor3(new SmartFactor(model, sharedK2));
+  smartFactor3->add(measurements_cam3, views);
+
+  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+
+  NonlinearFactorGraph graph;
+  graph.push_back(smartFactor1);
+  graph.push_back(smartFactor2);
+  graph.push_back(smartFactor3);
+  graph.addPrior(x1, cam1.pose(), noisePrior);
+  graph.addPrior(x2, cam2.pose(), noisePrior);
+
+  Values groundTruth;
+  groundTruth.insert(x1, cam1.pose());
+  groundTruth.insert(x2, cam2.pose());
+  groundTruth.insert(x3, cam3.pose());
+  DOUBLES_EQUAL(0, graph.error(groundTruth), 1e-9);
+
+  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+      Point3(0.1, 0.1, 0.1)); // smaller noise
+  Values values;
+  values.insert(x1, cam1.pose());
+  values.insert(x2, cam2.pose());
+  // initialize third pose with some noise, we expect it to move back to original pose_above
+  values.insert(x3, pose_above * noise_pose);
+  EXPECT(
+      assert_equal(
+          Pose3(
+              Rot3(0, -0.0314107591, 0.99950656, -0.99950656, -0.0313952598,
+                  -0.000986635786, 0.0314107591, -0.999013364, -0.0313952598),
+              Point3(0.1, -0.1, 1.9)), values.at<Pose3>(x3)));
+
+  Values result;
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  result = optimizer.optimize();
+  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-6));
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactor, Factors ) {
+
+  using namespace vanillaPose;
+
+  // Default cameras for simple derivatives
+  Rot3 R;
+  static Cal3_S2::shared_ptr sharedK(new Cal3_S2(100, 100, 0, 0, 0));
+  Camera cam1(Pose3(R, Point3(0, 0, 0)), sharedK), cam2(
+      Pose3(R, Point3(1, 0, 0)), sharedK);
+
+  // one landmarks 1m in front of camera
+  Point3 landmark1(0, 0, 10);
+
+  Point2Vector measurements_cam1;
+
+  // Project 2 landmarks into 2 cameras
+  measurements_cam1.push_back(cam1.project(landmark1));
+  measurements_cam1.push_back(cam2.project(landmark1));
+
+  // Create smart factors
+  KeyVector views {x1, x2};
+
+  SmartFactor::shared_ptr smartFactor1 = boost::make_shared<SmartFactor>(model, sharedK);
+  smartFactor1->add(measurements_cam1, views);
+
+  SmartFactor::Cameras cameras;
+  cameras.push_back(cam1);
+  cameras.push_back(cam2);
+
+  // Make sure triangulation works
+  CHECK(smartFactor1->triangulateSafe(cameras));
+  CHECK(!smartFactor1->isDegenerate());
+  CHECK(!smartFactor1->isPointBehindCamera());
+  boost::optional<Point3> p = smartFactor1->point();
+  CHECK(p);
+  EXPECT(assert_equal(landmark1, *p));
+
+  VectorValues zeroDelta;
+  Vector6 delta;
+  delta.setZero();
+  zeroDelta.insert(x1, delta);
+  zeroDelta.insert(x2, delta);
+
+  VectorValues perturbedDelta;
+  delta.setOnes();
+  perturbedDelta.insert(x1, delta);
+  perturbedDelta.insert(x2, delta);
+  double expectedError = 2500;
+
+  // After eliminating the point, A1 and A2 contain 2-rank information on cameras:
+  Matrix16 A1, A2;
+  A1 << -10, 0, 0, 0, 1, 0;
+  A2 << 10, 0, 1, 0, -1, 0;
+  A1 *= 10. / sigma;
+  A2 *= 10. / sigma;
+  Matrix expectedInformation; // filled below
+  {
+    // createHessianFactor
+    Matrix66 G11 = 0.5 * A1.transpose() * A1;
+    Matrix66 G12 = 0.5 * A1.transpose() * A2;
+    Matrix66 G22 = 0.5 * A2.transpose() * A2;
+
+    Vector6 g1;
+    g1.setZero();
+    Vector6 g2;
+    g2.setZero();
+
+    double f = 0;
+
+    RegularHessianFactor<6> expected(x1, x2, G11, G12, g1, G22, g2, f);
+    expectedInformation = expected.information();
+
+    boost::shared_ptr<RegularHessianFactor<6> > actual =
+        smartFactor1->createHessianFactor(cameras, 0.0);
+    EXPECT(assert_equal(expectedInformation, actual->information(), 1e-6));
+    EXPECT(assert_equal(expected, *actual, 1e-6));
+    EXPECT_DOUBLES_EQUAL(0, actual->error(zeroDelta), 1e-6);
+    EXPECT_DOUBLES_EQUAL(expectedError, actual->error(perturbedDelta), 1e-6);
+  }
+
+  {
+    Matrix26 F1;
+    F1.setZero();
+    F1(0, 1) = -100;
+    F1(0, 3) = -10;
+    F1(1, 0) = 100;
+    F1(1, 4) = -10;
+    Matrix26 F2;
+    F2.setZero();
+    F2(0, 1) = -101;
+    F2(0, 3) = -10;
+    F2(0, 5) = -1;
+    F2(1, 0) = 100;
+    F2(1, 2) = 10;
+    F2(1, 4) = -10;
+    Matrix E(4, 3);
+    E.setZero();
+    E(0, 0) = 10;
+    E(1, 1) = 10;
+    E(2, 0) = 10;
+    E(2, 2) = 1;
+    E(3, 1) = 10;
+    SmartFactor::FBlocks Fs = list_of<Matrix>(F1)(F2);
+    Vector b(4);
+    b.setZero();
+
+    // Create smart factors
+    KeyVector keys;
+    keys.push_back(x1);
+    keys.push_back(x2);
+
+    // createJacobianQFactor
+    SharedIsotropic n = noiseModel::Isotropic::Sigma(4, sigma);
+    Matrix3 P = (E.transpose() * E).inverse();
+    JacobianFactorQ<6, 2> expectedQ(keys, Fs, E, P, b, n);
+    EXPECT(assert_equal(expectedInformation, expectedQ.information(), 1e-6));
+
+    boost::shared_ptr<JacobianFactorQ<6, 2> > actualQ =
+        smartFactor1->createJacobianQFactor(cameras, 0.0);
+    CHECK(actualQ);
+    EXPECT(assert_equal(expectedInformation, actualQ->information(), 1e-6));
+    EXPECT(assert_equal(expectedQ, *actualQ));
+    EXPECT_DOUBLES_EQUAL(0, actualQ->error(zeroDelta), 1e-6);
+    EXPECT_DOUBLES_EQUAL(expectedError, actualQ->error(perturbedDelta), 1e-6);
+
+    // Whiten for RegularImplicitSchurFactor (does not have noise model)
+    model->WhitenSystem(E, b);
+    Matrix3 whiteP = (E.transpose() * E).inverse();
+    Fs[0] = model->Whiten(Fs[0]);
+    Fs[1] = model->Whiten(Fs[1]);
+
+    // createRegularImplicitSchurFactor
+    RegularImplicitSchurFactor<Camera> expected(keys, Fs, E, whiteP, b);
+
+    boost::shared_ptr<RegularImplicitSchurFactor<Camera> > actual =
+        smartFactor1->createRegularImplicitSchurFactor(cameras, 0.0);
+    CHECK(actual);
+    EXPECT(assert_equal(expectedInformation, expected.information(), 1e-6));
+    EXPECT(assert_equal(expectedInformation, actual->information(), 1e-6));
+    EXPECT(assert_equal(expected, *actual));
+    EXPECT_DOUBLES_EQUAL(0, actual->error(zeroDelta), 1e-6);
+    EXPECT_DOUBLES_EQUAL(expectedError, actual->error(perturbedDelta), 1e-6);
+  }
+
+  {
+    // createJacobianSVDFactor
+    Vector1 b;
+    b.setZero();
+    double s = sigma * sin(M_PI_4);
+    SharedIsotropic n = noiseModel::Isotropic::Sigma(4 - 3, sigma);
+    JacobianFactor expected(x1, s * A1, x2, s * A2, b, n);
+    EXPECT(assert_equal(expectedInformation, expected.information(), 1e-6));
+
+    boost::shared_ptr<JacobianFactor> actual =
+        smartFactor1->createJacobianSVDFactor(cameras, 0.0);
+    CHECK(actual);
+    EXPECT(assert_equal(expectedInformation, actual->information(), 1e-6));
+    EXPECT(assert_equal(expected, *actual));
+    EXPECT_DOUBLES_EQUAL(0, actual->error(zeroDelta), 1e-6);
+    EXPECT_DOUBLES_EQUAL(expectedError, actual->error(perturbedDelta), 1e-6);
+  }
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactor, 3poses_iterative_smart_projection_factor ) {
+
+  using namespace vanillaPose;
+
+  KeyVector views {x1, x2, x3};
+
+  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+
+  // Project three landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+
+  SmartFactor::shared_ptr smartFactor1(new SmartFactor(model, sharedK));
+  smartFactor1->add(measurements_cam1, views);
+
+  SmartFactor::shared_ptr smartFactor2(new SmartFactor(model, sharedK));
+  smartFactor2->add(measurements_cam2, views);
+
+  SmartFactor::shared_ptr smartFactor3(new SmartFactor(model, sharedK));
+  smartFactor3->add(measurements_cam3, views);
+
+  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+
+  NonlinearFactorGraph graph;
+  graph.push_back(smartFactor1);
+  graph.push_back(smartFactor2);
+  graph.push_back(smartFactor3);
+  graph.addPrior(x1, cam1.pose(), noisePrior);
+  graph.addPrior(x2, cam2.pose(), noisePrior);
+
+  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+      Point3(0.1, 0.1, 0.1)); // smaller noise
+  Values values;
+  values.insert(x1, cam1.pose());
+  values.insert(x2, cam2.pose());
+  // initialize third pose with some noise, we expect it to move back to original pose_above
+  values.insert(x3, pose_above * noise_pose);
+  EXPECT(
+      assert_equal(
+          Pose3(
+              Rot3(1.11022302e-16, -0.0314107591, 0.99950656, -0.99950656,
+                  -0.0313952598, -0.000986635786, 0.0314107591, -0.999013364,
+                  -0.0313952598), Point3(0.1, -0.1, 1.9)),
+          values.at<Pose3>(x3)));
+
+  Values result;
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  result = optimizer.optimize();
+  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-7));
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactor, jacobianSVD ) {
+
+  using namespace vanillaPose;
+
+  KeyVector views {x1, x2, x3};
+
+  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+
+  // Project three landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+
+  SmartProjectionParams params;
+  params.setRankTolerance(1.0);
+  params.setLinearizationMode(gtsam::JACOBIAN_SVD);
+  params.setDegeneracyMode(gtsam::IGNORE_DEGENERACY);
+  params.setEnableEPI(false);
+  SmartFactor factor1(model, sharedK, params);
+
+  SmartFactor::shared_ptr smartFactor1(
+      new SmartFactor(model, sharedK, params));
+  smartFactor1->add(measurements_cam1, views);
+
+  SmartFactor::shared_ptr smartFactor2(
+      new SmartFactor(model, sharedK, params));
+  smartFactor2->add(measurements_cam2, views);
+
+  SmartFactor::shared_ptr smartFactor3(
+      new SmartFactor(model, sharedK, params));
+  smartFactor3->add(measurements_cam3, views);
+
+  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+
+  NonlinearFactorGraph graph;
+  graph.push_back(smartFactor1);
+  graph.push_back(smartFactor2);
+  graph.push_back(smartFactor3);
+  graph.addPrior(x1, cam1.pose(), noisePrior);
+  graph.addPrior(x2, cam2.pose(), noisePrior);
+
+  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+      Point3(0.1, 0.1, 0.1)); // smaller noise
+  Values values;
+  values.insert(x1, cam1.pose());
+  values.insert(x2, cam2.pose());
+  values.insert(x3, pose_above * noise_pose);
+
+  Values result;
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  result = optimizer.optimize();
+  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-6));
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactor, landmarkDistance ) {
+
+  using namespace vanillaPose;
+
+  double excludeLandmarksFutherThanDist = 2;
+
+  KeyVector views {x1, x2, x3};
+
+  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+
+  // Project three landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+
+  SmartProjectionParams params;
+  params.setRankTolerance(1.0);
+  params.setLinearizationMode(gtsam::JACOBIAN_SVD);
+  params.setDegeneracyMode(gtsam::IGNORE_DEGENERACY);
+  params.setLandmarkDistanceThreshold(excludeLandmarksFutherThanDist);
+  params.setEnableEPI(false);
+
+  SmartFactor::shared_ptr smartFactor1(
+      new SmartFactor(model, sharedK, params));
+  smartFactor1->add(measurements_cam1, views);
+
+  SmartFactor::shared_ptr smartFactor2(
+      new SmartFactor(model, sharedK, params));
+  smartFactor2->add(measurements_cam2, views);
+
+  SmartFactor::shared_ptr smartFactor3(
+      new SmartFactor(model, sharedK, params));
+  smartFactor3->add(measurements_cam3, views);
+
+  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+
+  NonlinearFactorGraph graph;
+  graph.push_back(smartFactor1);
+  graph.push_back(smartFactor2);
+  graph.push_back(smartFactor3);
+  graph.addPrior(x1, cam1.pose(), noisePrior);
+  graph.addPrior(x2, cam2.pose(), noisePrior);
+
+  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+      Point3(0.1, 0.1, 0.1)); // smaller noise
+  Values values;
+  values.insert(x1, cam1.pose());
+  values.insert(x2, cam2.pose());
+  values.insert(x3, pose_above * noise_pose);
+
+  // All factors are disabled and pose should remain where it is
+  Values result;
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  result = optimizer.optimize();
+  EXPECT(assert_equal(values.at<Pose3>(x3), result.at<Pose3>(x3)));
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactor, dynamicOutlierRejection ) {
+
+  using namespace vanillaPose;
+
+  double excludeLandmarksFutherThanDist = 1e10;
+  double dynamicOutlierRejectionThreshold = 1; // max 1 pixel of average reprojection error
+
+  KeyVector views {x1, x2, x3};
+
+  // add fourth landmark
+  Point3 landmark4(5, -0.5, 1);
+
+  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3,
+      measurements_cam4;
+
+  // Project 4 landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark4, measurements_cam4);
+  measurements_cam4.at(0) = measurements_cam4.at(0) + Point2(10, 10); // add outlier
+
+  SmartProjectionParams params;
+  params.setLinearizationMode(gtsam::JACOBIAN_SVD);
+  params.setLandmarkDistanceThreshold(excludeLandmarksFutherThanDist);
+  params.setDynamicOutlierRejectionThreshold(dynamicOutlierRejectionThreshold);
+
+  SmartFactor::shared_ptr smartFactor1(
+      new SmartFactor(model, sharedK, params));
+  smartFactor1->add(measurements_cam1, views);
+
+  SmartFactor::shared_ptr smartFactor2(
+      new SmartFactor(model, sharedK, params));
+  smartFactor2->add(measurements_cam2, views);
+
+  SmartFactor::shared_ptr smartFactor3(
+      new SmartFactor(model, sharedK, params));
+  smartFactor3->add(measurements_cam3, views);
+
+  SmartFactor::shared_ptr smartFactor4(
+      new SmartFactor(model, sharedK, params));
+  smartFactor4->add(measurements_cam4, views);
+
+  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+
+  NonlinearFactorGraph graph;
+  graph.push_back(smartFactor1);
+  graph.push_back(smartFactor2);
+  graph.push_back(smartFactor3);
+  graph.push_back(smartFactor4);
+  graph.addPrior(x1, cam1.pose(), noisePrior);
+  graph.addPrior(x2, cam2.pose(), noisePrior);
+
+  Values values;
+  values.insert(x1, cam1.pose());
+  values.insert(x2, cam2.pose());
+  values.insert(x3, cam3.pose());
+
+  // All factors are disabled and pose should remain where it is
+  Values result;
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  result = optimizer.optimize();
+  EXPECT(assert_equal(cam3.pose(), result.at<Pose3>(x3)));
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactor, jacobianQ ) {
+
+  using namespace vanillaPose;
+
+  KeyVector views {x1, x2, x3};
+
+  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+
+  // Project three landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+
+  SmartProjectionParams params;
+  params.setLinearizationMode(gtsam::JACOBIAN_Q);
+
+  SmartFactor::shared_ptr smartFactor1(
+      new SmartFactor(model, sharedK, params));
+  smartFactor1->add(measurements_cam1, views);
+
+  SmartFactor::shared_ptr smartFactor2(
+      new SmartFactor(model, sharedK, params));
+  smartFactor2->add(measurements_cam2, views);
+
+  SmartFactor::shared_ptr smartFactor3(
+      new SmartFactor(model, sharedK, params));
+  smartFactor3->add(measurements_cam3, views);
+
+  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+
+  NonlinearFactorGraph graph;
+  graph.push_back(smartFactor1);
+  graph.push_back(smartFactor2);
+  graph.push_back(smartFactor3);
+  graph.addPrior(x1, cam1.pose(), noisePrior);
+  graph.addPrior(x2, cam2.pose(), noisePrior);
+
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+      Point3(0.1, 0.1, 0.1)); // smaller noise
+  Values values;
+  values.insert(x1, cam1.pose());
+  values.insert(x2, cam2.pose());
+  values.insert(x3, pose_above * noise_pose);
+
+  Values result;
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  result = optimizer.optimize();
+  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-6));
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactor, 3poses_projection_factor ) {
+
+  using namespace vanillaPose2;
+
+  KeyVector views {x1, x2, x3};
+
+  typedef GenericProjectionFactor<Pose3, Point3> ProjectionFactor;
+  NonlinearFactorGraph graph;
+
+  // Project three landmarks into three cameras
+  graph.emplace_shared<ProjectionFactor>(cam1.project(landmark1), model, x1, L(1), sharedK2);
+  graph.emplace_shared<ProjectionFactor>(cam2.project(landmark1), model, x2, L(1), sharedK2);
+  graph.emplace_shared<ProjectionFactor>(cam3.project(landmark1), model, x3, L(1), sharedK2);
+
+  graph.emplace_shared<ProjectionFactor>(cam1.project(landmark2), model, x1, L(2), sharedK2);
+  graph.emplace_shared<ProjectionFactor>(cam2.project(landmark2), model, x2, L(2), sharedK2);
+  graph.emplace_shared<ProjectionFactor>(cam3.project(landmark2), model, x3, L(2), sharedK2);
+
+  graph.emplace_shared<ProjectionFactor>(cam1.project(landmark3), model, x1, L(3), sharedK2);
+  graph.emplace_shared<ProjectionFactor>(cam2.project(landmark3), model, x2, L(3), sharedK2);
+  graph.emplace_shared<ProjectionFactor>(cam3.project(landmark3), model, x3, L(3), sharedK2);
+
+  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+  graph.addPrior(x1, level_pose, noisePrior);
+  graph.addPrior(x2, pose_right, noisePrior);
+
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 10, 0., -M_PI / 10),
+      Point3(0.5, 0.1, 0.3));
+  Values values;
+  values.insert(x1, level_pose);
+  values.insert(x2, pose_right);
+  values.insert(x3, pose_above * noise_pose);
+  values.insert(L(1), landmark1);
+  values.insert(L(2), landmark2);
+  values.insert(L(3), landmark3);
+
+  DOUBLES_EQUAL(48406055, graph.error(values), 1);
+
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  Values result = optimizer.optimize();
+
+  DOUBLES_EQUAL(0, graph.error(result), 1e-9);
+
+  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-7));
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactor, CheckHessian) {
+
+  KeyVector views {x1, x2, x3};
+
+  using namespace vanillaPose;
+
+  // Two slightly different cameras
+  Pose3 pose2 = level_pose
+      * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
+  Pose3 pose3 = pose2 * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
+  Camera cam2(pose2, sharedK);
+  Camera cam3(pose3, sharedK);
+
+  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+
+  // Project three landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+
+  SmartProjectionParams params;
+  params.setRankTolerance(10);
+
+  SmartFactor::shared_ptr smartFactor1(
+      new SmartFactor(model, sharedK, params)); // HESSIAN, by default
+  smartFactor1->add(measurements_cam1, views);
+
+  SmartFactor::shared_ptr smartFactor2(
+      new SmartFactor(model, sharedK, params)); // HESSIAN, by default
+  smartFactor2->add(measurements_cam2, views);
+
+  SmartFactor::shared_ptr smartFactor3(
+      new SmartFactor(model, sharedK, params)); // HESSIAN, by default
+  smartFactor3->add(measurements_cam3, views);
+
+  NonlinearFactorGraph graph;
+  graph.push_back(smartFactor1);
+  graph.push_back(smartFactor2);
+  graph.push_back(smartFactor3);
+
+  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+      Point3(0.1, 0.1, 0.1)); // smaller noise
+  Values values;
+  values.insert(x1, cam1.pose());
+  values.insert(x2, cam2.pose());
+  // initialize third pose with some noise, we expect it to move back to original pose_above
+  values.insert(x3, pose3 * noise_pose);
+  EXPECT(
+      assert_equal(
+          Pose3(
+              Rot3(0.00563056869, -0.130848107, 0.991386438, -0.991390265,
+                  -0.130426831, -0.0115837907, 0.130819108, -0.98278564,
+                  -0.130455917),
+              Point3(0.0897734171, -0.110201006, 0.901022872)),
+          values.at<Pose3>(x3)));
+
+  boost::shared_ptr<GaussianFactor> factor1 = smartFactor1->linearize(values);
+  boost::shared_ptr<GaussianFactor> factor2 = smartFactor2->linearize(values);
+  boost::shared_ptr<GaussianFactor> factor3 = smartFactor3->linearize(values);
+
+  Matrix CumulativeInformation = factor1->information() + factor2->information()
+      + factor3->information();
+
+  boost::shared_ptr<GaussianFactorGraph> GaussianGraph = graph.linearize(
+      values);
+  Matrix GraphInformation = GaussianGraph->hessian().first;
+
+  // Check Hessian
+  EXPECT(assert_equal(GraphInformation, CumulativeInformation, 1e-6));
+
+  Matrix AugInformationMatrix = factor1->augmentedInformation()
+      + factor2->augmentedInformation() + factor3->augmentedInformation();
+
+  // Check Information vector
+  Vector InfoVector = AugInformationMatrix.block(0, 18, 18, 1); // 18x18 Hessian + information vector
+
+  // Check Hessian
+  EXPECT(assert_equal(InfoVector, GaussianGraph->hessian().second, 1e-6));
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactor, 3poses_2land_rotation_only_smart_projection_factor ) {
+  using namespace vanillaPose2;
+
+  KeyVector views {x1, x2, x3};
+
+  // Two different cameras, at the same position, but different rotations
+  Pose3 pose2 = level_pose * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0,0,0));
+  Pose3 pose3 = pose2 * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0,0,0));
+  Camera cam2(pose2, sharedK2);
+  Camera cam3(pose3, sharedK2);
+
+  Point2Vector measurements_cam1, measurements_cam2;
+
+  // Project three landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+
+  SmartProjectionParams params;
+  params.setRankTolerance(50);
+  params.setDegeneracyMode(gtsam::HANDLE_INFINITY);
+
+  SmartFactor::shared_ptr smartFactor1(
+      new SmartFactor(model, sharedK2, params));
+  smartFactor1->add(measurements_cam1, views);
+
+  SmartFactor::shared_ptr smartFactor2(
+      new SmartFactor(model, sharedK2, params));
+  smartFactor2->add(measurements_cam2, views);
+
+  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+  const SharedDiagonal noisePriorTranslation = noiseModel::Isotropic::Sigma(3, 0.10);
+  Point3 positionPrior = Point3(0, 0, 1);
+
+  NonlinearFactorGraph graph;
+  graph.push_back(smartFactor1);
+  graph.push_back(smartFactor2);
+  graph.addPrior(x1, cam1.pose(), noisePrior);
+  graph.emplace_shared<PoseTranslationPrior<Pose3> >(x2, positionPrior, noisePriorTranslation);
+  graph.emplace_shared<PoseTranslationPrior<Pose3> >(x3, positionPrior, noisePriorTranslation);
+
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+      Point3(0.1, 0.1, 0.1)); // smaller noise
+  Values values;
+  values.insert(x1, cam1.pose());
+  values.insert(x2, pose2 * noise_pose);
+  values.insert(x3, pose3 * noise_pose);
+
+  // params.verbosityLM = LevenbergMarquardtParams::SUMMARY;
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  Values result = optimizer.optimize();
+  EXPECT(assert_equal(pose3, result.at<Pose3>(x3)));
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactor, 3poses_rotation_only_smart_projection_factor ) {
+
+  // this test considers a condition in which the cheirality constraint is triggered
+  using namespace vanillaPose;
+
+  KeyVector views {x1, x2, x3};
+
+  // Two different cameras, at the same position, but different rotations
+  Pose3 pose2 = level_pose
+      * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
+  Pose3 pose3 = pose2 * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
+  Camera cam2(pose2, sharedK);
+  Camera cam3(pose3, sharedK);
+
+  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+
+  // Project three landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+
+  SmartProjectionParams params;
+  params.setRankTolerance(10);
+  params.setDegeneracyMode(gtsam::ZERO_ON_DEGENERACY);
+
+  SmartFactor::shared_ptr smartFactor1(
+      new SmartFactor(model, sharedK, params));
+  smartFactor1->add(measurements_cam1, views);
+
+  SmartFactor::shared_ptr smartFactor2(
+      new SmartFactor(model, sharedK, params));
+  smartFactor2->add(measurements_cam2, views);
+
+  SmartFactor::shared_ptr smartFactor3(
+      new SmartFactor(model, sharedK, params));
+  smartFactor3->add(measurements_cam3, views);
+
+  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+  const SharedDiagonal noisePriorTranslation = noiseModel::Isotropic::Sigma(3,
+      0.10);
+  Point3 positionPrior = Point3(0, 0, 1);
+
+  NonlinearFactorGraph graph;
+  graph.push_back(smartFactor1);
+  graph.push_back(smartFactor2);
+  graph.push_back(smartFactor3);
+  graph.addPrior(x1, cam1.pose(), noisePrior);
+  graph.emplace_shared<PoseTranslationPrior<Pose3> >(x2, positionPrior, noisePriorTranslation);
+  graph.emplace_shared<PoseTranslationPrior<Pose3> >(x3, positionPrior, noisePriorTranslation);
+
+  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+      Point3(0.1, 0.1, 0.1)); // smaller noise
+  Values values;
+  values.insert(x1, cam1.pose());
+  values.insert(x2, cam2.pose());
+  values.insert(x3, pose3 * noise_pose);
+  EXPECT(
+      assert_equal(
+          Pose3(
+              Rot3(0.00563056869, -0.130848107, 0.991386438, -0.991390265,
+                  -0.130426831, -0.0115837907, 0.130819108, -0.98278564,
+                  -0.130455917),
+              Point3(0.0897734171, -0.110201006, 0.901022872)),
+          values.at<Pose3>(x3)));
+
+  Values result;
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  result = optimizer.optimize();
+
+  // Since we do not do anything on degenerate instances (ZERO_ON_DEGENERACY)
+  // rotation remains the same as the initial guess, but position is fixed by PoseTranslationPrior
+#ifdef GTSAM_THROW_CHEIRALITY_EXCEPTION
+  EXPECT(assert_equal(Pose3(values.at<Pose3>(x3).rotation(),
+      Point3(0,0,1)), result.at<Pose3>(x3)));
+#else
+  // if the check is disabled, no cheirality exception if thrown and the pose converges to the right rotation
+  // with modest accuracy since the configuration is essentially degenerate without the translation due to noise (noise_pose)
+  EXPECT(assert_equal(pose3, result.at<Pose3>(x3),1e-3));
+#endif
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactor, Hessian ) {
+
+  using namespace vanillaPose2;
+
+  KeyVector views {x1, x2};
+
+  // Project three landmarks into 2 cameras
+  Point2 cam1_uv1 = cam1.project(landmark1);
+  Point2 cam2_uv1 = cam2.project(landmark1);
+  Point2Vector measurements_cam1;
+  measurements_cam1.push_back(cam1_uv1);
+  measurements_cam1.push_back(cam2_uv1);
+
+  SmartFactor::shared_ptr smartFactor1(new SmartFactor(model, sharedK2));
+  smartFactor1->add(measurements_cam1, views);
+
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 10, 0., -M_PI / 10),
+      Point3(0.5, 0.1, 0.3));
+  Values values;
+  values.insert(x1, cam1.pose());
+  values.insert(x2, cam2.pose());
+
+  boost::shared_ptr<GaussianFactor> factor = smartFactor1->linearize(values);
+
+  // compute triangulation from linearization point
+  // compute reprojection errors (sum squared)
+  // compare with factor.info(): the bottom right element is the squared sum of the reprojection errors (normalized by the covariance)
+  // check that it is correctly scaled when using noiseProjection = [1/4  0; 0 1/4]
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactor, HessianWithRotation ) {
+  // cout << " ************************ SmartProjectionPoseFactor: rotated Hessian **********************" << endl;
+
+  using namespace vanillaPose;
+
+  KeyVector views {x1, x2, x3};
+
+  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+
+  SmartFactor::shared_ptr smartFactorInstance(new SmartFactor(model, sharedK));
+  smartFactorInstance->add(measurements_cam1, views);
+
+  Values values;
+  values.insert(x1, cam1.pose());
+  values.insert(x2, cam2.pose());
+  values.insert(x3, cam3.pose());
+
+  boost::shared_ptr<GaussianFactor> factor = smartFactorInstance->linearize(
+      values);
+
+  Pose3 poseDrift = Pose3(Rot3::Ypr(-M_PI / 2, 0., -M_PI / 2), Point3(0, 0, 0));
+
+  Values rotValues;
+  rotValues.insert(x1, poseDrift.compose(level_pose));
+  rotValues.insert(x2, poseDrift.compose(pose_right));
+  rotValues.insert(x3, poseDrift.compose(pose_above));
+
+  boost::shared_ptr<GaussianFactor> factorRot = smartFactorInstance->linearize(
+      rotValues);
+
+  // Hessian is invariant to rotations in the nondegenerate case
+  EXPECT(assert_equal(factor->information(), factorRot->information(), 1e-7));
+
+  Pose3 poseDrift2 = Pose3(Rot3::Ypr(-M_PI / 2, -M_PI / 3, -M_PI / 2),
+      Point3(10, -4, 5));
+
+  Values tranValues;
+  tranValues.insert(x1, poseDrift2.compose(level_pose));
+  tranValues.insert(x2, poseDrift2.compose(pose_right));
+  tranValues.insert(x3, poseDrift2.compose(pose_above));
+
+  boost::shared_ptr<GaussianFactor> factorRotTran =
+      smartFactorInstance->linearize(tranValues);
+
+  // Hessian is invariant to rotations and translations in the nondegenerate case
+  EXPECT(assert_equal(factor->information(), factorRotTran->information(), 1e-7));
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactor, HessianWithRotationDegenerate ) {
+
+  using namespace vanillaPose2;
+
+  KeyVector views {x1, x2, x3};
+
+  // All cameras have the same pose so will be degenerate !
+  Camera cam2(level_pose, sharedK2);
+  Camera cam3(level_pose, sharedK2);
+
+  Point2Vector measurements_cam1;
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+
+  SmartFactor::shared_ptr smartFactor(new SmartFactor(model, sharedK2));
+  smartFactor->add(measurements_cam1, views);
+
+  Values values;
+  values.insert(x1, cam1.pose());
+  values.insert(x2, cam2.pose());
+  values.insert(x3, cam3.pose());
+
+  boost::shared_ptr<GaussianFactor> factor = smartFactor->linearize(values);
+
+  Pose3 poseDrift = Pose3(Rot3::Ypr(-M_PI / 2, 0., -M_PI / 2), Point3(0, 0, 0));
+
+  Values rotValues;
+  rotValues.insert(x1, poseDrift.compose(level_pose));
+  rotValues.insert(x2, poseDrift.compose(level_pose));
+  rotValues.insert(x3, poseDrift.compose(level_pose));
+
+  boost::shared_ptr<GaussianFactor> factorRot = //
+      smartFactor->linearize(rotValues);
+
+  // Hessian is invariant to rotations in the nondegenerate case
+  EXPECT(assert_equal(factor->information(), factorRot->information(), 1e-7));
+
+  Pose3 poseDrift2 = Pose3(Rot3::Ypr(-M_PI / 2, -M_PI / 3, -M_PI / 2),
+      Point3(10, -4, 5));
+
+  Values tranValues;
+  tranValues.insert(x1, poseDrift2.compose(level_pose));
+  tranValues.insert(x2, poseDrift2.compose(level_pose));
+  tranValues.insert(x3, poseDrift2.compose(level_pose));
+
+  boost::shared_ptr<GaussianFactor> factorRotTran = smartFactor->linearize(
+      tranValues);
+
+  // Hessian is invariant to rotations and translations in the nondegenerate case
+  EXPECT(assert_equal(factor->information(), factorRotTran->information(), 1e-7));
+}
+
+/* ************************************************************************* */
+TEST( SmartProjectionPoseFactor, ConstructorWithCal3Bundler) {
+  using namespace bundlerPose;
+  SmartProjectionParams params;
+  params.setDegeneracyMode(gtsam::ZERO_ON_DEGENERACY);
+  SmartFactor factor(model, sharedBundlerK, params);
+  factor.add(measurement1, x1);
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactor, Cal3Bundler ) {
+
+  using namespace bundlerPose;
+
+  // three landmarks ~5 meters in front of camera
+  Point3 landmark3(3, 0, 3.0);
+
+  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+
+  // Project three landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+
+  KeyVector views {x1, x2, x3};
+
+  SmartFactor::shared_ptr smartFactor1(new SmartFactor(model, sharedBundlerK));
+  smartFactor1->add(measurements_cam1, views);
+
+  SmartFactor::shared_ptr smartFactor2(new SmartFactor(model, sharedBundlerK));
+  smartFactor2->add(measurements_cam2, views);
+
+  SmartFactor::shared_ptr smartFactor3(new SmartFactor(model, sharedBundlerK));
+  smartFactor3->add(measurements_cam3, views);
+
+  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+
+  NonlinearFactorGraph graph;
+  graph.push_back(smartFactor1);
+  graph.push_back(smartFactor2);
+  graph.push_back(smartFactor3);
+  graph.addPrior(x1, cam1.pose(), noisePrior);
+  graph.addPrior(x2, cam2.pose(), noisePrior);
+
+  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+      Point3(0.1, 0.1, 0.1)); // smaller noise
+  Values values;
+  values.insert(x1, cam1.pose());
+  values.insert(x2, cam2.pose());
+  // initialize third pose with some noise, we expect it to move back to original pose_above
+  values.insert(x3, pose_above * noise_pose);
+  EXPECT(
+      assert_equal(
+          Pose3(
+              Rot3(0, -0.0314107591, 0.99950656, -0.99950656, -0.0313952598,
+                  -0.000986635786, 0.0314107591, -0.999013364, -0.0313952598),
+              Point3(0.1, -0.1, 1.9)), values.at<Pose3>(x3)));
+
+  Values result;
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  result = optimizer.optimize();
+  EXPECT(assert_equal(cam3.pose(), result.at<Pose3>(x3), 1e-6));
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactor, Cal3BundlerRotationOnly ) {
+
+  using namespace bundlerPose;
+
+  KeyVector views {x1, x2, x3};
+
+  // Two different cameras
+  Pose3 pose2 = level_pose
+      * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
+  Pose3 pose3 = pose2 * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
+  Camera cam2(pose2, sharedBundlerK);
+  Camera cam3(pose3, sharedBundlerK);
+
+  // landmark3 at 3 meters now
+  Point3 landmark3(3, 0, 3.0);
+
+  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+
+  // Project three landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+
+  SmartProjectionParams params;
+  params.setRankTolerance(10);
+  params.setDegeneracyMode(gtsam::ZERO_ON_DEGENERACY);
+
+  SmartFactor::shared_ptr smartFactor1(
+      new SmartFactor(model, sharedBundlerK, params));
+  smartFactor1->add(measurements_cam1, views);
+
+  SmartFactor::shared_ptr smartFactor2(
+      new SmartFactor(model, sharedBundlerK, params));
+  smartFactor2->add(measurements_cam2, views);
+
+  SmartFactor::shared_ptr smartFactor3(
+      new SmartFactor(model, sharedBundlerK, params));
+  smartFactor3->add(measurements_cam3, views);
+
+  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+  const SharedDiagonal noisePriorTranslation = noiseModel::Isotropic::Sigma(3,
+      0.10);
+  Point3 positionPrior = Point3(0, 0, 1);
+
+  NonlinearFactorGraph graph;
+  graph.push_back(smartFactor1);
+  graph.push_back(smartFactor2);
+  graph.push_back(smartFactor3);
+  graph.addPrior(x1, cam1.pose(), noisePrior);
+  graph.emplace_shared<PoseTranslationPrior<Pose3> >(x2, positionPrior, noisePriorTranslation);
+  graph.emplace_shared<PoseTranslationPrior<Pose3> >(x3, positionPrior, noisePriorTranslation);
+
+  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+      Point3(0.1, 0.1, 0.1)); // smaller noise
+  Values values;
+  values.insert(x1, cam1.pose());
+  values.insert(x2, cam2.pose());
+  // initialize third pose with some noise, we expect it to move back to original pose_above
+  values.insert(x3, pose3 * noise_pose);
+  EXPECT(
+      assert_equal(
+          Pose3(
+              Rot3(0.00563056869, -0.130848107, 0.991386438, -0.991390265,
+                  -0.130426831, -0.0115837907, 0.130819108, -0.98278564,
+                  -0.130455917),
+              Point3(0.0897734171, -0.110201006, 0.901022872)),
+          values.at<Pose3>(x3)));
+
+  Values result;
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  result = optimizer.optimize();
+
+  EXPECT(
+      assert_equal(
+          Pose3(
+              Rot3(0.00563056869, -0.130848107, 0.991386438, -0.991390265,
+                  -0.130426831, -0.0115837907, 0.130819108, -0.98278564,
+                  -0.130455917),
+              Point3(0.0897734171, -0.110201006, 0.901022872)),
+          values.at<Pose3>(x3)));
+}
+
+/* ************************************************************************* */
+BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Constrained, "gtsam_noiseModel_Constrained");
+BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Diagonal, "gtsam_noiseModel_Diagonal");
+BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Gaussian, "gtsam_noiseModel_Gaussian");
+BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Unit, "gtsam_noiseModel_Unit");
+BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Isotropic, "gtsam_noiseModel_Isotropic");
+BOOST_CLASS_EXPORT_GUID(gtsam::SharedNoiseModel, "gtsam_SharedNoiseModel");
+BOOST_CLASS_EXPORT_GUID(gtsam::SharedDiagonal, "gtsam_SharedDiagonal");
+
+TEST(SmartProjectionPoseFactor, serialize) {
+  using namespace vanillaPose;
+  using namespace gtsam::serializationTestHelpers;
+  SmartProjectionParams params;
+  params.setRankTolerance(rankTol);
+  SmartFactor factor(model, sharedK, params);
+
+  EXPECT(equalsObj(factor));
+  EXPECT(equalsXML(factor));
+  EXPECT(equalsBinary(factor));
+}
+
+TEST(SmartProjectionPoseFactor, serialize2) {
+  using namespace vanillaPose;
+  using namespace gtsam::serializationTestHelpers;
+  SmartProjectionParams params;
+  params.setRankTolerance(rankTol);
+  Pose3 bts;
+  SmartFactor factor(model, sharedK, bts, params);
+
+  // insert some measurments
+  KeyVector key_view;
+  Point2Vector meas_view;
+  key_view.push_back(Symbol('x', 1));
+  meas_view.push_back(Point2(10, 10));
+  factor.add(meas_view, key_view);
+
+  EXPECT(equalsObj(factor));
+  EXPECT(equalsXML(factor));
+  EXPECT(equalsBinary(factor));
+}
+
+/* ************************************************************************* */
+int main() {
+  TestResult tr;
+  return TestRegistry::runAllTests(tr);
+}
+/* ************************************************************************* */
+

--- a/gtsam/slam/tests/testSmartProjectionFactorP.cpp
+++ b/gtsam/slam/tests/testSmartProjectionFactorP.cpp
@@ -106,7 +106,7 @@ TEST( SmartProjectionFactorP, noiseless ) {
   factor.add(level_uv, x1, sharedK);
   factor.add(level_uv_right, x2, sharedK);
 
-  Values values; // it's a pose factor, hence these are poses
+  Values values;  // it's a pose factor, hence these are poses
   values.insert(x1, cam1.pose());
   values.insert(x2, cam2.pose());
 
@@ -119,8 +119,9 @@ TEST( SmartProjectionFactorP, noiseless ) {
   EXPECT_DOUBLES_EQUAL(expectedError, actualError2, 1e-7);
 
   // Calculate expected derivative for point (easiest to check)
-  std::function<Vector(Point3)> f = //
-      std::bind(&SmartFactorP::whitenedError<Point3>, factor, cameras, std::placeholders::_1);
+  std::function<Vector(Point3)> f =  //
+      std::bind(&SmartFactorP::whitenedError<Point3>, factor, cameras,
+                std::placeholders::_1);
 
   // Calculate using computeEP
   Matrix actualE;
@@ -164,7 +165,7 @@ TEST( SmartProjectionFactorP, noisy ) {
   Values values;
   values.insert(x1, cam1.pose());
   Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 10, 0., -M_PI / 10),
-      Point3(0.5, 0.1, 0.3));
+                           Point3(0.5, 0.1, 0.3));
   values.insert(x2, pose_right.compose(noise_pose));
 
   SmartFactorP::shared_ptr factor(new SmartFactorP(model));
@@ -178,11 +179,11 @@ TEST( SmartProjectionFactorP, noisy ) {
   measurements.push_back(level_uv);
   measurements.push_back(level_uv_right);
 
-  std::vector<boost::shared_ptr<Cal3_S2>> sharedKs;
+  std::vector < boost::shared_ptr < Cal3_S2 >> sharedKs;
   sharedKs.push_back(sharedK);
   sharedKs.push_back(sharedK);
 
-  KeyVector views {x1, x2};
+  KeyVector views { x1, x2 };
 
   factor2->add(measurements, views, sharedKs);
   double actualError2 = factor2->error(values);
@@ -194,7 +195,8 @@ TEST(SmartProjectionFactorP, smartFactorWithSensorBodyTransform) {
   using namespace vanillaPose;
 
   // create arbitrary body_T_sensor (transforms from sensor to body)
-  Pose3 body_T_sensor = Pose3(Rot3::Ypr(-M_PI / 2, 0., -M_PI / 2), Point3(1, 1, 1));
+  Pose3 body_T_sensor = Pose3(Rot3::Ypr(-M_PI / 2, 0., -M_PI / 2),
+                              Point3(1, 1, 1));
 
   // These are the poses we want to estimate, from camera measurements
   const Pose3 sensor_T_body = body_T_sensor.inverse();
@@ -213,14 +215,14 @@ TEST(SmartProjectionFactorP, smartFactorWithSensorBodyTransform) {
   projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
 
   // Create smart factors
-  KeyVector views {x1, x2, x3};
+  KeyVector views { x1, x2, x3 };
 
   SmartProjectionParams params;
   params.setRankTolerance(1.0);
   params.setDegeneracyMode(IGNORE_DEGENERACY);
   params.setEnableEPI(false);
 
-  std::vector<boost::shared_ptr<Cal3_S2>> sharedKs;
+  std::vector < boost::shared_ptr < Cal3_S2 >> sharedKs;
   sharedKs.push_back(sharedK);
   sharedKs.push_back(sharedK);
   sharedKs.push_back(sharedK);
@@ -237,7 +239,8 @@ TEST(SmartProjectionFactorP, smartFactorWithSensorBodyTransform) {
   smartFactor2.add(measurements_cam2, views, sharedKs, body_T_sensors);
 
   SmartFactorP smartFactor3(model, params);
-  smartFactor3.add(measurements_cam3, views, sharedKs, body_T_sensors);;
+  smartFactor3.add(measurements_cam3, views, sharedKs, body_T_sensors);
+  ;
 
   const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
 
@@ -291,7 +294,7 @@ TEST( SmartProjectionFactorP, 3poses_smart_projection_factor ) {
   views.push_back(x2);
   views.push_back(x3);
 
-  std::vector<boost::shared_ptr<Cal3_S2>> sharedK2s;
+  std::vector < boost::shared_ptr < Cal3_S2 >> sharedK2s;
   sharedK2s.push_back(sharedK2);
   sharedK2s.push_back(sharedK2);
   sharedK2s.push_back(sharedK2);
@@ -322,7 +325,7 @@ TEST( SmartProjectionFactorP, 3poses_smart_projection_factor ) {
 
   //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
   Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-      Point3(0.1, 0.1, 0.1)); // smaller noise
+                           Point3(0.1, 0.1, 0.1));  // smaller noise
   Values values;
   values.insert(x1, cam1.pose());
   values.insert(x2, cam2.pose());
@@ -332,8 +335,9 @@ TEST( SmartProjectionFactorP, 3poses_smart_projection_factor ) {
       assert_equal(
           Pose3(
               Rot3(0, -0.0314107591, 0.99950656, -0.99950656, -0.0313952598,
-                  -0.000986635786, 0.0314107591, -0.999013364, -0.0313952598),
-              Point3(0.1, -0.1, 1.9)), values.at<Pose3>(x3)));
+                   -0.000986635786, 0.0314107591, -0.999013364, -0.0313952598),
+              Point3(0.1, -0.1, 1.9)),
+          values.at<Pose3>(x3)));
 
   Values result;
   LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
@@ -362,13 +366,14 @@ TEST( SmartProjectionFactorP, Factors ) {
   measurements_cam1.push_back(cam2.project(landmark1));
 
   // Create smart factors
-  KeyVector views {x1, x2};
+  KeyVector views { x1, x2 };
 
-  std::vector<boost::shared_ptr<Cal3_S2>> sharedKs;
+  std::vector < boost::shared_ptr < Cal3_S2 >> sharedKs;
   sharedKs.push_back(sharedK);
   sharedKs.push_back(sharedK);
 
-  SmartFactorP::shared_ptr smartFactor1 = boost::make_shared<SmartFactorP>(model);
+  SmartFactorP::shared_ptr smartFactor1 = boost::make_shared < SmartFactorP
+      > (model);
   smartFactor1->add(measurements_cam1, views, sharedKs);
 
   SmartFactorP::Cameras cameras;
@@ -401,7 +406,7 @@ TEST( SmartProjectionFactorP, Factors ) {
   A2 << 10, 0, 1, 0, -1, 0;
   A1 *= 10. / sigma;
   A2 *= 10. / sigma;
-  Matrix expectedInformation; // filled below
+  Matrix expectedInformation;  // filled below
   {
     // createHessianFactor
     Matrix66 G11 = 0.5 * A1.transpose() * A1;
@@ -422,8 +427,8 @@ TEST( SmartProjectionFactorP, Factors ) {
     values.insert(x1, cam1.pose());
     values.insert(x2, cam2.pose());
 
-    boost::shared_ptr<RegularHessianFactor<6> > actual =
-        smartFactor1->createHessianFactor(values, 0.0);
+    boost::shared_ptr < RegularHessianFactor<6> > actual = smartFactor1
+        ->createHessianFactor(values, 0.0);
     EXPECT(assert_equal(expectedInformation, actual->information(), 1e-6));
     EXPECT(assert_equal(expected, *actual, 1e-6));
     EXPECT_DOUBLES_EQUAL(0, actual->error(zeroDelta), 1e-6);
@@ -436,7 +441,7 @@ TEST( SmartProjectionFactorP, 3poses_iterative_smart_projection_factor ) {
 
   using namespace vanillaPose;
 
-  KeyVector views {x1, x2, x3};
+  KeyVector views { x1, x2, x3 };
 
   Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
 
@@ -445,7 +450,7 @@ TEST( SmartProjectionFactorP, 3poses_iterative_smart_projection_factor ) {
   projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
   projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
 
-  std::vector<boost::shared_ptr<Cal3_S2>> sharedKs;
+  std::vector < boost::shared_ptr < Cal3_S2 >> sharedKs;
   sharedKs.push_back(sharedK);
   sharedKs.push_back(sharedK);
   sharedKs.push_back(sharedK);
@@ -470,7 +475,7 @@ TEST( SmartProjectionFactorP, 3poses_iterative_smart_projection_factor ) {
 
   //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
   Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-      Point3(0.1, 0.1, 0.1)); // smaller noise
+                           Point3(0.1, 0.1, 0.1));  // smaller noise
   Values values;
   values.insert(x1, cam1.pose());
   values.insert(x2, cam2.pose());
@@ -480,8 +485,9 @@ TEST( SmartProjectionFactorP, 3poses_iterative_smart_projection_factor ) {
       assert_equal(
           Pose3(
               Rot3(1.11022302e-16, -0.0314107591, 0.99950656, -0.99950656,
-                  -0.0313952598, -0.000986635786, 0.0314107591, -0.999013364,
-                  -0.0313952598), Point3(0.1, -0.1, 1.9)),
+                   -0.0313952598, -0.000986635786, 0.0314107591, -0.999013364,
+                   -0.0313952598),
+              Point3(0.1, -0.1, 1.9)),
           values.at<Pose3>(x3)));
 
   Values result;
@@ -497,7 +503,7 @@ TEST( SmartProjectionFactorP, landmarkDistance ) {
 
   double excludeLandmarksFutherThanDist = 2;
 
-  KeyVector views {x1, x2, x3};
+  KeyVector views { x1, x2, x3 };
 
   Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
 
@@ -506,7 +512,7 @@ TEST( SmartProjectionFactorP, landmarkDistance ) {
   projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
   projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
 
-  std::vector<boost::shared_ptr<Cal3_S2>> sharedKs;
+  std::vector < boost::shared_ptr < Cal3_S2 >> sharedKs;
   sharedKs.push_back(sharedK);
   sharedKs.push_back(sharedK);
   sharedKs.push_back(sharedK);
@@ -518,16 +524,13 @@ TEST( SmartProjectionFactorP, landmarkDistance ) {
   params.setLandmarkDistanceThreshold(excludeLandmarksFutherThanDist);
   params.setEnableEPI(false);
 
-  SmartFactorP::shared_ptr smartFactor1(
-      new SmartFactorP(model, params));
+  SmartFactorP::shared_ptr smartFactor1(new SmartFactorP(model, params));
   smartFactor1->add(measurements_cam1, views, sharedKs);
 
-  SmartFactorP::shared_ptr smartFactor2(
-      new SmartFactorP(model, params));
+  SmartFactorP::shared_ptr smartFactor2(new SmartFactorP(model, params));
   smartFactor2->add(measurements_cam2, views, sharedKs);
 
-  SmartFactorP::shared_ptr smartFactor3(
-      new SmartFactorP(model, params));
+  SmartFactorP::shared_ptr smartFactor3(new SmartFactorP(model, params));
   smartFactor3->add(measurements_cam3, views, sharedKs);
 
   const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
@@ -541,7 +544,7 @@ TEST( SmartProjectionFactorP, landmarkDistance ) {
 
   //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
   Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-      Point3(0.1, 0.1, 0.1)); // smaller noise
+                           Point3(0.1, 0.1, 0.1));  // smaller noise
   Values values;
   values.insert(x1, cam1.pose());
   values.insert(x2, cam2.pose());
@@ -560,11 +563,11 @@ TEST( SmartProjectionFactorP, dynamicOutlierRejection ) {
   using namespace vanillaPose;
 
   double excludeLandmarksFutherThanDist = 1e10;
-  double dynamicOutlierRejectionThreshold = 1; // max 1 pixel of average reprojection error
+  double dynamicOutlierRejectionThreshold = 1;  // max 1 pixel of average reprojection error
 
-  KeyVector views {x1, x2, x3};
+  KeyVector views { x1, x2, x3 };
 
-  std::vector<boost::shared_ptr<Cal3_S2>> sharedKs;
+  std::vector < boost::shared_ptr < Cal3_S2 >> sharedKs;
   sharedKs.push_back(sharedK);
   sharedKs.push_back(sharedK);
   sharedKs.push_back(sharedK);
@@ -580,7 +583,7 @@ TEST( SmartProjectionFactorP, dynamicOutlierRejection ) {
   projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
   projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
   projectToMultipleCameras(cam1, cam2, cam3, landmark4, measurements_cam4);
-  measurements_cam4.at(0) = measurements_cam4.at(0) + Point2(10, 10); // add outlier
+  measurements_cam4.at(0) = measurements_cam4.at(0) + Point2(10, 10);  // add outlier
 
   SmartProjectionParams params;
   params.setLinearizationMode(gtsam::HESSIAN);
@@ -588,20 +591,16 @@ TEST( SmartProjectionFactorP, dynamicOutlierRejection ) {
   params.setLandmarkDistanceThreshold(excludeLandmarksFutherThanDist);
   params.setDynamicOutlierRejectionThreshold(dynamicOutlierRejectionThreshold);
 
-  SmartFactorP::shared_ptr smartFactor1(
-      new SmartFactorP(model, params));
+  SmartFactorP::shared_ptr smartFactor1(new SmartFactorP(model, params));
   smartFactor1->add(measurements_cam1, views, sharedKs);
 
-  SmartFactorP::shared_ptr smartFactor2(
-      new SmartFactorP(model, params));
+  SmartFactorP::shared_ptr smartFactor2(new SmartFactorP(model, params));
   smartFactor2->add(measurements_cam2, views, sharedKs);
 
-  SmartFactorP::shared_ptr smartFactor3(
-      new SmartFactorP(model, params));
+  SmartFactorP::shared_ptr smartFactor3(new SmartFactorP(model, params));
   smartFactor3->add(measurements_cam3, views, sharedKs);
 
-  SmartFactorP::shared_ptr smartFactor4(
-      new SmartFactorP(model, params));
+  SmartFactorP::shared_ptr smartFactor4(new SmartFactorP(model, params));
   smartFactor4->add(measurements_cam4, views, sharedKs);
 
   const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
@@ -629,7 +628,7 @@ TEST( SmartProjectionFactorP, dynamicOutlierRejection ) {
 /* *************************************************************************/
 TEST( SmartProjectionFactorP, CheckHessian) {
 
-  KeyVector views {x1, x2, x3};
+  KeyVector views { x1, x2, x3 };
 
   using namespace vanillaPose;
 
@@ -647,7 +646,7 @@ TEST( SmartProjectionFactorP, CheckHessian) {
   projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
   projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
 
-  std::vector<boost::shared_ptr<Cal3_S2>> sharedKs;
+  std::vector < boost::shared_ptr < Cal3_S2 >> sharedKs;
   sharedKs.push_back(sharedK);
   sharedKs.push_back(sharedK);
   sharedKs.push_back(sharedK);
@@ -656,16 +655,13 @@ TEST( SmartProjectionFactorP, CheckHessian) {
   params.setRankTolerance(10);
   params.setDegeneracyMode(gtsam::ZERO_ON_DEGENERACY);
 
-  SmartFactorP::shared_ptr smartFactor1(
-      new SmartFactorP(model, params)); // HESSIAN, by default
+  SmartFactorP::shared_ptr smartFactor1(new SmartFactorP(model, params));  // HESSIAN, by default
   smartFactor1->add(measurements_cam1, views, sharedKs);
 
-  SmartFactorP::shared_ptr smartFactor2(
-      new SmartFactorP(model, params)); // HESSIAN, by default
+  SmartFactorP::shared_ptr smartFactor2(new SmartFactorP(model, params));  // HESSIAN, by default
   smartFactor2->add(measurements_cam2, views, sharedKs);
 
-  SmartFactorP::shared_ptr smartFactor3(
-      new SmartFactorP(model, params)); // HESSIAN, by default
+  SmartFactorP::shared_ptr smartFactor3(new SmartFactorP(model, params));  // HESSIAN, by default
   smartFactor3->add(measurements_cam3, views, sharedKs);
 
   NonlinearFactorGraph graph;
@@ -675,7 +671,7 @@ TEST( SmartProjectionFactorP, CheckHessian) {
 
   //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
   Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-      Point3(0.1, 0.1, 0.1)); // smaller noise
+                           Point3(0.1, 0.1, 0.1));  // smaller noise
   Values values;
   values.insert(x1, cam1.pose());
   values.insert(x2, cam2.pose());
@@ -685,8 +681,8 @@ TEST( SmartProjectionFactorP, CheckHessian) {
       assert_equal(
           Pose3(
               Rot3(0.00563056869, -0.130848107, 0.991386438, -0.991390265,
-                  -0.130426831, -0.0115837907, 0.130819108, -0.98278564,
-                  -0.130455917),
+                   -0.130426831, -0.0115837907, 0.130819108, -0.98278564,
+                   -0.130455917),
               Point3(0.0897734171, -0.110201006, 0.901022872)),
           values.at<Pose3>(x3)));
 
@@ -708,7 +704,7 @@ TEST( SmartProjectionFactorP, CheckHessian) {
       + factor2->augmentedInformation() + factor3->augmentedInformation();
 
   // Check Information vector
-  Vector InfoVector = AugInformationMatrix.block(0, 18, 18, 1); // 18x18 Hessian + information vector
+  Vector InfoVector = AugInformationMatrix.block(0, 18, 18, 1);  // 18x18 Hessian + information vector
 
   // Check Hessian
   EXPECT(assert_equal(InfoVector, GaussianGraph->hessian().second, 1e-6));
@@ -719,7 +715,7 @@ TEST( SmartProjectionFactorP, Hessian ) {
 
   using namespace vanillaPose2;
 
-  KeyVector views {x1, x2};
+  KeyVector views { x1, x2 };
 
   // Project three landmarks into 2 cameras
   Point2 cam1_uv1 = cam1.project(landmark1);
@@ -728,7 +724,7 @@ TEST( SmartProjectionFactorP, Hessian ) {
   measurements_cam1.push_back(cam1_uv1);
   measurements_cam1.push_back(cam2_uv1);
 
-  std::vector<boost::shared_ptr<Cal3_S2>> sharedK2s;
+  std::vector < boost::shared_ptr < Cal3_S2 >> sharedK2s;
   sharedK2s.push_back(sharedK2);
   sharedK2s.push_back(sharedK2);
 
@@ -736,7 +732,7 @@ TEST( SmartProjectionFactorP, Hessian ) {
   smartFactor1->add(measurements_cam1, views, sharedK2s);
 
   Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 10, 0., -M_PI / 10),
-      Point3(0.5, 0.1, 0.3));
+                           Point3(0.5, 0.1, 0.3));
   Values values;
   values.insert(x1, cam1.pose());
   values.insert(x2, cam2.pose());
@@ -773,9 +769,9 @@ TEST( SmartProjectionFactorP, Cal3Bundler ) {
   projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
   projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
 
-  KeyVector views {x1, x2, x3};
+  KeyVector views { x1, x2, x3 };
 
-  std::vector<boost::shared_ptr<Cal3Bundler>> sharedBundlerKs;
+  std::vector < boost::shared_ptr < Cal3Bundler >> sharedBundlerKs;
   sharedBundlerKs.push_back(sharedBundlerK);
   sharedBundlerKs.push_back(sharedBundlerK);
   sharedBundlerKs.push_back(sharedBundlerK);
@@ -800,7 +796,7 @@ TEST( SmartProjectionFactorP, Cal3Bundler ) {
 
   //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
   Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-      Point3(0.1, 0.1, 0.1)); // smaller noise
+                           Point3(0.1, 0.1, 0.1));  // smaller noise
   Values values;
   values.insert(x1, cam1.pose());
   values.insert(x2, cam2.pose());
@@ -810,14 +806,288 @@ TEST( SmartProjectionFactorP, Cal3Bundler ) {
       assert_equal(
           Pose3(
               Rot3(0, -0.0314107591, 0.99950656, -0.99950656, -0.0313952598,
-                  -0.000986635786, 0.0314107591, -0.999013364, -0.0313952598),
-              Point3(0.1, -0.1, 1.9)), values.at<Pose3>(x3)));
+                   -0.000986635786, 0.0314107591, -0.999013364, -0.0313952598),
+              Point3(0.1, -0.1, 1.9)),
+          values.at<Pose3>(x3)));
 
   Values result;
   LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
   result = optimizer.optimize();
   EXPECT(assert_equal(cam3.pose(), result.at<Pose3>(x3), 1e-6));
 }
+
+#include <gtsam/slam/ProjectionFactor.h>
+typedef GenericProjectionFactor<Pose3, Point3> TestProjectionFactor;
+static Symbol l0('L', 0);
+/* *************************************************************************/
+TEST( SmartProjectionFactorP, hessianComparedToProjFactors_measurementsFromSamePose) {
+  // in this test we make sure the fact works even if we have multiple pixel measurements of the same landmark
+  // at a single pose, a setup that occurs in multi-camera systems
+
+  using namespace vanillaPose;
+  Point2Vector measurements_lmk1;
+
+  // Project three landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_lmk1);
+
+  // create redundant measurements:
+  Camera::MeasurementVector measurements_lmk1_redundant = measurements_lmk1;
+  measurements_lmk1_redundant.push_back(measurements_lmk1.at(0));  // we readd the first measurement
+
+  // create inputs
+  std::vector<Key> keys;
+  keys.push_back(x1);
+  keys.push_back(x2);
+  keys.push_back(x3);
+  keys.push_back(x1);
+
+  std::vector < boost::shared_ptr < Cal3_S2 >> sharedKs;
+  sharedKs.push_back(sharedK);
+  sharedKs.push_back(sharedK);
+  sharedKs.push_back(sharedK);
+  sharedKs.push_back(sharedK);
+
+  SmartFactorP::shared_ptr smartFactor1(new SmartFactorP(model));
+  smartFactor1->add(measurements_lmk1_redundant, keys, sharedKs);
+
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+                           Point3(0.1, 0.1, 0.1));  // smaller noise
+  Values values;
+  values.insert(x1, level_pose);
+  values.insert(x2, pose_right);
+  // initialize third pose with some noise to get a nontrivial linearization point
+  values.insert(x3, pose_above * noise_pose);
+  EXPECT(  // check that the pose is actually noisy
+      assert_equal( Pose3( Rot3(0, -0.0314107591, 0.99950656, -0.99950656, -0.0313952598, -0.000986635786, 0.0314107591, -0.999013364, -0.0313952598), Point3(0.1, -0.1, 1.9)), values.at<Pose3>(x3)));
+
+  // linearization point for the poses
+  Pose3 pose1 = level_pose;
+  Pose3 pose2 = pose_right;
+  Pose3 pose3 = pose_above * noise_pose;
+
+  // ==== check Hessian of smartFactor1 =====
+  // -- compute actual Hessian
+  boost::shared_ptr<GaussianFactor> linearfactor1 = smartFactor1->linearize(
+      values);
+  Matrix actualHessian = linearfactor1->information();
+
+  // -- compute expected Hessian from manual Schur complement from Jacobians
+  // linearization point for the 3D point
+  smartFactor1->triangulateSafe(smartFactor1->cameras(values));
+  TriangulationResult point = smartFactor1->point();
+  EXPECT(point.valid());  // check triangulated point is valid
+
+  // Use standard ProjectionFactor factor to calculate the Jacobians
+  Matrix F = Matrix::Zero(2 * 4, 6 * 3);
+  Matrix E = Matrix::Zero(2 * 4, 3);
+  Vector b = Vector::Zero(2 * 4);
+
+  // create projection factors rolling shutter
+  TestProjectionFactor factor11(measurements_lmk1_redundant[0], model, x1, l0,
+                                sharedK);
+  Matrix HPoseActual, HEActual;
+  // note: b is minus the reprojection error, cf the smart factor jacobian computation
+  b.segment<2>(0) = -factor11.evaluateError(pose1, *point, HPoseActual,
+                                            HEActual);
+  F.block<2, 6>(0, 0) = HPoseActual;
+  E.block<2, 3>(0, 0) = HEActual;
+
+  TestProjectionFactor factor12(measurements_lmk1_redundant[1], model, x2, l0,
+                                sharedK);
+  b.segment<2>(2) = -factor12.evaluateError(pose2, *point, HPoseActual,
+                                            HEActual);
+  F.block<2, 6>(2, 6) = HPoseActual;
+  E.block<2, 3>(2, 0) = HEActual;
+
+  TestProjectionFactor factor13(measurements_lmk1_redundant[2], model, x3, l0,
+                                sharedK);
+  b.segment<2>(4) = -factor13.evaluateError(pose3, *point, HPoseActual,
+                                            HEActual);
+  F.block<2, 6>(4, 12) = HPoseActual;
+  E.block<2, 3>(4, 0) = HEActual;
+
+  TestProjectionFactor factor14(measurements_lmk1_redundant[3], model, x1, l0,
+                                sharedK);
+  b.segment<2>(6) = -factor11.evaluateError(pose1, *point, HPoseActual,
+                                            HEActual);
+  F.block<2, 6>(6, 0) = HPoseActual;
+  E.block<2, 3>(6, 0) = HEActual;
+
+  // whiten
+  F = (1 / sigma) * F;
+  E = (1 / sigma) * E;
+  b = (1 / sigma) * b;
+  //* G = F' * F - F' * E * P * E' * F
+  Matrix P = (E.transpose() * E).inverse();
+  Matrix expectedHessian = F.transpose() * F
+      - (F.transpose() * E * P * E.transpose() * F);
+  EXPECT(assert_equal(expectedHessian, actualHessian, 1e-6));
+
+  // ==== check Information vector of smartFactor1 =====
+  GaussianFactorGraph gfg;
+  gfg.add(linearfactor1);
+  Matrix actualHessian_v2 = gfg.hessian().first;
+  EXPECT(assert_equal(actualHessian_v2, actualHessian, 1e-6));  // sanity check on hessian
+
+  // -- compute actual information vector
+  Vector actualInfoVector = gfg.hessian().second;
+
+  // -- compute expected information vector from manual Schur complement from Jacobians
+  //* g = F' * (b - E * P * E' * b)
+  Vector expectedInfoVector = F.transpose() * (b - E * P * E.transpose() * b);
+  EXPECT(assert_equal(expectedInfoVector, actualInfoVector, 1e-6));
+
+  // ==== check error of smartFactor1 (again) =====
+  NonlinearFactorGraph nfg_projFactors;
+  nfg_projFactors.add(factor11);
+  nfg_projFactors.add(factor12);
+  nfg_projFactors.add(factor13);
+  nfg_projFactors.add(factor14);
+  values.insert(l0, *point);
+
+  double actualError = smartFactor1->error(values);
+  double expectedError = nfg_projFactors.error(values);
+  EXPECT_DOUBLES_EQUAL(expectedError, actualError, 1e-7);
+}
+
+///* *************************************************************************/
+//TEST( SmartProjectionFactorP, optimization_3poses_measurementsFromSamePose ) {
+//
+//  using namespace vanillaPoseRS;
+//  Point2Vector measurements_lmk1, measurements_lmk2, measurements_lmk3;
+//
+//  // Project three landmarks into three cameras
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_lmk1);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_lmk2);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_lmk3);
+//
+//  // create inputs
+//  std::vector<std::pair<Key,Key>> key_pairs;
+//  key_pairs.push_back(std::make_pair(x1,x2));
+//  key_pairs.push_back(std::make_pair(x2,x3));
+//  key_pairs.push_back(std::make_pair(x3,x1));
+//
+//  std::vector<double> interp_factors;
+//  interp_factors.push_back(interp_factor1);
+//  interp_factors.push_back(interp_factor2);
+//  interp_factors.push_back(interp_factor3);
+//
+//  // For first factor, we create redundant measurement (taken by the same keys as factor 1, to
+//  // make sure the redundancy in the keys does not create problems)
+//  Camera::MeasurementVector& measurements_lmk1_redundant = measurements_lmk1;
+//  measurements_lmk1_redundant.push_back(measurements_lmk1.at(0)); // we readd the first measurement
+//  std::vector<std::pair<Key,Key>> key_pairs_redundant = key_pairs;
+//  key_pairs_redundant.push_back(key_pairs.at(0)); // we readd the first pair of keys
+//  std::vector<double> interp_factors_redundant = interp_factors;
+//  interp_factors_redundant.push_back(interp_factors.at(0));// we readd the first interp factor
+//
+//  SmartFactorRS::shared_ptr smartFactor1(new SmartFactorRS(model));
+//  smartFactor1->add(measurements_lmk1_redundant, key_pairs_redundant, interp_factors_redundant, sharedK);
+//
+//  SmartFactorRS::shared_ptr smartFactor2(new SmartFactorRS(model));
+//  smartFactor2->add(measurements_lmk2, key_pairs, interp_factors, sharedK);
+//
+//  SmartFactorRS::shared_ptr smartFactor3(new SmartFactorRS(model));
+//  smartFactor3->add(measurements_lmk3, key_pairs, interp_factors, sharedK);
+//
+//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+//
+//  NonlinearFactorGraph graph;
+//  graph.push_back(smartFactor1);
+//  graph.push_back(smartFactor2);
+//  graph.push_back(smartFactor3);
+//  graph.addPrior(x1, level_pose, noisePrior);
+//  graph.addPrior(x2, pose_right, noisePrior);
+//
+//  Values groundTruth;
+//  groundTruth.insert(x1, level_pose);
+//  groundTruth.insert(x2, pose_right);
+//  groundTruth.insert(x3, pose_above);
+//  DOUBLES_EQUAL(0, graph.error(groundTruth), 1e-9);
+//
+//  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+//                           Point3(0.1, 0.1, 0.1)); // smaller noise
+//  Values values;
+//  values.insert(x1, level_pose);
+//  values.insert(x2, pose_right);
+//  // initialize third pose with some noise, we expect it to move back to original pose_above
+//  values.insert(x3, pose_above * noise_pose);
+//  EXPECT( // check that the pose is actually noisy
+//      assert_equal(
+//          Pose3(
+//              Rot3(0, -0.0314107591, 0.99950656, -0.99950656, -0.0313952598,
+//                   -0.000986635786, 0.0314107591, -0.999013364, -0.0313952598),
+//                   Point3(0.1, -0.1, 1.9)), values.at<Pose3>(x3)));
+//
+//  Values result;
+//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+//  result = optimizer.optimize();
+//  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-5));
+//}
+
+//#ifndef DISABLE_TIMING
+//#include <gtsam/base/timing.h>
+//// -Total: 0 CPU (0 times, 0 wall, 0.04 children, min: 0 max: 0)
+////|   -SF RS LINEARIZE: 0.02 CPU (1000 times, 0.017244 wall, 0.02 children, min: 0 max: 0)
+////|   -RS LINEARIZE: 0.02 CPU (1000 times, 0.009035 wall, 0.02 children, min: 0 max: 0)
+///* *************************************************************************/
+//TEST( SmartProjectionPoseFactorRollingShutter, timing ) {
+//
+//  using namespace vanillaPose;
+//
+//  // Default cameras for simple derivatives
+//  static Cal3_S2::shared_ptr sharedKSimple(new Cal3_S2(100, 100, 0, 0, 0));
+//
+//  Rot3 R = Rot3::identity();
+//  Pose3 pose1 = Pose3(R, Point3(0, 0, 0));
+//  Pose3 pose2 = Pose3(R, Point3(1, 0, 0));
+//  Camera cam1(pose1, sharedKSimple), cam2(pose2, sharedKSimple);
+//  Pose3 body_P_sensorId = Pose3::identity();
+//
+//  // one landmarks 1m in front of camera
+//  Point3 landmark1(0, 0, 10);
+//
+//  Point2Vector measurements_lmk1;
+//
+//  // Project 2 landmarks into 2 cameras
+//  measurements_lmk1.push_back(cam1.project(landmark1));
+//  measurements_lmk1.push_back(cam2.project(landmark1));
+//
+//  size_t nrTests = 1000;
+//
+//  for(size_t i = 0; i<nrTests; i++){
+//    SmartFactorRS::shared_ptr smartFactorRS(new SmartFactorRS(model));
+//    double interp_factor = 0;  // equivalent to measurement taken at pose 1
+//    smartFactorRS->add(measurements_lmk1[0], x1, x2, interp_factor, sharedKSimple,
+//                       body_P_sensorId);
+//    interp_factor = 1;  // equivalent to measurement taken at pose 2
+//    smartFactorRS->add(measurements_lmk1[1], x1, x2, interp_factor, sharedKSimple,
+//                       body_P_sensorId);
+//
+//    Values values;
+//    values.insert(x1, pose1);
+//    values.insert(x2, pose2);
+//    gttic_(SF_RS_LINEARIZE);
+//    smartFactorRS->linearize(values);
+//    gttoc_(SF_RS_LINEARIZE);
+//  }
+//
+//  for(size_t i = 0; i<nrTests; i++){
+//    SmartFactor::shared_ptr smartFactor(new SmartFactor(model, sharedKSimple));
+//    smartFactor->add(measurements_lmk1[0], x1);
+//    smartFactor->add(measurements_lmk1[1], x2);
+//
+//    Values values;
+//    values.insert(x1, pose1);
+//    values.insert(x2, pose2);
+//    gttic_(RS_LINEARIZE);
+//    smartFactor->linearize(values);
+//    gttoc_(RS_LINEARIZE);
+//  }
+//  tictoc_print_();
+//}
+//#endif
 
 /* ************************************************************************* */
 BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Constrained, "gtsam_noiseModel_Constrained");

--- a/gtsam/slam/tests/testSmartProjectionFactorP.cpp
+++ b/gtsam/slam/tests/testSmartProjectionFactorP.cpp
@@ -10,17 +10,16 @@
  * -------------------------------------------------------------------------- */
 
 /**
- *  @file  testSmartProjectionPoseFactor.cpp
- *  @brief Unit tests for ProjectionFactor Class
+ *  @file  testSmartProjectionFactorP.cpp
+ *  @brief Unit tests for SmartProjectionFactorP Class
  *  @author Chris Beall
  *  @author Luca Carlone
  *  @author Zsolt Kira
  *  @author Frank Dellaert
- *  @date   Sept 2013
+ *  @date   August 2021
  */
 
 #include "smartFactorScenarios.h"
-#include <gtsam/slam/ProjectionFactor.h>
 #include <gtsam/slam/PoseTranslationPrior.h>
 #include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
 #include <gtsam/base/numericalDerivative.h>
@@ -52,1326 +51,1326 @@ LevenbergMarquardtParams lmParams;
 // Make more verbose like so (in tests):
 // params.verbosityLM = LevenbergMarquardtParams::SUMMARY;
 
-/* ************************************************************************* */
-TEST( SmartProjectionPoseFactor, Constructor) {
-  using namespace vanillaPose;
-  SmartFactor::shared_ptr factor1(new SmartFactor(model, sharedK));
-}
-
-/* ************************************************************************* */
-TEST( SmartProjectionPoseFactor, Constructor2) {
-  using namespace vanillaPose;
-  SmartProjectionParams params;
-  params.setRankTolerance(rankTol);
-  SmartFactor factor1(model, sharedK, params);
-}
-
-/* ************************************************************************* */
-TEST( SmartProjectionPoseFactor, Constructor3) {
-  using namespace vanillaPose;
-  SmartFactor::shared_ptr factor1(new SmartFactor(model, sharedK));
-  factor1->add(measurement1, x1);
-}
-
-/* ************************************************************************* */
-TEST( SmartProjectionPoseFactor, Constructor4) {
-  using namespace vanillaPose;
-  SmartProjectionParams params;
-  params.setRankTolerance(rankTol);
-  SmartFactor factor1(model, sharedK, params);
-  factor1.add(measurement1, x1);
-}
-
-/* ************************************************************************* */
-TEST( SmartProjectionPoseFactor, params) {
-  using namespace vanillaPose;
-  SmartProjectionParams params;
-  double rt = params.getRetriangulationThreshold();
-  EXPECT_DOUBLES_EQUAL(1e-5, rt, 1e-7);
-  params.setRetriangulationThreshold(1e-3);
-  rt = params.getRetriangulationThreshold();
-  EXPECT_DOUBLES_EQUAL(1e-3, rt, 1e-7);
-}
-
-/* ************************************************************************* */
-TEST( SmartProjectionPoseFactor, Equals ) {
-  using namespace vanillaPose;
-  SmartFactor::shared_ptr factor1(new SmartFactor(model, sharedK));
-  factor1->add(measurement1, x1);
-
-  SmartFactor::shared_ptr factor2(new SmartFactor(model,sharedK));
-  factor2->add(measurement1, x1);
-
-  CHECK(assert_equal(*factor1, *factor2));
-}
-
-/* *************************************************************************/
-TEST( SmartProjectionPoseFactor, noiseless ) {
-
-  using namespace vanillaPose;
-
-  // Project two landmarks into two cameras
-  Point2 level_uv = level_camera.project(landmark1);
-  Point2 level_uv_right = level_camera_right.project(landmark1);
-
-  SmartFactor factor(model, sharedK);
-  factor.add(level_uv, x1);
-  factor.add(level_uv_right, x2);
-
-  Values values; // it's a pose factor, hence these are poses
-  values.insert(x1, cam1.pose());
-  values.insert(x2, cam2.pose());
-
-  double actualError = factor.error(values);
-  double expectedError = 0.0;
-  EXPECT_DOUBLES_EQUAL(expectedError, actualError, 1e-7);
-
-  SmartFactor::Cameras cameras = factor.cameras(values);
-  double actualError2 = factor.totalReprojectionError(cameras);
-  EXPECT_DOUBLES_EQUAL(expectedError, actualError2, 1e-7);
-
-  // Calculate expected derivative for point (easiest to check)
-  std::function<Vector(Point3)> f = //
-      std::bind(&SmartFactor::whitenedError<Point3>, factor, cameras, std::placeholders::_1);
-
-  // Calculate using computeEP
-  Matrix actualE;
-  factor.triangulateAndComputeE(actualE, values);
-
-  // get point
-  boost::optional<Point3> point = factor.point();
-  CHECK(point);
-
-  // calculate numerical derivative with triangulated point
-  Matrix expectedE = sigma * numericalDerivative11<Vector, Point3>(f, *point);
-  EXPECT(assert_equal(expectedE, actualE, 1e-7));
-
-  // Calculate using reprojectionError
-  SmartFactor::Cameras::FBlocks F;
-  Matrix E;
-  Vector actualErrors = factor.unwhitenedError(cameras, *point, F, E);
-  EXPECT(assert_equal(expectedE, E, 1e-7));
-
-  EXPECT(assert_equal(Z_4x1, actualErrors, 1e-7));
-
-  // Calculate using computeJacobians
-  Vector b;
-  SmartFactor::FBlocks Fs;
-  factor.computeJacobians(Fs, E, b, cameras, *point);
-  double actualError3 = b.squaredNorm();
-  EXPECT(assert_equal(expectedE, E, 1e-7));
-  EXPECT_DOUBLES_EQUAL(expectedError, actualError3, 1e-6);
-}
-
-/* *************************************************************************/
-TEST( SmartProjectionPoseFactor, noisy ) {
-
-  using namespace vanillaPose;
-
-  // Project two landmarks into two cameras
-  Point2 pixelError(0.2, 0.2);
-  Point2 level_uv = level_camera.project(landmark1) + pixelError;
-  Point2 level_uv_right = level_camera_right.project(landmark1);
-
-  Values values;
-  values.insert(x1, cam1.pose());
-  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 10, 0., -M_PI / 10),
-      Point3(0.5, 0.1, 0.3));
-  values.insert(x2, pose_right.compose(noise_pose));
-
-  SmartFactor::shared_ptr factor(new SmartFactor(model, sharedK));
-  factor->add(level_uv, x1);
-  factor->add(level_uv_right, x2);
-
-  double actualError1 = factor->error(values);
-
-  SmartFactor::shared_ptr factor2(new SmartFactor(model, sharedK));
-  Point2Vector measurements;
-  measurements.push_back(level_uv);
-  measurements.push_back(level_uv_right);
-
-  KeyVector views {x1, x2};
-
-  factor2->add(measurements, views);
-  double actualError2 = factor2->error(values);
-  DOUBLES_EQUAL(actualError1, actualError2, 1e-7);
-}
-
-/* *************************************************************************/
-TEST(SmartProjectionPoseFactor, smartFactorWithSensorBodyTransform) {
-  using namespace vanillaPose;
-
-  // create arbitrary body_T_sensor (transforms from sensor to body)
-  Pose3 body_T_sensor = Pose3(Rot3::Ypr(-M_PI / 2, 0., -M_PI / 2), Point3(1, 1, 1));
-
-  // These are the poses we want to estimate, from camera measurements
-  const Pose3 sensor_T_body = body_T_sensor.inverse();
-  Pose3 wTb1 = cam1.pose() * sensor_T_body;
-  Pose3 wTb2 = cam2.pose() * sensor_T_body;
-  Pose3 wTb3 = cam3.pose() * sensor_T_body;
-
-  // three landmarks ~5 meters infront of camera
-  Point3 landmark1(5, 0.5, 1.2), landmark2(5, -0.5, 1.2), landmark3(5, 0, 3.0);
-
-  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
-
-  // Project three landmarks into three cameras
-  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
-  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
-
-  // Create smart factors
-  KeyVector views {x1, x2, x3};
-
-  SmartProjectionParams params;
-  params.setRankTolerance(1.0);
-  params.setDegeneracyMode(IGNORE_DEGENERACY);
-  params.setEnableEPI(false);
-
-  SmartFactor smartFactor1(model, sharedK, body_T_sensor, params);
-  smartFactor1.add(measurements_cam1, views);
-
-  SmartFactor smartFactor2(model, sharedK, body_T_sensor, params);
-  smartFactor2.add(measurements_cam2, views);
-
-  SmartFactor smartFactor3(model, sharedK, body_T_sensor, params);
-  smartFactor3.add(measurements_cam3, views);
-
-  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
-
-  // Put all factors in factor graph, adding priors
-  NonlinearFactorGraph graph;
-  graph.push_back(smartFactor1);
-  graph.push_back(smartFactor2);
-  graph.push_back(smartFactor3);
-  graph.addPrior(x1, wTb1, noisePrior);
-  graph.addPrior(x2, wTb2, noisePrior);
-
-  // Check errors at ground truth poses
-  Values gtValues;
-  gtValues.insert(x1, wTb1);
-  gtValues.insert(x2, wTb2);
-  gtValues.insert(x3, wTb3);
-  double actualError = graph.error(gtValues);
-  double expectedError = 0.0;
-  DOUBLES_EQUAL(expectedError, actualError, 1e-7)
-
-  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-                           Point3(0.1, 0.1, 0.1));
-  Values values;
-  values.insert(x1, wTb1);
-  values.insert(x2, wTb2);
-  // initialize third pose with some noise, we expect it to move back to
-  // original pose3
-  values.insert(x3, wTb3 * noise_pose);
-
-  LevenbergMarquardtParams lmParams;
-  Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
-  result = optimizer.optimize();
-  EXPECT(assert_equal(wTb3, result.at<Pose3>(x3)));
-}
-
-/* *************************************************************************/
-TEST( SmartProjectionPoseFactor, 3poses_smart_projection_factor ) {
-
-  using namespace vanillaPose2;
-  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
-
-  // Project three landmarks into three cameras
-  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
-  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
-
-  KeyVector views;
-  views.push_back(x1);
-  views.push_back(x2);
-  views.push_back(x3);
-
-  SmartFactor::shared_ptr smartFactor1(new SmartFactor(model, sharedK2));
-  smartFactor1->add(measurements_cam1, views);
-
-  SmartFactor::shared_ptr smartFactor2(new SmartFactor(model, sharedK2));
-  smartFactor2->add(measurements_cam2, views);
-
-  SmartFactor::shared_ptr smartFactor3(new SmartFactor(model, sharedK2));
-  smartFactor3->add(measurements_cam3, views);
-
-  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
-
-  NonlinearFactorGraph graph;
-  graph.push_back(smartFactor1);
-  graph.push_back(smartFactor2);
-  graph.push_back(smartFactor3);
-  graph.addPrior(x1, cam1.pose(), noisePrior);
-  graph.addPrior(x2, cam2.pose(), noisePrior);
-
-  Values groundTruth;
-  groundTruth.insert(x1, cam1.pose());
-  groundTruth.insert(x2, cam2.pose());
-  groundTruth.insert(x3, cam3.pose());
-  DOUBLES_EQUAL(0, graph.error(groundTruth), 1e-9);
-
-  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
-  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-      Point3(0.1, 0.1, 0.1)); // smaller noise
-  Values values;
-  values.insert(x1, cam1.pose());
-  values.insert(x2, cam2.pose());
-  // initialize third pose with some noise, we expect it to move back to original pose_above
-  values.insert(x3, pose_above * noise_pose);
-  EXPECT(
-      assert_equal(
-          Pose3(
-              Rot3(0, -0.0314107591, 0.99950656, -0.99950656, -0.0313952598,
-                  -0.000986635786, 0.0314107591, -0.999013364, -0.0313952598),
-              Point3(0.1, -0.1, 1.9)), values.at<Pose3>(x3)));
-
-  Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
-  result = optimizer.optimize();
-  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-6));
-}
-
-/* *************************************************************************/
-TEST( SmartProjectionPoseFactor, Factors ) {
-
-  using namespace vanillaPose;
-
-  // Default cameras for simple derivatives
-  Rot3 R;
-  static Cal3_S2::shared_ptr sharedK(new Cal3_S2(100, 100, 0, 0, 0));
-  Camera cam1(Pose3(R, Point3(0, 0, 0)), sharedK), cam2(
-      Pose3(R, Point3(1, 0, 0)), sharedK);
-
-  // one landmarks 1m in front of camera
-  Point3 landmark1(0, 0, 10);
-
-  Point2Vector measurements_cam1;
-
-  // Project 2 landmarks into 2 cameras
-  measurements_cam1.push_back(cam1.project(landmark1));
-  measurements_cam1.push_back(cam2.project(landmark1));
-
-  // Create smart factors
-  KeyVector views {x1, x2};
-
-  SmartFactor::shared_ptr smartFactor1 = boost::make_shared<SmartFactor>(model, sharedK);
-  smartFactor1->add(measurements_cam1, views);
-
-  SmartFactor::Cameras cameras;
-  cameras.push_back(cam1);
-  cameras.push_back(cam2);
-
-  // Make sure triangulation works
-  CHECK(smartFactor1->triangulateSafe(cameras));
-  CHECK(!smartFactor1->isDegenerate());
-  CHECK(!smartFactor1->isPointBehindCamera());
-  boost::optional<Point3> p = smartFactor1->point();
-  CHECK(p);
-  EXPECT(assert_equal(landmark1, *p));
-
-  VectorValues zeroDelta;
-  Vector6 delta;
-  delta.setZero();
-  zeroDelta.insert(x1, delta);
-  zeroDelta.insert(x2, delta);
-
-  VectorValues perturbedDelta;
-  delta.setOnes();
-  perturbedDelta.insert(x1, delta);
-  perturbedDelta.insert(x2, delta);
-  double expectedError = 2500;
-
-  // After eliminating the point, A1 and A2 contain 2-rank information on cameras:
-  Matrix16 A1, A2;
-  A1 << -10, 0, 0, 0, 1, 0;
-  A2 << 10, 0, 1, 0, -1, 0;
-  A1 *= 10. / sigma;
-  A2 *= 10. / sigma;
-  Matrix expectedInformation; // filled below
-  {
-    // createHessianFactor
-    Matrix66 G11 = 0.5 * A1.transpose() * A1;
-    Matrix66 G12 = 0.5 * A1.transpose() * A2;
-    Matrix66 G22 = 0.5 * A2.transpose() * A2;
-
-    Vector6 g1;
-    g1.setZero();
-    Vector6 g2;
-    g2.setZero();
-
-    double f = 0;
-
-    RegularHessianFactor<6> expected(x1, x2, G11, G12, g1, G22, g2, f);
-    expectedInformation = expected.information();
-
-    boost::shared_ptr<RegularHessianFactor<6> > actual =
-        smartFactor1->createHessianFactor(cameras, 0.0);
-    EXPECT(assert_equal(expectedInformation, actual->information(), 1e-6));
-    EXPECT(assert_equal(expected, *actual, 1e-6));
-    EXPECT_DOUBLES_EQUAL(0, actual->error(zeroDelta), 1e-6);
-    EXPECT_DOUBLES_EQUAL(expectedError, actual->error(perturbedDelta), 1e-6);
-  }
-
-  {
-    Matrix26 F1;
-    F1.setZero();
-    F1(0, 1) = -100;
-    F1(0, 3) = -10;
-    F1(1, 0) = 100;
-    F1(1, 4) = -10;
-    Matrix26 F2;
-    F2.setZero();
-    F2(0, 1) = -101;
-    F2(0, 3) = -10;
-    F2(0, 5) = -1;
-    F2(1, 0) = 100;
-    F2(1, 2) = 10;
-    F2(1, 4) = -10;
-    Matrix E(4, 3);
-    E.setZero();
-    E(0, 0) = 10;
-    E(1, 1) = 10;
-    E(2, 0) = 10;
-    E(2, 2) = 1;
-    E(3, 1) = 10;
-    SmartFactor::FBlocks Fs = list_of<Matrix>(F1)(F2);
-    Vector b(4);
-    b.setZero();
-
-    // Create smart factors
-    KeyVector keys;
-    keys.push_back(x1);
-    keys.push_back(x2);
-
-    // createJacobianQFactor
-    SharedIsotropic n = noiseModel::Isotropic::Sigma(4, sigma);
-    Matrix3 P = (E.transpose() * E).inverse();
-    JacobianFactorQ<6, 2> expectedQ(keys, Fs, E, P, b, n);
-    EXPECT(assert_equal(expectedInformation, expectedQ.information(), 1e-6));
-
-    boost::shared_ptr<JacobianFactorQ<6, 2> > actualQ =
-        smartFactor1->createJacobianQFactor(cameras, 0.0);
-    CHECK(actualQ);
-    EXPECT(assert_equal(expectedInformation, actualQ->information(), 1e-6));
-    EXPECT(assert_equal(expectedQ, *actualQ));
-    EXPECT_DOUBLES_EQUAL(0, actualQ->error(zeroDelta), 1e-6);
-    EXPECT_DOUBLES_EQUAL(expectedError, actualQ->error(perturbedDelta), 1e-6);
-
-    // Whiten for RegularImplicitSchurFactor (does not have noise model)
-    model->WhitenSystem(E, b);
-    Matrix3 whiteP = (E.transpose() * E).inverse();
-    Fs[0] = model->Whiten(Fs[0]);
-    Fs[1] = model->Whiten(Fs[1]);
-
-    // createRegularImplicitSchurFactor
-    RegularImplicitSchurFactor<Camera> expected(keys, Fs, E, whiteP, b);
-
-    boost::shared_ptr<RegularImplicitSchurFactor<Camera> > actual =
-        smartFactor1->createRegularImplicitSchurFactor(cameras, 0.0);
-    CHECK(actual);
-    EXPECT(assert_equal(expectedInformation, expected.information(), 1e-6));
-    EXPECT(assert_equal(expectedInformation, actual->information(), 1e-6));
-    EXPECT(assert_equal(expected, *actual));
-    EXPECT_DOUBLES_EQUAL(0, actual->error(zeroDelta), 1e-6);
-    EXPECT_DOUBLES_EQUAL(expectedError, actual->error(perturbedDelta), 1e-6);
-  }
-
-  {
-    // createJacobianSVDFactor
-    Vector1 b;
-    b.setZero();
-    double s = sigma * sin(M_PI_4);
-    SharedIsotropic n = noiseModel::Isotropic::Sigma(4 - 3, sigma);
-    JacobianFactor expected(x1, s * A1, x2, s * A2, b, n);
-    EXPECT(assert_equal(expectedInformation, expected.information(), 1e-6));
-
-    boost::shared_ptr<JacobianFactor> actual =
-        smartFactor1->createJacobianSVDFactor(cameras, 0.0);
-    CHECK(actual);
-    EXPECT(assert_equal(expectedInformation, actual->information(), 1e-6));
-    EXPECT(assert_equal(expected, *actual));
-    EXPECT_DOUBLES_EQUAL(0, actual->error(zeroDelta), 1e-6);
-    EXPECT_DOUBLES_EQUAL(expectedError, actual->error(perturbedDelta), 1e-6);
-  }
-}
-
-/* *************************************************************************/
-TEST( SmartProjectionPoseFactor, 3poses_iterative_smart_projection_factor ) {
-
-  using namespace vanillaPose;
-
-  KeyVector views {x1, x2, x3};
-
-  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
-
-  // Project three landmarks into three cameras
-  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
-  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
-
-  SmartFactor::shared_ptr smartFactor1(new SmartFactor(model, sharedK));
-  smartFactor1->add(measurements_cam1, views);
-
-  SmartFactor::shared_ptr smartFactor2(new SmartFactor(model, sharedK));
-  smartFactor2->add(measurements_cam2, views);
-
-  SmartFactor::shared_ptr smartFactor3(new SmartFactor(model, sharedK));
-  smartFactor3->add(measurements_cam3, views);
-
-  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
-
-  NonlinearFactorGraph graph;
-  graph.push_back(smartFactor1);
-  graph.push_back(smartFactor2);
-  graph.push_back(smartFactor3);
-  graph.addPrior(x1, cam1.pose(), noisePrior);
-  graph.addPrior(x2, cam2.pose(), noisePrior);
-
-  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
-  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-      Point3(0.1, 0.1, 0.1)); // smaller noise
-  Values values;
-  values.insert(x1, cam1.pose());
-  values.insert(x2, cam2.pose());
-  // initialize third pose with some noise, we expect it to move back to original pose_above
-  values.insert(x3, pose_above * noise_pose);
-  EXPECT(
-      assert_equal(
-          Pose3(
-              Rot3(1.11022302e-16, -0.0314107591, 0.99950656, -0.99950656,
-                  -0.0313952598, -0.000986635786, 0.0314107591, -0.999013364,
-                  -0.0313952598), Point3(0.1, -0.1, 1.9)),
-          values.at<Pose3>(x3)));
-
-  Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
-  result = optimizer.optimize();
-  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-7));
-}
-
-/* *************************************************************************/
-TEST( SmartProjectionPoseFactor, jacobianSVD ) {
-
-  using namespace vanillaPose;
-
-  KeyVector views {x1, x2, x3};
-
-  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
-
-  // Project three landmarks into three cameras
-  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
-  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
-
-  SmartProjectionParams params;
-  params.setRankTolerance(1.0);
-  params.setLinearizationMode(gtsam::JACOBIAN_SVD);
-  params.setDegeneracyMode(gtsam::IGNORE_DEGENERACY);
-  params.setEnableEPI(false);
-  SmartFactor factor1(model, sharedK, params);
-
-  SmartFactor::shared_ptr smartFactor1(
-      new SmartFactor(model, sharedK, params));
-  smartFactor1->add(measurements_cam1, views);
-
-  SmartFactor::shared_ptr smartFactor2(
-      new SmartFactor(model, sharedK, params));
-  smartFactor2->add(measurements_cam2, views);
-
-  SmartFactor::shared_ptr smartFactor3(
-      new SmartFactor(model, sharedK, params));
-  smartFactor3->add(measurements_cam3, views);
-
-  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
-
-  NonlinearFactorGraph graph;
-  graph.push_back(smartFactor1);
-  graph.push_back(smartFactor2);
-  graph.push_back(smartFactor3);
-  graph.addPrior(x1, cam1.pose(), noisePrior);
-  graph.addPrior(x2, cam2.pose(), noisePrior);
-
-  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
-  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-      Point3(0.1, 0.1, 0.1)); // smaller noise
-  Values values;
-  values.insert(x1, cam1.pose());
-  values.insert(x2, cam2.pose());
-  values.insert(x3, pose_above * noise_pose);
-
-  Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
-  result = optimizer.optimize();
-  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-6));
-}
-
-/* *************************************************************************/
-TEST( SmartProjectionPoseFactor, landmarkDistance ) {
-
-  using namespace vanillaPose;
-
-  double excludeLandmarksFutherThanDist = 2;
-
-  KeyVector views {x1, x2, x3};
-
-  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
-
-  // Project three landmarks into three cameras
-  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
-  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
-
-  SmartProjectionParams params;
-  params.setRankTolerance(1.0);
-  params.setLinearizationMode(gtsam::JACOBIAN_SVD);
-  params.setDegeneracyMode(gtsam::IGNORE_DEGENERACY);
-  params.setLandmarkDistanceThreshold(excludeLandmarksFutherThanDist);
-  params.setEnableEPI(false);
-
-  SmartFactor::shared_ptr smartFactor1(
-      new SmartFactor(model, sharedK, params));
-  smartFactor1->add(measurements_cam1, views);
-
-  SmartFactor::shared_ptr smartFactor2(
-      new SmartFactor(model, sharedK, params));
-  smartFactor2->add(measurements_cam2, views);
-
-  SmartFactor::shared_ptr smartFactor3(
-      new SmartFactor(model, sharedK, params));
-  smartFactor3->add(measurements_cam3, views);
-
-  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
-
-  NonlinearFactorGraph graph;
-  graph.push_back(smartFactor1);
-  graph.push_back(smartFactor2);
-  graph.push_back(smartFactor3);
-  graph.addPrior(x1, cam1.pose(), noisePrior);
-  graph.addPrior(x2, cam2.pose(), noisePrior);
-
-  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
-  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-      Point3(0.1, 0.1, 0.1)); // smaller noise
-  Values values;
-  values.insert(x1, cam1.pose());
-  values.insert(x2, cam2.pose());
-  values.insert(x3, pose_above * noise_pose);
-
-  // All factors are disabled and pose should remain where it is
-  Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
-  result = optimizer.optimize();
-  EXPECT(assert_equal(values.at<Pose3>(x3), result.at<Pose3>(x3)));
-}
-
-/* *************************************************************************/
-TEST( SmartProjectionPoseFactor, dynamicOutlierRejection ) {
-
-  using namespace vanillaPose;
-
-  double excludeLandmarksFutherThanDist = 1e10;
-  double dynamicOutlierRejectionThreshold = 1; // max 1 pixel of average reprojection error
-
-  KeyVector views {x1, x2, x3};
-
-  // add fourth landmark
-  Point3 landmark4(5, -0.5, 1);
-
-  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3,
-      measurements_cam4;
-
-  // Project 4 landmarks into three cameras
-  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
-  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
-  projectToMultipleCameras(cam1, cam2, cam3, landmark4, measurements_cam4);
-  measurements_cam4.at(0) = measurements_cam4.at(0) + Point2(10, 10); // add outlier
-
-  SmartProjectionParams params;
-  params.setLinearizationMode(gtsam::JACOBIAN_SVD);
-  params.setLandmarkDistanceThreshold(excludeLandmarksFutherThanDist);
-  params.setDynamicOutlierRejectionThreshold(dynamicOutlierRejectionThreshold);
-
-  SmartFactor::shared_ptr smartFactor1(
-      new SmartFactor(model, sharedK, params));
-  smartFactor1->add(measurements_cam1, views);
-
-  SmartFactor::shared_ptr smartFactor2(
-      new SmartFactor(model, sharedK, params));
-  smartFactor2->add(measurements_cam2, views);
-
-  SmartFactor::shared_ptr smartFactor3(
-      new SmartFactor(model, sharedK, params));
-  smartFactor3->add(measurements_cam3, views);
-
-  SmartFactor::shared_ptr smartFactor4(
-      new SmartFactor(model, sharedK, params));
-  smartFactor4->add(measurements_cam4, views);
-
-  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
-
-  NonlinearFactorGraph graph;
-  graph.push_back(smartFactor1);
-  graph.push_back(smartFactor2);
-  graph.push_back(smartFactor3);
-  graph.push_back(smartFactor4);
-  graph.addPrior(x1, cam1.pose(), noisePrior);
-  graph.addPrior(x2, cam2.pose(), noisePrior);
-
-  Values values;
-  values.insert(x1, cam1.pose());
-  values.insert(x2, cam2.pose());
-  values.insert(x3, cam3.pose());
-
-  // All factors are disabled and pose should remain where it is
-  Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
-  result = optimizer.optimize();
-  EXPECT(assert_equal(cam3.pose(), result.at<Pose3>(x3)));
-}
-
-/* *************************************************************************/
-TEST( SmartProjectionPoseFactor, jacobianQ ) {
-
-  using namespace vanillaPose;
-
-  KeyVector views {x1, x2, x3};
-
-  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
-
-  // Project three landmarks into three cameras
-  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
-  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
-
-  SmartProjectionParams params;
-  params.setLinearizationMode(gtsam::JACOBIAN_Q);
-
-  SmartFactor::shared_ptr smartFactor1(
-      new SmartFactor(model, sharedK, params));
-  smartFactor1->add(measurements_cam1, views);
-
-  SmartFactor::shared_ptr smartFactor2(
-      new SmartFactor(model, sharedK, params));
-  smartFactor2->add(measurements_cam2, views);
-
-  SmartFactor::shared_ptr smartFactor3(
-      new SmartFactor(model, sharedK, params));
-  smartFactor3->add(measurements_cam3, views);
-
-  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
-
-  NonlinearFactorGraph graph;
-  graph.push_back(smartFactor1);
-  graph.push_back(smartFactor2);
-  graph.push_back(smartFactor3);
-  graph.addPrior(x1, cam1.pose(), noisePrior);
-  graph.addPrior(x2, cam2.pose(), noisePrior);
-
-  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-      Point3(0.1, 0.1, 0.1)); // smaller noise
-  Values values;
-  values.insert(x1, cam1.pose());
-  values.insert(x2, cam2.pose());
-  values.insert(x3, pose_above * noise_pose);
-
-  Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
-  result = optimizer.optimize();
-  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-6));
-}
-
-/* *************************************************************************/
-TEST( SmartProjectionPoseFactor, 3poses_projection_factor ) {
-
-  using namespace vanillaPose2;
-
-  KeyVector views {x1, x2, x3};
-
-  typedef GenericProjectionFactor<Pose3, Point3> ProjectionFactor;
-  NonlinearFactorGraph graph;
-
-  // Project three landmarks into three cameras
-  graph.emplace_shared<ProjectionFactor>(cam1.project(landmark1), model, x1, L(1), sharedK2);
-  graph.emplace_shared<ProjectionFactor>(cam2.project(landmark1), model, x2, L(1), sharedK2);
-  graph.emplace_shared<ProjectionFactor>(cam3.project(landmark1), model, x3, L(1), sharedK2);
-
-  graph.emplace_shared<ProjectionFactor>(cam1.project(landmark2), model, x1, L(2), sharedK2);
-  graph.emplace_shared<ProjectionFactor>(cam2.project(landmark2), model, x2, L(2), sharedK2);
-  graph.emplace_shared<ProjectionFactor>(cam3.project(landmark2), model, x3, L(2), sharedK2);
-
-  graph.emplace_shared<ProjectionFactor>(cam1.project(landmark3), model, x1, L(3), sharedK2);
-  graph.emplace_shared<ProjectionFactor>(cam2.project(landmark3), model, x2, L(3), sharedK2);
-  graph.emplace_shared<ProjectionFactor>(cam3.project(landmark3), model, x3, L(3), sharedK2);
-
-  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
-  graph.addPrior(x1, level_pose, noisePrior);
-  graph.addPrior(x2, pose_right, noisePrior);
-
-  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 10, 0., -M_PI / 10),
-      Point3(0.5, 0.1, 0.3));
-  Values values;
-  values.insert(x1, level_pose);
-  values.insert(x2, pose_right);
-  values.insert(x3, pose_above * noise_pose);
-  values.insert(L(1), landmark1);
-  values.insert(L(2), landmark2);
-  values.insert(L(3), landmark3);
-
-  DOUBLES_EQUAL(48406055, graph.error(values), 1);
-
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
-  Values result = optimizer.optimize();
-
-  DOUBLES_EQUAL(0, graph.error(result), 1e-9);
-
-  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-7));
-}
-
-/* *************************************************************************/
-TEST( SmartProjectionPoseFactor, CheckHessian) {
-
-  KeyVector views {x1, x2, x3};
-
-  using namespace vanillaPose;
-
-  // Two slightly different cameras
-  Pose3 pose2 = level_pose
-      * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
-  Pose3 pose3 = pose2 * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
-  Camera cam2(pose2, sharedK);
-  Camera cam3(pose3, sharedK);
-
-  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
-
-  // Project three landmarks into three cameras
-  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
-  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
-
-  SmartProjectionParams params;
-  params.setRankTolerance(10);
-
-  SmartFactor::shared_ptr smartFactor1(
-      new SmartFactor(model, sharedK, params)); // HESSIAN, by default
-  smartFactor1->add(measurements_cam1, views);
-
-  SmartFactor::shared_ptr smartFactor2(
-      new SmartFactor(model, sharedK, params)); // HESSIAN, by default
-  smartFactor2->add(measurements_cam2, views);
-
-  SmartFactor::shared_ptr smartFactor3(
-      new SmartFactor(model, sharedK, params)); // HESSIAN, by default
-  smartFactor3->add(measurements_cam3, views);
-
-  NonlinearFactorGraph graph;
-  graph.push_back(smartFactor1);
-  graph.push_back(smartFactor2);
-  graph.push_back(smartFactor3);
-
-  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
-  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-      Point3(0.1, 0.1, 0.1)); // smaller noise
-  Values values;
-  values.insert(x1, cam1.pose());
-  values.insert(x2, cam2.pose());
-  // initialize third pose with some noise, we expect it to move back to original pose_above
-  values.insert(x3, pose3 * noise_pose);
-  EXPECT(
-      assert_equal(
-          Pose3(
-              Rot3(0.00563056869, -0.130848107, 0.991386438, -0.991390265,
-                  -0.130426831, -0.0115837907, 0.130819108, -0.98278564,
-                  -0.130455917),
-              Point3(0.0897734171, -0.110201006, 0.901022872)),
-          values.at<Pose3>(x3)));
-
-  boost::shared_ptr<GaussianFactor> factor1 = smartFactor1->linearize(values);
-  boost::shared_ptr<GaussianFactor> factor2 = smartFactor2->linearize(values);
-  boost::shared_ptr<GaussianFactor> factor3 = smartFactor3->linearize(values);
-
-  Matrix CumulativeInformation = factor1->information() + factor2->information()
-      + factor3->information();
-
-  boost::shared_ptr<GaussianFactorGraph> GaussianGraph = graph.linearize(
-      values);
-  Matrix GraphInformation = GaussianGraph->hessian().first;
-
-  // Check Hessian
-  EXPECT(assert_equal(GraphInformation, CumulativeInformation, 1e-6));
-
-  Matrix AugInformationMatrix = factor1->augmentedInformation()
-      + factor2->augmentedInformation() + factor3->augmentedInformation();
-
-  // Check Information vector
-  Vector InfoVector = AugInformationMatrix.block(0, 18, 18, 1); // 18x18 Hessian + information vector
-
-  // Check Hessian
-  EXPECT(assert_equal(InfoVector, GaussianGraph->hessian().second, 1e-6));
-}
-
-/* *************************************************************************/
-TEST( SmartProjectionPoseFactor, 3poses_2land_rotation_only_smart_projection_factor ) {
-  using namespace vanillaPose2;
-
-  KeyVector views {x1, x2, x3};
-
-  // Two different cameras, at the same position, but different rotations
-  Pose3 pose2 = level_pose * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0,0,0));
-  Pose3 pose3 = pose2 * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0,0,0));
-  Camera cam2(pose2, sharedK2);
-  Camera cam3(pose3, sharedK2);
-
-  Point2Vector measurements_cam1, measurements_cam2;
-
-  // Project three landmarks into three cameras
-  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
-
-  SmartProjectionParams params;
-  params.setRankTolerance(50);
-  params.setDegeneracyMode(gtsam::HANDLE_INFINITY);
-
-  SmartFactor::shared_ptr smartFactor1(
-      new SmartFactor(model, sharedK2, params));
-  smartFactor1->add(measurements_cam1, views);
-
-  SmartFactor::shared_ptr smartFactor2(
-      new SmartFactor(model, sharedK2, params));
-  smartFactor2->add(measurements_cam2, views);
-
-  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
-  const SharedDiagonal noisePriorTranslation = noiseModel::Isotropic::Sigma(3, 0.10);
-  Point3 positionPrior = Point3(0, 0, 1);
-
-  NonlinearFactorGraph graph;
-  graph.push_back(smartFactor1);
-  graph.push_back(smartFactor2);
-  graph.addPrior(x1, cam1.pose(), noisePrior);
-  graph.emplace_shared<PoseTranslationPrior<Pose3> >(x2, positionPrior, noisePriorTranslation);
-  graph.emplace_shared<PoseTranslationPrior<Pose3> >(x3, positionPrior, noisePriorTranslation);
-
-  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-      Point3(0.1, 0.1, 0.1)); // smaller noise
-  Values values;
-  values.insert(x1, cam1.pose());
-  values.insert(x2, pose2 * noise_pose);
-  values.insert(x3, pose3 * noise_pose);
-
-  // params.verbosityLM = LevenbergMarquardtParams::SUMMARY;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
-  Values result = optimizer.optimize();
-  EXPECT(assert_equal(pose3, result.at<Pose3>(x3)));
-}
-
-/* *************************************************************************/
-TEST( SmartProjectionPoseFactor, 3poses_rotation_only_smart_projection_factor ) {
-
-  // this test considers a condition in which the cheirality constraint is triggered
-  using namespace vanillaPose;
-
-  KeyVector views {x1, x2, x3};
-
-  // Two different cameras, at the same position, but different rotations
-  Pose3 pose2 = level_pose
-      * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
-  Pose3 pose3 = pose2 * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
-  Camera cam2(pose2, sharedK);
-  Camera cam3(pose3, sharedK);
-
-  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
-
-  // Project three landmarks into three cameras
-  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
-  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
-
-  SmartProjectionParams params;
-  params.setRankTolerance(10);
-  params.setDegeneracyMode(gtsam::ZERO_ON_DEGENERACY);
-
-  SmartFactor::shared_ptr smartFactor1(
-      new SmartFactor(model, sharedK, params));
-  smartFactor1->add(measurements_cam1, views);
-
-  SmartFactor::shared_ptr smartFactor2(
-      new SmartFactor(model, sharedK, params));
-  smartFactor2->add(measurements_cam2, views);
-
-  SmartFactor::shared_ptr smartFactor3(
-      new SmartFactor(model, sharedK, params));
-  smartFactor3->add(measurements_cam3, views);
-
-  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
-  const SharedDiagonal noisePriorTranslation = noiseModel::Isotropic::Sigma(3,
-      0.10);
-  Point3 positionPrior = Point3(0, 0, 1);
-
-  NonlinearFactorGraph graph;
-  graph.push_back(smartFactor1);
-  graph.push_back(smartFactor2);
-  graph.push_back(smartFactor3);
-  graph.addPrior(x1, cam1.pose(), noisePrior);
-  graph.emplace_shared<PoseTranslationPrior<Pose3> >(x2, positionPrior, noisePriorTranslation);
-  graph.emplace_shared<PoseTranslationPrior<Pose3> >(x3, positionPrior, noisePriorTranslation);
-
-  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
-  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-      Point3(0.1, 0.1, 0.1)); // smaller noise
-  Values values;
-  values.insert(x1, cam1.pose());
-  values.insert(x2, cam2.pose());
-  values.insert(x3, pose3 * noise_pose);
-  EXPECT(
-      assert_equal(
-          Pose3(
-              Rot3(0.00563056869, -0.130848107, 0.991386438, -0.991390265,
-                  -0.130426831, -0.0115837907, 0.130819108, -0.98278564,
-                  -0.130455917),
-              Point3(0.0897734171, -0.110201006, 0.901022872)),
-          values.at<Pose3>(x3)));
-
-  Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
-  result = optimizer.optimize();
-
-  // Since we do not do anything on degenerate instances (ZERO_ON_DEGENERACY)
-  // rotation remains the same as the initial guess, but position is fixed by PoseTranslationPrior
-#ifdef GTSAM_THROW_CHEIRALITY_EXCEPTION
-  EXPECT(assert_equal(Pose3(values.at<Pose3>(x3).rotation(),
-      Point3(0,0,1)), result.at<Pose3>(x3)));
-#else
-  // if the check is disabled, no cheirality exception if thrown and the pose converges to the right rotation
-  // with modest accuracy since the configuration is essentially degenerate without the translation due to noise (noise_pose)
-  EXPECT(assert_equal(pose3, result.at<Pose3>(x3),1e-3));
-#endif
-}
-
-/* *************************************************************************/
-TEST( SmartProjectionPoseFactor, Hessian ) {
-
-  using namespace vanillaPose2;
-
-  KeyVector views {x1, x2};
-
-  // Project three landmarks into 2 cameras
-  Point2 cam1_uv1 = cam1.project(landmark1);
-  Point2 cam2_uv1 = cam2.project(landmark1);
-  Point2Vector measurements_cam1;
-  measurements_cam1.push_back(cam1_uv1);
-  measurements_cam1.push_back(cam2_uv1);
-
-  SmartFactor::shared_ptr smartFactor1(new SmartFactor(model, sharedK2));
-  smartFactor1->add(measurements_cam1, views);
-
-  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 10, 0., -M_PI / 10),
-      Point3(0.5, 0.1, 0.3));
-  Values values;
-  values.insert(x1, cam1.pose());
-  values.insert(x2, cam2.pose());
-
-  boost::shared_ptr<GaussianFactor> factor = smartFactor1->linearize(values);
-
-  // compute triangulation from linearization point
-  // compute reprojection errors (sum squared)
-  // compare with factor.info(): the bottom right element is the squared sum of the reprojection errors (normalized by the covariance)
-  // check that it is correctly scaled when using noiseProjection = [1/4  0; 0 1/4]
-}
-
-/* *************************************************************************/
-TEST( SmartProjectionPoseFactor, HessianWithRotation ) {
-  // cout << " ************************ SmartProjectionPoseFactor: rotated Hessian **********************" << endl;
-
-  using namespace vanillaPose;
-
-  KeyVector views {x1, x2, x3};
-
-  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
-
-  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-
-  SmartFactor::shared_ptr smartFactorInstance(new SmartFactor(model, sharedK));
-  smartFactorInstance->add(measurements_cam1, views);
-
-  Values values;
-  values.insert(x1, cam1.pose());
-  values.insert(x2, cam2.pose());
-  values.insert(x3, cam3.pose());
-
-  boost::shared_ptr<GaussianFactor> factor = smartFactorInstance->linearize(
-      values);
-
-  Pose3 poseDrift = Pose3(Rot3::Ypr(-M_PI / 2, 0., -M_PI / 2), Point3(0, 0, 0));
-
-  Values rotValues;
-  rotValues.insert(x1, poseDrift.compose(level_pose));
-  rotValues.insert(x2, poseDrift.compose(pose_right));
-  rotValues.insert(x3, poseDrift.compose(pose_above));
-
-  boost::shared_ptr<GaussianFactor> factorRot = smartFactorInstance->linearize(
-      rotValues);
-
-  // Hessian is invariant to rotations in the nondegenerate case
-  EXPECT(assert_equal(factor->information(), factorRot->information(), 1e-7));
-
-  Pose3 poseDrift2 = Pose3(Rot3::Ypr(-M_PI / 2, -M_PI / 3, -M_PI / 2),
-      Point3(10, -4, 5));
-
-  Values tranValues;
-  tranValues.insert(x1, poseDrift2.compose(level_pose));
-  tranValues.insert(x2, poseDrift2.compose(pose_right));
-  tranValues.insert(x3, poseDrift2.compose(pose_above));
-
-  boost::shared_ptr<GaussianFactor> factorRotTran =
-      smartFactorInstance->linearize(tranValues);
-
-  // Hessian is invariant to rotations and translations in the nondegenerate case
-  EXPECT(assert_equal(factor->information(), factorRotTran->information(), 1e-7));
-}
-
-/* *************************************************************************/
-TEST( SmartProjectionPoseFactor, HessianWithRotationDegenerate ) {
-
-  using namespace vanillaPose2;
-
-  KeyVector views {x1, x2, x3};
-
-  // All cameras have the same pose so will be degenerate !
-  Camera cam2(level_pose, sharedK2);
-  Camera cam3(level_pose, sharedK2);
-
-  Point2Vector measurements_cam1;
-  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-
-  SmartFactor::shared_ptr smartFactor(new SmartFactor(model, sharedK2));
-  smartFactor->add(measurements_cam1, views);
-
-  Values values;
-  values.insert(x1, cam1.pose());
-  values.insert(x2, cam2.pose());
-  values.insert(x3, cam3.pose());
-
-  boost::shared_ptr<GaussianFactor> factor = smartFactor->linearize(values);
-
-  Pose3 poseDrift = Pose3(Rot3::Ypr(-M_PI / 2, 0., -M_PI / 2), Point3(0, 0, 0));
-
-  Values rotValues;
-  rotValues.insert(x1, poseDrift.compose(level_pose));
-  rotValues.insert(x2, poseDrift.compose(level_pose));
-  rotValues.insert(x3, poseDrift.compose(level_pose));
-
-  boost::shared_ptr<GaussianFactor> factorRot = //
-      smartFactor->linearize(rotValues);
-
-  // Hessian is invariant to rotations in the nondegenerate case
-  EXPECT(assert_equal(factor->information(), factorRot->information(), 1e-7));
-
-  Pose3 poseDrift2 = Pose3(Rot3::Ypr(-M_PI / 2, -M_PI / 3, -M_PI / 2),
-      Point3(10, -4, 5));
-
-  Values tranValues;
-  tranValues.insert(x1, poseDrift2.compose(level_pose));
-  tranValues.insert(x2, poseDrift2.compose(level_pose));
-  tranValues.insert(x3, poseDrift2.compose(level_pose));
-
-  boost::shared_ptr<GaussianFactor> factorRotTran = smartFactor->linearize(
-      tranValues);
-
-  // Hessian is invariant to rotations and translations in the nondegenerate case
-  EXPECT(assert_equal(factor->information(), factorRotTran->information(), 1e-7));
-}
-
-/* ************************************************************************* */
-TEST( SmartProjectionPoseFactor, ConstructorWithCal3Bundler) {
-  using namespace bundlerPose;
-  SmartProjectionParams params;
-  params.setDegeneracyMode(gtsam::ZERO_ON_DEGENERACY);
-  SmartFactor factor(model, sharedBundlerK, params);
-  factor.add(measurement1, x1);
-}
-
-/* *************************************************************************/
-TEST( SmartProjectionPoseFactor, Cal3Bundler ) {
-
-  using namespace bundlerPose;
-
-  // three landmarks ~5 meters in front of camera
-  Point3 landmark3(3, 0, 3.0);
-
-  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
-
-  // Project three landmarks into three cameras
-  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
-  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
-
-  KeyVector views {x1, x2, x3};
-
-  SmartFactor::shared_ptr smartFactor1(new SmartFactor(model, sharedBundlerK));
-  smartFactor1->add(measurements_cam1, views);
-
-  SmartFactor::shared_ptr smartFactor2(new SmartFactor(model, sharedBundlerK));
-  smartFactor2->add(measurements_cam2, views);
-
-  SmartFactor::shared_ptr smartFactor3(new SmartFactor(model, sharedBundlerK));
-  smartFactor3->add(measurements_cam3, views);
-
-  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
-
-  NonlinearFactorGraph graph;
-  graph.push_back(smartFactor1);
-  graph.push_back(smartFactor2);
-  graph.push_back(smartFactor3);
-  graph.addPrior(x1, cam1.pose(), noisePrior);
-  graph.addPrior(x2, cam2.pose(), noisePrior);
-
-  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
-  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-      Point3(0.1, 0.1, 0.1)); // smaller noise
-  Values values;
-  values.insert(x1, cam1.pose());
-  values.insert(x2, cam2.pose());
-  // initialize third pose with some noise, we expect it to move back to original pose_above
-  values.insert(x3, pose_above * noise_pose);
-  EXPECT(
-      assert_equal(
-          Pose3(
-              Rot3(0, -0.0314107591, 0.99950656, -0.99950656, -0.0313952598,
-                  -0.000986635786, 0.0314107591, -0.999013364, -0.0313952598),
-              Point3(0.1, -0.1, 1.9)), values.at<Pose3>(x3)));
-
-  Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
-  result = optimizer.optimize();
-  EXPECT(assert_equal(cam3.pose(), result.at<Pose3>(x3), 1e-6));
-}
-
-/* *************************************************************************/
-TEST( SmartProjectionPoseFactor, Cal3BundlerRotationOnly ) {
-
-  using namespace bundlerPose;
-
-  KeyVector views {x1, x2, x3};
-
-  // Two different cameras
-  Pose3 pose2 = level_pose
-      * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
-  Pose3 pose3 = pose2 * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
-  Camera cam2(pose2, sharedBundlerK);
-  Camera cam3(pose3, sharedBundlerK);
-
-  // landmark3 at 3 meters now
-  Point3 landmark3(3, 0, 3.0);
-
-  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
-
-  // Project three landmarks into three cameras
-  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
-  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
-
-  SmartProjectionParams params;
-  params.setRankTolerance(10);
-  params.setDegeneracyMode(gtsam::ZERO_ON_DEGENERACY);
-
-  SmartFactor::shared_ptr smartFactor1(
-      new SmartFactor(model, sharedBundlerK, params));
-  smartFactor1->add(measurements_cam1, views);
-
-  SmartFactor::shared_ptr smartFactor2(
-      new SmartFactor(model, sharedBundlerK, params));
-  smartFactor2->add(measurements_cam2, views);
-
-  SmartFactor::shared_ptr smartFactor3(
-      new SmartFactor(model, sharedBundlerK, params));
-  smartFactor3->add(measurements_cam3, views);
-
-  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
-  const SharedDiagonal noisePriorTranslation = noiseModel::Isotropic::Sigma(3,
-      0.10);
-  Point3 positionPrior = Point3(0, 0, 1);
-
-  NonlinearFactorGraph graph;
-  graph.push_back(smartFactor1);
-  graph.push_back(smartFactor2);
-  graph.push_back(smartFactor3);
-  graph.addPrior(x1, cam1.pose(), noisePrior);
-  graph.emplace_shared<PoseTranslationPrior<Pose3> >(x2, positionPrior, noisePriorTranslation);
-  graph.emplace_shared<PoseTranslationPrior<Pose3> >(x3, positionPrior, noisePriorTranslation);
-
-  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
-  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-      Point3(0.1, 0.1, 0.1)); // smaller noise
-  Values values;
-  values.insert(x1, cam1.pose());
-  values.insert(x2, cam2.pose());
-  // initialize third pose with some noise, we expect it to move back to original pose_above
-  values.insert(x3, pose3 * noise_pose);
-  EXPECT(
-      assert_equal(
-          Pose3(
-              Rot3(0.00563056869, -0.130848107, 0.991386438, -0.991390265,
-                  -0.130426831, -0.0115837907, 0.130819108, -0.98278564,
-                  -0.130455917),
-              Point3(0.0897734171, -0.110201006, 0.901022872)),
-          values.at<Pose3>(x3)));
-
-  Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
-  result = optimizer.optimize();
-
-  EXPECT(
-      assert_equal(
-          Pose3(
-              Rot3(0.00563056869, -0.130848107, 0.991386438, -0.991390265,
-                  -0.130426831, -0.0115837907, 0.130819108, -0.98278564,
-                  -0.130455917),
-              Point3(0.0897734171, -0.110201006, 0.901022872)),
-          values.at<Pose3>(x3)));
-}
-
-/* ************************************************************************* */
-BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Constrained, "gtsam_noiseModel_Constrained");
-BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Diagonal, "gtsam_noiseModel_Diagonal");
-BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Gaussian, "gtsam_noiseModel_Gaussian");
-BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Unit, "gtsam_noiseModel_Unit");
-BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Isotropic, "gtsam_noiseModel_Isotropic");
-BOOST_CLASS_EXPORT_GUID(gtsam::SharedNoiseModel, "gtsam_SharedNoiseModel");
-BOOST_CLASS_EXPORT_GUID(gtsam::SharedDiagonal, "gtsam_SharedDiagonal");
-
-TEST(SmartProjectionPoseFactor, serialize) {
-  using namespace vanillaPose;
-  using namespace gtsam::serializationTestHelpers;
-  SmartProjectionParams params;
-  params.setRankTolerance(rankTol);
-  SmartFactor factor(model, sharedK, params);
-
-  EXPECT(equalsObj(factor));
-  EXPECT(equalsXML(factor));
-  EXPECT(equalsBinary(factor));
-}
-
-TEST(SmartProjectionPoseFactor, serialize2) {
-  using namespace vanillaPose;
-  using namespace gtsam::serializationTestHelpers;
-  SmartProjectionParams params;
-  params.setRankTolerance(rankTol);
-  Pose3 bts;
-  SmartFactor factor(model, sharedK, bts, params);
-
-  // insert some measurments
-  KeyVector key_view;
-  Point2Vector meas_view;
-  key_view.push_back(Symbol('x', 1));
-  meas_view.push_back(Point2(10, 10));
-  factor.add(meas_view, key_view);
-
-  EXPECT(equalsObj(factor));
-  EXPECT(equalsXML(factor));
-  EXPECT(equalsBinary(factor));
-}
+///* ************************************************************************* */
+//TEST( SmartProjectionPoseFactor, Constructor) {
+//  using namespace vanillaPose;
+//  SmartFactor::shared_ptr factor1(new SmartFactor(model, sharedK));
+//}
+//
+///* ************************************************************************* */
+//TEST( SmartProjectionPoseFactor, Constructor2) {
+//  using namespace vanillaPose;
+//  SmartProjectionParams params;
+//  params.setRankTolerance(rankTol);
+//  SmartFactor factor1(model, sharedK, params);
+//}
+//
+///* ************************************************************************* */
+//TEST( SmartProjectionPoseFactor, Constructor3) {
+//  using namespace vanillaPose;
+//  SmartFactor::shared_ptr factor1(new SmartFactor(model, sharedK));
+//  factor1->add(measurement1, x1);
+//}
+//
+///* ************************************************************************* */
+//TEST( SmartProjectionPoseFactor, Constructor4) {
+//  using namespace vanillaPose;
+//  SmartProjectionParams params;
+//  params.setRankTolerance(rankTol);
+//  SmartFactor factor1(model, sharedK, params);
+//  factor1.add(measurement1, x1);
+//}
+//
+///* ************************************************************************* */
+//TEST( SmartProjectionPoseFactor, params) {
+//  using namespace vanillaPose;
+//  SmartProjectionParams params;
+//  double rt = params.getRetriangulationThreshold();
+//  EXPECT_DOUBLES_EQUAL(1e-5, rt, 1e-7);
+//  params.setRetriangulationThreshold(1e-3);
+//  rt = params.getRetriangulationThreshold();
+//  EXPECT_DOUBLES_EQUAL(1e-3, rt, 1e-7);
+//}
+//
+///* ************************************************************************* */
+//TEST( SmartProjectionPoseFactor, Equals ) {
+//  using namespace vanillaPose;
+//  SmartFactor::shared_ptr factor1(new SmartFactor(model, sharedK));
+//  factor1->add(measurement1, x1);
+//
+//  SmartFactor::shared_ptr factor2(new SmartFactor(model,sharedK));
+//  factor2->add(measurement1, x1);
+//
+//  CHECK(assert_equal(*factor1, *factor2));
+//}
+//
+///* *************************************************************************/
+//TEST( SmartProjectionPoseFactor, noiseless ) {
+//
+//  using namespace vanillaPose;
+//
+//  // Project two landmarks into two cameras
+//  Point2 level_uv = level_camera.project(landmark1);
+//  Point2 level_uv_right = level_camera_right.project(landmark1);
+//
+//  SmartFactor factor(model, sharedK);
+//  factor.add(level_uv, x1);
+//  factor.add(level_uv_right, x2);
+//
+//  Values values; // it's a pose factor, hence these are poses
+//  values.insert(x1, cam1.pose());
+//  values.insert(x2, cam2.pose());
+//
+//  double actualError = factor.error(values);
+//  double expectedError = 0.0;
+//  EXPECT_DOUBLES_EQUAL(expectedError, actualError, 1e-7);
+//
+//  SmartFactor::Cameras cameras = factor.cameras(values);
+//  double actualError2 = factor.totalReprojectionError(cameras);
+//  EXPECT_DOUBLES_EQUAL(expectedError, actualError2, 1e-7);
+//
+//  // Calculate expected derivative for point (easiest to check)
+//  std::function<Vector(Point3)> f = //
+//      std::bind(&SmartFactor::whitenedError<Point3>, factor, cameras, std::placeholders::_1);
+//
+//  // Calculate using computeEP
+//  Matrix actualE;
+//  factor.triangulateAndComputeE(actualE, values);
+//
+//  // get point
+//  boost::optional<Point3> point = factor.point();
+//  CHECK(point);
+//
+//  // calculate numerical derivative with triangulated point
+//  Matrix expectedE = sigma * numericalDerivative11<Vector, Point3>(f, *point);
+//  EXPECT(assert_equal(expectedE, actualE, 1e-7));
+//
+//  // Calculate using reprojectionError
+//  SmartFactor::Cameras::FBlocks F;
+//  Matrix E;
+//  Vector actualErrors = factor.unwhitenedError(cameras, *point, F, E);
+//  EXPECT(assert_equal(expectedE, E, 1e-7));
+//
+//  EXPECT(assert_equal(Z_4x1, actualErrors, 1e-7));
+//
+//  // Calculate using computeJacobians
+//  Vector b;
+//  SmartFactor::FBlocks Fs;
+//  factor.computeJacobians(Fs, E, b, cameras, *point);
+//  double actualError3 = b.squaredNorm();
+//  EXPECT(assert_equal(expectedE, E, 1e-7));
+//  EXPECT_DOUBLES_EQUAL(expectedError, actualError3, 1e-6);
+//}
+//
+///* *************************************************************************/
+//TEST( SmartProjectionPoseFactor, noisy ) {
+//
+//  using namespace vanillaPose;
+//
+//  // Project two landmarks into two cameras
+//  Point2 pixelError(0.2, 0.2);
+//  Point2 level_uv = level_camera.project(landmark1) + pixelError;
+//  Point2 level_uv_right = level_camera_right.project(landmark1);
+//
+//  Values values;
+//  values.insert(x1, cam1.pose());
+//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 10, 0., -M_PI / 10),
+//      Point3(0.5, 0.1, 0.3));
+//  values.insert(x2, pose_right.compose(noise_pose));
+//
+//  SmartFactor::shared_ptr factor(new SmartFactor(model, sharedK));
+//  factor->add(level_uv, x1);
+//  factor->add(level_uv_right, x2);
+//
+//  double actualError1 = factor->error(values);
+//
+//  SmartFactor::shared_ptr factor2(new SmartFactor(model, sharedK));
+//  Point2Vector measurements;
+//  measurements.push_back(level_uv);
+//  measurements.push_back(level_uv_right);
+//
+//  KeyVector views {x1, x2};
+//
+//  factor2->add(measurements, views);
+//  double actualError2 = factor2->error(values);
+//  DOUBLES_EQUAL(actualError1, actualError2, 1e-7);
+//}
+//
+///* *************************************************************************/
+//TEST(SmartProjectionPoseFactor, smartFactorWithSensorBodyTransform) {
+//  using namespace vanillaPose;
+//
+//  // create arbitrary body_T_sensor (transforms from sensor to body)
+//  Pose3 body_T_sensor = Pose3(Rot3::Ypr(-M_PI / 2, 0., -M_PI / 2), Point3(1, 1, 1));
+//
+//  // These are the poses we want to estimate, from camera measurements
+//  const Pose3 sensor_T_body = body_T_sensor.inverse();
+//  Pose3 wTb1 = cam1.pose() * sensor_T_body;
+//  Pose3 wTb2 = cam2.pose() * sensor_T_body;
+//  Pose3 wTb3 = cam3.pose() * sensor_T_body;
+//
+//  // three landmarks ~5 meters infront of camera
+//  Point3 landmark1(5, 0.5, 1.2), landmark2(5, -0.5, 1.2), landmark3(5, 0, 3.0);
+//
+//  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+//
+//  // Project three landmarks into three cameras
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+//
+//  // Create smart factors
+//  KeyVector views {x1, x2, x3};
+//
+//  SmartProjectionParams params;
+//  params.setRankTolerance(1.0);
+//  params.setDegeneracyMode(IGNORE_DEGENERACY);
+//  params.setEnableEPI(false);
+//
+//  SmartFactor smartFactor1(model, sharedK, body_T_sensor, params);
+//  smartFactor1.add(measurements_cam1, views);
+//
+//  SmartFactor smartFactor2(model, sharedK, body_T_sensor, params);
+//  smartFactor2.add(measurements_cam2, views);
+//
+//  SmartFactor smartFactor3(model, sharedK, body_T_sensor, params);
+//  smartFactor3.add(measurements_cam3, views);
+//
+//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+//
+//  // Put all factors in factor graph, adding priors
+//  NonlinearFactorGraph graph;
+//  graph.push_back(smartFactor1);
+//  graph.push_back(smartFactor2);
+//  graph.push_back(smartFactor3);
+//  graph.addPrior(x1, wTb1, noisePrior);
+//  graph.addPrior(x2, wTb2, noisePrior);
+//
+//  // Check errors at ground truth poses
+//  Values gtValues;
+//  gtValues.insert(x1, wTb1);
+//  gtValues.insert(x2, wTb2);
+//  gtValues.insert(x3, wTb3);
+//  double actualError = graph.error(gtValues);
+//  double expectedError = 0.0;
+//  DOUBLES_EQUAL(expectedError, actualError, 1e-7)
+//
+//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+//                           Point3(0.1, 0.1, 0.1));
+//  Values values;
+//  values.insert(x1, wTb1);
+//  values.insert(x2, wTb2);
+//  // initialize third pose with some noise, we expect it to move back to
+//  // original pose3
+//  values.insert(x3, wTb3 * noise_pose);
+//
+//  LevenbergMarquardtParams lmParams;
+//  Values result;
+//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+//  result = optimizer.optimize();
+//  EXPECT(assert_equal(wTb3, result.at<Pose3>(x3)));
+//}
+//
+///* *************************************************************************/
+//TEST( SmartProjectionPoseFactor, 3poses_smart_projection_factor ) {
+//
+//  using namespace vanillaPose2;
+//  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+//
+//  // Project three landmarks into three cameras
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+//
+//  KeyVector views;
+//  views.push_back(x1);
+//  views.push_back(x2);
+//  views.push_back(x3);
+//
+//  SmartFactor::shared_ptr smartFactor1(new SmartFactor(model, sharedK2));
+//  smartFactor1->add(measurements_cam1, views);
+//
+//  SmartFactor::shared_ptr smartFactor2(new SmartFactor(model, sharedK2));
+//  smartFactor2->add(measurements_cam2, views);
+//
+//  SmartFactor::shared_ptr smartFactor3(new SmartFactor(model, sharedK2));
+//  smartFactor3->add(measurements_cam3, views);
+//
+//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+//
+//  NonlinearFactorGraph graph;
+//  graph.push_back(smartFactor1);
+//  graph.push_back(smartFactor2);
+//  graph.push_back(smartFactor3);
+//  graph.addPrior(x1, cam1.pose(), noisePrior);
+//  graph.addPrior(x2, cam2.pose(), noisePrior);
+//
+//  Values groundTruth;
+//  groundTruth.insert(x1, cam1.pose());
+//  groundTruth.insert(x2, cam2.pose());
+//  groundTruth.insert(x3, cam3.pose());
+//  DOUBLES_EQUAL(0, graph.error(groundTruth), 1e-9);
+//
+//  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+//      Point3(0.1, 0.1, 0.1)); // smaller noise
+//  Values values;
+//  values.insert(x1, cam1.pose());
+//  values.insert(x2, cam2.pose());
+//  // initialize third pose with some noise, we expect it to move back to original pose_above
+//  values.insert(x3, pose_above * noise_pose);
+//  EXPECT(
+//      assert_equal(
+//          Pose3(
+//              Rot3(0, -0.0314107591, 0.99950656, -0.99950656, -0.0313952598,
+//                  -0.000986635786, 0.0314107591, -0.999013364, -0.0313952598),
+//              Point3(0.1, -0.1, 1.9)), values.at<Pose3>(x3)));
+//
+//  Values result;
+//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+//  result = optimizer.optimize();
+//  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-6));
+//}
+//
+///* *************************************************************************/
+//TEST( SmartProjectionPoseFactor, Factors ) {
+//
+//  using namespace vanillaPose;
+//
+//  // Default cameras for simple derivatives
+//  Rot3 R;
+//  static Cal3_S2::shared_ptr sharedK(new Cal3_S2(100, 100, 0, 0, 0));
+//  Camera cam1(Pose3(R, Point3(0, 0, 0)), sharedK), cam2(
+//      Pose3(R, Point3(1, 0, 0)), sharedK);
+//
+//  // one landmarks 1m in front of camera
+//  Point3 landmark1(0, 0, 10);
+//
+//  Point2Vector measurements_cam1;
+//
+//  // Project 2 landmarks into 2 cameras
+//  measurements_cam1.push_back(cam1.project(landmark1));
+//  measurements_cam1.push_back(cam2.project(landmark1));
+//
+//  // Create smart factors
+//  KeyVector views {x1, x2};
+//
+//  SmartFactor::shared_ptr smartFactor1 = boost::make_shared<SmartFactor>(model, sharedK);
+//  smartFactor1->add(measurements_cam1, views);
+//
+//  SmartFactor::Cameras cameras;
+//  cameras.push_back(cam1);
+//  cameras.push_back(cam2);
+//
+//  // Make sure triangulation works
+//  CHECK(smartFactor1->triangulateSafe(cameras));
+//  CHECK(!smartFactor1->isDegenerate());
+//  CHECK(!smartFactor1->isPointBehindCamera());
+//  boost::optional<Point3> p = smartFactor1->point();
+//  CHECK(p);
+//  EXPECT(assert_equal(landmark1, *p));
+//
+//  VectorValues zeroDelta;
+//  Vector6 delta;
+//  delta.setZero();
+//  zeroDelta.insert(x1, delta);
+//  zeroDelta.insert(x2, delta);
+//
+//  VectorValues perturbedDelta;
+//  delta.setOnes();
+//  perturbedDelta.insert(x1, delta);
+//  perturbedDelta.insert(x2, delta);
+//  double expectedError = 2500;
+//
+//  // After eliminating the point, A1 and A2 contain 2-rank information on cameras:
+//  Matrix16 A1, A2;
+//  A1 << -10, 0, 0, 0, 1, 0;
+//  A2 << 10, 0, 1, 0, -1, 0;
+//  A1 *= 10. / sigma;
+//  A2 *= 10. / sigma;
+//  Matrix expectedInformation; // filled below
+//  {
+//    // createHessianFactor
+//    Matrix66 G11 = 0.5 * A1.transpose() * A1;
+//    Matrix66 G12 = 0.5 * A1.transpose() * A2;
+//    Matrix66 G22 = 0.5 * A2.transpose() * A2;
+//
+//    Vector6 g1;
+//    g1.setZero();
+//    Vector6 g2;
+//    g2.setZero();
+//
+//    double f = 0;
+//
+//    RegularHessianFactor<6> expected(x1, x2, G11, G12, g1, G22, g2, f);
+//    expectedInformation = expected.information();
+//
+//    boost::shared_ptr<RegularHessianFactor<6> > actual =
+//        smartFactor1->createHessianFactor(cameras, 0.0);
+//    EXPECT(assert_equal(expectedInformation, actual->information(), 1e-6));
+//    EXPECT(assert_equal(expected, *actual, 1e-6));
+//    EXPECT_DOUBLES_EQUAL(0, actual->error(zeroDelta), 1e-6);
+//    EXPECT_DOUBLES_EQUAL(expectedError, actual->error(perturbedDelta), 1e-6);
+//  }
+//
+//  {
+//    Matrix26 F1;
+//    F1.setZero();
+//    F1(0, 1) = -100;
+//    F1(0, 3) = -10;
+//    F1(1, 0) = 100;
+//    F1(1, 4) = -10;
+//    Matrix26 F2;
+//    F2.setZero();
+//    F2(0, 1) = -101;
+//    F2(0, 3) = -10;
+//    F2(0, 5) = -1;
+//    F2(1, 0) = 100;
+//    F2(1, 2) = 10;
+//    F2(1, 4) = -10;
+//    Matrix E(4, 3);
+//    E.setZero();
+//    E(0, 0) = 10;
+//    E(1, 1) = 10;
+//    E(2, 0) = 10;
+//    E(2, 2) = 1;
+//    E(3, 1) = 10;
+//    SmartFactor::FBlocks Fs = list_of<Matrix>(F1)(F2);
+//    Vector b(4);
+//    b.setZero();
+//
+//    // Create smart factors
+//    KeyVector keys;
+//    keys.push_back(x1);
+//    keys.push_back(x2);
+//
+//    // createJacobianQFactor
+//    SharedIsotropic n = noiseModel::Isotropic::Sigma(4, sigma);
+//    Matrix3 P = (E.transpose() * E).inverse();
+//    JacobianFactorQ<6, 2> expectedQ(keys, Fs, E, P, b, n);
+//    EXPECT(assert_equal(expectedInformation, expectedQ.information(), 1e-6));
+//
+//    boost::shared_ptr<JacobianFactorQ<6, 2> > actualQ =
+//        smartFactor1->createJacobianQFactor(cameras, 0.0);
+//    CHECK(actualQ);
+//    EXPECT(assert_equal(expectedInformation, actualQ->information(), 1e-6));
+//    EXPECT(assert_equal(expectedQ, *actualQ));
+//    EXPECT_DOUBLES_EQUAL(0, actualQ->error(zeroDelta), 1e-6);
+//    EXPECT_DOUBLES_EQUAL(expectedError, actualQ->error(perturbedDelta), 1e-6);
+//
+//    // Whiten for RegularImplicitSchurFactor (does not have noise model)
+//    model->WhitenSystem(E, b);
+//    Matrix3 whiteP = (E.transpose() * E).inverse();
+//    Fs[0] = model->Whiten(Fs[0]);
+//    Fs[1] = model->Whiten(Fs[1]);
+//
+//    // createRegularImplicitSchurFactor
+//    RegularImplicitSchurFactor<Camera> expected(keys, Fs, E, whiteP, b);
+//
+//    boost::shared_ptr<RegularImplicitSchurFactor<Camera> > actual =
+//        smartFactor1->createRegularImplicitSchurFactor(cameras, 0.0);
+//    CHECK(actual);
+//    EXPECT(assert_equal(expectedInformation, expected.information(), 1e-6));
+//    EXPECT(assert_equal(expectedInformation, actual->information(), 1e-6));
+//    EXPECT(assert_equal(expected, *actual));
+//    EXPECT_DOUBLES_EQUAL(0, actual->error(zeroDelta), 1e-6);
+//    EXPECT_DOUBLES_EQUAL(expectedError, actual->error(perturbedDelta), 1e-6);
+//  }
+//
+//  {
+//    // createJacobianSVDFactor
+//    Vector1 b;
+//    b.setZero();
+//    double s = sigma * sin(M_PI_4);
+//    SharedIsotropic n = noiseModel::Isotropic::Sigma(4 - 3, sigma);
+//    JacobianFactor expected(x1, s * A1, x2, s * A2, b, n);
+//    EXPECT(assert_equal(expectedInformation, expected.information(), 1e-6));
+//
+//    boost::shared_ptr<JacobianFactor> actual =
+//        smartFactor1->createJacobianSVDFactor(cameras, 0.0);
+//    CHECK(actual);
+//    EXPECT(assert_equal(expectedInformation, actual->information(), 1e-6));
+//    EXPECT(assert_equal(expected, *actual));
+//    EXPECT_DOUBLES_EQUAL(0, actual->error(zeroDelta), 1e-6);
+//    EXPECT_DOUBLES_EQUAL(expectedError, actual->error(perturbedDelta), 1e-6);
+//  }
+//}
+//
+///* *************************************************************************/
+//TEST( SmartProjectionPoseFactor, 3poses_iterative_smart_projection_factor ) {
+//
+//  using namespace vanillaPose;
+//
+//  KeyVector views {x1, x2, x3};
+//
+//  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+//
+//  // Project three landmarks into three cameras
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+//
+//  SmartFactor::shared_ptr smartFactor1(new SmartFactor(model, sharedK));
+//  smartFactor1->add(measurements_cam1, views);
+//
+//  SmartFactor::shared_ptr smartFactor2(new SmartFactor(model, sharedK));
+//  smartFactor2->add(measurements_cam2, views);
+//
+//  SmartFactor::shared_ptr smartFactor3(new SmartFactor(model, sharedK));
+//  smartFactor3->add(measurements_cam3, views);
+//
+//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+//
+//  NonlinearFactorGraph graph;
+//  graph.push_back(smartFactor1);
+//  graph.push_back(smartFactor2);
+//  graph.push_back(smartFactor3);
+//  graph.addPrior(x1, cam1.pose(), noisePrior);
+//  graph.addPrior(x2, cam2.pose(), noisePrior);
+//
+//  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+//      Point3(0.1, 0.1, 0.1)); // smaller noise
+//  Values values;
+//  values.insert(x1, cam1.pose());
+//  values.insert(x2, cam2.pose());
+//  // initialize third pose with some noise, we expect it to move back to original pose_above
+//  values.insert(x3, pose_above * noise_pose);
+//  EXPECT(
+//      assert_equal(
+//          Pose3(
+//              Rot3(1.11022302e-16, -0.0314107591, 0.99950656, -0.99950656,
+//                  -0.0313952598, -0.000986635786, 0.0314107591, -0.999013364,
+//                  -0.0313952598), Point3(0.1, -0.1, 1.9)),
+//          values.at<Pose3>(x3)));
+//
+//  Values result;
+//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+//  result = optimizer.optimize();
+//  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-7));
+//}
+//
+///* *************************************************************************/
+//TEST( SmartProjectionPoseFactor, jacobianSVD ) {
+//
+//  using namespace vanillaPose;
+//
+//  KeyVector views {x1, x2, x3};
+//
+//  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+//
+//  // Project three landmarks into three cameras
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+//
+//  SmartProjectionParams params;
+//  params.setRankTolerance(1.0);
+//  params.setLinearizationMode(gtsam::JACOBIAN_SVD);
+//  params.setDegeneracyMode(gtsam::IGNORE_DEGENERACY);
+//  params.setEnableEPI(false);
+//  SmartFactor factor1(model, sharedK, params);
+//
+//  SmartFactor::shared_ptr smartFactor1(
+//      new SmartFactor(model, sharedK, params));
+//  smartFactor1->add(measurements_cam1, views);
+//
+//  SmartFactor::shared_ptr smartFactor2(
+//      new SmartFactor(model, sharedK, params));
+//  smartFactor2->add(measurements_cam2, views);
+//
+//  SmartFactor::shared_ptr smartFactor3(
+//      new SmartFactor(model, sharedK, params));
+//  smartFactor3->add(measurements_cam3, views);
+//
+//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+//
+//  NonlinearFactorGraph graph;
+//  graph.push_back(smartFactor1);
+//  graph.push_back(smartFactor2);
+//  graph.push_back(smartFactor3);
+//  graph.addPrior(x1, cam1.pose(), noisePrior);
+//  graph.addPrior(x2, cam2.pose(), noisePrior);
+//
+//  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+//      Point3(0.1, 0.1, 0.1)); // smaller noise
+//  Values values;
+//  values.insert(x1, cam1.pose());
+//  values.insert(x2, cam2.pose());
+//  values.insert(x3, pose_above * noise_pose);
+//
+//  Values result;
+//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+//  result = optimizer.optimize();
+//  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-6));
+//}
+//
+///* *************************************************************************/
+//TEST( SmartProjectionPoseFactor, landmarkDistance ) {
+//
+//  using namespace vanillaPose;
+//
+//  double excludeLandmarksFutherThanDist = 2;
+//
+//  KeyVector views {x1, x2, x3};
+//
+//  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+//
+//  // Project three landmarks into three cameras
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+//
+//  SmartProjectionParams params;
+//  params.setRankTolerance(1.0);
+//  params.setLinearizationMode(gtsam::JACOBIAN_SVD);
+//  params.setDegeneracyMode(gtsam::IGNORE_DEGENERACY);
+//  params.setLandmarkDistanceThreshold(excludeLandmarksFutherThanDist);
+//  params.setEnableEPI(false);
+//
+//  SmartFactor::shared_ptr smartFactor1(
+//      new SmartFactor(model, sharedK, params));
+//  smartFactor1->add(measurements_cam1, views);
+//
+//  SmartFactor::shared_ptr smartFactor2(
+//      new SmartFactor(model, sharedK, params));
+//  smartFactor2->add(measurements_cam2, views);
+//
+//  SmartFactor::shared_ptr smartFactor3(
+//      new SmartFactor(model, sharedK, params));
+//  smartFactor3->add(measurements_cam3, views);
+//
+//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+//
+//  NonlinearFactorGraph graph;
+//  graph.push_back(smartFactor1);
+//  graph.push_back(smartFactor2);
+//  graph.push_back(smartFactor3);
+//  graph.addPrior(x1, cam1.pose(), noisePrior);
+//  graph.addPrior(x2, cam2.pose(), noisePrior);
+//
+//  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+//      Point3(0.1, 0.1, 0.1)); // smaller noise
+//  Values values;
+//  values.insert(x1, cam1.pose());
+//  values.insert(x2, cam2.pose());
+//  values.insert(x3, pose_above * noise_pose);
+//
+//  // All factors are disabled and pose should remain where it is
+//  Values result;
+//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+//  result = optimizer.optimize();
+//  EXPECT(assert_equal(values.at<Pose3>(x3), result.at<Pose3>(x3)));
+//}
+//
+///* *************************************************************************/
+//TEST( SmartProjectionPoseFactor, dynamicOutlierRejection ) {
+//
+//  using namespace vanillaPose;
+//
+//  double excludeLandmarksFutherThanDist = 1e10;
+//  double dynamicOutlierRejectionThreshold = 1; // max 1 pixel of average reprojection error
+//
+//  KeyVector views {x1, x2, x3};
+//
+//  // add fourth landmark
+//  Point3 landmark4(5, -0.5, 1);
+//
+//  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3,
+//      measurements_cam4;
+//
+//  // Project 4 landmarks into three cameras
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark4, measurements_cam4);
+//  measurements_cam4.at(0) = measurements_cam4.at(0) + Point2(10, 10); // add outlier
+//
+//  SmartProjectionParams params;
+//  params.setLinearizationMode(gtsam::JACOBIAN_SVD);
+//  params.setLandmarkDistanceThreshold(excludeLandmarksFutherThanDist);
+//  params.setDynamicOutlierRejectionThreshold(dynamicOutlierRejectionThreshold);
+//
+//  SmartFactor::shared_ptr smartFactor1(
+//      new SmartFactor(model, sharedK, params));
+//  smartFactor1->add(measurements_cam1, views);
+//
+//  SmartFactor::shared_ptr smartFactor2(
+//      new SmartFactor(model, sharedK, params));
+//  smartFactor2->add(measurements_cam2, views);
+//
+//  SmartFactor::shared_ptr smartFactor3(
+//      new SmartFactor(model, sharedK, params));
+//  smartFactor3->add(measurements_cam3, views);
+//
+//  SmartFactor::shared_ptr smartFactor4(
+//      new SmartFactor(model, sharedK, params));
+//  smartFactor4->add(measurements_cam4, views);
+//
+//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+//
+//  NonlinearFactorGraph graph;
+//  graph.push_back(smartFactor1);
+//  graph.push_back(smartFactor2);
+//  graph.push_back(smartFactor3);
+//  graph.push_back(smartFactor4);
+//  graph.addPrior(x1, cam1.pose(), noisePrior);
+//  graph.addPrior(x2, cam2.pose(), noisePrior);
+//
+//  Values values;
+//  values.insert(x1, cam1.pose());
+//  values.insert(x2, cam2.pose());
+//  values.insert(x3, cam3.pose());
+//
+//  // All factors are disabled and pose should remain where it is
+//  Values result;
+//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+//  result = optimizer.optimize();
+//  EXPECT(assert_equal(cam3.pose(), result.at<Pose3>(x3)));
+//}
+//
+///* *************************************************************************/
+//TEST( SmartProjectionPoseFactor, jacobianQ ) {
+//
+//  using namespace vanillaPose;
+//
+//  KeyVector views {x1, x2, x3};
+//
+//  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+//
+//  // Project three landmarks into three cameras
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+//
+//  SmartProjectionParams params;
+//  params.setLinearizationMode(gtsam::JACOBIAN_Q);
+//
+//  SmartFactor::shared_ptr smartFactor1(
+//      new SmartFactor(model, sharedK, params));
+//  smartFactor1->add(measurements_cam1, views);
+//
+//  SmartFactor::shared_ptr smartFactor2(
+//      new SmartFactor(model, sharedK, params));
+//  smartFactor2->add(measurements_cam2, views);
+//
+//  SmartFactor::shared_ptr smartFactor3(
+//      new SmartFactor(model, sharedK, params));
+//  smartFactor3->add(measurements_cam3, views);
+//
+//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+//
+//  NonlinearFactorGraph graph;
+//  graph.push_back(smartFactor1);
+//  graph.push_back(smartFactor2);
+//  graph.push_back(smartFactor3);
+//  graph.addPrior(x1, cam1.pose(), noisePrior);
+//  graph.addPrior(x2, cam2.pose(), noisePrior);
+//
+//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+//      Point3(0.1, 0.1, 0.1)); // smaller noise
+//  Values values;
+//  values.insert(x1, cam1.pose());
+//  values.insert(x2, cam2.pose());
+//  values.insert(x3, pose_above * noise_pose);
+//
+//  Values result;
+//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+//  result = optimizer.optimize();
+//  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-6));
+//}
+//
+///* *************************************************************************/
+//TEST( SmartProjectionPoseFactor, 3poses_projection_factor ) {
+//
+//  using namespace vanillaPose2;
+//
+//  KeyVector views {x1, x2, x3};
+//
+//  typedef GenericProjectionFactor<Pose3, Point3> ProjectionFactor;
+//  NonlinearFactorGraph graph;
+//
+//  // Project three landmarks into three cameras
+//  graph.emplace_shared<ProjectionFactor>(cam1.project(landmark1), model, x1, L(1), sharedK2);
+//  graph.emplace_shared<ProjectionFactor>(cam2.project(landmark1), model, x2, L(1), sharedK2);
+//  graph.emplace_shared<ProjectionFactor>(cam3.project(landmark1), model, x3, L(1), sharedK2);
+//
+//  graph.emplace_shared<ProjectionFactor>(cam1.project(landmark2), model, x1, L(2), sharedK2);
+//  graph.emplace_shared<ProjectionFactor>(cam2.project(landmark2), model, x2, L(2), sharedK2);
+//  graph.emplace_shared<ProjectionFactor>(cam3.project(landmark2), model, x3, L(2), sharedK2);
+//
+//  graph.emplace_shared<ProjectionFactor>(cam1.project(landmark3), model, x1, L(3), sharedK2);
+//  graph.emplace_shared<ProjectionFactor>(cam2.project(landmark3), model, x2, L(3), sharedK2);
+//  graph.emplace_shared<ProjectionFactor>(cam3.project(landmark3), model, x3, L(3), sharedK2);
+//
+//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+//  graph.addPrior(x1, level_pose, noisePrior);
+//  graph.addPrior(x2, pose_right, noisePrior);
+//
+//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 10, 0., -M_PI / 10),
+//      Point3(0.5, 0.1, 0.3));
+//  Values values;
+//  values.insert(x1, level_pose);
+//  values.insert(x2, pose_right);
+//  values.insert(x3, pose_above * noise_pose);
+//  values.insert(L(1), landmark1);
+//  values.insert(L(2), landmark2);
+//  values.insert(L(3), landmark3);
+//
+//  DOUBLES_EQUAL(48406055, graph.error(values), 1);
+//
+//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+//  Values result = optimizer.optimize();
+//
+//  DOUBLES_EQUAL(0, graph.error(result), 1e-9);
+//
+//  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-7));
+//}
+//
+///* *************************************************************************/
+//TEST( SmartProjectionPoseFactor, CheckHessian) {
+//
+//  KeyVector views {x1, x2, x3};
+//
+//  using namespace vanillaPose;
+//
+//  // Two slightly different cameras
+//  Pose3 pose2 = level_pose
+//      * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
+//  Pose3 pose3 = pose2 * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
+//  Camera cam2(pose2, sharedK);
+//  Camera cam3(pose3, sharedK);
+//
+//  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+//
+//  // Project three landmarks into three cameras
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+//
+//  SmartProjectionParams params;
+//  params.setRankTolerance(10);
+//
+//  SmartFactor::shared_ptr smartFactor1(
+//      new SmartFactor(model, sharedK, params)); // HESSIAN, by default
+//  smartFactor1->add(measurements_cam1, views);
+//
+//  SmartFactor::shared_ptr smartFactor2(
+//      new SmartFactor(model, sharedK, params)); // HESSIAN, by default
+//  smartFactor2->add(measurements_cam2, views);
+//
+//  SmartFactor::shared_ptr smartFactor3(
+//      new SmartFactor(model, sharedK, params)); // HESSIAN, by default
+//  smartFactor3->add(measurements_cam3, views);
+//
+//  NonlinearFactorGraph graph;
+//  graph.push_back(smartFactor1);
+//  graph.push_back(smartFactor2);
+//  graph.push_back(smartFactor3);
+//
+//  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+//      Point3(0.1, 0.1, 0.1)); // smaller noise
+//  Values values;
+//  values.insert(x1, cam1.pose());
+//  values.insert(x2, cam2.pose());
+//  // initialize third pose with some noise, we expect it to move back to original pose_above
+//  values.insert(x3, pose3 * noise_pose);
+//  EXPECT(
+//      assert_equal(
+//          Pose3(
+//              Rot3(0.00563056869, -0.130848107, 0.991386438, -0.991390265,
+//                  -0.130426831, -0.0115837907, 0.130819108, -0.98278564,
+//                  -0.130455917),
+//              Point3(0.0897734171, -0.110201006, 0.901022872)),
+//          values.at<Pose3>(x3)));
+//
+//  boost::shared_ptr<GaussianFactor> factor1 = smartFactor1->linearize(values);
+//  boost::shared_ptr<GaussianFactor> factor2 = smartFactor2->linearize(values);
+//  boost::shared_ptr<GaussianFactor> factor3 = smartFactor3->linearize(values);
+//
+//  Matrix CumulativeInformation = factor1->information() + factor2->information()
+//      + factor3->information();
+//
+//  boost::shared_ptr<GaussianFactorGraph> GaussianGraph = graph.linearize(
+//      values);
+//  Matrix GraphInformation = GaussianGraph->hessian().first;
+//
+//  // Check Hessian
+//  EXPECT(assert_equal(GraphInformation, CumulativeInformation, 1e-6));
+//
+//  Matrix AugInformationMatrix = factor1->augmentedInformation()
+//      + factor2->augmentedInformation() + factor3->augmentedInformation();
+//
+//  // Check Information vector
+//  Vector InfoVector = AugInformationMatrix.block(0, 18, 18, 1); // 18x18 Hessian + information vector
+//
+//  // Check Hessian
+//  EXPECT(assert_equal(InfoVector, GaussianGraph->hessian().second, 1e-6));
+//}
+//
+///* *************************************************************************/
+//TEST( SmartProjectionPoseFactor, 3poses_2land_rotation_only_smart_projection_factor ) {
+//  using namespace vanillaPose2;
+//
+//  KeyVector views {x1, x2, x3};
+//
+//  // Two different cameras, at the same position, but different rotations
+//  Pose3 pose2 = level_pose * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0,0,0));
+//  Pose3 pose3 = pose2 * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0,0,0));
+//  Camera cam2(pose2, sharedK2);
+//  Camera cam3(pose3, sharedK2);
+//
+//  Point2Vector measurements_cam1, measurements_cam2;
+//
+//  // Project three landmarks into three cameras
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+//
+//  SmartProjectionParams params;
+//  params.setRankTolerance(50);
+//  params.setDegeneracyMode(gtsam::HANDLE_INFINITY);
+//
+//  SmartFactor::shared_ptr smartFactor1(
+//      new SmartFactor(model, sharedK2, params));
+//  smartFactor1->add(measurements_cam1, views);
+//
+//  SmartFactor::shared_ptr smartFactor2(
+//      new SmartFactor(model, sharedK2, params));
+//  smartFactor2->add(measurements_cam2, views);
+//
+//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+//  const SharedDiagonal noisePriorTranslation = noiseModel::Isotropic::Sigma(3, 0.10);
+//  Point3 positionPrior = Point3(0, 0, 1);
+//
+//  NonlinearFactorGraph graph;
+//  graph.push_back(smartFactor1);
+//  graph.push_back(smartFactor2);
+//  graph.addPrior(x1, cam1.pose(), noisePrior);
+//  graph.emplace_shared<PoseTranslationPrior<Pose3> >(x2, positionPrior, noisePriorTranslation);
+//  graph.emplace_shared<PoseTranslationPrior<Pose3> >(x3, positionPrior, noisePriorTranslation);
+//
+//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+//      Point3(0.1, 0.1, 0.1)); // smaller noise
+//  Values values;
+//  values.insert(x1, cam1.pose());
+//  values.insert(x2, pose2 * noise_pose);
+//  values.insert(x3, pose3 * noise_pose);
+//
+//  // params.verbosityLM = LevenbergMarquardtParams::SUMMARY;
+//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+//  Values result = optimizer.optimize();
+//  EXPECT(assert_equal(pose3, result.at<Pose3>(x3)));
+//}
+//
+///* *************************************************************************/
+//TEST( SmartProjectionPoseFactor, 3poses_rotation_only_smart_projection_factor ) {
+//
+//  // this test considers a condition in which the cheirality constraint is triggered
+//  using namespace vanillaPose;
+//
+//  KeyVector views {x1, x2, x3};
+//
+//  // Two different cameras, at the same position, but different rotations
+//  Pose3 pose2 = level_pose
+//      * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
+//  Pose3 pose3 = pose2 * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
+//  Camera cam2(pose2, sharedK);
+//  Camera cam3(pose3, sharedK);
+//
+//  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+//
+//  // Project three landmarks into three cameras
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+//
+//  SmartProjectionParams params;
+//  params.setRankTolerance(10);
+//  params.setDegeneracyMode(gtsam::ZERO_ON_DEGENERACY);
+//
+//  SmartFactor::shared_ptr smartFactor1(
+//      new SmartFactor(model, sharedK, params));
+//  smartFactor1->add(measurements_cam1, views);
+//
+//  SmartFactor::shared_ptr smartFactor2(
+//      new SmartFactor(model, sharedK, params));
+//  smartFactor2->add(measurements_cam2, views);
+//
+//  SmartFactor::shared_ptr smartFactor3(
+//      new SmartFactor(model, sharedK, params));
+//  smartFactor3->add(measurements_cam3, views);
+//
+//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+//  const SharedDiagonal noisePriorTranslation = noiseModel::Isotropic::Sigma(3,
+//      0.10);
+//  Point3 positionPrior = Point3(0, 0, 1);
+//
+//  NonlinearFactorGraph graph;
+//  graph.push_back(smartFactor1);
+//  graph.push_back(smartFactor2);
+//  graph.push_back(smartFactor3);
+//  graph.addPrior(x1, cam1.pose(), noisePrior);
+//  graph.emplace_shared<PoseTranslationPrior<Pose3> >(x2, positionPrior, noisePriorTranslation);
+//  graph.emplace_shared<PoseTranslationPrior<Pose3> >(x3, positionPrior, noisePriorTranslation);
+//
+//  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+//      Point3(0.1, 0.1, 0.1)); // smaller noise
+//  Values values;
+//  values.insert(x1, cam1.pose());
+//  values.insert(x2, cam2.pose());
+//  values.insert(x3, pose3 * noise_pose);
+//  EXPECT(
+//      assert_equal(
+//          Pose3(
+//              Rot3(0.00563056869, -0.130848107, 0.991386438, -0.991390265,
+//                  -0.130426831, -0.0115837907, 0.130819108, -0.98278564,
+//                  -0.130455917),
+//              Point3(0.0897734171, -0.110201006, 0.901022872)),
+//          values.at<Pose3>(x3)));
+//
+//  Values result;
+//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+//  result = optimizer.optimize();
+//
+//  // Since we do not do anything on degenerate instances (ZERO_ON_DEGENERACY)
+//  // rotation remains the same as the initial guess, but position is fixed by PoseTranslationPrior
+//#ifdef GTSAM_THROW_CHEIRALITY_EXCEPTION
+//  EXPECT(assert_equal(Pose3(values.at<Pose3>(x3).rotation(),
+//      Point3(0,0,1)), result.at<Pose3>(x3)));
+//#else
+//  // if the check is disabled, no cheirality exception if thrown and the pose converges to the right rotation
+//  // with modest accuracy since the configuration is essentially degenerate without the translation due to noise (noise_pose)
+//  EXPECT(assert_equal(pose3, result.at<Pose3>(x3),1e-3));
+//#endif
+//}
+//
+///* *************************************************************************/
+//TEST( SmartProjectionPoseFactor, Hessian ) {
+//
+//  using namespace vanillaPose2;
+//
+//  KeyVector views {x1, x2};
+//
+//  // Project three landmarks into 2 cameras
+//  Point2 cam1_uv1 = cam1.project(landmark1);
+//  Point2 cam2_uv1 = cam2.project(landmark1);
+//  Point2Vector measurements_cam1;
+//  measurements_cam1.push_back(cam1_uv1);
+//  measurements_cam1.push_back(cam2_uv1);
+//
+//  SmartFactor::shared_ptr smartFactor1(new SmartFactor(model, sharedK2));
+//  smartFactor1->add(measurements_cam1, views);
+//
+//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 10, 0., -M_PI / 10),
+//      Point3(0.5, 0.1, 0.3));
+//  Values values;
+//  values.insert(x1, cam1.pose());
+//  values.insert(x2, cam2.pose());
+//
+//  boost::shared_ptr<GaussianFactor> factor = smartFactor1->linearize(values);
+//
+//  // compute triangulation from linearization point
+//  // compute reprojection errors (sum squared)
+//  // compare with factor.info(): the bottom right element is the squared sum of the reprojection errors (normalized by the covariance)
+//  // check that it is correctly scaled when using noiseProjection = [1/4  0; 0 1/4]
+//}
+//
+///* *************************************************************************/
+//TEST( SmartProjectionPoseFactor, HessianWithRotation ) {
+//  // cout << " ************************ SmartProjectionPoseFactor: rotated Hessian **********************" << endl;
+//
+//  using namespace vanillaPose;
+//
+//  KeyVector views {x1, x2, x3};
+//
+//  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+//
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+//
+//  SmartFactor::shared_ptr smartFactorInstance(new SmartFactor(model, sharedK));
+//  smartFactorInstance->add(measurements_cam1, views);
+//
+//  Values values;
+//  values.insert(x1, cam1.pose());
+//  values.insert(x2, cam2.pose());
+//  values.insert(x3, cam3.pose());
+//
+//  boost::shared_ptr<GaussianFactor> factor = smartFactorInstance->linearize(
+//      values);
+//
+//  Pose3 poseDrift = Pose3(Rot3::Ypr(-M_PI / 2, 0., -M_PI / 2), Point3(0, 0, 0));
+//
+//  Values rotValues;
+//  rotValues.insert(x1, poseDrift.compose(level_pose));
+//  rotValues.insert(x2, poseDrift.compose(pose_right));
+//  rotValues.insert(x3, poseDrift.compose(pose_above));
+//
+//  boost::shared_ptr<GaussianFactor> factorRot = smartFactorInstance->linearize(
+//      rotValues);
+//
+//  // Hessian is invariant to rotations in the nondegenerate case
+//  EXPECT(assert_equal(factor->information(), factorRot->information(), 1e-7));
+//
+//  Pose3 poseDrift2 = Pose3(Rot3::Ypr(-M_PI / 2, -M_PI / 3, -M_PI / 2),
+//      Point3(10, -4, 5));
+//
+//  Values tranValues;
+//  tranValues.insert(x1, poseDrift2.compose(level_pose));
+//  tranValues.insert(x2, poseDrift2.compose(pose_right));
+//  tranValues.insert(x3, poseDrift2.compose(pose_above));
+//
+//  boost::shared_ptr<GaussianFactor> factorRotTran =
+//      smartFactorInstance->linearize(tranValues);
+//
+//  // Hessian is invariant to rotations and translations in the nondegenerate case
+//  EXPECT(assert_equal(factor->information(), factorRotTran->information(), 1e-7));
+//}
+//
+///* *************************************************************************/
+//TEST( SmartProjectionPoseFactor, HessianWithRotationDegenerate ) {
+//
+//  using namespace vanillaPose2;
+//
+//  KeyVector views {x1, x2, x3};
+//
+//  // All cameras have the same pose so will be degenerate !
+//  Camera cam2(level_pose, sharedK2);
+//  Camera cam3(level_pose, sharedK2);
+//
+//  Point2Vector measurements_cam1;
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+//
+//  SmartFactor::shared_ptr smartFactor(new SmartFactor(model, sharedK2));
+//  smartFactor->add(measurements_cam1, views);
+//
+//  Values values;
+//  values.insert(x1, cam1.pose());
+//  values.insert(x2, cam2.pose());
+//  values.insert(x3, cam3.pose());
+//
+//  boost::shared_ptr<GaussianFactor> factor = smartFactor->linearize(values);
+//
+//  Pose3 poseDrift = Pose3(Rot3::Ypr(-M_PI / 2, 0., -M_PI / 2), Point3(0, 0, 0));
+//
+//  Values rotValues;
+//  rotValues.insert(x1, poseDrift.compose(level_pose));
+//  rotValues.insert(x2, poseDrift.compose(level_pose));
+//  rotValues.insert(x3, poseDrift.compose(level_pose));
+//
+//  boost::shared_ptr<GaussianFactor> factorRot = //
+//      smartFactor->linearize(rotValues);
+//
+//  // Hessian is invariant to rotations in the nondegenerate case
+//  EXPECT(assert_equal(factor->information(), factorRot->information(), 1e-7));
+//
+//  Pose3 poseDrift2 = Pose3(Rot3::Ypr(-M_PI / 2, -M_PI / 3, -M_PI / 2),
+//      Point3(10, -4, 5));
+//
+//  Values tranValues;
+//  tranValues.insert(x1, poseDrift2.compose(level_pose));
+//  tranValues.insert(x2, poseDrift2.compose(level_pose));
+//  tranValues.insert(x3, poseDrift2.compose(level_pose));
+//
+//  boost::shared_ptr<GaussianFactor> factorRotTran = smartFactor->linearize(
+//      tranValues);
+//
+//  // Hessian is invariant to rotations and translations in the nondegenerate case
+//  EXPECT(assert_equal(factor->information(), factorRotTran->information(), 1e-7));
+//}
+//
+///* ************************************************************************* */
+//TEST( SmartProjectionPoseFactor, ConstructorWithCal3Bundler) {
+//  using namespace bundlerPose;
+//  SmartProjectionParams params;
+//  params.setDegeneracyMode(gtsam::ZERO_ON_DEGENERACY);
+//  SmartFactor factor(model, sharedBundlerK, params);
+//  factor.add(measurement1, x1);
+//}
+//
+///* *************************************************************************/
+//TEST( SmartProjectionPoseFactor, Cal3Bundler ) {
+//
+//  using namespace bundlerPose;
+//
+//  // three landmarks ~5 meters in front of camera
+//  Point3 landmark3(3, 0, 3.0);
+//
+//  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+//
+//  // Project three landmarks into three cameras
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+//
+//  KeyVector views {x1, x2, x3};
+//
+//  SmartFactor::shared_ptr smartFactor1(new SmartFactor(model, sharedBundlerK));
+//  smartFactor1->add(measurements_cam1, views);
+//
+//  SmartFactor::shared_ptr smartFactor2(new SmartFactor(model, sharedBundlerK));
+//  smartFactor2->add(measurements_cam2, views);
+//
+//  SmartFactor::shared_ptr smartFactor3(new SmartFactor(model, sharedBundlerK));
+//  smartFactor3->add(measurements_cam3, views);
+//
+//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+//
+//  NonlinearFactorGraph graph;
+//  graph.push_back(smartFactor1);
+//  graph.push_back(smartFactor2);
+//  graph.push_back(smartFactor3);
+//  graph.addPrior(x1, cam1.pose(), noisePrior);
+//  graph.addPrior(x2, cam2.pose(), noisePrior);
+//
+//  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+//      Point3(0.1, 0.1, 0.1)); // smaller noise
+//  Values values;
+//  values.insert(x1, cam1.pose());
+//  values.insert(x2, cam2.pose());
+//  // initialize third pose with some noise, we expect it to move back to original pose_above
+//  values.insert(x3, pose_above * noise_pose);
+//  EXPECT(
+//      assert_equal(
+//          Pose3(
+//              Rot3(0, -0.0314107591, 0.99950656, -0.99950656, -0.0313952598,
+//                  -0.000986635786, 0.0314107591, -0.999013364, -0.0313952598),
+//              Point3(0.1, -0.1, 1.9)), values.at<Pose3>(x3)));
+//
+//  Values result;
+//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+//  result = optimizer.optimize();
+//  EXPECT(assert_equal(cam3.pose(), result.at<Pose3>(x3), 1e-6));
+//}
+//
+///* *************************************************************************/
+//TEST( SmartProjectionPoseFactor, Cal3BundlerRotationOnly ) {
+//
+//  using namespace bundlerPose;
+//
+//  KeyVector views {x1, x2, x3};
+//
+//  // Two different cameras
+//  Pose3 pose2 = level_pose
+//      * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
+//  Pose3 pose3 = pose2 * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
+//  Camera cam2(pose2, sharedBundlerK);
+//  Camera cam3(pose3, sharedBundlerK);
+//
+//  // landmark3 at 3 meters now
+//  Point3 landmark3(3, 0, 3.0);
+//
+//  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+//
+//  // Project three landmarks into three cameras
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+//  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+//
+//  SmartProjectionParams params;
+//  params.setRankTolerance(10);
+//  params.setDegeneracyMode(gtsam::ZERO_ON_DEGENERACY);
+//
+//  SmartFactor::shared_ptr smartFactor1(
+//      new SmartFactor(model, sharedBundlerK, params));
+//  smartFactor1->add(measurements_cam1, views);
+//
+//  SmartFactor::shared_ptr smartFactor2(
+//      new SmartFactor(model, sharedBundlerK, params));
+//  smartFactor2->add(measurements_cam2, views);
+//
+//  SmartFactor::shared_ptr smartFactor3(
+//      new SmartFactor(model, sharedBundlerK, params));
+//  smartFactor3->add(measurements_cam3, views);
+//
+//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+//  const SharedDiagonal noisePriorTranslation = noiseModel::Isotropic::Sigma(3,
+//      0.10);
+//  Point3 positionPrior = Point3(0, 0, 1);
+//
+//  NonlinearFactorGraph graph;
+//  graph.push_back(smartFactor1);
+//  graph.push_back(smartFactor2);
+//  graph.push_back(smartFactor3);
+//  graph.addPrior(x1, cam1.pose(), noisePrior);
+//  graph.emplace_shared<PoseTranslationPrior<Pose3> >(x2, positionPrior, noisePriorTranslation);
+//  graph.emplace_shared<PoseTranslationPrior<Pose3> >(x3, positionPrior, noisePriorTranslation);
+//
+//  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+//      Point3(0.1, 0.1, 0.1)); // smaller noise
+//  Values values;
+//  values.insert(x1, cam1.pose());
+//  values.insert(x2, cam2.pose());
+//  // initialize third pose with some noise, we expect it to move back to original pose_above
+//  values.insert(x3, pose3 * noise_pose);
+//  EXPECT(
+//      assert_equal(
+//          Pose3(
+//              Rot3(0.00563056869, -0.130848107, 0.991386438, -0.991390265,
+//                  -0.130426831, -0.0115837907, 0.130819108, -0.98278564,
+//                  -0.130455917),
+//              Point3(0.0897734171, -0.110201006, 0.901022872)),
+//          values.at<Pose3>(x3)));
+//
+//  Values result;
+//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+//  result = optimizer.optimize();
+//
+//  EXPECT(
+//      assert_equal(
+//          Pose3(
+//              Rot3(0.00563056869, -0.130848107, 0.991386438, -0.991390265,
+//                  -0.130426831, -0.0115837907, 0.130819108, -0.98278564,
+//                  -0.130455917),
+//              Point3(0.0897734171, -0.110201006, 0.901022872)),
+//          values.at<Pose3>(x3)));
+//}
+//
+///* ************************************************************************* */
+//BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Constrained, "gtsam_noiseModel_Constrained");
+//BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Diagonal, "gtsam_noiseModel_Diagonal");
+//BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Gaussian, "gtsam_noiseModel_Gaussian");
+//BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Unit, "gtsam_noiseModel_Unit");
+//BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Isotropic, "gtsam_noiseModel_Isotropic");
+//BOOST_CLASS_EXPORT_GUID(gtsam::SharedNoiseModel, "gtsam_SharedNoiseModel");
+//BOOST_CLASS_EXPORT_GUID(gtsam::SharedDiagonal, "gtsam_SharedDiagonal");
+//
+//TEST(SmartProjectionPoseFactor, serialize) {
+//  using namespace vanillaPose;
+//  using namespace gtsam::serializationTestHelpers;
+//  SmartProjectionParams params;
+//  params.setRankTolerance(rankTol);
+//  SmartFactor factor(model, sharedK, params);
+//
+//  EXPECT(equalsObj(factor));
+//  EXPECT(equalsXML(factor));
+//  EXPECT(equalsBinary(factor));
+//}
+//
+//TEST(SmartProjectionPoseFactor, serialize2) {
+//  using namespace vanillaPose;
+//  using namespace gtsam::serializationTestHelpers;
+//  SmartProjectionParams params;
+//  params.setRankTolerance(rankTol);
+//  Pose3 bts;
+//  SmartFactor factor(model, sharedK, bts, params);
+//
+//  // insert some measurments
+//  KeyVector key_view;
+//  Point2Vector meas_view;
+//  key_view.push_back(Symbol('x', 1));
+//  meas_view.push_back(Point2(10, 10));
+//  factor.add(meas_view, key_view);
+//
+//  EXPECT(equalsObj(factor));
+//  EXPECT(equalsXML(factor));
+//  EXPECT(equalsBinary(factor));
+//}
 
 /* ************************************************************************* */
 int main() {

--- a/gtsam/slam/tests/testSmartProjectionFactorP.cpp
+++ b/gtsam/slam/tests/testSmartProjectionFactorP.cpp
@@ -950,144 +950,141 @@ TEST( SmartProjectionFactorP, hessianComparedToProjFactors_measurementsFromSameP
   EXPECT_DOUBLES_EQUAL(expectedError, actualError, 1e-7);
 }
 
-///* *************************************************************************/
-//TEST( SmartProjectionFactorP, optimization_3poses_measurementsFromSamePose ) {
-//
-//  using namespace vanillaPoseRS;
-//  Point2Vector measurements_lmk1, measurements_lmk2, measurements_lmk3;
-//
-//  // Project three landmarks into three cameras
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_lmk1);
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_lmk2);
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_lmk3);
-//
-//  // create inputs
-//  std::vector<std::pair<Key,Key>> key_pairs;
-//  key_pairs.push_back(std::make_pair(x1,x2));
-//  key_pairs.push_back(std::make_pair(x2,x3));
-//  key_pairs.push_back(std::make_pair(x3,x1));
-//
-//  std::vector<double> interp_factors;
-//  interp_factors.push_back(interp_factor1);
-//  interp_factors.push_back(interp_factor2);
-//  interp_factors.push_back(interp_factor3);
-//
-//  // For first factor, we create redundant measurement (taken by the same keys as factor 1, to
-//  // make sure the redundancy in the keys does not create problems)
-//  Camera::MeasurementVector& measurements_lmk1_redundant = measurements_lmk1;
-//  measurements_lmk1_redundant.push_back(measurements_lmk1.at(0)); // we readd the first measurement
-//  std::vector<std::pair<Key,Key>> key_pairs_redundant = key_pairs;
-//  key_pairs_redundant.push_back(key_pairs.at(0)); // we readd the first pair of keys
-//  std::vector<double> interp_factors_redundant = interp_factors;
-//  interp_factors_redundant.push_back(interp_factors.at(0));// we readd the first interp factor
-//
-//  SmartFactorRS::shared_ptr smartFactor1(new SmartFactorRS(model));
-//  smartFactor1->add(measurements_lmk1_redundant, key_pairs_redundant, interp_factors_redundant, sharedK);
-//
-//  SmartFactorRS::shared_ptr smartFactor2(new SmartFactorRS(model));
-//  smartFactor2->add(measurements_lmk2, key_pairs, interp_factors, sharedK);
-//
-//  SmartFactorRS::shared_ptr smartFactor3(new SmartFactorRS(model));
-//  smartFactor3->add(measurements_lmk3, key_pairs, interp_factors, sharedK);
-//
-//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
-//
-//  NonlinearFactorGraph graph;
-//  graph.push_back(smartFactor1);
-//  graph.push_back(smartFactor2);
-//  graph.push_back(smartFactor3);
-//  graph.addPrior(x1, level_pose, noisePrior);
-//  graph.addPrior(x2, pose_right, noisePrior);
-//
-//  Values groundTruth;
-//  groundTruth.insert(x1, level_pose);
-//  groundTruth.insert(x2, pose_right);
-//  groundTruth.insert(x3, pose_above);
-//  DOUBLES_EQUAL(0, graph.error(groundTruth), 1e-9);
-//
-//  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
-//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-//                           Point3(0.1, 0.1, 0.1)); // smaller noise
-//  Values values;
-//  values.insert(x1, level_pose);
-//  values.insert(x2, pose_right);
-//  // initialize third pose with some noise, we expect it to move back to original pose_above
-//  values.insert(x3, pose_above * noise_pose);
-//  EXPECT( // check that the pose is actually noisy
-//      assert_equal(
-//          Pose3(
-//              Rot3(0, -0.0314107591, 0.99950656, -0.99950656, -0.0313952598,
-//                   -0.000986635786, 0.0314107591, -0.999013364, -0.0313952598),
-//                   Point3(0.1, -0.1, 1.9)), values.at<Pose3>(x3)));
-//
-//  Values result;
-//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
-//  result = optimizer.optimize();
-//  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-5));
-//}
+/* *************************************************************************/
+TEST( SmartProjectionFactorP, optimization_3poses_measurementsFromSamePose ) {
 
-//#ifndef DISABLE_TIMING
-//#include <gtsam/base/timing.h>
-//// -Total: 0 CPU (0 times, 0 wall, 0.04 children, min: 0 max: 0)
-////|   -SF RS LINEARIZE: 0.02 CPU (1000 times, 0.017244 wall, 0.02 children, min: 0 max: 0)
-////|   -RS LINEARIZE: 0.02 CPU (1000 times, 0.009035 wall, 0.02 children, min: 0 max: 0)
-///* *************************************************************************/
-//TEST( SmartProjectionPoseFactorRollingShutter, timing ) {
-//
-//  using namespace vanillaPose;
-//
-//  // Default cameras for simple derivatives
-//  static Cal3_S2::shared_ptr sharedKSimple(new Cal3_S2(100, 100, 0, 0, 0));
-//
-//  Rot3 R = Rot3::identity();
-//  Pose3 pose1 = Pose3(R, Point3(0, 0, 0));
-//  Pose3 pose2 = Pose3(R, Point3(1, 0, 0));
-//  Camera cam1(pose1, sharedKSimple), cam2(pose2, sharedKSimple);
-//  Pose3 body_P_sensorId = Pose3::identity();
-//
-//  // one landmarks 1m in front of camera
-//  Point3 landmark1(0, 0, 10);
-//
-//  Point2Vector measurements_lmk1;
-//
-//  // Project 2 landmarks into 2 cameras
-//  measurements_lmk1.push_back(cam1.project(landmark1));
-//  measurements_lmk1.push_back(cam2.project(landmark1));
-//
-//  size_t nrTests = 1000;
-//
-//  for(size_t i = 0; i<nrTests; i++){
-//    SmartFactorRS::shared_ptr smartFactorRS(new SmartFactorRS(model));
-//    double interp_factor = 0;  // equivalent to measurement taken at pose 1
-//    smartFactorRS->add(measurements_lmk1[0], x1, x2, interp_factor, sharedKSimple,
-//                       body_P_sensorId);
-//    interp_factor = 1;  // equivalent to measurement taken at pose 2
-//    smartFactorRS->add(measurements_lmk1[1], x1, x2, interp_factor, sharedKSimple,
-//                       body_P_sensorId);
-//
-//    Values values;
-//    values.insert(x1, pose1);
-//    values.insert(x2, pose2);
-//    gttic_(SF_RS_LINEARIZE);
-//    smartFactorRS->linearize(values);
-//    gttoc_(SF_RS_LINEARIZE);
-//  }
-//
-//  for(size_t i = 0; i<nrTests; i++){
-//    SmartFactor::shared_ptr smartFactor(new SmartFactor(model, sharedKSimple));
-//    smartFactor->add(measurements_lmk1[0], x1);
-//    smartFactor->add(measurements_lmk1[1], x2);
-//
-//    Values values;
-//    values.insert(x1, pose1);
-//    values.insert(x2, pose2);
-//    gttic_(RS_LINEARIZE);
-//    smartFactor->linearize(values);
-//    gttoc_(RS_LINEARIZE);
-//  }
-//  tictoc_print_();
-//}
-//#endif
+  using namespace vanillaPose;
+  Point2Vector measurements_lmk1, measurements_lmk2, measurements_lmk3;
+
+  // Project three landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_lmk1);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_lmk2);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_lmk3);
+
+  // create inputs
+  std::vector<Key> keys;
+  keys.push_back(x1);
+  keys.push_back(x2);
+  keys.push_back(x3);
+
+  std::vector < boost::shared_ptr < Cal3_S2 >> sharedKs;
+  sharedKs.push_back(sharedK);
+  sharedKs.push_back(sharedK);
+  sharedKs.push_back(sharedK);
+
+  // For first factor, we create redundant measurement (taken by the same keys as factor 1, to
+  // make sure the redundancy in the keys does not create problems)
+  Camera::MeasurementVector& measurements_lmk1_redundant = measurements_lmk1;
+  measurements_lmk1_redundant.push_back(measurements_lmk1.at(0)); // we readd the first measurement
+  std::vector<Key> keys_redundant = keys;
+  keys_redundant.push_back(keys.at(0)); // we readd the first key
+  std::vector < boost::shared_ptr < Cal3_S2 >> sharedKs_redundant = sharedKs;
+  sharedKs_redundant.push_back(sharedK);// we readd the first calibration
+
+  SmartFactorP::shared_ptr smartFactor1(new SmartFactorP(model));
+  smartFactor1->add(measurements_lmk1_redundant, keys_redundant, sharedKs_redundant);
+
+  SmartFactorP::shared_ptr smartFactor2(new SmartFactorP(model));
+  smartFactor2->add(measurements_lmk2, keys, sharedKs);
+
+  SmartFactorP::shared_ptr smartFactor3(new SmartFactorP(model));
+  smartFactor3->add(measurements_lmk3, keys, sharedKs);
+
+  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+
+  NonlinearFactorGraph graph;
+  graph.push_back(smartFactor1);
+  graph.push_back(smartFactor2);
+  graph.push_back(smartFactor3);
+  graph.addPrior(x1, level_pose, noisePrior);
+  graph.addPrior(x2, pose_right, noisePrior);
+
+  Values groundTruth;
+  groundTruth.insert(x1, level_pose);
+  groundTruth.insert(x2, pose_right);
+  groundTruth.insert(x3, pose_above);
+  DOUBLES_EQUAL(0, graph.error(groundTruth), 1e-9);
+
+  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+                           Point3(0.1, 0.1, 0.1)); // smaller noise
+  Values values;
+  values.insert(x1, level_pose);
+  values.insert(x2, pose_right);
+  // initialize third pose with some noise, we expect it to move back to original pose_above
+  values.insert(x3, pose_above * noise_pose);
+  EXPECT( // check that the pose is actually noisy
+      assert_equal(
+          Pose3(
+              Rot3(0, -0.0314107591, 0.99950656, -0.99950656, -0.0313952598,
+                   -0.000986635786, 0.0314107591, -0.999013364, -0.0313952598),
+                   Point3(0.1, -0.1, 1.9)), values.at<Pose3>(x3)));
+
+  Values result;
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  result = optimizer.optimize();
+  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-5));
+}
+
+#ifndef DISABLE_TIMING
+#include <gtsam/base/timing.h>
+// this factor is actually slightly faster (but comparable) to original SmartProjectionPoseFactor
+//-Total: 0 CPU (0 times, 0 wall, 0.01 children, min: 0 max: 0)
+//|   -SmartFactorP LINEARIZE: 0 CPU (1000 times, 0.005481 wall, 0 children, min: 0 max: 0)
+//|   -SmartPoseFactor LINEARIZE: 0.01 CPU (1000 times, 0.007318 wall, 0.01 children, min: 0 max: 0)
+/* *************************************************************************/
+TEST( SmartProjectionFactorP, timing ) {
+
+  using namespace vanillaPose;
+
+  // Default cameras for simple derivatives
+  static Cal3_S2::shared_ptr sharedKSimple(new Cal3_S2(100, 100, 0, 0, 0));
+
+  Rot3 R = Rot3::identity();
+  Pose3 pose1 = Pose3(R, Point3(0, 0, 0));
+  Pose3 pose2 = Pose3(R, Point3(1, 0, 0));
+  Camera cam1(pose1, sharedKSimple), cam2(pose2, sharedKSimple);
+  Pose3 body_P_sensorId = Pose3::identity();
+
+  // one landmarks 1m in front of camera
+  Point3 landmark1(0, 0, 10);
+
+  Point2Vector measurements_lmk1;
+
+  // Project 2 landmarks into 2 cameras
+  measurements_lmk1.push_back(cam1.project(landmark1));
+  measurements_lmk1.push_back(cam2.project(landmark1));
+
+  size_t nrTests = 1000;
+
+  for(size_t i = 0; i<nrTests; i++){
+    SmartFactorP::shared_ptr smartFactorP(new SmartFactorP(model));
+    smartFactorP->add(measurements_lmk1[0], x1, sharedKSimple, body_P_sensorId);
+    smartFactorP->add(measurements_lmk1[1], x1, sharedKSimple, body_P_sensorId);
+
+    Values values;
+    values.insert(x1, pose1);
+    values.insert(x2, pose2);
+    gttic_(SmartFactorP_LINEARIZE);
+    smartFactorP->linearize(values);
+    gttoc_(SmartFactorP_LINEARIZE);
+  }
+
+  for(size_t i = 0; i<nrTests; i++){
+    SmartFactor::shared_ptr smartFactor(new SmartFactor(model, sharedKSimple));
+    smartFactor->add(measurements_lmk1[0], x1);
+    smartFactor->add(measurements_lmk1[1], x2);
+
+    Values values;
+    values.insert(x1, pose1);
+    values.insert(x2, pose2);
+    gttic_(SmartPoseFactor_LINEARIZE);
+    smartFactor->linearize(values);
+    gttoc_(SmartPoseFactor_LINEARIZE);
+  }
+  tictoc_print_();
+}
+#endif
 
 /* ************************************************************************* */
 BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Constrained, "gtsam_noiseModel_Constrained");

--- a/gtsam/slam/tests/testSmartProjectionFactorP.cpp
+++ b/gtsam/slam/tests/testSmartProjectionFactorP.cpp
@@ -275,1101 +275,589 @@ TEST(SmartProjectionFactorP, smartFactorWithSensorBodyTransform) {
   EXPECT(assert_equal(wTb3, result.at<Pose3>(x3)));
 }
 
-///* *************************************************************************/
-//TEST( SmartProjectionFactorP, 3poses_smart_projection_factor ) {
-//
-//  using namespace vanillaPose2;
-//  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
-//
-//  // Project three landmarks into three cameras
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
-//
-//  KeyVector views;
-//  views.push_back(x1);
-//  views.push_back(x2);
-//  views.push_back(x3);
-//
-//  SmartFactorP::shared_ptr smartFactor1(new SmartFactorP(model, sharedK2));
-//  smartFactor1->add(measurements_cam1, views);
-//
-//  SmartFactorP::shared_ptr smartFactor2(new SmartFactorP(model, sharedK2));
-//  smartFactor2->add(measurements_cam2, views);
-//
-//  SmartFactorP::shared_ptr smartFactor3(new SmartFactorP(model, sharedK2));
-//  smartFactor3->add(measurements_cam3, views);
-//
-//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
-//
-//  NonlinearFactorGraph graph;
-//  graph.push_back(smartFactor1);
-//  graph.push_back(smartFactor2);
-//  graph.push_back(smartFactor3);
-//  graph.addPrior(x1, cam1.pose(), noisePrior);
-//  graph.addPrior(x2, cam2.pose(), noisePrior);
-//
-//  Values groundTruth;
-//  groundTruth.insert(x1, cam1.pose());
-//  groundTruth.insert(x2, cam2.pose());
-//  groundTruth.insert(x3, cam3.pose());
-//  DOUBLES_EQUAL(0, graph.error(groundTruth), 1e-9);
-//
-//  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
-//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-//      Point3(0.1, 0.1, 0.1)); // smaller noise
-//  Values values;
-//  values.insert(x1, cam1.pose());
-//  values.insert(x2, cam2.pose());
-//  // initialize third pose with some noise, we expect it to move back to original pose_above
-//  values.insert(x3, pose_above * noise_pose);
-//  EXPECT(
-//      assert_equal(
-//          Pose3(
-//              Rot3(0, -0.0314107591, 0.99950656, -0.99950656, -0.0313952598,
-//                  -0.000986635786, 0.0314107591, -0.999013364, -0.0313952598),
-//              Point3(0.1, -0.1, 1.9)), values.at<Pose3>(x3)));
-//
-//  Values result;
-//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
-//  result = optimizer.optimize();
-//  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-6));
-//}
-//
-///* *************************************************************************/
-//TEST( SmartProjectionFactorP, Factors ) {
-//
-//  using namespace vanillaPose;
-//
-//  // Default cameras for simple derivatives
-//  Rot3 R;
-//  static Cal3_S2::shared_ptr sharedK(new Cal3_S2(100, 100, 0, 0, 0));
-//  Camera cam1(Pose3(R, Point3(0, 0, 0)), sharedK), cam2(
-//      Pose3(R, Point3(1, 0, 0)), sharedK);
-//
-//  // one landmarks 1m in front of camera
-//  Point3 landmark1(0, 0, 10);
-//
-//  Point2Vector measurements_cam1;
-//
-//  // Project 2 landmarks into 2 cameras
-//  measurements_cam1.push_back(cam1.project(landmark1));
-//  measurements_cam1.push_back(cam2.project(landmark1));
-//
-//  // Create smart factors
-//  KeyVector views {x1, x2};
-//
-//  SmartFactorP::shared_ptr smartFactor1 = boost::make_shared<SmartFactorP>(model, sharedK);
-//  smartFactor1->add(measurements_cam1, views);
-//
-//  SmartFactorP::Cameras cameras;
-//  cameras.push_back(cam1);
-//  cameras.push_back(cam2);
-//
-//  // Make sure triangulation works
-//  CHECK(smartFactor1->triangulateSafe(cameras));
-//  CHECK(!smartFactor1->isDegenerate());
-//  CHECK(!smartFactor1->isPointBehindCamera());
-//  boost::optional<Point3> p = smartFactor1->point();
-//  CHECK(p);
-//  EXPECT(assert_equal(landmark1, *p));
-//
-//  VectorValues zeroDelta;
-//  Vector6 delta;
-//  delta.setZero();
-//  zeroDelta.insert(x1, delta);
-//  zeroDelta.insert(x2, delta);
-//
-//  VectorValues perturbedDelta;
-//  delta.setOnes();
-//  perturbedDelta.insert(x1, delta);
-//  perturbedDelta.insert(x2, delta);
-//  double expectedError = 2500;
-//
-//  // After eliminating the point, A1 and A2 contain 2-rank information on cameras:
-//  Matrix16 A1, A2;
-//  A1 << -10, 0, 0, 0, 1, 0;
-//  A2 << 10, 0, 1, 0, -1, 0;
-//  A1 *= 10. / sigma;
-//  A2 *= 10. / sigma;
-//  Matrix expectedInformation; // filled below
-//  {
-//    // createHessianFactor
-//    Matrix66 G11 = 0.5 * A1.transpose() * A1;
-//    Matrix66 G12 = 0.5 * A1.transpose() * A2;
-//    Matrix66 G22 = 0.5 * A2.transpose() * A2;
-//
-//    Vector6 g1;
-//    g1.setZero();
-//    Vector6 g2;
-//    g2.setZero();
-//
-//    double f = 0;
-//
-//    RegularHessianFactor<6> expected(x1, x2, G11, G12, g1, G22, g2, f);
-//    expectedInformation = expected.information();
-//
-//    boost::shared_ptr<RegularHessianFactor<6> > actual =
-//        smartFactor1->createHessianFactor(cameras, 0.0);
-//    EXPECT(assert_equal(expectedInformation, actual->information(), 1e-6));
-//    EXPECT(assert_equal(expected, *actual, 1e-6));
-//    EXPECT_DOUBLES_EQUAL(0, actual->error(zeroDelta), 1e-6);
-//    EXPECT_DOUBLES_EQUAL(expectedError, actual->error(perturbedDelta), 1e-6);
-//  }
-//
-//  {
-//    Matrix26 F1;
-//    F1.setZero();
-//    F1(0, 1) = -100;
-//    F1(0, 3) = -10;
-//    F1(1, 0) = 100;
-//    F1(1, 4) = -10;
-//    Matrix26 F2;
-//    F2.setZero();
-//    F2(0, 1) = -101;
-//    F2(0, 3) = -10;
-//    F2(0, 5) = -1;
-//    F2(1, 0) = 100;
-//    F2(1, 2) = 10;
-//    F2(1, 4) = -10;
-//    Matrix E(4, 3);
-//    E.setZero();
-//    E(0, 0) = 10;
-//    E(1, 1) = 10;
-//    E(2, 0) = 10;
-//    E(2, 2) = 1;
-//    E(3, 1) = 10;
-//    SmartFactorP::FBlocks Fs = list_of<Matrix>(F1)(F2);
-//    Vector b(4);
-//    b.setZero();
-//
-//    // Create smart factors
-//    KeyVector keys;
-//    keys.push_back(x1);
-//    keys.push_back(x2);
-//
-//    // createJacobianQFactor
-//    SharedIsotropic n = noiseModel::Isotropic::Sigma(4, sigma);
-//    Matrix3 P = (E.transpose() * E).inverse();
-//    JacobianFactorQ<6, 2> expectedQ(keys, Fs, E, P, b, n);
-//    EXPECT(assert_equal(expectedInformation, expectedQ.information(), 1e-6));
-//
-//    boost::shared_ptr<JacobianFactorQ<6, 2> > actualQ =
-//        smartFactor1->createJacobianQFactor(cameras, 0.0);
-//    CHECK(actualQ);
-//    EXPECT(assert_equal(expectedInformation, actualQ->information(), 1e-6));
-//    EXPECT(assert_equal(expectedQ, *actualQ));
-//    EXPECT_DOUBLES_EQUAL(0, actualQ->error(zeroDelta), 1e-6);
-//    EXPECT_DOUBLES_EQUAL(expectedError, actualQ->error(perturbedDelta), 1e-6);
-//
-//    // Whiten for RegularImplicitSchurFactor (does not have noise model)
-//    model->WhitenSystem(E, b);
-//    Matrix3 whiteP = (E.transpose() * E).inverse();
-//    Fs[0] = model->Whiten(Fs[0]);
-//    Fs[1] = model->Whiten(Fs[1]);
-//
-//    // createRegularImplicitSchurFactor
-//    RegularImplicitSchurFactor<Camera> expected(keys, Fs, E, whiteP, b);
-//
-//    boost::shared_ptr<RegularImplicitSchurFactor<Camera> > actual =
-//        smartFactor1->createRegularImplicitSchurFactor(cameras, 0.0);
-//    CHECK(actual);
-//    EXPECT(assert_equal(expectedInformation, expected.information(), 1e-6));
-//    EXPECT(assert_equal(expectedInformation, actual->information(), 1e-6));
-//    EXPECT(assert_equal(expected, *actual));
-//    EXPECT_DOUBLES_EQUAL(0, actual->error(zeroDelta), 1e-6);
-//    EXPECT_DOUBLES_EQUAL(expectedError, actual->error(perturbedDelta), 1e-6);
-//  }
-//
-//  {
-//    // createJacobianSVDFactor
-//    Vector1 b;
-//    b.setZero();
-//    double s = sigma * sin(M_PI_4);
-//    SharedIsotropic n = noiseModel::Isotropic::Sigma(4 - 3, sigma);
-//    JacobianFactor expected(x1, s * A1, x2, s * A2, b, n);
-//    EXPECT(assert_equal(expectedInformation, expected.information(), 1e-6));
-//
-//    boost::shared_ptr<JacobianFactor> actual =
-//        smartFactor1->createJacobianSVDFactor(cameras, 0.0);
-//    CHECK(actual);
-//    EXPECT(assert_equal(expectedInformation, actual->information(), 1e-6));
-//    EXPECT(assert_equal(expected, *actual));
-//    EXPECT_DOUBLES_EQUAL(0, actual->error(zeroDelta), 1e-6);
-//    EXPECT_DOUBLES_EQUAL(expectedError, actual->error(perturbedDelta), 1e-6);
-//  }
-//}
-//
-///* *************************************************************************/
-//TEST( SmartProjectionFactorP, 3poses_iterative_smart_projection_factor ) {
-//
-//  using namespace vanillaPose;
-//
-//  KeyVector views {x1, x2, x3};
-//
-//  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
-//
-//  // Project three landmarks into three cameras
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
-//
-//  SmartFactorP::shared_ptr smartFactor1(new SmartFactorP(model, sharedK));
-//  smartFactor1->add(measurements_cam1, views);
-//
-//  SmartFactorP::shared_ptr smartFactor2(new SmartFactorP(model, sharedK));
-//  smartFactor2->add(measurements_cam2, views);
-//
-//  SmartFactorP::shared_ptr smartFactor3(new SmartFactorP(model, sharedK));
-//  smartFactor3->add(measurements_cam3, views);
-//
-//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
-//
-//  NonlinearFactorGraph graph;
-//  graph.push_back(smartFactor1);
-//  graph.push_back(smartFactor2);
-//  graph.push_back(smartFactor3);
-//  graph.addPrior(x1, cam1.pose(), noisePrior);
-//  graph.addPrior(x2, cam2.pose(), noisePrior);
-//
-//  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
-//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-//      Point3(0.1, 0.1, 0.1)); // smaller noise
-//  Values values;
-//  values.insert(x1, cam1.pose());
-//  values.insert(x2, cam2.pose());
-//  // initialize third pose with some noise, we expect it to move back to original pose_above
-//  values.insert(x3, pose_above * noise_pose);
-//  EXPECT(
-//      assert_equal(
-//          Pose3(
-//              Rot3(1.11022302e-16, -0.0314107591, 0.99950656, -0.99950656,
-//                  -0.0313952598, -0.000986635786, 0.0314107591, -0.999013364,
-//                  -0.0313952598), Point3(0.1, -0.1, 1.9)),
-//          values.at<Pose3>(x3)));
-//
-//  Values result;
-//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
-//  result = optimizer.optimize();
-//  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-7));
-//}
-//
-///* *************************************************************************/
-//TEST( SmartProjectionFactorP, jacobianSVD ) {
-//
-//  using namespace vanillaPose;
-//
-//  KeyVector views {x1, x2, x3};
-//
-//  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
-//
-//  // Project three landmarks into three cameras
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
-//
-//  SmartProjectionParams params;
-//  params.setRankTolerance(1.0);
-//  params.setLinearizationMode(gtsam::JACOBIAN_SVD);
-//  params.setDegeneracyMode(gtsam::IGNORE_DEGENERACY);
-//  params.setEnableEPI(false);
-//  SmartFactorP factor1(model, sharedK, params);
-//
-//  SmartFactorP::shared_ptr smartFactor1(
-//      new SmartFactorP(model, sharedK, params));
-//  smartFactor1->add(measurements_cam1, views);
-//
-//  SmartFactorP::shared_ptr smartFactor2(
-//      new SmartFactorP(model, sharedK, params));
-//  smartFactor2->add(measurements_cam2, views);
-//
-//  SmartFactorP::shared_ptr smartFactor3(
-//      new SmartFactorP(model, sharedK, params));
-//  smartFactor3->add(measurements_cam3, views);
-//
-//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
-//
-//  NonlinearFactorGraph graph;
-//  graph.push_back(smartFactor1);
-//  graph.push_back(smartFactor2);
-//  graph.push_back(smartFactor3);
-//  graph.addPrior(x1, cam1.pose(), noisePrior);
-//  graph.addPrior(x2, cam2.pose(), noisePrior);
-//
-//  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
-//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-//      Point3(0.1, 0.1, 0.1)); // smaller noise
-//  Values values;
-//  values.insert(x1, cam1.pose());
-//  values.insert(x2, cam2.pose());
-//  values.insert(x3, pose_above * noise_pose);
-//
-//  Values result;
-//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
-//  result = optimizer.optimize();
-//  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-6));
-//}
-//
-///* *************************************************************************/
-//TEST( SmartProjectionFactorP, landmarkDistance ) {
-//
-//  using namespace vanillaPose;
-//
-//  double excludeLandmarksFutherThanDist = 2;
-//
-//  KeyVector views {x1, x2, x3};
-//
-//  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
-//
-//  // Project three landmarks into three cameras
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
-//
-//  SmartProjectionParams params;
-//  params.setRankTolerance(1.0);
-//  params.setLinearizationMode(gtsam::JACOBIAN_SVD);
-//  params.setDegeneracyMode(gtsam::IGNORE_DEGENERACY);
-//  params.setLandmarkDistanceThreshold(excludeLandmarksFutherThanDist);
-//  params.setEnableEPI(false);
-//
-//  SmartFactorP::shared_ptr smartFactor1(
-//      new SmartFactorP(model, sharedK, params));
-//  smartFactor1->add(measurements_cam1, views);
-//
-//  SmartFactorP::shared_ptr smartFactor2(
-//      new SmartFactorP(model, sharedK, params));
-//  smartFactor2->add(measurements_cam2, views);
-//
-//  SmartFactorP::shared_ptr smartFactor3(
-//      new SmartFactorP(model, sharedK, params));
-//  smartFactor3->add(measurements_cam3, views);
-//
-//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
-//
-//  NonlinearFactorGraph graph;
-//  graph.push_back(smartFactor1);
-//  graph.push_back(smartFactor2);
-//  graph.push_back(smartFactor3);
-//  graph.addPrior(x1, cam1.pose(), noisePrior);
-//  graph.addPrior(x2, cam2.pose(), noisePrior);
-//
-//  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
-//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-//      Point3(0.1, 0.1, 0.1)); // smaller noise
-//  Values values;
-//  values.insert(x1, cam1.pose());
-//  values.insert(x2, cam2.pose());
-//  values.insert(x3, pose_above * noise_pose);
-//
-//  // All factors are disabled and pose should remain where it is
-//  Values result;
-//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
-//  result = optimizer.optimize();
-//  EXPECT(assert_equal(values.at<Pose3>(x3), result.at<Pose3>(x3)));
-//}
-//
-///* *************************************************************************/
-//TEST( SmartProjectionFactorP, dynamicOutlierRejection ) {
-//
-//  using namespace vanillaPose;
-//
-//  double excludeLandmarksFutherThanDist = 1e10;
-//  double dynamicOutlierRejectionThreshold = 1; // max 1 pixel of average reprojection error
-//
-//  KeyVector views {x1, x2, x3};
-//
-//  // add fourth landmark
-//  Point3 landmark4(5, -0.5, 1);
-//
-//  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3,
-//      measurements_cam4;
-//
-//  // Project 4 landmarks into three cameras
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark4, measurements_cam4);
-//  measurements_cam4.at(0) = measurements_cam4.at(0) + Point2(10, 10); // add outlier
-//
-//  SmartProjectionParams params;
-//  params.setLinearizationMode(gtsam::JACOBIAN_SVD);
-//  params.setLandmarkDistanceThreshold(excludeLandmarksFutherThanDist);
-//  params.setDynamicOutlierRejectionThreshold(dynamicOutlierRejectionThreshold);
-//
-//  SmartFactorP::shared_ptr smartFactor1(
-//      new SmartFactorP(model, sharedK, params));
-//  smartFactor1->add(measurements_cam1, views);
-//
-//  SmartFactorP::shared_ptr smartFactor2(
-//      new SmartFactorP(model, sharedK, params));
-//  smartFactor2->add(measurements_cam2, views);
-//
-//  SmartFactorP::shared_ptr smartFactor3(
-//      new SmartFactorP(model, sharedK, params));
-//  smartFactor3->add(measurements_cam3, views);
-//
-//  SmartFactorP::shared_ptr smartFactor4(
-//      new SmartFactorP(model, sharedK, params));
-//  smartFactor4->add(measurements_cam4, views);
-//
-//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
-//
-//  NonlinearFactorGraph graph;
-//  graph.push_back(smartFactor1);
-//  graph.push_back(smartFactor2);
-//  graph.push_back(smartFactor3);
-//  graph.push_back(smartFactor4);
-//  graph.addPrior(x1, cam1.pose(), noisePrior);
-//  graph.addPrior(x2, cam2.pose(), noisePrior);
-//
-//  Values values;
-//  values.insert(x1, cam1.pose());
-//  values.insert(x2, cam2.pose());
-//  values.insert(x3, cam3.pose());
-//
-//  // All factors are disabled and pose should remain where it is
-//  Values result;
-//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
-//  result = optimizer.optimize();
-//  EXPECT(assert_equal(cam3.pose(), result.at<Pose3>(x3)));
-//}
-//
-///* *************************************************************************/
-//TEST( SmartProjectionFactorP, jacobianQ ) {
-//
-//  using namespace vanillaPose;
-//
-//  KeyVector views {x1, x2, x3};
-//
-//  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
-//
-//  // Project three landmarks into three cameras
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
-//
-//  SmartProjectionParams params;
-//  params.setLinearizationMode(gtsam::JACOBIAN_Q);
-//
-//  SmartFactorP::shared_ptr smartFactor1(
-//      new SmartFactorP(model, sharedK, params));
-//  smartFactor1->add(measurements_cam1, views);
-//
-//  SmartFactorP::shared_ptr smartFactor2(
-//      new SmartFactorP(model, sharedK, params));
-//  smartFactor2->add(measurements_cam2, views);
-//
-//  SmartFactorP::shared_ptr smartFactor3(
-//      new SmartFactorP(model, sharedK, params));
-//  smartFactor3->add(measurements_cam3, views);
-//
-//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
-//
-//  NonlinearFactorGraph graph;
-//  graph.push_back(smartFactor1);
-//  graph.push_back(smartFactor2);
-//  graph.push_back(smartFactor3);
-//  graph.addPrior(x1, cam1.pose(), noisePrior);
-//  graph.addPrior(x2, cam2.pose(), noisePrior);
-//
-//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-//      Point3(0.1, 0.1, 0.1)); // smaller noise
-//  Values values;
-//  values.insert(x1, cam1.pose());
-//  values.insert(x2, cam2.pose());
-//  values.insert(x3, pose_above * noise_pose);
-//
-//  Values result;
-//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
-//  result = optimizer.optimize();
-//  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-6));
-//}
-//
-///* *************************************************************************/
-//TEST( SmartProjectionFactorP, 3poses_projection_factor ) {
-//
-//  using namespace vanillaPose2;
-//
-//  KeyVector views {x1, x2, x3};
-//
-//  typedef GenericProjectionFactor<Pose3, Point3> ProjectionFactor;
-//  NonlinearFactorGraph graph;
-//
-//  // Project three landmarks into three cameras
-//  graph.emplace_shared<ProjectionFactor>(cam1.project(landmark1), model, x1, L(1), sharedK2);
-//  graph.emplace_shared<ProjectionFactor>(cam2.project(landmark1), model, x2, L(1), sharedK2);
-//  graph.emplace_shared<ProjectionFactor>(cam3.project(landmark1), model, x3, L(1), sharedK2);
-//
-//  graph.emplace_shared<ProjectionFactor>(cam1.project(landmark2), model, x1, L(2), sharedK2);
-//  graph.emplace_shared<ProjectionFactor>(cam2.project(landmark2), model, x2, L(2), sharedK2);
-//  graph.emplace_shared<ProjectionFactor>(cam3.project(landmark2), model, x3, L(2), sharedK2);
-//
-//  graph.emplace_shared<ProjectionFactor>(cam1.project(landmark3), model, x1, L(3), sharedK2);
-//  graph.emplace_shared<ProjectionFactor>(cam2.project(landmark3), model, x2, L(3), sharedK2);
-//  graph.emplace_shared<ProjectionFactor>(cam3.project(landmark3), model, x3, L(3), sharedK2);
-//
-//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
-//  graph.addPrior(x1, level_pose, noisePrior);
-//  graph.addPrior(x2, pose_right, noisePrior);
-//
-//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 10, 0., -M_PI / 10),
-//      Point3(0.5, 0.1, 0.3));
-//  Values values;
-//  values.insert(x1, level_pose);
-//  values.insert(x2, pose_right);
-//  values.insert(x3, pose_above * noise_pose);
-//  values.insert(L(1), landmark1);
-//  values.insert(L(2), landmark2);
-//  values.insert(L(3), landmark3);
-//
-//  DOUBLES_EQUAL(48406055, graph.error(values), 1);
-//
-//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
-//  Values result = optimizer.optimize();
-//
-//  DOUBLES_EQUAL(0, graph.error(result), 1e-9);
-//
-//  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-7));
-//}
-//
-///* *************************************************************************/
-//TEST( SmartProjectionFactorP, CheckHessian) {
-//
-//  KeyVector views {x1, x2, x3};
-//
-//  using namespace vanillaPose;
-//
-//  // Two slightly different cameras
-//  Pose3 pose2 = level_pose
-//      * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
-//  Pose3 pose3 = pose2 * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
-//  Camera cam2(pose2, sharedK);
-//  Camera cam3(pose3, sharedK);
-//
-//  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
-//
-//  // Project three landmarks into three cameras
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
-//
-//  SmartProjectionParams params;
-//  params.setRankTolerance(10);
-//
-//  SmartFactorP::shared_ptr smartFactor1(
-//      new SmartFactorP(model, sharedK, params)); // HESSIAN, by default
-//  smartFactor1->add(measurements_cam1, views);
-//
-//  SmartFactorP::shared_ptr smartFactor2(
-//      new SmartFactorP(model, sharedK, params)); // HESSIAN, by default
-//  smartFactor2->add(measurements_cam2, views);
-//
-//  SmartFactorP::shared_ptr smartFactor3(
-//      new SmartFactorP(model, sharedK, params)); // HESSIAN, by default
-//  smartFactor3->add(measurements_cam3, views);
-//
-//  NonlinearFactorGraph graph;
-//  graph.push_back(smartFactor1);
-//  graph.push_back(smartFactor2);
-//  graph.push_back(smartFactor3);
-//
-//  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
-//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-//      Point3(0.1, 0.1, 0.1)); // smaller noise
-//  Values values;
-//  values.insert(x1, cam1.pose());
-//  values.insert(x2, cam2.pose());
-//  // initialize third pose with some noise, we expect it to move back to original pose_above
-//  values.insert(x3, pose3 * noise_pose);
-//  EXPECT(
-//      assert_equal(
-//          Pose3(
-//              Rot3(0.00563056869, -0.130848107, 0.991386438, -0.991390265,
-//                  -0.130426831, -0.0115837907, 0.130819108, -0.98278564,
-//                  -0.130455917),
-//              Point3(0.0897734171, -0.110201006, 0.901022872)),
-//          values.at<Pose3>(x3)));
-//
-//  boost::shared_ptr<GaussianFactor> factor1 = smartFactor1->linearize(values);
-//  boost::shared_ptr<GaussianFactor> factor2 = smartFactor2->linearize(values);
-//  boost::shared_ptr<GaussianFactor> factor3 = smartFactor3->linearize(values);
-//
-//  Matrix CumulativeInformation = factor1->information() + factor2->information()
-//      + factor3->information();
-//
-//  boost::shared_ptr<GaussianFactorGraph> GaussianGraph = graph.linearize(
-//      values);
-//  Matrix GraphInformation = GaussianGraph->hessian().first;
-//
-//  // Check Hessian
-//  EXPECT(assert_equal(GraphInformation, CumulativeInformation, 1e-6));
-//
-//  Matrix AugInformationMatrix = factor1->augmentedInformation()
-//      + factor2->augmentedInformation() + factor3->augmentedInformation();
-//
-//  // Check Information vector
-//  Vector InfoVector = AugInformationMatrix.block(0, 18, 18, 1); // 18x18 Hessian + information vector
-//
-//  // Check Hessian
-//  EXPECT(assert_equal(InfoVector, GaussianGraph->hessian().second, 1e-6));
-//}
-//
-///* *************************************************************************/
-//TEST( SmartProjectionFactorP, 3poses_2land_rotation_only_smart_projection_factor ) {
-//  using namespace vanillaPose2;
-//
-//  KeyVector views {x1, x2, x3};
-//
-//  // Two different cameras, at the same position, but different rotations
-//  Pose3 pose2 = level_pose * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0,0,0));
-//  Pose3 pose3 = pose2 * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0,0,0));
-//  Camera cam2(pose2, sharedK2);
-//  Camera cam3(pose3, sharedK2);
-//
-//  Point2Vector measurements_cam1, measurements_cam2;
-//
-//  // Project three landmarks into three cameras
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
-//
-//  SmartProjectionParams params;
-//  params.setRankTolerance(50);
-//  params.setDegeneracyMode(gtsam::HANDLE_INFINITY);
-//
-//  SmartFactorP::shared_ptr smartFactor1(
-//      new SmartFactorP(model, sharedK2, params));
-//  smartFactor1->add(measurements_cam1, views);
-//
-//  SmartFactorP::shared_ptr smartFactor2(
-//      new SmartFactorP(model, sharedK2, params));
-//  smartFactor2->add(measurements_cam2, views);
-//
-//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
-//  const SharedDiagonal noisePriorTranslation = noiseModel::Isotropic::Sigma(3, 0.10);
-//  Point3 positionPrior = Point3(0, 0, 1);
-//
-//  NonlinearFactorGraph graph;
-//  graph.push_back(smartFactor1);
-//  graph.push_back(smartFactor2);
-//  graph.addPrior(x1, cam1.pose(), noisePrior);
-//  graph.emplace_shared<PoseTranslationPrior<Pose3> >(x2, positionPrior, noisePriorTranslation);
-//  graph.emplace_shared<PoseTranslationPrior<Pose3> >(x3, positionPrior, noisePriorTranslation);
-//
-//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-//      Point3(0.1, 0.1, 0.1)); // smaller noise
-//  Values values;
-//  values.insert(x1, cam1.pose());
-//  values.insert(x2, pose2 * noise_pose);
-//  values.insert(x3, pose3 * noise_pose);
-//
-//  // params.verbosityLM = LevenbergMarquardtParams::SUMMARY;
-//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
-//  Values result = optimizer.optimize();
-//  EXPECT(assert_equal(pose3, result.at<Pose3>(x3)));
-//}
-//
-///* *************************************************************************/
-//TEST( SmartProjectionFactorP, 3poses_rotation_only_smart_projection_factor ) {
-//
-//  // this test considers a condition in which the cheirality constraint is triggered
-//  using namespace vanillaPose;
-//
-//  KeyVector views {x1, x2, x3};
-//
-//  // Two different cameras, at the same position, but different rotations
-//  Pose3 pose2 = level_pose
-//      * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
-//  Pose3 pose3 = pose2 * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
-//  Camera cam2(pose2, sharedK);
-//  Camera cam3(pose3, sharedK);
-//
-//  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
-//
-//  // Project three landmarks into three cameras
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
-//
-//  SmartProjectionParams params;
-//  params.setRankTolerance(10);
-//  params.setDegeneracyMode(gtsam::ZERO_ON_DEGENERACY);
-//
-//  SmartFactorP::shared_ptr smartFactor1(
-//      new SmartFactorP(model, sharedK, params));
-//  smartFactor1->add(measurements_cam1, views);
-//
-//  SmartFactorP::shared_ptr smartFactor2(
-//      new SmartFactorP(model, sharedK, params));
-//  smartFactor2->add(measurements_cam2, views);
-//
-//  SmartFactorP::shared_ptr smartFactor3(
-//      new SmartFactorP(model, sharedK, params));
-//  smartFactor3->add(measurements_cam3, views);
-//
-//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
-//  const SharedDiagonal noisePriorTranslation = noiseModel::Isotropic::Sigma(3,
-//      0.10);
-//  Point3 positionPrior = Point3(0, 0, 1);
-//
-//  NonlinearFactorGraph graph;
-//  graph.push_back(smartFactor1);
-//  graph.push_back(smartFactor2);
-//  graph.push_back(smartFactor3);
-//  graph.addPrior(x1, cam1.pose(), noisePrior);
-//  graph.emplace_shared<PoseTranslationPrior<Pose3> >(x2, positionPrior, noisePriorTranslation);
-//  graph.emplace_shared<PoseTranslationPrior<Pose3> >(x3, positionPrior, noisePriorTranslation);
-//
-//  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
-//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-//      Point3(0.1, 0.1, 0.1)); // smaller noise
-//  Values values;
-//  values.insert(x1, cam1.pose());
-//  values.insert(x2, cam2.pose());
-//  values.insert(x3, pose3 * noise_pose);
-//  EXPECT(
-//      assert_equal(
-//          Pose3(
-//              Rot3(0.00563056869, -0.130848107, 0.991386438, -0.991390265,
-//                  -0.130426831, -0.0115837907, 0.130819108, -0.98278564,
-//                  -0.130455917),
-//              Point3(0.0897734171, -0.110201006, 0.901022872)),
-//          values.at<Pose3>(x3)));
-//
-//  Values result;
-//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
-//  result = optimizer.optimize();
-//
-//  // Since we do not do anything on degenerate instances (ZERO_ON_DEGENERACY)
-//  // rotation remains the same as the initial guess, but position is fixed by PoseTranslationPrior
-//#ifdef GTSAM_THROW_CHEIRALITY_EXCEPTION
-//  EXPECT(assert_equal(Pose3(values.at<Pose3>(x3).rotation(),
-//      Point3(0,0,1)), result.at<Pose3>(x3)));
-//#else
-//  // if the check is disabled, no cheirality exception if thrown and the pose converges to the right rotation
-//  // with modest accuracy since the configuration is essentially degenerate without the translation due to noise (noise_pose)
-//  EXPECT(assert_equal(pose3, result.at<Pose3>(x3),1e-3));
-//#endif
-//}
-//
-///* *************************************************************************/
-//TEST( SmartProjectionFactorP, Hessian ) {
-//
-//  using namespace vanillaPose2;
-//
-//  KeyVector views {x1, x2};
-//
-//  // Project three landmarks into 2 cameras
-//  Point2 cam1_uv1 = cam1.project(landmark1);
-//  Point2 cam2_uv1 = cam2.project(landmark1);
-//  Point2Vector measurements_cam1;
-//  measurements_cam1.push_back(cam1_uv1);
-//  measurements_cam1.push_back(cam2_uv1);
-//
-//  SmartFactorP::shared_ptr smartFactor1(new SmartFactorP(model, sharedK2));
-//  smartFactor1->add(measurements_cam1, views);
-//
-//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 10, 0., -M_PI / 10),
-//      Point3(0.5, 0.1, 0.3));
-//  Values values;
-//  values.insert(x1, cam1.pose());
-//  values.insert(x2, cam2.pose());
-//
-//  boost::shared_ptr<GaussianFactor> factor = smartFactor1->linearize(values);
-//
-//  // compute triangulation from linearization point
-//  // compute reprojection errors (sum squared)
-//  // compare with factor.info(): the bottom right element is the squared sum of the reprojection errors (normalized by the covariance)
-//  // check that it is correctly scaled when using noiseProjection = [1/4  0; 0 1/4]
-//}
-//
-///* *************************************************************************/
-//TEST( SmartProjectionFactorP, HessianWithRotation ) {
-//  // cout << " ************************ SmartProjectionFactorP: rotated Hessian **********************" << endl;
-//
-//  using namespace vanillaPose;
-//
-//  KeyVector views {x1, x2, x3};
-//
-//  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
-//
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-//
-//  SmartFactorP::shared_ptr smartFactorInstance(new SmartFactorP(model, sharedK));
-//  smartFactorInstance->add(measurements_cam1, views);
-//
-//  Values values;
-//  values.insert(x1, cam1.pose());
-//  values.insert(x2, cam2.pose());
-//  values.insert(x3, cam3.pose());
-//
-//  boost::shared_ptr<GaussianFactor> factor = smartFactorInstance->linearize(
-//      values);
-//
-//  Pose3 poseDrift = Pose3(Rot3::Ypr(-M_PI / 2, 0., -M_PI / 2), Point3(0, 0, 0));
-//
-//  Values rotValues;
-//  rotValues.insert(x1, poseDrift.compose(level_pose));
-//  rotValues.insert(x2, poseDrift.compose(pose_right));
-//  rotValues.insert(x3, poseDrift.compose(pose_above));
-//
-//  boost::shared_ptr<GaussianFactor> factorRot = smartFactorInstance->linearize(
-//      rotValues);
-//
-//  // Hessian is invariant to rotations in the nondegenerate case
-//  EXPECT(assert_equal(factor->information(), factorRot->information(), 1e-7));
-//
-//  Pose3 poseDrift2 = Pose3(Rot3::Ypr(-M_PI / 2, -M_PI / 3, -M_PI / 2),
-//      Point3(10, -4, 5));
-//
-//  Values tranValues;
-//  tranValues.insert(x1, poseDrift2.compose(level_pose));
-//  tranValues.insert(x2, poseDrift2.compose(pose_right));
-//  tranValues.insert(x3, poseDrift2.compose(pose_above));
-//
-//  boost::shared_ptr<GaussianFactor> factorRotTran =
-//      smartFactorInstance->linearize(tranValues);
-//
-//  // Hessian is invariant to rotations and translations in the nondegenerate case
-//  EXPECT(assert_equal(factor->information(), factorRotTran->information(), 1e-7));
-//}
-//
-///* *************************************************************************/
-//TEST( SmartProjectionFactorP, HessianWithRotationDegenerate ) {
-//
-//  using namespace vanillaPose2;
-//
-//  KeyVector views {x1, x2, x3};
-//
-//  // All cameras have the same pose so will be degenerate !
-//  Camera cam2(level_pose, sharedK2);
-//  Camera cam3(level_pose, sharedK2);
-//
-//  Point2Vector measurements_cam1;
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-//
-//  SmartFactorP::shared_ptr smartFactor(new SmartFactorP(model, sharedK2));
-//  smartFactor->add(measurements_cam1, views);
-//
-//  Values values;
-//  values.insert(x1, cam1.pose());
-//  values.insert(x2, cam2.pose());
-//  values.insert(x3, cam3.pose());
-//
-//  boost::shared_ptr<GaussianFactor> factor = smartFactor->linearize(values);
-//
-//  Pose3 poseDrift = Pose3(Rot3::Ypr(-M_PI / 2, 0., -M_PI / 2), Point3(0, 0, 0));
-//
-//  Values rotValues;
-//  rotValues.insert(x1, poseDrift.compose(level_pose));
-//  rotValues.insert(x2, poseDrift.compose(level_pose));
-//  rotValues.insert(x3, poseDrift.compose(level_pose));
-//
-//  boost::shared_ptr<GaussianFactor> factorRot = //
-//      smartFactor->linearize(rotValues);
-//
-//  // Hessian is invariant to rotations in the nondegenerate case
-//  EXPECT(assert_equal(factor->information(), factorRot->information(), 1e-7));
-//
-//  Pose3 poseDrift2 = Pose3(Rot3::Ypr(-M_PI / 2, -M_PI / 3, -M_PI / 2),
-//      Point3(10, -4, 5));
-//
-//  Values tranValues;
-//  tranValues.insert(x1, poseDrift2.compose(level_pose));
-//  tranValues.insert(x2, poseDrift2.compose(level_pose));
-//  tranValues.insert(x3, poseDrift2.compose(level_pose));
-//
-//  boost::shared_ptr<GaussianFactor> factorRotTran = smartFactor->linearize(
-//      tranValues);
-//
-//  // Hessian is invariant to rotations and translations in the nondegenerate case
-//  EXPECT(assert_equal(factor->information(), factorRotTran->information(), 1e-7));
-//}
-//
-///* ************************************************************************* */
-//TEST( SmartProjectionFactorP, ConstructorWithCal3Bundler) {
-//  using namespace bundlerPose;
-//  SmartProjectionParams params;
-//  params.setDegeneracyMode(gtsam::ZERO_ON_DEGENERACY);
-//  SmartFactorP factor(model, sharedBundlerK, params);
-//  factor.add(measurement1, x1);
-//}
-//
-///* *************************************************************************/
-//TEST( SmartProjectionFactorP, Cal3Bundler ) {
-//
-//  using namespace bundlerPose;
-//
-//  // three landmarks ~5 meters in front of camera
-//  Point3 landmark3(3, 0, 3.0);
-//
-//  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
-//
-//  // Project three landmarks into three cameras
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
-//
-//  KeyVector views {x1, x2, x3};
-//
-//  SmartFactorP::shared_ptr smartFactor1(new SmartFactorP(model, sharedBundlerK));
-//  smartFactor1->add(measurements_cam1, views);
-//
-//  SmartFactorP::shared_ptr smartFactor2(new SmartFactorP(model, sharedBundlerK));
-//  smartFactor2->add(measurements_cam2, views);
-//
-//  SmartFactorP::shared_ptr smartFactor3(new SmartFactorP(model, sharedBundlerK));
-//  smartFactor3->add(measurements_cam3, views);
-//
-//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
-//
-//  NonlinearFactorGraph graph;
-//  graph.push_back(smartFactor1);
-//  graph.push_back(smartFactor2);
-//  graph.push_back(smartFactor3);
-//  graph.addPrior(x1, cam1.pose(), noisePrior);
-//  graph.addPrior(x2, cam2.pose(), noisePrior);
-//
-//  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
-//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-//      Point3(0.1, 0.1, 0.1)); // smaller noise
-//  Values values;
-//  values.insert(x1, cam1.pose());
-//  values.insert(x2, cam2.pose());
-//  // initialize third pose with some noise, we expect it to move back to original pose_above
-//  values.insert(x3, pose_above * noise_pose);
-//  EXPECT(
-//      assert_equal(
-//          Pose3(
-//              Rot3(0, -0.0314107591, 0.99950656, -0.99950656, -0.0313952598,
-//                  -0.000986635786, 0.0314107591, -0.999013364, -0.0313952598),
-//              Point3(0.1, -0.1, 1.9)), values.at<Pose3>(x3)));
-//
-//  Values result;
-//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
-//  result = optimizer.optimize();
-//  EXPECT(assert_equal(cam3.pose(), result.at<Pose3>(x3), 1e-6));
-//}
-//
-///* *************************************************************************/
-//TEST( SmartProjectionFactorP, Cal3BundlerRotationOnly ) {
-//
-//  using namespace bundlerPose;
-//
-//  KeyVector views {x1, x2, x3};
-//
-//  // Two different cameras
-//  Pose3 pose2 = level_pose
-//      * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
-//  Pose3 pose3 = pose2 * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
-//  Camera cam2(pose2, sharedBundlerK);
-//  Camera cam3(pose3, sharedBundlerK);
-//
-//  // landmark3 at 3 meters now
-//  Point3 landmark3(3, 0, 3.0);
-//
-//  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
-//
-//  // Project three landmarks into three cameras
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
-//  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
-//
-//  SmartProjectionParams params;
-//  params.setRankTolerance(10);
-//  params.setDegeneracyMode(gtsam::ZERO_ON_DEGENERACY);
-//
-//  SmartFactorP::shared_ptr smartFactor1(
-//      new SmartFactorP(model, sharedBundlerK, params));
-//  smartFactor1->add(measurements_cam1, views);
-//
-//  SmartFactorP::shared_ptr smartFactor2(
-//      new SmartFactorP(model, sharedBundlerK, params));
-//  smartFactor2->add(measurements_cam2, views);
-//
-//  SmartFactorP::shared_ptr smartFactor3(
-//      new SmartFactorP(model, sharedBundlerK, params));
-//  smartFactor3->add(measurements_cam3, views);
-//
-//  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
-//  const SharedDiagonal noisePriorTranslation = noiseModel::Isotropic::Sigma(3,
-//      0.10);
-//  Point3 positionPrior = Point3(0, 0, 1);
-//
-//  NonlinearFactorGraph graph;
-//  graph.push_back(smartFactor1);
-//  graph.push_back(smartFactor2);
-//  graph.push_back(smartFactor3);
-//  graph.addPrior(x1, cam1.pose(), noisePrior);
-//  graph.emplace_shared<PoseTranslationPrior<Pose3> >(x2, positionPrior, noisePriorTranslation);
-//  graph.emplace_shared<PoseTranslationPrior<Pose3> >(x3, positionPrior, noisePriorTranslation);
-//
-//  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
-//  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
-//      Point3(0.1, 0.1, 0.1)); // smaller noise
-//  Values values;
-//  values.insert(x1, cam1.pose());
-//  values.insert(x2, cam2.pose());
-//  // initialize third pose with some noise, we expect it to move back to original pose_above
-//  values.insert(x3, pose3 * noise_pose);
-//  EXPECT(
-//      assert_equal(
-//          Pose3(
-//              Rot3(0.00563056869, -0.130848107, 0.991386438, -0.991390265,
-//                  -0.130426831, -0.0115837907, 0.130819108, -0.98278564,
-//                  -0.130455917),
-//              Point3(0.0897734171, -0.110201006, 0.901022872)),
-//          values.at<Pose3>(x3)));
-//
-//  Values result;
-//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
-//  result = optimizer.optimize();
-//
-//  EXPECT(
-//      assert_equal(
-//          Pose3(
-//              Rot3(0.00563056869, -0.130848107, 0.991386438, -0.991390265,
-//                  -0.130426831, -0.0115837907, 0.130819108, -0.98278564,
-//                  -0.130455917),
-//              Point3(0.0897734171, -0.110201006, 0.901022872)),
-//          values.at<Pose3>(x3)));
-//}
-//
-///* ************************************************************************* */
-//BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Constrained, "gtsam_noiseModel_Constrained");
-//BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Diagonal, "gtsam_noiseModel_Diagonal");
-//BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Gaussian, "gtsam_noiseModel_Gaussian");
-//BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Unit, "gtsam_noiseModel_Unit");
-//BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Isotropic, "gtsam_noiseModel_Isotropic");
-//BOOST_CLASS_EXPORT_GUID(gtsam::SharedNoiseModel, "gtsam_SharedNoiseModel");
-//BOOST_CLASS_EXPORT_GUID(gtsam::SharedDiagonal, "gtsam_SharedDiagonal");
-//
-//TEST(SmartProjectionFactorP, serialize) {
-//  using namespace vanillaPose;
-//  using namespace gtsam::serializationTestHelpers;
-//  SmartProjectionParams params;
-//  params.setRankTolerance(rankTol);
-//  SmartFactorP factor(model, sharedK, params);
-//
-//  EXPECT(equalsObj(factor));
-//  EXPECT(equalsXML(factor));
-//  EXPECT(equalsBinary(factor));
-//}
-//
+/* *************************************************************************/
+TEST( SmartProjectionFactorP, 3poses_smart_projection_factor ) {
+
+  using namespace vanillaPose2;
+  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+
+  // Project three landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+
+  KeyVector views;
+  views.push_back(x1);
+  views.push_back(x2);
+  views.push_back(x3);
+
+  std::vector<boost::shared_ptr<Cal3_S2>> sharedK2s;
+  sharedK2s.push_back(sharedK2);
+  sharedK2s.push_back(sharedK2);
+  sharedK2s.push_back(sharedK2);
+
+  SmartFactorP::shared_ptr smartFactor1(new SmartFactorP(model));
+  smartFactor1->add(measurements_cam1, views, sharedK2s);
+
+  SmartFactorP::shared_ptr smartFactor2(new SmartFactorP(model));
+  smartFactor2->add(measurements_cam2, views, sharedK2s);
+
+  SmartFactorP::shared_ptr smartFactor3(new SmartFactorP(model));
+  smartFactor3->add(measurements_cam3, views, sharedK2s);
+
+  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+
+  NonlinearFactorGraph graph;
+  graph.push_back(smartFactor1);
+  graph.push_back(smartFactor2);
+  graph.push_back(smartFactor3);
+  graph.addPrior(x1, cam1.pose(), noisePrior);
+  graph.addPrior(x2, cam2.pose(), noisePrior);
+
+  Values groundTruth;
+  groundTruth.insert(x1, cam1.pose());
+  groundTruth.insert(x2, cam2.pose());
+  groundTruth.insert(x3, cam3.pose());
+  DOUBLES_EQUAL(0, graph.error(groundTruth), 1e-9);
+
+  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+      Point3(0.1, 0.1, 0.1)); // smaller noise
+  Values values;
+  values.insert(x1, cam1.pose());
+  values.insert(x2, cam2.pose());
+  // initialize third pose with some noise, we expect it to move back to original pose_above
+  values.insert(x3, pose_above * noise_pose);
+  EXPECT(
+      assert_equal(
+          Pose3(
+              Rot3(0, -0.0314107591, 0.99950656, -0.99950656, -0.0313952598,
+                  -0.000986635786, 0.0314107591, -0.999013364, -0.0313952598),
+              Point3(0.1, -0.1, 1.9)), values.at<Pose3>(x3)));
+
+  Values result;
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  result = optimizer.optimize();
+  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-6));
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionFactorP, Factors ) {
+
+  using namespace vanillaPose;
+
+  // Default cameras for simple derivatives
+  Rot3 R;
+  static Cal3_S2::shared_ptr sharedK(new Cal3_S2(100, 100, 0, 0, 0));
+  Camera cam1(Pose3(R, Point3(0, 0, 0)), sharedK), cam2(
+      Pose3(R, Point3(1, 0, 0)), sharedK);
+
+  // one landmarks 1m in front of camera
+  Point3 landmark1(0, 0, 10);
+
+  Point2Vector measurements_cam1;
+
+  // Project 2 landmarks into 2 cameras
+  measurements_cam1.push_back(cam1.project(landmark1));
+  measurements_cam1.push_back(cam2.project(landmark1));
+
+  // Create smart factors
+  KeyVector views {x1, x2};
+
+  std::vector<boost::shared_ptr<Cal3_S2>> sharedKs;
+  sharedKs.push_back(sharedK);
+  sharedKs.push_back(sharedK);
+
+  SmartFactorP::shared_ptr smartFactor1 = boost::make_shared<SmartFactorP>(model);
+  smartFactor1->add(measurements_cam1, views, sharedKs);
+
+  SmartFactorP::Cameras cameras;
+  cameras.push_back(cam1);
+  cameras.push_back(cam2);
+
+  // Make sure triangulation works
+  CHECK(smartFactor1->triangulateSafe(cameras));
+  CHECK(!smartFactor1->isDegenerate());
+  CHECK(!smartFactor1->isPointBehindCamera());
+  boost::optional<Point3> p = smartFactor1->point();
+  CHECK(p);
+  EXPECT(assert_equal(landmark1, *p));
+
+  VectorValues zeroDelta;
+  Vector6 delta;
+  delta.setZero();
+  zeroDelta.insert(x1, delta);
+  zeroDelta.insert(x2, delta);
+
+  VectorValues perturbedDelta;
+  delta.setOnes();
+  perturbedDelta.insert(x1, delta);
+  perturbedDelta.insert(x2, delta);
+  double expectedError = 2500;
+
+  // After eliminating the point, A1 and A2 contain 2-rank information on cameras:
+  Matrix16 A1, A2;
+  A1 << -10, 0, 0, 0, 1, 0;
+  A2 << 10, 0, 1, 0, -1, 0;
+  A1 *= 10. / sigma;
+  A2 *= 10. / sigma;
+  Matrix expectedInformation; // filled below
+  {
+    // createHessianFactor
+    Matrix66 G11 = 0.5 * A1.transpose() * A1;
+    Matrix66 G12 = 0.5 * A1.transpose() * A2;
+    Matrix66 G22 = 0.5 * A2.transpose() * A2;
+
+    Vector6 g1;
+    g1.setZero();
+    Vector6 g2;
+    g2.setZero();
+
+    double f = 0;
+
+    RegularHessianFactor<6> expected(x1, x2, G11, G12, g1, G22, g2, f);
+    expectedInformation = expected.information();
+
+    Values values;
+    values.insert(x1, cam1.pose());
+    values.insert(x2, cam2.pose());
+
+    boost::shared_ptr<RegularHessianFactor<6> > actual =
+        smartFactor1->createHessianFactor(values, 0.0);
+    EXPECT(assert_equal(expectedInformation, actual->information(), 1e-6));
+    EXPECT(assert_equal(expected, *actual, 1e-6));
+    EXPECT_DOUBLES_EQUAL(0, actual->error(zeroDelta), 1e-6);
+    EXPECT_DOUBLES_EQUAL(expectedError, actual->error(perturbedDelta), 1e-6);
+  }
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionFactorP, 3poses_iterative_smart_projection_factor ) {
+
+  using namespace vanillaPose;
+
+  KeyVector views {x1, x2, x3};
+
+  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+
+  // Project three landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+
+  std::vector<boost::shared_ptr<Cal3_S2>> sharedKs;
+  sharedKs.push_back(sharedK);
+  sharedKs.push_back(sharedK);
+  sharedKs.push_back(sharedK);
+
+  SmartFactorP::shared_ptr smartFactor1(new SmartFactorP(model));
+  smartFactor1->add(measurements_cam1, views, sharedKs);
+
+  SmartFactorP::shared_ptr smartFactor2(new SmartFactorP(model));
+  smartFactor2->add(measurements_cam2, views, sharedKs);
+
+  SmartFactorP::shared_ptr smartFactor3(new SmartFactorP(model));
+  smartFactor3->add(measurements_cam3, views, sharedKs);
+
+  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+
+  NonlinearFactorGraph graph;
+  graph.push_back(smartFactor1);
+  graph.push_back(smartFactor2);
+  graph.push_back(smartFactor3);
+  graph.addPrior(x1, cam1.pose(), noisePrior);
+  graph.addPrior(x2, cam2.pose(), noisePrior);
+
+  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+      Point3(0.1, 0.1, 0.1)); // smaller noise
+  Values values;
+  values.insert(x1, cam1.pose());
+  values.insert(x2, cam2.pose());
+  // initialize third pose with some noise, we expect it to move back to original pose_above
+  values.insert(x3, pose_above * noise_pose);
+  EXPECT(
+      assert_equal(
+          Pose3(
+              Rot3(1.11022302e-16, -0.0314107591, 0.99950656, -0.99950656,
+                  -0.0313952598, -0.000986635786, 0.0314107591, -0.999013364,
+                  -0.0313952598), Point3(0.1, -0.1, 1.9)),
+          values.at<Pose3>(x3)));
+
+  Values result;
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  result = optimizer.optimize();
+  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-7));
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionFactorP, landmarkDistance ) {
+
+  using namespace vanillaPose;
+
+  double excludeLandmarksFutherThanDist = 2;
+
+  KeyVector views {x1, x2, x3};
+
+  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+
+  // Project three landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+
+  std::vector<boost::shared_ptr<Cal3_S2>> sharedKs;
+  sharedKs.push_back(sharedK);
+  sharedKs.push_back(sharedK);
+  sharedKs.push_back(sharedK);
+
+  SmartProjectionParams params;
+  params.setRankTolerance(1.0);
+  params.setLinearizationMode(gtsam::JACOBIAN_SVD);
+  params.setDegeneracyMode(gtsam::IGNORE_DEGENERACY);
+  params.setLandmarkDistanceThreshold(excludeLandmarksFutherThanDist);
+  params.setEnableEPI(false);
+
+  SmartFactorP::shared_ptr smartFactor1(
+      new SmartFactorP(model, params));
+  smartFactor1->add(measurements_cam1, views, sharedKs);
+
+  SmartFactorP::shared_ptr smartFactor2(
+      new SmartFactorP(model, params));
+  smartFactor2->add(measurements_cam2, views, sharedKs);
+
+  SmartFactorP::shared_ptr smartFactor3(
+      new SmartFactorP(model, params));
+  smartFactor3->add(measurements_cam3, views, sharedKs);
+
+  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+
+  NonlinearFactorGraph graph;
+  graph.push_back(smartFactor1);
+  graph.push_back(smartFactor2);
+  graph.push_back(smartFactor3);
+  graph.addPrior(x1, cam1.pose(), noisePrior);
+  graph.addPrior(x2, cam2.pose(), noisePrior);
+
+  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+      Point3(0.1, 0.1, 0.1)); // smaller noise
+  Values values;
+  values.insert(x1, cam1.pose());
+  values.insert(x2, cam2.pose());
+  values.insert(x3, pose_above * noise_pose);
+
+  // All factors are disabled and pose should remain where it is
+  Values result;
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  result = optimizer.optimize();
+  EXPECT(assert_equal(values.at<Pose3>(x3), result.at<Pose3>(x3)));
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionFactorP, dynamicOutlierRejection ) {
+
+  using namespace vanillaPose;
+
+  double excludeLandmarksFutherThanDist = 1e10;
+  double dynamicOutlierRejectionThreshold = 1; // max 1 pixel of average reprojection error
+
+  KeyVector views {x1, x2, x3};
+
+  std::vector<boost::shared_ptr<Cal3_S2>> sharedKs;
+  sharedKs.push_back(sharedK);
+  sharedKs.push_back(sharedK);
+  sharedKs.push_back(sharedK);
+
+  // add fourth landmark
+  Point3 landmark4(5, -0.5, 1);
+
+  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3,
+      measurements_cam4;
+
+  // Project 4 landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark4, measurements_cam4);
+  measurements_cam4.at(0) = measurements_cam4.at(0) + Point2(10, 10); // add outlier
+
+  SmartProjectionParams params;
+  params.setLinearizationMode(gtsam::HESSIAN);
+  params.setDegeneracyMode(gtsam::ZERO_ON_DEGENERACY);
+  params.setLandmarkDistanceThreshold(excludeLandmarksFutherThanDist);
+  params.setDynamicOutlierRejectionThreshold(dynamicOutlierRejectionThreshold);
+
+  SmartFactorP::shared_ptr smartFactor1(
+      new SmartFactorP(model, params));
+  smartFactor1->add(measurements_cam1, views, sharedKs);
+
+  SmartFactorP::shared_ptr smartFactor2(
+      new SmartFactorP(model, params));
+  smartFactor2->add(measurements_cam2, views, sharedKs);
+
+  SmartFactorP::shared_ptr smartFactor3(
+      new SmartFactorP(model, params));
+  smartFactor3->add(measurements_cam3, views, sharedKs);
+
+  SmartFactorP::shared_ptr smartFactor4(
+      new SmartFactorP(model, params));
+  smartFactor4->add(measurements_cam4, views, sharedKs);
+
+  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+
+  NonlinearFactorGraph graph;
+  graph.push_back(smartFactor1);
+  graph.push_back(smartFactor2);
+  graph.push_back(smartFactor3);
+  graph.push_back(smartFactor4);
+  graph.addPrior(x1, cam1.pose(), noisePrior);
+  graph.addPrior(x2, cam2.pose(), noisePrior);
+
+  Values values;
+  values.insert(x1, cam1.pose());
+  values.insert(x2, cam2.pose());
+  values.insert(x3, cam3.pose());
+
+  // All factors are disabled and pose should remain where it is
+  Values result;
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  result = optimizer.optimize();
+  EXPECT(assert_equal(cam3.pose(), result.at<Pose3>(x3)));
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionFactorP, CheckHessian) {
+
+  KeyVector views {x1, x2, x3};
+
+  using namespace vanillaPose;
+
+  // Two slightly different cameras
+  Pose3 pose2 = level_pose
+      * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
+  Pose3 pose3 = pose2 * Pose3(Rot3::RzRyRx(-0.05, 0.0, -0.05), Point3(0, 0, 0));
+  Camera cam2(pose2, sharedK);
+  Camera cam3(pose3, sharedK);
+
+  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+
+  // Project three landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+
+  std::vector<boost::shared_ptr<Cal3_S2>> sharedKs;
+  sharedKs.push_back(sharedK);
+  sharedKs.push_back(sharedK);
+  sharedKs.push_back(sharedK);
+
+  SmartProjectionParams params;
+  params.setRankTolerance(10);
+  params.setDegeneracyMode(gtsam::ZERO_ON_DEGENERACY);
+
+  SmartFactorP::shared_ptr smartFactor1(
+      new SmartFactorP(model, params)); // HESSIAN, by default
+  smartFactor1->add(measurements_cam1, views, sharedKs);
+
+  SmartFactorP::shared_ptr smartFactor2(
+      new SmartFactorP(model, params)); // HESSIAN, by default
+  smartFactor2->add(measurements_cam2, views, sharedKs);
+
+  SmartFactorP::shared_ptr smartFactor3(
+      new SmartFactorP(model, params)); // HESSIAN, by default
+  smartFactor3->add(measurements_cam3, views, sharedKs);
+
+  NonlinearFactorGraph graph;
+  graph.push_back(smartFactor1);
+  graph.push_back(smartFactor2);
+  graph.push_back(smartFactor3);
+
+  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+      Point3(0.1, 0.1, 0.1)); // smaller noise
+  Values values;
+  values.insert(x1, cam1.pose());
+  values.insert(x2, cam2.pose());
+  // initialize third pose with some noise, we expect it to move back to original pose_above
+  values.insert(x3, pose3 * noise_pose);
+  EXPECT(
+      assert_equal(
+          Pose3(
+              Rot3(0.00563056869, -0.130848107, 0.991386438, -0.991390265,
+                  -0.130426831, -0.0115837907, 0.130819108, -0.98278564,
+                  -0.130455917),
+              Point3(0.0897734171, -0.110201006, 0.901022872)),
+          values.at<Pose3>(x3)));
+
+  boost::shared_ptr<GaussianFactor> factor1 = smartFactor1->linearize(values);
+  boost::shared_ptr<GaussianFactor> factor2 = smartFactor2->linearize(values);
+  boost::shared_ptr<GaussianFactor> factor3 = smartFactor3->linearize(values);
+
+  Matrix CumulativeInformation = factor1->information() + factor2->information()
+      + factor3->information();
+
+  boost::shared_ptr<GaussianFactorGraph> GaussianGraph = graph.linearize(
+      values);
+  Matrix GraphInformation = GaussianGraph->hessian().first;
+
+  // Check Hessian
+  EXPECT(assert_equal(GraphInformation, CumulativeInformation, 1e-6));
+
+  Matrix AugInformationMatrix = factor1->augmentedInformation()
+      + factor2->augmentedInformation() + factor3->augmentedInformation();
+
+  // Check Information vector
+  Vector InfoVector = AugInformationMatrix.block(0, 18, 18, 1); // 18x18 Hessian + information vector
+
+  // Check Hessian
+  EXPECT(assert_equal(InfoVector, GaussianGraph->hessian().second, 1e-6));
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionFactorP, Hessian ) {
+
+  using namespace vanillaPose2;
+
+  KeyVector views {x1, x2};
+
+  // Project three landmarks into 2 cameras
+  Point2 cam1_uv1 = cam1.project(landmark1);
+  Point2 cam2_uv1 = cam2.project(landmark1);
+  Point2Vector measurements_cam1;
+  measurements_cam1.push_back(cam1_uv1);
+  measurements_cam1.push_back(cam2_uv1);
+
+  std::vector<boost::shared_ptr<Cal3_S2>> sharedK2s;
+  sharedK2s.push_back(sharedK2);
+  sharedK2s.push_back(sharedK2);
+
+  SmartFactorP::shared_ptr smartFactor1(new SmartFactorP(model));
+  smartFactor1->add(measurements_cam1, views, sharedK2s);
+
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 10, 0., -M_PI / 10),
+      Point3(0.5, 0.1, 0.3));
+  Values values;
+  values.insert(x1, cam1.pose());
+  values.insert(x2, cam2.pose());
+
+  boost::shared_ptr<GaussianFactor> factor = smartFactor1->linearize(values);
+
+  // compute triangulation from linearization point
+  // compute reprojection errors (sum squared)
+  // compare with factor.info(): the bottom right element is the squared sum of the reprojection errors (normalized by the covariance)
+  // check that it is correctly scaled when using noiseProjection = [1/4  0; 0 1/4]
+}
+
+/* ************************************************************************* */
+TEST( SmartProjectionFactorP, ConstructorWithCal3Bundler) {
+  using namespace bundlerPose;
+  SmartProjectionParams params;
+  params.setDegeneracyMode(gtsam::ZERO_ON_DEGENERACY);
+  SmartFactorP factor(model, params);
+  factor.add(measurement1, x1, sharedBundlerK);
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionFactorP, Cal3Bundler ) {
+
+  using namespace bundlerPose;
+
+  // three landmarks ~5 meters in front of camera
+  Point3 landmark3(3, 0, 3.0);
+
+  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
+
+  // Project three landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
+
+  KeyVector views {x1, x2, x3};
+
+  std::vector<boost::shared_ptr<Cal3Bundler>> sharedBundlerKs;
+  sharedBundlerKs.push_back(sharedBundlerK);
+  sharedBundlerKs.push_back(sharedBundlerK);
+  sharedBundlerKs.push_back(sharedBundlerK);
+
+  SmartFactorP::shared_ptr smartFactor1(new SmartFactorP(model));
+  smartFactor1->add(measurements_cam1, views, sharedBundlerKs);
+
+  SmartFactorP::shared_ptr smartFactor2(new SmartFactorP(model));
+  smartFactor2->add(measurements_cam2, views, sharedBundlerKs);
+
+  SmartFactorP::shared_ptr smartFactor3(new SmartFactorP(model));
+  smartFactor3->add(measurements_cam3, views, sharedBundlerKs);
+
+  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+
+  NonlinearFactorGraph graph;
+  graph.push_back(smartFactor1);
+  graph.push_back(smartFactor2);
+  graph.push_back(smartFactor3);
+  graph.addPrior(x1, cam1.pose(), noisePrior);
+  graph.addPrior(x2, cam2.pose(), noisePrior);
+
+  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+      Point3(0.1, 0.1, 0.1)); // smaller noise
+  Values values;
+  values.insert(x1, cam1.pose());
+  values.insert(x2, cam2.pose());
+  // initialize third pose with some noise, we expect it to move back to original pose_above
+  values.insert(x3, pose_above * noise_pose);
+  EXPECT(
+      assert_equal(
+          Pose3(
+              Rot3(0, -0.0314107591, 0.99950656, -0.99950656, -0.0313952598,
+                  -0.000986635786, 0.0314107591, -0.999013364, -0.0313952598),
+              Point3(0.1, -0.1, 1.9)), values.at<Pose3>(x3)));
+
+  Values result;
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  result = optimizer.optimize();
+  EXPECT(assert_equal(cam3.pose(), result.at<Pose3>(x3), 1e-6));
+}
+
+/* ************************************************************************* */
+BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Constrained, "gtsam_noiseModel_Constrained");
+BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Diagonal, "gtsam_noiseModel_Diagonal");
+BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Gaussian, "gtsam_noiseModel_Gaussian");
+BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Unit, "gtsam_noiseModel_Unit");
+BOOST_CLASS_EXPORT_GUID(gtsam::noiseModel::Isotropic, "gtsam_noiseModel_Isotropic");
+BOOST_CLASS_EXPORT_GUID(gtsam::SharedNoiseModel, "gtsam_SharedNoiseModel");
+BOOST_CLASS_EXPORT_GUID(gtsam::SharedDiagonal, "gtsam_SharedDiagonal");
+
+TEST(SmartProjectionFactorP, serialize) {
+  using namespace vanillaPose;
+  using namespace gtsam::serializationTestHelpers;
+  SmartProjectionParams params;
+  params.setRankTolerance(rankTol);
+  SmartFactorP factor(model, params);
+
+  EXPECT(equalsObj(factor));
+  EXPECT(equalsXML(factor));
+  EXPECT(equalsBinary(factor));
+}
+
+// SERIALIZATION TEST FAILS: to be fixed
 //TEST(SmartProjectionFactorP, serialize2) {
 //  using namespace vanillaPose;
 //  using namespace gtsam::serializationTestHelpers;
 //  SmartProjectionParams params;
 //  params.setRankTolerance(rankTol);
-//  Pose3 bts;
-//  SmartFactorP factor(model, sharedK, bts, params);
+//  SmartFactorP factor(model, params);
 //
-//  // insert some measurments
+//  // insert some measurements
 //  KeyVector key_view;
 //  Point2Vector meas_view;
+//  std::vector<boost::shared_ptr<Cal3_S2>> sharedKs;
+//
+//
 //  key_view.push_back(Symbol('x', 1));
 //  meas_view.push_back(Point2(10, 10));
-//  factor.add(meas_view, key_view);
+//  sharedKs.push_back(sharedK);
+//  factor.add(meas_view, key_view, sharedKs);
 //
 //  EXPECT(equalsObj(factor));
 //  EXPECT(equalsXML(factor));

--- a/gtsam/slam/tests/testSmartProjectionFactorP.cpp
+++ b/gtsam/slam/tests/testSmartProjectionFactorP.cpp
@@ -51,87 +51,76 @@ LevenbergMarquardtParams lmParams;
 // Make more verbose like so (in tests):
 // params.verbosityLM = LevenbergMarquardtParams::SUMMARY;
 
-///* ************************************************************************* */
-//TEST( SmartProjectionPoseFactor, Constructor) {
-//  using namespace vanillaPose;
-//  SmartFactor::shared_ptr factor1(new SmartFactor(model, sharedK));
-//}
-//
-///* ************************************************************************* */
-//TEST( SmartProjectionPoseFactor, Constructor2) {
-//  using namespace vanillaPose;
-//  SmartProjectionParams params;
-//  params.setRankTolerance(rankTol);
-//  SmartFactor factor1(model, sharedK, params);
-//}
-//
-///* ************************************************************************* */
-//TEST( SmartProjectionPoseFactor, Constructor3) {
-//  using namespace vanillaPose;
-//  SmartFactor::shared_ptr factor1(new SmartFactor(model, sharedK));
-//  factor1->add(measurement1, x1);
-//}
-//
-///* ************************************************************************* */
-//TEST( SmartProjectionPoseFactor, Constructor4) {
-//  using namespace vanillaPose;
-//  SmartProjectionParams params;
-//  params.setRankTolerance(rankTol);
-//  SmartFactor factor1(model, sharedK, params);
-//  factor1.add(measurement1, x1);
-//}
-//
-///* ************************************************************************* */
-//TEST( SmartProjectionPoseFactor, params) {
-//  using namespace vanillaPose;
-//  SmartProjectionParams params;
-//  double rt = params.getRetriangulationThreshold();
-//  EXPECT_DOUBLES_EQUAL(1e-5, rt, 1e-7);
-//  params.setRetriangulationThreshold(1e-3);
-//  rt = params.getRetriangulationThreshold();
-//  EXPECT_DOUBLES_EQUAL(1e-3, rt, 1e-7);
-//}
-//
-///* ************************************************************************* */
-//TEST( SmartProjectionPoseFactor, Equals ) {
-//  using namespace vanillaPose;
-//  SmartFactor::shared_ptr factor1(new SmartFactor(model, sharedK));
-//  factor1->add(measurement1, x1);
-//
-//  SmartFactor::shared_ptr factor2(new SmartFactor(model,sharedK));
-//  factor2->add(measurement1, x1);
-//
-//  CHECK(assert_equal(*factor1, *factor2));
-//}
-//
-///* *************************************************************************/
-//TEST( SmartProjectionPoseFactor, noiseless ) {
-//
-//  using namespace vanillaPose;
-//
-//  // Project two landmarks into two cameras
-//  Point2 level_uv = level_camera.project(landmark1);
-//  Point2 level_uv_right = level_camera_right.project(landmark1);
-//
-//  SmartFactor factor(model, sharedK);
-//  factor.add(level_uv, x1);
-//  factor.add(level_uv_right, x2);
-//
-//  Values values; // it's a pose factor, hence these are poses
-//  values.insert(x1, cam1.pose());
-//  values.insert(x2, cam2.pose());
-//
-//  double actualError = factor.error(values);
-//  double expectedError = 0.0;
-//  EXPECT_DOUBLES_EQUAL(expectedError, actualError, 1e-7);
-//
-//  SmartFactor::Cameras cameras = factor.cameras(values);
+/* ************************************************************************* */
+TEST( SmartProjectionFactorP, Constructor) {
+  using namespace vanillaPose;
+  SmartFactorP::shared_ptr factor1(new SmartFactorP(model));
+}
+
+/* ************************************************************************* */
+TEST( SmartProjectionFactorP, Constructor2) {
+  using namespace vanillaPose;
+  SmartProjectionParams params;
+  params.setRankTolerance(rankTol);
+  SmartFactorP factor1(model, params);
+}
+
+/* ************************************************************************* */
+TEST( SmartProjectionFactorP, Constructor3) {
+  using namespace vanillaPose;
+  SmartFactorP::shared_ptr factor1(new SmartFactorP(model));
+  factor1->add(measurement1, x1, sharedK);
+}
+
+/* ************************************************************************* */
+TEST( SmartProjectionFactorP, Constructor4) {
+  using namespace vanillaPose;
+  SmartProjectionParams params;
+  params.setRankTolerance(rankTol);
+  SmartFactorP factor1(model, params);
+  factor1.add(measurement1, x1, sharedK);
+}
+
+/* ************************************************************************* */
+TEST( SmartProjectionFactorP, Equals ) {
+  using namespace vanillaPose;
+  SmartFactorP::shared_ptr factor1(new SmartFactorP(model));
+  factor1->add(measurement1, x1, sharedK);
+
+  SmartFactorP::shared_ptr factor2(new SmartFactorP(model));
+  factor2->add(measurement1, x1, sharedK);
+
+  CHECK(assert_equal(*factor1, *factor2));
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionFactorP, noiseless ) {
+
+  using namespace vanillaPose;
+
+  // Project two landmarks into two cameras
+  Point2 level_uv = level_camera.project(landmark1);
+  Point2 level_uv_right = level_camera_right.project(landmark1);
+
+  SmartFactorP factor(model);
+  factor.add(level_uv, x1, sharedK);
+  factor.add(level_uv_right, x2, sharedK);
+
+  Values values; // it's a pose factor, hence these are poses
+  values.insert(x1, cam1.pose());
+  values.insert(x2, cam2.pose());
+
+  double actualError = factor.error(values);
+  double expectedError = 0.0;
+  EXPECT_DOUBLES_EQUAL(expectedError, actualError, 1e-7);
+
+//  SmartFactorP::Cameras cameras = factor.cameras(values);
 //  double actualError2 = factor.totalReprojectionError(cameras);
 //  EXPECT_DOUBLES_EQUAL(expectedError, actualError2, 1e-7);
 //
 //  // Calculate expected derivative for point (easiest to check)
 //  std::function<Vector(Point3)> f = //
-//      std::bind(&SmartFactor::whitenedError<Point3>, factor, cameras, std::placeholders::_1);
+//      std::bind(&SmartFactorP::whitenedError<Point3>, factor, cameras, std::placeholders::_1);
 //
 //  // Calculate using computeEP
 //  Matrix actualE;
@@ -146,7 +135,7 @@ LevenbergMarquardtParams lmParams;
 //  EXPECT(assert_equal(expectedE, actualE, 1e-7));
 //
 //  // Calculate using reprojectionError
-//  SmartFactor::Cameras::FBlocks F;
+//  SmartFactorP::Cameras::FBlocks F;
 //  Matrix E;
 //  Vector actualErrors = factor.unwhitenedError(cameras, *point, F, E);
 //  EXPECT(assert_equal(expectedE, E, 1e-7));
@@ -155,15 +144,15 @@ LevenbergMarquardtParams lmParams;
 //
 //  // Calculate using computeJacobians
 //  Vector b;
-//  SmartFactor::FBlocks Fs;
+//  SmartFactorP::FBlocks Fs;
 //  factor.computeJacobians(Fs, E, b, cameras, *point);
 //  double actualError3 = b.squaredNorm();
 //  EXPECT(assert_equal(expectedE, E, 1e-7));
 //  EXPECT_DOUBLES_EQUAL(expectedError, actualError3, 1e-6);
-//}
-//
+}
+
 ///* *************************************************************************/
-//TEST( SmartProjectionPoseFactor, noisy ) {
+//TEST( SmartProjectionFactorP, noisy ) {
 //
 //  using namespace vanillaPose;
 //
@@ -178,13 +167,13 @@ LevenbergMarquardtParams lmParams;
 //      Point3(0.5, 0.1, 0.3));
 //  values.insert(x2, pose_right.compose(noise_pose));
 //
-//  SmartFactor::shared_ptr factor(new SmartFactor(model, sharedK));
+//  SmartFactorP::shared_ptr factor(new SmartFactorP(model, sharedK));
 //  factor->add(level_uv, x1);
 //  factor->add(level_uv_right, x2);
 //
 //  double actualError1 = factor->error(values);
 //
-//  SmartFactor::shared_ptr factor2(new SmartFactor(model, sharedK));
+//  SmartFactorP::shared_ptr factor2(new SmartFactorP(model, sharedK));
 //  Point2Vector measurements;
 //  measurements.push_back(level_uv);
 //  measurements.push_back(level_uv_right);
@@ -197,7 +186,7 @@ LevenbergMarquardtParams lmParams;
 //}
 //
 ///* *************************************************************************/
-//TEST(SmartProjectionPoseFactor, smartFactorWithSensorBodyTransform) {
+//TEST(SmartProjectionFactorP, smartFactorWithSensorBodyTransform) {
 //  using namespace vanillaPose;
 //
 //  // create arbitrary body_T_sensor (transforms from sensor to body)
@@ -227,13 +216,13 @@ LevenbergMarquardtParams lmParams;
 //  params.setDegeneracyMode(IGNORE_DEGENERACY);
 //  params.setEnableEPI(false);
 //
-//  SmartFactor smartFactor1(model, sharedK, body_T_sensor, params);
+//  SmartFactorP smartFactor1(model, sharedK, body_T_sensor, params);
 //  smartFactor1.add(measurements_cam1, views);
 //
-//  SmartFactor smartFactor2(model, sharedK, body_T_sensor, params);
+//  SmartFactorP smartFactor2(model, sharedK, body_T_sensor, params);
 //  smartFactor2.add(measurements_cam2, views);
 //
-//  SmartFactor smartFactor3(model, sharedK, body_T_sensor, params);
+//  SmartFactorP smartFactor3(model, sharedK, body_T_sensor, params);
 //  smartFactor3.add(measurements_cam3, views);
 //
 //  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
@@ -272,7 +261,7 @@ LevenbergMarquardtParams lmParams;
 //}
 //
 ///* *************************************************************************/
-//TEST( SmartProjectionPoseFactor, 3poses_smart_projection_factor ) {
+//TEST( SmartProjectionFactorP, 3poses_smart_projection_factor ) {
 //
 //  using namespace vanillaPose2;
 //  Point2Vector measurements_cam1, measurements_cam2, measurements_cam3;
@@ -287,13 +276,13 @@ LevenbergMarquardtParams lmParams;
 //  views.push_back(x2);
 //  views.push_back(x3);
 //
-//  SmartFactor::shared_ptr smartFactor1(new SmartFactor(model, sharedK2));
+//  SmartFactorP::shared_ptr smartFactor1(new SmartFactorP(model, sharedK2));
 //  smartFactor1->add(measurements_cam1, views);
 //
-//  SmartFactor::shared_ptr smartFactor2(new SmartFactor(model, sharedK2));
+//  SmartFactorP::shared_ptr smartFactor2(new SmartFactorP(model, sharedK2));
 //  smartFactor2->add(measurements_cam2, views);
 //
-//  SmartFactor::shared_ptr smartFactor3(new SmartFactor(model, sharedK2));
+//  SmartFactorP::shared_ptr smartFactor3(new SmartFactorP(model, sharedK2));
 //  smartFactor3->add(measurements_cam3, views);
 //
 //  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
@@ -333,7 +322,7 @@ LevenbergMarquardtParams lmParams;
 //}
 //
 ///* *************************************************************************/
-//TEST( SmartProjectionPoseFactor, Factors ) {
+//TEST( SmartProjectionFactorP, Factors ) {
 //
 //  using namespace vanillaPose;
 //
@@ -355,10 +344,10 @@ LevenbergMarquardtParams lmParams;
 //  // Create smart factors
 //  KeyVector views {x1, x2};
 //
-//  SmartFactor::shared_ptr smartFactor1 = boost::make_shared<SmartFactor>(model, sharedK);
+//  SmartFactorP::shared_ptr smartFactor1 = boost::make_shared<SmartFactorP>(model, sharedK);
 //  smartFactor1->add(measurements_cam1, views);
 //
-//  SmartFactor::Cameras cameras;
+//  SmartFactorP::Cameras cameras;
 //  cameras.push_back(cam1);
 //  cameras.push_back(cam2);
 //
@@ -435,7 +424,7 @@ LevenbergMarquardtParams lmParams;
 //    E(2, 0) = 10;
 //    E(2, 2) = 1;
 //    E(3, 1) = 10;
-//    SmartFactor::FBlocks Fs = list_of<Matrix>(F1)(F2);
+//    SmartFactorP::FBlocks Fs = list_of<Matrix>(F1)(F2);
 //    Vector b(4);
 //    b.setZero();
 //
@@ -497,7 +486,7 @@ LevenbergMarquardtParams lmParams;
 //}
 //
 ///* *************************************************************************/
-//TEST( SmartProjectionPoseFactor, 3poses_iterative_smart_projection_factor ) {
+//TEST( SmartProjectionFactorP, 3poses_iterative_smart_projection_factor ) {
 //
 //  using namespace vanillaPose;
 //
@@ -510,13 +499,13 @@ LevenbergMarquardtParams lmParams;
 //  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_cam2);
 //  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_cam3);
 //
-//  SmartFactor::shared_ptr smartFactor1(new SmartFactor(model, sharedK));
+//  SmartFactorP::shared_ptr smartFactor1(new SmartFactorP(model, sharedK));
 //  smartFactor1->add(measurements_cam1, views);
 //
-//  SmartFactor::shared_ptr smartFactor2(new SmartFactor(model, sharedK));
+//  SmartFactorP::shared_ptr smartFactor2(new SmartFactorP(model, sharedK));
 //  smartFactor2->add(measurements_cam2, views);
 //
-//  SmartFactor::shared_ptr smartFactor3(new SmartFactor(model, sharedK));
+//  SmartFactorP::shared_ptr smartFactor3(new SmartFactorP(model, sharedK));
 //  smartFactor3->add(measurements_cam3, views);
 //
 //  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
@@ -551,7 +540,7 @@ LevenbergMarquardtParams lmParams;
 //}
 //
 ///* *************************************************************************/
-//TEST( SmartProjectionPoseFactor, jacobianSVD ) {
+//TEST( SmartProjectionFactorP, jacobianSVD ) {
 //
 //  using namespace vanillaPose;
 //
@@ -569,18 +558,18 @@ LevenbergMarquardtParams lmParams;
 //  params.setLinearizationMode(gtsam::JACOBIAN_SVD);
 //  params.setDegeneracyMode(gtsam::IGNORE_DEGENERACY);
 //  params.setEnableEPI(false);
-//  SmartFactor factor1(model, sharedK, params);
+//  SmartFactorP factor1(model, sharedK, params);
 //
-//  SmartFactor::shared_ptr smartFactor1(
-//      new SmartFactor(model, sharedK, params));
+//  SmartFactorP::shared_ptr smartFactor1(
+//      new SmartFactorP(model, sharedK, params));
 //  smartFactor1->add(measurements_cam1, views);
 //
-//  SmartFactor::shared_ptr smartFactor2(
-//      new SmartFactor(model, sharedK, params));
+//  SmartFactorP::shared_ptr smartFactor2(
+//      new SmartFactorP(model, sharedK, params));
 //  smartFactor2->add(measurements_cam2, views);
 //
-//  SmartFactor::shared_ptr smartFactor3(
-//      new SmartFactor(model, sharedK, params));
+//  SmartFactorP::shared_ptr smartFactor3(
+//      new SmartFactorP(model, sharedK, params));
 //  smartFactor3->add(measurements_cam3, views);
 //
 //  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
@@ -607,7 +596,7 @@ LevenbergMarquardtParams lmParams;
 //}
 //
 ///* *************************************************************************/
-//TEST( SmartProjectionPoseFactor, landmarkDistance ) {
+//TEST( SmartProjectionFactorP, landmarkDistance ) {
 //
 //  using namespace vanillaPose;
 //
@@ -629,16 +618,16 @@ LevenbergMarquardtParams lmParams;
 //  params.setLandmarkDistanceThreshold(excludeLandmarksFutherThanDist);
 //  params.setEnableEPI(false);
 //
-//  SmartFactor::shared_ptr smartFactor1(
-//      new SmartFactor(model, sharedK, params));
+//  SmartFactorP::shared_ptr smartFactor1(
+//      new SmartFactorP(model, sharedK, params));
 //  smartFactor1->add(measurements_cam1, views);
 //
-//  SmartFactor::shared_ptr smartFactor2(
-//      new SmartFactor(model, sharedK, params));
+//  SmartFactorP::shared_ptr smartFactor2(
+//      new SmartFactorP(model, sharedK, params));
 //  smartFactor2->add(measurements_cam2, views);
 //
-//  SmartFactor::shared_ptr smartFactor3(
-//      new SmartFactor(model, sharedK, params));
+//  SmartFactorP::shared_ptr smartFactor3(
+//      new SmartFactorP(model, sharedK, params));
 //  smartFactor3->add(measurements_cam3, views);
 //
 //  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
@@ -666,7 +655,7 @@ LevenbergMarquardtParams lmParams;
 //}
 //
 ///* *************************************************************************/
-//TEST( SmartProjectionPoseFactor, dynamicOutlierRejection ) {
+//TEST( SmartProjectionFactorP, dynamicOutlierRejection ) {
 //
 //  using namespace vanillaPose;
 //
@@ -693,20 +682,20 @@ LevenbergMarquardtParams lmParams;
 //  params.setLandmarkDistanceThreshold(excludeLandmarksFutherThanDist);
 //  params.setDynamicOutlierRejectionThreshold(dynamicOutlierRejectionThreshold);
 //
-//  SmartFactor::shared_ptr smartFactor1(
-//      new SmartFactor(model, sharedK, params));
+//  SmartFactorP::shared_ptr smartFactor1(
+//      new SmartFactorP(model, sharedK, params));
 //  smartFactor1->add(measurements_cam1, views);
 //
-//  SmartFactor::shared_ptr smartFactor2(
-//      new SmartFactor(model, sharedK, params));
+//  SmartFactorP::shared_ptr smartFactor2(
+//      new SmartFactorP(model, sharedK, params));
 //  smartFactor2->add(measurements_cam2, views);
 //
-//  SmartFactor::shared_ptr smartFactor3(
-//      new SmartFactor(model, sharedK, params));
+//  SmartFactorP::shared_ptr smartFactor3(
+//      new SmartFactorP(model, sharedK, params));
 //  smartFactor3->add(measurements_cam3, views);
 //
-//  SmartFactor::shared_ptr smartFactor4(
-//      new SmartFactor(model, sharedK, params));
+//  SmartFactorP::shared_ptr smartFactor4(
+//      new SmartFactorP(model, sharedK, params));
 //  smartFactor4->add(measurements_cam4, views);
 //
 //  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
@@ -732,7 +721,7 @@ LevenbergMarquardtParams lmParams;
 //}
 //
 ///* *************************************************************************/
-//TEST( SmartProjectionPoseFactor, jacobianQ ) {
+//TEST( SmartProjectionFactorP, jacobianQ ) {
 //
 //  using namespace vanillaPose;
 //
@@ -748,16 +737,16 @@ LevenbergMarquardtParams lmParams;
 //  SmartProjectionParams params;
 //  params.setLinearizationMode(gtsam::JACOBIAN_Q);
 //
-//  SmartFactor::shared_ptr smartFactor1(
-//      new SmartFactor(model, sharedK, params));
+//  SmartFactorP::shared_ptr smartFactor1(
+//      new SmartFactorP(model, sharedK, params));
 //  smartFactor1->add(measurements_cam1, views);
 //
-//  SmartFactor::shared_ptr smartFactor2(
-//      new SmartFactor(model, sharedK, params));
+//  SmartFactorP::shared_ptr smartFactor2(
+//      new SmartFactorP(model, sharedK, params));
 //  smartFactor2->add(measurements_cam2, views);
 //
-//  SmartFactor::shared_ptr smartFactor3(
-//      new SmartFactor(model, sharedK, params));
+//  SmartFactorP::shared_ptr smartFactor3(
+//      new SmartFactorP(model, sharedK, params));
 //  smartFactor3->add(measurements_cam3, views);
 //
 //  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
@@ -783,7 +772,7 @@ LevenbergMarquardtParams lmParams;
 //}
 //
 ///* *************************************************************************/
-//TEST( SmartProjectionPoseFactor, 3poses_projection_factor ) {
+//TEST( SmartProjectionFactorP, 3poses_projection_factor ) {
 //
 //  using namespace vanillaPose2;
 //
@@ -830,7 +819,7 @@ LevenbergMarquardtParams lmParams;
 //}
 //
 ///* *************************************************************************/
-//TEST( SmartProjectionPoseFactor, CheckHessian) {
+//TEST( SmartProjectionFactorP, CheckHessian) {
 //
 //  KeyVector views {x1, x2, x3};
 //
@@ -853,16 +842,16 @@ LevenbergMarquardtParams lmParams;
 //  SmartProjectionParams params;
 //  params.setRankTolerance(10);
 //
-//  SmartFactor::shared_ptr smartFactor1(
-//      new SmartFactor(model, sharedK, params)); // HESSIAN, by default
+//  SmartFactorP::shared_ptr smartFactor1(
+//      new SmartFactorP(model, sharedK, params)); // HESSIAN, by default
 //  smartFactor1->add(measurements_cam1, views);
 //
-//  SmartFactor::shared_ptr smartFactor2(
-//      new SmartFactor(model, sharedK, params)); // HESSIAN, by default
+//  SmartFactorP::shared_ptr smartFactor2(
+//      new SmartFactorP(model, sharedK, params)); // HESSIAN, by default
 //  smartFactor2->add(measurements_cam2, views);
 //
-//  SmartFactor::shared_ptr smartFactor3(
-//      new SmartFactor(model, sharedK, params)); // HESSIAN, by default
+//  SmartFactorP::shared_ptr smartFactor3(
+//      new SmartFactorP(model, sharedK, params)); // HESSIAN, by default
 //  smartFactor3->add(measurements_cam3, views);
 //
 //  NonlinearFactorGraph graph;
@@ -912,7 +901,7 @@ LevenbergMarquardtParams lmParams;
 //}
 //
 ///* *************************************************************************/
-//TEST( SmartProjectionPoseFactor, 3poses_2land_rotation_only_smart_projection_factor ) {
+//TEST( SmartProjectionFactorP, 3poses_2land_rotation_only_smart_projection_factor ) {
 //  using namespace vanillaPose2;
 //
 //  KeyVector views {x1, x2, x3};
@@ -933,12 +922,12 @@ LevenbergMarquardtParams lmParams;
 //  params.setRankTolerance(50);
 //  params.setDegeneracyMode(gtsam::HANDLE_INFINITY);
 //
-//  SmartFactor::shared_ptr smartFactor1(
-//      new SmartFactor(model, sharedK2, params));
+//  SmartFactorP::shared_ptr smartFactor1(
+//      new SmartFactorP(model, sharedK2, params));
 //  smartFactor1->add(measurements_cam1, views);
 //
-//  SmartFactor::shared_ptr smartFactor2(
-//      new SmartFactor(model, sharedK2, params));
+//  SmartFactorP::shared_ptr smartFactor2(
+//      new SmartFactorP(model, sharedK2, params));
 //  smartFactor2->add(measurements_cam2, views);
 //
 //  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
@@ -966,7 +955,7 @@ LevenbergMarquardtParams lmParams;
 //}
 //
 ///* *************************************************************************/
-//TEST( SmartProjectionPoseFactor, 3poses_rotation_only_smart_projection_factor ) {
+//TEST( SmartProjectionFactorP, 3poses_rotation_only_smart_projection_factor ) {
 //
 //  // this test considers a condition in which the cheirality constraint is triggered
 //  using namespace vanillaPose;
@@ -991,16 +980,16 @@ LevenbergMarquardtParams lmParams;
 //  params.setRankTolerance(10);
 //  params.setDegeneracyMode(gtsam::ZERO_ON_DEGENERACY);
 //
-//  SmartFactor::shared_ptr smartFactor1(
-//      new SmartFactor(model, sharedK, params));
+//  SmartFactorP::shared_ptr smartFactor1(
+//      new SmartFactorP(model, sharedK, params));
 //  smartFactor1->add(measurements_cam1, views);
 //
-//  SmartFactor::shared_ptr smartFactor2(
-//      new SmartFactor(model, sharedK, params));
+//  SmartFactorP::shared_ptr smartFactor2(
+//      new SmartFactorP(model, sharedK, params));
 //  smartFactor2->add(measurements_cam2, views);
 //
-//  SmartFactor::shared_ptr smartFactor3(
-//      new SmartFactor(model, sharedK, params));
+//  SmartFactorP::shared_ptr smartFactor3(
+//      new SmartFactorP(model, sharedK, params));
 //  smartFactor3->add(measurements_cam3, views);
 //
 //  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
@@ -1049,7 +1038,7 @@ LevenbergMarquardtParams lmParams;
 //}
 //
 ///* *************************************************************************/
-//TEST( SmartProjectionPoseFactor, Hessian ) {
+//TEST( SmartProjectionFactorP, Hessian ) {
 //
 //  using namespace vanillaPose2;
 //
@@ -1062,7 +1051,7 @@ LevenbergMarquardtParams lmParams;
 //  measurements_cam1.push_back(cam1_uv1);
 //  measurements_cam1.push_back(cam2_uv1);
 //
-//  SmartFactor::shared_ptr smartFactor1(new SmartFactor(model, sharedK2));
+//  SmartFactorP::shared_ptr smartFactor1(new SmartFactorP(model, sharedK2));
 //  smartFactor1->add(measurements_cam1, views);
 //
 //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 10, 0., -M_PI / 10),
@@ -1080,8 +1069,8 @@ LevenbergMarquardtParams lmParams;
 //}
 //
 ///* *************************************************************************/
-//TEST( SmartProjectionPoseFactor, HessianWithRotation ) {
-//  // cout << " ************************ SmartProjectionPoseFactor: rotated Hessian **********************" << endl;
+//TEST( SmartProjectionFactorP, HessianWithRotation ) {
+//  // cout << " ************************ SmartProjectionFactorP: rotated Hessian **********************" << endl;
 //
 //  using namespace vanillaPose;
 //
@@ -1091,7 +1080,7 @@ LevenbergMarquardtParams lmParams;
 //
 //  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
 //
-//  SmartFactor::shared_ptr smartFactorInstance(new SmartFactor(model, sharedK));
+//  SmartFactorP::shared_ptr smartFactorInstance(new SmartFactorP(model, sharedK));
 //  smartFactorInstance->add(measurements_cam1, views);
 //
 //  Values values;
@@ -1131,7 +1120,7 @@ LevenbergMarquardtParams lmParams;
 //}
 //
 ///* *************************************************************************/
-//TEST( SmartProjectionPoseFactor, HessianWithRotationDegenerate ) {
+//TEST( SmartProjectionFactorP, HessianWithRotationDegenerate ) {
 //
 //  using namespace vanillaPose2;
 //
@@ -1144,7 +1133,7 @@ LevenbergMarquardtParams lmParams;
 //  Point2Vector measurements_cam1;
 //  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_cam1);
 //
-//  SmartFactor::shared_ptr smartFactor(new SmartFactor(model, sharedK2));
+//  SmartFactorP::shared_ptr smartFactor(new SmartFactorP(model, sharedK2));
 //  smartFactor->add(measurements_cam1, views);
 //
 //  Values values;
@@ -1183,16 +1172,16 @@ LevenbergMarquardtParams lmParams;
 //}
 //
 ///* ************************************************************************* */
-//TEST( SmartProjectionPoseFactor, ConstructorWithCal3Bundler) {
+//TEST( SmartProjectionFactorP, ConstructorWithCal3Bundler) {
 //  using namespace bundlerPose;
 //  SmartProjectionParams params;
 //  params.setDegeneracyMode(gtsam::ZERO_ON_DEGENERACY);
-//  SmartFactor factor(model, sharedBundlerK, params);
+//  SmartFactorP factor(model, sharedBundlerK, params);
 //  factor.add(measurement1, x1);
 //}
 //
 ///* *************************************************************************/
-//TEST( SmartProjectionPoseFactor, Cal3Bundler ) {
+//TEST( SmartProjectionFactorP, Cal3Bundler ) {
 //
 //  using namespace bundlerPose;
 //
@@ -1208,13 +1197,13 @@ LevenbergMarquardtParams lmParams;
 //
 //  KeyVector views {x1, x2, x3};
 //
-//  SmartFactor::shared_ptr smartFactor1(new SmartFactor(model, sharedBundlerK));
+//  SmartFactorP::shared_ptr smartFactor1(new SmartFactorP(model, sharedBundlerK));
 //  smartFactor1->add(measurements_cam1, views);
 //
-//  SmartFactor::shared_ptr smartFactor2(new SmartFactor(model, sharedBundlerK));
+//  SmartFactorP::shared_ptr smartFactor2(new SmartFactorP(model, sharedBundlerK));
 //  smartFactor2->add(measurements_cam2, views);
 //
-//  SmartFactor::shared_ptr smartFactor3(new SmartFactor(model, sharedBundlerK));
+//  SmartFactorP::shared_ptr smartFactor3(new SmartFactorP(model, sharedBundlerK));
 //  smartFactor3->add(measurements_cam3, views);
 //
 //  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
@@ -1248,7 +1237,7 @@ LevenbergMarquardtParams lmParams;
 //}
 //
 ///* *************************************************************************/
-//TEST( SmartProjectionPoseFactor, Cal3BundlerRotationOnly ) {
+//TEST( SmartProjectionFactorP, Cal3BundlerRotationOnly ) {
 //
 //  using namespace bundlerPose;
 //
@@ -1275,16 +1264,16 @@ LevenbergMarquardtParams lmParams;
 //  params.setRankTolerance(10);
 //  params.setDegeneracyMode(gtsam::ZERO_ON_DEGENERACY);
 //
-//  SmartFactor::shared_ptr smartFactor1(
-//      new SmartFactor(model, sharedBundlerK, params));
+//  SmartFactorP::shared_ptr smartFactor1(
+//      new SmartFactorP(model, sharedBundlerK, params));
 //  smartFactor1->add(measurements_cam1, views);
 //
-//  SmartFactor::shared_ptr smartFactor2(
-//      new SmartFactor(model, sharedBundlerK, params));
+//  SmartFactorP::shared_ptr smartFactor2(
+//      new SmartFactorP(model, sharedBundlerK, params));
 //  smartFactor2->add(measurements_cam2, views);
 //
-//  SmartFactor::shared_ptr smartFactor3(
-//      new SmartFactor(model, sharedBundlerK, params));
+//  SmartFactorP::shared_ptr smartFactor3(
+//      new SmartFactorP(model, sharedBundlerK, params));
 //  smartFactor3->add(measurements_cam3, views);
 //
 //  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
@@ -1340,25 +1329,25 @@ LevenbergMarquardtParams lmParams;
 //BOOST_CLASS_EXPORT_GUID(gtsam::SharedNoiseModel, "gtsam_SharedNoiseModel");
 //BOOST_CLASS_EXPORT_GUID(gtsam::SharedDiagonal, "gtsam_SharedDiagonal");
 //
-//TEST(SmartProjectionPoseFactor, serialize) {
+//TEST(SmartProjectionFactorP, serialize) {
 //  using namespace vanillaPose;
 //  using namespace gtsam::serializationTestHelpers;
 //  SmartProjectionParams params;
 //  params.setRankTolerance(rankTol);
-//  SmartFactor factor(model, sharedK, params);
+//  SmartFactorP factor(model, sharedK, params);
 //
 //  EXPECT(equalsObj(factor));
 //  EXPECT(equalsXML(factor));
 //  EXPECT(equalsBinary(factor));
 //}
 //
-//TEST(SmartProjectionPoseFactor, serialize2) {
+//TEST(SmartProjectionFactorP, serialize2) {
 //  using namespace vanillaPose;
 //  using namespace gtsam::serializationTestHelpers;
 //  SmartProjectionParams params;
 //  params.setRankTolerance(rankTol);
 //  Pose3 bts;
-//  SmartFactor factor(model, sharedK, bts, params);
+//  SmartFactorP factor(model, sharedK, bts, params);
 //
 //  // insert some measurments
 //  KeyVector key_view;

--- a/gtsam/slam/tests/testSmartProjectionFactorP.cpp
+++ b/gtsam/slam/tests/testSmartProjectionFactorP.cpp
@@ -271,6 +271,7 @@ TEST(SmartProjectionFactorP, smartFactorWithSensorBodyTransform) {
   Values result;
   LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
   result = optimizer.optimize();
+//  graph.print("graph\n");
   EXPECT(assert_equal(wTb3, result.at<Pose3>(x3)));
 }
 

--- a/gtsam/slam/tests/testSmartProjectionPoseFactor.cpp
+++ b/gtsam/slam/tests/testSmartProjectionPoseFactor.cpp
@@ -50,7 +50,7 @@ static Point2 measurement1(323.0, 240.0);
 
 LevenbergMarquardtParams lmParams;
 // Make more verbose like so (in tests):
-// params.verbosityLM = LevenbergMarquardtParams::SUMMARY;
+// lmParams.verbosityLM = LevenbergMarquardtParams::SUMMARY;
 
 /* ************************************************************************* */
 TEST( SmartProjectionPoseFactor, Constructor) {

--- a/gtsam_unstable/slam/ProjectionFactorRollingShutter.cpp
+++ b/gtsam_unstable/slam/ProjectionFactorRollingShutter.cpp
@@ -1,0 +1,73 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file ProjectionFactorRollingShutter.cpp
+ * @brief Basic projection factor for rolling shutter cameras
+ * @author Yotam Stern
+ */
+
+#include <gtsam_unstable/slam/ProjectionFactorRollingShutter.h>
+
+namespace gtsam {
+
+Vector ProjectionFactorRollingShutter::evaluateError(
+    const Pose3& pose_a, const Pose3& pose_b, const Point3& point,
+    boost::optional<Matrix&> H1, boost::optional<Matrix&> H2,
+    boost::optional<Matrix&> H3) const {
+
+  try {
+    Pose3 pose = interpolate<Pose3>(pose_a, pose_b, alpha_, H1, H2);
+    gtsam::Matrix Hprj;
+    if (body_P_sensor_) {
+      if (H1 || H2 || H3) {
+        gtsam::Matrix HbodySensor;
+        PinholeCamera<Cal3_S2> camera(
+            pose.compose(*body_P_sensor_, HbodySensor), *K_);
+        Point2 reprojectionError(
+            camera.project(point, Hprj, H3, boost::none) - measured_);
+        if (H1)
+          *H1 = Hprj * HbodySensor * (*H1);
+        if (H2)
+          *H2 = Hprj * HbodySensor * (*H2);
+        return reprojectionError;
+      } else {
+        PinholeCamera<Cal3_S2> camera(pose.compose(*body_P_sensor_), *K_);
+        return camera.project(point) - measured_;
+      }
+    } else {
+      PinholeCamera<Cal3_S2> camera(pose, *K_);
+      Point2 reprojectionError(
+          camera.project(point, Hprj, H3, boost::none) - measured_);
+      if (H1)
+        *H1 = Hprj * (*H1);
+      if (H2)
+        *H2 = Hprj * (*H2);
+      return reprojectionError;
+    }
+  } catch (CheiralityException& e) {
+    if (H1)
+      *H1 = Matrix::Zero(2, 6);
+    if (H2)
+      *H2 = Matrix::Zero(2, 6);
+    if (H3)
+      *H3 = Matrix::Zero(2, 3);
+    if (verboseCheirality_)
+      std::cout << e.what() << ": Landmark "
+          << DefaultKeyFormatter(this->key2()) << " moved behind camera "
+          << DefaultKeyFormatter(this->key1()) << std::endl;
+    if (throwCheirality_)
+      throw CheiralityException(this->key2());
+  }
+  return Vector2::Constant(2.0 * K_->fx());
+}
+
+}  //namespace gtsam

--- a/gtsam_unstable/slam/ProjectionFactorRollingShutter.h
+++ b/gtsam_unstable/slam/ProjectionFactorRollingShutter.h
@@ -1,0 +1,220 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file ProjectionFactorRollingShutter.h
+ * @brief Basic projection factor for rolling shutter cameras
+ * @author Yotam Stern
+ */
+
+#pragma once
+
+#include <gtsam/nonlinear/NonlinearFactor.h>
+#include <gtsam/geometry/PinholeCamera.h>
+#include <gtsam/geometry/CalibratedCamera.h>
+#include <gtsam/geometry/Cal3_S2.h>
+#include <boost/optional.hpp>
+
+namespace gtsam {
+
+/**
+ * Non-linear factor for 2D projection measurement obtained using a rolling shutter camera. The calibration is known here.
+ * This version takes rolling shutter information into account as follows: consider two consecutive poses A and B,
+ * and a Point2 measurement taken starting at time A using a rolling shutter camera.
+ * Pose A has timestamp t_A, and Pose B has timestamp t_B. The Point2 measurement has timestamp t_p (with t_A <= t_p <= t_B)
+ * corresponding to the time of exposure of the row of the image the pixel belongs to.
+ * Let us define the alpha = (t_p - t_A) / (t_B - t_A), we will use the pose interpolated between A and B by
+ * the alpha to project the corresponding landmark to Point2.
+ * @addtogroup SLAM
+ */
+
+class ProjectionFactorRollingShutter : public NoiseModelFactor3<Pose3, Pose3,
+    Point3> {
+ protected:
+
+  // Keep a copy of measurement and calibration for I/O
+  Point2 measured_;                   ///< 2D measurement
+  double alpha_;  ///< interpolation parameter in [0,1] corresponding to the point2 measurement
+  boost::shared_ptr<Cal3_S2> K_;  ///< shared pointer to calibration object
+  boost::optional<Pose3> body_P_sensor_;  ///< The pose of the sensor in the body frame
+
+  // verbosity handling for Cheirality Exceptions
+  bool throwCheirality_;  ///< If true, rethrows Cheirality exceptions (default: false)
+  bool verboseCheirality_;  ///< If true, prints text for Cheirality exceptions (default: false)
+
+ public:
+
+  /// shorthand for base class type
+  typedef NoiseModelFactor3<Pose3, Pose3, Point3> Base;
+
+  /// shorthand for this class
+  typedef ProjectionFactorRollingShutter This;
+
+  /// shorthand for a smart pointer to a factor
+  typedef boost::shared_ptr<This> shared_ptr;
+
+  /// Default constructor
+  ProjectionFactorRollingShutter()
+      : measured_(0, 0),
+        alpha_(0),
+        throwCheirality_(false),
+        verboseCheirality_(false) {
+  }
+
+  /**
+   * Constructor
+   * @param measured is the 2-dimensional pixel location of point in the image (the measurement)
+   * @param alpha in [0,1] is the rolling shutter parameter for the measurement
+   * @param model is the noise model
+   * @param poseKey_a is the key of the first camera
+   * @param poseKey_b is the key of the second camera
+   * @param pointKey is the key of the landmark
+   * @param K shared pointer to the constant calibration
+   * @param body_P_sensor is the transform from body to sensor frame (default identity)
+   */
+  ProjectionFactorRollingShutter(const Point2& measured, double alpha,
+                                 const SharedNoiseModel& model, Key poseKey_a,
+                                 Key poseKey_b, Key pointKey,
+                                 const boost::shared_ptr<Cal3_S2>& K,
+                                 boost::optional<Pose3> body_P_sensor =
+                                     boost::none)
+      : Base(model, poseKey_a, poseKey_b, pointKey),
+        measured_(measured),
+        alpha_(alpha),
+        K_(K),
+        body_P_sensor_(body_P_sensor),
+        throwCheirality_(false),
+        verboseCheirality_(false) {
+  }
+
+  /**
+   * Constructor with exception-handling flags
+   * @param measured is the 2-dimensional pixel location of point in the image (the measurement)
+   * @param alpha in [0,1] is the rolling shutter parameter for the measurement
+   * @param model is the noise model
+   * @param poseKey_a is the key of the first camera
+   * @param poseKey_b is the key of the second camera
+   * @param pointKey is the key of the landmark
+   * @param K shared pointer to the constant calibration
+   * @param throwCheirality determines whether Cheirality exceptions are rethrown
+   * @param verboseCheirality determines whether exceptions are printed for Cheirality
+   * @param body_P_sensor is the transform from body to sensor frame  (default identity)
+   */
+  ProjectionFactorRollingShutter(const Point2& measured, double alpha,
+                                 const SharedNoiseModel& model, Key poseKey_a,
+                                 Key poseKey_b, Key pointKey,
+                                 const boost::shared_ptr<Cal3_S2>& K,
+                                 bool throwCheirality, bool verboseCheirality,
+                                 boost::optional<Pose3> body_P_sensor =
+                                     boost::none)
+      : Base(model, poseKey_a, poseKey_b, pointKey),
+        measured_(measured),
+        alpha_(alpha),
+        K_(K),
+        body_P_sensor_(body_P_sensor),
+        throwCheirality_(throwCheirality),
+        verboseCheirality_(verboseCheirality) {
+  }
+
+  /** Virtual destructor */
+  virtual ~ProjectionFactorRollingShutter() {
+  }
+
+  /// @return a deep copy of this factor
+  virtual gtsam::NonlinearFactor::shared_ptr clone() const {
+    return boost::static_pointer_cast < gtsam::NonlinearFactor
+        > (gtsam::NonlinearFactor::shared_ptr(new This(*this)));
+  }
+
+  /**
+   * print
+   * @param s optional string naming the factor
+   * @param keyFormatter optional formatter useful for printing Symbols
+   */
+  void print(const std::string& s = "", const KeyFormatter& keyFormatter =
+                 DefaultKeyFormatter) const {
+    std::cout << s << "ProjectionFactorRollingShutter, z = ";
+    traits<Point2>::Print(measured_);
+    std::cout << " rolling shutter interpolation param = " << alpha_;
+    if (this->body_P_sensor_)
+      this->body_P_sensor_->print("  sensor pose in body frame: ");
+    Base::print("", keyFormatter);
+  }
+
+  /// equals
+  virtual bool equals(const NonlinearFactor& p, double tol = 1e-9) const {
+    const This *e = dynamic_cast<const This*>(&p);
+    return e && Base::equals(p, tol) && (alpha_ == e->alpha())
+        && traits<Point2>::Equals(this->measured_, e->measured_, tol)
+        && this->K_->equals(*e->K_, tol)
+        && (this->throwCheirality_ == e->throwCheirality_)
+        && (this->verboseCheirality_ == e->verboseCheirality_)
+        && ((!body_P_sensor_ && !e->body_P_sensor_)
+            || (body_P_sensor_ && e->body_P_sensor_
+                && body_P_sensor_->equals(*e->body_P_sensor_)));
+  }
+
+  /// Evaluate error h(x)-z and optionally derivatives
+  Vector evaluateError(const Pose3& pose_a, const Pose3& pose_b,
+                       const Point3& point, boost::optional<Matrix&> H1 =
+                           boost::none,
+                       boost::optional<Matrix&> H2 = boost::none,
+                       boost::optional<Matrix&> H3 = boost::none) const;
+
+  /** return the measurement */
+  const Point2& measured() const {
+    return measured_;
+  }
+
+  /** return the calibration object */
+  inline const boost::shared_ptr<Cal3_S2> calibration() const {
+    return K_;
+  }
+
+  /** returns the rolling shutter interp param*/
+  inline double alpha() const {
+    return alpha_;
+  }
+
+  /** return verbosity */
+  inline bool verboseCheirality() const {
+    return verboseCheirality_;
+  }
+
+  /** return flag for throwing cheirality exceptions */
+  inline bool throwCheirality() const {
+    return throwCheirality_;
+  }
+
+ private:
+
+  /// Serialization function
+  friend class boost::serialization::access;
+  template<class ARCHIVE>
+  void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
+    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
+    ar & BOOST_SERIALIZATION_NVP(measured_);
+    ar & BOOST_SERIALIZATION_NVP(alpha_);
+    ar & BOOST_SERIALIZATION_NVP(K_);
+    ar & BOOST_SERIALIZATION_NVP(body_P_sensor_);
+    ar & BOOST_SERIALIZATION_NVP(throwCheirality_);
+    ar & BOOST_SERIALIZATION_NVP(verboseCheirality_);
+  }
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+/// traits
+template<> struct traits<ProjectionFactorRollingShutter> : public Testable<
+    ProjectionFactorRollingShutter> {
+};
+
+}  //namespace gtsam

--- a/gtsam_unstable/slam/SmartProjectionPoseFactorRollingShutter.h
+++ b/gtsam_unstable/slam/SmartProjectionPoseFactorRollingShutter.h
@@ -37,9 +37,11 @@ namespace gtsam {
  * from which the pixel observation pose can be interpolated.
  * @addtogroup SLAM
  */
-template<class CALIBRATION>
-class SmartProjectionPoseFactorRollingShutter : public SmartProjectionFactor<
-PinholePose<CALIBRATION> > {
+template<class CAMERA>
+class SmartProjectionPoseFactorRollingShutter : public SmartProjectionFactor<CAMERA> {
+
+ public:
+  typedef typename CAMERA::CalibrationType CALIBRATION;
 
  protected:
   /// shared pointer to calibration object (one for each observation)
@@ -213,8 +215,8 @@ PinholePose<CALIBRATION> > {
 
   /// equals
   bool equals(const NonlinearFactor& p, double tol = 1e-9) const override {
-    const SmartProjectionPoseFactorRollingShutter<CALIBRATION>* e =
-        dynamic_cast<const SmartProjectionPoseFactorRollingShutter<CALIBRATION>*>(&p);
+    const SmartProjectionPoseFactorRollingShutter<CAMERA>* e =
+        dynamic_cast<const SmartProjectionPoseFactorRollingShutter<CAMERA>*>(&p);
 
     double keyPairsEqual = true;
     if(this->world_P_body_key_pairs_.size() == e->world_P_body_key_pairs().size()){
@@ -430,9 +432,9 @@ PinholePose<CALIBRATION> > {
 // end of class declaration
 
 /// traits
-template<class CALIBRATION>
-struct traits<SmartProjectionPoseFactorRollingShutter<CALIBRATION> > :
-public Testable<SmartProjectionPoseFactorRollingShutter<CALIBRATION> > {
+template<class CAMERA>
+struct traits<SmartProjectionPoseFactorRollingShutter<CAMERA> > :
+public Testable<SmartProjectionPoseFactorRollingShutter<CAMERA> > {
 };
 
 }  // namespace gtsam

--- a/gtsam_unstable/slam/SmartProjectionPoseFactorRollingShutter.h
+++ b/gtsam_unstable/slam/SmartProjectionPoseFactorRollingShutter.h
@@ -1,0 +1,438 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file   SmartProjectionPoseFactorRollingShutter.h
+ * @brief  Smart projection factor on poses modeling rolling shutter effect with given readout time
+ * @author Luca Carlone
+ */
+
+#pragma once
+
+#include <gtsam/slam/SmartProjectionFactor.h>
+
+namespace gtsam {
+/**
+ *
+ * @addtogroup SLAM
+ *
+ * If you are using the factor, please cite:
+ * L. Carlone, Z. Kira, C. Beall, V. Indelman, F. Dellaert,
+ * Eliminating conditionally independent sets in factor graphs:
+ * a unifying perspective based on smart factors,
+ * Int. Conf. on Robotics and Automation (ICRA), 2014.
+ */
+
+/**
+ * This factor optimizes two consecutive poses of the body assuming a rolling shutter model of the camera with given readout time.
+ * The factor requires that values contain (for each pixel observation) two consecutive camera poses
+ * from which the pixel observation pose can be interpolated.
+ * @addtogroup SLAM
+ */
+template<class CALIBRATION>
+class SmartProjectionPoseFactorRollingShutter : public SmartProjectionFactor<
+PinholePose<CALIBRATION> > {
+
+ protected:
+  /// shared pointer to calibration object (one for each observation)
+  std::vector<boost::shared_ptr<CALIBRATION> > K_all_;
+
+  /// The keys of the pose of the body (with respect to an external world frame): two consecutive poses for each observation
+  std::vector<std::pair<Key, Key>> world_P_body_key_pairs_;
+
+  /// interpolation factor (one for each observation) to interpolate between pair of consecutive poses
+  std::vector<double> alphas_;
+
+  /// Pose of the camera in the body frame
+  std::vector<Pose3> body_P_sensors_;
+
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  /// shorthand for base class type
+  typedef SmartProjectionFactor<PinholePose<CALIBRATION> > Base;
+
+  /// shorthand for this class
+  typedef SmartProjectionPoseFactorRollingShutter This;
+
+  /// shorthand for a smart pointer to a factor
+  typedef boost::shared_ptr<This> shared_ptr;
+
+  static const int DimBlock = 12;  ///< size of the variable stacking 2 poses from which the observation pose is interpolated
+  static const int DimPose = 6;  ///< Pose3 dimension
+  static const int ZDim = 2;  ///< Measurement dimension (Point2)
+  typedef Eigen::Matrix<double, ZDim, DimBlock> MatrixZD;  // F blocks (derivatives wrt block of 2 poses)
+  typedef std::vector<MatrixZD, Eigen::aligned_allocator<MatrixZD> > FBlocks;  // vector of F blocks
+
+  /**
+   * Constructor
+   * @param Isotropic measurement noise
+   * @param params internal parameters of the smart factors
+   */
+  SmartProjectionPoseFactorRollingShutter(
+      const SharedNoiseModel& sharedNoiseModel,
+      const SmartProjectionParams& params = SmartProjectionParams())
+  : Base(sharedNoiseModel, params) {
+  }
+
+  /** Virtual destructor */
+  ~SmartProjectionPoseFactorRollingShutter() override = default;
+
+  /**
+   * add a new measurement, with 2 pose keys, interpolation factor, camera (intrinsic and extrinsic) calibration, and observed pixel.
+   * @param measured 2-dimensional location of the projection of a
+   * single landmark in a single view (the measurement), interpolated from the 2 poses
+   * @param world_P_body_key1 key corresponding to the first body poses (time <= time pixel is acquired)
+   * @param world_P_body_key2 key corresponding to the second body poses (time >= time pixel is acquired)
+   * @param alpha interpolation factor in [0,1], such that if alpha = 0 the interpolated pose is the same as world_P_body_key1
+   * @param K (fixed) camera intrinsic calibration
+   * @param body_P_sensor (fixed) camera extrinsic calibration
+   */
+  void add(const Point2& measured, const Key& world_P_body_key1,
+           const Key& world_P_body_key2, const double& alpha,
+           const boost::shared_ptr<CALIBRATION>& K, const Pose3 body_P_sensor = Pose3::identity()) {
+    // store measurements in base class
+    this->measured_.push_back(measured);
+
+    // store the pair of keys for each measurement, in the same order
+    world_P_body_key_pairs_.push_back(
+        std::make_pair(world_P_body_key1, world_P_body_key2));
+
+    //  also store keys in the keys_ vector: these keys are assumed to be unique, so we avoid duplicates here
+    if (std::find(this->keys_.begin(), this->keys_.end(), world_P_body_key1) == this->keys_.end())
+      this->keys_.push_back(world_P_body_key1);  // add only unique keys
+    if (std::find(this->keys_.begin(), this->keys_.end(), world_P_body_key2) == this->keys_.end())
+      this->keys_.push_back(world_P_body_key2);  // add only unique keys
+
+    // store interpolation factor
+    alphas_.push_back(alpha);
+
+    // store fixed intrinsic calibration
+    K_all_.push_back(K);
+
+    // store fixed extrinsics of the camera
+    body_P_sensors_.push_back(body_P_sensor);
+  }
+
+  /**
+   * Variant of the previous "add" function in which we include multiple measurements
+   * @param measurements vector of the 2m dimensional location of the projection
+   * of a single landmark in the m views (the measurements)
+   * @param world_P_body_key_pairs vector where the i-th element contains a pair of keys corresponding
+   * to the pair of poses from which the observation pose for the i0-th measurement can be interpolated
+   * @param alphas vector of interpolation params (in [0,1]), one for each measurement (in the same order)
+   * @param Ks vector of (fixed) intrinsic calibration objects
+   * @param body_P_sensors vector of (fixed) extrinsic calibration objects
+   */
+  void add(const Point2Vector& measurements,
+           const std::vector<std::pair<Key, Key>>& world_P_body_key_pairs,
+           const std::vector<double>& alphas,
+           const std::vector<boost::shared_ptr<CALIBRATION>>& Ks,
+           const std::vector<Pose3> body_P_sensors) {
+    assert(world_P_body_key_pairs.size() == measurements.size());
+    assert(world_P_body_key_pairs.size() == alphas.size());
+    assert(world_P_body_key_pairs.size() == Ks.size());
+    for (size_t i = 0; i < measurements.size(); i++) {
+      add(measurements[i], world_P_body_key_pairs[i].first,
+          world_P_body_key_pairs[i].second, alphas[i], Ks[i],
+          body_P_sensors[i]);
+    }
+  }
+
+  /**
+   * Variant of the previous "add" function in which we include multiple measurements
+   * with the same (intrinsic and extrinsic) calibration
+   * @param measurements vector of the 2m dimensional location of the projection
+   * of a single landmark in the m views (the measurements)
+   * @param world_P_body_key_pairs vector where the i-th element contains a pair of keys corresponding
+   * to the pair of poses from which the observation pose for the i0-th measurement can be interpolated
+   * @param alphas vector of interpolation params (in [0,1]), one for each measurement (in the same order)
+   * @param K (fixed) camera intrinsic calibration (same for all measurements)
+   * @param body_P_sensor (fixed) camera extrinsic calibration (same for all measurements)
+   */
+  void add(const Point2Vector& measurements,
+           const std::vector<std::pair<Key, Key>>& world_P_body_key_pairs,
+           const std::vector<double>& alphas,
+           const boost::shared_ptr<CALIBRATION>& K, const Pose3 body_P_sensor = Pose3::identity()) {
+    assert(world_P_body_key_pairs.size() == measurements.size());
+    assert(world_P_body_key_pairs.size() == alphas.size());
+    for (size_t i = 0; i < measurements.size(); i++) {
+      add(measurements[i], world_P_body_key_pairs[i].first,
+          world_P_body_key_pairs[i].second, alphas[i], K, body_P_sensor);
+    }
+  }
+
+  /// return the calibration object
+  inline std::vector<boost::shared_ptr<CALIBRATION>> calibration() const {
+    return K_all_;
+  }
+
+  /// return (for each observation) the keys of the pair of poses from which we interpolate
+  const std::vector<std::pair<Key, Key>> world_P_body_key_pairs() const {
+    return world_P_body_key_pairs_;
+  }
+
+  /// return the interpolation factors alphas
+  const std::vector<double> alphas() const {
+    return alphas_;
+  }
+
+  /// return the extrinsic camera calibration body_P_sensors
+  const std::vector<Pose3> body_P_sensors() const {
+    return body_P_sensors_;
+  }
+
+  /**
+   * print
+   * @param s optional string naming the factor
+   * @param keyFormatter optional formatter useful for printing Symbols
+   */
+  void print(const std::string& s = "", const KeyFormatter& keyFormatter =
+      DefaultKeyFormatter) const override {
+    std::cout << s << "SmartProjectionPoseFactorRollingShutter: \n ";
+    for (size_t i = 0; i < K_all_.size(); i++) {
+      std::cout << "-- Measurement nr " << i << std::endl;
+      std::cout << " pose1 key: "
+          << keyFormatter(world_P_body_key_pairs_[i].first) << std::endl;
+      std::cout << " pose2 key: "
+          << keyFormatter(world_P_body_key_pairs_[i].second) << std::endl;
+      std::cout << " alpha: " << alphas_[i] << std::endl;
+      body_P_sensors_[i].print("extrinsic calibration:\n");
+      K_all_[i]->print("intrinsic calibration = ");
+    }
+    Base::print("", keyFormatter);
+  }
+
+  /// equals
+  bool equals(const NonlinearFactor& p, double tol = 1e-9) const override {
+    const SmartProjectionPoseFactorRollingShutter<CALIBRATION>* e =
+        dynamic_cast<const SmartProjectionPoseFactorRollingShutter<CALIBRATION>*>(&p);
+
+    double keyPairsEqual = true;
+    if(this->world_P_body_key_pairs_.size() == e->world_P_body_key_pairs().size()){
+      for(size_t k=0; k< this->world_P_body_key_pairs_.size(); k++){
+        const Key key1own = world_P_body_key_pairs_[k].first;
+        const Key key1e = e->world_P_body_key_pairs()[k].first;
+        const Key key2own = world_P_body_key_pairs_[k].second;
+        const Key key2e = e->world_P_body_key_pairs()[k].second;
+        if ( !(key1own == key1e) || !(key2own == key2e) ){
+          keyPairsEqual = false; break;
+        }
+      }
+    }else{ keyPairsEqual = false; }
+
+    double extrinsicCalibrationEqual = true;
+    if(this->body_P_sensors_.size() == e->body_P_sensors().size()){
+      for(size_t i=0; i< this->body_P_sensors_.size(); i++){
+        if (!body_P_sensors_[i].equals(e->body_P_sensors()[i])){
+          extrinsicCalibrationEqual = false; break;
+        }
+      }
+    }else{ extrinsicCalibrationEqual = false; }
+
+    return e && Base::equals(p, tol) && K_all_ == e->calibration()
+        && alphas_ == e->alphas() && keyPairsEqual && extrinsicCalibrationEqual;
+  }
+
+  /**
+   * Compute jacobian F, E and error vector at a given linearization point
+   * @param values Values structure which must contain camera poses
+   * corresponding to keys involved in this factor
+   * @return Return arguments are the camera jacobians Fs (including the jacobian with
+   * respect to both body poses we interpolate from), the point Jacobian E,
+   * and the error vector b. Note that the jacobians are computed for a given point.
+   */
+  void computeJacobiansWithTriangulatedPoint(FBlocks& Fs, Matrix& E, Vector& b,
+                                             const Values& values) const {
+    if (!this->result_) {
+      throw("computeJacobiansWithTriangulatedPoint");
+    } else {  // valid result: compute jacobians
+      size_t numViews = this->measured_.size();
+      E = Matrix::Zero(2 * numViews, 3);  // a Point2 for each view (point jacobian)
+      b = Vector::Zero(2 * numViews);  // a Point2 for each view
+      // intermediate Jacobians
+      Eigen::Matrix<double, ZDim, DimPose> dProject_dPoseCam;
+      Eigen::Matrix<double, DimPose, DimPose> dInterpPose_dPoseBody1,
+      dInterpPose_dPoseBody2, dPoseCam_dInterpPose;
+      Eigen::Matrix<double, ZDim, 3> Ei;
+
+      for (size_t i = 0; i < numViews; i++) {  // for each camera/measurement
+        const Pose3& w_P_body1 = values.at<Pose3>(world_P_body_key_pairs_[i].first);
+        const Pose3& w_P_body2 = values.at<Pose3>(world_P_body_key_pairs_[i].second);
+        double interpolationFactor = alphas_[i];
+        // get interpolated pose:
+        const Pose3& w_P_body = interpolate<Pose3>(w_P_body1, w_P_body2,interpolationFactor, dInterpPose_dPoseBody1, dInterpPose_dPoseBody2);
+        const Pose3& body_P_cam = body_P_sensors_[i];
+        const Pose3& w_P_cam = w_P_body.compose(body_P_cam, dPoseCam_dInterpPose);
+        PinholeCamera<CALIBRATION> camera(w_P_cam, *K_all_[i]);
+
+        // get jacobians and error vector for current measurement
+        Point2 reprojectionError_i = Point2(
+            camera.project(*this->result_, dProject_dPoseCam, Ei)
+            - this->measured_.at(i));
+        Eigen::Matrix<double, ZDim, DimBlock> J;  // 2 x 12
+        J.block(0, 0, ZDim, 6) = dProject_dPoseCam * dPoseCam_dInterpPose
+            * dInterpPose_dPoseBody1;  // (2x6) * (6x6) * (6x6)
+        J.block(0, 6, ZDim, 6) = dProject_dPoseCam * dPoseCam_dInterpPose
+            * dInterpPose_dPoseBody2;  // (2x6) * (6x6) * (6x6)
+
+        // fit into the output structures
+        Fs.push_back(J);
+        size_t row = 2 * i;
+        b.segment<ZDim>(row) = -reprojectionError_i;
+        E.block<ZDim, 3>(row, 0) = Ei;
+      }
+    }
+  }
+
+  /// linearize and return a Hessianfactor that is an approximation of error(p)
+  boost::shared_ptr<RegularHessianFactor<DimPose> > createHessianFactor(
+      const Values& values, const double lambda = 0.0, bool diagonalDamping =
+          false) const {
+
+    // we may have multiple observation sharing the same keys (due to the rolling shutter interpolation),
+    // hence the number of unique keys may be smaller than 2 * nrMeasurements
+    size_t nrUniqueKeys = this->keys_.size(); // note: by construction, keys_ only contains unique keys
+
+    // Create structures for Hessian Factors
+    KeyVector js;
+    std::vector < Matrix > Gs(nrUniqueKeys * (nrUniqueKeys + 1) / 2);
+    std::vector < Vector > gs(nrUniqueKeys);
+
+    if (this->measured_.size() != this->cameras(values).size()) // 1 observation per interpolated camera
+      throw std::runtime_error("SmartProjectionPoseFactorRollingShutter: "
+                               "measured_.size() inconsistent with input");
+
+    // triangulate 3D point at given linearization point
+    this->triangulateSafe(this->cameras(values));
+
+    if (!this->result_) {  // failed: return "empty/zero" Hessian
+      if (this->params_.degeneracyMode == ZERO_ON_DEGENERACY) {
+        for (Matrix& m : Gs)
+          m = Matrix::Zero(DimPose, DimPose);
+        for (Vector& v : gs)
+          v = Vector::Zero(DimPose);
+        return boost::make_shared < RegularHessianFactor<DimPose>
+            > (this->keys_, Gs, gs, 0.0);
+      } else {
+        throw std::runtime_error("SmartProjectionPoseFactorRollingShutter: "
+                                       "only supported degeneracy mode is ZERO_ON_DEGENERACY");
+      }
+    }
+    // compute Jacobian given triangulated 3D Point
+    FBlocks Fs;
+    Matrix E;
+    Vector b;
+    this->computeJacobiansWithTriangulatedPoint(Fs, E, b, values);
+
+    // Whiten using noise model
+    this->noiseModel_->WhitenSystem(E, b);
+    for (size_t i = 0; i < Fs.size(); i++)
+      Fs[i] = this->noiseModel_->Whiten(Fs[i]);
+
+    Matrix3 P = Base::Cameras::PointCov(E, lambda, diagonalDamping);
+
+    // Collect all the key pairs: these are the keys that correspond to the blocks in Fs (on which we apply the Schur Complement)
+    KeyVector nonuniqueKeys;
+    for (size_t i = 0; i < world_P_body_key_pairs_.size(); i++) {
+      nonuniqueKeys.push_back(world_P_body_key_pairs_.at(i).first);
+      nonuniqueKeys.push_back(world_P_body_key_pairs_.at(i).second);
+    }
+
+    // Build augmented Hessian (with last row/column being the information vector)
+    // Note: we need to get the augumented hessian wrt the unique keys in key_
+    SymmetricBlockMatrix augmentedHessianUniqueKeys =
+        Base::Cameras::SchurComplementAndRearrangeBlocks_3_12_6(
+            Fs, E, P, b, nonuniqueKeys, this->keys_);
+
+    return boost::make_shared < RegularHessianFactor<DimPose>
+        > (this->keys_, augmentedHessianUniqueKeys);
+  }
+
+  /**
+   * error calculates the error of the factor.
+   */
+  double error(const Values& values) const override {
+    if (this->active(values)) {
+      return this->totalReprojectionError(this->cameras(values));
+    } else { // else of active flag
+      return 0.0;
+    }
+  }
+
+  /**
+   * Collect all cameras involved in this factor
+   * @param values Values structure which must contain camera poses
+   * corresponding to keys involved in this factor
+   * @return Cameras
+   */
+  typename Base::Cameras cameras(const Values& values) const override {
+    size_t numViews = this->measured_.size();
+    assert(numViews == K_all_.size());
+    assert(numViews == alphas_.size());
+    assert(numViews == body_P_sensors_.size());
+    assert(numViews == world_P_body_key_pairs_.size());
+
+    typename Base::Cameras cameras;
+    for (size_t i = 0; i < numViews; i++) {  // for each measurement
+      const Pose3& w_P_body1 = values.at<Pose3>(world_P_body_key_pairs_[i].first);
+      const Pose3& w_P_body2 = values.at<Pose3>(world_P_body_key_pairs_[i].second);
+      double interpolationFactor = alphas_[i];
+      const Pose3& w_P_body = interpolate<Pose3>(w_P_body1, w_P_body2, interpolationFactor);
+      const Pose3& body_P_cam = body_P_sensors_[i];
+      const Pose3& w_P_cam = w_P_body.compose(body_P_cam);
+      cameras.emplace_back(w_P_cam, K_all_[i]);
+    }
+    return cameras;
+  }
+
+  /**
+   * Linearize to Gaussian Factor (possibly adding a damping factor Lambda for LM)
+   * @param values Values structure which must contain camera poses and extrinsic pose for this factor
+   * @return a Gaussian factor
+   */
+  boost::shared_ptr<GaussianFactor> linearizeDamped(
+      const Values& values, const double lambda = 0.0) const {
+    // depending on flag set on construction we may linearize to different linear factors
+    switch (this->params_.linearizationMode) {
+      case HESSIAN:
+        return this->createHessianFactor(values, lambda);
+      default:
+        throw std::runtime_error(
+            "SmartProjectionPoseFactorRollingShutter: unknown linearization mode");
+    }
+  }
+
+  /// linearize
+  boost::shared_ptr<GaussianFactor> linearize(const Values& values) const
+          override {
+    return this->linearizeDamped(values);
+  }
+
+ private:
+  /// Serialization function
+  friend class boost::serialization::access;
+  template<class ARCHIVE>
+  void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
+    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
+    ar & BOOST_SERIALIZATION_NVP(K_all_);
+  }
+
+};
+// end of class declaration
+
+/// traits
+template<class CALIBRATION>
+struct traits<SmartProjectionPoseFactorRollingShutter<CALIBRATION> > :
+public Testable<SmartProjectionPoseFactorRollingShutter<CALIBRATION> > {
+};
+
+}  // namespace gtsam

--- a/gtsam_unstable/slam/SmartStereoProjectionFactor.h
+++ b/gtsam_unstable/slam/SmartStereoProjectionFactor.h
@@ -11,7 +11,7 @@
 
 /**
  * @file   SmartStereoProjectionFactor.h
- * @brief  Smart stereo factor on StereoCameras (pose + calibration)
+ * @brief  Smart stereo factor on StereoCameras (pose)
  * @author Luca Carlone
  * @author Zsolt Kira
  * @author Frank Dellaert

--- a/gtsam_unstable/slam/SmartStereoProjectionFactorPP.h
+++ b/gtsam_unstable/slam/SmartStereoProjectionFactorPP.h
@@ -61,10 +61,10 @@ class SmartStereoProjectionFactorPP : public SmartStereoProjectionFactor {
   /// shorthand for a smart pointer to a factor
   typedef boost::shared_ptr<This> shared_ptr;
 
-  static const int Dim = 12;  ///< Camera dimension: 6 for body pose, 6 for extrinsic pose
+  static const int DimBlock = 12;  ///< Camera dimension: 6 for body pose, 6 for extrinsic pose
   static const int DimPose = 6;  ///< Pose3 dimension
   static const int ZDim = 3;  ///< Measurement dimension (for a StereoPoint2 measurement)
-  typedef Eigen::Matrix<double, ZDim, Dim> MatrixZD;  // F blocks (derivatives wrt camera)
+  typedef Eigen::Matrix<double, ZDim, DimBlock> MatrixZD;  // F blocks (derivatives wrt camera)
   typedef std::vector<MatrixZD, Eigen::aligned_allocator<MatrixZD> > FBlocks;  // vector of F blocks
 
   /**
@@ -180,7 +180,7 @@ class SmartStereoProjectionFactorPP : public SmartStereoProjectionFactor {
         // get jacobians and error vector for current measurement
         StereoPoint2 reprojectionError_i = StereoPoint2(
             camera.project(*result_, dProject_dPoseCam_i, Ei) - measured_.at(i));
-        Eigen::Matrix<double, ZDim, Dim> J;  // 3 x 12
+        Eigen::Matrix<double, ZDim, DimBlock> J;  // 3 x 12
         J.block<ZDim, 6>(0, 0) = dProject_dPoseCam_i * dPoseCam_dPoseBody_i;  // (3x6) * (6x6)
         J.block<ZDim, 6>(0, 6) = dProject_dPoseCam_i * dPoseCam_dPoseExt_i;  // (3x6) * (6x6)
         // if the right pixel is invalid, fix jacobians
@@ -209,8 +209,6 @@ class SmartStereoProjectionFactorPP : public SmartStereoProjectionFactor {
     // of keys may be smaller than 2 * nrMeasurements (which is the upper bound where we
     // have a body key and an extrinsic calibration key for each measurement)
     size_t nrUniqueKeys = keys_.size();
-    size_t nrNonuniqueKeys = world_P_body_keys_.size()
-        + body_P_cam_keys_.size();
 
     // Create structures for Hessian Factors
     KeyVector js;
@@ -246,81 +244,19 @@ class SmartStereoProjectionFactorPP : public SmartStereoProjectionFactor {
 
     // build augmented Hessian (with last row/column being the information vector)
     Matrix3 P;
-    Cameras::ComputePointCovariance<3>(P, E, lambda, diagonalDamping);
+    Cameras::ComputePointCovariance <3> (P, E, lambda, diagonalDamping);
 
-    // marginalize point: note - we reuse the standard SchurComplement function
-    SymmetricBlockMatrix augmentedHessian =
-        Cameras::SchurComplement<3, Dim>(Fs, E, P, b);
-
-    // now pack into an Hessian factor
-    std::vector<DenseIndex> dims(nrUniqueKeys + 1);  // this also includes the b term
-    std::fill(dims.begin(), dims.end() - 1, 6);
-    dims.back() = 1;
-    SymmetricBlockMatrix augmentedHessianUniqueKeys;
-
-    // here we have to deal with the fact that some cameras may share the same extrinsic key
-    if (nrUniqueKeys == nrNonuniqueKeys) {  // if there is 1 calibration key per camera
-      augmentedHessianUniqueKeys = SymmetricBlockMatrix(
-          dims, Matrix(augmentedHessian.selfadjointView()));
-    } else {  // if multiple cameras share a calibration we have to rearrange
-      // the results of the Schur complement matrix
-      std::vector<DenseIndex> nonuniqueDims(nrNonuniqueKeys + 1);  // this also includes the b term
-      std::fill(nonuniqueDims.begin(), nonuniqueDims.end() - 1, 6);
-      nonuniqueDims.back() = 1;
-      augmentedHessian = SymmetricBlockMatrix(
-          nonuniqueDims, Matrix(augmentedHessian.selfadjointView()));
-
-      // these are the keys that correspond to the blocks in augmentedHessian (output of SchurComplement)
-      KeyVector nonuniqueKeys;
-      for (size_t i = 0; i < world_P_body_keys_.size(); i++) {
-        nonuniqueKeys.push_back(world_P_body_keys_.at(i));
-        nonuniqueKeys.push_back(body_P_cam_keys_.at(i));
-      }
-
-      // get map from key to location in the new augmented Hessian matrix (the one including only unique keys)
-      std::map<Key, size_t> keyToSlotMap;
-      for (size_t k = 0; k < nrUniqueKeys; k++) {
-        keyToSlotMap[keys_[k]] = k;
-      }
-
-      // initialize matrix to zero
-      augmentedHessianUniqueKeys = SymmetricBlockMatrix(
-          dims, Matrix::Zero(6 * nrUniqueKeys + 1, 6 * nrUniqueKeys + 1));
-
-      // add contributions for each key: note this loops over the hessian with nonUnique keys (augmentedHessian)
-      // and populates an Hessian that only includes the unique keys (that is what we want to return)
-      for (size_t i = 0; i < nrNonuniqueKeys; i++) {  // rows
-        Key key_i = nonuniqueKeys.at(i);
-
-        // update information vector
-        augmentedHessianUniqueKeys.updateOffDiagonalBlock(
-            keyToSlotMap[key_i], nrUniqueKeys,
-            augmentedHessian.aboveDiagonalBlock(i, nrNonuniqueKeys));
-
-        // update blocks
-        for (size_t j = i; j < nrNonuniqueKeys; j++) {  // cols
-          Key key_j = nonuniqueKeys.at(j);
-          if (i == j) {
-            augmentedHessianUniqueKeys.updateDiagonalBlock(
-                keyToSlotMap[key_i], augmentedHessian.diagonalBlock(i));
-          } else {  // (i < j)
-            if (keyToSlotMap[key_i] != keyToSlotMap[key_j]) {
-              augmentedHessianUniqueKeys.updateOffDiagonalBlock(
-                  keyToSlotMap[key_i], keyToSlotMap[key_j],
-                  augmentedHessian.aboveDiagonalBlock(i, j));
-            } else {
-              augmentedHessianUniqueKeys.updateDiagonalBlock(
-                  keyToSlotMap[key_i],
-                  augmentedHessian.aboveDiagonalBlock(i, j)
-                      + augmentedHessian.aboveDiagonalBlock(i, j).transpose());
-            }
-          }
-        }
-      }
-      // update bottom right element of the matrix
-      augmentedHessianUniqueKeys.updateDiagonalBlock(
-          nrUniqueKeys, augmentedHessian.diagonalBlock(nrNonuniqueKeys));
+    // these are the keys that correspond to the blocks in augmentedHessian (output of SchurComplement)
+    KeyVector nonuniqueKeys;
+    for (size_t i = 0; i < world_P_body_keys_.size(); i++) {
+      nonuniqueKeys.push_back(world_P_body_keys_.at(i));
+      nonuniqueKeys.push_back(body_P_cam_keys_.at(i));
     }
+    // but we need to get the augumented hessian wrt the unique keys in key_
+    SymmetricBlockMatrix augmentedHessianUniqueKeys =
+        Cameras::SchurComplementAndRearrangeBlocks<3,DimBlock,DimPose>(Fs,E,P,b,
+                  nonuniqueKeys, keys_);
+
     return boost::make_shared < RegularHessianFactor<DimPose>
         > (keys_, augmentedHessianUniqueKeys);
   }

--- a/gtsam_unstable/slam/tests/testProjectionFactorRollingShutter.cpp
+++ b/gtsam_unstable/slam/tests/testProjectionFactorRollingShutter.cpp
@@ -1,0 +1,375 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ *  @file  ProjectionFactorRollingShutterRollingShutter.cpp
+ *  @brief Unit tests for ProjectionFactorRollingShutter Class
+ *  @author Luca Carlone
+ *  @date July 2021
+ */
+
+#include <gtsam/base/numericalDerivative.h>
+#include <gtsam/base/TestableAssertions.h>
+#include <gtsam_unstable/slam/ProjectionFactorRollingShutter.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/geometry/Cal3DS2.h>
+#include <gtsam/geometry/Cal3_S2.h>
+#include <gtsam/geometry/Pose3.h>
+#include <gtsam/geometry/Point3.h>
+#include <gtsam/geometry/Point2.h>
+
+#include <CppUnitLite/TestHarness.h>
+
+using namespace std::placeholders;
+using namespace std;
+using namespace gtsam;
+
+// make a realistic calibration matrix
+static double fov = 60; // degrees
+static size_t w=640,h=480;
+static Cal3_S2::shared_ptr K(new Cal3_S2(fov,w,h));
+
+// Create a noise model for the pixel error
+static SharedNoiseModel model(noiseModel::Unit::Create(2));
+
+// Convenience for named keys
+using symbol_shorthand::X;
+using symbol_shorthand::L;
+using symbol_shorthand::T;
+
+// Convenience to define common variables across many tests
+static Key poseKey1(X(1));
+static Key poseKey2(X(2));
+static Key pointKey(L(1));
+static double interp_params = 0.5;
+static Point2 measurement(323.0, 240.0);
+static Pose3 body_P_sensor(Rot3::RzRyRx(-M_PI_2, 0.0, -M_PI_2), Point3(0.25, -0.10, 1.0));
+
+/* ************************************************************************* */
+TEST( ProjectionFactorRollingShutter, Constructor) {
+  ProjectionFactorRollingShutter factor(measurement, interp_params, model, poseKey1, poseKey2, pointKey, K);
+}
+
+/* ************************************************************************* */
+TEST( ProjectionFactorRollingShutter, ConstructorWithTransform) {
+  ProjectionFactorRollingShutter factor(measurement, interp_params, model,
+                                        poseKey1, poseKey2, pointKey, K, body_P_sensor);
+}
+
+/* ************************************************************************* */
+TEST( ProjectionFactorRollingShutter, Equals ) {
+  { // factors are equal
+    ProjectionFactorRollingShutter factor1(measurement, interp_params,
+                                           model, poseKey1, poseKey2, pointKey, K);
+    ProjectionFactorRollingShutter factor2(measurement, interp_params,
+                                           model, poseKey1, poseKey2, pointKey, K);
+    CHECK(assert_equal(factor1, factor2));
+  }
+  { // factors are NOT equal (keys are different)
+    ProjectionFactorRollingShutter factor1(measurement, interp_params,
+                                           model, poseKey1, poseKey2, pointKey, K);
+    ProjectionFactorRollingShutter factor2(measurement, interp_params,
+                                           model, poseKey1, poseKey1, pointKey, K);
+    CHECK(!assert_equal(factor1, factor2)); // not equal
+  }
+  { // factors are NOT equal (different interpolation)
+    ProjectionFactorRollingShutter factor1(measurement, 0.1,
+                                           model, poseKey1, poseKey1, pointKey, K);
+    ProjectionFactorRollingShutter factor2(measurement, 0.5,
+                                           model, poseKey1, poseKey2, pointKey, K);
+    CHECK(!assert_equal(factor1, factor2)); // not equal
+  }
+}
+
+/* ************************************************************************* */
+TEST( ProjectionFactorRollingShutter, EqualsWithTransform ) {
+  { // factors are equal
+    ProjectionFactorRollingShutter factor1(measurement, interp_params, model,
+                                           poseKey1, poseKey2, pointKey, K, body_P_sensor);
+    ProjectionFactorRollingShutter factor2(measurement, interp_params, model,
+                                           poseKey1, poseKey2, pointKey, K, body_P_sensor);
+    CHECK(assert_equal(factor1, factor2));
+  }
+  { // factors are NOT equal
+    ProjectionFactorRollingShutter factor1(measurement, interp_params, model,
+                                           poseKey1, poseKey2, pointKey, K, body_P_sensor);
+    Pose3 body_P_sensor2(Rot3::RzRyRx(0.0, 0.0, 0.0), Point3(0.25, -0.10, 1.0)); // rotation different from body_P_sensor
+    ProjectionFactorRollingShutter factor2(measurement, interp_params, model,
+                                           poseKey1, poseKey2, pointKey, K, body_P_sensor2);
+    CHECK(!assert_equal(factor1, factor2));
+  }
+}
+
+/* ************************************************************************* */
+TEST( ProjectionFactorRollingShutter, Error ) {
+  {
+    // Create the factor with a measurement that is 3 pixels off in x
+    // Camera pose corresponds to the first camera
+    double t = 0.0;
+    ProjectionFactorRollingShutter factor(measurement, t, model, poseKey1, poseKey2, pointKey, K);
+
+    // Set the linearization point
+    Pose3 pose1(Rot3(), Point3(0,0,-6));
+    Pose3 pose2(Rot3(), Point3(0,0,-4));
+    Point3 point(0.0, 0.0, 0.0);
+
+    // Use the factor to calculate the error
+    Vector actualError(factor.evaluateError(pose1, pose2, point));
+
+    // The expected error is (-3.0, 0.0) pixels / UnitCovariance
+    Vector expectedError = Vector2(-3.0, 0.0);
+
+    // Verify we get the expected error
+    CHECK(assert_equal(expectedError, actualError, 1e-9));
+  }
+  {
+    // Create the factor with a measurement that is 3 pixels off in x
+    // Camera pose is actually interpolated now
+    double t = 0.5;
+    ProjectionFactorRollingShutter factor(measurement, t, model, poseKey1, poseKey2, pointKey, K);
+
+    // Set the linearization point
+    Pose3 pose1(Rot3(), Point3(0,0,-8));
+    Pose3 pose2(Rot3(), Point3(0,0,-4));
+    Point3 point(0.0, 0.0, 0.0);
+
+    // Use the factor to calculate the error
+    Vector actualError(factor.evaluateError(pose1, pose2, point));
+
+    // The expected error is (-3.0, 0.0) pixels / UnitCovariance
+    Vector expectedError = Vector2(-3.0, 0.0);
+
+    // Verify we get the expected error
+    CHECK(assert_equal(expectedError, actualError, 1e-9));
+  }
+  {
+    // Create measurement by projecting 3D landmark
+    double t = 0.3;
+    Pose3 pose1(Rot3::RzRyRx(0.1, 0.0, 0.1), Point3(0,0,0));
+    Pose3 pose2(Rot3::RzRyRx(-0.1, -0.1, 0.0), Point3(0,0,1));
+    Pose3 poseInterp = interpolate<Pose3>(pose1, pose2, t);
+    PinholeCamera<Cal3_S2> camera(poseInterp, *K);
+    Point3 point(0.0, 0.0, 5.0); // 5 meters in front of the camera
+    Point2 measured = camera.project(point);
+
+    // create factor
+    ProjectionFactorRollingShutter factor(measured, t, model, poseKey1, poseKey2, pointKey, K);
+
+    // Use the factor to calculate the error
+    Vector actualError(factor.evaluateError(pose1, pose2, point));
+
+    // The expected error is zero
+    Vector expectedError = Vector2(0.0, 0.0);
+
+    // Verify we get the expected error
+    CHECK(assert_equal(expectedError, actualError, 1e-9));
+  }
+}
+
+/* ************************************************************************* */
+TEST( ProjectionFactorRollingShutter, ErrorWithTransform ) {
+  // Create measurement by projecting 3D landmark
+  double t = 0.3;
+  Pose3 pose1(Rot3::RzRyRx(0.1, 0.0, 0.1), Point3(0,0,0));
+  Pose3 pose2(Rot3::RzRyRx(-0.1, -0.1, 0.0), Point3(0,0,1));
+  Pose3 poseInterp = interpolate<Pose3>(pose1, pose2, t);
+  Pose3 body_P_sensor3(Rot3::RzRyRx(-0.1, -0.1, 0.0), Point3(0,0.2,0.1));
+  PinholeCamera<Cal3_S2> camera(poseInterp*body_P_sensor3, *K);
+  Point3 point(0.0, 0.0, 5.0); // 5 meters in front of the camera
+  Point2 measured = camera.project(point);
+
+  // create factor
+  ProjectionFactorRollingShutter factor(measured, t, model, poseKey1, poseKey2, pointKey, K, body_P_sensor3);
+
+  // Use the factor to calculate the error
+  Vector actualError(factor.evaluateError(pose1, pose2, point));
+
+  // The expected error is zero
+  Vector expectedError = Vector2(0.0, 0.0);
+
+  // Verify we get the expected error
+  CHECK(assert_equal(expectedError, actualError, 1e-9));
+}
+
+/* ************************************************************************* */
+TEST( ProjectionFactorRollingShutter, Jacobian ) {
+  // Create measurement by projecting 3D landmark
+  double t = 0.3;
+  Pose3 pose1(Rot3::RzRyRx(0.1, 0.0, 0.1), Point3(0,0,0));
+  Pose3 pose2(Rot3::RzRyRx(-0.1, -0.1, 0.0), Point3(0,0,1));
+  Pose3 poseInterp = interpolate<Pose3>(pose1, pose2, t);
+  PinholeCamera<Cal3_S2> camera(poseInterp, *K);
+  Point3 point(0.0, 0.0, 5.0); // 5 meters in front of the camera
+  Point2 measured = camera.project(point);
+
+  // create factor
+  ProjectionFactorRollingShutter factor(measured, t, model, poseKey1, poseKey2, pointKey, K);
+
+  // Use the factor to calculate the Jacobians
+  Matrix H1Actual, H2Actual, H3Actual;
+  factor.evaluateError(pose1, pose2, point, H1Actual, H2Actual, H3Actual);
+
+  // Expected Jacobians via numerical derivatives
+  Matrix H1Expected = numericalDerivative31<Vector, Pose3, Pose3, Point3>(
+      std::function<Vector(const Pose3&, const Pose3&, const Point3&)>(
+          std::bind(&ProjectionFactorRollingShutter::evaluateError, &factor,
+                    std::placeholders::_1, std::placeholders::_2,
+                    std::placeholders::_3, boost::none, boost::none, boost::none)),
+                    pose1, pose2, point);
+
+  Matrix H2Expected = numericalDerivative32<Vector, Pose3, Pose3, Point3>(
+      std::function<Vector(const Pose3&, const Pose3&, const Point3&)>(
+          std::bind(&ProjectionFactorRollingShutter::evaluateError, &factor,
+                    std::placeholders::_1, std::placeholders::_2,
+                    std::placeholders::_3, boost::none, boost::none, boost::none)),
+                    pose1, pose2, point);
+
+  Matrix H3Expected = numericalDerivative33<Vector, Pose3, Pose3, Point3>(
+      std::function<Vector(const Pose3&, const Pose3&, const Point3&)>(
+          std::bind(&ProjectionFactorRollingShutter::evaluateError, &factor,
+                    std::placeholders::_1, std::placeholders::_2,
+                    std::placeholders::_3, boost::none, boost::none, boost::none)),
+                    pose1, pose2, point);
+
+  CHECK(assert_equal(H1Expected, H1Actual, 1e-5));
+  CHECK(assert_equal(H2Expected, H2Actual, 1e-5));
+  CHECK(assert_equal(H3Expected, H3Actual, 1e-5));
+}
+
+/* ************************************************************************* */
+TEST( ProjectionFactorRollingShutter, JacobianWithTransform ) {
+  // Create measurement by projecting 3D landmark
+  double t = 0.6;
+  Pose3 pose1(Rot3::RzRyRx(0.1, 0.0, 0.1), Point3(0,0,0));
+  Pose3 pose2(Rot3::RzRyRx(-0.1, -0.1, 0.0), Point3(0,0,1));
+  Pose3 poseInterp = interpolate<Pose3>(pose1, pose2, t);
+  Pose3 body_P_sensor3(Rot3::RzRyRx(-0.1, -0.1, 0.0), Point3(0,0.2,0.1));
+  PinholeCamera<Cal3_S2> camera(poseInterp*body_P_sensor3, *K);
+  Point3 point(0.0, 0.0, 5.0); // 5 meters in front of the camera
+  Point2 measured = camera.project(point);
+
+  // create factor
+  ProjectionFactorRollingShutter factor(measured, t, model, poseKey1, poseKey2, pointKey, K, body_P_sensor3);
+
+  // Use the factor to calculate the Jacobians
+  Matrix H1Actual, H2Actual, H3Actual;
+  factor.evaluateError(pose1, pose2, point, H1Actual, H2Actual, H3Actual);
+
+  // Expected Jacobians via numerical derivatives
+  Matrix H1Expected = numericalDerivative31<Vector, Pose3, Pose3, Point3>(
+      std::function<Vector(const Pose3&, const Pose3&, const Point3&)>(
+          std::bind(&ProjectionFactorRollingShutter::evaluateError, &factor,
+                    std::placeholders::_1, std::placeholders::_2,
+                    std::placeholders::_3, boost::none, boost::none, boost::none)),
+                    pose1, pose2, point);
+
+  Matrix H2Expected = numericalDerivative32<Vector, Pose3, Pose3, Point3>(
+      std::function<Vector(const Pose3&, const Pose3&, const Point3&)>(
+          std::bind(&ProjectionFactorRollingShutter::evaluateError, &factor,
+                    std::placeholders::_1, std::placeholders::_2,
+                    std::placeholders::_3, boost::none, boost::none, boost::none)),
+                    pose1, pose2, point);
+
+  Matrix H3Expected = numericalDerivative33<Vector, Pose3, Pose3, Point3>(
+      std::function<Vector(const Pose3&, const Pose3&, const Point3&)>(
+          std::bind(&ProjectionFactorRollingShutter::evaluateError, &factor,
+                    std::placeholders::_1, std::placeholders::_2,
+                    std::placeholders::_3, boost::none, boost::none, boost::none)),
+                    pose1, pose2, point);
+
+  CHECK(assert_equal(H1Expected, H1Actual, 1e-5));
+  CHECK(assert_equal(H2Expected, H2Actual, 1e-5));
+  CHECK(assert_equal(H3Expected, H3Actual, 1e-5));
+}
+
+/* ************************************************************************* */
+TEST( ProjectionFactorRollingShutter, cheirality ) {
+  // Create measurement by projecting 3D landmark behind camera
+  double t = 0.3;
+  Pose3 pose1(Rot3::RzRyRx(0.1, 0.0, 0.1), Point3(0,0,0));
+  Pose3 pose2(Rot3::RzRyRx(-0.1, -0.1, 0.0), Point3(0,0,1));
+  Pose3 poseInterp = interpolate<Pose3>(pose1, pose2, t);
+  PinholeCamera<Cal3_S2> camera(poseInterp, *K);
+  Point3 point(0.0, 0.0, -5.0); // 5 meters behind the camera
+
+#ifdef GTSAM_THROW_CHEIRALITY_EXCEPTION
+  Point2 measured = Point2(0.0,0.0); // project would throw an exception
+  { // check that exception is thrown if we set throwCheirality = true
+    bool throwCheirality = true;
+    bool verboseCheirality = true;
+    ProjectionFactorRollingShutter factor(measured, t, model, poseKey1, poseKey2, pointKey, K, throwCheirality, verboseCheirality);
+    CHECK_EXCEPTION(factor.evaluateError(pose1, pose2, point),
+                    CheiralityException);
+  }
+  { // check that exception is NOT thrown if we set throwCheirality = false, and outputs are correct
+    bool throwCheirality = false; // default
+    bool verboseCheirality = false; // default
+    ProjectionFactorRollingShutter factor(measured, t, model, poseKey1, poseKey2, pointKey, K, throwCheirality, verboseCheirality);
+
+    // Use the factor to calculate the error
+    Matrix H1Actual, H2Actual, H3Actual;
+    Vector actualError(factor.evaluateError(pose1, pose2, point, H1Actual, H2Actual, H3Actual));
+
+    // The expected error is zero
+    Vector expectedError = Vector2::Constant(2.0 * K->fx()); // this is what we return when point is behind camera
+
+    // Verify we get the expected error
+    CHECK(assert_equal(expectedError, actualError, 1e-9));
+    CHECK(assert_equal(Matrix::Zero(2,6), H1Actual, 1e-5));
+    CHECK(assert_equal(Matrix::Zero(2,6), H2Actual, 1e-5));
+    CHECK(assert_equal(Matrix::Zero(2,3), H3Actual, 1e-5));
+  }
+#else
+  {
+    // everything is well defined, hence this matches the test "Jacobian" above:
+    Point2 measured = camera.project(point);
+
+    // create factor
+    ProjectionFactorRollingShutter factor(measured, t, model, poseKey1, poseKey2, pointKey, K);
+
+    // Use the factor to calculate the Jacobians
+    Matrix H1Actual, H2Actual, H3Actual;
+    factor.evaluateError(pose1, pose2, point, H1Actual, H2Actual, H3Actual);
+
+    // Expected Jacobians via numerical derivatives
+    Matrix H1Expected = numericalDerivative31<Vector, Pose3, Pose3, Point3>(
+        std::function<Vector(const Pose3&, const Pose3&, const Point3&)>(
+            std::bind(&ProjectionFactorRollingShutter::evaluateError, &factor,
+                      std::placeholders::_1, std::placeholders::_2,
+                      std::placeholders::_3, boost::none, boost::none, boost::none)),
+                      pose1, pose2, point);
+
+    Matrix H2Expected = numericalDerivative32<Vector, Pose3, Pose3, Point3>(
+        std::function<Vector(const Pose3&, const Pose3&, const Point3&)>(
+            std::bind(&ProjectionFactorRollingShutter::evaluateError, &factor,
+                      std::placeholders::_1, std::placeholders::_2,
+                      std::placeholders::_3, boost::none, boost::none, boost::none)),
+                      pose1, pose2, point);
+
+    Matrix H3Expected = numericalDerivative33<Vector, Pose3, Pose3, Point3>(
+        std::function<Vector(const Pose3&, const Pose3&, const Point3&)>(
+            std::bind(&ProjectionFactorRollingShutter::evaluateError, &factor,
+                      std::placeholders::_1, std::placeholders::_2,
+                      std::placeholders::_3, boost::none, boost::none, boost::none)),
+                      pose1, pose2, point);
+
+    CHECK(assert_equal(H1Expected, H1Actual, 1e-5));
+    CHECK(assert_equal(H2Expected, H2Actual, 1e-5));
+    CHECK(assert_equal(H3Expected, H3Actual, 1e-5));
+  }
+#endif
+}
+
+
+/* ************************************************************************* */
+int main() { TestResult tr; return TestRegistry::runAllTests(tr); }
+/* ************************************************************************* */
+

--- a/gtsam_unstable/slam/tests/testSmartProjectionPoseFactorRollingShutter.cpp
+++ b/gtsam_unstable/slam/tests/testSmartProjectionPoseFactorRollingShutter.cpp
@@ -1,0 +1,842 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ *  @file  testSmartProjectionPoseFactorRollingShutter.cpp
+ *  @brief Unit tests for SmartProjectionPoseFactorRollingShutter Class
+ *  @author Luca Carlone
+ *  @date   July 2021
+ */
+
+#include "gtsam/slam/tests/smartFactorScenarios.h"
+#include <gtsam/slam/ProjectionFactor.h>
+#include <gtsam/slam/PoseTranslationPrior.h>
+#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
+#include <gtsam_unstable/slam/SmartProjectionPoseFactorRollingShutter.h>
+#include <gtsam_unstable/slam/ProjectionFactorRollingShutter.h>
+#include <gtsam/base/numericalDerivative.h>
+#include <gtsam/base/serializationTestHelpers.h>
+#include <CppUnitLite/TestHarness.h>
+#include <boost/assign/std/map.hpp>
+#include <iostream>
+#define DISABLE_TIMING
+
+using namespace gtsam;
+using namespace boost::assign;
+using namespace std::placeholders;
+
+static const double rankTol = 1.0;
+// Create a noise model for the pixel error
+static const double sigma = 0.1;
+static SharedIsotropic model(noiseModel::Isotropic::Sigma(2, sigma));
+
+// Convenience for named keys
+using symbol_shorthand::X;
+using symbol_shorthand::L;
+
+// tests data
+static Symbol x1('X', 1);
+static Symbol x2('X', 2);
+static Symbol x3('X', 3);
+static Symbol x4('X', 4);
+static Symbol l0('L', 0);
+static Pose3 body_P_sensor = Pose3(Rot3::Ypr(-0.1, 0.2, -0.2),
+                                   Point3(0.1, 0.0, 0.0));
+
+static Point2 measurement1(323.0, 240.0);
+static Point2 measurement2(200.0, 220.0);
+static Point2 measurement3(320.0, 10.0);
+static double interp_factor = 0.5;
+static double interp_factor1 = 0.3;
+static double interp_factor2 = 0.4;
+static double interp_factor3 = 0.5;
+
+/* ************************************************************************* */
+// default Cal3_S2 poses with rolling shutter effect
+namespace vanillaPoseRS {
+typedef PinholePose<Cal3_S2> Camera;
+static Cal3_S2::shared_ptr sharedK(new Cal3_S2(fov, w, h));
+Pose3 interp_pose1 = interpolate<Pose3>(level_pose,pose_right,interp_factor1);
+Pose3 interp_pose2 = interpolate<Pose3>(pose_right,pose_above,interp_factor2);
+Pose3 interp_pose3 = interpolate<Pose3>(pose_above,level_pose,interp_factor3);
+Camera cam1(interp_pose1, sharedK);
+Camera cam2(interp_pose2, sharedK);
+Camera cam3(interp_pose3, sharedK);
+}
+
+LevenbergMarquardtParams lmParams;
+typedef SmartProjectionPoseFactorRollingShutter<Cal3_S2> SmartFactorRS;
+
+/* ************************************************************************* */
+TEST( SmartProjectionPoseFactorRollingShutter, Constructor) {
+  SmartFactorRS::shared_ptr factor1(new SmartFactorRS(model));
+}
+
+/* ************************************************************************* */
+TEST( SmartProjectionPoseFactorRollingShutter, Constructor2) {
+  SmartProjectionParams params;
+  params.setRankTolerance(rankTol);
+  SmartFactorRS factor1(model, params);
+}
+
+/* ************************************************************************* */
+TEST( SmartProjectionPoseFactorRollingShutter, add) {
+  using namespace vanillaPose;
+  SmartFactorRS::shared_ptr factor1(new SmartFactorRS(model));
+  factor1->add(measurement1, x1, x2, interp_factor, sharedK, body_P_sensor);
+}
+
+/* ************************************************************************* */
+TEST( SmartProjectionPoseFactorRollingShutter, Equals ) {
+  using namespace vanillaPose;
+
+  // create fake measurements
+  Point2Vector measurements;
+  measurements.push_back(measurement1);
+  measurements.push_back(measurement2);
+  measurements.push_back(measurement3);
+
+  std::vector<std::pair<Key,Key>> key_pairs;
+  key_pairs.push_back(std::make_pair(x1,x2));
+  key_pairs.push_back(std::make_pair(x2,x3));
+  key_pairs.push_back(std::make_pair(x3,x4));
+
+  std::vector<boost::shared_ptr<Cal3_S2>> intrinsicCalibrations;
+  intrinsicCalibrations.push_back(sharedK);
+  intrinsicCalibrations.push_back(sharedK);
+  intrinsicCalibrations.push_back(sharedK);
+
+  std::vector<Pose3> extrinsicCalibrations;
+  extrinsicCalibrations.push_back(body_P_sensor);
+  extrinsicCalibrations.push_back(body_P_sensor);
+  extrinsicCalibrations.push_back(body_P_sensor);
+
+  std::vector<double> interp_factors;
+  interp_factors.push_back(interp_factor1);
+  interp_factors.push_back(interp_factor2);
+  interp_factors.push_back(interp_factor3);
+
+  // create by adding a batch of measurements with a bunch of calibrations
+  SmartFactorRS::shared_ptr factor2(new SmartFactorRS(model));
+  factor2->add(measurements, key_pairs, interp_factors, intrinsicCalibrations, extrinsicCalibrations);
+
+  // create by adding a batch of measurements with a single calibrations
+  SmartFactorRS::shared_ptr factor3(new SmartFactorRS(model));
+  factor3->add(measurements, key_pairs, interp_factors, sharedK, body_P_sensor);
+
+  { // create equal factors and show equal returns true
+    SmartFactorRS::shared_ptr factor1(new SmartFactorRS(model));
+    factor1->add(measurement1, x1, x2, interp_factor1, sharedK, body_P_sensor);
+    factor1->add(measurement2, x2, x3, interp_factor2, sharedK, body_P_sensor);
+    factor1->add(measurement3, x3, x4, interp_factor3, sharedK, body_P_sensor);
+
+    EXPECT(assert_equal(*factor1, *factor2));
+    EXPECT(assert_equal(*factor1, *factor3));
+  }
+  { // create slightly different factors (different keys) and show equal returns false
+    SmartFactorRS::shared_ptr factor1(new SmartFactorRS(model));
+    factor1->add(measurement1, x1, x2, interp_factor1, sharedK, body_P_sensor);
+    factor1->add(measurement2, x2, x2, interp_factor2, sharedK, body_P_sensor); // different!
+    factor1->add(measurement3, x3, x4, interp_factor3, sharedK, body_P_sensor);
+
+    EXPECT(!assert_equal(*factor1, *factor2));
+    EXPECT(!assert_equal(*factor1, *factor3));
+  }
+  { // create slightly different factors (different extrinsics) and show equal returns false
+    SmartFactorRS::shared_ptr factor1(new SmartFactorRS(model));
+    factor1->add(measurement1, x1, x2, interp_factor1, sharedK, body_P_sensor);
+    factor1->add(measurement2, x2, x3, interp_factor2, sharedK, body_P_sensor*body_P_sensor); // different!
+    factor1->add(measurement3, x3, x4, interp_factor3, sharedK, body_P_sensor);
+
+    EXPECT(!assert_equal(*factor1, *factor2));
+    EXPECT(!assert_equal(*factor1, *factor3));
+  }
+  { // create slightly different factors (different interp factors) and show equal returns false
+    SmartFactorRS::shared_ptr factor1(new SmartFactorRS(model));
+    factor1->add(measurement1, x1, x2, interp_factor1, sharedK, body_P_sensor);
+    factor1->add(measurement2, x2, x3, interp_factor1, sharedK, body_P_sensor); // different!
+    factor1->add(measurement3, x3, x4, interp_factor3, sharedK, body_P_sensor);
+
+    EXPECT(!assert_equal(*factor1, *factor2));
+    EXPECT(!assert_equal(*factor1, *factor3));
+  }
+}
+
+static const int DimBlock = 12;  ///< size of the variable stacking 2 poses from which the observation pose is interpolated
+static const int ZDim = 2;  ///< Measurement dimension (Point2)
+typedef Eigen::Matrix<double, ZDim, DimBlock> MatrixZD;  // F blocks (derivatives wrt camera)
+typedef std::vector<MatrixZD, Eigen::aligned_allocator<MatrixZD> > FBlocks;  // vector of F blocks
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactorRollingShutter, noiselessErrorAndJacobians ) {
+  using namespace vanillaPoseRS;
+
+  // Project two landmarks into two cameras
+  Point2 level_uv = cam1.project(landmark1);
+  Point2 level_uv_right = cam2.project(landmark1);
+  Pose3 body_P_sensorId = Pose3::identity();
+
+  SmartFactorRS factor(model);
+  factor.add(level_uv, x1, x2, interp_factor1, sharedK, body_P_sensorId);
+  factor.add(level_uv_right, x2, x3, interp_factor2, sharedK, body_P_sensorId);
+
+  Values values; // it's a pose factor, hence these are poses
+  values.insert(x1, level_pose);
+  values.insert(x2, pose_right);
+  values.insert(x3, pose_above);
+
+  double actualError = factor.error(values);
+  double expectedError = 0.0;
+  EXPECT_DOUBLES_EQUAL(expectedError, actualError, 1e-7);
+
+  // Check triangulation
+  factor.triangulateSafe(factor.cameras(values));
+  TriangulationResult point = factor.point();
+  EXPECT(point.valid()); // check triangulated point is valid
+  EXPECT(assert_equal(landmark1, *point)); // check triangulation result matches expected 3D landmark
+
+  // Check Jacobians
+  // -- actual Jacobians
+  FBlocks actualFs;
+  Matrix actualE;
+  Vector actualb;
+  factor.computeJacobiansWithTriangulatedPoint(actualFs, actualE, actualb, values);
+  EXPECT(actualE.rows() == 4); EXPECT(actualE.cols() == 3);
+  EXPECT(actualb.rows() == 4); EXPECT(actualb.cols() == 1);
+  EXPECT(actualFs.size() == 2);
+
+  // -- expected Jacobians from ProjectionFactorsRollingShutter
+  ProjectionFactorRollingShutter factor1(level_uv, interp_factor1, model, x1, x2, l0, sharedK, body_P_sensorId);
+  Matrix expectedF11, expectedF12, expectedE1;
+  Vector expectedb1 = factor1.evaluateError(level_pose, pose_right, landmark1, expectedF11, expectedF12, expectedE1);
+  EXPECT(assert_equal( expectedF11, Matrix(actualFs[0].block(0,0,2,6)), 1e-5));
+  EXPECT(assert_equal( expectedF12, Matrix(actualFs[0].block(0,6,2,6)), 1e-5));
+  EXPECT(assert_equal( expectedE1, Matrix(actualE.block(0,0,2,3)), 1e-5));
+  // by definition computeJacobiansWithTriangulatedPoint returns minus reprojectionError
+  EXPECT(assert_equal( expectedb1, -Vector(actualb.segment<2>(0)), 1e-5));
+
+  ProjectionFactorRollingShutter factor2(level_uv_right, interp_factor2, model, x2, x3, l0, sharedK, body_P_sensorId);
+  Matrix expectedF21, expectedF22, expectedE2;
+  Vector expectedb2 = factor2.evaluateError(pose_right, pose_above, landmark1, expectedF21, expectedF22, expectedE2);
+  EXPECT(assert_equal( expectedF21, Matrix(actualFs[1].block(0,0,2,6)), 1e-5));
+  EXPECT(assert_equal( expectedF22, Matrix(actualFs[1].block(0,6,2,6)), 1e-5));
+  EXPECT(assert_equal( expectedE2, Matrix(actualE.block(2,0,2,3)), 1e-5));
+  // by definition computeJacobiansWithTriangulatedPoint returns minus reprojectionError
+  EXPECT(assert_equal( expectedb2, -Vector(actualb.segment<2>(2)), 1e-5));
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactorRollingShutter, noisyErrorAndJacobians ) {
+  // also includes non-identical extrinsic calibration
+  using namespace vanillaPoseRS;
+
+  // Project two landmarks into two cameras
+  Point2 pixelError(0.5, 1.0);
+  Point2 level_uv = cam1.project(landmark1) + pixelError;
+  Point2 level_uv_right = cam2.project(landmark1);
+  Pose3 body_P_sensorNonId = body_P_sensor;
+
+  SmartFactorRS factor(model);
+  factor.add(level_uv, x1, x2, interp_factor1, sharedK, body_P_sensorNonId);
+  factor.add(level_uv_right, x2, x3, interp_factor2, sharedK, body_P_sensorNonId);
+
+  Values values; // it's a pose factor, hence these are poses
+  values.insert(x1, level_pose);
+  values.insert(x2, pose_right);
+  values.insert(x3, pose_above);
+
+  // Perform triangulation
+  factor.triangulateSafe(factor.cameras(values));
+  TriangulationResult point = factor.point();
+  EXPECT(point.valid()); // check triangulated point is valid
+  Point3 landmarkNoisy = *point;
+
+  // Check Jacobians
+  // -- actual Jacobians
+  FBlocks actualFs;
+  Matrix actualE;
+  Vector actualb;
+  factor.computeJacobiansWithTriangulatedPoint(actualFs, actualE, actualb, values);
+  EXPECT(actualE.rows() == 4); EXPECT(actualE.cols() == 3);
+  EXPECT(actualb.rows() == 4); EXPECT(actualb.cols() == 1);
+  EXPECT(actualFs.size() == 2);
+
+  // -- expected Jacobians from ProjectionFactorsRollingShutter
+  ProjectionFactorRollingShutter factor1(level_uv, interp_factor1, model, x1, x2, l0, sharedK, body_P_sensorNonId);
+  Matrix expectedF11, expectedF12, expectedE1;
+  Vector expectedb1 = factor1.evaluateError(level_pose, pose_right, landmarkNoisy, expectedF11, expectedF12, expectedE1);
+  EXPECT(assert_equal( expectedF11, Matrix(actualFs[0].block(0,0,2,6)), 1e-5));
+  EXPECT(assert_equal( expectedF12, Matrix(actualFs[0].block(0,6,2,6)), 1e-5));
+  EXPECT(assert_equal( expectedE1, Matrix(actualE.block(0,0,2,3)), 1e-5));
+  // by definition computeJacobiansWithTriangulatedPoint returns minus reprojectionError
+  EXPECT(assert_equal( expectedb1, -Vector(actualb.segment<2>(0)), 1e-5));
+
+  ProjectionFactorRollingShutter factor2(level_uv_right, interp_factor2, model, x2, x3, l0, sharedK, body_P_sensorNonId);
+  Matrix expectedF21, expectedF22, expectedE2;
+  Vector expectedb2 = factor2.evaluateError(pose_right, pose_above, landmarkNoisy, expectedF21, expectedF22, expectedE2);
+  EXPECT(assert_equal( expectedF21, Matrix(actualFs[1].block(0,0,2,6)), 1e-5));
+  EXPECT(assert_equal( expectedF22, Matrix(actualFs[1].block(0,6,2,6)), 1e-5));
+  EXPECT(assert_equal( expectedE2, Matrix(actualE.block(2,0,2,3)), 1e-5));
+  // by definition computeJacobiansWithTriangulatedPoint returns minus reprojectionError
+  EXPECT(assert_equal( expectedb2, -Vector(actualb.segment<2>(2)), 1e-5));
+
+  // Check errors
+  double actualError = factor.error(values); // from smart factor
+  NonlinearFactorGraph nfg;
+  nfg.add(factor1);
+  nfg.add(factor2);
+  values.insert(l0, landmarkNoisy);
+  double expectedError = nfg.error(values);
+  EXPECT_DOUBLES_EQUAL(expectedError, actualError, 1e-7);
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactorRollingShutter, optimization_3poses ) {
+
+  using namespace vanillaPoseRS;
+  Point2Vector measurements_lmk1, measurements_lmk2, measurements_lmk3;
+
+  // Project three landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_lmk1);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_lmk2);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_lmk3);
+
+  // create inputs
+  std::vector<std::pair<Key,Key>> key_pairs;
+  key_pairs.push_back(std::make_pair(x1,x2));
+  key_pairs.push_back(std::make_pair(x2,x3));
+  key_pairs.push_back(std::make_pair(x3,x1));
+
+  std::vector<double> interp_factors;
+  interp_factors.push_back(interp_factor1);
+  interp_factors.push_back(interp_factor2);
+  interp_factors.push_back(interp_factor3);
+
+  SmartFactorRS::shared_ptr smartFactor1(new SmartFactorRS(model));
+  smartFactor1->add(measurements_lmk1, key_pairs, interp_factors, sharedK);
+
+  SmartFactorRS::shared_ptr smartFactor2(new SmartFactorRS(model));
+  smartFactor2->add(measurements_lmk2, key_pairs, interp_factors, sharedK);
+
+  SmartFactorRS::shared_ptr smartFactor3(new SmartFactorRS(model));
+  smartFactor3->add(measurements_lmk3, key_pairs, interp_factors, sharedK);
+
+  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+
+  NonlinearFactorGraph graph;
+  graph.push_back(smartFactor1);
+  graph.push_back(smartFactor2);
+  graph.push_back(smartFactor3);
+  graph.addPrior(x1, level_pose, noisePrior);
+  graph.addPrior(x2, pose_right, noisePrior);
+
+  Values groundTruth;
+  groundTruth.insert(x1, level_pose);
+  groundTruth.insert(x2, pose_right);
+  groundTruth.insert(x3, pose_above);
+  DOUBLES_EQUAL(0, graph.error(groundTruth), 1e-9);
+
+  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+                           Point3(0.1, 0.1, 0.1)); // smaller noise
+  Values values;
+  values.insert(x1, level_pose);
+  values.insert(x2, pose_right);
+  // initialize third pose with some noise, we expect it to move back to original pose_above
+  values.insert(x3, pose_above * noise_pose);
+  EXPECT( // check that the pose is actually noisy
+      assert_equal(
+          Pose3(
+              Rot3(0, -0.0314107591, 0.99950656, -0.99950656, -0.0313952598,
+                   -0.000986635786, 0.0314107591, -0.999013364, -0.0313952598),
+                   Point3(0.1, -0.1, 1.9)), values.at<Pose3>(x3)));
+
+  Values result;
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  result = optimizer.optimize();
+  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-6));
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactorRollingShutter, hessian_simple_2poses ) {
+  // here we replicate a test in SmartProjectionPoseFactor by setting interpolation
+  // factors to 0 and 1 (such that the rollingShutter measurements falls back to standard pixel measurements)
+  // Note: this is a quite extreme test since in typical camera you would not have more than
+  // 1 measurement per landmark at each interpolated pose
+  using namespace vanillaPose;
+
+  // Default cameras for simple derivatives
+  static Cal3_S2::shared_ptr sharedKSimple(new Cal3_S2(100, 100, 0, 0, 0));
+
+  Rot3 R = Rot3::identity();
+  Pose3 pose1 = Pose3(R, Point3(0, 0, 0));
+  Pose3 pose2 = Pose3(R, Point3(1, 0, 0));
+  Camera cam1(pose1, sharedKSimple), cam2(pose2, sharedKSimple);
+  Pose3 body_P_sensorId = Pose3::identity();
+
+  // one landmarks 1m in front of camera
+  Point3 landmark1(0, 0, 10);
+
+  Point2Vector measurements_lmk1;
+
+  // Project 2 landmarks into 2 cameras
+  measurements_lmk1.push_back(cam1.project(landmark1));
+  measurements_lmk1.push_back(cam2.project(landmark1));
+
+  SmartFactorRS::shared_ptr smartFactor1(new SmartFactorRS(model));
+  double interp_factor = 0;  // equivalent to measurement taken at pose 1
+  smartFactor1->add(measurements_lmk1[0], x1, x2, interp_factor, sharedKSimple,
+                    body_P_sensorId);
+  interp_factor = 1;  // equivalent to measurement taken at pose 2
+  smartFactor1->add(measurements_lmk1[1], x1, x2, interp_factor, sharedKSimple,
+                    body_P_sensorId);
+
+  SmartFactor::Cameras cameras;
+  cameras.push_back(cam1);
+  cameras.push_back(cam2);
+
+  // Make sure triangulation works
+  EXPECT(smartFactor1->triangulateSafe(cameras));
+  EXPECT(!smartFactor1->isDegenerate());
+  EXPECT(!smartFactor1->isPointBehindCamera());
+  boost::optional<Point3> p = smartFactor1->point();
+  EXPECT(p);
+  EXPECT(assert_equal(landmark1, *p));
+
+  VectorValues zeroDelta;
+  Vector6 delta;
+  delta.setZero();
+  zeroDelta.insert(x1, delta);
+  zeroDelta.insert(x2, delta);
+
+  VectorValues perturbedDelta;
+  delta.setOnes();
+  perturbedDelta.insert(x1, delta);
+  perturbedDelta.insert(x2, delta);
+  double expectedError = 2500;
+
+  // After eliminating the point, A1 and A2 contain 2-rank information on cameras:
+  Matrix16 A1, A2;
+  A1 << -10, 0, 0, 0, 1, 0;
+  A2 << 10, 0, 1, 0, -1, 0;
+  A1 *= 10. / sigma;
+  A2 *= 10. / sigma;
+  Matrix expectedInformation;  // filled below
+
+  // createHessianFactor
+  Matrix66 G11 = 0.5 * A1.transpose() * A1;
+  Matrix66 G12 = 0.5 * A1.transpose() * A2;
+  Matrix66 G22 = 0.5 * A2.transpose() * A2;
+
+  Vector6 g1;
+  g1.setZero();
+  Vector6 g2;
+  g2.setZero();
+
+  double f = 0;
+
+  RegularHessianFactor<6> expected(x1, x2, G11, G12, g1, G22, g2, f);
+  expectedInformation = expected.information();
+
+  Values values;
+  values.insert(x1, pose1);
+  values.insert(x2, pose2);
+  boost::shared_ptr < RegularHessianFactor<6> > actual = smartFactor1
+      ->createHessianFactor(values);
+  EXPECT(assert_equal(expectedInformation, actual->information(), 1e-6));
+  EXPECT(assert_equal(expected, *actual, 1e-6));
+  EXPECT_DOUBLES_EQUAL(0, actual->error(zeroDelta), 1e-6);
+  EXPECT_DOUBLES_EQUAL(expectedError, actual->error(perturbedDelta), 1e-6);
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactorRollingShutter, optimization_3poses_EPI ) {
+  using namespace vanillaPoseRS;
+  Point2Vector measurements_lmk1, measurements_lmk2, measurements_lmk3;
+
+  // Project three landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_lmk1);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_lmk2);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_lmk3);
+
+  // create inputs
+  std::vector<std::pair<Key, Key>> key_pairs;
+  key_pairs.push_back(std::make_pair(x1, x2));
+  key_pairs.push_back(std::make_pair(x2, x3));
+  key_pairs.push_back(std::make_pair(x3, x1));
+
+  std::vector<double> interp_factors;
+  interp_factors.push_back(interp_factor1);
+  interp_factors.push_back(interp_factor2);
+  interp_factors.push_back(interp_factor3);
+
+  double excludeLandmarksFutherThanDist = 1e10; //very large
+  SmartProjectionParams params;
+  params.setRankTolerance(1.0);
+  params.setLinearizationMode(gtsam::HESSIAN);
+  params.setDegeneracyMode(gtsam::ZERO_ON_DEGENERACY);
+  params.setLandmarkDistanceThreshold(excludeLandmarksFutherThanDist);
+  params.setEnableEPI(true);
+
+  SmartFactorRS smartFactor1(model,params);
+  smartFactor1.add(measurements_lmk1, key_pairs, interp_factors, sharedK);
+
+  SmartFactorRS smartFactor2(model,params);
+  smartFactor2.add(measurements_lmk2, key_pairs, interp_factors, sharedK);
+
+  SmartFactorRS smartFactor3(model,params);
+  smartFactor3.add(measurements_lmk3, key_pairs, interp_factors, sharedK);
+
+  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+
+  NonlinearFactorGraph graph;
+  graph.push_back(smartFactor1);
+  graph.push_back(smartFactor2);
+  graph.push_back(smartFactor3);
+  graph.addPrior(x1, level_pose, noisePrior);
+  graph.addPrior(x2, pose_right, noisePrior);
+
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+                           Point3(0.1, 0.1, 0.1));  // smaller noise
+  Values values;
+  values.insert(x1, level_pose);
+  values.insert(x2, pose_right);
+  // initialize third pose with some noise, we expect it to move back to original pose_above
+  values.insert(x3, pose_above * noise_pose);
+
+  // Optimization should correct 3rd pose
+  Values result;
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  result = optimizer.optimize();
+  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-6));
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactorRollingShutter, optimization_3poses_landmarkDistance ) {
+  using namespace vanillaPoseRS;
+  Point2Vector measurements_lmk1, measurements_lmk2, measurements_lmk3;
+
+  // Project three landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_lmk1);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_lmk2);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_lmk3);
+
+  // create inputs
+  std::vector<std::pair<Key, Key>> key_pairs;
+  key_pairs.push_back(std::make_pair(x1, x2));
+  key_pairs.push_back(std::make_pair(x2, x3));
+  key_pairs.push_back(std::make_pair(x3, x1));
+
+  std::vector<double> interp_factors;
+  interp_factors.push_back(interp_factor1);
+  interp_factors.push_back(interp_factor2);
+  interp_factors.push_back(interp_factor3);
+
+  double excludeLandmarksFutherThanDist = 2;
+  SmartProjectionParams params;
+  params.setRankTolerance(1.0);
+  params.setLinearizationMode(gtsam::HESSIAN);
+  params.setDegeneracyMode(gtsam::IGNORE_DEGENERACY);
+  params.setLandmarkDistanceThreshold(excludeLandmarksFutherThanDist);
+  params.setEnableEPI(false);
+
+  SmartFactorRS smartFactor1(model,params);
+  smartFactor1.add(measurements_lmk1, key_pairs, interp_factors, sharedK);
+
+  SmartFactorRS smartFactor2(model,params);
+  smartFactor2.add(measurements_lmk2, key_pairs, interp_factors, sharedK);
+
+  SmartFactorRS smartFactor3(model,params);
+  smartFactor3.add(measurements_lmk3, key_pairs, interp_factors, sharedK);
+
+  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+
+  NonlinearFactorGraph graph;
+  graph.push_back(smartFactor1);
+  graph.push_back(smartFactor2);
+  graph.push_back(smartFactor3);
+  graph.addPrior(x1, level_pose, noisePrior);
+  graph.addPrior(x2, pose_right, noisePrior);
+
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+                           Point3(0.1, 0.1, 0.1));  // smaller noise
+  Values values;
+  values.insert(x1, level_pose);
+  values.insert(x2, pose_right);
+  // initialize third pose with some noise, we expect it to move back to original pose_above
+  values.insert(x3, pose_above * noise_pose);
+
+  // All factors are disabled (due to the distance threshold) and pose should remain where it is
+  Values result;
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  result = optimizer.optimize();
+  EXPECT(assert_equal(values.at<Pose3>(x3), result.at<Pose3>(x3)));
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactorRollingShutter, optimization_3poses_dynamicOutlierRejection ) {
+  using namespace vanillaPoseRS;
+  // add fourth landmark
+  Point3 landmark4(5, -0.5, 1);
+
+  Point2Vector measurements_lmk1, measurements_lmk2, measurements_lmk3,
+      measurements_lmk4;
+  // Project 4 landmarks into cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_lmk1);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_lmk2);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_lmk3);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark4, measurements_lmk4);
+  measurements_lmk4.at(0) = measurements_lmk4.at(0) + Point2(10, 10);  // add outlier
+
+  // create inputs
+  std::vector<std::pair<Key, Key>> key_pairs;
+  key_pairs.push_back(std::make_pair(x1, x2));
+  key_pairs.push_back(std::make_pair(x2, x3));
+  key_pairs.push_back(std::make_pair(x3, x1));
+
+  std::vector<double> interp_factors;
+  interp_factors.push_back(interp_factor1);
+  interp_factors.push_back(interp_factor2);
+  interp_factors.push_back(interp_factor3);
+
+  double excludeLandmarksFutherThanDist = 1e10;
+  double dynamicOutlierRejectionThreshold = 3;  // max 3 pixel of average reprojection error
+
+  SmartProjectionParams params;
+  params.setRankTolerance(1.0);
+  params.setLinearizationMode(gtsam::HESSIAN);
+  params.setDegeneracyMode(gtsam::ZERO_ON_DEGENERACY);
+  params.setLandmarkDistanceThreshold(excludeLandmarksFutherThanDist);
+  params.setDynamicOutlierRejectionThreshold(dynamicOutlierRejectionThreshold);
+  params.setEnableEPI(false);
+
+  SmartFactorRS::shared_ptr smartFactor1(new SmartFactorRS(model, params));
+  smartFactor1->add(measurements_lmk1, key_pairs, interp_factors, sharedK);
+
+  SmartFactorRS::shared_ptr smartFactor2(new SmartFactorRS(model, params));
+  smartFactor2->add(measurements_lmk2, key_pairs, interp_factors, sharedK);
+
+  SmartFactorRS::shared_ptr smartFactor3(new SmartFactorRS(model, params));
+  smartFactor3->add(measurements_lmk3, key_pairs, interp_factors, sharedK);
+
+  SmartFactorRS::shared_ptr smartFactor4(new SmartFactorRS(model, params));
+  smartFactor4->add(measurements_lmk4, key_pairs, interp_factors, sharedK);
+
+  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+
+  NonlinearFactorGraph graph;
+  graph.push_back(smartFactor1);
+  graph.push_back(smartFactor2);
+  graph.push_back(smartFactor3);
+  graph.push_back(smartFactor4);
+  graph.addPrior(x1, level_pose, noisePrior);
+  graph.addPrior(x2, pose_right, noisePrior);
+
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+                           Point3(0.01, 0.01, 0.01));  // smaller noise, otherwise outlier rejection will kick in
+  Values values;
+  values.insert(x1, level_pose);
+  values.insert(x2, pose_right);
+  // initialize third pose with some noise, we expect it to move back to original pose_above
+  values.insert(x3, pose_above * noise_pose);
+
+  // Optimization should correct 3rd pose
+  Values result;
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  result = optimizer.optimize();
+  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-6));
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactorRollingShutter, hessianComparedToProjFactorsRollingShutter) {
+
+  using namespace vanillaPoseRS;
+  Point2Vector measurements_lmk1;
+
+  // Project three landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_lmk1);
+
+  // create inputs
+  std::vector<std::pair<Key, Key>> key_pairs;
+  key_pairs.push_back(std::make_pair(x1, x2));
+  key_pairs.push_back(std::make_pair(x2, x3));
+  key_pairs.push_back(std::make_pair(x3, x1));
+
+  std::vector<double> interp_factors;
+  interp_factors.push_back(interp_factor1);
+  interp_factors.push_back(interp_factor2);
+  interp_factors.push_back(interp_factor3);
+
+  SmartFactorRS::shared_ptr smartFactor1(new SmartFactorRS(model));
+  smartFactor1->add(measurements_lmk1, key_pairs, interp_factors, sharedK);
+
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+                           Point3(0.1, 0.1, 0.1));  // smaller noise
+  Values values;
+  values.insert(x1, level_pose);
+  values.insert(x2, pose_right);
+  // initialize third pose with some noise to get a nontrivial linearization point
+  values.insert(x3, pose_above * noise_pose);
+  EXPECT(  // check that the pose is actually noisy
+      assert_equal( Pose3( Rot3(0, -0.0314107591, 0.99950656, -0.99950656, -0.0313952598, -0.000986635786, 0.0314107591, -0.999013364, -0.0313952598), Point3(0.1, -0.1, 1.9)), values.at<Pose3>(x3)));
+
+  // linearization point for the poses
+  Pose3 pose1 = level_pose;
+  Pose3 pose2 = pose_right;
+  Pose3 pose3 = pose_above * noise_pose;
+
+  // ==== check Hessian of smartFactor1 =====
+  // -- compute actual Hessian
+  boost::shared_ptr<GaussianFactor> linearfactor1 = smartFactor1->linearize(
+      values);
+  Matrix actualHessian = linearfactor1->information();
+
+  // -- compute expected Hessian from manual Schur complement from Jacobians
+  // linearization point for the 3D point
+  smartFactor1->triangulateSafe(smartFactor1->cameras(values));
+  TriangulationResult point = smartFactor1->point();
+  EXPECT(point.valid());  // check triangulated point is valid
+
+  // Use the factor to calculate the Jacobians
+  Matrix F = Matrix::Zero(2 * 3, 6 * 3);
+  Matrix E = Matrix::Zero(2 * 3, 3);
+  Vector b = Vector::Zero(6);
+
+  // create projection factors rolling shutter
+  ProjectionFactorRollingShutter factor11(measurements_lmk1[0], interp_factor1,
+                                          model, x1, x2, l0, sharedK);
+  Matrix H1Actual, H2Actual, H3Actual;
+  // note: b is minus the reprojection error, cf the smart factor jacobian computation
+  b.segment<2>(0) = -factor11.evaluateError(pose1, pose2, *point, H1Actual, H2Actual, H3Actual);
+  F.block<2, 6>(0, 0) = H1Actual;
+  F.block<2, 6>(0, 6) = H2Actual;
+  E.block<2, 3>(0, 0) = H3Actual;
+
+  ProjectionFactorRollingShutter factor12(measurements_lmk1[1], interp_factor2,
+                                          model, x2, x3, l0, sharedK);
+  b.segment<2>(2) = -factor12.evaluateError(pose2, pose3, *point, H1Actual, H2Actual, H3Actual);
+  F.block<2, 6>(2, 6) = H1Actual;
+  F.block<2, 6>(2, 12) = H2Actual;
+  E.block<2, 3>(2, 0) = H3Actual;
+
+  ProjectionFactorRollingShutter factor13(measurements_lmk1[2], interp_factor3,
+                                          model, x3, x1, l0, sharedK);
+  b.segment<2>(4) = -factor13.evaluateError(pose3, pose1, *point, H1Actual, H2Actual, H3Actual);
+  F.block<2, 6>(4, 12) = H1Actual;
+  F.block<2, 6>(4, 0) = H2Actual;
+  E.block<2, 3>(4, 0) = H3Actual;
+
+  // whiten
+  F = (1/sigma) * F;
+  E = (1/sigma) * E;
+  b = (1/sigma) * b;
+  //* G = F' * F - F' * E * P * E' * F
+  Matrix P = (E.transpose() * E).inverse();
+  Matrix expectedHessian = F.transpose() * F
+      - (F.transpose() * E * P * E.transpose() * F);
+  EXPECT(assert_equal(expectedHessian, actualHessian, 1e-6));
+
+  // ==== check Information vector of smartFactor1 =====
+  GaussianFactorGraph gfg;
+  gfg.add(linearfactor1);
+  Matrix actualHessian_v2 = gfg.hessian().first;
+  EXPECT(assert_equal(actualHessian_v2, actualHessian, 1e-6)); // sanity check on hessian
+
+  // -- compute actual information vector
+  Vector actualInfoVector = gfg.hessian().second;
+
+  // -- compute expected information vector from manual Schur complement from Jacobians
+  //* g = F' * (b - E * P * E' * b)
+  Vector expectedInfoVector = F.transpose() * (b - E * P * E.transpose() * b);
+  EXPECT(assert_equal(expectedInfoVector, actualInfoVector, 1e-6));
+
+  // ==== check error of smartFactor1 (again) =====
+  NonlinearFactorGraph nfg_projFactorsRS;
+  nfg_projFactorsRS.add(factor11);
+  nfg_projFactorsRS.add(factor12);
+  nfg_projFactorsRS.add(factor13);
+  values.insert(l0, *point);
+
+  double actualError = smartFactor1->error(values);
+  double expectedError = nfg_projFactorsRS.error(values);
+  EXPECT_DOUBLES_EQUAL(expectedError, actualError, 1e-7);
+}
+
+#ifndef DISABLE_TIMING
+#include <gtsam/base/timing.h>
+// -Total: 0 CPU (0 times, 0 wall, 0.04 children, min: 0 max: 0)
+//|   -SF RS LINEARIZE: 0.02 CPU (1000 times, 0.017244 wall, 0.02 children, min: 0 max: 0)
+//|   -RS LINEARIZE: 0.02 CPU (1000 times, 0.009035 wall, 0.02 children, min: 0 max: 0)
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactorRollingShutter, timing ) {
+
+  using namespace vanillaPose;
+
+  // Default cameras for simple derivatives
+  static Cal3_S2::shared_ptr sharedKSimple(new Cal3_S2(100, 100, 0, 0, 0));
+
+  Rot3 R = Rot3::identity();
+  Pose3 pose1 = Pose3(R, Point3(0, 0, 0));
+  Pose3 pose2 = Pose3(R, Point3(1, 0, 0));
+  Camera cam1(pose1, sharedKSimple), cam2(pose2, sharedKSimple);
+  Pose3 body_P_sensorId = Pose3::identity();
+
+  // one landmarks 1m in front of camera
+  Point3 landmark1(0, 0, 10);
+
+  Point2Vector measurements_lmk1;
+
+  // Project 2 landmarks into 2 cameras
+  measurements_lmk1.push_back(cam1.project(landmark1));
+  measurements_lmk1.push_back(cam2.project(landmark1));
+
+  size_t nrTests = 1000;
+
+  for(size_t i = 0; i<nrTests; i++){
+    SmartFactorRS::shared_ptr smartFactorRS(new SmartFactorRS(model));
+    double interp_factor = 0;  // equivalent to measurement taken at pose 1
+    smartFactorRS->add(measurements_lmk1[0], x1, x2, interp_factor, sharedKSimple,
+                       body_P_sensorId);
+    interp_factor = 1;  // equivalent to measurement taken at pose 2
+    smartFactorRS->add(measurements_lmk1[1], x1, x2, interp_factor, sharedKSimple,
+                       body_P_sensorId);
+
+    Values values;
+    values.insert(x1, pose1);
+    values.insert(x2, pose2);
+    gttic_(SF_RS_LINEARIZE);
+    smartFactorRS->linearize(values);
+    gttoc_(SF_RS_LINEARIZE);
+  }
+
+  for(size_t i = 0; i<nrTests; i++){
+    SmartFactor::shared_ptr smartFactor(new SmartFactor(model, sharedKSimple));
+    smartFactor->add(measurements_lmk1[0], x1);
+    smartFactor->add(measurements_lmk1[1], x2);
+
+    Values values;
+    values.insert(x1, pose1);
+    values.insert(x2, pose2);
+    gttic_(RS_LINEARIZE);
+    smartFactor->linearize(values);
+    gttoc_(RS_LINEARIZE);
+  }
+  tictoc_print_();
+}
+#endif
+
+/* ************************************************************************* */
+int main() {
+  TestResult tr;
+  return TestRegistry::runAllTests(tr);
+}
+/* ************************************************************************* */
+

--- a/gtsam_unstable/slam/tests/testSmartProjectionPoseFactorRollingShutter.cpp
+++ b/gtsam_unstable/slam/tests/testSmartProjectionPoseFactorRollingShutter.cpp
@@ -73,7 +73,7 @@ Camera cam3(interp_pose3, sharedK);
 }
 
 LevenbergMarquardtParams lmParams;
-typedef SmartProjectionPoseFactorRollingShutter<Cal3_S2> SmartFactorRS;
+typedef SmartProjectionPoseFactorRollingShutter< PinholePose<Cal3_S2> > SmartFactorRS;
 
 /* ************************************************************************* */
 TEST( SmartProjectionPoseFactorRollingShutter, Constructor) {
@@ -768,6 +768,213 @@ TEST( SmartProjectionPoseFactorRollingShutter, hessianComparedToProjFactorsRolli
   double actualError = smartFactor1->error(values);
   double expectedError = nfg_projFactorsRS.error(values);
   EXPECT_DOUBLES_EQUAL(expectedError, actualError, 1e-7);
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactorRollingShutter, hessianComparedToProjFactorsRollingShutter_measurementsFromSamePose) {
+  // in this test we make sure the fact works even if we have multiple pixel measurements of the same landmark
+  // at a single pose, a setup that occurs in multi-camera systems
+
+  using namespace vanillaPoseRS;
+  Point2Vector measurements_lmk1;
+
+  // Project three landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_lmk1);
+
+  // create redundant measurements:
+  Camera::MeasurementVector measurements_lmk1_redundant = measurements_lmk1;
+  measurements_lmk1_redundant.push_back(measurements_lmk1.at(0)); // we readd the first measurement
+
+  // create inputs
+  std::vector<std::pair<Key, Key>> key_pairs;
+  key_pairs.push_back(std::make_pair(x1, x2));
+  key_pairs.push_back(std::make_pair(x2, x3));
+  key_pairs.push_back(std::make_pair(x3, x1));
+  key_pairs.push_back(std::make_pair(x1, x2));
+
+  std::vector<double> interp_factors;
+  interp_factors.push_back(interp_factor1);
+  interp_factors.push_back(interp_factor2);
+  interp_factors.push_back(interp_factor3);
+  interp_factors.push_back(interp_factor1);
+
+  SmartFactorRS::shared_ptr smartFactor1(new SmartFactorRS(model));
+  smartFactor1->add(measurements_lmk1_redundant, key_pairs, interp_factors, sharedK);
+
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+                           Point3(0.1, 0.1, 0.1));  // smaller noise
+  Values values;
+  values.insert(x1, level_pose);
+  values.insert(x2, pose_right);
+  // initialize third pose with some noise to get a nontrivial linearization point
+  values.insert(x3, pose_above * noise_pose);
+  EXPECT(  // check that the pose is actually noisy
+      assert_equal( Pose3( Rot3(0, -0.0314107591, 0.99950656, -0.99950656, -0.0313952598, -0.000986635786, 0.0314107591, -0.999013364, -0.0313952598), Point3(0.1, -0.1, 1.9)), values.at<Pose3>(x3)));
+
+  // linearization point for the poses
+  Pose3 pose1 = level_pose;
+  Pose3 pose2 = pose_right;
+  Pose3 pose3 = pose_above * noise_pose;
+
+  // ==== check Hessian of smartFactor1 =====
+  // -- compute actual Hessian
+  boost::shared_ptr<GaussianFactor> linearfactor1 = smartFactor1->linearize(
+      values);
+  Matrix actualHessian = linearfactor1->information();
+
+  // -- compute expected Hessian from manual Schur complement from Jacobians
+  // linearization point for the 3D point
+  smartFactor1->triangulateSafe(smartFactor1->cameras(values));
+  TriangulationResult point = smartFactor1->point();
+  EXPECT(point.valid());  // check triangulated point is valid
+
+  // Use standard ProjectionFactorRollingShutter factor to calculate the Jacobians
+  Matrix F = Matrix::Zero(2 * 4, 6 * 3);
+  Matrix E = Matrix::Zero(2 * 4, 3);
+  Vector b = Vector::Zero(8);
+
+  // create projection factors rolling shutter
+  ProjectionFactorRollingShutter factor11(measurements_lmk1_redundant[0], interp_factor1,
+                                          model, x1, x2, l0, sharedK);
+  Matrix H1Actual, H2Actual, H3Actual;
+  // note: b is minus the reprojection error, cf the smart factor jacobian computation
+  b.segment<2>(0) = -factor11.evaluateError(pose1, pose2, *point, H1Actual, H2Actual, H3Actual);
+  F.block<2, 6>(0, 0) = H1Actual;
+  F.block<2, 6>(0, 6) = H2Actual;
+  E.block<2, 3>(0, 0) = H3Actual;
+
+  ProjectionFactorRollingShutter factor12(measurements_lmk1_redundant[1], interp_factor2,
+                                          model, x2, x3, l0, sharedK);
+  b.segment<2>(2) = -factor12.evaluateError(pose2, pose3, *point, H1Actual, H2Actual, H3Actual);
+  F.block<2, 6>(2, 6) = H1Actual;
+  F.block<2, 6>(2, 12) = H2Actual;
+  E.block<2, 3>(2, 0) = H3Actual;
+
+  ProjectionFactorRollingShutter factor13(measurements_lmk1_redundant[2], interp_factor3,
+                                          model, x3, x1, l0, sharedK);
+  b.segment<2>(4) = -factor13.evaluateError(pose3, pose1, *point, H1Actual, H2Actual, H3Actual);
+  F.block<2, 6>(4, 12) = H1Actual;
+  F.block<2, 6>(4, 0) = H2Actual;
+  E.block<2, 3>(4, 0) = H3Actual;
+
+  ProjectionFactorRollingShutter factor14(measurements_lmk1_redundant[3], interp_factor1,
+                                          model, x1, x2, l0, sharedK);
+  b.segment<2>(6) = -factor11.evaluateError(pose1, pose2, *point, H1Actual, H2Actual, H3Actual);
+  F.block<2, 6>(6, 0) = H1Actual;
+  F.block<2, 6>(6, 6) = H2Actual;
+  E.block<2, 3>(6, 0) = H3Actual;
+
+  // whiten
+  F = (1/sigma) * F;
+  E = (1/sigma) * E;
+  b = (1/sigma) * b;
+  //* G = F' * F - F' * E * P * E' * F
+  Matrix P = (E.transpose() * E).inverse();
+  Matrix expectedHessian = F.transpose() * F
+      - (F.transpose() * E * P * E.transpose() * F);
+  EXPECT(assert_equal(expectedHessian, actualHessian, 1e-6));
+
+  // ==== check Information vector of smartFactor1 =====
+  GaussianFactorGraph gfg;
+  gfg.add(linearfactor1);
+  Matrix actualHessian_v2 = gfg.hessian().first;
+  EXPECT(assert_equal(actualHessian_v2, actualHessian, 1e-6)); // sanity check on hessian
+
+  // -- compute actual information vector
+  Vector actualInfoVector = gfg.hessian().second;
+
+  // -- compute expected information vector from manual Schur complement from Jacobians
+  //* g = F' * (b - E * P * E' * b)
+  Vector expectedInfoVector = F.transpose() * (b - E * P * E.transpose() * b);
+  EXPECT(assert_equal(expectedInfoVector, actualInfoVector, 1e-6));
+
+  // ==== check error of smartFactor1 (again) =====
+  NonlinearFactorGraph nfg_projFactorsRS;
+  nfg_projFactorsRS.add(factor11);
+  nfg_projFactorsRS.add(factor12);
+  nfg_projFactorsRS.add(factor13);
+  nfg_projFactorsRS.add(factor14);
+  values.insert(l0, *point);
+
+  double actualError = smartFactor1->error(values);
+  double expectedError = nfg_projFactorsRS.error(values);
+  EXPECT_DOUBLES_EQUAL(expectedError, actualError, 1e-7);
+}
+
+/* *************************************************************************/
+TEST( SmartProjectionPoseFactorRollingShutter, optimization_3poses_measurementsFromSamePose ) {
+
+  using namespace vanillaPoseRS;
+  Point2Vector measurements_lmk1, measurements_lmk2, measurements_lmk3;
+
+  // Project three landmarks into three cameras
+  projectToMultipleCameras(cam1, cam2, cam3, landmark1, measurements_lmk1);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark2, measurements_lmk2);
+  projectToMultipleCameras(cam1, cam2, cam3, landmark3, measurements_lmk3);
+
+  // create inputs
+  std::vector<std::pair<Key,Key>> key_pairs;
+  key_pairs.push_back(std::make_pair(x1,x2));
+  key_pairs.push_back(std::make_pair(x2,x3));
+  key_pairs.push_back(std::make_pair(x3,x1));
+
+  std::vector<double> interp_factors;
+  interp_factors.push_back(interp_factor1);
+  interp_factors.push_back(interp_factor2);
+  interp_factors.push_back(interp_factor3);
+
+  // For first factor, we create redundant measurement (taken by the same keys as factor 1, to
+  // make sure the redundancy in the keys does not create problems)
+  Camera::MeasurementVector& measurements_lmk1_redundant = measurements_lmk1;
+  measurements_lmk1_redundant.push_back(measurements_lmk1.at(0)); // we readd the first measurement
+  std::vector<std::pair<Key,Key>> key_pairs_redundant = key_pairs;
+  key_pairs_redundant.push_back(key_pairs.at(0)); // we readd the first pair of keys
+  std::vector<double> interp_factors_redundant = interp_factors;
+  interp_factors_redundant.push_back(interp_factors.at(0));// we readd the first interp factor
+
+  SmartFactorRS::shared_ptr smartFactor1(new SmartFactorRS(model));
+  smartFactor1->add(measurements_lmk1_redundant, key_pairs_redundant, interp_factors_redundant, sharedK);
+
+  SmartFactorRS::shared_ptr smartFactor2(new SmartFactorRS(model));
+  smartFactor2->add(measurements_lmk2, key_pairs, interp_factors, sharedK);
+
+  SmartFactorRS::shared_ptr smartFactor3(new SmartFactorRS(model));
+  smartFactor3->add(measurements_lmk3, key_pairs, interp_factors, sharedK);
+
+  const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
+
+  NonlinearFactorGraph graph;
+  graph.push_back(smartFactor1);
+  graph.push_back(smartFactor2);
+  graph.push_back(smartFactor3);
+  graph.addPrior(x1, level_pose, noisePrior);
+  graph.addPrior(x2, pose_right, noisePrior);
+
+  Values groundTruth;
+  groundTruth.insert(x1, level_pose);
+  groundTruth.insert(x2, pose_right);
+  groundTruth.insert(x3, pose_above);
+  DOUBLES_EQUAL(0, graph.error(groundTruth), 1e-9);
+
+  //  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI/10, 0., -M_PI/10), Point3(0.5,0.1,0.3)); // noise from regular projection factor test below
+  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 100, 0., -M_PI / 100),
+                           Point3(0.1, 0.1, 0.1)); // smaller noise
+  Values values;
+  values.insert(x1, level_pose);
+  values.insert(x2, pose_right);
+  // initialize third pose with some noise, we expect it to move back to original pose_above
+  values.insert(x3, pose_above * noise_pose);
+  EXPECT( // check that the pose is actually noisy
+      assert_equal(
+          Pose3(
+              Rot3(0, -0.0314107591, 0.99950656, -0.99950656, -0.0313952598,
+                   -0.000986635786, 0.0314107591, -0.999013364, -0.0313952598),
+                   Point3(0.1, -0.1, 1.9)), values.at<Pose3>(x3)));
+
+  Values result;
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  result = optimizer.optimize();
+  EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-5));
 }
 
 #ifndef DISABLE_TIMING


### PR DESCRIPTION
This is a preliminary PR that will allow using other camera models (e.g., omnidirectional instead of pinhole) in the smart projection factors. This PR involves changing the smart factor template from CALIBRATION to CAMERA (strangely, the template argument is already CAMERA in the base classes, but becomes CALIBRATION in the final factors). Factors to be changed:

- [ ] SmartProjectionPoseFactor
- [ ] possibly simplify all Stereo factors by templating on StereoCamera 