### PR TITLE
Fix Python Tests Cmake

### DIFF
--- a/.github/scripts/python.sh
+++ b/.github/scripts/python.sh
@@ -85,4 +85,4 @@ make -j2 install
 cd $GITHUB_WORKSPACE/build/python
 $PYTHON setup.py install --user --prefix=
 cd $GITHUB_WORKSPACE/python/gtsam/tests
-$PYTHON -m unittest discover
+$PYTHON -m unittest discover -v

--- a/gtsam/basis/Fourier.h
+++ b/gtsam/basis/Fourier.h
@@ -40,9 +40,13 @@ class GTSAM_EXPORT FourierBasis : public Basis<FourierBasis> {
   static Weights CalculateWeights(size_t N, double x) {
     Weights b(N);
     b[0] = 1;
-    for (size_t i = 1, n = 1; i < N; i += 2, n++) {
-      b[i] = cos(n * x);
-      b[i + 1] = sin(n * x);
+    for (size_t i = 1, n = 1; i < N; i++) {
+      if (i % 2 == 1) {
+        b[i] = cos(n * x);
+      } else {
+        b[i] = sin(n * x);
+        n++;
+      }
     }
     return b;
   }

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -166,5 +166,6 @@ add_custom_target(
         COMMAND
           ${CMAKE_COMMAND} -E env # add package to python path so no need to install
           "PYTHONPATH=${GTSAM_PYTHON_BUILD_DIRECTORY}/$ENV{PYTHONPATH}"
-          ${PYTHON_EXECUTABLE} -m unittest discover -s "${GTSAM_PYTHON_BUILD_DIRECTORY}/gtsam/tests"
-          DEPENDS ${GTSAM_PYTHON_DEPENDENCIES})
+          ${PYTHON_EXECUTABLE} -m unittest discover -v -s .
+          DEPENDS ${GTSAM_PYTHON_DEPENDENCIES}
+          WORKING_DIRECTORY "${GTSAM_PYTHON_BUILD_DIRECTORY}/gtsam/tests")

--- a/python/gtsam/tests/test_basis.py
+++ b/python/gtsam/tests/test_basis.py
@@ -19,39 +19,77 @@ from gtsam.symbol_shorthand import B
 
 class TestBasis(GtsamTestCase):
     """
-    Tests Basis module python bindings.
+    Tests FitBasis python binding for FourierBasis, Chebyshev1Basis, Chebyshev2Basis, and Chebyshev2.
+    
+    It tests FitBasis by fitting to a ground-truth function that can be represented exactly in
+    the basis, then checking that the regression (fit result) matches the function.  For the
+    Chebyshev bases, the line y=x is used to generate the data while for Fourier, 0.7*cos(x) is
+    used.
     """
-    def test_fit_basis(self):
+    def setUp(self):
+        self.N = 2
+        self.x = [0., 0.5, 0.75]
+        self.interpx = np.linspace(0., 1., 10)
+        self.noise = gtsam.noiseModel.Unit.Create(1)
+
+    def evaluate(self, basis, fitparams, x):
         """
-        Tests FitBasis python binding for FourierBasis, Chebyshev1Basis, Chebyshev2Basis, and
-        Chebyshev2.
-        It tests FitBasis by fitting to a ground-truth function that can be represented exactly in
-        the basis, then checking that the regression (fit result) matches the function.  For the
-        Chebyshev bases, the line y=x is used to generate the data while for Fourier, 0.7*cos(x) is
-        used.
+        Until wrapper for Basis functors are ready,
+        this is how to evaluate a basis function.
         """
-        f = lambda x: x  # line y = x
-        N = 2
-        datax = [0., 0.5, 0.75]
-        interpx = np.linspace(0., 1., 10)
-        noise = gtsam.noiseModel.Unit.Create(1)
+        return basis.WeightMatrix(self.N, x) @ fitparams
 
-        def evaluate(basis, fitparams, x):
-            # until wrapper for Basis functors are ready, this is how to evaluate a basis function.
-            return basis.WeightMatrix(N, x) @ fitparams
+    def fit_basis_helper(self, fitter, basis, f=lambda x: x):
+        """Helper method to fit data to a specified fitter using a specified basis."""
+        data = {x: f(x) for x in self.x}
+        fit = fitter(data, self.noise, self.N)
+        coeff = fit.parameters()
+        interpy = self.evaluate(basis, coeff, self.interpx)
+        return interpy
 
-        def testBasis(fitter, basis, f=f):
-            # test a basis by checking that the fit result matches the function at x-values interpx.
-            data = {x: f(x) for x in datax}
-            fit = fitter(data, noise, N)
-            coeff = fit.parameters()
-            interpy = evaluate(basis, coeff, interpx)
-            np.testing.assert_almost_equal(interpy, np.array([f(x) for x in interpx]), decimal=7)
+    def test_fit_basis_fourier(self):
+        """Fit a Fourier basis."""
 
-        testBasis(gtsam.FitBasisFourierBasis, gtsam.FourierBasis, f=lambda x: 0.7 * np.cos(x))
-        testBasis(gtsam.FitBasisChebyshev1Basis, gtsam.Chebyshev1Basis)
-        testBasis(gtsam.FitBasisChebyshev2Basis, gtsam.Chebyshev2Basis)
-        testBasis(gtsam.FitBasisChebyshev2, gtsam.Chebyshev2)
+        f = lambda x: 0.7 * np.cos(x)
+        interpy = self.fit_basis_helper(gtsam.FitBasisFourierBasis,
+                                        gtsam.FourierBasis, f)
+        # test a basis by checking that the fit result matches the function at x-values interpx.
+        np.testing.assert_almost_equal(interpy,
+                                       np.array([f(x) for x in self.interpx]),
+                                       decimal=7)
+
+    def test_fit_basis_chebyshev1basis(self):
+        """Fit a Chebyshev1 basis."""
+
+        f = lambda x: x
+        interpy = self.fit_basis_helper(gtsam.FitBasisChebyshev1Basis,
+                                        gtsam.Chebyshev1Basis, f)
+        # test a basis by checking that the fit result matches the function at x-values interpx.
+        np.testing.assert_almost_equal(interpy,
+                                       np.array([f(x) for x in self.interpx]),
+                                       decimal=7)
+
+    def test_fit_basis_chebyshev2basis(self):
+        """Fit a Chebyshev2 basis."""
+
+        f = lambda x: x
+        interpy = self.fit_basis_helper(gtsam.FitBasisChebyshev2Basis,
+                                        gtsam.Chebyshev2Basis)
+        # test a basis by checking that the fit result matches the function at x-values interpx.
+        np.testing.assert_almost_equal(interpy,
+                                       np.array([f(x) for x in self.interpx]),
+                                       decimal=7)
+
+    def test_fit_basis_chebyshev2(self):
+        """Fit a Chebyshev2 pseudospectral basis."""
+
+        f = lambda x: x
+        interpy = self.fit_basis_helper(gtsam.FitBasisChebyshev2,
+                                        gtsam.Chebyshev2)
+        # test a basis by checking that the fit result matches the function at x-values interpx.
+        np.testing.assert_almost_equal(interpy,
+                                       np.array([f(x) for x in self.interpx]),
+                                       decimal=7)
 
 
 if __name__ == "__main__":

--- a/python/gtsam/tests/test_basis.py
+++ b/python/gtsam/tests/test_basis.py
@@ -18,10 +18,12 @@ from gtsam.symbol_shorthand import B
 
 
 class TestBasis(GtsamTestCase):
-    """Tests Basis module python bindings
+    """
+    Tests Basis module python bindings.
     """
     def test_fit_basis(self):
-        """Tests FitBasis python binding for FourierBasis, Chebyshev1Basis, Chebyshev2Basis, and
+        """
+        Tests FitBasis python binding for FourierBasis, Chebyshev1Basis, Chebyshev2Basis, and
         Chebyshev2.
         It tests FitBasis by fitting to a ground-truth function that can be represented exactly in
         the basis, then checking that the regression (fit result) matches the function.  For the


### PR DESCRIPTION
Updated the CMake so that the tests are verbose and easy to debug.

I also have some doubts about the working directory for the tests so updated that. Ever since I've done that, I haven't encountered any segfaults (was getting plenty of these before).

@gchenfc I am merging this into your `tests/basis_python` branch so we can debug whatever is going on there.