### PR TITLE
Added virtual destructor and re-formatted constructors

### DIFF
--- a/gtsam/inference/BayesTreeCliqueBase.h
+++ b/gtsam/inference/BayesTreeCliqueBase.h
@@ -70,16 +70,23 @@ namespace gtsam {
     /// @name Standard Constructors
     /// @{
 
-    /** Default constructor */
+    /// Default constructor
     BayesTreeCliqueBase() : problemSize_(1) {}
 
-    /** Construct from a conditional, leaving parent and child pointers uninitialized */
-    BayesTreeCliqueBase(const sharedConditional& conditional) : conditional_(conditional), problemSize_(1) {}
+    /// Construct from a conditional, leaving parent and child pointers
+    /// uninitialized.
+    BayesTreeCliqueBase(const sharedConditional& conditional)
+        : conditional_(conditional), problemSize_(1) {}
 
-    /** Shallow copy constructor */
-    BayesTreeCliqueBase(const BayesTreeCliqueBase& c) : conditional_(c.conditional_), parent_(c.parent_), children(c.children), problemSize_(c.problemSize_), is_root(c.is_root) {}
+    /// Shallow copy constructor.
+    BayesTreeCliqueBase(const BayesTreeCliqueBase& c)
+        : conditional_(c.conditional_),
+          parent_(c.parent_),
+          children(c.children),
+          problemSize_(c.problemSize_),
+          is_root(c.is_root) {}
 
-    /** Shallow copy assignment constructor */
+    /// Shallow copy assignment constructor
     BayesTreeCliqueBase& operator=(const BayesTreeCliqueBase& c) {
       conditional_ = c.conditional_;
       parent_ = c.parent_;
@@ -88,6 +95,9 @@ namespace gtsam {
       is_root = c.is_root;
       return *this;
     }
+
+    // Virtual destructor.
+    virtual ~BayesTreeCliqueBase() {}
 
     /// @}
 
@@ -119,7 +129,9 @@ namespace gtsam {
     bool equals(const DERIVED& other, double tol = 1e-9) const;
 
     /** print this node */
-    virtual void print(const std::string& s = "", const KeyFormatter& keyFormatter = DefaultKeyFormatter) const;
+    virtual void print(
+        const std::string& s = "",
+        const KeyFormatter& keyFormatter = DefaultKeyFormatter) const;
 
     /// @}
     /// @name Standard Interface


### PR DESCRIPTION
I saw a warning (output below) when I did make check on the latest develop, so I fixed it by adding a virtual constructor.

```
Consolidate compiler generated dependencies of target testFactorTesting
[ 65%] Building CXX object gtsam/nonlinear/tests/CMakeFiles/testFactorTesting.dir/testFactorTesting.cpp.o
In file included from /Users/dellaert/git/gtsam/gtsam/nonlinear/tests/testSerializationNonlinear.cpp:19:
In file included from /Users/dellaert/git/gtsam/gtsam/nonlinear/Values.h:27:
In file included from /Users/dellaert/git/gtsam/gtsam/base/GenericValue.h:22:
In file included from /Users/dellaert/git/gtsam/gtsam/base/Manifold.h:22:
In file included from /Users/dellaert/git/gtsam/gtsam/base/Matrix.h:28:
In file included from /Users/dellaert/git/gtsam/gtsam/base/Vector.h:267:
In file included from /opt/homebrew/include/boost/serialization/nvp.hpp:35:
In file included from /opt/homebrew/include/boost/serialization/split_free.hpp:22:
In file included from /opt/homebrew/include/boost/serialization/serialization.hpp:43:
/opt/homebrew/include/boost/serialization/access.hpp:123:9: warning: delete called on non-final 'gtsam::BayesTreeCliqueBase<gtsam::ISAM2Clique, gtsam::GaussianFactorGraph>' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
        delete const_cast<T *>(t);
        ^
/opt/homebrew/include/boost/serialization/extended_type_info_typeid.hpp:135:39: note: in instantiation of function template specialization 'boost::serialization::access::destroy<gtsam::BayesTreeCliqueBase<gtsam::ISAM2Clique, gtsam::GaussianFactorGraph>>' requested here
        boost::serialization::access::destroy(
                                      ^
/opt/homebrew/include/boost/serialization/singleton.hpp:147:5: note: in instantiation of member function 'boost::serialization::extended_type_info_typeid<gtsam::BayesTreeCliqueBase<gtsam::ISAM2Clique, gtsam::GaussianFactorGraph>>::destroy' requested here
    singleton_wrapper(){
    ^
/opt/homebrew/include/boost/serialization/singleton.hpp:171:47: note: in instantiation of member function 'boost::serialization::detail::singleton_wrapper<boost::serialization::extended_type_info_typeid<gtsam::BayesTreeCliqueBase<gtsam::ISAM2Clique, gtsam::GaussianFactorGraph>>>::singleton_wrapper' requested here
        static detail::singleton_wrapper< T > t;
                                              ^
/opt/homebrew/include/boost/serialization/singleton.hpp:196:16: note: in instantiation of member function 'boost::serialization::singleton<boost::serialization::extended_type_info_typeid<gtsam::BayesTreeCliqueBase<gtsam::ISAM2Clique, gtsam::GaussianFactorGraph>>>::get_instance' requested here
        return get_instance();
               ^
/opt/homebrew/include/boost/serialization/void_cast.hpp:193:49: note: in instantiation of member function 'boost::serialization::singleton<boost::serialization::extended_type_info_typeid<gtsam::BayesTreeCliqueBase<gtsam::ISAM2Clique, gtsam::GaussianFactorGraph>>>::get_const_instance' requested here
        & type_info_implementation<Base>::type::get_const_instance(),
                                                ^
/opt/homebrew/include/boost/serialization/singleton.hpp:147:5: note: (skipping 185 contexts in backtrace; use -ftemplate-backtrace-limit=0 to see all)
    singleton_wrapper(){
    ^
/opt/homebrew/include/boost/archive/detail/common_oarchive.hpp:71:18: note: in instantiation of function template specialization 'boost::archive::save<boost::archive::binary_oarchive, const gtsam::ISAM2>' requested here
        archive::save(* this->This(), t);
                 ^
/opt/homebrew/include/boost/archive/basic_binary_oarchive.hpp:80:37: note: in instantiation of function template specialization 'boost::archive::detail::common_oarchive<boost::archive::binary_oarchive>::save_override<const gtsam::ISAM2>' requested here
      this->detail_common_oarchive::save_override(t);
                                    ^
/opt/homebrew/include/boost/archive/binary_oarchive_impl.hpp:59:47: note: in instantiation of function template specialization 'boost::archive::basic_binary_oarchive<boost::archive::binary_oarchive>::save_override<gtsam::ISAM2>' requested here
        this->basic_binary_oarchive<Archive>::save_override(t);
                                              ^
/opt/homebrew/include/boost/archive/detail/interface_oarchive.hpp:70:23: note: in instantiation of function template specialization 'boost::archive::binary_oarchive_impl<boost::archive::binary_oarchive, char, std::__1::char_traits<char>>::save_override<const gtsam::ISAM2>' requested here
        this->This()->save_override(t);
                      ^
/Users/dellaert/git/gtsam/gtsam/nonlinear/tests/testSerializationNonlinear.cpp:136:19: note: in instantiation of function template specialization 'boost::archive::detail::interface_oarchive<boost::archive::binary_oarchive>::operator<<<gtsam::ISAM2>' requested here
    outputArchive << solver;
                  ^
```