### PR TITLE
Fix dangling reference in static allocation.

### DIFF
--- a/gtsam/slam/lago.cpp
+++ b/gtsam/slam/lago.cpp
@@ -36,7 +36,7 @@ static const Matrix I = I_1x1;
 static const Matrix I3 = I_3x3;
 
 static const noiseModel::Diagonal::shared_ptr priorOrientationNoise =
-    noiseModel::Diagonal::Sigmas((Vector(1) << 0).finished());
+    noiseModel::Diagonal::Sigmas(Vector1(0));
 static const noiseModel::Diagonal::shared_ptr priorPose2Noise =
     noiseModel::Diagonal::Variances(Vector3(1e-6, 1e-6, 1e-8));
 


### PR DESCRIPTION
This line caused a segfault on static object construction. Details and discussion on https://github.com/clearpathrobotics/gtsam/pull/1. Backtrace is similar to #75, but issue persisted with `march=native` and without, also confirmed that all libraries are using the exact same compilation flags.

Fyi @efernandez