### PR TITLE
Use Eigen expressions more effectively and kill & in code.

### DIFF
--- a/gtsam/geometry/Pose3.cpp
+++ b/gtsam/geometry/Pose3.cpp
@@ -85,20 +85,20 @@ Vector6 Pose3::Adjoint(const Vector6& xi_b, OptionalJacobian<6, 6> H_pose,
 /// The dual version of Adjoint
 Vector6 Pose3::AdjointTranspose(const Vector6& x, OptionalJacobian<6, 6> H_pose,
                                 OptionalJacobian<6, 6> H_x) const {
-  const Matrix6 &AdT = AdjointMap().transpose();
-  const Vector6 &AdTx = AdT * x;
+  const Matrix6 Ad = AdjointMap();
+  const Vector6 AdTx = Ad.transpose() * x;
 
   // Jacobians
   // See docs/math.pdf for more details.
   if (H_pose) {
-    const auto &w_T_hat = skewSymmetric(AdTx.head<3>()),
-               &v_T_hat = skewSymmetric(AdTx.tail<3>());
+    const auto w_T_hat = skewSymmetric(AdTx.head<3>()),
+               v_T_hat = skewSymmetric(AdTx.tail<3>());
     *H_pose = (Matrix6() << w_T_hat, v_T_hat,  //
                /*        */ v_T_hat, Z_3x3)
                   .finished();
   }
   if (H_x) {
-    *H_x = AdT;
+    *H_x = Ad.transpose();
   }
 
   return AdTx;

--- a/gtsam/geometry/Pose3.cpp
+++ b/gtsam/geometry/Pose3.cpp
@@ -93,9 +93,8 @@ Vector6 Pose3::AdjointTranspose(const Vector6& x, OptionalJacobian<6, 6> H_pose,
   if (H_pose) {
     const auto w_T_hat = skewSymmetric(AdTx.head<3>()),
                v_T_hat = skewSymmetric(AdTx.tail<3>());
-    *H_pose = (Matrix6() << w_T_hat, v_T_hat,  //
-               /*        */ v_T_hat, Z_3x3)
-                  .finished();
+    *H_pose << w_T_hat, v_T_hat,  //
+        /*  */ v_T_hat, Z_3x3;
   }
   if (H_x) {
     *H_x = Ad.transpose();


### PR DESCRIPTION
Quick edit on @gchenfc 's recent PR #433 
Be careful with having references for local variables. That's for arguments, not things on the stack. Also, though counter-intuitive I think doing transpose() twice here is actually more efficient as it will not actually store the transpose internally, which you forced. Read about Eigen expressions and tell me if I'm wrong :-)