### PR TITLE
Enable pickling

### DIFF
--- a/gtsam/linear/NoiseModel.h
+++ b/gtsam/linear/NoiseModel.h
@@ -177,16 +177,15 @@ namespace gtsam {
         return *sqrt_information_;
       }
 
-    protected:
-
-      /** protected constructor takes square root information matrix */
-      Gaussian(size_t dim = 1, const boost::optional<Matrix>& sqrt_information = boost::none) :
-        Base(dim), sqrt_information_(sqrt_information) {
-      }
 
     public:
 
       typedef boost::shared_ptr<Gaussian> shared_ptr;
+
+      /** constructor takes square root information matrix */
+      Gaussian(size_t dim = 1,
+               const boost::optional<Matrix>& sqrt_information = boost::none)
+          : Base(dim), sqrt_information_(sqrt_information) {}
 
       ~Gaussian() override {}
 
@@ -290,13 +289,13 @@ namespace gtsam {
       Vector sigmas_, invsigmas_, precisions_;
 
     protected:
-      /** protected constructor - no initializations */
-      Diagonal();
 
       /** constructor to allow for disabling initialization of invsigmas */
       Diagonal(const Vector& sigmas);
 
     public:
+      /** constructor - no initializations, for serialization */
+      Diagonal();
 
       typedef boost::shared_ptr<Diagonal> shared_ptr;
 
@@ -388,14 +387,6 @@ namespace gtsam {
       Vector mu_; ///< Penalty function weight - needs to be large enough to dominate soft constraints
 
       /**
-       * protected constructor takes sigmas.
-       * prevents any inf values
-       * from appearing in invsigmas or precisions.
-       * mu set to large default value (1000.0)
-       */
-      Constrained(const Vector& sigmas = Z_1x1);
-
-      /**
        * Constructor that prevents any inf values
        * from appearing in invsigmas or precisions.
        * Allows for specifying mu.
@@ -405,6 +396,14 @@ namespace gtsam {
     public:
 
       typedef boost::shared_ptr<Constrained> shared_ptr;
+
+      /**
+       * protected constructor takes sigmas.
+       * prevents any inf values
+       * from appearing in invsigmas or precisions.
+       * mu set to large default value (1000.0)
+       */
+      Constrained(const Vector& sigmas = Z_1x1);
 
       ~Constrained() override {}
 
@@ -531,10 +530,10 @@ namespace gtsam {
       Isotropic(size_t dim, double sigma) :
         Diagonal(Vector::Constant(dim, sigma)),sigma_(sigma),invsigma_(1.0/sigma) {}
 
+    public:
+
       /* dummy constructor to allow for serialization */
       Isotropic() : Diagonal(Vector1::Constant(1.0)),sigma_(1.0),invsigma_(1.0) {}
-
-    public:
 
       ~Isotropic() override {}
 
@@ -592,13 +591,12 @@ namespace gtsam {
      * Unit: i.i.d. unit-variance noise on all m dimensions.
      */
     class GTSAM_EXPORT Unit : public Isotropic {
-    protected:
-
-      Unit(size_t dim=1): Isotropic(dim,1.0) {}
-
     public:
 
       typedef boost::shared_ptr<Unit> shared_ptr;
+
+      /** constructor for serialization */
+      Unit(size_t dim=1): Isotropic(dim,1.0) {}
 
       ~Unit() override {}
 

--- a/gtsam/linear/linear.i
+++ b/gtsam/linear/linear.i
@@ -34,6 +34,9 @@ virtual class Gaussian : gtsam::noiseModel::Base {
 
   // enabling serialization functionality
   void serializable() const;
+
+  // enable pickling in python
+  void pickle() const;
 };
 
 virtual class Diagonal : gtsam::noiseModel::Gaussian {
@@ -49,6 +52,9 @@ virtual class Diagonal : gtsam::noiseModel::Gaussian {
 
   // enabling serialization functionality
   void serializable() const;
+
+  // enable pickling in python
+  void pickle() const;
 };
 
 virtual class Constrained : gtsam::noiseModel::Diagonal {
@@ -66,6 +72,9 @@ virtual class Constrained : gtsam::noiseModel::Diagonal {
 
     // enabling serialization functionality
     void serializable() const;
+
+    // enable pickling in python
+    void pickle() const;
 };
 
 virtual class Isotropic : gtsam::noiseModel::Diagonal {
@@ -78,6 +87,9 @@ virtual class Isotropic : gtsam::noiseModel::Diagonal {
 
   // enabling serialization functionality
   void serializable() const;
+
+  // enable pickling in python
+  void pickle() const;
 };
 
 virtual class Unit : gtsam::noiseModel::Isotropic {
@@ -85,6 +97,9 @@ virtual class Unit : gtsam::noiseModel::Isotropic {
 
   // enabling serialization functionality
   void serializable() const;
+
+  // enable pickling in python
+  void pickle() const;
 };
 
 namespace mEstimator {

--- a/gtsam/navigation/navigation.i
+++ b/gtsam/navigation/navigation.i
@@ -41,6 +41,12 @@ class ConstantBias {
   Vector gyroscope() const;
   Vector correctAccelerometer(Vector measurement) const;
   Vector correctGyroscope(Vector measurement) const;
+
+  // enabling serialization functionality
+  void serialize() const;
+
+  // enable pickling in python
+  void pickle() const;
 };
 
 }///\namespace imuBias
@@ -64,6 +70,12 @@ class NavState {
 
   gtsam::NavState retract(const Vector& x) const;
   Vector localCoordinates(const gtsam::NavState& g) const;
+
+  // enabling serialization functionality
+  void serialize() const;
+
+  // enable pickling in python
+  void pickle() const;
 };
 
 #include <gtsam/navigation/PreintegratedRotation.h>
@@ -106,6 +118,12 @@ virtual class PreintegrationParams : gtsam::PreintegratedRotationParams {
   Matrix getAccelerometerCovariance() const;
   Matrix getIntegrationCovariance()   const;
   bool   getUse2ndOrderCoriolis()     const;
+
+  // enabling serialization functionality
+  void serialize() const;
+
+  // enable pickling in python
+  void pickle() const;
 };
 
 #include <gtsam/navigation/ImuFactor.h>
@@ -135,6 +153,12 @@ class PreintegratedImuMeasurements {
   Vector biasHatVector() const;
   gtsam::NavState predict(const gtsam::NavState& state_i,
       const gtsam::imuBias::ConstantBias& bias) const;
+
+  // enabling serialization functionality
+  void serialize() const;
+
+  // enable pickling in python
+  void pickle() const;
 };
 
 virtual class ImuFactor: gtsam::NonlinearFactor {


### PR DESCRIPTION
Enable pickling so we can deep copy a bunch of things in the Python wrapper.

The wrapper expects declaration of the `pickle` method in the interface file and will use the underlying `serialize` method of the class. The wrapper has had this feature for a while, but the classes updated in this PR didn't have the pickling enabled.