### PR TITLE
Minor fixes to fix some warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .idea
 *.pyc
 *.DS_Store
+*.swp
 /examples/Data/dubrovnik-3-7-pre-rewritten.txt
 /examples/Data/pose2example-rewritten.txt
 /examples/Data/pose3example-rewritten.txt

--- a/gtsam/geometry/Similarity3.cpp
+++ b/gtsam/geometry/Similarity3.cpp
@@ -40,8 +40,8 @@ static Point3Pairs subtractCentroids(const Point3Pairs &abPointPairs,
 }
 
 /// Form inner products x and y and calculate scale.
-static const double calculateScale(const Point3Pairs &d_abPointPairs,
-                                   const Rot3 &aRb) {
+static double calculateScale(const Point3Pairs &d_abPointPairs,
+                             const Rot3 &aRb) {
   double x = 0, y = 0;
   Point3 da, db;
   for (const Point3Pair& d_abPair : d_abPointPairs) {

--- a/gtsam/inference/BayesTree.h
+++ b/gtsam/inference/BayesTree.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <boost/shared_ptr.hpp>
+
 #include <gtsam/inference/Key.h>
 #include <gtsam/base/FastList.h>
 #include <gtsam/base/ConcurrentMap.h>

--- a/gtsam/inference/Factor.h
+++ b/gtsam/inference/Factor.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <boost/serialization/nvp.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <gtsam/base/types.h>
 #include <gtsam/base/FastVector.h>

--- a/gtsam/slam/dataset.cpp
+++ b/gtsam/slam/dataset.cpp
@@ -392,7 +392,7 @@ parseMeasurements(const std::string &filename,
                   size_t maxIndex) {
   ParseMeasurement<Pose2> parse{model ? createSampler(model) : nullptr,
                                 maxIndex, true, NoiseFormatAUTO,
-                                KernelFunctionTypeNONE};
+                                KernelFunctionTypeNONE, nullptr};
   return parseToVector<BinaryMeasurement<Pose2>>(filename, parse);
 }
 


### PR DESCRIPTION
When I was building gtsam with my build system and my compiler flags I got a bunch or errors:
- return type should not be const `static const double fn()` --> `static double fn()`
- missing shared_ptr includes in 2 files
- missing arg in initializer list when initializing `ParseMeasurement<Pose2>`

I also added `*.swp` to `.gitignore` to ignore vim swp files.