### PR TITLE
add missing interface for PoseTranslationPrior

### DIFF
--- a/gtsam/slam/slam.i
+++ b/gtsam/slam/slam.i
@@ -168,6 +168,13 @@ template <POSE>
 virtual class PoseTranslationPrior : gtsam::NoiseModelFactor {
   PoseTranslationPrior(size_t key, const POSE& pose_z,
                        const gtsam::noiseModel::Base* noiseModel);
+  POSE measured() const;
+
+  // enabling serialization functionality
+  void serialize() const;
+
+  // enable pickling in python
+  void pickle() const;
 };
 
 typedef gtsam::PoseTranslationPrior<gtsam::Pose2> PoseTranslationPrior2D;
@@ -178,6 +185,7 @@ template <POSE>
 virtual class PoseRotationPrior : gtsam::NoiseModelFactor {
   PoseRotationPrior(size_t key, const POSE& pose_z,
                     const gtsam::noiseModel::Base* noiseModel);
+  POSE measured() const;
 };
 
 typedef gtsam::PoseRotationPrior<gtsam::Pose2> PoseRotationPrior2D;


### PR DESCRIPTION
Change is straight forward.

However, I'm not fully aware how the _pickle()_ works .. I can't call it from Python even though its listed in the interface and some stuff is done in the [wrapper](https://github.com/borglab/wrap/blob/d90abb52badb08c1c1a42b901a15fa5877024370/gtwrap/pybind_wrapper.py#L109)?
Lastly, I'd put up some unit-tests but would need some guidance where to put it, and how you want those interfaces being tested (or maybe you don't want to test them at all for the sake of flexibility?).