### PR TITLE
[WIP] Unify Discrete and Continuous Values dict

### DIFF
--- a/examples/DiscreteBayesNet_FG.cpp
+++ b/examples/DiscreteBayesNet_FG.cpp
@@ -33,11 +33,10 @@ using namespace gtsam;
 int main(int argc, char **argv) {
   // Define keys and a print function
   Key C(1), S(2), R(3), W(4);
-  auto print = [=](const DiscreteFactor::Values& values) {
-    cout << boolalpha << "Cloudy = " << static_cast<bool>(values.at(C))
-         << "  Sprinkler = " << static_cast<bool>(values.at(S))
-         << "  Rain = " << boolalpha << static_cast<bool>(values.at(R))
-         << "  WetGrass = " << static_cast<bool>(values.at(W)) << endl;
+  auto print = [=](const Values& values) {
+    cout << boolalpha << "Cloudy = " << values.at<bool>(C)
+         << "  Sprinkler = " << values.at<bool>(S) << "  Rain = " << boolalpha
+         << values.at<bool>(R) << "  WetGrass = " << values.at<bool>(W) << endl;
   };
 
   // We assume binary state variables
@@ -72,11 +71,11 @@ int main(int argc, char **argv) {
     for (size_t m = 0; m < nrStates; m++)
       for (size_t h = 0; h < nrStates; h++)
         for (size_t c = 0; c < nrStates; c++) {
-          DiscreteFactor::Values values;
-          values[C] = c;
-          values[S] = h;
-          values[R] = m;
-          values[W] = a;
+          Values values;
+          values.insert(C, c);
+          values.insert(S, h);
+          values.insert(R, m);
+          values.insert(W, a);
           double prodPot = graph(values);
           cout << setw(8) << static_cast<bool>(c) << setw(14)
                << static_cast<bool>(h) << setw(12) << static_cast<bool>(m)

--- a/examples/DiscreteBayesNet_FG.cpp
+++ b/examples/DiscreteBayesNet_FG.cpp
@@ -72,10 +72,10 @@ int main(int argc, char **argv) {
       for (size_t h = 0; h < nrStates; h++)
         for (size_t c = 0; c < nrStates; c++) {
           Values values;
-          values.insert(C, c);
-          values.insert(S, h);
-          values.insert(R, m);
-          values.insert(W, a);
+          values.insert<uint64_t>(C, c);
+          values.insert<uint64_t>(S, h);
+          values.insert<uint64_t>(R, m);
+          values.insert<uint64_t>(W, a);
           double prodPot = graph(values);
           cout << setw(8) << static_cast<bool>(c) << setw(14)
                << static_cast<bool>(h) << setw(12) << static_cast<bool>(m)

--- a/examples/UGM_small.cpp
+++ b/examples/UGM_small.cpp
@@ -50,14 +50,16 @@ int main(int argc, char** argv) {
 
   // Print the UGM distribution
   cout << "\nUGM distribution:" << endl;
-  vector<DiscreteFactor::Values> allPosbValues = cartesianProduct(
-      Cathy & Heather & Mark & Allison);
+  vector<Values> allPosbValues =
+      cartesianProduct(Cathy & Heather & Mark & Allison);
   for (size_t i = 0; i < allPosbValues.size(); ++i) {
-    DiscreteFactor::Values values = allPosbValues[i];
+    Values values = allPosbValues[i];
     double prodPot = graph(values);
-    cout << values[Cathy.first] << " " << values[Heather.first] << " "
-        << values[Mark.first] << " " << values[Allison.first] << " :\t"
-        << prodPot << "\t" << prodPot / 3790 << endl;
+    cout << values.at<size_t>(Cathy.first) << " "
+         << values.at<size_t>(Heather.first) << " "
+         << values.at<size_t>(Mark.first) << " "
+         << values.at<size_t>(Allison.first) << " :\t" << prodPot << "\t"
+         << prodPot / 3790 << endl;
   }
 
   // "Decoding", i.e., configuration with largest value (MPE)

--- a/examples/UGM_small.cpp
+++ b/examples/UGM_small.cpp
@@ -55,10 +55,10 @@ int main(int argc, char** argv) {
   for (size_t i = 0; i < allPosbValues.size(); ++i) {
     Values values = allPosbValues[i];
     double prodPot = graph(values);
-    cout << values.at<size_t>(Cathy.first) << " "
-         << values.at<size_t>(Heather.first) << " "
-         << values.at<size_t>(Mark.first) << " "
-         << values.at<size_t>(Allison.first) << " :\t" << prodPot << "\t"
+    cout << values.at<uint64_t>(Cathy.first) << " "
+         << values.at<uint64_t>(Heather.first) << " "
+         << values.at<uint64_t>(Mark.first) << " "
+         << values.at<uint64_t>(Allison.first) << " :\t" << prodPot << "\t"
          << prodPot / 3790 << endl;
   }
 

--- a/gtsam/base/Testable.h
+++ b/gtsam/base/Testable.h
@@ -72,6 +72,9 @@ namespace gtsam {
     }
   }; // \ Testable
 
+  inline void print(int v, const std::string& s = "") {
+    std::cout << (s.empty() ? s : s + " ") << v << std::endl;
+  }
   inline void print(float v, const std::string& s = "") {
     std::cout << (s.empty() ? s : s + " ") << v << std::endl;
   }

--- a/gtsam/base/VectorSpace.h
+++ b/gtsam/base/VectorSpace.h
@@ -270,6 +270,10 @@ struct ScalarTraits : VectorSpaceImpl<Scalar, 1> {
 
 } // namespace internal
 
+/// int
+template <>
+struct traits<int> : public internal::ScalarTraits<int> {};
+
 /// double
 template<> struct traits<double> : public internal::ScalarTraits<double> {
 };

--- a/gtsam/discrete/Assignment.h
+++ b/gtsam/discrete/Assignment.h
@@ -11,7 +11,7 @@
 
 /**
  * @file    Assignment.h
- * @brief    An assignment from labels to a discrete value index (size_t)
+ * @brief    An assignment from labels to a discrete value index (uint64_t)
  * @author  Frank Dellaert
  * @date    Feb 5, 2012
  */
@@ -27,12 +27,12 @@
 namespace gtsam {
 
   /**
-   * An assignment from labels to value index (size_t).
+   * An assignment from labels to value index (uint64_t).
    * Assigns to each label a value. Implemented as a simple map.
    * A discrete factor takes an Assignment and returns a value.
    */
   template<class L>
-  class Assignment: public std::map<L, size_t> {
+  class Assignment: public std::map<L, uint64_t> {
   public:
     void print(const std::string& s = "Assignment: ") const {
       std::cout << s << ": ";
@@ -59,30 +59,30 @@ namespace gtsam {
    * variables with each having cardinalities 4, we get 4096 possible
    * configurations!!
    */
-  template<typename L>
+  template <typename L>
   std::vector<Values> cartesianProduct(
-      const std::vector<std::pair<L, size_t> >& keys) {
+      const std::vector<std::pair<L, uint64_t> >& keys) {
     std::vector<Values> allPossValues;
     Values values;
-    typedef std::pair<L, size_t> DiscreteKey;
-    for(const DiscreteKey& key: keys) {
-      values.insert<size_t>(key.first, 0);  //Initialize from 0
+    typedef std::pair<L, uint64_t> DiscreteKey;
+    for (const DiscreteKey& key : keys) {
+      values.insert<uint64_t>(key.first, 0);  // Initialize from 0
     }
 
     while (true) {
       allPossValues.push_back(values);
-      size_t j = 0;
+      uint64_t j = 0;
       for (j = 0; j < keys.size(); j++) {
         L idx = keys[j].first;
         // increment the value at key `idx`
-        size_t val = values.at<size_t>(idx);
-        values.update<size_t>(idx, val + 1);
+        uint64_t val = values.at<uint64_t>(idx);
+        values.update<uint64_t>(idx, val + 1);
 
-        if (values.at<size_t>(idx) < keys[j].second) {
+        if (values.at<uint64_t>(idx) < keys[j].second) {
           break;
         }
         // Wrap condition
-        values.update<size_t>(idx, 0);
+        values.update<uint64_t>(idx, 0);
       }
       if (j == keys.size()) {
         break;

--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -127,7 +127,7 @@ namespace gtsam {
     }
 
     /** choose a branch, create new memory ! */
-    NodePtr choose(const L& label, size_t index) const override {
+    NodePtr choose(const L& label, uint64_t index) const override {
       return NodePtr(new Leaf(constant()));
     }
 
@@ -149,7 +149,7 @@ namespace gtsam {
 
   private:
     /** incremental allSame */
-    size_t allSame_;
+    uint64_t allSame_;
 
     typedef boost::shared_ptr<const Choice> ChoicePtr;
 
@@ -178,7 +178,7 @@ namespace gtsam {
     bool isLeaf() const override { return false; }
 
     /** Constructor, given choice label and mandatory expected branch count */
-    Choice(const L& label, size_t count) :
+    Choice(const L& label, uint64_t count) :
       label_(label), allSame_(true) {
       branches_.reserve(count);
     }
@@ -297,7 +297,7 @@ namespace gtsam {
             "DecisionTree::operator(): value undefined for a label");
       }
 #endif
-      size_t index = x.at<size_t>(label_);
+      uint64_t index = x.at<uint64_t>(label_);
       NodePtr child = branches_[index];
       return (*child)(x);
     }
@@ -352,7 +352,7 @@ namespace gtsam {
     }
 
     /** choose a branch, recursively */
-    NodePtr choose(const L& label, size_t index) const override {
+    NodePtr choose(const L& label, uint64_t index) const override {
       if (label_ == label)
         return branches_[index]; // choose branch
 

--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -96,7 +96,7 @@ namespace gtsam {
     }
 
     /** evaluate */
-    const Y& operator()(const Assignment<L>& x) const override {
+    const Y& operator()(const Values& x) const override {
       return constant_;
     }
 
@@ -288,16 +288,16 @@ namespace gtsam {
     }
 
     /** evaluate */
-    const Y& operator()(const Assignment<L>& x) const override {
+    const Y& operator()(const Values& x) const override {
 #ifndef NDEBUG
-      typename Assignment<L>::const_iterator it = x.find(label_);
+      typename Values::const_iterator it = x.find(label_);
       if (it == x.end()) {
         std::cout << "Trying to find value for " << label_ << std::endl;
         throw std::invalid_argument(
             "DecisionTree::operator(): value undefined for a label");
       }
 #endif
-      size_t index = x.at(label_);
+      size_t index = x.at<size_t>(label_);
       NodePtr child = branches_[index];
       return (*child)(x);
     }
@@ -615,9 +615,9 @@ namespace gtsam {
     return root_->equals(*other.root_);
   }
 
-  template<typename L, typename Y>
-  const Y& DecisionTree<L, Y>::operator()(const Assignment<L>& x) const {
-    return root_->operator ()(x);
+  template <typename L, typename Y>
+  const Y& DecisionTree<L, Y>::operator()(const Values& x) const {
+    return root_->operator()(x);
   }
 
   template<typename L, typename Y>

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -44,7 +44,7 @@ namespace gtsam {
     typedef std::function<Y(const Y&, const Y&)> Binary;
 
     /** A label annotated with cardinality */
-    typedef std::pair<L,size_t> LabelC;
+    using LabelC = std::pair<L, uint64_t>;
 
     /** DTs consist of Leaf and Choice nodes, both subclasses of Node */
     class Leaf;
@@ -87,7 +87,7 @@ namespace gtsam {
       virtual Ptr apply_f_op_g(const Node&, const Binary&) const = 0;
       virtual Ptr apply_g_op_fL(const Leaf&, const Binary&) const = 0;
       virtual Ptr apply_g_op_fC(const Choice&, const Binary&) const = 0;
-      virtual Ptr choose(const L& label, size_t index) const = 0;
+      virtual Ptr choose(const L& label, uint64_t index) const = 0;
       virtual bool isLeaf() const = 0;
     };
     /** ------------------------ Node base class --------------------------- */
@@ -179,7 +179,7 @@ namespace gtsam {
 
     /** create a new function where value(label)==index
      * It's like "restrict" in Darwiche09book pg329, 330? */
-    DecisionTree choose(const L& label, size_t index) const {
+    DecisionTree choose(const L& label, uint64_t index) const {
       NodePtr newRoot = root_->choose(label, index);
       return DecisionTree(newRoot);
     }

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include <gtsam/discrete/Assignment.h>
+#include <gtsam/nonlinear/Values.h>
 
 #include <boost/function.hpp>
 #include <functional>
@@ -82,7 +82,7 @@ namespace gtsam {
       virtual bool sameLeaf(const Leaf& q) const = 0;
       virtual bool sameLeaf(const Node& q) const = 0;
       virtual bool equals(const Node& other, double tol = 1e-9) const = 0;
-      virtual const Y& operator()(const Assignment<L>& x) const = 0;
+      virtual const Y& operator()(const Values& x) const = 0;
       virtual Ptr apply(const Unary& op) const = 0;
       virtual Ptr apply_f_op_g(const Node&, const Binary&) const = 0;
       virtual Ptr apply_g_op_fL(const Leaf&, const Binary&) const = 0;
@@ -169,7 +169,7 @@ namespace gtsam {
     bool operator==(const DecisionTree& q) const;
 
     /** evaluate */
-    const Y& operator()(const Assignment<L>& x) const;
+    const Y& operator()(const Values& x) const;
 
     /** apply Unary operation "op" to f */
     DecisionTree apply(const Unary& op) const;

--- a/gtsam/discrete/DiscreteBayesNet.cpp
+++ b/gtsam/discrete/DiscreteBayesNet.cpp
@@ -45,7 +45,7 @@ namespace gtsam {
   }
 
   /* ************************************************************************* */
-  double DiscreteBayesNet::evaluate(const DiscreteConditional::Values & values) const {
+  double DiscreteBayesNet::evaluate(const Values & values) const {
     // evaluate all conditionals and multiply
     double result = 1.0;
     for(DiscreteConditional::shared_ptr conditional: *this)
@@ -54,18 +54,18 @@ namespace gtsam {
   }
 
   /* ************************************************************************* */
-  DiscreteFactor::Values DiscreteBayesNet::optimize() const {
+  Values DiscreteBayesNet::optimize() const {
     // solve each node in turn in topological sort order (parents first)
-    DiscreteFactor::Values result;
+    Values result;
     for (auto conditional: boost::adaptors::reverse(*this))
       conditional->solveInPlace(&result);
     return result;
   }
 
   /* ************************************************************************* */
-  DiscreteFactor::Values DiscreteBayesNet::sample() const {
+  Values DiscreteBayesNet::sample() const {
     // sample each node in turn in topological sort order (parents first)
-    DiscreteFactor::Values result;
+    Values result;
     for (auto conditional: boost::adaptors::reverse(*this))
       conditional->sampleInPlace(&result);
     return result;

--- a/gtsam/discrete/DiscreteBayesNet.h
+++ b/gtsam/discrete/DiscreteBayesNet.h
@@ -78,15 +78,15 @@ namespace gtsam {
 //    GTSAM_EXPORT void add_front(const Signature& s);
 
     //** evaluate for given Values */
-    double evaluate(const DiscreteConditional::Values & values) const;
+    double evaluate(const Values & values) const;
 
     /**
     * Solve the DiscreteBayesNet by back-substitution
     */
-    DiscreteFactor::Values optimize() const;
+    Values optimize() const;
 
     /** Do ancestral sampling */
-    DiscreteFactor::Values sample() const;
+    Values sample() const;
 
     ///@}
 

--- a/gtsam/discrete/DiscreteBayesTree.cpp
+++ b/gtsam/discrete/DiscreteBayesTree.cpp
@@ -30,8 +30,7 @@ namespace gtsam {
   template class BayesTree<DiscreteBayesTreeClique>;
 
   /* ************************************************************************* */
-  double DiscreteBayesTreeClique::evaluate(
-      const DiscreteConditional::Values& values) const {
+  double DiscreteBayesTreeClique::evaluate(const Values& values) const {
     // evaluate all conditionals and multiply
     double result = (*conditional_)(values);
     for (const auto& child : children) {
@@ -46,8 +45,7 @@ namespace gtsam {
   }
 
   /* ************************************************************************* */
-  double DiscreteBayesTree::evaluate(
-      const DiscreteConditional::Values& values) const {
+  double DiscreteBayesTree::evaluate(const Values& values) const {
     double result = 1.0;
     for (const auto& root : roots_) {
       result *= root->evaluate(values);

--- a/gtsam/discrete/DiscreteBayesTree.h
+++ b/gtsam/discrete/DiscreteBayesTree.h
@@ -58,7 +58,7 @@ class GTSAM_EXPORT DiscreteBayesTreeClique
   }
 
   //** evaluate conditional probability of subtree for given Values */
-  double evaluate(const DiscreteConditional::Values& values) const;
+  double evaluate(const Values& values) const;
 };
 
 /* ************************************************************************* */
@@ -79,7 +79,7 @@ class GTSAM_EXPORT DiscreteBayesTree
   bool equals(const This& other, double tol = 1e-9) const;
 
   //** evaluate probability for given Values */
-  double evaluate(const DiscreteConditional::Values& values) const;
+  double evaluate(const Values& values) const;
 };
 
 }  // namespace gtsam

--- a/gtsam/discrete/DiscreteConditional.cpp
+++ b/gtsam/discrete/DiscreteConditional.cpp
@@ -99,11 +99,11 @@ bool DiscreteConditional::equals(const DiscreteFactor& other,
 /* ******************************************************************************** */
 Potentials::ADT DiscreteConditional::choose(const Values& parentsValues) const {
   ADT pFS(*this);
-  Key j; size_t value;
+  Key j; uint64_t value;
   for(Key key: parents()) {
     try {
       j = (key);
-      value = parentsValues.at<size_t>(j);
+      value = parentsValues.at<uint64_t>(j);
       pFS = pFS.choose(j, value);
     } catch (exception&) {
       cout << "Key: " << j << "  Value: " << value << endl;
@@ -145,7 +145,7 @@ void DiscreteConditional::solveInPlace(Values* values) const {
 
   //set values (inPlace) to mpe
   for(Key j: frontals()) {
-    values->upsert<size_t>(j, mpe.at<size_t>(j));
+    values->upsert<uint64_t>(j, mpe.at<uint64_t>(j));
   }
 }
 
@@ -153,25 +153,25 @@ void DiscreteConditional::solveInPlace(Values* values) const {
 void DiscreteConditional::sampleInPlace(Values* values) const {
   assert(nrFrontals() == 1);
   Key j = (firstFrontalKey());
-  size_t sampled = sample(*values); // Sample variable given parents
+  uint64_t sampled = sample(*values); // Sample variable given parents
   values->upsert(j,  sampled);  // store result in partial solution
 }
 
 /* ******************************************************************************** */
-size_t DiscreteConditional::solve(const Values& parentsValues) const {
+uint64_t DiscreteConditional::solve(const Values& parentsValues) const {
 
   // TODO: is this really the fastest way? I think it is.
   ADT pFS = choose(parentsValues); // P(F|S=parentsValues)
 
   // Then, find the max over all remaining
   // TODO, only works for one key now, seems horribly slow this way
-  size_t mpe = 0;
+  uint64_t mpe = 0;
   Values frontals;
   double maxP = 0;
   assert(nrFrontals() == 1);
   Key j = (firstFrontalKey());
   for (size_t value = 0; value < cardinality(j); value++) {
-    frontals.upsert(j,  value);
+    frontals.upsert<uint64_t>(j,  value);
     double pValueS = pFS(frontals); // P(F=value|S=parentsValues)
     // Update MPE solution if better
     if (pValueS > maxP) {
@@ -183,7 +183,7 @@ size_t DiscreteConditional::solve(const Values& parentsValues) const {
 }
 
 /* ******************************************************************************** */
-size_t DiscreteConditional::sample(const Values& parentsValues) const {
+uint64_t DiscreteConditional::sample(const Values& parentsValues) const {
   static mt19937 rng(2);  // random number generator
 
   // Get the correct conditional density
@@ -192,17 +192,17 @@ size_t DiscreteConditional::sample(const Values& parentsValues) const {
   // TODO(Duy): only works for one key now, seems horribly slow this way
   assert(nrFrontals() == 1);
   Key key = firstFrontalKey();
-  size_t nj = cardinality(key);
+  uint64_t nj = cardinality(key);
   vector<double> p(nj);
   Values frontals;
   for (size_t value = 0; value < nj; value++) {
-    frontals.upsert(key,  value);
+    frontals.upsert<uint64_t>(key,  value);
     p[value] = pFS(frontals);  // P(F=value|S=parentsValues)
     if (p[value] == 1.0) {
       return value;  // shortcut exit
     }
   }
-  std::discrete_distribution<size_t> distribution(p.begin(), p.end());
+  std::discrete_distribution<uint64_t> distribution(p.begin(), p.end());
   return distribution(rng);
 }
 

--- a/gtsam/discrete/DiscreteConditional.cpp
+++ b/gtsam/discrete/DiscreteConditional.cpp
@@ -103,7 +103,7 @@ Potentials::ADT DiscreteConditional::choose(const Values& parentsValues) const {
   for(Key key: parents()) {
     try {
       j = (key);
-      value = parentsValues.at(j);
+      value = parentsValues.at<size_t>(j);
       pFS = pFS.choose(j, value);
     } catch (exception&) {
       cout << "Key: " << j << "  Value: " << value << endl;
@@ -145,7 +145,7 @@ void DiscreteConditional::solveInPlace(Values* values) const {
 
   //set values (inPlace) to mpe
   for(Key j: frontals()) {
-    (*values)[j] = mpe[j];
+    values->upsert<size_t>(j, mpe.at<size_t>(j));
   }
 }
 
@@ -154,7 +154,7 @@ void DiscreteConditional::sampleInPlace(Values* values) const {
   assert(nrFrontals() == 1);
   Key j = (firstFrontalKey());
   size_t sampled = sample(*values); // Sample variable given parents
-  (*values)[j] = sampled; // store result in partial solution
+  values->upsert(j,  sampled);  // store result in partial solution
 }
 
 /* ******************************************************************************** */
@@ -171,7 +171,7 @@ size_t DiscreteConditional::solve(const Values& parentsValues) const {
   assert(nrFrontals() == 1);
   Key j = (firstFrontalKey());
   for (size_t value = 0; value < cardinality(j); value++) {
-    frontals[j] = value;
+    frontals.upsert(j,  value);
     double pValueS = pFS(frontals); // P(F=value|S=parentsValues)
     // Update MPE solution if better
     if (pValueS > maxP) {
@@ -196,7 +196,7 @@ size_t DiscreteConditional::sample(const Values& parentsValues) const {
   vector<double> p(nj);
   Values frontals;
   for (size_t value = 0; value < nj; value++) {
-    frontals[key] = value;
+    frontals.upsert(key,  value);
     p[value] = pFS(frontals);  // P(F=value|S=parentsValues)
     if (p[value] == 1.0) {
       return value;  // shortcut exit

--- a/gtsam/discrete/DiscreteConditional.h
+++ b/gtsam/discrete/DiscreteConditional.h
@@ -23,6 +23,7 @@
 #include <gtsam/inference/Conditional.h>
 #include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>
+#include <gtsam/nonlinear/Values.h>
 
 #include <string>
 
@@ -41,10 +42,6 @@ public:
   typedef boost::shared_ptr<This> shared_ptr; ///< shared_ptr to this class
   typedef DecisionTreeFactor BaseFactor; ///< Typedef to our factor base class
   typedef Conditional<BaseFactor, This> BaseConditional; ///< Typedef to our conditional base class
-
-  /** A map from keys to values..
-   * TODO: Again, do we need this??? */
-  typedef Assignment<Key> Values;
 
   /// @name Standard Constructors
   /// @{
@@ -111,7 +108,7 @@ public:
   }
 
   /** Restrict to given parent values, returns AlgebraicDecisionDiagram */
-  ADT choose(const Assignment<Key>& parentsValues) const;
+  ADT choose(const Values& parentsValues) const;
 
   /**
    * solve a conditional

--- a/gtsam/discrete/DiscreteConditional.h
+++ b/gtsam/discrete/DiscreteConditional.h
@@ -115,14 +115,14 @@ public:
    * @param parentsValues Known values of the parents
    * @return MPE value of the child (1 frontal variable).
    */
-  size_t solve(const Values& parentsValues) const;
+  uint64_t solve(const Values& parentsValues) const;
 
   /**
    * sample
    * @param parentsValues Known values of the parents
    * @return sample from conditional
    */
-  size_t sample(const Values& parentsValues) const;
+  uint64_t sample(const Values& parentsValues) const;
 
   /// @}
   /// @name Advanced Interface

--- a/gtsam/discrete/DiscreteFactor.h
+++ b/gtsam/discrete/DiscreteFactor.h
@@ -18,9 +18,10 @@
 
 #pragma once
 
+#include <gtsam/base/Testable.h>
 #include <gtsam/discrete/Assignment.h>
 #include <gtsam/inference/Factor.h>
-#include <gtsam/base/Testable.h>
+#include <gtsam/nonlinear/Values.h>
 
 namespace gtsam {
 
@@ -39,18 +40,6 @@ public:
   typedef DiscreteFactor This; ///< This class
   typedef boost::shared_ptr<DiscreteFactor> shared_ptr; ///< shared_ptr to this class
   typedef Factor Base; ///< Our base class
-
-  /** A map from keys to values
-   * TODO: Do we need this? Should we just use gtsam::Values?
-   * We just need another special DiscreteValue to represent labels,
-   * However, all other Lie's operators are undefined in this class.
-   * The good thing is we can have a Hybrid graph of discrete/continuous variables
-   * together..
-   * Another good thing is we don't need to have the special DiscreteKey which stores
-   * cardinality of a Discrete variable. It should be handled naturally in
-   * the new class DiscreteValue, as the varible's type (domain)
-   */
-  typedef Assignment<Key> Values;
 
 public:
 
@@ -104,6 +93,5 @@ public:
 
 // traits
 template<> struct traits<DiscreteFactor> : public Testable<DiscreteFactor> {};
-template<> struct traits<DiscreteFactor::Values> : public Testable<DiscreteFactor::Values> {};
 
 }// namespace gtsam

--- a/gtsam/discrete/DiscreteFactorGraph.cpp
+++ b/gtsam/discrete/DiscreteFactorGraph.cpp
@@ -55,8 +55,7 @@ namespace gtsam {
   }
 
   /* ************************************************************************* */
-  double DiscreteFactorGraph::operator()(
-      const DiscreteFactor::Values &values) const {
+  double DiscreteFactorGraph::operator()(const Values& values) const {
     double product = 1.0;
     for( const sharedFactor& factor: factors_ )
       product *= (*factor)(values);
@@ -94,7 +93,7 @@ namespace gtsam {
 //  }
 
   /* ************************************************************************* */
-  DiscreteFactorGraph::Values DiscreteFactorGraph::optimize() const
+  Values DiscreteFactorGraph::optimize() const
   {
     gttic(DiscreteFactorGraph_optimize);
     return BaseEliminateable::eliminateSequential()->optimize();

--- a/gtsam/discrete/DiscreteFactorGraph.h
+++ b/gtsam/discrete/DiscreteFactorGraph.h
@@ -73,7 +73,6 @@ public:
 
   /** A map from keys to values */
   typedef KeyVector Indices;
-  typedef Assignment<Key> Values;
 
   /** Default constructor */
   DiscreteFactorGraph() {}
@@ -130,7 +129,7 @@ public:
   DecisionTreeFactor product() const;
 
   /** Evaluates the factor graph given values, returns the joint probability of the factor graph given specific instantiation of values*/
-  double operator()(const DiscreteFactor::Values & values) const;
+  double operator()(const Values & values) const;
 
   /// print
   void print(

--- a/gtsam/discrete/DiscreteKey.h
+++ b/gtsam/discrete/DiscreteKey.h
@@ -31,7 +31,7 @@ namespace gtsam {
    * Key type for discrete conditionals
    * Includes name and cardinality
    */
-  typedef std::pair<Key,size_t> DiscreteKey;
+  using DiscreteKey = std::pair<Key,uint64_t>;
 
   /// DiscreteKeys is a set of keys that can be assembled using the & operator
   struct DiscreteKeys: public std::vector<DiscreteKey> {

--- a/gtsam/discrete/DiscreteMarginals.h
+++ b/gtsam/discrete/DiscreteMarginals.h
@@ -65,7 +65,7 @@ namespace gtsam {
     Vector vResult(key.second);
     for (size_t state = 0; state < key.second ; ++ state) {
       Values values;
-      values.insert<size_t>(key.first, state);
+      values.insert<uint64_t>(key.first, state);
       vResult(state) = (*marginalFactor)(values);
     }
     return vResult;

--- a/gtsam/discrete/DiscreteMarginals.h
+++ b/gtsam/discrete/DiscreteMarginals.h
@@ -64,8 +64,8 @@ namespace gtsam {
     //Create result
     Vector vResult(key.second);
     for (size_t state = 0; state < key.second ; ++ state) {
-      DiscreteFactor::Values values;
-      values[key.first] = state;
+      Values values;
+      values.insert<size_t>(key.first, state);
       vResult(state) = (*marginalFactor)(values);
     }
     return vResult;

--- a/gtsam/discrete/tests/testAlgebraicDecisionTree.cpp
+++ b/gtsam/discrete/tests/testAlgebraicDecisionTree.cpp
@@ -445,12 +445,12 @@ TEST(ADT, constructor)
 {
   DiscreteKey v0(0,2), v1(1,3);
   Values x00, x01, x02, x10, x11, x12;
-  x00.insert<size_t>(0, 0), x00.insert<size_t>(1, 0);
-  x01.insert<size_t>(0, 0), x01.insert<size_t>(1, 1);
-  x02.insert<size_t>(0, 0), x02.insert<size_t>(1, 2);
-  x10.insert<size_t>(0, 1), x10.insert<size_t>(1, 0);
-  x11.insert<size_t>(0, 1), x11.insert<size_t>(1, 1);
-  x12.insert<size_t>(0, 1), x12.insert<size_t>(1, 2);
+  x00.insert<uint64_t>(0, 0), x00.insert<uint64_t>(1, 0);
+  x01.insert<uint64_t>(0, 0), x01.insert<uint64_t>(1, 1);
+  x02.insert<uint64_t>(0, 0), x02.insert<uint64_t>(1, 2);
+  x10.insert<uint64_t>(0, 1), x10.insert<uint64_t>(1, 0);
+  x11.insert<uint64_t>(0, 1), x11.insert<uint64_t>(1, 1);
+  x12.insert<uint64_t>(0, 1), x12.insert<uint64_t>(1, 2);
 
   ADT f1(v0 & v1, "0 1 2 3 4 5");
   EXPECT_DOUBLES_EQUAL(0, f1(x00), 1e-9);
@@ -475,16 +475,16 @@ TEST(ADT, constructor)
   t = x++;
   ADT f3(z0 & z1 & z2 & z3, table);
   Values assignment;
-  assignment.insert<size_t>(0, 0);
-  assignment.insert<size_t>(1, 0);
-  assignment.insert<size_t>(2, 0);
-  assignment.insert<size_t>(3, 1);
+  assignment.insert<uint64_t>(0, 0);
+  assignment.insert<uint64_t>(1, 0);
+  assignment.insert<uint64_t>(2, 0);
+  assignment.insert<uint64_t>(3, 1);
   EXPECT_DOUBLES_EQUAL(1, f3(assignment), 1e-9);
 }
 
 /* ************************************************************************* */
 // test conversion to integer indices
-// Only works if DiscreteKeys are binary, as size_t has binary cardinality!
+// Only works if DiscreteKeys are binary, as uint64_t has binary cardinality!
 TEST(ADT, conversion)
 {
   DiscreteKey X(0,2), Y(1,2);
@@ -501,10 +501,10 @@ TEST(ADT, conversion)
   write_dot(fIndexKey, "conversion-f2");
 
   Values x00, x01, x02, x10, x11, x12;
-  x00.insert<size_t>(5, 0), x00.insert<size_t>(2, 0);
-  x01.insert<size_t>(5, 0), x01.insert<size_t>(2, 1);
-  x10.insert<size_t>(5, 1), x10.insert<size_t>(2, 0);
-  x11.insert<size_t>(5, 1), x11.insert<size_t>(2, 1);
+  x00.insert<uint64_t>(5, 0), x00.insert<uint64_t>(2, 0);
+  x01.insert<uint64_t>(5, 0), x01.insert<uint64_t>(2, 1);
+  x10.insert<uint64_t>(5, 1), x10.insert<uint64_t>(2, 0);
+  x11.insert<uint64_t>(5, 1), x11.insert<uint64_t>(2, 1);
   EXPECT_DOUBLES_EQUAL(0.2, fIndexKey(x00), 1e-9);
   EXPECT_DOUBLES_EQUAL(0.5, fIndexKey(x01), 1e-9);
   EXPECT_DOUBLES_EQUAL(0.3, fIndexKey(x10), 1e-9);
@@ -577,10 +577,10 @@ TEST(ADT, zero)
   ADT anotb = a * notb;
   //  GTSAM_PRINT(anotb);
   Values x00, x01, x10, x11;
-  x00.insert<size_t>(0, 0), x00.insert<size_t>(1, 0);
-  x01.insert<size_t>(0, 0), x01.insert<size_t>(1, 1);
-  x10.insert<size_t>(0, 1), x10.insert<size_t>(1, 0);
-  x11.insert<size_t>(0, 1), x11.insert<size_t>(1, 1);
+  x00.insert<uint64_t>(0, 0), x00.insert<uint64_t>(1, 0);
+  x01.insert<uint64_t>(0, 0), x01.insert<uint64_t>(1, 1);
+  x10.insert<uint64_t>(0, 1), x10.insert<uint64_t>(1, 0);
+  x11.insert<uint64_t>(0, 1), x11.insert<uint64_t>(1, 1);
   EXPECT_DOUBLES_EQUAL(0, anotb(x00), 1e-9);
   EXPECT_DOUBLES_EQUAL(0, anotb(x01), 1e-9);
   EXPECT_DOUBLES_EQUAL(1, anotb(x10), 1e-9);

--- a/gtsam/discrete/tests/testAlgebraicDecisionTree.cpp
+++ b/gtsam/discrete/tests/testAlgebraicDecisionTree.cpp
@@ -47,7 +47,7 @@ template<> struct traits<ADT> : public Testable<ADT> {};
 #define DISABLE_DOT
 
 template<typename T>
-void dot(const T&f, const string& filename) {
+void write_dot(const T&f, const string& filename) {
 #ifndef DISABLE_DOT
   f.dot(filename);
 #endif
@@ -111,7 +111,7 @@ TEST(ADT, example3)
   ADT note(E, 0.9, 0.1);
 
   ADT cnotb = c * notb;
-  dot(cnotb, "ADT-cnotb");
+  write_dot(cnotb, "ADT-cnotb");
 
 //  a.print("a: ");
 //  cnotb.print("cnotb: ");
@@ -119,11 +119,10 @@ TEST(ADT, example3)
 //  acnotb.print("acnotb: ");
 //  acnotb.printCache("acnotb Cache:");
 
-  dot(acnotb, "ADT-acnotb");
-
+  write_dot(acnotb, "ADT-acnotb");
 
   ADT big = apply(apply(d, note, &mul), acnotb, &add_);
-  dot(big, "ADT-big");
+  write_dot(big, "ADT-big");
 }
 
 /* ******************************************************************************** */
@@ -136,7 +135,7 @@ ADT create(const Signature& signature) {
   static size_t count = 0;
   const DiscreteKey& key = signature.key();
   string dotfile = (boost::format("CPT-%03d-%d") % ++count % key.first).str();
-  dot(p, dotfile);
+  write_dot(p, dotfile);
   return p;
 }
 
@@ -166,21 +165,21 @@ TEST(ADT, joint)
   resetCounts();
   gttic_(asiaJoint);
   ADT joint = pA;
-  dot(joint, "Asia-A");
+  write_dot(joint, "Asia-A");
   joint = apply(joint, pS, &mul);
-  dot(joint, "Asia-AS");
+  write_dot(joint, "Asia-AS");
   joint = apply(joint, pT, &mul);
-  dot(joint, "Asia-AST");
+  write_dot(joint, "Asia-AST");
   joint = apply(joint, pL, &mul);
-  dot(joint, "Asia-ASTL");
+  write_dot(joint, "Asia-ASTL");
   joint = apply(joint, pB, &mul);
-  dot(joint, "Asia-ASTLB");
+  write_dot(joint, "Asia-ASTLB");
   joint = apply(joint, pE, &mul);
-  dot(joint, "Asia-ASTLBE");
+  write_dot(joint, "Asia-ASTLBE");
   joint = apply(joint, pX, &mul);
-  dot(joint, "Asia-ASTLBEX");
+  write_dot(joint, "Asia-ASTLBEX");
   joint = apply(joint, pD, &mul);
-  dot(joint, "Asia-ASTLBEXD");
+  write_dot(joint, "Asia-ASTLBEXD");
   EXPECT_LONGS_EQUAL(346, muls);
   gttoc_(asiaJoint);
   tictoc_getNode(asiaJointNode, asiaJoint);
@@ -228,21 +227,21 @@ TEST(ADT, inference)
   resetCounts();
   gttic_(asiaProd);
   ADT joint = pA;
-  dot(joint, "Joint-Product-A");
+  write_dot(joint, "Joint-Product-A");
   joint = apply(joint, pS, &mul);
-  dot(joint, "Joint-Product-AS");
+  write_dot(joint, "Joint-Product-AS");
   joint = apply(joint, pT, &mul);
-  dot(joint, "Joint-Product-AST");
+  write_dot(joint, "Joint-Product-AST");
   joint = apply(joint, pL, &mul);
-  dot(joint, "Joint-Product-ASTL");
+  write_dot(joint, "Joint-Product-ASTL");
   joint = apply(joint, pB, &mul);
-  dot(joint, "Joint-Product-ASTLB");
+  write_dot(joint, "Joint-Product-ASTLB");
   joint = apply(joint, pE, &mul);
-  dot(joint, "Joint-Product-ASTLBE");
+  write_dot(joint, "Joint-Product-ASTLBE");
   joint = apply(joint, pX, &mul);
-  dot(joint, "Joint-Product-ASTLBEX");
+  write_dot(joint, "Joint-Product-ASTLBEX");
   joint = apply(joint, pD, &mul);
-  dot(joint, "Joint-Product-ASTLBEXD");
+  write_dot(joint, "Joint-Product-ASTLBEXD");
   EXPECT_LONGS_EQUAL(370, (long)muls); // different ordering
   gttoc_(asiaProd);
   tictoc_getNode(asiaProdNode, asiaProd);
@@ -254,13 +253,13 @@ TEST(ADT, inference)
   gttic_(asiaSum);
   ADT marginal = joint;
   marginal = marginal.combine(X, &add_);
-  dot(marginal, "Joint-Sum-ADBLEST");
+  write_dot(marginal, "Joint-Sum-ADBLEST");
   marginal = marginal.combine(T, &add_);
-  dot(marginal, "Joint-Sum-ADBLES");
+  write_dot(marginal, "Joint-Sum-ADBLES");
   marginal = marginal.combine(S, &add_);
-  dot(marginal, "Joint-Sum-ADBLE");
+  write_dot(marginal, "Joint-Sum-ADBLE");
   marginal = marginal.combine(E, &add_);
-  dot(marginal, "Joint-Sum-ADBL");
+  write_dot(marginal, "Joint-Sum-ADBL");
   EXPECT_LONGS_EQUAL(161, (long)adds);
   gttoc_(asiaSum);
   tictoc_getNode(asiaSumNode, asiaSum);
@@ -299,7 +298,7 @@ TEST(ADT, factor_graph)
   fg = apply(fg, pE, &mul);
   fg = apply(fg, pX, &mul);
   fg = apply(fg, pD, &mul);
-  dot(fg, "FactorGraph");
+  write_dot(fg, "FactorGraph");
   EXPECT_LONGS_EQUAL(158, (long)muls);
   gttoc_(asiaFG);
   tictoc_getNode(asiaFGNode, asiaFG);
@@ -310,15 +309,15 @@ TEST(ADT, factor_graph)
   resetCounts();
   gttic_(marg);
   fg = fg.combine(X, &add_);
-  dot(fg, "Marginalized-6X");
+  write_dot(fg, "Marginalized-6X");
   fg = fg.combine(T, &add_);
-  dot(fg, "Marginalized-5T");
+  write_dot(fg, "Marginalized-5T");
   fg = fg.combine(S, &add_);
-  dot(fg, "Marginalized-4S");
+  write_dot(fg, "Marginalized-4S");
   fg = fg.combine(E, &add_);
-  dot(fg, "Marginalized-3E");
+  write_dot(fg, "Marginalized-3E");
   fg = fg.combine(L, &add_);
-  dot(fg, "Marginalized-2L");
+  write_dot(fg, "Marginalized-2L");
   EXPECT(adds = 54);
   gttoc_(marg);
   tictoc_getNode(margNode, marg);
@@ -332,9 +331,9 @@ TEST(ADT, factor_graph)
   resetCounts();
   gttic_(elimX);
   ADT fE = pX;
-  dot(fE, "Eliminate-01-fEX");
+  write_dot(fE, "Eliminate-01-fEX");
   fE = fE.combine(X, &add_);
-  dot(fE, "Eliminate-02-fE");
+  write_dot(fE, "Eliminate-02-fE");
   gttoc_(elimX);
   tictoc_getNode(elimXNode, elimX);
   elapsed = elimXNode->secs() + elimXNode->wall();
@@ -346,9 +345,9 @@ TEST(ADT, factor_graph)
   gttic_(elimT);
   ADT fLE = pT;
   fLE = apply(fLE, pE, &mul);
-  dot(fLE, "Eliminate-03-fLET");
+  write_dot(fLE, "Eliminate-03-fLET");
   fLE = fLE.combine(T, &add_);
-  dot(fLE, "Eliminate-04-fLE");
+  write_dot(fLE, "Eliminate-04-fLE");
   gttoc_(elimT);
   tictoc_getNode(elimTNode, elimT);
   elapsed = elimTNode->secs() + elimTNode->wall();
@@ -361,9 +360,9 @@ TEST(ADT, factor_graph)
   ADT fBL = pS;
   fBL = apply(fBL, pL, &mul);
   fBL = apply(fBL, pB, &mul);
-  dot(fBL, "Eliminate-05-fBLS");
+  write_dot(fBL, "Eliminate-05-fBLS");
   fBL = fBL.combine(S, &add_);
-  dot(fBL, "Eliminate-06-fBL");
+  write_dot(fBL, "Eliminate-06-fBL");
   gttoc_(elimS);
   tictoc_getNode(elimSNode, elimS);
   elapsed = elimSNode->secs() + elimSNode->wall();
@@ -376,9 +375,9 @@ TEST(ADT, factor_graph)
   ADT fBL2 = fE;
   fBL2 = apply(fBL2, fLE, &mul);
   fBL2 = apply(fBL2, pD, &mul);
-  dot(fBL2, "Eliminate-07-fBLE");
+  write_dot(fBL2, "Eliminate-07-fBLE");
   fBL2 = fBL2.combine(E, &add_);
-  dot(fBL2, "Eliminate-08-fBL2");
+  write_dot(fBL2, "Eliminate-08-fBL2");
   gttoc_(elimE);
   tictoc_getNode(elimENode, elimE);
   elapsed = elimENode->secs() + elimENode->wall();
@@ -390,9 +389,9 @@ TEST(ADT, factor_graph)
   gttic_(elimL);
   ADT fB = fBL;
   fB = apply(fB, fBL2, &mul);
-  dot(fB, "Eliminate-09-fBL");
+  write_dot(fB, "Eliminate-09-fBL");
   fB = fB.combine(L, &add_);
-  dot(fB, "Eliminate-10-fB");
+  write_dot(fB, "Eliminate-10-fB");
   gttoc_(elimL);
   tictoc_getNode(elimLNode, elimL);
   elapsed = elimLNode->secs() + elimLNode->wall();
@@ -445,13 +444,13 @@ TEST(ADT, equality_parser)
 TEST(ADT, constructor)
 {
   DiscreteKey v0(0,2), v1(1,3);
-  Assignment<Key> x00, x01, x02, x10, x11, x12;
-  x00[0] = 0, x00[1] = 0;
-  x01[0] = 0, x01[1] = 1;
-  x02[0] = 0, x02[1] = 2;
-  x10[0] = 1, x10[1] = 0;
-  x11[0] = 1, x11[1] = 1;
-  x12[0] = 1, x12[1] = 2;
+  Values x00, x01, x02, x10, x11, x12;
+  x00.insert<size_t>(0, 0), x00.insert<size_t>(1, 0);
+  x01.insert<size_t>(0, 0), x01.insert<size_t>(1, 1);
+  x02.insert<size_t>(0, 0), x02.insert<size_t>(1, 2);
+  x10.insert<size_t>(0, 1), x10.insert<size_t>(1, 0);
+  x11.insert<size_t>(0, 1), x11.insert<size_t>(1, 1);
+  x12.insert<size_t>(0, 1), x12.insert<size_t>(1, 2);
 
   ADT f1(v0 & v1, "0 1 2 3 4 5");
   EXPECT_DOUBLES_EQUAL(0, f1(x00), 1e-9);
@@ -475,11 +474,11 @@ TEST(ADT, constructor)
   for(double& t: table)
   t = x++;
   ADT f3(z0 & z1 & z2 & z3, table);
-  Assignment<Key> assignment;
-  assignment[0] = 0;
-  assignment[1] = 0;
-  assignment[2] = 0;
-  assignment[3] = 1;
+  Values assignment;
+  assignment.insert<size_t>(0, 0);
+  assignment.insert<size_t>(1, 0);
+  assignment.insert<size_t>(2, 0);
+  assignment.insert<size_t>(3, 1);
   EXPECT_DOUBLES_EQUAL(1, f3(assignment), 1e-9);
 }
 
@@ -490,7 +489,7 @@ TEST(ADT, conversion)
 {
   DiscreteKey X(0,2), Y(1,2);
   ADT fDiscreteKey(X & Y, "0.2 0.5 0.3 0.6");
-  dot(fDiscreteKey, "conversion-f1");
+  write_dot(fDiscreteKey, "conversion-f1");
 
   std::map<Key, Key> keyMap;
   keyMap[0] = 5;
@@ -499,13 +498,13 @@ TEST(ADT, conversion)
   AlgebraicDecisionTree<Key> fIndexKey(fDiscreteKey, keyMap);
   //  f1.print("f1");
   //  f2.print("f2");
-  dot(fIndexKey, "conversion-f2");
+  write_dot(fIndexKey, "conversion-f2");
 
-  Assignment<Key> x00, x01, x02, x10, x11, x12;
-  x00[5] = 0, x00[2] = 0;
-  x01[5] = 0, x01[2] = 1;
-  x10[5] = 1, x10[2] = 0;
-  x11[5] = 1, x11[2] = 1;
+  Values x00, x01, x02, x10, x11, x12;
+  x00.insert<size_t>(5, 0), x00.insert<size_t>(2, 0);
+  x01.insert<size_t>(5, 0), x01.insert<size_t>(2, 1);
+  x10.insert<size_t>(5, 1), x10.insert<size_t>(2, 0);
+  x11.insert<size_t>(5, 1), x11.insert<size_t>(2, 1);
   EXPECT_DOUBLES_EQUAL(0.2, fIndexKey(x00), 1e-9);
   EXPECT_DOUBLES_EQUAL(0.5, fIndexKey(x01), 1e-9);
   EXPECT_DOUBLES_EQUAL(0.3, fIndexKey(x10), 1e-9);
@@ -518,7 +517,7 @@ TEST(ADT, elimination)
 {
   DiscreteKey A(0,2), B(1,3), C(2,2);
   ADT f1(A & B & C, "1 2  3 4  5 6    1 8  3 3  5 5");
-  dot(f1, "elimination-f1");
+  write_dot(f1, "elimination-f1");
 
   {
     // sum out lower key
@@ -577,11 +576,11 @@ TEST(ADT, zero)
   ADT notb(B, 1, 0);
   ADT anotb = a * notb;
   //  GTSAM_PRINT(anotb);
-  Assignment<Key> x00, x01, x10, x11;
-  x00[0] = 0, x00[1] = 0;
-  x01[0] = 0, x01[1] = 1;
-  x10[0] = 1, x10[1] = 0;
-  x11[0] = 1, x11[1] = 1;
+  Values x00, x01, x10, x11;
+  x00.insert<size_t>(0, 0), x00.insert<size_t>(1, 0);
+  x01.insert<size_t>(0, 0), x01.insert<size_t>(1, 1);
+  x10.insert<size_t>(0, 1), x10.insert<size_t>(1, 0);
+  x11.insert<size_t>(0, 1), x11.insert<size_t>(1, 1);
   EXPECT_DOUBLES_EQUAL(0, anotb(x00), 1e-9);
   EXPECT_DOUBLES_EQUAL(0, anotb(x01), 1e-9);
   EXPECT_DOUBLES_EQUAL(1, anotb(x10), 1e-9);

--- a/gtsam/discrete/tests/testDecisionTree.cpp
+++ b/gtsam/discrete/tests/testDecisionTree.cpp
@@ -83,10 +83,10 @@ TEST(DT, example)
 
   // create a value
   Values x00, x01, x10, x11;
-  x00.insert<size_t>(A, 0), x00.insert<size_t>(B, 0);
-  x01.insert<size_t>(A, 0), x01.insert<size_t>(B, 1);
-  x10.insert<size_t>(A, 1), x10.insert<size_t>(B, 0);
-  x11.insert<size_t>(A, 1), x11.insert<size_t>(B, 1);
+  x00.insert<uint64_t>(A, 0), x00.insert<uint64_t>(B, 0);
+  x01.insert<uint64_t>(A, 0), x01.insert<uint64_t>(B, 1);
+  x10.insert<uint64_t>(A, 1), x10.insert<uint64_t>(B, 0);
+  x11.insert<uint64_t>(A, 1), x11.insert<uint64_t>(B, 1);
 
   // A
   DT a(A, 0, 5);
@@ -161,9 +161,9 @@ TEST(DT, example)
 
   // and a model assigning stuff to C
   Values x101;
-  x101.insert<size_t>(A, 1);
-  x101.insert<size_t>(B, 0);
-  x101.insert<size_t>(C, 1);
+  x101.insert<uint64_t>(A, 1);
+  x101.insert<uint64_t>(B, 0);
+  x101.insert<uint64_t>(C, 1);
 
   // mul notba with C
   DT notbac = apply(notba, c, &Ring::mul);

--- a/gtsam/discrete/tests/testDecisionTreeFactor.cpp
+++ b/gtsam/discrete/tests/testDecisionTreeFactor.cpp
@@ -39,14 +39,10 @@ TEST( DecisionTreeFactor, constructors)
   EXPECT_LONGS_EQUAL(2,f2.size());
   EXPECT_LONGS_EQUAL(3,f3.size());
 
-  //    f1.print("f1:");
-  //    f2.print("f2:");
-  //    f3.print("f3:");
-
-  DecisionTreeFactor::Values values;
-  values[0] = 1; // x
-  values[1] = 2; // y
-  values[2] = 1; // z
+  Values values;
+  values.insert<size_t>(0, 1); // x
+  values.insert<size_t>(1, 2); // y
+  values.insert<size_t>(2, 1); // z
   EXPECT_DOUBLES_EQUAL(8, f1(values), 1e-9);
   EXPECT_DOUBLES_EQUAL(7, f2(values), 1e-9);
   EXPECT_DOUBLES_EQUAL(75, f3(values), 1e-9);

--- a/gtsam/discrete/tests/testDecisionTreeFactor.cpp
+++ b/gtsam/discrete/tests/testDecisionTreeFactor.cpp
@@ -40,9 +40,9 @@ TEST( DecisionTreeFactor, constructors)
   EXPECT_LONGS_EQUAL(3,f3.size());
 
   Values values;
-  values.insert<size_t>(0, 1); // x
-  values.insert<size_t>(1, 2); // y
-  values.insert<size_t>(2, 1); // z
+  values.insert<uint64_t>(0, 1); // x
+  values.insert<uint64_t>(1, 2); // y
+  values.insert<uint64_t>(2, 1); // z
   EXPECT_DOUBLES_EQUAL(8, f1(values), 1e-9);
   EXPECT_DOUBLES_EQUAL(7, f2(values), 1e-9);
   EXPECT_DOUBLES_EQUAL(75, f3(values), 1e-9);

--- a/gtsam/discrete/tests/testDiscreteBayesNet.cpp
+++ b/gtsam/discrete/tests/testDiscreteBayesNet.cpp
@@ -104,14 +104,14 @@ TEST(DiscreteBayesNet, Asia) {
   // solve
   auto actualMPE = chordal->optimize();
   Values expectedMPE;
-  expectedMPE.insert<size_t>(Asia.first, 0);
-  expectedMPE.insert<size_t>(Dyspnea.first, 0);
-  expectedMPE.insert<size_t>(XRay.first, 0);
-  expectedMPE.insert<size_t>(Tuberculosis.first, 0);
-  expectedMPE.insert<size_t>(Smoking.first, 0);
-  expectedMPE.insert<size_t>(Either.first, 0);
-  expectedMPE.insert<size_t>(LungCancer.first, 0);
-  expectedMPE.insert<size_t>(Bronchitis.first, 0);
+  expectedMPE.insert<uint64_t>(Asia.first, 0);
+  expectedMPE.insert<uint64_t>(Dyspnea.first, 0);
+  expectedMPE.insert<uint64_t>(XRay.first, 0);
+  expectedMPE.insert<uint64_t>(Tuberculosis.first, 0);
+  expectedMPE.insert<uint64_t>(Smoking.first, 0);
+  expectedMPE.insert<uint64_t>(Either.first, 0);
+  expectedMPE.insert<uint64_t>(LungCancer.first, 0);
+  expectedMPE.insert<uint64_t>(Bronchitis.first, 0);
 
   EXPECT(assert_equal(expectedMPE, actualMPE));
 
@@ -123,28 +123,28 @@ TEST(DiscreteBayesNet, Asia) {
   DiscreteBayesNet::shared_ptr chordal2 = fg.eliminateSequential(ordering);
   auto actualMPE2 = chordal2->optimize();
   Values expectedMPE2;
-  expectedMPE2.insert<size_t>(Asia.first, 1);
-  expectedMPE2.insert<size_t>(Dyspnea.first, 1);
-  expectedMPE2.insert<size_t>(XRay.first, 0);
-  expectedMPE2.insert<size_t>(Tuberculosis.first, 0);
-  expectedMPE2.insert<size_t>(Smoking.first, 1);
-  expectedMPE2.insert<size_t>(Either.first, 0);
-  expectedMPE2.insert<size_t>(LungCancer.first, 0);
-  expectedMPE2.insert<size_t>(Bronchitis.first, 1);
+  expectedMPE2.insert<uint64_t>(Asia.first, 1);
+  expectedMPE2.insert<uint64_t>(Dyspnea.first, 1);
+  expectedMPE2.insert<uint64_t>(XRay.first, 0);
+  expectedMPE2.insert<uint64_t>(Tuberculosis.first, 0);
+  expectedMPE2.insert<uint64_t>(Smoking.first, 1);
+  expectedMPE2.insert<uint64_t>(Either.first, 0);
+  expectedMPE2.insert<uint64_t>(LungCancer.first, 0);
+  expectedMPE2.insert<uint64_t>(Bronchitis.first, 1);
 
   EXPECT(assert_equal(expectedMPE2, actualMPE2));
 
   // now sample from it
   Values expectedSample;
   SETDEBUG("DiscreteConditional::sample", false);
-  expectedSample.insert<size_t>(Asia.first, 1);
-  expectedSample.insert<size_t>(Dyspnea.first, 1);
-  expectedSample.insert<size_t>(XRay.first, 1);
-  expectedSample.insert<size_t>(Tuberculosis.first, 0);
-  expectedSample.insert<size_t>(Smoking.first, 1);
-  expectedSample.insert<size_t>(Either.first, 1);
-  expectedSample.insert<size_t>(LungCancer.first, 1);
-  expectedSample.insert<size_t>(Bronchitis.first, 0);;
+  expectedSample.insert<uint64_t>(Asia.first, 1);
+  expectedSample.insert<uint64_t>(Dyspnea.first, 1);
+  expectedSample.insert<uint64_t>(XRay.first, 1);
+  expectedSample.insert<uint64_t>(Tuberculosis.first, 0);
+  expectedSample.insert<uint64_t>(Smoking.first, 1);
+  expectedSample.insert<uint64_t>(Either.first, 1);
+  expectedSample.insert<uint64_t>(LungCancer.first, 1);
+  expectedSample.insert<uint64_t>(Bronchitis.first, 0);;
 
   auto actualSample = chordal2->sample();
   EXPECT(assert_equal(expectedSample, actualSample));

--- a/gtsam/discrete/tests/testDiscreteBayesNet.cpp
+++ b/gtsam/discrete/tests/testDiscreteBayesNet.cpp
@@ -25,8 +25,6 @@
 
 #include <CppUnitLite/TestHarness.h>
 
-
-#include <boost/assign/list_inserter.hpp>
 #include <boost/assign/std/map.hpp>
 
 using namespace boost::assign;
@@ -105,10 +103,16 @@ TEST(DiscreteBayesNet, Asia) {
 
   // solve
   auto actualMPE = chordal->optimize();
-  DiscreteFactor::Values expectedMPE;
-  insert(expectedMPE)(Asia.first, 0)(Dyspnea.first, 0)(XRay.first, 0)(
-      Tuberculosis.first, 0)(Smoking.first, 0)(Either.first, 0)(
-      LungCancer.first, 0)(Bronchitis.first, 0);
+  Values expectedMPE;
+  expectedMPE.insert<size_t>(Asia.first, 0);
+  expectedMPE.insert<size_t>(Dyspnea.first, 0);
+  expectedMPE.insert<size_t>(XRay.first, 0);
+  expectedMPE.insert<size_t>(Tuberculosis.first, 0);
+  expectedMPE.insert<size_t>(Smoking.first, 0);
+  expectedMPE.insert<size_t>(Either.first, 0);
+  expectedMPE.insert<size_t>(LungCancer.first, 0);
+  expectedMPE.insert<size_t>(Bronchitis.first, 0);
+
   EXPECT(assert_equal(expectedMPE, actualMPE));
 
   // add evidence, we were in Asia and we have dyspnea
@@ -118,18 +122,30 @@ TEST(DiscreteBayesNet, Asia) {
   // solve again, now with evidence
   DiscreteBayesNet::shared_ptr chordal2 = fg.eliminateSequential(ordering);
   auto actualMPE2 = chordal2->optimize();
-  DiscreteFactor::Values expectedMPE2;
-  insert(expectedMPE2)(Asia.first, 1)(Dyspnea.first, 1)(XRay.first, 0)(
-      Tuberculosis.first, 0)(Smoking.first, 1)(Either.first, 0)(
-      LungCancer.first, 0)(Bronchitis.first, 1);
+  Values expectedMPE2;
+  expectedMPE2.insert<size_t>(Asia.first, 1);
+  expectedMPE2.insert<size_t>(Dyspnea.first, 1);
+  expectedMPE2.insert<size_t>(XRay.first, 0);
+  expectedMPE2.insert<size_t>(Tuberculosis.first, 0);
+  expectedMPE2.insert<size_t>(Smoking.first, 1);
+  expectedMPE2.insert<size_t>(Either.first, 0);
+  expectedMPE2.insert<size_t>(LungCancer.first, 0);
+  expectedMPE2.insert<size_t>(Bronchitis.first, 1);
+
   EXPECT(assert_equal(expectedMPE2, actualMPE2));
 
   // now sample from it
-  DiscreteFactor::Values expectedSample;
+  Values expectedSample;
   SETDEBUG("DiscreteConditional::sample", false);
-  insert(expectedSample)(Asia.first, 1)(Dyspnea.first, 1)(XRay.first, 1)(
-      Tuberculosis.first, 0)(Smoking.first, 1)(Either.first, 1)(
-      LungCancer.first, 1)(Bronchitis.first, 0);
+  expectedSample.insert<size_t>(Asia.first, 1);
+  expectedSample.insert<size_t>(Dyspnea.first, 1);
+  expectedSample.insert<size_t>(XRay.first, 1);
+  expectedSample.insert<size_t>(Tuberculosis.first, 0);
+  expectedSample.insert<size_t>(Smoking.first, 1);
+  expectedSample.insert<size_t>(Either.first, 1);
+  expectedSample.insert<size_t>(LungCancer.first, 1);
+  expectedSample.insert<size_t>(Bronchitis.first, 0);;
+
   auto actualSample = chordal2->sample();
   EXPECT(assert_equal(expectedSample, actualSample));
 }

--- a/gtsam/discrete/tests/testDiscreteBayesTree.cpp
+++ b/gtsam/discrete/tests/testDiscreteBayesTree.cpp
@@ -34,7 +34,7 @@ using namespace gtsam;
 static bool debug = false;
 
 bool getValue(const Values& values, Key key) {
-  return values.exists(key) && values.at<size_t>(key);
+  return values.exists(key) && values.at<uint64_t>(key);
 }
 
 /* ************************************************************************* */

--- a/gtsam/discrete/tests/testDiscreteFactorGraph.cpp
+++ b/gtsam/discrete/tests/testDiscreteFactorGraph.cpp
@@ -82,9 +82,9 @@ TEST_UNSAFE( DiscreteFactorGraph, DiscreteFactorGraphEvaluationTest) {
   graph.add(P1 & P2, "4 1 10 4");
 
   // Instantiate Values
-  DiscreteFactor::Values values;
-  values[0] = 1;
-  values[1] = 1;
+  Values values;
+  values.insert<size_t>(0, 1);
+  values.insert<size_t>(1, 1);
 
   // Check if graph evaluation works ( 0.3*0.6*4 )
   EXPECT_DOUBLES_EQUAL( .72, graph(values), 1e-9);
@@ -94,17 +94,17 @@ TEST_UNSAFE( DiscreteFactorGraph, DiscreteFactorGraphEvaluationTest) {
   graph.add(P1 & P2 & P3, "1 2 3 4 5 6 7 8 9 10 11 12");
 
   // Below values lead to selecting the 8th index in the ternary factor table
-  values[0] = 1;
-  values[1] = 0;
-  values[2] = 1;
+  values.update<size_t>(0, 1);
+  values.update<size_t>(1, 0);
+  values.insert<size_t>(2, 1);
 
   // Check if graph evaluation works (0.3*0.9*1*0.2*8)
   EXPECT_DOUBLES_EQUAL( 4.32, graph(values), 1e-9);
 
   // Below values lead to selecting the 3rd index in the ternary factor table
-  values[0] = 0;
-  values[1] = 1;
-  values[2] = 0;
+  values.update<size_t>(0, 0);
+  values.update<size_t>(1, 1);
+  values.update<size_t>(2, 0);
 
   // Check if graph evaluation works (0.9*0.6*1*0.9*4)
   EXPECT_DOUBLES_EQUAL( 1.944, graph(values), 1e-9);
@@ -151,7 +151,6 @@ TEST( DiscreteFactorGraph, test)
   // add conditionals to complete expected Bayes net
   expected.add(B | A = "5/3 3/5");
   expected.add(A % "1/1");
-  //  GTSAM_PRINT(expected);
 
   // Test elimination tree
   Ordering ordering;
@@ -167,8 +166,10 @@ TEST( DiscreteFactorGraph, test)
 //  EXPECT(assert_equal(expected, *actual2));
 
   // Test optimization
-  DiscreteFactor::Values expectedValues;
-  insert(expectedValues)(0, 0)(1, 0)(2, 0);
+  Values expectedValues;
+  expectedValues.insert<size_t>(0, 0);
+  expectedValues.insert<size_t>(1, 0);
+  expectedValues.insert<size_t>(2, 0);
   auto actualValues = graph.optimize();
   EXPECT(assert_equal(expectedValues, actualValues));
 }
@@ -183,13 +184,13 @@ TEST( DiscreteFactorGraph, testMPE)
   DiscreteFactorGraph graph;
   graph.add(C & A, "0.2 0.8 0.3 0.7");
   graph.add(C & B, "0.1 0.9 0.4 0.6");
-  //  graph.product().print();
-  //  DiscreteSequentialSolver(graph).eliminate()->print();
 
   auto actualMPE = graph.optimize();
 
-  DiscreteFactor::Values expectedMPE;
-  insert(expectedMPE)(0, 0)(1, 1)(2, 1);
+  Values expectedMPE;
+  expectedMPE.insert<size_t>(0, 0);
+  expectedMPE.insert<size_t>(1, 1);
+  expectedMPE.insert<size_t>(2, 1);
   EXPECT(assert_equal(expectedMPE, actualMPE));
 }
 
@@ -211,8 +212,12 @@ TEST( DiscreteFactorGraph, testMPE_Darwiche09book_p244)
   //  graph.product().potentials().dot("Darwiche-product");
   //  DiscreteSequentialSolver(graph).eliminate()->print();
 
-  DiscreteFactor::Values expectedMPE;
-  insert(expectedMPE)(4, 0)(2, 0)(3, 1)(0, 1)(1, 1);
+  Values expectedMPE;
+  expectedMPE.insert<size_t>(4, 0);
+  expectedMPE.insert<size_t>(2, 0);
+  expectedMPE.insert<size_t>(3, 1);
+  expectedMPE.insert<size_t>(0, 1);
+  expectedMPE.insert<size_t>(1, 1);
 
   // Use the solver machinery.
   DiscreteBayesNet::shared_ptr chordal = graph.eliminateSequential();

--- a/gtsam/discrete/tests/testDiscreteFactorGraph.cpp
+++ b/gtsam/discrete/tests/testDiscreteFactorGraph.cpp
@@ -83,8 +83,8 @@ TEST_UNSAFE( DiscreteFactorGraph, DiscreteFactorGraphEvaluationTest) {
 
   // Instantiate Values
   Values values;
-  values.insert<size_t>(0, 1);
-  values.insert<size_t>(1, 1);
+  values.insert<uint64_t>(0, 1);
+  values.insert<uint64_t>(1, 1);
 
   // Check if graph evaluation works ( 0.3*0.6*4 )
   EXPECT_DOUBLES_EQUAL( .72, graph(values), 1e-9);
@@ -94,17 +94,17 @@ TEST_UNSAFE( DiscreteFactorGraph, DiscreteFactorGraphEvaluationTest) {
   graph.add(P1 & P2 & P3, "1 2 3 4 5 6 7 8 9 10 11 12");
 
   // Below values lead to selecting the 8th index in the ternary factor table
-  values.update<size_t>(0, 1);
-  values.update<size_t>(1, 0);
-  values.insert<size_t>(2, 1);
+  values.update<uint64_t>(0, 1);
+  values.update<uint64_t>(1, 0);
+  values.insert<uint64_t>(2, 1);
 
   // Check if graph evaluation works (0.3*0.9*1*0.2*8)
   EXPECT_DOUBLES_EQUAL( 4.32, graph(values), 1e-9);
 
   // Below values lead to selecting the 3rd index in the ternary factor table
-  values.update<size_t>(0, 0);
-  values.update<size_t>(1, 1);
-  values.update<size_t>(2, 0);
+  values.update<uint64_t>(0, 0);
+  values.update<uint64_t>(1, 1);
+  values.update<uint64_t>(2, 0);
 
   // Check if graph evaluation works (0.9*0.6*1*0.9*4)
   EXPECT_DOUBLES_EQUAL( 1.944, graph(values), 1e-9);
@@ -167,9 +167,9 @@ TEST( DiscreteFactorGraph, test)
 
   // Test optimization
   Values expectedValues;
-  expectedValues.insert<size_t>(0, 0);
-  expectedValues.insert<size_t>(1, 0);
-  expectedValues.insert<size_t>(2, 0);
+  expectedValues.insert<uint64_t>(0, 0);
+  expectedValues.insert<uint64_t>(1, 0);
+  expectedValues.insert<uint64_t>(2, 0);
   auto actualValues = graph.optimize();
   EXPECT(assert_equal(expectedValues, actualValues));
 }
@@ -188,9 +188,9 @@ TEST( DiscreteFactorGraph, testMPE)
   auto actualMPE = graph.optimize();
 
   Values expectedMPE;
-  expectedMPE.insert<size_t>(0, 0);
-  expectedMPE.insert<size_t>(1, 1);
-  expectedMPE.insert<size_t>(2, 1);
+  expectedMPE.insert<uint64_t>(0, 0);
+  expectedMPE.insert<uint64_t>(1, 1);
+  expectedMPE.insert<uint64_t>(2, 1);
   EXPECT(assert_equal(expectedMPE, actualMPE));
 }
 
@@ -213,11 +213,11 @@ TEST( DiscreteFactorGraph, testMPE_Darwiche09book_p244)
   //  DiscreteSequentialSolver(graph).eliminate()->print();
 
   Values expectedMPE;
-  expectedMPE.insert<size_t>(4, 0);
-  expectedMPE.insert<size_t>(2, 0);
-  expectedMPE.insert<size_t>(3, 1);
-  expectedMPE.insert<size_t>(0, 1);
-  expectedMPE.insert<size_t>(1, 1);
+  expectedMPE.insert<uint64_t>(4, 0);
+  expectedMPE.insert<uint64_t>(2, 0);
+  expectedMPE.insert<uint64_t>(3, 1);
+  expectedMPE.insert<uint64_t>(0, 1);
+  expectedMPE.insert<uint64_t>(1, 1);
 
   // Use the solver machinery.
   DiscreteBayesNet::shared_ptr chordal = graph.eliminateSequential();

--- a/gtsam/discrete/tests/testDiscreteMarginals.cpp
+++ b/gtsam/discrete/tests/testDiscreteMarginals.cpp
@@ -49,7 +49,7 @@ TEST_UNSAFE( DiscreteMarginals, UGM_small ) {
   DiscreteFactor::shared_ptr actualC = marginals(Cathy.first);
   Values values;
 
-  values.insert<size_t>(Cathy.first, 0);
+  values.insert<uint64_t>(Cathy.first, 0);
   EXPECT_DOUBLES_EQUAL( 0.359631, (*actualC)(values), 1e-6);
 
   Vector actualCvector = marginals.marginalProbabilities(Cathy);
@@ -96,7 +96,7 @@ TEST_UNSAFE( DiscreteMarginals, UGM_chain ) {
   DiscreteFactor::shared_ptr actualC = marginals(key[2].first);
   Values values;
 
-  values.insert<size_t>(key[2].first, 0);
+  values.insert<uint64_t>(key[2].first, 0);
   EXPECT_DOUBLES_EQUAL( 0.03426, (*actualC)(values), 1e-4);
 }
 
@@ -171,7 +171,7 @@ TEST_UNSAFE(DiscreteMarginals, truss2) {
     Values x = allPosbValues[i];
     double px = graph(x);
     for (size_t j = 0; j < 5; j++)
-      if (x.exists(j) && x.at<size_t>(j))
+      if (x.exists(j) && x.at<uint64_t>(j))
         T[j] += px;
       else
         F[j] += px;

--- a/gtsam/discrete/tests/testDiscreteMarginals.cpp
+++ b/gtsam/discrete/tests/testDiscreteMarginals.cpp
@@ -47,9 +47,9 @@ TEST_UNSAFE( DiscreteMarginals, UGM_small ) {
 
   DiscreteMarginals marginals(graph);
   DiscreteFactor::shared_ptr actualC = marginals(Cathy.first);
-  DiscreteFactor::Values values;
+  Values values;
 
-  values[Cathy.first] = 0;
+  values.insert<size_t>(Cathy.first, 0);
   EXPECT_DOUBLES_EQUAL( 0.359631, (*actualC)(values), 1e-6);
 
   Vector actualCvector = marginals.marginalProbabilities(Cathy);
@@ -94,9 +94,9 @@ TEST_UNSAFE( DiscreteMarginals, UGM_chain ) {
 
   DiscreteMarginals marginals(graph);
   DiscreteFactor::shared_ptr actualC = marginals(key[2].first);
-  DiscreteFactor::Values values;
+  Values values;
 
-  values[key[2].first] = 0;
+  values.insert<size_t>(key[2].first, 0);
   EXPECT_DOUBLES_EQUAL( 0.03426, (*actualC)(values), 1e-4);
 }
 
@@ -164,14 +164,14 @@ TEST_UNSAFE(DiscreteMarginals, truss2) {
   graph.add(key[2] & key[3] & key[4], "1 2 3 4 5 6 7 8");
 
   // Calculate the marginals by brute force
-  vector<DiscreteFactor::Values> allPosbValues =
+  vector<Values> allPosbValues =
       cartesianProduct(key[0] & key[1] & key[2] & key[3] & key[4]);
   Vector T = Z_5x1, F = Z_5x1;
   for (size_t i = 0; i < allPosbValues.size(); ++i) {
-    DiscreteFactor::Values x = allPosbValues[i];
+    Values x = allPosbValues[i];
     double px = graph(x);
     for (size_t j = 0; j < 5; j++)
-      if (x[j])
+      if (x.exists(j) && x.at<size_t>(j))
         T[j] += px;
       else
         F[j] += px;

--- a/gtsam/inference/Key.h
+++ b/gtsam/inference/Key.h
@@ -22,11 +22,11 @@
 #include <gtsam/base/FastSet.h>
 #include <gtsam/base/FastVector.h>
 #include <gtsam/base/Testable.h>
+#include <gtsam/base/VectorSpace.h>
 #include <gtsam/base/types.h>
 #include <gtsam/dllexport.h>
 
 #include <functional>
-
 #include <iosfwd>
 
 namespace gtsam {
@@ -114,7 +114,7 @@ GTSAM_EXPORT void PrintKeySet(
 template<typename T> struct traits;
 
 template <>
-struct traits<Key> {
+struct traits<Key> : public internal::ScalarTraits<Key> {
   static void Print(const Key& val, const std::string& str = "") {
     PrintKey(val, str);
   }

--- a/gtsam_unstable/discrete/AllDiff.cpp
+++ b/gtsam_unstable/discrete/AllDiff.cpp
@@ -105,7 +105,7 @@ Constraint::shared_ptr AllDiff::partiallyApply(
   for (Key k : keys_) {
     const Domain& Dk = domains.at(k);
     if (Dk.isSingleton()) {
-      known.insert(k, Dk.firstValue());
+      known.insert<uint64_t>(k, Dk.firstValue());
     }
   }
   return partiallyApply(known);

--- a/gtsam_unstable/discrete/AllDiff.cpp
+++ b/gtsam_unstable/discrete/AllDiff.cpp
@@ -29,7 +29,7 @@ void AllDiff::print(const std::string& s, const KeyFormatter& formatter) const {
 double AllDiff::operator()(const Values& values) const {
   std::set<size_t> taken;  // record values taken by keys
   for (Key dkey : keys_) {
-    size_t value = values.at<size_t>(dkey);  // get the value for that key
+    uint64_t value = values.at<uint64_t>(dkey);  // get the value for that key
     if (taken.count(value)) return 0.0;  // check if value alreday taken
     taken.insert(value);  // if not, record it as taken and keep checking
   }

--- a/gtsam_unstable/discrete/AllDiff.cpp
+++ b/gtsam_unstable/discrete/AllDiff.cpp
@@ -29,7 +29,7 @@ void AllDiff::print(const std::string& s, const KeyFormatter& formatter) const {
 double AllDiff::operator()(const Values& values) const {
   std::set<size_t> taken;  // record values taken by keys
   for (Key dkey : keys_) {
-    size_t value = values.at(dkey);      // get the value for that key
+    size_t value = values.at<size_t>(dkey);  // get the value for that key
     if (taken.count(value)) return 0.0;  // check if value alreday taken
     taken.insert(value);  // if not, record it as taken and keep checking
   }
@@ -101,10 +101,12 @@ Constraint::shared_ptr AllDiff::partiallyApply(const Values& values) const {
 /* ************************************************************************* */
 Constraint::shared_ptr AllDiff::partiallyApply(
     const Domains& domains) const {
-  DiscreteFactor::Values known;
+  Values known;
   for (Key k : keys_) {
     const Domain& Dk = domains.at(k);
-    if (Dk.isSingleton()) known[k] = Dk.firstValue();
+    if (Dk.isSingleton()) {
+      known.insert(k, Dk.firstValue());
+    }
   }
   return partiallyApply(known);
 }

--- a/gtsam_unstable/discrete/BinaryAllDiff.h
+++ b/gtsam_unstable/discrete/BinaryAllDiff.h
@@ -48,7 +48,7 @@ class BinaryAllDiff : public Constraint {
 
   /// Calculate value
   double operator()(const Values& values) const override {
-    return (double)(values.at(keys_[0]) != values.at(keys_[1]));
+    return (double)(values.at<size_t>(keys_[0]) != values.at<size_t>(keys_[1]));
   }
 
   /// Convert into a decisiontree

--- a/gtsam_unstable/discrete/BinaryAllDiff.h
+++ b/gtsam_unstable/discrete/BinaryAllDiff.h
@@ -18,7 +18,7 @@ namespace gtsam {
  * Returns 1 if values for two keys are different, 0 otherwise.
  */
 class BinaryAllDiff : public Constraint {
-  size_t cardinality0_, cardinality1_;  /// cardinality
+  uint64_t cardinality0_, cardinality1_;  /// cardinality
 
  public:
   /// Constructor
@@ -48,7 +48,7 @@ class BinaryAllDiff : public Constraint {
 
   /// Calculate value
   double operator()(const Values& values) const override {
-    return (double)(values.at<size_t>(keys_[0]) != values.at<size_t>(keys_[1]));
+    return (double)(values.at<uint64_t>(keys_[0]) != values.at<uint64_t>(keys_[1]));
   }
 
   /// Convert into a decisiontree

--- a/gtsam_unstable/discrete/CSP.cpp
+++ b/gtsam_unstable/discrete/CSP.cpp
@@ -14,13 +14,13 @@ using namespace std;
 namespace gtsam {
 
 /// Find the best total assignment - can be expensive
-CSP::Values CSP::optimalAssignment() const {
+Values CSP::optimalAssignment() const {
   DiscreteBayesNet::shared_ptr chordal = this->eliminateSequential();
   return chordal->optimize();
 }
 
 /// Find the best total assignment - can be expensive
-CSP::Values CSP::optimalAssignment(const Ordering& ordering) const {
+Values CSP::optimalAssignment(const Ordering& ordering) const {
   DiscreteBayesNet::shared_ptr chordal = this->eliminateSequential(ordering);
   return chordal->optimize();
 }

--- a/gtsam_unstable/discrete/CSP.h
+++ b/gtsam_unstable/discrete/CSP.h
@@ -20,8 +20,6 @@ namespace gtsam {
  */
 class GTSAM_UNSTABLE_EXPORT CSP : public DiscreteFactorGraph {
  public:
-  /** A map from keys to values */
-  typedef Assignment<Key> Values;
 
  public:
   /// Add a unary constraint, allowing only a single value

--- a/gtsam_unstable/discrete/Domain.cpp
+++ b/gtsam_unstable/discrete/Domain.cpp
@@ -32,7 +32,7 @@ string Domain::base1Str() const {
 
 /* ************************************************************************* */
 double Domain::operator()(const Values& values) const {
-  return contains(values.at<size_t>(key()));
+  return contains(values.at<uint64_t>(key()));
 }
 
 /* ************************************************************************* */
@@ -81,7 +81,7 @@ boost::optional<Domain> Domain::checkAllDiff(const KeyVector keys,
 /* ************************************************************************* */
 Constraint::shared_ptr Domain::partiallyApply(const Values& values) const {
   Values::const_iterator it = values.find(key());
-  if (it != values.end() && !contains(it->value.cast<size_t>()))
+  if (it != values.end() && !contains(it->value.cast<uint64_t>()))
     throw runtime_error("Domain::partiallyApply: unsatisfiable");
   return boost::make_shared<Domain>(*this);
 }

--- a/gtsam_unstable/discrete/Domain.cpp
+++ b/gtsam_unstable/discrete/Domain.cpp
@@ -32,7 +32,7 @@ string Domain::base1Str() const {
 
 /* ************************************************************************* */
 double Domain::operator()(const Values& values) const {
-  return contains(values.at(key()));
+  return contains(values.at<size_t>(key()));
 }
 
 /* ************************************************************************* */
@@ -81,7 +81,7 @@ boost::optional<Domain> Domain::checkAllDiff(const KeyVector keys,
 /* ************************************************************************* */
 Constraint::shared_ptr Domain::partiallyApply(const Values& values) const {
   Values::const_iterator it = values.find(key());
-  if (it != values.end() && !contains(it->second))
+  if (it != values.end() && !contains(it->value.cast<size_t>()))
     throw runtime_error("Domain::partiallyApply: unsatisfiable");
   return boost::make_shared<Domain>(*this);
 }

--- a/gtsam_unstable/discrete/Domain.h
+++ b/gtsam_unstable/discrete/Domain.h
@@ -18,7 +18,7 @@ namespace gtsam {
  */
 class GTSAM_UNSTABLE_EXPORT Domain : public Constraint {
   size_t cardinality_;       /// Cardinality
-  std::set<size_t> values_;  /// allowed values
+  std::set<uint64_t> values_;  /// allowed values
 
  public:
   typedef boost::shared_ptr<Domain> shared_ptr;
@@ -43,16 +43,16 @@ class GTSAM_UNSTABLE_EXPORT Domain : public Constraint {
   DiscreteKey discreteKey() const { return DiscreteKey(key(), cardinality_); }
 
   /// Insert a value, non const :-(
-  void insert(size_t value) { values_.insert(value); }
+  void insert(uint64_t value) { values_.insert(value); }
 
   /// Erase a value, non const :-(
-  void erase(size_t value) { values_.erase(value); }
+  void erase(uint64_t value) { values_.erase(value); }
 
   size_t nrValues() const { return values_.size(); }
 
   bool isSingleton() const { return nrValues() == 1; }
 
-  size_t firstValue() const { return *values_.begin(); }
+  uint64_t firstValue() const { return *values_.begin(); }
 
   // print
   void print(const std::string& s = "", const KeyFormatter& formatter =
@@ -73,7 +73,7 @@ class GTSAM_UNSTABLE_EXPORT Domain : public Constraint {
   std::string base1Str() const;
 
   // Check whether domain cotains a specific value.
-  bool contains(size_t value) const { return values_.count(value) > 0; }
+  bool contains(uint64_t value) const { return values_.count(value) > 0; }
 
   /// Calculate value
   double operator()(const Values& values) const override;

--- a/gtsam_unstable/discrete/Scheduler.cpp
+++ b/gtsam_unstable/discrete/Scheduler.cpp
@@ -207,11 +207,11 @@ void Scheduler::printAssignment(const Values& assignment) const {
   cout << endl;
   for (size_t s = 0; s < nrStudents(); s++) {
     Key j = 3 * maxNrStudents_ + s;
-    size_t slot = assignment.at(j);
+    size_t slot = assignment.at<size_t>(j);
     cout << studentName(s) << " slot: " << slotName_[slot] << endl;
     Key base = 3 * s;
     for (size_t area = 0; area < 3; area++) {
-      size_t faculty = assignment.at(base + area);
+      size_t faculty = assignment.at<size_t>(base + area);
       cout << setw(12) << studentArea(s, area) << ": " << facultyName_[faculty]
            << endl;
     }
@@ -223,7 +223,7 @@ void Scheduler::printAssignment(const Values& assignment) const {
 void Scheduler::printSpecial(const Values& assignment) const {
   Values::const_iterator it = assignment.begin();
   for (size_t area = 0; area < 3; area++, it++) {
-    size_t f = it->second;
+    size_t f = it->value.cast<size_t>();
     cout << setw(12) << studentArea(0, area) << ": " << facultyName_[f] << endl;
   }
   cout << endl;
@@ -235,7 +235,7 @@ void Scheduler::accumulateStats(const Values& assignment,
   for (size_t s = 0; s < nrStudents(); s++) {
     Key base = 3 * s;
     for (size_t area = 0; area < 3; area++) {
-      size_t f = assignment.at(base + area);
+      size_t f = assignment.at<size_t>(base + area);
       assert(f < stats.size());
       stats[f]++;
     }  // area
@@ -256,7 +256,7 @@ DiscreteBayesNet::shared_ptr Scheduler::eliminate() const {
 }
 
 /** Find the best total assignment - can be expensive */
-Scheduler::Values Scheduler::optimalAssignment() const {
+Values Scheduler::optimalAssignment() const {
   DiscreteBayesNet::shared_ptr chordal = eliminate();
 
   if (ISDEBUG("Scheduler::optimalAssignment")) {
@@ -273,14 +273,14 @@ Scheduler::Values Scheduler::optimalAssignment() const {
 }
 
 /** find the assignment of students to slots with most possible committees */
-Scheduler::Values Scheduler::bestSchedule() const {
+Values Scheduler::bestSchedule() const {
   Values best;
   throw runtime_error("bestSchedule not implemented");
   return best;
 }
 
 /** find the corresponding most desirable committee assignment */
-Scheduler::Values Scheduler::bestAssignment(const Values& bestSchedule) const {
+Values Scheduler::bestAssignment(const Values& bestSchedule) const {
   Values best;
   throw runtime_error("bestAssignment not implemented");
   return best;

--- a/gtsam_unstable/discrete/Scheduler.cpp
+++ b/gtsam_unstable/discrete/Scheduler.cpp
@@ -78,29 +78,29 @@ void Scheduler::addStudent(const string& studentName, const string& area1,
 }
 
 /** get key for student and area, 0 is time slot itself */
-const DiscreteKey& Scheduler::key(size_t s,
-                                  boost::optional<size_t> area) const {
+const DiscreteKey& Scheduler::key(uint64_t s,
+                                  boost::optional<uint64_t> area) const {
   return area ? students_[s].keys_[*area] : students_[s].key_;
 }
 
-const string& Scheduler::studentName(size_t i) const {
+const string& Scheduler::studentName(uint64_t i) const {
   assert(i < nrStudents());
   return students_[i].name_;
 }
 
-const DiscreteKey& Scheduler::studentKey(size_t i) const {
+const DiscreteKey& Scheduler::studentKey(uint64_t i) const {
   assert(i < nrStudents());
   return students_[i].key_;
 }
 
-const string& Scheduler::studentArea(size_t i, size_t area) const {
+const string& Scheduler::studentArea(uint64_t i, uint64_t area) const {
   assert(i < nrStudents());
   return students_[i].areaName_[area];
 }
 
 /** Add student-specific constraints to the graph */
-void Scheduler::addStudentSpecificConstraints(size_t i,
-                                              boost::optional<size_t> slot) {
+void Scheduler::addStudentSpecificConstraints(uint64_t i,
+                                              boost::optional<uint64_t> slot) {
   bool debug = ISDEBUG("Scheduler::buildGraph");
 
   assert(i < nrStudents());
@@ -207,11 +207,11 @@ void Scheduler::printAssignment(const Values& assignment) const {
   cout << endl;
   for (size_t s = 0; s < nrStudents(); s++) {
     Key j = 3 * maxNrStudents_ + s;
-    size_t slot = assignment.at<size_t>(j);
+    uint64_t slot = assignment.at<uint64_t>(j);
     cout << studentName(s) << " slot: " << slotName_[slot] << endl;
     Key base = 3 * s;
     for (size_t area = 0; area < 3; area++) {
-      size_t faculty = assignment.at<size_t>(base + area);
+      uint64_t faculty = assignment.at<uint64_t>(base + area);
       cout << setw(12) << studentArea(s, area) << ": " << facultyName_[faculty]
            << endl;
     }
@@ -223,7 +223,7 @@ void Scheduler::printAssignment(const Values& assignment) const {
 void Scheduler::printSpecial(const Values& assignment) const {
   Values::const_iterator it = assignment.begin();
   for (size_t area = 0; area < 3; area++, it++) {
-    size_t f = it->value.cast<size_t>();
+    uint64_t f = it->value.cast<uint64_t>();
     cout << setw(12) << studentArea(0, area) << ": " << facultyName_[f] << endl;
   }
   cout << endl;
@@ -231,11 +231,11 @@ void Scheduler::printSpecial(const Values& assignment) const {
 
 /** Accumulate faculty stats */
 void Scheduler::accumulateStats(const Values& assignment,
-                                vector<size_t>& stats) const {
+                                vector<uint64_t>& stats) const {
   for (size_t s = 0; s < nrStudents(); s++) {
     Key base = 3 * s;
     for (size_t area = 0; area < 3; area++) {
-      size_t f = assignment.at<size_t>(base + area);
+      uint64_t f = assignment.at<uint64_t>(base + area);
       assert(f < stats.size());
       stats[f]++;
     }  // area

--- a/gtsam_unstable/discrete/Scheduler.h
+++ b/gtsam_unstable/discrete/Scheduler.h
@@ -106,8 +106,8 @@ class GTSAM_UNSTABLE_EXPORT Scheduler : public CSP {
   Scheduler(size_t maxNrStudents, const std::string& filename);
 
   /** get key for student and area, 0 is time slot itself */
-  const DiscreteKey& key(size_t s,
-                         boost::optional<size_t> area = boost::none) const;
+  const DiscreteKey& key(uint64_t s,
+                         boost::optional<uint64_t> area = boost::none) const;
 
   /** addStudent has to be called after adding slots and faculty */
   void addStudent(const std::string& studentName, const std::string& area1,
@@ -117,13 +117,13 @@ class GTSAM_UNSTABLE_EXPORT Scheduler : public CSP {
   /// current number of students
   size_t nrStudents() const { return students_.size(); }
 
-  const std::string& studentName(size_t i) const;
-  const DiscreteKey& studentKey(size_t i) const;
-  const std::string& studentArea(size_t i, size_t area) const;
+  const std::string& studentName(uint64_t i) const;
+  const DiscreteKey& studentKey(uint64_t i) const;
+  const std::string& studentArea(uint64_t i, uint64_t area) const;
 
   /** Add student-specific constraints to the graph */
   void addStudentSpecificConstraints(
-      size_t i, boost::optional<size_t> slot = boost::none);
+      uint64_t i, boost::optional<uint64_t> slot = boost::none);
 
   /** Main routine that builds factor graph */
   void buildGraph(size_t mutexBound = 7);

--- a/gtsam_unstable/discrete/Scheduler.h
+++ b/gtsam_unstable/discrete/Scheduler.h
@@ -141,7 +141,7 @@ class GTSAM_UNSTABLE_EXPORT Scheduler : public CSP {
 
   /** Accumulate faculty stats */
   void accumulateStats(const Values& assignment,
-                       std::vector<size_t>& stats) const;
+                       std::vector<uint64_t>& stats) const;
 
   /** Eliminate, return a Bayes net */
   DiscreteBayesNet::shared_ptr eliminate() const;

--- a/gtsam_unstable/discrete/SingleValue.cpp
+++ b/gtsam_unstable/discrete/SingleValue.cpp
@@ -24,7 +24,7 @@ void SingleValue::print(const string& s, const KeyFormatter& formatter) const {
 
 /* ************************************************************************* */
 double SingleValue::operator()(const Values& values) const {
-  return (double)(values.at<size_t>(keys_[0]) == value_);
+  return (double)(values.at<uint64_t>(keys_[0]) == value_);
 }
 
 /* ************************************************************************* */
@@ -59,7 +59,7 @@ bool SingleValue::ensureArcConsistency(Key j, Domains* domains) const {
 /* ************************************************************************* */
 Constraint::shared_ptr SingleValue::partiallyApply(const Values& values) const {
   Values::const_iterator it = values.find(keys_[0]);
-  if (it != values.end() && it->value.cast<size_t>() != value_)
+  if (it != values.end() && it->value.cast<uint64_t>() != value_)
     throw runtime_error("SingleValue::partiallyApply: unsatisfiable");
   return boost::make_shared<SingleValue>(keys_[0], cardinality_, value_);
 }

--- a/gtsam_unstable/discrete/SingleValue.cpp
+++ b/gtsam_unstable/discrete/SingleValue.cpp
@@ -24,7 +24,7 @@ void SingleValue::print(const string& s, const KeyFormatter& formatter) const {
 
 /* ************************************************************************* */
 double SingleValue::operator()(const Values& values) const {
-  return (double)(values.at(keys_[0]) == value_);
+  return (double)(values.at<size_t>(keys_[0]) == value_);
 }
 
 /* ************************************************************************* */
@@ -59,7 +59,7 @@ bool SingleValue::ensureArcConsistency(Key j, Domains* domains) const {
 /* ************************************************************************* */
 Constraint::shared_ptr SingleValue::partiallyApply(const Values& values) const {
   Values::const_iterator it = values.find(keys_[0]);
-  if (it != values.end() && it->second != value_)
+  if (it != values.end() && it->value.cast<size_t>() != value_)
     throw runtime_error("SingleValue::partiallyApply: unsatisfiable");
   return boost::make_shared<SingleValue>(keys_[0], cardinality_, value_);
 }

--- a/gtsam_unstable/discrete/examples/schedulingExample.cpp
+++ b/gtsam_unstable/discrete/examples/schedulingExample.cpp
@@ -165,12 +165,12 @@ void solveStaged(size_t addMutex = 2) {
       root->print(""/*scheduler.studentName(s)*/);
 
     // solve root node only
-    Scheduler::Values values;
+    Values values;
     size_t bestSlot = root->solve(values);
 
     // get corresponding count
     DiscreteKey dkey = scheduler.studentKey(6 - s);
-    values[dkey.first] = bestSlot;
+    values.insert(dkey.first, bestSlot);
     size_t count = (*root)(values);
 
     // remove this slot from consideration
@@ -225,7 +225,7 @@ void sampleSolutions() {
   // now, sample schedules
   for (size_t n = 0; n < 500; n++) {
     vector<size_t> stats(19, 0);
-    vector<Scheduler::Values> samples;
+    vector<Values> samples;
     for (size_t i = 0; i < 7; i++) {
       samples.push_back(samplers[i]->sample());
       schedulers[i].accumulateStats(samples[i], stats);
@@ -319,12 +319,12 @@ void accomodateStudent() {
   //  GTSAM_PRINT(*chordal);
 
   // solve root node only
-  Scheduler::Values values;
+  Values values;
   size_t bestSlot = root->solve(values);
 
   // get corresponding count
   DiscreteKey dkey = scheduler.studentKey(0);
-  values[dkey.first] = bestSlot;
+  values.insert(dkey.first, bestSlot);
   size_t count = (*root)(values);
   cout << boost::format("%s = %d (%d), count = %d") % scheduler.studentName(0)
       % scheduler.slotName(bestSlot) % bestSlot % count << endl;

--- a/gtsam_unstable/discrete/examples/schedulingExample.cpp
+++ b/gtsam_unstable/discrete/examples/schedulingExample.cpp
@@ -224,7 +224,7 @@ void sampleSolutions() {
 
   // now, sample schedules
   for (size_t n = 0; n < 500; n++) {
-    vector<size_t> stats(19, 0);
+    vector<uint64_t> stats(19, 0);
     vector<Values> samples;
     for (size_t i = 0; i < 7; i++) {
       samples.push_back(samplers[i]->sample());

--- a/gtsam_unstable/discrete/examples/schedulingExample.cpp
+++ b/gtsam_unstable/discrete/examples/schedulingExample.cpp
@@ -170,7 +170,7 @@ void solveStaged(size_t addMutex = 2) {
 
     // get corresponding count
     DiscreteKey dkey = scheduler.studentKey(6 - s);
-    values.insert(dkey.first, bestSlot);
+    values.insert<uint64_t>(dkey.first, bestSlot);
     size_t count = (*root)(values);
 
     // remove this slot from consideration
@@ -324,7 +324,7 @@ void accomodateStudent() {
 
   // get corresponding count
   DiscreteKey dkey = scheduler.studentKey(0);
-  values.insert(dkey.first, bestSlot);
+  values.insert<uint64_t>(dkey.first, bestSlot);
   size_t count = (*root)(values);
   cout << boost::format("%s = %d (%d), count = %d") % scheduler.studentName(0)
       % scheduler.slotName(bestSlot) % bestSlot % count << endl;

--- a/gtsam_unstable/discrete/examples/schedulingQuals12.cpp
+++ b/gtsam_unstable/discrete/examples/schedulingQuals12.cpp
@@ -130,7 +130,7 @@ void runLargeExample() {
   tictoc_print();
   for (size_t i=0;i<100;i++) {
     auto assignment = chordal->sample();
-    vector<size_t> stats(scheduler.nrFaculty());
+    vector<uint64_t> stats(scheduler.nrFaculty());
     scheduler.accumulateStats(assignment, stats);
     size_t max = *max_element(stats.begin(), stats.end());
     size_t min = *min_element(stats.begin(), stats.end());
@@ -233,7 +233,7 @@ void sampleSolutions() {
 
   // now, sample schedules
   for (size_t n = 0; n < 500; n++) {
-    vector<size_t> stats(19, 0);
+    vector<uint64_t> stats(19, 0);
     vector<Values> samples;
     for (size_t i = 0; i < NRSTUDENTS; i++) {
       samples.push_back(samplers[i]->sample());

--- a/gtsam_unstable/discrete/examples/schedulingQuals12.cpp
+++ b/gtsam_unstable/discrete/examples/schedulingQuals12.cpp
@@ -195,7 +195,7 @@ void solveStaged(size_t addMutex = 2) {
 
     // get corresponding count
     DiscreteKey dkey = scheduler.studentKey(NRSTUDENTS - 1 - s);
-    values.insert(dkey.first, bestSlot);
+    values.insert<uint64_t>(dkey.first, bestSlot);
     size_t count = (*root)(values);
 
     // remove this slot from consideration

--- a/gtsam_unstable/discrete/examples/schedulingQuals12.cpp
+++ b/gtsam_unstable/discrete/examples/schedulingQuals12.cpp
@@ -190,12 +190,12 @@ void solveStaged(size_t addMutex = 2) {
       root->print(""/*scheduler.studentName(s)*/);
 
     // solve root node only
-    Scheduler::Values values;
+    Values values;
     size_t bestSlot = root->solve(values);
 
     // get corresponding count
     DiscreteKey dkey = scheduler.studentKey(NRSTUDENTS - 1 - s);
-    values[dkey.first] = bestSlot;
+    values.insert(dkey.first, bestSlot);
     size_t count = (*root)(values);
 
     // remove this slot from consideration
@@ -234,7 +234,7 @@ void sampleSolutions() {
   // now, sample schedules
   for (size_t n = 0; n < 500; n++) {
     vector<size_t> stats(19, 0);
-    vector<Scheduler::Values> samples;
+    vector<Values> samples;
     for (size_t i = 0; i < NRSTUDENTS; i++) {
       samples.push_back(samplers[i]->sample());
       schedulers[i].accumulateStats(samples[i], stats);

--- a/gtsam_unstable/discrete/examples/schedulingQuals13.cpp
+++ b/gtsam_unstable/discrete/examples/schedulingQuals13.cpp
@@ -258,7 +258,7 @@ void sampleSolutions() {
 
   // now, sample schedules
   for (size_t n = 0; n < 10000; n++) {
-    vector<size_t> stats(nrFaculty, 0);
+    vector<uint64_t> stats(nrFaculty, 0);
     vector<Values> samples;
     for (size_t i = 0; i < NRSTUDENTS; i++) {
       samples.push_back(samplers[i]->sample());

--- a/gtsam_unstable/discrete/examples/schedulingQuals13.cpp
+++ b/gtsam_unstable/discrete/examples/schedulingQuals13.cpp
@@ -217,7 +217,7 @@ void solveStaged(size_t addMutex = 2) {
 
     // get corresponding count
     DiscreteKey dkey = scheduler.studentKey(NRSTUDENTS - 1 - s);
-    values.insert(dkey.first, bestSlot);
+    values.insert<uint64_t>(dkey.first, bestSlot);
     double count = (*root)(values);
 
     // remove this slot from consideration

--- a/gtsam_unstable/discrete/examples/schedulingQuals13.cpp
+++ b/gtsam_unstable/discrete/examples/schedulingQuals13.cpp
@@ -212,12 +212,12 @@ void solveStaged(size_t addMutex = 2) {
       root->print(""/*scheduler.studentName(s)*/);
 
     // solve root node only
-    Scheduler::Values values;
+    Values values;
     size_t bestSlot = root->solve(values);
 
     // get corresponding count
     DiscreteKey dkey = scheduler.studentKey(NRSTUDENTS - 1 - s);
-    values[dkey.first] = bestSlot;
+    values.insert(dkey.first, bestSlot);
     double count = (*root)(values);
 
     // remove this slot from consideration
@@ -259,7 +259,7 @@ void sampleSolutions() {
   // now, sample schedules
   for (size_t n = 0; n < 10000; n++) {
     vector<size_t> stats(nrFaculty, 0);
-    vector<Scheduler::Values> samples;
+    vector<Values> samples;
     for (size_t i = 0; i < NRSTUDENTS; i++) {
       samples.push_back(samplers[i]->sample());
       schedulers[i].accumulateStats(samples[i], stats);

--- a/gtsam_unstable/discrete/tests/testCSP.cpp
+++ b/gtsam_unstable/discrete/tests/testCSP.cpp
@@ -115,16 +115,16 @@ TEST(CSP, allInOne) {
 
   // Check an invalid combination, with ID==UT==AZ all same color
   Values invalid;
-  invalid.insert<size_t>(ID.first, 0);
-  invalid.insert<size_t>(UT.first, 0);
-  invalid.insert<size_t>(AZ.first, 0);
+  invalid.insert<uint64_t>(ID.first, 0);
+  invalid.insert<uint64_t>(UT.first, 0);
+  invalid.insert<uint64_t>(AZ.first, 0);
   EXPECT_DOUBLES_EQUAL(0, csp(invalid), 1e-9);
 
   // Check a valid combination
   Values valid;
-  valid.insert<size_t>(ID.first, 0);
-  valid.insert<size_t>(UT.first, 1);
-  valid.insert<size_t>(AZ.first, 0);
+  valid.insert<uint64_t>(ID.first, 0);
+  valid.insert<uint64_t>(UT.first, 1);
+  valid.insert<uint64_t>(AZ.first, 0);
   EXPECT_DOUBLES_EQUAL(1, csp(valid), 1e-9);
 
   // Just for fun, create the product and check it
@@ -136,9 +136,9 @@ TEST(CSP, allInOne) {
   // Solve
   auto mpe = csp.optimalAssignment();
   Values expected;
-  expected.insert<size_t>(ID.first, 1);
-  expected.insert<size_t>(UT.first, 0);
-  expected.insert<size_t>(AZ.first, 1);
+  expected.insert<uint64_t>(ID.first, 1);
+  expected.insert<uint64_t>(UT.first, 0);
+  expected.insert<uint64_t>(AZ.first, 1);
   EXPECT(assert_equal(expected, mpe));
   EXPECT_DOUBLES_EQUAL(1, csp(mpe), 1e-9);
 }
@@ -184,17 +184,17 @@ TEST(CSP, WesternUS) {
   auto mpe = csp.optimalAssignment(ordering);
   // GTSAM_PRINT(mpe);
   Values expected;
-  expected.insert<size_t>(WA.first, 1);
-  expected.insert<size_t>(CA.first, 1);
-  expected.insert<size_t>(NV.first, 3);
-  expected.insert<size_t>(OR.first, 0);
-  expected.insert<size_t>(MT.first, 1);
-  expected.insert<size_t>(WY.first, 0);
-  expected.insert<size_t>(NM.first, 3);
-  expected.insert<size_t>(CO.first, 2);
-  expected.insert<size_t>(ID.first, 2);
-  expected.insert<size_t>(UT.first, 1);
-  expected.insert<size_t>(AZ.first, 0);
+  expected.insert<uint64_t>(WA.first, 1);
+  expected.insert<uint64_t>(CA.first, 1);
+  expected.insert<uint64_t>(NV.first, 3);
+  expected.insert<uint64_t>(OR.first, 0);
+  expected.insert<uint64_t>(MT.first, 1);
+  expected.insert<uint64_t>(WY.first, 0);
+  expected.insert<uint64_t>(NM.first, 3);
+  expected.insert<uint64_t>(CO.first, 2);
+  expected.insert<uint64_t>(ID.first, 2);
+  expected.insert<uint64_t>(UT.first, 1);
+  expected.insert<uint64_t>(AZ.first, 0);
 
   // TODO: Fix me! mpe result seems to be right. (See the printing)
   // It has the same prob as the expected solution.
@@ -226,24 +226,24 @@ TEST(CSP, ArcConsistency) {
 
   // Check an invalid combination, with ID==UT==AZ all same color
   Values invalid;
-  invalid.insert<size_t>(ID.first, 0);
-  invalid.insert<size_t>(UT.first, 1);
-  invalid.insert<size_t>(AZ.first, 0);
+  invalid.insert<uint64_t>(ID.first, 0);
+  invalid.insert<uint64_t>(UT.first, 1);
+  invalid.insert<uint64_t>(AZ.first, 0);
   EXPECT_DOUBLES_EQUAL(0, csp(invalid), 1e-9);
 
   // Check a valid combination
   Values valid;
-  valid.insert<size_t>(ID.first, 0);
-  valid.insert<size_t>(UT.first, 1);
-  valid.insert<size_t>(AZ.first, 2);
+  valid.insert<uint64_t>(ID.first, 0);
+  valid.insert<uint64_t>(UT.first, 1);
+  valid.insert<uint64_t>(AZ.first, 2);
   EXPECT_DOUBLES_EQUAL(1, csp(valid), 1e-9);
 
   // Solve
   auto mpe = csp.optimalAssignment();
   Values expected;
-  expected.insert<size_t>(ID.first, 1);
-  expected.insert<size_t>(UT.first, 0);
-  expected.insert<size_t>(AZ.first, 2);
+  expected.insert<uint64_t>(ID.first, 1);
+  expected.insert<uint64_t>(UT.first, 0);
+  expected.insert<uint64_t>(AZ.first, 2);
   EXPECT(assert_equal(expected, mpe));
   EXPECT_DOUBLES_EQUAL(1, csp(mpe), 1e-9);
 
@@ -265,7 +265,7 @@ TEST(CSP, ArcConsistency) {
 
   // Parial application, version 1
   Values known;
-  known.insert<size_t>(AZ.first, 2);
+  known.insert<uint64_t>(AZ.first, 2);
   DiscreteFactor::shared_ptr reduced1 = alldiff.partiallyApply(known);
   DecisionTreeFactor f3(ID & UT, "0 1 1  1 0 1  1 1 0");
   EXPECT(assert_equal(f3, reduced1->toDecisionTreeFactor()));

--- a/gtsam_unstable/discrete/tests/testCSP.cpp
+++ b/gtsam_unstable/discrete/tests/testCSP.cpp
@@ -9,12 +9,12 @@
 #include <gtsam_unstable/discrete/Domain.h>
 
 #include <boost/assign/std/map.hpp>
-using boost::assign::insert;
 #include <CppUnitLite/TestHarness.h>
 
 #include <fstream>
 #include <iostream>
 
+using boost::assign::insert;
 using namespace std;
 using namespace gtsam;
 
@@ -74,8 +74,10 @@ TEST(CSP, AllDiff) {
   vector<DiscreteKey> dkeys{ID, UT, AZ};
   AllDiff alldiff(dkeys);
   DecisionTreeFactor actual = alldiff.toDecisionTreeFactor();
+
   // GTSAM_PRINT(actual);
-  actual.dot("actual");
+  // actual.dot("actual");
+
   DecisionTreeFactor f2(
       ID & AZ & UT,
       "0 0 0  0 0 1  0 1 0   0 0 1  0 0 0  1 0 0   0 1 0  1 0 0  0 0 0");
@@ -112,17 +114,17 @@ TEST(CSP, allInOne) {
   csp.addAllDiff(UT, AZ);
 
   // Check an invalid combination, with ID==UT==AZ all same color
-  DiscreteFactor::Values invalid;
-  invalid[ID.first] = 0;
-  invalid[UT.first] = 0;
-  invalid[AZ.first] = 0;
+  Values invalid;
+  invalid.insert<size_t>(ID.first, 0);
+  invalid.insert<size_t>(UT.first, 0);
+  invalid.insert<size_t>(AZ.first, 0);
   EXPECT_DOUBLES_EQUAL(0, csp(invalid), 1e-9);
 
   // Check a valid combination
-  DiscreteFactor::Values valid;
-  valid[ID.first] = 0;
-  valid[UT.first] = 1;
-  valid[AZ.first] = 0;
+  Values valid;
+  valid.insert<size_t>(ID.first, 0);
+  valid.insert<size_t>(UT.first, 1);
+  valid.insert<size_t>(AZ.first, 0);
   EXPECT_DOUBLES_EQUAL(1, csp(valid), 1e-9);
 
   // Just for fun, create the product and check it
@@ -133,8 +135,10 @@ TEST(CSP, allInOne) {
 
   // Solve
   auto mpe = csp.optimalAssignment();
-  CSP::Values expected;
-  insert(expected)(ID.first, 1)(UT.first, 0)(AZ.first, 1);
+  Values expected;
+  expected.insert<size_t>(ID.first, 1);
+  expected.insert<size_t>(UT.first, 0);
+  expected.insert<size_t>(AZ.first, 1);
   EXPECT(assert_equal(expected, mpe));
   EXPECT_DOUBLES_EQUAL(1, csp(mpe), 1e-9);
 }
@@ -179,10 +183,18 @@ TEST(CSP, WesternUS) {
   // Solve using that ordering:
   auto mpe = csp.optimalAssignment(ordering);
   // GTSAM_PRINT(mpe);
-  CSP::Values expected;
-  insert(expected)(WA.first, 1)(CA.first, 1)(NV.first, 3)(OR.first, 0)(
-      MT.first, 1)(WY.first, 0)(NM.first, 3)(CO.first, 2)(ID.first, 2)(
-      UT.first, 1)(AZ.first, 0);
+  Values expected;
+  expected.insert<size_t>(WA.first, 1);
+  expected.insert<size_t>(CA.first, 1);
+  expected.insert<size_t>(NV.first, 3);
+  expected.insert<size_t>(OR.first, 0);
+  expected.insert<size_t>(MT.first, 1);
+  expected.insert<size_t>(WY.first, 0);
+  expected.insert<size_t>(NM.first, 3);
+  expected.insert<size_t>(CO.first, 2);
+  expected.insert<size_t>(ID.first, 2);
+  expected.insert<size_t>(UT.first, 1);
+  expected.insert<size_t>(AZ.first, 0);
 
   // TODO: Fix me! mpe result seems to be right. (See the printing)
   // It has the same prob as the expected solution.
@@ -213,23 +225,25 @@ TEST(CSP, ArcConsistency) {
   // GTSAM_PRINT(csp);
 
   // Check an invalid combination, with ID==UT==AZ all same color
-  DiscreteFactor::Values invalid;
-  invalid[ID.first] = 0;
-  invalid[UT.first] = 1;
-  invalid[AZ.first] = 0;
+  Values invalid;
+  invalid.insert<size_t>(ID.first, 0);
+  invalid.insert<size_t>(UT.first, 1);
+  invalid.insert<size_t>(AZ.first, 0);
   EXPECT_DOUBLES_EQUAL(0, csp(invalid), 1e-9);
 
   // Check a valid combination
-  DiscreteFactor::Values valid;
-  valid[ID.first] = 0;
-  valid[UT.first] = 1;
-  valid[AZ.first] = 2;
+  Values valid;
+  valid.insert<size_t>(ID.first, 0);
+  valid.insert<size_t>(UT.first, 1);
+  valid.insert<size_t>(AZ.first, 2);
   EXPECT_DOUBLES_EQUAL(1, csp(valid), 1e-9);
 
   // Solve
   auto mpe = csp.optimalAssignment();
-  CSP::Values expected;
-  insert(expected)(ID.first, 1)(UT.first, 0)(AZ.first, 2);
+  Values expected;
+  expected.insert<size_t>(ID.first, 1);
+  expected.insert<size_t>(UT.first, 0);
+  expected.insert<size_t>(AZ.first, 2);
   EXPECT(assert_equal(expected, mpe));
   EXPECT_DOUBLES_EQUAL(1, csp(mpe), 1e-9);
 
@@ -250,8 +264,8 @@ TEST(CSP, ArcConsistency) {
   LONGS_EQUAL(2, domains.at(2).nrValues());
 
   // Parial application, version 1
-  DiscreteFactor::Values known;
-  known[AZ.first] = 2;
+  Values known;
+  known.insert<size_t>(AZ.first, 2);
   DiscreteFactor::shared_ptr reduced1 = alldiff.partiallyApply(known);
   DecisionTreeFactor f3(ID & UT, "0 1 1  1 0 1  1 1 0");
   EXPECT(assert_equal(f3, reduced1->toDecisionTreeFactor()));

--- a/gtsam_unstable/discrete/tests/testLoopyBelief.cpp
+++ b/gtsam_unstable/discrete/tests/testLoopyBelief.cpp
@@ -31,7 +31,7 @@ class LoopyBelief {
    * - the factor indices of the corrected belief factors of the neighboring
    * nodes
    */
-  typedef std::map<Key, size_t> CorrectedBeliefIndices;
+  typedef std::map<Key, uint64_t> CorrectedBeliefIndices;
   struct StarGraph {
     DiscreteFactorGraph::shared_ptr star;
     CorrectedBeliefIndices correctedBeliefIndices;
@@ -127,7 +127,7 @@ class LoopyBelief {
       double sum = 0.0;
       for (size_t v = 0; v < allDiscreteKeys.at(key).second; ++v) {
         Values val;
-        val.insert(key, v);
+        val.insert<uint64_t>(key, v);
         sum += (*beliefAtKey)(val);
       }
       string sumFactorTable;

--- a/gtsam_unstable/discrete/tests/testLoopyBelief.cpp
+++ b/gtsam_unstable/discrete/tests/testLoopyBelief.cpp
@@ -126,8 +126,8 @@ class LoopyBelief {
       // normalize belief
       double sum = 0.0;
       for (size_t v = 0; v < allDiscreteKeys.at(key).second; ++v) {
-        DiscreteFactor::Values val;
-        val[key] = v;
+        Values val;
+        val.insert(key, v);
         sum += (*beliefAtKey)(val);
       }
       string sumFactorTable;

--- a/gtsam_unstable/discrete/tests/testSudoku.cpp
+++ b/gtsam_unstable/discrete/tests/testSudoku.cpp
@@ -88,11 +88,11 @@ class Sudoku : public CSP {
   }
 
   /// Print readable form of assignment
-  void printAssignment(const DiscreteFactor::Values& assignment) const {
+  void printAssignment(const Values& assignment) const {
     for (size_t i = 0; i < n_; i++) {
       for (size_t j = 0; j < n_; j++) {
         Key k = key(i, j);
-        cout << 1 + assignment.at(k) << " ";
+        cout << 1 + assignment.at<size_t>(k) << " ";
       }
       cout << endl;
     }
@@ -127,12 +127,23 @@ TEST(Sudoku, small) {
 
   // optimize and check
   auto solution = csp.optimalAssignment();
-  CSP::Values expected;
-  insert(expected)(csp.key(0, 0), 0)(csp.key(0, 1), 1)(csp.key(0, 2), 2)(
-      csp.key(0, 3), 3)(csp.key(1, 0), 2)(csp.key(1, 1), 3)(csp.key(1, 2), 0)(
-      csp.key(1, 3), 1)(csp.key(2, 0), 3)(csp.key(2, 1), 2)(csp.key(2, 2), 1)(
-      csp.key(2, 3), 0)(csp.key(3, 0), 1)(csp.key(3, 1), 0)(csp.key(3, 2), 3)(
-      csp.key(3, 3), 2);
+  Values expected;
+  expected.insert<size_t>(csp.key(0, 0), 0);
+  expected.insert<size_t>(csp.key(0, 1), 1);
+  expected.insert<size_t>(csp.key(0, 2), 2);
+  expected.insert<size_t>(csp.key(0, 3), 3);
+  expected.insert<size_t>(csp.key(1, 0), 2);
+  expected.insert<size_t>(csp.key(1, 1), 3);
+  expected.insert<size_t>(csp.key(1, 2), 0);
+  expected.insert<size_t>(csp.key(1, 3), 1);
+  expected.insert<size_t>(csp.key(2, 0), 3);
+  expected.insert<size_t>(csp.key(2, 1), 2);
+  expected.insert<size_t>(csp.key(2, 2), 1);
+  expected.insert<size_t>(csp.key(2, 3), 0);
+  expected.insert<size_t>(csp.key(3, 0), 1);
+  expected.insert<size_t>(csp.key(3, 1), 0);
+  expected.insert<size_t>(csp.key(3, 2), 3);
+  expected.insert<size_t>(csp.key(3, 3), 2);
   EXPECT(assert_equal(expected, solution));
   // csp.printAssignment(solution);
 
@@ -252,7 +263,7 @@ TEST(Sudoku, AJC_3star_Feb8_2012) {
   // Check that solution
   auto solution = new_csp.optimalAssignment();
   // csp.printAssignment(solution);
-  EXPECT_LONGS_EQUAL(6, solution.at(key99));
+  EXPECT_LONGS_EQUAL(6, solution.at<size_t>(key99));
 }
 
 /* ************************************************************************* */

--- a/gtsam_unstable/discrete/tests/testSudoku.cpp
+++ b/gtsam_unstable/discrete/tests/testSudoku.cpp
@@ -31,12 +31,12 @@ class Sudoku : public CSP {
 
  public:
   /// return DiscreteKey for cell(i,j)
-  const DiscreteKey& dkey(size_t i, size_t j) const {
+  const DiscreteKey& dkey(uint64_t i, uint64_t j) const {
     return dkeys_.at(IJ(i, j));
   }
 
   /// return Key for cell(i,j)
-  Key key(size_t i, size_t j) const { return dkey(i, j).first; }
+  Key key(uint64_t i, uint64_t j) const { return dkey(i, j).first; }
 
   /// Constructor
   Sudoku(size_t n, ...) : n_(n) {
@@ -92,7 +92,7 @@ class Sudoku : public CSP {
     for (size_t i = 0; i < n_; i++) {
       for (size_t j = 0; j < n_; j++) {
         Key k = key(i, j);
-        cout << 1 + assignment.at<size_t>(k) << " ";
+        cout << 1 + assignment.at<uint64_t>(k) << " ";
       }
       cout << endl;
     }
@@ -128,22 +128,22 @@ TEST(Sudoku, small) {
   // optimize and check
   auto solution = csp.optimalAssignment();
   Values expected;
-  expected.insert<size_t>(csp.key(0, 0), 0);
-  expected.insert<size_t>(csp.key(0, 1), 1);
-  expected.insert<size_t>(csp.key(0, 2), 2);
-  expected.insert<size_t>(csp.key(0, 3), 3);
-  expected.insert<size_t>(csp.key(1, 0), 2);
-  expected.insert<size_t>(csp.key(1, 1), 3);
-  expected.insert<size_t>(csp.key(1, 2), 0);
-  expected.insert<size_t>(csp.key(1, 3), 1);
-  expected.insert<size_t>(csp.key(2, 0), 3);
-  expected.insert<size_t>(csp.key(2, 1), 2);
-  expected.insert<size_t>(csp.key(2, 2), 1);
-  expected.insert<size_t>(csp.key(2, 3), 0);
-  expected.insert<size_t>(csp.key(3, 0), 1);
-  expected.insert<size_t>(csp.key(3, 1), 0);
-  expected.insert<size_t>(csp.key(3, 2), 3);
-  expected.insert<size_t>(csp.key(3, 3), 2);
+  expected.insert<uint64_t>(csp.key(0, 0), 0);
+  expected.insert<uint64_t>(csp.key(0, 1), 1);
+  expected.insert<uint64_t>(csp.key(0, 2), 2);
+  expected.insert<uint64_t>(csp.key(0, 3), 3);
+  expected.insert<uint64_t>(csp.key(1, 0), 2);
+  expected.insert<uint64_t>(csp.key(1, 1), 3);
+  expected.insert<uint64_t>(csp.key(1, 2), 0);
+  expected.insert<uint64_t>(csp.key(1, 3), 1);
+  expected.insert<uint64_t>(csp.key(2, 0), 3);
+  expected.insert<uint64_t>(csp.key(2, 1), 2);
+  expected.insert<uint64_t>(csp.key(2, 2), 1);
+  expected.insert<uint64_t>(csp.key(2, 3), 0);
+  expected.insert<uint64_t>(csp.key(3, 0), 1);
+  expected.insert<uint64_t>(csp.key(3, 1), 0);
+  expected.insert<uint64_t>(csp.key(3, 2), 3);
+  expected.insert<uint64_t>(csp.key(3, 3), 2);
   EXPECT(assert_equal(expected, solution));
   // csp.printAssignment(solution);
 
@@ -263,7 +263,7 @@ TEST(Sudoku, AJC_3star_Feb8_2012) {
   // Check that solution
   auto solution = new_csp.optimalAssignment();
   // csp.printAssignment(solution);
-  EXPECT_LONGS_EQUAL(6, solution.at<size_t>(key99));
+  EXPECT_LONGS_EQUAL(6, solution.at<uint64_t>(key99));
 }
 
 /* ************************************************************************* */


### PR DESCRIPTION
This PR updates the `discrete` module to use `gtsam::Values` instead of `Assignment` maps which should make hybrid inference much easier and cleaner to code up.

1. Use `gtsam::Values` instead of other classes and typedefs.
2. Since all the values for discrete types are `size_t`, various Values operations are templated where required.
3. Unit tests have been updated and all pass on my local machine. CI might reveal more.