### PR TITLE
Add wrapper fixes for Matlab memory leak

### DIFF
--- a/gtsam/geometry/geometry.i
+++ b/gtsam/geometry/geometry.i
@@ -27,9 +27,6 @@ class Point2 {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
   
 class Point2Pairs {
@@ -104,9 +101,6 @@ class StereoPoint2 {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 #include <gtsam/geometry/Point3.h>
@@ -131,9 +125,6 @@ class Point3 {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 class Point3Pairs {
@@ -191,9 +182,6 @@ class Rot2 {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 #include <gtsam/geometry/SO3.h>
@@ -372,9 +360,6 @@ class Rot3 {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 #include <gtsam/geometry/Pose2.h>
@@ -433,9 +418,6 @@ class Pose2 {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
   
 boost::optional<gtsam::Pose2> align(const gtsam::Point2Pairs& pairs);
@@ -502,9 +484,6 @@ class Pose3 {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 class Pose3Pairs {
@@ -546,9 +525,6 @@ class Unit3 {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 
   // enabling function to compare objects
   bool equals(const gtsam::Unit3& expected, double tol) const;
@@ -611,9 +587,6 @@ class Cal3_S2 {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 #include <gtsam/geometry/Cal3DS2_Base.h>
@@ -642,9 +615,6 @@ virtual class Cal3DS2_Base {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 #include <gtsam/geometry/Cal3DS2.h>
@@ -668,9 +638,6 @@ virtual class Cal3DS2 : gtsam::Cal3DS2_Base {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 #include <gtsam/geometry/Cal3Unified.h>
@@ -705,9 +672,6 @@ virtual class Cal3Unified : gtsam::Cal3DS2_Base {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 #include <gtsam/geometry/Cal3Fisheye.h>
@@ -750,9 +714,6 @@ class Cal3Fisheye {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 #include <gtsam/geometry/Cal3_S2Stereo.h>
@@ -811,9 +772,6 @@ class Cal3Bundler {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 #include <gtsam/geometry/CalibratedCamera.h>
@@ -847,9 +805,6 @@ class CalibratedCamera {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 #include <gtsam/geometry/PinholeCamera.h>
@@ -889,9 +844,6 @@ class PinholeCamera {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 #include <gtsam/geometry/Similarity3.h>
@@ -962,9 +914,6 @@ class StereoCamera {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 #include <gtsam/geometry/triangulation.h>

--- a/gtsam/gtsam.i
+++ b/gtsam/gtsam.i
@@ -39,9 +39,6 @@ class KeyList {
   void remove(size_t key);
 
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 // Actually a FastSet<Key>
@@ -67,9 +64,6 @@ class KeySet {
   bool count(size_t key) const;  // returns true if value exists
 
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 // Actually a vector<Key>
@@ -91,9 +85,6 @@ class KeyVector {
   void push_back(size_t key) const;
 
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 // Actually a FastMap<Key,int>

--- a/gtsam/linear/linear.i
+++ b/gtsam/linear/linear.i
@@ -34,9 +34,6 @@ virtual class Gaussian : gtsam::noiseModel::Base {
 
   // enabling serialization functionality
   void serializable() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 virtual class Diagonal : gtsam::noiseModel::Gaussian {
@@ -52,9 +49,6 @@ virtual class Diagonal : gtsam::noiseModel::Gaussian {
 
   // enabling serialization functionality
   void serializable() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 virtual class Constrained : gtsam::noiseModel::Diagonal {
@@ -72,9 +66,6 @@ virtual class Constrained : gtsam::noiseModel::Diagonal {
 
     // enabling serialization functionality
     void serializable() const;
-
-    // enable pickling in python
-    void pickle() const;
 };
 
 virtual class Isotropic : gtsam::noiseModel::Diagonal {
@@ -87,9 +78,6 @@ virtual class Isotropic : gtsam::noiseModel::Diagonal {
 
   // enabling serialization functionality
   void serializable() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 virtual class Unit : gtsam::noiseModel::Isotropic {
@@ -97,9 +85,6 @@ virtual class Unit : gtsam::noiseModel::Isotropic {
 
   // enabling serialization functionality
   void serializable() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 namespace mEstimator {
@@ -270,9 +255,6 @@ class VectorValues {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 #include <gtsam/linear/GaussianFactor.h>
@@ -344,9 +326,6 @@ virtual class JacobianFactor : gtsam::GaussianFactor {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 #include <gtsam/linear/HessianFactor.h>
@@ -379,9 +358,6 @@ virtual class HessianFactor : gtsam::GaussianFactor {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 #include <gtsam/linear/GaussianFactorGraph.h>
@@ -463,9 +439,6 @@ class GaussianFactorGraph {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 #include <gtsam/linear/GaussianConditional.h>

--- a/gtsam/navigation/navigation.i
+++ b/gtsam/navigation/navigation.i
@@ -44,9 +44,6 @@ class ConstantBias {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 }///\namespace imuBias
@@ -73,9 +70,6 @@ class NavState {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 #include <gtsam/navigation/PreintegratedRotation.h>
@@ -121,9 +115,6 @@ virtual class PreintegrationParams : gtsam::PreintegratedRotationParams {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 #include <gtsam/navigation/ImuFactor.h>
@@ -156,9 +147,6 @@ class PreintegratedImuMeasurements {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 virtual class ImuFactor: gtsam::NonlinearFactor {

--- a/gtsam/nonlinear/nonlinear.i
+++ b/gtsam/nonlinear/nonlinear.i
@@ -131,9 +131,6 @@ class Ordering {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
@@ -195,9 +192,6 @@ class NonlinearFactorGraph {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 
   void saveGraph(const string& s) const;
 };
@@ -289,9 +283,6 @@ class Values {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 
   // New in 4.0, we have to specialize every insert/update/at to generate
   // wrappers Instead of the old: void insert(size_t j, const gtsam::Value&
@@ -851,9 +842,6 @@ virtual class PriorFactor : gtsam::NoiseModelFactor {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 #include <gtsam/nonlinear/NonlinearEquality.h>

--- a/gtsam/slam/slam.i
+++ b/gtsam/slam/slam.i
@@ -21,9 +21,6 @@ virtual class BetweenFactor : gtsam::NoiseModelFactor {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 #include <gtsam/slam/ProjectionFactor.h>
@@ -172,9 +169,6 @@ virtual class PoseTranslationPrior : gtsam::NoiseModelFactor {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 typedef gtsam::PoseTranslationPrior<gtsam::Pose2> PoseTranslationPrior2D;
@@ -234,9 +228,6 @@ class SfmTrack {
   // enabling serialization functionality
   void serialize() const;
 
-  // enable pickling in python
-  void pickle() const;
-
   // enabling function to compare objects
   bool equals(const gtsam::SfmTrack& expected, double tol) const;
 };
@@ -252,9 +243,6 @@ class SfmData {
 
   // enabling serialization functionality
   void serialize() const;
-
-  // enable pickling in python
-  void pickle() const;
 
   // enabling function to compare objects
   bool equals(const gtsam::SfmData& expected, double tol) const;

--- a/wrap/gtwrap/matlab_wrapper/templates.py
+++ b/wrap/gtwrap/matlab_wrapper/templates.py
@@ -66,7 +66,7 @@ class WrapperTemplate:
                 mxDestroyArray(registry);
 
                 mxArray *newAlreadyCreated = mxCreateNumericMatrix(0, 0, mxINT8_CLASS, mxREAL);
-                if(mexPutVariable("global", "gtsam_geometry_rttiRegistry_created", newAlreadyCreated) != 0) {{
+                if(mexPutVariable("global", "gtsam_{module_name}_rttiRegistry_created", newAlreadyCreated) != 0) {{
                   mexErrMsgTxt("gtsam wrap:  Error indexing RTTI types, inheritance will not work correctly");
                 }}
                 mxDestroyArray(newAlreadyCreated);

--- a/wrap/gtwrap/matlab_wrapper/wrapper.py
+++ b/wrap/gtwrap/matlab_wrapper/wrapper.py
@@ -5,16 +5,16 @@ that Matlab's MEX compiler can use.
 
 # pylint: disable=too-many-lines, no-self-use, too-many-arguments, too-many-branches, too-many-statements
 
+import copy
 import os
 import os.path as osp
 import textwrap
 from functools import partial, reduce
 from typing import Dict, Iterable, List, Union
-import copy
 
 import gtwrap.interface_parser as parser
-from gtwrap.interface_parser.function import ArgumentList
 import gtwrap.template_instantiator as instantiator
+from gtwrap.interface_parser.function import ArgumentList
 from gtwrap.matlab_wrapper.mixins import CheckMixin, FormatMixin
 from gtwrap.matlab_wrapper.templates import WrapperTemplate
 
@@ -1269,9 +1269,9 @@ class MatlabWrapper(CheckMixin, FormatMixin):
                     Collector_{class_name}::iterator item;
                     item = collector_{class_name}.find(self);
                     if(item != collector_{class_name}.end()) {{
-                      delete self;
                       collector_{class_name}.erase(item);
                     }}
+                    delete self;
                 ''').format(class_name_sep=class_name_separated,
                             class_name=class_name),
                                         prefix='  ')

--- a/wrap/tests/expected/matlab/class_wrapper.cpp
+++ b/wrap/tests/expected/matlab/class_wrapper.cpp
@@ -145,7 +145,7 @@ void _class_RTTIRegister() {
     mxDestroyArray(registry);
 
     mxArray *newAlreadyCreated = mxCreateNumericMatrix(0, 0, mxINT8_CLASS, mxREAL);
-    if(mexPutVariable("global", "gtsam_geometry_rttiRegistry_created", newAlreadyCreated) != 0) {
+    if(mexPutVariable("global", "gtsam_class_rttiRegistry_created", newAlreadyCreated) != 0) {
       mexErrMsgTxt("gtsam wrap:  Error indexing RTTI types, inheritance will not work correctly");
     }
     mxDestroyArray(newAlreadyCreated);
@@ -180,9 +180,9 @@ void FunRange_deconstructor_2(int nargout, mxArray *out[], int nargin, const mxA
   Collector_FunRange::iterator item;
   item = collector_FunRange.find(self);
   if(item != collector_FunRange.end()) {
-    delete self;
     collector_FunRange.erase(item);
   }
+  delete self;
 }
 
 void FunRange_range_3(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -216,9 +216,9 @@ void FunDouble_deconstructor_6(int nargout, mxArray *out[], int nargin, const mx
   Collector_FunDouble::iterator item;
   item = collector_FunDouble.find(self);
   if(item != collector_FunDouble.end()) {
-    delete self;
     collector_FunDouble.erase(item);
   }
+  delete self;
 }
 
 void FunDouble_multiTemplatedMethod_7(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -301,9 +301,9 @@ void Test_deconstructor_15(int nargout, mxArray *out[], int nargin, const mxArra
   Collector_Test::iterator item;
   item = collector_Test.find(self);
   if(item != collector_Test.end()) {
-    delete self;
     collector_Test.erase(item);
   }
+  delete self;
 }
 
 void Test_arg_EigenConstRef_16(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -544,9 +544,9 @@ void PrimitiveRefDouble_deconstructor_43(int nargout, mxArray *out[], int nargin
   Collector_PrimitiveRefDouble::iterator item;
   item = collector_PrimitiveRefDouble.find(self);
   if(item != collector_PrimitiveRefDouble.end()) {
-    delete self;
     collector_PrimitiveRefDouble.erase(item);
   }
+  delete self;
 }
 
 void PrimitiveRefDouble_Brutal_44(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -584,9 +584,9 @@ void MyVector3_deconstructor_47(int nargout, mxArray *out[], int nargin, const m
   Collector_MyVector3::iterator item;
   item = collector_MyVector3.find(self);
   if(item != collector_MyVector3.end()) {
-    delete self;
     collector_MyVector3.erase(item);
   }
+  delete self;
 }
 
 void MyVector12_collectorInsertAndMakeBase_48(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -617,9 +617,9 @@ void MyVector12_deconstructor_50(int nargout, mxArray *out[], int nargin, const 
   Collector_MyVector12::iterator item;
   item = collector_MyVector12.find(self);
   if(item != collector_MyVector12.end()) {
-    delete self;
     collector_MyVector12.erase(item);
   }
+  delete self;
 }
 
 void MultipleTemplatesIntDouble_collectorInsertAndMakeBase_51(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -639,9 +639,9 @@ void MultipleTemplatesIntDouble_deconstructor_52(int nargout, mxArray *out[], in
   Collector_MultipleTemplatesIntDouble::iterator item;
   item = collector_MultipleTemplatesIntDouble.find(self);
   if(item != collector_MultipleTemplatesIntDouble.end()) {
-    delete self;
     collector_MultipleTemplatesIntDouble.erase(item);
   }
+  delete self;
 }
 
 void MultipleTemplatesIntFloat_collectorInsertAndMakeBase_53(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -661,9 +661,9 @@ void MultipleTemplatesIntFloat_deconstructor_54(int nargout, mxArray *out[], int
   Collector_MultipleTemplatesIntFloat::iterator item;
   item = collector_MultipleTemplatesIntFloat.find(self);
   if(item != collector_MultipleTemplatesIntFloat.end()) {
-    delete self;
     collector_MultipleTemplatesIntFloat.erase(item);
   }
+  delete self;
 }
 
 void ForwardKinematics_collectorInsertAndMakeBase_55(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -714,9 +714,9 @@ void ForwardKinematics_deconstructor_58(int nargout, mxArray *out[], int nargin,
   Collector_ForwardKinematics::iterator item;
   item = collector_ForwardKinematics.find(self);
   if(item != collector_ForwardKinematics.end()) {
-    delete self;
     collector_ForwardKinematics.erase(item);
   }
+  delete self;
 }
 
 void TemplatedConstructor_collectorInsertAndMakeBase_59(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -783,9 +783,9 @@ void TemplatedConstructor_deconstructor_64(int nargout, mxArray *out[], int narg
   Collector_TemplatedConstructor::iterator item;
   item = collector_TemplatedConstructor.find(self);
   if(item != collector_TemplatedConstructor.end()) {
-    delete self;
     collector_TemplatedConstructor.erase(item);
   }
+  delete self;
 }
 
 void MyFactorPosePoint2_collectorInsertAndMakeBase_65(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -820,9 +820,9 @@ void MyFactorPosePoint2_deconstructor_67(int nargout, mxArray *out[], int nargin
   Collector_MyFactorPosePoint2::iterator item;
   item = collector_MyFactorPosePoint2.find(self);
   if(item != collector_MyFactorPosePoint2.end()) {
-    delete self;
     collector_MyFactorPosePoint2.erase(item);
   }
+  delete self;
 }
 
 void MyFactorPosePoint2_print_68(int nargout, mxArray *out[], int nargin, const mxArray *in[])

--- a/wrap/tests/expected/matlab/functions_wrapper.cpp
+++ b/wrap/tests/expected/matlab/functions_wrapper.cpp
@@ -51,7 +51,7 @@ void _functions_RTTIRegister() {
     mxDestroyArray(registry);
 
     mxArray *newAlreadyCreated = mxCreateNumericMatrix(0, 0, mxINT8_CLASS, mxREAL);
-    if(mexPutVariable("global", "gtsam_geometry_rttiRegistry_created", newAlreadyCreated) != 0) {
+    if(mexPutVariable("global", "gtsam_functions_rttiRegistry_created", newAlreadyCreated) != 0) {
       mexErrMsgTxt("gtsam wrap:  Error indexing RTTI types, inheritance will not work correctly");
     }
     mxDestroyArray(newAlreadyCreated);

--- a/wrap/tests/expected/matlab/geometry_wrapper.cpp
+++ b/wrap/tests/expected/matlab/geometry_wrapper.cpp
@@ -118,9 +118,9 @@ void gtsamPoint2_deconstructor_3(int nargout, mxArray *out[], int nargin, const 
   Collector_gtsamPoint2::iterator item;
   item = collector_gtsamPoint2.find(self);
   if(item != collector_gtsamPoint2.end()) {
-    delete self;
     collector_gtsamPoint2.erase(item);
   }
+  delete self;
 }
 
 void gtsamPoint2_argChar_4(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -262,9 +262,9 @@ void gtsamPoint3_deconstructor_20(int nargout, mxArray *out[], int nargin, const
   Collector_gtsamPoint3::iterator item;
   item = collector_gtsamPoint3.find(self);
   if(item != collector_gtsamPoint3.end()) {
-    delete self;
     collector_gtsamPoint3.erase(item);
   }
+  delete self;
 }
 
 void gtsamPoint3_norm_21(int nargout, mxArray *out[], int nargin, const mxArray *in[])

--- a/wrap/tests/expected/matlab/inheritance_wrapper.cpp
+++ b/wrap/tests/expected/matlab/inheritance_wrapper.cpp
@@ -88,7 +88,7 @@ void _inheritance_RTTIRegister() {
     mxDestroyArray(registry);
 
     mxArray *newAlreadyCreated = mxCreateNumericMatrix(0, 0, mxINT8_CLASS, mxREAL);
-    if(mexPutVariable("global", "gtsam_geometry_rttiRegistry_created", newAlreadyCreated) != 0) {
+    if(mexPutVariable("global", "gtsam_inheritance_rttiRegistry_created", newAlreadyCreated) != 0) {
       mexErrMsgTxt("gtsam wrap:  Error indexing RTTI types, inheritance will not work correctly");
     }
     mxDestroyArray(newAlreadyCreated);
@@ -121,9 +121,9 @@ void MyBase_deconstructor_2(int nargout, mxArray *out[], int nargin, const mxArr
   Collector_MyBase::iterator item;
   item = collector_MyBase.find(self);
   if(item != collector_MyBase.end()) {
-    delete self;
     collector_MyBase.erase(item);
   }
+  delete self;
 }
 
 void MyTemplatePoint2_collectorInsertAndMakeBase_3(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -171,9 +171,9 @@ void MyTemplatePoint2_deconstructor_6(int nargout, mxArray *out[], int nargin, c
   Collector_MyTemplatePoint2::iterator item;
   item = collector_MyTemplatePoint2.find(self);
   if(item != collector_MyTemplatePoint2.end()) {
-    delete self;
     collector_MyTemplatePoint2.erase(item);
   }
+  delete self;
 }
 
 void MyTemplatePoint2_accept_T_7(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -339,9 +339,9 @@ void MyTemplateMatrix_deconstructor_22(int nargout, mxArray *out[], int nargin, 
   Collector_MyTemplateMatrix::iterator item;
   item = collector_MyTemplateMatrix.find(self);
   if(item != collector_MyTemplateMatrix.end()) {
-    delete self;
     collector_MyTemplateMatrix.erase(item);
   }
+  delete self;
 }
 
 void MyTemplateMatrix_accept_T_23(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -492,9 +492,9 @@ void ForwardKinematicsFactor_deconstructor_37(int nargout, mxArray *out[], int n
   Collector_ForwardKinematicsFactor::iterator item;
   item = collector_ForwardKinematicsFactor.find(self);
   if(item != collector_ForwardKinematicsFactor.end()) {
-    delete self;
     collector_ForwardKinematicsFactor.erase(item);
   }
+  delete self;
 }
 
 

--- a/wrap/tests/expected/matlab/multiple_files_wrapper.cpp
+++ b/wrap/tests/expected/matlab/multiple_files_wrapper.cpp
@@ -75,7 +75,7 @@ void _multiple_files_RTTIRegister() {
     mxDestroyArray(registry);
 
     mxArray *newAlreadyCreated = mxCreateNumericMatrix(0, 0, mxINT8_CLASS, mxREAL);
-    if(mexPutVariable("global", "gtsam_geometry_rttiRegistry_created", newAlreadyCreated) != 0) {
+    if(mexPutVariable("global", "gtsam_multiple_files_rttiRegistry_created", newAlreadyCreated) != 0) {
       mexErrMsgTxt("gtsam wrap:  Error indexing RTTI types, inheritance will not work correctly");
     }
     mxDestroyArray(newAlreadyCreated);
@@ -110,9 +110,9 @@ void gtsamClass1_deconstructor_2(int nargout, mxArray *out[], int nargin, const 
   Collector_gtsamClass1::iterator item;
   item = collector_gtsamClass1.find(self);
   if(item != collector_gtsamClass1.end()) {
-    delete self;
     collector_gtsamClass1.erase(item);
   }
+  delete self;
 }
 
 void gtsamClass2_collectorInsertAndMakeBase_3(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -143,9 +143,9 @@ void gtsamClass2_deconstructor_5(int nargout, mxArray *out[], int nargin, const 
   Collector_gtsamClass2::iterator item;
   item = collector_gtsamClass2.find(self);
   if(item != collector_gtsamClass2.end()) {
-    delete self;
     collector_gtsamClass2.erase(item);
   }
+  delete self;
 }
 
 void gtsamClassA_collectorInsertAndMakeBase_6(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -176,9 +176,9 @@ void gtsamClassA_deconstructor_8(int nargout, mxArray *out[], int nargin, const 
   Collector_gtsamClassA::iterator item;
   item = collector_gtsamClassA.find(self);
   if(item != collector_gtsamClassA.end()) {
-    delete self;
     collector_gtsamClassA.erase(item);
   }
+  delete self;
 }
 
 

--- a/wrap/tests/expected/matlab/namespaces_wrapper.cpp
+++ b/wrap/tests/expected/matlab/namespaces_wrapper.cpp
@@ -112,7 +112,7 @@ void _namespaces_RTTIRegister() {
     mxDestroyArray(registry);
 
     mxArray *newAlreadyCreated = mxCreateNumericMatrix(0, 0, mxINT8_CLASS, mxREAL);
-    if(mexPutVariable("global", "gtsam_geometry_rttiRegistry_created", newAlreadyCreated) != 0) {
+    if(mexPutVariable("global", "gtsam_namespaces_rttiRegistry_created", newAlreadyCreated) != 0) {
       mexErrMsgTxt("gtsam wrap:  Error indexing RTTI types, inheritance will not work correctly");
     }
     mxDestroyArray(newAlreadyCreated);
@@ -147,9 +147,9 @@ void ns1ClassA_deconstructor_2(int nargout, mxArray *out[], int nargin, const mx
   Collector_ns1ClassA::iterator item;
   item = collector_ns1ClassA.find(self);
   if(item != collector_ns1ClassA.end()) {
-    delete self;
     collector_ns1ClassA.erase(item);
   }
+  delete self;
 }
 
 void ns1ClassB_collectorInsertAndMakeBase_3(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -180,9 +180,9 @@ void ns1ClassB_deconstructor_5(int nargout, mxArray *out[], int nargin, const mx
   Collector_ns1ClassB::iterator item;
   item = collector_ns1ClassB.find(self);
   if(item != collector_ns1ClassB.end()) {
-    delete self;
     collector_ns1ClassB.erase(item);
   }
+  delete self;
 }
 
 void aGlobalFunction_6(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -218,9 +218,9 @@ void ns2ClassA_deconstructor_9(int nargout, mxArray *out[], int nargin, const mx
   Collector_ns2ClassA::iterator item;
   item = collector_ns2ClassA.find(self);
   if(item != collector_ns2ClassA.end()) {
-    delete self;
     collector_ns2ClassA.erase(item);
   }
+  delete self;
 }
 
 void ns2ClassA_memberFunction_10(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -280,9 +280,9 @@ void ns2ns3ClassB_deconstructor_16(int nargout, mxArray *out[], int nargin, cons
   Collector_ns2ns3ClassB::iterator item;
   item = collector_ns2ns3ClassB.find(self);
   if(item != collector_ns2ns3ClassB.end()) {
-    delete self;
     collector_ns2ns3ClassB.erase(item);
   }
+  delete self;
 }
 
 void ns2ClassC_collectorInsertAndMakeBase_17(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -313,9 +313,9 @@ void ns2ClassC_deconstructor_19(int nargout, mxArray *out[], int nargin, const m
   Collector_ns2ClassC::iterator item;
   item = collector_ns2ClassC.find(self);
   if(item != collector_ns2ClassC.end()) {
-    delete self;
     collector_ns2ClassC.erase(item);
   }
+  delete self;
 }
 
 void aGlobalFunction_20(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -364,9 +364,9 @@ void ClassD_deconstructor_25(int nargout, mxArray *out[], int nargin, const mxAr
   Collector_ClassD::iterator item;
   item = collector_ClassD.find(self);
   if(item != collector_ClassD.end()) {
-    delete self;
     collector_ClassD.erase(item);
   }
+  delete self;
 }
 
 void gtsamValues_collectorInsertAndMakeBase_26(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -409,9 +409,9 @@ void gtsamValues_deconstructor_29(int nargout, mxArray *out[], int nargin, const
   Collector_gtsamValues::iterator item;
   item = collector_gtsamValues.find(self);
   if(item != collector_gtsamValues.end()) {
-    delete self;
     collector_gtsamValues.erase(item);
   }
+  delete self;
 }
 
 void gtsamValues_insert_30(int nargout, mxArray *out[], int nargin, const mxArray *in[])

--- a/wrap/tests/expected/matlab/special_cases_wrapper.cpp
+++ b/wrap/tests/expected/matlab/special_cases_wrapper.cpp
@@ -84,7 +84,7 @@ void _special_cases_RTTIRegister() {
     mxDestroyArray(registry);
 
     mxArray *newAlreadyCreated = mxCreateNumericMatrix(0, 0, mxINT8_CLASS, mxREAL);
-    if(mexPutVariable("global", "gtsam_geometry_rttiRegistry_created", newAlreadyCreated) != 0) {
+    if(mexPutVariable("global", "gtsam_special_cases_rttiRegistry_created", newAlreadyCreated) != 0) {
       mexErrMsgTxt("gtsam wrap:  Error indexing RTTI types, inheritance will not work correctly");
     }
     mxDestroyArray(newAlreadyCreated);
@@ -108,9 +108,9 @@ void gtsamNonlinearFactorGraph_deconstructor_1(int nargout, mxArray *out[], int 
   Collector_gtsamNonlinearFactorGraph::iterator item;
   item = collector_gtsamNonlinearFactorGraph.find(self);
   if(item != collector_gtsamNonlinearFactorGraph.end()) {
-    delete self;
     collector_gtsamNonlinearFactorGraph.erase(item);
   }
+  delete self;
 }
 
 void gtsamNonlinearFactorGraph_addPrior_2(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -140,9 +140,9 @@ void gtsamSfmTrack_deconstructor_4(int nargout, mxArray *out[], int nargin, cons
   Collector_gtsamSfmTrack::iterator item;
   item = collector_gtsamSfmTrack.find(self);
   if(item != collector_gtsamSfmTrack.end()) {
-    delete self;
     collector_gtsamSfmTrack.erase(item);
   }
+  delete self;
 }
 
 void gtsamPinholeCameraCal3Bundler_collectorInsertAndMakeBase_5(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -162,9 +162,9 @@ void gtsamPinholeCameraCal3Bundler_deconstructor_6(int nargout, mxArray *out[], 
   Collector_gtsamPinholeCameraCal3Bundler::iterator item;
   item = collector_gtsamPinholeCameraCal3Bundler.find(self);
   if(item != collector_gtsamPinholeCameraCal3Bundler.end()) {
-    delete self;
     collector_gtsamPinholeCameraCal3Bundler.erase(item);
   }
+  delete self;
 }
 
 void gtsamGeneralSFMFactorCal3Bundler_collectorInsertAndMakeBase_7(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -184,9 +184,9 @@ void gtsamGeneralSFMFactorCal3Bundler_deconstructor_8(int nargout, mxArray *out[
   Collector_gtsamGeneralSFMFactorCal3Bundler::iterator item;
   item = collector_gtsamGeneralSFMFactorCal3Bundler.find(self);
   if(item != collector_gtsamGeneralSFMFactorCal3Bundler.end()) {
-    delete self;
     collector_gtsamGeneralSFMFactorCal3Bundler.erase(item);
   }
+  delete self;
 }
 
 

--- a/wrap/tests/expected/matlab/template_wrapper.cpp
+++ b/wrap/tests/expected/matlab/template_wrapper.cpp
@@ -67,7 +67,7 @@ void _template_RTTIRegister() {
     mxDestroyArray(registry);
 
     mxArray *newAlreadyCreated = mxCreateNumericMatrix(0, 0, mxINT8_CLASS, mxREAL);
-    if(mexPutVariable("global", "gtsam_geometry_rttiRegistry_created", newAlreadyCreated) != 0) {
+    if(mexPutVariable("global", "gtsam_template_rttiRegistry_created", newAlreadyCreated) != 0) {
       mexErrMsgTxt("gtsam wrap:  Error indexing RTTI types, inheritance will not work correctly");
     }
     mxDestroyArray(newAlreadyCreated);
@@ -138,9 +138,9 @@ void TemplatedConstructor_deconstructor_5(int nargout, mxArray *out[], int nargi
   Collector_TemplatedConstructor::iterator item;
   item = collector_TemplatedConstructor.find(self);
   if(item != collector_TemplatedConstructor.end()) {
-    delete self;
     collector_TemplatedConstructor.erase(item);
   }
+  delete self;
 }
 
 void ScopedTemplateResult_collectorInsertAndMakeBase_6(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -172,9 +172,9 @@ void ScopedTemplateResult_deconstructor_8(int nargout, mxArray *out[], int nargi
   Collector_ScopedTemplateResult::iterator item;
   item = collector_ScopedTemplateResult.find(self);
   if(item != collector_ScopedTemplateResult.end()) {
-    delete self;
     collector_ScopedTemplateResult.erase(item);
   }
+  delete self;
 }
 
 

--- a/wrap/tests/fixtures/geometry.i
+++ b/wrap/tests/fixtures/geometry.i
@@ -24,9 +24,6 @@ class Point2 {
  VectorNotEigen vectorConfusion();
 
  void serializable() const; // Sets flag and creates export, but does not make serialization functions
-
- // enable pickling in python
- void pickle() const;
 };
 
 #include <gtsam/geometry/Point3.h>
@@ -40,9 +37,6 @@ class Point3 {
 
   // enabling serialization functionality
   void serialize() const; // Just triggers a flag internally and removes actual function
-
-  // enable pickling in python
-  void pickle() const;
 };
 
 }


### PR DESCRIPTION
This PR pulls the latest updates from `gtwrap` which has fixes for a memory leakage in the matlab wrapper.
@mattking-smith has already verified this works well, so it should be an easy approval.