### PR TITLE
Fix various warnings

### DIFF
--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <gtsam/base/types.h>
+
 #include <gtsam/discrete/Assignment.h>
 
 #include <boost/function.hpp>
@@ -35,7 +37,7 @@ namespace gtsam {
    * Y = function range (any algebra), e.g., bool, int, double
    */
   template<typename L, typename Y>
-  class DecisionTree {
+  class GTSAM_EXPORT DecisionTree {
 
   public:
 

--- a/gtsam/discrete/DiscreteKey.h
+++ b/gtsam/discrete/DiscreteKey.h
@@ -34,32 +34,32 @@ namespace gtsam {
   using DiscreteKey = std::pair<Key,size_t>;
 
   /// DiscreteKeys is a set of keys that can be assembled using the & operator
-  struct DiscreteKeys: public std::vector<DiscreteKey> {
+  struct GTSAM_EXPORT DiscreteKeys: public std::vector<DiscreteKey> {
 
     // Forward all constructors.
     using std::vector<DiscreteKey>::vector;
 
     /// Constructor for serialization
-    GTSAM_EXPORT DiscreteKeys() : std::vector<DiscreteKey>::vector() {}
+    DiscreteKeys() : std::vector<DiscreteKey>::vector() {}
 
     /// Construct from a key
-    GTSAM_EXPORT DiscreteKeys(const DiscreteKey& key) {
+    DiscreteKeys(const DiscreteKey& key) {
       push_back(key);
     }
 
     /// Construct from a vector of keys
-    GTSAM_EXPORT DiscreteKeys(const std::vector<DiscreteKey>& keys) :
+    DiscreteKeys(const std::vector<DiscreteKey>& keys) :
       std::vector<DiscreteKey>(keys) {
     }
 
     /// Construct from cardinalities with default names
-    GTSAM_EXPORT DiscreteKeys(const std::vector<int>& cs);
+    DiscreteKeys(const std::vector<int>& cs);
 
     /// Return a vector of indices
-    GTSAM_EXPORT KeyVector indices() const;
+    KeyVector indices() const;
 
     /// Return a map from index to cardinality
-    GTSAM_EXPORT std::map<Key,size_t> cardinalities() const;
+    std::map<Key,size_t> cardinalities() const;
 
     /// Add a key (non-const!)
     DiscreteKeys& operator&(const DiscreteKey& key) {
@@ -69,5 +69,5 @@ namespace gtsam {
   }; // DiscreteKeys
 
   /// Create a list from two keys
-  GTSAM_EXPORT DiscreteKeys operator&(const DiscreteKey& key1, const DiscreteKey& key2);
+  DiscreteKeys operator&(const DiscreteKey& key1, const DiscreteKey& key2);
 }

--- a/gtsam/discrete/DiscreteMarginals.h
+++ b/gtsam/discrete/DiscreteMarginals.h
@@ -29,7 +29,7 @@ namespace gtsam {
   /**
    * A class for computing marginals of variables in a DiscreteFactorGraph
    */
-  class DiscreteMarginals {
+class GTSAM_EXPORT DiscreteMarginals {
 
   protected:
 

--- a/gtsam/discrete/Potentials.cpp
+++ b/gtsam/discrete/Potentials.cpp
@@ -26,10 +26,6 @@ using namespace std;
 
 namespace gtsam {
 
-// explicit instantiation
-template class DecisionTree<Key, double>;
-template class AlgebraicDecisionTree<Key>;
-
 /* ************************************************************************* */
 double Potentials::safe_div(const double& a, const double& b) {
   // cout << boost::format("%g / %g = %g\n") % a % b % ((a == 0) ? 0 : (a / b));

--- a/gtsam/discrete/Potentials.h
+++ b/gtsam/discrete/Potentials.h
@@ -29,7 +29,7 @@ namespace gtsam {
   /**
    * A base class for both DiscreteFactor and DiscreteConditional
    */
-  class Potentials: public AlgebraicDecisionTree<Key> {
+  class GTSAM_EXPORT Potentials: public AlgebraicDecisionTree<Key> {
 
   public:
 
@@ -46,7 +46,7 @@ namespace gtsam {
     }
 
     // Safe division for probabilities
-    GTSAM_EXPORT static double safe_div(const double& a, const double& b);
+    static double safe_div(const double& a, const double& b);
 
 //    // Apply either a permutation or a reduction
 //    template<class P>
@@ -55,10 +55,10 @@ namespace gtsam {
   public:
 
     /** Default constructor for I/O */
-    GTSAM_EXPORT Potentials();
+    Potentials();
 
     /** Constructor from Indices and ADT */
-    GTSAM_EXPORT Potentials(const DiscreteKeys& keys, const ADT& decisionTree);
+    Potentials(const DiscreteKeys& keys, const ADT& decisionTree);
 
     /** Constructor from Indices and (string or doubles) */
     template<class SOURCE>
@@ -67,8 +67,8 @@ namespace gtsam {
     }
 
     // Testable
-    GTSAM_EXPORT bool equals(const Potentials& other, double tol = 1e-9) const;
-    GTSAM_EXPORT void print(const std::string& s = "Potentials: ",
+    bool equals(const Potentials& other, double tol = 1e-9) const;
+    void print(const std::string& s = "Potentials: ",
         const KeyFormatter& formatter = DefaultKeyFormatter) const;
 
     size_t cardinality(Key j) const { return cardinalities_.at(j);}

--- a/gtsam/linear/Errors.cpp
+++ b/gtsam/linear/Errors.cpp
@@ -110,7 +110,6 @@ double dot(const Errors& a, const Errors& b) {
 }
 
 /* ************************************************************************* */
-template<>
 void axpy(double alpha, const Errors& x, Errors& y) {
   Errors::const_iterator it = x.begin();
   for(Vector& yi: y)

--- a/gtsam/linear/Errors.h
+++ b/gtsam/linear/Errors.h
@@ -65,7 +65,6 @@ namespace gtsam {
   /**
   * BLAS level 2 style
   */
-  template <>
   GTSAM_EXPORT void axpy(double alpha, const Errors& x, Errors& y);
 
   /** print with optional string */

--- a/gtsam/slam/TriangulationFactor.h
+++ b/gtsam/slam/TriangulationFactor.h
@@ -33,18 +33,18 @@ class TriangulationFactor: public NoiseModelFactor1<Point3> {
 public:
 
   /// CAMERA type
-  typedef CAMERA Camera;
+  using Camera = CAMERA;
 
 protected:
 
   /// shorthand for base class type
-  typedef NoiseModelFactor1<Point3> Base;
+  using Base = NoiseModelFactor1<Point3>;
 
   /// shorthand for this class
-  typedef TriangulationFactor<CAMERA> This;
+  using This = TriangulationFactor<CAMERA>;
 
   /// shorthand for measurement type, e.g. Point2 or StereoPoint2
-  typedef typename CAMERA::Measurement Measurement;
+  using Measurement = typename CAMERA::Measurement;
 
   // Keep a copy of measurement and calibration for I/O
   const CAMERA camera_; ///< CAMERA in which this landmark was seen
@@ -55,9 +55,10 @@ protected:
   const bool verboseCheirality_; ///< If true, prints text for Cheirality exceptions (default: false)
 
 public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /// shorthand for a smart pointer to a factor
-  typedef boost::shared_ptr<This> shared_ptr;
+  using shared_ptr = boost::shared_ptr<This>;
 
   /// Default constructor
   TriangulationFactor() :


### PR DESCRIPTION
This PR fixes a bunch of compilation warnings.

1. Alignment warnings for `TriangulationFactor`.
2. Deprecation warnings for `axpy` in `Errors.h`.
3. OSX Clang visibility warnings due to instantiations in `Potentials.cpp`.
4. I also added a bunch of GTSAM_EXPORTs in various classes of `discrete/` for cross-platform compatibility.