### PR TITLE
Conformize various print statements

### DIFF
--- a/gtsam/base/deprecated/LieScalar.h
+++ b/gtsam/base/deprecated/LieScalar.h
@@ -49,8 +49,8 @@ namespace gtsam {
 
     /// @name Testable
     /// @{
-    void print(const std::string& name = "") const {
-      std::cout << name << ": " << d_ << std::endl;
+    void print(const std::string& s = "") const {
+      std::cout << (s.empty() ? s : s + ": ") << d_ << std::endl;
     }
     bool equals(const LieScalar& expected, double tol = 1e-5) const {
       return std::abs(expected.d_ - d_) <= tol;

--- a/gtsam/basis/Basis.h
+++ b/gtsam/basis/Basis.h
@@ -159,7 +159,7 @@ class GTSAM_EXPORT Basis {
     }
 
     void print(const std::string& s = "") const {
-      std::cout << s << (s != "" ? " " : "") << weights_ << std::endl;
+      std::cout << (s.empty() ? s : s + " ") << weights_ << std::endl;
     }
   };
 
@@ -350,7 +350,7 @@ class GTSAM_EXPORT Basis {
         : weights_(DERIVED::DerivativeWeights(N, x, a, b)) {}
 
     void print(const std::string& s = "") const {
-      std::cout << s << (s != "" ? " " : "") << weights_ << std::endl;
+      std::cout << (s.empty() ? s : s + " ") << weights_ << std::endl;
     }
   };
 

--- a/gtsam/basis/ParameterMatrix.h
+++ b/gtsam/basis/ParameterMatrix.h
@@ -161,7 +161,7 @@ class ParameterMatrix {
    * @param s: The prepend string to add more contextual info.
    */
   void print(const std::string& s = "") const {
-    std::cout << (s == "" ? s : s + " ") << matrix_ << std::endl;
+    std::cout << (s.empty() ? s : s + " ") << matrix_ << std::endl;
   }
 
   /**

--- a/gtsam/linear/Errors.cpp
+++ b/gtsam/linear/Errors.cpp
@@ -37,9 +37,10 @@ Errors::Errors(const VectorValues& V) {
 
 /* ************************************************************************* */
 void Errors::print(const std::string& s) const {
-  cout << s << endl;
-  for(const Vector& v: *this)
+  cout << (s.empty() ? s : s + "\n");
+  for (const Vector& v : *this) {
     gtsam::print(v);
+  }
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/GaussianConditional.cpp
+++ b/gtsam/linear/GaussianConditional.cpp
@@ -57,7 +57,7 @@ namespace gtsam {
 
   /* ************************************************************************* */
   void GaussianConditional::print(const string &s, const KeyFormatter& formatter) const {
-    cout << s << "  Conditional density ";
+    cout << (s.empty() ? s : s + "  ") << "Conditional density ";
     for (const_iterator it = beginFrontals(); it != endFrontals(); ++it) {
       cout << (boost::format("[%1%]")%(formatter(*it))).str() << " ";
     }

--- a/gtsam/linear/GaussianDensity.cpp
+++ b/gtsam/linear/GaussianDensity.cpp
@@ -31,7 +31,7 @@ namespace gtsam {
   /* ************************************************************************* */
   void GaussianDensity::print(const string &s, const KeyFormatter& formatter) const
   {
-    cout << s << ": density on ";
+    cout << (s.empty() ? s : s + ": ") << "density on ";
     for(const_iterator it = beginFrontals(); it != endFrontals(); ++it)
       cout << (boost::format("[%1%]")%(formatter(*it))).str() << " ";
     cout << endl;

--- a/gtsam/linear/JacobianFactor.cpp
+++ b/gtsam/linear/JacobianFactor.cpp
@@ -413,8 +413,7 @@ JacobianFactor::JacobianFactor(const GaussianFactorGraph& graph,
 /* ************************************************************************* */
 void JacobianFactor::print(const string& s,
     const KeyFormatter& formatter) const {
-  if (!s.empty())
-    cout << s << "\n";
+  cout << (s.empty() ? s : s + "\n");
   for (const_iterator key = begin(); key != end(); ++key) {
     cout << boost::format("  A[%1%] = ") % formatter(*key);
     cout << getA(key).format(matlabFormat()) << endl;

--- a/gtsam/linear/KalmanFilter.cpp
+++ b/gtsam/linear/KalmanFilter.cpp
@@ -84,7 +84,7 @@ KalmanFilter::State KalmanFilter::init(const Vector& x, const Matrix& P0) const 
 
 /* ************************************************************************* */
 void KalmanFilter::print(const string& s) const {
-  cout << "KalmanFilter " << s << ", dim = " << n_ << endl;
+  cout << "KalmanFilter" << (s.empty() ? s : " " + s) << ", dim = " << n_ << endl;
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/LossFunctions.cpp
+++ b/gtsam/linear/LossFunctions.cpp
@@ -121,8 +121,9 @@ void Base::reweight(Matrix &A1, Matrix &A2, Matrix &A3, Vector &error) const {
 // Null model
 /* ************************************************************************* */
 
-void Null::print(const std::string &s="") const
-{ cout << s << "null ()" << endl; }
+void Null::print(const std::string &s) const {
+  cout << (s.empty() ? s : s + ": ") << "Null ()" << endl;
+}
 
 Null::shared_ptr Null::Create()
 { return shared_ptr(new Null()); }
@@ -148,8 +149,9 @@ double Fair::loss(double distance) const {
   return c_2 * (normalizedError - std::log1p(normalizedError));
 }
 
-void Fair::print(const std::string &s="") const
-{ cout << s << "fair (" << c_ << ")" << endl; }
+void Fair::print(const std::string &s) const {
+  cout << (s.empty() ? s : s + ": ") << "Fair (" << c_ << ")" << endl;
+}
 
 bool Fair::equals(const Base &expected, double tol) const {
   const Fair* p = dynamic_cast<const Fair*> (&expected);
@@ -184,8 +186,8 @@ double Huber::loss(double distance) const {
   }
 }
 
-void Huber::print(const std::string &s="") const {
-  cout << s << "huber (" << k_ << ")" << endl;
+void Huber::print(const std::string &s) const {
+  cout << (s.empty() ? s : s + ": ") << "Huber (" << k_ << ")" << endl;
 }
 
 bool Huber::equals(const Base &expected, double tol) const {
@@ -217,8 +219,8 @@ double Cauchy::loss(double distance) const {
   return ksquared_ * val * 0.5;
 }
 
-void Cauchy::print(const std::string &s="") const {
-  cout << s << "cauchy (" << k_ << ")" << endl;
+void Cauchy::print(const std::string &s) const {
+  cout << (s.empty() ? s : s + ": ") << "Cauchy (" << k_ << ")" << endl;
 }
 
 bool Cauchy::equals(const Base &expected, double tol) const {
@@ -260,8 +262,8 @@ double Tukey::loss(double distance) const {
   }
 }
 
-void Tukey::print(const std::string &s="") const {
-  std::cout << s << ": Tukey (" << c_ << ")" << std::endl;
+void Tukey::print(const std::string &s) const {
+  cout << (s.empty() ? s : s + ": ") << "Tukey (" << c_ << ")" << endl;
 }
 
 bool Tukey::equals(const Base &expected, double tol) const {
@@ -290,8 +292,8 @@ double Welsch::loss(double distance) const {
   return csquared_ * 0.5 * -std::expm1(-xc2);
 }
 
-void Welsch::print(const std::string &s="") const {
-  std::cout << s << ": Welsch (" << c_ << ")" << std::endl;
+void Welsch::print(const std::string &s) const {
+  cout << (s.empty() ? s : s + ": ") << "Welsch (" << c_ << ")" << endl;
 }
 
 bool Welsch::equals(const Base &expected, double tol) const {
@@ -324,8 +326,8 @@ double GemanMcClure::loss(double distance) const {
   return 0.5 * (c2 * error2) / (c2 + error2);
 }
 
-void GemanMcClure::print(const std::string &s="") const {
-  std::cout << s << ": Geman-McClure (" << c_ << ")" << std::endl;
+void GemanMcClure::print(const std::string &s) const {
+  cout << (s.empty() ? s : s + ": ") << "Geman-McClure (" << c_ << ")" << endl;
 }
 
 bool GemanMcClure::equals(const Base &expected, double tol) const {
@@ -366,8 +368,8 @@ double DCS::loss(double distance) const {
   return (c2*e2 + c_*e4) / ((e2 + c_)*(e2 + c_));
 }
 
-void DCS::print(const std::string &s="") const {
-  std::cout << s << ": DCS (" << c_ << ")" << std::endl;
+void DCS::print(const std::string &s) const {
+  cout << (s.empty() ? s : s + ": ") << "DCS (" << c_ << ")" << endl;
 }
 
 bool DCS::equals(const Base &expected, double tol) const {
@@ -405,8 +407,8 @@ double L2WithDeadZone::loss(double distance) const {
   return (abs_error < k_) ? 0.0 : 0.5*(k_-abs_error)*(k_-abs_error);
 }
 
-void L2WithDeadZone::print(const std::string &s="") const {
-  std::cout << s << ": L2WithDeadZone (" << k_ << ")" << std::endl;
+void L2WithDeadZone::print(const std::string &s) const {
+  cout << (s.empty() ? s : s + ": ") << "L2WithDeadZone (" << k_ << ")" << endl;
 }
 
 bool L2WithDeadZone::equals(const Base &expected, double tol) const {

--- a/gtsam/linear/LossFunctions.h
+++ b/gtsam/linear/LossFunctions.h
@@ -93,7 +93,7 @@ class GTSAM_EXPORT Base {
    */
   virtual double weight(double distance) const = 0;
 
-  virtual void print(const std::string &s) const = 0;
+  virtual void print(const std::string &s="") const = 0;
   virtual bool equals(const Base &expected, double tol = 1e-8) const = 0;
 
   double sqrtWeight(double distance) const { return std::sqrt(weight(distance)); }
@@ -133,7 +133,7 @@ class GTSAM_EXPORT Null : public Base {
   ~Null() override {}
   double weight(double /*error*/) const override { return 1.0; }
   double loss(double distance) const override { return 0.5 * distance * distance; }
-  void print(const std::string &s) const override;
+  void print(const std::string &s = "") const override;
   bool equals(const Base & /*expected*/, double /*tol*/) const override { return true; }
   static shared_ptr Create();
 
@@ -157,7 +157,7 @@ class GTSAM_EXPORT Fair : public Base {
   Fair(double c = 1.3998, const ReweightScheme reweight = Block);
   double weight(double distance) const override;
   double loss(double distance) const override;
-  void print(const std::string &s) const override;
+  void print(const std::string &s = "") const override;
   bool equals(const Base &expected, double tol = 1e-8) const override;
   static shared_ptr Create(double c, const ReweightScheme reweight = Block);
 
@@ -182,7 +182,7 @@ class GTSAM_EXPORT Huber : public Base {
   Huber(double k = 1.345, const ReweightScheme reweight = Block);
   double weight(double distance) const override;
   double loss(double distance) const override;
-  void print(const std::string &s) const override;
+  void print(const std::string &s = "") const override;
   bool equals(const Base &expected, double tol = 1e-8) const override;
   static shared_ptr Create(double k, const ReweightScheme reweight = Block);
 
@@ -212,7 +212,7 @@ class GTSAM_EXPORT Cauchy : public Base {
   Cauchy(double k = 0.1, const ReweightScheme reweight = Block);
   double weight(double distance) const override;
   double loss(double distance) const override;
-  void print(const std::string &s) const override;
+  void print(const std::string &s = "") const override;
   bool equals(const Base &expected, double tol = 1e-8) const override;
   static shared_ptr Create(double k, const ReweightScheme reweight = Block);
 
@@ -237,7 +237,7 @@ class GTSAM_EXPORT Tukey : public Base {
   Tukey(double c = 4.6851, const ReweightScheme reweight = Block);
   double weight(double distance) const override;
   double loss(double distance) const override;
-  void print(const std::string &s) const override;
+  void print(const std::string &s = "") const override;
   bool equals(const Base &expected, double tol = 1e-8) const override;
   static shared_ptr Create(double k, const ReweightScheme reweight = Block);
 
@@ -262,7 +262,7 @@ class GTSAM_EXPORT Welsch : public Base {
   Welsch(double c = 2.9846, const ReweightScheme reweight = Block);
   double weight(double distance) const override;
   double loss(double distance) const override;
-  void print(const std::string &s) const override;
+  void print(const std::string &s = "") const override;
   bool equals(const Base &expected, double tol = 1e-8) const override;
   static shared_ptr Create(double k, const ReweightScheme reweight = Block);
 
@@ -290,7 +290,7 @@ class GTSAM_EXPORT GemanMcClure : public Base {
   ~GemanMcClure() override {}
   double weight(double distance) const override;
   double loss(double distance) const override;
-  void print(const std::string &s) const override;
+  void print(const std::string &s = "") const override;
   bool equals(const Base &expected, double tol = 1e-8) const override;
   static shared_ptr Create(double k, const ReweightScheme reweight = Block);
 
@@ -320,7 +320,7 @@ class GTSAM_EXPORT DCS : public Base {
   ~DCS() override {}
   double weight(double distance) const override;
   double loss(double distance) const override;
-  void print(const std::string &s) const override;
+  void print(const std::string &s = "") const override;
   bool equals(const Base &expected, double tol = 1e-8) const override;
   static shared_ptr Create(double k, const ReweightScheme reweight = Block);
 
@@ -353,7 +353,7 @@ class GTSAM_EXPORT L2WithDeadZone : public Base {
   L2WithDeadZone(double k = 1.0, const ReweightScheme reweight = Block);
   double weight(double distance) const override;
   double loss(double distance) const override;
-  void print(const std::string &s) const override;
+  void print(const std::string &s = "") const override;
   bool equals(const Base &expected, double tol = 1e-8) const override;
   static shared_ptr Create(double k, const ReweightScheme reweight = Block);
 

--- a/gtsam/linear/NoiseModel.h
+++ b/gtsam/linear/NoiseModel.h
@@ -210,7 +210,7 @@ namespace gtsam {
        */
       static shared_ptr Covariance(const Matrix& covariance, bool smart = true);
 
-      void print(const std::string& name) const override;
+      void print(const std::string& name = "") const override;
       bool equals(const Base& expected, double tol=1e-9) const override;
       Vector sigmas() const override;
       Vector whiten(const Vector& v) const override;
@@ -323,7 +323,7 @@ namespace gtsam {
         return Variances(precisions.array().inverse(), smart);
       }
 
-      void print(const std::string& name) const override;
+      void print(const std::string& name = "") const override;
       Vector sigmas() const override { return sigmas_; }
       Vector whiten(const Vector& v) const override;
       Vector unwhiten(const Vector& v) const override;
@@ -482,7 +482,7 @@ namespace gtsam {
         return shared_ptr(new Constrained(Vector::Constant(dim, mu), Vector::Constant(dim,0)));
       }
 
-      void print(const std::string& name) const override;
+      void print(const std::string& name = "") const override;
 
       /// Calculates error vector with weights applied
       Vector whiten(const Vector& v) const override;
@@ -564,7 +564,7 @@ namespace gtsam {
         return Variance(dim, 1.0/precision, smart);
       }
 
-      void print(const std::string& name) const override;
+      void print(const std::string& name = "") const override;
       double squaredMahalanobisDistance(const Vector& v) const override;
       Vector whiten(const Vector& v) const override;
       Vector unwhiten(const Vector& v) const override;
@@ -615,7 +615,7 @@ namespace gtsam {
       /// true if a unit noise model, saves slow/clumsy dynamic casting
       bool isUnit() const override { return true; }
 
-      void print(const std::string& name) const override;
+      void print(const std::string& name = "") const override;
       double squaredMahalanobisDistance(const Vector& v) const override {return v.dot(v); }
       Vector whiten(const Vector& v) const override { return v; }
       Vector unwhiten(const Vector& v) const override { return v; }
@@ -676,7 +676,7 @@ namespace gtsam {
       /// Destructor
       ~Robust() override {}
 
-      void print(const std::string& name) const override;
+      void print(const std::string& name = "") const override;
       bool equals(const Base& expected, double tol=1e-9) const override;
 
       /// Return the contained robust error function

--- a/gtsam/linear/PCGSolver.cpp
+++ b/gtsam/linear/PCGSolver.cpp
@@ -50,7 +50,7 @@ void PCGSolverParameters::setPreconditionerParams(const boost::shared_ptr<Precon
 }
 
 void PCGSolverParameters::print(const std::string &s) const {
-  std::cout << s << std::endl;;
+  std::cout << (s.empty() ? s : s + "\n");
   std::ostringstream os;
   print(os);
   std::cout << os.str() << std::endl;

--- a/gtsam/linear/PCGSolver.h
+++ b/gtsam/linear/PCGSolver.h
@@ -49,7 +49,7 @@ public:
   }
 
   // needed for python wrapper
-  void print(const std::string &s) const;
+  void print(const std::string &s = "") const;
 
   boost::shared_ptr<PreconditionerParameters> preconditioner_;
 

--- a/gtsam/linear/SubgraphPreconditioner.cpp
+++ b/gtsam/linear/SubgraphPreconditioner.cpp
@@ -196,7 +196,7 @@ void SubgraphPreconditioner::transposeMultiplyAdd2 (double alpha,
 
 /* ************************************************************************* */
 void SubgraphPreconditioner::print(const std::string& s) const {
-  cout << s << endl;
+  cout << (s.empty() ? s : s + "\n");
   Ab2_->print();
 }
 

--- a/gtsam/linear/VectorValues.cpp
+++ b/gtsam/linear/VectorValues.cpp
@@ -151,12 +151,12 @@ namespace gtsam {
   }
 
   /* ************************************************************************* */
-  void VectorValues::print(const string& str,
+  void VectorValues::print(const string& s,
                            const KeyFormatter& formatter) const {
-    cout << str << ": " << size() << " elements\n";
+    cout << (s.empty() ? s : s + ": ") << size() << " elements\n";
     cout << key_formatter(formatter) << *this;
     cout.flush();
-}
+  }
 
   /* ************************************************************************* */
   bool VectorValues::equals(const VectorValues& x, double tol) const {

--- a/gtsam/linear/VectorValues.h
+++ b/gtsam/linear/VectorValues.h
@@ -244,7 +244,7 @@ namespace gtsam {
     GTSAM_EXPORT friend std::ostream& operator<<(std::ostream&, const VectorValues&);
 
     /** print required by Testable for unit testing */
-    void print(const std::string& str = "VectorValues",
+    void print(const std::string& s = "VectorValues",
         const KeyFormatter& formatter = DefaultKeyFormatter) const;
 
     /** equals required by Testable for unit testing */

--- a/gtsam/linear/iterative-inl.h
+++ b/gtsam/linear/iterative-inl.h
@@ -60,7 +60,7 @@ namespace gtsam {
     // print
     void print(const V& x) {
       std::cout << "iteration = " << k << std::endl;
-      gtsam::print(x,"x");
+      gtsam::print(x, "x");
       gtsam::print(g, "g");
       std::cout << "dotg = " << gamma << std::endl;
       gtsam::print(d, "d");

--- a/gtsam/linear/iterative.cpp
+++ b/gtsam/linear/iterative.cpp
@@ -30,7 +30,7 @@ namespace gtsam {
 
   /* ************************************************************************* */
   void System::print(const string& s) const {
-    cout << s << endl;
+    cout << (s.empty() ? s : s + "\n");
     gtsam::print(A_, "A");
     gtsam::print(b_, "b");
   }

--- a/gtsam/navigation/PreintegratedRotation.h
+++ b/gtsam/navigation/PreintegratedRotation.h
@@ -46,7 +46,7 @@ struct GTSAM_EXPORT PreintegratedRotationParams {
 
   virtual ~PreintegratedRotationParams() {}
 
-  virtual void print(const std::string& s) const;
+  virtual void print(const std::string& s = "") const;
   virtual bool equals(const PreintegratedRotationParams& other, double tol=1e-9) const;
 
   void setGyroscopeCovariance(const Matrix3& cov)   { gyroscopeCovariance = cov;  }
@@ -148,7 +148,7 @@ class GTSAM_EXPORT PreintegratedRotation {
 
   /// @name Testable
   /// @{
-  void print(const std::string& s) const;
+  void print(const std::string& s = "") const;
   bool equals(const PreintegratedRotation& other, double tol) const;
   /// @}
 

--- a/gtsam/nonlinear/CustomFactor.h
+++ b/gtsam/nonlinear/CustomFactor.h
@@ -80,7 +80,7 @@ public:
   Vector unwhitenedError(const Values &x, boost::optional<std::vector<Matrix> &> H = boost::none) const override;
 
   /** print */
-  void print(const std::string &s,
+  void print(const std::string &s = "",
              const KeyFormatter &keyFormatter = DefaultKeyFormatter) const override;
 
   /**

--- a/gtsam/nonlinear/Expression.h
+++ b/gtsam/nonlinear/Expression.h
@@ -148,7 +148,7 @@ public:
   void dims(std::map<Key, int>& map) const;
 
   /// Print
-  void print(const std::string& s) const;
+  void print(const std::string& s = "") const;
 
   /**
    * @brief Return value and optional derivatives, reverse AD version

--- a/gtsam/nonlinear/ExtendedKalmanFilter.h
+++ b/gtsam/nonlinear/ExtendedKalmanFilter.h
@@ -74,7 +74,7 @@ class ExtendedKalmanFilter {
 
   /// print
   void print(const std::string& s = "") const {
-    std::cout << s << "\n";
+    std::cout << (s.empty() ? s : s + "\n");
     x_.print(s + "x");
     priorFactor_->print(s + "density");
   }

--- a/gtsam/nonlinear/GncParams.h
+++ b/gtsam/nonlinear/GncParams.h
@@ -140,8 +140,8 @@ class GTSAM_EXPORT GncParams {
   }
 
   /// Print.
-  void print(const std::string& str) const {
-    std::cout << str << "\n";
+  void print(const std::string& s = "") const {
+    std::cout << (s.empty() ? s : s + "\n");
     switch (lossType) {
       case GM:
         std::cout << "lossType: Geman McClure" << "\n";
@@ -161,7 +161,7 @@ class GTSAM_EXPORT GncParams {
       std::cout << "knownInliers: " << knownInliers[i] << "\n";
     for (size_t i = 0; i < knownOutliers.size(); i++)
       std::cout << "knownOutliers: " << knownOutliers[i] << "\n";
-    baseOptimizerParams.print(str);
+    baseOptimizerParams.print(s);
   }
 };
 

--- a/gtsam/nonlinear/Marginals.cpp
+++ b/gtsam/nonlinear/Marginals.cpp
@@ -101,11 +101,12 @@ void Marginals::computeBayesTree(const Ordering& ordering) {
 }
 
 /* ************************************************************************* */
-void Marginals::print(const std::string& str, const KeyFormatter& keyFormatter) const
-{
-  graph_.print(str+"Graph: ");
-  values_.print(str+"Solution: ", keyFormatter);
-  bayesTree_.print(str+"Bayes Tree: ");
+void Marginals::print(const std::string& s,
+                      const KeyFormatter& keyFormatter) const {
+  std::string str = (s.empty() ? s : s + " ");
+  graph_.print(str + "Graph: ");
+  values_.print(str + "Solution: ", keyFormatter);
+  bayesTree_.print(str + "Bayes Tree: ");
 }
 
 /* ************************************************************************* */
@@ -195,7 +196,7 @@ VectorValues Marginals::optimize() const {
 
 /* ************************************************************************* */
 void JointMarginal::print(const std::string& s, const KeyFormatter& formatter) const {
-  cout << s << "Joint marginal on keys ";
+  cout << (s.empty() ? s : s + " ") << "Joint marginal on keys ";
   bool first = true;
   for(const auto& key: keys_) {
     if(!first)

--- a/gtsam/nonlinear/Marginals.h
+++ b/gtsam/nonlinear/Marginals.h
@@ -101,7 +101,8 @@ public:
               Factorization factorization = CHOLESKY);
 
   /** print */
-  void print(const std::string& str = "Marginals: ", const KeyFormatter& keyFormatter = DefaultKeyFormatter) const;
+  void print(const std::string& s = "Marginals:",
+             const KeyFormatter& keyFormatter = DefaultKeyFormatter) const;
 
   /** Compute the marginal factor of a single variable */
   GaussianFactor::shared_ptr marginalFactor(Key variable) const;

--- a/gtsam/nonlinear/NonlinearOptimizerParams.cpp
+++ b/gtsam/nonlinear/NonlinearOptimizerParams.cpp
@@ -72,10 +72,10 @@ void NonlinearOptimizerParams::setIterativeParams(
 }
 
 /* ************************************************************************* */
-void NonlinearOptimizerParams::print(const std::string& str) const {
+void NonlinearOptimizerParams::print(const std::string& s) const {
 
   //NonlinearOptimizerParams::print(str);
-  std::cout << str << "\n";
+  std::cout << (s.empty() ? s : s + "\n");
   std::cout << "relative decrease threshold: " << relativeErrorTol << "\n";
   std::cout << "absolute decrease threshold: " << absoluteErrorTol << "\n";
   std::cout << "      total error threshold: " << errorTol << "\n";

--- a/gtsam/nonlinear/NonlinearOptimizerParams.h
+++ b/gtsam/nonlinear/NonlinearOptimizerParams.h
@@ -111,7 +111,7 @@ public:
   virtual ~NonlinearOptimizerParams() {
   }
 
-  virtual void print(const std::string& str = "") const;
+  virtual void print(const std::string& s = "") const;
 
   bool equals(const NonlinearOptimizerParams& other, double tol = 1e-9) const {
     return maxIterations == other.getMaxIterations()

--- a/gtsam/nonlinear/Values.cpp
+++ b/gtsam/nonlinear/Values.cpp
@@ -66,8 +66,8 @@ namespace gtsam {
   }
 
   /* ************************************************************************* */
-  void Values::print(const string& str, const KeyFormatter& keyFormatter) const {
-    cout << str << (str.empty() ? "" : "\n");
+  void Values::print(const string& s, const KeyFormatter& keyFormatter) const {
+    cout << (s.empty() ? s : s + "\n");
     cout << "Values with " << size() << " values:\n";
     for(const_iterator key_value = begin(); key_value != end(); ++key_value) {
       cout << "Value " << keyFormatter(key_value->key) << ": ";

--- a/gtsam/nonlinear/Values.h
+++ b/gtsam/nonlinear/Values.h
@@ -165,7 +165,8 @@ namespace gtsam {
     /// @{
 
     /** print method for testing and debugging */
-    void print(const std::string& str = "", const KeyFormatter& keyFormatter = DefaultKeyFormatter) const;
+    void print(const std::string& s = "",
+               const KeyFormatter& keyFormatter = DefaultKeyFormatter) const;
 
     /** Test whether the sets of keys and values are identical */
     bool equals(const Values& other, double tol=1e-9) const;

--- a/gtsam/nonlinear/internal/ExpressionNode.h
+++ b/gtsam/nonlinear/internal/ExpressionNode.h
@@ -280,7 +280,7 @@ public:
         : value1(expression1.traceExecution(values, trace1, ptr + upAligned(sizeof(Record)))) {}
 
     /// Print to std::cout
-    void print(const std::string& indent) const {
+    void print(const std::string& indent = "") const {
       std::cout << indent << "UnaryExpression::Record {" << std::endl;
       PrintJacobianAndTrace<T,A1>(indent, dTdA1, trace1);
       std::cout << indent << "}" << std::endl;
@@ -404,7 +404,7 @@ public:
           value2(expression2.traceExecution(values, trace2, ptr += expression1.traceSize())) {}
 
     /// Print to std::cout
-    void print(const std::string& indent) const {
+    void print(const std::string& indent = "") const {
       std::cout << indent << "BinaryExpression::Record {" << std::endl;
       PrintJacobianAndTrace<T,A1>(indent, dTdA1, trace1);
       PrintJacobianAndTrace<T,A2>(indent, dTdA2, trace2);
@@ -519,7 +519,7 @@ public:
           value3(expression3.traceExecution(values, trace3, ptr += expression2.traceSize())) {}
 
     /// Print to std::cout
-    void print(const std::string& indent) const {
+    void print(const std::string& indent = "") const {
       std::cout << indent << "TernaryExpression::Record {" << std::endl;
       PrintJacobianAndTrace<T,A1>(indent, dTdA1, trace1);
       PrintJacobianAndTrace<T,A2>(indent, dTdA2, trace2);
@@ -603,7 +603,7 @@ class ScalarMultiplyNode : public ExpressionNode<T> {
     ExecutionTrace<T> trace;
 
     /// Print to std::cout
-    void print(const std::string& indent) const {
+    void print(const std::string& indent = "") const {
       std::cout << indent << "ScalarMultiplyNode::Record {" << std::endl;
       std::cout << indent << "D(" << demangle(typeid(T).name()) << ")/D(" << demangle(typeid(T).name())
                 << ") = " << scalar_dTdA << std::endl;
@@ -693,7 +693,7 @@ class BinarySumNode : public ExpressionNode<T> {
     ExecutionTrace<T> trace2;
 
     /// Print to std::cout
-    void print(const std::string& indent) const {
+    void print(const std::string& indent = "") const {
       std::cout << indent << "BinarySumNode::Record {" << std::endl;
       trace1.print(indent);
       trace2.print(indent);

--- a/gtsam/nonlinear/tests/testValues.cpp
+++ b/gtsam/nonlinear/tests/testValues.cpp
@@ -60,7 +60,7 @@ class TestValue {
   TestValueData data_;
 public:
   enum {dimension = 0};
-  void print(const std::string& str = "") const {}
+  void print(const std::string& s = "") const {}
   bool equals(const TestValue& other, double tol = 1e-9) const { return true; }
   size_t dim() const { return 0; }
   TestValue retract(const Vector&,

--- a/gtsam/sfm/ShonanFactor.h
+++ b/gtsam/sfm/ShonanFactor.h
@@ -58,7 +58,7 @@ public:
 
   /// print with optional string
   void
-  print(const std::string &s,
+  print(const std::string &s = "",
         const KeyFormatter &keyFormatter = DefaultKeyFormatter) const override;
 
   /// assert equality up to a tolerance

--- a/gtsam/slam/OrientedPlane3Factor.cpp
+++ b/gtsam/slam/OrientedPlane3Factor.cpp
@@ -14,7 +14,7 @@ namespace gtsam {
 //***************************************************************************
 void OrientedPlane3Factor::print(const string& s,
     const KeyFormatter& keyFormatter) const {
-  cout << s << (s == "" ? "" : "\n");
+  cout << (s.empty() ? s : s + "\n");
   cout << "OrientedPlane3Factor Factor (" << keyFormatter(key1()) << ", "
        << keyFormatter(key2()) << ")\n";
   measured_p_.print("Measured Plane");
@@ -48,8 +48,8 @@ Vector OrientedPlane3Factor::evaluateError(const Pose3& pose,
 //***************************************************************************
 void OrientedPlane3DirectionPrior::print(const string& s,
     const KeyFormatter& keyFormatter) const {
-  cout << s << (s == "" ? "" : "\n");
-  cout << s << "Prior Factor on " << keyFormatter(key()) << "\n";
+  cout << (s.empty() ? s : s + "\n");
+  cout << "Prior Factor on " << keyFormatter(key()) << "\n";
   measured_p_.print("Measured Plane");
   this->noiseModel_->print("  noise model: ");
 }

--- a/gtsam/slam/PoseRotationPrior.h
+++ b/gtsam/slam/PoseRotationPrior.h
@@ -66,8 +66,9 @@ public:
   }
 
   /** print contents */
-  void print(const std::string& s="", const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override {
-    Base::print(s + "PoseRotationPrior", keyFormatter);
+  void print(const std::string& s = "",
+      const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override {
+    Base::print((s.empty() ? s : s + " ") + "PoseRotationPrior", keyFormatter);
     measured_.print("Measured Rotation");
   }
 

--- a/gtsam/slam/SmartFactorParams.h
+++ b/gtsam/slam/SmartFactorParams.h
@@ -68,7 +68,8 @@ struct SmartProjectionParams {
   virtual ~SmartProjectionParams() {
   }
 
-  void print(const std::string& str = "") const {
+  void print(const std::string& s = "") const {
+    std::cout << (s.empty() ? s : s + " ");
     std::cout << "linearizationMode: " << linearizationMode << "\n";
     std::cout << "   degeneracyMode: " << degeneracyMode << "\n";
     std::cout << triangulation << std::endl;

--- a/gtsam/slam/dataset.h
+++ b/gtsam/slam/dataset.h
@@ -389,6 +389,7 @@ struct SfmData {
 
   /// print
   void print(const std::string& s = "") const {
+    std::cout << (s.empty() ? s : s + " ");
     std::cout << "Number of cameras = " << number_cameras() << std::endl;
     std::cout << "Number of tracks = " << number_tracks() << std::endl;
   }


### PR DESCRIPTION
This PR updates all the print functions to have a common pattern and to be cleaner when printing with or without the optional `s` argument.

It also adds defaults for `string& s` where they were missing.