### PR TITLE
HybridFactorGraph linearize method

### DIFF
--- a/gtsam/hybrid/DCFactor.h
+++ b/gtsam/hybrid/DCFactor.h
@@ -105,6 +105,9 @@ class DCFactor : public gtsam::Factor {
       const gtsam::Values& continuousVals,
       const DiscreteValues& discreteVals) const = 0;
 
+  virtual DCFactor::shared_ptr linearize(
+      const Values& continuousVals) const = 0;
+
   /**
    * Returns true when the DCFactor is equal to `other`
    *

--- a/gtsam/hybrid/DCFactor.h
+++ b/gtsam/hybrid/DCFactor.h
@@ -105,6 +105,13 @@ class DCFactor : public gtsam::Factor {
       const gtsam::Values& continuousVals,
       const DiscreteValues& discreteVals) const = 0;
 
+  /**
+   * @brief Linearize all the continuous factors only with respect to the
+   * continuous variables (as given in `keys_`).
+   *
+   * @param continuousVals The continuous variables referenced by `keys_`.
+   * @return DCFactor::shared_ptr
+   */
   virtual DCFactor::shared_ptr linearize(
       const Values& continuousVals) const = 0;
 

--- a/gtsam/hybrid/DCFactor.h
+++ b/gtsam/hybrid/DCFactor.h
@@ -39,7 +39,7 @@ class DCFactor : public gtsam::Factor {
 
  public:
   using Base = gtsam::Factor;
-  using shared_ptr = boost::shared_ptr<Factor>;
+  using shared_ptr = boost::shared_ptr<DCFactor>;
 
   DCFactor() = default;
 
@@ -101,7 +101,7 @@ class DCFactor : public gtsam::Factor {
    * @param discreteVals - Likewise, assignment to the discrete variables in
    * `discreteKeys__`.
    */
-  virtual boost::shared_ptr<gtsam::GaussianFactor> linearize(
+  virtual GaussianFactor::shared_ptr linearize(
       const gtsam::Values& continuousVals,
       const DiscreteValues& discreteVals) const = 0;
 

--- a/gtsam/hybrid/DCFactor.h
+++ b/gtsam/hybrid/DCFactor.h
@@ -109,6 +109,10 @@ class DCFactor : public gtsam::Factor {
    * @brief Linearize all the continuous factors only with respect to the
    * continuous variables (as given in `keys_`).
    *
+   * This `linearize` is different from the `linearize(continuous, discrete)` in
+   * that it assumes no assignment of discrete keys and linearizes all
+   * continuous factors associated with this factor.
+   *
    * @param continuousVals The continuous variables referenced by `keys_`.
    * @return DCFactor::shared_ptr
    */

--- a/gtsam/hybrid/DCGaussianMixtureFactor.h
+++ b/gtsam/hybrid/DCGaussianMixtureFactor.h
@@ -80,10 +80,10 @@ class DCGaussianMixtureFactor : public DCFactor {
     return factors_[0];
   }
 
-  /// Return this linear factor as a DCFactor::shared_ptr
+  /// Return linearized version of this factor.
   virtual DCFactor::shared_ptr linearize(
       const Values& continuousVals) const override {
-    return boost::make_shared<DCGaussianMixtureFactor>(*this);
+    throw std::runtime_error("DCGaussianFactor is already linear");
   }
 
   // TODO(dellaert): implement

--- a/gtsam/hybrid/DCGaussianMixtureFactor.h
+++ b/gtsam/hybrid/DCGaussianMixtureFactor.h
@@ -67,17 +67,17 @@ class DCGaussianMixtureFactor : public DCFactor {
     return 0;
   }
 
-  // TODO(dellaert): Does not make sense
   double error(const gtsam::Values& continuousVals,
                const gtsam::DiscreteValues& discreteVals) const override {
-    return 0;
+    throw std::runtime_error("DCGaussianMixtureFactor::error not implemented");
   }
 
-  // TODO(dellaert): Does not make sense
   GaussianFactor::shared_ptr linearize(
       const gtsam::Values& continuousVals,
       const DiscreteValues& discreteVals) const override {
-    return factors_[0];
+    throw std::runtime_error(
+        "DCGaussianMixtureFactor::linearize(continuous, discrete) not "
+        "implemented");
   }
 
   /// Return linearized version of this factor.
@@ -87,7 +87,9 @@ class DCGaussianMixtureFactor : public DCFactor {
   }
 
   // TODO(dellaert): implement
-  size_t dim() const override { return 0; };
+  size_t dim() const override {
+    throw std::runtime_error("DCGaussianMixtureFactor::dim not implemented");
+  };
 
   /// Testable
   /// @{

--- a/gtsam/hybrid/DCGaussianMixtureFactor.h
+++ b/gtsam/hybrid/DCGaussianMixtureFactor.h
@@ -51,12 +51,9 @@ class DCGaussianMixtureFactor : public DCFactor {
   DCGaussianMixtureFactor() = default;
 
   DCGaussianMixtureFactor(
-      const KeyVector& keys, const DiscreteKeys& dk,
+      const KeyVector& keys, const DiscreteKeys& discreteKeys,
       const std::vector<GaussianFactor::shared_ptr>& factors)
-      : discreteKeys_(dk), factors_(factors) {
-    // Compiler doesn't like `keys_` in the initializer list.
-    keys_ = keys;
-  }
+      : Base(keys, discreteKeys), factors_(factors) {}
 
   /// Discrete key selecting mixture component
   const DiscreteKeys& discreteKeys() const { return discreteKeys_; }
@@ -98,7 +95,7 @@ class DCGaussianMixtureFactor : public DCFactor {
     }
     std::cout << "; " << formatter(discreteKeys_.front().first) << " ]";
     std::cout << "{\n";
-    for (int i = 0; i < factors_.size(); i++) {
+    for (size_t i = 0; i < factors_.size(); i++) {
       auto t = boost::format("component %1%: ") % i;
       factors_[i]->print(t.str());
     }

--- a/gtsam/hybrid/DCGaussianMixtureFactor.h
+++ b/gtsam/hybrid/DCGaussianMixtureFactor.h
@@ -55,6 +55,8 @@ class DCGaussianMixtureFactor : public DCFactor {
       const std::vector<GaussianFactor::shared_ptr>& factors)
       : Base(keys, discreteKeys), factors_(factors) {}
 
+  DCGaussianMixtureFactor(const DCGaussianMixtureFactor& x) = default;
+
   /// Discrete key selecting mixture component
   const DiscreteKeys& discreteKeys() const { return discreteKeys_; }
 
@@ -72,10 +74,16 @@ class DCGaussianMixtureFactor : public DCFactor {
   }
 
   // TODO(dellaert): Does not make sense
-  boost::shared_ptr<gtsam::GaussianFactor> linearize(
+  GaussianFactor::shared_ptr linearize(
       const gtsam::Values& continuousVals,
       const DiscreteValues& discreteVals) const override {
     return factors_[0];
+  }
+
+  /// Return this linear factor as a DCFactor::shared_ptr
+  virtual DCFactor::shared_ptr linearize(
+      const Values& continuousVals) const override {
+    return boost::make_shared<DCGaussianMixtureFactor>(*this);
   }
 
   // TODO(dellaert): implement

--- a/gtsam/hybrid/DCGaussianMixtureFactor.h
+++ b/gtsam/hybrid/DCGaussianMixtureFactor.h
@@ -42,7 +42,6 @@ namespace gtsam {
  */
 class DCGaussianMixtureFactor : public DCFactor {
  private:
-  DiscreteKeys discreteKeys_;
   std::vector<GaussianFactor::shared_ptr> factors_;
 
  public:

--- a/gtsam/hybrid/DCMixtureFactor.h
+++ b/gtsam/hybrid/DCMixtureFactor.h
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <gtsam/hybrid/DCGaussianMixtureFactor.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/Symbol.h>
 
@@ -40,6 +41,7 @@ class DCMixtureFactor : public DCFactor {
 
  public:
   using Base = DCFactor;
+  using shared_ptr = boost::shared_ptr<DCMixtureFactor>;
 
   DCMixtureFactor() = default;
 
@@ -133,7 +135,9 @@ class DCMixtureFactor : public DCFactor {
 
   /// @}
 
-  boost::shared_ptr<GaussianFactor> linearize(
+  /// Linearize specific nonlinear factors based on the assignment in
+  /// discreteValues.
+  GaussianFactor::shared_ptr linearize(
       const Values& continuousVals,
       const DiscreteValues& discreteVals) const override {
     // Retrieve the assignment to our discrete key.
@@ -142,6 +146,17 @@ class DCMixtureFactor : public DCFactor {
     // `assignment` indexes the nonlinear factors we have stored to compute the
     // error.
     return factors_[assignment].linearize(continuousVals);
+  }
+
+  /// Linearize all the continuous factors to get a DCGaussianMixtureFactor.
+  DCFactor::shared_ptr linearize(const Values& continuousVals) const override {
+    std::vector<GaussianFactor::shared_ptr> linearized_factors;
+    for (size_t i = 0; i < factors_.size(); i++) {
+      auto linearized = factors_[i].linearize(continuousVals);
+      linearized_factors.push_back(linearized);
+    }
+    DCGaussianMixtureFactor linearized(keys_, dk_, linearized_factors);
+    return boost::make_shared<DCGaussianMixtureFactor>(linearized);
   }
 
   /**

--- a/gtsam/hybrid/DCMixtureFactor.h
+++ b/gtsam/hybrid/DCMixtureFactor.h
@@ -97,7 +97,7 @@ class DCMixtureFactor : public DCFactor {
       std::cout << " " << formatter(key);
     }
     std::cout << "; " << formatter(discreteKey().first) << " ) {\n";
-    for (int i = 0; i < factors_.size(); i++) {
+    for (size_t i = 0; i < factors_.size(); i++) {
       auto t = boost::format("component %1%: ") % i;
       factors_[i].print(t.str());
     }

--- a/gtsam/hybrid/DCMixtureFactor.h
+++ b/gtsam/hybrid/DCMixtureFactor.h
@@ -155,8 +155,7 @@ class DCMixtureFactor : public DCFactor {
       auto linearized = factors_[i].linearize(continuousVals);
       linearized_factors.push_back(linearized);
     }
-    DCGaussianMixtureFactor linearized(keys_, dk_, linearized_factors);
-    return boost::make_shared<DCGaussianMixtureFactor>(linearized);
+    return boost::make_shared<DCGaussianMixtureFactor>(keys_, dk_, linearized_factors);
   }
 
   /**

--- a/gtsam/hybrid/HybridFactorGraph.cpp
+++ b/gtsam/hybrid/HybridFactorGraph.cpp
@@ -69,8 +69,7 @@ HybridFactorGraph HybridFactorGraph::linearize(
   // linearize the DCFactors
   DCFactorGraph linearized_DC_factors;
   for (DCFactor::shared_ptr factor : dcGraph_) {
-    // Check if the factor is a DCGaussianMixtureFactor since we don't linearize
-    // those.
+    // If factor is a DCGaussianMixtureFactor, we don't linearize.
     auto dcgm = dynamic_cast<const DCGaussianMixtureFactor*>(factor.get());
     if (dcgm) {
       linearized_DC_factors.push_back(factor);

--- a/gtsam/hybrid/HybridFactorGraph.cpp
+++ b/gtsam/hybrid/HybridFactorGraph.cpp
@@ -32,15 +32,11 @@ void HybridFactorGraph::push_dc(const DCFactor::shared_ptr& dcFactor) {
 
 void HybridFactorGraph::print(const std::string& str,
                               const gtsam::KeyFormatter& keyFormatter) const {
-  std::string nonlinearStr = str + ": NonlinearFactorGraph";
-  std::string discreteStr = str + ": DiscreteFactorGraph";
-  std::string dcStr = str + ": DCFactorGraph";
-  std::string gStr = str + ": GaussianGraph";
-
-  nonlinearGraph_.print(nonlinearStr, keyFormatter);
-  discreteGraph_.print(discreteStr, keyFormatter);
-  dcGraph_.print(dcStr, keyFormatter);
-  gaussianGraph_.print(gStr, keyFormatter);
+  std::string prefix = str.empty() ? str : str + ": ";
+  nonlinearGraph_.print(prefix + "NonlinearFactorGraph", keyFormatter);
+  discreteGraph_.print(prefix + "DiscreteFactorGraph", keyFormatter);
+  dcGraph_.print(prefix + "DCFactorGraph", keyFormatter);
+  gaussianGraph_.print(prefix + "GaussianGraph", keyFormatter);
 }
 
 gtsam::FastSet<gtsam::Key> HybridFactorGraph::keys() const {

--- a/gtsam/hybrid/HybridFactorGraph.cpp
+++ b/gtsam/hybrid/HybridFactorGraph.cpp
@@ -72,6 +72,11 @@ HybridFactorGraph HybridFactorGraph::linearize(
     linearized_DC_factors.push_back(dcgf);
   }
 
+  // Add the original factors from the gaussian factor graph
+  for (auto&& factor : this->gaussianGraph()) {
+    gaussian_factor_graph->push_back(factor);
+  }
+
   // Construct new linearized HybridFactorGraph
   HybridFactorGraph linearizedGraph(this->nonlinearGraph_, this->discreteGraph_,
                                     linearized_DC_factors,

--- a/gtsam/hybrid/HybridFactorGraph.cpp
+++ b/gtsam/hybrid/HybridFactorGraph.cpp
@@ -10,6 +10,7 @@
  * @date   December 2021
  */
 
+#include <gtsam/hybrid/DCGaussianMixtureFactor.h>
 #include <gtsam/hybrid/HybridFactorGraph.h>
 
 namespace gtsam {
@@ -68,8 +69,16 @@ HybridFactorGraph HybridFactorGraph::linearize(
   // linearize the DCFactors
   DCFactorGraph linearized_DC_factors;
   for (DCFactor::shared_ptr factor : dcGraph_) {
-    auto dcgf = factor->linearize(continuousValues);
-    linearized_DC_factors.push_back(dcgf);
+    // Check if the factor is a DCGaussianMixtureFactor since we don't linearize
+    // those.
+    auto dcgm = dynamic_cast<const DCGaussianMixtureFactor*>(factor.get());
+    if (dcgm) {
+      linearized_DC_factors.push_back(factor);
+
+    } else {
+      auto dcgf = factor->linearize(continuousValues);
+      linearized_DC_factors.push_back(dcgf);
+    }
   }
 
   // Add the original factors from the gaussian factor graph

--- a/gtsam/hybrid/HybridFactorGraph.cpp
+++ b/gtsam/hybrid/HybridFactorGraph.cpp
@@ -56,6 +56,10 @@ const gtsam::DiscreteFactorGraph& HybridFactorGraph::discreteGraph() const {
   return discreteGraph_;
 }
 
+const GaussianFactorGraph& HybridFactorGraph::gaussianGraph() const {
+  return gaussianGraph_;
+}
+
 HybridFactorGraph HybridFactorGraph::linearize(
     const Values& continuousValues) const {
   // linearize the continuous factors

--- a/gtsam/hybrid/HybridFactorGraph.cpp
+++ b/gtsam/hybrid/HybridFactorGraph.cpp
@@ -58,6 +58,16 @@ const gtsam::DiscreteFactorGraph& HybridFactorGraph::discreteGraph() const {
   return discreteGraph_;
 }
 
+HybridFactorGraph HybridFactorGraph::linearize(
+    const Values& continuousValues) const {
+  auto gaussian_factor_graph = nonlinearGraph_.linearize(continuousValues);
+
+  HybridFactorGraph linearizedGraph(this->nonlinearGraph_,
+                                    this->discreteGraph_, this->dcGraph_,
+                                    *gaussian_factor_graph);
+  return linearizedGraph;
+}
+
 const DCFactorGraph& HybridFactorGraph::dcGraph() const { return dcGraph_; }
 
 bool HybridFactorGraph::empty() const {

--- a/gtsam/hybrid/HybridFactorGraph.h
+++ b/gtsam/hybrid/HybridFactorGraph.h
@@ -37,10 +37,10 @@ class HybridFactorGraph {
 
   /**
    * @brief Construct a new Hybrid Factor Graph object.
-   * 
+   *
    * @param nonlinearGraph A factor graph with continuous factors.
    * @param discreteGraph A factor graph with only discrete factors.
-   * @param dcGraph A DCFactorGraph containing DCFactors. 
+   * @param dcGraph A DCFactorGraph containing DCFactors.
    */
   HybridFactorGraph(
       const NonlinearFactorGraph& nonlinearGraph,
@@ -109,7 +109,7 @@ class HybridFactorGraph {
    * @param nonlinearFactor - the factor to add
    */
   template <typename NonlinearFactorType>
-  void push_nonlinear(const NonlinearFactorType &nonlinearFactor) {
+  void push_nonlinear(const NonlinearFactorType& nonlinearFactor) {
     nonlinearGraph_.push_back(
         boost::make_shared<NonlinearFactorType>(nonlinearFactor));
   }
@@ -126,7 +126,7 @@ class HybridFactorGraph {
    * @param discreteFactor - the factor to add
    */
   template <typename DiscreteFactorType>
-  void push_discrete(const DiscreteFactorType &discreteFactor) {
+  void push_discrete(const DiscreteFactorType& discreteFactor) {
     discreteGraph_.emplace_shared<DiscreteFactorType>(discreteFactor);
   }
 
@@ -134,14 +134,15 @@ class HybridFactorGraph {
    * Add a discrete factor *pointer* to the internal discrete graph
    * @param discreteFactor - boost::shared_ptr to the factor to add
    */
-  void push_discrete(const boost::shared_ptr<gtsam::DiscreteFactor>& discreteFactor);
+  void push_discrete(
+      const boost::shared_ptr<gtsam::DiscreteFactor>& discreteFactor);
 
   /**
    * Add a discrete-continuous (DC) factor to the internal DC graph
    * @param dcFactor - the factor to add
    */
   template <typename DCFactorType>
-  void push_dc(const DCFactorType &dcFactor) {
+  void push_dc(const DCFactorType& dcFactor) {
     dcGraph_.push_back(boost::make_shared<DCFactorType>(dcFactor));
   }
 
@@ -163,9 +164,9 @@ class HybridFactorGraph {
   /**
    * Simply prints the factor graph.
    */
-  void print(const std::string &str = "HybridFactorGraph",
-             const gtsam::KeyFormatter &keyFormatter = 
-             gtsam::DefaultKeyFormatter) const;
+  void print(const std::string& str = "HybridFactorGraph",
+             const gtsam::KeyFormatter& keyFormatter =
+                 gtsam::DefaultKeyFormatter) const;
 
   /**
    * Mimics the GTSAM::FactorGraph API: retrieve the keys from each internal
@@ -186,13 +187,19 @@ class HybridFactorGraph {
    * Utility for retrieving the internal discrete factor graph
    * @return the member variable discreteGraph_
    */
-  const gtsam::DiscreteFactorGraph& discreteGraph() const;
+  const DiscreteFactorGraph& discreteGraph() const;
+
+  /**
+   * Utility for retrieving the internal gaussian factor graph
+   * @return the member variable gaussianGraph_
+   */
+  const GaussianFactorGraph& gaussianGraph() const;
 
   /**
    * @brief Linearize all the continuous factors in the HybridFactorGraph.
-   * 
+   *
    * @param continuousValues: Dictionary of continuous values.
-   * @return HybridFactorGraph 
+   * @return HybridFactorGraph
    */
   HybridFactorGraph linearize(const Values& continuousValues) const;
 
@@ -210,7 +217,7 @@ class HybridFactorGraph {
   /**
    * @return true if all internal graphs of `this` are equal to those of `other`
    */
-  bool equals(const HybridFactorGraph &other, double tol = 1e-9) const;
+  bool equals(const HybridFactorGraph& other, double tol = 1e-9) const;
 
   /**
    * @return the total number of factors across all internal graphs

--- a/gtsam/hybrid/HybridFactorGraph.h
+++ b/gtsam/hybrid/HybridFactorGraph.h
@@ -188,6 +188,12 @@ class HybridFactorGraph {
    */
   const gtsam::DiscreteFactorGraph& discreteGraph() const;
 
+  /**
+   * @brief Linearize all the continuous factors in the HybridFactorGraph.
+   * 
+   * @param continuousValues: Dictionary of continuous values.
+   * @return HybridFactorGraph 
+   */
   HybridFactorGraph linearize(const Values& continuousValues) const;
 
   /**

--- a/gtsam/hybrid/HybridFactorGraph.h
+++ b/gtsam/hybrid/HybridFactorGraph.h
@@ -14,8 +14,9 @@
 
 #include <gtsam/discrete/DiscreteFactor.h>
 #include <gtsam/discrete/DiscreteFactorGraph.h>
-#include <gtsam/hybrid/DCFactorGraph.h>
 #include <gtsam/hybrid/DCFactor.h>
+#include <gtsam/hybrid/DCFactorGraph.h>
+#include <gtsam/linear/GaussianFactorGraph.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 
@@ -26,12 +27,29 @@ namespace gtsam {
 class HybridFactorGraph {
  protected:
   // Separate internal factor graphs for different types of factors
-  gtsam::NonlinearFactorGraph nonlinearGraph_;
-  gtsam::DiscreteFactorGraph discreteGraph_;
+  NonlinearFactorGraph nonlinearGraph_;
+  DiscreteFactorGraph discreteGraph_;
   DCFactorGraph dcGraph_;
+  GaussianFactorGraph gaussianGraph_;
 
  public:
   HybridFactorGraph();
+
+  /**
+   * @brief Construct a new Hybrid Factor Graph object.
+   * 
+   * @param nonlinearGraph A factor graph with continuous factors.
+   * @param discreteGraph A factor graph with only discrete factors.
+   * @param dcGraph A DCFactorGraph containing DCFactors. 
+   */
+  HybridFactorGraph(
+      const NonlinearFactorGraph& nonlinearGraph,
+      const DiscreteFactorGraph& discreteGraph, const DCFactorGraph& dcGraph,
+      const GaussianFactorGraph& gaussianGraph = GaussianFactorGraph())
+      : nonlinearGraph_(nonlinearGraph),
+        discreteGraph_(discreteGraph),
+        dcGraph_(dcGraph),
+        gaussianGraph_(gaussianGraph) {}
 
   // TODO(dellaert): I propose we only have emplace_shared below.
 
@@ -100,7 +118,7 @@ class HybridFactorGraph {
 
   /**
    * Utility for retrieving the internal nonlinear factor graph
-   * @return the member variable nolinearGraph_
+   * @return the member variable nonlinearGraph_
    */
   const gtsam::NonlinearFactorGraph& nonlinearGraph() const;
 
@@ -109,6 +127,8 @@ class HybridFactorGraph {
    * @return the member variable discreteGraph_
    */
   const gtsam::DiscreteFactorGraph& discreteGraph() const;
+
+  HybridFactorGraph linearize(const Values& continuousValues) const;
 
   /**
    * Utility for retrieving the internal DC factor graph

--- a/gtsam/hybrid/tests/testDCFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testDCFactorGraph.cpp
@@ -219,13 +219,14 @@ TEST(DiscreteBayesTree, Switching) {
   DCGaussianMixtureFactorGraph dcmfg;  // TODO: = fg.linearize(values);
   GTSAM_PRINT(dcmfg);
 
-  // Eliminate partially.
-  Ordering ordering;
-  for (size_t k = 1; k <= K; k++) ordering += X(k);
-  using dc_traits = EliminationTraits<DCGaussianMixtureFactorGraph>;
-  auto result = dc_traits::eliminatePartialSequential(dcmfg, ordering);
-  GTSAM_PRINT(*result.first); // DCGaussianBayesNet
-  GTSAM_PRINT(*result.second); // DCGaussianMixtureFactorGraph
+  //TODO(Varun) uncomment and finish implementing
+  // // Eliminate partially.
+  // Ordering ordering;
+  // for (size_t k = 1; k <= K; k++) ordering += X(k);
+  // using dc_traits = EliminationTraits<DCGaussianMixtureFactorGraph>;
+  // auto result = dc_traits::eliminatePartialSequential(dcmfg, ordering);
+  // GTSAM_PRINT(*result.first); // DCGaussianBayesNet
+  // GTSAM_PRINT(*result.second); // DCGaussianMixtureFactorGraph
 }
 
 /* ************************************************************************* */

--- a/gtsam/hybrid/tests/testDCGaussianElimination.cpp
+++ b/gtsam/hybrid/tests/testDCGaussianElimination.cpp
@@ -160,7 +160,7 @@ struct EliminationTraits<DCGaussianMixtureFactorGraph> {
 };
 
 /* TODO(dellaert) EliminateableFactorGraph does not play well with hybrid:
-/// Speical DCFactorGraph that can be eliminated partially
+/// Special DCFactorGraph that can be eliminated partially
 class MixtureFactorGraph : public FactorGraph<DCMixtureFactor>,
                            public EliminateableFactorGraph<MixtureFactorGraph> {
 };

--- a/gtsam/hybrid/tests/testHybridFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridFactorGraph.cpp
@@ -70,11 +70,11 @@ TEST(HybridFactorGraph, Switching) {
 
   GTSAM_PRINT(fg);
 
-  // Values values;
+  Values values;
   // TODO: create 4 linearization points.
 
   // Linearize here:
-  HybridFactorGraph dcmfg;  // TODO: = fg.linearize(values);
+  HybridFactorGraph dcmfg = fg.linearize(values);
   GTSAM_PRINT(dcmfg);
 }
 

--- a/gtsam/hybrid/tests/testHybridFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridFactorGraph.cpp
@@ -92,6 +92,8 @@ TEST(HybridFactorGraph, Switching) {
   // There should only be one linearized continuous factor corresponding to the
   // PriorFactor on X(1).
   EXPECT(dcmfg.gaussianGraph().size() == 1);
+  // There should be two linearized DCGaussianMixtureFactors for each DCMixtureFactor.
+  EXPECT(dcmfg.dcGraph().size() == 2);
 }
 
 /* ************************************************************************* */

--- a/gtsam/hybrid/tests/testHybridFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridFactorGraph.cpp
@@ -83,7 +83,7 @@ TEST(HybridFactorGraph, Switching) {
 
   // There original hybrid factor graph should not have any Gaussian factors.
   // This ensures there are no unintentional factors being created.
-  EXPECT(assert_equal(fg.gaussianGraph().size(), size_t(0)));
+  EXPECT(fg.gaussianGraph().size() == 0);
 
   // Linearize here:
   HybridFactorGraph dcmfg = fg.linearize(values);
@@ -91,7 +91,7 @@ TEST(HybridFactorGraph, Switching) {
 
   // There should only be one linearized continuous factor corresponding to the
   // PriorFactor on X(1).
-  EXPECT(assert_equal(dcmfg.gaussianGraph().size(), size_t(1)));
+  EXPECT(dcmfg.gaussianGraph().size() == 1);
 }
 
 /* ************************************************************************* */

--- a/gtsam/hybrid/tests/testHybridFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridFactorGraph.cpp
@@ -72,6 +72,10 @@ TEST(HybridFactorGraph, Switching) {
   GTSAM_PRINT(fg);
 
   Values values;
+  for(size_t k=1; k < K; k++){
+    values.insert<double>(X(k), 0.0);
+  }
+
   // TODO: create 4 linearization points.
 
   // Linearize here:

--- a/gtsam/hybrid/tests/testHybridFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridFactorGraph.cpp
@@ -36,6 +36,32 @@ using symbol_shorthand::M;
 using symbol_shorthand::X;
 
 /* ****************************************************************************
+ * Test that any linearized gaussian factors are appended to the existing
+ * gaussian factor graph in the hybrid factor graph.
+ */
+TEST(HybridFactorGraph, GaussianFactorGraph) {
+  NonlinearFactorGraph cfg;
+  GaussianFactorGraph gfg;
+
+  // Add a simple prior factor to the nonlinear factor graph
+  cfg.emplace_shared<PriorFactor<double>>(X(0), 0, Isotropic::Sigma(1, 0.1));
+
+  // Add a factor to the GaussianFactorGraph
+  gfg.add(X(0), I_1x1, Vector1(5));
+
+  // Initialize the hybrid factor graph
+  HybridFactorGraph fg(cfg, DiscreteFactorGraph(), DCFactorGraph(), gfg);
+
+  // Linearization point
+  Values values;
+  values.insert<double>(X(0), 0);
+
+  HybridFactorGraph dcmfg = fg.linearize(values);
+
+  EXPECT(dcmfg.gaussianGraph().size() == 2);
+}
+
+/* ****************************************************************************
  * Test elimination on a switching-like hybrid factor graph.
  */
 TEST(HybridFactorGraph, Switching) {
@@ -92,7 +118,8 @@ TEST(HybridFactorGraph, Switching) {
   // There should only be one linearized continuous factor corresponding to the
   // PriorFactor on X(1).
   EXPECT(dcmfg.gaussianGraph().size() == 1);
-  // There should be two linearized DCGaussianMixtureFactors for each DCMixtureFactor.
+  // There should be two linearized DCGaussianMixtureFactors for each
+  // DCMixtureFactor.
   EXPECT(dcmfg.dcGraph().size() == 2);
 }
 

--- a/gtsam/hybrid/tests/testHybridFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridFactorGraph.cpp
@@ -54,8 +54,8 @@ TEST(HybridFactorGraph, Switching) {
 
   // Add "motion models".
   for (size_t k = 1; k < K; k++) {
-    BetweenFactor<double> still(X(k), X(k + 1), 0.0, Isotropic::Sigma(2, 1.0)),
-        moving(X(k), X(k + 1), 1.0, Isotropic::Sigma(2, 1.0));
+    BetweenFactor<double> still(X(k), X(k + 1), 0.0, Isotropic::Sigma(1, 1.0)),
+        moving(X(k), X(k + 1), 1.0, Isotropic::Sigma(1, 1.0));
     using MotionMixture = DCMixtureFactor<BetweenFactor<double>>;
     auto keys = {X(k), X(k + 1)};
     auto components = {still, moving};
@@ -72,7 +72,7 @@ TEST(HybridFactorGraph, Switching) {
   GTSAM_PRINT(fg);
 
   Values values;
-  for(size_t k=1; k < K; k++){
+  for(size_t k=1; k <= K; k++){
     values.insert<double>(X(k), 0.0);
   }
 

--- a/gtsam/hybrid/tests/testHybridFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridFactorGraph.cpp
@@ -24,6 +24,8 @@
 #include <gtsam/nonlinear/PriorFactor.h>
 #include <gtsam/slam/BetweenFactor.h>
 
+#include <cstdlib>
+
 // Include for test suite
 #include <CppUnitLite/TestHarness.h>
 
@@ -72,15 +74,24 @@ TEST(HybridFactorGraph, Switching) {
   GTSAM_PRINT(fg);
 
   Values values;
-  for(size_t k=1; k <= K; k++){
+  // Add a bunch of values for the linearization point.
+  for (size_t k = 1; k <= K; k++) {
     values.insert<double>(X(k), 0.0);
   }
 
   // TODO: create 4 linearization points.
 
+  // There original hybrid factor graph should not have any Gaussian factors.
+  // This ensures there are no unintentional factors being created.
+  EXPECT(assert_equal(fg.gaussianGraph().size(), size_t(0)));
+
   // Linearize here:
   HybridFactorGraph dcmfg = fg.linearize(values);
   GTSAM_PRINT(dcmfg);
+
+  // There should only be one linearized continuous factor corresponding to the
+  // PriorFactor on X(1).
+  EXPECT(assert_equal(dcmfg.gaussianGraph().size(), size_t(1)));
 }
 
 /* ************************************************************************* */


### PR DESCRIPTION
This PR adds a `linearize` method to the `HybridFactorGraph` which linearizes the nonlinear factors around a given point.