### PR TITLE
_repr_markdown_ -> markdown

### DIFF
--- a/gtsam/discrete/DecisionTreeFactor.cpp
+++ b/gtsam/discrete/DecisionTreeFactor.cpp
@@ -135,7 +135,7 @@ namespace gtsam {
   }
 
   /* ************************************************************************* */
-  std::string DecisionTreeFactor::_repr_markdown_(
+  std::string DecisionTreeFactor::markdown(
       const KeyFormatter& keyFormatter) const {
     std::stringstream ss;
 

--- a/gtsam/discrete/DecisionTreeFactor.h
+++ b/gtsam/discrete/DecisionTreeFactor.h
@@ -167,7 +167,7 @@ namespace gtsam {
     /// @{
     
     /// Render as markdown table.
-    std::string _repr_markdown_(
+    std::string markdown(
         const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override;
 
     /// @}

--- a/gtsam/discrete/DiscreteConditional.cpp
+++ b/gtsam/discrete/DiscreteConditional.cpp
@@ -223,7 +223,7 @@ size_t DiscreteConditional::sample(const DiscreteValues& parentsValues) const {
 }
 
 /* ************************************************************************* */
-std::string DiscreteConditional::_repr_markdown_(
+std::string DiscreteConditional::markdown(
     const KeyFormatter& keyFormatter) const {
   std::stringstream ss;
 

--- a/gtsam/discrete/DiscreteConditional.h
+++ b/gtsam/discrete/DiscreteConditional.h
@@ -171,7 +171,7 @@ public:
   /// @{
 
   /// Render as markdown table.
-  std::string _repr_markdown_(
+  std::string markdown(
       const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override;
 
   /// @}

--- a/gtsam/discrete/discrete.i
+++ b/gtsam/discrete/discrete.i
@@ -39,7 +39,7 @@ virtual class DecisionTreeFactor: gtsam::DiscreteFactor {
                  gtsam::DefaultKeyFormatter) const;
   bool equals(const gtsam::DecisionTreeFactor& other, double tol = 1e-9) const;
   string dot(bool showZero = false) const;
-  string _repr_markdown_(const gtsam::KeyFormatter& keyFormatter =
+  string markdown(const gtsam::KeyFormatter& keyFormatter =
                  gtsam::DefaultKeyFormatter) const;
 };
 
@@ -67,7 +67,7 @@ virtual class DiscreteConditional : gtsam::DecisionTreeFactor {
   size_t sample(const gtsam::DiscreteValues& parentsValues) const;
   void solveInPlace(gtsam::DiscreteValues@ parentsValues) const;
   void sampleInPlace(gtsam::DiscreteValues@ parentsValues) const;
-  string _repr_markdown_(const gtsam::KeyFormatter& keyFormatter =
+  string markdown(const gtsam::KeyFormatter& keyFormatter =
                  gtsam::DefaultKeyFormatter) const;
 };
 

--- a/gtsam/discrete/tests/testDecisionTreeFactor.cpp
+++ b/gtsam/discrete/tests/testDecisionTreeFactor.cpp
@@ -97,7 +97,7 @@ TEST(DecisionTreeFactor, markdown) {
       "|2|0|5|\n"
       "|2|1|6|\n";
   auto formatter = [](Key key) { return key == 12 ? "A" : "B"; };
-  string actual = f1._repr_markdown_(formatter);
+  string actual = f1.markdown(formatter);
   EXPECT(actual == expected);
 }
 

--- a/gtsam/discrete/tests/testDiscreteConditional.cpp
+++ b/gtsam/discrete/tests/testDiscreteConditional.cpp
@@ -119,7 +119,7 @@ TEST(DiscreteConditional, markdown_prior) {
       "|0|0.2|\n"
       "|1|0.4|\n"
       "|2|0.4|\n";
-  string actual = conditional._repr_markdown_();
+  string actual = conditional.markdown();
   EXPECT(actual == expected);
 }
 
@@ -138,7 +138,7 @@ TEST(DiscreteConditional, markdown_multivalued) {
       "|2|0.33|0.33|0.34|\n"
       "|3|0.33|0.33|0.34|\n"
       "|4|0.95|0.02|0.03|\n";
-  string actual = conditional._repr_markdown_();
+  string actual = conditional.markdown();
   EXPECT(actual == expected);
 }
 
@@ -159,7 +159,7 @@ TEST(DiscreteConditional, markdown) {
       "|1|2|1|0|\n";
   vector<string> names{"C", "B", "A"};
   auto formatter = [names](Key key) { return names[key]; };
-  string actual = conditional._repr_markdown_(formatter);
+  string actual = conditional.markdown(formatter);
   EXPECT(actual == expected);
 }
 

--- a/python/gtsam/tests/test_DiscreteConditional.py
+++ b/python/gtsam/tests/test_DiscreteConditional.py
@@ -1,0 +1,54 @@
+"""
+GTSAM Copyright 2010-2021, Georgia Tech Research Corporation,
+Atlanta, Georgia 30332-0415
+All Rights Reserved
+
+See LICENSE for the license information
+
+Unit tests for Discrete Conditionals.
+Author: Varun Agrawal
+"""
+
+# pylint: disable=no-name-in-module, invalid-name
+
+import unittest
+
+from gtsam import DiscreteConditional, DiscreteKeys
+from gtsam.utils.test_case import GtsamTestCase
+
+
+class TestDiscreteConditional(GtsamTestCase):
+    """Tests for Discrete Conditionals."""
+    def test_markdown(self):
+        """Test whether the _repr_markdown_ method."""
+
+        A = (2, 2)
+        B = (1, 2)
+        C = (0, 3)
+        parents = DiscreteKeys()
+        parents.push_back(B)
+        parents.push_back(C)
+
+        conditional = DiscreteConditional(A, parents,
+                                          "0/1 1/3  1/1 3/1  0/1 1/0")
+        expected = \
+            " $P(A|B,C)$:\n" \
+            "|B|C|0|1|\n" \
+            "|:-:|:-:|:-:|:-:|\n" \
+            "|0|0|0|1|\n" \
+            "|0|1|0.25|0.75|\n" \
+            "|0|2|0.5|0.5|\n" \
+            "|1|0|0.75|0.25|\n" \
+            "|1|1|0|1|\n" \
+            "|1|2|1|0|\n"
+
+        def formatter(x: int):
+            names = ["C", "B", "A"]
+            return names[x]
+
+        actual = conditional._repr_markdown_(formatter)
+        self.assertEqual(actual, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wrap/tests/expected/matlab/ForwardKinematics.m
+++ b/wrap/tests/expected/matlab/ForwardKinematics.m
@@ -12,11 +12,11 @@ classdef ForwardKinematics < handle
     function obj = ForwardKinematics(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(55, my_ptr);
+        class_wrapper(57, my_ptr);
       elseif nargin == 5 && isa(varargin{1},'gtdynamics.Robot') && isa(varargin{2},'char') && isa(varargin{3},'char') && isa(varargin{4},'gtsam.Values') && isa(varargin{5},'gtsam.Pose3')
-        my_ptr = class_wrapper(56, varargin{1}, varargin{2}, varargin{3}, varargin{4}, varargin{5});
+        my_ptr = class_wrapper(58, varargin{1}, varargin{2}, varargin{3}, varargin{4}, varargin{5});
       elseif nargin == 4 && isa(varargin{1},'gtdynamics.Robot') && isa(varargin{2},'char') && isa(varargin{3},'char') && isa(varargin{4},'gtsam.Values')
-        my_ptr = class_wrapper(57, varargin{1}, varargin{2}, varargin{3}, varargin{4});
+        my_ptr = class_wrapper(59, varargin{1}, varargin{2}, varargin{3}, varargin{4});
       else
         error('Arguments do not match any overload of ForwardKinematics constructor');
       end
@@ -24,7 +24,7 @@ classdef ForwardKinematics < handle
     end
 
     function delete(obj)
-      class_wrapper(58, obj.ptr_ForwardKinematics);
+      class_wrapper(60, obj.ptr_ForwardKinematics);
     end
 
     function display(obj), obj.print(''); end

--- a/wrap/tests/expected/matlab/MultipleTemplatesIntDouble.m
+++ b/wrap/tests/expected/matlab/MultipleTemplatesIntDouble.m
@@ -9,7 +9,7 @@ classdef MultipleTemplatesIntDouble < handle
     function obj = MultipleTemplatesIntDouble(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(51, my_ptr);
+        class_wrapper(53, my_ptr);
       else
         error('Arguments do not match any overload of MultipleTemplatesIntDouble constructor');
       end
@@ -17,7 +17,7 @@ classdef MultipleTemplatesIntDouble < handle
     end
 
     function delete(obj)
-      class_wrapper(52, obj.ptr_MultipleTemplatesIntDouble);
+      class_wrapper(54, obj.ptr_MultipleTemplatesIntDouble);
     end
 
     function display(obj), obj.print(''); end

--- a/wrap/tests/expected/matlab/MultipleTemplatesIntFloat.m
+++ b/wrap/tests/expected/matlab/MultipleTemplatesIntFloat.m
@@ -9,7 +9,7 @@ classdef MultipleTemplatesIntFloat < handle
     function obj = MultipleTemplatesIntFloat(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(53, my_ptr);
+        class_wrapper(55, my_ptr);
       else
         error('Arguments do not match any overload of MultipleTemplatesIntFloat constructor');
       end
@@ -17,7 +17,7 @@ classdef MultipleTemplatesIntFloat < handle
     end
 
     function delete(obj)
-      class_wrapper(54, obj.ptr_MultipleTemplatesIntFloat);
+      class_wrapper(56, obj.ptr_MultipleTemplatesIntFloat);
     end
 
     function display(obj), obj.print(''); end

--- a/wrap/tests/expected/matlab/MyFactorPosePoint2.m
+++ b/wrap/tests/expected/matlab/MyFactorPosePoint2.m
@@ -15,9 +15,9 @@ classdef MyFactorPosePoint2 < handle
     function obj = MyFactorPosePoint2(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(65, my_ptr);
+        class_wrapper(67, my_ptr);
       elseif nargin == 4 && isa(varargin{1},'numeric') && isa(varargin{2},'numeric') && isa(varargin{3},'double') && isa(varargin{4},'gtsam.noiseModel.Base')
-        my_ptr = class_wrapper(66, varargin{1}, varargin{2}, varargin{3}, varargin{4});
+        my_ptr = class_wrapper(68, varargin{1}, varargin{2}, varargin{3}, varargin{4});
       else
         error('Arguments do not match any overload of MyFactorPosePoint2 constructor');
       end
@@ -25,7 +25,7 @@ classdef MyFactorPosePoint2 < handle
     end
 
     function delete(obj)
-      class_wrapper(67, obj.ptr_MyFactorPosePoint2);
+      class_wrapper(69, obj.ptr_MyFactorPosePoint2);
     end
 
     function display(obj), obj.print(''); end
@@ -36,19 +36,19 @@ classdef MyFactorPosePoint2 < handle
       % PRINT usage: print(string s, KeyFormatter keyFormatter) : returns void
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 2 && isa(varargin{1},'char') && isa(varargin{2},'gtsam.KeyFormatter')
-        class_wrapper(68, this, varargin{:});
+        class_wrapper(70, this, varargin{:});
         return
       end
       % PRINT usage: print(string s) : returns void
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'char')
-        class_wrapper(69, this, varargin{:});
+        class_wrapper(71, this, varargin{:});
         return
       end
       % PRINT usage: print() : returns void
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 0
-        class_wrapper(70, this, varargin{:});
+        class_wrapper(72, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function MyFactorPosePoint2.print');

--- a/wrap/tests/expected/matlab/MyVector12.m
+++ b/wrap/tests/expected/matlab/MyVector12.m
@@ -12,9 +12,9 @@ classdef MyVector12 < handle
     function obj = MyVector12(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(48, my_ptr);
+        class_wrapper(50, my_ptr);
       elseif nargin == 0
-        my_ptr = class_wrapper(49);
+        my_ptr = class_wrapper(51);
       else
         error('Arguments do not match any overload of MyVector12 constructor');
       end
@@ -22,7 +22,7 @@ classdef MyVector12 < handle
     end
 
     function delete(obj)
-      class_wrapper(50, obj.ptr_MyVector12);
+      class_wrapper(52, obj.ptr_MyVector12);
     end
 
     function display(obj), obj.print(''); end

--- a/wrap/tests/expected/matlab/MyVector3.m
+++ b/wrap/tests/expected/matlab/MyVector3.m
@@ -12,9 +12,9 @@ classdef MyVector3 < handle
     function obj = MyVector3(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(45, my_ptr);
+        class_wrapper(47, my_ptr);
       elseif nargin == 0
-        my_ptr = class_wrapper(46);
+        my_ptr = class_wrapper(48);
       else
         error('Arguments do not match any overload of MyVector3 constructor');
       end
@@ -22,7 +22,7 @@ classdef MyVector3 < handle
     end
 
     function delete(obj)
-      class_wrapper(47, obj.ptr_MyVector3);
+      class_wrapper(49, obj.ptr_MyVector3);
     end
 
     function display(obj), obj.print(''); end

--- a/wrap/tests/expected/matlab/PrimitiveRefDouble.m
+++ b/wrap/tests/expected/matlab/PrimitiveRefDouble.m
@@ -19,9 +19,9 @@ classdef PrimitiveRefDouble < handle
     function obj = PrimitiveRefDouble(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(41, my_ptr);
+        class_wrapper(43, my_ptr);
       elseif nargin == 0
-        my_ptr = class_wrapper(42);
+        my_ptr = class_wrapper(44);
       else
         error('Arguments do not match any overload of PrimitiveRefDouble constructor');
       end
@@ -29,7 +29,7 @@ classdef PrimitiveRefDouble < handle
     end
 
     function delete(obj)
-      class_wrapper(43, obj.ptr_PrimitiveRefDouble);
+      class_wrapper(45, obj.ptr_PrimitiveRefDouble);
     end
 
     function display(obj), obj.print(''); end
@@ -43,7 +43,7 @@ classdef PrimitiveRefDouble < handle
       % BRUTAL usage: Brutal(double t) : returns PrimitiveRefdouble
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'double')
-        varargout{1} = class_wrapper(44, varargin{:});
+        varargout{1} = class_wrapper(46, varargin{:});
         return
       end
 

--- a/wrap/tests/expected/matlab/Test.m
+++ b/wrap/tests/expected/matlab/Test.m
@@ -11,6 +11,7 @@
 %create_ptrs() : returns pair< Test, Test >
 %get_container() : returns std::vector<testing::Test>
 %lambda() : returns void
+%markdown(KeyFormatter keyFormatter) : returns string
 %print() : returns void
 %return_Point2Ptr(bool value) : returns Point2
 %return_Test(Test value) : returns Test
@@ -109,11 +110,27 @@ classdef Test < handle
       error('Arguments do not match any overload of function Test.lambda');
     end
 
+    function varargout = markdown(this, varargin)
+      % MARKDOWN usage: markdown(KeyFormatter keyFormatter) : returns string
+      % Doxygen can be found at https://gtsam.org/doxygen/
+      if length(varargin) == 1 && isa(varargin{1},'gtsam.KeyFormatter')
+        varargout{1} = class_wrapper(21, this, varargin{:});
+        return
+      end
+      % MARKDOWN usage: markdown() : returns string
+      % Doxygen can be found at https://gtsam.org/doxygen/
+      if length(varargin) == 0
+        varargout{1} = class_wrapper(22, this, varargin{:});
+        return
+      end
+      error('Arguments do not match any overload of function Test.markdown');
+    end
+
     function varargout = print(this, varargin)
       % PRINT usage: print() : returns void
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 0
-        class_wrapper(21, this, varargin{:});
+        class_wrapper(23, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.print');
@@ -123,7 +140,7 @@ classdef Test < handle
       % RETURN_POINT2PTR usage: return_Point2Ptr(bool value) : returns Point2
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'logical')
-        varargout{1} = class_wrapper(22, this, varargin{:});
+        varargout{1} = class_wrapper(24, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_Point2Ptr');
@@ -133,7 +150,7 @@ classdef Test < handle
       % RETURN_TEST usage: return_Test(Test value) : returns Test
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'Test')
-        varargout{1} = class_wrapper(23, this, varargin{:});
+        varargout{1} = class_wrapper(25, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_Test');
@@ -143,7 +160,7 @@ classdef Test < handle
       % RETURN_TESTPTR usage: return_TestPtr(Test value) : returns Test
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'Test')
-        varargout{1} = class_wrapper(24, this, varargin{:});
+        varargout{1} = class_wrapper(26, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_TestPtr');
@@ -153,7 +170,7 @@ classdef Test < handle
       % RETURN_BOOL usage: return_bool(bool value) : returns bool
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'logical')
-        varargout{1} = class_wrapper(25, this, varargin{:});
+        varargout{1} = class_wrapper(27, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_bool');
@@ -163,7 +180,7 @@ classdef Test < handle
       % RETURN_DOUBLE usage: return_double(double value) : returns double
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'double')
-        varargout{1} = class_wrapper(26, this, varargin{:});
+        varargout{1} = class_wrapper(28, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_double');
@@ -173,7 +190,7 @@ classdef Test < handle
       % RETURN_FIELD usage: return_field(Test t) : returns bool
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'Test')
-        varargout{1} = class_wrapper(27, this, varargin{:});
+        varargout{1} = class_wrapper(29, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_field');
@@ -183,7 +200,7 @@ classdef Test < handle
       % RETURN_INT usage: return_int(int value) : returns int
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'numeric')
-        varargout{1} = class_wrapper(28, this, varargin{:});
+        varargout{1} = class_wrapper(30, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_int');
@@ -193,7 +210,7 @@ classdef Test < handle
       % RETURN_MATRIX1 usage: return_matrix1(Matrix value) : returns Matrix
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'double')
-        varargout{1} = class_wrapper(29, this, varargin{:});
+        varargout{1} = class_wrapper(31, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_matrix1');
@@ -203,7 +220,7 @@ classdef Test < handle
       % RETURN_MATRIX2 usage: return_matrix2(Matrix value) : returns Matrix
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'double')
-        varargout{1} = class_wrapper(30, this, varargin{:});
+        varargout{1} = class_wrapper(32, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_matrix2');
@@ -213,13 +230,13 @@ classdef Test < handle
       % RETURN_PAIR usage: return_pair(Vector v, Matrix A) : returns pair< Vector, Matrix >
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 2 && isa(varargin{1},'double') && size(varargin{1},2)==1 && isa(varargin{2},'double')
-        [ varargout{1} varargout{2} ] = class_wrapper(31, this, varargin{:});
+        [ varargout{1} varargout{2} ] = class_wrapper(33, this, varargin{:});
         return
       end
       % RETURN_PAIR usage: return_pair(Vector v) : returns pair< Vector, Matrix >
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'double') && size(varargin{1},2)==1
-        [ varargout{1} varargout{2} ] = class_wrapper(32, this, varargin{:});
+        [ varargout{1} varargout{2} ] = class_wrapper(34, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_pair');
@@ -229,7 +246,7 @@ classdef Test < handle
       % RETURN_PTRS usage: return_ptrs(Test p1, Test p2) : returns pair< Test, Test >
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 2 && isa(varargin{1},'Test') && isa(varargin{2},'Test')
-        [ varargout{1} varargout{2} ] = class_wrapper(33, this, varargin{:});
+        [ varargout{1} varargout{2} ] = class_wrapper(35, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_ptrs');
@@ -239,7 +256,7 @@ classdef Test < handle
       % RETURN_SIZE_T usage: return_size_t(size_t value) : returns size_t
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'numeric')
-        varargout{1} = class_wrapper(34, this, varargin{:});
+        varargout{1} = class_wrapper(36, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_size_t');
@@ -249,7 +266,7 @@ classdef Test < handle
       % RETURN_STRING usage: return_string(string value) : returns string
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'char')
-        varargout{1} = class_wrapper(35, this, varargin{:});
+        varargout{1} = class_wrapper(37, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_string');
@@ -259,7 +276,7 @@ classdef Test < handle
       % RETURN_VECTOR1 usage: return_vector1(Vector value) : returns Vector
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'double') && size(varargin{1},2)==1
-        varargout{1} = class_wrapper(36, this, varargin{:});
+        varargout{1} = class_wrapper(38, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_vector1');
@@ -269,7 +286,7 @@ classdef Test < handle
       % RETURN_VECTOR2 usage: return_vector2(Vector value) : returns Vector
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'double') && size(varargin{1},2)==1
-        varargout{1} = class_wrapper(37, this, varargin{:});
+        varargout{1} = class_wrapper(39, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_vector2');
@@ -279,19 +296,19 @@ classdef Test < handle
       % SET_CONTAINER usage: set_container(vector<Test> container) : returns void
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'std.vectorTest')
-        class_wrapper(38, this, varargin{:});
-        return
-      end
-      % SET_CONTAINER usage: set_container(vector<Test> container) : returns void
-      % Doxygen can be found at https://gtsam.org/doxygen/
-      if length(varargin) == 1 && isa(varargin{1},'std.vectorTest')
-        class_wrapper(39, this, varargin{:});
-        return
-      end
-      % SET_CONTAINER usage: set_container(vector<Test> container) : returns void
-      % Doxygen can be found at https://gtsam.org/doxygen/
-      if length(varargin) == 1 && isa(varargin{1},'std.vectorTest')
         class_wrapper(40, this, varargin{:});
+        return
+      end
+      % SET_CONTAINER usage: set_container(vector<Test> container) : returns void
+      % Doxygen can be found at https://gtsam.org/doxygen/
+      if length(varargin) == 1 && isa(varargin{1},'std.vectorTest')
+        class_wrapper(41, this, varargin{:});
+        return
+      end
+      % SET_CONTAINER usage: set_container(vector<Test> container) : returns void
+      % Doxygen can be found at https://gtsam.org/doxygen/
+      if length(varargin) == 1 && isa(varargin{1},'std.vectorTest')
+        class_wrapper(42, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.set_container');

--- a/wrap/tests/expected/matlab/class_wrapper.cpp
+++ b/wrap/tests/expected/matlab/class_wrapper.cpp
@@ -346,14 +346,29 @@ void Test_lambda_20(int nargout, mxArray *out[], int nargin, const mxArray *in[]
   obj->lambda();
 }
 
-void Test_print_21(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_markdown_21(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("markdown",nargout,nargin-1,1);
+  auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
+  gtsam::KeyFormatter& keyFormatter = *unwrap_shared_ptr< gtsam::KeyFormatter >(in[1], "ptr_gtsamKeyFormatter");
+  out[0] = wrap< string >(obj->markdown(keyFormatter));
+}
+
+void Test_markdown_22(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("markdown",nargout,nargin-1,0);
+  auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
+  out[0] = wrap< string >(obj->markdown(gtsam::DefaultKeyFormatter));
+}
+
+void Test_print_23(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("print",nargout,nargin-1,0);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
   obj->print();
 }
 
-void Test_return_Point2Ptr_22(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_Point2Ptr_24(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_Point2Ptr",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -364,7 +379,7 @@ void Test_return_Point2Ptr_22(int nargout, mxArray *out[], int nargin, const mxA
   }
 }
 
-void Test_return_Test_23(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_Test_25(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_Test",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -372,7 +387,7 @@ void Test_return_Test_23(int nargout, mxArray *out[], int nargin, const mxArray 
   out[0] = wrap_shared_ptr(boost::make_shared<Test>(obj->return_Test(value)),"Test", false);
 }
 
-void Test_return_TestPtr_24(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_TestPtr_26(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_TestPtr",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -380,7 +395,7 @@ void Test_return_TestPtr_24(int nargout, mxArray *out[], int nargin, const mxArr
   out[0] = wrap_shared_ptr(obj->return_TestPtr(value),"Test", false);
 }
 
-void Test_return_bool_25(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_bool_27(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_bool",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -388,7 +403,7 @@ void Test_return_bool_25(int nargout, mxArray *out[], int nargin, const mxArray 
   out[0] = wrap< bool >(obj->return_bool(value));
 }
 
-void Test_return_double_26(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_double_28(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_double",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -396,7 +411,7 @@ void Test_return_double_26(int nargout, mxArray *out[], int nargin, const mxArra
   out[0] = wrap< double >(obj->return_double(value));
 }
 
-void Test_return_field_27(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_field_29(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_field",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -404,7 +419,7 @@ void Test_return_field_27(int nargout, mxArray *out[], int nargin, const mxArray
   out[0] = wrap< bool >(obj->return_field(t));
 }
 
-void Test_return_int_28(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_int_30(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_int",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -412,7 +427,7 @@ void Test_return_int_28(int nargout, mxArray *out[], int nargin, const mxArray *
   out[0] = wrap< int >(obj->return_int(value));
 }
 
-void Test_return_matrix1_29(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_matrix1_31(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_matrix1",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -420,7 +435,7 @@ void Test_return_matrix1_29(int nargout, mxArray *out[], int nargin, const mxArr
   out[0] = wrap< Matrix >(obj->return_matrix1(value));
 }
 
-void Test_return_matrix2_30(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_matrix2_32(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_matrix2",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -428,7 +443,7 @@ void Test_return_matrix2_30(int nargout, mxArray *out[], int nargin, const mxArr
   out[0] = wrap< Matrix >(obj->return_matrix2(value));
 }
 
-void Test_return_pair_31(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_pair_33(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_pair",nargout,nargin-1,2);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -439,7 +454,7 @@ void Test_return_pair_31(int nargout, mxArray *out[], int nargin, const mxArray 
   out[1] = wrap< Matrix >(pairResult.second);
 }
 
-void Test_return_pair_32(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_pair_34(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_pair",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -449,7 +464,7 @@ void Test_return_pair_32(int nargout, mxArray *out[], int nargin, const mxArray 
   out[1] = wrap< Matrix >(pairResult.second);
 }
 
-void Test_return_ptrs_33(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_ptrs_35(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_ptrs",nargout,nargin-1,2);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -460,7 +475,7 @@ void Test_return_ptrs_33(int nargout, mxArray *out[], int nargin, const mxArray 
   out[1] = wrap_shared_ptr(pairResult.second,"Test", false);
 }
 
-void Test_return_size_t_34(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_size_t_36(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_size_t",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -468,7 +483,7 @@ void Test_return_size_t_34(int nargout, mxArray *out[], int nargin, const mxArra
   out[0] = wrap< size_t >(obj->return_size_t(value));
 }
 
-void Test_return_string_35(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_string_37(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_string",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -476,7 +491,7 @@ void Test_return_string_35(int nargout, mxArray *out[], int nargin, const mxArra
   out[0] = wrap< string >(obj->return_string(value));
 }
 
-void Test_return_vector1_36(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_vector1_38(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_vector1",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -484,28 +499,12 @@ void Test_return_vector1_36(int nargout, mxArray *out[], int nargin, const mxArr
   out[0] = wrap< Vector >(obj->return_vector1(value));
 }
 
-void Test_return_vector2_37(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_vector2_39(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_vector2",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
   Vector value = unwrap< Vector >(in[1]);
   out[0] = wrap< Vector >(obj->return_vector2(value));
-}
-
-void Test_set_container_38(int nargout, mxArray *out[], int nargin, const mxArray *in[])
-{
-  checkArguments("set_container",nargout,nargin-1,1);
-  auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
-  boost::shared_ptr<std::vector<testing::Test>> container = unwrap_shared_ptr< std::vector<testing::Test> >(in[1], "ptr_stdvectorTest");
-  obj->set_container(*container);
-}
-
-void Test_set_container_39(int nargout, mxArray *out[], int nargin, const mxArray *in[])
-{
-  checkArguments("set_container",nargout,nargin-1,1);
-  auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
-  boost::shared_ptr<std::vector<testing::Test>> container = unwrap_shared_ptr< std::vector<testing::Test> >(in[1], "ptr_stdvectorTest");
-  obj->set_container(*container);
 }
 
 void Test_set_container_40(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -516,7 +515,23 @@ void Test_set_container_40(int nargout, mxArray *out[], int nargin, const mxArra
   obj->set_container(*container);
 }
 
-void PrimitiveRefDouble_collectorInsertAndMakeBase_41(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_set_container_41(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("set_container",nargout,nargin-1,1);
+  auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
+  boost::shared_ptr<std::vector<testing::Test>> container = unwrap_shared_ptr< std::vector<testing::Test> >(in[1], "ptr_stdvectorTest");
+  obj->set_container(*container);
+}
+
+void Test_set_container_42(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("set_container",nargout,nargin-1,1);
+  auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
+  boost::shared_ptr<std::vector<testing::Test>> container = unwrap_shared_ptr< std::vector<testing::Test> >(in[1], "ptr_stdvectorTest");
+  obj->set_container(*container);
+}
+
+void PrimitiveRefDouble_collectorInsertAndMakeBase_43(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<PrimitiveRef<double>> Shared;
@@ -525,7 +540,7 @@ void PrimitiveRefDouble_collectorInsertAndMakeBase_41(int nargout, mxArray *out[
   collector_PrimitiveRefDouble.insert(self);
 }
 
-void PrimitiveRefDouble_constructor_42(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void PrimitiveRefDouble_constructor_44(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<PrimitiveRef<double>> Shared;
@@ -536,7 +551,7 @@ void PrimitiveRefDouble_constructor_42(int nargout, mxArray *out[], int nargin, 
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void PrimitiveRefDouble_deconstructor_43(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void PrimitiveRefDouble_deconstructor_45(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<PrimitiveRef<double>> Shared;
   checkArguments("delete_PrimitiveRefDouble",nargout,nargin,1);
@@ -549,14 +564,14 @@ void PrimitiveRefDouble_deconstructor_43(int nargout, mxArray *out[], int nargin
   delete self;
 }
 
-void PrimitiveRefDouble_Brutal_44(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void PrimitiveRefDouble_Brutal_46(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("PrimitiveRef<double>.Brutal",nargout,nargin,1);
   double t = unwrap< double >(in[0]);
   out[0] = wrap_shared_ptr(boost::make_shared<PrimitiveRef<double>>(PrimitiveRef<double>::Brutal(t)),"PrimitiveRefdouble", false);
 }
 
-void MyVector3_collectorInsertAndMakeBase_45(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyVector3_collectorInsertAndMakeBase_47(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyVector<3>> Shared;
@@ -565,7 +580,7 @@ void MyVector3_collectorInsertAndMakeBase_45(int nargout, mxArray *out[], int na
   collector_MyVector3.insert(self);
 }
 
-void MyVector3_constructor_46(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyVector3_constructor_48(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyVector<3>> Shared;
@@ -576,7 +591,7 @@ void MyVector3_constructor_46(int nargout, mxArray *out[], int nargin, const mxA
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void MyVector3_deconstructor_47(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyVector3_deconstructor_49(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<MyVector<3>> Shared;
   checkArguments("delete_MyVector3",nargout,nargin,1);
@@ -589,7 +604,7 @@ void MyVector3_deconstructor_47(int nargout, mxArray *out[], int nargin, const m
   delete self;
 }
 
-void MyVector12_collectorInsertAndMakeBase_48(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyVector12_collectorInsertAndMakeBase_50(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyVector<12>> Shared;
@@ -598,7 +613,7 @@ void MyVector12_collectorInsertAndMakeBase_48(int nargout, mxArray *out[], int n
   collector_MyVector12.insert(self);
 }
 
-void MyVector12_constructor_49(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyVector12_constructor_51(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyVector<12>> Shared;
@@ -609,7 +624,7 @@ void MyVector12_constructor_49(int nargout, mxArray *out[], int nargin, const mx
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void MyVector12_deconstructor_50(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyVector12_deconstructor_52(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<MyVector<12>> Shared;
   checkArguments("delete_MyVector12",nargout,nargin,1);
@@ -622,7 +637,7 @@ void MyVector12_deconstructor_50(int nargout, mxArray *out[], int nargin, const 
   delete self;
 }
 
-void MultipleTemplatesIntDouble_collectorInsertAndMakeBase_51(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MultipleTemplatesIntDouble_collectorInsertAndMakeBase_53(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MultipleTemplates<int, double>> Shared;
@@ -631,7 +646,7 @@ void MultipleTemplatesIntDouble_collectorInsertAndMakeBase_51(int nargout, mxArr
   collector_MultipleTemplatesIntDouble.insert(self);
 }
 
-void MultipleTemplatesIntDouble_deconstructor_52(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MultipleTemplatesIntDouble_deconstructor_54(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<MultipleTemplates<int, double>> Shared;
   checkArguments("delete_MultipleTemplatesIntDouble",nargout,nargin,1);
@@ -644,7 +659,7 @@ void MultipleTemplatesIntDouble_deconstructor_52(int nargout, mxArray *out[], in
   delete self;
 }
 
-void MultipleTemplatesIntFloat_collectorInsertAndMakeBase_53(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MultipleTemplatesIntFloat_collectorInsertAndMakeBase_55(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MultipleTemplates<int, float>> Shared;
@@ -653,7 +668,7 @@ void MultipleTemplatesIntFloat_collectorInsertAndMakeBase_53(int nargout, mxArra
   collector_MultipleTemplatesIntFloat.insert(self);
 }
 
-void MultipleTemplatesIntFloat_deconstructor_54(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MultipleTemplatesIntFloat_deconstructor_56(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<MultipleTemplates<int, float>> Shared;
   checkArguments("delete_MultipleTemplatesIntFloat",nargout,nargin,1);
@@ -666,7 +681,7 @@ void MultipleTemplatesIntFloat_deconstructor_54(int nargout, mxArray *out[], int
   delete self;
 }
 
-void ForwardKinematics_collectorInsertAndMakeBase_55(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void ForwardKinematics_collectorInsertAndMakeBase_57(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<ForwardKinematics> Shared;
@@ -675,7 +690,7 @@ void ForwardKinematics_collectorInsertAndMakeBase_55(int nargout, mxArray *out[]
   collector_ForwardKinematics.insert(self);
 }
 
-void ForwardKinematics_constructor_56(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void ForwardKinematics_constructor_58(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<ForwardKinematics> Shared;
@@ -691,7 +706,7 @@ void ForwardKinematics_constructor_56(int nargout, mxArray *out[], int nargin, c
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void ForwardKinematics_constructor_57(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void ForwardKinematics_constructor_59(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<ForwardKinematics> Shared;
@@ -706,7 +721,7 @@ void ForwardKinematics_constructor_57(int nargout, mxArray *out[], int nargin, c
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void ForwardKinematics_deconstructor_58(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void ForwardKinematics_deconstructor_60(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<ForwardKinematics> Shared;
   checkArguments("delete_ForwardKinematics",nargout,nargin,1);
@@ -719,7 +734,7 @@ void ForwardKinematics_deconstructor_58(int nargout, mxArray *out[], int nargin,
   delete self;
 }
 
-void TemplatedConstructor_collectorInsertAndMakeBase_59(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedConstructor_collectorInsertAndMakeBase_61(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<TemplatedConstructor> Shared;
@@ -728,7 +743,7 @@ void TemplatedConstructor_collectorInsertAndMakeBase_59(int nargout, mxArray *ou
   collector_TemplatedConstructor.insert(self);
 }
 
-void TemplatedConstructor_constructor_60(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedConstructor_constructor_62(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<TemplatedConstructor> Shared;
@@ -739,7 +754,7 @@ void TemplatedConstructor_constructor_60(int nargout, mxArray *out[], int nargin
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void TemplatedConstructor_constructor_61(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedConstructor_constructor_63(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<TemplatedConstructor> Shared;
@@ -751,7 +766,7 @@ void TemplatedConstructor_constructor_61(int nargout, mxArray *out[], int nargin
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void TemplatedConstructor_constructor_62(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedConstructor_constructor_64(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<TemplatedConstructor> Shared;
@@ -763,7 +778,7 @@ void TemplatedConstructor_constructor_62(int nargout, mxArray *out[], int nargin
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void TemplatedConstructor_constructor_63(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedConstructor_constructor_65(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<TemplatedConstructor> Shared;
@@ -775,7 +790,7 @@ void TemplatedConstructor_constructor_63(int nargout, mxArray *out[], int nargin
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void TemplatedConstructor_deconstructor_64(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedConstructor_deconstructor_66(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<TemplatedConstructor> Shared;
   checkArguments("delete_TemplatedConstructor",nargout,nargin,1);
@@ -788,7 +803,7 @@ void TemplatedConstructor_deconstructor_64(int nargout, mxArray *out[], int narg
   delete self;
 }
 
-void MyFactorPosePoint2_collectorInsertAndMakeBase_65(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_collectorInsertAndMakeBase_67(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>> Shared;
@@ -797,7 +812,7 @@ void MyFactorPosePoint2_collectorInsertAndMakeBase_65(int nargout, mxArray *out[
   collector_MyFactorPosePoint2.insert(self);
 }
 
-void MyFactorPosePoint2_constructor_66(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_constructor_68(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>> Shared;
@@ -812,7 +827,7 @@ void MyFactorPosePoint2_constructor_66(int nargout, mxArray *out[], int nargin, 
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void MyFactorPosePoint2_deconstructor_67(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_deconstructor_69(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>> Shared;
   checkArguments("delete_MyFactorPosePoint2",nargout,nargin,1);
@@ -825,7 +840,7 @@ void MyFactorPosePoint2_deconstructor_67(int nargout, mxArray *out[], int nargin
   delete self;
 }
 
-void MyFactorPosePoint2_print_68(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_print_70(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("print",nargout,nargin-1,2);
   auto obj = unwrap_shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>>(in[0], "ptr_MyFactorPosePoint2");
@@ -834,7 +849,7 @@ void MyFactorPosePoint2_print_68(int nargout, mxArray *out[], int nargin, const 
   obj->print(s,keyFormatter);
 }
 
-void MyFactorPosePoint2_print_69(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_print_71(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("print",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>>(in[0], "ptr_MyFactorPosePoint2");
@@ -842,7 +857,7 @@ void MyFactorPosePoint2_print_69(int nargout, mxArray *out[], int nargin, const 
   obj->print(s,gtsam::DefaultKeyFormatter);
 }
 
-void MyFactorPosePoint2_print_70(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_print_72(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("print",nargout,nargin-1,0);
   auto obj = unwrap_shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>>(in[0], "ptr_MyFactorPosePoint2");
@@ -925,127 +940,127 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       Test_lambda_20(nargout, out, nargin-1, in+1);
       break;
     case 21:
-      Test_print_21(nargout, out, nargin-1, in+1);
+      Test_markdown_21(nargout, out, nargin-1, in+1);
       break;
     case 22:
-      Test_return_Point2Ptr_22(nargout, out, nargin-1, in+1);
+      Test_markdown_22(nargout, out, nargin-1, in+1);
       break;
     case 23:
-      Test_return_Test_23(nargout, out, nargin-1, in+1);
+      Test_print_23(nargout, out, nargin-1, in+1);
       break;
     case 24:
-      Test_return_TestPtr_24(nargout, out, nargin-1, in+1);
+      Test_return_Point2Ptr_24(nargout, out, nargin-1, in+1);
       break;
     case 25:
-      Test_return_bool_25(nargout, out, nargin-1, in+1);
+      Test_return_Test_25(nargout, out, nargin-1, in+1);
       break;
     case 26:
-      Test_return_double_26(nargout, out, nargin-1, in+1);
+      Test_return_TestPtr_26(nargout, out, nargin-1, in+1);
       break;
     case 27:
-      Test_return_field_27(nargout, out, nargin-1, in+1);
+      Test_return_bool_27(nargout, out, nargin-1, in+1);
       break;
     case 28:
-      Test_return_int_28(nargout, out, nargin-1, in+1);
+      Test_return_double_28(nargout, out, nargin-1, in+1);
       break;
     case 29:
-      Test_return_matrix1_29(nargout, out, nargin-1, in+1);
+      Test_return_field_29(nargout, out, nargin-1, in+1);
       break;
     case 30:
-      Test_return_matrix2_30(nargout, out, nargin-1, in+1);
+      Test_return_int_30(nargout, out, nargin-1, in+1);
       break;
     case 31:
-      Test_return_pair_31(nargout, out, nargin-1, in+1);
+      Test_return_matrix1_31(nargout, out, nargin-1, in+1);
       break;
     case 32:
-      Test_return_pair_32(nargout, out, nargin-1, in+1);
+      Test_return_matrix2_32(nargout, out, nargin-1, in+1);
       break;
     case 33:
-      Test_return_ptrs_33(nargout, out, nargin-1, in+1);
+      Test_return_pair_33(nargout, out, nargin-1, in+1);
       break;
     case 34:
-      Test_return_size_t_34(nargout, out, nargin-1, in+1);
+      Test_return_pair_34(nargout, out, nargin-1, in+1);
       break;
     case 35:
-      Test_return_string_35(nargout, out, nargin-1, in+1);
+      Test_return_ptrs_35(nargout, out, nargin-1, in+1);
       break;
     case 36:
-      Test_return_vector1_36(nargout, out, nargin-1, in+1);
+      Test_return_size_t_36(nargout, out, nargin-1, in+1);
       break;
     case 37:
-      Test_return_vector2_37(nargout, out, nargin-1, in+1);
+      Test_return_string_37(nargout, out, nargin-1, in+1);
       break;
     case 38:
-      Test_set_container_38(nargout, out, nargin-1, in+1);
+      Test_return_vector1_38(nargout, out, nargin-1, in+1);
       break;
     case 39:
-      Test_set_container_39(nargout, out, nargin-1, in+1);
+      Test_return_vector2_39(nargout, out, nargin-1, in+1);
       break;
     case 40:
       Test_set_container_40(nargout, out, nargin-1, in+1);
       break;
     case 41:
-      PrimitiveRefDouble_collectorInsertAndMakeBase_41(nargout, out, nargin-1, in+1);
+      Test_set_container_41(nargout, out, nargin-1, in+1);
       break;
     case 42:
-      PrimitiveRefDouble_constructor_42(nargout, out, nargin-1, in+1);
+      Test_set_container_42(nargout, out, nargin-1, in+1);
       break;
     case 43:
-      PrimitiveRefDouble_deconstructor_43(nargout, out, nargin-1, in+1);
+      PrimitiveRefDouble_collectorInsertAndMakeBase_43(nargout, out, nargin-1, in+1);
       break;
     case 44:
-      PrimitiveRefDouble_Brutal_44(nargout, out, nargin-1, in+1);
+      PrimitiveRefDouble_constructor_44(nargout, out, nargin-1, in+1);
       break;
     case 45:
-      MyVector3_collectorInsertAndMakeBase_45(nargout, out, nargin-1, in+1);
+      PrimitiveRefDouble_deconstructor_45(nargout, out, nargin-1, in+1);
       break;
     case 46:
-      MyVector3_constructor_46(nargout, out, nargin-1, in+1);
+      PrimitiveRefDouble_Brutal_46(nargout, out, nargin-1, in+1);
       break;
     case 47:
-      MyVector3_deconstructor_47(nargout, out, nargin-1, in+1);
+      MyVector3_collectorInsertAndMakeBase_47(nargout, out, nargin-1, in+1);
       break;
     case 48:
-      MyVector12_collectorInsertAndMakeBase_48(nargout, out, nargin-1, in+1);
+      MyVector3_constructor_48(nargout, out, nargin-1, in+1);
       break;
     case 49:
-      MyVector12_constructor_49(nargout, out, nargin-1, in+1);
+      MyVector3_deconstructor_49(nargout, out, nargin-1, in+1);
       break;
     case 50:
-      MyVector12_deconstructor_50(nargout, out, nargin-1, in+1);
+      MyVector12_collectorInsertAndMakeBase_50(nargout, out, nargin-1, in+1);
       break;
     case 51:
-      MultipleTemplatesIntDouble_collectorInsertAndMakeBase_51(nargout, out, nargin-1, in+1);
+      MyVector12_constructor_51(nargout, out, nargin-1, in+1);
       break;
     case 52:
-      MultipleTemplatesIntDouble_deconstructor_52(nargout, out, nargin-1, in+1);
+      MyVector12_deconstructor_52(nargout, out, nargin-1, in+1);
       break;
     case 53:
-      MultipleTemplatesIntFloat_collectorInsertAndMakeBase_53(nargout, out, nargin-1, in+1);
+      MultipleTemplatesIntDouble_collectorInsertAndMakeBase_53(nargout, out, nargin-1, in+1);
       break;
     case 54:
-      MultipleTemplatesIntFloat_deconstructor_54(nargout, out, nargin-1, in+1);
+      MultipleTemplatesIntDouble_deconstructor_54(nargout, out, nargin-1, in+1);
       break;
     case 55:
-      ForwardKinematics_collectorInsertAndMakeBase_55(nargout, out, nargin-1, in+1);
+      MultipleTemplatesIntFloat_collectorInsertAndMakeBase_55(nargout, out, nargin-1, in+1);
       break;
     case 56:
-      ForwardKinematics_constructor_56(nargout, out, nargin-1, in+1);
+      MultipleTemplatesIntFloat_deconstructor_56(nargout, out, nargin-1, in+1);
       break;
     case 57:
-      ForwardKinematics_constructor_57(nargout, out, nargin-1, in+1);
+      ForwardKinematics_collectorInsertAndMakeBase_57(nargout, out, nargin-1, in+1);
       break;
     case 58:
-      ForwardKinematics_deconstructor_58(nargout, out, nargin-1, in+1);
+      ForwardKinematics_constructor_58(nargout, out, nargin-1, in+1);
       break;
     case 59:
-      TemplatedConstructor_collectorInsertAndMakeBase_59(nargout, out, nargin-1, in+1);
+      ForwardKinematics_constructor_59(nargout, out, nargin-1, in+1);
       break;
     case 60:
-      TemplatedConstructor_constructor_60(nargout, out, nargin-1, in+1);
+      ForwardKinematics_deconstructor_60(nargout, out, nargin-1, in+1);
       break;
     case 61:
-      TemplatedConstructor_constructor_61(nargout, out, nargin-1, in+1);
+      TemplatedConstructor_collectorInsertAndMakeBase_61(nargout, out, nargin-1, in+1);
       break;
     case 62:
       TemplatedConstructor_constructor_62(nargout, out, nargin-1, in+1);
@@ -1054,25 +1069,31 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       TemplatedConstructor_constructor_63(nargout, out, nargin-1, in+1);
       break;
     case 64:
-      TemplatedConstructor_deconstructor_64(nargout, out, nargin-1, in+1);
+      TemplatedConstructor_constructor_64(nargout, out, nargin-1, in+1);
       break;
     case 65:
-      MyFactorPosePoint2_collectorInsertAndMakeBase_65(nargout, out, nargin-1, in+1);
+      TemplatedConstructor_constructor_65(nargout, out, nargin-1, in+1);
       break;
     case 66:
-      MyFactorPosePoint2_constructor_66(nargout, out, nargin-1, in+1);
+      TemplatedConstructor_deconstructor_66(nargout, out, nargin-1, in+1);
       break;
     case 67:
-      MyFactorPosePoint2_deconstructor_67(nargout, out, nargin-1, in+1);
+      MyFactorPosePoint2_collectorInsertAndMakeBase_67(nargout, out, nargin-1, in+1);
       break;
     case 68:
-      MyFactorPosePoint2_print_68(nargout, out, nargin-1, in+1);
+      MyFactorPosePoint2_constructor_68(nargout, out, nargin-1, in+1);
       break;
     case 69:
-      MyFactorPosePoint2_print_69(nargout, out, nargin-1, in+1);
+      MyFactorPosePoint2_deconstructor_69(nargout, out, nargin-1, in+1);
       break;
     case 70:
       MyFactorPosePoint2_print_70(nargout, out, nargin-1, in+1);
+      break;
+    case 71:
+      MyFactorPosePoint2_print_71(nargout, out, nargin-1, in+1);
+      break;
+    case 72:
+      MyFactorPosePoint2_print_72(nargout, out, nargin-1, in+1);
       break;
     }
   } catch(const std::exception& e) {

--- a/wrap/tests/expected/python/class_pybind.cpp
+++ b/wrap/tests/expected/python/class_pybind.cpp
@@ -69,6 +69,7 @@ PYBIND11_MODULE(class_py, m_) {
         .def("set_container",[](Test* self, std::vector<std::shared_ptr<testing::Test>> container){ self->set_container(container);}, py::arg("container"))
         .def("set_container",[](Test* self, std::vector<testing::Test&> container){ self->set_container(container);}, py::arg("container"))
         .def("get_container",[](Test* self){return self->get_container();})
+        .def("_repr_markdown_",[](Test* self, const gtsam::KeyFormatter& keyFormatter){return self->markdown(keyFormatter);}, py::arg("keyFormatter") = gtsam::DefaultKeyFormatter)
         .def_readwrite("model_ptr", &Test::model_ptr);
 
     py::class_<PrimitiveRef<double>, std::shared_ptr<PrimitiveRef<double>>>(m_, "PrimitiveRefDouble")

--- a/wrap/tests/fixtures/class.i
+++ b/wrap/tests/fixtures/class.i
@@ -77,6 +77,10 @@ class Test {
   void set_container(std::vector<testing::Test&> container);
   std::vector<testing::Test*> get_container() const;
 
+  // special ipython method
+  string markdown(const gtsam::KeyFormatter& keyFormatter =
+                 gtsam::DefaultKeyFormatter) const;
+
   // comments at the end!
 
   // even more comments at the end!

--- a/wrap/tests/test_interface_parser.py
+++ b/wrap/tests/test_interface_parser.py
@@ -657,8 +657,6 @@ class TestInterfaceParser(unittest.TestCase):
         int globalVar;
         """)
 
-        # print("module: ", module)
-        # print(dir(module.content[0].name))
         self.assertEqual(["one", "Global", "globalVar"],
                          [x.name for x in module.content])
         self.assertEqual(["two", "two_dummy", "two", "oneVar"],


### PR DESCRIPTION
This PR adds the latest wrap updates so we can specify various functions like `markdown`, `latex`, `jpeg` etc.

I've also replaced all instances of `_repr_markdown_` with `markdown` and added a python unit test in `DiscreteConditional`.

@dellaert if you want me to add the unit tests for the other classes, I can do so today evening. :slightly_smiling_face: 