### PR TITLE
Use DecisionTree of factors instead of vector

### DIFF
--- a/gtsam/discrete/AlgebraicDecisionTree.h
+++ b/gtsam/discrete/AlgebraicDecisionTree.h
@@ -30,6 +30,13 @@ namespace gtsam {
   template<typename L>
   class AlgebraicDecisionTree: public DecisionTree<L, double> {
 
+    /**
+     * @brief Default method for comparison of two doubles upto some tolerance.
+     */
+    static bool DefaultComparator(double a, double b, double tol) {
+      return std::abs(a - b) < tol;
+    }
+
   public:
 
     typedef DecisionTree<L, double> Super;
@@ -138,6 +145,12 @@ namespace gtsam {
       return this->combine(labelC, &Ring::add);
     }
 
+    /// Equality method customized to node type `double`.
+    bool equals(const AlgebraicDecisionTree& other, double tol = 1e-9,
+                const std::function<bool(double, double, double)>& comparator =
+                    &DefaultComparator) const {
+      return this->root_->equals(*other.root_, tol, comparator);
+    }
   };
 // AlgebraicDecisionTree
 

--- a/gtsam/discrete/AlgebraicDecisionTree.h
+++ b/gtsam/discrete/AlgebraicDecisionTree.h
@@ -30,14 +30,7 @@ namespace gtsam {
   template<typename L>
   class AlgebraicDecisionTree: public DecisionTree<L, double> {
 
-    /**
-     * @brief Default method for comparison of two doubles upto some tolerance.
-     */
-    static bool DefaultComparator(double a, double b, double tol) {
-      return std::abs(a - b) < tol;
-    }
-
-  public:
+   public:
 
     typedef DecisionTree<L, double> Super;
 
@@ -146,9 +139,11 @@ namespace gtsam {
     }
 
     /// Equality method customized to node type `double`.
-    bool equals(const AlgebraicDecisionTree& other, double tol = 1e-9,
-                const std::function<bool(double, double, double)>& comparator =
-                    &DefaultComparator) const {
+    bool equals(const AlgebraicDecisionTree& other, double tol = 1e-9) const {
+      // lambda for comparison of two doubles upto some tolerance.
+      auto comparator = [](double a, double b, double tol) {
+        return std::abs(a - b) < tol;
+      };
       return this->root_->equals(*other.root_, tol, comparator);
     }
   };

--- a/gtsam/discrete/AlgebraicDecisionTree.h
+++ b/gtsam/discrete/AlgebraicDecisionTree.h
@@ -141,10 +141,10 @@ namespace gtsam {
     /// Equality method customized to node type `double`.
     bool equals(const AlgebraicDecisionTree& other, double tol = 1e-9) const {
       // lambda for comparison of two doubles upto some tolerance.
-      auto comparator = [](double a, double b, double tol) {
+      auto compare = [tol](double a, double b) {
         return std::abs(a - b) < tol;
       };
-      return this->root_->equals(*other.root_, tol, comparator);
+      return this->root_->equals(*other.root_, tol, compare);
     }
   };
 // AlgebraicDecisionTree

--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -79,7 +79,7 @@ namespace gtsam {
     bool equals(const Node& q, double tol) const override {
       const Leaf* other = dynamic_cast<const Leaf*> (&q);
       if (!other) return false;
-      return std::abs(double(this->constant_ - other->constant_)) < tol;
+      return this->constant_ == other->constant_;
     }
 
     /** print */

--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -108,7 +108,7 @@ namespace gtsam {
 
     /** print */
     void print(const std::string& s,
-               const std::function<std::string(L)> formatter) const override {
+               const std::function<std::string(L)>& formatter) const override {
       bool showZero = true;
       if (showZero || constant_) std::cout << s << " Leaf " << constant_ << std::endl;
     }
@@ -261,7 +261,8 @@ namespace gtsam {
     }
 
     /** print (as a tree) */
-    void print(const std::string& s, const std::function<std::string(L)> formatter) const override {
+    void print(const std::string& s,
+               const std::function<std::string(L)>& formatter) const override {
       std::cout << s << " Choice(";
       std::cout << formatter(label_) << ") " << std::endl;
       for (size_t i = 0; i < branches_.size(); i++)
@@ -675,7 +676,7 @@ namespace gtsam {
   template <typename L, typename Y>
   void DecisionTree<L, Y>::print(
       const std::string& s,
-      const std::function<std::string(L)> formatter) const {
+      const std::function<std::string(L)>& formatter) const {
     root_->print(s, formatter);
   }
 

--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -19,7 +19,6 @@
 
 #pragma once
 
-#include <gtsam/base/Testable.h>
 #include <gtsam/discrete/DecisionTree.h>
 
 #include <boost/assign/std/vector.hpp>
@@ -78,8 +77,7 @@ namespace gtsam {
 
     /** equality up to tolerance */
     bool equals(const Node& q, double tol,
-                const std::function<bool(const Y&, const Y&, double)>&
-                    comparator) const override {
+                const ComparatorFunc& comparator) const override {
       const Leaf* other = dynamic_cast<const Leaf*>(&q);
       if (!other) return false;
       return comparator(this->constant_, other->constant_, tol);
@@ -87,7 +85,7 @@ namespace gtsam {
 
     /** print */
     void print(const std::string& s,
-               const std::function<std::string(L)>& formatter) const override {
+               const FormatterFunc& formatter) const override {
       bool showZero = true;
       if (showZero || constant_) std::cout << s << " Leaf " << constant_ << std::endl;
     }
@@ -241,7 +239,7 @@ namespace gtsam {
 
     /** print (as a tree) */
     void print(const std::string& s,
-               const std::function<std::string(L)>& formatter) const override {
+               const FormatterFunc& formatter) const override {
       std::cout << s << " Choice(";
       std::cout << formatter(label_) << ") " << std::endl;
       for (size_t i = 0; i < branches_.size(); i++)
@@ -284,8 +282,7 @@ namespace gtsam {
 
     /** equality up to tolerance */
     bool equals(const Node& q, double tol,
-                const std::function<bool(const Y&, const Y&, double)>&
-                    comparator) const override {
+                const ComparatorFunc& comparator) const override {
       const Choice* other = dynamic_cast<const Choice*>(&q);
       if (!other) return false;
       if (this->label_ != other->label_) return false;
@@ -651,16 +648,14 @@ namespace gtsam {
 
   /*********************************************************************************/
   template <typename L, typename Y>
-  bool DecisionTree<L, Y>::equals(
-      const DecisionTree& other, double tol,
-      const std::function<bool(const Y&, const Y&, double)>& comparator) const {
+  bool DecisionTree<L, Y>::equals(const DecisionTree& other, double tol,
+                                  const ComparatorFunc& comparator) const {
     return root_->equals(*other.root_, tol, comparator);
   }
 
   template <typename L, typename Y>
-  void DecisionTree<L, Y>::print(
-      const std::string& s,
-      const std::function<std::string(L)>& formatter) const {
+  void DecisionTree<L, Y>::print(const std::string& s,
+                                 const FormatterFunc& formatter) const {
     root_->print(s, formatter);
   }
 

--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -77,7 +77,7 @@ namespace gtsam {
 
     /** equality up to tolerance */
     bool equals(const Node& q, double tol) const override {
-      const Leaf* other = dynamic_cast<const Leaf*> (&q);
+      const Leaf* other = dynamic_cast<const Leaf*>(&q);
       if (!other) return false;
       return this->constant_ == other->constant_;
     }

--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -77,10 +77,10 @@ namespace gtsam {
 
     /** equality up to tolerance */
     bool equals(const Node& q, double tol,
-                const ComparatorFunc& comparator) const override {
+                const CompareFunc& compare) const override {
       const Leaf* other = dynamic_cast<const Leaf*>(&q);
       if (!other) return false;
-      return comparator(this->constant_, other->constant_, tol);
+      return compare(this->constant_, other->constant_);
     }
 
     /** print */
@@ -282,14 +282,14 @@ namespace gtsam {
 
     /** equality up to tolerance */
     bool equals(const Node& q, double tol,
-                const ComparatorFunc& comparator) const override {
+                const CompareFunc& compare) const override {
       const Choice* other = dynamic_cast<const Choice*>(&q);
       if (!other) return false;
       if (this->label_ != other->label_) return false;
       if (branches_.size() != other->branches_.size()) return false;
       // we don't care about shared pointers being equal here
       for (size_t i = 0; i < branches_.size(); i++)
-        if (!(branches_[i]->equals(*(other->branches_[i]), tol, comparator)))
+        if (!(branches_[i]->equals(*(other->branches_[i]), tol, compare)))
           return false;
       return true;
     }
@@ -649,8 +649,8 @@ namespace gtsam {
   /*********************************************************************************/
   template <typename L, typename Y>
   bool DecisionTree<L, Y>::equals(const DecisionTree& other, double tol,
-                                  const ComparatorFunc& comparator) const {
-    return root_->equals(*other.root_, tol, comparator);
+                                  const CompareFunc& compare) const {
+    return root_->equals(*other.root_, tol, compare);
   }
 
   template <typename L, typename Y>

--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -83,7 +83,8 @@ namespace gtsam {
     }
 
     /** print */
-    void print(const std::string& s) const override {
+    void print(const std::string& s,
+               const std::function<std::string(L)> formatter) const override {
       bool showZero = true;
       if (showZero || constant_) std::cout << s << " Leaf " << constant_ << std::endl;
     }
@@ -236,12 +237,11 @@ namespace gtsam {
     }
 
     /** print (as a tree) */
-    void print(const std::string& s) const override {
+    void print(const std::string& s, const std::function<std::string(L)> formatter) const override {
       std::cout << s << " Choice(";
-      //        std::cout << this << ",";
-      std::cout << label_ << ") " << std::endl;
+      std::cout << formatter(label_) << ") " << std::endl;
       for (size_t i = 0; i < branches_.size(); i++)
-        branches_[i]->print((boost::format("%s %d") % s % i).str());
+        branches_[i]->print((boost::format("%s %d") % s % i).str(), formatter);
     }
 
     /** output to graphviz (as a a graph) */
@@ -591,7 +591,7 @@ namespace gtsam {
 
     // get new label
     M oldLabel = choice->label();
-    L newLabel = map.at(oldLabel);
+    L newLabel = oldLabel; //map.at(oldLabel);
 
     // put together via Shannon expansion otherwise not sorted.
     std::vector<LY> functions;
@@ -608,9 +608,11 @@ namespace gtsam {
     return root_->equals(*other.root_, tol);
   }
 
-  template<typename L, typename Y>
-  void DecisionTree<L, Y>::print(const std::string& s) const {
-    root_->print(s);
+  template <typename L, typename Y>
+  void DecisionTree<L, Y>::print(
+      const std::string& s,
+      const std::function<std::string(L)> formatter) const {
+    root_->print(s, formatter);
   }
 
   template<typename L, typename Y>

--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -591,7 +591,7 @@ namespace gtsam {
 
     // get new label
     M oldLabel = choice->label();
-    L newLabel = oldLabel; //map.at(oldLabel);
+    L newLabel = map.at(oldLabel);
 
     // put together via Shannon expansion otherwise not sorted.
     std::vector<LY> functions;

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -53,6 +53,9 @@ namespace gtsam {
 
   public:
 
+    using FormatterFunc = std::function<std::string(L)>;
+    using ComparatorFunc = std::function<bool(const Y&, const Y&, double)>;
+
     /** Handy typedefs for unary and binary function types */
     typedef std::function<Y(const Y&)> Unary;
     typedef std::function<Y(const Y&, const Y&)> Binary;
@@ -91,15 +94,15 @@ namespace gtsam {
       const void* id() const { return this; }
 
       // everything else is virtual, no documentation here as internal
-      virtual void print(const std::string& s = "",
-                         const std::function<std::string(L)>& formatter =
-                             &DefaultFormatter) const = 0;
+      virtual void print(
+          const std::string& s = "",
+          const FormatterFunc& formatter = &DefaultFormatter) const = 0;
       virtual void dot(std::ostream& os, bool showZero) const = 0;
       virtual bool sameLeaf(const Leaf& q) const = 0;
       virtual bool sameLeaf(const Node& q) const = 0;
-      virtual bool equals(const Node& other, double tol = 1e-9,
-                          const std::function<bool(const Y&, const Y&, double)>&
-                              comparator = &DefaultComparator) const = 0;
+      virtual bool equals(
+          const Node& other, double tol = 1e-9,
+          const ComparatorFunc& comparator = &DefaultComparator) const = 0;
       virtual const Y& operator()(const Assignment<L>& x) const = 0;
       virtual Ptr apply(const Unary& op) const = 0;
       virtual Ptr apply_f_op_g(const Node&, const Binary&) const = 0;
@@ -181,13 +184,11 @@ namespace gtsam {
 
     /** GTSAM-style print */
     void print(const std::string& s = "DecisionTree",
-               const std::function<std::string(L)>& formatter =
-                   &DefaultFormatter) const;
+               const FormatterFunc& formatter = &DefaultFormatter) const;
 
     // Testable
     bool equals(const DecisionTree& other, double tol = 1e-9,
-                const std::function<bool(const Y&, const Y&, double)>&
-                    comparator = &DefaultComparator) const;
+                const ComparatorFunc& comparator = &DefaultComparator) const;
 
     /// @}
     /// @name Standard Interface

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -113,13 +113,13 @@ namespace gtsam {
     convert(const typename DecisionTree<M, X>::NodePtr& f, const std::map<M,
         L>& map, std::function<Y(const X&)> op);
 
-    /** Default constructor */
-    DecisionTree();
-
   public:
 
     /// @name Standard Constructors
     /// @{
+
+    /** Default constructor (for serialization) */
+    DecisionTree();
 
     /** Create a constant */
     DecisionTree(const Y& y);

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -39,6 +39,13 @@ namespace gtsam {
   template<typename L, typename Y>
   class GTSAM_EXPORT DecisionTree {
 
+    /// default method used by `formatter` when printing.
+    static std::string DefaultFormatter(const L& x) {
+      std::stringstream ss;
+      ss << x;
+      return ss.str();
+    }
+
   public:
 
     /** Handy typedefs for unary and binary function types */
@@ -79,13 +86,9 @@ namespace gtsam {
       const void* id() const { return this; }
 
       // everything else is virtual, no documentation here as internal
-      virtual void print(
-          const std::string& s = "",
-          const std::function<std::string(L)> formatter = [](const L& x) {
-            std::stringstream ss;
-            ss << x;
-            return ss.str();
-          }) const = 0;
+      virtual void print(const std::string& s = "",
+                         const std::function<std::string(L)>& formatter =
+                             &DefaultFormatter) const = 0;
       virtual void dot(std::ostream& os, bool showZero) const = 0;
       virtual bool sameLeaf(const Leaf& q) const = 0;
       virtual bool sameLeaf(const Node& q) const = 0;
@@ -170,13 +173,9 @@ namespace gtsam {
     /// @{
 
     /** GTSAM-style print */
-    void print(
-        const std::string& s = "DecisionTree",
-        const std::function<std::string(L)> formatter = [](const L& x) {
-          std::stringstream ss;
-          ss << x;
-          return ss.str();
-        }) const;
+    void print(const std::string& s = "DecisionTree",
+               const std::function<std::string(L)>& formatter =
+                   &DefaultFormatter) const;
 
     // Testable
     bool equals(const DecisionTree& other, double tol = 1e-9) const;
@@ -241,20 +240,19 @@ namespace gtsam {
 
   /** free versions of apply */
 
-  //TODO(Varun) where are these templates Y, L and not L, Y?
-  template<typename Y, typename L>
+  template<typename L, typename Y>
   DecisionTree<L, Y> apply(const DecisionTree<L, Y>& f,
       const typename DecisionTree<L, Y>::Unary& op) {
     return f.apply(op);
   }
 
-  template<typename Y, typename L, typename X>
+  template<typename L, typename Y, typename X>
   DecisionTree<L, Y> apply(const DecisionTree<L, Y>& f,
       const std::function<Y(const X&)>& op) {
     return f.apply(op);
   }
 
-  template<typename Y, typename L>
+  template<typename L, typename Y>
   DecisionTree<L, Y> apply(const DecisionTree<L, Y>& f,
       const DecisionTree<L, Y>& g,
       const typename DecisionTree<L, Y>::Binary& op) {

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -39,11 +39,16 @@ namespace gtsam {
   template<typename L, typename Y>
   class GTSAM_EXPORT DecisionTree {
 
-    /// default method used by `formatter` when printing.
+    /// Default method used by `formatter` when printing.
     static std::string DefaultFormatter(const L& x) {
       std::stringstream ss;
       ss << x;
       return ss.str();
+    }
+
+    /// Default method for comparison of two objects of type Y.
+    static bool DefaultComparator(const Y& a, const Y& b, double tol) {
+      return a == b;
     }
 
   public:
@@ -92,7 +97,9 @@ namespace gtsam {
       virtual void dot(std::ostream& os, bool showZero) const = 0;
       virtual bool sameLeaf(const Leaf& q) const = 0;
       virtual bool sameLeaf(const Node& q) const = 0;
-      virtual bool equals(const Node& other, double tol = 1e-9) const = 0;
+      virtual bool equals(const Node& other, double tol = 1e-9,
+                          const std::function<bool(const Y&, const Y&, double)>&
+                              comparator = &DefaultComparator) const = 0;
       virtual const Y& operator()(const Assignment<L>& x) const = 0;
       virtual Ptr apply(const Unary& op) const = 0;
       virtual Ptr apply_f_op_g(const Node&, const Binary&) const = 0;
@@ -178,7 +185,9 @@ namespace gtsam {
                    &DefaultFormatter) const;
 
     // Testable
-    bool equals(const DecisionTree& other, double tol = 1e-9) const;
+    bool equals(const DecisionTree& other, double tol = 1e-9,
+                const std::function<bool(const Y&, const Y&, double)>&
+                    comparator = &DefaultComparator) const;
 
     /// @}
     /// @name Standard Interface

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -119,7 +119,12 @@ namespace gtsam {
     convert(const typename DecisionTree<M, X>::NodePtr& f, const std::map<M,
         L>& map, std::function<Y(const X&)> op);
 
-  public:
+    /** Convert only node to a different type */
+    template <typename X>
+    NodePtr convert(const typename DecisionTree<L, X>::NodePtr& f,
+                    const std::function<Y(const X&)> op);
+
+   public:
 
     /// @name Standard Constructors
     /// @{
@@ -154,6 +159,11 @@ namespace gtsam {
     template<typename M, typename X>
     DecisionTree(const DecisionTree<M, X>& other,
         const std::map<M, L>& map, std::function<Y(const X&)> op);
+
+    /** Convert only nodes from a different type */
+    template <typename X>
+    DecisionTree(const DecisionTree<L, X>& other,
+                 std::function<Y(const X&)> op);
 
     /// @}
     /// @name Testable
@@ -231,9 +241,16 @@ namespace gtsam {
 
   /** free versions of apply */
 
+  //TODO(Varun) where are these templates Y, L and not L, Y?
   template<typename Y, typename L>
   DecisionTree<L, Y> apply(const DecisionTree<L, Y>& f,
       const typename DecisionTree<L, Y>::Unary& op) {
+    return f.apply(op);
+  }
+
+  template<typename Y, typename L, typename X>
+  DecisionTree<L, Y> apply(const DecisionTree<L, Y>& f,
+      const std::function<Y(const X&)>& op) {
     return f.apply(op);
   }
 

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -47,14 +47,14 @@ namespace gtsam {
     }
 
     /// Default method for comparison of two objects of type Y.
-    static bool DefaultComparator(const Y& a, const Y& b, double tol) {
+    static bool DefaultCompare(const Y& a, const Y& b) {
       return a == b;
     }
 
   public:
 
     using FormatterFunc = std::function<std::string(L)>;
-    using ComparatorFunc = std::function<bool(const Y&, const Y&, double)>;
+    using CompareFunc = std::function<bool(const Y&, const Y&)>;
 
     /** Handy typedefs for unary and binary function types */
     typedef std::function<Y(const Y&)> Unary;
@@ -102,7 +102,7 @@ namespace gtsam {
       virtual bool sameLeaf(const Node& q) const = 0;
       virtual bool equals(
           const Node& other, double tol = 1e-9,
-          const ComparatorFunc& comparator = &DefaultComparator) const = 0;
+          const CompareFunc& compare = &DefaultCompare) const = 0;
       virtual const Y& operator()(const Assignment<L>& x) const = 0;
       virtual Ptr apply(const Unary& op) const = 0;
       virtual Ptr apply_f_op_g(const Node&, const Binary&) const = 0;
@@ -188,7 +188,7 @@ namespace gtsam {
 
     // Testable
     bool equals(const DecisionTree& other, double tol = 1e-9,
-                const ComparatorFunc& comparator = &DefaultComparator) const;
+                const CompareFunc& compare = &DefaultCompare) const;
 
     /// @}
     /// @name Standard Interface

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -20,13 +20,13 @@
 #pragma once
 
 #include <gtsam/base/types.h>
-
 #include <gtsam/discrete/Assignment.h>
 
 #include <boost/function.hpp>
 #include <functional>
 #include <iostream>
 #include <map>
+#include <sstream>
 #include <vector>
 
 namespace gtsam {
@@ -79,7 +79,13 @@ namespace gtsam {
       const void* id() const { return this; }
 
       // everything else is virtual, no documentation here as internal
-      virtual void print(const std::string& s = "") const = 0;
+      virtual void print(
+          const std::string& s = "",
+          const std::function<std::string(L)> formatter = [](const L& x) {
+            std::stringstream ss;
+            ss << x;
+            return ss.str();
+          }) const = 0;
       virtual void dot(std::ostream& os, bool showZero) const = 0;
       virtual bool sameLeaf(const Leaf& q) const = 0;
       virtual bool sameLeaf(const Node& q) const = 0;
@@ -154,7 +160,13 @@ namespace gtsam {
     /// @{
 
     /** GTSAM-style print */
-    void print(const std::string& s = "DecisionTree") const;
+    void print(
+        const std::string& s = "DecisionTree",
+        const std::function<std::string(L)> formatter = [](const L& x) {
+          std::stringstream ss;
+          ss << x;
+          return ss.str();
+        }) const;
 
     // Testable
     bool equals(const DecisionTree& other, double tol = 1e-9) const;

--- a/gtsam/discrete/Potentials.cpp
+++ b/gtsam/discrete/Potentials.cpp
@@ -51,11 +51,11 @@ bool Potentials::equals(const Potentials& other, double tol) const {
 
 /* ************************************************************************* */
 void Potentials::print(const string& s, const KeyFormatter& formatter) const {
-  cout << s << "\n  Cardinalities: {";
+  cout << s << "\n  Cardinalities: { ";
   for (const std::pair<const Key,size_t>& key : cardinalities_)
     cout << formatter(key.first) << ":" << key.second << ", ";
   cout << "}" << endl;
-  ADT::print(" ");
+  ADT::print(" ", formatter);
 }
 //
 //  /* ************************************************************************* */

--- a/gtsam/discrete/tests/testAlgebraicDecisionTree.cpp
+++ b/gtsam/discrete/tests/testAlgebraicDecisionTree.cpp
@@ -48,7 +48,7 @@ template<> struct traits<ADT> : public Testable<ADT> {};
 #define DISABLE_DOT
 
 template<typename T>
-void dot(const T&f, const string& filename) {
+void DOT(const T&f, const string& filename) {
 #ifndef DISABLE_DOT
   f.dot(filename);
 #endif
@@ -112,7 +112,7 @@ TEST(ADT, example3)
   ADT note(E, 0.9, 0.1);
 
   ADT cnotb = c * notb;
-  dot(cnotb, "ADT-cnotb");
+  DOT(cnotb, "ADT-cnotb");
 
 //  a.print("a: ");
 //  cnotb.print("cnotb: ");
@@ -120,11 +120,11 @@ TEST(ADT, example3)
 //  acnotb.print("acnotb: ");
 //  acnotb.printCache("acnotb Cache:");
 
-  dot(acnotb, "ADT-acnotb");
+  DOT(acnotb, "ADT-acnotb");
 
 
   ADT big = apply(apply(d, note, &mul), acnotb, &add_);
-  dot(big, "ADT-big");
+  DOT(big, "ADT-big");
 }
 
 /* ******************************************************************************** */
@@ -136,8 +136,8 @@ ADT create(const Signature& signature) {
   ADT p(signature.discreteKeys(), signature.cpt());
   static size_t count = 0;
   const DiscreteKey& key = signature.key();
-  string dotfile = (boost::format("CPT-%03d-%d") % ++count % key.first).str();
-  dot(p, dotfile);
+  string DOTfile = (boost::format("CPT-%03d-%d") % ++count % key.first).str();
+  DOT(p, DOTfile);
   return p;
 }
 
@@ -167,21 +167,21 @@ TEST(ADT, joint)
   resetCounts();
   gttic_(asiaJoint);
   ADT joint = pA;
-  dot(joint, "Asia-A");
+  DOT(joint, "Asia-A");
   joint = apply(joint, pS, &mul);
-  dot(joint, "Asia-AS");
+  DOT(joint, "Asia-AS");
   joint = apply(joint, pT, &mul);
-  dot(joint, "Asia-AST");
+  DOT(joint, "Asia-AST");
   joint = apply(joint, pL, &mul);
-  dot(joint, "Asia-ASTL");
+  DOT(joint, "Asia-ASTL");
   joint = apply(joint, pB, &mul);
-  dot(joint, "Asia-ASTLB");
+  DOT(joint, "Asia-ASTLB");
   joint = apply(joint, pE, &mul);
-  dot(joint, "Asia-ASTLBE");
+  DOT(joint, "Asia-ASTLBE");
   joint = apply(joint, pX, &mul);
-  dot(joint, "Asia-ASTLBEX");
+  DOT(joint, "Asia-ASTLBEX");
   joint = apply(joint, pD, &mul);
-  dot(joint, "Asia-ASTLBEXD");
+  DOT(joint, "Asia-ASTLBEXD");
   EXPECT_LONGS_EQUAL(346, muls);
   gttoc_(asiaJoint);
   tictoc_getNode(asiaJointNode, asiaJoint);
@@ -229,21 +229,21 @@ TEST(ADT, inference)
   resetCounts();
   gttic_(asiaProd);
   ADT joint = pA;
-  dot(joint, "Joint-Product-A");
+  DOT(joint, "Joint-Product-A");
   joint = apply(joint, pS, &mul);
-  dot(joint, "Joint-Product-AS");
+  DOT(joint, "Joint-Product-AS");
   joint = apply(joint, pT, &mul);
-  dot(joint, "Joint-Product-AST");
+  DOT(joint, "Joint-Product-AST");
   joint = apply(joint, pL, &mul);
-  dot(joint, "Joint-Product-ASTL");
+  DOT(joint, "Joint-Product-ASTL");
   joint = apply(joint, pB, &mul);
-  dot(joint, "Joint-Product-ASTLB");
+  DOT(joint, "Joint-Product-ASTLB");
   joint = apply(joint, pE, &mul);
-  dot(joint, "Joint-Product-ASTLBE");
+  DOT(joint, "Joint-Product-ASTLBE");
   joint = apply(joint, pX, &mul);
-  dot(joint, "Joint-Product-ASTLBEX");
+  DOT(joint, "Joint-Product-ASTLBEX");
   joint = apply(joint, pD, &mul);
-  dot(joint, "Joint-Product-ASTLBEXD");
+  DOT(joint, "Joint-Product-ASTLBEXD");
   EXPECT_LONGS_EQUAL(370, (long)muls); // different ordering
   gttoc_(asiaProd);
   tictoc_getNode(asiaProdNode, asiaProd);
@@ -255,13 +255,13 @@ TEST(ADT, inference)
   gttic_(asiaSum);
   ADT marginal = joint;
   marginal = marginal.combine(X, &add_);
-  dot(marginal, "Joint-Sum-ADBLEST");
+  DOT(marginal, "Joint-Sum-ADBLEST");
   marginal = marginal.combine(T, &add_);
-  dot(marginal, "Joint-Sum-ADBLES");
+  DOT(marginal, "Joint-Sum-ADBLES");
   marginal = marginal.combine(S, &add_);
-  dot(marginal, "Joint-Sum-ADBLE");
+  DOT(marginal, "Joint-Sum-ADBLE");
   marginal = marginal.combine(E, &add_);
-  dot(marginal, "Joint-Sum-ADBL");
+  DOT(marginal, "Joint-Sum-ADBL");
   EXPECT_LONGS_EQUAL(161, (long)adds);
   gttoc_(asiaSum);
   tictoc_getNode(asiaSumNode, asiaSum);
@@ -300,7 +300,7 @@ TEST(ADT, factor_graph)
   fg = apply(fg, pE, &mul);
   fg = apply(fg, pX, &mul);
   fg = apply(fg, pD, &mul);
-  dot(fg, "FactorGraph");
+  DOT(fg, "FactorGraph");
   EXPECT_LONGS_EQUAL(158, (long)muls);
   gttoc_(asiaFG);
   tictoc_getNode(asiaFGNode, asiaFG);
@@ -311,15 +311,15 @@ TEST(ADT, factor_graph)
   resetCounts();
   gttic_(marg);
   fg = fg.combine(X, &add_);
-  dot(fg, "Marginalized-6X");
+  DOT(fg, "Marginalized-6X");
   fg = fg.combine(T, &add_);
-  dot(fg, "Marginalized-5T");
+  DOT(fg, "Marginalized-5T");
   fg = fg.combine(S, &add_);
-  dot(fg, "Marginalized-4S");
+  DOT(fg, "Marginalized-4S");
   fg = fg.combine(E, &add_);
-  dot(fg, "Marginalized-3E");
+  DOT(fg, "Marginalized-3E");
   fg = fg.combine(L, &add_);
-  dot(fg, "Marginalized-2L");
+  DOT(fg, "Marginalized-2L");
   EXPECT(adds = 54);
   gttoc_(marg);
   tictoc_getNode(margNode, marg);
@@ -333,9 +333,9 @@ TEST(ADT, factor_graph)
   resetCounts();
   gttic_(elimX);
   ADT fE = pX;
-  dot(fE, "Eliminate-01-fEX");
+  DOT(fE, "Eliminate-01-fEX");
   fE = fE.combine(X, &add_);
-  dot(fE, "Eliminate-02-fE");
+  DOT(fE, "Eliminate-02-fE");
   gttoc_(elimX);
   tictoc_getNode(elimXNode, elimX);
   elapsed = elimXNode->secs() + elimXNode->wall();
@@ -347,9 +347,9 @@ TEST(ADT, factor_graph)
   gttic_(elimT);
   ADT fLE = pT;
   fLE = apply(fLE, pE, &mul);
-  dot(fLE, "Eliminate-03-fLET");
+  DOT(fLE, "Eliminate-03-fLET");
   fLE = fLE.combine(T, &add_);
-  dot(fLE, "Eliminate-04-fLE");
+  DOT(fLE, "Eliminate-04-fLE");
   gttoc_(elimT);
   tictoc_getNode(elimTNode, elimT);
   elapsed = elimTNode->secs() + elimTNode->wall();
@@ -362,9 +362,9 @@ TEST(ADT, factor_graph)
   ADT fBL = pS;
   fBL = apply(fBL, pL, &mul);
   fBL = apply(fBL, pB, &mul);
-  dot(fBL, "Eliminate-05-fBLS");
+  DOT(fBL, "Eliminate-05-fBLS");
   fBL = fBL.combine(S, &add_);
-  dot(fBL, "Eliminate-06-fBL");
+  DOT(fBL, "Eliminate-06-fBL");
   gttoc_(elimS);
   tictoc_getNode(elimSNode, elimS);
   elapsed = elimSNode->secs() + elimSNode->wall();
@@ -377,9 +377,9 @@ TEST(ADT, factor_graph)
   ADT fBL2 = fE;
   fBL2 = apply(fBL2, fLE, &mul);
   fBL2 = apply(fBL2, pD, &mul);
-  dot(fBL2, "Eliminate-07-fBLE");
+  DOT(fBL2, "Eliminate-07-fBLE");
   fBL2 = fBL2.combine(E, &add_);
-  dot(fBL2, "Eliminate-08-fBL2");
+  DOT(fBL2, "Eliminate-08-fBL2");
   gttoc_(elimE);
   tictoc_getNode(elimENode, elimE);
   elapsed = elimENode->secs() + elimENode->wall();
@@ -391,9 +391,9 @@ TEST(ADT, factor_graph)
   gttic_(elimL);
   ADT fB = fBL;
   fB = apply(fB, fBL2, &mul);
-  dot(fB, "Eliminate-09-fBL");
+  DOT(fB, "Eliminate-09-fBL");
   fB = fB.combine(L, &add_);
-  dot(fB, "Eliminate-10-fB");
+  DOT(fB, "Eliminate-10-fB");
   gttoc_(elimL);
   tictoc_getNode(elimLNode, elimL);
   elapsed = elimLNode->secs() + elimLNode->wall();
@@ -491,7 +491,7 @@ TEST(ADT, conversion)
 {
   DiscreteKey X(0,2), Y(1,2);
   ADT fDiscreteKey(X & Y, "0.2 0.5 0.3 0.6");
-  dot(fDiscreteKey, "conversion-f1");
+  DOT(fDiscreteKey, "conversion-f1");
 
   std::map<Key, Key> keyMap;
   keyMap[0] = 5;
@@ -500,7 +500,7 @@ TEST(ADT, conversion)
   AlgebraicDecisionTree<Key> fIndexKey(fDiscreteKey, keyMap);
   //  f1.print("f1");
   //  f2.print("f2");
-  dot(fIndexKey, "conversion-f2");
+  DOT(fIndexKey, "conversion-f2");
 
   DiscreteValues x00, x01, x02, x10, x11, x12;
   x00[5] = 0, x00[2] = 0;
@@ -519,7 +519,7 @@ TEST(ADT, elimination)
 {
   DiscreteKey A(0,2), B(1,3), C(2,2);
   ADT f1(A & B & C, "1 2  3 4  5 6    1 8  3 3  5 5");
-  dot(f1, "elimination-f1");
+  DOT(f1, "elimination-f1");
 
   {
     // sum out lower key

--- a/gtsam/discrete/tests/testAlgebraicDecisionTree.cpp
+++ b/gtsam/discrete/tests/testAlgebraicDecisionTree.cpp
@@ -48,7 +48,7 @@ template<> struct traits<ADT> : public Testable<ADT> {};
 #define DISABLE_DOT
 
 template<typename T>
-void DOT(const T&f, const string& filename) {
+void dot(const T&f, const string& filename) {
 #ifndef DISABLE_DOT
   f.dot(filename);
 #endif
@@ -112,7 +112,7 @@ TEST(ADT, example3)
   ADT note(E, 0.9, 0.1);
 
   ADT cnotb = c * notb;
-  DOT(cnotb, "ADT-cnotb");
+  dot(cnotb, "ADT-cnotb");
 
 //  a.print("a: ");
 //  cnotb.print("cnotb: ");
@@ -120,11 +120,11 @@ TEST(ADT, example3)
 //  acnotb.print("acnotb: ");
 //  acnotb.printCache("acnotb Cache:");
 
-  DOT(acnotb, "ADT-acnotb");
+  dot(acnotb, "ADT-acnotb");
 
 
   ADT big = apply(apply(d, note, &mul), acnotb, &add_);
-  DOT(big, "ADT-big");
+  dot(big, "ADT-big");
 }
 
 /* ******************************************************************************** */
@@ -137,7 +137,7 @@ ADT create(const Signature& signature) {
   static size_t count = 0;
   const DiscreteKey& key = signature.key();
   string DOTfile = (boost::format("CPT-%03d-%d") % ++count % key.first).str();
-  DOT(p, DOTfile);
+  dot(p, DOTfile);
   return p;
 }
 
@@ -167,21 +167,21 @@ TEST(ADT, joint)
   resetCounts();
   gttic_(asiaJoint);
   ADT joint = pA;
-  DOT(joint, "Asia-A");
+  dot(joint, "Asia-A");
   joint = apply(joint, pS, &mul);
-  DOT(joint, "Asia-AS");
+  dot(joint, "Asia-AS");
   joint = apply(joint, pT, &mul);
-  DOT(joint, "Asia-AST");
+  dot(joint, "Asia-AST");
   joint = apply(joint, pL, &mul);
-  DOT(joint, "Asia-ASTL");
+  dot(joint, "Asia-ASTL");
   joint = apply(joint, pB, &mul);
-  DOT(joint, "Asia-ASTLB");
+  dot(joint, "Asia-ASTLB");
   joint = apply(joint, pE, &mul);
-  DOT(joint, "Asia-ASTLBE");
+  dot(joint, "Asia-ASTLBE");
   joint = apply(joint, pX, &mul);
-  DOT(joint, "Asia-ASTLBEX");
+  dot(joint, "Asia-ASTLBEX");
   joint = apply(joint, pD, &mul);
-  DOT(joint, "Asia-ASTLBEXD");
+  dot(joint, "Asia-ASTLBEXD");
   EXPECT_LONGS_EQUAL(346, muls);
   gttoc_(asiaJoint);
   tictoc_getNode(asiaJointNode, asiaJoint);
@@ -229,21 +229,21 @@ TEST(ADT, inference)
   resetCounts();
   gttic_(asiaProd);
   ADT joint = pA;
-  DOT(joint, "Joint-Product-A");
+  dot(joint, "Joint-Product-A");
   joint = apply(joint, pS, &mul);
-  DOT(joint, "Joint-Product-AS");
+  dot(joint, "Joint-Product-AS");
   joint = apply(joint, pT, &mul);
-  DOT(joint, "Joint-Product-AST");
+  dot(joint, "Joint-Product-AST");
   joint = apply(joint, pL, &mul);
-  DOT(joint, "Joint-Product-ASTL");
+  dot(joint, "Joint-Product-ASTL");
   joint = apply(joint, pB, &mul);
-  DOT(joint, "Joint-Product-ASTLB");
+  dot(joint, "Joint-Product-ASTLB");
   joint = apply(joint, pE, &mul);
-  DOT(joint, "Joint-Product-ASTLBE");
+  dot(joint, "Joint-Product-ASTLBE");
   joint = apply(joint, pX, &mul);
-  DOT(joint, "Joint-Product-ASTLBEX");
+  dot(joint, "Joint-Product-ASTLBEX");
   joint = apply(joint, pD, &mul);
-  DOT(joint, "Joint-Product-ASTLBEXD");
+  dot(joint, "Joint-Product-ASTLBEXD");
   EXPECT_LONGS_EQUAL(370, (long)muls); // different ordering
   gttoc_(asiaProd);
   tictoc_getNode(asiaProdNode, asiaProd);
@@ -255,13 +255,13 @@ TEST(ADT, inference)
   gttic_(asiaSum);
   ADT marginal = joint;
   marginal = marginal.combine(X, &add_);
-  DOT(marginal, "Joint-Sum-ADBLEST");
+  dot(marginal, "Joint-Sum-ADBLEST");
   marginal = marginal.combine(T, &add_);
-  DOT(marginal, "Joint-Sum-ADBLES");
+  dot(marginal, "Joint-Sum-ADBLES");
   marginal = marginal.combine(S, &add_);
-  DOT(marginal, "Joint-Sum-ADBLE");
+  dot(marginal, "Joint-Sum-ADBLE");
   marginal = marginal.combine(E, &add_);
-  DOT(marginal, "Joint-Sum-ADBL");
+  dot(marginal, "Joint-Sum-ADBL");
   EXPECT_LONGS_EQUAL(161, (long)adds);
   gttoc_(asiaSum);
   tictoc_getNode(asiaSumNode, asiaSum);
@@ -300,7 +300,7 @@ TEST(ADT, factor_graph)
   fg = apply(fg, pE, &mul);
   fg = apply(fg, pX, &mul);
   fg = apply(fg, pD, &mul);
-  DOT(fg, "FactorGraph");
+  dot(fg, "FactorGraph");
   EXPECT_LONGS_EQUAL(158, (long)muls);
   gttoc_(asiaFG);
   tictoc_getNode(asiaFGNode, asiaFG);
@@ -311,15 +311,15 @@ TEST(ADT, factor_graph)
   resetCounts();
   gttic_(marg);
   fg = fg.combine(X, &add_);
-  DOT(fg, "Marginalized-6X");
+  dot(fg, "Marginalized-6X");
   fg = fg.combine(T, &add_);
-  DOT(fg, "Marginalized-5T");
+  dot(fg, "Marginalized-5T");
   fg = fg.combine(S, &add_);
-  DOT(fg, "Marginalized-4S");
+  dot(fg, "Marginalized-4S");
   fg = fg.combine(E, &add_);
-  DOT(fg, "Marginalized-3E");
+  dot(fg, "Marginalized-3E");
   fg = fg.combine(L, &add_);
-  DOT(fg, "Marginalized-2L");
+  dot(fg, "Marginalized-2L");
   EXPECT(adds = 54);
   gttoc_(marg);
   tictoc_getNode(margNode, marg);
@@ -333,9 +333,9 @@ TEST(ADT, factor_graph)
   resetCounts();
   gttic_(elimX);
   ADT fE = pX;
-  DOT(fE, "Eliminate-01-fEX");
+  dot(fE, "Eliminate-01-fEX");
   fE = fE.combine(X, &add_);
-  DOT(fE, "Eliminate-02-fE");
+  dot(fE, "Eliminate-02-fE");
   gttoc_(elimX);
   tictoc_getNode(elimXNode, elimX);
   elapsed = elimXNode->secs() + elimXNode->wall();
@@ -347,9 +347,9 @@ TEST(ADT, factor_graph)
   gttic_(elimT);
   ADT fLE = pT;
   fLE = apply(fLE, pE, &mul);
-  DOT(fLE, "Eliminate-03-fLET");
+  dot(fLE, "Eliminate-03-fLET");
   fLE = fLE.combine(T, &add_);
-  DOT(fLE, "Eliminate-04-fLE");
+  dot(fLE, "Eliminate-04-fLE");
   gttoc_(elimT);
   tictoc_getNode(elimTNode, elimT);
   elapsed = elimTNode->secs() + elimTNode->wall();
@@ -362,9 +362,9 @@ TEST(ADT, factor_graph)
   ADT fBL = pS;
   fBL = apply(fBL, pL, &mul);
   fBL = apply(fBL, pB, &mul);
-  DOT(fBL, "Eliminate-05-fBLS");
+  dot(fBL, "Eliminate-05-fBLS");
   fBL = fBL.combine(S, &add_);
-  DOT(fBL, "Eliminate-06-fBL");
+  dot(fBL, "Eliminate-06-fBL");
   gttoc_(elimS);
   tictoc_getNode(elimSNode, elimS);
   elapsed = elimSNode->secs() + elimSNode->wall();
@@ -377,9 +377,9 @@ TEST(ADT, factor_graph)
   ADT fBL2 = fE;
   fBL2 = apply(fBL2, fLE, &mul);
   fBL2 = apply(fBL2, pD, &mul);
-  DOT(fBL2, "Eliminate-07-fBLE");
+  dot(fBL2, "Eliminate-07-fBLE");
   fBL2 = fBL2.combine(E, &add_);
-  DOT(fBL2, "Eliminate-08-fBL2");
+  dot(fBL2, "Eliminate-08-fBL2");
   gttoc_(elimE);
   tictoc_getNode(elimENode, elimE);
   elapsed = elimENode->secs() + elimENode->wall();
@@ -391,9 +391,9 @@ TEST(ADT, factor_graph)
   gttic_(elimL);
   ADT fB = fBL;
   fB = apply(fB, fBL2, &mul);
-  DOT(fB, "Eliminate-09-fBL");
+  dot(fB, "Eliminate-09-fBL");
   fB = fB.combine(L, &add_);
-  DOT(fB, "Eliminate-10-fB");
+  dot(fB, "Eliminate-10-fB");
   gttoc_(elimL);
   tictoc_getNode(elimLNode, elimL);
   elapsed = elimLNode->secs() + elimLNode->wall();
@@ -414,13 +414,13 @@ TEST(ADT, equality_noparser)
   // Check straight equality
   ADT pA1 = create(A % tableA);
   ADT pA2 = create(A % tableA);
-  EXPECT(pA1 == pA2); // should be equal
+  EXPECT(pA1.equals(pA2)); // should be equal
 
   // Check equality after apply
   ADT pB = create(B % tableB);
   ADT pAB1 = apply(pA1, pB, &mul);
   ADT pAB2 = apply(pB, pA1, &mul);
-  EXPECT(pAB2 == pAB1);
+  EXPECT(pAB2.equals(pAB1));
 }
 
 /* ************************************************************************* */
@@ -431,13 +431,13 @@ TEST(ADT, equality_parser)
   // Check straight equality
   ADT pA1 = create(A % "80/20");
   ADT pA2 = create(A % "80/20");
-  EXPECT(pA1 == pA2); // should be equal
+  EXPECT(pA1.equals(pA2)); // should be equal
 
   // Check equality after apply
   ADT pB = create(B % "60/40");
   ADT pAB1 = apply(pA1, pB, &mul);
   ADT pAB2 = apply(pB, pA1, &mul);
-  EXPECT(pAB2 == pAB1);
+  EXPECT(pAB2.equals(pAB1));
 }
 
 /* ******************************************************************************** */
@@ -491,7 +491,7 @@ TEST(ADT, conversion)
 {
   DiscreteKey X(0,2), Y(1,2);
   ADT fDiscreteKey(X & Y, "0.2 0.5 0.3 0.6");
-  DOT(fDiscreteKey, "conversion-f1");
+  dot(fDiscreteKey, "conversion-f1");
 
   std::map<Key, Key> keyMap;
   keyMap[0] = 5;
@@ -500,7 +500,7 @@ TEST(ADT, conversion)
   AlgebraicDecisionTree<Key> fIndexKey(fDiscreteKey, keyMap);
   //  f1.print("f1");
   //  f2.print("f2");
-  DOT(fIndexKey, "conversion-f2");
+  dot(fIndexKey, "conversion-f2");
 
   DiscreteValues x00, x01, x02, x10, x11, x12;
   x00[5] = 0, x00[2] = 0;
@@ -519,7 +519,7 @@ TEST(ADT, elimination)
 {
   DiscreteKey A(0,2), B(1,3), C(2,2);
   ADT f1(A & B & C, "1 2  3 4  5 6    1 8  3 3  5 5");
-  DOT(f1, "elimination-f1");
+  dot(f1, "elimination-f1");
 
   {
     // sum out lower key

--- a/gtsam/discrete/tests/testDecisionTree.cpp
+++ b/gtsam/discrete/tests/testDecisionTree.cpp
@@ -179,8 +179,8 @@ TEST(DT, example)
 enum Label {
   U, V, X, Y, Z
 };
-typedef DecisionTree<Label, int> BDT;
-int convert(const int& y) {
+typedef DecisionTree<Label, bool> BDT;
+bool convert(const int& y) {
   return y != 0;
 }
 
@@ -196,7 +196,7 @@ TEST(DT, conversion)
   map<string, Label> ordering;
   ordering[A] = X;
   ordering[B] = Y;
-  std::function<int(const int&)> op = convert;
+  std::function<bool(const int&)> op = convert;
   BDT f2(f1, ordering, op);
   //  f1.print("f1");
   //  f2.print("f2");

--- a/gtsam/discrete/tests/testDecisionTree.cpp
+++ b/gtsam/discrete/tests/testDecisionTree.cpp
@@ -32,13 +32,13 @@ using namespace std;
 using namespace gtsam;
 
 template<typename T>
-void write_dot(const T&f, const string& filename) {
+void dot(const T&f, const string& filename) {
 #ifndef DISABLE_DOT
   f.dot(filename);
 #endif
 }
 
-#define DOT(x)(write_dot(x,#x))
+#define DOT(x)(dot(x,#x))
 
 struct Crazy { int a; double b; };
 typedef DecisionTree<string,Crazy> CrazyDecisionTree; // check that DecisionTree is actually generic (as it pretends to be)

--- a/gtsam/discrete/tests/testDecisionTree.cpp
+++ b/gtsam/discrete/tests/testDecisionTree.cpp
@@ -32,11 +32,13 @@ using namespace std;
 using namespace gtsam;
 
 template<typename T>
-void DOT(const T&f, const string& filename) {
+void write_dot(const T&f, const string& filename) {
 #ifndef DISABLE_DOT
   f.dot(filename);
 #endif
 }
+
+#define DOT(x)(write_dot(x,#x))
 
 struct Crazy { int a; double b; };
 typedef DecisionTree<string,Crazy> CrazyDecisionTree; // check that DecisionTree is actually generic (as it pretends to be)

--- a/gtsam/discrete/tests/testDecisionTree.cpp
+++ b/gtsam/discrete/tests/testDecisionTree.cpp
@@ -32,13 +32,11 @@ using namespace std;
 using namespace gtsam;
 
 template<typename T>
-void dot(const T&f, const string& filename) {
+void DOT(const T&f, const string& filename) {
 #ifndef DISABLE_DOT
   f.dot(filename);
 #endif
 }
-
-#define DOT(x)(dot(x,#x))
 
 struct Crazy { int a; double b; };
 typedef DecisionTree<string,Crazy> CrazyDecisionTree; // check that DecisionTree is actually generic (as it pretends to be)
@@ -179,8 +177,8 @@ TEST(DT, example)
 enum Label {
   U, V, X, Y, Z
 };
-typedef DecisionTree<Label, bool> BDT;
-bool convert(const int& y) {
+typedef DecisionTree<Label, int> BDT;
+int convert(const int& y) {
   return y != 0;
 }
 
@@ -196,7 +194,7 @@ TEST(DT, conversion)
   map<string, Label> ordering;
   ordering[A] = X;
   ordering[B] = Y;
-  std::function<bool(const int&)> op = convert;
+  std::function<int(const int&)> op = convert;
   BDT f2(f1, ordering, op);
   //  f1.print("f1");
   //  f2.print("f2");

--- a/gtsam/discrete/tests/testDecisionTree.cpp
+++ b/gtsam/discrete/tests/testDecisionTree.cpp
@@ -40,7 +40,19 @@ void dot(const T&f, const string& filename) {
 
 #define DOT(x)(dot(x,#x))
 
-struct Crazy { int a; double b; };
+struct Crazy {
+  int a;
+  double b;
+
+  bool equals(const Crazy& other, double tol = 1e-12) const {
+    return a == other.a && std::abs(b - other.b) < tol;
+  }
+
+  bool operator==(const Crazy& other) const {
+    return this->equals(other);
+  }
+};
+
 typedef DecisionTree<string,Crazy> CrazyDecisionTree; // check that DecisionTree is actually generic (as it pretends to be)
 
 // traits

--- a/gtsam/hybrid/DCGaussianMixtureFactor.h
+++ b/gtsam/hybrid/DCGaussianMixtureFactor.h
@@ -41,19 +41,26 @@ namespace gtsam {
  * of measurement.
  */
 class DCGaussianMixtureFactor : public DCFactor {
- private:
-  std::vector<GaussianFactor::shared_ptr> factors_;
-
  public:
   using Base = DCFactor;
   using shared_ptr = boost::shared_ptr<DCGaussianMixtureFactor>;
+  using FactorDecisionTree = DecisionTree<Key, GaussianFactor::shared_ptr>;
 
+ private:
+  FactorDecisionTree factors_;
+
+ public:
   DCGaussianMixtureFactor() = default;
 
+  DCGaussianMixtureFactor(const KeyVector& keys,
+                          const DiscreteKeys& discreteKeys,
+                          const FactorDecisionTree factors)
+      : Base(keys, discreteKeys), factors_(factors) {}
   DCGaussianMixtureFactor(
       const KeyVector& keys, const DiscreteKeys& discreteKeys,
       const std::vector<GaussianFactor::shared_ptr>& factors)
-      : Base(keys, discreteKeys), factors_(factors) {}
+      : Base(keys, discreteKeys),
+        factors_(FactorDecisionTree(discreteKeys, factors)) {}
 
   DCGaussianMixtureFactor(const DCGaussianMixtureFactor& x) = default;
 
@@ -105,10 +112,7 @@ class DCGaussianMixtureFactor : public DCFactor {
     }
     std::cout << "; " << formatter(discreteKeys_.front().first) << " ]";
     std::cout << "{\n";
-    for (size_t i = 0; i < factors_.size(); i++) {
-      auto t = boost::format("component %1%: ") % i;
-      factors_[i]->print(t.str());
-    }
+    factors_.print("", formatter);
     std::cout << "}";
     std::cout << "\n";
   }

--- a/gtsam/hybrid/DCGaussianMixtureFactor.h
+++ b/gtsam/hybrid/DCGaussianMixtureFactor.h
@@ -46,7 +46,7 @@ class DCGaussianMixtureFactor : public DCFactor {
   using FactorDecisionTree = DecisionTree<Key, GaussianFactor::shared_ptr>;
 
  private:
-  /// Decision tree of Gaussian factors indexed by a Key.
+  /// Decision tree of Gaussian factors indexed by discrete keys.
   FactorDecisionTree factors_;
 
  public:
@@ -76,8 +76,8 @@ class DCGaussianMixtureFactor : public DCFactor {
   DCGaussianMixtureFactor(
       const KeyVector& keys, const DiscreteKeys& discreteKeys,
       const std::vector<GaussianFactor::shared_ptr>& factors)
-      : Base(keys, discreteKeys),
-        factors_(FactorDecisionTree(discreteKeys, factors)) {}
+      : DCGaussianMixtureFactor(keys, discreteKeys,
+                                FactorDecisionTree(discreteKeys, factors)) {}
 
   /// Copy constructor.
   DCGaussianMixtureFactor(const DCGaussianMixtureFactor& x) = default;

--- a/gtsam/hybrid/DCGaussianMixtureFactor.h
+++ b/gtsam/hybrid/DCGaussianMixtureFactor.h
@@ -46,21 +46,40 @@ class DCGaussianMixtureFactor : public DCFactor {
   using FactorDecisionTree = DecisionTree<Key, GaussianFactor::shared_ptr>;
 
  private:
+  /// Decision tree of Gaussian factors indexed by a Key.
   FactorDecisionTree factors_;
 
  public:
   DCGaussianMixtureFactor() = default;
 
+  /**
+   * @brief Construct a new DCGaussianMixtureFactor object.
+   *
+   * @param keys Vector of keys for continuous factors.
+   * @param discreteKeys Vector of discrete assignments.
+   * @param factors A decision tree of Gaussian factors (as shared pointers)
+   * where each node has a Key label.
+   */
   DCGaussianMixtureFactor(const KeyVector& keys,
                           const DiscreteKeys& discreteKeys,
                           const FactorDecisionTree factors)
       : Base(keys, discreteKeys), factors_(factors) {}
+
+  /**
+   * @brief Construct a new DCGaussianMixtureFactor object using a vector of
+   * GaussianFactor shared pointers.
+   *
+   * @param keys Vector of keys for continuous factors.
+   * @param discreteKeys Vector of discrete assignments.
+   * @param factors Vector of gaussian factor shared pointers.
+   */
   DCGaussianMixtureFactor(
       const KeyVector& keys, const DiscreteKeys& discreteKeys,
       const std::vector<GaussianFactor::shared_ptr>& factors)
       : Base(keys, discreteKeys),
         factors_(FactorDecisionTree(discreteKeys, factors)) {}
 
+  /// Copy constructor.
   DCGaussianMixtureFactor(const DCGaussianMixtureFactor& x) = default;
 
   /// Discrete key selecting mixture component

--- a/gtsam/hybrid/DCGaussianMixtureFactor.h
+++ b/gtsam/hybrid/DCGaussianMixtureFactor.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <gtsam/discrete/DiscreteKey.h>
+#include <gtsam/hybrid/DCFactor.h>
 #include <gtsam/inference/Factor.h>
 #include <gtsam/linear/GaussianFactor.h>
 
@@ -29,8 +30,6 @@
 #include <cmath>
 #include <limits>
 #include <vector>
-
-#include "DCFactor.h"
 
 namespace gtsam {
 

--- a/gtsam/hybrid/DCMixtureFactor.h
+++ b/gtsam/hybrid/DCMixtureFactor.h
@@ -89,7 +89,6 @@ class DCMixtureFactor : public DCFactor {
 
   double error(const Values& continuousVals,
                const DiscreteValues& discreteVals) const override {
-    /********************************************************/
     // Retrieve the factor corresponding to the assignment in discreteVals.
     auto factor = factors_(discreteVals);
     // Compute the error for the selected factor
@@ -104,8 +103,7 @@ class DCMixtureFactor : public DCFactor {
     // TODO(kevin) Need to modify this? Maybe we take discrete vals as parameter
     // and DCContinuousFactor will pass this in as needed.
     // return (factors_.size() > 0) ? factors_[0].dim() : 0;
-    // TODO (Varun) find the best way to implement this
-    return 0;
+    throw std::runtime_error("DCMixtureFactor::dim not implemented.");
   }
 
   /// Testable

--- a/gtsam/hybrid/DCMixtureFactor.h
+++ b/gtsam/hybrid/DCMixtureFactor.h
@@ -138,7 +138,12 @@ class DCMixtureFactor : public DCFactor {
     const DCMixtureFactor& f(static_cast<const DCMixtureFactor&>(other));
 
     // Ensure that this DCMixtureFactor and `f` have the same `factors_`.
-    if (!factors_.equals(f.factors_)) return false;
+    auto comparator = [](const boost::shared_ptr<NonlinearFactorType>& a,
+                         const boost::shared_ptr<NonlinearFactorType>& b,
+                         double tol) {
+      return traits<NonlinearFactorType>::Equals(*a, *b, tol);
+    };
+    if (!factors_.equals(f.factors_, 1e-9, comparator)) return false;
 
     // If everything above passes, and the keys_, discreteKeys_ and normalized_
     // member variables are identical, return true.

--- a/gtsam/hybrid/DCMixtureFactor.h
+++ b/gtsam/hybrid/DCMixtureFactor.h
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <gtsam/hybrid/DCFactor.h>
 #include <gtsam/hybrid/DCGaussianMixtureFactor.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/Symbol.h>
@@ -21,8 +22,6 @@
 #include <cmath>
 #include <limits>
 #include <vector>
-
-#include "DCFactor.h"
 
 namespace gtsam {
 

--- a/gtsam/hybrid/DCMixtureFactor.h
+++ b/gtsam/hybrid/DCMixtureFactor.h
@@ -141,12 +141,11 @@ class DCMixtureFactor : public DCFactor {
     const DCMixtureFactor& f(static_cast<const DCMixtureFactor&>(other));
 
     // Ensure that this DCMixtureFactor and `f` have the same `factors_`.
-    auto comparator = [](const boost::shared_ptr<NonlinearFactorType>& a,
-                         const boost::shared_ptr<NonlinearFactorType>& b,
-                         double tol) {
+    auto compare = [tol](const boost::shared_ptr<NonlinearFactorType>& a,
+                         const boost::shared_ptr<NonlinearFactorType>& b) {
       return traits<NonlinearFactorType>::Equals(*a, *b, tol);
     };
-    if (!factors_.equals(f.factors_, 1e-9, comparator)) return false;
+    if (!factors_.equals(f.factors_, 1e-9, compare)) return false;
 
     // If everything above passes, and the keys_, discreteKeys_ and normalized_
     // member variables are identical, return true.

--- a/gtsam/hybrid/DCMixtureFactor.h
+++ b/gtsam/hybrid/DCMixtureFactor.h
@@ -55,9 +55,10 @@ class DCMixtureFactor : public DCFactor {
    * @brief Convenience constructor that generates the underlying factor
    * decision tree for us.
    *
-   * Here it is important that the vector of discrete keys and the vector of
-   * factors have a 1-to-1 mapping so that the decision tree is constructed
-   * accordingly.
+   * Here it is important that the vector of
+   * factors has the correct number of elements based on the number of discrete
+   * keys and the cardinality of the keys, so that the decision tree is
+   * constructed appropriately.
    *
    * @param keys Vector of keys for continuous factors.
    * @param discreteKeys Vector of discrete keys.

--- a/gtsam/hybrid/DCMixtureFactor.h
+++ b/gtsam/hybrid/DCMixtureFactor.h
@@ -105,7 +105,7 @@ class DCMixtureFactor : public DCFactor {
     // TODO(kevin) Need to modify this? Maybe we take discrete vals as parameter
     // and DCContinuousFactor will pass this in as needed.
     // return (factors_.size() > 0) ? factors_[0].dim() : 0;
-    //TODO (Varun) find the best way to implement this
+    // TODO (Varun) find the best way to implement this
     return 0;
   }
 
@@ -170,14 +170,8 @@ class DCMixtureFactor : public DCFactor {
               return factor->linearize(continuousVals);
             };
 
-    // Helper class to create identity map
-    class identity_map : public std::map<Key, Key> {
-      Key at(const Key& key) { return key; }
-    };
-    identity_map key_map;
-
     DecisionTree<Key, GaussianFactor::shared_ptr> linearized_factors(
-        factors_, key_map, linearizeDT);
+        factors_, linearizeDT);
 
     return boost::make_shared<DCGaussianMixtureFactor>(keys_, discreteKeys_,
                                                        linearized_factors);

--- a/gtsam/hybrid/DCMixtureFactor.h
+++ b/gtsam/hybrid/DCMixtureFactor.h
@@ -37,10 +37,13 @@ class DCMixtureFactor : public DCFactor {
   using Base = DCFactor;
   using shared_ptr = boost::shared_ptr<DCMixtureFactor>;
 
+  /// typedef for DecisionTree which has Keys as node labels and
+  /// NonlinearFactorType as leaf nodes.
   using FactorDecisionTree =
       DecisionTree<Key, boost::shared_ptr<NonlinearFactorType>>;
 
  private:
+  /// Decision tree of Gaussian factors indexed by discrete keys.
   FactorDecisionTree factors_;
   bool normalized_;
 

--- a/gtsam/hybrid/tests/testDCMixtureFactor.cpp
+++ b/gtsam/hybrid/tests/testDCMixtureFactor.cpp
@@ -21,18 +21,55 @@ using namespace gtsam;
 
 /******************************************************************************/
 
-/*
- * Test DCDiscreteFactor using a simple mixture.
- *
- * Construct a single factor (for a single variable) consisting of a
- * discrete-conditional mixture. Here we have a "null hypothesis" consisting of
- * a Gaussian with large variance and an "alternative hypothesis" consisting of
- * a Gaussian with smaller variance.
- */
-TEST(TestSuite, dcdiscrete_mixture) {
+// /*
+//  * Test DCDiscreteFactor using a simple mixture.
+//  *
+//  * Construct a single factor (for a single variable) consisting of a
+//  * discrete-conditional mixture. Here we have a "null hypothesis" consisting
+//  of
+//  * a Gaussian with large variance and an "alternative hypothesis" consisting
+//  of
+//  * a Gaussian with smaller variance.
+//  */
+// TEST(TestSuite, dcdiscrete_mixture) {
+//   // We'll make a variable with 2 possible assignments
+//   const size_t cardinality = 2;
+//   DiscreteKey dk(Symbol('d', 1), cardinality);
+
+//   // Make a symbol for a single continuous variable and add to KeyVector
+//   Symbol x1 = Symbol('x', 1);
+//   KeyVector keys;
+//   keys.push_back(x1);
+
+//   // Make a factor for non-null hypothesis
+//   const double loc = 0.0;
+//   const double sigma1 = 1.0;
+//   auto prior_noise1 = noiseModel::Isotropic::Sigma(1, sigma1);
+//   PriorFactor<double> f1(x1, loc, prior_noise1);
+
+//   // Make a factor for null hypothesis
+//   const double sigmaNullHypo = 8.0;
+//   auto prior_noiseNullHypo = noiseModel::Isotropic::Sigma(1, sigmaNullHypo);
+//   PriorFactor<double> fNullHypo(x1, loc, prior_noiseNullHypo);
+
+//   DCMixtureFactor<PriorFactor<double>> dcMixture(keys, dk, {f1, fNullHypo});
+
+//   // Check error.
+//   Values continuousVals;
+//   continuousVals.insert(x1, -2.5);
+//   DiscreteValues discreteVals;
+//   discreteVals[dk.first] = 0;
+
+//   // regression
+//   EXPECT_DOUBLES_EQUAL(2.2, dcMixture.error(continuousVals, discreteVals),
+//                        1e-1);
+// }
+
+TEST(DCMixtureFactor, Error) {
   // We'll make a variable with 2 possible assignments
   const size_t cardinality = 2;
   DiscreteKey dk(Symbol('d', 1), cardinality);
+  DiscreteKeys dKeys = {dk};
 
   // Make a symbol for a single continuous variable and add to KeyVector
   Symbol x1 = Symbol('x', 1);
@@ -40,29 +77,15 @@ TEST(TestSuite, dcdiscrete_mixture) {
   keys.push_back(x1);
 
   // Make a factor for non-null hypothesis
-  const double loc = 0.0;
-  const double sigma1 = 1.0;
-  auto prior_noise1 = noiseModel::Isotropic::Sigma(1, sigma1);
-  PriorFactor<double> f1(x1, loc, prior_noise1);
+  auto prior_noise1 = noiseModel::Isotropic::Sigma(1, 1.0);
+  PriorFactor<double> f1(x1, 0.0, prior_noise1);
 
   // Make a factor for null hypothesis
-  const double sigmaNullHypo = 8.0;
-  auto prior_noiseNullHypo = noiseModel::Isotropic::Sigma(1, sigmaNullHypo);
-  PriorFactor<double> fNullHypo(x1, loc, prior_noiseNullHypo);
+  auto prior_noiseNullHypo = noiseModel::Isotropic::Sigma(1, 8.0);
+  PriorFactor<double> fNullHypo(x1, 0.0, prior_noiseNullHypo);
 
-  DCMixtureFactor<PriorFactor<double>> dcMixture(keys, dk, {f1, fNullHypo});
-
-  // Check error.
-  Values continuousVals;
-  continuousVals.insert(x1, -2.5);
-  DiscreteValues discreteVals;
-  discreteVals[dk.first] = 0;
-
-  // regression
-  EXPECT_DOUBLES_EQUAL(2.2, dcMixture.error(continuousVals, discreteVals),
-                       1e-1);
+  DCMixtureFactor<PriorFactor<double>> factor(keys, dKeys, {f1, fNullHypo});
 }
-
 /* ************************************************************************* */
 int main() {
   TestResult tr;

--- a/gtsam/hybrid/tests/testDCMixtureFactor.cpp
+++ b/gtsam/hybrid/tests/testDCMixtureFactor.cpp
@@ -69,7 +69,8 @@ TEST(DCMixtureFactor, Error) {
   // We'll make a variable with 2 possible assignments
   const size_t cardinality = 2;
   DiscreteKey dk(Symbol('d', 1), cardinality);
-  DiscreteKeys dKeys = {dk};
+  DiscreteKeys dKeys;
+  dKeys.push_back(dk);
 
   // Make a symbol for a single continuous variable and add to KeyVector
   Symbol x1 = Symbol('x', 1);

--- a/gtsam/hybrid/tests/testDCMixtureFactor.cpp
+++ b/gtsam/hybrid/tests/testDCMixtureFactor.cpp
@@ -21,49 +21,49 @@ using namespace gtsam;
 
 /******************************************************************************/
 
-// /*
-//  * Test DCDiscreteFactor using a simple mixture.
-//  *
-//  * Construct a single factor (for a single variable) consisting of a
-//  * discrete-conditional mixture. Here we have a "null hypothesis" consisting
-//  of
-//  * a Gaussian with large variance and an "alternative hypothesis" consisting
-//  of
-//  * a Gaussian with smaller variance.
-//  */
-// TEST(TestSuite, dcdiscrete_mixture) {
-//   // We'll make a variable with 2 possible assignments
-//   const size_t cardinality = 2;
-//   DiscreteKey dk(Symbol('d', 1), cardinality);
+/*
+ * Test DCDiscreteFactor using a simple mixture.
+ *
+ * Construct a single factor (for a single variable) consisting of a
+ * discrete-conditional mixture. Here we have a "null hypothesis" consisting
+ of
+ * a Gaussian with large variance and an "alternative hypothesis" consisting
+ of
+ * a Gaussian with smaller variance.
+ */
+TEST(TestSuite, dcdiscrete_mixture) {
+  // We'll make a variable with 2 possible assignments
+  const size_t cardinality = 2;
+  DiscreteKey dk(Symbol('d', 1), cardinality);
 
-//   // Make a symbol for a single continuous variable and add to KeyVector
-//   Symbol x1 = Symbol('x', 1);
-//   KeyVector keys;
-//   keys.push_back(x1);
+  // Make a symbol for a single continuous variable and add to KeyVector
+  Symbol x1 = Symbol('x', 1);
+  KeyVector keys;
+  keys.push_back(x1);
 
-//   // Make a factor for non-null hypothesis
-//   const double loc = 0.0;
-//   const double sigma1 = 1.0;
-//   auto prior_noise1 = noiseModel::Isotropic::Sigma(1, sigma1);
-//   PriorFactor<double> f1(x1, loc, prior_noise1);
+  // Make a factor for non-null hypothesis
+  const double loc = 0.0;
+  const double sigma1 = 1.0;
+  auto prior_noise1 = noiseModel::Isotropic::Sigma(1, sigma1);
+  PriorFactor<double> f1(x1, loc, prior_noise1);
 
-//   // Make a factor for null hypothesis
-//   const double sigmaNullHypo = 8.0;
-//   auto prior_noiseNullHypo = noiseModel::Isotropic::Sigma(1, sigmaNullHypo);
-//   PriorFactor<double> fNullHypo(x1, loc, prior_noiseNullHypo);
+  // Make a factor for null hypothesis
+  const double sigmaNullHypo = 8.0;
+  auto prior_noiseNullHypo = noiseModel::Isotropic::Sigma(1, sigmaNullHypo);
+  PriorFactor<double> fNullHypo(x1, loc, prior_noiseNullHypo);
 
-//   DCMixtureFactor<PriorFactor<double>> dcMixture(keys, dk, {f1, fNullHypo});
+  DCMixtureFactor<PriorFactor<double>> dcMixture(keys, dk, {f1, fNullHypo});
 
-//   // Check error.
-//   Values continuousVals;
-//   continuousVals.insert(x1, -2.5);
-//   DiscreteValues discreteVals;
-//   discreteVals[dk.first] = 0;
+  // Check error.
+  Values continuousVals;
+  continuousVals.insert(x1, -2.5);
+  DiscreteValues discreteVals;
+  discreteVals[dk.first] = 0;
 
-//   // regression
-//   EXPECT_DOUBLES_EQUAL(2.2, dcMixture.error(continuousVals, discreteVals),
-//                        1e-1);
-// }
+  // regression
+  EXPECT_DOUBLES_EQUAL(2.2, dcMixture.error(continuousVals, discreteVals),
+                       1e-1);
+}
 
 TEST(DCMixtureFactor, Error) {
   // We'll make a variable with 2 possible assignments
@@ -77,16 +77,35 @@ TEST(DCMixtureFactor, Error) {
   KeyVector keys;
   keys.push_back(x1);
 
-  // Make a factor for non-null hypothesis
+  // Make a factor for non-null hypothesis which has mu=1.0.
   auto prior_noise1 = noiseModel::Isotropic::Sigma(1, 1.0);
-  PriorFactor<double> f1(x1, 0.0, prior_noise1);
+  PriorFactor<double> f1(x1, 1.0, prior_noise1);
 
-  // Make a factor for null hypothesis
+  // Make a factor for null hypothesis with mu = 0.0.
   auto prior_noiseNullHypo = noiseModel::Isotropic::Sigma(1, 8.0);
   PriorFactor<double> fNullHypo(x1, 0.0, prior_noiseNullHypo);
 
-  DCMixtureFactor<PriorFactor<double>> factor(keys, dKeys, {f1, fNullHypo});
+  // Create the factor to test. We set normalize to true so that expected values
+  // are easy to compute manually (they should be 0.0)
+  DCMixtureFactor<PriorFactor<double>> factor(keys, dKeys, {fNullHypo, f1},
+                                              true);
+
+  Values continuousValues;
+  DiscreteValues discreteValues;
+
+  // Test the null hypothesis
+  continuousValues.insert(x1, 0.0);
+  discreteValues[dk.first] = 0;
+  double error = factor.error(continuousValues, discreteValues);
+  EXPECT_DOUBLES_EQUAL(0.0, error, 1e-9);
+
+  // Test the alternate hypothesis
+  continuousValues.update(x1, 1.0);
+  discreteValues[dk.first] = 1;
+  error = factor.error(continuousValues, discreteValues);
+  EXPECT_DOUBLES_EQUAL(0.0, error, 1e-9);
 }
+
 /* ************************************************************************* */
 int main() {
   TestResult tr;


### PR DESCRIPTION
Replace the use of `std::vector<FactorType>` for `DCMixtureFactor`s with `DecisionTree<Key, FactorType>`.

This should enable much easier ways for performing discrete key selection and overall elimination.