### PR TITLE
Moved empty to Factor base class.

### DIFF
--- a/gtsam/discrete/DiscreteFactor.h
+++ b/gtsam/discrete/DiscreteFactor.h
@@ -73,9 +73,6 @@ public:
     Base::print(s, formatter);
   }
 
-  /** Test whether the factor is empty */
-  virtual bool empty() const { return size() == 0; }
-
   /// @}
   /// @name Standard Interface
   /// @{

--- a/gtsam/inference/Factor.h
+++ b/gtsam/inference/Factor.h
@@ -112,6 +112,9 @@ typedef FastSet<FactorIndex> FactorIndexSet;
    /// @name Standard Interface
    /// @{
 
+   /// Whether the factor is empty (involves zero variables).
+   bool empty() const { return keys_.empty(); }
+
    /// First key
    Key front() const { return keys_.front(); }
 

--- a/gtsam/linear/GaussianFactor.h
+++ b/gtsam/linear/GaussianFactor.h
@@ -117,9 +117,6 @@ namespace gtsam {
     /** Clone a factor (make a deep copy) */
     virtual GaussianFactor::shared_ptr clone() const = 0;
 
-    /** Test whether the factor is empty */
-    virtual bool empty() const = 0;
-
     /**
      * Construct the corresponding anti-factor to negate information
      * stored stored in this factor.

--- a/gtsam/linear/HessianFactor.h
+++ b/gtsam/linear/HessianFactor.h
@@ -221,9 +221,6 @@ namespace gtsam {
      */
     GaussianFactor::shared_ptr negate() const override;
 
-    /** Check if the factor is empty.  TODO: How should this be defined? */
-    bool empty() const override { return size() == 0 /*|| rows() == 0*/; }
-
     /** Return the constant term \f$ f \f$ as described above
      * @return The constant term \f$ f \f$
      */

--- a/gtsam/linear/JacobianFactor.h
+++ b/gtsam/linear/JacobianFactor.h
@@ -260,9 +260,6 @@ namespace gtsam {
      */
     GaussianFactor::shared_ptr negate() const override;
 
-    /** Check if the factor is empty.  TODO: How should this be defined? */
-    bool empty() const override { return size() == 0 /*|| rows() == 0*/; }
-
     /** is noise model constrained ? */
     bool isConstrained() const {
       return model_ && model_->isConstrained();

--- a/gtsam/slam/RegularImplicitSchurFactor.h
+++ b/gtsam/slam/RegularImplicitSchurFactor.h
@@ -260,10 +260,6 @@ public:
         "RegularImplicitSchurFactor::clone non implemented");
   }
 
-  bool empty() const override {
-    return false;
-  }
-
   GaussianFactor::shared_ptr negate() const override {
     return boost::make_shared<RegularImplicitSchurFactor<CAMERA> >(keys_,
         FBlocks_, PointCovariance_, E_, b_);

--- a/gtsam/symbolic/SymbolicFactor.h
+++ b/gtsam/symbolic/SymbolicFactor.h
@@ -144,9 +144,6 @@ namespace gtsam {
     /// @name Standard Interface
     /// @{
 
-    /** Whether the factor is empty (involves zero variables). */
-    bool empty() const { return keys_.empty(); }
-
     /** Eliminate the variables in \c keys, in the order specified in \c keys, returning a
      *  conditional and marginal. */
     std::pair<boost::shared_ptr<SymbolicConditional>, boost::shared_ptr<SymbolicFactor> >


### PR DESCRIPTION
Because it was inconsistently defined, and this one (from Symbolic) seems to works for all Factor types.