### PR TITLE
Fix documentation on ProjectionFactorPPPC

### DIFF
--- a/gtsam_unstable/slam/ProjectionFactorPPPC.h
+++ b/gtsam_unstable/slam/ProjectionFactorPPPC.h
@@ -115,8 +115,8 @@ class GTSAM_UNSTABLE_EXPORT ProjectionFactorPPPC
       try {
           if(H1 || H2 || H3 || H4) {
             Matrix H0, H02;
-            PinholeCamera<CALIBRATION> camera(pose.compose(transform, H0, H02), K);
-            Point2 reprojectionError(camera.project(point, H1, H3, H4) - measured_);
+            const PinholeCamera<CALIBRATION> camera(pose.compose(transform, H0, H02), K);
+            const Point2 reprojectionError(camera.project(point, H1, H3, H4) - measured_);
             *H2 = *H1 * H02;
             *H1 = *H1 * H0;
             return reprojectionError;

--- a/gtsam_unstable/slam/ProjectionFactorPPPC.h
+++ b/gtsam_unstable/slam/ProjectionFactorPPPC.h
@@ -57,19 +57,6 @@ class GTSAM_UNSTABLE_EXPORT ProjectionFactorPPPC
       measured_(0.0, 0.0), throwCheirality_(false), verboseCheirality_(false) {
   }
 
-    /**
-     * Constructor
-     * TODO: Mark argument order standard (keys, measurement, parameters)
-     * @param measured is the 2 dimensional location of point in image (the measurement)
-     * @param model is the standard deviation
-     * @param poseKey is the index of the camera
-     * @param pointKey is the index of the landmark
-     * @param K shared pointer to the constant calibration
-     */
-    ProjectionFactorPPPC(const Point2& measured, const SharedNoiseModel& model,
-        Key poseKey, Key transformKey,  Key pointKey, Key calibKey) :
-          Base(model, poseKey, transformKey, pointKey, calibKey), measured_(measured),
-          throwCheirality_(false), verboseCheirality_(false) {}
 
     /**
      * Constructor with exception-handling flags
@@ -84,7 +71,7 @@ class GTSAM_UNSTABLE_EXPORT ProjectionFactorPPPC
      */
     ProjectionFactorPPPC(const Point2& measured, const SharedNoiseModel& model,
         Key poseKey, Key transformKey, Key pointKey, Key calibKey,
-        bool throwCheirality, bool verboseCheirality) :
+        bool throwCheirality = false, bool verboseCheirality = false) :
           Base(model, poseKey, transformKey, pointKey, calibKey), measured_(measured),
           throwCheirality_(throwCheirality), verboseCheirality_(verboseCheirality) {}
 

--- a/gtsam_unstable/slam/ProjectionFactorPPPC.h
+++ b/gtsam_unstable/slam/ProjectionFactorPPPC.h
@@ -61,13 +61,17 @@ class GTSAM_UNSTABLE_EXPORT ProjectionFactorPPPC
     /**
      * Constructor with exception-handling flags
      * TODO: Mark argument order standard (keys, measurement, parameters)
-     * @param measured is the 2 dimensional location of point in image (the measurement)
+     * @param measured is the 2 dimensional location of point in image (the
+     * measurement)
      * @param model is the standard deviation
      * @param poseKey is the index of the camera
+     * @param transformKey is the index of the extrinsic calibration
      * @param pointKey is the index of the landmark
-     * @param K shared pointer to the constant calibration
-     * @param throwCheirality determines whether Cheirality exceptions are rethrown
-     * @param verboseCheirality determines whether exceptions are printed for Cheirality
+     * @param calibKey is the index of the intrinsic calibration
+     * @param throwCheirality determines whether Cheirality exceptions are
+     * rethrown
+     * @param verboseCheirality determines whether exceptions are printed for
+     * Cheirality
      */
     ProjectionFactorPPPC(const Point2& measured, const SharedNoiseModel& model,
         Key poseKey, Key transformKey, Key pointKey, Key calibKey,


### PR DESCRIPTION
A couple of small changes to `ProjectionFactorPPPC`:

- Remove excess constructor, use default arguments instead
- Fix construction documentation
- Make some variables `const` where possible