### PR TITLE
Add HybridFactorGraph::toDecisionTreeFactor method

### DIFF
--- a/gtsam/discrete/DecisionTreeFactor.cpp
+++ b/gtsam/discrete/DecisionTreeFactor.cpp
@@ -66,7 +66,7 @@ namespace gtsam {
   void DecisionTreeFactor::print(const string& s,
       const KeyFormatter& formatter) const {
     cout << s;
-    ADT::print("Potentials:",formatter);
+    ADT::print("", formatter);
   }
 
   /* ************************************************************************* */

--- a/gtsam/discrete/DiscreteConditional.cpp
+++ b/gtsam/discrete/DiscreteConditional.cpp
@@ -80,7 +80,7 @@ void DiscreteConditional::print(const string& s,
     }
   }
   cout << ")";
-  ADT::print("");
+  ADT::print("", formatter);
   cout << endl;
 }
 

--- a/gtsam/hybrid/HybridFactorGraph.h
+++ b/gtsam/hybrid/HybridFactorGraph.h
@@ -199,7 +199,8 @@ class HybridFactorGraph : protected FactorGraph<Factor>,
 
   /**
    * @brief Add a single factor shared pointer to the hybrid factor graph.
-   * Dynamically handles the factor type and assigns it to the correct underlying container.
+   * Dynamically handles the factor type and assigns it to the correct
+   * underlying container.
    *
    * @tparam FACTOR The factor type template
    * @param sharedFactor The factor to add to this factor graph.
@@ -355,6 +356,11 @@ class HybridFactorGraph : protected FactorGraph<Factor>,
    * different structure, and creating a different decision tree for Gaussians.
    */
   DCGaussianMixtureFactor::Sum sum() const;
+
+  /// Convert the DecisionTree of (Key, GaussianFactorGraph) to (Key, Graph
+  /// Error).
+  DecisionTreeFactor::shared_ptr toDecisionTreeFactor() const;
+
   /// @}
 };
 

--- a/gtsam/hybrid/tests/testHybridFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridFactorGraph.cpp
@@ -335,6 +335,27 @@ TEST(DCGaussianElimination, Eliminate_fully) {
 }
 
 /* ****************************************************************************/
+/// Test the toDecisionTreeFactor method
+TEST(HybridFactorGraph, AssignmentFactors) {
+  Switching self(3);
+
+  // Clear out discrete factors since sum() cannot hanldle those
+  HybridFactorGraph linearizedFactorGraph(
+      NonlinearFactorGraph(), DiscreteFactorGraph(),
+      self.linearizedFactorGraph.dcGraph(),
+      self.linearizedFactorGraph.gaussianGraph());
+
+  auto decisionTreeFactor = linearizedFactorGraph.toDecisionTreeFactor();
+
+  auto allAssignments =
+      cartesianProduct(linearizedFactorGraph.discreteKeys());
+
+  for (auto&& assignment : allAssignments) {
+    std::cout << (*decisionTreeFactor)(assignment) << std::endl << std::endl;
+  }
+}
+
+/* ****************************************************************************/
 // Test elimination
 TEST(HybridFactorGraph, Elimination) {
   Switching self(3);

--- a/gtsam/hybrid/tests/testHybridFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridFactorGraph.cpp
@@ -163,7 +163,6 @@ struct Switching {
                          components[1]->linearize(linearizationPoint)};
       linearizedFactorGraph.emplace_dc<DCGaussianMixtureFactor>(
           keys, DiscreteKeys{modes[k]}, linearized);
-      std::cout << "linearizedFactorGraph size: " << linearizedFactorGraph.size() << std::endl << std::endl;
     }
 
     // Add "mode chain"
@@ -183,7 +182,7 @@ struct Switching {
   void addModeChain(HybridFactorGraph* fg) {
     auto prior = boost::make_shared<DiscretePrior>(modes[1], "1/1");
     fg->push_discrete(prior);
-    for (size_t k = 1; k < K; k++) {
+    for (size_t k = 1; k < K - 1; k++) {
       auto parents = {modes[k]};
       auto conditional = boost::make_shared<DiscreteConditional>(
           modes[k + 1], parents, "1/2 3/2");
@@ -196,15 +195,15 @@ struct Switching {
 // Test construction of switching-like hybrid factor graph.
 TEST(HybridFactorGraph, Switching) {
   Switching self(3);
-  EXPECT_LONGS_EQUAL(6, self.nonlinearFactorGraph.size());
+  EXPECT_LONGS_EQUAL(5, self.nonlinearFactorGraph.size());
   EXPECT_LONGS_EQUAL(1, self.nonlinearFactorGraph.nonlinearGraph().size());
-  EXPECT_LONGS_EQUAL(3, self.nonlinearFactorGraph.discreteGraph().size());
+  EXPECT_LONGS_EQUAL(2, self.nonlinearFactorGraph.discreteGraph().size());
   EXPECT_LONGS_EQUAL(2, self.nonlinearFactorGraph.dcGraph().size());
   EXPECT_LONGS_EQUAL(0, self.nonlinearFactorGraph.gaussianGraph().size());
 
-  EXPECT_LONGS_EQUAL(6, self.linearizedFactorGraph.size());
+  EXPECT_LONGS_EQUAL(5, self.linearizedFactorGraph.size());
   EXPECT_LONGS_EQUAL(0, self.linearizedFactorGraph.nonlinearGraph().size());
-  EXPECT_LONGS_EQUAL(3, self.linearizedFactorGraph.discreteGraph().size());
+  EXPECT_LONGS_EQUAL(2, self.linearizedFactorGraph.discreteGraph().size());
   EXPECT_LONGS_EQUAL(2, self.linearizedFactorGraph.dcGraph().size());
   EXPECT_LONGS_EQUAL(1, self.linearizedFactorGraph.gaussianGraph().size());
 }
@@ -223,9 +222,9 @@ TEST(HybridFactorGraph, Linearization) {
   HybridFactorGraph actualLinearized =
       self.nonlinearFactorGraph.linearize(self.linearizationPoint);
 
-  EXPECT_LONGS_EQUAL(6, actualLinearized.size());
+  EXPECT_LONGS_EQUAL(5, actualLinearized.size());
   EXPECT_LONGS_EQUAL(0, actualLinearized.nonlinearGraph().size());
-  EXPECT_LONGS_EQUAL(3, actualLinearized.discreteGraph().size());
+  EXPECT_LONGS_EQUAL(2, actualLinearized.discreteGraph().size());
   EXPECT_LONGS_EQUAL(2, actualLinearized.dcGraph().size());
   EXPECT_LONGS_EQUAL(1, actualLinearized.gaussianGraph().size());
 
@@ -338,7 +337,7 @@ TEST(DCGaussianElimination, Eliminate_fully) {
 /* ****************************************************************************/
 // Test elimination
 TEST(HybridFactorGraph, Elimination) {
-  Switching self(4);
+  Switching self(3);
 
   // Create ordering.
   Ordering ordering;
@@ -349,11 +348,11 @@ TEST(HybridFactorGraph, Elimination) {
 
   CHECK(result.first);
   GTSAM_PRINT(*result.first);  // HybridBayesNet
-  EXPECT_LONGS_EQUAL(4, result.first->size())
+  EXPECT_LONGS_EQUAL(3, result.first->size());
 
   CHECK(result.second);
   GTSAM_PRINT(*result.second);  // HybridFactorGraph
-  EXPECT_LONGS_EQUAL(4, result.second->size())
+  EXPECT_LONGS_EQUAL(3, result.second->size());
 }
 
 /* ************************************************************************* */


### PR DESCRIPTION
This PR adds a new `toDecisionTreeFactor` which can be used to generate the final factor over all discrete values after the continuous values have been eliminated.