### PR TITLE
Add discrete keys to separator for elimination

### DIFF
--- a/gtsam/discrete/DecisionTreeFactor.cpp
+++ b/gtsam/discrete/DecisionTreeFactor.cpp
@@ -163,6 +163,15 @@ namespace gtsam {
   }
 
   /* ************************************************************************* */
+  DiscreteKeys DecisionTreeFactor::discreteKeys() const {
+    DiscreteKeys result;
+    for (auto&& key : keys()) {
+        result.emplace_back(key, cardinality(key));
+      }
+    return result;
+  }
+
+  /* ************************************************************************* */
   static std::string valueFormatter(const double& v) {
     return (boost::format("%4.2g") % v).str();
   }

--- a/gtsam/discrete/DecisionTreeFactor.h
+++ b/gtsam/discrete/DecisionTreeFactor.h
@@ -183,6 +183,9 @@ namespace gtsam {
     /// Enumerate all values into a map from values to double.
     std::vector<std::pair<DiscreteValues, double>> enumerate() const;
 
+    /// Return all the discrete keys associated with this factor.
+    DiscreteKeys discreteKeys() const;
+
     /// @}
     /// @name Wrapper support
     /// @{

--- a/gtsam/discrete/DiscreteFactorGraph.cpp
+++ b/gtsam/discrete/DiscreteFactorGraph.cpp
@@ -50,6 +50,20 @@ namespace gtsam {
   }
 
   /* ************************************************************************* */
+  DiscreteKeys DiscreteFactorGraph::discreteKeys() const {
+    DiscreteKeys result;
+    for (auto&& factor : *this) {
+      if (auto p = boost::dynamic_pointer_cast<DecisionTreeFactor>(factor)) {
+        for (auto&& key : factor->keys()) {
+          result.emplace_back(key, p->cardinality(key));
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /* ************************************************************************* */
   DecisionTreeFactor DiscreteFactorGraph::product() const {
     DecisionTreeFactor result;
     for(const sharedFactor& factor: *this)

--- a/gtsam/discrete/DiscreteFactorGraph.cpp
+++ b/gtsam/discrete/DiscreteFactorGraph.cpp
@@ -43,8 +43,9 @@ namespace gtsam {
   /* ************************************************************************* */
   KeySet DiscreteFactorGraph::keys() const {
     KeySet keys;
-    for(const sharedFactor& factor: *this)
-    if (factor) keys.insert(factor->begin(), factor->end());
+    for (const sharedFactor& factor : *this) {
+      if (factor) keys.insert(factor->begin(), factor->end());
+    }
     return keys;
   }
 

--- a/gtsam/discrete/DiscreteFactorGraph.cpp
+++ b/gtsam/discrete/DiscreteFactorGraph.cpp
@@ -54,9 +54,8 @@ namespace gtsam {
     DiscreteKeys result;
     for (auto&& factor : *this) {
       if (auto p = boost::dynamic_pointer_cast<DecisionTreeFactor>(factor)) {
-        for (auto&& key : factor->keys()) {
-          result.emplace_back(key, p->cardinality(key));
-        }
+        DiscreteKeys factor_keys = p->discreteKeys();
+        result.insert(result.end(), factor_keys.begin(), factor_keys.end());
       }
     }
 

--- a/gtsam/discrete/DiscreteFactorGraph.h
+++ b/gtsam/discrete/DiscreteFactorGraph.h
@@ -113,6 +113,9 @@ public:
   /** Return the set of variables involved in the factors (set union) */
   KeySet keys() const;
 
+  /// Return the DiscreteKeys in this factor graph.
+  DiscreteKeys discreteKeys() const;
+
   /** return product of all factors as a single factor */
   DecisionTreeFactor product() const;
 

--- a/gtsam/discrete/DiscreteKey.h
+++ b/gtsam/discrete/DiscreteKey.h
@@ -33,9 +33,6 @@ namespace gtsam {
    */
   using DiscreteKey = std::pair<Key,size_t>;
 
-  // TODO(Frank): make this the type?
-  // using DiscreteKeys = std::map<Key, size_t>;
-
   /// DiscreteKeys is a set of keys that can be assembled using the & operator
   struct GTSAM_EXPORT DiscreteKeys: public std::vector<DiscreteKey> {
 
@@ -74,11 +71,6 @@ namespace gtsam {
       return *this;
     }
 
-    /// Helper method to append additional discrete keys.
-    DiscreteKeys& append(const DiscreteKeys& keys) {
-      this->insert(this->begin(), keys.begin(), keys.end());
-      return *this;
-    }
   }; // DiscreteKeys
 
   /// Create a list from two keys

--- a/gtsam/discrete/DiscreteKey.h
+++ b/gtsam/discrete/DiscreteKey.h
@@ -73,6 +73,12 @@ namespace gtsam {
       push_back(key);
       return *this;
     }
+
+    /// Helper method to append additional discrete keys.
+    DiscreteKeys& append(const DiscreteKeys& keys) {
+      this->insert(this->begin(), keys.begin(), keys.end());
+      return *this;
+    }
   }; // DiscreteKeys
 
   /// Create a list from two keys

--- a/gtsam/hybrid/DCFactor.h
+++ b/gtsam/hybrid/DCFactor.h
@@ -63,7 +63,9 @@ class DCFactor : public gtsam::Factor {
    */
   DCFactor(const gtsam::KeyVector& continuousKeys,
            const gtsam::DiscreteKeys& discreteKeys)
-      : Base(AllKeys(continuousKeys, discreteKeys)),
+      //TODO(Varun) This causes double counting of keys
+      // : Base(AllKeys(continuousKeys, discreteKeys)),
+      : Base(continuousKeys),
         discreteKeys_(discreteKeys) {}
 
   // NOTE unsure if needed?
@@ -150,6 +152,9 @@ class DCFactor : public gtsam::Factor {
    * function with respect to continuous variables for
    */
   virtual size_t dim() const = 0;
+
+  /// Return the number of variables involved in this factor
+  size_t size() const override { return keys_.size() + discreteKeys_.size(); }
 
   /*
    * Return the discrete keys for this factor.

--- a/gtsam/hybrid/DCFactor.h
+++ b/gtsam/hybrid/DCFactor.h
@@ -63,9 +63,7 @@ class DCFactor : public gtsam::Factor {
    */
   DCFactor(const gtsam::KeyVector& continuousKeys,
            const gtsam::DiscreteKeys& discreteKeys)
-      //TODO(Varun) This causes double counting of keys
-      // : Base(AllKeys(continuousKeys, discreteKeys)),
-      : Base(continuousKeys),
+      : Base(AllKeys(continuousKeys, discreteKeys)),
         discreteKeys_(discreteKeys) {}
 
   // NOTE unsure if needed?
@@ -152,9 +150,6 @@ class DCFactor : public gtsam::Factor {
    * function with respect to continuous variables for
    */
   virtual size_t dim() const = 0;
-
-  /// Return the number of variables involved in this factor
-  size_t size() const override { return keys_.size() + discreteKeys_.size(); }
 
   /*
    * Return the discrete keys for this factor.

--- a/gtsam/hybrid/DCFactorGraph.h
+++ b/gtsam/hybrid/DCFactorGraph.h
@@ -24,6 +24,19 @@ class DCFactorGraph : public gtsam::FactorGraph<DCFactor> {
   using shared_ptr = boost::shared_ptr<DCFactorGraph>;
 
   DCFactorGraph() : FactorGraph<DCFactor>() {}
+
+  /// Get all the discrete keys in all the factors in the DCFactorGraph
+  DiscreteKeys discreteKeys() const {
+    DiscreteKeys result;
+    for (const sharedFactor& factor : *this) {
+      if (factor) {
+        // Efficiently insert all the discrete keys to the final result.
+        result.append(factor->discreteKeys());
+      }
+    }
+
+    return result;
+  }
 };
 
 }  // namespace gtsam

--- a/gtsam/hybrid/DCFactorGraph.h
+++ b/gtsam/hybrid/DCFactorGraph.h
@@ -14,6 +14,8 @@
 #include <gtsam/hybrid/DCFactor.h>
 #include <gtsam/inference/FactorGraph.h>
 
+#include <algorithm>
+
 namespace gtsam {
 
 /**
@@ -30,8 +32,13 @@ class DCFactorGraph : public gtsam::FactorGraph<DCFactor> {
     DiscreteKeys result;
     for (const sharedFactor& factor : *this) {
       if (factor) {
-        // Efficiently insert all the discrete keys to the final result.
-        result.append(factor->discreteKeys());
+        // Insert all the discrete keys to the final result.
+        for (auto&& key : factor->discreteKeys()) {
+          // Check if key doesn't already exist. If it doesn't then add it.
+          if (std::find(result.begin(), result.end(), key) == result.end()) {
+            result.push_back(key);
+          }
+        }
       }
     }
 

--- a/gtsam/hybrid/HybridFactorGraph.cpp
+++ b/gtsam/hybrid/HybridFactorGraph.cpp
@@ -84,7 +84,8 @@ DiscreteKeys HybridFactorGraph::discreteKeys() const {
   // Discrete keys from the discrete graph.
   result = discreteGraph_.discreteKeys();
   // Discrete keys from the DC factor graph.
-  result.append(dcGraph_.discreteKeys());
+  auto dcKeys = dcGraph_.discreteKeys();
+  result.insert(result.begin(), dcKeys.begin(), dcKeys.end());
   return result;
 }
 

--- a/gtsam/hybrid/HybridFactorGraph.cpp
+++ b/gtsam/hybrid/HybridFactorGraph.cpp
@@ -82,13 +82,7 @@ void HybridFactorGraph::clear() {
 DiscreteKeys HybridFactorGraph::discreteKeys() const {
   DiscreteKeys result;
   // Discrete keys from the discrete graph.
-  for (auto&& factor : discreteGraph_) {
-    if (auto p = boost::dynamic_pointer_cast<DecisionTreeFactor>(factor)) {
-      for (auto&& key : factor->keys()) {
-        result.emplace_back(key, p->cardinality(key));
-      }
-    }
-  }
+  result = discreteGraph_.discreteKeys();
   // Discrete keys from the DC factor graph.
   result.append(dcGraph_.discreteKeys());
   return result;

--- a/gtsam/hybrid/HybridFactorGraph.cpp
+++ b/gtsam/hybrid/HybridFactorGraph.cpp
@@ -85,7 +85,7 @@ DiscreteKeys HybridFactorGraph::discreteKeys() const {
   result = discreteGraph_.discreteKeys();
   // Discrete keys from the DC factor graph.
   auto dcKeys = dcGraph_.discreteKeys();
-  result.insert(result.begin(), dcKeys.begin(), dcKeys.end());
+  result.insert(result.end(), dcKeys.begin(), dcKeys.end());
   return result;
 }
 

--- a/gtsam/hybrid/HybridFactorGraph.cpp
+++ b/gtsam/hybrid/HybridFactorGraph.cpp
@@ -79,6 +79,21 @@ void HybridFactorGraph::clear() {
   gaussianGraph_.resize(0);
 }
 
+DiscreteKeys HybridFactorGraph::discreteKeys() const {
+  DiscreteKeys result;
+  // Discrete keys from the discrete graph.
+  for (auto&& factor : discreteGraph_) {
+    if (auto p = boost::dynamic_pointer_cast<DecisionTreeFactor>(factor)) {
+      for (auto&& key : factor->keys()) {
+        result.emplace_back(key, p->cardinality(key));
+      }
+    }
+  }
+  // Discrete keys from the DC factor graph.
+  result.append(dcGraph_.discreteKeys());
+  return result;
+}
+
 /// Define adding a GaussianFactor to a sum.
 using Sum = DCGaussianMixtureFactor::Sum;
 static Sum& operator+=(Sum& sum, const GaussianFactor::shared_ptr& factor) {

--- a/gtsam/hybrid/HybridFactorGraph.h
+++ b/gtsam/hybrid/HybridFactorGraph.h
@@ -315,10 +315,12 @@ class HybridFactorGraph : protected FactorGraph<Factor>,
   /// The total number of factors in the Gaussian factor graph.
   DiscreteKeys discreteKeys() const {
     DiscreteKeys result;
-    // TODO(Frank): implement!
-    // DiscreteKeys result = discreteGraph_.discreteKeys();
-    // DiscreteKeys dcKeys = dcGraph_.discreteKeys();
-    // result += dcKeys
+    for(auto&& key: discreteGraph_.keys()) {
+      //TODO(Varun) how to get cardinality?
+      result.emplace_back(key, 2);
+    }
+    DiscreteKeys dcKeys = dcGraph_.discreteKeys();
+    result.append(dcKeys);
     return result;
   }
 

--- a/gtsam/hybrid/HybridFactorGraph.h
+++ b/gtsam/hybrid/HybridFactorGraph.h
@@ -325,20 +325,7 @@ class HybridFactorGraph : protected FactorGraph<Factor>,
   void clear();
 
   /// Get all the discrete keys in the hybrid factor graph.
-  DiscreteKeys discreteKeys() const {
-    DiscreteKeys result;
-    // Discrete keys from the discrete graph.
-    for (auto&& factor : discreteGraph_) {
-      if (auto p = boost::dynamic_pointer_cast<DecisionTreeFactor>(factor)) {
-        for (auto&& key : factor->keys()) {
-          result.emplace_back(key, p->cardinality(key));
-        }
-      }
-    }
-    // Discrete keys from the DC factor graph.
-    result.append(dcGraph_.discreteKeys());
-    return result;
-  }
+  DiscreteKeys discreteKeys() const;
 
   /// @name Elimination machinery
   /// @{

--- a/gtsam/hybrid/HybridFactorGraph.h
+++ b/gtsam/hybrid/HybridFactorGraph.h
@@ -324,9 +324,10 @@ class HybridFactorGraph : protected FactorGraph<Factor>,
    */
   void clear();
 
-  /// The total number of factors in the Gaussian factor graph.
+  /// Get all the discrete keys in the hybrid factor graph.
   DiscreteKeys discreteKeys() const {
     DiscreteKeys result;
+    // Discrete keys from the discrete graph.
     for (auto&& factor : discreteGraph_) {
       if (auto p = boost::dynamic_pointer_cast<DecisionTreeFactor>(factor)) {
         for (auto&& key : factor->keys()) {
@@ -334,6 +335,7 @@ class HybridFactorGraph : protected FactorGraph<Factor>,
         }
       }
     }
+    // Discrete keys from the DC factor graph.
     result.append(dcGraph_.discreteKeys());
     return result;
   }

--- a/gtsam/hybrid/tests/testDCGaussianMixtureFactor.cpp
+++ b/gtsam/hybrid/tests/testDCGaussianMixtureFactor.cpp
@@ -66,7 +66,7 @@ TEST(DCGaussianMixtureFactor, Sum) {
   DCGaussianMixtureFactor mixtureFactorA({X(1), X(2)}, {m1}, factorsA);
   DCGaussianMixtureFactor mixtureFactorB({X(1), X(3)}, {m2}, factorsB);
 
-  // Check that number of keys is 2
+  // Check that number of keys is 3
   EXPECT_LONGS_EQUAL(3, mixtureFactorA.keys().size());
 
   // Check that number of discrete keys is 1 // TODO(Frank): should not exist?

--- a/gtsam/hybrid/tests/testDCGaussianMixtureFactor.cpp
+++ b/gtsam/hybrid/tests/testDCGaussianMixtureFactor.cpp
@@ -66,8 +66,8 @@ TEST(DCGaussianMixtureFactor, Sum) {
   DCGaussianMixtureFactor mixtureFactorA({X(1), X(2)}, {m1}, factorsA);
   DCGaussianMixtureFactor mixtureFactorB({X(1), X(3)}, {m2}, factorsB);
 
-  // Check that number of keys is 2 // TODO(Frank): it should be 3 !
-  EXPECT_LONGS_EQUAL(2, mixtureFactorA.keys().size());
+  // Check that number of keys is 3
+  EXPECT_LONGS_EQUAL(3, mixtureFactorA.keys().size());
 
   // Check that number of discrete keys is 1 // TODO(Frank): should not exist?
   EXPECT_LONGS_EQUAL(1, mixtureFactorA.discreteKeys().size());

--- a/gtsam/hybrid/tests/testDCGaussianMixtureFactor.cpp
+++ b/gtsam/hybrid/tests/testDCGaussianMixtureFactor.cpp
@@ -66,8 +66,9 @@ TEST(DCGaussianMixtureFactor, Sum) {
   DCGaussianMixtureFactor mixtureFactorA({X(1), X(2)}, {m1}, factorsA);
   DCGaussianMixtureFactor mixtureFactorB({X(1), X(3)}, {m2}, factorsB);
 
-  // Check that number of keys is 3
-  EXPECT_LONGS_EQUAL(3, mixtureFactorA.keys().size());
+  // Check that number of keys is 2
+  // TODO(Frank): it should be 3 once we figure out setting all keys together!
+  EXPECT_LONGS_EQUAL(2, mixtureFactorA.keys().size());
 
   // Check that number of discrete keys is 1 // TODO(Frank): should not exist?
   EXPECT_LONGS_EQUAL(1, mixtureFactorA.discreteKeys().size());

--- a/gtsam/hybrid/tests/testDCGaussianMixtureFactor.cpp
+++ b/gtsam/hybrid/tests/testDCGaussianMixtureFactor.cpp
@@ -67,8 +67,7 @@ TEST(DCGaussianMixtureFactor, Sum) {
   DCGaussianMixtureFactor mixtureFactorB({X(1), X(3)}, {m2}, factorsB);
 
   // Check that number of keys is 2
-  // TODO(Frank): it should be 3 once we figure out setting all keys together!
-  EXPECT_LONGS_EQUAL(2, mixtureFactorA.keys().size());
+  EXPECT_LONGS_EQUAL(3, mixtureFactorA.keys().size());
 
   // Check that number of discrete keys is 1 // TODO(Frank): should not exist?
   EXPECT_LONGS_EQUAL(1, mixtureFactorA.discreteKeys().size());

--- a/gtsam/hybrid/tests/testHybridFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridFactorGraph.cpp
@@ -226,7 +226,8 @@ TEST(DCGaussianElimination, Eliminate_x1) {
   CHECK(result.first);
   EXPECT_LONGS_EQUAL(1, result.first->nrFrontals());
   CHECK(result.second);
-  EXPECT_LONGS_EQUAL(1, result.second->size());
+  // Has two keys, x2 and m1
+  EXPECT_LONGS_EQUAL(2, result.second->size());
 }
 
 /* ****************************************************************************/

--- a/gtsam/hybrid/tests/testHybridFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridFactorGraph.cpp
@@ -163,7 +163,6 @@ struct Switching {
                          components[1]->linearize(linearizationPoint)};
       linearizedFactorGraph.emplace_dc<DCGaussianMixtureFactor>(
           keys, DiscreteKeys{modes[k]}, linearized);
-      std::cout << "linearizedFactorGraph size: " << linearizedFactorGraph.size() << std::endl << std::endl;
     }
 
     // Add "mode chain"

--- a/gtsam/hybrid/tests/testHybridFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridFactorGraph.cpp
@@ -65,6 +65,51 @@ TEST(HybridFactorGraph, GaussianFactorGraph) {
   EXPECT_LONGS_EQUAL(2, dcmfg.gaussianGraph().size());
 }
 
+/* ****************************************************************************
+ * Test push_back on HFG makes the correct distinction.
+ */
+TEST(HybridFactorGraph, PushBack) {
+  HybridFactorGraph fg;
+
+  auto gaussianFactor = boost::make_shared<JacobianFactor>();
+  fg.push_back(gaussianFactor);
+
+  EXPECT_LONGS_EQUAL(fg.dcGraph().size(), 0);
+  EXPECT_LONGS_EQUAL(fg.discreteGraph().size(), 0);
+  EXPECT_LONGS_EQUAL(fg.nonlinearGraph().size(), 0);
+  EXPECT_LONGS_EQUAL(fg.gaussianGraph().size(), 1);
+
+  fg.clear();
+
+  auto nonlinearFactor = boost::make_shared<BetweenFactor<double>>();
+  fg.push_back(nonlinearFactor);
+
+  EXPECT_LONGS_EQUAL(fg.dcGraph().size(), 0);
+  EXPECT_LONGS_EQUAL(fg.discreteGraph().size(), 0);
+  EXPECT_LONGS_EQUAL(fg.nonlinearGraph().size(), 1);
+  EXPECT_LONGS_EQUAL(fg.gaussianGraph().size(), 0);
+
+  fg.clear();
+
+  auto discreteFactor = boost::make_shared<DecisionTreeFactor>();
+  fg.push_back(discreteFactor);
+
+  EXPECT_LONGS_EQUAL(fg.dcGraph().size(), 0);
+  EXPECT_LONGS_EQUAL(fg.discreteGraph().size(), 1);
+  EXPECT_LONGS_EQUAL(fg.nonlinearGraph().size(), 0);
+  EXPECT_LONGS_EQUAL(fg.gaussianGraph().size(), 0);
+
+  fg.clear();
+
+  auto dcFactor = boost::make_shared<DCMixtureFactor<MotionModel>>();
+  fg.push_back(dcFactor);
+
+  EXPECT_LONGS_EQUAL(fg.dcGraph().size(), 1);
+  EXPECT_LONGS_EQUAL(fg.discreteGraph().size(), 0);
+  EXPECT_LONGS_EQUAL(fg.nonlinearGraph().size(), 0);
+  EXPECT_LONGS_EQUAL(fg.gaussianGraph().size(), 0);
+}
+
 /* ****************************************************************************/
 // Test fixture with switching network.
 using MotionMixture = DCMixtureFactor<MotionModel>;
@@ -118,6 +163,7 @@ struct Switching {
                          components[1]->linearize(linearizationPoint)};
       linearizedFactorGraph.emplace_dc<DCGaussianMixtureFactor>(
           keys, DiscreteKeys{modes[k]}, linearized);
+      std::cout << "linearizedFactorGraph size: " << linearizedFactorGraph.size() << std::endl << std::endl;
     }
 
     // Add "mode chain"

--- a/gtsam/inference/Factor.h
+++ b/gtsam/inference/Factor.h
@@ -136,7 +136,7 @@ typedef FastSet<FactorIndex> FactorIndexSet;
    /**
     * @return the number of variables involved in this factor
     */
-   virtual size_t size() const { return keys_.size(); }
+   size_t size() const { return keys_.size(); }
 
    /// @}
 

--- a/gtsam/inference/Factor.h
+++ b/gtsam/inference/Factor.h
@@ -136,7 +136,7 @@ typedef FastSet<FactorIndex> FactorIndexSet;
    /**
     * @return the number of variables involved in this factor
     */
-   size_t size() const { return keys_.size(); }
+   virtual size_t size() const { return keys_.size(); }
 
    /// @}
 

--- a/gtsam/slam/BetweenFactor.h
+++ b/gtsam/slam/BetweenFactor.h
@@ -80,10 +80,11 @@ namespace gtsam {
     /// @{
 
     /// print with optional string
-    void print(const std::string& s, const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override {
-      std::cout << s << "BetweenFactor("
-          << keyFormatter(this->key1()) << ","
-          << keyFormatter(this->key2()) << ")\n";
+    void print(
+        const std::string& s = "",
+        const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override {
+      std::cout << s << "BetweenFactor(" << keyFormatter(this->key1()) << ","
+                << keyFormatter(this->key2()) << ")\n";
       traits<T>::Print(measured_, "  measured: ");
       this->noiseModel_->print("  noise model: ");
     }


### PR DESCRIPTION
This PR adds a bunch of things:

1. Add a generic `push_back` method for the `HybridFactorGraph`.
2. Implement the necessary `discreteKeys` methods so that the elimination method can get the appropriate discrete keys.
3. Other minor fixes and test updates.