### PR TITLE
Fix Issue with Hybrid Elimination

### DIFF
--- a/gtsam/hybrid/HybridFactorGraph.cpp
+++ b/gtsam/hybrid/HybridFactorGraph.cpp
@@ -108,11 +108,6 @@ static Sum& operator+=(Sum& sum, const GaussianFactor::shared_ptr& factor) {
 }
 
 Sum HybridFactorGraph::sum() const {
-  if (nrNonlinearFactors()) {
-    throw runtime_error(
-        "HybridFactorGraph::sum cannot handle NonlinearFactors.");
-  }
-
   if (nrDiscreteFactors()) {
     throw runtime_error(
         "HybridFactorGraph::sum cannot handle DiscreteFactors.");

--- a/gtsam/hybrid/HybridFactorGraph.cpp
+++ b/gtsam/hybrid/HybridFactorGraph.cpp
@@ -139,7 +139,7 @@ DecisionTreeFactor::shared_ptr HybridFactorGraph::toDecisionTreeFactor() const {
   // Get the decision tree with each leaf as the error for that assignment
   auto gfgError = [&](const GaussianFactorGraph& graph) {
     VectorValues values = graph.optimize();
-    return graph.error(values);
+    return graph.probPrime(values);
   };
   DecisionTree<Key, double> gfgdt(sum, gfgError);
 


### PR DESCRIPTION
@ProfFan and I finished writing up the test that confirms our suspicion about Hybrid Elimination being myopic.

So for a simple factor graph 
```
*-X1-*-X2
    /
   M1
```

when we eliminate X1 and X2 in order, the final elimination for X2 only involves a factor between X2 and M1, and not X1. Because of this, the decision tree formed is only on the gaussian factor graph on X2, thus for either 0/1 assignment of M1 the error is only on X2 (which is 0) hence the tree gets pruned to be just a leaf rather than a choice + 2 leaves.

__UPDATE__

By modifying the factor graph a bit to add a measurement factor on each variable, we are able to show that we do get the correct behavior.

```
    /*  /*
*-X1-*-X2
    /
   M1
```