### PR TITLE
Fix printing for Hybrid Factors

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,6 +1,6 @@
 name: Linux CI
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,6 +1,6 @@
 name: Linux CI
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/gtsam/discrete/DecisionTreeFactor.cpp
+++ b/gtsam/discrete/DecisionTreeFactor.cpp
@@ -166,7 +166,11 @@ namespace gtsam {
   DiscreteKeys DecisionTreeFactor::discreteKeys() const {
     DiscreteKeys result;
     for (auto&& key : keys()) {
-        result.emplace_back(key, cardinality(key));
+        DiscreteKey discreteKey(key, cardinality(key));
+        // Only add unique keys
+        if (std::find(result.begin(), result.end(), discreteKey) == result.end()) {
+          result.push_back(discreteKey);
+        }
       }
     return result;
   }

--- a/gtsam/discrete/DecisionTreeFactor.cpp
+++ b/gtsam/discrete/DecisionTreeFactor.cpp
@@ -166,12 +166,9 @@ namespace gtsam {
   DiscreteKeys DecisionTreeFactor::discreteKeys() const {
     DiscreteKeys result;
     for (auto&& key : keys()) {
-        DiscreteKey discreteKey(key, cardinality(key));
-        // Only add unique keys
-        if (std::find(result.begin(), result.end(), discreteKey) == result.end()) {
-          result.push_back(discreteKey);
-        }
-      }
+      DiscreteKey discreteKey(key, cardinality(key));
+      result.push_back(discreteKey);
+    }
     return result;
   }
 

--- a/gtsam/discrete/DecisionTreeFactor.cpp
+++ b/gtsam/discrete/DecisionTreeFactor.cpp
@@ -166,8 +166,7 @@ namespace gtsam {
   DiscreteKeys DecisionTreeFactor::discreteKeys() const {
     DiscreteKeys result;
     for (auto&& key : keys()) {
-      DiscreteKey discreteKey(key, cardinality(key));
-      result.push_back(discreteKey);
+      result.emplace_back(key, cardinality(key));
     }
     return result;
   }

--- a/gtsam/hybrid/DCFactor.h
+++ b/gtsam/hybrid/DCFactor.h
@@ -35,7 +35,6 @@ namespace gtsam {
 class DCFactor : public gtsam::Factor {
  protected:
   // Set of DiscreteKeys for this factor.
-  // TODO(Frank): This will be a map once we make DiscreteKeys a map!
   gtsam::DiscreteKeys discreteKeys_;
 
  public:

--- a/gtsam/hybrid/DCFactorGraph.h
+++ b/gtsam/hybrid/DCFactorGraph.h
@@ -34,10 +34,7 @@ class DCFactorGraph : public gtsam::FactorGraph<DCFactor> {
       if (factor) {
         // Insert all the discrete keys to the final result.
         for (auto&& key : factor->discreteKeys()) {
-          // Check if key doesn't already exist. If it doesn't then add it.
-          if (std::find(result.begin(), result.end(), key) == result.end()) {
             result.push_back(key);
-          }
         }
       }
     }

--- a/gtsam/hybrid/DCGaussianMixtureFactor.cpp
+++ b/gtsam/hybrid/DCGaussianMixtureFactor.cpp
@@ -1,0 +1,84 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file DCGaussianMixtureFactor.cpp
+ * @brief Gaussian Mixture formed after linearizing DCGaussianFactor
+ * @date Jan 10, 2022
+ * @author Varun Agrawal
+ * @author Frank Dellaert
+ */
+
+#include <gtsam/hybrid/DCGaussianMixtureFactor.h>
+
+namespace gtsam {
+
+/* *******************************************************************************/
+void DCGaussianMixtureFactor::printKeys(
+    const std::string& s = "",
+    const KeyFormatter& keyFormatter = DefaultKeyFormatter) const {
+  std::cout << (s.empty() ? "" : s + " ");
+  std::cout << "[";
+
+  KeyVector dKeys = discreteKeys_.indices();
+  for (Key key : keys()) {
+    if (std::find(dKeys.begin(), dKeys.end(), key) == dKeys.end()) {
+      std::cout << " " << keyFormatter(key);
+    }
+  }
+
+  std::cout << "; ";
+  for (Key dk : dKeys) std::cout << keyFormatter(dk) << " ";
+  std::cout << "]";
+  std::cout << "{\n";
+}
+
+/* *******************************************************************************/
+void DCGaussianMixtureFactor::print(
+    const std::string& s = "",
+    const KeyFormatter& keyFormatter = DefaultKeyFormatter) const {
+  printKeys(s, keyFormatter);
+
+  auto valueFormatter = [](const GaussianFactor::shared_ptr& v) {
+    return (boost::format("Gaussian factor on %d keys") % v->size()).str();
+  };
+  factors_.print("", keyFormatter, valueFormatter);
+  std::cout << "}";
+  std::cout << "\n";
+}
+
+using Sum = DecisionTree<Key, GaussianFactorGraph>;
+
+/* *******************************************************************************/
+Sum DCGaussianMixtureFactor::addTo(const Sum& sum) const {
+  using Y = GaussianFactorGraph;
+  auto add = [](const Y& graph1, const Y& graph2) {
+    auto result = graph1;
+    result.push_back(graph2);
+    return result;
+  };
+  const Sum wrapped = wrappedFactors();
+  return sum.empty() ? wrapped : sum.apply(wrapped, add);
+}
+
+/* *******************************************************************************/
+Sum DCGaussianMixtureFactor::wrappedFactors() const {
+  auto wrap = [](const GaussianFactor::shared_ptr& factor) {
+    GaussianFactorGraph result;
+    result.push_back(factor);
+    return result;
+  };
+  return Sum(factors_, wrap);
+}
+
+/* *******************************************************************************/
+
+}  // namespace gtsam

--- a/gtsam/hybrid/DCGaussianMixtureFactor.cpp
+++ b/gtsam/hybrid/DCGaussianMixtureFactor.cpp
@@ -23,8 +23,7 @@ namespace gtsam {
 
 /* *******************************************************************************/
 void DCGaussianMixtureFactor::printKeys(
-    const std::string& s = "",
-    const KeyFormatter& keyFormatter = DefaultKeyFormatter) const {
+    const std::string& s, const KeyFormatter& keyFormatter) const {
   std::cout << (s.empty() ? "" : s + " ");
   std::cout << "[";
 
@@ -42,9 +41,8 @@ void DCGaussianMixtureFactor::printKeys(
 }
 
 /* *******************************************************************************/
-void DCGaussianMixtureFactor::print(
-    const std::string& s = "",
-    const KeyFormatter& keyFormatter = DefaultKeyFormatter) const {
+void DCGaussianMixtureFactor::print(const std::string& s,
+                                    const KeyFormatter& keyFormatter) const {
   printKeys(s, keyFormatter);
 
   auto valueFormatter = [](const GaussianFactor::shared_ptr& v) {

--- a/gtsam/hybrid/DCGaussianMixtureFactor.h
+++ b/gtsam/hybrid/DCGaussianMixtureFactor.h
@@ -134,36 +134,11 @@ class DCGaussianMixtureFactor : public DCFactor {
   /// Print the keys, taking care of continuous and discrete.
   void printKeys(
       const std::string& s = "",
-      const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override {
-    std::cout << (s.empty() ? "" : s + " ");
-    std::cout << "[";
-
-    KeyVector dKeys = discreteKeys_.indices();
-    for (Key key : keys()) {
-      if (std::find(dKeys.begin(), dKeys.end(), key) == dKeys.end()) {
-        std::cout << " " << keyFormatter(key);
-      }
-    }
-
-    std::cout << "; ";
-    for (Key dk : dKeys) std::cout << keyFormatter(dk) << " ";
-    std::cout << "]";
-    std::cout << "{\n";
-  }
+      const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override;
 
   /// print to stdout
-  void print(
-      const std::string& s = "",
-      const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override {
-    printKeys(s, keyFormatter);
-
-    auto valueFormatter = [](const GaussianFactor::shared_ptr& v) {
-      return (boost::format("Gaussian factor on %d keys") % v->size()).str();
-    };
-    factors_.print("", keyFormatter, valueFormatter);
-    std::cout << "}";
-    std::cout << "\n";
-  }
+  void print(const std::string& s = "", const KeyFormatter& keyFormatter =
+                                            DefaultKeyFormatter) const override;
 
   /// Check equality
   bool equals(const DCFactor& f, double tol = 1e-9) const override {
@@ -181,16 +156,7 @@ class DCGaussianMixtureFactor : public DCFactor {
   using Sum = DecisionTree<Key, GaussianFactorGraph>;
 
   /// Add MixtureFactor to a Sum
-  Sum addTo(const Sum& sum) const {
-    using Y = GaussianFactorGraph;
-    auto add = [](const Y& graph1, const Y& graph2) {
-      auto result = graph1;
-      result.push_back(graph2);
-      return result;
-    };
-    const Sum wrapped = wrappedFactors();
-    return sum.empty() ? wrapped : sum.apply(wrapped, add);
-  }
+  Sum addTo(const Sum& sum) const;
 
   /// Add MixtureFactor to a Sum, sugar.
   friend Sum& operator+=(Sum& sum, const DCGaussianMixtureFactor& factor) {
@@ -201,14 +167,7 @@ class DCGaussianMixtureFactor : public DCFactor {
 
  private:
   /// Return Sum decision tree with factors wrapped in Singleton FGs.
-  Sum wrappedFactors() const {
-    auto wrap = [](const GaussianFactor::shared_ptr& factor) {
-      GaussianFactorGraph result;
-      result.push_back(factor);
-      return result;
-    };
-    return Sum(factors_, wrap);
-  }
+  Sum wrappedFactors() const;
 };
 
 }  // namespace gtsam

--- a/gtsam/hybrid/DCGaussianMixtureFactor.h
+++ b/gtsam/hybrid/DCGaussianMixtureFactor.h
@@ -131,19 +131,32 @@ class DCGaussianMixtureFactor : public DCFactor {
   /// @name Testable
   /// @{
 
-  /// print to stdout
-  void print(
+  /// Print the keys, taking care of continuous and discrete.
+  void printKeys(
       const std::string& s = "",
       const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override {
     std::cout << (s.empty() ? "" : s + " ");
     std::cout << "[";
+
+    KeyVector dKeys = discreteKeys_.indices();
     for (Key key : keys()) {
-      std::cout << " " << keyFormatter(key);
+      if (std::find(dKeys.begin(), dKeys.end(), key) == dKeys.end()) {
+        std::cout << " " << keyFormatter(key);
+      }
     }
+
     std::cout << "; ";
-    for (auto&& dk : discreteKeys_) std::cout << keyFormatter(dk.first) << " ";
-    std::cout << " ]";
+    for (Key dk : dKeys) std::cout << keyFormatter(dk) << " ";
+    std::cout << "]";
     std::cout << "{\n";
+  }
+
+  /// print to stdout
+  void print(
+      const std::string& s = "",
+      const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override {
+    printKeys(s, keyFormatter);
+
     auto valueFormatter = [](const GaussianFactor::shared_ptr& v) {
       return (boost::format("Gaussian factor on %d keys") % v->size()).str();
     };

--- a/gtsam/hybrid/GaussianMixture.cpp
+++ b/gtsam/hybrid/GaussianMixture.cpp
@@ -26,15 +26,8 @@ template class Conditional<DCGaussianMixtureFactor, GaussianMixture>;
 
 void GaussianMixture::print(const std::string& s,
                             const KeyFormatter& keyFormatter) const {
-  std::cout << (s.empty() ? "" : s + " ");
-  std::cout << "[";
-  for (Key key : keys()) {
-    std::cout << " " << keyFormatter(key);
-  }
-  std::cout << "; ";
-  for (auto&& dk : discreteKeys_) std::cout << keyFormatter(dk.first) << " ";
-  std::cout << " ]";
-  std::cout << "{\n";
+  BaseFactor::printKeys(s, keyFormatter);
+
   auto valueFormatter =
       [](const GaussianFactor::shared_ptr& factor) -> std::string {
     if (auto conditional =

--- a/gtsam/hybrid/GaussianMixture.h
+++ b/gtsam/hybrid/GaussianMixture.h
@@ -35,10 +35,6 @@ namespace gtsam {
 class GaussianMixture
     : public DCGaussianMixtureFactor,
       public Conditional<DCGaussianMixtureFactor, GaussianMixture> {
- protected:
-  // Set of DiscreteKeys for this factor.
-  DiscreteKeys discreteKeys_;
-
  public:
   using This = GaussianMixture;
   using shared_ptr = boost::shared_ptr<This>;

--- a/gtsam/hybrid/HybridFactorGraph.cpp
+++ b/gtsam/hybrid/HybridFactorGraph.cpp
@@ -90,7 +90,12 @@ DiscreteKeys HybridFactorGraph::discreteKeys() const {
   result = discreteGraph_.discreteKeys();
   // Discrete keys from the DC factor graph.
   auto dcKeys = dcGraph_.discreteKeys();
-  result.insert(result.end(), dcKeys.begin(), dcKeys.end());
+  for(auto&& key: dcKeys) {
+    // Only insert unique keys
+    if(std::find(result.begin(), result.end(), key) == result.end()) {
+      result.push_back(key);
+    }
+  }
   return result;
 }
 
@@ -108,16 +113,6 @@ static Sum& operator+=(Sum& sum, const GaussianFactor::shared_ptr& factor) {
 }
 
 Sum HybridFactorGraph::sum() const {
-  if (nrNonlinearFactors()) {
-    throw runtime_error(
-        "HybridFactorGraph::sum cannot handle NonlinearFactors.");
-  }
-
-  if (nrDiscreteFactors()) {
-    throw runtime_error(
-        "HybridFactorGraph::sum cannot handle DiscreteFactors.");
-  }
-
   // "sum" all factors, gathering into GaussianFactorGraph
   DCGaussianMixtureFactor::Sum sum;
   for (auto&& dcFactor : dcGraph()) {

--- a/gtsam/hybrid/tests/testDCGaussianMixtureFactor.cpp
+++ b/gtsam/hybrid/tests/testDCGaussianMixtureFactor.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <gtsam/hybrid/DCGaussianMixtureFactor.h>
+#include <gtsam/hybrid/GaussianMixture.h>
 
 // Include for test suite
 #include <CppUnitLite/TestHarness.h>
@@ -85,6 +86,22 @@ TEST(DCGaussianMixtureFactor, Sum) {
   auto actual = sum(mode);
   EXPECT(actual.at(0) == f11);
   EXPECT(actual.at(1) == f22);
+}
+
+TEST(DCGaussianMixtureFactor, GaussianMixture) {
+  KeyVector keys;
+  keys.push_back(X(0));
+  keys.push_back(X(1));
+
+  DiscreteKeys dKeys;
+  dKeys.emplace_back(M(0), 2);
+  dKeys.emplace_back(M(1), 2);
+
+  auto gaussians = boost::make_shared<GaussianConditional>();
+  GaussianMixture::Conditionals conditionals(gaussians);
+  GaussianMixture gm(keys, dKeys, conditionals);
+
+  EXPECT_LONGS_EQUAL(2, gm.discreteKeys().size());
 }
 
 /* ************************************************************************* */


### PR DESCRIPTION
This PR makes some updates to print the discrete keys correctly for hybrid factors.

### Previous Printing

```
.size: 2
NonlinearFactorGraphsize: 0

DiscreteFactorGraph
size: 0
DCFactorGraph 
size: 2
factor 0:  [ x2 x3 m2; m2  ]{
 Choice(m2) 
 0 Leaf Gaussian factor on 2 keys
 1 Leaf Gaussian factor on 2 keys
}
factor 1:  [ x2 m1; m1  ]{
 Choice(m1) 
 0 Leaf Gaussian factor on 1 keys
 1 Leaf Gaussian factor on 1 keys
}
GaussianGraph 
size: 0
```

### New Printing

```
.size: 2
NonlinearFactorGraphsize: 0

DiscreteFactorGraph
size: 0
DCFactorGraph 
size: 2
factor 0:  [ x2 x3; m2  ]{
 Choice(m2) 
 0 Leaf Gaussian factor on 2 keys
 1 Leaf Gaussian factor on 2 keys
}
factor 1:  [ x2; m1  ]{
 Choice(m1) 
 0 Leaf Gaussian factor on 1 keys
 1 Leaf Gaussian factor on 1 keys
}
GaussianGraph 
size: 0
```

I've also disabled running the CI on every push, instead running it on PRs only to save CI time.