### PR TITLE
Fix DiscreteFactorGraph::optimize to return MPE

### DIFF
--- a/.github/scripts/python.sh
+++ b/.github/scripts/python.sh
@@ -83,6 +83,6 @@ cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
 make -j2 install
 
 cd $GITHUB_WORKSPACE/build/python
-$PYTHON setup.py install --user --prefix=
+pip install --user --install-option="--prefix=" .
 cd $GITHUB_WORKSPACE/python/gtsam/tests
 $PYTHON -m unittest discover -v

--- a/examples/DiscreteBayesNetExample.cpp
+++ b/examples/DiscreteBayesNetExample.cpp
@@ -53,10 +53,9 @@ int main(int argc, char **argv) {
   // Create solver and eliminate
   Ordering ordering;
   ordering += Key(0), Key(1), Key(2), Key(3), Key(4), Key(5), Key(6), Key(7);
-  DiscreteBayesNet::shared_ptr chordal = fg.eliminateSequential(ordering);
 
   // solve
-  auto mpe = chordal->optimize();
+  auto mpe = fg.optimize();
   GTSAM_PRINT(mpe);
 
   // We can also build a Bayes tree (directed junction tree).
@@ -69,14 +68,14 @@ int main(int argc, char **argv) {
   fg.add(Dyspnea, "0 1");
 
   // solve again, now with evidence
-  DiscreteBayesNet::shared_ptr chordal2 = fg.eliminateSequential(ordering);
-  auto mpe2 = chordal2->optimize();
+  auto mpe2 = fg.optimize();
   GTSAM_PRINT(mpe2);
 
   // We can also sample from it
+  DiscreteBayesNet::shared_ptr chordal = fg.eliminateSequential(ordering);
   cout << "\n10 samples:" << endl;
   for (size_t i = 0; i < 10; i++) {
-    auto sample = chordal2->sample();
+    auto sample = chordal->sample();
     GTSAM_PRINT(sample);
   }
   return 0;

--- a/examples/DiscreteBayesNet_FG.cpp
+++ b/examples/DiscreteBayesNet_FG.cpp
@@ -85,7 +85,7 @@ int main(int argc, char **argv) {
         }
 
   // "Most Probable Explanation", i.e., configuration with largest value
-  auto mpe = graph.eliminateSequential()->optimize();
+  auto mpe = graph.optimize();
   cout << "\nMost Probable Explanation (MPE):" << endl;
   print(mpe);
 
@@ -96,8 +96,7 @@ int main(int argc, char **argv) {
   graph.add(Cloudy, "1 0");
 
   // solve again, now with evidence
-  DiscreteBayesNet::shared_ptr chordal = graph.eliminateSequential();
-  auto mpe_with_evidence = chordal->optimize();
+  auto mpe_with_evidence = graph.optimize();
 
   cout << "\nMPE given C=0:" << endl;
   print(mpe_with_evidence);
@@ -110,7 +109,8 @@ int main(int argc, char **argv) {
   cout << "\nP(W=1|C=0):" << marginals.marginalProbabilities(WetGrass)[1]
        << endl;
 
-  // We can also sample from it
+  // We can also sample from the eliminated graph
+  DiscreteBayesNet::shared_ptr chordal = graph.eliminateSequential();
   cout << "\n10 samples:" << endl;
   for (size_t i = 0; i < 10; i++) {
     auto sample = chordal->sample();

--- a/examples/HMMExample.cpp
+++ b/examples/HMMExample.cpp
@@ -59,15 +59,15 @@ int main(int argc, char **argv) {
   // Convert to factor graph
   DiscreteFactorGraph factorGraph(hmm);
 
+  // Do max-prodcut
+  auto mpe = factorGraph.optimize();
+  GTSAM_PRINT(mpe);
+
   // Create solver and eliminate
   // This will create a DAG ordered with arrow of time reversed
   DiscreteBayesNet::shared_ptr chordal =
       factorGraph.eliminateSequential(ordering);
   chordal->print("Eliminated");
-
-  // solve
-  auto mpe = chordal->optimize();
-  GTSAM_PRINT(mpe);
 
   // We can also sample from it
   cout << "\n10 samples:" << endl;

--- a/examples/UGM_chain.cpp
+++ b/examples/UGM_chain.cpp
@@ -68,9 +68,8 @@ int main(int argc, char** argv) {
        << graph.size() << " factors (Unary+Edge).";
 
   // "Decoding", i.e., configuration with largest value
-  // We use sequential variable elimination
-  DiscreteBayesNet::shared_ptr chordal = graph.eliminateSequential();
-  auto optimalDecoding = chordal->optimize();
+  // Uses max-product.
+  auto optimalDecoding = graph.optimize();
   optimalDecoding.print("\nMost Probable Explanation (optimalDecoding)\n");
 
   // "Inference" Computing marginals for each node

--- a/examples/UGM_small.cpp
+++ b/examples/UGM_small.cpp
@@ -61,9 +61,8 @@ int main(int argc, char** argv) {
   }
 
   // "Decoding", i.e., configuration with largest value (MPE)
-  // We use sequential variable elimination
-  DiscreteBayesNet::shared_ptr chordal = graph.eliminateSequential();
-  auto optimalDecoding = chordal->optimize();
+  // Uses max-product
+  auto optimalDecoding = graph.optimize();
   GTSAM_PRINT(optimalDecoding);
 
   // "Inference" Computing marginals

--- a/gtsam/discrete/DecisionTreeFactor.cpp
+++ b/gtsam/discrete/DecisionTreeFactor.cpp
@@ -22,6 +22,7 @@
 #include <gtsam/base/FastSet.h>
 
 #include <boost/make_shared.hpp>
+#include <boost/format.hpp>
 #include <utility>
 
 using namespace std;
@@ -65,9 +66,13 @@ namespace gtsam {
 
   /* ************************************************************************* */
   void DecisionTreeFactor::print(const string& s,
-      const KeyFormatter& formatter) const {
+                                 const KeyFormatter& formatter) const {
     cout << s;
-    ADT::print("Potentials:",formatter);
+    cout << " f[";
+    for (auto&& key : keys())
+      cout << boost::format(" (%1%,%2%),") % formatter(key) % cardinality(key);
+    cout << " ]" << endl;
+    ADT::print("Potentials:", formatter);
   }
 
   /* ************************************************************************* */

--- a/gtsam/discrete/DecisionTreeFactor.h
+++ b/gtsam/discrete/DecisionTreeFactor.h
@@ -127,9 +127,14 @@ namespace gtsam {
       return combine(keys, ADT::Ring::add);
     }
 
-    /// Create new factor by maximizing over all values with the same separator values
+    /// Create new factor by maximizing over all values with the same separator.
     shared_ptr max(size_t nrFrontals) const {
       return combine(nrFrontals, ADT::Ring::max);
+    }
+
+    /// Create new factor by maximizing over all values with the same separator.
+    shared_ptr max(const Ordering& keys) const {
+      return combine(keys, ADT::Ring::max);
     }
 
     /// @}

--- a/gtsam/discrete/DiscreteBayesNet.cpp
+++ b/gtsam/discrete/DiscreteBayesNet.cpp
@@ -43,6 +43,7 @@ double DiscreteBayesNet::evaluate(const DiscreteValues& values) const {
 }
 
 /* ************************************************************************* */
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V42
 DiscreteValues DiscreteBayesNet::optimize() const {
   DiscreteValues result;
   return optimize(result);
@@ -50,10 +51,16 @@ DiscreteValues DiscreteBayesNet::optimize() const {
 
 DiscreteValues DiscreteBayesNet::optimize(DiscreteValues result) const {
   // solve each node in turn in topological sort order (parents first)
+#ifdef _MSC_VER
+#pragma message("DiscreteBayesNet::optimize (deprecated) does not compute MPE!")
+#else
+#warning "DiscreteBayesNet::optimize (deprecated) does not compute MPE!"
+#endif
   for (auto conditional : boost::adaptors::reverse(*this))
     conditional->solveInPlace(&result);
   return result;
 }
+#endif
 
 /* ************************************************************************* */
 DiscreteValues DiscreteBayesNet::sample() const {

--- a/gtsam/discrete/DiscreteBayesNet.h
+++ b/gtsam/discrete/DiscreteBayesNet.h
@@ -31,12 +31,12 @@
 
 namespace gtsam {
 
-/** A Bayes net made from linear-Discrete densities */
+/** A Bayes net made from discrete conditional distributions. */
   class GTSAM_EXPORT DiscreteBayesNet: public BayesNet<DiscreteConditional>
   {
   public:
 
-    typedef FactorGraph<DiscreteConditional> Base;
+    typedef BayesNet<DiscreteConditional> Base;
     typedef DiscreteBayesNet This;
     typedef DiscreteConditional ConditionalType;
     typedef boost::shared_ptr<This> shared_ptr;
@@ -45,7 +45,7 @@ namespace gtsam {
     /// @name Standard Constructors
     /// @{
 
-    /** Construct empty factor graph */
+    /// Construct empty Bayes net.
     DiscreteBayesNet() {}
 
     /** Construct from iterator over conditionals */
@@ -99,27 +99,6 @@ namespace gtsam {
     }
 
     /**
-     * @brief solve by back-substitution.
-     *
-     * Assumes the Bayes net is reverse topologically sorted, i.e. last
-     * conditional will be optimized first. If the Bayes net resulted from
-     * eliminating a factor graph, this is true for the elimination ordering.
-     *
-     * @return a sampled value for all variables.
-    */
-    DiscreteValues optimize() const;
-
-    /**
-     * @brief solve by back-substitution, given certain variables.
-     *
-     * Assumes the Bayes net is reverse topologically sorted *and* that the
-     * Bayes net does not contain any conditionals for the given values.
-     *
-     * @return given values extended with optimized value for other variables.
-     */
-    DiscreteValues optimize(DiscreteValues given) const;
-
-    /**
      * @brief do ancestral sampling
      *
      * Assumes the Bayes net is reverse topologically sorted, i.e. last
@@ -152,7 +131,16 @@ namespace gtsam {
     std::string html(const KeyFormatter& keyFormatter = DefaultKeyFormatter,
                      const DiscreteFactor::Names& names = {}) const;
 
+    ///@}
+
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V42
+    /// @name Deprecated functionality
+    /// @{
+
+    DiscreteValues GTSAM_DEPRECATED optimize() const;
+    DiscreteValues GTSAM_DEPRECATED optimize(DiscreteValues given) const;
     /// @}
+#endif
 
  private:
     /** Serialization function */

--- a/gtsam/discrete/DiscreteConditional.cpp
+++ b/gtsam/discrete/DiscreteConditional.cpp
@@ -322,8 +322,7 @@ size_t DiscreteConditional::sample(const DiscreteValues& parentsValues) const {
   return distribution(rng);
 }
 
-/* ********************************************************************************
- */
+/* ************************************************************************** */
 size_t DiscreteConditional::sample(size_t parent_value) const {
   if (nrParents() != 1)
     throw std::invalid_argument(
@@ -334,8 +333,7 @@ size_t DiscreteConditional::sample(size_t parent_value) const {
   return sample(values);
 }
 
-/* ********************************************************************************
- */
+/* ************************************************************************** */
 size_t DiscreteConditional::sample() const {
   if (nrParents() != 0)
     throw std::invalid_argument(

--- a/gtsam/discrete/DiscreteConditional.cpp
+++ b/gtsam/discrete/DiscreteConditional.cpp
@@ -238,6 +238,7 @@ DecisionTreeFactor::shared_ptr DiscreteConditional::likelihood(
 }
 
 /* ************************************************************************** */
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V42
 void DiscreteConditional::solveInPlace(DiscreteValues* values) const {
   ADT pFS = Choose(*this, *values);  // P(F|S=parentsValues)
 
@@ -264,14 +265,6 @@ void DiscreteConditional::solveInPlace(DiscreteValues* values) const {
   }
 }
 
-/* ******************************************************************************** */
-void DiscreteConditional::sampleInPlace(DiscreteValues* values) const {
-  assert(nrFrontals() == 1);
-  Key j = (firstFrontalKey());
-  size_t sampled = sample(*values); // Sample variable given parents
-  (*values)[j] = sampled; // store result in partial solution
-}
-
 /* ************************************************************************** */
 size_t DiscreteConditional::solve(const DiscreteValues& parentsValues) const {
   ADT pFS = Choose(*this, parentsValues);  // P(F|S=parentsValues)
@@ -294,8 +287,17 @@ size_t DiscreteConditional::solve(const DiscreteValues& parentsValues) const {
   }
   return mpe;
 }
+#endif
 
-/* ******************************************************************************** */
+/* ************************************************************************** */
+void DiscreteConditional::sampleInPlace(DiscreteValues* values) const {
+  assert(nrFrontals() == 1);
+  Key j = (firstFrontalKey());
+  size_t sampled = sample(*values);  // Sample variable given parents
+  (*values)[j] = sampled;            // store result in partial solution
+}
+
+/* ************************************************************************** */
 size_t DiscreteConditional::sample(const DiscreteValues& parentsValues) const {
   static mt19937 rng(2);  // random number generator
 

--- a/gtsam/discrete/DiscreteConditional.cpp
+++ b/gtsam/discrete/DiscreteConditional.cpp
@@ -248,17 +248,17 @@ void DiscreteConditional::solveInPlace(DiscreteValues* values) const {
   // Get all Possible Configurations
   const auto allPosbValues = frontalAssignments();
 
-  // Find the MPE
+  // Find the maximum
   for (const auto& frontalVals : allPosbValues) {
     double pValueS = pFS(frontalVals);  // P(F=value|S=parentsValues)
-    // Update MPE solution if better
+    // Update maximum solution if better
     if (pValueS > maxP) {
       maxP = pValueS;
       mpe = frontalVals;
     }
   }
 
-  // set values (inPlace) to mpe
+  // set values (inPlace) to maximum
   for (Key j : frontals()) {
     (*values)[j] = mpe[j];
   }

--- a/gtsam/discrete/DiscreteConditional.cpp
+++ b/gtsam/discrete/DiscreteConditional.cpp
@@ -287,6 +287,26 @@ size_t DiscreteConditional::solve(const DiscreteValues& parentsValues) const {
 #endif
 
 /* ************************************************************************** */
+size_t DiscreteConditional::argmax() const {
+  size_t maxValue = 0;
+  double maxP = 0;
+  assert(nrFrontals() == 1);
+  assert(nrParents() == 0);
+  DiscreteValues frontals;
+  Key j = firstFrontalKey();
+  for (size_t value = 0; value < cardinality(j); value++) {
+    frontals[j] = value;
+    double pValueS = (*this)(frontals);
+    // Update MPE solution if better
+    if (pValueS > maxP) {
+      maxP = pValueS;
+      maxValue = value;
+    }
+  }
+  return maxValue;
+}
+
+/* ************************************************************************** */
 void DiscreteConditional::sampleInPlace(DiscreteValues* values) const {
   assert(nrFrontals() == 1);
   Key j = (firstFrontalKey());

--- a/gtsam/discrete/DiscreteConditional.h
+++ b/gtsam/discrete/DiscreteConditional.h
@@ -182,7 +182,7 @@ class GTSAM_EXPORT DiscreteConditional
   /**
    * solve a conditional
    * @param parentsValues Known values of the parents
-   * @return MPE value of the child (1 frontal variable).
+   * @return maximum value for the (single) frontal variable.
    */
   size_t solve(const DiscreteValues& parentsValues) const;
 

--- a/gtsam/discrete/DiscreteConditional.h
+++ b/gtsam/discrete/DiscreteConditional.h
@@ -192,6 +192,12 @@ class GTSAM_EXPORT DiscreteConditional
   /// Zero parent version.
   size_t sample() const;
 
+  /**
+   * @brief Return assignment that maximizes distribution.
+   * @return Optimal assignment (1 frontal variable).
+   */
+  size_t argmax() const;
+
   /// @}
   /// @name Advanced Interface
   /// @{

--- a/gtsam/discrete/DiscreteConditional.h
+++ b/gtsam/discrete/DiscreteConditional.h
@@ -93,14 +93,14 @@ class GTSAM_EXPORT DiscreteConditional
   DiscreteConditional(const DiscreteKey& key, const std::string& spec)
       : DiscreteConditional(Signature(key, {}, spec)) {}
 
-  /** 
+  /**
    * @brief construct P(X|Y) = f(X,Y)/f(Y) from f(X,Y) and f(Y)
-   * Assumes but *does not check* that f(Y)=sum_X f(X,Y). 
+   * Assumes but *does not check* that f(Y)=sum_X f(X,Y).
    */
   DiscreteConditional(const DecisionTreeFactor& joint,
                       const DecisionTreeFactor& marginal);
 
-  /** 
+  /**
    * @brief construct P(X|Y) = f(X,Y)/f(Y) from f(X,Y) and f(Y)
    * Assumes but *does not check* that f(Y)=sum_X f(X,Y).
    * Makes sure the keys are ordered as given. Does not check orderedKeys.
@@ -157,17 +157,17 @@ class GTSAM_EXPORT DiscreteConditional
     return ADT::operator()(values);
   }
 
-  /** 
+  /**
    * @brief restrict to given *parent* values.
-   * 
+   *
    * Note: does not need be complete set. Examples:
-   * 
+   *
    * P(C|D,E) + . -> P(C|D,E)
    * P(C|D,E) + E -> P(C|D)
    * P(C|D,E) + D -> P(C|E)
    * P(C|D,E) + D,E -> P(C)
    * P(C|D,E) + C -> error!
-   * 
+   *
    * @return a shared_ptr to a new DiscreteConditional
    */
   shared_ptr choose(const DiscreteValues& given) const;
@@ -226,6 +226,11 @@ class GTSAM_EXPORT DiscreteConditional
   void GTSAM_DEPRECATED solveInPlace(DiscreteValues* parentsValues) const;
   /// @}
 #endif
+
+ protected:
+  /// Internal version of choose
+  DiscreteConditional::ADT choose(const DiscreteValues& given,
+                                  bool forceComplete) const;
 };
 // DiscreteConditional
 

--- a/gtsam/discrete/DiscreteConditional.h
+++ b/gtsam/discrete/DiscreteConditional.h
@@ -180,13 +180,6 @@ class GTSAM_EXPORT DiscreteConditional
   DecisionTreeFactor::shared_ptr likelihood(size_t parent_value) const;
 
   /**
-   * solve a conditional
-   * @param parentsValues Known values of the parents
-   * @return maximum value for the (single) frontal variable.
-   */
-  size_t solve(const DiscreteValues& parentsValues) const;
-
-  /**
    * sample
    * @param parentsValues Known values of the parents
    * @return sample from conditional
@@ -202,9 +195,6 @@ class GTSAM_EXPORT DiscreteConditional
   /// @}
   /// @name Advanced Interface
   /// @{
-
-  /// solve a conditional, in place
-  void solveInPlace(DiscreteValues* parentsValues) const;
 
   /// sample in place, stores result in partial solution
   void sampleInPlace(DiscreteValues* parentsValues) const;
@@ -228,6 +218,14 @@ class GTSAM_EXPORT DiscreteConditional
                    const Names& names = {}) const override;
 
   /// @}
+
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V42
+  /// @name Deprecated functionality
+  /// @{
+  size_t GTSAM_DEPRECATED solve(const DiscreteValues& parentsValues) const;
+  void GTSAM_DEPRECATED solveInPlace(DiscreteValues* parentsValues) const;
+  /// @}
+#endif
 };
 // DiscreteConditional
 

--- a/gtsam/discrete/DiscreteDistribution.cpp
+++ b/gtsam/discrete/DiscreteDistribution.cpp
@@ -49,4 +49,21 @@ std::vector<double> DiscreteDistribution::pmf() const {
   return array;
 }
 
+/* ************************************************************************** */
+size_t DiscreteDistribution::argmax() const {
+  size_t maxValue = 0;
+  double maxP = 0;
+  assert(nrFrontals() == 1);
+  Key j = firstFrontalKey();
+  for (size_t value = 0; value < cardinality(j); value++) {
+    double pValueS = (*this)(value);
+    // Update MPE solution if better
+    if (pValueS > maxP) {
+      maxP = pValueS;
+      maxValue = value;
+    }
+  }
+  return maxValue;
+}
+
 }  // namespace gtsam

--- a/gtsam/discrete/DiscreteDistribution.cpp
+++ b/gtsam/discrete/DiscreteDistribution.cpp
@@ -49,21 +49,4 @@ std::vector<double> DiscreteDistribution::pmf() const {
   return array;
 }
 
-/* ************************************************************************** */
-size_t DiscreteDistribution::argmax() const {
-  size_t maxValue = 0;
-  double maxP = 0;
-  assert(nrFrontals() == 1);
-  Key j = firstFrontalKey();
-  for (size_t value = 0; value < cardinality(j); value++) {
-    double pValueS = (*this)(value);
-    // Update MPE solution if better
-    if (pValueS > maxP) {
-      maxP = pValueS;
-      maxValue = value;
-    }
-  }
-  return maxValue;
-}
-
 }  // namespace gtsam

--- a/gtsam/discrete/DiscreteDistribution.h
+++ b/gtsam/discrete/DiscreteDistribution.h
@@ -91,10 +91,10 @@ class GTSAM_EXPORT DiscreteDistribution : public DiscreteConditional {
   std::vector<double> pmf() const;
 
   /**
-   * solve a conditional
-   * @return MPE value of the child (1 frontal variable).
+   * @brief Return assignment that maximizes distribution.
+   * @return Optimal assignment (1 frontal variable).
    */
-  size_t solve() const { return Base::solve({}); }
+  size_t argmax() const;
 
   /**
    * sample
@@ -103,6 +103,12 @@ class GTSAM_EXPORT DiscreteDistribution : public DiscreteConditional {
   size_t sample() const { return Base::sample(); }
 
   /// @}
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V42
+  /// @name Deprecated functionality
+  /// @{
+  size_t GTSAM_DEPRECATED solve() const { return Base::solve({}); }
+  /// @}
+#endif
 };
 // DiscreteDistribution
 

--- a/gtsam/discrete/DiscreteDistribution.h
+++ b/gtsam/discrete/DiscreteDistribution.h
@@ -90,18 +90,6 @@ class GTSAM_EXPORT DiscreteDistribution : public DiscreteConditional {
   /// Return entire probability mass function.
   std::vector<double> pmf() const;
 
-  /**
-   * @brief Return assignment that maximizes distribution.
-   * @return Optimal assignment (1 frontal variable).
-   */
-  size_t argmax() const;
-
-  /**
-   * sample
-   * @return sample from conditional
-   */
-  size_t sample() const { return Base::sample(); }
-
   /// @}
 #ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V42
   /// @name Deprecated functionality

--- a/gtsam/discrete/DiscreteFactorGraph.h
+++ b/gtsam/discrete/DiscreteFactorGraph.h
@@ -163,14 +163,6 @@ class GTSAM_EXPORT DiscreteFactorGraph
    */
   DiscreteValues optimize(const Ordering& ordering) const;
 
-  //  /** Permute the variables in the factors */
-  //  GTSAM_EXPORT void permuteWithInverse(const Permutation&
-  //  inversePermutation);
-  //
-  //  /** Apply a reduction, which is a remapping of variable indices. */
-  //  GTSAM_EXPORT void reduceWithInverse(const internal::Reduction&
-  //  inverseReduction);
-
   /// @name Wrapper support
   /// @{
 

--- a/gtsam/discrete/DiscreteFactorGraph.h
+++ b/gtsam/discrete/DiscreteFactorGraph.h
@@ -139,6 +139,14 @@ class GTSAM_EXPORT DiscreteFactorGraph
       OptionalOrderingType orderingType = boost::none) const;
 
   /**
+   * @brief Implement the max-product algorithm
+   *
+   * @param ordering
+   * @return DiscreteLookupDAG::shared_ptr `DAG with lookup tables
+   */
+  DiscreteLookupDAG maxProduct(const Ordering& ordering) const;
+
+  /**
    * @brief Find the maximum probable explanation (MPE) by doing max-product.
    *
    * @param orderingType
@@ -146,6 +154,14 @@ class GTSAM_EXPORT DiscreteFactorGraph
    */
   DiscreteValues optimize(
       OptionalOrderingType orderingType = boost::none) const;
+
+  /**
+   * @brief Find the maximum probable explanation (MPE) by doing max-product.
+   *
+   * @param ordering
+   * @return DiscreteValues : MPE
+   */
+  DiscreteValues optimize(const Ordering& ordering) const;
 
   //  /** Permute the variables in the factors */
   //  GTSAM_EXPORT void permuteWithInverse(const Permutation&

--- a/gtsam/discrete/DiscreteFactorGraph.h
+++ b/gtsam/discrete/DiscreteFactorGraph.h
@@ -18,10 +18,11 @@
 
 #pragma once
 
-#include <gtsam/inference/FactorGraph.h>
-#include <gtsam/inference/EliminateableFactorGraph.h>
-#include <gtsam/inference/Ordering.h>
 #include <gtsam/discrete/DecisionTreeFactor.h>
+#include <gtsam/discrete/DiscreteLookupDAG.h>
+#include <gtsam/inference/EliminateableFactorGraph.h>
+#include <gtsam/inference/FactorGraph.h>
+#include <gtsam/inference/Ordering.h>
 #include <gtsam/base/FastSet.h>
 
 #include <boost/make_shared.hpp>
@@ -132,9 +133,9 @@ class GTSAM_EXPORT DiscreteFactorGraph
    * @brief Implement the max-product algorithm
    *
    * @param orderingType : one of COLAMD, METIS, NATURAL, CUSTOM
-   * @return DiscreteBayesNet::shared_ptr DAG with lookup tables
+   * @return DiscreteLookupDAG::shared_ptr DAG with lookup tables
    */
-  boost::shared_ptr<DiscreteBayesNet> maxProduct(
+  DiscreteLookupDAG maxProduct(
       OptionalOrderingType orderingType = boost::none) const;
 
   /**

--- a/gtsam/discrete/DiscreteFactorGraph.h
+++ b/gtsam/discrete/DiscreteFactorGraph.h
@@ -128,18 +128,31 @@ class GTSAM_EXPORT DiscreteFactorGraph
       const std::string& s = "DiscreteFactorGraph",
       const KeyFormatter& formatter = DefaultKeyFormatter) const override;
 
-  /** Solve the factor graph by performing variable elimination in COLAMD order using
-   *  the dense elimination function specified in \c function,
-   *  followed by back-substitution resulting from elimination.  Is equivalent
-   *  to calling graph.eliminateSequential()->optimize(). */
-  DiscreteValues optimize() const;
+  /**
+   * @brief Implement the max-product algorithm
+   *
+   * @param orderingType : one of COLAMD, METIS, NATURAL, CUSTOM
+   * @return DiscreteBayesNet::shared_ptr DAG with lookup tables
+   */
+  boost::shared_ptr<DiscreteBayesNet> maxProduct(
+      OptionalOrderingType orderingType = boost::none) const;
 
+  /**
+   * @brief Find the maximum probable explanation (MPE) by doing max-product.
+   *
+   * @param orderingType
+   * @return DiscreteValues : MPE
+   */
+  DiscreteValues optimize(
+      OptionalOrderingType orderingType = boost::none) const;
 
-//  /** Permute the variables in the factors */
-//  GTSAM_EXPORT void permuteWithInverse(const Permutation& inversePermutation);
-//
-//  /** Apply a reduction, which is a remapping of variable indices. */
-//  GTSAM_EXPORT void reduceWithInverse(const internal::Reduction& inverseReduction);
+  //  /** Permute the variables in the factors */
+  //  GTSAM_EXPORT void permuteWithInverse(const Permutation&
+  //  inversePermutation);
+  //
+  //  /** Apply a reduction, which is a remapping of variable indices. */
+  //  GTSAM_EXPORT void reduceWithInverse(const internal::Reduction&
+  //  inverseReduction);
 
   /// @name Wrapper support
   /// @{

--- a/gtsam/discrete/DiscreteKey.cpp
+++ b/gtsam/discrete/DiscreteKey.cpp
@@ -33,16 +33,13 @@ namespace gtsam {
 
   KeyVector DiscreteKeys::indices() const {
     KeyVector js;
-    for(const DiscreteKey& key: *this)
-      js.push_back(key.first);
+    for (const DiscreteKey& key : *this) js.push_back(key.first);
     return js;
   }
 
-  map<Key,size_t> DiscreteKeys::cardinalities() const {
-    map<Key,size_t> cs;
-    cs.insert(begin(),end());
-//    for(const DiscreteKey& key: *this)
-//      cs.insert(key);
+  map<Key, size_t> DiscreteKeys::cardinalities() const {
+    map<Key, size_t> cs;
+    cs.insert(begin(), end());
     return cs;
   }
 

--- a/gtsam/discrete/DiscreteLookupDAG.cpp
+++ b/gtsam/discrete/DiscreteLookupDAG.cpp
@@ -16,6 +16,7 @@
  *  @author Frank Dellaert
  */
 
+#include <gtsam/discrete/DiscreteBayesNet.h>
 #include <gtsam/discrete/DiscreteLookupDAG.h>
 #include <gtsam/discrete/DiscreteValues.h>
 
@@ -97,6 +98,22 @@ size_t DiscreteLookupTable::argmax(const DiscreteValues& parentsValues) const {
     }
   }
   return mpe;
+}
+
+/* ************************************************************************** */
+DiscreteLookupDAG DiscreteLookupDAG::FromBayesNet(
+    const DiscreteBayesNet& bayesNet) {
+  DiscreteLookupDAG dag;
+  for (auto&& conditional : bayesNet) {
+    if (auto lookupTable =
+            boost::dynamic_pointer_cast<DiscreteLookupTable>(conditional)) {
+      dag.push_back(lookupTable);
+    } else {
+      throw std::runtime_error(
+          "DiscreteFactorGraph::maxProduct: Expected look up table.");
+    }
+  }
+  return dag;
 }
 
 /* ************************************************************************** */

--- a/gtsam/discrete/DiscreteLookupDAG.cpp
+++ b/gtsam/discrete/DiscreteLookupDAG.cpp
@@ -1,0 +1,153 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ *  @file DiscreteLookupTable.cpp
+ *  @date Feb 14, 2011
+ *  @author Duy-Nguyen Ta
+ *  @author Frank Dellaert
+ */
+
+#include <gtsam/discrete/DiscreteLookupDAG.h>
+#include <gtsam/discrete/DiscreteValues.h>
+
+#include <string>
+#include <utility>
+
+using std::pair;
+using std::vector;
+
+namespace gtsam {
+
+// Instantiate base class
+template class GTSAM_EXPORT
+    Conditional<DecisionTreeFactor, DiscreteLookupTable>;
+
+/* ************************************************************************** */
+// TODO(dellaert): copy/paste from DiscreteConditional.cpp :-(
+void DiscreteLookupTable::print(const std::string& s,
+                                const KeyFormatter& formatter) const {
+  using std::cout;
+  using std::endl;
+
+  cout << s << " g( ";
+  for (const_iterator it = beginFrontals(); it != endFrontals(); ++it) {
+    cout << formatter(*it) << " ";
+  }
+  if (nrParents()) {
+    cout << "; ";
+    for (const_iterator it = beginParents(); it != endParents(); ++it) {
+      cout << formatter(*it) << " ";
+    }
+  }
+  cout << "):\n";
+  ADT::print("", formatter);
+  cout << endl;
+}
+
+/* ************************************************************************* */
+// TODO(dellaert): copy/paste from DiscreteConditional.cpp :-(
+vector<DiscreteValues> DiscreteLookupTable::frontalAssignments() const {
+  vector<pair<Key, size_t>> pairs;
+  for (Key key : frontals()) pairs.emplace_back(key, cardinalities_.at(key));
+  vector<pair<Key, size_t>> rpairs(pairs.rbegin(), pairs.rend());
+  return DiscreteValues::CartesianProduct(rpairs);
+}
+
+/* ************************************************************************** */
+// TODO(dellaert): copy/paste from DiscreteConditional.cpp :-(
+static DiscreteLookupTable::ADT Choose(const DiscreteLookupTable& conditional,
+                                       const DiscreteValues& given,
+                                       bool forceComplete = true) {
+  // Get the big decision tree with all the levels, and then go down the
+  // branches based on the value of the parent variables.
+  DiscreteLookupTable::ADT adt(conditional);
+  size_t value;
+  for (Key j : conditional.parents()) {
+    try {
+      value = given.at(j);
+      adt = adt.choose(j, value);  // ADT keeps getting smaller.
+    } catch (std::out_of_range&) {
+      if (forceComplete) {
+        given.print("parentsValues: ");
+        throw std::runtime_error(
+            "DiscreteLookupTable::Choose: parent value missing");
+      }
+    }
+  }
+  return adt;
+}
+
+/* ************************************************************************** */
+void DiscreteLookupTable::argmaxInPlace(DiscreteValues* values) const {
+  ADT pFS = Choose(*this, *values);  // P(F|S=parentsValues)
+
+  // Initialize
+  DiscreteValues mpe;
+  double maxP = 0;
+
+  // Get all Possible Configurations
+  const auto allPosbValues = frontalAssignments();
+
+  // Find the maximum
+  for (const auto& frontalVals : allPosbValues) {
+    double pValueS = pFS(frontalVals);  // P(F=value|S=parentsValues)
+    // Update maximum solution if better
+    if (pValueS > maxP) {
+      maxP = pValueS;
+      mpe = frontalVals;
+    }
+  }
+
+  // set values (inPlace) to maximum
+  for (Key j : frontals()) {
+    (*values)[j] = mpe[j];
+  }
+}
+
+/* ************************************************************************** */
+size_t DiscreteLookupTable::argmax(const DiscreteValues& parentsValues) const {
+  ADT pFS = Choose(*this, parentsValues);  // P(F|S=parentsValues)
+
+  // Then, find the max over all remaining
+  // TODO(Duy): only works for one key now, seems horribly slow this way
+  size_t mpe = 0;
+  DiscreteValues frontals;
+  double maxP = 0;
+  assert(nrFrontals() == 1);
+  Key j = (firstFrontalKey());
+  for (size_t value = 0; value < cardinality(j); value++) {
+    frontals[j] = value;
+    double pValueS = pFS(frontals);  // P(F=value|S=parentsValues)
+    // Update MPE solution if better
+    if (pValueS > maxP) {
+      maxP = pValueS;
+      mpe = value;
+    }
+  }
+  return mpe;
+}
+
+/* ************************************************************************** */
+DiscreteValues DiscreteLookupDAG::argmax() const {
+  DiscreteValues result;
+  return argmax(result);
+}
+
+DiscreteValues DiscreteLookupDAG::argmax(DiscreteValues result) const {
+  // Argmax each node in turn in topological sort order (parents first).
+  for (auto lookupTable : boost::adaptors::reverse(*this))
+    lookupTable->argmaxInPlace(&result);
+  return result;
+}
+/* ************************************************************************** */
+
+}  // namespace gtsam

--- a/gtsam/discrete/DiscreteLookupDAG.cpp
+++ b/gtsam/discrete/DiscreteLookupDAG.cpp
@@ -27,10 +27,6 @@ using std::vector;
 
 namespace gtsam {
 
-// Instantiate base class
-template class GTSAM_EXPORT
-    Conditional<DecisionTreeFactor, DiscreteLookupTable>;
-
 /* ************************************************************************** */
 // TODO(dellaert): copy/paste from DiscreteConditional.cpp :-(
 void DiscreteLookupTable::print(const std::string& s,

--- a/gtsam/discrete/DiscreteLookupDAG.cpp
+++ b/gtsam/discrete/DiscreteLookupDAG.cpp
@@ -10,7 +10,7 @@
  * -------------------------------------------------------------------------- */
 
 /**
- *  @file DiscreteLookupTable.cpp
+ *  @file DiscreteLookupDAG.cpp
  *  @date Feb 14, 2011
  *  @author Duy-Nguyen Ta
  *  @author Frank Dellaert
@@ -114,12 +114,6 @@ DiscreteLookupDAG DiscreteLookupDAG::FromBayesNet(
     }
   }
   return dag;
-}
-
-/* ************************************************************************** */
-DiscreteValues DiscreteLookupDAG::argmax() const {
-  DiscreteValues result;
-  return argmax(result);
 }
 
 DiscreteValues DiscreteLookupDAG::argmax(DiscreteValues result) const {

--- a/gtsam/discrete/DiscreteLookupDAG.h
+++ b/gtsam/discrete/DiscreteLookupDAG.h
@@ -1,0 +1,138 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file DiscreteLookupDAG.h
+ * @date JAnuary, 2022
+ * @author Frank dellaert
+ */
+
+#pragma once
+
+#include <gtsam/discrete/DiscreteDistribution.h>
+#include <gtsam/inference/BayesNet.h>
+#include <gtsam/inference/FactorGraph.h>
+
+#include <boost/shared_ptr.hpp>
+
+#include <vector>
+
+namespace gtsam {
+
+/**
+ * @brief DiscreteLookupTable table for max-product
+ */
+class DiscreteLookupTable
+    : public DecisionTreeFactor,
+      public Conditional<DecisionTreeFactor, DiscreteLookupTable> {
+ public:
+  using This = DiscreteLookupTable;
+  using shared_ptr = boost::shared_ptr<This>;
+  using BaseConditional = Conditional<DecisionTreeFactor, This>;
+
+  /**
+   * @brief Construct a new Discrete Lookup Table object
+   *
+   * @param nFrontals number of frontal variables
+   * @param keys a orted list of gtsam::Keys
+   * @param potentials the algebraic decision tree with lookup values
+   */
+  DiscreteLookupTable(size_t nFrontals, const DiscreteKeys& keys,
+                      const ADT& potentials)
+      : DecisionTreeFactor(keys, potentials), BaseConditional(nFrontals) {}
+
+  /// GTSAM-style print
+  void print(
+      const std::string& s = "Discrete Lookup Table: ",
+      const KeyFormatter& formatter = DefaultKeyFormatter) const override;
+
+  /**
+   * @brief return assignment for single frontal variable that maximizes value.
+   * @param parentsValues Known assignments for the parents.
+   * @return maximizing assignment for the frontal variable.
+   */
+  size_t argmax(const DiscreteValues& parentsValues) const;
+
+  /**
+   * @brief Calculate assignment for frontal variables that maximizes value.
+   * @param (in/out) parentsValues Known assignments for the parents.
+   */
+  void argmaxInPlace(DiscreteValues* parentsValues) const;
+
+  /// Return all assignments for frontal variables.
+  std::vector<DiscreteValues> frontalAssignments() const;
+};
+
+/** A DAG made from lookup tables, as defined above. */
+class GTSAM_EXPORT DiscreteLookupDAG : public BayesNet<DiscreteLookupTable> {
+ public:
+  using Base = BayesNet<DiscreteLookupTable>;
+  using This = DiscreteLookupDAG;
+  using shared_ptr = boost::shared_ptr<This>;
+
+  /// @name Standard Constructors
+  /// @{
+
+  /// Construct empty DAG.
+  DiscreteLookupDAG() {}
+
+  /// Destructor
+  virtual ~DiscreteLookupDAG() {}
+
+  /// @}
+
+  /// @name Testable
+  /// @{
+
+  /** Check equality */
+  bool equals(const This& bn, double tol = 1e-9) const;
+
+  /// @}
+
+  /// @name Standard Interface
+  /// @{
+
+  /**
+   * @brief argmax by back-substitution.
+   *
+   * Assumes the DAG is reverse topologically sorted, i.e. last
+   * conditional will be optimized first. If the DAG resulted from
+   * eliminating a factor graph, this is true for the elimination ordering.
+   *
+   * @return optimal assignment for all variables.
+   */
+  DiscreteValues argmax() const;
+
+  /**
+   * @brief argmax by back-substitution, given certain variables.
+   *
+   * Assumes the DAG is reverse topologically sorted *and* that the
+   * DAG does not contain any conditionals for the given variables.
+   *
+   * @return given assignment extended w. optimal assignment for all variables.
+   */
+  DiscreteValues argmax(DiscreteValues given) const;
+  /// @}
+
+ private:
+  /** Serialization function */
+  friend class boost::serialization::access;
+  template <class ARCHIVE>
+  void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
+    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
+  }
+};
+
+// traits
+template <>
+struct traits<DiscreteLookupDAG> : public Testable<DiscreteLookupDAG> {};
+
+}  // namespace gtsam

--- a/gtsam/discrete/DiscreteLookupDAG.h
+++ b/gtsam/discrete/DiscreteLookupDAG.h
@@ -11,7 +11,7 @@
 
 /**
  * @file DiscreteLookupDAG.h
- * @date JAnuary, 2022
+ * @date January, 2022
  * @author Frank dellaert
  */
 
@@ -34,7 +34,7 @@ class DiscreteBayesNet;
  * @brief DiscreteLookupTable table for max-product
  *
  * Inherits from discrete conditional for convenience, but is not normalized.
- * Is used in pax-product algorithm.
+ * Is used in the max-product algorithm.
  */
 class DiscreteLookupTable : public DiscreteConditional {
  public:
@@ -85,7 +85,7 @@ class GTSAM_EXPORT DiscreteLookupDAG : public BayesNet<DiscreteLookupTable> {
   /// Construct empty DAG.
   DiscreteLookupDAG() {}
 
-  // Create from BayesNet with LookupTables
+  /// Create from BayesNet with LookupTables
   static DiscreteLookupDAG FromBayesNet(const DiscreteBayesNet& bayesNet);
 
   /// Destructor
@@ -111,25 +111,17 @@ class GTSAM_EXPORT DiscreteLookupDAG : public BayesNet<DiscreteLookupTable> {
   }
 
   /**
-   * @brief argmax by back-substitution.
+   * @brief argmax by back-substitution, optionally given certain variables.
    *
    * Assumes the DAG is reverse topologically sorted, i.e. last
-   * conditional will be optimized first. If the DAG resulted from
-   * eliminating a factor graph, this is true for the elimination ordering.
-   *
-   * @return optimal assignment for all variables.
-   */
-  DiscreteValues argmax() const;
-
-  /**
-   * @brief argmax by back-substitution, given certain variables.
-   *
-   * Assumes the DAG is reverse topologically sorted *and* that the
-   * DAG does not contain any conditionals for the given variables.
+   * conditional will be optimized first *and* that the
+   * DAG does not contain any conditionals for the given variables. If the DAG
+   * resulted from eliminating a factor graph, this is true for the elimination
+   * ordering.
    *
    * @return given assignment extended w. optimal assignment for all variables.
    */
-  DiscreteValues argmax(DiscreteValues given) const;
+  DiscreteValues argmax(DiscreteValues given = DiscreteValues()) const;
   /// @}
 
  private:

--- a/gtsam/discrete/DiscreteLookupDAG.h
+++ b/gtsam/discrete/DiscreteLookupDAG.h
@@ -28,6 +28,8 @@
 
 namespace gtsam {
 
+class DiscreteBayesNet;
+
 /**
  * @brief DiscreteLookupTable table for max-product
  *
@@ -82,6 +84,9 @@ class GTSAM_EXPORT DiscreteLookupDAG : public BayesNet<DiscreteLookupTable> {
 
   /// Construct empty DAG.
   DiscreteLookupDAG() {}
+
+  // Create from BayesNet with LookupTables
+  static DiscreteLookupDAG FromBayesNet(const DiscreteBayesNet& bayesNet);
 
   /// Destructor
   virtual ~DiscreteLookupDAG() {}

--- a/gtsam/discrete/DiscreteLookupDAG.h
+++ b/gtsam/discrete/DiscreteLookupDAG.h
@@ -22,17 +22,19 @@
 #include <gtsam/inference/FactorGraph.h>
 
 #include <boost/shared_ptr.hpp>
-
+#include <string>
+#include <utility>
 #include <vector>
 
 namespace gtsam {
 
 /**
  * @brief DiscreteLookupTable table for max-product
+ *
+ * Inherits from discrete conditional for convenience, but is not normalized.
+ * Is used in pax-product algorithm.
  */
-class DiscreteLookupTable
-    : public DecisionTreeFactor,
-      public Conditional<DecisionTreeFactor, DiscreteLookupTable> {
+class DiscreteLookupTable : public DiscreteConditional {
  public:
   using This = DiscreteLookupTable;
   using shared_ptr = boost::shared_ptr<This>;
@@ -47,7 +49,7 @@ class DiscreteLookupTable
    */
   DiscreteLookupTable(size_t nFrontals, const DiscreteKeys& keys,
                       const ADT& potentials)
-      : DecisionTreeFactor(keys, potentials), BaseConditional(nFrontals) {}
+      : DiscreteConditional(nFrontals, keys, potentials) {}
 
   /// GTSAM-style print
   void print(
@@ -99,6 +101,12 @@ class GTSAM_EXPORT DiscreteLookupDAG : public BayesNet<DiscreteLookupTable> {
 
   /// @name Standard Interface
   /// @{
+
+  /** Add a DiscreteLookupTable */
+  template <typename... Args>
+  void add(Args&&... args) {
+    emplace_shared<DiscreteLookupTable>(std::forward<Args>(args)...);
+  }
 
   /**
    * @brief argmax by back-substitution.

--- a/gtsam/discrete/DiscreteLookupDAG.h
+++ b/gtsam/discrete/DiscreteLookupDAG.h
@@ -68,9 +68,6 @@ class DiscreteLookupTable : public DiscreteConditional {
    * @param (in/out) parentsValues Known assignments for the parents.
    */
   void argmaxInPlace(DiscreteValues* parentsValues) const;
-
-  /// Return all assignments for frontal variables.
-  std::vector<DiscreteValues> frontalAssignments() const;
 };
 
 /** A DAG made from lookup tables, as defined above. */

--- a/gtsam/discrete/discrete.i
+++ b/gtsam/discrete/discrete.i
@@ -111,11 +111,9 @@ virtual class DiscreteConditional : gtsam::DecisionTreeFactor {
   gtsam::DecisionTreeFactor* likelihood(
       const gtsam::DiscreteValues& frontalValues) const;
   gtsam::DecisionTreeFactor* likelihood(size_t value) const;
-  size_t solve(const gtsam::DiscreteValues& parentsValues) const;
   size_t sample(const gtsam::DiscreteValues& parentsValues) const;
   size_t sample(size_t value) const;
   size_t sample() const;
-  void solveInPlace(gtsam::DiscreteValues @parentsValues) const;
   void sampleInPlace(gtsam::DiscreteValues @parentsValues) const;
   string markdown(const gtsam::KeyFormatter& keyFormatter =
                       gtsam::DefaultKeyFormatter) const;
@@ -138,7 +136,7 @@ virtual class DiscreteDistribution : gtsam::DiscreteConditional {
                  gtsam::DefaultKeyFormatter) const;
   double operator()(size_t value) const;
   std::vector<double> pmf() const;
-  size_t solve() const;
+  size_t argmax() const;
 };
 
 #include <gtsam/discrete/DiscreteBayesNet.h>
@@ -163,8 +161,6 @@ class DiscreteBayesNet {
   void saveGraph(string s, const gtsam::KeyFormatter& keyFormatter =
                                gtsam::DefaultKeyFormatter) const;
   double operator()(const gtsam::DiscreteValues& values) const;
-  gtsam::DiscreteValues optimize() const;
-  gtsam::DiscreteValues optimize(gtsam::DiscreteValues given) const;
   gtsam::DiscreteValues sample() const;
   gtsam::DiscreteValues sample(gtsam::DiscreteValues given) const;
   string markdown(const gtsam::KeyFormatter& keyFormatter =
@@ -217,6 +213,21 @@ class DiscreteBayesTree {
               std::map<gtsam::Key, std::vector<std::string>> names) const;
 };
 
+#include <gtsam/discrete/DiscreteLookupDAG.h>
+class DiscreteLookupDAG {
+  DiscreteLookupDAG();
+  void push_back(const gtsam::DiscreteLookupTable* table);
+  bool empty() const;
+  size_t size() const;
+  gtsam::KeySet keys() const;
+  const gtsam::DiscreteLookupTable* at(size_t i) const;
+  void print(string s = "DiscreteLookupDAG\n",
+             const gtsam::KeyFormatter& keyFormatter =
+                 gtsam::DefaultKeyFormatter) const;
+  gtsam::DiscreteValues argmax() const;
+  gtsam::DiscreteValues argmax(gtsam::DiscreteValues given) const;
+};
+
 #include <gtsam/inference/DotWriter.h>
 class DotWriter {
   DotWriter(double figureWidthInches = 5, double figureHeightInches = 5,
@@ -259,6 +270,9 @@ class DiscreteFactorGraph {
   gtsam::DecisionTreeFactor product() const;
   double operator()(const gtsam::DiscreteValues& values) const;
   gtsam::DiscreteValues optimize() const;
+
+  gtsam::DiscreteLookupDAG maxProduct();
+  gtsam::DiscreteLookupDAG maxProduct(const gtsam::Ordering& ordering);
 
   gtsam::DiscreteBayesNet eliminateSequential();
   gtsam::DiscreteBayesNet eliminateSequential(const gtsam::Ordering& ordering);

--- a/gtsam/discrete/tests/testDiscreteBayesNet.cpp
+++ b/gtsam/discrete/tests/testDiscreteBayesNet.cpp
@@ -106,26 +106,13 @@ TEST(DiscreteBayesNet, Asia) {
   DiscreteConditional expected2(Bronchitis % "11/9");
   EXPECT(assert_equal(expected2, *chordal->back()));
 
-  // solve
-  auto actualMPE = chordal->optimize();
-  DiscreteValues expectedMPE;
-  insert(expectedMPE)(Asia.first, 0)(Dyspnea.first, 0)(XRay.first, 0)(
-      Tuberculosis.first, 0)(Smoking.first, 0)(Either.first, 0)(
-      LungCancer.first, 0)(Bronchitis.first, 0);
-  EXPECT(assert_equal(expectedMPE, actualMPE));
-
   // add evidence, we were in Asia and we have dyspnea
   fg.add(Asia, "0 1");
   fg.add(Dyspnea, "0 1");
 
   // solve again, now with evidence
   DiscreteBayesNet::shared_ptr chordal2 = fg.eliminateSequential(ordering);
-  auto actualMPE2 = chordal2->optimize();
-  DiscreteValues expectedMPE2;
-  insert(expectedMPE2)(Asia.first, 1)(Dyspnea.first, 1)(XRay.first, 0)(
-      Tuberculosis.first, 0)(Smoking.first, 1)(Either.first, 0)(
-      LungCancer.first, 0)(Bronchitis.first, 1);
-  EXPECT(assert_equal(expectedMPE2, actualMPE2));
+  EXPECT(assert_equal(expected2, *chordal->back()));
 
   // now sample from it
   DiscreteValues expectedSample;

--- a/gtsam/discrete/tests/testDiscreteDistribution.cpp
+++ b/gtsam/discrete/tests/testDiscreteDistribution.cpp
@@ -10,7 +10,7 @@
  * -------------------------------------------------------------------------- */
 
 /*
- * @file    testDiscretePrior.cpp
+ * @file    testDiscreteDistribution.cpp
  * @brief   unit tests for DiscreteDistribution
  * @author  Frank dellaert
  * @date    December 2021

--- a/gtsam/discrete/tests/testDiscreteDistribution.cpp
+++ b/gtsam/discrete/tests/testDiscreteDistribution.cpp
@@ -75,6 +75,12 @@ TEST(DiscreteDistribution, sample) {
 }
 
 /* ************************************************************************* */
+TEST(DiscreteDistribution, argmax) {
+  DiscreteDistribution prior(X % "2/3");
+  EXPECT_LONGS_EQUAL(prior.argmax(), 1);
+}
+
+/* ************************************************************************* */
 int main() {
   TestResult tr;
   return TestRegistry::runAllTests(tr);

--- a/gtsam/discrete/tests/testDiscreteFactorGraph.cpp
+++ b/gtsam/discrete/tests/testDiscreteFactorGraph.cpp
@@ -239,7 +239,7 @@ TEST(DiscreteFactorGraph, testMPE_Darwiche09book_p244) {
   Ordering ordering;
   ordering += Key(0), Key(1), Key(2), Key(3), Key(4);
   auto chordal = graph.eliminateSequential(ordering);
-  EXPECT_LONGS_EQUAL(2, chordal->size());
+  EXPECT_LONGS_EQUAL(5, chordal->size());
 #ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V42
   auto notOptimal = chordal->optimize();  // not MPE !
   EXPECT(graph(notOptimal) < graph(mpe));

--- a/gtsam/discrete/tests/testDiscreteLookupDAG.cpp
+++ b/gtsam/discrete/tests/testDiscreteLookupDAG.cpp
@@ -1,0 +1,58 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/*
+ * testDiscreteLookupDAG.cpp
+ *
+ *  @date January, 2022
+ *  @author Frank Dellaert
+ */
+
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/Testable.h>
+#include <gtsam/discrete/DiscreteLookupDAG.h>
+
+#include <boost/assign/list_inserter.hpp>
+#include <boost/assign/std/map.hpp>
+
+using namespace gtsam;
+using namespace boost::assign;
+
+/* ************************************************************************* */
+TEST(DiscreteLookupDAG, argmax) {
+  using ADT = AlgebraicDecisionTree<Key>;
+
+  // Declare 2 keys
+  DiscreteKey A(0, 2), B(1, 2);
+
+  // Create lookup table corresponding to "marginalIsNotMPE" in testDFG.
+  DiscreteLookupDAG dag;
+
+  ADT adtB(DiscreteKeys{B, A}, std::vector<double>{0.5, 1. / 3, 0.5, 2. / 3});
+  dag.add(1, DiscreteKeys{B, A}, adtB);
+
+  ADT adtA(A, 0.5 * 10 / 19, (2. / 3) * (9. / 19));
+  dag.add(1, DiscreteKeys{A}, adtA);
+
+  // The expected MPE is A=1, B=1
+  DiscreteValues mpe;
+  insert(mpe)(0, 1)(1, 1);
+
+  // check:
+  auto actualMPE = dag.argmax();
+  EXPECT(assert_equal(mpe, actualMPE));
+}
+/* ************************************************************************* */
+int main() {
+  TestResult tr;
+  return TestRegistry::runAllTests(tr);
+}
+/* ************************************************************************* */

--- a/gtsam/inference/Conditional.h
+++ b/gtsam/inference/Conditional.h
@@ -25,15 +25,12 @@
 namespace gtsam {
 
   /**
-   * TODO: Update comments. The following comments are out of date!!!
-   *
-   * Base class for conditional densities, templated on KEY type.  This class
-   * provides storage for the keys involved in a conditional, and iterators and
+   * Base class for conditional densities.  This class iterators and
    * access to the frontal and separator keys.
    *
    * Derived classes *must* redefine the Factor and shared_ptr typedefs to refer
    * to the associated factor type and shared_ptr type of the derived class.  See
-   * IndexConditional and GaussianConditional for examples.
+   * SymbolicConditional and GaussianConditional for examples.
    * \nosubgrouping
    */
   template<class FACTOR, class DERIVEDCONDITIONAL>

--- a/gtsam_unstable/discrete/CSP.cpp
+++ b/gtsam_unstable/discrete/CSP.cpp
@@ -14,18 +14,6 @@ using namespace std;
 
 namespace gtsam {
 
-/// Find the best total assignment - can be expensive
-DiscreteValues CSP::optimalAssignment() const {
-  DiscreteBayesNet::shared_ptr chordal = this->eliminateSequential();
-  return chordal->optimize();
-}
-
-/// Find the best total assignment - can be expensive
-DiscreteValues CSP::optimalAssignment(const Ordering& ordering) const {
-  DiscreteBayesNet::shared_ptr chordal = this->eliminateSequential(ordering);
-  return chordal->optimize();
-}
-
 bool CSP::runArcConsistency(const VariableIndex& index,
                             Domains* domains) const {
   bool changed = false;

--- a/gtsam_unstable/discrete/CSP.h
+++ b/gtsam_unstable/discrete/CSP.h
@@ -43,12 +43,6 @@ class GTSAM_UNSTABLE_EXPORT CSP : public DiscreteFactorGraph {
   //      return result;
   //    }
 
-  /// Find the best total assignment - can be expensive.
-  DiscreteValues optimalAssignment() const;
-
-  /// Find the best total assignment, with given ordering - can be expensive.
-  DiscreteValues optimalAssignment(const Ordering& ordering) const;
-
   //    /*
   //     * Perform loopy belief propagation
   //     * True belief propagation would check for each value in domain

--- a/gtsam_unstable/discrete/Scheduler.cpp
+++ b/gtsam_unstable/discrete/Scheduler.cpp
@@ -255,23 +255,6 @@ DiscreteBayesNet::shared_ptr Scheduler::eliminate() const {
   return chordal;
 }
 
-/** Find the best total assignment - can be expensive */
-DiscreteValues Scheduler::optimalAssignment() const {
-  DiscreteBayesNet::shared_ptr chordal = eliminate();
-
-  if (ISDEBUG("Scheduler::optimalAssignment")) {
-    DiscreteBayesNet::const_iterator it = chordal->end() - 1;
-    const Student& student = students_.front();
-    cout << endl;
-    (*it)->print(student.name_);
-  }
-
-  gttic(my_optimize);
-  DiscreteValues mpe = chordal->optimize();
-  gttoc(my_optimize);
-  return mpe;
-}
-
 /** find the assignment of students to slots with most possible committees */
 DiscreteValues Scheduler::bestSchedule() const {
   DiscreteValues best;

--- a/gtsam_unstable/discrete/Scheduler.h
+++ b/gtsam_unstable/discrete/Scheduler.h
@@ -147,9 +147,6 @@ class GTSAM_UNSTABLE_EXPORT Scheduler : public CSP {
   /** Eliminate, return a Bayes net */
   DiscreteBayesNet::shared_ptr eliminate() const;
 
-  /** Find the best total assignment - can be expensive */
-  DiscreteValues optimalAssignment() const;
-
   /** find the assignment of students to slots with most possible committees */
   DiscreteValues bestSchedule() const;
 

--- a/gtsam_unstable/discrete/examples/schedulingExample.cpp
+++ b/gtsam_unstable/discrete/examples/schedulingExample.cpp
@@ -122,7 +122,7 @@ void runLargeExample() {
   //  SETDEBUG("timing-verbose", true);
   SETDEBUG("DiscreteConditional::DiscreteConditional", true);
   gttic(large);
-  auto MPE = scheduler.optimalAssignment();
+  auto MPE = scheduler.optimize();
   gttoc(large);
   tictoc_finishedIteration();
   tictoc_print();

--- a/gtsam_unstable/discrete/examples/schedulingExample.cpp
+++ b/gtsam_unstable/discrete/examples/schedulingExample.cpp
@@ -165,11 +165,11 @@ void solveStaged(size_t addMutex = 2) {
       root->print(""/*scheduler.studentName(s)*/);
 
     // solve root node only
-    DiscreteValues values;
-    size_t bestSlot = root->solve(values);
+    size_t bestSlot = root->argmax();
 
     // get corresponding count
     DiscreteKey dkey = scheduler.studentKey(6 - s);
+    DiscreteValues values;
     values[dkey.first] = bestSlot;
     size_t count = (*root)(values);
 
@@ -319,11 +319,11 @@ void accomodateStudent() {
   //  GTSAM_PRINT(*chordal);
 
   // solve root node only
-  DiscreteValues values;
-  size_t bestSlot = root->solve(values);
+  size_t bestSlot = root->argmax();
 
   // get corresponding count
   DiscreteKey dkey = scheduler.studentKey(0);
+  DiscreteValues values;
   values[dkey.first] = bestSlot;
   size_t count = (*root)(values);
   cout << boost::format("%s = %d (%d), count = %d") % scheduler.studentName(0)

--- a/gtsam_unstable/discrete/examples/schedulingQuals12.cpp
+++ b/gtsam_unstable/discrete/examples/schedulingQuals12.cpp
@@ -143,7 +143,7 @@ void runLargeExample() {
   }
 #else
   gttic(large);
-  auto MPE = scheduler.optimalAssignment();
+  auto MPE = scheduler.optimize();
   gttoc(large);
   tictoc_finishedIteration();
   tictoc_print();

--- a/gtsam_unstable/discrete/examples/schedulingQuals12.cpp
+++ b/gtsam_unstable/discrete/examples/schedulingQuals12.cpp
@@ -190,11 +190,11 @@ void solveStaged(size_t addMutex = 2) {
       root->print(""/*scheduler.studentName(s)*/);
 
     // solve root node only
-    DiscreteValues values;
-    size_t bestSlot = root->solve(values);
+    size_t bestSlot = root->argmax();
 
     // get corresponding count
     DiscreteKey dkey = scheduler.studentKey(NRSTUDENTS - 1 - s);
+    DiscreteValues values;
     values[dkey.first] = bestSlot;
     size_t count = (*root)(values);
 

--- a/gtsam_unstable/discrete/examples/schedulingQuals13.cpp
+++ b/gtsam_unstable/discrete/examples/schedulingQuals13.cpp
@@ -167,7 +167,7 @@ void runLargeExample() {
   }
 #else
   gttic(large);
-  auto MPE = scheduler.optimalAssignment();
+  auto MPE = scheduler.optimize();
   gttoc(large);
   tictoc_finishedIteration();
   tictoc_print();

--- a/gtsam_unstable/discrete/examples/schedulingQuals13.cpp
+++ b/gtsam_unstable/discrete/examples/schedulingQuals13.cpp
@@ -212,11 +212,11 @@ void solveStaged(size_t addMutex = 2) {
       root->print(""/*scheduler.studentName(s)*/);
 
     // solve root node only
-    DiscreteValues values;
-    size_t bestSlot = root->solve(values);
+    size_t bestSlot = root->argmax();
 
     // get corresponding count
     DiscreteKey dkey = scheduler.studentKey(NRSTUDENTS - 1 - s);
+    DiscreteValues values;
     values[dkey.first] = bestSlot;
     double count = (*root)(values);
 

--- a/gtsam_unstable/discrete/tests/testCSP.cpp
+++ b/gtsam_unstable/discrete/tests/testCSP.cpp
@@ -132,7 +132,7 @@ TEST(CSP, allInOne) {
   EXPECT(assert_equal(expectedProduct, product));
 
   // Solve
-  auto mpe = csp.optimalAssignment();
+  auto mpe = csp.optimize();
   DiscreteValues expected;
   insert(expected)(ID.first, 1)(UT.first, 0)(AZ.first, 1);
   EXPECT(assert_equal(expected, mpe));
@@ -172,22 +172,18 @@ TEST(CSP, WesternUS) {
   csp.addAllDiff(WY, CO);
   csp.addAllDiff(CO, NM);
 
+  DiscreteValues mpe;
+  insert(mpe)(0, 2)(1, 3)(2, 2)(3, 1)(4, 1)(5, 3)(6, 3)(7, 2)(8, 0)(9, 1)(10, 0);
+
   // Create ordering according to example in ND-CSP.lyx
   Ordering ordering;
   ordering += Key(0), Key(1), Key(2), Key(3), Key(4), Key(5), Key(6), Key(7),
       Key(8), Key(9), Key(10);
-  // Solve using that ordering:
-  auto mpe = csp.optimalAssignment(ordering);
-  // GTSAM_PRINT(mpe);
-  DiscreteValues expected;
-  insert(expected)(WA.first, 1)(CA.first, 1)(NV.first, 3)(OR.first, 0)(
-      MT.first, 1)(WY.first, 0)(NM.first, 3)(CO.first, 2)(ID.first, 2)(
-      UT.first, 1)(AZ.first, 0);
 
-  // TODO: Fix me! mpe result seems to be right. (See the printing)
-  // It has the same prob as the expected solution.
-  // Is mpe another solution, or the expected solution is unique???
-  EXPECT(assert_equal(expected, mpe));
+  // Solve using that ordering:
+  auto actualMPE = csp.optimize(ordering);
+
+  EXPECT(assert_equal(mpe, actualMPE));
   EXPECT_DOUBLES_EQUAL(1, csp(mpe), 1e-9);
 
   // Write out the dual graph for hmetis
@@ -227,7 +223,7 @@ TEST(CSP, ArcConsistency) {
   EXPECT_DOUBLES_EQUAL(1, csp(valid), 1e-9);
 
   // Solve
-  auto mpe = csp.optimalAssignment();
+  auto mpe = csp.optimize();
   DiscreteValues expected;
   insert(expected)(ID.first, 1)(UT.first, 0)(AZ.first, 2);
   EXPECT(assert_equal(expected, mpe));

--- a/gtsam_unstable/discrete/tests/testScheduler.cpp
+++ b/gtsam_unstable/discrete/tests/testScheduler.cpp
@@ -122,7 +122,7 @@ TEST(schedulingExample, test) {
 
   // Do exact inference
   gttic(small);
-  auto MPE = s.optimalAssignment();
+  auto MPE = s.optimize();
   gttoc(small);
 
   // print MPE, commented out as unit tests don't print

--- a/gtsam_unstable/discrete/tests/testSudoku.cpp
+++ b/gtsam_unstable/discrete/tests/testSudoku.cpp
@@ -100,7 +100,7 @@ class Sudoku : public CSP {
 
   /// solve and print solution
   void printSolution() const {
-    auto MPE = optimalAssignment();
+    auto MPE = optimize();
     printAssignment(MPE);
   }
 
@@ -126,7 +126,7 @@ TEST(Sudoku, small) {
              0, 1, 0, 0);
 
   // optimize and check
-  auto solution = csp.optimalAssignment();
+  auto solution = csp.optimize();
   DiscreteValues expected;
   insert(expected)(csp.key(0, 0), 0)(csp.key(0, 1), 1)(csp.key(0, 2), 2)(
       csp.key(0, 3), 3)(csp.key(1, 0), 2)(csp.key(1, 1), 3)(csp.key(1, 2), 0)(
@@ -148,7 +148,7 @@ TEST(Sudoku, small) {
   EXPECT_LONGS_EQUAL(16, new_csp.size());
 
   // Check that solution
-  auto new_solution = new_csp.optimalAssignment();
+  auto new_solution = new_csp.optimize();
   // csp.printAssignment(new_solution);
   EXPECT(assert_equal(expected, new_solution));
 }
@@ -250,7 +250,7 @@ TEST(Sudoku, AJC_3star_Feb8_2012) {
   EXPECT_LONGS_EQUAL(81, new_csp.size());
 
   // Check that solution
-  auto solution = new_csp.optimalAssignment();
+  auto solution = new_csp.optimize();
   // csp.printAssignment(solution);
   EXPECT_LONGS_EQUAL(6, solution.at(key99));
 }

--- a/python/gtsam/tests/test_DiscreteBayesNet.py
+++ b/python/gtsam/tests/test_DiscreteBayesNet.py
@@ -79,7 +79,7 @@ class TestDiscreteBayesNet(GtsamTestCase):
         self.gtsamAssertEquals(chordal.at(7), expected2)
 
         # solve
-        actualMPE = chordal.optimize()
+        actualMPE = fg.optimize()
         expectedMPE = DiscreteValues()
         for key in [Asia, Dyspnea, XRay, Tuberculosis, Smoking, Either, LungCancer, Bronchitis]:
             expectedMPE[key[0]] = 0
@@ -94,8 +94,7 @@ class TestDiscreteBayesNet(GtsamTestCase):
         fg.add(Dyspnea, "0 1")
 
         # solve again, now with evidence
-        chordal2 = fg.eliminateSequential(ordering)
-        actualMPE2 = chordal2.optimize()
+        actualMPE2 = fg.optimize()
         expectedMPE2 = DiscreteValues()
         for key in [XRay, Tuberculosis, Either, LungCancer]:
             expectedMPE2[key[0]] = 0
@@ -105,6 +104,7 @@ class TestDiscreteBayesNet(GtsamTestCase):
                          list(expectedMPE2.items()))
 
         # now sample from it
+        chordal2 = fg.eliminateSequential(ordering)
         actualSample = chordal2.sample()
         self.assertEqual(len(actualSample), 8)
 
@@ -121,10 +121,6 @@ class TestDiscreteBayesNet(GtsamTestCase):
         given = DiscreteValues()
         for key in [Asia, Smoking]:
             given[key[0]] = 0
-
-        # Now optimize fragment:
-        actual = fragment.optimize(given)
-        self.assertEqual(len(actual), 5)
 
         # Now sample from fragment:
         actual = fragment.sample(given)

--- a/python/gtsam/tests/test_DiscreteDistribution.py
+++ b/python/gtsam/tests/test_DiscreteDistribution.py
@@ -20,7 +20,7 @@ from gtsam.utils.test_case import GtsamTestCase
 X = 0, 2
 
 
-class TestDiscretePrior(GtsamTestCase):
+class TestDiscreteDistribution(GtsamTestCase):
     """Tests for Discrete Priors."""
 
     def test_constructor(self):


### PR DESCRIPTION
## Major Changes

This PR fixes #1048. In particular:
- `DiscreteFactorGraph::optimize` now really computes the MPE (maximum probable explanation)
- added a method `DiscreteFactorGraph::maxProduct`
- created two versions of each to take `OrderingType` or `Ordering`
- deprecated `DiscreteBayesNet::optimize` and `DiscreteConditional::solve`, as they do nothing really useful
- removed optimalAssignment in `gtsam_unstable/discrete`: redundant with optimize. Not deprecated, just gone!

## Max-product details:
I introduce two new classes (in one header/cpp):
- `DiscreteLookupTable`: inherits from `DiscreteConditional` to play well with generic elimination, but is supposed to be a lookup table of the maximum values obtained during max-product
- `DiscreteLookupDAG`: a DAG of lookup tables. Made this separate from BayesNet as to not confuse.
- `maxProduct` is implemented with a custom `Eliminate` function in `DiscreteFactorGraph.cpp`