### PR TITLE
Update python install in CI

### DIFF
--- a/.github/scripts/python.sh
+++ b/.github/scripts/python.sh
@@ -83,6 +83,6 @@ cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
 make -j2 install
 
 cd $GITHUB_WORKSPACE/build/python
-$PYTHON setup.py install --user --prefix=
+$PYTHON -m pip install --user .
 cd $GITHUB_WORKSPACE/python/gtsam/tests
 $PYTHON -m unittest discover -v


### PR DESCRIPTION
The Python Packaging Authority has decided to deprecate direct builds via calling setup.py (aka `python setup.py install`) due to the need to enforce a standard for wheel builds. [More details here.](https://github.com/pypa/pip/issues/8368)

This effect first showed up on MacOS with the following error:
```
python3 setup.py install --user --prefix=
PACKAGES:  ['gtsam', 'gtsam_unstable', 'gtsam.utils', 'gtsam.examples', 'gtsam_unstable.tests', 'gtsam_unstable.examples']
running install
/usr/local/lib/python3.9/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
/usr/local/lib/python3.9/site-packages/setuptools/command/easy_install.py:156: EasyInstallDeprecationWarning: easy_install command is deprecated. Use build and pip and other standards-based tools.
```
We are now seeing the deprecation effects in Ubuntu as well, so yeah this is going to need a bit of refactoring of the CI. I imagine this will effect the entirety of GTSAM going forward, hence this PR.