### PR TITLE
Add position to Point2 nodes in GraphViz

### DIFF
--- a/gtsam/nonlinear/GraphvizFormatting.cpp
+++ b/gtsam/nonlinear/GraphvizFormatting.cpp
@@ -53,6 +53,17 @@ boost::optional<Vector2> GraphvizFormatting::operator()(
   } else if (const GenericValue<Vector2>* p =
                  dynamic_cast<const GenericValue<Vector2>*>(&value)) {
     t << p->value().x(), p->value().y(), 0;
+  } else if (const GenericValue<Vector>* p =
+                 dynamic_cast<const GenericValue<Vector>*>(&value)) {
+    if (p->dim() == 2) {
+      const Eigen::Ref<const Vector2> p_2d(p->value());
+      t << p_2d.x(), p_2d.y(), 0;
+    } else if (p->dim() == 3) {
+      const Eigen::Ref<const Vector3> p_3d(p->value());
+      t = p_3d;
+    } else {
+      return boost::none;
+    }
   } else if (const GenericValue<Pose3>* p =
                  dynamic_cast<const GenericValue<Pose3>*>(&value)) {
     t = p->value().translation();


### PR DESCRIPTION
I had the problem that with me using the Python binding the position of Point2 nodes were not present in the GraphViz code of `saveGraph`.

After a little bit of debugging I knew why. When inserting values like so

```python
values = gtsam.Values()
values.insert(0, gtsam.Point2(100, 200))
values.serialize()
```

the result gives a hint about the values type:

```
 '22 serialization::archive 15 1 0\n0 0 0 1 0 2 34 gtsam::GenericValue<gtsam::Vector> 1 0\n1 0 0 0 0 2 1.00000000000000000e+02 2.00000000000000000e+02\n
```

It is a gtsam::Vector which is equivalent to `(Eigen::Matrix<double, -1, 1, 0, -1, 1>)` meaning the dynamic vector type. Thus, the dynamic_casts near the diff can't capture the values I added in this way.

This PR would also capture those. But I don't know if it is a good idea because maybe some other factors have this underlying type where it has no positional meaning. **So that's the first point to discuss.** 

After having implemented this "fix", I additionally stumbled over the following difference when using this kind of value adding:

```python
values = gtsam.Values()
values.insert_point2(0, gtsam.Point2(100, 200))
values.serialize()
```
```
'22 serialization::archive 15 1 0\n0 0 0 1 0 2 34 gtsam::GenericValue<gtsam::Point2> 1 0\n1 0 0 0 0 1.00000000000000000e+02 2.00000000000000000e+02\n'
```
As you can see, the type has changed and it is of a fixed size Eigen matrix `(Eigen::Matrix<double, 2, 1, 0, 2, 1>).` This type also gets correctly captured by the existing GraphViz formatting code. **So the second point of discussion is if this PR is needed at all then.** If it is not needed, I'd argue that the examples should not use the generic insert then. And I guess it should be documented somehow such that any beginner like me is not wondering why it is not doing what it should.