### PR TITLE
Abstract Conditional for Hybrid

### DIFF
--- a/gtsam/hybrid/GaussianMixture.cpp
+++ b/gtsam/hybrid/GaussianMixture.cpp
@@ -18,7 +18,7 @@
 
 #include <gtsam/base/utilities.h>
 #include <gtsam/hybrid/GaussianMixture.h>
-#include <gtsam/inference/Conditional.h>
+#include <gtsam/inference/Conditional-inst.h>
 
 namespace gtsam {
 

--- a/gtsam/hybrid/GaussianMixture.h
+++ b/gtsam/hybrid/GaussianMixture.h
@@ -22,6 +22,7 @@
 #include <gtsam/discrete/DiscreteKey.h>
 #include <gtsam/hybrid/DCGaussianMixtureFactor.h>
 #include <gtsam/linear/GaussianConditional.h>
+#include <gtsam/inference/Conditional.h>
 
 namespace gtsam {
 

--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -1,0 +1,13 @@
+//
+// Created by Fan Jiang on 1/24/22.
+//
+
+#include <gtsam/hybrid/HybridBayesNet.h>
+
+namespace gtsam {
+
+GaussianMixture::shared_ptr HybridBayesNet::atGaussian(size_t i) {
+  return boost::dynamic_pointer_cast<GaussianMixture>(factors_.at(i));
+}
+
+}

--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -9,5 +9,8 @@ namespace gtsam {
 GaussianMixture::shared_ptr HybridBayesNet::atGaussian(size_t i) {
   return boost::dynamic_pointer_cast<GaussianMixture>(factors_.at(i));
 }
+DiscreteConditional::shared_ptr HybridBayesNet::atDiscrete(size_t i) {
+  return boost::dynamic_pointer_cast<DiscreteConditional>(factors_.at(i));
+}
 
 }

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <gtsam/discrete/DiscreteKey.h>
+#include <gtsam/discrete/DiscreteConditional.h>
 #include <gtsam/hybrid/GaussianMixture.h>
 #include <gtsam/inference/BayesNet.h>
 #include <gtsam/linear/GaussianConditional.h>
@@ -29,11 +30,26 @@
 
 namespace gtsam {
 
-/// Bayes net
-class HybridBayesNet : public BayesNet<GaussianMixture> {
+/**
+ * A hybrid Bayes net can have discrete conditionals, Gaussian mixtures,
+ * or pure Gaussian conditionals.
+ */
+class GTSAM_EXPORT HybridBayesNet : public BayesNet<AbstractConditional> {
  public:
-  using ConditionalType = GaussianMixture;
+  using ConditionalType = AbstractConditional;
   using shared_ptr = boost::shared_ptr<HybridBayesNet>;
+
+  void add(const DiscreteKey &key, const std::string &table) {
+    DiscreteConditional dc;
+    // TODO(fan): implement this method
+  }
+
+  /**
+   * Get a specific Gaussian mixture factor by index
+   * (this checks array bounds and may throw an exception, as opposed to
+   * operator[] which does not).
+   */
+  GaussianMixture::shared_ptr atGaussian(size_t i);
 };
 
 }  // namespace gtsam

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -40,8 +40,9 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<AbstractConditional> {
   using shared_ptr = boost::shared_ptr<HybridBayesNet>;
 
   void add(const DiscreteKey &key, const std::string &table) {
-    DiscreteConditional dc;
+    DiscreteConditional dc(key, table);
     // TODO(fan): implement this method
+    push_back(dc);
   }
 
   /**
@@ -50,6 +51,14 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<AbstractConditional> {
    * operator[] which does not).
    */
   GaussianMixture::shared_ptr atGaussian(size_t i);
+
+  /**
+   * Get a specific Gaussian mixture factor by index
+   * (this checks array bounds and may throw an exception, as opposed to
+   * operator[] which does not).
+   */
+  DiscreteConditional::shared_ptr atDiscrete(size_t i);
+
 };
 
 }  // namespace gtsam

--- a/gtsam/hybrid/tests/testHybridBayesNet.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesNet.cpp
@@ -37,6 +37,12 @@ TEST(HybridBayesNet, Creation) {
   HybridBayesNet bayesNet;
 
   bayesNet.add(Asia, "99/1");
+
+  DiscreteConditional expected (Asia, "99/1");
+
+  CHECK(bayesNet.atDiscrete(0));
+  auto& df = *bayesNet.atDiscrete(0);
+  EXPECT(df.equals(expected));
 }
 
 /* ************************************************************************* */

--- a/gtsam/hybrid/tests/testHybridBayesNet.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesNet.cpp
@@ -1,0 +1,47 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file    testHybridBayesNet.cpp
+ * @brief   Unit tests for DCFactorGraph
+ * @author  Varun Agrawal
+ * @author  Fan Jiang
+ * @author  Frank Dellaert
+ * @date    December 2021
+ */
+
+#include <gtsam/hybrid/HybridBayesNet.h>
+
+// Include for test suite
+#include <CppUnitLite/TestHarness.h>
+
+using namespace std;
+using namespace gtsam;
+using noiseModel::Isotropic;
+using symbol_shorthand::M;
+using symbol_shorthand::X;
+
+static const DiscreteKey Asia(0, 2);
+
+/* ****************************************************************************/
+// Test creation
+TEST(HybridBayesNet, Creation) {
+  HybridBayesNet bayesNet;
+
+  bayesNet.add(Asia, "99/1");
+}
+
+/* ************************************************************************* */
+int main() {
+  TestResult tr;
+  return TestRegistry::runAllTests(tr);
+}
+/* ************************************************************************* */

--- a/gtsam/hybrid/tests/testIncrementalHybrid.cpp
+++ b/gtsam/hybrid/tests/testIncrementalHybrid.cpp
@@ -140,7 +140,7 @@ TEST(DCGaussianElimination, Incremental_inference) {
     auto dcMixture =
         dynamic_pointer_cast<DCGaussianMixtureFactor>(graph2.dcGraph().at(0));
     gf.add(dcMixture->factors()(m00));
-    auto x2_mixed = hybridBayesNet->at(1);
+    auto x2_mixed = boost::dynamic_pointer_cast<GaussianMixture>(hybridBayesNet->at(1));
     gf.add(x2_mixed->factors()(m00));
     auto result_gf = gf.eliminateSequential();
     return gf.probPrime(result_gf->optimize());
@@ -250,13 +250,13 @@ TEST(DCGaussianElimination, Approx_inference) {
 
   CHECK(hybridBayesNet);
   EXPECT_LONGS_EQUAL(4, hybridBayesNet->size());
-  EXPECT_LONGS_EQUAL(2, hybridBayesNet->at(0)->nrComponents());
-  EXPECT_LONGS_EQUAL(4, hybridBayesNet->at(1)->nrComponents());
-  EXPECT_LONGS_EQUAL(8, hybridBayesNet->at(2)->nrComponents());
-  EXPECT_LONGS_EQUAL(5, hybridBayesNet->at(3)->nrComponents());
+  EXPECT_LONGS_EQUAL(2, hybridBayesNet->atGaussian(0)->nrComponents());
+  EXPECT_LONGS_EQUAL(4, hybridBayesNet->atGaussian(1)->nrComponents());
+  EXPECT_LONGS_EQUAL(8, hybridBayesNet->atGaussian(2)->nrComponents());
+  EXPECT_LONGS_EQUAL(5, hybridBayesNet->atGaussian(3)->nrComponents());
 
-  auto &lastDensity = *(hybridBayesNet->at(3));
-  auto &unprunedLastDensity = *(unprunedHybridBayesNet->at(3));
+  auto &lastDensity = *(hybridBayesNet->atGaussian(3));
+  auto &unprunedLastDensity = *(unprunedHybridBayesNet->atGaussian(3));
   std::vector<std::pair<DiscreteValues, double>>
       assignments = discreteFactor_m1.enumerate();
   // Loop over all assignments and check the pruned components
@@ -304,10 +304,10 @@ TEST_UNSAFE(DCGaussianElimination, Incremental_approximate) {
 
   auto &actualBayesNet1 = *incrementalHybrid.hybridBayesNet_;
   CHECK_EQUAL(4, actualBayesNet1.size());
-  EXPECT_LONGS_EQUAL(2, actualBayesNet1.at(0)->nrComponents());
-  EXPECT_LONGS_EQUAL(4, actualBayesNet1.at(1)->nrComponents());
-  EXPECT_LONGS_EQUAL(8, actualBayesNet1.at(2)->nrComponents());
-  EXPECT_LONGS_EQUAL(5, actualBayesNet1.at(3)->nrComponents());
+  EXPECT_LONGS_EQUAL(2, actualBayesNet1.atGaussian(0)->nrComponents());
+  EXPECT_LONGS_EQUAL(4, actualBayesNet1.atGaussian(1)->nrComponents());
+  EXPECT_LONGS_EQUAL(8, actualBayesNet1.atGaussian(2)->nrComponents());
+  EXPECT_LONGS_EQUAL(5, actualBayesNet1.atGaussian(3)->nrComponents());
 
   GaussianHybridFactorGraph graph2;
   graph2.push_back(switching.linearizedFactorGraph.dcGraph().at(3));
@@ -321,8 +321,8 @@ TEST_UNSAFE(DCGaussianElimination, Incremental_approximate) {
 
   auto &actualBayesNet = *incrementalHybrid.hybridBayesNet_;
   CHECK_EQUAL(2, actualBayesNet.size());
-  EXPECT_LONGS_EQUAL(10, actualBayesNet.at(0)->nrComponents());
-  EXPECT_LONGS_EQUAL(5, actualBayesNet.at(1)->nrComponents());
+  EXPECT_LONGS_EQUAL(10, actualBayesNet.atGaussian(0)->nrComponents());
+  EXPECT_LONGS_EQUAL(5, actualBayesNet.atGaussian(1)->nrComponents());
 }
 
 

--- a/gtsam/inference/AbstractConditional.cpp
+++ b/gtsam/inference/AbstractConditional.cpp
@@ -1,0 +1,28 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file    AbstractConditional.cpp
+ * @brief   Concrete base class for conditional densities
+ * @author  Fan Jiang
+ */
+
+
+#include <gtsam/inference/AbstractConditional.h>
+
+namespace gtsam {
+/* ************************************************************************* */
+bool AbstractConditional::equals(const AbstractConditional &c,
+                                 double tol) const {
+  return nrFrontals_ == c.nrFrontals_;
+}
+
+}

--- a/gtsam/inference/AbstractConditional.h
+++ b/gtsam/inference/AbstractConditional.h
@@ -1,0 +1,90 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file    AbstractConditional.h
+ * @brief   Concrete base class for conditional densities
+ * @author  Fan Jiang
+ */
+
+// \callgraph
+#pragma once
+
+#include <boost/range.hpp>
+
+#include <gtsam/inference/Key.h>
+
+namespace gtsam {
+
+class GTSAM_EXPORT AbstractConditional {
+ protected:
+  /** The first nrFrontal variables are frontal and the rest are parents. */
+  size_t nrFrontals_;
+
+ public:
+  /** View of the frontal keys (call frontals()) */
+  typedef boost::iterator_range<typename KeyVector::const_iterator> Frontals;
+
+  /** View of the separator keys (call parents()) */
+  typedef boost::iterator_range<typename KeyVector::const_iterator> Parents;
+
+ protected:
+  /// @name Standard Constructors
+  /// @{
+
+  /** Empty Constructor to make serialization possible */
+  AbstractConditional() : nrFrontals_(0) {}
+
+  /** Constructor */
+  AbstractConditional(size_t nrFrontals) : nrFrontals_(nrFrontals) {}
+
+  /// @}
+
+ public:
+  virtual ~AbstractConditional() = default;
+
+  /// @name Testable
+  /// @{
+
+  /** print with optional formatter */
+  virtual void print(const std::string &s = "Conditional",
+                     const KeyFormatter &formatter = DefaultKeyFormatter) const = 0;
+
+  /** check equality */
+  bool equals(const AbstractConditional &c, double tol = 1e-9) const;
+
+  /// @}
+
+  /// @name Standard Interface
+  /// @{
+
+  /** return the number of frontals */
+  size_t nrFrontals() const { return nrFrontals_; }
+
+  /** Mutable version of nrFrontals */
+  size_t &nrFrontals() { return nrFrontals_; }
+
+  /** return the number of parents */
+  virtual size_t nrParents() const = 0;
+
+
+  /** return a view of the frontal keys */
+  virtual Frontals frontals() const = 0;
+
+  virtual Parents parents() const = 0;
+  /// @}
+};
+
+/// traits
+template <>
+struct traits<AbstractConditional> : public Testable<AbstractConditional> {};
+
+}

--- a/gtsam/inference/Conditional-inst.h
+++ b/gtsam/inference/Conditional-inst.h
@@ -37,11 +37,4 @@ namespace gtsam {
     std::cout << ")" << std::endl;
   }
 
-  /* ************************************************************************* */
-  template<class FACTOR, class DERIVEDFACTOR>
-  bool Conditional<FACTOR,DERIVEDFACTOR>::equals(const This& c, double tol) const
-  {
-    return nrFrontals_ == c.nrFrontals_;
-  }
-
 }

--- a/gtsam/inference/Conditional.h
+++ b/gtsam/inference/Conditional.h
@@ -20,131 +20,132 @@
 
 #include <boost/range.hpp>
 
+#include <gtsam/inference/AbstractConditional.h>
 #include <gtsam/inference/Key.h>
 
 namespace gtsam {
 
-  /**
-   * Base class for conditional densities.  This class iterators and
-   * access to the frontal and separator keys.
-   *
-   * Derived classes *must* redefine the Factor and shared_ptr typedefs to refer
-   * to the associated factor type and shared_ptr type of the derived class.  See
-   * SymbolicConditional and GaussianConditional for examples.
-   * \nosubgrouping
-   */
-  template<class FACTOR, class DERIVEDCONDITIONAL>
-  class Conditional
-  {
-  protected:
-    /** The first nrFrontal variables are frontal and the rest are parents. */
-    size_t nrFrontals_;
+/**
+ * Base class for conditional densities.  This class iterators and
+ * access to the frontal and separator keys.
+ *
+ * Derived classes *must* redefine the Factor and shared_ptr typedefs to refer
+ * to the associated factor type and shared_ptr type of the derived class.  See
+ * SymbolicConditional and GaussianConditional for examples.
+ * \nosubgrouping
+ */
+template<class FACTOR, class DERIVEDCONDITIONAL>
+class Conditional : public AbstractConditional {
 
-  private:
-    /// Typedef to this class
-    typedef Conditional<FACTOR,DERIVEDCONDITIONAL> This;
+ private:
+  /// Typedef to this class
+  typedef Conditional<FACTOR, DERIVEDCONDITIONAL> This;
 
-  public:
-    /** View of the frontal keys (call frontals()) */
-    typedef boost::iterator_range<typename FACTOR::const_iterator> Frontals;
+ protected:
 
-    /** View of the separator keys (call parents()) */
-    typedef boost::iterator_range<typename FACTOR::const_iterator> Parents;
+  /// @name Standard Constructors
+  /// @{
 
-  protected:
-    /// @name Standard Constructors
-    /// @{
+  /** Empty Constructor to make serialization possible */
+  Conditional() {}
 
-    /** Empty Constructor to make serialization possible */
-    Conditional() : nrFrontals_(0) {}
+  /** Constructor */
+  Conditional(size_t nrFrontals) : AbstractConditional(nrFrontals) {}
 
-    /** Constructor */
-    Conditional(size_t nrFrontals) : nrFrontals_(nrFrontals) {}
+  /// @}
 
-    /// @}
+ public:
+  /// @name Testable
+  /// @{
 
-  public:
-    /// @name Testable
-    /// @{
+  /** print with optional formatter */
+  void print(const std::string &s = "Conditional",
+             const KeyFormatter &formatter = DefaultKeyFormatter) const override;
 
-    /** print with optional formatter */
-    void print(const std::string& s = "Conditional", const KeyFormatter& formatter = DefaultKeyFormatter) const;
+  /** check equality */
+  bool equals(const This &c, double tol = 1e-9) const {
+    return AbstractConditional::equals(c, tol);
+  }
 
-    /** check equality */
-    bool equals(const This& c, double tol = 1e-9) const;
+  /// @}
 
-    /// @}
+  /// @name Standard Interface
+  /// @{
 
-    /// @name Standard Interface
-    /// @{
+  /** return the number of parents */
+  size_t nrParents() const override { return asFactor().size() - nrFrontals_; }
 
-    /** return the number of frontals */
-    size_t nrFrontals() const { return nrFrontals_; }
+  /** Convenience function to get the first frontal key */
+  Key firstFrontalKey() const {
+    if (nrFrontals_ > 0)
+      return asFactor().front();
+    else
+      throw std::invalid_argument(
+          "Requested Conditional::firstFrontalKey from a conditional with zero frontal keys");
+  }
 
-    /** return the number of parents */
-    size_t nrParents() const { return asFactor().size() - nrFrontals_; }
+  /** return a view of the frontal keys */
+  Frontals frontals() const override {
+    return boost::make_iterator_range(beginFrontals(),
+                                      endFrontals());
+  }
 
-    /** Convenience function to get the first frontal key */
-    Key firstFrontalKey() const {
-      if(nrFrontals_ > 0)
-        return asFactor().front();
-      else
-        throw std::invalid_argument("Requested Conditional::firstFrontalKey from a conditional with zero frontal keys");
-    }
+  /** return a view of the parent keys */
+  Parents parents() const override {
+    return boost::make_iterator_range(beginParents(),
+                                      endParents());
+  }
 
-    /** return a view of the frontal keys */
-    Frontals frontals() const { return boost::make_iterator_range(beginFrontals(), endFrontals()); }
+  /** Iterator pointing to first frontal key. */
+  typename FACTOR::const_iterator beginFrontals() const { return asFactor().begin(); }
 
-    /** return a view of the parent keys */
-    Parents parents() const { return boost::make_iterator_range(beginParents(), endParents()); }
+  /** Iterator pointing past the last frontal key. */
+  typename FACTOR::const_iterator endFrontals() const {
+    return asFactor().begin() + nrFrontals_;
+  }
 
-    /** Iterator pointing to first frontal key. */
-    typename FACTOR::const_iterator beginFrontals() const { return asFactor().begin(); }
+  /** Iterator pointing to the first parent key. */
+  typename FACTOR::const_iterator beginParents() const { return endFrontals(); }
 
-    /** Iterator pointing past the last frontal key. */
-    typename FACTOR::const_iterator endFrontals() const { return asFactor().begin() + nrFrontals_; }
+  /** Iterator pointing past the last parent key. */
+  typename FACTOR::const_iterator endParents() const { return asFactor().end(); }
 
-    /** Iterator pointing to the first parent key. */
-    typename FACTOR::const_iterator beginParents() const { return endFrontals(); }
+  /// @}
+  /// @name Advanced Interface
+  /// @{
 
-    /** Iterator pointing past the last parent key. */
-    typename FACTOR::const_iterator endParents() const { return asFactor().end(); }
+  /** Mutable iterator pointing to first frontal key. */
+  typename FACTOR::iterator beginFrontals() { return asFactor().begin(); }
 
-    /// @}
-    /// @name Advanced Interface
-    /// @{
+  /** Mutable iterator pointing past the last frontal key. */
+  typename FACTOR::iterator endFrontals() {
+    return asFactor().begin() + nrFrontals_;
+  }
 
-    /** Mutable version of nrFrontals */
-    size_t& nrFrontals() { return nrFrontals_; }
+  /** Mutable iterator pointing to the first parent key. */
+  typename FACTOR::iterator beginParents() {
+    return asFactor().begin() + nrFrontals_;
+  }
 
-    /** Mutable iterator pointing to first frontal key. */
-    typename FACTOR::iterator beginFrontals() { return asFactor().begin(); }
+  /** Mutable iterator pointing past the last parent key. */
+  typename FACTOR::iterator endParents() { return asFactor().end(); }
 
-    /** Mutable iterator pointing past the last frontal key. */
-    typename FACTOR::iterator endFrontals() { return asFactor().begin() + nrFrontals_; }
+ private:
+  // Cast to factor type (non-const) (casts down to derived conditional type, then up to factor type)
+  FACTOR &asFactor() { return static_cast<FACTOR &>(static_cast<DERIVEDCONDITIONAL &>(*this)); }
 
-    /** Mutable iterator pointing to the first parent key. */
-    typename FACTOR::iterator beginParents() { return asFactor().begin() + nrFrontals_; }
+  // Cast to derived type (const) (casts down to derived conditional type, then up to factor type)
+  const FACTOR &asFactor() const { return static_cast<const FACTOR &>(static_cast<const DERIVEDCONDITIONAL &>(*this)); }
 
-    /** Mutable iterator pointing past the last parent key. */
-    typename FACTOR::iterator endParents() { return asFactor().end(); }
+  /** Serialization function */
+  friend class boost::serialization::access;
+  template<class ARCHIVE>
+  void serialize(ARCHIVE &ar, const unsigned int /*version*/) {
+    ar & BOOST_SERIALIZATION_NVP(nrFrontals_);
+  }
 
-  private:
-    // Cast to factor type (non-const) (casts down to derived conditional type, then up to factor type)
-    FACTOR& asFactor() { return static_cast<FACTOR&>(static_cast<DERIVEDCONDITIONAL&>(*this)); }
+  /// @}
 
-    // Cast to derived type (const) (casts down to derived conditional type, then up to factor type)
-    const FACTOR& asFactor() const { return static_cast<const FACTOR&>(static_cast<const DERIVEDCONDITIONAL&>(*this)); }
-
-    /** Serialization function */
-    friend class boost::serialization::access;
-    template<class ARCHIVE>
-    void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
-      ar & BOOST_SERIALIZATION_NVP(nrFrontals_);
-    }
-
-    /// @}
-
-  };
+};
 
 } // gtsam


### PR DESCRIPTION
This PR implements the idea of making `Conditional` base on a concrete `AbstractConditional` so we can using virtual dispatch.

All tests pass except one - hybrid now actually does hybrid, so the full elimination fails, as we didn't implement discrete elimination in `EliminateHybrid`:

```
testHybridFactorGraph
gtsam/hybrid/tests/testHybridFactorGraph.cpp:377: Failure: "Exception: DecisionTree::convertFrom: Invalid NodePtr" 
There were 1 failures

Process finished with exit code 1
```