### PR TITLE
Use CMAKE_INSTALL_PREFIX for python-install target

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -172,7 +172,7 @@ endif()
 # Add custom target so we can install with `make python-install`
 set(GTSAM_PYTHON_INSTALL_TARGET python-install)
 add_custom_target(${GTSAM_PYTHON_INSTALL_TARGET}
-        COMMAND ${PYTHON_EXECUTABLE} ${GTSAM_PYTHON_BUILD_DIRECTORY}/setup.py install
+        COMMAND ${PYTHON_EXECUTABLE} ${GTSAM_PYTHON_BUILD_DIRECTORY}/setup.py install --prefix ${CMAKE_INSTALL_PREFIX}
         DEPENDS ${GTSAM_PYTHON_DEPENDENCIES}
         WORKING_DIRECTORY ${GTSAM_PYTHON_BUILD_DIRECTORY})
 


### PR DESCRIPTION
Currently the `python-install` target wants to install to the default location of setup.py which is `/usr/local` (see [here](https://docs.python.org/3/install/#how-installation-works)). That typically means you need to `sudo make python-install` (root privileges). The normal gtsam C++ code gets installed to `CMAKE_INSTALL_PREFIX` as usual with CMake (e.g. you could choose `$HOME/.local` for a per-user installation without root privileges).

If you don't specify any custom `CMAKE_INSTALL_PREFIX`, CMake should default to `/usr/local` on Linux which then should be the same behavior as before (on my machine it does). I am not sure about Windows though...

I propose to also use this CMake mechanism to select where the python bindings are going to be installed. Actually, the current readme says that it actually would work this way:

https://github.com/borglab/gtsam/blob/d6edcea4c44dcb36f77fba996621e5f125918899/python/README.md?plain=1#L32

But it does not. This PR fixes that.

Edit: Just for reference, was already topic in https://github.com/borglab/gtsam/pull/1059#issuecomment-1019493453