### PR TITLE
Add default constructor to PoseRotationPrior to fix serialization

### DIFF
--- a/gtsam/slam/PoseRotationPrior.h
+++ b/gtsam/slam/PoseRotationPrior.h
@@ -39,6 +39,9 @@ protected:
 
 public:
 
+  /** default constructor - only use for serialization */
+  PoseRotationPrior() {}
+
   /** standard constructor */
   PoseRotationPrior(Key key, const Rotation& rot_z, const SharedNoiseModel& model)
   : Base(model, key), measured_(rot_z) {}


### PR DESCRIPTION
This matches the existing code here:  https://github.com/borglab/gtsam/blob/develop/gtsam/slam/PoseTranslationPrior.h