### PR TITLE
Fix DotWriter wrapping

### DIFF
--- a/gtsam/discrete/tests/testDiscreteBayesNet.cpp
+++ b/gtsam/discrete/tests/testDiscreteBayesNet.cpp
@@ -150,7 +150,6 @@ TEST(DiscreteBayesNet, Dot) {
   fragment.add((Either | Tuberculosis, LungCancer) = "F T T T");
 
   string actual = fragment.dot();
-  cout << actual << endl;
   EXPECT(actual ==
          "digraph {\n"
          "  size=\"5,5\";\n"

--- a/python/gtsam/preamble/inference.h
+++ b/python/gtsam/preamble/inference.h
@@ -10,3 +10,5 @@
  * Without this they will be automatically converted to a Python object, and all
  * mutations on Python side will not be reflected on C++.
  */
+
+#include <pybind11/stl.h>

--- a/python/gtsam/tests/test_DiscreteBayesNet.py
+++ b/python/gtsam/tests/test_DiscreteBayesNet.py
@@ -12,7 +12,9 @@ Author: Frank Dellaert
 # pylint: disable=no-name-in-module, invalid-name
 
 import unittest
+import textwrap
 
+import gtsam
 from gtsam import (DiscreteBayesNet, DiscreteConditional, DiscreteFactorGraph,
                    DiscreteKeys, DiscreteDistribution, DiscreteValues, Ordering)
 from gtsam.utils.test_case import GtsamTestCase
@@ -125,6 +127,39 @@ class TestDiscreteBayesNet(GtsamTestCase):
         # Now sample from fragment:
         actual = fragment.sample(given)
         self.assertEqual(len(actual), 5)
+
+    def test_dot(self):
+        """Check that dot works with position hints."""
+        fragment = DiscreteBayesNet()
+        fragment.add(Either, [Tuberculosis, LungCancer], "F T T T")
+        MyAsia = gtsam.symbol('a', 0), 2  # use a symbol!
+        fragment.add(Tuberculosis, [MyAsia], "99/1 95/5")
+        fragment.add(LungCancer, [Smoking], "99/1 90/10")
+
+        # Make sure we can *update* position hints
+        writer = gtsam.DotWriter()
+        ph: dict = writer.positionHints
+        ph.update({'a': 2})  # hint at symbol position
+        writer.positionHints = ph
+
+        # Check the output of dot
+        actual = fragment.dot(writer=writer)
+        expected_result = """\
+            digraph {
+              size="5,5";
+
+              var3[label="3"];
+              var4[label="4"];
+              var5[label="5"];
+              var6[label="6"];
+              vara0[label="a0", pos="0,2!"];
+
+              var4->var6
+              vara0->var3
+              var3->var5
+              var6->var5
+            }"""
+        self.assertEqual(actual, textwrap.dedent(expected_result))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
@varunagrawal , [this commit](https://github.com/borglab/gtsam/pull/1083/commits/134e82836e0ff19cd0a2cfeb91d91f3502d74b10) removed the line

```
#include <pybind11/stl.h>
```

which was needed to access and update the fields in `gtsam.DotWriter`, which I need in [gtbook](https://gtbook.github.io/gtbook/). Admittedly, there was no test in gtsam that showed this line is crucial. This PR fixes that by adding a test and adding the line back in.

PS, this was a pain to debug as the wrapper cmake scripts do *not* copy over files in preamble and specializations after they have been touched. I had to manually update the copy in the build folder. Maybe something to fix in wrap after IROS deadline.