### PR TITLE
EXPORT statements to help Windows build. In Constraint.h, there was a…

### DIFF
--- a/gtsam/discrete/DiscreteKey.h
+++ b/gtsam/discrete/DiscreteKey.h
@@ -72,5 +72,5 @@ namespace gtsam {
   }; // DiscreteKeys
 
   /// Create a list from two keys
-  DiscreteKeys operator&(const DiscreteKey& key1, const DiscreteKey& key2);
+  GTSAM_EXPORT DiscreteKeys operator&(const DiscreteKey& key1, const DiscreteKey& key2);
 }

--- a/gtsam_unstable/discrete/Constraint.h
+++ b/gtsam_unstable/discrete/Constraint.h
@@ -34,7 +34,7 @@ using Domains = std::map<Key, Domain>;
  * Base class for constraint factors
  * Derived classes include SingleValue, BinaryAllDiff, and AllDiff.
  */
-class GTSAM_EXPORT Constraint : public DiscreteFactor {
+class GTSAM_UNSTABLE_EXPORT Constraint : public DiscreteFactor {
  public:
   typedef boost::shared_ptr<Constraint> shared_ptr;
 


### PR DESCRIPTION
* In Constraint.h, there was a GTSAM_EXPORT that should have been GTSAM_UNSTABLE_EXPORT, and
* In DiscreteKey.h, there should be a GTSAM_EXPORT in front of an operator definition for a class that is being exported.

This does **not** fix _all_ of the `gtsam_unstable` build issues on MSVC / Windows, but it fixes all of the issues stemming from `gtsam_unstable\Discrete`