### PR TITLE
Fix MSVC / Windows Build of GTSAM_UNSTABLE

### DIFF
--- a/gtsam/geometry/PinholeCamera.h
+++ b/gtsam/geometry/PinholeCamera.h
@@ -30,7 +30,7 @@ namespace gtsam {
  * \nosubgrouping
  */
 template<typename Calibration>
-class GTSAM_EXPORT PinholeCamera: public PinholeBaseK<Calibration> {
+class PinholeCamera: public PinholeBaseK<Calibration> {
 
 public:
 

--- a/gtsam/geometry/PinholePose.h
+++ b/gtsam/geometry/PinholePose.h
@@ -31,7 +31,7 @@ namespace gtsam {
  * \nosubgrouping
  */
 template<typename CALIBRATION>
-class GTSAM_EXPORT PinholeBaseK: public PinholeBase {
+class PinholeBaseK: public PinholeBase {
 
 private:
 

--- a/gtsam/nonlinear/NonlinearFactor.h
+++ b/gtsam/nonlinear/NonlinearFactor.h
@@ -282,7 +282,7 @@ public:
  * which are objects in non-linear manifolds (Lie groups).
  */
 template<class VALUE>
-class GTSAM_EXPORT NoiseModelFactor1: public NoiseModelFactor {
+class NoiseModelFactor1: public NoiseModelFactor {
 
 public:
 
@@ -366,7 +366,7 @@ private:
 /** A convenient base class for creating your own NoiseModelFactor with 2
  * variables.  To derive from this class, implement evaluateError(). */
 template<class VALUE1, class VALUE2>
-class GTSAM_EXPORT NoiseModelFactor2: public NoiseModelFactor {
+class NoiseModelFactor2: public NoiseModelFactor {
 
 public:
 
@@ -441,7 +441,7 @@ private:
 /** A convenient base class for creating your own NoiseModelFactor with 3
  * variables.  To derive from this class, implement evaluateError(). */
 template<class VALUE1, class VALUE2, class VALUE3>
-class GTSAM_EXPORT NoiseModelFactor3: public NoiseModelFactor {
+class NoiseModelFactor3: public NoiseModelFactor {
 
 public:
 
@@ -518,7 +518,7 @@ private:
 /** A convenient base class for creating your own NoiseModelFactor with 4
  * variables.  To derive from this class, implement evaluateError(). */
 template<class VALUE1, class VALUE2, class VALUE3, class VALUE4>
-class GTSAM_EXPORT NoiseModelFactor4: public NoiseModelFactor {
+class NoiseModelFactor4: public NoiseModelFactor {
 
 public:
 
@@ -599,7 +599,7 @@ private:
 /** A convenient base class for creating your own NoiseModelFactor with 5
  * variables.  To derive from this class, implement evaluateError(). */
 template<class VALUE1, class VALUE2, class VALUE3, class VALUE4, class VALUE5>
-class GTSAM_EXPORT NoiseModelFactor5: public NoiseModelFactor {
+class NoiseModelFactor5: public NoiseModelFactor {
 
 public:
 
@@ -684,7 +684,7 @@ private:
 /** A convenient base class for creating your own NoiseModelFactor with 6
  * variables.  To derive from this class, implement evaluateError(). */
 template<class VALUE1, class VALUE2, class VALUE3, class VALUE4, class VALUE5, class VALUE6>
-class GTSAM_EXPORT NoiseModelFactor6: public NoiseModelFactor {
+class NoiseModelFactor6: public NoiseModelFactor {
 
 public:
 

--- a/gtsam/slam/SmartFactorBase.h
+++ b/gtsam/slam/SmartFactorBase.h
@@ -47,7 +47,7 @@ namespace gtsam {
  * @tparam CAMERA should behave like a PinholeCamera.
  */
 template<class CAMERA>
-class GTSAM_EXPORT SmartFactorBase: public NonlinearFactor {
+class SmartFactorBase: public NonlinearFactor {
 
 private:
   typedef NonlinearFactor Base;

--- a/gtsam_unstable/slam/SmartStereoProjectionFactor.h
+++ b/gtsam_unstable/slam/SmartStereoProjectionFactor.h
@@ -49,7 +49,7 @@ typedef SmartProjectionParams SmartStereoProjectionParams;
  * If you'd like to store poses in values instead of cameras, use
  * SmartStereoProjectionPoseFactor instead
 */
-class GTSAM_UNSTABLE_EXPORT SmartStereoProjectionFactor
+class SmartStereoProjectionFactor
     : public SmartFactorBase<StereoCamera> {
  private:
 


### PR DESCRIPTION
Per https://github.com/borglab/gtsam/blob/develop/Using-GTSAM-EXPORT.md , classes with no methods defined in a .cpp file shouldn't have the GTSAM_EXPORT or GTSAM_UNSTABLE_EXPORT modifier. This was causing problems with the building of gtsam_unstable on MSVC / Windows.

What I don't like about this PR is that it is reverses several changes @varunagrawal made in #904. I think that the way it is done in this PR is probably correct, but I think @varunagrawal should weigh in, just in case I'm missing something.

This is in service of #1087, but it isn't a resolution, since that issue is about MATLAB. I started this little cul-de-sac as a waypoint on the way to examining the MATLAB build, and I'll take a look at that soon.

Two requests from @dellaert are ignored here:

1) **_Silence some / all of the C4834 warnings about ignored returns from [[nodiscard]] functions:_** Doing this file-by-file with `#pragma warning(disable : 4834)` resulted in, I think, 85 files with changes. I made a patch of that change just in case we _do_ want it, but I thought that changing that many files was probably a sign it was not the right approach.

2) **_Add more actions to the Windows CI:_** There are six targets in `.github/workflows/build-windows.yml`:
```
          cmake --build build -j 4 --config ${{ matrix.build_type }} --target gtsam
          cmake --build build -j 4 --config ${{ matrix.build_type }} --target gtsam_unstable
          cmake --build build -j 4 --config ${{ matrix.build_type }} --target wrap
          cmake --build build -j 4 --config ${{ matrix.build_type }} --target check.base
          cmake --build build -j 4 --config ${{ matrix.build_type }} --target check.base_unstable
          cmake --build build -j 4 --config ${{ matrix.build_type }} --target check.linear
```
 and it turns out that that is all of the the `check`s that _will_ pass right now. I can modify the list to include more targets, but they will fail. I haven't tried to look at them and see _why_ they're failing.