### PR TITLE
Allow more functionality through system METIS

### DIFF
--- a/cmake/HandleMetis.cmake
+++ b/cmake/HandleMetis.cmake
@@ -22,7 +22,7 @@ if(GTSAM_USE_SYSTEM_METIS)
 
     add_library(metis-gtsam-if INTERFACE)
     target_include_directories(metis-gtsam-if BEFORE INTERFACE ${METIS_INCLUDE_DIR}
-      # gtsam_unstable/partition/FindSeparator-inl.h uses internel metislib.h API
+      # gtsam_unstable/partition/FindSeparator-inl.h uses internal metislib.h API
       # via extern "C"
       $<BUILD_INTERFACE:${GTSAM_SOURCE_DIR}/gtsam/3rdparty/metis/libmetis>
       $<BUILD_INTERFACE:${GTSAM_SOURCE_DIR}/gtsam/3rdparty/metis/GKlib>
@@ -37,7 +37,7 @@ else()
   target_include_directories(metis-gtsam BEFORE PUBLIC
     $<INSTALL_INTERFACE:include/gtsam/3rdparty/metis/>
     $<BUILD_INTERFACE:${GTSAM_SOURCE_DIR}/gtsam/3rdparty/metis/include>
-    # gtsam_unstable/partition/FindSeparator-inl.h uses internel metislib.h API
+    # gtsam_unstable/partition/FindSeparator-inl.h uses internal metislib.h API
     # via extern "C"
     $<BUILD_INTERFACE:${GTSAM_SOURCE_DIR}/gtsam/3rdparty/metis/libmetis>
     $<BUILD_INTERFACE:${GTSAM_SOURCE_DIR}/gtsam/3rdparty/metis/GKlib>

--- a/cmake/HandleMetis.cmake
+++ b/cmake/HandleMetis.cmake
@@ -21,7 +21,12 @@ if(GTSAM_USE_SYSTEM_METIS)
     mark_as_advanced(METIS_LIBRARY)
 
     add_library(metis-gtsam-if INTERFACE)
-    target_include_directories(metis-gtsam-if BEFORE INTERFACE ${METIS_INCLUDE_DIR})
+    target_include_directories(metis-gtsam-if BEFORE INTERFACE ${METIS_INCLUDE_DIR}
+      # gtsam_unstable/partition/FindSeparator-inl.h uses internel metislib.h API
+      # via extern "C"
+      $<BUILD_INTERFACE:${GTSAM_SOURCE_DIR}/gtsam/3rdparty/metis/libmetis>
+      $<BUILD_INTERFACE:${GTSAM_SOURCE_DIR}/gtsam/3rdparty/metis/GKlib>
+    )
     target_link_libraries(metis-gtsam-if INTERFACE ${METIS_LIBRARY})
   endif()
 else()
@@ -30,10 +35,12 @@ else()
   add_subdirectory(${GTSAM_SOURCE_DIR}/gtsam/3rdparty/metis)
 
   target_include_directories(metis-gtsam BEFORE PUBLIC
+    $<INSTALL_INTERFACE:include/gtsam/3rdparty/metis/>
     $<BUILD_INTERFACE:${GTSAM_SOURCE_DIR}/gtsam/3rdparty/metis/include>
+    # gtsam_unstable/partition/FindSeparator-inl.h uses internel metislib.h API
+    # via extern "C"
     $<BUILD_INTERFACE:${GTSAM_SOURCE_DIR}/gtsam/3rdparty/metis/libmetis>
     $<BUILD_INTERFACE:${GTSAM_SOURCE_DIR}/gtsam/3rdparty/metis/GKlib>
-    $<INSTALL_INTERFACE:include/gtsam/3rdparty/metis/>
   )
 
   add_library(metis-gtsam-if INTERFACE)

--- a/gtsam/inference/Ordering.cpp
+++ b/gtsam/inference/Ordering.cpp
@@ -25,11 +25,7 @@
 #include <gtsam/3rdparty/CCOLAMD/Include/ccolamd.h>
 
 #ifdef GTSAM_SUPPORT_NESTED_DISSECTION
-#ifdef GTSAM_USE_SYSTEM_METIS
 #include <metis.h>
-#else
-#include <gtsam/3rdparty/metis/include/metis.h>
-#endif
 #endif
 
 using namespace std;

--- a/gtsam_unstable/partition/FindSeparator-inl.h
+++ b/gtsam_unstable/partition/FindSeparator-inl.h
@@ -20,10 +20,9 @@
 
 #include "FindSeparator.h"
 
-#ifndef GTSAM_USE_SYSTEM_METIS
+#include <metis.h>
 
 extern "C" {
-#include <metis.h>
 #include <metislib.h>
 }
 
@@ -566,5 +565,3 @@ namespace gtsam { namespace partition {
   }
 
 }} //namespace
-
-#endif

--- a/gtsam_unstable/partition/FindSeparator-inl.h
+++ b/gtsam_unstable/partition/FindSeparator-inl.h
@@ -24,7 +24,7 @@
 
 extern "C" {
 #include <metis.h>
-#include "metislib.h"
+#include <metislib.h>
 }
 
 

--- a/gtsam_unstable/partition/tests/testFindSeparator.cpp
+++ b/gtsam_unstable/partition/tests/testFindSeparator.cpp
@@ -20,8 +20,6 @@ using namespace std;
 using namespace gtsam;
 using namespace gtsam::partition;
 
-#ifndef GTSAM_USE_SYSTEM_METIS
-
 /* ************************************************************************* */
 // x0 - x1 - x2
 // l3        l4
@@ -228,8 +226,6 @@ TEST ( Partition, findSeparator3_with_reduced_camera )
   LONGS_EQUAL(2, partitionTable[27]);
   LONGS_EQUAL(2, partitionTable[28]);
 }
-
-#endif
 
 /* ************************************************************************* */
 int main() { TestResult tr; return TestRegistry::runAllTests(tr);}


### PR DESCRIPTION
This is a follow up PR to #570 as when it was merged I was not available to provide my review.

There is no reason to specify the full local `metis.h` include path, with how metis is treated in cmake, `metis.h` works for both local and system metis.

See: https://github.com/borglab/gtsam/pull/570/files#diff-0106693c254359c8aceceb57d5b6c0643760cc8cce6760ccfd2d31bc6d0be2dbR26
where only metis.h is used without the ifdef.

More importantly this PR enables metis's internal api ("metislib.h") via extern C for SYSTEM_METIS. We already use the internal API for our local metis install and since we carry the header files of metis with us I do not see a problem in enabling `extern "C"` for system metis as well. The only problem that can occur with this is a desync between the local headers we carry for metis and what metis is compiled under at the system level. Considering metis is a very old and stable package that hasn't seen updates for a long time, I do not see this issue occurring and if it does should be easily fixable, by just updating our local metis copy.

Tagging @jlblancoc and @varunagrawal  for reviews. Also @berndpfrommer ig