### PR TITLE
Decision Tree `prune` method 

### DIFF
--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -702,7 +702,7 @@ namespace gtsam {
     // If leaf, check the predicate and return accordingly.
     if (auto leaf = boost::dynamic_pointer_cast<const Leaf>(node)) {  
       if(predicate(leaf->constant())) {
-        return nullptr;
+        return NodePtr();
       }
       return NodePtr(new Leaf(leaf->constant()));
     }

--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -697,8 +697,6 @@ namespace gtsam {
   template <typename L, typename Y>
   template <typename Func>
   typename DecisionTree<L, Y>::NodePtr DecisionTree<L, Y>::prune(const NodePtr& node, Func predicate) {
-    // Prune<L, Y> prune(f);
-    // prune(root_);
     using LY = DecisionTree<L, Y>;
     // If leaf, check the predicate and return accordingly.
     if (auto leaf = boost::dynamic_pointer_cast<const Leaf>(node)) {  

--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -559,15 +559,6 @@ namespace gtsam {
     if (labelC == end) {
       // Base case: only one key left
       // Create a simple choice node with values as leaves.
-      if (size != nrChoices) {
-        std::cout << "Trying to create DD on " << begin->first << std::endl;
-        std::cout << boost::format(
-                         "DecisionTree::create: expected %d values but got %d "
-                         "instead") %
-                         nrChoices % size
-                  << std::endl;
-        throw std::invalid_argument("DecisionTree::create invalid argument");
-      }
       auto choice = boost::make_shared<Choice>(begin->first, endY - beginY);
       for (ValueIt y = beginY; y != endY; y++)
         choice->push_back(NodePtr(new Leaf(*y)));

--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -171,10 +171,13 @@ namespace gtsam {
       if (f->allSame_) {
         assert(f->branches().size() > 0);
         NodePtr f0 = f->branches_[0];
-        assert(f0->isLeaf());
-        NodePtr newLeaf(
+        if (f0->isLeaf()) {
+          NodePtr newLeaf(
             new Leaf(boost::dynamic_pointer_cast<const Leaf>(f0)->constant()));
-        return newLeaf;
+          return newLeaf;
+        } else {
+          return f;
+        }
       } else
 #endif
         return f;
@@ -309,7 +312,7 @@ namespace gtsam {
       }
 #endif
       size_t index = x.at(label_);
-      NodePtr child = branches_[index];
+      NodePtr child = branches_.at(index);
       return (*child)(x);
     }
 
@@ -698,6 +701,36 @@ namespace gtsam {
     };
     visitWith(f);
     return unique;
+  }
+
+  template <typename L, typename Y>
+  template <typename Func>
+  typename DecisionTree<L, Y>::NodePtr DecisionTree<L, Y>::prune(const NodePtr& node, Func predicate) {
+    // Prune<L, Y> prune(f);
+    // prune(root_);
+    using LY = DecisionTree<L, Y>;
+    // If leaf, check the predicate and return accordingly.
+    if (auto leaf = boost::dynamic_pointer_cast<const Leaf>(node)) {  
+      if(predicate(leaf->constant())) {
+        return nullptr;
+      }
+      return NodePtr(new Leaf(leaf->constant()));
+    }
+     // Check if Choice
+    auto choice = boost::dynamic_pointer_cast<const Choice>(node);
+    if (!choice) throw std::invalid_argument(
+        "DecisionTree::convertFrom: Invalid NodePtr");
+
+    // put together via Shannon expansion otherwise not sorted.
+    std::vector<LY> functions;
+    for (auto&& branch : choice->branches()) {
+      auto new_node = prune(branch, predicate);
+      // If valid node, then add it.
+      if (new_node) {
+        functions.emplace_back(new_node);
+      }
+    }
+    return LY::compose(functions.begin(), functions.end(), choice->label());
   }
 
 /****************************************************************************/

--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -694,6 +694,7 @@ namespace gtsam {
     return unique;
   }
 
+  /****************************************************************************/
   template <typename L, typename Y>
   template <typename Func>
   typename DecisionTree<L, Y>::NodePtr DecisionTree<L, Y>::prune(const NodePtr& node, Func predicate) {
@@ -720,6 +721,13 @@ namespace gtsam {
       }
     }
     return LY::compose(functions.begin(), functions.end(), choice->label());
+  }
+
+  /****************************************************************************/
+  template <typename L, typename Y>
+  template <typename Func>
+  typename DecisionTree<L, Y>::NodePtr DecisionTree<L, Y>::prune(Func predicate) {
+    return prune(root_, predicate);
   }
 
 /****************************************************************************/

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -274,6 +274,16 @@ namespace gtsam {
     template <typename Func>
     NodePtr prune(const NodePtr& node, Func predicate);
 
+    /**
+     * @brief Prune the tree based on the predicate. Starts at root by default.
+     *
+     * @tparam Func
+     * @param predicate Function which returns true if leaf is to be pruned.
+     * @return NodePtr
+     */
+    template <typename Func>
+    NodePtr prune(Func predicate);
+
     /// Return the number of leaves in the tree.
     size_t nrLeaves() {
       size_t total = 0;

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -239,7 +239,7 @@ namespace gtsam {
      * Example:
      *   int sum = 0;
      *   auto visitor = [&](int y) { sum += y; };
-     *   tree.visitWith(visitor);
+     *   tree.visit(visitor);
      */
     template <typename Func>
     void visit(Func f) const;
@@ -258,6 +258,28 @@ namespace gtsam {
      */
     template <typename Func>
     void visitWith(Func f) const;
+
+    /**
+     * @brief Prune leaves satisfying boolean predicate `f`.
+     *
+     * @param predicate A functional which returns true/false given a leaf constant.
+     *
+     * Example:
+     *  // return true if leaf value is nullptr.
+     *  auto predicate = [&](const Y& value) { 
+     *      if (value) {return false;} else {return true}
+     *  };
+     *  tree.prune(predicate);
+     */
+    template <typename Func>
+    NodePtr prune(const NodePtr& node, Func predicate);
+
+    /// Return the number of leaves in the tree.
+    size_t nrLeaves() {
+      size_t total = 0;
+      visit([&total](const Y& node) { total += 1; });
+      return total;
+    }
 
     /**
      * @brief Fold a binary function over the tree, returning accumulator.

--- a/gtsam/discrete/DecisionTreeFactor.cpp
+++ b/gtsam/discrete/DecisionTreeFactor.cpp
@@ -167,7 +167,13 @@ namespace gtsam {
     // Construct unordered_map with values
     std::vector<std::pair<DiscreteValues, double>> result;
     for (const auto& assignment : assignments) {
-      result.emplace_back(assignment, operator()(assignment));
+      try {
+        result.emplace_back(assignment, operator()(assignment));
+      } catch (std::exception& e) {
+        // Got invalid assignment so we just skip
+        continue;
+      }
+      
     }
     return result;
   }

--- a/gtsam/discrete/tests/testDecisionTree.cpp
+++ b/gtsam/discrete/tests/testDecisionTree.cpp
@@ -86,6 +86,7 @@ struct DT : public DecisionTree<string, int> {
 
   /// print to stdout
   void print(const std::string& s = "") const {
+    std::cout << s;
     auto keyFormatter = [](const std::string& s) { return s; };
     auto valueFormatter = [](const int& v) {
       return (boost::format("%d") % v).str();
@@ -413,6 +414,23 @@ TEST(DecisionTree, threshold) {
   EXPECT_LONGS_EQUAL(2, thresholded.fold(count, 0));
 }
 
+/* ************************************************************************** */
+// Test erasing branches.
+TEST(DecisionTree, Erase) {
+  // Create three level tree
+  vector<DT::LabelC> keys;
+  keys += DT::LabelC("C", 2), DT::LabelC("B", 2), DT::LabelC("A", 2);
+  DT tree(keys, "0 1 2 3 -1 5 6 7");
+  
+  auto predicate = [](const double& d) { return d == -1;};
+  DT prunedTree(tree.prune(tree.root_, predicate));
+
+  // Duplicating the value should simulate pruning.
+  DT expectedTree(keys, "0 1 2 3 5 5 6 7");
+
+  EXPECT(assert_equal(expectedTree, prunedTree));
+
+}
 /* ************************************************************************* */
 int main() {
   TestResult tr;

--- a/gtsam/discrete/tests/testDecisionTree.cpp
+++ b/gtsam/discrete/tests/testDecisionTree.cpp
@@ -423,7 +423,7 @@ TEST(DecisionTree, Erase) {
   DT tree(keys, "0 1 2 3 -1 5 6 7");
   
   auto predicate = [](const double& d) { return d == -1;};
-  DT prunedTree(tree.prune(tree.root_, predicate));
+  DT prunedTree(tree.prune(predicate));
 
   // Duplicating the value should simulate pruning.
   DT expectedTree(keys, "0 1 2 3 5 5 6 7");

--- a/gtsam/discrete/tests/testDecisionTree.cpp
+++ b/gtsam/discrete/tests/testDecisionTree.cpp
@@ -430,6 +430,14 @@ TEST(DecisionTree, Erase) {
 
   EXPECT(assert_equal(expectedTree, prunedTree));
 
+  DT tree2(keys, "0 1 2 3 -1 -1 6 7");
+  DT prunedTree2(tree2.prune(predicate));
+  DT expectedTree2(keys, "0 1 2 3 6 7");
+  tree2.print("tree2\n");
+  prunedTree2.print("prunedTree2\n");
+  expectedTree2.print("expectedTree2\n");
+  EXPECT(assert_equal(expectedTree2, prunedTree2));
+
 }
 /* ************************************************************************* */
 int main() {


### PR DESCRIPTION
Added a new method to prune decision trees in general based on a predicate function.

This also required modifying some other parts to remove some assumptions about the code.