### PR TITLE
Decision Tree Constructor

### DIFF
--- a/gtsam/discrete/tests/testDecisionTree.cpp
+++ b/gtsam/discrete/tests/testDecisionTree.cpp
@@ -20,12 +20,11 @@
 // #define DT_DEBUG_MEMORY
 // #define DT_NO_PRUNING
 #define DISABLE_DOT
-#include <gtsam/discrete/DecisionTree-inl.h>
-
-#include <gtsam/base/Testable.h>
-#include <gtsam/discrete/Signature.h>
-
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/Testable.h>
+#include <gtsam/discrete/DecisionTree-inl.h>
+#include <gtsam/discrete/DiscreteValues.h>
+#include <gtsam/discrete/Signature.h>
 
 #include <boost/assign/std/vector.hpp>
 using namespace boost::assign;
@@ -411,6 +410,28 @@ TEST(DecisionTree, threshold) {
   // Check number of leaves equal to zero now = 2
   // Note: it is 2, because the pruned branches are counted as 1!
   EXPECT_LONGS_EQUAL(2, thresholded.fold(count, 0));
+}
+
+/* ************************************************************************** */
+// Test convertFromWithChoice constructor.
+TEST(DecisionTree, ConvertFromWithChoice) {
+  // Create three level tree
+  vector<DT::LabelC> keys;
+  keys += DT::LabelC("C", 2), DT::LabelC("B", 2), DT::LabelC("A", 2);
+  DT tree(keys, "0 1 2 3 4 5 6 7");
+
+  DT predicateTree(keys, "0 1 2 -1 4 5 -1 -1");
+
+  std::vector<int> nodes;
+  auto collector = [&](const int& x) {
+    nodes.push_back(x);
+  };
+  predicateTree.print();
+  predicateTree.visit(collector);
+  std::cout << "Number of node (should be < 8): " << nodes.size() << std::endl;
+
+  // This constructor will fail because the last 2 -1s are merged together.
+  DT actualTree(keys, nodes);
 }
 
 /* ************************************************************************* */

--- a/gtsam/discrete/tests/testDecisionTree.cpp
+++ b/gtsam/discrete/tests/testDecisionTree.cpp
@@ -418,20 +418,21 @@ TEST(DecisionTree, ConvertFromWithChoice) {
   // Create three level tree
   vector<DT::LabelC> keys;
   keys += DT::LabelC("C", 2), DT::LabelC("B", 2), DT::LabelC("A", 2);
-  DT tree(keys, "0 1 2 3 4 5 6 7");
 
-  DT predicateTree(keys, "0 1 2 -1 4 5 -1 -1");
+  DT tree(keys, "0 1 2 -1 4 5 -1 -1");
 
   std::vector<int> nodes;
   auto collector = [&](const int& x) {
     nodes.push_back(x);
   };
-  predicateTree.print();
-  predicateTree.visit(collector);
+  tree.print();
+  tree.visit(collector);
   std::cout << "Number of node (should be < 8): " << nodes.size() << std::endl;
 
   // This constructor will fail because the last 2 -1s are merged together.
   DT actualTree(keys, nodes);
+
+  EXPECT(assert_equal(tree, actualTree));
 }
 
 /* ************************************************************************* */


### PR DESCRIPTION
This PR demonstrates and tries to fix a shortcoming in the decision tree constructor.

Essentially, the constructor assumes that the number of nodes passed in is equal to `numberOfLabels * cardinality` (here cardinality is assumed equal for each label but this holds in general).

#### Detailed Look
I create a DecisionTree that looks like this:

```
 Choice(C) 
 0 Choice(B) 
 0 0 Choice(A) 
 0 0 0 Leaf 0
 0 0 1 Leaf 1
 0 1 Choice(A) 
 0 1 0 Leaf 2
 0 1 1 Leaf -1
 1 Choice(B) 
 1 0 Choice(A) 
 1 0 0 Leaf 4
 1 0 1 Leaf 5
 1 1 Leaf -1
```

As one can see, the final `1 1` node is all `-1` because the decision tree combines equal branches into a single branch. When trying to create a new tree from this result, the constructor complains with:
```
Trying to create DD on A
DecisionTree::create: expected 2 values but got 1 instead
/home/varun/borglab/gtsam/gtsam/discrete/tests/testDecisionTree.cpp:417: Failure: "Exception: DecisionTree::create invalid argument" 
```
which is basically saying that it expected 2 values since the cardinality of `A` is 2.

#### Why is this an issue?

We want to enable pruning of the decision tree, so we should be able to say that a leaf has value 0 or a nullptr, and check for that. 

This would involve going to each leaf, and based on some conditions, set that leaf to null. However, we want to be functional, so we should create a new tree that has the corresponding structure and null assignments.

This scheme works fine for the first time we do it, but if all leaves in a subtree are null, then the tree will automatically collapse all the branches into one. When this happen, a subsequent traversal and tree creation step will fail with the above error.

#### Potential Fix

The general way to fix this is to make the constructor aware of the assignment for each node.

One current fix I though of is to create a constructor that uses the same mechanics as `convertFrom` but passes in the assignment as well to the functional.

So instead of
```
template <typename X, typename Func>
    DecisionTree(const DecisionTree<L, X>& other, std::function<Y(X)> Y_of_X);
```
we should have
```
template <typename X, typename Func>
    DecisionTree(const DecisionTree<L, X>& other, std::function<Y(X, Assignment<L>)> Y_of_X);
```
and call a new method `convertFromWithChoice` that accounts for the assignment as well.