### PR TITLE
Python optimizer iteration hook

### DIFF
--- a/gtsam/nonlinear/nonlinear.i
+++ b/gtsam/nonlinear/nonlinear.i
@@ -404,6 +404,7 @@ virtual class NonlinearOptimizerParams {
   bool isCholmod() const;
   bool isIterative() const;
 
+  // This only applies to python since matlab does not have lambda machinery.
   gtsam::NonlinearOptimizerParams::IterationHook iterationHook;
 };
 

--- a/gtsam/nonlinear/nonlinear.i
+++ b/gtsam/nonlinear/nonlinear.i
@@ -403,6 +403,8 @@ virtual class NonlinearOptimizerParams {
   bool isSequential() const;
   bool isCholmod() const;
   bool isIterative() const;
+
+  gtsam::NonlinearOptimizerParams::IterationHook iterationHook;
 };
 
 bool checkConvergence(double relativeErrorTreshold,

--- a/python/gtsam/tests/test_NonlinearOptimizer.py
+++ b/python/gtsam/tests/test_NonlinearOptimizer.py
@@ -83,6 +83,26 @@ class TestScenario(GtsamTestCase):
         actual = GncLMOptimizer(self.fg, self.initial_values, gncParams).optimize()
         self.assertAlmostEqual(0, self.fg.error(actual))
 
+    def test_iteration_hook(self):
+        # set up iteration hook to track some testable values
+        iteration_count = 0
+        final_error = 0
+        final_values = None
+        def iteration_hook(iter, error_before, error_after):
+            nonlocal iteration_count, final_error, final_values
+            iteration_count = iter
+            final_error = error_after
+            final_values = optimizer.values()
+        # optimize
+        params = LevenbergMarquardtParams.CeresDefaults()
+        params.setOrdering(self.ordering)
+        params.iterationHook = iteration_hook
+        optimizer = LevenbergMarquardtOptimizer(self.fg, self.initial_values, params)
+        actual = optimizer.optimize()
+        self.assertAlmostEqual(0, self.fg.error(actual))
+        self.gtsamAssertEquals(final_values, actual)
+        self.assertEqual(self.fg.error(actual), final_error)
+        self.assertEqual(optimizer.iterations(), iteration_count)
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/gtsam/tests/test_NonlinearOptimizer.py
+++ b/python/gtsam/tests/test_NonlinearOptimizer.py
@@ -15,12 +15,10 @@ from __future__ import print_function
 import unittest
 
 import gtsam
-from gtsam import (DoglegOptimizer, DoglegParams,
-                   DummyPreconditionerParameters, GaussNewtonOptimizer,
-                   GaussNewtonParams, GncLMParams, GncLMOptimizer,
-                   LevenbergMarquardtOptimizer, LevenbergMarquardtParams,
-                   NonlinearFactorGraph, Ordering,
-                   PCGSolverParameters, Point2, PriorFactorPoint2, Values)
+from gtsam import (DoglegOptimizer, DoglegParams, DummyPreconditionerParameters,
+                   GaussNewtonOptimizer, GaussNewtonParams, GncLMParams, GncLMOptimizer,
+                   LevenbergMarquardtOptimizer, LevenbergMarquardtParams, NonlinearFactorGraph,
+                   Ordering, PCGSolverParameters, Point2, PriorFactorPoint2, Values)
 from gtsam.utils.test_case import GtsamTestCase
 
 KEY1 = 1
@@ -28,62 +26,62 @@ KEY2 = 2
 
 
 class TestScenario(GtsamTestCase):
-    def test_optimize(self):
-        """Do trivial test with three optimizer variants."""
-        fg = NonlinearFactorGraph()
+    """Do trivial test with three optimizer variants."""
+
+    def setUp(self):
+        """Set up the optimization problem and ordering"""
+        # create graph
+        self.fg = NonlinearFactorGraph()
         model = gtsam.noiseModel.Unit.Create(2)
-        fg.add(PriorFactorPoint2(KEY1, Point2(0, 0), model))
+        self.fg.add(PriorFactorPoint2(KEY1, Point2(0, 0), model))
 
         # test error at minimum
         xstar = Point2(0, 0)
-        optimal_values = Values()
-        optimal_values.insert(KEY1, xstar)
-        self.assertEqual(0.0, fg.error(optimal_values), 0.0)
+        self.optimal_values = Values()
+        self.optimal_values.insert(KEY1, xstar)
+        self.assertEqual(0.0, self.fg.error(self.optimal_values), 0.0)
 
         # test error at initial = [(1-cos(3))^2 + (sin(3))^2]*50 =
         x0 = Point2(3, 3)
-        initial_values = Values()
-        initial_values.insert(KEY1, x0)
-        self.assertEqual(9.0, fg.error(initial_values), 1e-3)
+        self.initial_values = Values()
+        self.initial_values.insert(KEY1, x0)
+        self.assertEqual(9.0, self.fg.error(self.initial_values), 1e-3)
 
         # optimize parameters
-        ordering = Ordering()
-        ordering.push_back(KEY1)
+        self.ordering = Ordering()
+        self.ordering.push_back(KEY1)
 
-        # Gauss-Newton
+    def test_gauss_newton(self):
         gnParams = GaussNewtonParams()
-        gnParams.setOrdering(ordering)
-        actual1 = GaussNewtonOptimizer(fg, initial_values, gnParams).optimize()
-        self.assertAlmostEqual(0, fg.error(actual1))
+        gnParams.setOrdering(self.ordering)
+        actual = GaussNewtonOptimizer(self.fg, self.initial_values, gnParams).optimize()
+        self.assertAlmostEqual(0, self.fg.error(actual))
 
-        # Levenberg-Marquardt
+    def test_levenberg_marquardt(self):
         lmParams = LevenbergMarquardtParams.CeresDefaults()
-        lmParams.setOrdering(ordering)
-        actual2 = LevenbergMarquardtOptimizer(
-            fg, initial_values, lmParams).optimize()
-        self.assertAlmostEqual(0, fg.error(actual2))
+        lmParams.setOrdering(self.ordering)
+        actual = LevenbergMarquardtOptimizer(self.fg, self.initial_values, lmParams).optimize()
+        self.assertAlmostEqual(0, self.fg.error(actual))
 
-        # Levenberg-Marquardt
+    def test_levenberg_marquardt_pcg(self):
         lmParams = LevenbergMarquardtParams.CeresDefaults()
         lmParams.setLinearSolverType("ITERATIVE")
         cgParams = PCGSolverParameters()
         cgParams.setPreconditionerParams(DummyPreconditionerParameters())
         lmParams.setIterativeParams(cgParams)
-        actual2 = LevenbergMarquardtOptimizer(
-            fg, initial_values, lmParams).optimize()
-        self.assertAlmostEqual(0, fg.error(actual2))
+        actual = LevenbergMarquardtOptimizer(self.fg, self.initial_values, lmParams).optimize()
+        self.assertAlmostEqual(0, self.fg.error(actual))
 
-        # Dogleg
+    def test_dogleg(self):
         dlParams = DoglegParams()
-        dlParams.setOrdering(ordering)
-        actual3 = DoglegOptimizer(fg, initial_values, dlParams).optimize()
-        self.assertAlmostEqual(0, fg.error(actual3))
-        
-        # Graduated Non-Convexity (GNC)
+        dlParams.setOrdering(self.ordering)
+        actual = DoglegOptimizer(self.fg, self.initial_values, dlParams).optimize()
+        self.assertAlmostEqual(0, self.fg.error(actual))
+
+    def test_graduated_non_convexity(self):
         gncParams = GncLMParams()
-        actual4 = GncLMOptimizer(fg, initial_values, gncParams).optimize()
-        self.assertAlmostEqual(0, fg.error(actual4))
-        
+        actual = GncLMOptimizer(self.fg, self.initial_values, gncParams).optimize()
+        self.assertAlmostEqual(0, self.fg.error(actual))
 
 
 if __name__ == "__main__":

--- a/python/gtsam/tests/test_logging_optimizer.py
+++ b/python/gtsam/tests/test_logging_optimizer.py
@@ -66,9 +66,9 @@ class TestOptimizeComet(GtsamTestCase):
 
         # Wrapper function sets the hook and calls optimizer.optimize() for us.
         params = gtsam.GaussNewtonParams()
-        actual = optimize_using(gtsam.GaussNewtonOptimizer, hook)(self.graph, self.initial)
+        actual = optimize_using(gtsam.GaussNewtonOptimizer, hook, self.graph, self.initial)
         self.check(actual)
-        actual = optimize_using(gtsam.GaussNewtonOptimizer, hook)(self.graph, self.initial, params)
+        actual = optimize_using(gtsam.GaussNewtonOptimizer, hook, self.graph, self.initial, params)
         self.check(actual)
         actual = gtsam_optimize(gtsam.GaussNewtonOptimizer(self.graph, self.initial, params),
                                 params, hook)
@@ -80,10 +80,10 @@ class TestOptimizeComet(GtsamTestCase):
             print(error)
 
         params = gtsam.LevenbergMarquardtParams()
-        actual = optimize_using(gtsam.LevenbergMarquardtOptimizer, hook)(self.graph, self.initial)
+        actual = optimize_using(gtsam.LevenbergMarquardtOptimizer, hook, self.graph, self.initial)
         self.check(actual)
-        actual = optimize_using(gtsam.LevenbergMarquardtOptimizer, hook)(self.graph, self.initial,
-                                                                         params)
+        actual = optimize_using(gtsam.LevenbergMarquardtOptimizer, hook, self.graph, self.initial,
+                                params)
         self.check(actual)
         actual = gtsam_optimize(gtsam.LevenbergMarquardtOptimizer(self.graph, self.initial, params),
                                 params, hook)

--- a/python/gtsam/tests/test_logging_optimizer.py
+++ b/python/gtsam/tests/test_logging_optimizer.py
@@ -63,12 +63,14 @@ class TestOptimizeComet(GtsamTestCase):
         def hook(_, error):
             print(error)
 
-        # Only thing we require from optimizer is an iterate method
+        # Wrapper function sets the hook and calls optimizer.optimize() for us.
         gtsam_optimize(self.optimizer, self.params, hook)
 
         # Check that optimizing yields the identity.
         actual = self.optimizer.values()
         self.gtsamAssertEquals(actual.atRot3(KEY), self.expected, tol=1e-6)
+        self.assertEqual(self.capturedOutput.getvalue(),
+                         "0.020000000000000004\n0.010000000000000005\n0.010000000000000004\n")
 
     def test_lm_simple_printing(self):
         """Make sure we are properly terminating LM"""
@@ -79,6 +81,8 @@ class TestOptimizeComet(GtsamTestCase):
 
         actual = self.lmoptimizer.values()
         self.gtsamAssertEquals(actual.atRot3(KEY), self.expected, tol=1e-6)
+        self.assertEqual(self.capturedOutput.getvalue(),
+                         "0.020000000000000004\n0.010000000000249996\n0.009999999999999998\n")
 
     @unittest.skip("Not a test we want run every time, as needs comet.ml account")
     def test_comet(self):

--- a/python/gtsam/tests/test_logging_optimizer.py
+++ b/python/gtsam/tests/test_logging_optimizer.py
@@ -39,6 +39,8 @@ class TestOptimizeComet(GtsamTestCase):
             self.gtsamAssertEquals(actual.atRot3(KEY), self.expected, tol=1e-6)
             # Check that logging output prints out 3 lines (exact intermediate values differ by OS)
             self.assertEqual(self.capturedOutput.getvalue().count('\n'), 3)
+            # reset stdout catcher
+            self.capturedOutput.truncate(0)
         self.check = check
 
         self.graph = gtsam.NonlinearFactorGraph()

--- a/python/gtsam/tests/test_logging_optimizer.py
+++ b/python/gtsam/tests/test_logging_optimizer.py
@@ -18,7 +18,7 @@ import numpy as np
 from gtsam import Rot3
 from gtsam.utils.test_case import GtsamTestCase
 
-from gtsam.utils.logging_optimizer import gtsam_optimize
+from gtsam.utils.logging_optimizer import gtsam_optimize, optimize_using
 
 KEY = 0
 MODEL = gtsam.noiseModel.Unit.Create(3)
@@ -34,19 +34,18 @@ class TestOptimizeComet(GtsamTestCase):
         rotations = {R, R.inverse()}  # mean is the identity
         self.expected = Rot3()
 
-        graph = gtsam.NonlinearFactorGraph()
-        for R in rotations:
-            graph.add(gtsam.PriorFactorRot3(KEY, R, MODEL))
-        initial = gtsam.Values()
-        initial.insert(KEY, R)
-        self.params = gtsam.GaussNewtonParams()
-        self.optimizer = gtsam.GaussNewtonOptimizer(
-            graph, initial, self.params)
+        def check(actual):
+            # Check that optimizing yields the identity
+            self.gtsamAssertEquals(actual.atRot3(KEY), self.expected, tol=1e-6)
+            # Check that logging output prints out 3 lines (exact intermediate values differ by OS)
+            self.assertEqual(self.capturedOutput.getvalue().count('\n'), 3)
+        self.check = check
 
-        self.lmparams = gtsam.LevenbergMarquardtParams()
-        self.lmoptimizer = gtsam.LevenbergMarquardtOptimizer(
-            graph, initial, self.lmparams
-        )
+        self.graph = gtsam.NonlinearFactorGraph()
+        for R in rotations:
+            self.graph.add(gtsam.PriorFactorRot3(KEY, R, MODEL))
+        self.initial = gtsam.Values()
+        self.initial.insert(KEY, R)
 
         # setup output capture
         self.capturedOutput = StringIO()
@@ -64,25 +63,28 @@ class TestOptimizeComet(GtsamTestCase):
             print(error)
 
         # Wrapper function sets the hook and calls optimizer.optimize() for us.
-        gtsam_optimize(self.optimizer, self.params, hook)
-
-        # Check that optimizing yields the identity.
-        actual = self.optimizer.values()
-        self.gtsamAssertEquals(actual.atRot3(KEY), self.expected, tol=1e-6)
-        self.assertEqual(self.capturedOutput.getvalue(),
-                         "0.020000000000000004\n0.010000000000000005\n0.010000000000000004\n")
+        params = gtsam.GaussNewtonParams()
+        actual = optimize_using(gtsam.GaussNewtonOptimizer, hook)(self.graph, self.initial)
+        self.check(actual)
+        actual = optimize_using(gtsam.GaussNewtonOptimizer, hook)(self.graph, self.initial, params)
+        self.check(actual)
+        actual = gtsam_optimize(gtsam.GaussNewtonOptimizer(self.graph, self.initial, params),
+                                params, hook)
+        self.check(actual)
 
     def test_lm_simple_printing(self):
         """Make sure we are properly terminating LM"""
         def hook(_, error):
             print(error)
 
-        gtsam_optimize(self.lmoptimizer, self.lmparams, hook)
-
-        actual = self.lmoptimizer.values()
-        self.gtsamAssertEquals(actual.atRot3(KEY), self.expected, tol=1e-6)
-        self.assertEqual(self.capturedOutput.getvalue(),
-                         "0.020000000000000004\n0.010000000000249996\n0.009999999999999998\n")
+        params = gtsam.LevenbergMarquardtParams()
+        actual = optimize_using(gtsam.LevenbergMarquardtOptimizer, hook)(self.graph, self.initial)
+        self.check(actual)
+        actual = optimize_using(gtsam.LevenbergMarquardtOptimizer, hook)(self.graph, self.initial,
+                                                                         params)
+        self.check(actual)
+        actual = gtsam_optimize(gtsam.LevenbergMarquardtOptimizer(self.graph, self.initial, params),
+                                params, hook)
 
     @unittest.skip("Not a test we want run every time, as needs comet.ml account")
     def test_comet(self):

--- a/python/gtsam/utils/logging_optimizer.py
+++ b/python/gtsam/utils/logging_optimizer.py
@@ -21,7 +21,8 @@ def optimize(optimizer, check_convergence, hook):
     current_error = optimizer.error()
     hook(optimizer, current_error)
 
-    # Iterative loop
+    # Iterative loop.  Cannot use `params.iterationHook` because we don't have access to params
+    # (backwards compatibility issue).
     while True:
         # Do next iteration
         optimizer.iterate()
@@ -35,7 +36,7 @@ def optimize(optimizer, check_convergence, hook):
 def gtsam_optimize(optimizer,
                    params,
                    hook):
-    """ Given an optimizer and params, iterate until convergence.
+    """ Given an optimizer and its params, iterate until convergence.
         After each iteration, hook(optimizer) is called.
         After the function, use values and errors to get the result.
         Arguments:
@@ -43,10 +44,6 @@ def gtsam_optimize(optimizer,
                 params {NonlinearOptimizarParams} -- Nonlinear optimizer parameters
                 hook -- hook function to record the error
     """
-    def check_convergence(optimizer, current_error, new_error):
-        return (optimizer.iterations() >= params.getMaxIterations()) or (
-            gtsam.checkConvergence(params.getRelativeErrorTol(), params.getAbsoluteErrorTol(), params.getErrorTol(),
-                                   current_error, new_error)) or (
-            isinstance(optimizer, gtsam.LevenbergMarquardtOptimizer) and optimizer.lambda_() > params.getlambdaUpperBound())
-    optimize(optimizer, check_convergence, hook)
-    return optimizer.values()
+    hook(optimizer, optimizer.error()) # call once at start (backwards compatibility)
+    params.iterationHook = lambda iteration, error_before, error_after: hook(optimizer, error_after)
+    return optimizer.optimize()

--- a/python/gtsam/utils/logging_optimizer.py
+++ b/python/gtsam/utils/logging_optimizer.py
@@ -39,7 +39,6 @@ def gtsam_optimize(optimizer,
     """ Given an optimizer and its params, iterate until convergence.
         After each iteration, hook(optimizer) is called.
         After the function, use values and errors to get the result.
-        Optimizer must have been created with the same params as the one passed into this function!
         Arguments:
                 optimizer {NonlinearOptimizer} -- Nonlinear optimizer
                 params {NonlinearOptimizarParams} -- Nonlinear optimizer parameters

--- a/python/gtsam/utils/logging_optimizer.py
+++ b/python/gtsam/utils/logging_optimizer.py
@@ -39,6 +39,7 @@ def gtsam_optimize(optimizer,
     """ Given an optimizer and its params, iterate until convergence.
         After each iteration, hook(optimizer) is called.
         After the function, use values and errors to get the result.
+        Optimizer must have been created with the same params as the one passed into this function!
         Arguments:
                 optimizer {NonlinearOptimizer} -- Nonlinear optimizer
                 params {NonlinearOptimizarParams} -- Nonlinear optimizer parameters


### PR DESCRIPTION
In c++ there's an iteration hook that can be called on each iteration of the optimizer for logging/debugging purposes.  Previously it wasn't wrapped in python.

It's a super easy addition to wrap in python thanks to the wonderful lambda's machinery of pybind11 / gtwrap.

While I was adding a unit test for the iteration hook, I also minorly refactored the python nonlinear optimizer unit test to put each test in its own function so that, in the event any fail, unittest will print out more obviously which one was the one that failed.