### PR TITLE
Fix `visitWith` for Pruned Tree

### DIFF
--- a/gtsam/discrete/Assignment.h
+++ b/gtsam/discrete/Assignment.h
@@ -33,6 +33,8 @@ namespace gtsam {
 template <class L>
 class Assignment : public std::map<L, size_t> {
  public:
+  using std::map<L, size_t>::operator=;
+
   void print(const std::string& s = "Assignment: ") const {
     std::cout << s << ": ";
     for (const typename Assignment::value_type& keyValue : *this)

--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -668,9 +668,11 @@ namespace gtsam {
       for (size_t i = 0; i < choice->nrChoices(); i++) {
         choices[choice->label()] = i;  // Set assignment for label to i
 
-        VisitWith<L, Y> visit(f);
-        visit.choices = choices;
-        visit(choice->branches()[i]);  // recurse!
+        (*this)(choice->branches()[i]);  // recurse!
+
+        // Remove the choice so we are backtracking
+        auto choice_it = choices.find(choice->label());
+        choices.erase(choice_it);
       }
     }
   };

--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -666,8 +666,11 @@ namespace gtsam {
       if (!choice)
         throw std::invalid_argument("DecisionTree::VisitWith: Invalid NodePtr");
       for (size_t i = 0; i < choice->nrChoices(); i++) {
-        choices[choice->label()] = i;    // Set assignment for label to i
-        (*this)(choice->branches()[i]);  // recurse!
+        choices[choice->label()] = i;  // Set assignment for label to i
+
+        VisitWith<L, Y> visit(f);
+        visit.choices = choices;
+        visit(choice->branches()[i]);  // recurse!
       }
     }
   };

--- a/gtsam/discrete/tests/testDecisionTree.cpp
+++ b/gtsam/discrete/tests/testDecisionTree.cpp
@@ -20,10 +20,12 @@
 // #define DT_DEBUG_MEMORY
 // #define DT_NO_PRUNING
 #define DISABLE_DOT
-#include <CppUnitLite/TestHarness.h>
-#include <gtsam/base/Testable.h>
 #include <gtsam/discrete/DecisionTree-inl.h>
+
+#include <gtsam/base/Testable.h>
 #include <gtsam/discrete/Signature.h>
+
+#include <CppUnitLite/TestHarness.h>
 
 #include <boost/assign/std/vector.hpp>
 using namespace boost::assign;


### PR DESCRIPTION
Added a unit test demonstrating a bug in partial assignments of `visitWith` and added a fix for it.

For example, if we have a pruned tree like below:

```
 Choice(C)
 0 Choice(B)
 0 0 Leaf 0
 0 1 Choice(A)
 0 1 0 Leaf 2
 0 1 1 Leaf 3
 1 Choice(B)
 1 0 Leaf 4
 1 1 Choice(A)
 1 1 0 Leaf 6
 1 1 1 Leaf 7
```

if we look at all the assignments that get generated by `visitWith`, we get

```
>>: (B, 0)(C, 0)
>>: (A, 0)(B, 1)(C, 0)
>>: (A, 1)(B, 1)(C, 0)
>>: (A, 1)(B, 0)(C, 1)  // This is WRONG!
>>: (A, 0)(B, 1)(C, 1)
>>: (A, 1)(B, 1)(C, 1)
```

and we should instead get

```
>>: (B, 0)(C, 0)
>>: (A, 0)(B, 1)(C, 0)
>>: (A, 1)(B, 1)(C, 0)
>>: (B, 0)(C, 1)  // This is CORRECT.
>>: (A, 0)(B, 1)(C, 1)
>>: (A, 1)(B, 1)(C, 1)
```