### PR TITLE
Various Fixes

### DIFF
--- a/cmake/GtsamBuildTypes.cmake
+++ b/cmake/GtsamBuildTypes.cmake
@@ -191,7 +191,7 @@ endif()
 
 if (NOT MSVC)
   option(GTSAM_BUILD_WITH_MARCH_NATIVE  "Enable/Disable building with all instructions supported by native architecture (binary may not be portable!)" ON)
-  if(GTSAM_BUILD_WITH_MARCH_NATIVE)
+  if(GTSAM_BUILD_WITH_MARCH_NATIVE AND (APPLE AND NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64"))
     # Add as public flag so all dependant projects also use it, as required
     # by Eigen to avid crashes due to SIMD vectorization:
     list_append_cache(GTSAM_COMPILE_OPTIONS_PUBLIC "-march=native")

--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -786,7 +786,6 @@ namespace gtsam {
   template <typename L, typename Y>
   DecisionTree<L, Y> DecisionTree<L, Y>::apply(
       const UnaryAssignment& op) const {
-        std::cout << "Calling the correct apply" << std::endl;
     // It is unclear what should happen if tree is empty:
     if (empty()) {
       throw std::runtime_error(

--- a/gtsam/discrete/tests/testDecisionTree.cpp
+++ b/gtsam/discrete/tests/testDecisionTree.cpp
@@ -462,7 +462,7 @@ TEST(DecisionTree, ApplyWithAssignment) {
 
   DecisionTree<string, double> probTree(
       keys, "0.01 0.02 0.03 0.04 0.05 0.06 0.07 0.08");
-  double threshold = 0.035;
+  double threshold = 0.045;
 
   // We test pruning one tree by indexing into another.
   auto pruner = [&](const Assignment<string>& choices, const int& x) {
@@ -475,8 +475,18 @@ TEST(DecisionTree, ApplyWithAssignment) {
   };
   DT prunedTree = tree.apply(pruner);
 
-  DT expectedTree(keys, "0 0 0 4 5 6 7 8");
+  DT expectedTree(keys, "0 0 0 0 5 6 7 8");
   EXPECT(assert_equal(expectedTree, prunedTree));
+
+  size_t count = 0;
+  auto counter = [&](const Assignment<string>& choices, const int& x) {
+    count += 1;
+    return x;
+  };
+  DT prunedTree2 = prunedTree.apply(counter);
+
+  // Check if apply doesn't enumerate all leaves.
+  EXPECT_LONGS_EQUAL(5, count);
 }
 
 /* ************************************************************************* */

--- a/gtsam/sfm/SfmData.cpp
+++ b/gtsam/sfm/SfmData.cpp
@@ -426,7 +426,6 @@ NonlinearFactorGraph SfmData::generalSfmFactors(
 NonlinearFactorGraph SfmData::sfmFactorGraph(
     const SharedNoiseModel &model, boost::optional<size_t> fixedCamera,
     boost::optional<size_t> fixedPoint) const {
-  using ProjectionFactor = GeneralSFMFactor<SfmCamera, Point3>;
   NonlinearFactorGraph graph = generalSfmFactors(model);
   using noiseModel::Constrained;
   if (fixedCamera) {


### PR DESCRIPTION
1. Added a second test for `DecisionTree::apply` to show it doesn't enumerate all leaf options (so pruning actually works as expected).
2. Check for Apple Silicon before setting `-march=native`. If Apple system and architecture is arm64, then we don't set `-march=native`. Fixes #1057.
3. Remove spurious `using` statement so that the corresponding warning is resolved.