### PR TITLE
Print parents when printing GaussianConditional

### DIFF
--- a/gtsam/linear/GaussianConditional.cpp
+++ b/gtsam/linear/GaussianConditional.cpp
@@ -89,7 +89,7 @@ namespace gtsam {
 
   /* ************************************************************************ */
   void GaussianConditional::print(const string &s, const KeyFormatter& formatter) const {
-    cout << s << "Conditional density [";
+    cout << s << " p(";
     for (const_iterator it = beginFrontals(); it != endFrontals(); ++it) {
       cout << (boost::format("%1%")%(formatter(*it))).str() << " ";
     }
@@ -97,7 +97,7 @@ namespace gtsam {
     for (const_iterator it = beginParents(); it != endParents(); ++it) {
       cout << " " << (boost::format("%1%")%(formatter(*it))).str();
     }
-    cout << "]" << endl;
+    cout << ")" << endl;
     cout << formatMatrixIndented("  R = ", R()) << endl;
     for (const_iterator it = beginParents() ; it != endParents() ; ++it) {
       cout << formatMatrixIndented((boost::format("  S[%1%] = ")%(formatter(*it))).str(), getA(it))

--- a/gtsam/linear/GaussianConditional.cpp
+++ b/gtsam/linear/GaussianConditional.cpp
@@ -89,11 +89,15 @@ namespace gtsam {
 
   /* ************************************************************************ */
   void GaussianConditional::print(const string &s, const KeyFormatter& formatter) const {
-    cout << s << "  Conditional density ";
+    cout << s << "Conditional density [";
     for (const_iterator it = beginFrontals(); it != endFrontals(); ++it) {
-      cout << (boost::format("[%1%]")%(formatter(*it))).str() << " ";
+      cout << (boost::format("%1%")%(formatter(*it))).str() << " ";
     }
-    cout << endl;
+    cout << "|";
+    for (const_iterator it = beginParents(); it != endParents(); ++it) {
+      cout << " " << (boost::format("%1%")%(formatter(*it))).str();
+    }
+    cout << "]" << endl;
     cout << formatMatrixIndented("  R = ", R()) << endl;
     for (const_iterator it = beginParents() ; it != endParents() ; ++it) {
       cout << formatMatrixIndented((boost::format("  S[%1%] = ")%(formatter(*it))).str(), getA(it))

--- a/gtsam/linear/GaussianConditional.h
+++ b/gtsam/linear/GaussianConditional.h
@@ -109,8 +109,8 @@ namespace gtsam {
     /// @{
 
     /** print */
-    void print(const std::string& = "GaussianConditional",
-      const KeyFormatter& formatter = DefaultKeyFormatter) const override;
+    void print(const std::string& = "", const KeyFormatter& formatter =
+                                            DefaultKeyFormatter) const override;
 
     /** equals function */
     bool equals(const GaussianFactor&cg, double tol = 1e-9) const override;

--- a/gtsam/linear/GaussianConditional.h
+++ b/gtsam/linear/GaussianConditional.h
@@ -109,8 +109,8 @@ namespace gtsam {
     /// @{
 
     /** print */
-    void print(const std::string& = "", const KeyFormatter& formatter =
-                                            DefaultKeyFormatter) const override;
+    void print(const std::string& = "GaussianConditional",
+      const KeyFormatter& formatter = DefaultKeyFormatter) const override;
 
     /** equals function */
     bool equals(const GaussianFactor&cg, double tol = 1e-9) const override;

--- a/gtsam/linear/tests/testGaussianConditional.cpp
+++ b/gtsam/linear/tests/testGaussianConditional.cpp
@@ -404,25 +404,27 @@ TEST(GaussianConditional, Print) {
   const Vector2 b(20, 40);
   const double sigma = 3;
 
+  std::string s = "GaussianConditional";
+
   auto conditional =
       GaussianConditional::FromMeanAndStddev(X(0), A1, X(1), b, sigma);
 
   // Test printing for single parent.
   std::string expected =
-    "Conditional density [x0 | x1]\n"
+    "GaussianConditional p(x0 | x1)\n"
     "  R = [ 1 0 ]\n"
     "      [ 0 1 ]\n"
     "  S[x1] = [ -1 -2 ]\n"
     "          [ -3 -4 ]\n"
     "  d = [ 20 40 ]\n"
     "isotropic dim=2 sigma=3\n";
-  EXPECT(assert_print_equal(expected, conditional));
+  EXPECT(assert_print_equal(expected, conditional, s));
 
   // Test printing for multiple parents.
   auto conditional2 = GaussianConditional::FromMeanAndStddev(X(0), A1, Y(0), A2,
                                                              Y(1), b, sigma);
   std::string expected2 =
-    "Conditional density [x0 | y0 y1]\n"
+    "GaussianConditional p(x0 | y0 y1)\n"
     "  R = [ 1 0 ]\n"
     "      [ 0 1 ]\n"
     "  S[y0] = [ -1 -2 ]\n"
@@ -431,7 +433,7 @@ TEST(GaussianConditional, Print) {
     "          [ -7 -8 ]\n"
     "  d = [ 20 40 ]\n"
     "isotropic dim=2 sigma=3\n";
-  EXPECT(assert_print_equal(expected2, conditional2));
+  EXPECT(assert_print_equal(expected2, conditional2, s));
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/tests/testGaussianConditional.cpp
+++ b/gtsam/linear/tests/testGaussianConditional.cpp
@@ -40,6 +40,7 @@ using namespace gtsam;
 using namespace std;
 using namespace boost::assign;
 using symbol_shorthand::X;
+using symbol_shorthand::Y;
 
 static const double tol = 1e-5;
 
@@ -394,6 +395,43 @@ TEST(GaussianConditional, sample) {
   EXPECT_LONGS_EQUAL(1, actual2.size());
   // regression is not repeatable across platforms/versions :-(
   // EXPECT(assert_equal(Vector2(31.0111856, 64.9850775), actual2[X(0)], 1e-5));
+}
+
+/* ************************************************************************* */
+TEST(GaussianConditional, Print) {
+  Matrix A1 = (Matrix(2, 2) << 1., 2., 3., 4.).finished();
+  Matrix A2 = (Matrix(2, 2) << 5., 6., 7., 8.).finished();
+  const Vector2 b(20, 40);
+  const double sigma = 3;
+
+  auto conditional =
+      GaussianConditional::FromMeanAndStddev(X(0), A1, X(1), b, sigma);
+
+  // Test printing for single parent.
+  std::string expected =
+    "Conditional density [x0 | x1]\n"
+    "  R = [ 1 0 ]\n"
+    "      [ 0 1 ]\n"
+    "  S[x1] = [ -1 -2 ]\n"
+    "          [ -3 -4 ]\n"
+    "  d = [ 20 40 ]\n"
+    "isotropic dim=2 sigma=3\n";
+  EXPECT(assert_print_equal(expected, conditional));
+
+  // Test printing for multiple parents.
+  auto conditional2 = GaussianConditional::FromMeanAndStddev(X(0), A1, Y(0), A2,
+                                                             Y(1), b, sigma);
+  std::string expected2 =
+    "Conditional density [x0 | y0 y1]\n"
+    "  R = [ 1 0 ]\n"
+    "      [ 0 1 ]\n"
+    "  S[y0] = [ -1 -2 ]\n"
+    "          [ -3 -4 ]\n"
+    "  S[y1] = [ -5 -6 ]\n"
+    "          [ -7 -8 ]\n"
+    "  d = [ 20 40 ]\n"
+    "isotropic dim=2 sigma=3\n";
+  EXPECT(assert_print_equal(expected2, conditional2));
 }
 
 /* ************************************************************************* */


### PR DESCRIPTION
Currently, `GaussianConditional`s don't print the parents, only the frontals. This PR fixes that.

For the following conditional
```
auto conditional =
      GaussianConditional::FromMeanAndStddev(X(0), A1, X(1), b, sigma);
```
which is just `P(X0 | X1)`.

#### Before
```
GaussianConditional  Conditional density [x0] 
  R = [ 1 0 ]
      [ 0 1 ]
  S[x1] = [ -1 -2 ]
          [ -3 -4 ]
  d = [ 20 40 ]
isotropic dim=2 sigma=3
```

#### After
```
Conditional density [x0 | x1]
  R = [ 1 0 ]
      [ 0 1 ]
  S[x1] = [ -1 -2 ]
          [ -3 -4 ]
  d = [ 20 40 ]
isotropic dim=2 sigma=3
```