### PR TITLE
Fix `python-install`

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -172,7 +172,7 @@ endif()
 # Add custom target so we can install with `make python-install`
 set(GTSAM_PYTHON_INSTALL_TARGET python-install)
 add_custom_target(${GTSAM_PYTHON_INSTALL_TARGET}
-        COMMAND ${PYTHON_EXECUTABLE} ${GTSAM_PYTHON_BUILD_DIRECTORY}/setup.py install
+        COMMAND ${PYTHON_EXECUTABLE} -m pip install --user .
         DEPENDS ${GTSAM_PYTHON_DEPENDENCIES}
         WORKING_DIRECTORY ${GTSAM_PYTHON_BUILD_DIRECTORY})
 


### PR DESCRIPTION
Added a quick fix to the CMake for `python-install` so it no longer needs to install to access protected directories. Also modernized it to use `pip install` rather than the now deprecated `python setup.py install`.