### PR TITLE
Improve Gaussian Conditional printing

### DIFF
--- a/gtsam/linear/GaussianConditional.cpp
+++ b/gtsam/linear/GaussianConditional.cpp
@@ -89,15 +89,20 @@ namespace gtsam {
 
   /* ************************************************************************ */
   void GaussianConditional::print(const string &s, const KeyFormatter& formatter) const {
-    cout << s << " p(";
+    cout << s << "GaussianConditional p(";
     for (const_iterator it = beginFrontals(); it != endFrontals(); ++it) {
-      cout << (boost::format("%1%")%(formatter(*it))).str() << " ";
+      cout << (boost::format("%1%") % (formatter(*it))).str()
+           << (nrFrontals() > 1 ? " " : "");
     }
-    cout << "|";
-    for (const_iterator it = beginParents(); it != endParents(); ++it) {
-      cout << " " << (boost::format("%1%")%(formatter(*it))).str();
+
+    if (nrParents()) {
+      cout << " |";
+      for (const_iterator it = beginParents(); it != endParents(); ++it) {
+        cout << " " << (boost::format("%1%") % (formatter(*it))).str();
+      }
     }
     cout << ")" << endl;
+
     cout << formatMatrixIndented("  R = ", R()) << endl;
     for (const_iterator it = beginParents() ; it != endParents() ; ++it) {
       cout << formatMatrixIndented((boost::format("  S[%1%] = ")%(formatter(*it))).str(), getA(it))

--- a/gtsam/linear/GaussianConditional.h
+++ b/gtsam/linear/GaussianConditional.h
@@ -109,8 +109,8 @@ namespace gtsam {
     /// @{
 
     /** print */
-    void print(const std::string& = "GaussianConditional",
-      const KeyFormatter& formatter = DefaultKeyFormatter) const override;
+    void print(const std::string& = "", const KeyFormatter& formatter =
+                                            DefaultKeyFormatter) const override;
 
     /** equals function */
     bool equals(const GaussianFactor&cg, double tol = 1e-9) const override;

--- a/gtsam/linear/tests/testGaussianConditional.cpp
+++ b/gtsam/linear/tests/testGaussianConditional.cpp
@@ -404,13 +404,23 @@ TEST(GaussianConditional, Print) {
   const Vector2 b(20, 40);
   const double sigma = 3;
 
-  std::string s = "GaussianConditional";
-
-  auto conditional =
-      GaussianConditional::FromMeanAndStddev(X(0), A1, X(1), b, sigma);
+  GaussianConditional conditional(X(0), b, Matrix2::Identity(),
+                                  noiseModel::Isotropic::Sigma(2, sigma));
 
   // Test printing for single parent.
   std::string expected =
+    "GaussianConditional p(x0)\n"
+    "  R = [ 1 0 ]\n"
+    "      [ 0 1 ]\n"
+    "  d = [ 20 40 ]\n"
+    "isotropic dim=2 sigma=3\n";
+  EXPECT(assert_print_equal(expected, conditional));
+
+  auto conditional1 =
+      GaussianConditional::FromMeanAndStddev(X(0), A1, X(1), b, sigma);
+
+  // Test printing for single parent.
+  std::string expected1 =
     "GaussianConditional p(x0 | x1)\n"
     "  R = [ 1 0 ]\n"
     "      [ 0 1 ]\n"
@@ -418,7 +428,7 @@ TEST(GaussianConditional, Print) {
     "          [ -3 -4 ]\n"
     "  d = [ 20 40 ]\n"
     "isotropic dim=2 sigma=3\n";
-  EXPECT(assert_print_equal(expected, conditional, s));
+  EXPECT(assert_print_equal(expected1, conditional1));
 
   // Test printing for multiple parents.
   auto conditional2 = GaussianConditional::FromMeanAndStddev(X(0), A1, Y(0), A2,
@@ -433,7 +443,7 @@ TEST(GaussianConditional, Print) {
     "          [ -7 -8 ]\n"
     "  d = [ 20 40 ]\n"
     "isotropic dim=2 sigma=3\n";
-  EXPECT(assert_print_equal(expected2, conditional2, s));
+  EXPECT(assert_print_equal(expected2, conditional2));
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/tests/testGaussianConditional.cpp
+++ b/gtsam/linear/tests/testGaussianConditional.cpp
@@ -407,7 +407,7 @@ TEST(GaussianConditional, Print) {
   GaussianConditional conditional(X(0), b, Matrix2::Identity(),
                                   noiseModel::Isotropic::Sigma(2, sigma));
 
-  // Test printing for single parent.
+  // Test printing for no parents.
   std::string expected =
     "GaussianConditional p(x0)\n"
     "  R = [ 1 0 ]\n"


### PR DESCRIPTION
I am still not satisfied with the printing of `GaussianConditional` since if we provide a value for the preface string `s`, it no longer prints out "GaussianConditional". This is pretty problematic in the hybrid decision tree.

I also updated the printing for when there are no parents. Before it was
```
GaussianConditional p(x0 |)
```

but now it is
```
GaussianConditional p(x0)
```