### PR TITLE
DecisionTreeFactor `prune` method

### DIFF
--- a/gtsam/discrete/DecisionTreeFactor.cpp
+++ b/gtsam/discrete/DecisionTreeFactor.cpp
@@ -287,4 +287,42 @@ namespace gtsam {
         cardinalities_(keys.cardinalities()) {}
 
   /* ************************************************************************ */
+  DecisionTreeFactor DecisionTreeFactor::prune(size_t maxNrLeaves) const {
+    const size_t N = maxNrLeaves;
+
+    // Let's assume that the structure of the last discrete density will be the
+    // same as the last continuous
+    std::vector<double> probabilities;
+    // number of choices
+    this->visit([&](const double& prob) { probabilities.emplace_back(prob); });
+
+    // The number of probabilities can be lower than max_leaves
+    if (probabilities.size() <= N) {
+      return *this;
+    }
+
+    std::sort(probabilities.begin(), probabilities.end(),
+              std::greater<double>{});
+
+    double threshold = probabilities[N - 1];
+
+    // Now threshold the decision tree
+    size_t total = 0;
+    auto thresholdFunc = [threshold, &total, N](const double& value) {
+      if (value < threshold || total >= N) {
+        return 0.0;
+      } else {
+        total += 1;
+        return value;
+      }
+    };
+    DecisionTree<Key, double> thresholded(*this, thresholdFunc);
+
+    // Create pruned decision tree factor
+    DecisionTreeFactor prunedDiscreteFactor(this->discreteKeys(), thresholded);
+
+    return prunedDiscreteFactor;
+  }
+
+  /* ************************************************************************ */
 }  // namespace gtsam

--- a/gtsam/discrete/DecisionTreeFactor.cpp
+++ b/gtsam/discrete/DecisionTreeFactor.cpp
@@ -290,10 +290,8 @@ namespace gtsam {
   DecisionTreeFactor DecisionTreeFactor::prune(size_t maxNrLeaves) const {
     const size_t N = maxNrLeaves;
 
-    // Let's assume that the structure of the last discrete density will be the
-    // same as the last continuous
+    // Get the probabilities in the decision tree so we can threshold.
     std::vector<double> probabilities;
-    // number of choices
     this->visit([&](const double& prob) { probabilities.emplace_back(prob); });
 
     // The number of probabilities can be lower than max_leaves
@@ -318,10 +316,8 @@ namespace gtsam {
     };
     DecisionTree<Key, double> thresholded(*this, thresholdFunc);
 
-    // Create pruned decision tree factor
-    DecisionTreeFactor prunedDiscreteFactor(this->discreteKeys(), thresholded);
-
-    return prunedDiscreteFactor;
+    // Create pruned decision tree factor and return.
+    return DecisionTreeFactor(this->discreteKeys(), thresholded);
   }
 
   /* ************************************************************************ */

--- a/gtsam/discrete/DecisionTreeFactor.h
+++ b/gtsam/discrete/DecisionTreeFactor.h
@@ -178,7 +178,7 @@ namespace gtsam {
      * A leaf is pruned if it is not in the top `maxNrLeaves` values.
      *
      * @param maxNrLeaves The maximum number of leaves to keep.
-     * @return DecisionTreeFactor::shared_ptr
+     * @return DecisionTreeFactor
      */
     DecisionTreeFactor prune(size_t maxNrLeaves) const;
 

--- a/gtsam/discrete/DecisionTreeFactor.h
+++ b/gtsam/discrete/DecisionTreeFactor.h
@@ -170,6 +170,18 @@ namespace gtsam {
     /// Return all the discrete keys associated with this factor.
     DiscreteKeys discreteKeys() const;
 
+    /**
+     * @brief Prune the decision tree of discrete variables.
+     *
+     * Pruning will set the leaves to be "pruned" to 0 indicating a 0
+     * probability.
+     * A leaf is pruned if it is not in the top `maxNrLeaves` values.
+     *
+     * @param maxNrLeaves The maximum number of leaves to keep.
+     * @return DecisionTreeFactor::shared_ptr
+     */
+    DecisionTreeFactor prune(size_t maxNrLeaves) const;
+
     /// @}
     /// @name Wrapper support
     /// @{

--- a/gtsam/discrete/tests/testDecisionTreeFactor.cpp
+++ b/gtsam/discrete/tests/testDecisionTreeFactor.cpp
@@ -107,6 +107,27 @@ TEST(DecisionTreeFactor, enumerate) {
 }
 
 /* ************************************************************************* */
+// Check pruning of the decision tree works as expected.
+TEST(DecisionTreeFactor, Prune) {
+  DiscreteKey A(1, 2), B(2, 2), C(3, 2);
+  DecisionTreeFactor f(A & B & C, "1 5 3 7 2 6 4 8");
+
+  // Only keep the leaves with the top 5 values.
+  size_t maxNrLeaves = 5;
+  auto pruned5 = f.prune(maxNrLeaves);
+
+  // Pruned leaves should be 0
+  DecisionTreeFactor expected(A & B & C, "0 5 0 7 0 6 4 8");
+  EXPECT(assert_equal(expected, pruned5));
+
+  // Check for more extreme pruning where we only keep the top 2 leaves
+  maxNrLeaves = 2;
+  auto pruned2 = f.prune(maxNrLeaves);
+  DecisionTreeFactor expected2(A & B & C, "0 0 0 7 0 0 0 8");
+  EXPECT(assert_equal(expected2, pruned2));
+}
+
+/* ************************************************************************* */
 TEST(DecisionTreeFactor, DotWithNames) {
   DiscreteKey A(12, 3), B(5, 2);
   DecisionTreeFactor f(A & B, "1 2  3 4  5 6");


### PR DESCRIPTION
This PR adds a new prune method to `DecisionTreeFactor` which will allow for managing exponential growth.

Given a `DecisionTreeFactor`
```
DecisionTreeFactor:
 f[ (1,2), (2,2), (3,2), ]
 Choice(3)
 0 Choice(2)
 0 0 Choice(1)
 0 0 0 Leaf    1
 0 0 1 Leaf    2
 0 1 Choice(1)
 0 1 0 Leaf    3
 0 1 1 Leaf    4
 1 Choice(2)
 1 0 Choice(1)
 1 0 0 Leaf    5
 1 0 1 Leaf    6
 1 1 Choice(1)
 1 1 0 Leaf    7
 1 1 1 Leaf    8
```

if we set `maxNrLeaves` to 5, which means only keep the top 5 leaves, we get
```
DecisionTreeFactor:
 f[ (1,2), (2,2), (3,2), ]
 Choice(3)
 0 Choice(2)
 0 0 Leaf    0
 0 1 Choice(1)
 0 1 0 Leaf    0
 0 1 1 Leaf    4
 1 Choice(2)
 1 0 Choice(1)
 1 0 0 Leaf    5
 1 0 1 Leaf    6
 1 1 Choice(1)
 1 1 0 Leaf    7
 1 1 1 Leaf    8
```
as expected.