### PR TITLE
New `maxNrAssignment` scheme for pruning

### DIFF
--- a/gtsam/discrete/AlgebraicDecisionTree.h
+++ b/gtsam/discrete/AlgebraicDecisionTree.h
@@ -160,7 +160,7 @@ namespace gtsam {
               const typename Base::LabelFormatter& labelFormatter =
                   &DefaultFormatter) const {
       auto valueFormatter = [](const double& v) {
-        return (boost::format("%4.4g") % v).str();
+        return (boost::format("%4.8g") % v).str();
       };
       Base::print(s, labelFormatter, valueFormatter);
     }

--- a/gtsam/discrete/DecisionTreeFactor.h
+++ b/gtsam/discrete/DecisionTreeFactor.h
@@ -174,9 +174,16 @@ namespace gtsam {
      * @brief Prune the decision tree of discrete variables.
      *
      * Pruning will set the leaves to be "pruned" to 0 indicating a 0
-     * probability.
-     * An assignment is pruned if it is not in the top `maxNrAssignments`
-     * values.
+     * probability. An assignment is pruned if it is not in the top
+     * `maxNrAssignments` values.
+     *
+     * A violation can occur if there are more
+     * duplicate values than `maxNrAssignments`. A violation here is the need to
+     * un-prune the decision tree (e.g. all assignment values are 1.0). We could
+     * have another case where some subset of duplicates exist (e.g. for a tree
+     * with 8 assignments we have 1, 1, 1, 1, 0.8, 0.7, 0.6, 0.5), but this is
+     * not a violation since the for `maxNrAssignments=5` the top values are (1,
+     * 0.8).
      *
      * @param maxNrAssignments The maximum number of assignments to keep.
      * @return DecisionTreeFactor

--- a/gtsam/discrete/tests/testDecisionTreeFactor.cpp
+++ b/gtsam/discrete/tests/testDecisionTreeFactor.cpp
@@ -113,18 +113,32 @@ TEST(DecisionTreeFactor, Prune) {
   DecisionTreeFactor f(A & B & C, "1 5 3 7 2 6 4 8");
 
   // Only keep the leaves with the top 5 values.
-  size_t maxNrLeaves = 5;
-  auto pruned5 = f.prune(maxNrLeaves);
+  size_t maxNrAssignments = 5;
+  auto pruned5 = f.prune(maxNrAssignments);
 
   // Pruned leaves should be 0
   DecisionTreeFactor expected(A & B & C, "0 5 0 7 0 6 4 8");
   EXPECT(assert_equal(expected, pruned5));
 
   // Check for more extreme pruning where we only keep the top 2 leaves
-  maxNrLeaves = 2;
-  auto pruned2 = f.prune(maxNrLeaves);
+  maxNrAssignments = 2;
+  auto pruned2 = f.prune(maxNrAssignments);
   DecisionTreeFactor expected2(A & B & C, "0 0 0 7 0 0 0 8");
   EXPECT(assert_equal(expected2, pruned2));
+
+  DiscreteKey D(4, 2);
+  DecisionTreeFactor factor(
+      D & C & B & A,
+      "0.0 0.0 0.0 0.60658897 0.61241912 0.61241969 0.61247685 0.61247742 0.0 "
+      "0.0 0.0 0.99995287 1.0 1.0 1.0 1.0");
+
+  DecisionTreeFactor expected3(
+      D & C & B & A,
+      "0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 "
+      "0.999952870000 1.0 1.0 1.0 1.0");
+  maxNrAssignments = 5;
+  auto pruned3 = factor.prune(maxNrAssignments);
+  EXPECT(assert_equal(expected3, pruned3));
 }
 
 /* ************************************************************************* */
@@ -133,7 +147,7 @@ TEST(DecisionTreeFactor, DotWithNames) {
   DecisionTreeFactor f(A & B, "1 2  3 4  5 6");
   auto formatter = [](Key key) { return key == 12 ? "A" : "B"; };
 
-  for (bool showZero:{true, false}) {  
+  for (bool showZero:{true, false}) {
     string actual = f.dot(formatter, showZero);
     // pretty weak test, as ids are pointers and not stable across platforms.
     string expected = "digraph G {";
@@ -215,4 +229,3 @@ int main() {
   return TestRegistry::runAllTests(tr);
 }
 /* ************************************************************************* */
-


### PR DESCRIPTION
As discussed in our meeting yesterday, this PR updates the `DecisionTreeFactor::prune` method to use the new `maxNrAssignments` scheme.

Here, we use the record of assignments for each leaf to compute the number of duplicate values in the tree without enumerating all the (exponential) number of assignments, and threshold on the top `maxNrAssignments` values. To facilitate this, I added a new `visitLeaf` method to `DecisionTree` which follows the same idea as `visit` in that we visit all the leaves (and not assignments), but `visitLeaf` passes the full leaf object to the functional, allowing us to do `leaf.nrAssignments()` and `leaf.constant()` quite easily.

**NOTE** I have one question: should the functional receive the leaf object or the leaf pointer? It is a const either way, but I've made it as a leaf object const-ref so there shouldn't be a memory hit and it is convenient to use (since we don't declare a `LeafPtr` typedef).