### PR TITLE
ISAM2 marginalization fixes

### DIFF
--- a/tests/testGaussianISAM2.cpp
+++ b/tests/testGaussianISAM2.cpp
@@ -714,16 +714,17 @@ namespace {
     const boost::optional<FastMap<Key, int>> orderingConstraints = createOrderingConstraints(isam, newValues.keys(), marginalizableKeys);
 
     // Mark additional keys between the marginalized keys and the leaves
-    KeyList additionalMarkedKeys;
+    KeyList markedKeys;
     for (Key key : marginalizableKeys) {
+      markedKeys.push_back(key);
       ISAM2Clique::shared_ptr clique = isam[key];
       for (const ISAM2Clique::shared_ptr& child : clique->children) {
-        markAffectedKeys(key, child, additionalMarkedKeys);
+        markAffectedKeys(key, child, markedKeys);
       }
     }
 
     // Update
-    isam.update(newFactors, newValues, FactorIndices{}, orderingConstraints, boost::none, additionalMarkedKeys);
+    isam.update(newFactors, newValues, FactorIndices{}, orderingConstraints, boost::none, markedKeys);
 
     if (!marginalizableKeys.empty()) {
       FastList<Key> leafKeys(marginalizableKeys.begin(), marginalizableKeys.end());


### PR DESCRIPTION
Fixes https://github.com/borglab/gtsam/issues/1101

This PR addresses 3 separate problems with the ISAM2 marginalization.

1. The first issue is that a missing null pointer check would cause a segfault if a root was attempted to be marginalized. A test was added in https://github.com/borglab/gtsam/pull/1105 ( [TEST(ISAM2, MarginalizeRoot)](https://github.com/borglab/gtsam/pull/1105/files#:~:text=TEST(ISAM2%2C%20MarginalizeRoot)) ) which triggers this behavior. The fix added here is to add a null pointer check before the addition of the marginal factor. This works since, if we are marginalizing a root, we don't need to keep track of the resulting marginal factor as the entire tree is discarded. The new test passes with the fix included here.
2. The second issue is that the clique conditional's block matrix was being incorrectly updated. When we remove variables from a clique, the column start of the vertical block matrix needs to be incremented by the number of variables removed (it was being set equal to the number of variables instead). Triggering this behavior can be difficult: you need to repeatedly marginalize variables from the same clique, but not remove the entire clique. A test was added in https://github.com/borglab/gtsam/pull/1105 ([TEST(ISAM2, marginalizeLeaves6)](https://github.com/borglab/gtsam/pull/1105/files#:~:text=TEST(ISAM2%2C%20marginalizeLeaves6)) which manages to trigger this behavior. That test now passes with these fixes.
3. The last issue is that `marginalizeLeaves` ignores the `findUnusedFactorSlots` parameter, and always pushes new marginal factors onto the back of the graph instead of inserting them into unused slots. This was fixed by replacing the call to `push_back` with a call to `add_factors` which takes into account the `findUnusedFactorSlots` param, and then using the `newFactorIndices` returned by that call to insert new factors into the graph. Another related change is removing factors _before_ inserting the new marginal factors into the graph. Together, these changes prevent the graph from growing when variables are marginalized. A new test which failed previously (and now passes) had been added in this PR ([TEST(ISAM2, marginalizationSize)](https://github.com/borglab/gtsam/pull/1172/files#:~:text=TEST(ISAM2%2C%20marginalizationSize))


