### PR TITLE
Regenerate python utils files upon edit

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -98,10 +98,14 @@ set(GTSAM_MODULE_PATH ${GTSAM_PYTHON_BUILD_DIRECTORY}/gtsam)
 copy_directory("${CMAKE_CURRENT_SOURCE_DIR}/gtsam"
         "${GTSAM_MODULE_PATH}")
 
-# Hack to get python test files copied every time they are modified
+# Hack to get python test and util files copied every time they are modified
 file(GLOB GTSAM_PYTHON_TEST_FILES "${CMAKE_CURRENT_SOURCE_DIR}/gtsam/tests/*.py")
 foreach(test_file ${GTSAM_PYTHON_TEST_FILES})
         configure_file(${test_file} "${GTSAM_MODULE_PATH}/tests/${test_file}" COPYONLY)
+endforeach()
+file(GLOB GTSAM_PYTHON_UTIL_FILES "${CMAKE_CURRENT_SOURCE_DIR}/gtsam/utils/*.py")
+foreach(util_file ${GTSAM_PYTHON_UTIL_FILES})
+        configure_file(${util_file} "${GTSAM_MODULE_PATH}/utils/${test_file}" COPYONLY)
 endforeach()
 
 # Common directory for data/datasets stored with the package.
@@ -160,7 +164,7 @@ if(GTSAM_UNSTABLE_BUILD_PYTHON)
 
     # Hack to get python test files copied every time they are modified
     file(GLOB GTSAM_UNSTABLE_PYTHON_TEST_FILES "${CMAKE_CURRENT_SOURCE_DIR}/gtsam_unstable/tests/*.py")
-    foreach(test_file ${GTSAM_PYTHON_TEST_FILES})
+    foreach(test_file ${GTSAM_UNSTABLE_PYTHON_TEST_FILES})
         configure_file(${test_file} "${GTSAM_UNSTABLE_MODULE_PATH}/tests/${test_file}" COPYONLY)
     endforeach()
 


### PR DESCRIPTION
Fixes a bug that editing `python/gtsam/utils/xxx.py` wouldn't automatically re-copy / re-generate after editing during make python-install.

There was already some code to do this for the `tests` folder, so I just duplicated it to do it for the `utils` folder as well.

Also I noticed a typo for `python/gtsam_unstable/tests/xxx.py` so I corrected that.