### PR TITLE
Fix templated type declaration in geometry.i

### DIFF
--- a/gtsam/geometry/geometry.i
+++ b/gtsam/geometry/geometry.i
@@ -873,7 +873,7 @@ template <CALIBRATION>
 class PinholeCamera {
   // Standard Constructors and Named Constructors
   PinholeCamera();
-  PinholeCamera(const gtsam::PinholeCamera<CALIBRATION> other);
+  PinholeCamera(const This other);
   PinholeCamera(const gtsam::Pose3& pose);
   PinholeCamera(const gtsam::Pose3& pose, const CALIBRATION& K);
   static This Level(const CALIBRATION& K, const gtsam::Pose2& pose,
@@ -942,7 +942,7 @@ template <CALIBRATION>
 class PinholePose {
   // Standard Constructors and Named Constructors
   PinholePose();
-  PinholePose(const gtsam::PinholePose<CALIBRATION> other);
+  PinholePose(const This other);
   PinholePose(const gtsam::Pose3& pose);
   PinholePose(const gtsam::Pose3& pose, const CALIBRATION* K);
   static This Level(const gtsam::Pose2& pose, double height);


### PR DESCRIPTION
For using templated types in methods in the wrapper, we need to use `This` instead of `Class<T>`.

This may be a strong requirement, but it is convenient and unless there is a strong argument for changing this default behavior, I'm going to keep it as is.

Fixes #1184 