### PR TITLE
Fix / Move `Rot3::quaternion` to deprecated block

### DIFF
--- a/gtsam/geometry/Rot3.cpp
+++ b/gtsam/geometry/Rot3.cpp
@@ -228,6 +228,7 @@ double Rot3::yaw(OptionalJacobian<1, 3> H) const {
 }
 
 /* ************************************************************************* */
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V42
 Vector Rot3::quaternion() const {
   gtsam::Quaternion q = toQuaternion();
   Vector v(4);
@@ -237,6 +238,7 @@ Vector Rot3::quaternion() const {
   v(3) = q.z();
   return v;
 }
+#endif
 
 /* ************************************************************************* */
 pair<Unit3, double> Rot3::axisAngle() const {

--- a/gtsam/geometry/Rot3.h
+++ b/gtsam/geometry/Rot3.h
@@ -515,11 +515,16 @@ class GTSAM_EXPORT Rot3 : public LieGroup<Rot3, 3> {
      */
     gtsam::Quaternion toQuaternion() const;
 
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V42
     /**
      * Converts to a generic matrix to allow for use with matlab
      * In format: w x y z
+     * @deprecated: use Rot3::toQuaternion() instead.
+     * If still using this API, remind that in the returned Vector `V`,
+     * `V.x()` denotes the actual `qw`, `V.y()` denotes 'qx', `V.z()` denotes `qy`, and `V.w()` denotes 'qz'.
      */
-    Vector quaternion() const;
+    Vector GTSAM_DEPRECATED quaternion() const;
+#endif
 
     /**
      * @brief Spherical Linear intERPolation between *this and other

--- a/gtsam/geometry/geometry.i
+++ b/gtsam/geometry/geometry.i
@@ -355,7 +355,7 @@ class Rot3 {
   double yaw() const;
   pair<gtsam::Unit3, double> axisAngle() const;
   gtsam::Quaternion toQuaternion() const;
-  Vector quaternion() const;
+  // Vector quaternion() const; // @deprecated, see https://github.com/borglab/gtsam/pull/1219
   gtsam::Rot3 slerp(double t, const gtsam::Rot3& other) const;
 
   // enabling serialization functionality

--- a/gtsam_unstable/timing/timeShonanAveraging.cpp
+++ b/gtsam_unstable/timing/timeShonanAveraging.cpp
@@ -79,9 +79,9 @@ void saveG2oResult(string name, const Values& values, std::map<Key, Pose3> poses
         myfile << "VERTEX_SE3:QUAT" << " ";
         myfile << i << " ";
         myfile << poses[i].x() << " " << poses[i].y() << " " << poses[i].z() << " ";
-        Vector quaternion = Rot3(R).quaternion();
-        myfile << quaternion(3) << " " << quaternion(2) << " " << quaternion(1)
-               << " " << quaternion(0);
+        Quaternion quaternion = Rot3(R).toQuaternion();
+        myfile << quaternion.x() << " " << quaternion.y() << " " << quaternion.z()
+               << " " << quaternion.w();
         myfile << "\n";
     }
     myfile.close();


### PR DESCRIPTION
This PR fixes #1209. More details about this issue can be found in the group discussion https://groups.google.com/g/gtsam-users/c/AxbAAEgMHTA.

Basically, this issue is because `Rot3::quaternion()` returns a `Vector` as `[qw, qx, qy, qz]`, not a quaternion. `Vector` is a typedef for `Eigen::VectorXd`, for which `.x()` returns the first element (instead of qw), `.y()` the second (so here qx), etc... Therefore this `Rot3::quaternion()` API is very non-intuitive and it could lead to a bug in user code if they don't pay attention enough. 

This fix modifies the `Rot3::quaternion()` API and makes sure the ordering of the returned `[qw,qx,qy,qz]` are consistent with  `gtsam::Quaternion`. 
