### PR TITLE
Wrapper Update

### DIFF
--- a/wrap/cmake/MatlabWrap.cmake
+++ b/wrap/cmake/MatlabWrap.cmake
@@ -242,6 +242,13 @@ function(wrap_library_internal interfaceHeader moduleName linkLibraries extraInc
   find_package(PythonInterp ${WRAP_PYTHON_VERSION} EXACT)
   find_package(PythonLibs ${WRAP_PYTHON_VERSION} EXACT)
 
+  # Set the path separator for PYTHONPATH
+  if(UNIX)
+    set(GTWRAP_PATH_SEPARATOR ":")
+  else()
+    set(GTWRAP_PATH_SEPARATOR ";")
+  endif()
+
   add_custom_command(
     OUTPUT ${generated_cpp_file}
     DEPENDS ${interfaceHeader} ${module_library_target} ${otherLibraryTargets}


### PR DESCRIPTION
Fixes #1118 

ca357ccdd Merge pull request #149 from borglab/install-package
886846724 set the GTWRAP_PATH_SEPARATOR properly for MatlabWrap
4abed7fa0 install the python package explicitly

git-subtree-dir: wrap
git-subtree-split: ca357ccdd27f0661e73ff7a1771768dc4bf8f746