### PR TITLE
Clear ConcurrentMap before loading archive data

### DIFF
--- a/gtsam/base/ConcurrentMap.h
+++ b/gtsam/base/ConcurrentMap.h
@@ -113,6 +113,7 @@ private:
   template<class Archive>
   void load(Archive& ar, const unsigned int /*version*/)
   {
+    this->clear();
     // Load into STL container and then fill our map
     FastVector<std::pair<KEY, VALUE> > map;
     ar & BOOST_SERIALIZATION_NVP(map);

--- a/gtsam/base/tests/testSerializationBase.cpp
+++ b/gtsam/base/tests/testSerializationBase.cpp
@@ -18,6 +18,7 @@
 
 #include <gtsam/inference/Key.h>
 
+#include <gtsam/base/ConcurrentMap.h>
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/MatrixSerialization.h>
 #include <gtsam/base/Vector.h>
@@ -104,6 +105,39 @@ TEST (Serialization, matrix_vector) {
   EXPECT(equalityBinary<Vector3>(Vector3(1.0, 2.0, 3.0)));
   EXPECT(equalityBinary<Vector6>((Vector6() << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0).finished()));
   EXPECT(equalityBinary<Matrix>((Matrix(2, 2) << 1.0, 2.0, 3.0, 4.0).finished()));
+}
+
+/* ************************************************************************* */
+TEST (Serialization, ConcurrentMap) {
+
+  ConcurrentMap<int, std::string> map;
+
+  map.insert(make_pair(1, "apple"));
+  map.insert(make_pair(2, "banana"));
+
+  std::string binaryPath = "saved_map.dat";
+    try {
+    std::ofstream outputStream(binaryPath);
+    boost::archive::binary_oarchive outputArchive(outputStream);
+    outputArchive << map;
+  } catch(...) {
+    EXPECT(false);
+  }
+
+  // Verify that the existing map contents are replaced by the archive data
+  ConcurrentMap<int, std::string> mapFromDisk;
+  mapFromDisk.insert(make_pair(3, "clam"));
+  EXPECT(mapFromDisk.exists(3));
+  try {
+    std::ifstream ifs(binaryPath);
+    boost::archive::binary_iarchive inputArchive(ifs);
+    inputArchive >> mapFromDisk;
+  } catch(...) {
+    EXPECT(false);
+  }
+  EXPECT(mapFromDisk.exists(1));
+  EXPECT(mapFromDisk.exists(2));
+  EXPECT(!mapFromDisk.exists(3));
 }
 
 /* ************************************************************************* */


### PR DESCRIPTION
Adding the clear() call causes the contents of the ConcurrentMap to be replaced by the archive data, without it the archive data is appended to the current object contents.