### PR TITLE
Fix Python CI: More swap space

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -112,6 +112,11 @@ jobs:
         run: |
           echo "GTSAM_WITH_TBB=ON" >> $GITHUB_ENV
           echo "GTSAM Uses TBB"
+      - name: Set Swap Space
+        if: runner.os == 'Linux'
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 6
       - name: Build (Linux)
         if: runner.os == 'Linux'
         run: |


### PR DESCRIPTION
Recent CI's have been failing due to Python compile needing large amounts of RAM.  Specifically, gcc in DEBUG mode appears to be pushing the CI over the edge.  e.g.

> [ 93%] Built target gtsam_unstable_py
> [ 93%] Building CXX object python/CMakeFiles/gtsam_py.dir/slam.cpp.o
> g++-5: internal compiler error: Killed (program cc1plus)
> Please submit a full bug report,
> with preprocessed source if appropriate.
> See <file:///usr/share/doc/gcc-5/README.Bugs> for instructions.
> make[2]: *** [python/CMakeFiles/gtsam_py.dir/nonlinear.cpp.o] Error 4
> python/CMakeFiles/gtsam_py.dir/build.make:257: recipe for target 'python/CMakeFiles/gtsam_py.dir/nonlinear.cpp.o' failed
> make[2]: *** Waiting for unfinished jobs....
> CMakeFiles/Makefile2:6887: recipe for target 'python/CMakeFiles/gtsam_py.dir/all' failed
> make[1]: *** [python/CMakeFiles/gtsam_py.dir/all] Error 2
> make: *** [all] Error 2
> Makefile:165: recipe for target 'all' failed
> Error: Process completed with exit code 2.

Varun/Fan/I discussed this issue.

This PR increases the (Linux) swap space from (default) 4GB to 6GB.  Alternatively, we could also reduce number of threads from `-j2` to `-j1` but that will ~double build times.

Also for reference, currently hard drive usage is very low, only 4.1G / 14G.  Here's output of `df` after python DEBUG build on python CI:
```
runner@fv-az199-378:~/work/gtsam/gtsam$ df -h
Filesystem      Size  Used Avail Use% Mounted on
udev            3.4G     0  3.4G   0% /dev
tmpfs           696M  740K  695M   1% /run
/dev/sdb1        84G   59G   25G  71% /
tmpfs           3.4G     0  3.4G   0% /dev/shm
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs           3.4G     0  3.4G   0% /sys/fs/cgroup
/dev/sdb15      105M  4.4M  100M   5% /boot/efi
/dev/sda1        14G  4.1G  9.0G  31% /mnt
tmpfs           696M     0  696M   0% /run/user/1001
```