### PR TITLE
replace addtogroup with ingroup for the SLAM group

### DIFF
--- a/gtsam/groups.dox
+++ b/gtsam/groups.dox
@@ -11,4 +11,7 @@
 
 @}
 
-*/ 
+\defgroup SLAM Useful SLAM components
+@{ @}
+
+*/

--- a/gtsam/navigation/CombinedImuFactor.h
+++ b/gtsam/navigation/CombinedImuFactor.h
@@ -123,7 +123,7 @@ public:
  * it is received from the IMU) so as to avoid costly integration at time of
  * factor construction.
  *
- * @addtogroup SLAM
+ * @ingroup SLAM
  */
 class GTSAM_EXPORT PreintegratedCombinedMeasurements : public PreintegrationType {
 
@@ -252,7 +252,7 @@ public:
  *    the correlation between the bias uncertainty and the preintegrated
  *    measurements uncertainty.
  *
- * @addtogroup SLAM
+ * @ingroup SLAM
  */
 class GTSAM_EXPORT CombinedImuFactor: public NoiseModelFactor6<Pose3, Vector3, Pose3,
     Vector3, imuBias::ConstantBias, imuBias::ConstantBias> {

--- a/gtsam/navigation/ImuFactor.h
+++ b/gtsam/navigation/ImuFactor.h
@@ -66,7 +66,7 @@ typedef ManifoldPreintegration PreintegrationType;
  * as soon as it is received from the IMU) so as to avoid costly integration
  * at time of factor construction.
  *
- * @addtogroup SLAM
+ * @ingroup SLAM
  */
 class GTSAM_EXPORT PreintegratedImuMeasurements: public PreintegrationType {
 
@@ -165,7 +165,7 @@ public:
  * (which are usually slowly varying quantities), which is up to the caller.
  * See also CombinedImuFactor for a class that does this for you.
  *
- * @addtogroup SLAM
+ * @ingroup SLAM
  */
 class GTSAM_EXPORT ImuFactor: public NoiseModelFactor5<Pose3, Vector3, Pose3, Vector3,
     imuBias::ConstantBias> {
@@ -256,7 +256,7 @@ public:
 
 /**
  * ImuFactor2 is a ternary factor that uses NavStates rather than Pose/Velocity.
- * @addtogroup SLAM
+ * @ingroup SLAM
  */
 class GTSAM_EXPORT ImuFactor2 : public NoiseModelFactor3<NavState, NavState, imuBias::ConstantBias> {
 private:

--- a/gtsam/nonlinear/PriorFactor.h
+++ b/gtsam/nonlinear/PriorFactor.h
@@ -24,7 +24,7 @@ namespace gtsam {
 
   /**
    * A class for a soft prior on any Value type
-   * @addtogroup SLAM
+   * @ingroup SLAM
    */
   template<class VALUE>
   class PriorFactor: public NoiseModelFactor1<VALUE> {

--- a/gtsam/sam/BearingRangeFactor.h
+++ b/gtsam/sam/BearingRangeFactor.h
@@ -27,7 +27,7 @@ namespace gtsam {
 
 /**
  * Binary factor for a bearing/range measurement
- * @addtogroup SLAM
+ * @ingroup SLAM
  */
 template <typename A1, typename A2,
           typename B = typename Bearing<A1, A2>::result_type,

--- a/gtsam/slam/AntiFactor.h
+++ b/gtsam/slam/AntiFactor.h
@@ -26,7 +26,7 @@ namespace gtsam {
    * A class for downdating an existing factor from a graph. The AntiFactor returns the same
    * linearized Hessian matrices of the original factor, but with the opposite sign. This effectively
    * cancels out any affects of the original factor during optimization."
-   * @addtogroup SLAM
+   * @ingroup SLAM
    */
   class AntiFactor: public NonlinearFactor {
 

--- a/gtsam/slam/BetweenFactor.h
+++ b/gtsam/slam/BetweenFactor.h
@@ -34,7 +34,7 @@ namespace gtsam {
   /**
    * A class for a measurement predicted by "between(config[key1],config[key2])"
    * @tparam VALUE the Value type
-   * @addtogroup SLAM
+   * @ingroup SLAM
    */
   template<class VALUE>
   class BetweenFactor: public NoiseModelFactor2<VALUE, VALUE> {

--- a/gtsam/slam/BoundingConstraint.h
+++ b/gtsam/slam/BoundingConstraint.h
@@ -27,7 +27,7 @@ namespace gtsam {
  * greater/less than a fixed threshold.  The function
  * will need to have its value function implemented to return
  * a scalar for comparison.
- * @addtogroup SLAM
+ * @ingroup SLAM
  */
 template<class VALUE>
 struct BoundingConstraint1: public NoiseModelFactor1<VALUE> {

--- a/gtsam/slam/EssentialMatrixConstraint.h
+++ b/gtsam/slam/EssentialMatrixConstraint.h
@@ -25,7 +25,7 @@ namespace gtsam {
 
 /**
  * Binary factor between two Pose3 variables induced by an EssentialMatrix measurement
- * @addtogroup SLAM
+ * @ingroup SLAM
  */
 class GTSAM_EXPORT EssentialMatrixConstraint: public NoiseModelFactor2<Pose3, Pose3> {
 

--- a/gtsam/slam/GeneralSFMFactor.h
+++ b/gtsam/slam/GeneralSFMFactor.h
@@ -54,7 +54,7 @@ namespace gtsam {
 /**
  * Non-linear factor for a constraint derived from a 2D measurement.
  * The calibration is unknown here compared to GenericProjectionFactor
- * @addtogroup SLAM
+ * @ingroup SLAM
  */
 template<class CAMERA, class LANDMARK>
 class GeneralSFMFactor: public NoiseModelFactor2<CAMERA, LANDMARK> {

--- a/gtsam/slam/ProjectionFactor.h
+++ b/gtsam/slam/ProjectionFactor.h
@@ -33,7 +33,7 @@ namespace gtsam {
    * Non-linear factor for a constraint derived from a 2D measurement. 
    * The calibration is known here.
    * The main building block for visual SLAM.
-   * @addtogroup SLAM
+   * @ingroup SLAM
    */
   template <class POSE = Pose3, class LANDMARK = Point3,
             class CALIBRATION = Cal3_S2>

--- a/gtsam/slam/SmartProjectionPoseFactor.h
+++ b/gtsam/slam/SmartProjectionPoseFactor.h
@@ -24,7 +24,7 @@
 namespace gtsam {
 /**
  *
- * @addtogroup SLAM
+ * @ingroup SLAM
  *
  * If you are using the factor, please cite:
  * L. Carlone, Z. Kira, C. Beall, V. Indelman, F. Dellaert, Eliminating conditionally
@@ -39,7 +39,7 @@ namespace gtsam {
  * The factor only constrains poses (variable dimension is 6).
  * This factor requires that values contains the involved poses (Pose3).
  * If the calibration should be optimized, as well, use SmartProjectionFactor instead!
- * @addtogroup SLAM
+ * @ingroup SLAM
  */
 template <class CALIBRATION>
 class SmartProjectionPoseFactor

--- a/gtsam/slam/SmartProjectionRigFactor.h
+++ b/gtsam/slam/SmartProjectionRigFactor.h
@@ -29,7 +29,7 @@
 namespace gtsam {
 /**
  *
- * @addtogroup SLAM
+ * @ingroup SLAM
  *
  * If you are using the factor, please cite:
  * L. Carlone, Z. Kira, C. Beall, V. Indelman, F. Dellaert, Eliminating
@@ -46,7 +46,7 @@ namespace gtsam {
  * calibration (i.e., are from the same camera), use SmartProjectionPoseFactor
  * instead! If the calibration should be optimized, as well, use
  * SmartProjectionFactor instead!
- * @addtogroup SLAM
+ * @ingroup SLAM
  */
 template <class CAMERA>
 class SmartProjectionRigFactor : public SmartProjectionFactor<CAMERA> {

--- a/gtsam/slam/StereoFactor.h
+++ b/gtsam/slam/StereoFactor.h
@@ -25,7 +25,7 @@ namespace gtsam {
 
 /**
  * A Generic Stereo Factor
- * @addtogroup SLAM
+ * @ingroup SLAM
  */
 template<class POSE, class LANDMARK>
 class GenericStereoFactor: public NoiseModelFactor2<POSE, LANDMARK> {

--- a/gtsam/slam/TriangulationFactor.h
+++ b/gtsam/slam/TriangulationFactor.h
@@ -27,7 +27,7 @@ namespace gtsam {
 /**
  * Non-linear factor for a constraint derived from a 2D measurement.
  * The calibration and pose are assumed known.
- * @addtogroup SLAM
+ * @ingroup SLAM
  */
 template<class CAMERA>
 class TriangulationFactor: public NoiseModelFactor1<Point3> {

--- a/gtsam_unstable/slam/BetweenFactorEM.h
+++ b/gtsam_unstable/slam/BetweenFactorEM.h
@@ -28,7 +28,7 @@ namespace gtsam {
 /**
  * A class for a measurement predicted by "between(config[key1],config[key2])"
  * @tparam VALUE the Value type
- * @addtogroup SLAM
+ * @ingroup SLAM
  */
 template<class VALUE>
 class BetweenFactorEM: public NonlinearFactor {

--- a/gtsam_unstable/slam/BiasedGPSFactor.h
+++ b/gtsam_unstable/slam/BiasedGPSFactor.h
@@ -25,7 +25,7 @@ namespace gtsam {
   /**
    * A class to model GPS measurements, including a bias term which models
    * common-mode errors and that can be partially corrected if other sensors are used
-   * @addtogroup SLAM
+   * @ingroup SLAM
    */
   class BiasedGPSFactor: public NoiseModelFactor2<Pose3, Point3> {
 

--- a/gtsam_unstable/slam/MultiProjectionFactor.h
+++ b/gtsam_unstable/slam/MultiProjectionFactor.h
@@ -29,7 +29,7 @@ namespace gtsam {
   /**
    * Non-linear factor for a constraint derived from a 2D measurement. The calibration is known here.
    * i.e. the main building block for visual SLAM.
-   * @addtogroup SLAM
+   * @ingroup SLAM
    */
   template<class POSE, class LANDMARK, class CALIBRATION = Cal3_S2>
   class MultiProjectionFactor: public NoiseModelFactor {

--- a/gtsam_unstable/slam/PoseBetweenFactor.h
+++ b/gtsam_unstable/slam/PoseBetweenFactor.h
@@ -26,7 +26,7 @@ namespace gtsam {
   /**
    * A class for a measurement predicted by "between(config[key1],config[key2])"
    * @tparam POSE the Pose type
-   * @addtogroup SLAM
+   * @ingroup SLAM
    */
   template<class POSE>
   class PoseBetweenFactor: public NoiseModelFactor2<POSE, POSE> {

--- a/gtsam_unstable/slam/PosePriorFactor.h
+++ b/gtsam_unstable/slam/PosePriorFactor.h
@@ -23,7 +23,7 @@ namespace gtsam {
 
   /**
    * A class for a soft prior on any Value type
-   * @addtogroup SLAM
+   * @ingroup SLAM
    */
   template<class POSE>
   class PosePriorFactor: public NoiseModelFactor1<POSE> {

--- a/gtsam_unstable/slam/PoseToPointFactor.h
+++ b/gtsam_unstable/slam/PoseToPointFactor.h
@@ -18,7 +18,7 @@ namespace gtsam {
 
 /**
  * A class for a measurement between a pose and a point.
- * @addtogroup SLAM
+ * @ingroup SLAM
  */
 template<typename POSE = Pose3, typename POINT = Point3>
 class PoseToPointFactor : public NoiseModelFactor2<POSE, POINT> {

--- a/gtsam_unstable/slam/ProjectionFactorPPP.h
+++ b/gtsam_unstable/slam/ProjectionFactorPPP.h
@@ -28,7 +28,7 @@ namespace gtsam {
   /**
    * Non-linear factor for a constraint derived from a 2D measurement. The calibration is known here.
    * i.e. the main building block for visual SLAM.
-   * @addtogroup SLAM
+   * @ingroup SLAM
    */
   template<class POSE, class LANDMARK, class CALIBRATION = Cal3_S2>
   class ProjectionFactorPPP: public NoiseModelFactor3<POSE, POSE, LANDMARK> {

--- a/gtsam_unstable/slam/ProjectionFactorPPPC.h
+++ b/gtsam_unstable/slam/ProjectionFactorPPPC.h
@@ -30,7 +30,7 @@ namespace gtsam {
   /**
    * Non-linear factor for a constraint derived from a 2D measurement. This factor
    * estimates the body pose, body-camera transform, 3D landmark, and calibration.
-   * @addtogroup SLAM
+   * @ingroup SLAM
    */
 template <class POSE, class LANDMARK, class CALIBRATION = Cal3_S2>
 class GTSAM_UNSTABLE_EXPORT ProjectionFactorPPPC

--- a/gtsam_unstable/slam/ProjectionFactorRollingShutter.h
+++ b/gtsam_unstable/slam/ProjectionFactorRollingShutter.h
@@ -38,7 +38,7 @@ namespace gtsam {
  * define the alpha = (t_p - t_A) / (t_B - t_A), we will use the pose
  * interpolated between A and B by the alpha to project the corresponding
  * landmark to Point2.
- * @addtogroup SLAM
+ * @ingroup SLAM
  */
 
 class GTSAM_UNSTABLE_EXPORT ProjectionFactorRollingShutter

--- a/gtsam_unstable/slam/SmartProjectionPoseFactorRollingShutter.h
+++ b/gtsam_unstable/slam/SmartProjectionPoseFactorRollingShutter.h
@@ -25,7 +25,7 @@
 namespace gtsam {
 /**
  *
- * @addtogroup SLAM
+ * @ingroup SLAM
  *
  * If you are using the factor, please cite:
  * L. Carlone, Z. Kira, C. Beall, V. Indelman, F. Dellaert,
@@ -39,7 +39,7 @@ namespace gtsam {
  * shutter model of the camera with given readout time. The factor requires that
  * values contain (for each pixel observation) two consecutive camera poses from
  * which the pixel observation pose can be interpolated.
- * @addtogroup SLAM
+ * @ingroup SLAM
  */
 template <class CAMERA>
 class GTSAM_UNSTABLE_EXPORT SmartProjectionPoseFactorRollingShutter

--- a/gtsam_unstable/slam/SmartRangeFactor.h
+++ b/gtsam_unstable/slam/SmartRangeFactor.h
@@ -24,7 +24,7 @@ namespace gtsam {
 
 /**
  * Smart factor for range SLAM
- * @addtogroup SLAM
+ * @ingroup SLAM
  */
 class SmartRangeFactor: public NoiseModelFactor {
  protected:

--- a/gtsam_unstable/slam/SmartStereoProjectionFactorPP.h
+++ b/gtsam_unstable/slam/SmartStereoProjectionFactorPP.h
@@ -23,7 +23,7 @@
 namespace gtsam {
 /**
  *
- * @addtogroup SLAM
+ * @ingroup SLAM
  *
  * If you are using the factor, please cite:
  * L. Carlone, Z. Kira, C. Beall, V. Indelman, F. Dellaert,
@@ -38,7 +38,7 @@ namespace gtsam {
  * calibration or the same calibration can be shared by multiple cameras. This
  * factor requires that values contain the involved poses and extrinsics (both
  * are Pose3 variables).
- * @addtogroup SLAM
+ * @ingroup SLAM
  */
 class GTSAM_UNSTABLE_EXPORT SmartStereoProjectionFactorPP
     : public SmartStereoProjectionFactor {

--- a/gtsam_unstable/slam/SmartStereoProjectionPoseFactor.h
+++ b/gtsam_unstable/slam/SmartStereoProjectionPoseFactor.h
@@ -26,7 +26,7 @@
 namespace gtsam {
 /**
  *
- * @addtogroup SLAM
+ * @ingroup SLAM
  *
  * If you are using the factor, please cite:
  * L. Carlone, Z. Kira, C. Beall, V. Indelman, F. Dellaert,
@@ -41,7 +41,7 @@ namespace gtsam {
  * has its own calibration.
  * The factor only constrains poses (variable dimension is 6).
  * This factor requires that values contains the involved poses (Pose3).
- * @addtogroup SLAM
+ * @ingroup SLAM
  */
 class GTSAM_UNSTABLE_EXPORT SmartStereoProjectionPoseFactor
     : public SmartStereoProjectionFactor {

--- a/gtsam_unstable/slam/TransformBtwRobotsUnaryFactor.h
+++ b/gtsam_unstable/slam/TransformBtwRobotsUnaryFactor.h
@@ -29,7 +29,7 @@ namespace gtsam {
   /**
    * A class for a measurement predicted by "between(config[key1],config[key2])"
    * @tparam VALUE the Value type
-   * @addtogroup SLAM
+   * @ingroup SLAM
    */
   template<class VALUE>
   class TransformBtwRobotsUnaryFactor: public NonlinearFactor { // TODO why not NoiseModelFactor1 ?

--- a/gtsam_unstable/slam/TransformBtwRobotsUnaryFactorEM.h
+++ b/gtsam_unstable/slam/TransformBtwRobotsUnaryFactorEM.h
@@ -31,7 +31,7 @@ namespace gtsam {
   /**
    * A class for a measurement predicted by "between(config[key1],config[key2])"
    * @tparam VALUE the Value type
-   * @addtogroup SLAM
+   * @ingroup SLAM
    */
   template<class VALUE>
   class TransformBtwRobotsUnaryFactorEM: public NonlinearFactor {


### PR DESCRIPTION
I was recently browing GTSAM doxygen documentation and I noticed that the detailed description for some classes is not present in the generated website. For instance here for [CombinedImuFactor](https://gtsam.org/doxygen/a04060.html#a5edf3d620bbec01e8c9f24146a79a251).

Instead the docs are kind of collated into the separate [SLAM](https://gtsam.org/doxygen/a01590.html) page, due to the `@addtogroup` command. Not an expert on doxygen, but it looks like an `@ingroup` is a better suited command, since it retains the detailed description with the class itself, and only adds a link to the group page.

With these changes, the new version looks like this:

![combined-imu-factor](https://user-images.githubusercontent.com/87449851/180602758-e2360f4f-5463-40bc-894b-6859a0b61ace.png)

And the group page looks like this:

![slam-page](https://user-images.githubusercontent.com/87449851/180602775-f03457ed-d0da-419a-9002-387f7b5dc0ba.png)

Hope that improves the docs a bit.

