### PR TITLE
Break up Python CI steps so reading logs is easier

### DIFF
--- a/.github/scripts/python.sh
+++ b/.github/scripts/python.sh
@@ -100,6 +100,7 @@ function test()
 case $1 in
   -d)
     install_dependencies
+    ;;
   -b)
     build
     ;;

--- a/.github/scripts/python.sh
+++ b/.github/scripts/python.sh
@@ -43,46 +43,67 @@ if [ -z ${PYTHON_VERSION+x} ]; then
     exit 127
 fi
 
-PYTHON="python${PYTHON_VERSION}"
+export PYTHON="python${PYTHON_VERSION}"
 
-if [[ $(uname) == "Darwin" ]]; then
+function install_dependencies()
+{
+  if [[ $(uname) == "Darwin" ]]; then
     brew install wget
-else
+  else
     # Install a system package required by our library
     sudo apt-get install -y wget libicu-dev python3-pip python3-setuptools
-fi
+  fi
 
-PATH=$PATH:$($PYTHON -c "import site; print(site.USER_BASE)")/bin
+  export PATH=$PATH:$($PYTHON -c "import site; print(site.USER_BASE)")/bin
 
-[ "${GTSAM_WITH_TBB:-OFF}" = "ON" ] && install_tbb
+  [ "${GTSAM_WITH_TBB:-OFF}" = "ON" ] && install_tbb
+
+  $PYTHON -m pip install -r $GITHUB_WORKSPACE/python/requirements.txt
+}
+
+function build()
+{
+  mkdir $GITHUB_WORKSPACE/build
+  cd $GITHUB_WORKSPACE/build
+
+  BUILD_PYBIND="ON"
+
+  cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
+      -DGTSAM_BUILD_TESTS=OFF \
+      -DGTSAM_BUILD_UNSTABLE=${GTSAM_BUILD_UNSTABLE:-ON} \
+      -DGTSAM_USE_QUATERNIONS=OFF \
+      -DGTSAM_WITH_TBB=${GTSAM_WITH_TBB:-OFF} \
+      -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF \
+      -DGTSAM_BUILD_WITH_MARCH_NATIVE=OFF \
+      -DGTSAM_BUILD_PYTHON=${BUILD_PYBIND} \
+      -DGTSAM_UNSTABLE_BUILD_PYTHON=${GTSAM_BUILD_UNSTABLE:-ON} \
+      -DGTSAM_PYTHON_VERSION=$PYTHON_VERSION \
+      -DPYTHON_EXECUTABLE:FILEPATH=$(which $PYTHON) \
+      -DGTSAM_ALLOW_DEPRECATED_SINCE_V42=OFF \
+      -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/gtsam_install
 
 
-BUILD_PYBIND="ON"
+  # Set to 2 cores so that Actions does not error out during resource provisioning.
+  make -j2 install
 
-sudo $PYTHON -m pip install -r $GITHUB_WORKSPACE/python/requirements.txt
+  cd $GITHUB_WORKSPACE/build/python
+  $PYTHON -m pip install --user .
+}
 
-mkdir $GITHUB_WORKSPACE/build
-cd $GITHUB_WORKSPACE/build
+function test()
+{
+  cd $GITHUB_WORKSPACE/python/gtsam/tests
+  $PYTHON -m unittest discover -v
+}
 
-cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
-    -DGTSAM_BUILD_TESTS=OFF \
-    -DGTSAM_BUILD_UNSTABLE=${GTSAM_BUILD_UNSTABLE:-ON} \
-    -DGTSAM_USE_QUATERNIONS=OFF \
-    -DGTSAM_WITH_TBB=${GTSAM_WITH_TBB:-OFF} \
-    -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF \
-    -DGTSAM_BUILD_WITH_MARCH_NATIVE=OFF \
-    -DGTSAM_BUILD_PYTHON=${BUILD_PYBIND} \
-    -DGTSAM_UNSTABLE_BUILD_PYTHON=${GTSAM_BUILD_UNSTABLE:-ON} \
-    -DGTSAM_PYTHON_VERSION=$PYTHON_VERSION \
-    -DPYTHON_EXECUTABLE:FILEPATH=$(which $PYTHON) \
-    -DGTSAM_ALLOW_DEPRECATED_SINCE_V42=OFF \
-    -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/gtsam_install
-
-
-# Set to 2 cores so that Actions does not error out during resource provisioning.
-make -j2 install
-
-cd $GITHUB_WORKSPACE/build/python
-$PYTHON -m pip install --user .
-cd $GITHUB_WORKSPACE/python/gtsam/tests
-$PYTHON -m unittest discover -v
+# select between build or test
+case $1 in
+  -d)
+    install_dependencies
+  -b)
+    build
+    ;;
+  -t)
+    test
+    ;;
+esac

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -117,11 +117,12 @@ jobs:
         uses: pierotofy/set-swap-space@master
         with:
           swap-size-gb: 6
-      - name: Build (Linux)
-        if: runner.os == 'Linux'
+      - name: Install Dependencies
         run: |
-          bash .github/scripts/python.sh
-      - name: Build (macOS)
-        if: runner.os == 'macOS'
+          bash .github/scripts/python.sh -d
+      - name: Build
         run: |
-          bash .github/scripts/python.sh
+          bash .github/scripts/python.sh -b
+      - name: Test
+        run: |
+          bash .github/scripts/python.sh -t


### PR DESCRIPTION
This PR makes the Python CI run smaller steps so we're not inundated with information when debugging the CI.