### PR TITLE
Fix exports on Windows

### DIFF
--- a/gtsam/nonlinear/GncOptimizer.h
+++ b/gtsam/nonlinear/GncOptimizer.h
@@ -42,7 +42,7 @@ static double Chi2inv(const double alpha, const size_t dofs) {
 
 /* ************************************************************************* */
 template<class GncParameters>
-class GTSAM_EXPORT GncOptimizer {
+class GncOptimizer {
  public:
   /// For each parameter, specify the corresponding optimizer: e.g., GaussNewtonParams -> GaussNewtonOptimizer.
   typedef typename GncParameters::OptimizerType BaseOptimizer;

--- a/gtsam/nonlinear/GncParams.h
+++ b/gtsam/nonlinear/GncParams.h
@@ -39,7 +39,7 @@ enum GncLossType {
 };
 
 template<class BaseOptimizerParameters>
-class GTSAM_EXPORT GncParams {
+class GncParams {
  public:
   /// For each parameter, specify the corresponding optimizer: e.g., GaussNewtonParams -> GaussNewtonOptimizer.
   typedef typename BaseOptimizerParameters::OptimizerType OptimizerType;


### PR DESCRIPTION
Hi there,

This is the first of a few PRs which emerged from our efforts to package gtsam in conda-forge (see https://github.com/conda-forge/gtsam-feedstock/tree/main/recipe).

Related: #1109 

This one is relatively simple - there is no associated cpp file that exports symbols, so GTSAM_EXPORT needs to be removed in these two instances.