### PR TITLE
Link to interface library in case system metis is used

### DIFF
--- a/gtsam_unstable/partition/tests/CMakeLists.txt
+++ b/gtsam_unstable/partition/tests/CMakeLists.txt
@@ -1,2 +1,2 @@
 set(ignore_test "testNestedDissection.cpp")
-gtsamAddTestsGlob(partition "test*.cpp" "${ignore_test}" "gtsam_unstable;gtsam;metis-gtsam")
+gtsamAddTestsGlob(partition "test*.cpp" "${ignore_test}" "gtsam_unstable;gtsam;metis-gtsam-if")


### PR DESCRIPTION
This test links to `metis-gtsam`, which only exists if the vendored metis is being built. If the system metis is used, only `metis-gtsam-if` exists (and it also exists in the vendor case, so all good to change).

Related: #1257 - this issue was found as part of packaging gtsam for conda-forge.