### PR TITLE
Fix matlab toolbox compilation

### DIFF
--- a/cmake/HandlePrintConfiguration.cmake
+++ b/cmake/HandlePrintConfiguration.cmake
@@ -33,6 +33,7 @@ print_build_options_for_target(gtsam)
 
 print_config("Use System Eigen" "${GTSAM_USE_SYSTEM_EIGEN} (Using version: ${GTSAM_EIGEN_VERSION})")
 print_config("Use System Metis" "${GTSAM_USE_SYSTEM_METIS}")
+print_config("Using Boost version" "${Boost_VERSION}")
 
 if(GTSAM_USE_TBB)
     print_config("Use Intel TBB" "Yes (Version: ${TBB_VERSION})")

--- a/gtsam/basis/basis.i
+++ b/gtsam/basis/basis.i
@@ -137,7 +137,7 @@ class FitBasis {
   static gtsam::GaussianFactorGraph::shared_ptr LinearGraph(
       const std::map<double, double>& sequence,
       const gtsam::noiseModel::Base* model, size_t N);
-  This::Parameters parameters() const;
+  gtsam::This::Parameters parameters() const;
 };
 
 }  // namespace gtsam

--- a/gtsam/geometry/geometry.i
+++ b/gtsam/geometry/geometry.i
@@ -1126,10 +1126,10 @@ class TriangulationResult {
   Status status;
   TriangulationResult(const gtsam::Point3& p);
   const gtsam::Point3& get() const;
-  static TriangulationResult Degenerate();
-  static TriangulationResult Outlier();
-  static TriangulationResult FarPoint();
-  static TriangulationResult BehindCamera();
+  static gtsam::TriangulationResult Degenerate();
+  static gtsam::TriangulationResult Outlier();
+  static gtsam::TriangulationResult FarPoint();
+  static gtsam::TriangulationResult BehindCamera();
   bool valid() const;
   bool degenerate() const;
   bool outlier() const;

--- a/gtsam/nonlinear/nonlinear.i
+++ b/gtsam/nonlinear/nonlinear.i
@@ -701,7 +701,7 @@ class ISAM2Result {
   /** Getters and Setters for all properties */
   size_t getVariablesRelinearized() const;
   size_t getVariablesReeliminated() const;
-  FactorIndices getNewFactorsIndices() const;
+  gtsam::FactorIndices getNewFactorsIndices() const;
   size_t getCliques() const;
   double getErrorBefore() const;
   double getErrorAfter() const;

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -99,7 +99,6 @@ endif(GTSAM_UNSTABLE_INSTALL_MATLAB_TOOLBOX)
 
 # Record the root dir for gtsam - needed during external builds, e.g., ROS
 set(GTSAM_SOURCE_ROOT_DIR ${GTSAM_SOURCE_DIR})
-message(STATUS "GTSAM_SOURCE_ROOT_DIR: [${GTSAM_SOURCE_ROOT_DIR}]")
 
 # Tests message(STATUS "Installing Matlab Toolbox")
 install_matlab_scripts("${GTSAM_SOURCE_ROOT_DIR}/matlab/" "*.m;*.fig")


### PR DESCRIPTION
Interface files for Matlab toolbox were missing some namespaces. This PR adds them so that matlab wrapper compilation works as expected.

Fixes #1246 