### PR TITLE
Fix HybridBayesTree Optimize

### DIFF
--- a/gtsam/base/treeTraversal-inst.h
+++ b/gtsam/base/treeTraversal-inst.h
@@ -221,6 +221,6 @@ void PrintForest(const FOREST& forest, std::string str,
   PrintForestVisitorPre visitor(keyFormatter);
   DepthFirstForest(forest, str, visitor);
 }
-}
+}  // namespace treeTraversal
 
-}
+}  // namespace gtsam

--- a/gtsam/hybrid/tests/testHybridBayesNet.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesNet.cpp
@@ -20,6 +20,7 @@
 
 #include <gtsam/base/serializationTestHelpers.h>
 #include <gtsam/hybrid/HybridBayesNet.h>
+#include <gtsam/hybrid/HybridBayesTree.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 
 #include "Switching.h"
@@ -139,6 +140,25 @@ TEST(HybridBayesNet, Optimize) {
   expectedAssignment[M(2)] = 0;
   expectedAssignment[M(3)] = 1;
   EXPECT(assert_equal(expectedAssignment, delta.discrete()));
+
+  VectorValues expectedValues;
+  expectedValues.insert(X(1), -0.999904 * Vector1::Ones());
+  expectedValues.insert(X(2), -0.99029 * Vector1::Ones());
+  expectedValues.insert(X(3), -1.00971 * Vector1::Ones());
+  expectedValues.insert(X(4), -1.0001 * Vector1::Ones());
+
+  EXPECT(assert_equal(expectedValues, delta.continuous(), 1e-5));
+}
+
+/* ****************************************************************************/
+// Test bayes net multifrontal optimize
+TEST(HybridBayesNet, OptimizeMultifrontal) {
+  Switching s(4);
+
+  Ordering hybridOrdering = s.linearizedFactorGraph.getHybridOrdering();
+  HybridBayesTree::shared_ptr hybridBayesTree =
+      s.linearizedFactorGraph.eliminateMultifrontal(hybridOrdering);
+  HybridValues delta = hybridBayesTree->optimize();
 
   VectorValues expectedValues;
   expectedValues.insert(X(1), -0.999904 * Vector1::Ones());


### PR DESCRIPTION
This PR fixes an issue in the HybridBayesTree optimization by traversing the tree rather than looping over all the nodes.
Doing this ensures we don't optimize a child before its parent aka we maintain the reverse topological sort of the BayesTree.