### PR TITLE
`MixtureFactor ` continuous keys check

### DIFF
--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -153,12 +153,14 @@ std::pair<HybridConditional::shared_ptr, HybridFactor::shared_ptr>
 discreteElimination(const HybridGaussianFactorGraph &factors,
                     const Ordering &frontalKeys) {
   DiscreteFactorGraph dfg;
-  for (auto &fp : factors) {
-    if (auto ptr = boost::dynamic_pointer_cast<HybridDiscreteFactor>(fp)) {
-      dfg.push_back(ptr->inner());
-    } else if (auto p =
-                   boost::static_pointer_cast<HybridConditional>(fp)->inner()) {
-      dfg.push_back(boost::static_pointer_cast<DiscreteConditional>(p));
+
+  for (auto &factor : factors) {
+    if (auto p = boost::dynamic_pointer_cast<HybridDiscreteFactor>(factor)) {
+      dfg.push_back(p->inner());
+    } else if (auto p = boost::static_pointer_cast<HybridConditional>(factor)) {
+      auto discrete_conditional =
+          boost::static_pointer_cast<DiscreteConditional>(p->inner());
+      dfg.push_back(discrete_conditional);
     } else {
       // It is an orphan wrapper
     }
@@ -244,6 +246,7 @@ hybridElimination(const HybridGaussianFactorGraph &factors,
       return exp(-factor->error(empty_values));
     };
     DecisionTree<Key, double> fdt(separatorFactors, factorError);
+
     auto discreteFactor =
         boost::make_shared<DecisionTreeFactor>(discreteSeparator, fdt);
 

--- a/gtsam/hybrid/MixtureFactor.h
+++ b/gtsam/hybrid/MixtureFactor.h
@@ -100,11 +100,23 @@ class MixtureFactor : public HybridFactor {
                 bool normalized = false)
       : Base(keys, discreteKeys), normalized_(normalized) {
     std::vector<NonlinearFactor::shared_ptr> nonlinear_factors;
+    KeySet continuous_keys_set(keys.begin(), keys.end());
+    KeySet factor_keys_set;
     for (auto&& f : factors) {
+      // Insert all factor continuous keys in the continuous keys set.
+      std::copy(f->keys().begin(), f->keys().end(),
+                std::inserter(factor_keys_set, factor_keys_set.end()));
+
       nonlinear_factors.push_back(
           boost::dynamic_pointer_cast<NonlinearFactor>(f));
     }
     factors_ = Factors(discreteKeys, nonlinear_factors);
+
+    if (continuous_keys_set != factor_keys_set) {
+      throw std::runtime_error(
+          "The specified continuous keys and the keys in the factors don't "
+          "match!");
+    }
   }
 
   ~MixtureFactor() = default;


### PR DESCRIPTION
Add a check for the number of continuous keys in the `MixtureFactor` and verify that it is the same set of keys as in the factors passed in.

I encountered an issue where I wasn't passing in the full set of keys and the hybrid elimination fails due to the unspecified continuous key being present in the final discrete factor graph. There is no warning and I ended up spending hours debugging this, so hopefully no more. :slightly_smiling_face: 