### PR TITLE
Check for native architecture and set GTSAM_COMPILE_OPTIONS_PUBLIC accordingly

### DIFF
--- a/cmake/GtsamBuildTypes.cmake
+++ b/cmake/GtsamBuildTypes.cmake
@@ -190,27 +190,28 @@ if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
 endif()
 
 if (NOT MSVC)
-  # Add as public flag so all dependant projects also use it, as required
-  # by Eigen to avid crashes due to SIMD vectorization:  option(GTSAM_BUILD_WITH_MARCH_NATIVE  "Enable/Disable building with all instructions supported by native architecture (binary may not be portable!)" OFF)
-  if(APPLE AND (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang") AND ("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "15.0"))
-    if(GTSAM_BUILD_WITH_MARCH_NATIVE)
+  option(GTSAM_BUILD_WITH_MARCH_NATIVE  "Enable/Disable building with all instructions supported by native architecture (binary may not be portable!)" OFF)
+  if(GTSAM_BUILD_WITH_MARCH_NATIVE)
+    if(APPLE AND (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang") AND ("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "15.0"))
       if(NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+        # Add as public flag so all dependant projects also use it, as required
+        # by Eigen to avoid crashes due to SIMD vectorization:
         list_append_cache(GTSAM_COMPILE_OPTIONS_PUBLIC "-march=native")
       else()
         message(WARNING "The option GTSAM_BUILD_WITH_MARCH_NATIVE is ignored, because native architecture is not supported.")
-      endif()
-    endif()
-  else()
-    include(CheckCXXCompilerFlag)
-    CHECK_CXX_COMPILER_FLAG("-march=native" COMPILER_SUPPORTS_MARCH_NATIVE)
-    if(GTSAM_BUILD_WITH_MARCH_NATIVE)
+      endif() # CMAKE_SYSTEM_PROCESSOR
+    else()
+      include(CheckCXXCompilerFlag)
+      CHECK_CXX_COMPILER_FLAG("-march=native" COMPILER_SUPPORTS_MARCH_NATIVE)
       if(COMPILER_SUPPORTS_MARCH_NATIVE)
-      list_append_cache(GTSAM_COMPILE_OPTIONS_PUBLIC "-march=native")
+        # Add as public flag so all dependant projects also use it, as required
+        # by Eigen to avoid crashes due to SIMD vectorization:
+        list_append_cache(GTSAM_COMPILE_OPTIONS_PUBLIC "-march=native")
       else()
         message(WARNING "The option GTSAM_BUILD_WITH_MARCH_NATIVE is ignored, because native architecture is not supported.")
-      endif()
-    endif()
-  endif()
+      endif() # COMPILER_SUPPORTS_MARCH_NATIVE
+    endif() # APPLE
+  endif() # GTSAM_BUILD_WITH_MARCH_NATIVE
 endif()
 
 # Set up build type library postfixes

--- a/cmake/GtsamBuildTypes.cmake
+++ b/cmake/GtsamBuildTypes.cmake
@@ -192,23 +192,31 @@ endif()
 if (NOT MSVC)
   option(GTSAM_BUILD_WITH_MARCH_NATIVE  "Enable/Disable building with all instructions supported by native architecture (binary may not be portable!)" OFF)
   if(GTSAM_BUILD_WITH_MARCH_NATIVE)
-    if(APPLE AND (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang") AND ("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "15.0"))
-      if(NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-        # Add as public flag so all dependant projects also use it, as required
+    # Check if Apple OS and compiler is [Apple]Clang
+    if(APPLE AND (${CMAKE_CXX_COMPILER_ID} MATCHES "^(Apple)?Clang$"))
+      # Check Clang version since march=native is only supported for version 15.0+.
+      if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "15.0")
+        if(NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+          # Add as public flag so all dependent projects also use it, as required
+          # by Eigen to avoid crashes due to SIMD vectorization:
+          list_append_cache(GTSAM_COMPILE_OPTIONS_PUBLIC "-march=native")
+        else()
+          message(WARNING "Option GTSAM_BUILD_WITH_MARCH_NATIVE ignored, because native architecture is not supported for Apple silicon and AppleClang version < 15.0.")
+        endif() # CMAKE_SYSTEM_PROCESSOR
+      else()
+        # Add as public flag so all dependent projects also use it, as required
         # by Eigen to avoid crashes due to SIMD vectorization:
         list_append_cache(GTSAM_COMPILE_OPTIONS_PUBLIC "-march=native")
-      else()
-        message(WARNING "The option GTSAM_BUILD_WITH_MARCH_NATIVE is ignored, because native architecture is not supported.")
-      endif() # CMAKE_SYSTEM_PROCESSOR
+      endif() # CMAKE_CXX_COMPILER_VERSION
     else()
       include(CheckCXXCompilerFlag)
       CHECK_CXX_COMPILER_FLAG("-march=native" COMPILER_SUPPORTS_MARCH_NATIVE)
       if(COMPILER_SUPPORTS_MARCH_NATIVE)
-        # Add as public flag so all dependant projects also use it, as required
+        # Add as public flag so all dependent projects also use it, as required
         # by Eigen to avoid crashes due to SIMD vectorization:
         list_append_cache(GTSAM_COMPILE_OPTIONS_PUBLIC "-march=native")
       else()
-        message(WARNING "The option GTSAM_BUILD_WITH_MARCH_NATIVE is ignored, because native architecture is not supported.")
+        message(WARNING "Option GTSAM_BUILD_WITH_MARCH_NATIVE ignored, because native architecture is not supported.")
       endif() # COMPILER_SUPPORTS_MARCH_NATIVE
     endif() # APPLE
   endif() # GTSAM_BUILD_WITH_MARCH_NATIVE


### PR DESCRIPTION
Currently, the flag `GTSAM_BUILD_WITH_MARCH_NATIVE` is limited to Apple architecture only. The commit checks, if the compiler supports `-march=native` and adds the option to `GTSAM_COMPILE_OPTIONS_PUBLIC` if `GTSAM_BUILD_WITH_MARCH_NATIVE` is on, see https://github.com/borglab/gtsam/pull/1138#pullrequestreview-1107033447

Note, could not test with Apple architecture, because hardware missing.
