### PR TITLE
fix typo in g2o file format parsing for the information matrix

### DIFF
--- a/gtsam/slam/dataset.cpp
+++ b/gtsam/slam/dataset.cpp
@@ -853,12 +853,12 @@ template <> struct ParseMeasurement<Pose3> {
       if (sampler)
         T12 = T12.retract(sampler->sample());
 
-      // EDGE_SE3:QUAT stores covariance in t,R order, unlike GTSAM:
+      // EDGE_SE3:QUAT stores information/precision in t,R order, unlike GTSAM:
       Matrix6 mgtsam;
-      mgtsam.block<3, 3>(0, 0) = m.block<3, 3>(3, 3); // cov rotation
-      mgtsam.block<3, 3>(3, 3) = m.block<3, 3>(0, 0); // cov translation
-      mgtsam.block<3, 3>(0, 3) = m.block<3, 3>(0, 3); // off diagonal
-      mgtsam.block<3, 3>(3, 0) = m.block<3, 3>(3, 0); // off diagonal
+      mgtsam.block<3, 3>(0, 0) = m.block<3, 3>(3, 3); // info rotation
+      mgtsam.block<3, 3>(3, 3) = m.block<3, 3>(0, 0); // info translation
+      mgtsam.block<3, 3>(3, 0) = m.block<3, 3>(0, 3); // off diagonal swap
+      mgtsam.block<3, 3>(0, 3) = m.block<3, 3>(3, 0); // off diagonal swap
       SharedNoiseModel model = noiseModel::Gaussian::Information(mgtsam);
 
       return BinaryMeasurement<Pose3>(


### PR DESCRIPTION
the g2o parser seems to have a bug when parsing the information matrix.

In brief:
- g2o variable ordering is t, R - translation then rotation
- GTSAM ordering is the other way around.
- the g2o information matrix is parsed to form a 6x6 information matrix.
- to convert it to [R, t] format the upper left 3x3 needs to be swapped with the lower right 3x3 (correct at present). But this also needs to be done with the offdiagonal blocks - which is where the bug is.

IMO the correct values would be:
g2o info matrix is: (input)
 00 10 20 30 40 50
 10 **01** 21 **31** 41 51
 20 21 02 32 42 52
 30 31 32 **03** 43 53
 40 41 42 43 04 54
 50 51 52 53 54 05

the **correct** gtsam information matrix is: (output, with my fix)
 **03** 43 53 30 **31** 32
 43 04 54 40 41 42
 53 54 05 50 51 52
 30 40 50 00 **10** 20
31 41 51 10  01 21
 32 42 52 20 21 02

After the reordering the offdiagonal elements (e.g. 31) should still be aligned with corresponding dimensions (1 and 3)

A test string for g2o:
EDGE_SE3:QUAT 1054 1055 0.251779 0.0571828 0.0217246 -0.0167946 -0.0087881 -0.0277189 0.999436 0 10 20 30 40 50 1 21 31 41 51 2 32 42 52 3 43 53 4 54 5


Final question:
way are there no GTSAM tests failing? Do some of them not have off diagonal terms e.g. the spheres dataset?

For reference Ceres parser:
https://github.com/ceres-solver/ceres-solver/blob/master/examples/slam/common/read_g2o.h#L94