### PR TITLE
Update Switching fixture to be 0 indexed

### DIFF
--- a/gtsam/hybrid/tests/testHybridBayesNet.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesNet.cpp
@@ -82,9 +82,9 @@ TEST(HybridBayesNet, Choose) {
       s.linearizedFactorGraph.eliminatePartialSequential(ordering);
 
   DiscreteValues assignment;
+  assignment[M(0)] = 1;
   assignment[M(1)] = 1;
-  assignment[M(2)] = 1;
-  assignment[M(3)] = 0;
+  assignment[M(2)] = 0;
 
   GaussianBayesNet gbn = hybridBayesNet->choose(assignment);
 
@@ -120,20 +120,20 @@ TEST(HybridBayesNet, OptimizeAssignment) {
       s.linearizedFactorGraph.eliminatePartialSequential(ordering);
 
   DiscreteValues assignment;
+  assignment[M(0)] = 1;
   assignment[M(1)] = 1;
   assignment[M(2)] = 1;
-  assignment[M(3)] = 1;
 
   VectorValues delta = hybridBayesNet->optimize(assignment);
 
   // The linearization point has the same value as the key index,
-  // e.g. X(1) = 1, X(2) = 2,
+  // e.g. X(0) = 1, X(1) = 2,
   // but the factors specify X(k) = k-1, so delta should be -1.
   VectorValues expected_delta;
+  expected_delta.insert(make_pair(X(0), -Vector1::Ones()));
   expected_delta.insert(make_pair(X(1), -Vector1::Ones()));
   expected_delta.insert(make_pair(X(2), -Vector1::Ones()));
   expected_delta.insert(make_pair(X(3), -Vector1::Ones()));
-  expected_delta.insert(make_pair(X(4), -Vector1::Ones()));
 
   EXPECT(assert_equal(expected_delta, delta));
 }
@@ -150,16 +150,16 @@ TEST(HybridBayesNet, Optimize) {
   HybridValues delta = hybridBayesNet->optimize();
 
   DiscreteValues expectedAssignment;
-  expectedAssignment[M(1)] = 1;
-  expectedAssignment[M(2)] = 0;
-  expectedAssignment[M(3)] = 1;
+  expectedAssignment[M(0)] = 1;
+  expectedAssignment[M(1)] = 0;
+  expectedAssignment[M(2)] = 1;
   EXPECT(assert_equal(expectedAssignment, delta.discrete()));
 
   VectorValues expectedValues;
-  expectedValues.insert(X(1), -0.999904 * Vector1::Ones());
-  expectedValues.insert(X(2), -0.99029 * Vector1::Ones());
-  expectedValues.insert(X(3), -1.00971 * Vector1::Ones());
-  expectedValues.insert(X(4), -1.0001 * Vector1::Ones());
+  expectedValues.insert(X(0), -0.999904 * Vector1::Ones());
+  expectedValues.insert(X(1), -0.99029 * Vector1::Ones());
+  expectedValues.insert(X(2), -1.00971 * Vector1::Ones());
+  expectedValues.insert(X(3), -1.0001 * Vector1::Ones());
 
   EXPECT(assert_equal(expectedValues, delta.continuous(), 1e-5));
 }
@@ -175,10 +175,10 @@ TEST(HybridBayesNet, OptimizeMultifrontal) {
   HybridValues delta = hybridBayesTree->optimize();
 
   VectorValues expectedValues;
-  expectedValues.insert(X(1), -0.999904 * Vector1::Ones());
-  expectedValues.insert(X(2), -0.99029 * Vector1::Ones());
-  expectedValues.insert(X(3), -1.00971 * Vector1::Ones());
-  expectedValues.insert(X(4), -1.0001 * Vector1::Ones());
+  expectedValues.insert(X(0), -0.999904 * Vector1::Ones());
+  expectedValues.insert(X(1), -0.99029 * Vector1::Ones());
+  expectedValues.insert(X(2), -1.00971 * Vector1::Ones());
+  expectedValues.insert(X(3), -1.0001 * Vector1::Ones());
 
   EXPECT(assert_equal(expectedValues, delta.continuous(), 1e-5));
 }

--- a/gtsam/hybrid/tests/testHybridBayesTree.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesTree.cpp
@@ -60,9 +60,9 @@ TEST(HybridBayesTree, OptimizeAssignment) {
   isam.update(graph1);
 
   DiscreteValues assignment;
+  assignment[M(0)] = 1;
   assignment[M(1)] = 1;
   assignment[M(2)] = 1;
-  assignment[M(3)] = 1;
 
   VectorValues delta = isam.optimize(assignment);
 
@@ -70,16 +70,16 @@ TEST(HybridBayesTree, OptimizeAssignment) {
   // e.g. X(1) = 1, X(2) = 2,
   // but the factors specify X(k) = k-1, so delta should be -1.
   VectorValues expected_delta;
+  expected_delta.insert(make_pair(X(0), -Vector1::Ones()));
   expected_delta.insert(make_pair(X(1), -Vector1::Ones()));
   expected_delta.insert(make_pair(X(2), -Vector1::Ones()));
   expected_delta.insert(make_pair(X(3), -Vector1::Ones()));
-  expected_delta.insert(make_pair(X(4), -Vector1::Ones()));
 
   EXPECT(assert_equal(expected_delta, delta));
 
   // Create ordering.
   Ordering ordering;
-  for (size_t k = 1; k <= s.K; k++) ordering += X(k);
+  for (size_t k = 0; k < s.K; k++) ordering += X(k);
 
   HybridBayesNet::shared_ptr hybridBayesNet;
   HybridGaussianFactorGraph::shared_ptr remainingFactorGraph;
@@ -123,7 +123,7 @@ TEST(HybridBayesTree, Optimize) {
 
   // Create ordering.
   Ordering ordering;
-  for (size_t k = 1; k <= s.K; k++) ordering += X(k);
+  for (size_t k = 0; k < s.K; k++) ordering += X(k);
 
   HybridBayesNet::shared_ptr hybridBayesNet;
   HybridGaussianFactorGraph::shared_ptr remainingFactorGraph;

--- a/gtsam/hybrid/tests/testHybridEstimation.cpp
+++ b/gtsam/hybrid/tests/testHybridEstimation.cpp
@@ -82,9 +82,9 @@ TEST(HybridNonlinearISAM, Incremental) {
   HybridNonlinearFactorGraph graph;
   Values initial;
 
-  // Add the X(1) prior
+  // Add the X(0) prior
   graph.push_back(switching.nonlinearFactorGraph.at(0));
-  initial.insert(X(1), switching.linearizationPoint.at<double>(X(1)));
+  initial.insert(X(0), switching.linearizationPoint.at<double>(X(0)));
 
   HybridGaussianFactorGraph linearized;
   HybridGaussianFactorGraph bayesNet;
@@ -96,7 +96,7 @@ TEST(HybridNonlinearISAM, Incremental) {
     // Measurement
     graph.push_back(switching.nonlinearFactorGraph.at(k + K - 1));
 
-    initial.insert(X(k + 1), switching.linearizationPoint.at<double>(X(k + 1)));
+    initial.insert(X(k), switching.linearizationPoint.at<double>(X(k)));
 
     bayesNet = smoother.hybridBayesNet();
     linearized = *graph.linearize(initial);
@@ -111,13 +111,13 @@ TEST(HybridNonlinearISAM, Incremental) {
 
   DiscreteValues expected_discrete;
   for (size_t k = 0; k < K - 1; k++) {
-    expected_discrete[M(k + 1)] = discrete_seq[k];
+    expected_discrete[M(k)] = discrete_seq[k];
   }
   EXPECT(assert_equal(expected_discrete, delta.discrete()));
 
   Values expected_continuous;
   for (size_t k = 0; k < K; k++) {
-    expected_continuous.insert(X(k + 1), measurements[k]);
+    expected_continuous.insert(X(k), measurements[k]);
   }
   EXPECT(assert_equal(expected_continuous, result));
 }

--- a/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
@@ -531,34 +531,34 @@ TEST(HybridGaussianFactorGraph, Conditionals) {
 
   hfg.push_back(switching.linearizedFactorGraph.at(0));  // P(X1)
   Ordering ordering;
-  ordering.push_back(X(1));
+  ordering.push_back(X(0));
   HybridBayesNet::shared_ptr bayes_net = hfg.eliminateSequential(ordering);
 
   hfg.push_back(switching.linearizedFactorGraph.at(1));  // P(X1, X2 | M1)
   hfg.push_back(*bayes_net);
   hfg.push_back(switching.linearizedFactorGraph.at(2));  // P(X2, X3 | M2)
   hfg.push_back(switching.linearizedFactorGraph.at(5));  // P(M1)
+  ordering.push_back(X(1));
   ordering.push_back(X(2));
-  ordering.push_back(X(3));
+  ordering.push_back(M(0));
   ordering.push_back(M(1));
-  ordering.push_back(M(2));
 
   bayes_net = hfg.eliminateSequential(ordering);
 
   HybridValues result = bayes_net->optimize();
 
   Values expected_continuous;
-  expected_continuous.insert<double>(X(1), 0);
-  expected_continuous.insert<double>(X(2), 1);
-  expected_continuous.insert<double>(X(3), 2);
-  expected_continuous.insert<double>(X(4), 4);
+  expected_continuous.insert<double>(X(0), 0);
+  expected_continuous.insert<double>(X(1), 1);
+  expected_continuous.insert<double>(X(2), 2);
+  expected_continuous.insert<double>(X(3), 4);
   Values result_continuous =
       switching.linearizationPoint.retract(result.continuous());
   EXPECT(assert_equal(expected_continuous, result_continuous));
 
   DiscreteValues expected_discrete;
+  expected_discrete[M(0)] = 1;
   expected_discrete[M(1)] = 1;
-  expected_discrete[M(2)] = 1;
   EXPECT(assert_equal(expected_discrete, result.discrete()));
 }
 


### PR DESCRIPTION
Based on a recent conversation between @dellaert and myself, this PR converts the Switching test fixture from a 1-indexed scheme (e.g. `X(1)`) to a 0-indexed scheme (`X(0)`) since it better matches the iMHS paper.

This will ensure we have consistency of notation across papers and documents we write.