### PR TITLE
Hybrid ISAM GetOrdering method

### DIFF
--- a/gtsam/hybrid/HybridGaussianISAM.h
+++ b/gtsam/hybrid/HybridGaussianISAM.h
@@ -67,6 +67,17 @@ class GTSAM_EXPORT HybridGaussianISAM : public ISAM<HybridBayesTree> {
               const boost::optional<Ordering>& ordering = boost::none,
               const HybridBayesTree::Eliminate& function =
                   HybridBayesTree::EliminationTraitsType::DefaultEliminate);
+
+  /**
+   * @brief Helper method to get an ordering given the existing factors and any
+   * new factors added.
+   *
+   * @param factors The existing factors in the BayesTree.
+   * @param newFactors New factors added during the update step.
+   * @return Ordering
+   */
+  static Ordering GetOrdering(HybridGaussianFactorGraph& factors,
+                              const HybridGaussianFactorGraph& newFactors);
 };
 
 /// traits


### PR DESCRIPTION
Move the ordering generation code to a separate static function that can be re-used in other places (e.g. unit tests).