### PR TITLE
Housekeeping Updates

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,4 +2,4 @@ set (excluded_examples
     elaboratePoint2KalmanFilter.cpp
 )
 
-gtsamAddExamplesGlob("*.cpp" "${excluded_examples}" "gtsam;${Boost_PROGRAM_OPTIONS_LIBRARY}")
+gtsamAddExamplesGlob("*.cpp" "${excluded_examples}" "gtsam;gtsam_unstable;${Boost_PROGRAM_OPTIONS_LIBRARY}")

--- a/python/gtsam/gtsam.tpl
+++ b/python/gtsam/gtsam.tpl
@@ -7,6 +7,8 @@
  * ** THIS FILE IS AUTO-GENERATED, DO NOT MODIFY! **
  */
 
+#define PYBIND11_DETAILED_ERROR_MESSAGES
+
 // Include relevant boost libraries required by GTSAM
 {include_boost}
 


### PR DESCRIPTION
Some updates while I was working with @raabuchanan to finish up the _Buchanan22ral_ paper.

1. Allow scripts in `examples` directory to link to `gtsam_unstable`. This helps prevent weird build errors.
2. Set macro for better Pybind error messages.