### PR TITLE
Remove unnecessary functions in ImuFactorsExample.cpp

### DIFF
--- a/examples/ImuFactorsExample.cpp
+++ b/examples/ImuFactorsExample.cpp
@@ -267,7 +267,6 @@ int main(int argc, char* argv[]) {
 
       if (use_isam) {
         isam2->update(*graph, initial_values);
-        isam2->update();
         result = isam2->calculateEstimate();
 
         // reset the graph


### PR DESCRIPTION
@varunagrawal   
This is a simple PR to improve code readability.  

In `ImuFactorsExample.cpp`, when optimizing using isam2, the `isam2->update();` function does not affect the results.  
I think it's better to remove this function to avoid confusion.  

If this PR helps, I'd appreciate it if you merge. :smile:  
Thanks,  
