### PR TITLE
add workflow to trigger ubuntu packaging

### DIFF
--- a/.github/workflows/trigger-packaging.yml
+++ b/.github/workflows/trigger-packaging.yml
@@ -1,0 +1,21 @@
+# This triggers building of packages
+name: Trigger Package Builds
+on:
+  push:
+    branches:
+      - develop
+jobs:
+  trigger-package-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Package Rebuild
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.PACKAGING_REPO_ACCESS_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'borglab-launchpad',
+              repo: 'gtsam-packaging',
+              workflow_id: 'main.yaml',
+              ref: 'master'
+            })


### PR DESCRIPTION
Currently Ubuntu nightly packaging runs on a daily basis. This is wasteful and brittle since github automatically stops such workflows after 60 days. This PR fixes the issue by using the github workflow dispatch mechanism.

A SECRET with the name PACKAGING_REPO_ACCESS_TOKEN needs to be installed on the gtsam repo. This will authorize the gtsam repo to trigger a workflow in the gtsam-packaging repo.

Once/if this PR is approved please contact me to get the value (shared secret) of the PACKAGING_REPO_ACCESS_TOKEN.