### PR TITLE
Added max_angle parameter for Random() in Rot3

### DIFF
--- a/gtsam/geometry/Rot3.cpp
+++ b/gtsam/geometry/Rot3.cpp
@@ -37,9 +37,9 @@ void Rot3::print(const std::string& s) const {
 }
 
 /* ************************************************************************* */
-Rot3 Rot3::Random(std::mt19937& rng) {
+Rot3 Rot3::Random(std::mt19937& rng, double max_angle) {
   Unit3 axis = Unit3::Random(rng);
-  uniform_real_distribution<double> randomAngle(-M_PI, M_PI);
+  uniform_real_distribution<double> randomAngle(-max_angle, max_angle);
   double angle = randomAngle(rng);
   return AxisAngle(axis, angle);
 }

--- a/gtsam/geometry/Rot3.h
+++ b/gtsam/geometry/Rot3.h
@@ -129,12 +129,12 @@ class GTSAM_EXPORT Rot3 : public LieGroup<Rot3, 3> {
     Rot3(double w, double x, double y, double z) : Rot3(Quaternion(w, x, y, z)) {}
 
     /**
-     * Random, generates a random axis, then random angle \f$\in\f$ [-pi,pi]
+     * Random, generates a random axis, then random angle \f$\in\f$ [-max_angle,max_angle]
      * Example:
      *   std::mt19937 engine(42);
      *   Unit3 unit = Unit3::Random(engine);
      */
-    static Rot3 Random(std::mt19937 & rng);
+    static Rot3 Random(std::mt19937 & rng, double max_angle = M_PI);
 
     /** Virtual destructor */
     virtual ~Rot3() {}


### PR DESCRIPTION
Added the ability to provide the maximum angle as a parameter for the generated random `Rot3` instead of necessarily having the max_angle as a value in `[-M_PI, M_PI]`. A default value for `max_angle` is provided and set to `M_PI` to ensure backward compatibility.