### PR TITLE
Fixed Jacobian in python CustomFactorExample

### DIFF
--- a/python/gtsam/examples/CustomFactorExample.py
+++ b/python/gtsam/examples/CustomFactorExample.py
@@ -60,10 +60,10 @@ def error_odom(measurement: np.ndarray, this: gtsam.CustomFactor,
     key1 = this.keys()[0]
     key2 = this.keys()[1]
     pos1, pos2 = values.atVector(key1), values.atVector(key2)
-    error = measurement - (pos1 - pos2)
+    error = (pos2 - pos1) - measurement
     if jacobians is not None:
-        jacobians[0] = I
-        jacobians[1] = -I
+        jacobians[0] = -I
+        jacobians[1] = I
 
     return error
 


### PR DESCRIPTION
The original Jacobian does not meet the error function.
The modified error function and Jacobian are the correct ones. 
They also match the order of ```unknown[k], unknown[k + 1]``` and ```o[k]``` when constructing the factors.