### PR TITLE
Fix HybridGaussianFactorGraph error

### DIFF
--- a/gtsam/hybrid/GaussianMixture.cpp
+++ b/gtsam/hybrid/GaussianMixture.cpp
@@ -149,9 +149,10 @@ boost::shared_ptr<GaussianMixtureFactor> GaussianMixture::likelihood(
   const DiscreteKeys discreteParentKeys = discreteKeys();
   const KeyVector continuousParentKeys = continuousParents();
   const GaussianMixtureFactor::Factors likelihoods(
-      conditionals(), [&](const GaussianConditional::shared_ptr &conditional) {
-        return std::make_pair(conditional->likelihood(frontals),
-                              0.5 * conditional->logDeterminant());
+      conditionals_, [&](const GaussianConditional::shared_ptr &conditional) {
+        return GaussianMixtureFactor::FactorAndConstant{
+            conditional->likelihood(frontals),
+            0.5 * conditional->logDeterminant()};
       });
   return boost::make_shared<GaussianMixtureFactor>(
       continuousParentKeys, discreteParentKeys, likelihoods);

--- a/gtsam/hybrid/GaussianMixture.cpp
+++ b/gtsam/hybrid/GaussianMixture.cpp
@@ -150,7 +150,8 @@ boost::shared_ptr<GaussianMixtureFactor> GaussianMixture::likelihood(
   const KeyVector continuousParentKeys = continuousParents();
   const GaussianMixtureFactor::Factors likelihoods(
       conditionals(), [&](const GaussianConditional::shared_ptr &conditional) {
-        return conditional->likelihood(frontals);
+        return std::make_pair(conditional->likelihood(frontals),
+                              0.5 * conditional->logDeterminant());
       });
   return boost::make_shared<GaussianMixtureFactor>(
       continuousParentKeys, discreteParentKeys, likelihoods);

--- a/gtsam/hybrid/GaussianMixture.cpp
+++ b/gtsam/hybrid/GaussianMixture.cpp
@@ -153,7 +153,7 @@ boost::shared_ptr<GaussianMixtureFactor> GaussianMixture::likelihood(
       conditionals_, [&](const GaussianConditional::shared_ptr &conditional) {
         return GaussianMixtureFactor::FactorAndConstant{
             conditional->likelihood(frontals),
-            0.5 * conditional->logDeterminant()};
+            conditional->logNormalizationConstant()};
       });
   return boost::make_shared<GaussianMixtureFactor>(
       continuousParentKeys, discreteParentKeys, likelihoods);

--- a/gtsam/hybrid/GaussianMixture.cpp
+++ b/gtsam/hybrid/GaussianMixture.cpp
@@ -22,6 +22,7 @@
 #include <gtsam/discrete/DiscreteValues.h>
 #include <gtsam/hybrid/GaussianMixture.h>
 #include <gtsam/hybrid/GaussianMixtureFactor.h>
+#include <gtsam/hybrid/HybridValues.h>
 #include <gtsam/inference/Conditional-inst.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
 
@@ -159,9 +160,9 @@ boost::shared_ptr<GaussianMixtureFactor> GaussianMixture::likelihood(
 }
 
 /* ************************************************************************* */
-std::set<DiscreteKey> DiscreteKeysAsSet(const DiscreteKeys &dkeys) {
+std::set<DiscreteKey> DiscreteKeysAsSet(const DiscreteKeys &discreteKeys) {
   std::set<DiscreteKey> s;
-  s.insert(dkeys.begin(), dkeys.end());
+  s.insert(discreteKeys.begin(), discreteKeys.end());
   return s;
 }
 
@@ -186,7 +187,7 @@ GaussianMixture::prunerFunc(const DecisionTreeFactor &decisionTree) {
                     const GaussianConditional::shared_ptr &conditional)
       -> GaussianConditional::shared_ptr {
     // typecast so we can use this to get probability value
-    DiscreteValues values(choices);
+    const DiscreteValues values(choices);
 
     // Case where the gaussian mixture has the same
     // discrete keys as the decision tree.
@@ -256,11 +257,10 @@ AlgebraicDecisionTree<Key> GaussianMixture::error(
 }
 
 /* *******************************************************************************/
-double GaussianMixture::error(const VectorValues &continuousValues,
-                              const DiscreteValues &discreteValues) const {
+double GaussianMixture::error(const HybridValues &values) const {
   // Directly index to get the conditional, no need to build the whole tree.
-  auto conditional = conditionals_(discreteValues);
-  return conditional->error(continuousValues);
+  auto conditional = conditionals_(values.discrete());
+  return conditional->error(values.continuous());
 }
 
 }  // namespace gtsam

--- a/gtsam/hybrid/GaussianMixture.h
+++ b/gtsam/hybrid/GaussianMixture.h
@@ -30,6 +30,7 @@
 namespace gtsam {
 
 class GaussianMixtureFactor;
+class HybridValues;
 
 /**
  * @brief A conditional of gaussian mixtures indexed by discrete variables, as
@@ -87,7 +88,7 @@ class GTSAM_EXPORT GaussianMixture
   /// @name Constructors
   /// @{
 
-  /// Defaut constructor, mainly for serialization.
+  /// Default constructor, mainly for serialization.
   GaussianMixture() = default;
 
   /**
@@ -135,6 +136,7 @@ class GTSAM_EXPORT GaussianMixture
   /// @name Standard API
   /// @{
 
+  /// @brief Return the conditional Gaussian for the given discrete assignment.
   GaussianConditional::shared_ptr operator()(
       const DiscreteValues &discreteValues) const;
 
@@ -165,12 +167,10 @@ class GTSAM_EXPORT GaussianMixture
    * @brief Compute the error of this Gaussian Mixture given the continuous
    * values and a discrete assignment.
    *
-   * @param continuousValues Continuous values at which to compute the error.
-   * @param discreteValues The discrete assignment for a specific mode sequence.
+   * @param values Continuous values and discrete assignment.
    * @return double
    */
-  double error(const VectorValues &continuousValues,
-               const DiscreteValues &discreteValues) const;
+  double error(const HybridValues &values) const;
 
   /**
    * @brief Prune the decision tree of Gaussian factors as per the discrete
@@ -193,7 +193,7 @@ class GTSAM_EXPORT GaussianMixture
 };
 
 /// Return the DiscreteKey vector as a set.
-std::set<DiscreteKey> DiscreteKeysAsSet(const DiscreteKeys &dkeys);
+std::set<DiscreteKey> DiscreteKeysAsSet(const DiscreteKeys &discreteKeys);
 
 // traits
 template <>

--- a/gtsam/hybrid/GaussianMixture.h
+++ b/gtsam/hybrid/GaussianMixture.h
@@ -170,7 +170,7 @@ class GTSAM_EXPORT GaussianMixture
    * @param values Continuous values and discrete assignment.
    * @return double
    */
-  double error(const HybridValues &values) const;
+  double error(const HybridValues &values) const override;
 
   /**
    * @brief Prune the decision tree of Gaussian factors as per the discrete

--- a/gtsam/hybrid/GaussianMixtureFactor.cpp
+++ b/gtsam/hybrid/GaussianMixtureFactor.cpp
@@ -125,7 +125,8 @@ AlgebraicDecisionTree<Key> GaussianMixtureFactor::error(
 /* *******************************************************************************/
 double GaussianMixtureFactor::error(const HybridValues &values) const {
   const FactorAndConstant factor_z = factors_(values.discrete());
-  return factor_z.factor->error(values.continuous()) + factor_z.constant;
+  return factor_z.error(values.continuous());
 }
+/* *******************************************************************************/
 
 }  // namespace gtsam

--- a/gtsam/hybrid/GaussianMixtureFactor.h
+++ b/gtsam/hybrid/GaussianMixtureFactor.h
@@ -165,7 +165,7 @@ class GTSAM_EXPORT GaussianMixtureFactor : public HybridFactor {
    * @brief Compute the log-likelihood, including the log-normalizing constant.
    * @return double
    */
-  double error(const HybridValues &values) const;
+  double error(const HybridValues &values) const override;
 
   /// Add MixtureFactor to a Sum, syntactic sugar.
   friend Sum &operator+=(Sum &sum, const GaussianMixtureFactor &factor) {

--- a/gtsam/hybrid/GaussianMixtureFactor.h
+++ b/gtsam/hybrid/GaussianMixtureFactor.h
@@ -54,8 +54,11 @@ class GTSAM_EXPORT GaussianMixtureFactor : public HybridFactor {
 
   using Sum = DecisionTree<Key, GaussianFactorGraph>;
 
-  /// typedef for Decision Tree of Gaussian Factors
-  using Factors = DecisionTree<Key, GaussianFactor::shared_ptr>;
+  /// typedef of pair of Gaussian factor and log of normalizing constant.
+  using FactorAndLogZ = std::pair<GaussianFactor::shared_ptr, double>;
+  /// typedef for Decision Tree of Gaussian Factors and log-constant.
+  using Factors = DecisionTree<Key, FactorAndLogZ>;
+  using Mixture = DecisionTree<Key, GaussianFactor::shared_ptr>;
 
  private:
   /// Decision tree of Gaussian factors indexed by discrete keys.
@@ -87,7 +90,12 @@ class GTSAM_EXPORT GaussianMixtureFactor : public HybridFactor {
    */
   GaussianMixtureFactor(const KeyVector &continuousKeys,
                         const DiscreteKeys &discreteKeys,
-                        const Factors &factors);
+                        const Mixture &factors);
+
+  GaussianMixtureFactor(const KeyVector &continuousKeys,
+                        const DiscreteKeys &discreteKeys,
+                        const Factors &factors_and_z)
+      : Base(continuousKeys, discreteKeys), factors_(factors_and_z) {}
 
   /**
    * @brief Construct a new GaussianMixtureFactor object using a vector of
@@ -101,7 +109,7 @@ class GTSAM_EXPORT GaussianMixtureFactor : public HybridFactor {
                         const DiscreteKeys &discreteKeys,
                         const std::vector<GaussianFactor::shared_ptr> &factors)
       : GaussianMixtureFactor(continuousKeys, discreteKeys,
-                              Factors(discreteKeys, factors)) {}
+                              Mixture(discreteKeys, factors)) {}
 
   /// @}
   /// @name Testable
@@ -115,7 +123,7 @@ class GTSAM_EXPORT GaussianMixtureFactor : public HybridFactor {
   /// @}
 
   /// Getter for the underlying Gaussian Factor Decision Tree.
-  const Factors &factors();
+  const Mixture factors();
 
   /**
    * @brief Combine the Gaussian Factor Graphs in `sum` and `this` while

--- a/gtsam/hybrid/GaussianMixtureFactor.h
+++ b/gtsam/hybrid/GaussianMixtureFactor.h
@@ -58,9 +58,11 @@ class GTSAM_EXPORT GaussianMixtureFactor : public HybridFactor {
     sharedFactor factor;
     double constant;
 
-    // Return error with constant added.
+    // Return error with constant correction.
     double error(const VectorValues &values) const {
-      return factor->error(values) + constant;
+      // Note minus sign: constant is log of normalization constant for probabilities.
+      // Errors is the negative log-likelihood, hence we subtract the constant here.
+      return factor->error(values) - constant;
     }
 
     // Check pointer equality.

--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -1,5 +1,5 @@
 /* ----------------------------------------------------------------------------
- * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,
  * Atlanta, Georgia 30332-0415
  * All Rights Reserved
  * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
@@ -12,6 +12,7 @@
  * @author Fan Jiang
  * @author Varun Agrawal
  * @author Shangjie Xue
+ * @author Frank Dellaert
  * @date   January 2022
  */
 
@@ -321,10 +322,9 @@ HybridValues HybridBayesNet::sample() const {
 }
 
 /* ************************************************************************* */
-double HybridBayesNet::error(const VectorValues &continuousValues,
-                             const DiscreteValues &discreteValues) const {
-  GaussianBayesNet gbn = choose(discreteValues);
-  return gbn.error(continuousValues);
+double HybridBayesNet::error(const HybridValues &values) const {
+  GaussianBayesNet gbn = choose(values.discrete());
+  return gbn.error(values.continuous());
 }
 
 /* ************************************************************************* */

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -206,12 +206,10 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
    * @brief 0.5 * sum of squared Mahalanobis distances
    * for a specific discrete assignment.
    *
-   * @param continuousValues Continuous values at which to compute the error.
-   * @param discreteValues Discrete assignment for a specific mode sequence.
+   * @param values Continuous values and discrete assignment.
    * @return double
    */
-  double error(const VectorValues &continuousValues,
-               const DiscreteValues &discreteValues) const;
+  double error(const HybridValues &values) const;
 
   /**
    * @brief Compute conditional error for each discrete assignment,

--- a/gtsam/hybrid/HybridConditional.h
+++ b/gtsam/hybrid/HybridConditional.h
@@ -52,7 +52,7 @@ namespace gtsam {
  * having diamond inheritances, and neutralized the need to change other
  * components of GTSAM to make hybrid elimination work.
  *
- * A great reference to the type-erasure pattern is Eduaado Madrid's CppCon
+ * A great reference to the type-erasure pattern is Eduardo Madrid's CppCon
  * talk (https://www.youtube.com/watch?v=s082Qmd_nHs).
  *
  * @ingroup hybrid
@@ -129,33 +129,6 @@ class GTSAM_EXPORT HybridConditional
    */
   HybridConditional(boost::shared_ptr<GaussianMixture> gaussianMixture);
 
-  /**
-   * @brief Return HybridConditional as a GaussianMixture
-   * @return nullptr if not a mixture
-   * @return GaussianMixture::shared_ptr otherwise
-   */
-  GaussianMixture::shared_ptr asMixture() {
-    return boost::dynamic_pointer_cast<GaussianMixture>(inner_);
-  }
-
-  /**
-   * @brief Return HybridConditional as a GaussianConditional
-   * @return nullptr if not a GaussianConditional
-   * @return GaussianConditional::shared_ptr otherwise
-   */
-  GaussianConditional::shared_ptr asGaussian() {
-    return boost::dynamic_pointer_cast<GaussianConditional>(inner_);
-  }
-
-  /**
-   * @brief Return conditional as a DiscreteConditional
-   * @return nullptr if not a DiscreteConditional
-   * @return DiscreteConditional::shared_ptr
-   */
-  DiscreteConditional::shared_ptr asDiscrete() {
-    return boost::dynamic_pointer_cast<DiscreteConditional>(inner_);
-  }
-
   /// @}
   /// @name Testable
   /// @{
@@ -169,9 +142,51 @@ class GTSAM_EXPORT HybridConditional
   bool equals(const HybridFactor& other, double tol = 1e-9) const override;
 
   /// @}
+  /// @name Standard Interface
+  /// @{
+
+  /**
+   * @brief Return HybridConditional as a GaussianMixture
+   * @return nullptr if not a mixture
+   * @return GaussianMixture::shared_ptr otherwise
+   */
+  GaussianMixture::shared_ptr asMixture() const {
+    return boost::dynamic_pointer_cast<GaussianMixture>(inner_);
+  }
+
+  /**
+   * @brief Return HybridConditional as a GaussianConditional
+   * @return nullptr if not a GaussianConditional
+   * @return GaussianConditional::shared_ptr otherwise
+   */
+  GaussianConditional::shared_ptr asGaussian() const {
+    return boost::dynamic_pointer_cast<GaussianConditional>(inner_);
+  }
+
+  /**
+   * @brief Return conditional as a DiscreteConditional
+   * @return nullptr if not a DiscreteConditional
+   * @return DiscreteConditional::shared_ptr
+   */
+  DiscreteConditional::shared_ptr asDiscrete() const {
+    return boost::dynamic_pointer_cast<DiscreteConditional>(inner_);
+  }
 
   /// Get the type-erased pointer to the inner type
   boost::shared_ptr<Factor> inner() { return inner_; }
+
+  /// Return the error of the underlying conditional.
+  /// Currently only implemented for Gaussian mixture.
+  double error(const HybridValues& values) const override {
+    if (auto gm = asMixture()) {
+      return gm->error(values);
+    } else {
+      throw std::runtime_error(
+          "HybridConditional::error: only implemented for Gaussian mixture");
+    }
+  }
+
+  /// @}
 
  private:
   /** Serialization function */

--- a/gtsam/hybrid/HybridConditional.h
+++ b/gtsam/hybrid/HybridConditional.h
@@ -173,7 +173,7 @@ class GTSAM_EXPORT HybridConditional
   }
 
   /// Get the type-erased pointer to the inner type
-  boost::shared_ptr<Factor> inner() { return inner_; }
+  boost::shared_ptr<Factor> inner() const { return inner_; }
 
   /// Return the error of the underlying conditional.
   /// Currently only implemented for Gaussian mixture.

--- a/gtsam/hybrid/HybridDiscreteFactor.cpp
+++ b/gtsam/hybrid/HybridDiscreteFactor.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <gtsam/hybrid/HybridDiscreteFactor.h>
+#include <gtsam/hybrid/HybridValues.h>
 
 #include <boost/make_shared.hpp>
 
@@ -49,5 +50,11 @@ void HybridDiscreteFactor::print(const std::string &s,
   HybridFactor::print(s, formatter);
   inner_->print("\n", formatter);
 };
+
+/* ************************************************************************ */
+double HybridDiscreteFactor::error(const HybridValues &values) const {
+  return -log((*inner_)(values.discrete()));
+}
+/* ************************************************************************ */
 
 }  // namespace gtsam

--- a/gtsam/hybrid/HybridDiscreteFactor.h
+++ b/gtsam/hybrid/HybridDiscreteFactor.h
@@ -64,7 +64,7 @@ class GTSAM_EXPORT HybridDiscreteFactor : public HybridFactor {
   /// @name Standard Interface
   /// @{
 
-  /// Return pointer to the internal discrete factor
+  /// Return pointer to the internal discrete factor.
   DiscreteFactor::shared_ptr inner() const { return inner_; }
 
   /// Return the error of the underlying Discrete Factor.

--- a/gtsam/hybrid/HybridDiscreteFactor.h
+++ b/gtsam/hybrid/HybridDiscreteFactor.h
@@ -24,10 +24,12 @@
 
 namespace gtsam {
 
+class HybridValues;
+
 /**
- * A HybridDiscreteFactor is a thin container for DiscreteFactor, which allows
- * us to hide the implementation of DiscreteFactor and thus avoid diamond
- * inheritance.
+ * A HybridDiscreteFactor is a thin container for DiscreteFactor, which
+ * allows us to hide the implementation of DiscreteFactor and thus avoid
+ * diamond inheritance.
  *
  * @ingroup hybrid
  */
@@ -59,9 +61,15 @@ class GTSAM_EXPORT HybridDiscreteFactor : public HybridFactor {
       const KeyFormatter &formatter = DefaultKeyFormatter) const override;
 
   /// @}
+  /// @name Standard Interface
+  /// @{
 
   /// Return pointer to the internal discrete factor
   DiscreteFactor::shared_ptr inner() const { return inner_; }
+
+  /// Return the error of the underlying Discrete Factor.
+  double error(const HybridValues &values) const override;
+  /// @}
 };
 
 // traits

--- a/gtsam/hybrid/HybridFactor.h
+++ b/gtsam/hybrid/HybridFactor.h
@@ -26,6 +26,8 @@
 #include <string>
 namespace gtsam {
 
+class HybridValues;
+
 KeyVector CollectKeys(const KeyVector &continuousKeys,
                       const DiscreteKeys &discreteKeys);
 KeyVector CollectKeys(const KeyVector &keys1, const KeyVector &keys2);
@@ -109,6 +111,15 @@ class GTSAM_EXPORT HybridFactor : public Factor {
   /// @}
   /// @name Standard Interface
   /// @{
+
+  /**
+   * @brief Compute the error of this Gaussian Mixture given the continuous
+   * values and a discrete assignment.
+   *
+   * @param values Continuous values and discrete assignment.
+   * @return double
+   */
+  virtual double error(const HybridValues &values) const = 0;
 
   /// True if this is a factor of discrete variables only.
   bool isDiscrete() const { return isDiscrete_; }

--- a/gtsam/hybrid/HybridGaussianFactor.cpp
+++ b/gtsam/hybrid/HybridGaussianFactor.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <gtsam/hybrid/HybridGaussianFactor.h>
+#include <gtsam/hybrid/HybridValues.h>
 #include <gtsam/linear/HessianFactor.h>
 #include <gtsam/linear/JacobianFactor.h>
 
@@ -53,5 +54,11 @@ void HybridGaussianFactor::print(const std::string &s,
   HybridFactor::print(s, formatter);
   inner_->print("\n", formatter);
 };
+
+/* ************************************************************************ */
+double HybridGaussianFactor::error(const HybridValues &values) const {
+  return inner_->error(values.continuous());
+}
+/* ************************************************************************ */
 
 }  // namespace gtsam

--- a/gtsam/hybrid/HybridGaussianFactor.h
+++ b/gtsam/hybrid/HybridGaussianFactor.h
@@ -96,7 +96,7 @@ class GTSAM_EXPORT HybridGaussianFactor : public HybridFactor {
   /// @name Standard Interface
   /// @{
 
-  /// Return pointer to the internal discrete factor
+  /// Return pointer to the internal Gaussian factor.
   GaussianFactor::shared_ptr inner() const { return inner_; }
 
   /// Return the error of the underlying Discrete Factor.

--- a/gtsam/hybrid/HybridGaussianFactor.h
+++ b/gtsam/hybrid/HybridGaussianFactor.h
@@ -25,6 +25,7 @@ namespace gtsam {
 // Forward declarations
 class JacobianFactor;
 class HessianFactor;
+class HybridValues;
 
 /**
  * A HybridGaussianFactor is a layer over GaussianFactor so that we do not have
@@ -92,8 +93,15 @@ class GTSAM_EXPORT HybridGaussianFactor : public HybridFactor {
       const KeyFormatter &formatter = DefaultKeyFormatter) const override;
 
   /// @}
+  /// @name Standard Interface
+  /// @{
 
+  /// Return pointer to the internal discrete factor
   GaussianFactor::shared_ptr inner() const { return inner_; }
+
+  /// Return the error of the underlying Discrete Factor.
+  double error(const HybridValues &values) const override;
+  /// @}
 };
 
 // traits

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -206,9 +206,8 @@ hybridElimination(const HybridGaussianFactorGraph &factors,
   };
   sum = GaussianMixtureFactor::Sum(sum, emptyGaussian);
 
-  using EliminationPair =
-      std::pair<boost::shared_ptr<GaussianConditional>,
-                std::pair<boost::shared_ptr<GaussianFactor>, double>>;
+  using EliminationPair = std::pair<boost::shared_ptr<GaussianConditional>,
+                                    GaussianMixtureFactor::FactorAndConstant>;
 
   KeyVector keysOfEliminated;  // Not the ordering
   KeyVector keysOfSeparator;   // TODO(frank): Is this just (keys - ordering)?
@@ -216,7 +215,7 @@ hybridElimination(const HybridGaussianFactorGraph &factors,
   // This is the elimination method on the leaf nodes
   auto eliminate = [&](const GaussianFactorGraph &graph) -> EliminationPair {
     if (graph.empty()) {
-      return {nullptr, std::make_pair(nullptr, 0.0)};
+      return {nullptr, {nullptr, 0.0}};
     }
 
 #ifdef HYBRID_TIMING
@@ -236,11 +235,7 @@ hybridElimination(const HybridGaussianFactorGraph &factors,
     gttoc_(hybrid_eliminate);
 #endif
 
-    std::pair<boost::shared_ptr<GaussianConditional>,
-              std::pair<boost::shared_ptr<GaussianFactor>, double>>
-        result = std::make_pair(conditional_factor.first,
-                                std::make_pair(conditional_factor.second, 0.0));
-    return result;
+    return {conditional_factor.first, {conditional_factor.second, 0.0}};
   };
 
   // Perform elimination!

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -263,16 +263,15 @@ hybridElimination(const HybridGaussianFactorGraph &factors,
   if (keysOfSeparator.empty()) {
     VectorValues empty_values;
     auto factorProb =
-        [&](const GaussianMixtureFactor::FactorAndLogZ &factor_z) {
-          if (!factor_z.first) {
+        [&](const GaussianMixtureFactor::FactorAndConstant &factor_z) {
+          GaussianFactor::shared_ptr factor = factor_z.factor;
+          if (!factor) {
             return 0.0;  // If nullptr, return 0.0 probability
           } else {
-            GaussianFactor::shared_ptr factor = factor_z.first;
-            double log_z = factor_z.second;
             // This is the probability q(μ) at the MLE point.
             double error =
                 0.5 * std::abs(factor->augmentedInformation().determinant()) +
-                log_z;
+                factor_z.constant;
             return std::exp(-error);
           }
         };

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -498,26 +498,8 @@ AlgebraicDecisionTree<Key> HybridGaussianFactorGraph::error(
 /* ************************************************************************ */
 double HybridGaussianFactorGraph::error(const HybridValues &values) const {
   double error = 0.0;
-  for (size_t idx = 0; idx < size(); idx++) {
-    // TODO(dellaert): just use a virtual method defined in HybridFactor.
-    auto factor = factors_.at(idx);
-
-    if (factor->isHybrid()) {
-      if (auto c = boost::dynamic_pointer_cast<HybridConditional>(factor)) {
-        error += c->asMixture()->error(values);
-      }
-      if (auto f = boost::dynamic_pointer_cast<GaussianMixtureFactor>(factor)) {
-        error += f->error(values);
-      }
-
-    } else if (factor->isContinuous()) {
-      if (auto f = boost::dynamic_pointer_cast<HybridGaussianFactor>(factor)) {
-        error += f->inner()->error(values.continuous());
-      }
-      if (auto cg = boost::dynamic_pointer_cast<HybridConditional>(factor)) {
-        error += cg->asGaussian()->error(values.continuous());
-      }
-    }
+  for (auto &factor : factors_) {
+    error += factor->error(values);
   }
   return error;
 }

--- a/gtsam/hybrid/HybridGaussianFactorGraph.h
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.h
@@ -186,14 +186,9 @@ class GTSAM_EXPORT HybridGaussianFactorGraph
    * @brief Compute error given a continuous vector values
    * and a discrete assignment.
    *
-   * @param continuousValues The continuous VectorValues
-   * for computing the error.
-   * @param discreteValues The specific discrete assignment
-   * whose error we wish to compute.
    * @return double
    */
-  double error(const VectorValues& continuousValues,
-               const DiscreteValues& discreteValues) const;
+  double error(const HybridValues& values) const;
 
   /**
    * @brief Compute unnormalized probability \f$ P(X | M, Z) \f$
@@ -210,13 +205,9 @@ class GTSAM_EXPORT HybridGaussianFactorGraph
    * @brief Compute the unnormalized posterior probability for a continuous
    * vector values given a specific assignment.
    *
-   * @param continuousValues The vector values for which to compute the
-   * posterior probability.
-   * @param discreteValues The specific assignment to use for the computation.
    * @return double
    */
-  double probPrime(const VectorValues& continuousValues,
-                   const DiscreteValues& discreteValues) const;
+  double probPrime(const HybridValues& values) const;
 
   /**
    * @brief Return a Colamd constrained ordering where the discrete keys are

--- a/gtsam/hybrid/HybridGaussianFactorGraph.h
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.h
@@ -12,7 +12,7 @@
 /**
  * @file   HybridGaussianFactorGraph.h
  * @brief  Linearized Hybrid factor graph that uses type erasure
- * @author Fan Jiang, Varun Agrawal
+ * @author Fan Jiang, Varun Agrawal, Frank Dellaert
  * @date   Mar 11, 2022
  */
 
@@ -38,6 +38,7 @@ class HybridBayesTree;
 class HybridJunctionTree;
 class DecisionTreeFactor;
 class JacobianFactor;
+class HybridValues;
 
 /**
  * @brief Main elimination function for HybridGaussianFactorGraph.

--- a/gtsam/hybrid/HybridNonlinearFactor.h
+++ b/gtsam/hybrid/HybridNonlinearFactor.h
@@ -51,12 +51,22 @@ class HybridNonlinearFactor : public HybridFactor {
       const KeyFormatter &formatter = DefaultKeyFormatter) const override;
 
   /// @}
+  /// @name Standard Interface
+  /// @{
 
   NonlinearFactor::shared_ptr inner() const { return inner_; }
+
+  /// Error for HybridValues is not provided for nonlinear factor.
+  double error(const HybridValues &values) const override {
+    throw std::runtime_error(
+        "HybridNonlinearFactor::error(HybridValues) not implemented.");
+  }
 
   /// Linearize to a HybridGaussianFactor at the linearization point `c`.
   boost::shared_ptr<HybridGaussianFactor> linearize(const Values &c) const {
     return boost::make_shared<HybridGaussianFactor>(inner_->linearize(c));
   }
+
+  /// @}
 };
 }  // namespace gtsam

--- a/gtsam/hybrid/HybridNonlinearFactor.h
+++ b/gtsam/hybrid/HybridNonlinearFactor.h
@@ -54,6 +54,7 @@ class HybridNonlinearFactor : public HybridFactor {
   /// @name Standard Interface
   /// @{
 
+  /// Return pointer to the internal nonlinear factor.
   NonlinearFactor::shared_ptr inner() const { return inner_; }
 
   /// Error for HybridValues is not provided for nonlinear factor.

--- a/gtsam/hybrid/MixtureFactor.h
+++ b/gtsam/hybrid/MixtureFactor.h
@@ -161,6 +161,12 @@ class MixtureFactor : public HybridFactor {
                              factor, continuousValues);
   }
 
+  /// Error for HybridValues is not provided for nonlinear hybrid factor.
+  double error(const HybridValues &values) const override {
+    throw std::runtime_error(
+        "MixtureFactor::error(HybridValues) not implemented.");
+  }
+
   size_t dim() const {
     // TODO(Varun)
     throw std::runtime_error("MixtureFactor::dim not implemented.");

--- a/gtsam/hybrid/hybrid.i
+++ b/gtsam/hybrid/hybrid.i
@@ -183,10 +183,8 @@ class HybridGaussianFactorGraph {
   bool equals(const gtsam::HybridGaussianFactorGraph& fg, double tol = 1e-9) const;
 
   // evaluation
-  double error(const gtsam::VectorValues& continuousValues,
-               const gtsam::DiscreteValues& discreteValues) const;
-  double probPrime(const gtsam::VectorValues& continuousValues,
-                   const gtsam::DiscreteValues& discreteValues) const;
+  double error(const gtsam::HybridValues& values) const;
+  double probPrime(const gtsam::HybridValues& values) const;
 
   gtsam::HybridBayesNet* eliminateSequential();
   gtsam::HybridBayesNet* eliminateSequential(

--- a/gtsam/hybrid/tests/testGaussianMixture.cpp
+++ b/gtsam/hybrid/tests/testGaussianMixture.cpp
@@ -179,8 +179,9 @@ TEST(GaussianMixture, Likelihood) {
   const GaussianMixtureFactor::Factors factors(
       gm.conditionals(),
       [measurements](const GaussianConditional::shared_ptr& conditional) {
-        return std::make_pair(conditional->likelihood(measurements),
-                              0.5 * conditional->logDeterminant());
+        return GaussianMixtureFactor::FactorAndConstant{
+            conditional->likelihood(measurements),
+            conditional->logNormalizationConstant()};
       });
   const GaussianMixtureFactor expected({X(0)}, {mode}, factors);
   EXPECT(assert_equal(*factor, expected));

--- a/gtsam/hybrid/tests/testGaussianMixture.cpp
+++ b/gtsam/hybrid/tests/testGaussianMixture.cpp
@@ -179,7 +179,8 @@ TEST(GaussianMixture, Likelihood) {
   const GaussianMixtureFactor::Factors factors(
       gm.conditionals(),
       [measurements](const GaussianConditional::shared_ptr& conditional) {
-        return conditional->likelihood(measurements);
+        return std::make_pair(conditional->likelihood(measurements),
+                              0.5 * conditional->logDeterminant());
       });
   const GaussianMixtureFactor expected({X(0)}, {mode}, factors);
   EXPECT(assert_equal(*factor, expected));

--- a/gtsam/hybrid/tests/testGaussianMixture.cpp
+++ b/gtsam/hybrid/tests/testGaussianMixture.cpp
@@ -128,9 +128,9 @@ TEST(GaussianMixture, Error) {
   // Regression for non-tree version.
   DiscreteValues assignment;
   assignment[M(1)] = 0;
-  EXPECT_DOUBLES_EQUAL(0.5, mixture.error(values, assignment), 1e-8);
+  EXPECT_DOUBLES_EQUAL(0.5, mixture.error({values, assignment}), 1e-8);
   assignment[M(1)] = 1;
-  EXPECT_DOUBLES_EQUAL(4.3252595155709335, mixture.error(values, assignment),
+  EXPECT_DOUBLES_EQUAL(4.3252595155709335, mixture.error({values, assignment}),
                        1e-8);
 }
 

--- a/gtsam/hybrid/tests/testGaussianMixtureFactor.cpp
+++ b/gtsam/hybrid/tests/testGaussianMixtureFactor.cpp
@@ -22,6 +22,7 @@
 #include <gtsam/discrete/DiscreteValues.h>
 #include <gtsam/hybrid/GaussianMixture.h>
 #include <gtsam/hybrid/GaussianMixtureFactor.h>
+#include <gtsam/hybrid/HybridValues.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
 
@@ -188,7 +189,8 @@ TEST(GaussianMixtureFactor, Error) {
   DiscreteValues discreteValues;
   discreteValues[m1.first] = 1;
   EXPECT_DOUBLES_EQUAL(
-      4.0, mixtureFactor.error({continuousValues, discreteValues}), 1e-9);
+      4.0, mixtureFactor.error({continuousValues, discreteValues}),
+      1e-9);
 }
 
 /* ************************************************************************* */

--- a/gtsam/hybrid/tests/testGaussianMixtureFactor.cpp
+++ b/gtsam/hybrid/tests/testGaussianMixtureFactor.cpp
@@ -188,7 +188,7 @@ TEST(GaussianMixtureFactor, Error) {
   DiscreteValues discreteValues;
   discreteValues[m1.first] = 1;
   EXPECT_DOUBLES_EQUAL(
-      4.0, mixtureFactor.error(continuousValues, discreteValues), 1e-9);
+      4.0, mixtureFactor.error({continuousValues, discreteValues}), 1e-9);
 }
 
 /* ************************************************************************* */

--- a/gtsam/hybrid/tests/testHybridBayesNet.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesNet.cpp
@@ -188,14 +188,14 @@ TEST(HybridBayesNet, Optimize) {
 
   HybridValues delta = hybridBayesNet->optimize();
 
-  //TODO(Varun) The expectedAssignment should be 111, not 101
+  // TODO(Varun) The expectedAssignment should be 111, not 101
   DiscreteValues expectedAssignment;
   expectedAssignment[M(0)] = 1;
   expectedAssignment[M(1)] = 0;
   expectedAssignment[M(2)] = 1;
   EXPECT(assert_equal(expectedAssignment, delta.discrete()));
 
-  //TODO(Varun) This should be all -Vector1::Ones()
+  // TODO(Varun) This should be all -Vector1::Ones()
   VectorValues expectedValues;
   expectedValues.insert(X(0), -0.999904 * Vector1::Ones());
   expectedValues.insert(X(1), -0.99029 * Vector1::Ones());
@@ -243,8 +243,8 @@ TEST(HybridBayesNet, Error) {
   double total_error = 0;
   for (size_t idx = 0; idx < hybridBayesNet->size(); idx++) {
     if (hybridBayesNet->at(idx)->isHybrid()) {
-      double error = hybridBayesNet->atMixture(idx)->error(delta.continuous(),
-                                                           discrete_values);
+      double error = hybridBayesNet->atMixture(idx)->error(
+          {delta.continuous(), discrete_values});
       total_error += error;
     } else if (hybridBayesNet->at(idx)->isContinuous()) {
       double error = hybridBayesNet->atGaussian(idx)->error(delta.continuous());
@@ -253,7 +253,7 @@ TEST(HybridBayesNet, Error) {
   }
 
   EXPECT_DOUBLES_EQUAL(
-      total_error, hybridBayesNet->error(delta.continuous(), discrete_values),
+      total_error, hybridBayesNet->error({delta.continuous(), discrete_values}),
       1e-9);
   EXPECT_DOUBLES_EQUAL(total_error, error_tree(discrete_values), 1e-9);
   EXPECT_DOUBLES_EQUAL(total_error, pruned_error_tree(discrete_values), 1e-9);

--- a/gtsam/hybrid/tests/testHybridEstimation.cpp
+++ b/gtsam/hybrid/tests/testHybridEstimation.cpp
@@ -273,7 +273,7 @@ AlgebraicDecisionTree<Key> getProbPrimeTree(
       continue;
     }
 
-    double error = graph.error(delta, assignment);
+    double error = graph.error({delta, assignment});
     probPrimes.push_back(exp(-error));
   }
   AlgebraicDecisionTree<Key> probPrimeTree(discrete_keys, probPrimes);
@@ -487,8 +487,8 @@ TEST(HybridEstimation, CorrectnessViaSampling) {
          const HybridValues& sample) -> double {
     const DiscreteValues assignment = sample.discrete();
     // Compute in log form for numerical stability
-    double log_ratio = bayesNet->error(sample.continuous(), assignment) -
-                       factorGraph->error(sample.continuous(), assignment);
+    double log_ratio = bayesNet->error({sample.continuous(), assignment}) -
+                       factorGraph->error({sample.continuous(), assignment});
     double ratio = exp(-log_ratio);
     return ratio;
   };

--- a/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
@@ -579,13 +579,10 @@ TEST(HybridGaussianFactorGraph, ErrorAndProbPrime) {
   const double error = graph.error(delta);
 
   // regression
-  EXPECT(assert_equal(0.490243199, error, 1e-9));
+  EXPECT(assert_equal(1.58886, error, 1e-5));
 
-  double probs = exp(-error);
-  double expected_probs = graph.probPrime(delta);
-
-  // regression
-  EXPECT(assert_equal(expected_probs, probs, 1e-7));
+  // Real test:
+  EXPECT(assert_equal(graph.probPrime(delta), exp(-error), 1e-7));
 }
 
 /* ****************************************************************************/

--- a/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
@@ -575,15 +575,14 @@ TEST(HybridGaussianFactorGraph, ErrorAndProbPrime) {
   HybridBayesNet::shared_ptr hybridBayesNet =
       graph.eliminateSequential(hybridOrdering);
 
-  HybridValues delta = hybridBayesNet->optimize();
-  double error = graph.error(delta.continuous(), delta.discrete());
+  const HybridValues delta = hybridBayesNet->optimize();
+  const double error = graph.error(delta);
 
-  double expected_error = 0.490243199;
   // regression
-  EXPECT(assert_equal(expected_error, error, 1e-9));
+  EXPECT(assert_equal(0.490243199, error, 1e-9));
 
   double probs = exp(-error);
-  double expected_probs = graph.probPrime(delta.continuous(), delta.discrete());
+  double expected_probs = graph.probPrime(delta);
 
   // regression
   EXPECT(assert_equal(expected_probs, probs, 1e-7));

--- a/gtsam/linear/GaussianConditional.h
+++ b/gtsam/linear/GaussianConditional.h
@@ -169,7 +169,7 @@ namespace gtsam {
      *
      * @return double
      */
-    double determinant() const { return exp(this->logDeterminant()); }
+    inline double determinant() const { return exp(logDeterminant()); }
 
     /**
      * @brief Compute the log determinant of the R matrix.
@@ -183,6 +183,19 @@ namespace gtsam {
      * @return double
      */
     double logDeterminant() const;
+
+    /**
+     * normalization constant = 1.0 / sqrt((2*pi)^n*det(Sigma))
+     * log = - 0.5 * n*log(2*pi) - 0.5 * log det(Sigma)
+     */
+    double logNormalizationConstant() const;
+
+    /**
+     * normalization constant = 1.0 / sqrt((2*pi)^n*det(Sigma))
+     */
+    inline double normalizationConstant() const {
+      return exp(logNormalizationConstant());
+    }
 
     /**
     * Solves a conditional Gaussian and writes the solution into the entries of

--- a/python/gtsam/tests/test_HybridFactorGraph.py
+++ b/python/gtsam/tests/test_HybridFactorGraph.py
@@ -114,7 +114,7 @@ class TestHybridGaussianFactorGraph(GtsamTestCase):
         bayesNet.addGaussian(prior_on_x0)
 
         # Add prior on mode.
-        bayesNet.emplaceDiscrete(mode, "1/1")
+        bayesNet.emplaceDiscrete(mode, "6/4")
 
         return bayesNet
 
@@ -216,10 +216,10 @@ class TestHybridGaussianFactorGraph(GtsamTestCase):
         for i in range(10):
             other = bayesNet.sample()
             other.update(measurements)
-            # print(other)
             ratio = self.calculate_ratio(bayesNet, fg, other)
             # print(f"Ratio: {ratio}\n")
-            # self.assertAlmostEqual(ratio, expected_ratio)
+            if (ratio > 0):
+                self.assertAlmostEqual(ratio, expected_ratio)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
With Frank:
- Store a FactorAndConstant in GaussianMixtureFactor, to properly account for different noise models for different modes. Small extra compute if they are all the same.

Frank fixed the ratios, and the marginals work out as well:
- used HybridValues where possible.
- define, unit test, and use logNormalizationConstant
- define virtual `error` method.
- because HybridDiscreteFactor now also defines an error, unequal mode priors are also properly handled (which was not the case before).

Now we are in a position where the factor graph is proportional to the joint, and we can think about elimination.