### PR TITLE
Slightly expand Python API

### DIFF
--- a/gtsam/linear/linear.i
+++ b/gtsam/linear/linear.i
@@ -236,6 +236,7 @@ class VectorValues {
   bool equals(const gtsam::VectorValues& expected, double tol) const;
   void insert(size_t j, Vector value);
   Vector vector() const;
+  Vector vector(const gtsam::KeyVector& keys) const;
   Vector at(size_t j) const;
   void update(const gtsam::VectorValues& values);
 
@@ -401,6 +402,7 @@ class GaussianFactorGraph {
 
   // Optimizing and linear algebra
   gtsam::VectorValues optimize() const;
+  gtsam::VectorValues optimizeDensely() const;
   gtsam::VectorValues optimize(const gtsam::Ordering& ordering) const;
   gtsam::VectorValues optimizeGradientSearch() const;
   gtsam::VectorValues gradient(const gtsam::VectorValues& x0) const;


### PR DESCRIPTION
Exposes GaussianFactorGraph::optimizeDensely and VectorValues::vector(KeyVector) to python, which are the minimal changes required to enable [NeRF-SLAM](https://github.com/ToniRV/NeRF-SLAM)