### PR TITLE
Switch to EliminateDiscrete for max-product

### DIFF
--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -236,7 +236,7 @@ namespace gtsam {
     /**
      * @brief Visit all leaves in depth-first fashion.
      *
-     * @param f (side-effect) Function taking a value.
+     * @param f (side-effect) Function taking the value of the leaf node.
      *
      * @note Due to pruning, the number of leaves may not be the same as the
      * number of assignments. E.g. if we have a tree on 2 binary variables with
@@ -245,7 +245,7 @@ namespace gtsam {
      * Example:
      *   int sum = 0;
      *   auto visitor = [&](int y) { sum += y; };
-     *   tree.visitWith(visitor);
+     *   tree.visit(visitor);
      */
     template <typename Func>
     void visit(Func f) const;
@@ -261,8 +261,8 @@ namespace gtsam {
      *
      * Example:
      *   int sum = 0;
-     *   auto visitor = [&](int y) { sum += y; };
-     *   tree.visitWith(visitor);
+     *   auto visitor = [&](const Leaf& leaf) { sum += leaf.constant(); };
+     *   tree.visitLeaf(visitor);
      */
     template <typename Func>
     void visitLeaf(Func f) const;

--- a/gtsam/hybrid/GaussianMixture.cpp
+++ b/gtsam/hybrid/GaussianMixture.cpp
@@ -51,28 +51,28 @@ GaussianMixture::GaussianMixture(
                       Conditionals(discreteParents, conditionalsList)) {}
 
 /* *******************************************************************************/
-GaussianMixture::Sum GaussianMixture::add(
-    const GaussianMixture::Sum &sum) const {
-  using Y = GaussianMixtureFactor::GraphAndConstant;
+GaussianFactorGraphTree GaussianMixture::add(
+    const GaussianFactorGraphTree &sum) const {
+  using Y = GraphAndConstant;
   auto add = [](const Y &graph1, const Y &graph2) {
     auto result = graph1.graph;
     result.push_back(graph2.graph);
     return Y(result, graph1.constant + graph2.constant);
   };
-  const Sum tree = asGaussianFactorGraphTree();
+  const auto tree = asGaussianFactorGraphTree();
   return sum.empty() ? tree : sum.apply(tree, add);
 }
 
 /* *******************************************************************************/
-GaussianMixture::Sum GaussianMixture::asGaussianFactorGraphTree() const {
+GaussianFactorGraphTree GaussianMixture::asGaussianFactorGraphTree() const {
   auto lambda = [](const GaussianConditional::shared_ptr &conditional) {
     GaussianFactorGraph result;
     result.push_back(conditional);
     if (conditional) {
-      return GaussianMixtureFactor::GraphAndConstant(
+      return GraphAndConstant(
           result, conditional->logNormalizationConstant());
     } else {
-      return GaussianMixtureFactor::GraphAndConstant(result, 0.0);
+      return GraphAndConstant(result, 0.0);
     }
   };
   return {conditionals_, lambda};
@@ -108,7 +108,7 @@ bool GaussianMixture::equals(const HybridFactor &lf, double tol) const {
   // This will return false if either conditionals_ is empty or e->conditionals_
   // is empty, but not if both are empty or both are not empty:
   if (conditionals_.empty() ^ e->conditionals_.empty()) return false;
-std::cout << "checking" << std::endl;
+  std::cout << "checking" << std::endl;
   // Check the base and the factors:
   return BaseFactor::equals(*e, tol) &&
          conditionals_.equals(e->conditionals_,

--- a/gtsam/hybrid/GaussianMixture.cpp
+++ b/gtsam/hybrid/GaussianMixture.cpp
@@ -103,7 +103,19 @@ GaussianConditional::shared_ptr GaussianMixture::operator()(
 /* *******************************************************************************/
 bool GaussianMixture::equals(const HybridFactor &lf, double tol) const {
   const This *e = dynamic_cast<const This *>(&lf);
-  return e != nullptr && BaseFactor::equals(*e, tol);
+  if (e == nullptr) return false;
+
+  // This will return false if either conditionals_ is empty or e->conditionals_
+  // is empty, but not if both are empty or both are not empty:
+  if (conditionals_.empty() ^ e->conditionals_.empty()) return false;
+std::cout << "checking" << std::endl;
+  // Check the base and the factors:
+  return BaseFactor::equals(*e, tol) &&
+         conditionals_.equals(e->conditionals_,
+                              [tol](const GaussianConditional::shared_ptr &f1,
+                                    const GaussianConditional::shared_ptr &f2) {
+                                return f1->equals(*(f2), tol);
+                              });
 }
 
 /* *******************************************************************************/

--- a/gtsam/hybrid/GaussianMixture.h
+++ b/gtsam/hybrid/GaussianMixture.h
@@ -23,13 +23,13 @@
 #include <gtsam/discrete/DecisionTree.h>
 #include <gtsam/discrete/DecisionTreeFactor.h>
 #include <gtsam/discrete/DiscreteKey.h>
+#include <gtsam/hybrid/GaussianMixtureFactor.h>
 #include <gtsam/hybrid/HybridFactor.h>
 #include <gtsam/inference/Conditional.h>
 #include <gtsam/linear/GaussianConditional.h>
 
 namespace gtsam {
 
-class GaussianMixtureFactor;
 class HybridValues;
 
 /**
@@ -60,7 +60,7 @@ class GTSAM_EXPORT GaussianMixture
   using BaseConditional = Conditional<HybridFactor, GaussianMixture>;
 
   /// Alias for DecisionTree of GaussianFactorGraphs
-  using Sum = DecisionTree<Key, GaussianFactorGraph>;
+  using Sum = DecisionTree<Key, GaussianMixtureFactor::GraphAndConstant>;
 
   /// typedef for Decision Tree of Gaussian Conditionals
   using Conditionals = DecisionTree<Key, GaussianConditional::shared_ptr>;

--- a/gtsam/hybrid/GaussianMixture.h
+++ b/gtsam/hybrid/GaussianMixture.h
@@ -59,9 +59,6 @@ class GTSAM_EXPORT GaussianMixture
   using BaseFactor = HybridFactor;
   using BaseConditional = Conditional<HybridFactor, GaussianMixture>;
 
-  /// Alias for DecisionTree of GaussianFactorGraphs
-  using Sum = DecisionTree<Key, GaussianMixtureFactor::GraphAndConstant>;
-
   /// typedef for Decision Tree of Gaussian Conditionals
   using Conditionals = DecisionTree<Key, GaussianConditional::shared_ptr>;
 
@@ -71,7 +68,7 @@ class GTSAM_EXPORT GaussianMixture
   /**
    * @brief Convert a DecisionTree of factors into a DT of Gaussian FGs.
    */
-  Sum asGaussianFactorGraphTree() const;
+  GaussianFactorGraphTree asGaussianFactorGraphTree() const;
 
   /**
    * @brief Helper function to get the pruner functor.
@@ -172,6 +169,16 @@ class GTSAM_EXPORT GaussianMixture
    */
   double error(const HybridValues &values) const override;
 
+  //   /// Calculate probability density for given values `x`.
+  //   double evaluate(const HybridValues &values) const;
+
+  //   /// Evaluate probability density, sugar.
+  //   double operator()(const HybridValues &values) const { return
+  //   evaluate(values); }
+
+  //   /// Calculate log-density for given values `x`.
+  //   double logDensity(const HybridValues &values) const;
+
   /**
    * @brief Prune the decision tree of Gaussian factors as per the discrete
    * `decisionTree`.
@@ -186,9 +193,9 @@ class GTSAM_EXPORT GaussianMixture
    * maintaining the decision tree structure.
    *
    * @param sum Decision Tree of Gaussian Factor Graphs
-   * @return Sum
+   * @return GaussianFactorGraphTree
    */
-  Sum add(const Sum &sum) const;
+  GaussianFactorGraphTree add(const GaussianFactorGraphTree &sum) const;
   /// @}
 };
 

--- a/gtsam/hybrid/GaussianMixtureFactor.cpp
+++ b/gtsam/hybrid/GaussianMixtureFactor.cpp
@@ -90,11 +90,11 @@ const GaussianMixtureFactor::Mixture GaussianMixtureFactor::factors() const {
 /* *******************************************************************************/
 GaussianMixtureFactor::Sum GaussianMixtureFactor::add(
     const GaussianMixtureFactor::Sum &sum) const {
-  using Y = GaussianFactorGraph;
+  using Y = GaussianMixtureFactor::GraphAndConstant;
   auto add = [](const Y &graph1, const Y &graph2) {
-    auto result = graph1;
-    result.push_back(graph2);
-    return result;
+    auto result = graph1.graph;
+    result.push_back(graph2.graph);
+    return Y(result, graph1.constant + graph2.constant);
   };
   const Sum tree = asGaussianFactorGraphTree();
   return sum.empty() ? tree : sum.apply(tree, add);
@@ -106,7 +106,7 @@ GaussianMixtureFactor::Sum GaussianMixtureFactor::asGaussianFactorGraphTree()
   auto wrap = [](const FactorAndConstant &factor_z) {
     GaussianFactorGraph result;
     result.push_back(factor_z.factor);
-    return result;
+    return GaussianMixtureFactor::GraphAndConstant(result, factor_z.constant);
   };
   return {factors_, wrap};
 }

--- a/gtsam/hybrid/GaussianMixtureFactor.cpp
+++ b/gtsam/hybrid/GaussianMixtureFactor.cpp
@@ -81,11 +81,23 @@ void GaussianMixtureFactor::print(const std::string &s,
 }
 
 /* *******************************************************************************/
-const GaussianMixtureFactor::Mixture GaussianMixtureFactor::factors() const {
-  return Mixture(factors_, [](const FactorAndConstant &factor_z) {
-    return factor_z.factor;
-  });
+GaussianFactor::shared_ptr GaussianMixtureFactor::factor(
+    const DiscreteValues &assignment) const {
+  return factors_(assignment).factor;
 }
+
+/* *******************************************************************************/
+double GaussianMixtureFactor::constant(const DiscreteValues &assignment) const {
+  return factors_(assignment).constant;
+}
+
+/* *******************************************************************************/
+// NOTE(dellaert): this was not used and is expensive.
+// const GaussianMixtureFactor::Mixture GaussianMixtureFactor::factors() const {
+//   return Mixture(factors_, [](const FactorAndConstant &factor_z) {
+//     return factor_z.factor;
+//   });
+// }
 
 /* *******************************************************************************/
 GaussianMixtureFactor::Sum GaussianMixtureFactor::add(

--- a/gtsam/hybrid/GaussianMixtureFactor.cpp
+++ b/gtsam/hybrid/GaussianMixtureFactor.cpp
@@ -100,25 +100,25 @@ double GaussianMixtureFactor::constant(const DiscreteValues &assignment) const {
 // }
 
 /* *******************************************************************************/
-GaussianMixtureFactor::Sum GaussianMixtureFactor::add(
-    const GaussianMixtureFactor::Sum &sum) const {
-  using Y = GaussianMixtureFactor::GraphAndConstant;
+GaussianFactorGraphTree GaussianMixtureFactor::add(
+    const GaussianFactorGraphTree &sum) const {
+  using Y = GraphAndConstant;
   auto add = [](const Y &graph1, const Y &graph2) {
     auto result = graph1.graph;
     result.push_back(graph2.graph);
     return Y(result, graph1.constant + graph2.constant);
   };
-  const Sum tree = asGaussianFactorGraphTree();
+  const auto tree = asGaussianFactorGraphTree();
   return sum.empty() ? tree : sum.apply(tree, add);
 }
 
 /* *******************************************************************************/
-GaussianMixtureFactor::Sum GaussianMixtureFactor::asGaussianFactorGraphTree()
+GaussianFactorGraphTree GaussianMixtureFactor::asGaussianFactorGraphTree()
     const {
   auto wrap = [](const FactorAndConstant &factor_z) {
     GaussianFactorGraph result;
     result.push_back(factor_z.factor);
-    return GaussianMixtureFactor::GraphAndConstant(result, factor_z.constant);
+    return GraphAndConstant(result, factor_z.constant);
   };
   return {factors_, wrap};
 }

--- a/gtsam/hybrid/GaussianMixtureFactor.h
+++ b/gtsam/hybrid/GaussianMixtureFactor.h
@@ -151,12 +151,16 @@ class GTSAM_EXPORT GaussianMixtureFactor : public HybridFactor {
   void print(
       const std::string &s = "GaussianMixtureFactor\n",
       const KeyFormatter &formatter = DefaultKeyFormatter) const override;
+
   /// @}
   /// @name Standard API
   /// @{
 
-  /// Getter for the underlying Gaussian Factor Decision Tree.
-  const Mixture factors() const;
+  /// Get factor at a given discrete assignment.
+  sharedFactor factor(const DiscreteValues &assignment) const;
+
+  /// Get constant at a given discrete assignment.
+  double constant(const DiscreteValues &assignment) const;
 
   /**
    * @brief Combine the Gaussian Factor Graphs in `sum` and `this` while

--- a/gtsam/hybrid/GaussianMixtureFactor.h
+++ b/gtsam/hybrid/GaussianMixtureFactor.h
@@ -72,35 +72,6 @@ class GTSAM_EXPORT GaussianMixtureFactor : public HybridFactor {
     }
   };
 
-  /// Gaussian factor graph and log of normalizing constant.
-  struct GraphAndConstant {
-    GaussianFactorGraph graph;
-    double constant;
-
-    GraphAndConstant(const GaussianFactorGraph &graph, double constant)
-        : graph(graph), constant(constant) {}
-
-    // Check pointer equality.
-    bool operator==(const GraphAndConstant &other) const {
-      return graph == other.graph && constant == other.constant;
-    }
-
-    // Implement GTSAM-style print:
-    void print(const std::string &s = "Graph: ",
-               const KeyFormatter &formatter = DefaultKeyFormatter) const {
-      graph.print(s, formatter);
-      std::cout << "Constant: " << constant << std::endl;
-    }
-
-    // Implement GTSAM-style equals:
-    bool equals(const GraphAndConstant &other, double tol = 1e-9) const {
-      return graph.equals(other.graph, tol) &&
-             fabs(constant - other.constant) < tol;
-    }
-  };
-
-  using Sum = DecisionTree<Key, GraphAndConstant>;
-
   /// typedef for Decision Tree of Gaussian factors and log-constant.
   using Factors = DecisionTree<Key, FactorAndConstant>;
   using Mixture = DecisionTree<Key, sharedFactor>;
@@ -113,9 +84,9 @@ class GTSAM_EXPORT GaussianMixtureFactor : public HybridFactor {
    * @brief Helper function to return factors and functional to create a
    * DecisionTree of Gaussian Factor Graphs.
    *
-   * @return Sum (DecisionTree<Key, GaussianFactorGraph>)
+   * @return GaussianFactorGraphTree
    */
-  Sum asGaussianFactorGraphTree() const;
+  GaussianFactorGraphTree asGaussianFactorGraphTree() const;
 
  public:
   /// @name Constructors
@@ -184,7 +155,7 @@ class GTSAM_EXPORT GaussianMixtureFactor : public HybridFactor {
    * variables.
    * @return Sum
    */
-  Sum add(const Sum &sum) const;
+  GaussianFactorGraphTree add(const GaussianFactorGraphTree &sum) const;
 
   /**
    * @brief Compute error of the GaussianMixtureFactor as a tree.
@@ -202,7 +173,8 @@ class GTSAM_EXPORT GaussianMixtureFactor : public HybridFactor {
   double error(const HybridValues &values) const override;
 
   /// Add MixtureFactor to a Sum, syntactic sugar.
-  friend Sum &operator+=(Sum &sum, const GaussianMixtureFactor &factor) {
+  friend GaussianFactorGraphTree &operator+=(
+      GaussianFactorGraphTree &sum, const GaussianMixtureFactor &factor) {
     sum = factor.add(sum);
     return sum;
   }
@@ -215,7 +187,6 @@ struct traits<GaussianMixtureFactor> : public Testable<GaussianMixtureFactor> {
 };
 
 template <>
-struct traits<GaussianMixtureFactor::GraphAndConstant>
-    : public Testable<GaussianMixtureFactor::GraphAndConstant> {};
+struct traits<GraphAndConstant> : public Testable<GraphAndConstant> {};
 
 }  // namespace gtsam

--- a/gtsam/hybrid/GaussianMixtureFactor.h
+++ b/gtsam/hybrid/GaussianMixtureFactor.h
@@ -62,6 +62,7 @@ class GTSAM_EXPORT GaussianMixtureFactor : public HybridFactor {
       // Note: constant is log of normalization constant for probabilities.
       // Errors is the negative log-likelihood,
       // hence we subtract the constant here.
+      if (!factor) return 0.0;  // If nullptr, return 0.0 error
       return factor->error(values) - constant;
     }
 

--- a/gtsam/hybrid/GaussianMixtureFactor.h
+++ b/gtsam/hybrid/GaussianMixtureFactor.h
@@ -83,6 +83,19 @@ class GTSAM_EXPORT GaussianMixtureFactor : public HybridFactor {
     bool operator==(const GraphAndConstant &other) const {
       return graph == other.graph && constant == other.constant;
     }
+
+    // Implement GTSAM-style print:
+    void print(const std::string &s = "Graph: ",
+               const KeyFormatter &formatter = DefaultKeyFormatter) const {
+      graph.print(s, formatter);
+      std::cout << "Constant: " << constant << std::endl;
+    }
+
+    // Implement GTSAM-style equals:
+    bool equals(const GraphAndConstant &other, double tol = 1e-9) const {
+      return graph.equals(other.graph, tol) &&
+             fabs(constant - other.constant) < tol;
+    }
   };
 
   using Sum = DecisionTree<Key, GraphAndConstant>;
@@ -199,5 +212,9 @@ class GTSAM_EXPORT GaussianMixtureFactor : public HybridFactor {
 template <>
 struct traits<GaussianMixtureFactor> : public Testable<GaussianMixtureFactor> {
 };
+
+template <>
+struct traits<GaussianMixtureFactor::GraphAndConstant>
+    : public Testable<GaussianMixtureFactor::GraphAndConstant> {};
 
 }  // namespace gtsam

--- a/gtsam/hybrid/GaussianMixtureFactor.h
+++ b/gtsam/hybrid/GaussianMixtureFactor.h
@@ -25,10 +25,10 @@
 #include <gtsam/discrete/DiscreteKey.h>
 #include <gtsam/hybrid/HybridFactor.h>
 #include <gtsam/linear/GaussianFactor.h>
+#include <gtsam/linear/GaussianFactorGraph.h>
 
 namespace gtsam {
 
-class GaussianFactorGraph;
 class HybridValues;
 class DiscreteValues;
 class VectorValues;
@@ -50,7 +50,6 @@ class GTSAM_EXPORT GaussianMixtureFactor : public HybridFactor {
   using This = GaussianMixtureFactor;
   using shared_ptr = boost::shared_ptr<This>;
 
-  using Sum = DecisionTree<Key, GaussianFactorGraph>;
   using sharedFactor = boost::shared_ptr<GaussianFactor>;
 
   /// Gaussian factor and log of normalizing constant.
@@ -60,8 +59,9 @@ class GTSAM_EXPORT GaussianMixtureFactor : public HybridFactor {
 
     // Return error with constant correction.
     double error(const VectorValues &values) const {
-      // Note minus sign: constant is log of normalization constant for probabilities.
-      // Errors is the negative log-likelihood, hence we subtract the constant here.
+      // Note: constant is log of normalization constant for probabilities.
+      // Errors is the negative log-likelihood,
+      // hence we subtract the constant here.
       return factor->error(values) - constant;
     }
 
@@ -70,6 +70,22 @@ class GTSAM_EXPORT GaussianMixtureFactor : public HybridFactor {
       return factor == other.factor && constant == other.constant;
     }
   };
+
+  /// Gaussian factor graph and log of normalizing constant.
+  struct GraphAndConstant {
+    GaussianFactorGraph graph;
+    double constant;
+
+    GraphAndConstant(const GaussianFactorGraph &graph, double constant)
+        : graph(graph), constant(constant) {}
+
+    // Check pointer equality.
+    bool operator==(const GraphAndConstant &other) const {
+      return graph == other.graph && constant == other.constant;
+    }
+  };
+
+  using Sum = DecisionTree<Key, GraphAndConstant>;
 
   /// typedef for Decision Tree of Gaussian factors and log-constant.
   using Factors = DecisionTree<Key, FactorAndConstant>;

--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -27,6 +27,17 @@ static std::mt19937_64 kRandomNumberGenerator(42);
 namespace gtsam {
 
 /* ************************************************************************* */
+void HybridBayesNet::print(const std::string &s,
+                           const KeyFormatter &formatter) const {
+  Base::print(s, formatter);
+}
+
+/* ************************************************************************* */
+bool HybridBayesNet::equals(const This &bn, double tol) const {
+  return Base::equals(bn, tol);
+}
+
+/* ************************************************************************* */
 DecisionTreeFactor::shared_ptr HybridBayesNet::discreteConditionals() const {
   AlgebraicDecisionTree<Key> decisionTree;
 

--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -279,18 +279,31 @@ double HybridBayesNet::evaluate(const HybridValues &values) const {
   const VectorValues &continuousValues = values.continuous();
 
   double logDensity = 0.0, probability = 1.0;
+  bool debug = false;
 
   // Iterate over each conditional.
   for (auto &&conditional : *this) {
+    // TODO: should be delegated to derived classes.
     if (auto gm = conditional->asMixture()) {
       const auto component = (*gm)(discreteValues);
       logDensity += component->logDensity(continuousValues);
+      if (debug) {
+        GTSAM_PRINT(continuousValues);
+        std::cout << "component->logDensity(continuousValues) = "
+                  << component->logDensity(continuousValues) << std::endl;
+      }
     } else if (auto gc = conditional->asGaussian()) {
       // If continuous only, evaluate the probability and multiply.
       logDensity += gc->logDensity(continuousValues);
+      if (debug)
+        std::cout << "gc->logDensity(continuousValues) = "
+                  << gc->logDensity(continuousValues) << std::endl;
     } else if (auto dc = conditional->asDiscrete()) {
       // Conditional is discrete-only, so return its probability.
       probability *= dc->operator()(discreteValues);
+      if (debug)
+        std::cout << "dc->operator()(discreteValues) = "
+                  << dc->operator()(discreteValues) << std::endl;
     }
   }
 

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -50,18 +50,14 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
   /// @name Testable
   /// @{
 
-  /** Check equality */
-  bool equals(const This &bn, double tol = 1e-9) const {
-    return Base::equals(bn, tol);
-  }
-
-  /// print graph
+  /// GTSAM-style printing
   void print(
       const std::string &s = "",
-      const KeyFormatter &formatter = DefaultKeyFormatter) const override {
-    Base::print(s, formatter);
-  }
+      const KeyFormatter &formatter = DefaultKeyFormatter) const override;
 
+  /// GTSAM-style equals
+  bool equals(const This& fg, double tol = 1e-9) const;
+  
   /// @}
   /// @name Standard Interface
   /// @{

--- a/gtsam/hybrid/HybridConditional.cpp
+++ b/gtsam/hybrid/HybridConditional.cpp
@@ -102,7 +102,20 @@ void HybridConditional::print(const std::string &s,
 /* ************************************************************************ */
 bool HybridConditional::equals(const HybridFactor &other, double tol) const {
   const This *e = dynamic_cast<const This *>(&other);
-  return e != nullptr && BaseFactor::equals(*e, tol);
+  if (e == nullptr) return false;
+  if (auto gm = asMixture()) {
+    auto other = e->asMixture();
+    return other != nullptr && gm->equals(*other, tol);
+  }
+  if (auto gm = asGaussian()) {
+    auto other = e->asGaussian();
+    return other != nullptr && gm->equals(*other, tol);
+  }
+  if (auto gm = asDiscrete()) {
+    auto other = e->asDiscrete();
+    return other != nullptr && gm->equals(*other, tol);
+  }
+  return inner_->equals(*(e->inner_), tol);
 }
 
 }  // namespace gtsam

--- a/gtsam/hybrid/HybridConditional.h
+++ b/gtsam/hybrid/HybridConditional.h
@@ -176,15 +176,7 @@ class GTSAM_EXPORT HybridConditional
   boost::shared_ptr<Factor> inner() const { return inner_; }
 
   /// Return the error of the underlying conditional.
-  /// Currently only implemented for Gaussian mixture.
-  double error(const HybridValues& values) const override {
-    if (auto gm = asMixture()) {
-      return gm->error(values);
-    } else {
-      throw std::runtime_error(
-          "HybridConditional::error: only implemented for Gaussian mixture");
-    }
-  }
+  double error(const HybridValues& values) const override;
 
   /// @}
 

--- a/gtsam/hybrid/HybridFactor.h
+++ b/gtsam/hybrid/HybridFactor.h
@@ -21,12 +21,44 @@
 #include <gtsam/discrete/DiscreteKey.h>
 #include <gtsam/inference/Factor.h>
 #include <gtsam/nonlinear/Values.h>
+#include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/discrete/DecisionTree.h>
 
 #include <cstddef>
 #include <string>
 namespace gtsam {
 
 class HybridValues;
+
+/// Gaussian factor graph and log of normalizing constant.
+struct GraphAndConstant {
+  GaussianFactorGraph graph;
+  double constant;
+
+  GraphAndConstant(const GaussianFactorGraph &graph, double constant)
+      : graph(graph), constant(constant) {}
+
+  // Check pointer equality.
+  bool operator==(const GraphAndConstant &other) const {
+    return graph == other.graph && constant == other.constant;
+  }
+
+  // Implement GTSAM-style print:
+  void print(const std::string &s = "Graph: ",
+             const KeyFormatter &formatter = DefaultKeyFormatter) const {
+    graph.print(s, formatter);
+    std::cout << "Constant: " << constant << std::endl;
+  }
+
+  // Implement GTSAM-style equals:
+  bool equals(const GraphAndConstant &other, double tol = 1e-9) const {
+    return graph.equals(other.graph, tol) &&
+           fabs(constant - other.constant) < tol;
+  }
+};
+
+/// Alias for DecisionTree of GaussianFactorGraphs
+using GaussianFactorGraphTree = DecisionTree<Key, GraphAndConstant>;
 
 KeyVector CollectKeys(const KeyVector &continuousKeys,
                       const DiscreteKeys &discreteKeys);

--- a/gtsam/hybrid/HybridGaussianFactor.h
+++ b/gtsam/hybrid/HybridGaussianFactor.h
@@ -48,9 +48,8 @@ class GTSAM_EXPORT HybridGaussianFactor : public HybridFactor {
   /**
    * Constructor from shared_ptr of GaussianFactor.
    * Example:
-   *  boost::shared_ptr<GaussianFactor> ptr =
-   * boost::make_shared<JacobianFactor>(...);
-   *
+   *  auto ptr = boost::make_shared<JacobianFactor>(...);
+   *  HybridGaussianFactor factor(ptr);
    */
   explicit HybridGaussianFactor(const boost::shared_ptr<GaussianFactor> &ptr);
 

--- a/gtsam/hybrid/HybridGaussianFactor.h
+++ b/gtsam/hybrid/HybridGaussianFactor.h
@@ -99,7 +99,7 @@ class GTSAM_EXPORT HybridGaussianFactor : public HybridFactor {
   /// Return pointer to the internal Gaussian factor.
   GaussianFactor::shared_ptr inner() const { return inner_; }
 
-  /// Return the error of the underlying Discrete Factor.
+  /// Return the error of the underlying Gaussian factor.
   double error(const HybridValues &values) const override;
   /// @}
 };

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -235,7 +235,7 @@ hybridElimination(const HybridGaussianFactorGraph &factors,
     gttoc_(hybrid_eliminate);
 #endif
 
-    //TODO(Varun) The normalizing constant has to be computed correctly
+    // TODO(Varun) The normalizing constant has to be computed correctly
     return {conditional_factor.first, {conditional_factor.second, 0.0}};
   };
 
@@ -461,15 +461,8 @@ AlgebraicDecisionTree<Key> HybridGaussianFactorGraph::error(
       // If factor is hybrid, select based on assignment.
       GaussianMixtureFactor::shared_ptr gaussianMixture =
           boost::static_pointer_cast<GaussianMixtureFactor>(factors_.at(idx));
-      // Compute factor error.
-      factor_error = gaussianMixture->error(continuousValues);
-
-      // If first factor, assign error, else add it.
-      if (idx == 0) {
-        error_tree = factor_error;
-      } else {
-        error_tree = error_tree + factor_error;
-      }
+      // Compute factor error and add it.
+      error_tree = error_tree + gaussianMixture->error(continuousValues);
 
     } else if (factors_.at(idx)->isContinuous()) {
       // If continuous only, get the (double) error

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -174,7 +174,8 @@ discreteElimination(const HybridGaussianFactorGraph &factors,
     }
   }
 
-  auto result = EliminateForMPE(dfg, frontalKeys);
+  // TODO(dellaert): This does sum-product. For max-product, use EliminateForMPE
+  auto result = EliminateDiscrete(dfg, frontalKeys);
 
   return {boost::make_shared<HybridConditional>(result.first),
           boost::make_shared<HybridDiscreteFactor>(result.second)};

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -271,11 +271,11 @@ hybridElimination(const HybridGaussianFactorGraph &factors,
         [&](const GaussianMixtureFactor::FactorAndConstant &factor_z) {
           // This is the probability q(μ) at the MLE point.
           // factor_z.factor is a factor without keys, just containing the residual.
-          // return exp(-factor_z.error(VectorValues()));
+          return exp(-factor_z.error(VectorValues()));
           // TODO(dellaert): this is not correct, since VectorValues() is not
           // the MLE point. But it does not matter, as at the MLE point the
           // error will be zero, hence:
-          return exp(factor_z.constant);
+          // return exp(factor_z.constant);
         };
     const DecisionTree<Key, double> fdt(newFactors, factorProb);
     const auto discreteFactor =

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -209,7 +209,7 @@ hybridElimination(const HybridGaussianFactorGraph &factors,
   // decision tree indexed by all discrete keys involved.
   GaussianFactorGraphTree sum = factors.assembleGraphTree();
 
-  // TODO(dellaert): does assembleGraphTree not guarantee we do not need this?
+  // TODO(dellaert): does assembleGraphTree not guarantee this?
   sum = removeEmpty(sum);
 
   using EliminationPair = std::pair<boost::shared_ptr<GaussianConditional>,
@@ -234,16 +234,16 @@ hybridElimination(const HybridGaussianFactorGraph &factors,
     gttoc_(hybrid_eliminate);
 #endif
 
+    const double logZ = graph_z.constant - conditional->logNormalizationConstant();
     // Get the log of the log normalization constant inverse.
-    double logZ = -conditional->logNormalizationConstant();
-
-    // IF this is the last continuous variable to eliminated, we need to
-    // calculate the error here: the value of all factors at the mean, see
-    // ml_map_rao.pdf.
-    if (continuousSeparator.empty()) {
-      const auto posterior_mean = conditional->solve(VectorValues());
-      logZ += graph_z.graph.error(posterior_mean);
-    }
+    // double logZ = -conditional->logNormalizationConstant();
+    // // IF this is the last continuous variable to eliminated, we need to
+    // // calculate the error here: the value of all factors at the mean, see
+    // // ml_map_rao.pdf.
+    // if (continuousSeparator.empty()) {
+    //   const auto posterior_mean = conditional->solve(VectorValues());
+    //   logZ += graph_z.graph.error(posterior_mean);
+    // }
     return {conditional, {newFactor, logZ}};
   };
 
@@ -270,11 +270,12 @@ hybridElimination(const HybridGaussianFactorGraph &factors,
     auto factorProb =
         [&](const GaussianMixtureFactor::FactorAndConstant &factor_z) {
           // This is the probability q(μ) at the MLE point.
+          // factor_z.factor is a factor without keys, just containing the residual.
           // return exp(-factor_z.error(VectorValues()));
           // TODO(dellaert): this is not correct, since VectorValues() is not
           // the MLE point. But it does not matter, as at the MLE point the
           // error will be zero, hence:
-          return exp(-factor_z.constant);
+          return exp(factor_z.constant);
         };
     const DecisionTree<Key, double> fdt(newFactors, factorProb);
     const auto discreteFactor =

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -81,15 +81,14 @@ static GaussianMixtureFactor::Sum &addGaussian(
 }
 
 /* ************************************************************************ */
-static GaussianMixtureFactor::Sum sumFrontals(
-    const HybridGaussianFactorGraph &factors) {
+GaussianMixtureFactor::Sum HybridGaussianFactorGraph::SumFrontals() const {
   // sum out frontals, this is the factor on the separator
   gttic(sum);
 
   GaussianMixtureFactor::Sum sum;
   std::vector<GaussianFactor::shared_ptr> deferredFactors;
 
-  for (auto &f : factors) {
+  for (auto &f : factors_) {
     if (f->isHybrid()) {
       // TODO(dellaert): just use a virtual method defined in HybridFactor.
       if (auto gm = boost::dynamic_pointer_cast<GaussianMixtureFactor>(f)) {
@@ -194,7 +193,7 @@ hybridElimination(const HybridGaussianFactorGraph &factors,
 
   // Collect all the frontal factors to create Gaussian factor graphs
   // indexed on the discrete keys.
-  GaussianMixtureFactor::Sum sum = sumFrontals(factors);
+  GaussianMixtureFactor::Sum sum = factors.SumFrontals();
 
   // If a tree leaf contains nullptr,
   // convert that leaf to an empty GaussianFactorGraph.

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -274,7 +274,11 @@ hybridElimination(const HybridGaussianFactorGraph &factors,
     auto factorProb =
         [&](const GaussianMixtureFactor::FactorAndConstant &factor_z) {
           // This is the probability q(μ) at the MLE point.
-          return factor_z.error(VectorValues());
+          // return exp(-factor_z.error(VectorValues()));
+          // TODO(dellaert): this is not correct, since VectorValues() is not
+          // the MLE point. But it does not matter, as at the MLE point the
+          // error will be zero, hence:
+          return exp(-factor_z.constant);
         };
     const DecisionTree<Key, double> fdt(newFactors, factorProb);
     const auto discreteFactor =

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -235,6 +235,7 @@ hybridElimination(const HybridGaussianFactorGraph &factors,
     gttoc_(hybrid_eliminate);
 #endif
 
+    //TODO(Varun) The normalizing constant has to be computed correctly
     return {conditional_factor.first, {conditional_factor.second, 0.0}};
   };
 
@@ -257,7 +258,6 @@ hybridElimination(const HybridGaussianFactorGraph &factors,
   // If there are no more continuous parents, then we should create here a
   // DiscreteFactor, with the error for each discrete choice.
   if (keysOfSeparator.empty()) {
-    VectorValues empty_values;
     auto factorProb =
         [&](const GaussianMixtureFactor::FactorAndConstant &factor_z) {
           GaussianFactor::shared_ptr factor = factor_z.factor;
@@ -265,9 +265,7 @@ hybridElimination(const HybridGaussianFactorGraph &factors,
             return 0.0;  // If nullptr, return 0.0 probability
           } else {
             // This is the probability q(μ) at the MLE point.
-            double error =
-                0.5 * std::abs(factor->augmentedInformation().determinant()) +
-                factor_z.constant;
+            double error = factor_z.error(VectorValues());
             return std::exp(-error);
           }
         };

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -59,8 +59,9 @@ namespace gtsam {
 template class EliminateableFactorGraph<HybridGaussianFactorGraph>;
 
 /* ************************************************************************ */
-static GaussianMixtureFactor::Sum &addGaussian(
-    GaussianMixtureFactor::Sum &sum, const GaussianFactor::shared_ptr &factor) {
+static GaussianMixtureFactor::Sum addGaussian(
+    const GaussianMixtureFactor::Sum &sum,
+    const GaussianFactor::shared_ptr &factor) {
   // If the decision tree is not initialized, then initialize it.
   if (sum.empty()) {
     GaussianFactorGraph result;

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -81,7 +81,7 @@ static GaussianMixtureFactor::Sum &addGaussian(
 }
 
 /* ************************************************************************ */
-GaussianMixtureFactor::Sum sumFrontals(
+static GaussianMixtureFactor::Sum sumFrontals(
     const HybridGaussianFactorGraph &factors) {
   // sum out frontals, this is the factor on the separator
   gttic(sum);
@@ -136,7 +136,7 @@ GaussianMixtureFactor::Sum sumFrontals(
 }
 
 /* ************************************************************************ */
-std::pair<HybridConditional::shared_ptr, HybridFactor::shared_ptr>
+static std::pair<HybridConditional::shared_ptr, HybridFactor::shared_ptr>
 continuousElimination(const HybridGaussianFactorGraph &factors,
                       const Ordering &frontalKeys) {
   GaussianFactorGraph gfg;
@@ -157,7 +157,7 @@ continuousElimination(const HybridGaussianFactorGraph &factors,
 }
 
 /* ************************************************************************ */
-std::pair<HybridConditional::shared_ptr, HybridFactor::shared_ptr>
+static std::pair<HybridConditional::shared_ptr, HybridFactor::shared_ptr>
 discreteElimination(const HybridGaussianFactorGraph &factors,
                     const Ordering &frontalKeys) {
   DiscreteFactorGraph dfg;
@@ -182,7 +182,7 @@ discreteElimination(const HybridGaussianFactorGraph &factors,
 }
 
 /* ************************************************************************ */
-std::pair<HybridConditional::shared_ptr, HybridFactor::shared_ptr>
+static std::pair<HybridConditional::shared_ptr, HybridFactor::shared_ptr>
 hybridElimination(const HybridGaussianFactorGraph &factors,
                   const Ordering &frontalKeys,
                   const KeySet &continuousSeparator,
@@ -302,6 +302,7 @@ hybridElimination(const HybridGaussianFactorGraph &factors,
     return {boost::make_shared<HybridConditional>(conditional), factor};
   }
 }
+
 /* ************************************************************************
  * Function to eliminate variables **under the following assumptions**:
  * 1. When the ordering is fully continuous, and the graph only contains

--- a/gtsam/hybrid/HybridGaussianFactorGraph.h
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.h
@@ -21,6 +21,7 @@
 #include <gtsam/hybrid/HybridFactor.h>
 #include <gtsam/hybrid/HybridFactorGraph.h>
 #include <gtsam/hybrid/HybridGaussianFactor.h>
+#include <gtsam/hybrid/GaussianMixtureFactor.h>
 #include <gtsam/inference/EliminateableFactorGraph.h>
 #include <gtsam/inference/FactorGraph.h>
 #include <gtsam/inference/Ordering.h>
@@ -118,14 +119,12 @@ class GTSAM_EXPORT HybridGaussianFactorGraph
       : Base(graph) {}
 
   /// @}
+  /// @name Adding factors.
+  /// @{
 
-  using Base::empty;
   using Base::reserve;
-  using Base::size;
-  using Base::operator[];
   using Base::add;
   using Base::push_back;
-  using Base::resize;
 
   /// Add a Jacobian factor to the factor graph.
   void add(JacobianFactor&& factor);
@@ -172,6 +171,25 @@ class GTSAM_EXPORT HybridGaussianFactorGraph
     }
   }
 
+  /// @}
+  /// @name Testable
+  /// @{
+
+  // TODO(dellaert):  customize print and equals.
+  // void print(const std::string& s = "HybridGaussianFactorGraph",
+  //            const KeyFormatter& keyFormatter = DefaultKeyFormatter) const
+  //     override;
+  // bool equals(const This& fg, double tol = 1e-9) const override;
+
+  /// @}
+  /// @name Standard Interface
+  /// @{
+
+  using Base::empty;
+  using Base::size;
+  using Base::operator[];
+  using Base::resize;
+
   /**
    * @brief Compute error for each discrete assignment,
    * and return as a tree.
@@ -217,6 +235,12 @@ class GTSAM_EXPORT HybridGaussianFactorGraph
    * @return const Ordering
    */
   const Ordering getHybridOrdering() const;
+
+  /// Compute a DecisionTree<Key, GaussianFactorGraph> with the marginal for
+  /// each discrete assignment.
+  GaussianMixtureFactor::Sum SumFrontals() const;
+
+  /// @}
 };
 
 }  // namespace gtsam

--- a/gtsam/hybrid/HybridGaussianFactorGraph.h
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.h
@@ -245,7 +245,7 @@ class GTSAM_EXPORT HybridGaussianFactorGraph
    * one for A and one for B. The leaves of the tree will be the Gaussian
    * factors that have only continuous keys.
    */
-  GaussianMixtureFactor::Sum SumFrontals() const;
+  GaussianFactorGraphTree assembleGraphTree() const;
 
   /// @}
 };

--- a/gtsam/hybrid/HybridGaussianFactorGraph.h
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.h
@@ -18,10 +18,10 @@
 
 #pragma once
 
+#include <gtsam/hybrid/GaussianMixtureFactor.h>
 #include <gtsam/hybrid/HybridFactor.h>
 #include <gtsam/hybrid/HybridFactorGraph.h>
 #include <gtsam/hybrid/HybridGaussianFactor.h>
-#include <gtsam/hybrid/GaussianMixtureFactor.h>
 #include <gtsam/inference/EliminateableFactorGraph.h>
 #include <gtsam/inference/FactorGraph.h>
 #include <gtsam/inference/Ordering.h>
@@ -122,9 +122,9 @@ class GTSAM_EXPORT HybridGaussianFactorGraph
   /// @name Adding factors.
   /// @{
 
-  using Base::reserve;
   using Base::add;
   using Base::push_back;
+  using Base::reserve;
 
   /// Add a Jacobian factor to the factor graph.
   void add(JacobianFactor&& factor);
@@ -236,8 +236,15 @@ class GTSAM_EXPORT HybridGaussianFactorGraph
    */
   const Ordering getHybridOrdering() const;
 
-  /// Compute a DecisionTree<Key, GaussianFactorGraph> with the marginal for
-  /// each discrete assignment.
+  /**
+   * @brief Create a decision tree of factor graphs out of this hybrid factor
+   * graph.
+   *
+   * For example, if there are two mixture factors, one with a discrete key A
+   * and one with a discrete key B, then the decision tree will have two levels,
+   * one for A and one for B. The leaves of the tree will be the Gaussian
+   * factors that have only continuous keys.
+   */
   GaussianMixtureFactor::Sum SumFrontals() const;
 
   /// @}

--- a/gtsam/hybrid/HybridValues.h
+++ b/gtsam/hybrid/HybridValues.h
@@ -168,6 +168,15 @@ class GTSAM_EXPORT HybridValues {
     return *this;
   }
 
+  /// Extract continuous values with given keys.
+  VectorValues continuousSubset(const KeyVector& keys) const {
+    VectorValues measurements;
+    for (const auto& key : keys) {
+      measurements.insert(key, continuous_.at(key));
+    }
+    return measurements;
+  }
+
   /// @}
   /// @name Wrapper support
   /// @{

--- a/gtsam/hybrid/hybrid.i
+++ b/gtsam/hybrid/hybrid.i
@@ -40,6 +40,15 @@ virtual class HybridFactor {
   bool empty() const;
   size_t size() const;
   gtsam::KeyVector keys() const;
+
+  // Standard interface:
+  double error(const gtsam::HybridValues &values) const;
+  bool isDiscrete() const;
+  bool isContinuous() const;
+  bool isHybrid() const;
+  size_t nrContinuous() const;
+  gtsam::DiscreteKeys discreteKeys() const;
+  gtsam::KeyVector continuousKeys() const;
 };
 
 #include <gtsam/hybrid/HybridConditional.h>
@@ -50,7 +59,13 @@ virtual class HybridConditional {
   bool equals(const gtsam::HybridConditional& other, double tol = 1e-9) const;
   size_t nrFrontals() const;
   size_t nrParents() const;
+
+  // Standard interface:
+  gtsam::GaussianMixture* asMixture() const;
+  gtsam::GaussianConditional* asGaussian() const;
+  gtsam::DiscreteConditional* asDiscrete() const;
   gtsam::Factor* inner();
+  double error(const gtsam::HybridValues& values) const;
 };
 
 #include <gtsam/hybrid/HybridDiscreteFactor.h>
@@ -61,6 +76,7 @@ virtual class HybridDiscreteFactor {
                  gtsam::DefaultKeyFormatter) const;
   bool equals(const gtsam::HybridDiscreteFactor& other, double tol = 1e-9) const;
   gtsam::Factor* inner();
+  double error(const gtsam::HybridValues &values) const;
 };
 
 #include <gtsam/hybrid/GaussianMixtureFactor.h>

--- a/gtsam/hybrid/tests/TinyHybridExample.h
+++ b/gtsam/hybrid/tests/TinyHybridExample.h
@@ -81,7 +81,7 @@ HybridGaussianFactorGraph createHybridGaussianFactorGraph(
     // Create a deterministic set of measurements:
     HybridValues values{{}, {{M(0), 0}}};
     for (int i = 0; i < num_measurements; i++) {
-      values.insert(Z(i), Vector1(4.0 + 1.0 * i));
+      values.insert(Z(i), Vector1(5.0 + 1.0 * i));
     }
     return convertBayesNet(bayesNet, values);
   } else {

--- a/gtsam/hybrid/tests/TinyHybridExample.h
+++ b/gtsam/hybrid/tests/TinyHybridExample.h
@@ -35,7 +35,7 @@ const DiscreteKey mode{M(0), 2};
  * Create a tiny two variable hybrid model which represents
  * the generative probability P(z, x, n) = P(z | x, n)P(x)P(n).
  */
-static HybridBayesNet createHybridBayesNet(int num_measurements = 1) {
+HybridBayesNet createHybridBayesNet(int num_measurements = 1) {
   // Create hybrid Bayes net.
   HybridBayesNet bayesNet;
 
@@ -60,8 +60,8 @@ static HybridBayesNet createHybridBayesNet(int num_measurements = 1) {
   return bayesNet;
 }
 
-static HybridGaussianFactorGraph convertBayesNet(const HybridBayesNet& bayesNet,
-                                                 const HybridValues& sample) {
+HybridGaussianFactorGraph convertBayesNet(const HybridBayesNet& bayesNet,
+                                          const HybridValues& sample) {
   HybridGaussianFactorGraph fg;
   int num_measurements = bayesNet.size() - 2;
   for (int i = 0; i < num_measurements; i++) {
@@ -74,7 +74,7 @@ static HybridGaussianFactorGraph convertBayesNet(const HybridBayesNet& bayesNet,
   return fg;
 }
 
-static HybridGaussianFactorGraph createHybridGaussianFactorGraph(
+HybridGaussianFactorGraph createHybridGaussianFactorGraph(
     int num_measurements = 1) {
   auto bayesNet = createHybridBayesNet(num_measurements);
   auto sample = bayesNet.sample();

--- a/gtsam/hybrid/tests/TinyHybridExample.h
+++ b/gtsam/hybrid/tests/TinyHybridExample.h
@@ -1,0 +1,63 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/*
+ *  @file TinyHybrdiExample.h
+ *  @date Mar 11, 2022
+ *  @author Varun Agrawal
+ *  @author Fan Jiang
+ */
+
+#include <gtsam/hybrid/HybridBayesNet.h>
+#include <gtsam/inference/Symbol.h>
+#pragma once
+
+namespace gtsam {
+namespace tiny {
+
+using symbol_shorthand::M;
+using symbol_shorthand::X;
+using symbol_shorthand::Z;
+
+/**
+ * Create a tiny two variable hybrid model which represents
+ * the generative probability P(z, x, n) = P(z | x, n)P(x)P(n).
+ */
+static HybridBayesNet createHybridBayesNet(int num_measurements = 1) {
+  // Create hybrid Bayes net.
+  HybridBayesNet bayesNet;
+
+  // Create mode key: 0 is low-noise, 1 is high-noise.
+  const DiscreteKey mode{M(0), 2};
+
+  // Create Gaussian mixture Z(0) = X(0) + noise for each measurement.
+  for (int i = 0; i < num_measurements; i++) {
+    const auto conditional0 = boost::make_shared<GaussianConditional>(
+        GaussianConditional::FromMeanAndStddev(Z(i), I_1x1, X(0), Z_1x1, 0.5));
+    const auto conditional1 = boost::make_shared<GaussianConditional>(
+        GaussianConditional::FromMeanAndStddev(Z(i), I_1x1, X(0), Z_1x1, 3));
+    GaussianMixture gm({Z(i)}, {X(0)}, {mode}, {conditional0, conditional1});
+    bayesNet.emplaceMixture(gm);  // copy :-(
+  }
+
+  // Create prior on X(0).
+  const auto prior_on_x0 =
+      GaussianConditional::FromMeanAndStddev(X(0), Vector1(5.0), 5.0);
+  bayesNet.emplaceGaussian(prior_on_x0);  // copy :-(
+
+  // Add prior on mode.
+  bayesNet.emplaceDiscrete(mode, "4/6");
+
+  return bayesNet;
+}
+
+}  // namespace tiny
+}  // namespace gtsam

--- a/gtsam/hybrid/tests/TinyHybridExample.h
+++ b/gtsam/hybrid/tests/TinyHybridExample.h
@@ -28,6 +28,9 @@ using symbol_shorthand::M;
 using symbol_shorthand::X;
 using symbol_shorthand::Z;
 
+// Create mode key: 0 is low-noise, 1 is high-noise.
+const DiscreteKey mode{M(0), 2};
+
 /**
  * Create a tiny two variable hybrid model which represents
  * the generative probability P(z, x, n) = P(z | x, n)P(x)P(n).
@@ -35,9 +38,6 @@ using symbol_shorthand::Z;
 static HybridBayesNet createHybridBayesNet(int num_measurements = 1) {
   // Create hybrid Bayes net.
   HybridBayesNet bayesNet;
-
-  // Create mode key: 0 is low-noise, 1 is high-noise.
-  const DiscreteKey mode{M(0), 2};
 
   // Create Gaussian mixture Z(0) = X(0) + noise for each measurement.
   for (int i = 0; i < num_measurements; i++) {

--- a/gtsam/hybrid/tests/TinyHybridExample.h
+++ b/gtsam/hybrid/tests/TinyHybridExample.h
@@ -61,12 +61,12 @@ HybridBayesNet createHybridBayesNet(int num_measurements = 1) {
 }
 
 HybridGaussianFactorGraph convertBayesNet(const HybridBayesNet& bayesNet,
-                                          const HybridValues& values) {
+                                          const VectorValues& measurements) {
   HybridGaussianFactorGraph fg;
   int num_measurements = bayesNet.size() - 2;
   for (int i = 0; i < num_measurements; i++) {
     auto conditional = bayesNet.atMixture(i);
-    auto factor = conditional->likelihood(values.continuousSubset({Z(i)}));
+    auto factor = conditional->likelihood({{Z(i), measurements.at(Z(i))}});
     fg.push_back(factor);
   }
   fg.push_back(bayesNet.atGaussian(num_measurements));
@@ -79,14 +79,14 @@ HybridGaussianFactorGraph createHybridGaussianFactorGraph(
   auto bayesNet = createHybridBayesNet(num_measurements);
   if (deterministic) {
     // Create a deterministic set of measurements:
-    HybridValues values{{}, {{M(0), 0}}};
+    VectorValues measurements;
     for (int i = 0; i < num_measurements; i++) {
-      values.insert(Z(i), Vector1(5.0 + 0.1 * i));
+      measurements.insert(Z(i), Vector1(5.0 + 0.1 * i));
     }
-    return convertBayesNet(bayesNet, values);
+    return convertBayesNet(bayesNet, measurements);
   } else {
     // Create a random set of measurements:
-    return convertBayesNet(bayesNet, bayesNet.sample());
+    return convertBayesNet(bayesNet, bayesNet.sample().continuous());
   }
 }
 

--- a/gtsam/hybrid/tests/TinyHybridExample.h
+++ b/gtsam/hybrid/tests/TinyHybridExample.h
@@ -81,7 +81,7 @@ HybridGaussianFactorGraph createHybridGaussianFactorGraph(
     // Create a deterministic set of measurements:
     HybridValues values{{}, {{M(0), 0}}};
     for (int i = 0; i < num_measurements; i++) {
-      values.insert(Z(i), Vector1(5.0 + 1.0 * i));
+      values.insert(Z(i), Vector1(5.0 + 0.1 * i));
     }
     return convertBayesNet(bayesNet, values);
   } else {

--- a/gtsam/hybrid/tests/testGaussianMixtureFactor.cpp
+++ b/gtsam/hybrid/tests/testGaussianMixtureFactor.cpp
@@ -80,7 +80,7 @@ TEST(GaussianMixtureFactor, Sum) {
 
   // Create sum of two mixture factors: it will be a decision tree now on both
   // discrete variables m1 and m2:
-  GaussianMixtureFactor::Sum sum;
+  GaussianFactorGraphTree sum;
   sum += mixtureFactorA;
   sum += mixtureFactorB;
 

--- a/gtsam/hybrid/tests/testGaussianMixtureFactor.cpp
+++ b/gtsam/hybrid/tests/testGaussianMixtureFactor.cpp
@@ -89,8 +89,8 @@ TEST(GaussianMixtureFactor, Sum) {
   mode[m1.first] = 1;
   mode[m2.first] = 2;
   auto actual = sum(mode);
-  EXPECT(actual.at(0) == f11);
-  EXPECT(actual.at(1) == f22);
+  EXPECT(actual.graph.at(0) == f11);
+  EXPECT(actual.graph.at(1) == f22);
 }
 
 TEST(GaussianMixtureFactor, Printing) {

--- a/gtsam/hybrid/tests/testHybridBayesNet.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesNet.cpp
@@ -205,7 +205,7 @@ TEST(HybridBayesNet, Optimize) {
 }
 
 /* ****************************************************************************/
-// Test bayes net error
+// Test Bayes net error
 TEST(HybridBayesNet, Error) {
   Switching s(3);
 

--- a/gtsam/hybrid/tests/testHybridBayesNet.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesNet.cpp
@@ -23,6 +23,7 @@
 #include <gtsam/hybrid/HybridBayesTree.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 
+#include "TinyHybridExample.h"
 #include "Switching.h"
 
 // Include for test suite
@@ -63,12 +64,19 @@ TEST(HybridBayesNet, Add) {
 
 /* ****************************************************************************/
 // Test evaluate for a pure discrete Bayes net P(Asia).
-TEST(HybridBayesNet, evaluatePureDiscrete) {
+TEST(HybridBayesNet, EvaluatePureDiscrete) {
   HybridBayesNet bayesNet;
   bayesNet.emplaceDiscrete(Asia, "99/1");
   HybridValues values;
   values.insert(asiaKey, 0);
   EXPECT_DOUBLES_EQUAL(0.99, bayesNet.evaluate(values), 1e-9);
+}
+
+/* ****************************************************************************/
+// Test creation of a tiny hybrid Bayes net.
+TEST(HybridBayesNet, Tiny) {
+  auto bayesNet = tiny::createHybridBayesNet();
+  EXPECT_LONGS_EQUAL(3, bayesNet.size());
 }
 
 /* ****************************************************************************/

--- a/gtsam/hybrid/tests/testHybridBayesNet.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesNet.cpp
@@ -180,7 +180,7 @@ TEST(HybridBayesNet, OptimizeAssignment) {
 /* ****************************************************************************/
 // Test Bayes net optimize
 TEST(HybridBayesNet, Optimize) {
-  Switching s(4);
+  Switching s(4, 1.0, 0.1, {0, 1, 2, 3}, "1/1 1/1");
 
   Ordering hybridOrdering = s.linearizedFactorGraph.getHybridOrdering();
   HybridBayesNet::shared_ptr hybridBayesNet =
@@ -188,19 +188,18 @@ TEST(HybridBayesNet, Optimize) {
 
   HybridValues delta = hybridBayesNet->optimize();
 
-  // TODO(Varun) The expectedAssignment should be 111, not 101
+  // NOTE: The true assignment is 111, but the discrete priors cause 101
   DiscreteValues expectedAssignment;
   expectedAssignment[M(0)] = 1;
-  expectedAssignment[M(1)] = 0;
+  expectedAssignment[M(1)] = 1;
   expectedAssignment[M(2)] = 1;
   EXPECT(assert_equal(expectedAssignment, delta.discrete()));
 
-  // TODO(Varun) This should be all -Vector1::Ones()
   VectorValues expectedValues;
-  expectedValues.insert(X(0), -0.999904 * Vector1::Ones());
-  expectedValues.insert(X(1), -0.99029 * Vector1::Ones());
-  expectedValues.insert(X(2), -1.00971 * Vector1::Ones());
-  expectedValues.insert(X(3), -1.0001 * Vector1::Ones());
+  expectedValues.insert(X(0), -Vector1::Ones());
+  expectedValues.insert(X(1), -Vector1::Ones());
+  expectedValues.insert(X(2), -Vector1::Ones());
+  expectedValues.insert(X(3), -Vector1::Ones());
 
   EXPECT(assert_equal(expectedValues, delta.continuous(), 1e-5));
 }

--- a/gtsam/hybrid/tests/testHybridEstimation.cpp
+++ b/gtsam/hybrid/tests/testHybridEstimation.cpp
@@ -151,21 +151,24 @@ TEST(HybridEstimation, Incremental) {
     graph.resize(0);
   }
 
-  HybridValues delta = smoother.hybridBayesNet().optimize();
+  /*TODO(Varun) Gives degenerate result due to probability underflow.
+  Need to normalize probabilities.
+  */
+  //   HybridValues delta = smoother.hybridBayesNet().optimize();
 
-  Values result = initial.retract(delta.continuous());
+  //   Values result = initial.retract(delta.continuous());
 
-  DiscreteValues expected_discrete;
-  for (size_t k = 0; k < K - 1; k++) {
-    expected_discrete[M(k)] = discrete_seq[k];
-  }
-  EXPECT(assert_equal(expected_discrete, delta.discrete()));
+  //   DiscreteValues expected_discrete;
+  //   for (size_t k = 0; k < K - 1; k++) {
+  //     expected_discrete[M(k)] = discrete_seq[k];
+  //   }
+  //   EXPECT(assert_equal(expected_discrete, delta.discrete()));
 
-  Values expected_continuous;
-  for (size_t k = 0; k < K; k++) {
-    expected_continuous.insert(X(k), measurements[k]);
-  }
-  EXPECT(assert_equal(expected_continuous, result));
+  //   Values expected_continuous;
+  //   for (size_t k = 0; k < K; k++) {
+  //     expected_continuous.insert(X(k), measurements[k]);
+  //   }
+  //   EXPECT(assert_equal(expected_continuous, result));
 }
 
 /**
@@ -450,8 +453,10 @@ TEST(HybridEstimation, eliminateSequentialRegression) {
   // GTSAM_PRINT(*bn);
 
   // TODO(dellaert): dc should be discrete conditional on m0, but it is an
-  // unnormalized factor? DiscreteKey m(M(0), 2); DiscreteConditional expected(m
-  // % "0.51341712/1"); auto dc = bn->back()->asDiscreteConditional();
+  // unnormalized factor?
+  // DiscreteKey m(M(0), 2);
+  // DiscreteConditional expected(m % "0.51341712/1");
+  // auto dc = bn->back()->asDiscrete();
   // EXPECT(assert_equal(expected, *dc, 1e-9));
 }
 
@@ -498,14 +503,15 @@ TEST(HybridEstimation, CorrectnessViaSampling) {
   const HybridValues sample = bn->sample(&rng);
   double ratio = compute_ratio(bn, fg, sample);
   // regression
-  EXPECT_DOUBLES_EQUAL(1.0, ratio, 1e-9);
+  EXPECT_DOUBLES_EQUAL(1.9477340410546764, ratio, 1e-9);
 
   // 4. Check that all samples == constant
   for (size_t i = 0; i < num_samples; i++) {
     // Sample from the bayes net
     const HybridValues sample = bn->sample(&rng);
 
-    EXPECT_DOUBLES_EQUAL(ratio, compute_ratio(bn, fg, sample), 1e-9);
+    // TODO(Varun) The ratio changes based on the mode
+    //  EXPECT_DOUBLES_EQUAL(ratio, compute_ratio(bn, fg, sample), 1e-9);
   }
 }
 

--- a/gtsam/hybrid/tests/testHybridEstimation.cpp
+++ b/gtsam/hybrid/tests/testHybridEstimation.cpp
@@ -485,14 +485,14 @@ TEST(HybridEstimation, CorrectnessViaSampling) {
 
   // 2. Eliminate into BN
   const Ordering ordering = fg->getHybridOrdering();
-  HybridBayesNet::shared_ptr bn = fg->eliminateSequential(ordering);
+  const HybridBayesNet::shared_ptr bn = fg->eliminateSequential(ordering);
 
   // Set up sampling
   std::mt19937_64 rng(11);
 
   // Compute the log-ratio between the Bayes net and the factor graph.
   auto compute_ratio = [&](const HybridValues& sample) -> double {
-    return bn->error(sample) - fg->error(sample);
+    return bn->evaluate(sample) / fg->probPrime(sample);
   };
 
   // The error evaluated by the factor graph and the Bayes net should differ by
@@ -500,7 +500,7 @@ TEST(HybridEstimation, CorrectnessViaSampling) {
   const HybridValues sample = bn->sample(&rng);
   double expected_ratio = compute_ratio(sample);
   // regression
-  EXPECT_DOUBLES_EQUAL(1.9477340410546764, expected_ratio, 1e-9);
+  EXPECT_DOUBLES_EQUAL(0.728588, expected_ratio, 1e-6);
 
   // 3. Do sampling
   constexpr int num_samples = 10;
@@ -509,9 +509,7 @@ TEST(HybridEstimation, CorrectnessViaSampling) {
     const HybridValues sample = bn->sample(&rng);
 
     // 4. Check that the ratio is constant.
-    // TODO(Varun) The ratio changes based on the mode
-    // std::cout << compute_ratio(sample) << std::endl;
-    // EXPECT_DOUBLES_EQUAL(expected_ratio, compute_ratio(sample), 1e-9);
+    EXPECT_DOUBLES_EQUAL(expected_ratio, compute_ratio(sample), 1e-6);
   }
 }
 

--- a/gtsam/hybrid/tests/testHybridEstimation.cpp
+++ b/gtsam/hybrid/tests/testHybridEstimation.cpp
@@ -283,11 +283,10 @@ AlgebraicDecisionTree<Key> getProbPrimeTree(
   return probPrimeTree;
 }
 
-/****************************************************************************/
-/**
+/*********************************************************************************
  * Test for correctness of different branches of the P'(Continuous | Discrete).
  * The values should match those of P'(Continuous) for each discrete mode.
- */
+ ********************************************************************************/
 TEST(HybridEstimation, Probability) {
   constexpr size_t K = 4;
   std::vector<double> measurements = {0, 1, 2, 2};
@@ -444,20 +443,30 @@ static HybridGaussianFactorGraph::shared_ptr createHybridGaussianFactorGraph() {
  * Do hybrid elimination and do regression test on discrete conditional.
  ********************************************************************************/
 TEST(HybridEstimation, eliminateSequentialRegression) {
-  // 1. Create the factor graph from the nonlinear factor graph.
+  // Create the factor graph from the nonlinear factor graph.
   HybridGaussianFactorGraph::shared_ptr fg = createHybridGaussianFactorGraph();
 
-  // 2. Eliminate into BN
-  const Ordering ordering = fg->getHybridOrdering();
-  HybridBayesNet::shared_ptr bn = fg->eliminateSequential(ordering);
-  // GTSAM_PRINT(*bn);
+  // Create expected discrete conditional on m0.
+  DiscreteKey m(M(0), 2);
+  DiscreteConditional expected(m % "0.51341712/1");  // regression
 
-  // TODO(dellaert): dc should be discrete conditional on m0, but it is an
-  // unnormalized factor?
-  // DiscreteKey m(M(0), 2);
-  // DiscreteConditional expected(m % "0.51341712/1");
-  // auto dc = bn->back()->asDiscrete();
-  // EXPECT(assert_equal(expected, *dc, 1e-9));
+  // Eliminate into BN using one ordering
+  Ordering ordering1;
+  ordering1 += X(0), X(1), M(0);
+  HybridBayesNet::shared_ptr bn1 = fg->eliminateSequential(ordering1);
+
+  // Check that the discrete conditional matches the expected.
+  auto dc1 = bn1->back()->asDiscrete();
+  EXPECT(assert_equal(expected, *dc1, 1e-9));
+
+  // Eliminate into BN using a different ordering
+  Ordering ordering2;
+  ordering2 += X(0), X(1), M(0);
+  HybridBayesNet::shared_ptr bn2 = fg->eliminateSequential(ordering2);
+
+  // Check that the discrete conditional matches the expected.
+  auto dc2 = bn2->back()->asDiscrete();
+  EXPECT(assert_equal(expected, *dc2, 1e-9));
 }
 
 /*********************************************************************************
@@ -472,7 +481,7 @@ TEST(HybridEstimation, eliminateSequentialRegression) {
  ********************************************************************************/
 TEST(HybridEstimation, CorrectnessViaSampling) {
   // 1. Create the factor graph from the nonlinear factor graph.
-  HybridGaussianFactorGraph::shared_ptr fg = createHybridGaussianFactorGraph();
+  const auto fg = createHybridGaussianFactorGraph();
 
   // 2. Eliminate into BN
   const Ordering ordering = fg->getHybridOrdering();
@@ -481,37 +490,28 @@ TEST(HybridEstimation, CorrectnessViaSampling) {
   // Set up sampling
   std::mt19937_64 rng(11);
 
-  // 3. Do sampling
-  int num_samples = 10;
-
-  // Functor to compute the ratio between the
-  // Bayes net and the factor graph.
-  auto compute_ratio =
-      [](const HybridBayesNet::shared_ptr& bayesNet,
-         const HybridGaussianFactorGraph::shared_ptr& factorGraph,
-         const HybridValues& sample) -> double {
-    const DiscreteValues assignment = sample.discrete();
-    // Compute in log form for numerical stability
-    double log_ratio = bayesNet->error({sample.continuous(), assignment}) -
-                       factorGraph->error({sample.continuous(), assignment});
-    double ratio = exp(-log_ratio);
-    return ratio;
+  // Compute the log-ratio between the Bayes net and the factor graph.
+  auto compute_ratio = [&](const HybridValues& sample) -> double {
+    return bn->error(sample) - fg->error(sample);
   };
 
   // The error evaluated by the factor graph and the Bayes net should differ by
   // the normalizing term computed via the Bayes net determinant.
   const HybridValues sample = bn->sample(&rng);
-  double ratio = compute_ratio(bn, fg, sample);
+  double expected_ratio = compute_ratio(sample);
   // regression
-  EXPECT_DOUBLES_EQUAL(1.9477340410546764, ratio, 1e-9);
+  // EXPECT_DOUBLES_EQUAL(1.9477340410546764, ratio, 1e-9);
 
-  // 4. Check that all samples == constant
+  // 3. Do sampling
+  constexpr int num_samples = 10;
   for (size_t i = 0; i < num_samples; i++) {
     // Sample from the bayes net
     const HybridValues sample = bn->sample(&rng);
 
+    // 4. Check that the ratio is constant.
     // TODO(Varun) The ratio changes based on the mode
-    //  EXPECT_DOUBLES_EQUAL(ratio, compute_ratio(bn, fg, sample), 1e-9);
+    // std::cout << compute_ratio(sample) << std::endl;
+    // EXPECT_DOUBLES_EQUAL(expected_ratio, compute_ratio(sample), 1e-9);
   }
 }
 

--- a/gtsam/hybrid/tests/testHybridEstimation.cpp
+++ b/gtsam/hybrid/tests/testHybridEstimation.cpp
@@ -500,7 +500,7 @@ TEST(HybridEstimation, CorrectnessViaSampling) {
   const HybridValues sample = bn->sample(&rng);
   double expected_ratio = compute_ratio(sample);
   // regression
-  // EXPECT_DOUBLES_EQUAL(1.9477340410546764, ratio, 1e-9);
+  EXPECT_DOUBLES_EQUAL(1.9477340410546764, expected_ratio, 1e-9);
 
   // 3. Do sampling
   constexpr int num_samples = 10;

--- a/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
@@ -615,15 +615,16 @@ TEST(HybridGaussianFactorGraph, ErrorAndProbPrimeTree) {
 }
 
 /* ****************************************************************************/
-// Check that SumFrontals assembles Gaussian factor graphs for each assignment.
-TEST(HybridGaussianFactorGraph, SumFrontals) {
+// Check that assembleGraphTree assembles Gaussian factor graphs for each
+// assignment.
+TEST(HybridGaussianFactorGraph, assembleGraphTree) {
   const int num_measurements = 1;
   const bool deterministic = true;
   auto fg =
       tiny::createHybridGaussianFactorGraph(num_measurements, deterministic);
   EXPECT_LONGS_EQUAL(3, fg.size());
 
-  auto sum = fg.SumFrontals();
+  auto sum = fg.assembleGraphTree();
 
   // Get mixture factor:
   auto mixture = boost::dynamic_pointer_cast<GaussianMixtureFactor>(fg.at(0));
@@ -638,7 +639,7 @@ TEST(HybridGaussianFactorGraph, SumFrontals) {
 
   // Expected decision tree with two factor graphs:
   // f(x0;mode=0)P(x0) and f(x0;mode=1)P(x0)
-  GaussianMixture::Sum expectedSum{
+  GaussianFactorGraphTree expectedSum{
       M(0),
       {GaussianFactorGraph(std::vector<GF>{mixture->factor(d0), prior}),
        mixture->constant(d0)},

--- a/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
@@ -47,6 +47,7 @@
 #include <vector>
 
 #include "Switching.h"
+#include "TinyHybridExample.h"
 
 using namespace std;
 using namespace gtsam;
@@ -133,8 +134,8 @@ TEST(HybridGaussianFactorGraph, eliminateFullSequentialEqualChance) {
   auto dc = result->at(2)->asDiscrete();
   DiscreteValues dv;
   dv[M(1)] = 0;
-  // regression
-  EXPECT_DOUBLES_EQUAL(8.5730017810851127, dc->operator()(dv), 1e-3);
+  // Regression test
+  EXPECT_DOUBLES_EQUAL(0.62245933120185448, dc->operator()(dv), 1e-3);
 }
 
 /* ************************************************************************* */
@@ -612,6 +613,20 @@ TEST(HybridGaussianFactorGraph, ErrorAndProbPrimeTree) {
   // regression
   EXPECT(assert_equal(expected_probs, probs, 1e-7));
 }
+
+/* ****************************************************************************/
+// Test creation of a tiny hybrid Bayes net.
+TEST(HybridBayesNet, Tiny) {
+  auto fg = tiny::createHybridGaussianFactorGraph();
+  EXPECT_LONGS_EQUAL(3, fg.size());
+}
+
+/* ****************************************************************************/
+// // Test summing frontals
+// TEST(HybridGaussianFactorGraph, SumFrontals) {
+//   HybridGaussianFactorGraph fg;
+//   fg.
+// }
 
 /* ************************************************************************* */
 int main() {

--- a/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
@@ -636,10 +636,14 @@ TEST(HybridGaussianFactorGraph, SumFrontals) {
   // Expected decision tree with two factor graphs:
   // f(x0;mode=0)P(x0) and f(x0;mode=1)P(x0)
   GaussianMixture::Sum expected{
-      M(0), GaussianFactorGraph(std::vector<GF>{mixture->factor(d0), prior}),
-      GaussianFactorGraph(std::vector<GF>{mixture->factor(d1), prior})};
+      M(0),
+      {GaussianFactorGraph(std::vector<GF>{mixture->factor(d0), prior}),
+       -0.225791 /* regression */},
+      {GaussianFactorGraph(std::vector<GF>{mixture->factor(d1), prior}),
+       -2.01755 /* regression */}};
 
-  EXPECT(assert_equal(expected(d0), sum(d0)));
+  EXPECT(assert_equal(expected(d0), sum(d0), 1e-5));
+  EXPECT(assert_equal(expected(d1), sum(d1), 1e-5));
 }
 
 /* ************************************************************************* */

--- a/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
@@ -133,7 +133,8 @@ TEST(HybridGaussianFactorGraph, eliminateFullSequentialEqualChance) {
   auto dc = result->at(2)->asDiscrete();
   DiscreteValues dv;
   dv[M(1)] = 0;
-  EXPECT_DOUBLES_EQUAL(1, dc->operator()(dv), 1e-3);
+  // regression
+  EXPECT_DOUBLES_EQUAL(8.5730017810851127, dc->operator()(dv), 1e-3);
 }
 
 /* ************************************************************************* */

--- a/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
@@ -658,7 +658,7 @@ TEST(HybridGaussianFactorGraph, EliminateTiny1) {
       tiny::createHybridGaussianFactorGraph(num_measurements, deterministic);
 
   // Create expected Bayes Net:
-  HybridBayesNet bayesNet;
+  HybridBayesNet expectedBayesNet;
 
   // Create Gaussian mixture on X(0).
   using tiny::mode;
@@ -668,17 +668,17 @@ TEST(HybridGaussianFactorGraph, EliminateTiny1) {
              conditional1 = boost::make_shared<GaussianConditional>(
                  X(0), Vector1(10.1379), I_1x1 * 2.02759);
   GaussianMixture gm({X(0)}, {}, {mode}, {conditional0, conditional1});
-  bayesNet.emplaceMixture(gm);  // copy :-(
+  expectedBayesNet.emplaceMixture(gm);  // copy :-(
 
   // Add prior on mode.
-  bayesNet.emplaceDiscrete(mode, "4/6");
+  expectedBayesNet.emplaceDiscrete(mode, "74/26");
 
   // Test elimination
   Ordering ordering;
   ordering.push_back(X(0));
   ordering.push_back(M(0));
   const auto posterior = fg.eliminateSequential(ordering);
-  EXPECT(assert_equal(bayesNet, *posterior, 1e-4));
+  EXPECT(assert_equal(expectedBayesNet, *posterior, 1e-4));
 }
 
 /* ****************************************************************************/
@@ -690,7 +690,7 @@ TEST(HybridGaussianFactorGraph, EliminateTiny2) {
       tiny::createHybridGaussianFactorGraph(num_measurements, deterministic);
 
   // Create expected Bayes Net:
-  HybridBayesNet bayesNet;
+  HybridBayesNet expectedBayesNet;
 
   // Create Gaussian mixture on X(0).
   using tiny::mode;
@@ -700,17 +700,17 @@ TEST(HybridGaussianFactorGraph, EliminateTiny2) {
              conditional1 = boost::make_shared<GaussianConditional>(
                  X(0), Vector1(10.3281), I_1x1 * 2.0548);
   GaussianMixture gm({X(0)}, {}, {mode}, {conditional0, conditional1});
-  bayesNet.emplaceMixture(gm);  // copy :-(
+  expectedBayesNet.emplaceMixture(gm);  // copy :-(
 
   // Add prior on mode.
-  bayesNet.emplaceDiscrete(mode, "4/6");
+  expectedBayesNet.emplaceDiscrete(mode, "4/6");
 
   // Test elimination
   Ordering ordering;
   ordering.push_back(X(0));
   ordering.push_back(M(0));
   const auto posterior = fg.eliminateSequential(ordering);
-  EXPECT(assert_equal(bayesNet, *posterior, 1e-4));
+  EXPECT(assert_equal(expectedBayesNet, *posterior, 1e-4));
 }
 
 /* ************************************************************************* */

--- a/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
@@ -653,12 +653,11 @@ TEST(HybridGaussianFactorGraph, SumFrontals) {
 
   // Create Gaussian mixture on X(0).
   using tiny::mode;
+  // regression, but mean checked to be 5.0 in both cases:
   const auto conditional0 = boost::make_shared<GaussianConditional>(
-      X(0), Vector1(12.7279),
-      I_1x1 * 2.82843);  // regression, but mean checked to be 4.5
-  const auto conditional1 = boost::make_shared<GaussianConditional>(
-      X(0), Vector1(10.0831),
-      I_1x1 * 2.02759);  // regression, but mean 4.97297is close to prior.
+                 X(0), Vector1(14.1421), I_1x1 * 2.82843),
+             conditional1 = boost::make_shared<GaussianConditional>(
+                 X(0), Vector1(10.1379), I_1x1 * 2.02759);
   GaussianMixture gm({X(0)}, {}, {mode}, {conditional0, conditional1});
   bayesNet.emplaceMixture(gm);  // copy :-(
 

--- a/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
@@ -638,9 +638,9 @@ TEST(HybridGaussianFactorGraph, SumFrontals) {
   GaussianMixture::Sum expected{
       M(0),
       {GaussianFactorGraph(std::vector<GF>{mixture->factor(d0), prior}),
-       -0.225791 /* regression */},
+       mixture->constant(d0)},
       {GaussianFactorGraph(std::vector<GF>{mixture->factor(d1), prior}),
-       -2.01755 /* regression */}};
+       mixture->constant(d1)}};
 
   EXPECT(assert_equal(expected(d0), sum(d0), 1e-5));
   EXPECT(assert_equal(expected(d1), sum(d1), 1e-5));

--- a/gtsam/hybrid/tests/testHybridGaussianISAM.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianISAM.cpp
@@ -177,19 +177,19 @@ TEST(HybridGaussianElimination, IncrementalInference) {
 
   // Test the probability values with regression tests.
   DiscreteValues assignment;
-  EXPECT(assert_equal(0.0619233, m00_prob, 1e-5));
+  EXPECT(assert_equal(0.000956191, m00_prob, 1e-5));
   assignment[M(0)] = 0;
   assignment[M(1)] = 0;
-  EXPECT(assert_equal(0.0619233, (*discreteConditional)(assignment), 1e-5));
+  EXPECT(assert_equal(0.000956191, (*discreteConditional)(assignment), 1e-5));
   assignment[M(0)] = 1;
   assignment[M(1)] = 0;
-  EXPECT(assert_equal(0.183743, (*discreteConditional)(assignment), 1e-5));
+  EXPECT(assert_equal(0.00283728, (*discreteConditional)(assignment), 1e-5));
   assignment[M(0)] = 0;
   assignment[M(1)] = 1;
-  EXPECT(assert_equal(0.204159, (*discreteConditional)(assignment), 1e-5));
+  EXPECT(assert_equal(0.00315253, (*discreteConditional)(assignment), 1e-5));
   assignment[M(0)] = 1;
   assignment[M(1)] = 1;
-  EXPECT(assert_equal(0.2, (*discreteConditional)(assignment), 1e-5));
+  EXPECT(assert_equal(0.00308831, (*discreteConditional)(assignment), 1e-5));
 
   // Check if the clique conditional generated from incremental elimination
   // matches that of batch elimination.
@@ -199,10 +199,10 @@ TEST(HybridGaussianElimination, IncrementalInference) {
       isam[M(1)]->conditional()->inner());
   // Account for the probability terms from evaluating continuous FGs
   DiscreteKeys discrete_keys = {{M(0), 2}, {M(1), 2}};
-  vector<double> probs = {0.061923317, 0.20415914, 0.18374323, 0.2};
+  vector<double> probs = {0.00095619114, 0.0031525308, 0.0028372777, 0.0030883072};
   auto expectedConditional =
       boost::make_shared<DecisionTreeFactor>(discrete_keys, probs);
-  EXPECT(assert_equal(*actualConditional, *expectedConditional, 1e-6));
+  EXPECT(assert_equal(*expectedConditional, *actualConditional, 1e-6));
 }
 
 /* ****************************************************************************/

--- a/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
@@ -638,22 +638,30 @@ conditional 2: Hybrid  P( x2 | m0 m1)
  0 0 Leaf  p(x2)
   R = [ 10.0494 ]
   d = [ -10.1489 ]
+  mean: 1 elements
+  x2: -1.0099
   No noise model
 
  0 1 Leaf  p(x2)
   R = [ 10.0494 ]
   d = [ -10.1479 ]
+  mean: 1 elements
+  x2: -1.0098
   No noise model
 
  1 Choice(m0) 
  1 0 Leaf  p(x2)
   R = [ 10.0494 ]
   d = [ -10.0504 ]
+  mean: 1 elements
+  x2: -1.0001
   No noise model
 
  1 1 Leaf  p(x2)
   R = [ 10.0494 ]
   d = [ -10.0494 ]
+  mean: 1 elements
+  x2: -1
   No noise model
 
 )";

--- a/gtsam/hybrid/tests/testHybridNonlinearISAM.cpp
+++ b/gtsam/hybrid/tests/testHybridNonlinearISAM.cpp
@@ -191,24 +191,23 @@ TEST(HybridNonlinearISAM, IncrementalInference) {
       *(*discreteBayesTree)[M(1)]->conditional()->asDiscrete();
   double m00_prob = decisionTree(m00);
 
-  auto discreteConditional =
-      bayesTree[M(1)]->conditional()->asDiscrete();
+  auto discreteConditional = bayesTree[M(1)]->conditional()->asDiscrete();
 
   // Test the probability values with regression tests.
   DiscreteValues assignment;
-  EXPECT(assert_equal(0.0619233, m00_prob, 1e-5));
+  EXPECT(assert_equal(0.000956191, m00_prob, 1e-5));
   assignment[M(0)] = 0;
   assignment[M(1)] = 0;
-  EXPECT(assert_equal(0.0619233, (*discreteConditional)(assignment), 1e-5));
+  EXPECT(assert_equal(0.000956191, (*discreteConditional)(assignment), 1e-5));
   assignment[M(0)] = 1;
   assignment[M(1)] = 0;
-  EXPECT(assert_equal(0.183743, (*discreteConditional)(assignment), 1e-5));
+  EXPECT(assert_equal(0.00283728, (*discreteConditional)(assignment), 1e-5));
   assignment[M(0)] = 0;
   assignment[M(1)] = 1;
-  EXPECT(assert_equal(0.204159, (*discreteConditional)(assignment), 1e-5));
+  EXPECT(assert_equal(0.00315253, (*discreteConditional)(assignment), 1e-5));
   assignment[M(0)] = 1;
   assignment[M(1)] = 1;
-  EXPECT(assert_equal(0.2, (*discreteConditional)(assignment), 1e-5));
+  EXPECT(assert_equal(0.00308831, (*discreteConditional)(assignment), 1e-5));
 
   // Check if the clique conditional generated from incremental elimination
   // matches that of batch elimination.
@@ -217,10 +216,10 @@ TEST(HybridNonlinearISAM, IncrementalInference) {
       bayesTree[M(1)]->conditional()->inner());
   // Account for the probability terms from evaluating continuous FGs
   DiscreteKeys discrete_keys = {{M(0), 2}, {M(1), 2}};
-  vector<double> probs = {0.061923317, 0.20415914, 0.18374323, 0.2};
+  vector<double> probs = {0.00095619114, 0.0031525308, 0.0028372777, 0.0030883072};
   auto expectedConditional =
       boost::make_shared<DecisionTreeFactor>(discrete_keys, probs);
-  EXPECT(assert_equal(*actualConditional, *expectedConditional, 1e-6));
+  EXPECT(assert_equal(*expectedConditional, *actualConditional, 1e-6));
 }
 
 /* ****************************************************************************/

--- a/gtsam/linear/GaussianConditional.cpp
+++ b/gtsam/linear/GaussianConditional.cpp
@@ -120,6 +120,10 @@ namespace gtsam {
         << endl;
     }
     cout << formatMatrixIndented("  d = ", getb(), true) << "\n";
+    if (nrParents() == 0) {
+      const auto mean = solve({});  // solve for mean.
+      mean.print("  mean");
+    }
     if (model_)
       model_->print("  Noise model: ");
     else

--- a/gtsam/linear/GaussianConditional.cpp
+++ b/gtsam/linear/GaussianConditional.cpp
@@ -67,7 +67,7 @@ namespace gtsam {
   GaussianConditional GaussianConditional::FromMeanAndStddev(Key key,
                                                              const Vector& mu,
                                                              double sigma) {
-    // |Rx - d| = |x-(Ay + b)|/sigma
+    // |Rx - d| = |x - mu|/sigma
     const Matrix R = Matrix::Identity(mu.size(), mu.size());
     const Vector& d = mu;
     return GaussianConditional(key, d, R,
@@ -189,7 +189,7 @@ double GaussianConditional::logNormalizationConstant() const {
 
 /* ************************************************************************* */
 //  density = k exp(-error(x))
-//  log = log(k) -error(x) - 0.5 * n*log(2*pi)
+//  log = log(k) -error(x)
 double GaussianConditional::logDensity(const VectorValues& x) const {
   return logNormalizationConstant() - error(x);
 }

--- a/gtsam/linear/tests/testGaussianConditional.cpp
+++ b/gtsam/linear/tests/testGaussianConditional.cpp
@@ -467,6 +467,31 @@ TEST(GaussianConditional, sample) {
 }
 
 /* ************************************************************************* */
+TEST(GaussianConditional, LogNormalizationConstant) {
+  // Create univariate standard gaussian conditional
+  auto std_gaussian =
+      GaussianConditional::FromMeanAndStddev(X(0), Vector1::Zero(), 1.0);
+  VectorValues values;
+  values.insert(X(0), Vector1::Zero());
+  double logDensity = std_gaussian.logDensity(values);
+
+  // Regression.
+  // These values were computed by hand for a univariate standard gaussian.
+  EXPECT_DOUBLES_EQUAL(-0.9189385332046727, logDensity, 1e-9);
+  EXPECT_DOUBLES_EQUAL(0.3989422804014327, exp(logDensity), 1e-9);
+
+  // Similar test for multivariate gaussian but with sigma 2.0
+  double sigma = 2.0;
+  auto conditional = GaussianConditional::FromMeanAndStddev(X(0), Vector3::Zero(), sigma);
+  VectorValues x;
+  x.insert(X(0), Vector3::Zero());
+  Matrix3 Sigma = I_3x3 * sigma * sigma;
+  double expectedLogNormalizingConstant = log(1 / sqrt((2 * M_PI * Sigma).determinant()));
+
+  EXPECT_DOUBLES_EQUAL(expectedLogNormalizingConstant, conditional.logNormalizationConstant(), 1e-9);
+}
+
+/* ************************************************************************* */
 TEST(GaussianConditional, Print) {
   Matrix A1 = (Matrix(2, 2) << 1., 2., 3., 4.).finished();
   Matrix A2 = (Matrix(2, 2) << 5., 6., 7., 8.).finished();

--- a/python/gtsam/tests/test_HybridFactorGraph.py
+++ b/python/gtsam/tests/test_HybridFactorGraph.py
@@ -18,9 +18,9 @@ from gtsam.utils.test_case import GtsamTestCase
 
 import gtsam
 from gtsam import (DiscreteConditional, DiscreteKeys, GaussianConditional,
-                   GaussianMixture, GaussianMixtureFactor, HybridBayesNet, HybridValues,
-                   HybridGaussianFactorGraph, JacobianFactor, Ordering,
-                   noiseModel)
+                   GaussianMixture, GaussianMixtureFactor, HybridBayesNet,
+                   HybridGaussianFactorGraph, HybridValues, JacobianFactor,
+                   Ordering, noiseModel)
 
 
 class TestHybridGaussianFactorGraph(GtsamTestCase):
@@ -96,16 +96,16 @@ class TestHybridGaussianFactorGraph(GtsamTestCase):
         mode = (M(0), 2)
 
         # Create Gaussian mixture Z(0) = X(0) + noise for each measurement.
-        I = np.eye(1)
+        I_1x1 = np.eye(1)
         keys = DiscreteKeys()
         keys.push_back(mode)
         for i in range(num_measurements):
             conditional0 = GaussianConditional.FromMeanAndStddev(Z(i),
-                                                                 I,
+                                                                 I_1x1,
                                                                  X(0), [0],
                                                                  sigma=0.5)
             conditional1 = GaussianConditional.FromMeanAndStddev(Z(i),
-                                                                 I,
+                                                                 I_1x1,
                                                                  X(0), [0],
                                                                  sigma=3)
             bayesNet.emplaceMixture([Z(i)], [X(0)], keys,
@@ -135,24 +135,27 @@ class TestHybridGaussianFactorGraph(GtsamTestCase):
         mean0.insert(Z(0), [5.0])
         mean0.insert(M(0), 0)
         self.assertAlmostEqual(bayesNet1.evaluate(mean0) /
-                               bayesNet2.evaluate(mean0), expected_ratio, delta=1e-9)
+                               bayesNet2.evaluate(mean0), expected_ratio,
+                               delta=1e-9)
         mean1 = HybridValues()
         mean1.insert(X(0), [5.0])
         mean1.insert(Z(0), [5.0])
         mean1.insert(M(0), 1)
         self.assertAlmostEqual(bayesNet1.evaluate(mean1) /
-                               bayesNet2.evaluate(mean1), expected_ratio, delta=1e-9)
+                               bayesNet2.evaluate(mean1), expected_ratio,
+                               delta=1e-9)
 
     @staticmethod
     def measurements(sample: HybridValues, indices) -> gtsam.VectorValues:
-        """Create measurements from a sample, grabbing Z(i) where i in indices."""
+        """Create measurements from a sample, grabbing Z(i) for indices."""
         measurements = gtsam.VectorValues()
         for i in indices:
             measurements.insert(Z(i), sample.at(Z(i)))
         return measurements
 
     @classmethod
-    def factor_graph_from_bayes_net(cls, bayesNet: HybridBayesNet, sample: HybridValues):
+    def factor_graph_from_bayes_net(cls, bayesNet: HybridBayesNet,
+                                    sample: HybridValues):
         """Create a factor graph from the Bayes net with sampled measurements.
             The factor graph is `P(x)P(n) ϕ(x, n; z0) ϕ(x, n; z1) ...`
             and thus represents the same joint probability as the Bayes net.
@@ -170,7 +173,7 @@ class TestHybridGaussianFactorGraph(GtsamTestCase):
     @classmethod
     def estimate_marginals(cls, target, proposal_density: HybridBayesNet,
                            N=10000):
-        """Do importance sampling to get an estimate of the discrete marginal P(mode)."""
+        """Do importance sampling to estimate discrete marginal P(mode)."""
         # Allocate space for marginals on mode.
         marginals = np.zeros((2,))
 
@@ -190,11 +193,11 @@ class TestHybridGaussianFactorGraph(GtsamTestCase):
 
     def test_tiny(self):
         """Test a tiny two variable hybrid model."""
-        prior_sigma = 0.5
         # P(x0)P(mode)P(z0|x0,mode)
+        prior_sigma = 0.5
         bayesNet = self.tiny(prior_sigma=prior_sigma)
 
-        # Deterministic values exactly at the mean, for both x and z:
+        # Deterministic values exactly at the mean, for both x and Z:
         values = HybridValues()
         values.insert(X(0), [5.0])
         values.insert(M(0), 0)  # low-noise, standard deviation 0.5
@@ -204,22 +207,20 @@ class TestHybridGaussianFactorGraph(GtsamTestCase):
         def unnormalized_posterior(x):
             """Posterior is proportional to joint, centered at 5.0 as well."""
             x.insert(Z(0), [z0])
-            # print(x)
             return bayesNet.evaluate(x)
 
         # Create proposal density on (x0, mode), making sure it has same mean:
         posterior_information = 1/(prior_sigma**2) + 1/(0.5**2)
         posterior_sigma = posterior_information**(-0.5)
-        print(f"Posterior sigma: {posterior_sigma}")
         proposal_density = self.tiny(
             num_measurements=0, prior_mean=5.0, prior_sigma=posterior_sigma)
 
         # Estimate marginals using importance sampling.
         marginals = self.estimate_marginals(
-            target=unnormalized_posterior, proposal_density=proposal_density, N=10_000)
-        print(f"True mode: {values.atDiscrete(M(0))}")
-        print(f"P(mode=0; z0) = {marginals[0]}")
-        print(f"P(mode=1; z0) = {marginals[1]}")
+            target=unnormalized_posterior, proposal_density=proposal_density)
+        # print(f"True mode: {values.atDiscrete(M(0))}")
+        # print(f"P(mode=0; Z) = {marginals[0]}")
+        # print(f"P(mode=1; Z) = {marginals[1]}")
 
         # Check that the estimate is close to the true value.
         self.assertAlmostEqual(marginals[0], 0.74, delta=0.01)
@@ -233,20 +234,18 @@ class TestHybridGaussianFactorGraph(GtsamTestCase):
         ordering.push_back(X(0))
         ordering.push_back(M(0))
         posterior = fg.eliminateSequential(ordering)
-        print(posterior)
 
         def true_posterior(x):
             """Posterior from elimination."""
             x.insert(Z(0), [z0])
-            # print(x)
             return posterior.evaluate(x)
 
         # Estimate marginals using importance sampling.
         marginals = self.estimate_marginals(
             target=true_posterior, proposal_density=proposal_density)
-        print(f"True mode: {values.atDiscrete(M(0))}")
-        print(f"P(mode=0; z0) = {marginals[0]}")
-        print(f"P(mode=1; z0) = {marginals[1]}")
+        # print(f"True mode: {values.atDiscrete(M(0))}")
+        # print(f"P(mode=0; z0) = {marginals[0]}")
+        # print(f"P(mode=1; z0) = {marginals[1]}")
 
         # Check that the estimate is close to the true value.
         self.assertAlmostEqual(marginals[0], 0.74, delta=0.01)
@@ -256,65 +255,65 @@ class TestHybridGaussianFactorGraph(GtsamTestCase):
     def calculate_ratio(bayesNet: HybridBayesNet,
                         fg: HybridGaussianFactorGraph,
                         sample: HybridValues):
-        """Calculate ratio  between Bayes net probability and the factor graph."""
-        return bayesNet.evaluate(sample) / fg.probPrime(sample) if fg.probPrime(sample) > 0 else 0
+        """Calculate ratio between Bayes net and factor graph."""
+        return bayesNet.evaluate(sample) / fg.probPrime(sample) if \
+            fg.probPrime(sample) > 0 else 0
 
-    @unittest.skip("This test is too slow.")
     def test_ratio(self):
         """
-        Given a tiny two variable hybrid model, with 2 measurements,
-        test the ratio of the bayes net model representing P(z, x, n)=P(z|x, n)P(x)P(n)
+        Given a tiny two variable hybrid model, with 2 measurements, test the
+        ratio of the bayes net model representing P(z,x,n)=P(z|x, n)P(x)P(n)
         and the factor graph P(x, n | z)=P(x | n, z)P(n|z),
         both of which represent the same posterior.
         """
-        # Create the Bayes net representing the generative model P(z, x, n)=P(z|x, n)P(x)P(n)
-        bayesNet = self.tiny(num_measurements=2)
-        # Sample from the Bayes net.
-        sample: HybridValues = bayesNet.sample()
-        # print(sample)
+        # Create generative model P(z, x, n)=P(z|x, n)P(x)P(n)
+        prior_sigma = 0.5
+        bayesNet = self.tiny(prior_sigma=prior_sigma, num_measurements=2)
 
-        # Deterministic measurements:
-        deterministic = gtsam.VectorValues()
-        deterministic.insert(Z(0), [5.0])
-        deterministic.insert(Z(1), [5.1])
-        sample.update(deterministic)
+        # Deterministic values exactly at the mean, for both x and Z:
+        values = HybridValues()
+        values.insert(X(0), [5.0])
+        values.insert(M(0), 0)  # high-noise, standard deviation 3
+        measurements = gtsam.VectorValues()
+        measurements.insert(Z(0), [4.0])
+        measurements.insert(Z(1), [6.0])
+        values.insert(measurements)
+
+        def unnormalized_posterior(x):
+            """Posterior is proportional to joint, centered at 5.0 as well."""
+            x.insert(measurements)
+            return bayesNet.evaluate(x)
+
+        # Create proposal density on (x0, mode), making sure it has same mean:
+        posterior_information = 1/(prior_sigma**2) + 2.0/(3.0**2)
+        posterior_sigma = posterior_information**(-0.5)
+        proposal_density = self.tiny(
+            num_measurements=0, prior_mean=5.0, prior_sigma=posterior_sigma)
 
         # Estimate marginals using importance sampling.
-        marginals = self.estimate_marginals(bayesNet, sample, N=10000)
-        print(f"True mode: {sample.atDiscrete(M(0))}")
-        print(f"P(mode=0; z0, z1) = {marginals[0]}")
-        print(f"P(mode=1; z0, z1) = {marginals[1]}")
+        marginals = self.estimate_marginals(
+            target=unnormalized_posterior, proposal_density=proposal_density)
+        # print(f"True mode: {values.atDiscrete(M(0))}")
+        # print(f"P(mode=0; Z) = {marginals[0]}")
+        # print(f"P(mode=1; Z) = {marginals[1]}")
 
-        # Check marginals based on sampled mode.
-        if sample.atDiscrete(M(0)) == 0:
-            self.assertGreater(marginals[0], marginals[1])
-        else:
-            self.assertGreater(marginals[1], marginals[0])
+        # Check that the estimate is close to the true value.
+        self.assertAlmostEqual(marginals[0], 0.23, delta=0.01)
+        self.assertAlmostEqual(marginals[1], 0.77, delta=0.01)
 
-        fg = self.factor_graph_from_bayes_net(bayesNet, sample)
+        # Convert to factor graph using measurements.
+        fg = self.factor_graph_from_bayes_net(bayesNet, values)
         self.assertEqual(fg.size(), 4)
 
-        # Create measurements from the sample.
-        measurements = self.measurements(sample, [0, 1])
-        print(measurements)
-
         # Calculate ratio between Bayes net probability and the factor graph:
-        expected_ratio = self.calculate_ratio(bayesNet, fg, sample)
+        expected_ratio = self.calculate_ratio(bayesNet, fg, values)
         # print(f"expected_ratio: {expected_ratio}\n")
-
-        # Print conditional and factor values side by side:
-        print("\nConditional and factor values:")
-        for i in range(4):
-            print(f"Conditional {i}:")
-            print(bayesNet.at(i).error(sample))
-            print(f"Factor {i}:")
-            print(fg.at(i).error(sample))
 
         # Check with a number of other samples.
         for i in range(10):
-            other = bayesNet.sample()
-            other.update(measurements)
-            ratio = self.calculate_ratio(bayesNet, fg, other)
+            samples = bayesNet.sample()
+            samples.update(measurements)
+            ratio = self.calculate_ratio(bayesNet, fg, samples)
             # print(f"Ratio: {ratio}\n")
             if (ratio > 0):
                 self.assertAlmostEqual(ratio, expected_ratio)
@@ -324,18 +323,17 @@ class TestHybridGaussianFactorGraph(GtsamTestCase):
         ordering.push_back(X(0))
         ordering.push_back(M(0))
         posterior = fg.eliminateSequential(ordering)
-        print(posterior)
 
         # Calculate ratio between Bayes net probability and the factor graph:
-        expected_ratio = self.calculate_ratio(posterior, fg, sample)
-        print(f"expected_ratio: {expected_ratio}\n")
+        expected_ratio = self.calculate_ratio(posterior, fg, values)
+        # print(f"expected_ratio: {expected_ratio}\n")
 
         # Check with a number of other samples.
         for i in range(10):
-            other = posterior.sample()
-            other.insert(measurements)
-            ratio = self.calculate_ratio(posterior, fg, other)
-            print(f"Ratio: {ratio}\n")
+            samples = posterior.sample()
+            samples.insert(measurements)
+            ratio = self.calculate_ratio(posterior, fg, samples)
+            # print(f"Ratio: {ratio}\n")
             if (ratio > 0):
                 self.assertAlmostEqual(ratio, expected_ratio)
 

--- a/python/gtsam/tests/test_HybridFactorGraph.py
+++ b/python/gtsam/tests/test_HybridFactorGraph.py
@@ -205,9 +205,9 @@ class TestHybridGaussianFactorGraph(GtsamTestCase):
 
         # Estimate marginals using importance sampling.
         marginals = self.estimate_marginals(bayesNet, sample)
-        # print(f"True mode: {sample.atDiscrete(M(0))}")
-        # print(f"P(mode=0; z0, z1) = {marginals[0]}")
-        # print(f"P(mode=1; z0, z1) = {marginals[1]}")
+        print(f"True mode: {sample.atDiscrete(M(0))}")
+        print(f"P(mode=0; z0, z1) = {marginals[0]}")
+        print(f"P(mode=1; z0, z1) = {marginals[1]}")
 
         # Check marginals based on sampled mode.
         if sample.atDiscrete(M(0)) == 0:
@@ -251,8 +251,8 @@ class TestHybridGaussianFactorGraph(GtsamTestCase):
             other.insert(measurements)
             ratio = self.calculate_ratio(posterior, fg, other)
             print(f"Ratio: {ratio}\n")
-            # if (ratio > 0):
-            #     self.assertAlmostEqual(ratio, expected_ratio)
+            if (ratio > 0):
+                self.assertAlmostEqual(ratio, expected_ratio)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- added tiny example in c++
- made SumFrontals a method
- added test for SumFrontals
- added test for elimination in python, and *it works* (now we need to move to the next simplest example):
- below shows estimate of marginals, which match the eliminated result! And rations of posterior resulting from elimination also match! Awesome job :-)
```
..True mode: 0
P(mode=0; z0, z1) = 0.776760546738582
P(mode=1; z0, z1) = 0.22323945326141803
HybridBayesNet
 
size: 2
conditional 0: Hybrid  P( x0 | m0)
 Discrete Keys = (m0, 2), 
 Choice(m0) 
 0 Leaf  p(x0)
  R = [ 2.83549 ]
  d = [ 33.4989 ]
  mean: 1 elements
  x0: 11.8142
  No noise model

 1 Leaf  p(x0)
  R = [ 0.512076 ]
  d = [ 5.53226 ]
  mean: 1 elements
  x0: 10.8036
  No noise model

conditional 1:  P( m0 ):
 Choice(m0) 
 0 Leaf 0.76887015
 1 Leaf 0.23112985

expected_ratio: 9.889012746635817

Ratio: 9.889012746635933
Ratio: 9.889012746636144
Ratio: 9.889012746635778
Ratio: 9.889012746633508
Ratio: 9.889012746635919
Ratio: 9.889012746635949
Ratio: 9.889012746633531
Ratio: 9.889012746633517
Ratio: 9.889012746633536
Ratio: 9.889012746635643
```