### PR TITLE
Two new tests, one with 5 modes

### DIFF
--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -229,6 +229,12 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
   AlgebraicDecisionTree<Key> probPrime(
       const VectorValues &continuousValues) const;
 
+  /**
+   * Convert a hybrid Bayes net to a hybrid Gaussian factor graph by converting
+   * all conditionals with instantiated measurements into likelihood factors.
+   */
+  HybridGaussianFactorGraph toFactorGraph(
+      const VectorValues &measurements) const;
   /// @}
 
  private:

--- a/gtsam/hybrid/HybridConditional.h
+++ b/gtsam/hybrid/HybridConditional.h
@@ -178,6 +178,16 @@ class GTSAM_EXPORT HybridConditional
   /// Return the error of the underlying conditional.
   double error(const HybridValues& values) const override;
 
+  /// Check if VectorValues `measurements` contains all frontal keys.
+  bool frontalsIn(const VectorValues& measurements) const {
+    for (Key key : frontals()) {
+      if (!measurements.exists(key)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   /// @}
 
  private:

--- a/gtsam/hybrid/tests/TinyHybridExample.h
+++ b/gtsam/hybrid/tests/TinyHybridExample.h
@@ -33,15 +33,15 @@ const DiscreteKey mode{M(0), 2};
 /**
  * Create a tiny two variable hybrid model which represents
  * the generative probability P(z,x,mode) = P(z|x,mode)P(x)P(mode).
- * numMeasurements is the number of measurements of the continuous variable x0.
+ * num_measurements is the number of measurements of the continuous variable x0.
  * If manyModes is true, then we introduce one mode per measurement.
  */
-inline HybridBayesNet createHybridBayesNet(int numMeasurements = 1,
+inline HybridBayesNet createHybridBayesNet(int num_measurements = 1,
                                            bool manyModes = false) {
   HybridBayesNet bayesNet;
 
   // Create Gaussian mixture z_i = x0 + noise for each measurement.
-  for (int i = 0; i < numMeasurements; i++) {
+  for (int i = 0; i < num_measurements; i++) {
     const auto mode_i = manyModes ? DiscreteKey{M(i), 2} : mode;
     GaussianMixture gm({Z(i)}, {X(0)}, {mode_i},
                        {GaussianConditional::sharedMeanAndStddev(
@@ -56,7 +56,7 @@ inline HybridBayesNet createHybridBayesNet(int numMeasurements = 1,
       GaussianConditional::sharedMeanAndStddev(X(0), Vector1(5.0), 0.5));
 
   // Add prior on mode.
-  const size_t nrModes = manyModes ? numMeasurements : 1;
+  const size_t nrModes = manyModes ? num_measurements : 1;
   for (int i = 0; i < nrModes; i++) {
     bayesNet.emplaceDiscrete(DiscreteKey{M(i), 2}, "4/6");
   }
@@ -67,13 +67,13 @@ inline HybridBayesNet createHybridBayesNet(int numMeasurements = 1,
  * Create a tiny two variable hybrid factor graph which represents a discrete
  * mode and a continuous variable x0, given a number of measurements of the
  * continuous variable x0. If no measurements are given, they are sampled from
- * the generative Bayes net model HybridBayesNet::Example(numMeasurements)
+ * the generative Bayes net model HybridBayesNet::Example(num_measurements)
  */
 inline HybridGaussianFactorGraph createHybridGaussianFactorGraph(
-    int numMeasurements = 1,
+    int num_measurements = 1,
     boost::optional<VectorValues> measurements = boost::none,
     bool manyModes = false) {
-  auto bayesNet = createHybridBayesNet(numMeasurements, manyModes);
+  auto bayesNet = createHybridBayesNet(num_measurements, manyModes);
   if (measurements) {
     // Use the measurements to create a hybrid factor graph.
     return bayesNet.toFactorGraph(*measurements);

--- a/gtsam/hybrid/tests/TinyHybridExample.h
+++ b/gtsam/hybrid/tests/TinyHybridExample.h
@@ -42,19 +42,18 @@ inline HybridBayesNet createHybridBayesNet(int numMeasurements = 1,
 
   // Create Gaussian mixture z_i = x0 + noise for each measurement.
   for (int i = 0; i < numMeasurements; i++) {
-    const auto conditional0 = boost::make_shared<GaussianConditional>(
-        GaussianConditional::FromMeanAndStddev(Z(i), I_1x1, X(0), Z_1x1, 0.5));
-    const auto conditional1 = boost::make_shared<GaussianConditional>(
-        GaussianConditional::FromMeanAndStddev(Z(i), I_1x1, X(0), Z_1x1, 3));
     const auto mode_i = manyModes ? DiscreteKey{M(i), 2} : mode;
-    GaussianMixture gm({Z(i)}, {X(0)}, {mode_i}, {conditional0, conditional1});
+    GaussianMixture gm({Z(i)}, {X(0)}, {mode_i},
+                       {GaussianConditional::sharedMeanAndStddev(
+                            Z(i), I_1x1, X(0), Z_1x1, 0.5),
+                        GaussianConditional::sharedMeanAndStddev(
+                            Z(i), I_1x1, X(0), Z_1x1, 3)});
     bayesNet.emplaceMixture(gm);  // copy :-(
   }
 
   // Create prior on X(0).
-  const auto prior_on_x0 =
-      GaussianConditional::FromMeanAndStddev(X(0), Vector1(5.0), 0.5);
-  bayesNet.emplaceGaussian(prior_on_x0);  // copy :-(
+  bayesNet.addGaussian(
+      GaussianConditional::sharedMeanAndStddev(X(0), Vector1(5.0), 0.5));
 
   // Add prior on mode.
   const size_t nrModes = manyModes ? numMeasurements : 1;

--- a/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
@@ -735,7 +735,7 @@ TEST(HybridGaussianFactorGraph, EliminateTiny22) {
   // Create Bayes net and convert to factor graph.
   auto bn = tiny::createHybridBayesNet(numMeasurements, manyModes);
   const VectorValues measurements{{Z(0), Vector1(4.0)}, {Z(1), Vector1(6.0)}};
-  auto fg = tiny::convertBayesNet(bn, measurements);
+  auto fg = bn.toFactorGraph(measurements);
   EXPECT_LONGS_EQUAL(5, fg.size());
 
   // Test elimination

--- a/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
@@ -621,9 +621,9 @@ TEST(HybridGaussianFactorGraph, ErrorAndProbPrimeTree) {
 // assignment.
 TEST(HybridGaussianFactorGraph, assembleGraphTree) {
   using symbol_shorthand::Z;
-  const int numMeasurements = 1;
+  const int num_measurements = 1;
   auto fg = tiny::createHybridGaussianFactorGraph(
-      numMeasurements, VectorValues{{Z(0), Vector1(5.0)}});
+      num_measurements, VectorValues{{Z(0), Vector1(5.0)}});
   EXPECT_LONGS_EQUAL(3, fg.size());
 
   // Assemble graph tree:
@@ -662,9 +662,9 @@ TEST(HybridGaussianFactorGraph, assembleGraphTree) {
 // Check that eliminating tiny net with 1 measurement yields correct result.
 TEST(HybridGaussianFactorGraph, EliminateTiny1) {
   using symbol_shorthand::Z;
-  const int numMeasurements = 1;
+  const int num_measurements = 1;
   auto fg = tiny::createHybridGaussianFactorGraph(
-      numMeasurements, VectorValues{{Z(0), Vector1(5.0)}});
+      num_measurements, VectorValues{{Z(0), Vector1(5.0)}});
   EXPECT_LONGS_EQUAL(3, fg.size());
 
   // Create expected Bayes Net:
@@ -696,9 +696,9 @@ TEST(HybridGaussianFactorGraph, EliminateTiny1) {
 TEST(HybridGaussianFactorGraph, EliminateTiny2) {
   // Create factor graph with 2 measurements such that posterior mean = 5.0.
   using symbol_shorthand::Z;
-  const int numMeasurements = 2;
+  const int num_measurements = 2;
   auto fg = tiny::createHybridGaussianFactorGraph(
-      numMeasurements,
+      num_measurements,
       VectorValues{{Z(0), Vector1(4.0)}, {Z(1), Vector1(6.0)}});
   EXPECT_LONGS_EQUAL(4, fg.size());
 
@@ -731,11 +731,11 @@ TEST(HybridGaussianFactorGraph, EliminateTiny2) {
 TEST(HybridGaussianFactorGraph, EliminateTiny22) {
   // Create factor graph with 2 measurements such that posterior mean = 5.0.
   using symbol_shorthand::Z;
-  const int numMeasurements = 2;
+  const int num_measurements = 2;
   const bool manyModes = true;
 
   // Create Bayes net and convert to factor graph.
-  auto bn = tiny::createHybridBayesNet(numMeasurements, manyModes);
+  auto bn = tiny::createHybridBayesNet(num_measurements, manyModes);
   const VectorValues measurements{{Z(0), Vector1(4.0)}, {Z(1), Vector1(6.0)}};
   auto fg = bn.toFactorGraph(measurements);
   EXPECT_LONGS_EQUAL(5, fg.size());

--- a/gtsam/linear/GaussianConditional.cpp
+++ b/gtsam/linear/GaussianConditional.cpp
@@ -263,7 +263,7 @@ double GaussianConditional::evaluate(const VectorValues& x) const {
     Vector frontalVec = gy.vector(KeyVector(beginFrontals(), endFrontals()));
     frontalVec = R().transpose().triangularView<Eigen::Lower>().solve(frontalVec);
 
-    // Check for indeterminant solution
+    // Check for indeterminate solution
     if (frontalVec.hasNaN()) throw IndeterminantLinearSystemException(this->keys().front());
 
     for (const_iterator it = beginParents(); it!= endParents(); it++)

--- a/gtsam/linear/GaussianConditional.h
+++ b/gtsam/linear/GaussianConditional.h
@@ -100,6 +100,12 @@ namespace gtsam {
                                                  const Matrix& A2, Key parent2,
                                                  const Vector& b, double sigma);
 
+    /// Create shared pointer by forwarding arguments to fromMeanAndStddev.
+    template<typename... Args>
+    static shared_ptr sharedMeanAndStddev(Args&&... args) {
+      return boost::make_shared<This>(FromMeanAndStddev(std::forward<Args>(args)...));
+    }
+
     /** Combine several GaussianConditional into a single dense GC.  The conditionals enumerated by
     *   \c first and \c last must be in increasing order, meaning that the parents of any
     *   conditional may not include a conditional coming before it.


### PR DESCRIPTION
Added two examples;

- variant of tiny with one mode per measurement
- variant of switching with one mode per measurement

Also 
- made converting to FG a method, `toFactorGraph`
- added `sharedMeanAndStddev` in `GaussianConditional` to make BNs easier to create. 

Works like a charm - at least ratio tests do.