### PR TITLE
New-style Errors

### DIFF
--- a/gtsam/linear/Errors.cpp
+++ b/gtsam/linear/Errors.cpp
@@ -26,19 +26,18 @@ using namespace std;
 namespace gtsam {
 
 /* ************************************************************************* */
-Errors::Errors(){}
-
-/* ************************************************************************* */
-Errors::Errors(const VectorValues& V) {
-  for(const Vector& e: V | boost::adaptors::map_values) {
-    push_back(e);
+Errors createErrors(const VectorValues& V) {
+  Errors result;
+  for (const Vector& e : V | boost::adaptors::map_values) {
+    result.push_back(e);
   }
+  return result;
 }
 
 /* ************************************************************************* */
-void Errors::print(const std::string& s) const {
+void print(const Errors& e, const string& s) {
   cout << s << endl;
-  for(const Vector& v: *this)
+  for(const Vector& v: e)
     gtsam::print(v);
 }
 
@@ -51,49 +50,48 @@ struct equalsVector : public std::function<bool(const Vector&, const Vector&)> {
   }
 };
 
-bool Errors::equals(const Errors& expected, double tol) const {
-  if( size() != expected.size() ) return false;
-  return equal(begin(),end(),expected.begin(),equalsVector(tol));
+bool equality(const Errors& actual, const Errors& expected, double tol) {
+  if (actual.size() != expected.size()) return false;
+  return equal(actual.begin(), actual.end(), expected.begin(),
+               equalsVector(tol));
 }
 
 /* ************************************************************************* */
-Errors Errors::operator+(const Errors& b) const {
+Errors operator+(const Errors& a, const Errors& b) {
 #ifndef NDEBUG
-  size_t m = size();
+  size_t m = a.size();
   if (b.size()!=m)
     throw(std::invalid_argument("Errors::operator+: incompatible sizes"));
 #endif
   Errors result;
   Errors::const_iterator it = b.begin();
-    for(const Vector& ai: *this)
+    for(const Vector& ai: a)
     result.push_back(ai + *(it++));
   return result;
 }
 
 
 /* ************************************************************************* */
-Errors Errors::operator-(const Errors& b) const {
+Errors operator-(const Errors& a, const Errors& b) {
 #ifndef NDEBUG
-  size_t m = size();
+  size_t m = a.size();
   if (b.size()!=m)
     throw(std::invalid_argument("Errors::operator-: incompatible sizes"));
 #endif
   Errors result;
   Errors::const_iterator it = b.begin();
-  for(const Vector& ai: *this)
+  for(const Vector& ai: a)
     result.push_back(ai - *(it++));
   return result;
 }
 
 /* ************************************************************************* */
-Errors Errors::operator-() const {
+Errors operator-(const Errors& a) {
   Errors result;
-  for(const Vector& ai: *this)
+  for(const Vector& ai: a)
     result.push_back(-ai);
   return result;
 }
-
-
 
 /* ************************************************************************* */
 double dot(const Errors& a, const Errors& b) {
@@ -105,7 +103,7 @@ double dot(const Errors& a, const Errors& b) {
   double result = 0.0;
   Errors::const_iterator it = b.begin();
   for(const Vector& ai: a)
-    result += gtsam::dot(ai, *(it++));
+    result += gtsam::dot<Vector,Vector>(ai, *(it++));
   return result;
 }
 
@@ -114,11 +112,6 @@ void axpy(double alpha, const Errors& x, Errors& y) {
   Errors::const_iterator it = x.begin();
   for(Vector& yi: y)
     yi += alpha * (*(it++));
-}
-
-/* ************************************************************************* */
-void print(const Errors& a, const string& s) {
-  a.print(s);
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/Errors.h
+++ b/gtsam/linear/Errors.h
@@ -20,59 +20,54 @@
 #pragma once
 
 #include <gtsam/base/FastList.h>
-#include <gtsam/base/Vector.h>
 #include <gtsam/base/Testable.h>
+#include <gtsam/base/Vector.h>
 
 #include <string>
 
 namespace gtsam {
 
-  // Forward declarations
-  class VectorValues;
+// Forward declarations
+class VectorValues;
 
-  /** vector of errors */
-  class Errors : public FastList<Vector> {
+/// Errors is a vector of errors.
+using Errors = FastList<Vector>;
 
-  public:
+/// Break V into pieces according to its start indices.
+GTSAM_EXPORT Errors createErrors(const VectorValues& V);
 
-    GTSAM_EXPORT Errors() ;
+/// Print an Errors instance.
+GTSAM_EXPORT void print(const Errors& e, const std::string& s = "Errors");
 
-    /** break V into pieces according to its start indices */
-    GTSAM_EXPORT Errors(const VectorValues&V);
+// Check equality for unit testing.
+GTSAM_EXPORT bool equality(const Errors& actual, const Errors& expected,
+                           double tol = 1e-9);
 
-    /** print */
-    GTSAM_EXPORT void print(const std::string& s = "Errors") const;
+/// Addition.
+GTSAM_EXPORT Errors operator+(const Errors& a, const Errors& b);
 
-    /** equals, for unit testing */
-    GTSAM_EXPORT bool equals(const Errors& expected, double tol=1e-9) const;
+/// Subtraction.
+GTSAM_EXPORT Errors operator-(const Errors& a, const Errors& b);
 
-    /** Addition */
-    GTSAM_EXPORT Errors operator+(const Errors& b) const;
+/// Negation.
+GTSAM_EXPORT Errors operator-(const Errors& a);
 
-    /** subtraction */
-    GTSAM_EXPORT Errors operator-(const Errors& b) const;
+/// Dot product.
+GTSAM_EXPORT double dot(const Errors& a, const Errors& b);
 
-    /** negation */
-    GTSAM_EXPORT Errors operator-() const ;
+/// BLAS level 2 style AXPY, `y := alpha*x + y`
+GTSAM_EXPORT void axpy(double alpha, const Errors& x, Errors& y);
 
-  }; // Errors
+/// traits
+template <>
+struct traits<Errors> {
+  static void Print(const Errors& e, const std::string& str = "") {
+    print(e, str);
+  }
+  static bool Equals(const Errors& actual, const Errors& expected,
+                     double tol = 1e-8) {
+    return equality(actual, expected, tol);
+  }
+};
 
-  /**
-  * dot product
-  */
-  GTSAM_EXPORT double dot(const Errors& a, const Errors& b);
-
-  /**
-  * BLAS level 2 style
-  */
-  GTSAM_EXPORT void axpy(double alpha, const Errors& x, Errors& y);
-
-  /** print with optional string */
-  GTSAM_EXPORT void print(const Errors& a, const std::string& s = "Error");
-
-  /// traits
-  template<>
-  struct traits<Errors> : public Testable<Errors> {
-  };
-
-} //\ namespace gtsam
+}  // namespace gtsam

--- a/gtsam/linear/SubgraphPreconditioner.cpp
+++ b/gtsam/linear/SubgraphPreconditioner.cpp
@@ -110,7 +110,7 @@ VectorValues SubgraphPreconditioner::x(const VectorValues& y) const {
 
 /* ************************************************************************* */
 double SubgraphPreconditioner::error(const VectorValues& y) const {
-  Errors e(y);
+  Errors e = createErrors(y);
   VectorValues x = this->x(y);
   Errors e2 = Ab2_.gaussianErrors(x);
   return 0.5 * (dot(e, e) + dot(e2,e2));
@@ -129,7 +129,7 @@ VectorValues SubgraphPreconditioner::gradient(const VectorValues &y) const {
 /* ************************************************************************* */
 // Apply operator A, A*y = [I;A2*inv(R1)]*y = [y; A2*inv(R1)*y]
 Errors SubgraphPreconditioner::operator*(const VectorValues &y) const {
-  Errors e(y);
+  Errors e = createErrors(y);
   VectorValues x = Rc1_.backSubstitute(y); /* x=inv(R1)*y */
   Errors e2 = Ab2_ * x;                      /* A2*x */
   e.splice(e.end(), e2);


### PR DESCRIPTION
In an effort to get past the Windows compilation problems on #1375, and, because "friends don't let friends inherit from STL containers", here is an attempt to define `Errors` as a typedef to `FastList<Vector>`.

This might still run into the same problem of needing a compare operator for `merge` on Windows, we'll see in CI...

Thanks @gchenfc for your help in identifying the issue.