### PR TITLE
Harmonized error/logProbability in entire Factor/Conditional hierarchy

### DIFF
--- a/gtsam/discrete/DecisionTreeFactor.cpp
+++ b/gtsam/discrete/DecisionTreeFactor.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <gtsam/base/FastSet.h>
+#include <gtsam/hybrid/HybridValues.h>
 #include <gtsam/discrete/DecisionTreeFactor.h>
 #include <gtsam/discrete/DiscreteConditional.h>
 
@@ -54,6 +55,16 @@ namespace gtsam {
       const auto& f(static_cast<const DecisionTreeFactor&>(other));
       return ADT::equals(f, tol);
     }
+  }
+
+  /* ************************************************************************ */
+  double DecisionTreeFactor::error(const DiscreteValues& values) const {
+    return -std::log(evaluate(values));
+  }
+  
+  /* ************************************************************************ */
+  double DecisionTreeFactor::error(const HybridValues& values) const {
+    return error(values.discrete());
   }
 
   /* ************************************************************************ */

--- a/gtsam/discrete/DecisionTreeFactor.h
+++ b/gtsam/discrete/DecisionTreeFactor.h
@@ -34,6 +34,7 @@
 namespace gtsam {
 
   class DiscreteConditional;
+  class HybridValues;
 
   /**
    * A discrete probabilistic factor.
@@ -97,10 +98,19 @@ namespace gtsam {
     /// @name Standard Interface
     /// @{
 
-    /// Value is just look up in AlgebraicDecisionTree.
+    /// Calculate probability for given values `x`, 
+    /// is just look up in AlgebraicDecisionTree.
+    double evaluate(const DiscreteValues& values) const  {
+      return ADT::operator()(values);
+    }
+
+    /// Evaluate probability density, sugar.
     double operator()(const DiscreteValues& values) const override {
       return ADT::operator()(values);
     }
+
+    /// Calculate error for DiscreteValues `x`, is -log(probability).
+    double error(const DiscreteValues& values) const;
 
     /// multiply two factors
     DecisionTreeFactor operator*(const DecisionTreeFactor& f) const override {
@@ -230,7 +240,17 @@ namespace gtsam {
     std::string html(const KeyFormatter& keyFormatter = DefaultKeyFormatter,
                     const Names& names = {}) const override;
 
-    /// @}
+  /// @}
+  /// @name HybridValues methods.
+  /// @{
+
+  /**
+   * Calculate error for HybridValues `x`, is -log(probability)
+   * Simply dispatches to DiscreteValues version.
+   */
+  double error(const HybridValues& values) const override;
+
+  /// @}
 
    private:
     /** Serialization function */

--- a/gtsam/discrete/DecisionTreeFactor.h
+++ b/gtsam/discrete/DecisionTreeFactor.h
@@ -97,7 +97,7 @@ namespace gtsam {
     /// @name Standard Interface
     /// @{
 
-    /// Value is just look up in AlgebraicDecisonTree
+    /// Value is just look up in AlgebraicDecisionTree.
     double operator()(const DiscreteValues& values) const override {
       return ADT::operator()(values);
     }

--- a/gtsam/discrete/DiscreteBayesNet.cpp
+++ b/gtsam/discrete/DiscreteBayesNet.cpp
@@ -34,6 +34,15 @@ bool DiscreteBayesNet::equals(const This& bn, double tol) const {
 }
 
 /* ************************************************************************* */
+double DiscreteBayesNet::logProbability(const DiscreteValues& values) const {
+  // evaluate all conditionals and add
+  double result = 0.0;
+  for (const DiscreteConditional::shared_ptr& conditional : *this)
+    result += conditional->logProbability(values);
+  return result;
+}
+
+/* ************************************************************************* */
 double DiscreteBayesNet::evaluate(const DiscreteValues& values) const {
   // evaluate all conditionals and multiply
   double result = 1.0;

--- a/gtsam/discrete/DiscreteBayesNet.h
+++ b/gtsam/discrete/DiscreteBayesNet.h
@@ -103,6 +103,9 @@ class GTSAM_EXPORT DiscreteBayesNet: public BayesNet<DiscreteConditional> {
       return evaluate(values);
     }
 
+    //** log(evaluate(values)) for given DiscreteValues */
+    double logProbability(const DiscreteValues & values) const;
+
     /**
      * @brief do ancestral sampling
      *
@@ -136,7 +139,15 @@ class GTSAM_EXPORT DiscreteBayesNet: public BayesNet<DiscreteConditional> {
     std::string html(const KeyFormatter& keyFormatter = DefaultKeyFormatter,
                      const DiscreteFactor::Names& names = {}) const;
 
-    ///@}
+    /// @}
+    /// @name HybridValues methods.
+    /// @{
+
+    using Base::error;     // Expose error(const HybridValues&) method..
+    using Base::evaluate;  // Expose evaluate(const HybridValues&) method..
+    using Base::logProbability;  // Expose logProbability(const HybridValues&)
+
+    /// @}
 
 #ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V42
     /// @name Deprecated functionality

--- a/gtsam/discrete/DiscreteConditional.h
+++ b/gtsam/discrete/DiscreteConditional.h
@@ -18,9 +18,9 @@
 
 #pragma once
 
+#include <gtsam/inference/Conditional-inst.h>
 #include <gtsam/discrete/DecisionTreeFactor.h>
 #include <gtsam/discrete/Signature.h>
-#include <gtsam/inference/Conditional.h>
 
 #include <boost/make_shared.hpp>
 #include <boost/shared_ptr.hpp>
@@ -147,6 +147,11 @@ class GTSAM_EXPORT DiscreteConditional
   /// @name Standard Interface
   /// @{
 
+  /// Log-probability is just -error(x).
+  double logProbability(const DiscreteValues& x) const  {
+    return -error(x);
+  }
+
   /// print index signature only
   void printSignature(
       const std::string& s = "Discrete Conditional: ",
@@ -224,6 +229,21 @@ class GTSAM_EXPORT DiscreteConditional
   /// Render as html table.
   std::string html(const KeyFormatter& keyFormatter = DefaultKeyFormatter,
                    const Names& names = {}) const override;
+
+
+  /// @}
+  /// @name HybridValues methods.
+  /// @{
+
+  /**
+   * Calculate log-probability log(evaluate(x)) for HybridValues `x`.
+   * This is actually just -error(x).
+   */
+  double logProbability(const HybridValues& x) const override {
+    return -error(x);
+  }
+
+  using DecisionTreeFactor::evaluate;
 
   /// @}
 

--- a/gtsam/discrete/DiscreteFactor.cpp
+++ b/gtsam/discrete/DiscreteFactor.cpp
@@ -19,6 +19,7 @@
 
 #include <gtsam/base/Vector.h>
 #include <gtsam/discrete/DiscreteFactor.h>
+#include <gtsam/hybrid/HybridValues.h>
 
 #include <cmath>
 #include <sstream>
@@ -26,6 +27,21 @@
 using namespace std;
 
 namespace gtsam {
+
+/* ************************************************************************* */
+const DiscreteValues& GetDiscreteValues(const HybridValues& c) {
+  return c.discrete();
+}
+
+/* ************************************************************************* */
+double DiscreteFactor::error(const DiscreteValues& values) const {
+  return -std::log((*this)(values));
+}
+
+/* ************************************************************************* */
+double DiscreteFactor::error(const HybridValues& c) const {
+  return DiscreteFactor::error(GetDiscreteValues(c));
+}
 
 /* ************************************************************************* */
 std::vector<double> expNormalize(const std::vector<double>& logProbs) {

--- a/gtsam/discrete/DiscreteFactor.cpp
+++ b/gtsam/discrete/DiscreteFactor.cpp
@@ -29,18 +29,13 @@ using namespace std;
 namespace gtsam {
 
 /* ************************************************************************* */
-const DiscreteValues& GetDiscreteValues(const HybridValues& c) {
-  return c.discrete();
-}
-
-/* ************************************************************************* */
 double DiscreteFactor::error(const DiscreteValues& values) const {
   return -std::log((*this)(values));
 }
 
 /* ************************************************************************* */
 double DiscreteFactor::error(const HybridValues& c) const {
-  return DiscreteFactor::error(GetDiscreteValues(c));
+  return this->error(c.discrete());
 }
 
 /* ************************************************************************* */

--- a/gtsam/discrete/DiscreteFactor.h
+++ b/gtsam/discrete/DiscreteFactor.h
@@ -27,6 +27,10 @@ namespace gtsam {
 
 class DecisionTreeFactor;
 class DiscreteConditional;
+class HybridValues;
+
+// Forward declaration of function to extract Values from HybridValues.
+const DiscreteValues& GetDiscreteValues(const HybridValues& c);
 
 /**
  * Base class for discrete probabilistic factors
@@ -82,6 +86,15 @@ public:
 
   /// Find value for given assignment of values to variables
   virtual double operator()(const DiscreteValues&) const = 0;
+
+  /// Error is just -log(value)
+  double error(const DiscreteValues& values) const;
+
+  /**
+   * The Factor::error simply extracts the \class DiscreteValues from the
+   * \class HybridValues and calculates the error.
+   */
+  double error(const HybridValues& c) const override;
 
   /// Multiply in a DecisionTreeFactor and return the result as DecisionTreeFactor
   virtual DecisionTreeFactor operator*(const DecisionTreeFactor&) const = 0;

--- a/gtsam/discrete/DiscreteFactor.h
+++ b/gtsam/discrete/DiscreteFactor.h
@@ -29,9 +29,6 @@ class DecisionTreeFactor;
 class DiscreteConditional;
 class HybridValues;
 
-// Forward declaration of function to extract Values from HybridValues.
-const DiscreteValues& GetDiscreteValues(const HybridValues& c);
-
 /**
  * Base class for discrete probabilistic factors
  * The most general one is the derived DecisionTreeFactor

--- a/gtsam/discrete/DiscreteFactorGraph.h
+++ b/gtsam/discrete/DiscreteFactorGraph.h
@@ -223,6 +223,12 @@ class GTSAM_EXPORT DiscreteFactorGraph
                    const DiscreteFactor::Names& names = {}) const;
 
   /// @}
+  /// @name HybridValues methods.
+  /// @{
+
+  using Base::error;  // Expose error(const HybridValues&) method..
+
+  /// @}
 };  // \ DiscreteFactorGraph
 
 std::pair<DiscreteConditional::shared_ptr, DecisionTreeFactor::shared_ptr>  //

--- a/gtsam/discrete/discrete.i
+++ b/gtsam/discrete/discrete.i
@@ -95,6 +95,9 @@ virtual class DiscreteConditional : gtsam::DecisionTreeFactor {
   DiscreteConditional(const gtsam::DecisionTreeFactor& joint,
                       const gtsam::DecisionTreeFactor& marginal,
                       const gtsam::Ordering& orderedKeys);
+  double logProbability(const gtsam::DiscreteValues& values) const;
+  double evaluate(const gtsam::DiscreteValues& values) const;
+  double operator()(const gtsam::DiscreteValues& values) const;
   gtsam::DiscreteConditional operator*(
       const gtsam::DiscreteConditional& other) const;
   gtsam::DiscreteConditional marginal(gtsam::Key key) const;
@@ -157,7 +160,12 @@ class DiscreteBayesNet {
              const gtsam::KeyFormatter& keyFormatter =
                  gtsam::DefaultKeyFormatter) const;
   bool equals(const gtsam::DiscreteBayesNet& other, double tol = 1e-9) const;
+
+  // Standard interface.
+  double logProbability(const gtsam::DiscreteValues& values) const;
+  double evaluate(const gtsam::DiscreteValues& values) const;
   double operator()(const gtsam::DiscreteValues& values) const;
+
   gtsam::DiscreteValues sample() const;
   gtsam::DiscreteValues sample(gtsam::DiscreteValues given) const;
 

--- a/gtsam/discrete/tests/testDecisionTreeFactor.cpp
+++ b/gtsam/discrete/tests/testDecisionTreeFactor.cpp
@@ -48,6 +48,9 @@ TEST( DecisionTreeFactor, constructors)
   EXPECT_DOUBLES_EQUAL(8, f1(values), 1e-9);
   EXPECT_DOUBLES_EQUAL(7, f2(values), 1e-9);
   EXPECT_DOUBLES_EQUAL(75, f3(values), 1e-9);
+
+  // Assert that error = -log(value)
+  EXPECT_DOUBLES_EQUAL(-log(f1(values)), f1.error(values), 1e-9);
 }
 
 /* ************************************************************************* */

--- a/gtsam/discrete/tests/testDiscreteBayesNet.cpp
+++ b/gtsam/discrete/tests/testDiscreteBayesNet.cpp
@@ -25,7 +25,6 @@
 
 #include <CppUnitLite/TestHarness.h>
 
-
 #include <iostream>
 #include <string>
 #include <vector>
@@ -100,6 +99,11 @@ TEST(DiscreteBayesNet, Asia) {
   DiscreteBayesNet::shared_ptr chordal = fg.eliminateSequential(ordering);
   DiscreteConditional expected2(Bronchitis % "11/9");
   EXPECT(assert_equal(expected2, *chordal->back()));
+
+  // Check evaluate and logProbability
+  auto result = chordal->optimize();
+  EXPECT_DOUBLES_EQUAL(asia.logProbability(result),
+                       std::log(asia.evaluate(result)), 1e-9);
 
   // add evidence, we were in Asia and we have dyspnea
   fg.add(Asia, "0 1");

--- a/gtsam/discrete/tests/testDiscreteBayesNet.cpp
+++ b/gtsam/discrete/tests/testDiscreteBayesNet.cpp
@@ -101,7 +101,7 @@ TEST(DiscreteBayesNet, Asia) {
   EXPECT(assert_equal(expected2, *chordal->back()));
 
   // Check evaluate and logProbability
-  auto result = chordal->optimize();
+  auto result = fg.optimize();
   EXPECT_DOUBLES_EQUAL(asia.logProbability(result),
                        std::log(asia.evaluate(result)), 1e-9);
 

--- a/gtsam/discrete/tests/testDiscreteConditional.cpp
+++ b/gtsam/discrete/tests/testDiscreteConditional.cpp
@@ -88,6 +88,29 @@ TEST(DiscreteConditional, constructors3) {
   EXPECT(assert_equal(expected, static_cast<DecisionTreeFactor>(actual)));
 }
 
+/* ****************************************************************************/
+// Test evaluate for a discrete Prior P(Asia).
+TEST(DiscreteConditional, PriorProbability) {
+  constexpr Key asiaKey = 0;
+  const DiscreteKey Asia(asiaKey, 2);
+  DiscreteConditional dc(Asia, "4/6");
+  DiscreteValues values{{asiaKey, 0}};
+  EXPECT_DOUBLES_EQUAL(0.4, dc.evaluate(values), 1e-9);
+}
+
+/* ************************************************************************* */
+// Check that error, logProbability, evaluate all work as expected.
+TEST(DiscreteConditional, probability) {
+  DiscreteKey C(2, 2), D(4, 2), E(3, 2);
+  DiscreteConditional C_given_DE((C | D, E) = "4/1 1/1 1/1 1/4");
+
+  DiscreteValues given {{C.first, 1}, {D.first, 0}, {E.first, 0}};
+  EXPECT_DOUBLES_EQUAL(0.2, C_given_DE.evaluate(given), 1e-9);
+  EXPECT_DOUBLES_EQUAL(0.2, C_given_DE(given), 1e-9);
+  EXPECT_DOUBLES_EQUAL(log(0.2), C_given_DE.logProbability(given), 1e-9);
+  EXPECT_DOUBLES_EQUAL(-log(0.2), C_given_DE.error(given), 1e-9);
+}
+
 /* ************************************************************************* */
 // Check calculation of joint P(A,B)
 TEST(DiscreteConditional, Multiply) {

--- a/gtsam/hybrid/GaussianMixture.cpp
+++ b/gtsam/hybrid/GaussianMixture.cpp
@@ -271,15 +271,16 @@ void GaussianMixture::prune(const DecisionTreeFactor &decisionTree) {
 }
 
 /* *******************************************************************************/
-AlgebraicDecisionTree<Key> GaussianMixture::error(
+AlgebraicDecisionTree<Key> GaussianMixture::logProbability(
     const VectorValues &continuousValues) const {
-  // functor to calculate to double error value from GaussianConditional.
+  // functor to calculate to double logProbability value from
+  // GaussianConditional.
   auto errorFunc =
       [continuousValues](const GaussianConditional::shared_ptr &conditional) {
         if (conditional) {
-          return conditional->error(continuousValues);
+          return conditional->logProbability(continuousValues);
         } else {
-          // Return arbitrarily large error if conditional is null
+          // Return arbitrarily large logProbability if conditional is null
           // Conditional is null if it is pruned out.
           return 1e50;
         }
@@ -289,10 +290,10 @@ AlgebraicDecisionTree<Key> GaussianMixture::error(
 }
 
 /* *******************************************************************************/
-double GaussianMixture::error(const HybridValues &values) const {
+double GaussianMixture::logProbability(const HybridValues &values) const {
   // Directly index to get the conditional, no need to build the whole tree.
   auto conditional = conditionals_(values.discrete());
-  return conditional->error(values.continuous());
+  return conditional->logProbability(values.continuous());
 }
 
 }  // namespace gtsam

--- a/gtsam/hybrid/GaussianMixture.h
+++ b/gtsam/hybrid/GaussianMixture.h
@@ -188,9 +188,6 @@ class GTSAM_EXPORT GaussianMixture
   //   double operator()(const HybridValues &values) const { return
   //   evaluate(values); }
 
-  //   /// Calculate log-density for given values `x`.
-  //   double logDensity(const HybridValues &values) const;
-
   /**
    * @brief Prune the decision tree of Gaussian factors as per the discrete
    * `decisionTree`.

--- a/gtsam/hybrid/GaussianMixture.h
+++ b/gtsam/hybrid/GaussianMixture.h
@@ -164,22 +164,23 @@ class GTSAM_EXPORT GaussianMixture
   const Conditionals &conditionals() const;
 
   /**
-   * @brief Compute error of the GaussianMixture as a tree.
+   * @brief Compute logProbability of the GaussianMixture as a tree.
    *
    * @param continuousValues The continuous VectorValues.
    * @return AlgebraicDecisionTree<Key> A decision tree with the same keys
-   * as the conditionals, and leaf values as the error.
+   * as the conditionals, and leaf values as the logProbability.
    */
-  AlgebraicDecisionTree<Key> error(const VectorValues &continuousValues) const;
+  AlgebraicDecisionTree<Key> logProbability(
+      const VectorValues &continuousValues) const;
 
   /**
-   * @brief Compute the error of this Gaussian Mixture given the continuous
-   * values and a discrete assignment.
+   * @brief Compute the logProbability of this Gaussian Mixture given the
+   * continuous values and a discrete assignment.
    *
    * @param values Continuous values and discrete assignment.
    * @return double
    */
-  double error(const HybridValues &values) const override;
+  double logProbability(const HybridValues &values) const override;
 
   //   /// Calculate probability density for given values `x`.
   //   double evaluate(const HybridValues &values) const;

--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -260,18 +260,18 @@ double HybridBayesNet::evaluate(const HybridValues &values) const {
   const DiscreteValues &discreteValues = values.discrete();
   const VectorValues &continuousValues = values.continuous();
 
-  double logDensity = 0.0, probability = 1.0;
+  double error = 0.0, probability = 1.0;
 
   // Iterate over each conditional.
   for (auto &&conditional : *this) {
     // TODO: should be delegated to derived classes.
     if (auto gm = conditional->asMixture()) {
       const auto component = (*gm)(discreteValues);
-      logDensity += component->logDensity(continuousValues);
+      error += component->error(continuousValues);
 
     } else if (auto gc = conditional->asGaussian()) {
       // If continuous only, evaluate the probability and multiply.
-      logDensity += gc->logDensity(continuousValues);
+      error += gc->error(continuousValues);
 
     } else if (auto dc = conditional->asDiscrete()) {
       // Conditional is discrete-only, so return its probability.
@@ -279,7 +279,7 @@ double HybridBayesNet::evaluate(const HybridValues &values) const {
     }
   }
 
-  return probability * exp(logDensity);
+  return probability * exp(-error);
 }
 
 /* ************************************************************************* */

--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -293,21 +293,21 @@ HybridValues HybridBayesNet::sample() const {
 /* ************************************************************************* */
 AlgebraicDecisionTree<Key> HybridBayesNet::logProbability(
     const VectorValues &continuousValues) const {
-  AlgebraicDecisionTree<Key> error_tree(0.0);
+  AlgebraicDecisionTree<Key> result(0.0);
 
   // Iterate over each conditional.
   for (auto &&conditional : *this) {
     if (auto gm = conditional->asMixture()) {
       // If conditional is hybrid, select based on assignment and compute
       // logProbability.
-      error_tree = error_tree + gm->logProbability(continuousValues);
+      result = result + gm->logProbability(continuousValues);
     } else if (auto gc = conditional->asGaussian()) {
       // If continuous, get the (double) logProbability and add it to the
-      // error_tree
+      // result
       double logProbability = gc->logProbability(continuousValues);
       // Add the computed logProbability to every leaf of the logProbability
       // tree.
-      error_tree = error_tree.apply([logProbability](double leaf_value) {
+      result = result.apply([logProbability](double leaf_value) {
         return leaf_value + logProbability;
       });
     } else if (auto dc = conditional->asDiscrete()) {
@@ -317,7 +317,7 @@ AlgebraicDecisionTree<Key> HybridBayesNet::logProbability(
     }
   }
 
-  return error_tree;
+  return result;
 }
 
 /* ************************************************************************* */

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -187,14 +187,7 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
   /// Prune the Hybrid Bayes Net such that we have at most maxNrLeaves leaves.
   HybridBayesNet prune(size_t maxNrLeaves);
 
-  /**
-   * @brief 0.5 * sum of squared Mahalanobis distances
-   * for a specific discrete assignment.
-   *
-   * @param values Continuous values and discrete assignment.
-   * @return double
-   */
-  double error(const HybridValues &values) const;
+  using Base::error; // Expose error(const HybridValues&) method..
 
   /**
    * @brief Compute conditional error for each discrete assignment,

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -187,8 +187,6 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
   /// Prune the Hybrid Bayes Net such that we have at most maxNrLeaves leaves.
   HybridBayesNet prune(size_t maxNrLeaves);
 
-  using Base::error; // Expose error(const HybridValues&) method..
-
   /**
    * @brief Compute conditional error for each discrete assignment,
    * and return as a tree.
@@ -196,7 +194,10 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
    * @param continuousValues Continuous values at which to compute the error.
    * @return AlgebraicDecisionTree<Key>
    */
-  AlgebraicDecisionTree<Key> error(const VectorValues &continuousValues) const;
+  AlgebraicDecisionTree<Key> logProbability(
+      const VectorValues &continuousValues) const;
+
+  using BayesNet::logProbability;  // expose HybridValues version
 
   /**
    * @brief Compute unnormalized probability q(μ|M),
@@ -208,7 +209,7 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
    * probability.
    * @return AlgebraicDecisionTree<Key>
    */
-  AlgebraicDecisionTree<Key> probPrime(
+  AlgebraicDecisionTree<Key> evaluate(
       const VectorValues &continuousValues) const;
 
   /**

--- a/gtsam/hybrid/HybridConditional.cpp
+++ b/gtsam/hybrid/HybridConditional.cpp
@@ -122,18 +122,18 @@ bool HybridConditional::equals(const HybridFactor &other, double tol) const {
 }
 
 /* ************************************************************************ */
-double HybridConditional::error(const HybridValues &values) const {
-  if (auto gm = asMixture()) {
-    return gm->error(values);
-  }
+double HybridConditional::logProbability(const HybridValues &values) const {
   if (auto gc = asGaussian()) {
-    return gc->error(values.continuous());
+    return gc->logProbability(values.continuous());
+  }
+  if (auto gm = asMixture()) {
+    return gm->logProbability(values);
   }
   if (auto dc = asDiscrete()) {
-    return -log((*dc)(values.discrete()));
+    return dc->logProbability(values.discrete());
   }
   throw std::runtime_error(
-      "HybridConditional::error: conditional type not handled");
+      "HybridConditional::logProbability: conditional type not handled");
 }
 
 }  // namespace gtsam

--- a/gtsam/hybrid/HybridConditional.h
+++ b/gtsam/hybrid/HybridConditional.h
@@ -176,8 +176,8 @@ class GTSAM_EXPORT HybridConditional
   /// Get the type-erased pointer to the inner type
   boost::shared_ptr<Factor> inner() const { return inner_; }
 
-  /// Return the error of the underlying conditional.
-  double error(const HybridValues& values) const override;
+  /// Return the logProbability of the underlying conditional.
+  double logProbability(const HybridValues& values) const override;
 
   /// Check if VectorValues `measurements` contains all frontal keys.
   bool frontalsIn(const VectorValues& measurements) const {

--- a/gtsam/hybrid/HybridFactor.h
+++ b/gtsam/hybrid/HybridFactor.h
@@ -143,15 +143,6 @@ class GTSAM_EXPORT HybridFactor : public Factor {
   /// @name Standard Interface
   /// @{
 
-  /**
-   * @brief Compute the error of this Gaussian Mixture given the continuous
-   * values and a discrete assignment.
-   *
-   * @param values Continuous values and discrete assignment.
-   * @return double
-   */
-  virtual double error(const HybridValues &values) const = 0;
-
   /// True if this is a factor of discrete variables only.
   bool isDiscrete() const { return isDiscrete_; }
 

--- a/gtsam/hybrid/HybridFactorGraph.cpp
+++ b/gtsam/hybrid/HybridFactorGraph.cpp
@@ -25,17 +25,17 @@
 namespace gtsam {
 
 /* ************************************************************************* */
-DiscreteKeys HybridFactorGraph::discreteKeys() const {
-  DiscreteKeys keys;
+std::set<DiscreteKey> HybridFactorGraph::discreteKeys() const {
+  std::set<DiscreteKey> keys;
   for (auto& factor : factors_) {
     if (auto p = boost::dynamic_pointer_cast<DecisionTreeFactor>(factor)) {
       for (const DiscreteKey& key : p->discreteKeys()) {
-        keys.push_back(key);
+        keys.insert(key);
       }
     }
     if (auto p = boost::dynamic_pointer_cast<HybridFactor>(factor)) {
       for (const DiscreteKey& key : p->discreteKeys()) {
-        keys.push_back(key);
+        keys.insert(key);
       }
     }
   }

--- a/gtsam/hybrid/HybridFactorGraph.h
+++ b/gtsam/hybrid/HybridFactorGraph.h
@@ -65,7 +65,7 @@ class HybridFactorGraph : public FactorGraph<Factor> {
   /// @{
 
   /// Get all the discrete keys in the factor graph.
-  DiscreteKeys discreteKeys() const;
+  std::set<DiscreteKey> discreteKeys() const;
 
   /// Get all the discrete keys in the factor graph, as a set.
   KeySet discreteKeySet() const;

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -464,24 +464,6 @@ AlgebraicDecisionTree<Key> HybridGaussianFactorGraph::error(
 }
 
 /* ************************************************************************ */
-double HybridGaussianFactorGraph::error(const HybridValues &values) const {
-  double error = 0.0;
-  for (auto &f : factors_) {
-    if (auto hf = dynamic_pointer_cast<GaussianFactor>(f)) {
-      error += hf->error(values.continuous());
-    } else if (auto hf = dynamic_pointer_cast<HybridFactor>(f)) {
-      // TODO(dellaert): needs to change when we discard other wrappers.
-      error += hf->error(values);
-    } else if (auto dtf = dynamic_pointer_cast<DecisionTreeFactor>(f)) {
-      error -= log((*dtf)(values.discrete()));
-    } else {
-      throwRuntimeError("HybridGaussianFactorGraph::error(HV)", f);
-    }
-  }
-  return error;
-}
-
-/* ************************************************************************ */
 double HybridGaussianFactorGraph::probPrime(const HybridValues &values) const {
   double error = this->error(values);
   // NOTE: The 0.5 term is handled by each factor

--- a/gtsam/hybrid/HybridGaussianFactorGraph.h
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.h
@@ -145,6 +145,8 @@ class GTSAM_EXPORT HybridGaussianFactorGraph
   /// @name Standard Interface
   /// @{
 
+  using Base::error; // Expose error(const HybridValues&) method..
+
   /**
    * @brief Compute error for each discrete assignment,
    * and return as a tree.
@@ -155,14 +157,6 @@ class GTSAM_EXPORT HybridGaussianFactorGraph
    * @return AlgebraicDecisionTree<Key>
    */
   AlgebraicDecisionTree<Key> error(const VectorValues& continuousValues) const;
-
-  /**
-   * @brief Compute error given a continuous vector values
-   * and a discrete assignment.
-   *
-   * @return double
-   */
-  double error(const HybridValues& values) const;
 
   /**
    * @brief Compute unnormalized probability \f$ P(X | M, Z) \f$

--- a/gtsam/hybrid/HybridNonlinearFactorGraph.h
+++ b/gtsam/hybrid/HybridNonlinearFactorGraph.h
@@ -55,11 +55,17 @@ class GTSAM_EXPORT HybridNonlinearFactorGraph : public HybridFactorGraph {
       : Base(graph) {}
 
   /// @}
+  /// @name Constructors
+  /// @{
 
   /// Print the factor graph.
   void print(
       const std::string& s = "HybridNonlinearFactorGraph",
       const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override;
+
+  /// @}
+  /// @name Standard Interface
+  /// @{
 
   /**
    * @brief Linearize all the continuous factors in the
@@ -70,6 +76,7 @@ class GTSAM_EXPORT HybridNonlinearFactorGraph : public HybridFactorGraph {
    */
   HybridGaussianFactorGraph::shared_ptr linearize(
       const Values& continuousValues) const;
+  /// @}
 };
 
 template <>

--- a/gtsam/hybrid/hybrid.i
+++ b/gtsam/hybrid/hybrid.i
@@ -61,6 +61,9 @@ virtual class HybridConditional {
   size_t nrParents() const;
 
   // Standard interface:
+  double logProbability(const gtsam::HybridValues& values) const;
+  double evaluate(const gtsam::HybridValues& values) const;
+  double operator()(const gtsam::HybridValues& values) const;
   gtsam::GaussianMixture* asMixture() const;
   gtsam::GaussianConditional* asGaussian() const;
   gtsam::DiscreteConditional* asDiscrete() const;
@@ -133,7 +136,10 @@ class HybridBayesNet {
   gtsam::KeySet keys() const;
   const gtsam::HybridConditional* at(size_t i) const;
   
-  double evaluate(const gtsam::HybridValues& x) const;
+  // Standard interface:
+  double logProbability(const gtsam::HybridValues& values) const;
+  double evaluate(const gtsam::HybridValues& values) const;
+
   gtsam::HybridValues optimize() const;
   gtsam::HybridValues sample(const gtsam::HybridValues &given) const;
   gtsam::HybridValues sample() const;

--- a/gtsam/hybrid/tests/testGaussianMixture.cpp
+++ b/gtsam/hybrid/tests/testGaussianMixture.cpp
@@ -116,12 +116,12 @@ TEST(GaussianMixture, Error) {
   VectorValues values;
   values.insert(X(1), Vector2::Ones());
   values.insert(X(2), Vector2::Zero());
-  auto error_tree = mixture.error(values);
+  auto error_tree = mixture.logProbability(values);
 
   // Check result.
   std::vector<DiscreteKey> discrete_keys = {m1};
-  std::vector<double> leaves = {conditional0->error(values),
-                                conditional1->error(values)};
+  std::vector<double> leaves = {conditional0->logProbability(values),
+                                conditional1->logProbability(values)};
   AlgebraicDecisionTree<Key> expected_error(discrete_keys, leaves);
 
   EXPECT(assert_equal(expected_error, error_tree, 1e-6));
@@ -129,11 +129,11 @@ TEST(GaussianMixture, Error) {
   // Regression for non-tree version.
   DiscreteValues assignment;
   assignment[M(1)] = 0;
-  EXPECT_DOUBLES_EQUAL(conditional0->error(values),
-                       mixture.error({values, assignment}), 1e-8);
+  EXPECT_DOUBLES_EQUAL(conditional0->logProbability(values),
+                       mixture.logProbability({values, assignment}), 1e-8);
   assignment[M(1)] = 1;
-  EXPECT_DOUBLES_EQUAL(conditional1->error(values),
-                       mixture.error({values, assignment}), 1e-8);
+  EXPECT_DOUBLES_EQUAL(conditional1->logProbability(values),
+                       mixture.logProbability({values, assignment}), 1e-8);
 }
 
 /* ************************************************************************* */

--- a/gtsam/hybrid/tests/testGaussianMixture.cpp
+++ b/gtsam/hybrid/tests/testGaussianMixture.cpp
@@ -118,9 +118,10 @@ TEST(GaussianMixture, Error) {
   values.insert(X(2), Vector2::Zero());
   auto error_tree = mixture.error(values);
 
-  // regression
+  // Check result.
   std::vector<DiscreteKey> discrete_keys = {m1};
-  std::vector<double> leaves = {0.5, 4.3252595};
+  std::vector<double> leaves = {conditional0->error(values),
+                                conditional1->error(values)};
   AlgebraicDecisionTree<Key> expected_error(discrete_keys, leaves);
 
   EXPECT(assert_equal(expected_error, error_tree, 1e-6));
@@ -128,10 +129,11 @@ TEST(GaussianMixture, Error) {
   // Regression for non-tree version.
   DiscreteValues assignment;
   assignment[M(1)] = 0;
-  EXPECT_DOUBLES_EQUAL(0.5, mixture.error({values, assignment}), 1e-8);
+  EXPECT_DOUBLES_EQUAL(conditional0->error(values),
+                       mixture.error({values, assignment}), 1e-8);
   assignment[M(1)] = 1;
-  EXPECT_DOUBLES_EQUAL(4.3252595155709335, mixture.error({values, assignment}),
-                       1e-8);
+  EXPECT_DOUBLES_EQUAL(conditional1->error(values),
+                       mixture.error({values, assignment}), 1e-8);
 }
 
 /* ************************************************************************* */

--- a/gtsam/hybrid/tests/testHybridBayesNet.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesNet.cpp
@@ -217,23 +217,22 @@ TEST(HybridBayesNet, Error) {
   auto error_tree = hybridBayesNet->error(delta.continuous());
 
   std::vector<DiscreteKey> discrete_keys = {{M(0), 2}, {M(1), 2}};
-  std::vector<double> leaves = {0.0097568009, 3.3973404e-31, 0.029126214,
-                                0.0097568009};
+  std::vector<double> leaves = {-4.1609374, -4.1706942, -4.141568, -4.1609374};
   AlgebraicDecisionTree<Key> expected_error(discrete_keys, leaves);
 
   // regression
-  EXPECT(assert_equal(expected_error, error_tree, 1e-9));
+  EXPECT(assert_equal(expected_error, error_tree, 1e-6));
 
   // Error on pruned Bayes net
   auto prunedBayesNet = hybridBayesNet->prune(2);
   auto pruned_error_tree = prunedBayesNet.error(delta.continuous());
 
-  std::vector<double> pruned_leaves = {2e50, 3.3973404e-31, 2e50, 0.0097568009};
+  std::vector<double> pruned_leaves = {2e50, -4.1706942, 2e50, -4.1609374};
   AlgebraicDecisionTree<Key> expected_pruned_error(discrete_keys,
                                                    pruned_leaves);
 
   // regression
-  EXPECT(assert_equal(expected_pruned_error, pruned_error_tree, 1e-9));
+  EXPECT(assert_equal(expected_pruned_error, pruned_error_tree, 1e-6));
 
   // Verify error computation and check for specific error value
   DiscreteValues discrete_values{{M(0), 1}, {M(1), 1}};

--- a/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
@@ -60,12 +60,14 @@ TEST(HybridFactorGraph, GaussianFactorGraph) {
   Values linearizationPoint;
   linearizationPoint.insert<double>(X(0), 0);
 
+  // Linearize the factor graph.
   HybridGaussianFactorGraph ghfg = *fg.linearize(linearizationPoint);
+  EXPECT_LONGS_EQUAL(1, ghfg.size());
 
-  // Add a factor to the GaussianFactorGraph
-  ghfg.add(JacobianFactor(X(0), I_1x1, Vector1(5)));
-
-  EXPECT_LONGS_EQUAL(2, ghfg.size());
+  // Check that the error is the same for the nonlinear values.
+  const VectorValues zero{{X(0), Vector1(0)}};
+  const HybridValues hybridValues{zero, {}, linearizationPoint};
+  EXPECT_DOUBLES_EQUAL(fg.error(hybridValues), ghfg.error(hybridValues), 1e-9);
 }
 
 /***************************************************************************

--- a/gtsam/inference/BayesNet-inst.h
+++ b/gtsam/inference/BayesNet-inst.h
@@ -89,5 +89,21 @@ void BayesNet<CONDITIONAL>::saveGraph(const std::string& filename,
 }
 
 /* ************************************************************************* */
+template <class CONDITIONAL>
+double BayesNet<CONDITIONAL>::logProbability(const HybridValues& x) const {
+  double sum = 0.;
+  for (const auto& gc : *this) {
+    if (gc) sum += gc->logProbability(x);
+  }
+  return sum;
+}
+
+/* ************************************************************************* */
+template <class CONDITIONAL>
+double BayesNet<CONDITIONAL>::evaluate(const HybridValues& x) const {
+  return exp(-logProbability(x));
+}
+
+/* ************************************************************************* */
 
 }  // namespace gtsam

--- a/gtsam/inference/BayesNet.h
+++ b/gtsam/inference/BayesNet.h
@@ -25,6 +25,8 @@
 
 namespace gtsam {
 
+class HybridValues;
+
 /**
  * A BayesNet is a tree of conditionals, stored in elimination order.
  * @ingroup inference
@@ -68,7 +70,6 @@ class BayesNet : public FactorGraph<CONDITIONAL> {
       const KeyFormatter& formatter = DefaultKeyFormatter) const override;
 
   /// @}
-
   /// @name Graph Display
   /// @{
 
@@ -85,6 +86,13 @@ class BayesNet : public FactorGraph<CONDITIONAL> {
   void saveGraph(const std::string& filename,
                  const KeyFormatter& keyFormatter = DefaultKeyFormatter,
                  const DotWriter& writer = DotWriter()) const;
+
+  /// @}
+  /// @name HybridValues methods
+  /// @{
+
+  double logProbability(const HybridValues& x) const;
+  double evaluate(const HybridValues& c) const;
 
   /// @}
 };

--- a/gtsam/inference/BayesNet.h
+++ b/gtsam/inference/BayesNet.h
@@ -54,9 +54,11 @@ class BayesNet : public FactorGraph<CONDITIONAL> {
 
   /**
    * Constructor that takes an initializer list of shared pointers.
-   *  BayesNet<SymbolicConditional> bn = {make_shared<SymbolicConditional>(), ...};
+   *  BayesNet<SymbolicConditional> bn = {make_shared<SymbolicConditional>(),
+   * ...};
    */
-  BayesNet(std::initializer_list<sharedConditional> conditionals): Base(conditionals) {}
+  BayesNet(std::initializer_list<sharedConditional> conditionals)
+      : Base(conditionals) {}
 
   /// @}
 
@@ -91,7 +93,10 @@ class BayesNet : public FactorGraph<CONDITIONAL> {
   /// @name HybridValues methods
   /// @{
 
+  // Expose HybridValues version of logProbability.
   double logProbability(const HybridValues& x) const;
+
+  // Expose HybridValues version of evaluate.
   double evaluate(const HybridValues& c) const;
 
   /// @}

--- a/gtsam/inference/Conditional-inst.h
+++ b/gtsam/inference/Conditional-inst.h
@@ -54,6 +54,6 @@ double Conditional<FACTOR, DERIVEDCONDITIONAL>::logProbability(
 template <class FACTOR, class DERIVEDCONDITIONAL>
 double Conditional<FACTOR, DERIVEDCONDITIONAL>::evaluate(
     const HybridValues& c) const {
-  return exp(static_cast<const DERIVEDCONDITIONAL*>(this)->logProbability(c));
+  throw std::runtime_error("Conditional::evaluate is not implemented");
 }
 }  // namespace gtsam

--- a/gtsam/inference/Conditional-inst.h
+++ b/gtsam/inference/Conditional-inst.h
@@ -18,30 +18,42 @@
 // \callgraph
 #pragma once
 
-#include <iostream>
-
 #include <gtsam/inference/Conditional.h>
+
+#include <cmath>
+#include <iostream>
 
 namespace gtsam {
 
-  /* ************************************************************************* */
-  template<class FACTOR, class DERIVEDFACTOR>
-  void Conditional<FACTOR,DERIVEDFACTOR>::print(const std::string& s, const KeyFormatter& formatter) const {
-    std::cout << s << " P(";
-    for(Key key: frontals())
-      std::cout << " " << formatter(key);
-    if (nrParents() > 0)
-      std::cout << " |";
-    for(Key parent: parents())
-      std::cout << " " << formatter(parent);
-    std::cout << ")" << std::endl;
-  }
-
-  /* ************************************************************************* */
-  template<class FACTOR, class DERIVEDFACTOR>
-  bool Conditional<FACTOR,DERIVEDFACTOR>::equals(const This& c, double tol) const
-  {
-    return nrFrontals_ == c.nrFrontals_;
-  }
-
+/* ************************************************************************* */
+template <class FACTOR, class DERIVEDCONDITIONAL>
+void Conditional<FACTOR, DERIVEDCONDITIONAL>::print(
+    const std::string& s, const KeyFormatter& formatter) const {
+  std::cout << s << " P(";
+  for (Key key : frontals()) std::cout << " " << formatter(key);
+  if (nrParents() > 0) std::cout << " |";
+  for (Key parent : parents()) std::cout << " " << formatter(parent);
+  std::cout << ")" << std::endl;
 }
+
+/* ************************************************************************* */
+template <class FACTOR, class DERIVEDCONDITIONAL>
+bool Conditional<FACTOR, DERIVEDCONDITIONAL>::equals(const This& c,
+                                                     double tol) const {
+  return nrFrontals_ == c.nrFrontals_;
+}
+
+/* ************************************************************************* */
+template <class FACTOR, class DERIVEDCONDITIONAL>
+double Conditional<FACTOR, DERIVEDCONDITIONAL>::logProbability(
+    const HybridValues& c) const {
+  throw std::runtime_error("Conditional::logProbability is not implemented");
+}
+
+/* ************************************************************************* */
+template <class FACTOR, class DERIVEDCONDITIONAL>
+double Conditional<FACTOR, DERIVEDCONDITIONAL>::evaluate(
+    const HybridValues& c) const {
+  return exp(static_cast<const DERIVEDCONDITIONAL*>(this)->logProbability(c));
+}
+}  // namespace gtsam

--- a/gtsam/inference/Factor.cpp
+++ b/gtsam/inference/Factor.cpp
@@ -43,4 +43,10 @@ namespace gtsam {
     return keys_ == other.keys_;
   }
 
+  /* ************************************************************************* */
+  double Factor::error(const HybridValues& c) const {
+    throw std::runtime_error("Factor::error is not implemented");
+  }
+
+
 }

--- a/gtsam/inference/Factor.h
+++ b/gtsam/inference/Factor.h
@@ -44,10 +44,7 @@ namespace gtsam {
    *
    * The `error` method is used to evaluate the factor, and is the only method
    * that is required to be implemented in derived classes, although it has a 
-   * default implementation that throws an exception. The meaning of the error
-   * is slightly different for factors and conditionals: in the former it is the
-   * negative log-likelihood, and in the latter it is the negative log of the 
-   * properly normalized conditional distribution or density.
+   * default implementation that throws an exception.
    * 
    * There are five broad classes of factors that derive from Factor:
    *
@@ -55,15 +52,12 @@ namespace gtsam {
    *   represent a nonlinear likelihood function over a set of variables.
    * - \b Gaussian factors, such as \class JacobianFactor and \class HessianFactor, which
    *   represent a Gaussian likelihood over a set of variables.
-   *   A \class GaussianConditional, which represent a Gaussian density over a set of
-   *   variables conditioned on another set of variables.
-   * - \b Discrete factors, such as \class DiscreteFactor and \class DiscreteConditional, which
+   * - \b Discrete factors, such as \class DiscreteFactor and \class DecisionTreeFactor, which
    *   represent a discrete distribution over a set of variables.
    * - \b Hybrid factors, such as \class HybridFactor, which represent a mixture of
    *   Gaussian and discrete distributions over a set of variables.
    * - \b Symbolic factors, used to represent a graph structure, such as
-   *   \class SymbolicFactor and \class SymbolicConditional. They do not override the
-   *  `error` method, and are used only for symbolic elimination etc.
+   *   \class SymbolicFactor, only used for symbolic elimination etc.
    *
    * Note that derived classes must also redefine the `This` and `shared_ptr`
    * typedefs. See JacobianFactor, etc. for examples.
@@ -154,11 +148,8 @@ namespace gtsam {
   /**
    * All factor types need to implement an error function.
    * In factor graphs, this is the negative log-likelihood.
-   * In Bayes nets, it is the negative log density, i.e., properly normalized.
    */
-  virtual double error(const HybridValues& c) const {
-    throw std::runtime_error("Factor::error is not implemented");
-  }
+  virtual double error(const HybridValues& c) const;
 
    /**
     * @return the number of variables involved in this factor

--- a/gtsam/inference/Factor.h
+++ b/gtsam/inference/Factor.h
@@ -38,8 +38,28 @@ typedef FastSet<FactorIndex> FactorIndexSet;
    * data other than its keys.  Derived classes store data such as matrices and
    * probability tables.
    *
-   * Note that derived classes *must* redefine the `This` and `shared_ptr`
-   * typedefs. See JacobianFactor, etc. for examples.
+   * The `error` method is used to evaluate the factor, and is the only method
+   * that is required to be implemented in derived classes, although it has a 
+   * default implementation that throws an exception. The meaning of the error
+   * is slightly different for factors and conditionals: in the former it is the
+   * negative log-likelihood, and in the latter it is the negative log of the 
+   * properly normalized conditional distribution or density.
+   * 
+   * There are five broad classes of factors that derive from Factor:
+   *
+   * - \b Nonlinear factors, such as \class NonlinearFactor and \class NoiseModelFactor, which
+   *   represent a nonlinear likelihood function over a set of variables.
+   * - \b Gaussian factors, such as \class JacobianFactor and \class HessianFactor, which
+   *   represent a Gaussian likelihood over a set of variables.
+   *   A \class GaussianConditional, which represent a Gaussian density over a set of
+   *   variables conditioned on another set of variables.
+   * - \b Discrete factors, such as \class DiscreteFactor and \class DiscreteConditional, which
+   *   represent a discrete distribution over a set of variables.
+   * - \b Hybrid factors, such as \class HybridFactor, which represent a mixture of
+   *   Gaussian and discrete distributions over a set of variables.
+   * - \b Symbolic factors, used to represent a graph structure, such as
+   *   \class SymbolicFactor and \class SymbolicConditional. They do not override the
+   *  `error` method, and are used only for symbolic elimination etc.
    *
    * This class is \b not virtual for performance reasons - the derived class
    * SymbolicFactor needs to be created and destroyed quickly during symbolic

--- a/gtsam/inference/FactorGraph-inst.h
+++ b/gtsam/inference/FactorGraph-inst.h
@@ -61,6 +61,16 @@ bool FactorGraph<FACTOR>::equals(const This& fg, double tol) const {
   return true;
 }
 
+/* ************************************************************************ */
+template <class FACTOR>
+double FactorGraph<FACTOR>::error(const HybridValues &values) const {
+  double error = 0.0;
+  for (auto &f : factors_) {
+    error += f->error(values);
+  }
+  return error;
+}
+
 /* ************************************************************************* */
 template <class FACTOR>
 size_t FactorGraph<FACTOR>::nrFactors() const {

--- a/gtsam/inference/FactorGraph.h
+++ b/gtsam/inference/FactorGraph.h
@@ -47,6 +47,8 @@ typedef FastVector<FactorIndex> FactorIndices;
 template <class CLIQUE>
 class BayesTree;
 
+class HybridValues;
+
 /** Helper */
 template <class C>
 class CRefCallPushBack {
@@ -358,6 +360,9 @@ class FactorGraph {
 
   /** Get the last factor */
   sharedFactor back() const { return factors_.back(); }
+
+  /** Add error for all factors. */
+  double error(const HybridValues &values) const;
 
   /// @}
   /// @name Modifying Factor Graphs (imperative, discouraged)

--- a/gtsam/linear/GaussianBayesNet.cpp
+++ b/gtsam/linear/GaussianBayesNet.cpp
@@ -104,12 +104,25 @@ namespace gtsam {
 
   /* ************************************************************************* */
   double GaussianBayesNet::error(const VectorValues& x) const {
-    return GaussianFactorGraph(*this).error(x);
+    double sum = 0.;
+    for (const auto& gc : *this) {
+      if (gc) sum += gc->error(x);
+    }
+    return sum;
+  }
+
+  /* ************************************************************************* */
+  double GaussianBayesNet::logProbability(const VectorValues& x) const {
+    double sum = 0.;
+    for (const auto& gc : *this) {
+      if (gc) sum += gc->logProbability(x);
+    }
+    return sum;
   }
 
   /* ************************************************************************* */
   double GaussianBayesNet::evaluate(const VectorValues& x) const {
-    return exp(-error(x));
+    return exp(-logProbability(x));
   }
 
   /* ************************************************************************* */

--- a/gtsam/linear/GaussianBayesNet.cpp
+++ b/gtsam/linear/GaussianBayesNet.cpp
@@ -108,6 +108,11 @@ namespace gtsam {
   }
 
   /* ************************************************************************* */
+  double GaussianBayesNet::evaluate(const VectorValues& x) const {
+    return exp(-error(x));
+  }
+
+  /* ************************************************************************* */
   VectorValues GaussianBayesNet::backSubstitute(const VectorValues& rhs) const
   {
     VectorValues result;
@@ -222,20 +227,6 @@ namespace gtsam {
       logDet += cg->logDeterminant();
     }
     return logDet;
-  }
-
-  /* ************************************************************************* */
-  double GaussianBayesNet::logDensity(const VectorValues& x) const {
-    double sum = 0.0;
-    for (const auto& conditional : *this) {
-      if (conditional) sum += conditional->logDensity(x);
-    }
-    return sum;
-  }
-
-  /* ************************************************************************* */
-  double GaussianBayesNet::evaluate(const VectorValues& x) const {
-    return exp(logDensity(x));
   }
 
   /* ************************************************************************* */

--- a/gtsam/linear/GaussianBayesNet.cpp
+++ b/gtsam/linear/GaussianBayesNet.cpp
@@ -122,7 +122,7 @@ namespace gtsam {
 
   /* ************************************************************************* */
   double GaussianBayesNet::evaluate(const VectorValues& x) const {
-    return exp(-logProbability(x));
+    return exp(logProbability(x));
   }
 
   /* ************************************************************************* */

--- a/gtsam/linear/GaussianBayesNet.h
+++ b/gtsam/linear/GaussianBayesNet.h
@@ -98,10 +98,16 @@ namespace gtsam {
     /// @{
 
     /**
-     * Calculate probability density for given values `x`:
-     *   exp(-error(x)) / sqrt((2*pi)^n*det(Sigma))
+     * The error is the negative log-density for given values `x`:
+     *  neg_log_likelihood(x) + 0.5 * n*log(2*pi) + 0.5 * log det(Sigma)
      * where x is the vector of values, and Sigma is the covariance matrix.
-     * Note that error(x)=0.5*e'*e includes the 0.5 factor already.
+     */
+    double error(const VectorValues& x) const;
+
+    /**
+     * Calculate probability density for given values `x`:
+     *   exp(-error) == exp(-neg_log_likelihood(x)) / sqrt((2*pi)^n*det(Sigma))
+     * where x is the vector of values, and Sigma is the covariance matrix.
      */
     double evaluate(const VectorValues& x) const;
 
@@ -109,13 +115,6 @@ namespace gtsam {
     double operator()(const VectorValues& x) const {
       return evaluate(x);
     }
-
-    /**
-     * Calculate log-density for given values `x`:
-     *  -error(x) - 0.5 * n*log(2*pi) - 0.5 * log det(Sigma)
-     * where x is the vector of values, and Sigma is the covariance matrix.
-     */
-    double logDensity(const VectorValues& x) const;
 
     /// Solve the GaussianBayesNet, i.e. return \f$ x = R^{-1}*d \f$, by
     /// back-substitution
@@ -215,9 +214,6 @@ namespace gtsam {
      * @param [output] g A VectorValues to store the gradient, which must be preallocated, see
      *        allocateVectorValues */
     VectorValues gradientAtZero() const;
-
-    /** 0.5 * sum of squared Mahalanobis distances. */
-    double error(const VectorValues& x) const;
 
     /**
      * Computes the determinant of a GassianBayesNet. A GaussianBayesNet is an upper triangular

--- a/gtsam/linear/GaussianBayesNet.h
+++ b/gtsam/linear/GaussianBayesNet.h
@@ -97,17 +97,16 @@ namespace gtsam {
     /// @name Standard Interface
     /// @{
 
-    /**
-     * The error is the negative log-density for given values `x`:
-     *  neg_log_likelihood(x) + 0.5 * n*log(2*pi) + 0.5 * log det(Sigma)
-     * where x is the vector of values, and Sigma is the covariance matrix.
-     */
+    /// Sum error over all variables.
     double error(const VectorValues& x) const;
+
+    /// Sum logProbability over all variables.
+    double logProbability(const VectorValues& x) const;
 
     /**
      * Calculate probability density for given values `x`:
-     *   exp(-error) == exp(-neg_log_likelihood(x)) / sqrt((2*pi)^n*det(Sigma))
-     * where x is the vector of values, and Sigma is the covariance matrix.
+     *   exp(logProbability)
+     * where x is the vector of values.
      */
     double evaluate(const VectorValues& x) const;
 
@@ -245,6 +244,14 @@ namespace gtsam {
      * gz'*R'=gx', gy = gz.*sigmas
      */
     VectorValues backSubstituteTranspose(const VectorValues& gx) const;
+
+    /// @}
+    /// @name HybridValues methods.
+    /// @{
+
+    using Base::evaluate; // Expose evaluate(const HybridValues&) method..
+    using Base::logProbability; // Expose logProbability(const HybridValues&) method..
+    using Base::error; // Expose error(const HybridValues&) method..
 
     /// @}
 

--- a/gtsam/linear/GaussianConditional.cpp
+++ b/gtsam/linear/GaussianConditional.cpp
@@ -193,14 +193,14 @@ double GaussianConditional::logNormalizationConstant() const {
 
 /* ************************************************************************* */
 //  density = k exp(-error(x))
-//  log = log(k) -error(x)
-double GaussianConditional::logDensity(const VectorValues& x) const {
-  return logNormalizationConstant() - error(x);
+//  -log(density) = error(x) - log(k)
+double GaussianConditional::error(const VectorValues& x) const {
+  return JacobianFactor::error(x) - logNormalizationConstant();
 }
 
 /* ************************************************************************* */
 double GaussianConditional::evaluate(const VectorValues& x) const {
-  return exp(logDensity(x));
+  return exp(-error(x));
 }
 
   /* ************************************************************************* */

--- a/gtsam/linear/GaussianConditional.cpp
+++ b/gtsam/linear/GaussianConditional.cpp
@@ -19,6 +19,7 @@
 #include <gtsam/linear/Sampler.h>
 #include <gtsam/linear/VectorValues.h>
 #include <gtsam/linear/linearExceptions.h>
+#include <gtsam/hybrid/HybridValues.h>
 
 #include <boost/format.hpp>
 #ifdef __GNUC__
@@ -34,6 +35,7 @@
 #include <functional>
 #include <list>
 #include <string>
+#include <cmath>
 
 // In Wrappers we have no access to this so have a default ready
 static std::mt19937_64 kRandomNumberGenerator(42);
@@ -170,39 +172,42 @@ namespace gtsam {
     }
   }
 
-/* ************************************************************************* */
-double GaussianConditional::logDeterminant() const {
-  if (get_model()) {
-    Vector diag = R().diagonal();
-    get_model()->whitenInPlace(diag);
-    return diag.unaryExpr([](double x) { return log(x); }).sum();
-  } else {
-    return R().diagonal().unaryExpr([](double x) { return log(x); }).sum();
+  /* ************************************************************************* */
+  double GaussianConditional::logDeterminant() const {
+    if (get_model()) {
+      Vector diag = R().diagonal();
+      get_model()->whitenInPlace(diag);
+      return diag.unaryExpr([](double x) { return log(x); }).sum();
+    } else {
+      return R().diagonal().unaryExpr([](double x) { return log(x); }).sum();
+    }
   }
-}
 
-/* ************************************************************************* */
-//  normalization constant = 1.0 / sqrt((2*pi)^n*det(Sigma))
-//  log = - 0.5 * n*log(2*pi) - 0.5 * log det(Sigma)
-double GaussianConditional::logNormalizationConstant() const {
-  constexpr double log2pi = 1.8378770664093454835606594728112;
-  size_t n = d().size();
-  // log det(Sigma)) = - 2.0 * logDeterminant()
-  return - 0.5 * n * log2pi + logDeterminant();
-}
+  /* ************************************************************************* */
+  //  normalization constant = 1.0 / sqrt((2*pi)^n*det(Sigma))
+  //  log = - 0.5 * n*log(2*pi) - 0.5 * log det(Sigma)
+  double GaussianConditional::logNormalizationConstant() const {
+    constexpr double log2pi = 1.8378770664093454835606594728112;
+    size_t n = d().size();
+    // log det(Sigma)) = - 2.0 * logDeterminant()
+    return - 0.5 * n * log2pi + logDeterminant();
+  }
 
-/* ************************************************************************* */
-//  density = k exp(-error(x))
-//  -log(density) = error(x) - log(k)
-double GaussianConditional::error(const VectorValues& x) const {
-  return JacobianFactor::error(x) - logNormalizationConstant();
-}
+  /* ************************************************************************* */
+  //  density = k exp(-error(x))
+  //  log = log(k) - error(x)
+  double GaussianConditional::logProbability(const VectorValues& x) const {
+    return logNormalizationConstant() - error(x);
+  }
 
-/* ************************************************************************* */
-double GaussianConditional::evaluate(const VectorValues& x) const {
-  return exp(-error(x));
-}
+  double GaussianConditional::logProbability(const HybridValues& x) const {
+    return logProbability(x.continuous());
+  }
 
+  /* ************************************************************************* */
+  double GaussianConditional::evaluate(const VectorValues& c) const {
+    return exp(logProbability(c));
+  }
   /* ************************************************************************* */
   VectorValues GaussianConditional::solve(const VectorValues& x) const {
     // Concatenate all vector values that correspond to parent variables

--- a/gtsam/linear/GaussianConditional.h
+++ b/gtsam/linear/GaussianConditional.h
@@ -145,19 +145,18 @@ namespace gtsam {
       return exp(logNormalizationConstant());
     }
 
-    using Base::error; // Expose error(const HybridValues&) method..
-
     /**
-     * Calculate error(x) == -log(evaluate()) for given values `x`:
-     *  - GaussianFactor::error(x) - 0.5 * n*log(2*pi) - 0.5 * log det(Sigma)
+     * Calculate log-probability log(evaluate(x)) for given values `x`:
+     *  -error(x) - 0.5 * n*log(2*pi) - 0.5 * log det(Sigma)
      * where x is the vector of values, and Sigma is the covariance matrix.
-     * Note that GaussianFactor:: error(x)=0.5*e'*e includes the 0.5 factor already.
+     * This differs from error as it is log, not negative log, and it
+     * includes the normalization constant.
      */
-    double error(const VectorValues& x) const override;
+    double logProbability(const VectorValues& x) const;
 
     /**
      * Calculate probability density for given values `x`:
-     *   exp(-error(x)) == exp(-GaussianFactor::error(x)) / sqrt((2*pi)^n*det(Sigma))
+     *   exp(logProbability(x)) == exp(-GaussianFactor::error(x)) / sqrt((2*pi)^n*det(Sigma))
      * where x is the vector of values, and Sigma is the covariance matrix.
      */
     double evaluate(const VectorValues& x) const;
@@ -261,6 +260,21 @@ namespace gtsam {
     double logDeterminant() const;
 
     /// @}
+    /// @name HybridValues methods.
+    /// @{
+
+    /**
+     * Calculate log-probability log(evaluate(x)) for HybridValues `x`.
+     * Simply dispatches to VectorValues version.
+     */
+    double logProbability(const HybridValues& x) const override;
+
+    using Conditional::evaluate; // Expose evaluate(const HybridValues&) method..
+    using Conditional::operator(); // Expose evaluate(const HybridValues&) method..
+    using Base::error; // Expose error(const HybridValues&) method..
+
+    /// @}
+
 
 #ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V42
     /// @name Deprecated

--- a/gtsam/linear/GaussianConditional.h
+++ b/gtsam/linear/GaussianConditional.h
@@ -145,6 +145,8 @@ namespace gtsam {
       return exp(logNormalizationConstant());
     }
 
+    using Base::error; // Expose error(const HybridValues&) method..
+
     /**
      * Calculate error(x) == -log(evaluate()) for given values `x`:
      *  - GaussianFactor::error(x) - 0.5 * n*log(2*pi) - 0.5 * log det(Sigma)

--- a/gtsam/linear/GaussianConditional.h
+++ b/gtsam/linear/GaussianConditional.h
@@ -133,64 +133,6 @@ namespace gtsam {
     /// @{
 
     /**
-     * Calculate probability density for given values `x`:
-     *   exp(-error(x)) / sqrt((2*pi)^n*det(Sigma))
-     * where x is the vector of values, and Sigma is the covariance matrix.
-     * Note that error(x)=0.5*e'*e includes the 0.5 factor already.
-     */
-    double evaluate(const VectorValues& x) const;
-
-    /// Evaluate probability density, sugar.
-    double operator()(const VectorValues& x) const {
-      return evaluate(x);
-    }
-
-    /**
-     * Calculate log-density for given values `x`:
-     *  -error(x) - 0.5 * n*log(2*pi) - 0.5 * log det(Sigma)
-     * where x is the vector of values, and Sigma is the covariance matrix.
-     */
-    double logDensity(const VectorValues& x) const;
-
-    /** Return a view of the upper-triangular R block of the conditional */
-    constABlock R() const { return Ab_.range(0, nrFrontals()); }
-
-    /** Get a view of the parent blocks. */
-    constABlock S() const { return Ab_.range(nrFrontals(), size()); }
-
-    /** Get a view of the S matrix for the variable pointed to by the given key iterator */
-    constABlock S(const_iterator it) const { return BaseFactor::getA(it); }
-
-    /** Get a view of the r.h.s. vector d */
-    const constBVector d() const { return BaseFactor::getb(); }
-
-    /**
-     * @brief Compute the determinant of the R matrix.
-     *
-     * The determinant is computed in log form using logDeterminant for
-     * numerical stability and then exponentiated.
-     * 
-     * Note, the covariance matrix \f$ \Sigma = (R^T R)^{-1} \f$, and hence
-     * \f$ \det(\Sigma) = 1 / \det(R^T R) = 1 / determinant()^ 2 \f$.
-     *
-     * @return double
-     */
-    inline double determinant() const { return exp(logDeterminant()); }
-
-    /**
-     * @brief Compute the log determinant of the R matrix.
-     * 
-     * For numerical stability, the determinant is computed in log
-     * form, so it is a summation rather than a multiplication.
-     *
-     * Note, the covariance matrix \f$ \Sigma = (R^T R)^{-1} \f$, and hence
-     * \f$ \log \det(\Sigma) = - \log \det(R^T R) = - 2 logDeterminant() \f$.
-     *
-     * @return double
-     */
-    double logDeterminant() const;
-
-    /**
      * normalization constant = 1.0 / sqrt((2*pi)^n*det(Sigma))
      * log = - 0.5 * n*log(2*pi) - 0.5 * log det(Sigma)
      */
@@ -201,6 +143,26 @@ namespace gtsam {
      */
     inline double normalizationConstant() const {
       return exp(logNormalizationConstant());
+    }
+
+    /**
+     * Calculate error(x) == -log(evaluate()) for given values `x`:
+     *  - GaussianFactor::error(x) - 0.5 * n*log(2*pi) - 0.5 * log det(Sigma)
+     * where x is the vector of values, and Sigma is the covariance matrix.
+     * Note that GaussianFactor:: error(x)=0.5*e'*e includes the 0.5 factor already.
+     */
+    double error(const VectorValues& x) const override;
+
+    /**
+     * Calculate probability density for given values `x`:
+     *   exp(-error(x)) == exp(-GaussianFactor::error(x)) / sqrt((2*pi)^n*det(Sigma))
+     * where x is the vector of values, and Sigma is the covariance matrix.
+     */
+    double evaluate(const VectorValues& x) const;
+
+    /// Evaluate probability density, sugar.
+    double operator()(const VectorValues& x) const {
+      return evaluate(x);
     }
 
     /**
@@ -253,6 +215,48 @@ namespace gtsam {
 
     /// Sample with given values, use default rng
     VectorValues sample(const VectorValues& parentsValues) const;
+
+    /// @}
+    /// @name Linear algebra.
+    /// @{
+
+    /** Return a view of the upper-triangular R block of the conditional */
+    constABlock R() const { return Ab_.range(0, nrFrontals()); }
+
+    /** Get a view of the parent blocks. */
+    constABlock S() const { return Ab_.range(nrFrontals(), size()); }
+
+    /** Get a view of the S matrix for the variable pointed to by the given key iterator */
+    constABlock S(const_iterator it) const { return BaseFactor::getA(it); }
+
+    /** Get a view of the r.h.s. vector d */
+    const constBVector d() const { return BaseFactor::getb(); }
+
+    /**
+     * @brief Compute the determinant of the R matrix.
+     *
+     * The determinant is computed in log form using logDeterminant for
+     * numerical stability and then exponentiated.
+     * 
+     * Note, the covariance matrix \f$ \Sigma = (R^T R)^{-1} \f$, and hence
+     * \f$ \det(\Sigma) = 1 / \det(R^T R) = 1 / determinant()^ 2 \f$.
+     *
+     * @return double
+     */
+    inline double determinant() const { return exp(logDeterminant()); }
+
+    /**
+     * @brief Compute the log determinant of the R matrix.
+     * 
+     * For numerical stability, the determinant is computed in log
+     * form, so it is a summation rather than a multiplication.
+     *
+     * Note, the covariance matrix \f$ \Sigma = (R^T R)^{-1} \f$, and hence
+     * \f$ \log \det(\Sigma) = - \log \det(R^T R) = - 2 logDeterminant() \f$.
+     *
+     * @return double
+     */
+    double logDeterminant() const;
 
     /// @}
 

--- a/gtsam/linear/GaussianFactor.cpp
+++ b/gtsam/linear/GaussianFactor.cpp
@@ -24,12 +24,14 @@
 
 namespace gtsam {
 
-/* ************************************************************************* */
-const VectorValues& GetVectorValues(const HybridValues& c) {
-  return c.continuous();
+double GaussianFactor::error(const VectorValues& c) const {
+  throw std::runtime_error("GaussianFactor::error is not implemented");
 }
 
-/* ************************************************************************* */
+double GaussianFactor::error(const HybridValues& c) const {
+  return this->error(c.continuous());
+}
+
 VectorValues GaussianFactor::hessianDiagonal() const {
   VectorValues d;
   hessianDiagonalAdd(d);

--- a/gtsam/linear/GaussianFactor.cpp
+++ b/gtsam/linear/GaussianFactor.cpp
@@ -18,16 +18,22 @@
 
 // \callgraph
 
+#include <gtsam/hybrid/HybridValues.h>
 #include <gtsam/linear/GaussianFactor.h>
 #include <gtsam/linear/VectorValues.h>
 
 namespace gtsam {
 
 /* ************************************************************************* */
-  VectorValues GaussianFactor::hessianDiagonal() const {
-    VectorValues d;
-    hessianDiagonalAdd(d);
-    return d;
-  }
-
+const VectorValues& GetVectorValues(const HybridValues& c) {
+  return c.continuous();
 }
+
+/* ************************************************************************* */
+VectorValues GaussianFactor::hessianDiagonal() const {
+  VectorValues d;
+  hessianDiagonalAdd(d);
+  return d;
+}
+
+}  // namespace gtsam

--- a/gtsam/linear/GaussianFactor.h
+++ b/gtsam/linear/GaussianFactor.h
@@ -31,9 +31,6 @@ namespace gtsam {
   class Scatter;
   class SymmetricBlockMatrix;
 
-  // Forward declaration of function to extract VectorValues from HybridValues.
-  const VectorValues& GetVectorValues(const HybridValues& c);
-
   /**
    * An abstract virtual base class for JacobianFactor and HessianFactor. A GaussianFactor has a
    * quadratic error function. GaussianFactor is non-mutable (all methods const!). The factor value
@@ -73,17 +70,13 @@ namespace gtsam {
      *   0.5*(A*x-b)'*D*(A*x-b) - log(k)
      * for a \class GaussianConditional, where k is the normalization constant.
      */
-    virtual double error(const VectorValues& c) const {
-      throw std::runtime_error("GaussianFactor::error::error is not implemented");
-    }
+    virtual double error(const VectorValues& c) const;
 
     /**
      * The Factor::error simply extracts the \class VectorValues from the
      * \class HybridValues and calculates the error.
      */
-    double error(const HybridValues& c) const override {
-      return GaussianFactor::error(GetVectorValues(c));
-    }
+    double error(const HybridValues& c) const override;
 
     /** Return the dimension of the variable pointed to by the given key iterator */
     virtual DenseIndex getDim(const_iterator variable) const = 0;

--- a/gtsam/linear/GaussianFactor.h
+++ b/gtsam/linear/GaussianFactor.h
@@ -78,7 +78,7 @@ namespace gtsam {
     }
 
     /**
-     * The factor::error simply extracts the \class VectorValues from the
+     * The Factor::error simply extracts the \class VectorValues from the
      * \class HybridValues and calculates the error.
      */
     double error(const HybridValues& c) const override {

--- a/gtsam/linear/GaussianFactor.h
+++ b/gtsam/linear/GaussianFactor.h
@@ -31,6 +31,9 @@ namespace gtsam {
   class Scatter;
   class SymmetricBlockMatrix;
 
+  // Forward declaration of function to extract VectorValues from HybridValues.
+  const VectorValues& GetVectorValues(const HybridValues& c);
+
   /**
    * An abstract virtual base class for JacobianFactor and HessianFactor. A GaussianFactor has a
    * quadratic error function. GaussianFactor is non-mutable (all methods const!). The factor value
@@ -63,8 +66,24 @@ namespace gtsam {
     /** Equals for testable */
     virtual bool equals(const GaussianFactor& lf, double tol = 1e-9) const = 0;
 
-    /** Print for testable */
-    virtual double error(const VectorValues& c) const = 0; /**  0.5*(A*x-b)'*D*(A*x-b) */
+    /**
+     * In Gaussian factors, the error function returns either the negative log-likelihood, e.g.,
+     *   0.5*(A*x-b)'*D*(A*x-b) 
+     * for a \class JacobianFactor, or the negative log-density, e.g.,
+     *   0.5*(A*x-b)'*D*(A*x-b) - log(k)
+     * for a \class GaussianConditional, where k is the normalization constant.
+     */
+    virtual double error(const VectorValues& c) const {
+      throw std::runtime_error("GaussianFactor::error::error is not implemented");
+    }
+
+    /**
+     * The factor::error simply extracts the \class VectorValues from the
+     * \class HybridValues and calculates the error.
+     */
+    double error(const HybridValues& c) const override {
+      return GaussianFactor::error(GetVectorValues(c));
+    }
 
     /** Return the dimension of the variable pointed to by the given key iterator */
     virtual DenseIndex getDim(const_iterator variable) const = 0;

--- a/gtsam/linear/GaussianFactorGraph.cpp
+++ b/gtsam/linear/GaussianFactorGraph.cpp
@@ -68,6 +68,22 @@ namespace gtsam {
   }
 
   /* ************************************************************************* */
+  double GaussianFactorGraph::error(const VectorValues& x) const {
+    double total_error = 0.;
+    for(const sharedFactor& factor: *this){
+      if(factor)
+        total_error += factor->error(x);
+    }
+    return total_error;
+  }
+
+  /* ************************************************************************* */
+  double GaussianFactorGraph::probPrime(const VectorValues& c) const {
+    // NOTE the 0.5 constant is handled by the factor error.
+    return exp(-error(c));
+  }
+
+  /* ************************************************************************* */
   GaussianFactorGraph::shared_ptr GaussianFactorGraph::cloneToPtr() const {
     gtsam::GaussianFactorGraph::shared_ptr result(new GaussianFactorGraph());
     *result = *this;

--- a/gtsam/linear/GaussianFactorGraph.h
+++ b/gtsam/linear/GaussianFactorGraph.h
@@ -167,20 +167,10 @@ namespace gtsam {
     std::map<Key, size_t> getKeyDimMap() const;
 
     /** unnormalized error */
-    double error(const VectorValues& x) const {
-      double total_error = 0.;
-      for(const sharedFactor& factor: *this){
-        if(factor)
-          total_error += factor->error(x);
-      }
-      return total_error;
-    }
+    double error(const VectorValues& x) const;
 
     /** Unnormalized probability. O(n) */
-    double probPrime(const VectorValues& c) const {
-      // NOTE the 0.5 constant is handled by the factor error.
-      return exp(-error(c));
-    }
+    double probPrime(const VectorValues& c) const;
 
     /**
      * Clone() performs a deep-copy of the graph, including all of the factors.

--- a/gtsam/linear/linear.i
+++ b/gtsam/linear/linear.i
@@ -497,6 +497,7 @@ virtual class GaussianConditional : gtsam::JacobianFactor {
   bool equals(const gtsam::GaussianConditional& cg, double tol) const;
   
   // Standard Interface
+  double logProbability(const gtsam::VectorValues& x) const;
   double evaluate(const gtsam::VectorValues& x) const;
   double error(const gtsam::VectorValues& x) const;
   gtsam::Key firstFrontalKey() const;
@@ -558,6 +559,8 @@ virtual class GaussianBayesNet {
   gtsam::GaussianConditional* back() const;
 
   // Standard interface
+  // Standard Interface
+  double logProbability(const gtsam::VectorValues& x) const;
   double evaluate(const gtsam::VectorValues& x) const;
   double error(const gtsam::VectorValues& x) const;
 

--- a/gtsam/linear/linear.i
+++ b/gtsam/linear/linear.i
@@ -498,7 +498,7 @@ virtual class GaussianConditional : gtsam::JacobianFactor {
   
   // Standard Interface
   double evaluate(const gtsam::VectorValues& x) const;
-  double logDensity(const gtsam::VectorValues& x) const;
+  double error(const gtsam::VectorValues& x) const;
   gtsam::Key firstFrontalKey() const;
   gtsam::VectorValues solve(const gtsam::VectorValues& parents) const;
   gtsam::JacobianFactor* likelihood(
@@ -559,7 +559,7 @@ virtual class GaussianBayesNet {
 
   // Standard interface
   double evaluate(const gtsam::VectorValues& x) const;
-  double logDensity(const gtsam::VectorValues& x) const;
+  double error(const gtsam::VectorValues& x) const;
 
   gtsam::VectorValues optimize() const;
   gtsam::VectorValues optimize(const gtsam::VectorValues& given) const;

--- a/gtsam/linear/tests/testGaussianBayesNet.cpp
+++ b/gtsam/linear/tests/testGaussianBayesNet.cpp
@@ -78,9 +78,13 @@ TEST(GaussianBayesNet, Evaluate1) {
   // which at the mean is 1.0! So, the only thing we need to calculate is
   // the normalization constant 1.0/sqrt((2*pi*Sigma).det()).
   // The covariance matrix inv(Sigma) = R'*R, so the determinant is
-  const double expected = sqrt((invSigma / (2 * M_PI)).determinant());
+  const double constant = sqrt((invSigma / (2 * M_PI)).determinant());
+  EXPECT_DOUBLES_EQUAL(log(constant),
+                       smallBayesNet.at(0)->logNormalizationConstant() +
+                           smallBayesNet.at(1)->logNormalizationConstant(),
+                       1e-9);
   const double actual = smallBayesNet.evaluate(mean);
-  EXPECT_DOUBLES_EQUAL(expected, actual, 1e-9);
+  EXPECT_DOUBLES_EQUAL(constant, actual, 1e-9);
 }
 
 // Check the evaluate with non-unit noise.
@@ -89,9 +93,9 @@ TEST(GaussianBayesNet, Evaluate2) {
   const VectorValues mean = noisyBayesNet.optimize();
   const Matrix R = noisyBayesNet.matrix().first;
   const Matrix invSigma = R.transpose() * R;
-  const double expected = sqrt((invSigma / (2 * M_PI)).determinant());
+  const double constant = sqrt((invSigma / (2 * M_PI)).determinant());
   const double actual = noisyBayesNet.evaluate(mean);
-  EXPECT_DOUBLES_EQUAL(expected, actual, 1e-9);
+  EXPECT_DOUBLES_EQUAL(constant, actual, 1e-9);
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/tests/testGaussianConditional.cpp
+++ b/gtsam/linear/tests/testGaussianConditional.cpp
@@ -381,14 +381,20 @@ TEST(GaussianConditional, FromMeanAndStddev) {
   auto conditional1 =
       GaussianConditional::FromMeanAndStddev(X(0), A1, X(1), b, sigma);
   Vector2 e1 = (x0 - (A1 * x1 + b)) / sigma;
-  double expected1 = 0.5 * e1.dot(e1) - conditional1.logNormalizationConstant();
+  double expected1 = 0.5 * e1.dot(e1);
   EXPECT_DOUBLES_EQUAL(expected1, conditional1.error(values), 1e-9);
+
+  double expected2 = conditional1.logNormalizationConstant() - 0.5 * e1.dot(e1);
+  EXPECT_DOUBLES_EQUAL(expected2, conditional1.logProbability(values), 1e-9);
 
   auto conditional2 = GaussianConditional::FromMeanAndStddev(X(0), A1, X(1), A2,
                                                              X(2), b, sigma);
   Vector2 e2 = (x0 - (A1 * x1 + A2 * x2 + b)) / sigma;
-  double expected2 = 0.5 * e2.dot(e2) - conditional2.logNormalizationConstant();
-  EXPECT_DOUBLES_EQUAL(expected2, conditional2.error(values), 1e-9);
+  double expected3 = 0.5 * e2.dot(e2);
+  EXPECT_DOUBLES_EQUAL(expected3, conditional2.error(values), 1e-9);
+
+  double expected4 = conditional2.logNormalizationConstant() - 0.5 * e2.dot(e2);
+  EXPECT_DOUBLES_EQUAL(expected4, conditional2.logProbability(values), 1e-9);
 }
 
 /* ************************************************************************* */
@@ -454,12 +460,13 @@ TEST(GaussianConditional, Error) {
       GaussianConditional::FromMeanAndStddev(X(0), Vector1::Zero(), 1.0);
   VectorValues values;
   values.insert(X(0), Vector1::Zero());
-  double error = stdGaussian.error(values);
+  double logProbability = stdGaussian.logProbability(values);
 
   // Regression.
   // These values were computed by hand for a univariate standard gaussian.
-  EXPECT_DOUBLES_EQUAL(0.9189385332046727, error, 1e-9);
-  EXPECT_DOUBLES_EQUAL(0.3989422804014327, exp(-error), 1e-9);
+  EXPECT_DOUBLES_EQUAL(-0.9189385332046727, logProbability, 1e-9);
+  EXPECT_DOUBLES_EQUAL(0.3989422804014327, exp(logProbability), 1e-9);
+  EXPECT_DOUBLES_EQUAL(stdGaussian(values), exp(logProbability), 1e-9);
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/tests/testGaussianDensity.cpp
+++ b/gtsam/linear/tests/testGaussianDensity.cpp
@@ -52,7 +52,7 @@ TEST(GaussianDensity, FromMeanAndStddev) {
 
   auto density = GaussianDensity::FromMeanAndStddev(X(0), b, sigma);
   Vector2 e = (x0 - b) / sigma;
-  double expected = 0.5 * e.dot(e);
+  double expected = 0.5 * e.dot(e) - density.logNormalizationConstant();
   EXPECT_DOUBLES_EQUAL(expected, density.error(values), 1e-9);
 }
 

--- a/gtsam/linear/tests/testGaussianDensity.cpp
+++ b/gtsam/linear/tests/testGaussianDensity.cpp
@@ -52,8 +52,11 @@ TEST(GaussianDensity, FromMeanAndStddev) {
 
   auto density = GaussianDensity::FromMeanAndStddev(X(0), b, sigma);
   Vector2 e = (x0 - b) / sigma;
-  double expected = 0.5 * e.dot(e) - density.logNormalizationConstant();
-  EXPECT_DOUBLES_EQUAL(expected, density.error(values), 1e-9);
+  double expected1 = 0.5 * e.dot(e);
+  EXPECT_DOUBLES_EQUAL(expected1, density.error(values), 1e-9);
+
+  double expected2 = density.logNormalizationConstant()- 0.5 * e.dot(e);
+  EXPECT_DOUBLES_EQUAL(expected2, density.logProbability(values), 1e-9);
 }
 
 /* ************************************************************************* */

--- a/gtsam/nonlinear/NonlinearFactor.cpp
+++ b/gtsam/nonlinear/NonlinearFactor.cpp
@@ -24,8 +24,13 @@
 namespace gtsam {
 
 /* ************************************************************************* */
-const Values& GetValues(const HybridValues& c) {
-  return c.nonlinear();
+double NonlinearFactor::error(const Values& c) const {
+  throw std::runtime_error("NonlinearFactor::error is not implemented");
+}
+
+/* ************************************************************************* */
+double NonlinearFactor::error(const HybridValues& c) const {
+  return this->error(c.nonlinear());
 }
 
 /* ************************************************************************* */

--- a/gtsam/nonlinear/NonlinearFactor.cpp
+++ b/gtsam/nonlinear/NonlinearFactor.cpp
@@ -16,11 +16,17 @@
  * @author  Richard Roberts
  */
 
+#include <gtsam/hybrid/HybridValues.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 #include <boost/make_shared.hpp>
 #include <boost/format.hpp>
 
 namespace gtsam {
+
+/* ************************************************************************* */
+const Values& GetValues(const HybridValues& c) {
+  return c.nonlinear();
+}
 
 /* ************************************************************************* */
 void NonlinearFactor::print(const std::string& s,

--- a/gtsam/nonlinear/NonlinearFactor.h
+++ b/gtsam/nonlinear/NonlinearFactor.h
@@ -98,11 +98,11 @@ public:
    * \code double evaluateError(const Values& c) const \endcode.
    */
   virtual double error(const Values& c) const {
-    throw std::runtime_error("NonlinearFactor::error::error is not implemented");
+    throw std::runtime_error("NonlinearFactor::error is not implemented");
   }
 
   /**
-   * The factor::error simply extracts the \class Values from the
+   * The Factor::error simply extracts the \class Values from the
    * \class HybridValues and calculates the error.
    */
   double error(const HybridValues& c) const override {

--- a/gtsam/nonlinear/NonlinearFactor.h
+++ b/gtsam/nonlinear/NonlinearFactor.h
@@ -34,9 +34,6 @@ namespace gtsam {
 
 /* ************************************************************************* */
 
-// Forward declaration of function to extract Values from HybridValues.
-const Values& GetValues(const HybridValues& c);
-
 /**
  * Nonlinear factor base class
  *
@@ -97,17 +94,13 @@ public:
    * and calculates the error by asking the user to implement the method
    * \code double evaluateError(const Values& c) const \endcode.
    */
-  virtual double error(const Values& c) const {
-    throw std::runtime_error("NonlinearFactor::error is not implemented");
-  }
+  virtual double error(const Values& c) const;
 
   /**
    * The Factor::error simply extracts the \class Values from the
    * \class HybridValues and calculates the error.
    */
-  double error(const HybridValues& c) const override {
-    return NonlinearFactor::error(GetValues(c));
-  }
+  double error(const HybridValues& c) const override;
 
   /** get the dimension of the factor (number of rows on linearization) */
   virtual size_t dim() const = 0;

--- a/gtsam/nonlinear/NonlinearFactor.h
+++ b/gtsam/nonlinear/NonlinearFactor.h
@@ -34,6 +34,9 @@ namespace gtsam {
 
 /* ************************************************************************* */
 
+// Forward declaration of function to extract Values from HybridValues.
+const Values& GetValues(const HybridValues& c);
+
 /**
  * Nonlinear factor base class
  *
@@ -74,6 +77,7 @@ public:
 
   /** Check if two factors are equal */
   virtual bool equals(const NonlinearFactor& f, double tol = 1e-9) const;
+
   /// @}
   /// @name Standard Interface
   /// @{
@@ -81,13 +85,29 @@ public:
   /** Destructor */
   virtual ~NonlinearFactor() {}
 
+  /**
+   * In nonlinear factors, the error function returns the negative log-likelihood
+   * as a non-linear function of the values in a \class Values object.
+   * 
+   * The idea is that Gaussian factors have a quadratic error function that locally 
+   * approximates the negative log-likelihood, and are obtained by \b linearizing
+   * the nonlinear error function at a given linearization.
+   * 
+   * The derived class, \class NoiseModelFactor, adds a noise model to the factor,
+   * and calculates the error by asking the user to implement the method
+   * \code double evaluateError(const Values& c) const \endcode.
+   */
+  virtual double error(const Values& c) const {
+    throw std::runtime_error("NonlinearFactor::error::error is not implemented");
+  }
 
   /**
-   * Calculate the error of the factor
-   * This is typically equal to log-likelihood, e.g. \f$ 0.5(h(x)-z)^2/sigma^2 \f$ in case of Gaussian.
-   * You can override this for systems with unusual noise models.
+   * The factor::error simply extracts the \class Values from the
+   * \class HybridValues and calculates the error.
    */
-  virtual double error(const Values& c) const = 0;
+  double error(const HybridValues& c) const override {
+    return NonlinearFactor::error(GetValues(c));
+  }
 
   /** get the dimension of the factor (number of rows on linearization) */
   virtual size_t dim() const = 0;

--- a/gtsam/symbolic/SymbolicConditional.cpp
+++ b/gtsam/symbolic/SymbolicConditional.cpp
@@ -15,7 +15,6 @@
  * @date    Oct 17, 2010
  */
 
-#include <gtsam/inference/Conditional-inst.h>
 #include <gtsam/symbolic/SymbolicConditional.h>
 
 namespace gtsam {
@@ -36,6 +35,11 @@ bool SymbolicConditional::equals(const This& c, double tol) const {
 /* ************************************************************************* */
 double SymbolicConditional::logProbability(const HybridValues& c) const {
   throw std::runtime_error("SymbolicConditional::logProbability is not implemented");
+}
+
+/* ************************************************************************* */
+double SymbolicConditional::evaluate(const HybridValues& c) const {
+  throw std::runtime_error("SymbolicConditional::evaluate is not implemented");
 }
 
 

--- a/gtsam/symbolic/SymbolicConditional.cpp
+++ b/gtsam/symbolic/SymbolicConditional.cpp
@@ -33,4 +33,10 @@ bool SymbolicConditional::equals(const This& c, double tol) const {
   return BaseFactor::equals(c) && BaseConditional::equals(c);
 }
 
+/* ************************************************************************* */
+double SymbolicConditional::logProbability(const HybridValues& c) const {
+  throw std::runtime_error("SymbolicConditional::logProbability is not implemented");
+}
+
+
 }  // namespace gtsam

--- a/gtsam/symbolic/SymbolicConditional.h
+++ b/gtsam/symbolic/SymbolicConditional.h
@@ -17,10 +17,10 @@
 
 #pragma once
 
-#include <gtsam/symbolic/SymbolicFactor.h>
-#include <gtsam/inference/Conditional.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/types.h>
+#include <gtsam/inference/Conditional-inst.h>
+#include <gtsam/symbolic/SymbolicFactor.h>
 
 namespace gtsam {
 
@@ -114,12 +114,12 @@ namespace gtsam {
     /// @name HybridValues methods.
     /// @{
 
-    /**
-     * logProbability throws exception, symbolic.
-     */
+    /// logProbability throws exception, symbolic.
     double logProbability(const HybridValues& x) const override;
 
-    using Conditional::evaluate; // Expose evaluate(const HybridValues&) method..
+    /// evaluate throws exception, symbolic.
+    double evaluate(const HybridValues& x) const override;
+
     using Conditional::operator(); // Expose evaluate(const HybridValues&) method..
     using SymbolicFactor::error; // Expose error(const HybridValues&) method..
 

--- a/gtsam/symbolic/SymbolicConditional.h
+++ b/gtsam/symbolic/SymbolicConditional.h
@@ -95,13 +95,10 @@ namespace gtsam {
       return FromIteratorsShared(keys.begin(), keys.end(), nrFrontals);
     }
 
-    ~SymbolicConditional() override {}
-
     /// Copy this object as its actual derived type.
     SymbolicFactor::shared_ptr clone() const { return boost::make_shared<This>(*this); }
 
     /// @}
-
     /// @name Testable
     /// @{
 
@@ -112,6 +109,19 @@ namespace gtsam {
 
     /** Check equality */
     bool equals(const This& c, double tol = 1e-9) const;
+
+    /// @}
+    /// @name HybridValues methods.
+    /// @{
+
+    /**
+     * logProbability throws exception, symbolic.
+     */
+    double logProbability(const HybridValues& x) const override;
+
+    using Conditional::evaluate; // Expose evaluate(const HybridValues&) method..
+    using Conditional::operator(); // Expose evaluate(const HybridValues&) method..
+    using SymbolicFactor::error; // Expose error(const HybridValues&) method..
 
     /// @}
 

--- a/gtsam/symbolic/SymbolicFactor.cpp
+++ b/gtsam/symbolic/SymbolicFactor.cpp
@@ -27,6 +27,11 @@ using namespace std;
 namespace gtsam {
 
   /* ************************************************************************* */
+  double SymbolicFactor::error(const HybridValues& c) const {
+    throw std::runtime_error("SymbolicFactor::error is not implemented");
+  }
+
+  /* ************************************************************************* */
   std::pair<boost::shared_ptr<SymbolicConditional>, boost::shared_ptr<SymbolicFactor> >
     EliminateSymbolic(const SymbolicFactorGraph& factors, const Ordering& keys)
   {

--- a/gtsam/symbolic/SymbolicFactor.h
+++ b/gtsam/symbolic/SymbolicFactor.h
@@ -30,6 +30,7 @@ namespace gtsam {
 
   // Forward declarations
   class SymbolicConditional;
+  class HybridValues;
   class Ordering;
 
   /** SymbolicFactor represents a symbolic factor that specifies graph topology but is not
@@ -46,7 +47,7 @@ namespace gtsam {
     /** Overriding the shared_ptr typedef */
     typedef boost::shared_ptr<This> shared_ptr;
 
-    /// @name Standard Interface
+    /// @name Standard Constructors
     /// @{
 
     /** Default constructor for I/O */
@@ -106,10 +107,9 @@ namespace gtsam {
     }
 
     /// @}
-
     /// @name Advanced Constructors
     /// @{
-  public:
+  
     /** Constructor from a collection of keys */
     template<typename KEYITERATOR>
     static SymbolicFactor FromIterators(KEYITERATOR beginKey, KEYITERATOR endKey) {
@@ -142,6 +142,9 @@ namespace gtsam {
 
     /// @name Standard Interface
     /// @{
+
+    /// The `error` method throws an exception.
+    double error(const HybridValues& c) const override;
 
     /** Eliminate the variables in \c keys, in the order specified in \c keys, returning a
      *  conditional and marginal. */

--- a/python/gtsam/tests/test_GaussianBayesNet.py
+++ b/python/gtsam/tests/test_GaussianBayesNet.py
@@ -10,9 +10,6 @@ Author: Frank Dellaert
 """
 # pylint: disable=invalid-name, no-name-in-module, no-member
 
-from __future__ import print_function
-
-import math
 import unittest
 
 import numpy as np
@@ -55,9 +52,9 @@ class TestGaussianBayesNet(GtsamTestCase):
         values.insert(_y_, np.array([5.0]))
         for i in [0, 1]:
             self.assertAlmostEqual(bayesNet.at(i).logProbability(values),
-                                   math.log(bayesNet.at(i).evaluate(values)))
+                                   np.log(bayesNet.at(i).evaluate(values)))
         self.assertAlmostEqual(bayesNet.logProbability(values),
-                               math.log(bayesNet.evaluate(values)))
+                               np.log(bayesNet.evaluate(values)))
 
     def test_sample(self):
         """Test sample method"""

--- a/python/gtsam/tests/test_GaussianBayesNet.py
+++ b/python/gtsam/tests/test_GaussianBayesNet.py
@@ -12,12 +12,14 @@ Author: Frank Dellaert
 
 from __future__ import print_function
 
+import math
 import unittest
 
-import gtsam
 import numpy as np
-from gtsam import GaussianBayesNet, GaussianConditional
 from gtsam.utils.test_case import GtsamTestCase
+
+import gtsam
+from gtsam import GaussianBayesNet, GaussianConditional
 
 # some keys
 _x_ = 11
@@ -44,6 +46,18 @@ class TestGaussianBayesNet(GtsamTestCase):
         d1 = np.array([9.0, 5.0])
         np.testing.assert_equal(R, R1)
         np.testing.assert_equal(d, d1)
+
+    def test_evaluate(self):
+        """Test evaluate method"""
+        bayesNet = smallBayesNet()
+        values = gtsam.VectorValues()
+        values.insert(_x_, np.array([9.0]))
+        values.insert(_y_, np.array([5.0]))
+        for i in [0, 1]:
+            self.assertAlmostEqual(bayesNet.at(i).logProbability(values),
+                                   math.log(bayesNet.at(i).evaluate(values)))
+        self.assertAlmostEqual(bayesNet.logProbability(values),
+                               math.log(bayesNet.evaluate(values)))
 
     def test_sample(self):
         """Test sample method"""


### PR DESCRIPTION
Cleaning up before releasing 4.2 and implementing last hybrid PR
- renamed logDensity to logProbability, as density is continuous only
- we now have logProbability(x) = log(evaluate(x)) = K - error(x) for all conditionals
- probPrime(x) = exp(-error(x)) as always, but is only supposed to be used in factors

My advice for reviewing (seems daunting but most is rote):
- start with Factor.h, Conditional.h and the rest of inference - read the updated docs (and please flag issues).
- Then hybrid.
- Then linear, discrete, symbolic

Note that some methods are gone as now implemented in bottom base classes.
