### PR TITLE
Test and fix all conditionals

### DIFF
--- a/gtsam/discrete/DiscreteConditional.cpp
+++ b/gtsam/discrete/DiscreteConditional.cpp
@@ -20,7 +20,7 @@
 #include <gtsam/base/debug.h>
 #include <gtsam/discrete/DiscreteConditional.h>
 #include <gtsam/discrete/Signature.h>
-#include <gtsam/inference/Conditional-inst.h>
+#include <gtsam/hybrid/HybridValues.h>
 
 #include <algorithm>
 #include <boost/make_shared.hpp>
@@ -510,6 +510,10 @@ string DiscreteConditional::html(const KeyFormatter& keyFormatter,
   return ss.str();
 }
 
+/* ************************************************************************* */
+double DiscreteConditional::evaluate(const HybridValues& x) const{
+  return this->evaluate(x.discrete());
+}
 /* ************************************************************************* */
 
 }  // namespace gtsam

--- a/gtsam/discrete/DiscreteConditional.h
+++ b/gtsam/discrete/DiscreteConditional.h
@@ -160,9 +160,12 @@ class GTSAM_EXPORT DiscreteConditional
   }
 
   /// Evaluate, just look up in AlgebraicDecisonTree
-  double operator()(const DiscreteValues& values) const override {
+  double evaluate(const DiscreteValues& values) const {
     return ADT::operator()(values);
   }
+
+  using DecisionTreeFactor::error;       ///< DiscreteValues version
+  using DecisionTreeFactor::operator();  ///< DiscreteValues version
 
   /**
    * @brief restrict to given *parent* values.
@@ -236,15 +239,20 @@ class GTSAM_EXPORT DiscreteConditional
   /// @{
 
   /**
+   * Calculate probability for HybridValues `x`.
+   * Dispatches to DiscreteValues version.
+   */
+  double evaluate(const HybridValues& x) const override;
+
+  using BaseConditional::operator();  ///< HybridValues version
+
+  /**
    * Calculate log-probability log(evaluate(x)) for HybridValues `x`.
    * This is actually just -error(x).
    */
   double logProbability(const HybridValues& x) const override {
     return -error(x);
   }
-
-  using DecisionTreeFactor::error;     ///< HybridValues version
-  using DecisionTreeFactor::evaluate;  ///< HybridValues version
 
   /// @}
 

--- a/gtsam/discrete/DiscreteConditional.h
+++ b/gtsam/discrete/DiscreteConditional.h
@@ -243,7 +243,8 @@ class GTSAM_EXPORT DiscreteConditional
     return -error(x);
   }
 
-  using DecisionTreeFactor::evaluate;
+  using DecisionTreeFactor::error;     ///< HybridValues version
+  using DecisionTreeFactor::evaluate;  ///< HybridValues version
 
   /// @}
 

--- a/gtsam/discrete/discrete.i
+++ b/gtsam/discrete/discrete.i
@@ -82,6 +82,7 @@ virtual class DecisionTreeFactor : gtsam::DiscreteFactor {
 };
 
 #include <gtsam/discrete/DiscreteConditional.h>
+#include <gtsam/hybrid/HybridValues.h>
 virtual class DiscreteConditional : gtsam::DecisionTreeFactor {
   DiscreteConditional();
   DiscreteConditional(size_t nFrontals, const gtsam::DecisionTreeFactor& f);
@@ -95,9 +96,12 @@ virtual class DiscreteConditional : gtsam::DecisionTreeFactor {
   DiscreteConditional(const gtsam::DecisionTreeFactor& joint,
                       const gtsam::DecisionTreeFactor& marginal,
                       const gtsam::Ordering& orderedKeys);
+
+  // Standard interface
+  double logNormalizationConstant() const;
   double logProbability(const gtsam::DiscreteValues& values) const;
   double evaluate(const gtsam::DiscreteValues& values) const;
-  double operator()(const gtsam::DiscreteValues& values) const;
+  double error(const gtsam::DiscreteValues& values) const;
   gtsam::DiscreteConditional operator*(
       const gtsam::DiscreteConditional& other) const;
   gtsam::DiscreteConditional marginal(gtsam::Key key) const;
@@ -119,6 +123,8 @@ virtual class DiscreteConditional : gtsam::DecisionTreeFactor {
   size_t sample(size_t value) const;
   size_t sample() const;
   void sampleInPlace(gtsam::DiscreteValues @parentsValues) const;
+
+  // Markdown and HTML
   string markdown(const gtsam::KeyFormatter& keyFormatter =
                       gtsam::DefaultKeyFormatter) const;
   string markdown(const gtsam::KeyFormatter& keyFormatter,
@@ -127,6 +133,11 @@ virtual class DiscreteConditional : gtsam::DecisionTreeFactor {
                   gtsam::DefaultKeyFormatter) const;
   string html(const gtsam::KeyFormatter& keyFormatter,
               std::map<gtsam::Key, std::vector<std::string>> names) const;
+
+  // Expose HybridValues versions
+  double logProbability(const gtsam::HybridValues& x) const;
+  double evaluate(const gtsam::HybridValues& x) const;
+  double error(const gtsam::HybridValues& x) const;
 };
 
 #include <gtsam/discrete/DiscreteDistribution.h>

--- a/gtsam/discrete/tests/testDiscreteConditional.cpp
+++ b/gtsam/discrete/tests/testDiscreteConditional.cpp
@@ -96,6 +96,7 @@ TEST(DiscreteConditional, PriorProbability) {
   DiscreteConditional dc(Asia, "4/6");
   DiscreteValues values{{asiaKey, 0}};
   EXPECT_DOUBLES_EQUAL(0.4, dc.evaluate(values), 1e-9);
+  EXPECT(DiscreteConditional::CheckInvariants(dc, values));
 }
 
 /* ************************************************************************* */
@@ -109,6 +110,7 @@ TEST(DiscreteConditional, probability) {
   EXPECT_DOUBLES_EQUAL(0.2, C_given_DE(given), 1e-9);
   EXPECT_DOUBLES_EQUAL(log(0.2), C_given_DE.logProbability(given), 1e-9);
   EXPECT_DOUBLES_EQUAL(-log(0.2), C_given_DE.error(given), 1e-9);
+  EXPECT(DiscreteConditional::CheckInvariants(C_given_DE, given));
 }
 
 /* ************************************************************************* */

--- a/gtsam/hybrid/GaussianMixture.cpp
+++ b/gtsam/hybrid/GaussianMixture.cpp
@@ -290,6 +290,13 @@ AlgebraicDecisionTree<Key> GaussianMixture::logProbability(
 }
 
 /* *******************************************************************************/
+double GaussianMixture::error(const HybridValues &values) const {
+  // Directly index to get the conditional, no need to build the whole tree.
+  auto conditional = conditionals_(values.discrete());
+  return conditional->error(values.continuous());
+}
+
+/* *******************************************************************************/
 double GaussianMixture::logProbability(const HybridValues &values) const {
   // Directly index to get the conditional, no need to build the whole tree.
   auto conditional = conditionals_(values.discrete());

--- a/gtsam/hybrid/GaussianMixture.cpp
+++ b/gtsam/hybrid/GaussianMixture.cpp
@@ -298,9 +298,14 @@ double GaussianMixture::error(const HybridValues &values) const {
 
 /* *******************************************************************************/
 double GaussianMixture::logProbability(const HybridValues &values) const {
-  // Directly index to get the conditional, no need to build the whole tree.
   auto conditional = conditionals_(values.discrete());
   return conditional->logProbability(values.continuous());
+}
+
+/* *******************************************************************************/
+double GaussianMixture::evaluate(const HybridValues &values) const {
+  auto conditional = conditionals_(values.discrete());
+  return conditional->evaluate(values.continuous());
 }
 
 }  // namespace gtsam

--- a/gtsam/hybrid/GaussianMixture.cpp
+++ b/gtsam/hybrid/GaussianMixture.cpp
@@ -293,7 +293,7 @@ AlgebraicDecisionTree<Key> GaussianMixture::logProbability(
 double GaussianMixture::error(const HybridValues &values) const {
   // Directly index to get the conditional, no need to build the whole tree.
   auto conditional = conditionals_(values.discrete());
-  return conditional->error(values.continuous());
+  return conditional->error(values.continuous()) - conditional->logNormalizationConstant();
 }
 
 /* *******************************************************************************/

--- a/gtsam/hybrid/GaussianMixture.h
+++ b/gtsam/hybrid/GaussianMixture.h
@@ -176,7 +176,21 @@ class GTSAM_EXPORT GaussianMixture
   /**
    * @brief Compute the error of this Gaussian Mixture.
    *
-   * log(probability(x)) = K - error(x)
+   * This requires some care, as different mixture components may have
+   * different normalization constants. Let's consider p(x|y,m), where m is
+   * discrete. We need the error to satisfy the invariant:
+   *
+   *    error(x;y,m) = K - log(probability(x;y,m))
+   *
+   * For all x,y,m. But note that K, for the GaussianMixture, cannot depend on
+   * any arguments. Hence, we delegate to the underlying Gaussian
+   * conditionals, indexed by m, which do satisfy:
+   * 
+   *    log(probability_m(x;y)) = K_m - error_m(x;y)
+   * 
+   * We resolve by having K == 0.0 and
+   * 
+   *    error(x;y,m) = error_m(x;y) - K_m
    *
    * @param values Continuous values and discrete assignment.
    * @return double

--- a/gtsam/hybrid/GaussianMixture.h
+++ b/gtsam/hybrid/GaussianMixture.h
@@ -174,8 +174,17 @@ class GTSAM_EXPORT GaussianMixture
       const VectorValues &continuousValues) const;
 
   /**
-   * @brief Compute the logProbability of this Gaussian Mixture given the
-   * continuous values and a discrete assignment.
+   * @brief Compute the error of this Gaussian Mixture.
+   * 
+   * log(probability(x)) = K - error(x)
+   *
+   * @param values Continuous values and discrete assignment.
+   * @return double
+   */
+  double error(const HybridValues &values) const override;
+
+  /**
+   * @brief Compute the logProbability of this Gaussian Mixture.
    *
    * @param values Continuous values and discrete assignment.
    * @return double

--- a/gtsam/hybrid/GaussianMixture.h
+++ b/gtsam/hybrid/GaussianMixture.h
@@ -175,7 +175,7 @@ class GTSAM_EXPORT GaussianMixture
 
   /**
    * @brief Compute the error of this Gaussian Mixture.
-   * 
+   *
    * log(probability(x)) = K - error(x)
    *
    * @param values Continuous values and discrete assignment.
@@ -191,12 +191,13 @@ class GTSAM_EXPORT GaussianMixture
    */
   double logProbability(const HybridValues &values) const override;
 
-  //   /// Calculate probability density for given values `x`.
-  //   double evaluate(const HybridValues &values) const;
+  /// Calculate probability density for given `values`.
+  double evaluate(const HybridValues &values) const override;
 
-  //   /// Evaluate probability density, sugar.
-  //   double operator()(const HybridValues &values) const { return
-  //   evaluate(values); }
+  /// Evaluate probability density, sugar.
+  double operator()(const HybridValues &values) const {
+    return evaluate(values);
+  }
 
   /**
    * @brief Prune the decision tree of Gaussian factors as per the discrete

--- a/gtsam/hybrid/HybridConditional.cpp
+++ b/gtsam/hybrid/HybridConditional.cpp
@@ -122,6 +122,21 @@ bool HybridConditional::equals(const HybridFactor &other, double tol) const {
 }
 
 /* ************************************************************************ */
+double HybridConditional::error(const HybridValues &values) const {
+  if (auto gc = asGaussian()) {
+    return gc->error(values.continuous());
+  }
+  if (auto gm = asMixture()) {
+    return gm->error(values);
+  }
+  if (auto dc = asDiscrete()) {
+    return dc->error(values.discrete());
+  }
+  throw std::runtime_error(
+      "HybridConditional::error: conditional type not handled");
+}
+
+/* ************************************************************************ */
 double HybridConditional::logProbability(const HybridValues &values) const {
   if (auto gc = asGaussian()) {
     return gc->logProbability(values.continuous());

--- a/gtsam/hybrid/HybridConditional.cpp
+++ b/gtsam/hybrid/HybridConditional.cpp
@@ -151,4 +151,24 @@ double HybridConditional::logProbability(const HybridValues &values) const {
       "HybridConditional::logProbability: conditional type not handled");
 }
 
+/* ************************************************************************ */
+double HybridConditional::logNormalizationConstant() const {
+  if (auto gc = asGaussian()) {
+    return gc->logNormalizationConstant();
+  }
+  if (auto gm = asMixture()) {
+    return gm->logNormalizationConstant(); // 0.0!
+  }
+  if (auto dc = asDiscrete()) {
+    return dc->logNormalizationConstant(); // 0.0!
+  }
+  throw std::runtime_error(
+      "HybridConditional::logProbability: conditional type not handled");
+}
+
+/* ************************************************************************ */
+double HybridConditional::evaluate(const HybridValues &values) const {
+  return std::exp(logProbability(values));
+}
+
 }  // namespace gtsam

--- a/gtsam/hybrid/HybridConditional.h
+++ b/gtsam/hybrid/HybridConditional.h
@@ -179,8 +179,18 @@ class GTSAM_EXPORT HybridConditional
   /// Return the error of the underlying conditional.
   double error(const HybridValues& values) const override;
 
-  /// Return the logProbability of the underlying conditional.
+  /// Return the log-probability (or density) of the underlying conditional.
   double logProbability(const HybridValues& values) const override;
+
+  /**
+   * Return the log normalization constant.
+   * Note this is 0.0 for discrete and hybrid conditionals, but depends
+   * on the continuous parameters for Gaussian conditionals.
+   */ 
+  double logNormalizationConstant() const override;
+
+  /// Return the probability (or density) of the underlying conditional.
+  double evaluate(const HybridValues& values) const override;
 
   /// Check if VectorValues `measurements` contains all frontal keys.
   bool frontalsIn(const VectorValues& measurements) const {

--- a/gtsam/hybrid/HybridConditional.h
+++ b/gtsam/hybrid/HybridConditional.h
@@ -176,6 +176,9 @@ class GTSAM_EXPORT HybridConditional
   /// Get the type-erased pointer to the inner type
   boost::shared_ptr<Factor> inner() const { return inner_; }
 
+  /// Return the error of the underlying conditional.
+  double error(const HybridValues& values) const override;
+
   /// Return the logProbability of the underlying conditional.
   double logProbability(const HybridValues& values) const override;
 

--- a/gtsam/hybrid/hybrid.i
+++ b/gtsam/hybrid/hybrid.i
@@ -61,6 +61,7 @@ virtual class HybridConditional {
   size_t nrParents() const;
 
   // Standard interface:
+  double logNormalizationConstant() const;
   double logProbability(const gtsam::HybridValues& values) const;
   double evaluate(const gtsam::HybridValues& values) const;
   double operator()(const gtsam::HybridValues& values) const;

--- a/gtsam/hybrid/tests/testHybridConditional.cpp
+++ b/gtsam/hybrid/tests/testHybridConditional.cpp
@@ -40,31 +40,39 @@ TEST(HybridConditional, Invariants) {
   const HybridValues values{c, d};
 
   // Check invariants for p(z|x,m)
-  auto hc1 = bn.at(0);
-  CHECK(hc1->isHybrid());
-  GTSAM_PRINT(*hc1);
+  auto hc0 = bn.at(0);
+  CHECK(hc0->isHybrid());
 
   // Check invariants as a GaussianMixture.
-  const auto mixture = hc1->asMixture();
-  double probability = mixture->evaluate(values);
-  CHECK(probability >= 0.0);
-  EXPECT_DOUBLES_EQUAL(probability, (*mixture)(values), 1e-9);
-  double logProb = mixture->logProbability(values);
-  EXPECT_DOUBLES_EQUAL(probability, std::exp(logProb), 1e-9);
-  double expected =
-      mixture->logNormalizationConstant() - mixture->error(values);
-  EXPECT_DOUBLES_EQUAL(logProb, expected, 1e-9);
+  const auto mixture = hc0->asMixture();
   EXPECT(GaussianMixture::CheckInvariants(*mixture, values));
 
   // Check invariants as a HybridConditional.
-  probability = hc1->evaluate(values);
-  CHECK(probability >= 0.0);
-  EXPECT_DOUBLES_EQUAL(probability, (*hc1)(values), 1e-9);
-  logProb = hc1->logProbability(values);
-  EXPECT_DOUBLES_EQUAL(probability, std::exp(logProb), 1e-9);
-  expected = hc1->logNormalizationConstant() - hc1->error(values);
-  EXPECT_DOUBLES_EQUAL(logProb, expected, 1e-9);
+  EXPECT(HybridConditional::CheckInvariants(*hc0, values));
+
+  // Check invariants for p(x)
+  auto hc1 = bn.at(1);
+  CHECK(hc1->isContinuous());
+
+  // Check invariants as a GaussianConditional.
+  const auto gaussian = hc1->asGaussian();
+  EXPECT(GaussianConditional::CheckInvariants(*gaussian, c));
+  EXPECT(GaussianConditional::CheckInvariants(*gaussian, values));
+
+  // Check invariants as a HybridConditional.
   EXPECT(HybridConditional::CheckInvariants(*hc1, values));
+
+  // Check invariants for p(m)
+  auto hc2 = bn.at(2);
+  CHECK(hc2->isDiscrete());
+
+  // Check invariants as a DiscreteConditional.
+  const auto discrete = hc2->asDiscrete();
+  EXPECT(DiscreteConditional::CheckInvariants(*discrete, d));
+  EXPECT(DiscreteConditional::CheckInvariants(*discrete, values));
+
+  // Check invariants as a HybridConditional.
+  EXPECT(HybridConditional::CheckInvariants(*hc2, values));
 }
 
 /* ************************************************************************* */

--- a/gtsam/hybrid/tests/testHybridConditional.cpp
+++ b/gtsam/hybrid/tests/testHybridConditional.cpp
@@ -1,0 +1,75 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file    testHybridConditional.cpp
+ * @brief   Unit tests for HybridConditional class
+ * @date    January 2023
+ */
+
+#include <gtsam/hybrid/HybridConditional.h>
+
+#include "TinyHybridExample.h"
+
+// Include for test suite
+#include <CppUnitLite/TestHarness.h>
+
+using namespace gtsam;
+
+using symbol_shorthand::M;
+using symbol_shorthand::X;
+using symbol_shorthand::Z;
+
+/* ****************************************************************************/
+// Check invariants for all conditionals in a tiny Bayes net.
+TEST(HybridConditional, Invariants) {
+  // Create hybrid Bayes net p(z|x,m)p(x)P(m)
+  auto bn = tiny::createHybridBayesNet();
+
+  // Create values to check invariants.
+  const VectorValues c{{X(0), Vector1(5.1)}, {Z(0), Vector1(4.9)}};
+  const DiscreteValues d{{M(0), 1}};
+  const HybridValues values{c, d};
+
+  // Check invariants for p(z|x,m)
+  auto hc1 = bn.at(0);
+  CHECK(hc1->isHybrid());
+  GTSAM_PRINT(*hc1);
+
+  // Check invariants as a GaussianMixture.
+  const auto mixture = hc1->asMixture();
+  double probability = mixture->evaluate(values);
+  CHECK(probability >= 0.0);
+  EXPECT_DOUBLES_EQUAL(probability, (*mixture)(values), 1e-9);
+  double logProb = mixture->logProbability(values);
+  EXPECT_DOUBLES_EQUAL(probability, std::exp(logProb), 1e-9);
+  double expected =
+      mixture->logNormalizationConstant() - mixture->error(values);
+  EXPECT_DOUBLES_EQUAL(logProb, expected, 1e-9);
+  EXPECT(GaussianMixture::CheckInvariants(*mixture, values));
+
+  // Check invariants as a HybridConditional.
+  probability = hc1->evaluate(values);
+  CHECK(probability >= 0.0);
+  EXPECT_DOUBLES_EQUAL(probability, (*hc1)(values), 1e-9);
+  logProb = hc1->logProbability(values);
+  EXPECT_DOUBLES_EQUAL(probability, std::exp(logProb), 1e-9);
+  expected = hc1->logNormalizationConstant() - hc1->error(values);
+  EXPECT_DOUBLES_EQUAL(logProb, expected, 1e-9);
+  EXPECT(HybridConditional::CheckInvariants(*hc1, values));
+}
+
+/* ************************************************************************* */
+int main() {
+  TestResult tr;
+  return TestRegistry::runAllTests(tr);
+}
+/* ************************************************************************* */

--- a/gtsam/inference/Conditional-inst.h
+++ b/gtsam/inference/Conditional-inst.h
@@ -68,12 +68,13 @@ template <class FACTOR, class DERIVEDCONDITIONAL>
 template <class VALUES>
 bool Conditional<FACTOR, DERIVEDCONDITIONAL>::CheckInvariants(
     const DERIVEDCONDITIONAL& conditional, const VALUES& values) {
-  const double probability = conditional.evaluate(values);
-  if (probability < 0.0 || probability > 1.0)
-    return false;  // probability is not in [0,1]
+  const double prob_or_density = conditional.evaluate(values);
+  if (prob_or_density < 0.0) return false;  // prob_or_density is negative.
+  if (std::abs(prob_or_density - conditional(values)) > 1e-9)
+    return false;  // operator and evaluate differ
   const double logProb = conditional.logProbability(values);
-  if (std::abs(probability - std::exp(logProb)) > 1e-9)
-    return false;  // logProb is not consistent with probability
+  if (std::abs(prob_or_density - std::exp(logProb)) > 1e-9)
+    return false;  // logProb is not consistent with prob_or_density
   const double expected =
       conditional.logNormalizationConstant() - conditional.error(values);
   if (std::abs(logProb - expected) > 1e-9)

--- a/gtsam/inference/Conditional-inst.h
+++ b/gtsam/inference/Conditional-inst.h
@@ -63,4 +63,22 @@ double Conditional<FACTOR, DERIVEDCONDITIONAL>::normalizationConstant() const {
   return std::exp(logNormalizationConstant());
 }
 
+/* ************************************************************************* */
+template <class FACTOR, class DERIVEDCONDITIONAL>
+template <class VALUES>
+bool Conditional<FACTOR, DERIVEDCONDITIONAL>::CheckInvariants(
+    const DERIVEDCONDITIONAL& conditional, const VALUES& values) {
+  const double probability = conditional.evaluate(values);
+  if (probability < 0.0 || probability > 1.0)
+    return false;  // probability is not in [0,1]
+  const double logProb = conditional.logProbability(values);
+  if (std::abs(probability - std::exp(logProb)) > 1e-9)
+    return false;  // logProb is not consistent with probability
+  const double expected =
+      conditional.logNormalizationConstant() - conditional.error(values);
+  if (std::abs(logProb - expected) > 1e-9)
+    return false;  // logProb is not consistent with error
+  return true;
+}
+
 }  // namespace gtsam

--- a/gtsam/inference/Conditional-inst.h
+++ b/gtsam/inference/Conditional-inst.h
@@ -63,20 +63,4 @@ double Conditional<FACTOR, DERIVEDCONDITIONAL>::normalizationConstant() const {
   return std::exp(logNormalizationConstant());
 }
 
-/* ************************************************************************* */
-template <class FACTOR, class DERIVEDCONDITIONAL>
-bool Conditional<FACTOR, DERIVEDCONDITIONAL>::checkInvariants(
-    const HybridValues& values) const {
-  const double probability = evaluate(values);
-  if (probability < 0.0 || probability > 1.0)
-    return false;  // probability is not in [0,1]
-  const double logProb = logProbability(values);
-  if (std::abs(probability - std::exp(logProb)) > 1e-9)
-    return false;  // logProb is not consistent with probability
-  const double expected =
-      this->logNormalizationConstant() - this->error(values);
-  if (std::abs(logProb - expected) > 1e-9)
-    return false;  // logProb is not consistent with error
-}
-
 }  // namespace gtsam

--- a/gtsam/inference/Conditional-inst.h
+++ b/gtsam/inference/Conditional-inst.h
@@ -56,4 +56,27 @@ double Conditional<FACTOR, DERIVEDCONDITIONAL>::evaluate(
     const HybridValues& c) const {
   throw std::runtime_error("Conditional::evaluate is not implemented");
 }
+
+/* ************************************************************************* */
+template <class FACTOR, class DERIVEDCONDITIONAL>
+double Conditional<FACTOR, DERIVEDCONDITIONAL>::normalizationConstant() const {
+  return std::exp(logNormalizationConstant());
+}
+
+/* ************************************************************************* */
+template <class FACTOR, class DERIVEDCONDITIONAL>
+bool Conditional<FACTOR, DERIVEDCONDITIONAL>::checkInvariants(
+    const HybridValues& values) const {
+  const double probability = evaluate(values);
+  if (probability < 0.0 || probability > 1.0)
+    return false;  // probability is not in [0,1]
+  const double logProb = logProbability(values);
+  if (std::abs(probability - std::exp(logProb)) > 1e-9)
+    return false;  // logProb is not consistent with probability
+  const double expected =
+      this->logNormalizationConstant() - this->error(values);
+  if (std::abs(logProb - expected) > 1e-9)
+    return false;  // logProb is not consistent with error
+}
+
 }  // namespace gtsam

--- a/gtsam/inference/Conditional.h
+++ b/gtsam/inference/Conditional.h
@@ -141,6 +141,15 @@ namespace gtsam {
       return evaluate(x);
     }
 
+    /**
+     * By default, log normalization constant = 0.0.
+     * Override if this depends on the parameters.
+     */
+    virtual double logNormalizationConstant() const;
+
+    /** Non-virtual, exponentiate logNormalizationConstant. */
+    double normalizationConstant() const;
+
     /// @}
     /// @name Advanced Interface
     /// @{
@@ -172,7 +181,16 @@ namespace gtsam {
     /** Mutable iterator pointing past the last parent key. */
     typename FACTOR::iterator endParents() { return asFactor().end(); }
 
+    /** Check that the invariants hold for derived class at a given point. */
+    bool checkInvariants(const HybridValues& values) const;
+
+    /// @}
+
   private:
+
+    /// @name Serialization
+    /// @{
+
     // Cast to factor type (non-const) (casts down to derived conditional type, then up to factor type)
     FACTOR& asFactor() { return static_cast<FACTOR&>(static_cast<DERIVEDCONDITIONAL&>(*this)); }
 

--- a/gtsam/inference/Conditional.h
+++ b/gtsam/inference/Conditional.h
@@ -181,6 +181,10 @@ namespace gtsam {
     /** Mutable iterator pointing past the last parent key. */
     typename FACTOR::iterator endParents() { return asFactor().end(); }
 
+    template <class VALUES>
+    static bool CheckInvariants(const DERIVEDCONDITIONAL& conditional,
+                                const VALUES& values);
+
     /// @}
 
   private:

--- a/gtsam/inference/Conditional.h
+++ b/gtsam/inference/Conditional.h
@@ -145,7 +145,7 @@ namespace gtsam {
      * By default, log normalization constant = 0.0.
      * Override if this depends on the parameters.
      */
-    virtual double logNormalizationConstant() const;
+    virtual double logNormalizationConstant() const { return 0.0; }
 
     /** Non-virtual, exponentiate logNormalizationConstant. */
     double normalizationConstant() const;
@@ -180,9 +180,6 @@ namespace gtsam {
 
     /** Mutable iterator pointing past the last parent key. */
     typename FACTOR::iterator endParents() { return asFactor().end(); }
-
-    /** Check that the invariants hold for derived class at a given point. */
-    bool checkInvariants(const HybridValues& values) const;
 
     /// @}
 

--- a/gtsam/linear/GaussianConditional.cpp
+++ b/gtsam/linear/GaussianConditional.cpp
@@ -205,9 +205,14 @@ namespace gtsam {
   }
 
   /* ************************************************************************* */
-  double GaussianConditional::evaluate(const VectorValues& c) const {
-    return exp(logProbability(c));
+  double GaussianConditional::evaluate(const VectorValues& x) const {
+    return exp(logProbability(x));
   }
+
+  double GaussianConditional::evaluate(const HybridValues& x) const {
+    return evaluate(x.continuous());
+  }
+
   /* ************************************************************************* */
   VectorValues GaussianConditional::solve(const VectorValues& x) const {
     // Concatenate all vector values that correspond to parent variables

--- a/gtsam/linear/GaussianConditional.h
+++ b/gtsam/linear/GaussianConditional.h
@@ -264,7 +264,7 @@ namespace gtsam {
 
     using Conditional::evaluate; // Expose evaluate(const HybridValues&) method..
     using Conditional::operator(); // Expose evaluate(const HybridValues&) method..
-    using Base::error; // Expose error(const HybridValues&) method..
+    using JacobianFactor::error; // Expose error(const HybridValues&) method..
 
     /// @}
 

--- a/gtsam/linear/GaussianConditional.h
+++ b/gtsam/linear/GaussianConditional.h
@@ -262,7 +262,12 @@ namespace gtsam {
      */
     double logProbability(const HybridValues& x) const override;
 
-    using Conditional::evaluate; // Expose evaluate(const HybridValues&) method..
+    /**
+     * Calculate probability for HybridValues `x`.
+     * Simply dispatches to VectorValues version.
+     */
+    double evaluate(const HybridValues& x) const override;
+
     using Conditional::operator(); // Expose evaluate(const HybridValues&) method..
     using JacobianFactor::error; // Expose error(const HybridValues&) method..
 

--- a/gtsam/linear/GaussianConditional.h
+++ b/gtsam/linear/GaussianConditional.h
@@ -34,7 +34,7 @@ namespace gtsam {
   /**
   * A GaussianConditional functions as the node in a Bayes network.
   * It has a set of parents y,z, etc. and implements a probability density on x.
-  * The negative log-probability is given by \f$ \frac{1}{2} |Rx - (d - Sy - Tz - ...)|^2 \f$
+  * The negative log-density is given by \f$ \frac{1}{2} |Rx - (d - Sy - Tz - ...)|^2 \f$
   * @ingroup linear
   */
   class GTSAM_EXPORT GaussianConditional :

--- a/gtsam/linear/GaussianConditional.h
+++ b/gtsam/linear/GaussianConditional.h
@@ -136,14 +136,7 @@ namespace gtsam {
      * normalization constant = 1.0 / sqrt((2*pi)^n*det(Sigma))
      * log = - 0.5 * n*log(2*pi) - 0.5 * log det(Sigma)
      */
-    double logNormalizationConstant() const;
-
-    /**
-     * normalization constant = 1.0 / sqrt((2*pi)^n*det(Sigma))
-     */
-    inline double normalizationConstant() const {
-      return exp(logNormalizationConstant());
-    }
+    double logNormalizationConstant() const override;
 
     /**
      * Calculate log-probability log(evaluate(x)) for given values `x`:

--- a/gtsam/linear/HessianFactor.h
+++ b/gtsam/linear/HessianFactor.h
@@ -196,6 +196,9 @@ namespace gtsam {
     /** Compare to another factor for testing (implementing Testable) */
     bool equals(const GaussianFactor& lf, double tol = 1e-9) const override;
 
+    /// HybridValues simply extracts the \class VectorValues and calls error.
+    using GaussianFactor::error;
+
     /** 
      * Evaluate the factor error f(x). 
      * returns 0.5*[x -1]'*H*[x -1] (also see constructor documentation)

--- a/gtsam/linear/JacobianFactor.h
+++ b/gtsam/linear/JacobianFactor.h
@@ -198,7 +198,12 @@ namespace gtsam {
 
     Vector unweighted_error(const VectorValues& c) const; /** (A*x-b) */
     Vector error_vector(const VectorValues& c) const; /** (A*x-b)/sigma */
-    double error(const VectorValues& c) const override; /**  0.5*(A*x-b)'*D*(A*x-b) */
+
+    /// HybridValues simply extracts the \class VectorValues and calls error.
+    using GaussianFactor::error;
+
+    //// 0.5*(A*x-b)'*D*(A*x-b).
+    double error(const VectorValues& c) const override; 
 
     /** Return the augmented information matrix represented by this GaussianFactor.
      * The augmented information matrix contains the information matrix with an

--- a/gtsam/linear/linear.i
+++ b/gtsam/linear/linear.i
@@ -456,6 +456,7 @@ class GaussianFactorGraph {
 };
 
 #include <gtsam/linear/GaussianConditional.h>
+#include <gtsam/hybrid/HybridValues.h>
 virtual class GaussianConditional : gtsam::JacobianFactor {
   // Constructors
   GaussianConditional(size_t key, Vector d, Matrix R,
@@ -497,6 +498,7 @@ virtual class GaussianConditional : gtsam::JacobianFactor {
   bool equals(const gtsam::GaussianConditional& cg, double tol) const;
   
   // Standard Interface
+  double logNormalizationConstant() const;
   double logProbability(const gtsam::VectorValues& x) const;
   double evaluate(const gtsam::VectorValues& x) const;
   double error(const gtsam::VectorValues& x) const;
@@ -518,6 +520,11 @@ virtual class GaussianConditional : gtsam::JacobianFactor {
 
   // enabling serialization functionality
   void serialize() const;
+
+  // Expose HybridValues versions
+  double logProbability(const gtsam::HybridValues& x) const;
+  double evaluate(const gtsam::HybridValues& x) const;
+  double error(const gtsam::HybridValues& x) const;
 };
 
 #include <gtsam/linear/GaussianDensity.h>

--- a/gtsam/linear/tests/testGaussianConditional.cpp
+++ b/gtsam/linear/tests/testGaussianConditional.cpp
@@ -136,23 +136,6 @@ static const auto unitPrior =
 }  // namespace density
 
 /* ************************************************************************* */
-template <class VALUES>
-bool checkInvariants(const GaussianConditional& conditional,
-                     const VALUES& values) {
-  const double probability = conditional.evaluate(values);
-  if (probability < 0.0 || probability > 1.0)
-    return false;  // probability is not in [0,1]
-  const double logProb = conditional.logProbability(values);
-  if (std::abs(probability - std::exp(logProb)) > 1e-9)
-    return false;  // logProb is not consistent with probability
-  const double expected =
-      conditional.logNormalizationConstant() - conditional.error(values);
-  if (std::abs(logProb - expected) > 1e-9)
-    return false;  // logProb is not consistent with error
-  return true;
-}
-
-/* ************************************************************************* */
 // Check that the evaluate function matches direct calculation with R.
 TEST(GaussianConditional, Evaluate1) {
   // Let's evaluate at the mean
@@ -174,8 +157,9 @@ TEST(GaussianConditional, Evaluate1) {
 
   // Check Invariants at the mean and a different value
   for (auto vv : {mean, VectorValues{{key, Vector1(4)}}}) {
-    EXPECT(checkInvariants(density::unitPrior, vv));
-    EXPECT(checkInvariants(density::unitPrior, HybridValues{vv, {}, {}}));
+    EXPECT(GaussianConditional::CheckInvariants(density::unitPrior, vv));
+    EXPECT(GaussianConditional::CheckInvariants(density::unitPrior,
+                                                HybridValues{vv, {}, {}}));
   }
 
   // Let's numerically integrate and see that we integrate to 1.0.
@@ -206,8 +190,9 @@ TEST(GaussianConditional, Evaluate2) {
 
   // Check Invariants at the mean and a different value
   for (auto vv : {mean, VectorValues{{key, Vector1(4)}}}) {
-    EXPECT(checkInvariants(density::widerPrior, vv));
-    EXPECT(checkInvariants(density::widerPrior, HybridValues{vv, {}, {}}));
+    EXPECT(GaussianConditional::CheckInvariants(density::widerPrior, vv));
+    EXPECT(GaussianConditional::CheckInvariants(density::widerPrior,
+                                                HybridValues{vv, {}, {}}));
   }
 
   // Let's numerically integrate and see that we integrate to 1.0.
@@ -422,8 +407,9 @@ TEST(GaussianConditional, FromMeanAndStddev) {
 
   // Check Invariants for both conditionals
   for (auto conditional : {conditional1, conditional2}) {
-    EXPECT(checkInvariants(conditional, values));
-    EXPECT(checkInvariants(conditional, HybridValues{values, {}, {}}));
+    EXPECT(GaussianConditional::CheckInvariants(conditional, values));
+    EXPECT(GaussianConditional::CheckInvariants(conditional,
+                                                HybridValues{values, {}, {}}));
   }
 }
 


### PR DESCRIPTION
Turns out GaussianMixture error() was wrong! I added very thorough checking of all conditionals with all supported arguments, in both C++ and python, and made sure all compiled and worked. In the process I found out that GaussianMixture did *not* satisfy its invariants. The resolution is documented in GaussianMixture.h:

```
   * @brief Compute the error of this Gaussian Mixture.
   *
   * This requires some care, as different mixture components may have
   * different normalization constants. Let's consider p(x|y,m), where m is
   * discrete. We need the error to satisfy the invariant:
   *
   *    error(x;y,m) = K - log(probability(x;y,m))
   *
   * For all x,y,m. But note that K, for the GaussianMixture, cannot depend on
   * any arguments. Hence, we delegate to the underlying Gaussian
   * conditionals, indexed by m, which do satisfy:
   * 
   *    log(probability_m(x;y)) = K_m - error_m(x;y)
   * 
   * We resolve by having K == 0.0 and
   * 
   *    error(x;y,m) = error_m(x;y) - K_m
```

This was a lot of work but I think this level of care is needed to ensure correctness in hybrid inference.