### PR TITLE
Some Hybrid Improvements

### DIFF
--- a/gtsam/hybrid/HybridFactorGraph.cpp
+++ b/gtsam/hybrid/HybridFactorGraph.cpp
@@ -25,7 +25,7 @@
 namespace gtsam {
 
 /* ************************************************************************* */
-std::set<DiscreteKey> HybridFactorGraph::discreteKeys() const {
+DiscreteKeys HybridFactorGraph::discreteKeys() const {
   std::set<DiscreteKey> keys;
   for (auto& factor : factors_) {
     if (auto p = boost::dynamic_pointer_cast<DecisionTreeFactor>(factor)) {
@@ -39,7 +39,7 @@ std::set<DiscreteKey> HybridFactorGraph::discreteKeys() const {
       }
     }
   }
-  return keys;
+  return DiscreteKeys(keys.begin(), keys.end());
 }
 
 /* ************************************************************************* */

--- a/gtsam/hybrid/HybridFactorGraph.cpp
+++ b/gtsam/hybrid/HybridFactorGraph.cpp
@@ -25,7 +25,7 @@
 namespace gtsam {
 
 /* ************************************************************************* */
-DiscreteKeys HybridFactorGraph::discreteKeys() const {
+std::set<DiscreteKey> HybridFactorGraph::discreteKeys() const {
   std::set<DiscreteKey> keys;
   for (auto& factor : factors_) {
     if (auto p = boost::dynamic_pointer_cast<DecisionTreeFactor>(factor)) {
@@ -39,14 +39,14 @@ DiscreteKeys HybridFactorGraph::discreteKeys() const {
       }
     }
   }
-  return DiscreteKeys(keys.begin(), keys.end());
+  return keys;
 }
 
 /* ************************************************************************* */
 KeySet HybridFactorGraph::discreteKeySet() const {
   KeySet keys;
-  DiscreteKeys key_vector = discreteKeys();
-  std::transform(key_vector.begin(), key_vector.end(),
+  std::set<DiscreteKey> key_set = discreteKeys();
+  std::transform(key_set.begin(), key_set.end(),
                  std::inserter(keys, keys.begin()),
                  [](const DiscreteKey& k) { return k.first; });
   return keys;

--- a/gtsam/hybrid/HybridFactorGraph.cpp
+++ b/gtsam/hybrid/HybridFactorGraph.cpp
@@ -45,9 +45,10 @@ DiscreteKeys HybridFactorGraph::discreteKeys() const {
 /* ************************************************************************* */
 KeySet HybridFactorGraph::discreteKeySet() const {
   KeySet keys;
-  for (const DiscreteKey& k : discreteKeys()) {
-    keys.insert(k.first);
-  }
+  DiscreteKeys key_vector = discreteKeys();
+  std::transform(key_vector.begin(), key_vector.end(),
+                 std::inserter(keys, keys.begin()),
+                 [](const DiscreteKey& k) { return k.first; });
   return keys;
 }
 

--- a/gtsam/hybrid/HybridFactorGraph.h
+++ b/gtsam/hybrid/HybridFactorGraph.h
@@ -65,7 +65,7 @@ class HybridFactorGraph : public FactorGraph<Factor> {
   /// @{
 
   /// Get all the discrete keys in the factor graph.
-  DiscreteKeys discreteKeys() const;
+  std::set<DiscreteKey> discreteKeys() const;
 
   /// Get all the discrete keys in the factor graph, as a set.
   KeySet discreteKeySet() const;

--- a/gtsam/hybrid/HybridFactorGraph.h
+++ b/gtsam/hybrid/HybridFactorGraph.h
@@ -65,7 +65,7 @@ class HybridFactorGraph : public FactorGraph<Factor> {
   /// @{
 
   /// Get all the discrete keys in the factor graph.
-  std::set<DiscreteKey> discreteKeys() const;
+  DiscreteKeys discreteKeys() const;
 
   /// Get all the discrete keys in the factor graph, as a set.
   KeySet discreteKeySet() const;

--- a/gtsam/hybrid/HybridNonlinearFactorGraph.h
+++ b/gtsam/hybrid/HybridNonlinearFactorGraph.h
@@ -74,7 +74,7 @@ class GTSAM_EXPORT HybridNonlinearFactorGraph : public HybridFactorGraph {
    * @param continuousValues: Dictionary of continuous values.
    * @return HybridGaussianFactorGraph::shared_ptr
    */
-  HybridGaussianFactorGraph::shared_ptr linearize(
+  boost::shared_ptr<HybridGaussianFactorGraph> linearize(
       const Values& continuousValues) const;
   /// @}
 };

--- a/gtsam/hybrid/MixtureFactor.h
+++ b/gtsam/hybrid/MixtureFactor.h
@@ -21,6 +21,7 @@
 
 #include <gtsam/discrete/DiscreteValues.h>
 #include <gtsam/hybrid/GaussianMixtureFactor.h>
+#include <gtsam/hybrid/HybridValues.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/Symbol.h>
@@ -160,10 +161,14 @@ class MixtureFactor : public HybridFactor {
                              factor, continuousValues);
   }
 
-  /// Error for HybridValues is not provided for nonlinear hybrid factor.
+  /**
+   * @brief Compute error of factor given hybrid values.
+   *
+   * @param values The continuous Values and the discrete assignment.
+   * @return double The error of this factor.
+   */
   double error(const HybridValues& values) const override {
-    throw std::runtime_error(
-        "MixtureFactor::error(HybridValues) not implemented.");
+    return error(values.nonlinear(), values.discrete());
   }
 
   /**

--- a/gtsam/linear/GaussianConditional.cpp
+++ b/gtsam/linear/GaussianConditional.cpp
@@ -124,7 +124,7 @@ namespace gtsam {
     cout << formatMatrixIndented("  d = ", getb(), true) << "\n";
     if (nrParents() == 0) {
       const auto mean = solve({});  // solve for mean.
-      mean.print("  mean");
+      mean.print("  mean", formatter);
     }
     if (model_)
       model_->print("  Noise model: ");


### PR DESCRIPTION
1. `HybridFactorGraph::discreteKeys` returns a discrete key vector aka `DiscreteKeys` since they are the main workhorse in discrete.
2. Made `discreteKeySet` more efficient by using a STL-style container transform instead of a loop. This also makes the transformation more _functional_.
3. Implement `MixtureFactor::error(HybridValues)` since it was low hanging fruit.
4. Pass in the formatter when printing the mean of a `GaussianConditional`. Found this while debugging since I use GTD keys.