### PR TITLE
Verdant/boost serialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,14 +48,6 @@ if(${GTSAM_SOURCE_DIR} STREQUAL ${GTSAM_BINARY_DIR})
   message(FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there. You may need to remove CMakeCache.txt. ")
 endif()
 
-# TODO(kartikarcot): Determine a proper home for this option
-# a flag to enable or disable serialization with GTSAM_ENABLE_BOOST_SERIALIZATION
-option(GTSAM_ENABLE_BOOST_SERIALIZATION "Enable Boost serialization" ON)
-# set a compiler flag to enable or disable serialization with GTSAM_DISABLE_BOOST_SERIALIZATION
-if(GTSAM_ENABLE_BOOST_SERIALIZATION)
-  add_definitions(-DGTSAM_ENABLE_BOOST_SERIALIZATION)
-endif()
-
 include(cmake/HandleGeneralOptions.cmake)   # CMake build options
 
 # Libraries:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,14 @@ if(${GTSAM_SOURCE_DIR} STREQUAL ${GTSAM_BINARY_DIR})
   message(FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there. You may need to remove CMakeCache.txt. ")
 endif()
 
+# TODO(kartikarcot): Determine a proper home for this option
+# a flag to enable or disable serialization with GTSAM_ENABLE_BOOST_SERIALIZATION
+option(GTSAM_ENABLE_BOOST_SERIALIZATION "Enable Boost serialization" ON)
+# set a compiler flag to enable or disable serialization with GTSAM_DISABLE_BOOST_SERIALIZATION
+if(GTSAM_ENABLE_BOOST_SERIALIZATION)
+  add_definitions(-DGTSAM_ENABLE_BOOST_SERIALIZATION)
+endif()
+
 include(cmake/HandleGeneralOptions.cmake)   # CMake build options
 
 # Libraries:

--- a/cmake/HandleGeneralOptions.cmake
+++ b/cmake/HandleGeneralOptions.cmake
@@ -29,6 +29,7 @@ option(GTSAM_ALLOW_DEPRECATED_SINCE_V43     "Allow use of methods/functions depr
 option(GTSAM_SUPPORT_NESTED_DISSECTION      "Support Metis-based nested dissection" ON)
 option(GTSAM_TANGENT_PREINTEGRATION         "Use new ImuFactor with integration on tangent space" ON)
 option(GTSAM_SLOW_BUT_CORRECT_BETWEENFACTOR "Use the slower but correct version of BetweenFactor" OFF)
+option(GTSAM_ENABLE_BOOST_SERIALIZATION "Enable Boost serialization" ON)
 if(NOT MSVC AND NOT XCODE_VERSION)
     option(GTSAM_BUILD_WITH_CCACHE           "Use ccache compiler cache" ON)
 endif()

--- a/cmake/HandleGeneralOptions.cmake
+++ b/cmake/HandleGeneralOptions.cmake
@@ -30,6 +30,12 @@ option(GTSAM_SUPPORT_NESTED_DISSECTION      "Support Metis-based nested dissecti
 option(GTSAM_TANGENT_PREINTEGRATION         "Use new ImuFactor with integration on tangent space" ON)
 option(GTSAM_SLOW_BUT_CORRECT_BETWEENFACTOR "Use the slower but correct version of BetweenFactor" OFF)
 option(GTSAM_ENABLE_BOOST_SERIALIZATION "Enable Boost serialization" ON)
+
+#TODO(kartikarcot) defining it in config.h.in did not work
+if (GTSAM_ENABLE_BOOST_SERIALIZATION)
+    add_definitions(-DGTSAM_ENABLE_BOOST_SERIALIZATION)
+endif()
+
 if(NOT MSVC AND NOT XCODE_VERSION)
     option(GTSAM_BUILD_WITH_CCACHE           "Use ccache compiler cache" ON)
 endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,4 +2,12 @@ set (excluded_examples
     elaboratePoint2KalmanFilter.cpp
 )
 
+# if GTSAM_ENABLE_BOOST_SERIALIZATION is not set then SolverComparer.cpp will not compile
+if (NOT GTSAM_ENABLE_BOOST_SERIALIZATION)
+  set (excluded_examples
+    ${excluded_examples}
+    SolverComparer.cpp
+  )
+endif()
+
 gtsamAddExamplesGlob("*.cpp" "${excluded_examples}" "gtsam;gtsam_unstable;${Boost_PROGRAM_OPTIONS_LIBRARY}")

--- a/gtsam/base/ConcurrentMap.h
+++ b/gtsam/base/ConcurrentMap.h
@@ -113,7 +113,6 @@ private:
     std::copy(this->begin(), this->end(), map.begin());
     ar & BOOST_SERIALIZATION_NVP(map);
   }
-#endif
   template<class Archive>
   void load(Archive& ar, const unsigned int /*version*/)
   {
@@ -124,6 +123,7 @@ private:
     this->insert(map.begin(), map.end());
   }
   BOOST_SERIALIZATION_SPLIT_MEMBER()
+#endif
 };
 
 }

--- a/gtsam/base/ConcurrentMap.h
+++ b/gtsam/base/ConcurrentMap.h
@@ -100,8 +100,8 @@ public:
 #endif
 
 private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class Archive>
   void save(Archive& ar, const unsigned int /*version*/) const

--- a/gtsam/base/ConcurrentMap.h
+++ b/gtsam/base/ConcurrentMap.h
@@ -48,8 +48,10 @@ using ConcurrentMapBase = gtsam::FastMap<KEY, VALUE>;
 
 #endif
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/split_member.hpp>
+#endif
 #include <boost/static_assert.hpp>
 
 #include <gtsam/base/FastVector.h>

--- a/gtsam/base/ConcurrentMap.h
+++ b/gtsam/base/ConcurrentMap.h
@@ -101,6 +101,7 @@ public:
 
 private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class Archive>
   void save(Archive& ar, const unsigned int /*version*/) const
@@ -110,6 +111,7 @@ private:
     std::copy(this->begin(), this->end(), map.begin());
     ar & BOOST_SERIALIZATION_NVP(map);
   }
+#endif
   template<class Archive>
   void load(Archive& ar, const unsigned int /*version*/)
   {

--- a/gtsam/base/FastList.h
+++ b/gtsam/base/FastList.h
@@ -77,11 +77,13 @@ public:
 
 private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
     ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
   }
+#endif
 
 };
 

--- a/gtsam/base/FastList.h
+++ b/gtsam/base/FastList.h
@@ -76,8 +76,8 @@ public:
   }
 
 private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/base/FastList.h
+++ b/gtsam/base/FastList.h
@@ -21,10 +21,11 @@
 #include <gtsam/base/FastDefaultAllocator.h>
 #include <list>
 #include <boost/utility/enable_if.hpp>
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/version.hpp>
-#include <boost/serialization/optional.hpp>
 #include <boost/serialization/list.hpp>
+#endif
 
 namespace gtsam {
 

--- a/gtsam/base/FastMap.h
+++ b/gtsam/base/FastMap.h
@@ -68,11 +68,13 @@ public:
 
 private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
     ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
   }
+#endif
 };
 
 }

--- a/gtsam/base/FastMap.h
+++ b/gtsam/base/FastMap.h
@@ -67,8 +67,8 @@ public:
   bool exists(const KEY& e) const { return this->find(e) != this->end(); }
 
 private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/base/FastMap.h
+++ b/gtsam/base/FastMap.h
@@ -19,8 +19,10 @@
 #pragma once
 
 #include <gtsam/base/FastDefaultAllocator.h>
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/map.hpp>
+#endif
 #include <map>
 
 namespace gtsam {

--- a/gtsam/base/FastSet.h
+++ b/gtsam/base/FastSet.h
@@ -19,11 +19,13 @@
 #pragma once
 
 #include <boost/version.hpp>
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #if BOOST_VERSION >= 107400
 #include <boost/serialization/library_version_type.hpp>
 #endif
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/set.hpp>
+#endif
 #include <gtsam/base/FastDefaultAllocator.h>
 #include <gtsam/base/Testable.h>
 

--- a/gtsam/base/FastSet.h
+++ b/gtsam/base/FastSet.h
@@ -122,11 +122,13 @@ public:
 
 private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
     ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
   }
+#endif
 };
 
 }

--- a/gtsam/base/FastSet.h
+++ b/gtsam/base/FastSet.h
@@ -121,8 +121,8 @@ public:
   }
 
 private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/base/GenericValue.h
+++ b/gtsam/base/GenericValue.h
@@ -175,8 +175,8 @@ public:
 
   private:
 
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/base/GenericValue.h
+++ b/gtsam/base/GenericValue.h
@@ -176,6 +176,7 @@ public:
   private:
 
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -183,6 +184,7 @@ public:
               boost::serialization::base_object<Value>(*this));
       ar & boost::serialization::make_nvp("value", value_);
 	}
+#endif
 
 
   // Alignment, see https://eigen.tuxfamily.org/dox/group__TopicStructHavingEigenMembers.html

--- a/gtsam/base/MatrixSerialization.h
+++ b/gtsam/base/MatrixSerialization.h
@@ -18,6 +18,8 @@
 
 // \callgraph
 
+// Defined only if boost serialization is enabled
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #pragma once
 
 #include <gtsam/base/Matrix.h>
@@ -87,3 +89,4 @@ void serialize(Archive& ar, gtsam::Matrix& m, const unsigned int version) {
 
 }  // namespace serialization
 }  // namespace boost
+#endif

--- a/gtsam/base/SymmetricBlockMatrix.h
+++ b/gtsam/base/SymmetricBlockMatrix.h
@@ -398,8 +398,8 @@ namespace gtsam {
     template<typename SymmetricBlockMatrixType> friend class SymmetricBlockMatrixBlockExpr;
 
   private:
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/base/SymmetricBlockMatrix.h
+++ b/gtsam/base/SymmetricBlockMatrix.h
@@ -21,7 +21,9 @@
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/types.h>
 #include <gtsam/dllexport.h>
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/nvp.hpp>
+#endif
 #include <cassert>
 #include <stdexcept>
 #include <array>

--- a/gtsam/base/SymmetricBlockMatrix.h
+++ b/gtsam/base/SymmetricBlockMatrix.h
@@ -399,6 +399,7 @@ namespace gtsam {
 
   private:
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -410,6 +411,7 @@ namespace gtsam {
       ar & BOOST_SERIALIZATION_NVP(variableColOffsets_);
       ar & BOOST_SERIALIZATION_NVP(blockStart_);
     }
+#endif
   };
 
   /// Foward declare exception class

--- a/gtsam/base/Value.h
+++ b/gtsam/base/Value.h
@@ -119,10 +119,12 @@ namespace gtsam {
      *       The last two links explain why these export lines have to be in the same source module that includes
      *       any of the archive class headers.
      * */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & /*ar*/, const unsigned int /*version*/) {
     }
+#endif
 
   };
 

--- a/gtsam/base/Value.h
+++ b/gtsam/base/Value.h
@@ -21,8 +21,10 @@
 #include <gtsam/config.h>      // Configuration from CMake
 
 #include <gtsam/base/Vector.h>
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/assume_abstract.hpp>
+#endif
 #include <memory>
 
 namespace gtsam {

--- a/gtsam/base/Value.h
+++ b/gtsam/base/Value.h
@@ -132,4 +132,6 @@ namespace gtsam {
 
 } /* namespace gtsam */
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 BOOST_SERIALIZATION_ASSUME_ABSTRACT(gtsam::Value)
+#endif

--- a/gtsam/base/VectorSerialization.h
+++ b/gtsam/base/VectorSerialization.h
@@ -16,6 +16,8 @@
  * @date    February 2022
  */
 
+// Defined only if boost serialization is enabled
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #pragma once
 
 #include <gtsam/base/Vector.h>
@@ -63,3 +65,4 @@ BOOST_SERIALIZATION_SPLIT_FREE(gtsam::Vector)
 BOOST_SERIALIZATION_SPLIT_FREE(gtsam::Vector2)
 BOOST_SERIALIZATION_SPLIT_FREE(gtsam::Vector3)
 BOOST_SERIALIZATION_SPLIT_FREE(gtsam::Vector6)
+#endif

--- a/gtsam/base/VerticalBlockMatrix.h
+++ b/gtsam/base/VerticalBlockMatrix.h
@@ -220,6 +220,7 @@ namespace gtsam {
 
   private:
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -229,6 +230,7 @@ namespace gtsam {
       ar & BOOST_SERIALIZATION_NVP(rowEnd_);
       ar & BOOST_SERIALIZATION_NVP(blockStart_);
     }
+#endif
   };
 
 }

--- a/gtsam/base/VerticalBlockMatrix.h
+++ b/gtsam/base/VerticalBlockMatrix.h
@@ -219,8 +219,8 @@ namespace gtsam {
     friend class SymmetricBlockMatrix;
 
   private:
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/base/serializationTestHelpers.h
+++ b/gtsam/base/serializationTestHelpers.h
@@ -17,6 +17,7 @@
  * @date Feb 7, 2012
  */
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #pragma once
 
 #include <iostream>
@@ -175,3 +176,4 @@ bool equalsDereferencedBinary(const T& input = T()) {
 
 } // \namespace serializationTestHelpers
 } // \namespace gtsam
+#endif

--- a/gtsam/base/std_optional_serialization.h
+++ b/gtsam/base/std_optional_serialization.h
@@ -9,6 +9,8 @@
 * Inspired from this PR: https://github.com/boostorg/serialization/pull/163
 * ---------------------------------------------------------------------------- */
 
+// Defined only if boost serialization is enabled
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #pragma once
 #include <optional>
 #include <boost/config.hpp>
@@ -97,4 +99,4 @@ void serialize(Archive& ar, std::optional<T>& t, const unsigned int version) {
 
 }  // namespace serialization
 }  // namespace boost
-
+#endif

--- a/gtsam/base/tests/CMakeLists.txt
+++ b/gtsam/base/tests/CMakeLists.txt
@@ -6,4 +6,4 @@ else()
   set(EXCLUDE_TESTS "")
 endif()
 
-gtsamAddTestsGlob(discrete "test*.cpp" "${EXCLUDE_TESTS}" "gtsam")
+gtsamAddTestsGlob(base "test*.cpp" "${EXCLUDE_TESTS}" "gtsam")

--- a/gtsam/base/tests/CMakeLists.txt
+++ b/gtsam/base/tests/CMakeLists.txt
@@ -1,1 +1,9 @@
-gtsamAddTestsGlob(base "test*.cpp" "" "gtsam")
+# if GTSAM_ENABLE_BOOST_SERIALIZATION is OFF then exclude some tests
+if (NOT GTSAM_ENABLE_BOOST_SERIALIZATION)
+  # create a semicolon seperated list of files to exclude
+  set(EXCLUDE_TESTS "testSerializationBase.cpp" "testStdOptionalSerialization.cpp")
+else()
+  set(EXCLUDE_TESTS "")
+endif()
+
+gtsamAddTestsGlob(discrete "test*.cpp" "${EXCLUDE_TESTS}" "gtsam")

--- a/gtsam/base/timing.h
+++ b/gtsam/base/timing.h
@@ -23,6 +23,7 @@
 
 #include <boost/version.hpp>
 
+#include <memory>
 #include <cstddef>
 #include <string>
 

--- a/gtsam/base/treeTraversal-inst.h
+++ b/gtsam/base/treeTraversal-inst.h
@@ -28,6 +28,7 @@
 #include <vector>
 #include <string>
 #include <memory>
+#include <cassert>
 
 namespace gtsam {
 

--- a/gtsam/config.h.in
+++ b/gtsam/config.h.in
@@ -83,3 +83,6 @@
 
 // Toggle switch for BetweenFactor jacobian computation
 #cmakedefine GTSAM_SLOW_BUT_CORRECT_BETWEENFACTOR
+
+// Toggle Boost serialization definitions
+#cmakedefine GTSAM_ENABLE_BOOST_SERIALIZATION

--- a/gtsam/config.h.in
+++ b/gtsam/config.h.in
@@ -83,6 +83,3 @@
 
 // Toggle switch for BetweenFactor jacobian computation
 #cmakedefine GTSAM_SLOW_BUT_CORRECT_BETWEENFACTOR
-
-// Toggle Boost serialization definitions
-#cmakedefine GTSAM_ENABLE_BOOST_SERIALIZATION

--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -154,8 +154,8 @@ namespace gtsam {
    private:
     using Base = DecisionTree<L, Y>::Node;
 
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template <class ARCHIVE>
     void serialize(ARCHIVE& ar, const unsigned int /*version*/) {

--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -155,6 +155,7 @@ namespace gtsam {
     using Base = DecisionTree<L, Y>::Node;
 
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template <class ARCHIVE>
     void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
@@ -162,6 +163,7 @@ namespace gtsam {
       ar& BOOST_SERIALIZATION_NVP(constant_);
       ar& BOOST_SERIALIZATION_NVP(nrAssignments_);
     }
+#endif
   };  // Leaf
 
   /****************************************************************************/

--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -445,6 +445,7 @@ namespace gtsam {
    private:
     using Base = DecisionTree<L, Y>::Node;
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     /** Serialization function */
     friend class boost::serialization::access;
     template <class ARCHIVE>
@@ -454,6 +455,7 @@ namespace gtsam {
       ar& BOOST_SERIALIZATION_NVP(branches_);
       ar& BOOST_SERIALIZATION_NVP(allSame_);
     }
+#endif
   };  // Choice
 
   /****************************************************************************/

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -378,12 +378,14 @@ namespace gtsam {
     /// @}
 
    private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     /** Serialization function */
     friend class boost::serialization::access;
     template <class ARCHIVE>
     void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
       ar& BOOST_SERIALIZATION_NVP(root_);
     }
+#endif
   };  // DecisionTree
 
   template <class L, class Y>

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -117,8 +117,8 @@ namespace gtsam {
       virtual bool isLeaf() const = 0;
 
      private:
-      /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+      /** Serialization function */
       friend class boost::serialization::access;
       template <class ARCHIVE>
       void serialize(ARCHIVE& ar, const unsigned int /*version*/) {}

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -118,9 +118,11 @@ namespace gtsam {
 
      private:
       /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
       friend class boost::serialization::access;
       template <class ARCHIVE>
       void serialize(ARCHIVE& ar, const unsigned int /*version*/) {}
+#endif
     };
     /** ------------------------ Node base class --------------------------- */
 

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -23,7 +23,9 @@
 #include <gtsam/base/types.h>
 #include <gtsam/discrete/Assignment.h>
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/nvp.hpp>
+#endif
 #include <memory>
 #include <functional>
 #include <iostream>

--- a/gtsam/discrete/DecisionTreeFactor.h
+++ b/gtsam/discrete/DecisionTreeFactor.h
@@ -253,8 +253,8 @@ namespace gtsam {
   /// @}
 
    private:
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template <class ARCHIVE>
     void serialize(ARCHIVE& ar, const unsigned int /*version*/) {

--- a/gtsam/discrete/DecisionTreeFactor.h
+++ b/gtsam/discrete/DecisionTreeFactor.h
@@ -254,6 +254,7 @@ namespace gtsam {
 
    private:
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template <class ARCHIVE>
     void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
@@ -261,6 +262,7 @@ namespace gtsam {
       ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(ADT);
       ar& BOOST_SERIALIZATION_NVP(cardinalities_);
     }
+#endif
   };
 
 // traits

--- a/gtsam/discrete/DiscreteBayesNet.h
+++ b/gtsam/discrete/DiscreteBayesNet.h
@@ -150,8 +150,8 @@ class GTSAM_EXPORT DiscreteBayesNet: public BayesNet<DiscreteConditional> {
     /// @}
 
  private:
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/discrete/DiscreteBayesNet.h
+++ b/gtsam/discrete/DiscreteBayesNet.h
@@ -151,11 +151,13 @@ class GTSAM_EXPORT DiscreteBayesNet: public BayesNet<DiscreteConditional> {
 
  private:
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
       ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     }
+#endif
   };
 
 // traits

--- a/gtsam/discrete/DiscreteConditional.h
+++ b/gtsam/discrete/DiscreteConditional.h
@@ -268,8 +268,8 @@ class GTSAM_EXPORT DiscreteConditional
                                   bool forceComplete) const;
 
  private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {

--- a/gtsam/discrete/DiscreteConditional.h
+++ b/gtsam/discrete/DiscreteConditional.h
@@ -269,12 +269,14 @@ class GTSAM_EXPORT DiscreteConditional
 
  private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {
     ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(BaseFactor);
     ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(BaseConditional);
   }
+#endif
 };
 // DiscreteConditional
 

--- a/gtsam/discrete/DiscreteKey.h
+++ b/gtsam/discrete/DiscreteKey.h
@@ -80,6 +80,7 @@ namespace gtsam {
     bool equals(const DiscreteKeys& other, double tol = 0) const;
 
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template <class ARCHIVE>
     void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
@@ -87,6 +88,7 @@ namespace gtsam {
           "DiscreteKeys",
           boost::serialization::base_object<std::vector<DiscreteKey>>(*this));
     }
+#endif
 
   }; // DiscreteKeys
 

--- a/gtsam/discrete/DiscreteKey.h
+++ b/gtsam/discrete/DiscreteKey.h
@@ -21,7 +21,9 @@
 #include <gtsam/global_includes.h>
 #include <gtsam/inference/Key.h>
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/vector.hpp>
+#endif
 #include <map>
 #include <string>
 #include <vector>

--- a/gtsam/discrete/DiscreteKey.h
+++ b/gtsam/discrete/DiscreteKey.h
@@ -79,8 +79,8 @@ namespace gtsam {
     /// Check equality to another DiscreteKeys object.
     bool equals(const DiscreteKeys& other, double tol = 0) const;
 
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template <class ARCHIVE>
     void serialize(ARCHIVE& ar, const unsigned int /*version*/) {

--- a/gtsam/discrete/DiscreteLookupDAG.h
+++ b/gtsam/discrete/DiscreteLookupDAG.h
@@ -126,8 +126,8 @@ class GTSAM_EXPORT DiscreteLookupDAG : public BayesNet<DiscreteLookupTable> {
   /// @}
 
  private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {

--- a/gtsam/discrete/DiscreteLookupDAG.h
+++ b/gtsam/discrete/DiscreteLookupDAG.h
@@ -127,11 +127,13 @@ class GTSAM_EXPORT DiscreteLookupDAG : public BayesNet<DiscreteLookupTable> {
 
  private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
     ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
   }
+#endif
 };
 
 // traits

--- a/gtsam/discrete/tests/CMakeLists.txt
+++ b/gtsam/discrete/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 # if GTSAM_ENABLE_BOOST_SERIALIZATION is OFF then exclude some tests
 if (NOT GTSAM_ENABLE_BOOST_SERIALIZATION)
   # create a semicolon seperated list of files to exclude
-  set(EXCLUDE_TESTS "testSerializationDiscrete.cpp")
+  set(EXCLUDE_TESTS "testSerializationDiscrete.cpp" "testDiscreteFactor.cpp")
 else()
   set(EXCLUDE_TESTS "")
 endif()

--- a/gtsam/discrete/tests/CMakeLists.txt
+++ b/gtsam/discrete/tests/CMakeLists.txt
@@ -1,1 +1,9 @@
-gtsamAddTestsGlob(discrete "test*.cpp" "" "gtsam")
+# if GTSAM_ENABLE_BOOST_SERIALIZATION is OFF then exclude some tests
+if (NOT GTSAM_ENABLE_BOOST_SERIALIZATION)
+  # create a semicolon seperated list of files to exclude
+  set(EXCLUDE_TESTS "testSerializationDiscrete.cpp")
+else()
+  set(EXCLUDE_TESTS "")
+endif()
+
+gtsamAddTestsGlob(discrete "test*.cpp" "${EXCLUDE_TESTS}" "gtsam")

--- a/gtsam/geometry/BearingRange.h
+++ b/gtsam/geometry/BearingRange.h
@@ -154,6 +154,7 @@ private:
     ar& boost::serialization::make_nvp("range", range_);
   }
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
 
   /// @}
@@ -162,6 +163,7 @@ private:
   enum {
     NeedsToAlign = (sizeof(B) % 16) == 0 || (sizeof(R) % 16) == 0
   };
+#endif
 public:
   GTSAM_MAKE_ALIGNED_OPERATOR_NEW_IF(NeedsToAlign)
 };

--- a/gtsam/geometry/BearingRange.h
+++ b/gtsam/geometry/BearingRange.h
@@ -22,7 +22,9 @@
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/OptionalJacobian.h>
 #include <boost/concept/assert.hpp>
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/nvp.hpp>
+#endif
 #include <iostream>
 
 namespace gtsam {
@@ -147,15 +149,16 @@ public:
   /// @{
 
 private:
-  template <class ARCHIVE>
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /// Serialization function
+  template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
     ar& boost::serialization::make_nvp("bearing", bearing_);
     ar& boost::serialization::make_nvp("range", range_);
   }
 
-#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
+#endif
 
   /// @}
 
@@ -163,7 +166,6 @@ private:
   enum {
     NeedsToAlign = (sizeof(B) % 16) == 0 || (sizeof(R) % 16) == 0
   };
-#endif
 public:
   GTSAM_MAKE_ALIGNED_OPERATOR_NEW_IF(NeedsToAlign)
 };

--- a/gtsam/geometry/BearingRange.h
+++ b/gtsam/geometry/BearingRange.h
@@ -147,8 +147,8 @@ public:
   /// @{
 
 private:
-  /// Serialization function
   template <class ARCHIVE>
+  /// Serialization function
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
     ar& boost::serialization::make_nvp("bearing", bearing_);
     ar& boost::serialization::make_nvp("range", range_);

--- a/gtsam/geometry/Cal3.h
+++ b/gtsam/geometry/Cal3.h
@@ -185,6 +185,7 @@ class GTSAM_EXPORT Cal3 {
 
  private:
   /// Serialization function
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {
@@ -194,6 +195,7 @@ class GTSAM_EXPORT Cal3 {
     ar& BOOST_SERIALIZATION_NVP(u0_);
     ar& BOOST_SERIALIZATION_NVP(v0_);
   }
+#endif
 
   /// @}
 };

--- a/gtsam/geometry/Cal3.h
+++ b/gtsam/geometry/Cal3.h
@@ -184,8 +184,8 @@ class GTSAM_EXPORT Cal3 {
   /// @{
 
  private:
-  /// Serialization function
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
+  /// Serialization function
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {

--- a/gtsam/geometry/Cal3Bundler.h
+++ b/gtsam/geometry/Cal3Bundler.h
@@ -157,6 +157,7 @@ class GTSAM_EXPORT Cal3Bundler : public Cal3 {
   /// @{
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {
@@ -166,6 +167,7 @@ class GTSAM_EXPORT Cal3Bundler : public Cal3 {
     ar& BOOST_SERIALIZATION_NVP(k2_);
     ar& BOOST_SERIALIZATION_NVP(tol_);
   }
+#endif
 
   /// @}
 };

--- a/gtsam/geometry/Cal3Bundler.h
+++ b/gtsam/geometry/Cal3Bundler.h
@@ -156,8 +156,8 @@ class GTSAM_EXPORT Cal3Bundler : public Cal3 {
   /// @name Advanced Interface
   /// @{
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {

--- a/gtsam/geometry/Cal3DS2.h
+++ b/gtsam/geometry/Cal3DS2.h
@@ -104,8 +104,8 @@ class GTSAM_EXPORT Cal3DS2 : public Cal3DS2_Base {
   /// @name Advanced Interface
   /// @{
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {

--- a/gtsam/geometry/Cal3DS2.h
+++ b/gtsam/geometry/Cal3DS2.h
@@ -105,12 +105,14 @@ class GTSAM_EXPORT Cal3DS2 : public Cal3DS2_Base {
   /// @{
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {
     ar& boost::serialization::make_nvp(
         "Cal3DS2", boost::serialization::base_object<Cal3DS2_Base>(*this));
   }
+#endif
 
   /// @}
 };

--- a/gtsam/geometry/Cal3DS2_Base.h
+++ b/gtsam/geometry/Cal3DS2_Base.h
@@ -157,6 +157,7 @@ class GTSAM_EXPORT Cal3DS2_Base : public Cal3 {
   /// @{
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {
@@ -168,6 +169,7 @@ class GTSAM_EXPORT Cal3DS2_Base : public Cal3 {
     ar& BOOST_SERIALIZATION_NVP(p2_);
     ar& BOOST_SERIALIZATION_NVP(tol_);
   }
+#endif
 
   /// @}
 };

--- a/gtsam/geometry/Cal3DS2_Base.h
+++ b/gtsam/geometry/Cal3DS2_Base.h
@@ -156,8 +156,8 @@ class GTSAM_EXPORT Cal3DS2_Base : public Cal3 {
   /// @name Advanced Interface
   /// @{
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {

--- a/gtsam/geometry/Cal3Fisheye.h
+++ b/gtsam/geometry/Cal3Fisheye.h
@@ -184,8 +184,8 @@ class GTSAM_EXPORT Cal3Fisheye : public Cal3 {
   /// @name Advanced Interface
   /// @{
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {

--- a/gtsam/geometry/Cal3Fisheye.h
+++ b/gtsam/geometry/Cal3Fisheye.h
@@ -185,6 +185,7 @@ class GTSAM_EXPORT Cal3Fisheye : public Cal3 {
   /// @{
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {
@@ -195,6 +196,7 @@ class GTSAM_EXPORT Cal3Fisheye : public Cal3 {
     ar& BOOST_SERIALIZATION_NVP(k3_);
     ar& BOOST_SERIALIZATION_NVP(k4_);
   }
+#endif
 
   /// @}
 };

--- a/gtsam/geometry/Cal3Unified.h
+++ b/gtsam/geometry/Cal3Unified.h
@@ -139,6 +139,7 @@ class GTSAM_EXPORT Cal3Unified : public Cal3DS2_Base {
 
  private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {
@@ -146,6 +147,7 @@ class GTSAM_EXPORT Cal3Unified : public Cal3DS2_Base {
         "Cal3Unified", boost::serialization::base_object<Cal3DS2_Base>(*this));
     ar& BOOST_SERIALIZATION_NVP(xi_);
   }
+#endif
 };
 
 template <>

--- a/gtsam/geometry/Cal3Unified.h
+++ b/gtsam/geometry/Cal3Unified.h
@@ -138,8 +138,8 @@ class GTSAM_EXPORT Cal3Unified : public Cal3DS2_Base {
   /// @}
 
  private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {

--- a/gtsam/geometry/Cal3_S2.h
+++ b/gtsam/geometry/Cal3_S2.h
@@ -132,8 +132,8 @@ class GTSAM_EXPORT Cal3_S2 : public Cal3 {
   /// @{
 
  private:
-  /// Serialization function
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
+  /// Serialization function
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {

--- a/gtsam/geometry/Cal3_S2.h
+++ b/gtsam/geometry/Cal3_S2.h
@@ -133,12 +133,14 @@ class GTSAM_EXPORT Cal3_S2 : public Cal3 {
 
  private:
   /// Serialization function
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {
     ar& boost::serialization::make_nvp(
         "Cal3_S2", boost::serialization::base_object<Cal3>(*this));
   }
+#endif
 
   /// @}
 };

--- a/gtsam/geometry/Cal3_S2Stereo.h
+++ b/gtsam/geometry/Cal3_S2Stereo.h
@@ -144,6 +144,7 @@ class GTSAM_EXPORT Cal3_S2Stereo : public Cal3_S2 {
 
  private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {
@@ -151,6 +152,7 @@ class GTSAM_EXPORT Cal3_S2Stereo : public Cal3_S2 {
         "Cal3_S2", boost::serialization::base_object<Cal3_S2>(*this));
     ar& BOOST_SERIALIZATION_NVP(b_);
   }
+#endif
   /// @}
 };
 

--- a/gtsam/geometry/Cal3_S2Stereo.h
+++ b/gtsam/geometry/Cal3_S2Stereo.h
@@ -143,8 +143,8 @@ class GTSAM_EXPORT Cal3_S2Stereo : public Cal3_S2 {
   /// @{
 
  private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {

--- a/gtsam/geometry/CalibratedCamera.h
+++ b/gtsam/geometry/CalibratedCamera.h
@@ -416,6 +416,7 @@ private:
   /// @name Advanced Interface
   /// @{
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template<class Archive>
@@ -424,6 +425,7 @@ private:
         & boost::serialization::make_nvp("PinholeBase",
             boost::serialization::base_object<PinholeBase>(*this));
   }
+#endif
 
   /// @}
 };

--- a/gtsam/geometry/CalibratedCamera.h
+++ b/gtsam/geometry/CalibratedCamera.h
@@ -228,8 +228,8 @@ public:
 
 private:
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class Archive>
   void serialize(Archive & ar, const unsigned int /*version*/) {

--- a/gtsam/geometry/CalibratedCamera.h
+++ b/gtsam/geometry/CalibratedCamera.h
@@ -25,7 +25,9 @@
 #include <gtsam/base/Manifold.h>
 #include <gtsam/base/ThreadsafeException.h>
 #include <gtsam/dllexport.h>
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/nvp.hpp>
+#endif
 
 namespace gtsam {
 

--- a/gtsam/geometry/CalibratedCamera.h
+++ b/gtsam/geometry/CalibratedCamera.h
@@ -229,11 +229,13 @@ public:
 private:
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class Archive>
   void serialize(Archive & ar, const unsigned int /*version*/) {
     ar & BOOST_SERIALIZATION_NVP(pose_);
   }
+#endif
 };
 // end of class PinholeBase
 

--- a/gtsam/geometry/CameraSet.h
+++ b/gtsam/geometry/CameraSet.h
@@ -466,11 +466,13 @@ class CameraSet : public std::vector<CAMERA, Eigen::aligned_allocator<CAMERA>> {
 
  private:
   /// Serialization function
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
     ar&(*this);
   }
+#endif
 
  public:
   GTSAM_MAKE_ALIGNED_OPERATOR_NEW

--- a/gtsam/geometry/CameraSet.h
+++ b/gtsam/geometry/CameraSet.h
@@ -465,8 +465,8 @@ class CameraSet : public std::vector<CAMERA, Eigen::aligned_allocator<CAMERA>> {
   }
 
  private:
-  /// Serialization function
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
+  /// Serialization function
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {

--- a/gtsam/geometry/EssentialMatrix.h
+++ b/gtsam/geometry/EssentialMatrix.h
@@ -181,6 +181,7 @@ class EssentialMatrix {
   /// @{
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -197,6 +198,7 @@ class EssentialMatrix {
       ar & boost::serialization::make_nvp("E32", E_(2, 1));
       ar & boost::serialization::make_nvp("E33", E_(2, 2));
     }
+#endif
 
   /// @}
 

--- a/gtsam/geometry/EssentialMatrix.h
+++ b/gtsam/geometry/EssentialMatrix.h
@@ -180,8 +180,8 @@ class EssentialMatrix {
   /// @name Advanced Interface
   /// @{
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/geometry/PinholeCamera.h
+++ b/gtsam/geometry/PinholeCamera.h
@@ -326,8 +326,8 @@ public:
 
 private:
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class Archive>
   void serialize(Archive & ar, const unsigned int /*version*/) {

--- a/gtsam/geometry/PinholeCamera.h
+++ b/gtsam/geometry/PinholeCamera.h
@@ -327,6 +327,7 @@ public:
 private:
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class Archive>
   void serialize(Archive & ar, const unsigned int /*version*/) {
@@ -335,6 +336,7 @@ private:
             boost::serialization::base_object<Base>(*this));
     ar & BOOST_SERIALIZATION_NVP(K_);
   }
+#endif
 
 public:
   GTSAM_MAKE_ALIGNED_OPERATOR_NEW

--- a/gtsam/geometry/PinholePose.h
+++ b/gtsam/geometry/PinholePose.h
@@ -217,8 +217,8 @@ public:
 
 private:
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class Archive>
   void serialize(Archive & ar, const unsigned int /*version*/) {

--- a/gtsam/geometry/PinholePose.h
+++ b/gtsam/geometry/PinholePose.h
@@ -431,6 +431,7 @@ public:
 
 private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template<class Archive>
@@ -440,6 +441,7 @@ private:
             boost::serialization::base_object<Base>(*this));
     ar & BOOST_SERIALIZATION_NVP(K_);
   }
+#endif
 
 public:
   GTSAM_MAKE_ALIGNED_OPERATOR_NEW

--- a/gtsam/geometry/PinholePose.h
+++ b/gtsam/geometry/PinholePose.h
@@ -218,6 +218,7 @@ public:
 private:
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class Archive>
   void serialize(Archive & ar, const unsigned int /*version*/) {
@@ -225,6 +226,7 @@ private:
     & boost::serialization::make_nvp("PinholeBase",
         boost::serialization::base_object<PinholeBase>(*this));
   }
+#endif
 
 public:
   GTSAM_MAKE_ALIGNED_OPERATOR_NEW

--- a/gtsam/geometry/PinholeSet.h
+++ b/gtsam/geometry/PinholeSet.h
@@ -64,8 +64,8 @@ public:
 
 private:
 
-  /// Serialization function
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
+  /// Serialization function
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int version) {

--- a/gtsam/geometry/PinholeSet.h
+++ b/gtsam/geometry/PinholeSet.h
@@ -65,11 +65,13 @@ public:
 private:
 
   /// Serialization function
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int version) {
     ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
   }
+#endif
 };
 
 template<class CAMERA>

--- a/gtsam/geometry/Point2.h
+++ b/gtsam/geometry/Point2.h
@@ -19,7 +19,9 @@
 
 #include <gtsam/base/VectorSpace.h>
 #include <gtsam/base/std_optional_serialization.h>
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/nvp.hpp>
+#endif
 
 #include <optional>
 

--- a/gtsam/geometry/Point3.h
+++ b/gtsam/geometry/Point3.h
@@ -26,7 +26,9 @@
 #include <gtsam/base/Vector.h>
 #include <gtsam/dllexport.h>
 #include <gtsam/base/VectorSerialization.h>
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/nvp.hpp>
+#endif
 #include <numeric>
 
 namespace gtsam {

--- a/gtsam/geometry/Pose2.h
+++ b/gtsam/geometry/Pose2.h
@@ -327,12 +327,14 @@ public:
  private:
 
   // Serialization function
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  //
   friend class boost::serialization::access;
   template<class Archive>
   void serialize(Archive & ar, const unsigned int /*version*/) {
     ar & BOOST_SERIALIZATION_NVP(t_);
     ar & BOOST_SERIALIZATION_NVP(r_);
   }
+#endif
 
 public:
   // Align for Point2, which is either derived from, or is typedef, of Vector2

--- a/gtsam/geometry/Pose2.h
+++ b/gtsam/geometry/Pose2.h
@@ -326,8 +326,8 @@ public:
 
  private:
 
-  // Serialization function
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  //
+  // Serialization function
   friend class boost::serialization::access;
   template<class Archive>
   void serialize(Archive & ar, const unsigned int /*version*/) {

--- a/gtsam/geometry/Pose3.h
+++ b/gtsam/geometry/Pose3.h
@@ -393,12 +393,14 @@ public:
 
  private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class Archive>
   void serialize(Archive & ar, const unsigned int /*version*/) {
     ar & BOOST_SERIALIZATION_NVP(R_);
     ar & BOOST_SERIALIZATION_NVP(t_);
   }
+#endif
   /// @}
 
 #ifdef GTSAM_USE_QUATERNIONS

--- a/gtsam/geometry/Pose3.h
+++ b/gtsam/geometry/Pose3.h
@@ -392,8 +392,8 @@ public:
   friend std::ostream &operator<<(std::ostream &os, const Pose3& p);
 
  private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class Archive>
   void serialize(Archive & ar, const unsigned int /*version*/) {

--- a/gtsam/geometry/Rot2.h
+++ b/gtsam/geometry/Rot2.h
@@ -214,12 +214,14 @@ namespace gtsam {
 
   private:
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
       ar & BOOST_SERIALIZATION_NVP(c_);
       ar & BOOST_SERIALIZATION_NVP(s_);
     }
+#endif
 
   };
 

--- a/gtsam/geometry/Rot2.h
+++ b/gtsam/geometry/Rot2.h
@@ -213,8 +213,8 @@ namespace gtsam {
     static Rot2 ClosestTo(const Matrix2& M);
 
   private:
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/geometry/Rot3.h
+++ b/gtsam/geometry/Rot3.h
@@ -529,6 +529,7 @@ class GTSAM_EXPORT Rot3 : public LieGroup<Rot3, 3> {
 
    private:
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template <class ARCHIVE>
     void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
@@ -550,6 +551,7 @@ class GTSAM_EXPORT Rot3 : public LieGroup<Rot3, 3> {
       ar& boost::serialization::make_nvp("z", quaternion_.z());
 #endif
     }
+#endif
 
 #ifdef GTSAM_USE_QUATERNIONS
   // only align if quaternion, Matrix3 has no alignment requirements

--- a/gtsam/geometry/Rot3.h
+++ b/gtsam/geometry/Rot3.h
@@ -528,8 +528,8 @@ class GTSAM_EXPORT Rot3 : public LieGroup<Rot3, 3> {
     /// @}
 
    private:
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template <class ARCHIVE>
     void serialize(ARCHIVE& ar, const unsigned int /*version*/) {

--- a/gtsam/geometry/SO3.h
+++ b/gtsam/geometry/SO3.h
@@ -99,8 +99,8 @@ template <>
 GTSAM_EXPORT
 Vector9 SO3::vec(OptionalJacobian<9, 3> H) const;
 
-/** Serialization function */
 template <class Archive>
+/** Serialization function */
 void serialize(Archive& ar, SO3& R, const unsigned int /*version*/) {
   Matrix3& M = R.matrix_;
   ar& boost::serialization::make_nvp("R11", M(0, 0));

--- a/gtsam/geometry/SO3.h
+++ b/gtsam/geometry/SO3.h
@@ -99,6 +99,7 @@ template <>
 GTSAM_EXPORT
 Vector9 SO3::vec(OptionalJacobian<9, 3> H) const;
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 template <class Archive>
 /** Serialization function */
 void serialize(Archive& ar, SO3& R, const unsigned int /*version*/) {
@@ -113,6 +114,7 @@ void serialize(Archive& ar, SO3& R, const unsigned int /*version*/) {
   ar& boost::serialization::make_nvp("R32", M(2, 1));
   ar& boost::serialization::make_nvp("R33", M(2, 2));
 }
+#endif
 
 namespace so3 {
 

--- a/gtsam/geometry/SO4.h
+++ b/gtsam/geometry/SO4.h
@@ -78,8 +78,8 @@ GTSAM_EXPORT Matrix3 topLeft(const SO4 &Q, OptionalJacobian<9, 6> H = {});
  */
 GTSAM_EXPORT Matrix43 stiefel(const SO4 &Q, OptionalJacobian<12, 6> H = {});
 
-/** Serialization function */
 template <class Archive>
+/** Serialization function */
 void serialize(Archive &ar, SO4 &Q, const unsigned int /*version*/) {
   Matrix4 &M = Q.matrix_;
   ar &boost::serialization::make_nvp("Q11", M(0, 0));

--- a/gtsam/geometry/SO4.h
+++ b/gtsam/geometry/SO4.h
@@ -78,6 +78,7 @@ GTSAM_EXPORT Matrix3 topLeft(const SO4 &Q, OptionalJacobian<9, 6> H = {});
  */
 GTSAM_EXPORT Matrix43 stiefel(const SO4 &Q, OptionalJacobian<12, 6> H = {});
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 template <class Archive>
 /** Serialization function */
 void serialize(Archive &ar, SO4 &Q, const unsigned int /*version*/) {
@@ -102,6 +103,7 @@ void serialize(Archive &ar, SO4 &Q, const unsigned int /*version*/) {
   ar &boost::serialization::make_nvp("Q43", M(3, 2));
   ar &boost::serialization::make_nvp("Q44", M(3, 3));
 }
+#endif
 
 /*
  * Define the traits. internal::LieGroup provides both Lie group and Testable

--- a/gtsam/geometry/SOn.h
+++ b/gtsam/geometry/SOn.h
@@ -377,8 +377,8 @@ template <>
 GTSAM_EXPORT
 typename SOn::VectorN2 SOn::vec(DynamicJacobian H) const;
 
-/** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+/** Serialization function */
 template<class Archive>
 void serialize(
   Archive& ar, SOn& Q,

--- a/gtsam/geometry/SOn.h
+++ b/gtsam/geometry/SOn.h
@@ -323,6 +323,7 @@ class SO : public LieGroup<SO<N>, internal::DimensionSO(N)> {
   /// @name Serialization
   /// @{
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   template <class Archive>
   friend void save(Archive&, SO&, const unsigned int);
   template <class Archive>
@@ -331,6 +332,7 @@ class SO : public LieGroup<SO<N>, internal::DimensionSO(N)> {
   friend void serialize(Archive&, SO&, const unsigned int);
   friend class boost::serialization::access;
   friend class Rot3;  // for serialize
+#endif
 
   /// @}
 };
@@ -376,6 +378,7 @@ GTSAM_EXPORT
 typename SOn::VectorN2 SOn::vec(DynamicJacobian H) const;
 
 /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 template<class Archive>
 void serialize(
   Archive& ar, SOn& Q,
@@ -384,6 +387,7 @@ void serialize(
   Matrix& M = Q.matrix_;
   ar& BOOST_SERIALIZATION_NVP(M);
 }
+#endif
 
 /*
  * Define the traits. internal::LieGroup provides both Lie group and Testable

--- a/gtsam/geometry/SOn.h
+++ b/gtsam/geometry/SOn.h
@@ -24,7 +24,9 @@
 #include <gtsam/dllexport.h>
 #include <Eigen/Core>
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/nvp.hpp>
+#endif
 
 #include <iostream> // TODO(frank): how to avoid?
 #include <string>

--- a/gtsam/geometry/SphericalCamera.h
+++ b/gtsam/geometry/SphericalCamera.h
@@ -26,7 +26,9 @@
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/geometry/Unit3.h>
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/nvp.hpp>
+#endif
 
 namespace gtsam {
 

--- a/gtsam/geometry/SphericalCamera.h
+++ b/gtsam/geometry/SphericalCamera.h
@@ -52,8 +52,8 @@ class GTSAM_EXPORT EmptyCal {
   }
 
  private:
-  /// Serialization function
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
+  /// Serialization function
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {

--- a/gtsam/geometry/SphericalCamera.h
+++ b/gtsam/geometry/SphericalCamera.h
@@ -223,12 +223,14 @@ class GTSAM_EXPORT SphericalCamera {
   static size_t Dim() { return 6; }
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {
     ar& BOOST_SERIALIZATION_NVP(pose_);
   }
+#endif
 
  public:
   GTSAM_MAKE_ALIGNED_OPERATOR_NEW

--- a/gtsam/geometry/SphericalCamera.h
+++ b/gtsam/geometry/SphericalCamera.h
@@ -53,12 +53,14 @@ class GTSAM_EXPORT EmptyCal {
 
  private:
   /// Serialization function
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {
     ar& boost::serialization::make_nvp(
         "EmptyCal", boost::serialization::base_object<EmptyCal>(*this));
   }
+#endif
 };
 
 /**

--- a/gtsam/geometry/StereoCamera.h
+++ b/gtsam/geometry/StereoCamera.h
@@ -179,12 +179,14 @@ public:
 
 private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class Archive>
   void serialize(Archive & ar, const unsigned int /*version*/) {
     ar & BOOST_SERIALIZATION_NVP(leftCamPose_);
     ar & BOOST_SERIALIZATION_NVP(K_);
   }
+#endif
 
 };
 

--- a/gtsam/geometry/StereoPoint2.h
+++ b/gtsam/geometry/StereoPoint2.h
@@ -147,6 +147,7 @@ private:
   /// @{
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -154,6 +155,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(uR_);
     ar & BOOST_SERIALIZATION_NVP(v_);
   }
+#endif
 
   /// @}
 

--- a/gtsam/geometry/StereoPoint2.h
+++ b/gtsam/geometry/StereoPoint2.h
@@ -146,8 +146,8 @@ private:
   /// @name Advanced Interface
   /// @{
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/geometry/StereoPoint2.h
+++ b/gtsam/geometry/StereoPoint2.h
@@ -20,7 +20,9 @@
 
 #include <gtsam/geometry/Point2.h>
 #include <gtsam/base/VectorSpace.h>
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/nvp.hpp>
+#endif
 
 namespace gtsam {
 

--- a/gtsam/geometry/Unit3.h
+++ b/gtsam/geometry/Unit3.h
@@ -206,8 +206,8 @@ private:
 
   /// @name Advanced Interface
   /// @{
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/geometry/Unit3.h
+++ b/gtsam/geometry/Unit3.h
@@ -207,11 +207,13 @@ private:
   /// @name Advanced Interface
   /// @{
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
     ar & BOOST_SERIALIZATION_NVP(p_);
   }
+#endif
 
   /// @}
 

--- a/gtsam/geometry/tests/CMakeLists.txt
+++ b/gtsam/geometry/tests/CMakeLists.txt
@@ -1,1 +1,9 @@
-gtsamAddTestsGlob(geometry "test*.cpp" "" "gtsam")
+# if GTSAM_ENABLE_BOOST_SERIALIZATION is OFF then exclude some tests
+if (NOT GTSAM_ENABLE_BOOST_SERIALIZATION)
+  # create a semicolon seperated list of files to exclude
+  set(EXCLUDE_TESTS "testSerializationGeometry.cpp")
+else()
+  set(EXCLUDE_TESTS "")
+endif()
+
+gtsamAddTestsGlob(discrete "test*.cpp" "${EXCLUDE_TESTS}" "gtsam")

--- a/gtsam/geometry/tests/CMakeLists.txt
+++ b/gtsam/geometry/tests/CMakeLists.txt
@@ -6,4 +6,4 @@ else()
   set(EXCLUDE_TESTS "")
 endif()
 
-gtsamAddTestsGlob(discrete "test*.cpp" "${EXCLUDE_TESTS}" "gtsam")
+gtsamAddTestsGlob(geometry "test*.cpp" "${EXCLUDE_TESTS}" "gtsam")

--- a/gtsam/geometry/tests/testBearingRange.cpp
+++ b/gtsam/geometry/tests/testBearingRange.cpp
@@ -25,7 +25,6 @@
 
 using namespace std;
 using namespace gtsam;
-using namespace serializationTestHelpers;
 
 typedef BearingRange<Pose2, Point2> BearingRange2D;
 BearingRange2D br2D(1, 2);
@@ -45,13 +44,6 @@ TEST(BearingRange, 2D) {
   EXPECT(assert_equal(expected, actual));
 }
 
-/* ************************************************************************* */
-TEST(BearingRange, Serialization2D) {
-  EXPECT(equalsObj<BearingRange2D>(br2D));
-  EXPECT(equalsXML<BearingRange2D>(br2D));
-  EXPECT(equalsBinary<BearingRange2D>(br2D));
-}
-
 //******************************************************************************
 TEST(BearingRange3D, Concept) {
   BOOST_CONCEPT_ASSERT((IsManifold<BearingRange3D>));
@@ -64,12 +56,22 @@ TEST(BearingRange, 3D) {
   EXPECT(assert_equal(expected, actual));
 }
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+using namespace serializationTestHelpers;
+/* ************************************************************************* */
+TEST(BearingRange, Serialization2D) {
+  EXPECT(equalsObj<BearingRange2D>(br2D));
+  EXPECT(equalsXML<BearingRange2D>(br2D));
+  EXPECT(equalsBinary<BearingRange2D>(br2D));
+}
+
 /* ************************************************************************* */
 TEST(BearingRange, Serialization3D) {
   EXPECT(equalsObj<BearingRange3D>(br3D));
   EXPECT(equalsXML<BearingRange3D>(br3D));
   EXPECT(equalsBinary<BearingRange3D>(br3D));
 }
+#endif
 
 /* ************************************************************************* */
 int main() {

--- a/gtsam/geometry/tests/testUnit3.cpp
+++ b/gtsam/geometry/tests/testUnit3.cpp
@@ -499,12 +499,14 @@ TEST(Unit3, CopyAssign) {
 }
 
 /* ************************************************************************* */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 TEST(actualH, Serialization) {
   Unit3 p(0, 1, 0);
   EXPECT(serializationTestHelpers::equalsObj(p));
   EXPECT(serializationTestHelpers::equalsXML(p));
   EXPECT(serializationTestHelpers::equalsBinary(p));
 }
+#endif
 
 
 /* ************************************************************************* */

--- a/gtsam/geometry/triangulation.h
+++ b/gtsam/geometry/triangulation.h
@@ -611,8 +611,8 @@ struct GTSAM_EXPORT TriangulationParameters {
 
 private:
 
-  /// Serialization function
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
+  /// Serialization function
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int version) {

--- a/gtsam/geometry/triangulation.h
+++ b/gtsam/geometry/triangulation.h
@@ -676,12 +676,14 @@ class TriangulationResult : public std::optional<Point3> {
   }
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   /// Serialization function
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int version) {
     ar& BOOST_SERIALIZATION_NVP(status);
   }
+#endif
 };
 
 /// triangulateSafe: extensive checking of the outcome

--- a/gtsam/geometry/triangulation.h
+++ b/gtsam/geometry/triangulation.h
@@ -612,6 +612,7 @@ struct GTSAM_EXPORT TriangulationParameters {
 private:
 
   /// Serialization function
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int version) {
@@ -620,6 +621,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(landmarkDistanceThreshold);
     ar & BOOST_SERIALIZATION_NVP(dynamicOutlierRejectionThreshold);
   }
+#endif
 };
 
 /**

--- a/gtsam/hybrid/GaussianMixture.h
+++ b/gtsam/hybrid/GaussianMixture.h
@@ -255,8 +255,8 @@ class GTSAM_EXPORT GaussianMixture
   /// Check whether `given` has values for all frontal keys.
   bool allFrontalsGiven(const VectorValues &given) const;
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive &ar, const unsigned int /*version*/) {

--- a/gtsam/hybrid/GaussianMixture.h
+++ b/gtsam/hybrid/GaussianMixture.h
@@ -256,6 +256,7 @@ class GTSAM_EXPORT GaussianMixture
   bool allFrontalsGiven(const VectorValues &given) const;
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive &ar, const unsigned int /*version*/) {
@@ -263,6 +264,7 @@ class GTSAM_EXPORT GaussianMixture
     ar &BOOST_SERIALIZATION_BASE_OBJECT_NVP(BaseConditional);
     ar &BOOST_SERIALIZATION_NVP(conditionals_);
   }
+#endif
 };
 
 /// Return the DiscreteKey vector as a set.

--- a/gtsam/hybrid/GaussianMixtureFactor.h
+++ b/gtsam/hybrid/GaussianMixtureFactor.h
@@ -152,6 +152,7 @@ class GTSAM_EXPORT GaussianMixtureFactor : public HybridFactor {
   /// @}
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -159,6 +160,7 @@ class GTSAM_EXPORT GaussianMixtureFactor : public HybridFactor {
     ar &BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     ar &BOOST_SERIALIZATION_NVP(factors_);
   }
+#endif
 };
 
 // traits

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -229,11 +229,13 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
   void updateDiscreteConditionals(const DecisionTreeFactor &prunedDecisionTree);
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int /*version*/) {
     ar &BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
   }
+#endif
 };
 
 /// traits

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -228,8 +228,8 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
    */
   void updateDiscreteConditionals(const DecisionTreeFactor &prunedDecisionTree);
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int /*version*/) {

--- a/gtsam/hybrid/HybridBayesTree.h
+++ b/gtsam/hybrid/HybridBayesTree.h
@@ -114,8 +114,8 @@ class GTSAM_EXPORT HybridBayesTree : public BayesTree<HybridBayesTreeClique> {
   /// @}
 
  private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {

--- a/gtsam/hybrid/HybridBayesTree.h
+++ b/gtsam/hybrid/HybridBayesTree.h
@@ -115,11 +115,13 @@ class GTSAM_EXPORT HybridBayesTree : public BayesTree<HybridBayesTreeClique> {
 
  private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
     ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
   }
+#endif
 };
 
 /// traits

--- a/gtsam/hybrid/HybridConditional.h
+++ b/gtsam/hybrid/HybridConditional.h
@@ -205,6 +205,7 @@ class GTSAM_EXPORT HybridConditional
 
  private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {
@@ -225,6 +226,7 @@ class GTSAM_EXPORT HybridConditional
           static_cast<GaussianMixture*>(NULL), static_cast<Factor*>(NULL));
     }
   }
+#endif
 
 };  // HybridConditional
 

--- a/gtsam/hybrid/HybridConditional.h
+++ b/gtsam/hybrid/HybridConditional.h
@@ -204,8 +204,8 @@ class GTSAM_EXPORT HybridConditional
   /// @}
 
  private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {

--- a/gtsam/hybrid/HybridFactor.h
+++ b/gtsam/hybrid/HybridFactor.h
@@ -137,8 +137,8 @@ class GTSAM_EXPORT HybridFactor : public Factor {
   /// @}
 
  private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int /*version*/) {

--- a/gtsam/hybrid/HybridFactor.h
+++ b/gtsam/hybrid/HybridFactor.h
@@ -138,6 +138,7 @@ class GTSAM_EXPORT HybridFactor : public Factor {
 
  private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int /*version*/) {
@@ -148,6 +149,7 @@ class GTSAM_EXPORT HybridFactor : public Factor {
     ar &BOOST_SERIALIZATION_NVP(discreteKeys_);
     ar &BOOST_SERIALIZATION_NVP(continuousKeys_);
   }
+#endif
 };
 // HybridFactor
 

--- a/gtsam/hybrid/tests/CMakeLists.txt
+++ b/gtsam/hybrid/tests/CMakeLists.txt
@@ -6,4 +6,4 @@ else()
   set(EXCLUDE_TESTS "")
 endif()
 
-gtsamAddTestsGlob(discrete "test*.cpp" "${EXCLUDE_TESTS}" "gtsam")
+gtsamAddTestsGlob(hybrid "test*.cpp" "${EXCLUDE_TESTS}" "gtsam")

--- a/gtsam/hybrid/tests/CMakeLists.txt
+++ b/gtsam/hybrid/tests/CMakeLists.txt
@@ -1,1 +1,9 @@
-gtsamAddTestsGlob(hybrid "test*.cpp" "" "gtsam")
+# if GTSAM_ENABLE_BOOST_SERIALIZATION is OFF then exclude some tests
+if (NOT GTSAM_ENABLE_BOOST_SERIALIZATION)
+  # create a semicolon seperated list of files to exclude
+  set(EXCLUDE_TESTS "testSerializationHybrid.cpp")
+else()
+  set(EXCLUDE_TESTS "")
+endif()
+
+gtsamAddTestsGlob(discrete "test*.cpp" "${EXCLUDE_TESTS}" "gtsam")

--- a/gtsam/inference/BayesTree.h
+++ b/gtsam/inference/BayesTree.h
@@ -259,8 +259,8 @@ namespace gtsam {
     template<class BAYESTREE, class GRAPH> friend class EliminatableClusterTree;
 
    private:
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/inference/BayesTree.h
+++ b/gtsam/inference/BayesTree.h
@@ -260,12 +260,14 @@ namespace gtsam {
 
    private:
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
       ar & BOOST_SERIALIZATION_NVP(nodes_);
       ar & BOOST_SERIALIZATION_NVP(roots_);
     }
+#endif
 
     /// @}
 

--- a/gtsam/inference/BayesTreeCliqueBase.h
+++ b/gtsam/inference/BayesTreeCliqueBase.h
@@ -200,6 +200,7 @@ namespace gtsam {
   private:
 
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -213,6 +214,7 @@ namespace gtsam {
       }
       ar & BOOST_SERIALIZATION_NVP(children);
     }
+#endif
 
     /// @}
 

--- a/gtsam/inference/BayesTreeCliqueBase.h
+++ b/gtsam/inference/BayesTreeCliqueBase.h
@@ -199,8 +199,8 @@ namespace gtsam {
 
   private:
 
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/inference/Conditional.h
+++ b/gtsam/inference/Conditional.h
@@ -213,8 +213,8 @@ namespace gtsam {
     // Cast to derived type (const) (casts down to derived conditional type, then up to factor type)
     const FACTOR& asFactor() const { return static_cast<const FACTOR&>(static_cast<const DERIVEDCONDITIONAL&>(*this)); }
 
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/inference/Conditional.h
+++ b/gtsam/inference/Conditional.h
@@ -214,11 +214,13 @@ namespace gtsam {
     const FACTOR& asFactor() const { return static_cast<const FACTOR&>(static_cast<const DERIVEDCONDITIONAL&>(*this)); }
 
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
       ar & BOOST_SERIALIZATION_NVP(nrFrontals_);
     }
+#endif
 
     /// @}
 

--- a/gtsam/inference/Factor.h
+++ b/gtsam/inference/Factor.h
@@ -195,11 +195,13 @@ namespace gtsam {
     /// @{
 
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class Archive>
     void serialize(Archive & ar, const unsigned int /*version*/) {
       ar & BOOST_SERIALIZATION_NVP(keys_);
     }
+#endif
 
     /// @}
 

--- a/gtsam/inference/Factor.h
+++ b/gtsam/inference/Factor.h
@@ -21,7 +21,9 @@
 
 #pragma once
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/nvp.hpp>
+#endif
 #include <memory>
 
 #include <gtsam/base/types.h>

--- a/gtsam/inference/Factor.h
+++ b/gtsam/inference/Factor.h
@@ -190,12 +190,10 @@ namespace gtsam {
     /// @}
 
   private:
-
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     /// @name Serialization
     /// @{
-
     /** Serialization function */
-#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class Archive>
     void serialize(Archive & ar, const unsigned int /*version*/) {

--- a/gtsam/inference/FactorGraph.h
+++ b/gtsam/inference/FactorGraph.h
@@ -434,11 +434,13 @@ class FactorGraph {
 
  private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
     ar& BOOST_SERIALIZATION_NVP(factors_);
   }
+#endif
 
   /// @}
 };  // FactorGraph

--- a/gtsam/inference/FactorGraph.h
+++ b/gtsam/inference/FactorGraph.h
@@ -30,8 +30,10 @@
 #include <Eigen/Core>  // for Eigen::aligned_allocator
 
 #include <boost/assign/list_inserter.hpp>
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/vector.hpp>
+#endif
 
 #include <string>
 #include <type_traits>

--- a/gtsam/inference/FactorGraph.h
+++ b/gtsam/inference/FactorGraph.h
@@ -433,8 +433,8 @@ class FactorGraph {
   inline bool exists(size_t idx) const { return idx < size() && at(idx); }
 
  private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {

--- a/gtsam/inference/LabeledSymbol.h
+++ b/gtsam/inference/LabeledSymbol.h
@@ -113,6 +113,7 @@ public:
 private:
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -120,6 +121,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(label_);
     ar & BOOST_SERIALIZATION_NVP(j_);
   }
+#endif
 }; // \class LabeledSymbol
 
 /** Create a symbol key from a character, label and index, i.e. xA5. */

--- a/gtsam/inference/LabeledSymbol.h
+++ b/gtsam/inference/LabeledSymbol.h
@@ -112,8 +112,8 @@ public:
 
 private:
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/inference/Ordering.h
+++ b/gtsam/inference/Ordering.h
@@ -257,11 +257,13 @@ private:
       const VariableIndex& variableIndex, std::vector<int>& cmember);
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int version) {
     ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
   }
+#endif
 };
 
 /// traits

--- a/gtsam/inference/Ordering.h
+++ b/gtsam/inference/Ordering.h
@@ -256,8 +256,8 @@ private:
   static GTSAM_EXPORT Ordering ColamdConstrained(
       const VariableIndex& variableIndex, std::vector<int>& cmember);
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int version) {

--- a/gtsam/inference/Symbol.h
+++ b/gtsam/inference/Symbol.h
@@ -123,12 +123,14 @@ public:
 private:
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
     ar & BOOST_SERIALIZATION_NVP(c_);
     ar & BOOST_SERIALIZATION_NVP(j_);
   }
+#endif
 };
 
 /** Create a symbol key from a character and index, i.e. x5. */

--- a/gtsam/inference/Symbol.h
+++ b/gtsam/inference/Symbol.h
@@ -21,7 +21,9 @@
 #include <gtsam/base/Testable.h>
 #include <gtsam/inference/Key.h>
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/nvp.hpp>
+#endif
 #include <cstdint>
 #include <functional>
 

--- a/gtsam/inference/Symbol.h
+++ b/gtsam/inference/Symbol.h
@@ -122,8 +122,8 @@ public:
 
 private:
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/inference/VariableIndex.h
+++ b/gtsam/inference/VariableIndex.h
@@ -191,6 +191,7 @@ protected:
 
 private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -198,6 +199,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(nFactors_);
     ar & BOOST_SERIALIZATION_NVP(nEntries_);
   }
+#endif
 
   /// @}
 };

--- a/gtsam/inference/VariableIndex.h
+++ b/gtsam/inference/VariableIndex.h
@@ -190,8 +190,8 @@ protected:
   }
 
 private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/linear/GaussianBayesNet.h
+++ b/gtsam/linear/GaussianBayesNet.h
@@ -256,8 +256,8 @@ namespace gtsam {
     /// @}
 
   private:
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/linear/GaussianBayesNet.h
+++ b/gtsam/linear/GaussianBayesNet.h
@@ -257,11 +257,13 @@ namespace gtsam {
 
   private:
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
       ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     }
+#endif
   };
 
   /// traits

--- a/gtsam/linear/GaussianConditional.h
+++ b/gtsam/linear/GaussianConditional.h
@@ -274,8 +274,8 @@ namespace gtsam {
     /// @}
 
    private:
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class Archive>
     void serialize(Archive & ar, const unsigned int /*version*/) {

--- a/gtsam/linear/GaussianConditional.h
+++ b/gtsam/linear/GaussianConditional.h
@@ -275,12 +275,14 @@ namespace gtsam {
 
    private:
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class Archive>
     void serialize(Archive & ar, const unsigned int /*version*/) {
       ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(BaseFactor);
       ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(BaseConditional);
     }
+#endif
   }; // GaussianConditional
 
 /// traits

--- a/gtsam/linear/GaussianFactor.h
+++ b/gtsam/linear/GaussianFactor.h
@@ -164,11 +164,13 @@ namespace gtsam {
 
   private:
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
       ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     }
+#endif
 
   }; // GaussianFactor
 

--- a/gtsam/linear/GaussianFactor.h
+++ b/gtsam/linear/GaussianFactor.h
@@ -163,8 +163,8 @@ namespace gtsam {
     }
 
   private:
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/linear/GaussianFactorGraph.h
+++ b/gtsam/linear/GaussianFactorGraph.h
@@ -404,11 +404,13 @@ namespace gtsam {
 
   private:
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
       ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     }
+#endif
   };
 
   /**

--- a/gtsam/linear/GaussianFactorGraph.h
+++ b/gtsam/linear/GaussianFactorGraph.h
@@ -403,8 +403,8 @@ namespace gtsam {
     /// @}
 
   private:
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/linear/HessianFactor.h
+++ b/gtsam/linear/HessianFactor.h
@@ -363,8 +363,8 @@ namespace gtsam {
     friend class NonlinearFactorGraph;
     friend class NonlinearClusterTree;
 
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/linear/HessianFactor.h
+++ b/gtsam/linear/HessianFactor.h
@@ -364,12 +364,14 @@ namespace gtsam {
     friend class NonlinearClusterTree;
 
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
       ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(GaussianFactor);
       ar & BOOST_SERIALIZATION_NVP(info_);
     }
+#endif
   };
 
 /**

--- a/gtsam/linear/JacobianFactor.h
+++ b/gtsam/linear/JacobianFactor.h
@@ -435,7 +435,6 @@ namespace gtsam {
         ar << BOOST_SERIALIZATION_NVP(model_);
       }
     }
-#endif
 
     template<class ARCHIVE>
     void load(ARCHIVE & ar, const unsigned int version) {
@@ -454,6 +453,7 @@ namespace gtsam {
     }
 
     BOOST_SERIALIZATION_SPLIT_MEMBER()
+#endif
   }; // JacobianFactor
 /// traits
 template<>
@@ -462,7 +462,9 @@ struct traits<JacobianFactor> : public Testable<JacobianFactor> {
 
 } // \ namespace gtsam
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 BOOST_CLASS_VERSION(gtsam::JacobianFactor, 1)
+#endif
 
 #include <gtsam/linear/JacobianFactor-inl.h>
 

--- a/gtsam/linear/JacobianFactor.h
+++ b/gtsam/linear/JacobianFactor.h
@@ -414,6 +414,7 @@ namespace gtsam {
     template<typename T> friend class ExpressionFactor;
 
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void save(ARCHIVE & ar, const unsigned int version) const {
@@ -432,6 +433,7 @@ namespace gtsam {
         ar << BOOST_SERIALIZATION_NVP(model_);
       }
     }
+#endif
 
     template<class ARCHIVE>
     void load(ARCHIVE & ar, const unsigned int version) {

--- a/gtsam/linear/JacobianFactor.h
+++ b/gtsam/linear/JacobianFactor.h
@@ -24,8 +24,10 @@
 #include <gtsam/global_includes.h>
 #include <gtsam/inference/VariableSlots.h>
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/version.hpp>
 #include <boost/serialization/split_member.hpp>
+#endif
 
 namespace gtsam {
 

--- a/gtsam/linear/JacobianFactor.h
+++ b/gtsam/linear/JacobianFactor.h
@@ -413,8 +413,8 @@ namespace gtsam {
     // be very selective on who can access these private methods:
     template<typename T> friend class ExpressionFactor;
 
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void save(ARCHIVE & ar, const unsigned int version) const {

--- a/gtsam/linear/LossFunctions.h
+++ b/gtsam/linear/LossFunctions.h
@@ -128,8 +128,8 @@ class GTSAM_EXPORT Base {
   void reweight(Matrix &A1, Matrix &A2, Matrix &A3, Vector &error) const;
 
  private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int /*version*/) {

--- a/gtsam/linear/LossFunctions.h
+++ b/gtsam/linear/LossFunctions.h
@@ -129,11 +129,13 @@ class GTSAM_EXPORT Base {
 
  private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int /*version*/) {
     ar &BOOST_SERIALIZATION_NVP(reweight_);
   }
+#endif
 };
 
 /** "Null" robust loss function, equivalent to a Gaussian pdf noise model, or

--- a/gtsam/linear/LossFunctions.h
+++ b/gtsam/linear/LossFunctions.h
@@ -23,12 +23,14 @@
 #include <gtsam/base/Testable.h>
 #include <gtsam/dllexport.h>
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/extended_type_info.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/version.hpp>
 #include <boost/serialization/optional.hpp>
 #include <boost/serialization/shared_ptr.hpp>
 #include <boost/serialization/singleton.hpp>
+#endif
 
 namespace gtsam {
 namespace noiseModel {

--- a/gtsam/linear/LossFunctions.h
+++ b/gtsam/linear/LossFunctions.h
@@ -162,12 +162,14 @@ class GTSAM_EXPORT Null : public Base {
   static shared_ptr Create();
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int /*version*/) {
     ar &BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
   }
+#endif
 };
 
 /** Implementation of the "Fair" robust error model (Zhang97ivc)
@@ -194,6 +196,7 @@ class GTSAM_EXPORT Fair : public Base {
   double modelParameter() const { return c_; }
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -201,6 +204,7 @@ class GTSAM_EXPORT Fair : public Base {
     ar &BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     ar &BOOST_SERIALIZATION_NVP(c_);
   }
+#endif
 };
 
 /** The "Huber" robust error model (Zhang97ivc).
@@ -227,6 +231,7 @@ class GTSAM_EXPORT Huber : public Base {
   double modelParameter() const { return k_; }
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -234,6 +239,7 @@ class GTSAM_EXPORT Huber : public Base {
     ar &BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     ar &BOOST_SERIALIZATION_NVP(k_);
   }
+#endif
 };
 
 /** Implementation of the "Cauchy" robust error model (Lee2013IROS).
@@ -265,6 +271,7 @@ class GTSAM_EXPORT Cauchy : public Base {
   double modelParameter() const { return k_; }
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -273,6 +280,7 @@ class GTSAM_EXPORT Cauchy : public Base {
     ar &BOOST_SERIALIZATION_NVP(k_);
     ar &BOOST_SERIALIZATION_NVP(ksquared_);
   }
+#endif
 };
 
 /** Implementation of the "Tukey" robust error model (Zhang97ivc).
@@ -299,6 +307,7 @@ class GTSAM_EXPORT Tukey : public Base {
   double modelParameter() const { return c_; }
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -306,6 +315,7 @@ class GTSAM_EXPORT Tukey : public Base {
     ar &BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     ar &BOOST_SERIALIZATION_NVP(c_);
   }
+#endif
 };
 
 /** Implementation of the "Welsch" robust error model (Zhang97ivc).
@@ -332,6 +342,7 @@ class GTSAM_EXPORT Welsch : public Base {
   double modelParameter() const { return c_; }
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -340,6 +351,7 @@ class GTSAM_EXPORT Welsch : public Base {
     ar &BOOST_SERIALIZATION_NVP(c_);
     ar &BOOST_SERIALIZATION_NVP(csquared_);
   }
+#endif
 };
 
 /** Implementation of the "Geman-McClure" robust error model (Zhang97ivc).
@@ -369,6 +381,7 @@ class GTSAM_EXPORT GemanMcClure : public Base {
   double c_;
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -376,6 +389,7 @@ class GTSAM_EXPORT GemanMcClure : public Base {
     ar &BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     ar &BOOST_SERIALIZATION_NVP(c_);
   }
+#endif
 };
 
 /** DCS implements the Dynamic Covariance Scaling robust error model
@@ -407,6 +421,7 @@ class GTSAM_EXPORT DCS : public Base {
   double c_;
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -414,6 +429,7 @@ class GTSAM_EXPORT DCS : public Base {
     ar &BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     ar &BOOST_SERIALIZATION_NVP(c_);
   }
+#endif
 };
 
 /** L2WithDeadZone implements a standard L2 penalty, but with a dead zone of
@@ -445,6 +461,7 @@ class GTSAM_EXPORT L2WithDeadZone : public Base {
   double modelParameter() const { return k_; }
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -452,6 +469,7 @@ class GTSAM_EXPORT L2WithDeadZone : public Base {
     ar &BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     ar &BOOST_SERIALIZATION_NVP(k_);
   }
+#endif
 };
 
 }  // namespace mEstimator

--- a/gtsam/linear/NoiseModel.h
+++ b/gtsam/linear/NoiseModel.h
@@ -139,8 +139,8 @@ namespace gtsam {
       virtual double weight(const Vector& v) const { return 1.0; }
 
     private:
-      /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+      /** Serialization function */
       friend class boost::serialization::access;
       template<class ARCHIVE>
       void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/linear/NoiseModel.h
+++ b/gtsam/linear/NoiseModel.h
@@ -267,6 +267,7 @@ namespace gtsam {
       virtual Matrix covariance() const;
 
     private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
       /** Serialization function */
       friend class boost::serialization::access;
       template<class ARCHIVE>
@@ -274,7 +275,7 @@ namespace gtsam {
         ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
         ar & BOOST_SERIALIZATION_NVP(sqrt_information_);
       }
-
+#endif
     }; // Gaussian
 
     //---------------------------------------------------------------------------------------
@@ -362,6 +363,7 @@ namespace gtsam {
       }
 
     private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
       /** Serialization function */
       friend class boost::serialization::access;
       template<class ARCHIVE>
@@ -370,6 +372,7 @@ namespace gtsam {
         ar & BOOST_SERIALIZATION_NVP(sigmas_);
         ar & BOOST_SERIALIZATION_NVP(invsigmas_);
       }
+#endif
     }; // Diagonal
 
     //---------------------------------------------------------------------------------------
@@ -517,6 +520,7 @@ namespace gtsam {
       shared_ptr unit() const;
 
     private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
       /** Serialization function */
       friend class boost::serialization::access;
       template<class ARCHIVE>
@@ -524,6 +528,7 @@ namespace gtsam {
         ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Diagonal);
         ar & BOOST_SERIALIZATION_NVP(mu_);
       }
+#endif
 
     }; // Constrained
 
@@ -585,6 +590,7 @@ namespace gtsam {
       inline double sigma() const { return sigma_; }
 
     private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
       /** Serialization function */
       friend class boost::serialization::access;
       template<class ARCHIVE>
@@ -593,6 +599,7 @@ namespace gtsam {
         ar & BOOST_SERIALIZATION_NVP(sigma_);
         ar & BOOST_SERIALIZATION_NVP(invsigma_);
       }
+#endif
 
     };
 
@@ -634,12 +641,14 @@ namespace gtsam {
       void unwhitenInPlace(Eigen::Block<Vector>& /*v*/) const override {}
 
     private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
       /** Serialization function */
       friend class boost::serialization::access;
       template<class ARCHIVE>
       void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
         ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Isotropic);
       }
+#endif
     };
 
     /**
@@ -727,6 +736,7 @@ namespace gtsam {
         const RobustModel::shared_ptr &robust, const NoiseModel::shared_ptr noise);
 
     private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
       /** Serialization function */
       friend class boost::serialization::access;
       template<class ARCHIVE>
@@ -735,6 +745,7 @@ namespace gtsam {
         ar & boost::serialization::make_nvp("robust_", const_cast<RobustModel::shared_ptr&>(robust_));
         ar & boost::serialization::make_nvp("noise_", const_cast<NoiseModel::shared_ptr&>(noise_));
       }
+#endif
     };
 
     // Helper function

--- a/gtsam/linear/NoiseModel.h
+++ b/gtsam/linear/NoiseModel.h
@@ -24,10 +24,12 @@
 #include <gtsam/dllexport.h>
 #include <gtsam/linear/LossFunctions.h>
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/extended_type_info.hpp>
 #include <boost/serialization/singleton.hpp>
 #include <boost/serialization/shared_ptr.hpp>
+#endif
 
 #include <optional>
 

--- a/gtsam/linear/NoiseModel.h
+++ b/gtsam/linear/NoiseModel.h
@@ -140,11 +140,13 @@ namespace gtsam {
 
     private:
       /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
       friend class boost::serialization::access;
       template<class ARCHIVE>
       void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
         ar & BOOST_SERIALIZATION_NVP(dim_);
       }
+#endif
     };
 
     //---------------------------------------------------------------------------------------

--- a/gtsam/linear/SubgraphBuilder.cpp
+++ b/gtsam/linear/SubgraphBuilder.cpp
@@ -93,6 +93,7 @@ vector<size_t> Subgraph::edgeIndices() const {
   return eid;
 }
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 /****************************************************************************/
 void Subgraph::save(const std::string &fn) const {
   std::ofstream os(fn.c_str());
@@ -110,6 +111,7 @@ Subgraph Subgraph::load(const std::string &fn) {
   is.close();
   return subgraph;
 }
+#endif
 
 /****************************************************************************/
 ostream &operator<<(ostream &os, const Subgraph::Edge &edge) {

--- a/gtsam/linear/SubgraphBuilder.cpp
+++ b/gtsam/linear/SubgraphBuilder.cpp
@@ -27,7 +27,9 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/vector.hpp>
+#endif
 
 #include <algorithm>
 #include <cmath>

--- a/gtsam/linear/SubgraphBuilder.h
+++ b/gtsam/linear/SubgraphBuilder.h
@@ -21,8 +21,10 @@
 #include <gtsam/base/types.h>
 #include <gtsam/dllexport.h>
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/version.hpp>
 #include <boost/serialization/nvp.hpp>
+#endif
 #include <memory>
 
 #include <vector>

--- a/gtsam/linear/SubgraphBuilder.h
+++ b/gtsam/linear/SubgraphBuilder.h
@@ -84,16 +84,18 @@ class GTSAM_EXPORT Subgraph {
   iterator end() { return edges_.end(); }
   const_iterator end() const { return edges_.end(); }
 
-  void save(const std::string &fn) const;
-  static Subgraph load(const std::string &fn);
   friend std::ostream &operator<<(std::ostream &os, const Subgraph &subgraph);
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive &ar, const unsigned int /*version*/) {
     ar &BOOST_SERIALIZATION_NVP(edges_);
   }
+  void save(const std::string &fn) const;
+  static Subgraph load(const std::string &fn);
+#endif
 };
 
 /****************************************************************************/

--- a/gtsam/linear/SubgraphBuilder.h
+++ b/gtsam/linear/SubgraphBuilder.h
@@ -49,12 +49,14 @@ class GTSAM_EXPORT Subgraph {
     friend std::ostream &operator<<(std::ostream &os, const Edge &edge);
 
    private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template <class Archive>
     void serialize(Archive &ar, const unsigned int /*version*/) {
       ar &BOOST_SERIALIZATION_NVP(index);
       ar &BOOST_SERIALIZATION_NVP(weight);
     }
+#endif
   };
 
   typedef std::vector<Edge> Edges;

--- a/gtsam/linear/VectorValues.h
+++ b/gtsam/linear/VectorValues.h
@@ -369,11 +369,13 @@ namespace gtsam {
 
   private:
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
       ar & BOOST_SERIALIZATION_NVP(values_);
     }
+#endif
   }; // VectorValues definition
 
   /// traits

--- a/gtsam/linear/VectorValues.h
+++ b/gtsam/linear/VectorValues.h
@@ -368,8 +368,8 @@ namespace gtsam {
     /// @}
 
   private:
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/linear/tests/CMakeLists.txt
+++ b/gtsam/linear/tests/CMakeLists.txt
@@ -1,6 +1,15 @@
-gtsamAddTestsGlob(linear "test*.cpp" "" "gtsam")
+# if GTSAM_ENABLE_BOOST_SERIALIZATION is OFF then exclude some tests
+if (NOT GTSAM_ENABLE_BOOST_SERIALIZATION)
+  # create a semicolon seperated list of files to exclude
+	set(EXCLUDE_TESTS "testSerializationLinear.cpp")
+else()
+  set(EXCLUDE_TESTS "")
+endif()
 
-if(MSVC)
-	set_property(SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/testSerializationLinear.cpp"
-		APPEND PROPERTY COMPILE_FLAGS "/bigobj")
+gtsamAddTestsGlob(linear "test*.cpp" "${EXCLUDE_TESTS}" "gtsam")
+
+# Set properties to serialization target if Boost serialization is enabled and MSVC
+if (GTSAM_ENABLE_BOOST_SERIALIZATION AND MSVC)
+		set_property(SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/testSerializationLinear.cpp"
+			APPEND PROPERTY COMPILE_FLAGS "/bigobj")
 endif()

--- a/gtsam/navigation/AHRSFactor.h
+++ b/gtsam/navigation/AHRSFactor.h
@@ -208,6 +208,7 @@ public:
 
 private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
@@ -218,6 +219,7 @@ private:
             boost::serialization::base_object<Base>(*this));
     ar & BOOST_SERIALIZATION_NVP(_PIM_);
   }
+#endif
 
 };
 // AHRSFactor

--- a/gtsam/navigation/AHRSFactor.h
+++ b/gtsam/navigation/AHRSFactor.h
@@ -121,6 +121,7 @@ class GTSAM_EXPORT PreintegratedAhrsMeasurements : public PreintegratedRotation 
 private:
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -128,6 +129,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(p_);
     ar & BOOST_SERIALIZATION_NVP(biasHat_);
   }
+#endif
 };
 
 class GTSAM_EXPORT AHRSFactor: public NoiseModelFactorN<Rot3, Rot3, Vector3> {

--- a/gtsam/navigation/AHRSFactor.h
+++ b/gtsam/navigation/AHRSFactor.h
@@ -120,8 +120,8 @@ class GTSAM_EXPORT PreintegratedAhrsMeasurements : public PreintegratedRotation 
 
 private:
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/navigation/AttitudeFactor.h
+++ b/gtsam/navigation/AttitudeFactor.h
@@ -64,12 +64,14 @@ public:
   }
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
     ar & boost::serialization::make_nvp("nZ_",  nZ_);
     ar & boost::serialization::make_nvp("bRef_", bRef_);
   }
+#endif
 };
 
 /**

--- a/gtsam/navigation/AttitudeFactor.h
+++ b/gtsam/navigation/AttitudeFactor.h
@@ -132,6 +132,7 @@ public:
 
 private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
@@ -142,6 +143,7 @@ private:
     ar & boost::serialization::make_nvp("AttitudeFactor",
         boost::serialization::base_object<AttitudeFactor>(*this));
   }
+#endif
 
 public:
   GTSAM_MAKE_ALIGNED_OPERATOR_NEW
@@ -215,6 +217,7 @@ public:
 
 private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
@@ -225,6 +228,7 @@ private:
     ar & boost::serialization::make_nvp("AttitudeFactor",
         boost::serialization::base_object<AttitudeFactor>(*this));
   }
+#endif
 
 public:
   GTSAM_MAKE_ALIGNED_OPERATOR_NEW

--- a/gtsam/navigation/AttitudeFactor.h
+++ b/gtsam/navigation/AttitudeFactor.h
@@ -63,8 +63,8 @@ public:
     return bRef_;
   }
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/navigation/BarometricFactor.h
+++ b/gtsam/navigation/BarometricFactor.h
@@ -97,8 +97,8 @@ class GTSAM_EXPORT BarometricFactor : public NoiseModelFactorN<Pose3, double> {
     };
 
    private:
-    /// Serialization function
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION    ///
+    /// Serialization function
     friend class boost::serialization::access;
     template <class ARCHIVE>
     void serialize(ARCHIVE& ar, const unsigned int /*version*/) {

--- a/gtsam/navigation/BarometricFactor.h
+++ b/gtsam/navigation/BarometricFactor.h
@@ -98,6 +98,7 @@ class GTSAM_EXPORT BarometricFactor : public NoiseModelFactorN<Pose3, double> {
 
    private:
     /// Serialization function
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION    ///
     friend class boost::serialization::access;
     template <class ARCHIVE>
     void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
@@ -107,6 +108,7 @@ class GTSAM_EXPORT BarometricFactor : public NoiseModelFactorN<Pose3, double> {
             boost::serialization::base_object<Base>(*this));
         ar& BOOST_SERIALIZATION_NVP(nT_);
     }
+#endif
 };
 
 }  // namespace gtsam

--- a/gtsam/navigation/CombinedImuFactor.cpp
+++ b/gtsam/navigation/CombinedImuFactor.cpp
@@ -21,7 +21,9 @@
  **/
 
 #include <gtsam/navigation/CombinedImuFactor.h>
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/export.hpp>
+#endif
 
 /* External or standard includes */
 #include <ostream>

--- a/gtsam/navigation/CombinedImuFactor.h
+++ b/gtsam/navigation/CombinedImuFactor.h
@@ -102,6 +102,7 @@ struct GTSAM_EXPORT PreintegrationCombinedParams : PreintegrationParams {
 private:
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
@@ -111,6 +112,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(biasOmegaCovariance);
     ar & BOOST_SERIALIZATION_NVP(biasAccOmegaInt);
   }
+#endif
 
 public:
   GTSAM_MAKE_ALIGNED_OPERATOR_NEW

--- a/gtsam/navigation/CombinedImuFactor.h
+++ b/gtsam/navigation/CombinedImuFactor.h
@@ -101,8 +101,8 @@ struct GTSAM_EXPORT PreintegrationCombinedParams : PreintegrationParams {
   
 private:
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {

--- a/gtsam/navigation/CombinedImuFactor.h
+++ b/gtsam/navigation/CombinedImuFactor.h
@@ -225,6 +225,7 @@ public:
   /// @}
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   /// Serialization function
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -233,6 +234,7 @@ public:
     ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(PreintegrationType);
     ar& BOOST_SERIALIZATION_NVP(preintMeasCov_);
   }
+#endif
 
 public:
   GTSAM_MAKE_ALIGNED_OPERATOR_NEW

--- a/gtsam/navigation/GPSFactor.h
+++ b/gtsam/navigation/GPSFactor.h
@@ -166,6 +166,7 @@ public:
 
 private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /// Serialization function
   friend class boost::serialization::access;
   template<class ARCHIVE>
@@ -176,6 +177,7 @@ private:
             boost::serialization::base_object<Base>(*this));
     ar & BOOST_SERIALIZATION_NVP(nT_);
   }
+#endif
 };
 
 } /// namespace gtsam

--- a/gtsam/navigation/GPSFactor.h
+++ b/gtsam/navigation/GPSFactor.h
@@ -98,6 +98,7 @@ public:
 private:
 
   /// Serialization function
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -107,6 +108,7 @@ private:
             boost::serialization::base_object<Base>(*this));
     ar & BOOST_SERIALIZATION_NVP(nT_);
   }
+#endif
 };
 
 /**

--- a/gtsam/navigation/GPSFactor.h
+++ b/gtsam/navigation/GPSFactor.h
@@ -97,8 +97,8 @@ public:
 
 private:
 
-  /// Serialization function
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
+  /// Serialization function
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/navigation/ImuBias.h
+++ b/gtsam/navigation/ImuBias.h
@@ -140,8 +140,8 @@ private:
   /// @name Advanced Interface
   /// @{
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/navigation/ImuBias.h
+++ b/gtsam/navigation/ImuBias.h
@@ -141,12 +141,14 @@ private:
   /// @{
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
     ar & BOOST_SERIALIZATION_NVP(biasAcc_);
     ar & BOOST_SERIALIZATION_NVP(biasGyro_);
   }
+#endif
 
 
 public:

--- a/gtsam/navigation/ImuBias.h
+++ b/gtsam/navigation/ImuBias.h
@@ -20,7 +20,9 @@
 #include <gtsam/base/OptionalJacobian.h>
 #include <gtsam/base/VectorSpace.h>
 #include <iosfwd>
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/nvp.hpp>
+#endif
 
 namespace gtsam {
 

--- a/gtsam/navigation/ImuFactor.h
+++ b/gtsam/navigation/ImuFactor.h
@@ -147,6 +147,7 @@ public:
 
  private:
   /// Serialization function
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -154,6 +155,7 @@ public:
     ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(PreintegrationType);
     ar & BOOST_SERIALIZATION_NVP(preintMeasCov_);
   }
+#endif
 };
 
 /**

--- a/gtsam/navigation/ImuFactor.h
+++ b/gtsam/navigation/ImuFactor.h
@@ -146,8 +146,8 @@ public:
 #endif
 
  private:
-  /// Serialization function
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
+  /// Serialization function
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/navigation/ImuFactor.h
+++ b/gtsam/navigation/ImuFactor.h
@@ -248,6 +248,7 @@ public:
 
  private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -256,6 +257,7 @@ public:
          boost::serialization::base_object<Base>(*this));
     ar & BOOST_SERIALIZATION_NVP(_PIM_);
   }
+#endif
 };
 // class ImuFactor
 

--- a/gtsam/navigation/MagPoseFactor.h
+++ b/gtsam/navigation/MagPoseFactor.h
@@ -133,6 +133,7 @@ class MagPoseFactor: public NoiseModelFactorN<POSE> {
 
  private:
   /// Serialization function.
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -144,6 +145,7 @@ class MagPoseFactor: public NoiseModelFactorN<POSE> {
     ar & BOOST_SERIALIZATION_NVP(bias_);
     ar & BOOST_SERIALIZATION_NVP(body_P_sensor_);
   }
+#endif
 };  // \class MagPoseFactor
 
 } /// namespace gtsam

--- a/gtsam/navigation/MagPoseFactor.h
+++ b/gtsam/navigation/MagPoseFactor.h
@@ -132,8 +132,8 @@ class MagPoseFactor: public NoiseModelFactorN<POSE> {
   }
 
  private:
-  /// Serialization function.
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
+  /// Serialization function.
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/navigation/ManifoldPreintegration.h
+++ b/gtsam/navigation/ManifoldPreintegration.h
@@ -113,8 +113,8 @@ public:
   /// @}
 
 private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/navigation/ManifoldPreintegration.h
+++ b/gtsam/navigation/ManifoldPreintegration.h
@@ -114,6 +114,7 @@ public:
 
 private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -126,6 +127,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(delVdelBiasAcc_);
     ar & BOOST_SERIALIZATION_NVP(delVdelBiasOmega_);
   }
+#endif
 };
 
 } /// namespace gtsam

--- a/gtsam/navigation/NavState.h
+++ b/gtsam/navigation/NavState.h
@@ -190,6 +190,7 @@ public:
 private:
   /// @{
   /// serialization
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -197,6 +198,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(t_);
     ar & BOOST_SERIALIZATION_NVP(v_);
   }
+#endif
   /// @}
 };
 

--- a/gtsam/navigation/PreintegratedRotation.h
+++ b/gtsam/navigation/PreintegratedRotation.h
@@ -61,6 +61,7 @@ struct GTSAM_EXPORT PreintegratedRotationParams {
 
  private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -75,6 +76,7 @@ struct GTSAM_EXPORT PreintegratedRotationParams {
       ar & BOOST_SERIALIZATION_NVP(*omegaCoriolis);
     }
   }
+#endif
 
 #ifdef GTSAM_USE_QUATERNIONS
   // Align if we are using Quaternions

--- a/gtsam/navigation/PreintegratedRotation.h
+++ b/gtsam/navigation/PreintegratedRotation.h
@@ -60,8 +60,8 @@ struct GTSAM_EXPORT PreintegratedRotationParams {
   std::optional<Pose3>   getBodyPSensor()   const { return body_P_sensor; }
 
  private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/navigation/PreintegratedRotation.h
+++ b/gtsam/navigation/PreintegratedRotation.h
@@ -181,6 +181,7 @@ class GTSAM_EXPORT PreintegratedRotation {
   /// @}
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -190,6 +191,7 @@ class GTSAM_EXPORT PreintegratedRotation {
     ar& BOOST_SERIALIZATION_NVP(deltaRij_);
     ar& BOOST_SERIALIZATION_NVP(delRdelBiasOmega_);
   }
+#endif
 
 #ifdef GTSAM_USE_QUATERNIONS
   // Align if we are using Quaternions

--- a/gtsam/navigation/PreintegrationBase.h
+++ b/gtsam/navigation/PreintegrationBase.h
@@ -173,8 +173,8 @@ class GTSAM_EXPORT PreintegrationBase {
       OptionalJacobian<9, 6> H5 = {}) const;
 
  private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/navigation/PreintegrationBase.h
+++ b/gtsam/navigation/PreintegrationBase.h
@@ -174,6 +174,7 @@ class GTSAM_EXPORT PreintegrationBase {
 
  private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -181,6 +182,7 @@ class GTSAM_EXPORT PreintegrationBase {
     ar & BOOST_SERIALIZATION_NVP(biasHat_);
     ar & BOOST_SERIALIZATION_NVP(deltaTij_);
   }
+#endif
 
  public:
   GTSAM_MAKE_ALIGNED_OPERATOR_NEW

--- a/gtsam/navigation/PreintegrationParams.h
+++ b/gtsam/navigation/PreintegrationParams.h
@@ -71,8 +71,8 @@ struct GTSAM_EXPORT PreintegrationParams: PreintegratedRotationParams {
 
 protected:
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/navigation/PreintegrationParams.h
+++ b/gtsam/navigation/PreintegrationParams.h
@@ -72,6 +72,7 @@ struct GTSAM_EXPORT PreintegrationParams: PreintegratedRotationParams {
 protected:
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -82,6 +83,7 @@ protected:
     ar & BOOST_SERIALIZATION_NVP(use2ndOrderCoriolis);
     ar & BOOST_SERIALIZATION_NVP(n_gravity);
   }
+#endif
 
 #ifdef GTSAM_USE_QUATERNIONS
   // Align if we are using Quaternions

--- a/gtsam/navigation/TangentPreintegration.h
+++ b/gtsam/navigation/TangentPreintegration.h
@@ -128,6 +128,7 @@ public:
 
 private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -137,6 +138,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(preintegrated_H_biasAcc_);
     ar & BOOST_SERIALIZATION_NVP(preintegrated_H_biasOmega_);
   }
+#endif
 
 public:
   GTSAM_MAKE_ALIGNED_OPERATOR_NEW

--- a/gtsam/navigation/TangentPreintegration.h
+++ b/gtsam/navigation/TangentPreintegration.h
@@ -127,8 +127,8 @@ public:
   /// @}
 
 private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/navigation/tests/CMakeLists.txt
+++ b/gtsam/navigation/tests/CMakeLists.txt
@@ -24,4 +24,9 @@ else()
   endif()
 endif()
 
+# if GTSAM_ENABLE_BOOST_SERIALIZATION is OFF then exclude some tests
+if (NOT GTSAM_ENABLE_BOOST_SERIALIZATION)
+  list(APPEND tests_excluded testSerializationNavigation.cpp)
+endif()
+
 gtsamAddTestsGlob(navigation "test*.cpp" "${tests_excluded}" "${test_link_libraries}")

--- a/gtsam/nonlinear/CustomFactor.h
+++ b/gtsam/nonlinear/CustomFactor.h
@@ -90,8 +90,8 @@ public:
 
 private:
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int /*version*/) {

--- a/gtsam/nonlinear/CustomFactor.h
+++ b/gtsam/nonlinear/CustomFactor.h
@@ -91,12 +91,14 @@ public:
 private:
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int /*version*/) {
     ar & boost::serialization::make_nvp("CustomFactor",
                                         boost::serialization::base_object<Base>(*this));
   }
+#endif
 };
 
 }

--- a/gtsam/nonlinear/ExpressionFactor.h
+++ b/gtsam/nonlinear/ExpressionFactor.h
@@ -198,6 +198,7 @@ protected:
  }
 
 private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
  /// Save to an archive: just saves the base class
  template <class Archive>
  void save(Archive& ar, const unsigned int /*version*/) const {
@@ -218,6 +219,7 @@ private:
  BOOST_SERIALIZATION_SPLIT_MEMBER()
 
  friend class boost::serialization::access;
+#endif
 
  // Alignment, see https://eigen.tuxfamily.org/dox/group__TopicStructHavingEigenMembers.html
  enum { NeedsToAlign = (sizeof(T) % 16) == 0 };

--- a/gtsam/nonlinear/FunctorizedFactor.h
+++ b/gtsam/nonlinear/FunctorizedFactor.h
@@ -119,8 +119,8 @@ class FunctorizedFactor : public NoiseModelFactorN<T> {
   /// @}
 
  private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int /*version*/) {

--- a/gtsam/nonlinear/FunctorizedFactor.h
+++ b/gtsam/nonlinear/FunctorizedFactor.h
@@ -120,6 +120,7 @@ class FunctorizedFactor : public NoiseModelFactorN<T> {
 
  private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int /*version*/) {
@@ -129,6 +130,7 @@ class FunctorizedFactor : public NoiseModelFactorN<T> {
     ar &BOOST_SERIALIZATION_NVP(measured_);
     ar &BOOST_SERIALIZATION_NVP(func_);
   }
+#endif
 };
 
 /// traits

--- a/gtsam/nonlinear/FunctorizedFactor.h
+++ b/gtsam/nonlinear/FunctorizedFactor.h
@@ -231,6 +231,7 @@ class FunctorizedFactor2 : public NoiseModelFactorN<T1, T2> {
   /// @}
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -241,6 +242,7 @@ class FunctorizedFactor2 : public NoiseModelFactorN<T1, T2> {
     ar &BOOST_SERIALIZATION_NVP(measured_);
     ar &BOOST_SERIALIZATION_NVP(func_);
   }
+#endif
 };
 
 /// traits

--- a/gtsam/nonlinear/ISAM2.h
+++ b/gtsam/nonlinear/ISAM2.h
@@ -340,8 +340,8 @@ class GTSAM_EXPORT ISAM2 : public BayesTree<ISAM2Clique> {
   void updateDelta(bool forceFullSolve = false) const;
 
  private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/nonlinear/ISAM2.h
+++ b/gtsam/nonlinear/ISAM2.h
@@ -341,6 +341,7 @@ class GTSAM_EXPORT ISAM2 : public BayesTree<ISAM2Clique> {
 
  private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -357,6 +358,7 @@ class GTSAM_EXPORT ISAM2 : public BayesTree<ISAM2Clique> {
       ar & BOOST_SERIALIZATION_NVP(fixedVariables_);
       ar & BOOST_SERIALIZATION_NVP(update_count_);
   }
+#endif
 
 };  // ISAM2
 

--- a/gtsam/nonlinear/ISAM2Clique.h
+++ b/gtsam/nonlinear/ISAM2Clique.h
@@ -147,8 +147,8 @@ class GTSAM_EXPORT ISAM2Clique
   void restoreFromOriginals(const Vector& originalValues,
                             VectorValues* delta) const;
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {

--- a/gtsam/nonlinear/ISAM2Clique.h
+++ b/gtsam/nonlinear/ISAM2Clique.h
@@ -148,6 +148,7 @@ class GTSAM_EXPORT ISAM2Clique
                             VectorValues* delta) const;
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
@@ -155,6 +156,7 @@ class GTSAM_EXPORT ISAM2Clique
     ar& BOOST_SERIALIZATION_NVP(cachedFactor_);
     ar& BOOST_SERIALIZATION_NVP(gradientContribution_);
   }
+#endif
 };  // \struct ISAM2Clique
 
 /**

--- a/gtsam/nonlinear/LinearContainerFactor.h
+++ b/gtsam/nonlinear/LinearContainerFactor.h
@@ -163,8 +163,8 @@ public:
   void initializeLinearizationPoint(const Values& linearizationPoint);
 
  private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/nonlinear/LinearContainerFactor.h
+++ b/gtsam/nonlinear/LinearContainerFactor.h
@@ -164,6 +164,7 @@ public:
 
  private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -172,6 +173,7 @@ public:
     ar & BOOST_SERIALIZATION_NVP(factor_);
     ar & BOOST_SERIALIZATION_NVP(linearizationPoint_);
   }
+#endif
 
 }; // \class LinearContainerFactor
 

--- a/gtsam/nonlinear/NonlinearEquality.h
+++ b/gtsam/nonlinear/NonlinearEquality.h
@@ -182,8 +182,8 @@ public:
 
 private:
 
-  /// Serialization function
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
+  /// Serialization function
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/nonlinear/NonlinearEquality.h
+++ b/gtsam/nonlinear/NonlinearEquality.h
@@ -275,6 +275,7 @@ public:
 
 private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   /// Serialization function
   friend class boost::serialization::access;
   template<class ARCHIVE>
@@ -285,6 +286,7 @@ private:
             boost::serialization::base_object<Base>(*this));
     ar & BOOST_SERIALIZATION_NVP(value_);
   }
+#endif
 };
 // \NonlinearEquality1
 

--- a/gtsam/nonlinear/NonlinearEquality.h
+++ b/gtsam/nonlinear/NonlinearEquality.h
@@ -183,6 +183,7 @@ public:
 private:
 
   /// Serialization function
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -194,6 +195,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(allow_error_);
     ar & BOOST_SERIALIZATION_NVP(error_gain_);
   }
+#endif
 
 };
 // \class NonlinearEquality

--- a/gtsam/nonlinear/NonlinearFactor.h
+++ b/gtsam/nonlinear/NonlinearFactor.h
@@ -28,7 +28,9 @@
 #include <gtsam/base/OptionalJacobian.h>
 #include <gtsam/base/utilities.h>  // boost::index_sequence
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/base_object.hpp>
+#endif
 #include <cstddef>
 #include <type_traits>
 

--- a/gtsam/nonlinear/NonlinearFactor.h
+++ b/gtsam/nonlinear/NonlinearFactor.h
@@ -304,6 +304,7 @@ public:
 
  private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -311,6 +312,7 @@ public:
          boost::serialization::base_object<Base>(*this));
     ar & BOOST_SERIALIZATION_NVP(noiseModel_);
   }
+#endif
 
 }; // \class NoiseModelFactor
 

--- a/gtsam/nonlinear/NonlinearFactor.h
+++ b/gtsam/nonlinear/NonlinearFactor.h
@@ -717,6 +717,7 @@ protected:
     }
   }
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -724,6 +725,7 @@ protected:
     ar& boost::serialization::make_nvp(
         "NoiseModelFactor", boost::serialization::base_object<Base>(*this));
   }
+#endif
 
  public:
   /// @name Shortcut functions `key1()` -> `key<1>()`

--- a/gtsam/nonlinear/NonlinearFactor.h
+++ b/gtsam/nonlinear/NonlinearFactor.h
@@ -303,8 +303,8 @@ public:
   shared_ptr cloneWithNewNoiseModel(const SharedNoiseModel newNoise) const;
 
  private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/nonlinear/NonlinearFactorGraph.h
+++ b/gtsam/nonlinear/NonlinearFactorGraph.h
@@ -254,12 +254,14 @@ namespace gtsam {
         const Values& values, const Scatter& scatter, const Dampen& dampen = nullptr) const;
 
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
       ar & boost::serialization::make_nvp("NonlinearFactorGraph",
                 boost::serialization::base_object<Base>(*this));
     }
+#endif
   };
 
 /// traits

--- a/gtsam/nonlinear/NonlinearFactorGraph.h
+++ b/gtsam/nonlinear/NonlinearFactorGraph.h
@@ -253,8 +253,8 @@ namespace gtsam {
     std::shared_ptr<HessianFactor> linearizeToHessianFactor(
         const Values& values, const Scatter& scatter, const Dampen& dampen = nullptr) const;
 
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/nonlinear/PriorFactor.h
+++ b/gtsam/nonlinear/PriorFactor.h
@@ -105,8 +105,8 @@ namespace gtsam {
 
   private:
 
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/nonlinear/PriorFactor.h
+++ b/gtsam/nonlinear/PriorFactor.h
@@ -106,6 +106,7 @@ namespace gtsam {
   private:
 
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -114,6 +115,7 @@ namespace gtsam {
           boost::serialization::base_object<Base>(*this));
       ar & BOOST_SERIALIZATION_NVP(prior_);
     }
+#endif
 
   // Alignment, see https://eigen.tuxfamily.org/dox/group__TopicStructHavingEigenMembers.html
   enum { NeedsToAlign = (sizeof(T) % 16) == 0 };

--- a/gtsam/nonlinear/Values.h
+++ b/gtsam/nonlinear/Values.h
@@ -350,11 +350,13 @@ namespace gtsam {
     }
 
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
       ar & BOOST_SERIALIZATION_NVP(values_);
     }
+#endif
 
     static ConstKeyValuePair make_const_deref_pair(const KeyValueMap::const_iterator::value_type& key_value) {
       return ConstKeyValuePair(key_value.first, *key_value.second); }

--- a/gtsam/nonlinear/Values.h
+++ b/gtsam/nonlinear/Values.h
@@ -349,8 +349,8 @@ namespace gtsam {
       return filter(key_value.key) && (dynamic_cast<const GenericValue<ValueType>*>(&key_value.value));
     }
 
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/nonlinear/tests/CMakeLists.txt
+++ b/gtsam/nonlinear/tests/CMakeLists.txt
@@ -1,1 +1,9 @@
-gtsamAddTestsGlob(nonlinear "test*.cpp" "" "gtsam")
+# if GTSAM_ENABLE_BOOST_SERIALIZATION is OFF then exclude some tests
+if (NOT GTSAM_ENABLE_BOOST_SERIALIZATION)
+  # create a semicolon seperated list of files to exclude
+  set(EXCLUDE_TESTS "testSerializationNonlinear.cpp")
+else()
+  set(EXCLUDE_TESTS "")
+endif()
+
+gtsamAddTestsGlob(discrete "test*.cpp" "${EXCLUDE_TESTS}" "gtsam")

--- a/gtsam/nonlinear/tests/CMakeLists.txt
+++ b/gtsam/nonlinear/tests/CMakeLists.txt
@@ -6,4 +6,4 @@ else()
   set(EXCLUDE_TESTS "")
 endif()
 
-gtsamAddTestsGlob(discrete "test*.cpp" "${EXCLUDE_TESTS}" "gtsam")
+gtsamAddTestsGlob(nonlinear "test*.cpp" "${EXCLUDE_TESTS}" "gtsam")

--- a/gtsam/sam/BearingFactor.h
+++ b/gtsam/sam/BearingFactor.h
@@ -75,12 +75,14 @@ struct BearingFactor : public ExpressionFactorN<T, A1, A2> {
 
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
     ar& boost::serialization::make_nvp(
         "Base", boost::serialization::base_object<Base>(*this));
   }
+#endif
 };  // BearingFactor
 
 /// traits

--- a/gtsam/sam/BearingRangeFactor.h
+++ b/gtsam/sam/BearingRangeFactor.h
@@ -93,12 +93,14 @@ class BearingRangeFactor
 
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
     ar& boost::serialization::make_nvp(
         "Base", boost::serialization::base_object<Base>(*this));
   }
+#endif
 };  // BearingRangeFactor
 
 /// traits

--- a/gtsam/sam/RangeFactor.h
+++ b/gtsam/sam/RangeFactor.h
@@ -80,12 +80,14 @@ class RangeFactor : public ExpressionFactorN<T, A1, A2> {
   }
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
     ar& boost::serialization::make_nvp(
         "Base", boost::serialization::base_object<Base>(*this));
   }
+#endif
 };  // \ RangeFactor
 
 /// traits

--- a/gtsam/sam/RangeFactor.h
+++ b/gtsam/sam/RangeFactor.h
@@ -164,6 +164,7 @@ class RangeFactorWithTransform : public ExpressionFactorN<T, A1, A2> {
   }
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   /** Serialization function */
   template <typename ARCHIVE>
@@ -175,6 +176,7 @@ class RangeFactorWithTransform : public ExpressionFactorN<T, A1, A2> {
     ar& boost::serialization::make_nvp(
         "Base", boost::serialization::base_object<Base>(*this));
   }
+#endif
 };  // \ RangeFactorWithTransform
 
 /// traits

--- a/gtsam/sam/RangeFactor.h
+++ b/gtsam/sam/RangeFactor.h
@@ -164,8 +164,8 @@ class RangeFactorWithTransform : public ExpressionFactorN<T, A1, A2> {
   }
 
  private:
-  /** Serialization function */
   friend class boost::serialization::access;
+  /** Serialization function */
   template <typename ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
     // **IMPORTANT** We need to (de)serialize parameters before the base class,

--- a/gtsam/sam/tests/CMakeLists.txt
+++ b/gtsam/sam/tests/CMakeLists.txt
@@ -1,1 +1,9 @@
-gtsamAddTestsGlob(sam "test*.cpp" "" "gtsam")
+# if GTSAM_ENABLE_BOOST_SERIALIZATION is OFF then exclude some tests
+if (NOT GTSAM_ENABLE_BOOST_SERIALIZATION)
+  # create a semicolon seperated list of files to exclude
+  set(EXCLUDE_TESTS "testSerializationSam.cpp")
+else()
+  set(EXCLUDE_TESTS "")
+endif()
+
+gtsamAddTestsGlob(discrete "test*.cpp" "${EXCLUDE_TESTS}" "gtsam")

--- a/gtsam/sam/tests/CMakeLists.txt
+++ b/gtsam/sam/tests/CMakeLists.txt
@@ -6,4 +6,4 @@ else()
   set(EXCLUDE_TESTS "")
 endif()
 
-gtsamAddTestsGlob(discrete "test*.cpp" "${EXCLUDE_TESTS}" "gtsam")
+gtsamAddTestsGlob(sam "test*.cpp" "${EXCLUDE_TESTS}" "gtsam")

--- a/gtsam/sfm/SfmData.h
+++ b/gtsam/sfm/SfmData.h
@@ -126,12 +126,15 @@ struct GTSAM_EXPORT SfmData {
   /// @{
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {
     ar& BOOST_SERIALIZATION_NVP(cameras);
     ar& BOOST_SERIALIZATION_NVP(tracks);
   }
+#endif
+
 
   /// @}
 };

--- a/gtsam/sfm/SfmData.h
+++ b/gtsam/sfm/SfmData.h
@@ -125,9 +125,9 @@ struct GTSAM_EXPORT SfmData {
   /// @name Serialization
   /// @{
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
+  /** Serialization function */
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/) {
     ar& BOOST_SERIALIZATION_NVP(cameras);

--- a/gtsam/sfm/SfmTrack.h
+++ b/gtsam/sfm/SfmTrack.h
@@ -162,6 +162,7 @@ struct GTSAM_EXPORT SfmTrack : SfmTrack2d {
   /// @{
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
@@ -172,6 +173,7 @@ struct GTSAM_EXPORT SfmTrack : SfmTrack2d {
     ar& BOOST_SERIALIZATION_NVP(measurements);
     ar& BOOST_SERIALIZATION_NVP(siftIndices);
   }
+#endif
   /// @}
 };
 

--- a/gtsam/sfm/SfmTrack.h
+++ b/gtsam/sfm/SfmTrack.h
@@ -161,8 +161,8 @@ struct GTSAM_EXPORT SfmTrack : SfmTrack2d {
   /// @name Serialization
   /// @{
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {

--- a/gtsam/sfm/TranslationFactor.h
+++ b/gtsam/sfm/TranslationFactor.h
@@ -80,11 +80,13 @@ class TranslationFactor : public NoiseModelFactorN<Point3, Point3> {
   }
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
     ar& boost::serialization::make_nvp(
         "Base", boost::serialization::base_object<Base>(*this));
   }
+#endif
 };  // \ TranslationFactor
 }  // namespace gtsam

--- a/gtsam/slam/AntiFactor.h
+++ b/gtsam/slam/AntiFactor.h
@@ -107,6 +107,7 @@ namespace gtsam {
   private:
 
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -114,6 +115,7 @@ namespace gtsam {
           boost::serialization::base_object<Base>(*this));
       ar & BOOST_SERIALIZATION_NVP(factor_);
     }
+#endif
   }; // \class AntiFactor
 
 } /// namespace gtsam

--- a/gtsam/slam/AntiFactor.h
+++ b/gtsam/slam/AntiFactor.h
@@ -106,8 +106,8 @@ namespace gtsam {
 
   private:
 
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/slam/BetweenFactor.h
+++ b/gtsam/slam/BetweenFactor.h
@@ -176,12 +176,14 @@ namespace gtsam {
   private:
 
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
       ar & boost::serialization::make_nvp("BetweenFactor",
           boost::serialization::base_object<BetweenFactor<VALUE> >(*this));
     }
+#endif
   }; // \class BetweenConstraint
 
   /// traits

--- a/gtsam/slam/BetweenFactor.h
+++ b/gtsam/slam/BetweenFactor.h
@@ -136,6 +136,7 @@ namespace gtsam {
   private:
 
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -144,6 +145,7 @@ namespace gtsam {
           boost::serialization::base_object<Base>(*this));
       ar & BOOST_SERIALIZATION_NVP(measured_);
     }
+#endif
 
 	  // Alignment, see https://eigen.tuxfamily.org/dox/group__TopicStructHavingEigenMembers.html
 	  enum { NeedsToAlign = (sizeof(VALUE) % 16) == 0 };

--- a/gtsam/slam/BetweenFactor.h
+++ b/gtsam/slam/BetweenFactor.h
@@ -135,8 +135,8 @@ namespace gtsam {
 
   private:
 
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/slam/BoundingConstraint.h
+++ b/gtsam/slam/BoundingConstraint.h
@@ -83,8 +83,8 @@ struct BoundingConstraint1: public NoiseModelFactorN<VALUE> {
 
 private:
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/slam/BoundingConstraint.h
+++ b/gtsam/slam/BoundingConstraint.h
@@ -161,6 +161,7 @@ struct BoundingConstraint2: public NoiseModelFactorN<VALUE1, VALUE2> {
 
 private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
@@ -171,6 +172,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(threshold_);
     ar & BOOST_SERIALIZATION_NVP(isGreaterThan_);
   }
+#endif
 };
 
 } // \namespace gtsam

--- a/gtsam/slam/BoundingConstraint.h
+++ b/gtsam/slam/BoundingConstraint.h
@@ -84,6 +84,7 @@ struct BoundingConstraint1: public NoiseModelFactorN<VALUE> {
 private:
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -93,6 +94,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(threshold_);
     ar & BOOST_SERIALIZATION_NVP(isGreaterThan_);
   }
+#endif
 };
 
 /**

--- a/gtsam/slam/EssentialMatrixConstraint.h
+++ b/gtsam/slam/EssentialMatrixConstraint.h
@@ -91,8 +91,8 @@ public:
 
 private:
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/slam/EssentialMatrixConstraint.h
+++ b/gtsam/slam/EssentialMatrixConstraint.h
@@ -92,6 +92,7 @@ public:
 private:
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -101,6 +102,7 @@ private:
             boost::serialization::base_object<Base>(*this));
     ar & BOOST_SERIALIZATION_NVP(measuredE_);
   }
+#endif
 
 public:
   GTSAM_MAKE_ALIGNED_OPERATOR_NEW

--- a/gtsam/slam/GeneralSFMFactor.h
+++ b/gtsam/slam/GeneralSFMFactor.h
@@ -181,8 +181,8 @@ public:
   }
 
 private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class Archive>
   void serialize(Archive & ar, const unsigned int /*version*/) {

--- a/gtsam/slam/GeneralSFMFactor.h
+++ b/gtsam/slam/GeneralSFMFactor.h
@@ -284,6 +284,7 @@ public:
   }
 
 private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template<class Archive>
@@ -293,6 +294,7 @@ private:
         boost::serialization::base_object<Base>(*this));
     ar & BOOST_SERIALIZATION_NVP(measured_);
   }
+#endif
 };
 
 template<class CALIBRATION>

--- a/gtsam/slam/GeneralSFMFactor.h
+++ b/gtsam/slam/GeneralSFMFactor.h
@@ -37,7 +37,9 @@
 #include <gtsam/base/timing.h>
 
 #include <boost/none.hpp>
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/nvp.hpp>
+#endif
 #include <iostream>
 #include <string>
 

--- a/gtsam/slam/GeneralSFMFactor.h
+++ b/gtsam/slam/GeneralSFMFactor.h
@@ -182,6 +182,7 @@ public:
 
 private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class Archive>
   void serialize(Archive & ar, const unsigned int /*version*/) {
@@ -190,6 +191,7 @@ private:
         boost::serialization::base_object<Base>(*this));
     ar & BOOST_SERIALIZATION_NVP(measured_);
   }
+#endif
 };
 
 template<class CAMERA, class LANDMARK>

--- a/gtsam/slam/PoseRotationPrior.h
+++ b/gtsam/slam/PoseRotationPrior.h
@@ -91,8 +91,8 @@ public:
 
 private:
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/slam/PoseRotationPrior.h
+++ b/gtsam/slam/PoseRotationPrior.h
@@ -92,6 +92,7 @@ public:
 private:
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -100,6 +101,7 @@ private:
         boost::serialization::base_object<Base>(*this));
     ar & BOOST_SERIALIZATION_NVP(measured_);
   }
+#endif
 };
 
 } // \namespace gtsam

--- a/gtsam/slam/PoseTranslationPrior.h
+++ b/gtsam/slam/PoseTranslationPrior.h
@@ -91,6 +91,7 @@ public:
 private:
 
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -99,6 +100,7 @@ private:
         boost::serialization::base_object<Base>(*this));
     ar & BOOST_SERIALIZATION_NVP(measured_);
   }
+#endif
 
 };
 

--- a/gtsam/slam/PoseTranslationPrior.h
+++ b/gtsam/slam/PoseTranslationPrior.h
@@ -90,8 +90,8 @@ public:
 
 private:
 
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/slam/ProjectionFactor.h
+++ b/gtsam/slam/ProjectionFactor.h
@@ -189,6 +189,7 @@ namespace gtsam {
   private:
 
     /// Serialization function
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION    ///
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -199,6 +200,7 @@ namespace gtsam {
       ar & BOOST_SERIALIZATION_NVP(throwCheirality_);
       ar & BOOST_SERIALIZATION_NVP(verboseCheirality_);
     }
+#endif
 
   public:
     GTSAM_MAKE_ALIGNED_OPERATOR_NEW

--- a/gtsam/slam/ProjectionFactor.h
+++ b/gtsam/slam/ProjectionFactor.h
@@ -188,8 +188,8 @@ namespace gtsam {
 
   private:
 
-    /// Serialization function
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION    ///
+    /// Serialization function
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/slam/ReferenceFrameFactor.h
+++ b/gtsam/slam/ReferenceFrameFactor.h
@@ -123,12 +123,14 @@ public:
 
 private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
     ar & boost::serialization::make_nvp("NonlinearFactor3",
         boost::serialization::base_object<Base>(*this));
   }
+#endif
 };
 
 /// traits

--- a/gtsam/slam/ReferenceFrameFactor.h
+++ b/gtsam/slam/ReferenceFrameFactor.h
@@ -122,8 +122,8 @@ public:
   Key local_key() const { return this->key3(); }
 
 private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/slam/SmartFactorBase.h
+++ b/gtsam/slam/SmartFactorBase.h
@@ -443,8 +443,8 @@ protected:
 
 private:
 
-/// Serialization function
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION///
+/// Serialization function
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/slam/SmartFactorBase.h
+++ b/gtsam/slam/SmartFactorBase.h
@@ -30,7 +30,9 @@
 #include <gtsam/geometry/CameraSet.h>
 
 #include <optional>
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/optional.hpp>
+#endif
 #include <vector>
 
 namespace gtsam {

--- a/gtsam/slam/SmartFactorBase.h
+++ b/gtsam/slam/SmartFactorBase.h
@@ -444,6 +444,7 @@ protected:
 private:
 
 /// Serialization function
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION///
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -452,6 +453,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(measured_);
     ar & BOOST_SERIALIZATION_NVP(body_P_sensor_);
   }
+#endif
 };
 // end class SmartFactorBase
 

--- a/gtsam/slam/SmartFactorParams.h
+++ b/gtsam/slam/SmartFactorParams.h
@@ -119,6 +119,7 @@ struct SmartProjectionParams {
 private:
 
   /// Serialization function
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int version) {
@@ -129,6 +130,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(throwCheirality);
     ar & BOOST_SERIALIZATION_NVP(verboseCheirality);
   }
+#endif
 };
 
 } // \ namespace gtsam

--- a/gtsam/slam/SmartFactorParams.h
+++ b/gtsam/slam/SmartFactorParams.h
@@ -118,8 +118,8 @@ struct SmartProjectionParams {
 
 private:
 
-  /// Serialization function
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
+  /// Serialization function
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int version) {

--- a/gtsam/slam/SmartProjectionFactor.h
+++ b/gtsam/slam/SmartProjectionFactor.h
@@ -466,8 +466,8 @@ protected:
 
  private:
 
-  /// Serialization function
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
+  /// Serialization function
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int version) {

--- a/gtsam/slam/SmartProjectionFactor.h
+++ b/gtsam/slam/SmartProjectionFactor.h
@@ -467,6 +467,7 @@ protected:
  private:
 
   /// Serialization function
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int version) {
@@ -475,6 +476,7 @@ protected:
     ar & BOOST_SERIALIZATION_NVP(result_);
     ar & BOOST_SERIALIZATION_NVP(cameraPosesTriangulation_);
   }
+#endif
 }
 ;
 

--- a/gtsam/slam/SmartProjectionPoseFactor.h
+++ b/gtsam/slam/SmartProjectionPoseFactor.h
@@ -149,12 +149,14 @@ public:
  private:
 
   /// Serialization function
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
     ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     ar & BOOST_SERIALIZATION_NVP(K_);
   }
+#endif
 };
 // end of class declaration
 

--- a/gtsam/slam/SmartProjectionPoseFactor.h
+++ b/gtsam/slam/SmartProjectionPoseFactor.h
@@ -148,8 +148,8 @@ public:
 
  private:
 
-  /// Serialization function
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
+  /// Serialization function
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/slam/SmartProjectionRigFactor.h
+++ b/gtsam/slam/SmartProjectionRigFactor.h
@@ -353,6 +353,7 @@ class SmartProjectionRigFactor : public SmartProjectionFactor<CAMERA> {
 
  private:
   /// Serialization function
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
@@ -361,6 +362,7 @@ class SmartProjectionRigFactor : public SmartProjectionFactor<CAMERA> {
     // ar& BOOST_SERIALIZATION_NVP(cameraRig_);
     // ar& BOOST_SERIALIZATION_NVP(cameraIds_);
   }
+#endif
 };
 // end of class declaration
 

--- a/gtsam/slam/SmartProjectionRigFactor.h
+++ b/gtsam/slam/SmartProjectionRigFactor.h
@@ -352,8 +352,8 @@ class SmartProjectionRigFactor : public SmartProjectionFactor<CAMERA> {
   }
 
  private:
-  /// Serialization function
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
+  /// Serialization function
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {

--- a/gtsam/slam/StereoFactor.h
+++ b/gtsam/slam/StereoFactor.h
@@ -171,6 +171,7 @@ public:
 
 private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class Archive>
   void serialize(Archive & ar, const unsigned int /*version*/) {
@@ -183,6 +184,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(throwCheirality_);
     ar & BOOST_SERIALIZATION_NVP(verboseCheirality_);
   }
+#endif
 };
 
 /// traits

--- a/gtsam/slam/StereoFactor.h
+++ b/gtsam/slam/StereoFactor.h
@@ -170,8 +170,8 @@ public:
   inline bool throwCheirality() const { return throwCheirality_; }
 
 private:
-  /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
   friend class boost::serialization::access;
   template<class Archive>
   void serialize(Archive & ar, const unsigned int /*version*/) {

--- a/gtsam/slam/TriangulationFactor.h
+++ b/gtsam/slam/TriangulationFactor.h
@@ -190,6 +190,7 @@ public:
 private:
 
   /// Serialization function
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -199,6 +200,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(throwCheirality_);
     ar & BOOST_SERIALIZATION_NVP(verboseCheirality_);
   }
+#endif
 };
 } // \ namespace gtsam
 

--- a/gtsam/slam/TriangulationFactor.h
+++ b/gtsam/slam/TriangulationFactor.h
@@ -189,8 +189,8 @@ public:
 
 private:
 
-  /// Serialization function
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
+  /// Serialization function
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/slam/tests/CMakeLists.txt
+++ b/gtsam/slam/tests/CMakeLists.txt
@@ -1,7 +1,8 @@
 # if GTSAM_ENABLE_BOOST_SERIALIZATION is OFF then exclude some tests
 if (NOT GTSAM_ENABLE_BOOST_SERIALIZATION)
   # create a semicolon seperated list of files to exclude
-  set(EXCLUDE_TESTS "testSerializationDatataset.cpp" "testSerializationInSlam.cpp")
+  set(EXCLUDE_TESTS "testSerializationDataset.cpp" "testSerializationInSlam.cpp")
+  message(STATUS "Excluding tests: ${EXCLUDE_TESTS}")
 else()
   set(EXCLUDE_TESTS "")
 endif()

--- a/gtsam/slam/tests/CMakeLists.txt
+++ b/gtsam/slam/tests/CMakeLists.txt
@@ -7,4 +7,4 @@ else()
   set(EXCLUDE_TESTS "")
 endif()
 
-gtsamAddTestsGlob(discrete "test*.cpp" "${EXCLUDE_TESTS}" "gtsam")
+gtsamAddTestsGlob(slam "test*.cpp" "${EXCLUDE_TESTS}" "gtsam")

--- a/gtsam/slam/tests/CMakeLists.txt
+++ b/gtsam/slam/tests/CMakeLists.txt
@@ -1,1 +1,9 @@
-gtsamAddTestsGlob(slam "test*.cpp" "" "gtsam")
+# if GTSAM_ENABLE_BOOST_SERIALIZATION is OFF then exclude some tests
+if (NOT GTSAM_ENABLE_BOOST_SERIALIZATION)
+  # create a semicolon seperated list of files to exclude
+  set(EXCLUDE_TESTS "testSerializationDatataset.cpp" "testSerializationInSlam.cpp")
+else()
+  set(EXCLUDE_TESTS "")
+endif()
+
+gtsamAddTestsGlob(discrete "test*.cpp" "${EXCLUDE_TESTS}" "gtsam")

--- a/gtsam/symbolic/SymbolicBayesNet.h
+++ b/gtsam/symbolic/SymbolicBayesNet.h
@@ -105,11 +105,13 @@ namespace gtsam {
 
   private:
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
       ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     }
+#endif
 };
 
   /// traits

--- a/gtsam/symbolic/SymbolicBayesNet.h
+++ b/gtsam/symbolic/SymbolicBayesNet.h
@@ -104,8 +104,8 @@ namespace gtsam {
     /// @}
 
   private:
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/symbolic/SymbolicBayesTree.h
+++ b/gtsam/symbolic/SymbolicBayesTree.h
@@ -63,8 +63,8 @@ namespace gtsam {
     bool equals(const This& other, double tol = 1e-9) const;
 
   private:
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/symbolic/SymbolicBayesTree.h
+++ b/gtsam/symbolic/SymbolicBayesTree.h
@@ -64,11 +64,13 @@ namespace gtsam {
 
   private:
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
       ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     }
+#endif
   };
 
 /// traits

--- a/gtsam/symbolic/SymbolicConditional.h
+++ b/gtsam/symbolic/SymbolicConditional.h
@@ -126,8 +126,8 @@ namespace gtsam {
     /// @}
 
   private:
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class Archive>
     void serialize(Archive & ar, const unsigned int /*version*/) {

--- a/gtsam/symbolic/SymbolicConditional.h
+++ b/gtsam/symbolic/SymbolicConditional.h
@@ -127,12 +127,14 @@ namespace gtsam {
 
   private:
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class Archive>
     void serialize(Archive & ar, const unsigned int /*version*/) {
       ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(BaseFactor);
       ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(BaseConditional);
     }
+#endif
   };
 
 /// traits

--- a/gtsam/symbolic/SymbolicFactor.h
+++ b/gtsam/symbolic/SymbolicFactor.h
@@ -154,11 +154,13 @@ namespace gtsam {
 
   private:
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
       ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     }
+#endif
   }; // IndexFactor
 
   // Forward declarations

--- a/gtsam/symbolic/SymbolicFactor.h
+++ b/gtsam/symbolic/SymbolicFactor.h
@@ -153,8 +153,8 @@ namespace gtsam {
     /// @}
 
   private:
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/symbolic/SymbolicFactorGraph.h
+++ b/gtsam/symbolic/SymbolicFactorGraph.h
@@ -149,11 +149,13 @@ namespace gtsam {
 
   private:
     /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
       ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     }
+#endif
   };
 
 /// traits

--- a/gtsam/symbolic/SymbolicFactorGraph.h
+++ b/gtsam/symbolic/SymbolicFactorGraph.h
@@ -148,8 +148,8 @@ namespace gtsam {
     /// @}
 
   private:
-    /** Serialization function */
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+    /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
     void serialize(ARCHIVE & ar, const unsigned int /*version*/) {

--- a/gtsam/symbolic/tests/CMakeLists.txt
+++ b/gtsam/symbolic/tests/CMakeLists.txt
@@ -1,1 +1,9 @@
-gtsamAddTestsGlob(symbolic "test*.cpp" "" "gtsam")
+# if GTSAM_ENABLE_BOOST_SERIALIZATION is OFF then exclude some tests
+if (NOT GTSAM_ENABLE_BOOST_SERIALIZATION)
+  # create a semicolon seperated list of files to exclude
+  set(EXCLUDE_TESTS "testSerializationSymbolic.cpp")
+else()
+  set(EXCLUDE_TESTS "")
+endif()
+
+gtsamAddTestsGlob(discrete "test*.cpp" "${EXCLUDE_TESTS}" "gtsam")

--- a/gtsam/symbolic/tests/CMakeLists.txt
+++ b/gtsam/symbolic/tests/CMakeLists.txt
@@ -6,4 +6,4 @@ else()
   set(EXCLUDE_TESTS "")
 endif()
 
-gtsamAddTestsGlob(discrete "test*.cpp" "${EXCLUDE_TESTS}" "gtsam")
+gtsamAddTestsGlob(symbolic "test*.cpp" "${EXCLUDE_TESTS}" "gtsam")

--- a/gtsam_unstable/dynamics/PoseRTV.h
+++ b/gtsam_unstable/dynamics/PoseRTV.h
@@ -157,6 +157,7 @@ public:
   /// @}
 
 private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template<class Archive>
@@ -164,6 +165,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(first);
     ar & BOOST_SERIALIZATION_NVP(second);
   }
+#endif
 };
 
 

--- a/gtsam_unstable/dynamics/VelocityConstraint3.h
+++ b/gtsam_unstable/dynamics/VelocityConstraint3.h
@@ -51,6 +51,7 @@ public:
 
 private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
@@ -59,6 +60,7 @@ private:
     ar & boost::serialization::make_nvp("NoiseModelFactor3",
         boost::serialization::base_object<Base>(*this));
   }
+#endif
 }; // \VelocityConstraint3
 
 }

--- a/gtsam_unstable/geometry/BearingS2.h
+++ b/gtsam_unstable/geometry/BearingS2.h
@@ -90,6 +90,7 @@ private:
   /// @name Advanced Interface
   /// @{
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  //
   // Serialization function
   friend class boost::serialization::access;
   template<class Archive>
@@ -97,6 +98,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(azimuth_);
     ar & BOOST_SERIALIZATION_NVP(elevation_);
   }
+#endif
 
 };
 

--- a/gtsam_unstable/geometry/InvDepthCamera3.h
+++ b/gtsam_unstable/geometry/InvDepthCamera3.h
@@ -172,6 +172,7 @@ private:
   /// @name Advanced Interface
   /// @{
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template<class Archive>
@@ -179,6 +180,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(pose_);
     ar & BOOST_SERIALIZATION_NVP(k_);
   }
+#endif
   /// @}
 }; // \class InvDepthCamera
-} // \namesapce gtsam
+} // \namespace gtsam

--- a/gtsam_unstable/geometry/Pose3Upright.h
+++ b/gtsam_unstable/geometry/Pose3Upright.h
@@ -130,6 +130,7 @@ public:
 
 private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  //
   // Serialization function
   friend class boost::serialization::access;
   template<class Archive>
@@ -137,6 +138,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(T_);
     ar & BOOST_SERIALIZATION_NVP(z_);
   }
+#endif
 
 }; // \class Pose3Upright
 

--- a/gtsam_unstable/nonlinear/LinearizedFactor.h
+++ b/gtsam_unstable/nonlinear/LinearizedFactor.h
@@ -148,6 +148,7 @@ public:
   Vector error_vector(const Values& c) const;
 
 private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   /** Serialization function */
   template<class ARCHIVE>
@@ -156,6 +157,7 @@ private:
         boost::serialization::base_object<Base>(*this));
     ar & BOOST_SERIALIZATION_NVP(Ab_);
   }
+#endif
 };
 
 /// traits
@@ -277,6 +279,7 @@ public:
 
 private:
   /** Serialization function */
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -284,6 +287,7 @@ private:
         boost::serialization::base_object<Base>(*this));
     ar & BOOST_SERIALIZATION_NVP(info_);
   }
+#endif
 };
 
 /// traits

--- a/gtsam_unstable/nonlinear/LinearizedFactor.h
+++ b/gtsam_unstable/nonlinear/LinearizedFactor.h
@@ -59,6 +59,7 @@ public:
   const Values& linearizationPoint() const { return lin_points_; }
 
 private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
@@ -67,6 +68,7 @@ private:
         boost::serialization::base_object<Base>(*this));
     ar & BOOST_SERIALIZATION_NVP(lin_points_);
   }
+#endif
 
 };
 
@@ -146,8 +148,8 @@ public:
   Vector error_vector(const Values& c) const;
 
 private:
-  /** Serialization function */
   friend class boost::serialization::access;
+  /** Serialization function */
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
     ar & boost::serialization::make_nvp("LinearizedJacobianFactor",

--- a/gtsam_unstable/slam/BetweenFactorEM.h
+++ b/gtsam_unstable/slam/BetweenFactorEM.h
@@ -415,6 +415,7 @@ public:
 
 private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
@@ -424,6 +425,7 @@ private:
             boost::serialization::base_object<Base>(*this));
     ar & BOOST_SERIALIZATION_NVP(measured_);
   }
+#endif
 };
 // \class BetweenFactorEM
 

--- a/gtsam_unstable/slam/BiasedGPSFactor.h
+++ b/gtsam_unstable/slam/BiasedGPSFactor.h
@@ -94,6 +94,7 @@ namespace gtsam {
 
   private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
@@ -103,6 +104,7 @@ namespace gtsam {
           boost::serialization::base_object<Base>(*this));
       ar & BOOST_SERIALIZATION_NVP(measured_);
     }
+#endif
   }; // \class BiasedGPSFactor
 
 } /// namespace gtsam

--- a/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel.h
+++ b/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel.h
@@ -706,6 +706,7 @@ public:
     }
 private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
@@ -713,6 +714,7 @@ private:
     ar & boost::serialization::make_nvp("NonlinearFactor2",
         boost::serialization::base_object<Base>(*this));
   }
+#endif
 
 
 

--- a/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel_NoBias.h
+++ b/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel_NoBias.h
@@ -573,6 +573,7 @@ public:
     }
 private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
@@ -580,6 +581,7 @@ private:
     ar & boost::serialization::make_nvp("NonlinearFactor2",
         boost::serialization::base_object<Base>(*this));
   }
+#endif
 
 
 

--- a/gtsam_unstable/slam/GaussMarkov1stOrderFactor.h
+++ b/gtsam_unstable/slam/GaussMarkov1stOrderFactor.h
@@ -113,6 +113,7 @@ public:
 
 private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
@@ -121,6 +122,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(dt_);
     ar & BOOST_SERIALIZATION_NVP(tau_);
   }
+#endif
 
   SharedGaussian calcDiscreteNoiseModel(const SharedGaussian& model, double delta_t){
     /* Q_d (approx)= Q * delta_t */

--- a/gtsam_unstable/slam/InertialNavFactor_GlobalVelocity.h
+++ b/gtsam_unstable/slam/InertialNavFactor_GlobalVelocity.h
@@ -413,6 +413,7 @@ public:
 
 private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
@@ -420,6 +421,7 @@ private:
     ar & boost::serialization::make_nvp("NonlinearFactor2",
         boost::serialization::base_object<Base>(*this));
   }
+#endif
 
 }; // \class InertialNavFactor_GlobalVelocity
 

--- a/gtsam_unstable/slam/InvDepthFactor3.h
+++ b/gtsam_unstable/slam/InvDepthFactor3.h
@@ -113,6 +113,7 @@ public:
 
 private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   /// Serialization function
   friend class boost::serialization::access;
   template<class ARCHIVE>
@@ -121,5 +122,6 @@ private:
     ar & BOOST_SERIALIZATION_NVP(measured_);
     ar & BOOST_SERIALIZATION_NVP(K_);
   }
+#endif
 };
 } // \ namespace gtsam

--- a/gtsam_unstable/slam/InvDepthFactorVariant1.h
+++ b/gtsam_unstable/slam/InvDepthFactorVariant1.h
@@ -135,6 +135,7 @@ public:
 
 private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   /// Serialization function
   friend class boost::serialization::access;
   template<class ARCHIVE>
@@ -143,6 +144,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(measured_);
     ar & BOOST_SERIALIZATION_NVP(K_);
   }
+#endif
 };
 
 } // \ namespace gtsam

--- a/gtsam_unstable/slam/InvDepthFactorVariant2.h
+++ b/gtsam_unstable/slam/InvDepthFactorVariant2.h
@@ -142,6 +142,7 @@ public:
 
 private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   /// Serialization function
   friend class boost::serialization::access;
   template<class ARCHIVE>
@@ -151,6 +152,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(K_);
     ar & BOOST_SERIALIZATION_NVP(referencePoint_);
   }
+#endif
 };
 
 } // \ namespace gtsam

--- a/gtsam_unstable/slam/InvDepthFactorVariant3.h
+++ b/gtsam_unstable/slam/InvDepthFactorVariant3.h
@@ -139,8 +139,8 @@ public:
 
 private:
 
-  /// Serialization function
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
+  /// Serialization function
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -271,6 +271,7 @@ public:
 
 private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
   /// Serialization function
   template<class ARCHIVE>
@@ -279,6 +280,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(measured_);
     ar & BOOST_SERIALIZATION_NVP(K_);
   }
+#endif
 };
 
 } // \ namespace gtsam

--- a/gtsam_unstable/slam/InvDepthFactorVariant3.h
+++ b/gtsam_unstable/slam/InvDepthFactorVariant3.h
@@ -140,6 +140,7 @@ public:
 private:
 
   /// Serialization function
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
@@ -147,6 +148,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(measured_);
     ar & BOOST_SERIALIZATION_NVP(K_);
   }
+#endif
 };
 
 /**
@@ -269,8 +271,8 @@ public:
 
 private:
 
-  /// Serialization function
   friend class boost::serialization::access;
+  /// Serialization function
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
     ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);

--- a/gtsam_unstable/slam/MultiProjectionFactor.h
+++ b/gtsam_unstable/slam/MultiProjectionFactor.h
@@ -213,6 +213,7 @@ namespace gtsam {
 
   private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION    ///
     /// Serialization function
     friend class boost::serialization::access;
     template<class ARCHIVE>
@@ -224,5 +225,6 @@ namespace gtsam {
       ar & BOOST_SERIALIZATION_NVP(throwCheirality_);
       ar & BOOST_SERIALIZATION_NVP(verboseCheirality_);
     }
+#endif
   };
 } // \ namespace gtsam

--- a/gtsam_unstable/slam/PartialPriorFactor.h
+++ b/gtsam_unstable/slam/PartialPriorFactor.h
@@ -140,6 +140,7 @@ namespace gtsam {
     const std::vector<size_t>& indices() const { return indices_; }
 
   private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
@@ -151,6 +152,7 @@ namespace gtsam {
       ar & BOOST_SERIALIZATION_NVP(indices_);
       // ar & BOOST_SERIALIZATION_NVP(H_);
     }
+#endif
   }; // \class PartialPriorFactor
 
 } /// namespace gtsam

--- a/gtsam_unstable/slam/PoseBetweenFactor.h
+++ b/gtsam_unstable/slam/PoseBetweenFactor.h
@@ -119,6 +119,7 @@ namespace gtsam {
 
   private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
@@ -127,6 +128,7 @@ namespace gtsam {
       ar & BOOST_SERIALIZATION_NVP(measured_);
 
     }
+#endif
   }; // \class PoseBetweenFactor
 
 } /// namespace gtsam

--- a/gtsam_unstable/slam/PosePriorFactor.h
+++ b/gtsam_unstable/slam/PosePriorFactor.h
@@ -101,6 +101,7 @@ namespace gtsam {
 
   private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
@@ -109,6 +110,7 @@ namespace gtsam {
       ar & BOOST_SERIALIZATION_NVP(prior_);
       ar & BOOST_SERIALIZATION_NVP(body_P_sensor_);
     }
+#endif
   };
 
 } /// namespace gtsam

--- a/gtsam_unstable/slam/PoseToPointFactor.h
+++ b/gtsam_unstable/slam/PoseToPointFactor.h
@@ -92,6 +92,7 @@ class PoseToPointFactor : public NoiseModelFactorN<POSE, POINT> {
   const POINT& measured() const { return measured_; }
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -102,6 +103,7 @@ class PoseToPointFactor : public NoiseModelFactorN<POSE, POINT> {
         boost::serialization::base_object<Base>(*this));
     ar& BOOST_SERIALIZATION_NVP(measured_);
   }
+#endif
 
 };  // \class PoseToPointFactor
 

--- a/gtsam_unstable/slam/ProjectionFactorPPP.h
+++ b/gtsam_unstable/slam/ProjectionFactorPPP.h
@@ -171,6 +171,7 @@ namespace gtsam {
 
   private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION    ///
     /// Serialization function
     friend class boost::serialization::access;
     template<class ARCHIVE>
@@ -181,6 +182,7 @@ namespace gtsam {
       ar & BOOST_SERIALIZATION_NVP(throwCheirality_);
       ar & BOOST_SERIALIZATION_NVP(verboseCheirality_);
     }
+#endif
   };
 
   /// traits

--- a/gtsam_unstable/slam/ProjectionFactorPPPC.h
+++ b/gtsam_unstable/slam/ProjectionFactorPPPC.h
@@ -151,6 +151,7 @@ class GTSAM_UNSTABLE_EXPORT ProjectionFactorPPPC
 
   private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION    ///
     /// Serialization function
     friend class boost::serialization::access;
     template<class ARCHIVE>
@@ -160,6 +161,7 @@ class GTSAM_UNSTABLE_EXPORT ProjectionFactorPPPC
       ar & BOOST_SERIALIZATION_NVP(throwCheirality_);
       ar & BOOST_SERIALIZATION_NVP(verboseCheirality_);
     }
+#endif
 };
 
   /// traits

--- a/gtsam_unstable/slam/ProjectionFactorRollingShutter.h
+++ b/gtsam_unstable/slam/ProjectionFactorRollingShutter.h
@@ -194,6 +194,7 @@ class GTSAM_UNSTABLE_EXPORT ProjectionFactorRollingShutter
   inline bool throwCheirality() const { return throwCheirality_; }
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   /// Serialization function
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -206,6 +207,7 @@ class GTSAM_UNSTABLE_EXPORT ProjectionFactorRollingShutter
     ar& BOOST_SERIALIZATION_NVP(throwCheirality_);
     ar& BOOST_SERIALIZATION_NVP(verboseCheirality_);
   }
+#endif
 
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/gtsam_unstable/slam/RelativeElevationFactor.h
+++ b/gtsam_unstable/slam/RelativeElevationFactor.h
@@ -65,6 +65,7 @@ public:
 
 private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template<class ARCHIVE>
@@ -74,6 +75,7 @@ private:
         boost::serialization::base_object<Base>(*this));
     ar & BOOST_SERIALIZATION_NVP(measured_);
   }
+#endif
 }; // RelativeElevationFactor
 
 

--- a/gtsam_unstable/slam/SmartProjectionPoseFactorRollingShutter.h
+++ b/gtsam_unstable/slam/SmartProjectionPoseFactorRollingShutter.h
@@ -456,12 +456,14 @@ class GTSAM_UNSTABLE_EXPORT SmartProjectionPoseFactorRollingShutter
   }
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   /// Serialization function
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
     ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
   }
+#endif
 };
 // end of class declaration
 

--- a/gtsam_unstable/slam/SmartStereoProjectionFactor.h
+++ b/gtsam_unstable/slam/SmartStereoProjectionFactor.h
@@ -501,6 +501,7 @@ public:
 
 private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   /// Serialization function
   friend class boost::serialization::access;
   template<class ARCHIVE>
@@ -509,6 +510,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(params_.throwCheirality);
     ar & BOOST_SERIALIZATION_NVP(params_.verboseCheirality);
   }
+#endif
 };
 
 /// traits

--- a/gtsam_unstable/slam/SmartStereoProjectionFactorPP.h
+++ b/gtsam_unstable/slam/SmartStereoProjectionFactorPP.h
@@ -288,6 +288,7 @@ class GTSAM_UNSTABLE_EXPORT SmartStereoProjectionFactorPP
   }
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   /// Serialization function
   friend class boost::serialization::access;
   template<class ARCHIVE>
@@ -295,6 +296,7 @@ class GTSAM_UNSTABLE_EXPORT SmartStereoProjectionFactorPP
     ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     ar & BOOST_SERIALIZATION_NVP(K_all_);
   }
+#endif
 };
 // end of class declaration
 

--- a/gtsam_unstable/slam/SmartStereoProjectionPoseFactor.h
+++ b/gtsam_unstable/slam/SmartStereoProjectionPoseFactor.h
@@ -141,6 +141,7 @@ class GTSAM_UNSTABLE_EXPORT SmartStereoProjectionPoseFactor
   Base::Cameras cameras(const Values& values) const override;
 
  private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION  ///
   /// Serialization function
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -148,6 +149,7 @@ class GTSAM_UNSTABLE_EXPORT SmartStereoProjectionPoseFactor
     ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     ar& BOOST_SERIALIZATION_NVP(K_all_);
   }
+#endif
 
 };  // end of class declaration
 

--- a/gtsam_unstable/slam/TransformBtwRobotsUnaryFactor.h
+++ b/gtsam_unstable/slam/TransformBtwRobotsUnaryFactor.h
@@ -216,6 +216,7 @@ namespace gtsam {
 
   private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
@@ -224,6 +225,7 @@ namespace gtsam {
           boost::serialization::base_object<Base>(*this));
       //ar & BOOST_SERIALIZATION_NVP(measured_);
     }
+#endif
   }; // \class TransformBtwRobotsUnaryFactor
 
   /// traits

--- a/gtsam_unstable/slam/TransformBtwRobotsUnaryFactorEM.h
+++ b/gtsam_unstable/slam/TransformBtwRobotsUnaryFactorEM.h
@@ -414,6 +414,7 @@ namespace gtsam {
 
   private:
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
     /** Serialization function */
     friend class boost::serialization::access;
     template<class ARCHIVE>
@@ -422,6 +423,7 @@ namespace gtsam {
           boost::serialization::base_object<Base>(*this));
       //ar & BOOST_SERIALIZATION_NVP(measured_);
     }
+#endif
   }; // \class TransformBtwRobotsUnaryFactorEM
 
   /// traits

--- a/tests/simulated2D.h
+++ b/tests/simulated2D.h
@@ -160,6 +160,7 @@ namespace simulated2D {
     /// Default constructor
     GenericPrior() { }
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION    ///
     /// Serialization function
     friend class boost::serialization::access;
     template<class ARCHIVE>
@@ -167,6 +168,7 @@ namespace simulated2D {
       ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
       ar & BOOST_SERIALIZATION_NVP(measured_);
     }
+#endif
   };
 
   /**

--- a/tests/simulated2D.h
+++ b/tests/simulated2D.h
@@ -210,6 +210,7 @@ namespace simulated2D {
     /// Default constructor
     GenericOdometry() { }
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION    ///
     /// Serialization function
     friend class boost::serialization::access;
     template<class ARCHIVE>
@@ -217,6 +218,7 @@ namespace simulated2D {
       ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
       ar & BOOST_SERIALIZATION_NVP(measured_);
     }
+#endif
   };
 
   /**
@@ -259,6 +261,7 @@ namespace simulated2D {
     /// Default constructor
     GenericMeasurement() { }
 
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION    ///
     /// Serialization function
     friend class boost::serialization::access;
     template<class ARCHIVE>
@@ -266,6 +269,7 @@ namespace simulated2D {
       ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
       ar & BOOST_SERIALIZATION_NVP(measured_);
     }
+#endif
   };
 
   /** Typedefs for regular use */

--- a/tests/testExpressionFactor.cpp
+++ b/tests/testExpressionFactor.cpp
@@ -695,6 +695,7 @@ public:
   }
 
 private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -704,6 +705,7 @@ private:
         boost::serialization::base_object<Base>(*this));
     ar &BOOST_SERIALIZATION_NVP(measured_);
   }
+#endif
 };
 
 TEST(ExpressionFactor, variadicTemplate) {


### PR DESCRIPTION
This PR introduces a new flag to disable boost serialization functionality. Another move towards being able to build GTSAM without boost. Implemented this mainly through a compile time definition that conditionally deactivates all references to boost serialization.

Question for the reviewers:
- Where should this flag be placed? I chose to put it in the main CMakelists.txt

Note:
If you see some code changes in the diff that don't seem to be part of this PR, it's because it has changes from another branch (`feature/remove_boost_in_Values`) and will go away when that branch gets merged, which will happen before this will go in.