### PR TITLE
fix boost 1.74 error by including library_version_type.hpp

### DIFF
--- a/gtsam/base/FastList.h
+++ b/gtsam/base/FastList.h
@@ -24,6 +24,9 @@
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/version.hpp>
+#if BOOST_VERSION >= 107400
+#include <boost/serialization/library_version_type.hpp>
+#endif
 #include <boost/serialization/list.hpp>
 #endif
 


### PR DESCRIPTION
Fix for #1412.

Tested that this change will allow successful building of GTSAM on Ubuntu 22.04 (Jammy).

@dellaert mentioned having a fix for this ready that also fixes issues related to FastSet.h, see #1412.

PS: consider adding Ubuntu 22.04 coverage to CI.

