### PR TITLE
Update ROS package.xml format to v3

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>gtsam</name>
-  <version>4.1.0</version>
+  <version>4.1.1</version>
   <description>gtsam</description>
 
   <maintainer email="gtsam@lists.gatech.edu">Frank Dellaert</maintainer>


### PR DESCRIPTION
Update package.xml to format v3. 
Also, update the version to 4.1.1 since that seems to be the last stable release... is this correct? Anyhow, that `<version>` line should be updated just before the next release so its contents remain consistent when tagging the repository.
