### PR TITLE
Add maintainers to package xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -7,6 +7,10 @@
 
   <maintainer email="gtsam@lists.gatech.edu">Frank Dellaert</maintainer>
   <license>BSD</license>
+  
+  <!-- Maintainers of the ROS packaging -->
+  <maintainer email="fan.jiang@gatech.edu">Fan Jiang</maintainer>
+  <maintainer email="jlblanco@ual.es">José Luis Blanco-Claraco</maintainer>
 
   <buildtool_depend>cmake</buildtool_depend>
 


### PR DESCRIPTION
Apparently, the ros2-gbp rules say that maintainers of a package per their system should appear in the manifest XML file as authors / maintainers.

cc: @ProfFan