### PR TITLE
replace boost phoenix parser with SignatureParser

### DIFF
--- a/gtsam/discrete/DecisionTreeFactor.h
+++ b/gtsam/discrete/DecisionTreeFactor.h
@@ -104,7 +104,7 @@ namespace gtsam {
       return ADT::operator()(values);
     }
 
-    /// Evaluate probability density, sugar.
+    /// Evaluate probability distribution, sugar.
     double operator()(const DiscreteValues& values) const override {
       return ADT::operator()(values);
     }

--- a/gtsam/discrete/DiscreteBayesTree.h
+++ b/gtsam/discrete/DiscreteBayesTree.h
@@ -63,7 +63,7 @@ class GTSAM_EXPORT DiscreteBayesTreeClique
 
 /* ************************************************************************* */
 /**
- * @brief A Bayes tree representing a Discrete density.
+ * @brief A Bayes tree representing a Discrete distribution.
  * @ingroup discrete
  */
 class GTSAM_EXPORT DiscreteBayesTree

--- a/gtsam/discrete/DiscreteConditional.cpp
+++ b/gtsam/discrete/DiscreteConditional.cpp
@@ -266,7 +266,7 @@ void DiscreteConditional::sampleInPlace(DiscreteValues* values) const {
 size_t DiscreteConditional::sample(const DiscreteValues& parentsValues) const {
   static mt19937 rng(2);  // random number generator
 
-  // Get the correct conditional density
+  // Get the correct conditional distribution
   ADT pFS = choose(parentsValues, true);  // P(F|S=parentsValues)
 
   // TODO(Duy): only works for one key now, seems horribly slow this way

--- a/gtsam/discrete/DiscreteMarginals.h
+++ b/gtsam/discrete/DiscreteMarginals.h
@@ -41,7 +41,7 @@ class DiscreteMarginals {
   DiscreteMarginals() {}
 
   /** Construct a marginals class.
-   * @param graph The factor graph defining the full joint density on all variables.
+   * @param graph The factor graph defining the full joint distribution on all variables.
    */
   DiscreteMarginals(const DiscreteFactorGraph& graph) {
     bayesTree_ = graph.eliminateMultifrontal();

--- a/gtsam/discrete/Signature.cpp
+++ b/gtsam/discrete/Signature.cpp
@@ -16,136 +16,129 @@
  * @date Feb 27, 2011
  */
 
-#include "gtsam/discrete/SignatureParser.h"
 #include "Signature.h"
 
-#include <sstream>
 #include <cassert>
+#include <sstream>
+
+#include "gtsam/discrete/SignatureParser.h"
 
 namespace gtsam {
 
-  using namespace std;
+using namespace std;
 
-  ostream& operator <<(ostream &os, const Signature::Row &row) {
-    os << row[0];
-    for (size_t i = 1; i < row.size(); i++)
-      os << " " << row[i];
-    return os;
-  }
+ostream& operator<<(ostream& os, const Signature::Row& row) {
+  os << row[0];
+  for (size_t i = 1; i < row.size(); i++) os << " " << row[i];
+  return os;
+}
 
-  ostream& operator <<(ostream &os, const Signature::Table &table) {
-    for (size_t i = 0; i < table.size(); i++)
-      os << table[i] << endl;
-    return os;
-  }
+ostream& operator<<(ostream& os, const Signature::Table& table) {
+  for (size_t i = 0; i < table.size(); i++) os << table[i] << endl;
+  return os;
+}
 
-  Signature::Signature(const DiscreteKey& key, const DiscreteKeys& parents,
-                       const Table& table)
-      : key_(key), parents_(parents) {
-    operator=(table);
-  }
+Signature::Signature(const DiscreteKey& key, const DiscreteKeys& parents,
+                     const Table& table)
+    : key_(key), parents_(parents) {
+  operator=(table);
+}
 
-  Signature::Signature(const DiscreteKey& key, const DiscreteKeys& parents,
-                       const std::string& spec)
-      : key_(key), parents_(parents) {
-    operator=(spec);
-  }
+Signature::Signature(const DiscreteKey& key, const DiscreteKeys& parents,
+                     const std::string& spec)
+    : key_(key), parents_(parents) {
+  operator=(spec);
+}
 
-  Signature::Signature(const DiscreteKey& key) :
-    key_(key) {
-  }
+Signature::Signature(const DiscreteKey& key) : key_(key) {}
 
-  DiscreteKeys Signature::discreteKeys() const {
-    DiscreteKeys keys;
-    keys.push_back(key_);
-    for (const DiscreteKey& key : parents_) keys.push_back(key);
-    return keys;
-  }
+DiscreteKeys Signature::discreteKeys() const {
+  DiscreteKeys keys;
+  keys.push_back(key_);
+  for (const DiscreteKey& key : parents_) keys.push_back(key);
+  return keys;
+}
 
-  KeyVector Signature::indices() const {
-    KeyVector js;
-    js.push_back(key_.first);
-    for (const DiscreteKey& key : parents_) js.push_back(key.first);
-    return js;
-  }
+KeyVector Signature::indices() const {
+  KeyVector js;
+  js.push_back(key_.first);
+  for (const DiscreteKey& key : parents_) js.push_back(key.first);
+  return js;
+}
 
-  vector<double> Signature::cpt() const {
-    vector<double> cpt;
-    if (table_) {
-      const size_t nrStates = table_->at(0).size();
-      for (size_t j = 0; j < nrStates; j++) {
-        for (const Row& row : *table_) {
-          assert(row.size() == nrStates);
-          cpt.push_back(row[j]);
-        }
+vector<double> Signature::cpt() const {
+  vector<double> cpt;
+  if (table_) {
+    const size_t nrStates = table_->at(0).size();
+    for (size_t j = 0; j < nrStates; j++) {
+      for (const Row& row : *table_) {
+        assert(row.size() == nrStates);
+        cpt.push_back(row[j]);
       }
     }
-    return cpt;
   }
+  return cpt;
+}
 
-  Signature& Signature::operator,(const DiscreteKey& parent) {
-    parents_.push_back(parent);
-    return *this;
+Signature &Signature::operator,(const DiscreteKey& parent) {
+  parents_.push_back(parent);
+  return *this;
+}
+
+static void normalize(Signature::Row& row) {
+  double sum = 0;
+  for (size_t i = 0; i < row.size(); i++) sum += row[i];
+  for (size_t i = 0; i < row.size(); i++) row[i] /= sum;
+}
+
+Signature& Signature::operator=(const string& spec) {
+  spec_ = spec;
+  auto table = SignatureParser::Parse(spec);
+  if (table) {
+    for (Row& row : *table) normalize(row);
+    table_ = *table;
   }
+  return *this;
+}
 
-  static void normalize(Signature::Row& row) {
-    double sum = 0;
-    for (size_t i = 0; i < row.size(); i++)
-      sum += row[i];
-    for (size_t i = 0; i < row.size(); i++)
-      row[i] /= sum;
+Signature& Signature::operator=(const Table& t) {
+  Table table = t;
+  for (Row& row : table) normalize(row);
+  table_ = table;
+  return *this;
+}
+
+ostream& operator<<(ostream& os, const Signature& s) {
+  os << s.key_.first;
+  if (s.parents_.empty()) {
+    os << " % ";
+  } else {
+    os << " | " << s.parents_[0].first;
+    for (size_t i = 1; i < s.parents_.size(); i++)
+      os << " && " << s.parents_[i].first;
+    os << " = ";
   }
+  os << (s.spec_ ? *s.spec_ : "no spec") << endl;
+  if (s.table_)
+    os << (*s.table_);
+  else
+    os << "spec could not be parsed" << endl;
+  return os;
+}
 
-  Signature& Signature::operator=(const string& spec) {
-    spec_ = spec;
-    Table table;
-    bool success = gtsam::SignatureParser::parse(spec, table);
-    if (success) {
-      for (Row& row : table) normalize(row);
-      table_ = table;
-    }
-    return *this;
-  }
+Signature operator|(const DiscreteKey& key, const DiscreteKey& parent) {
+  Signature s(key);
+  return s, parent;
+}
 
-  Signature& Signature::operator=(const Table& t) {
-    Table table = t;
-    for(Row& row: table)
-      normalize(row);
-    table_ = table;
-    return *this;
-  }
+Signature operator%(const DiscreteKey& key, const string& parent) {
+  Signature s(key);
+  return s = parent;
+}
 
-  ostream& operator <<(ostream &os, const Signature &s) {
-    os << s.key_.first;
-    if (s.parents_.empty()) {
-      os << " % ";
-    } else {
-      os << " | " << s.parents_[0].first;
-      for (size_t i = 1; i < s.parents_.size(); i++)
-        os << " && " << s.parents_[i].first;
-      os << " = ";
-    }
-    os << (s.spec_ ? *s.spec_ : "no spec") << endl;
-    if (s.table_)
-      os << (*s.table_);
-    else
-      os << "spec could not be parsed" << endl;
-    return os;
-  }
+Signature operator%(const DiscreteKey& key, const Signature::Table& parent) {
+  Signature s(key);
+  return s = parent;
+}
 
-  Signature operator|(const DiscreteKey& key, const DiscreteKey& parent) {
-    Signature s(key);
-    return s, parent;
-  }
-
-  Signature operator%(const DiscreteKey& key, const string& parent) {
-    Signature s(key);
-    return s = parent;
-  }
-
-  Signature operator%(const DiscreteKey& key, const Signature::Table& parent) {
-    Signature s(key);
-    return s = parent;
-  }
-
-} // namespace gtsam
+}  // namespace gtsam

--- a/gtsam/discrete/Signature.h
+++ b/gtsam/discrete/Signature.h
@@ -25,7 +25,7 @@
 namespace gtsam {
 
   /**
-   * Signature for a discrete conditional density, used to construct conditionals.
+   * Signature for a discrete conditional distribution, used to construct conditionals.
    *
    * The format is (Key % string) for nodes with no parents,
    * and (Key | Key, Key = string) for nodes with parents.

--- a/gtsam/discrete/SignatureParser.cpp
+++ b/gtsam/discrete/SignatureParser.cpp
@@ -18,7 +18,8 @@ inline static SignatureParser::Table ParseAnd() {
   return {ParseFalseRow(), ParseFalseRow(), ParseFalseRow(), ParseTrueRow()};
 }
 
-bool static ParseConditional(const std::string& token, std::vector<double>& row) {
+bool static ParseConditional(const std::string& token,
+                             std::vector<double>& row) {
   // Expect something like a/b/c
   std::istringstream iss2(token);
   try {
@@ -35,7 +36,8 @@ bool static ParseConditional(const std::string& token, std::vector<double>& row)
   return true;
 }
 
-void static ParseConditionalTable(const std::vector<std::string>& tokens, SignatureParser::Table& table) {
+void static ParseConditionalTable(const std::vector<std::string>& tokens,
+                                  SignatureParser::Table& table) {
   // loop over the words
   // for each word, split it into doubles using a stringstream
   for (const auto& word : tokens) {
@@ -105,8 +107,8 @@ bool SignatureParser::parse(const std::string& str, Table& table) {
   if (table.empty()) {
     return false;
   }
-  // the boost::phoenix parser did not return an error if we could not fully parse a string
-  // it just returned whatever it could parse
+  // the boost::phoenix parser did not return an error if we could not fully
+  // parse a string it just returned whatever it could parse
   return true;
 }
 }  // namespace gtsam

--- a/gtsam/discrete/SignatureParser.cpp
+++ b/gtsam/discrete/SignatureParser.cpp
@@ -1,0 +1,112 @@
+#include <gtsam/discrete/SignatureParser.h>
+
+#include <algorithm>
+#include <iterator>
+#include <sstream>
+
+namespace gtsam {
+
+inline static std::vector<double> ParseTrueRow() { return {0, 1}; }
+
+inline static std::vector<double> ParseFalseRow() { return {1, 0}; }
+
+inline static SignatureParser::Table ParseOr() {
+  return {ParseFalseRow(), ParseTrueRow(), ParseTrueRow(), ParseTrueRow()};
+}
+
+inline static SignatureParser::Table ParseAnd() {
+  return {ParseFalseRow(), ParseFalseRow(), ParseFalseRow(), ParseTrueRow()};
+}
+
+bool static ParseConditional(const std::string& token, std::vector<double>& row) {
+  // Expect something like a/b/c
+  std::istringstream iss2(token);
+  try {
+    // if the string has no / then return false
+    if (std::count(token.begin(), token.end(), '/') == 0) return false;
+    // split the word on the '/' character
+    for (std::string s; std::getline(iss2, s, '/');) {
+      // can throw exception
+      row.push_back(std::stod(s));
+    }
+  } catch (...) {
+    return false;
+  }
+  return true;
+}
+
+void static ParseConditionalTable(const std::vector<std::string>& tokens, SignatureParser::Table& table) {
+  // loop over the words
+  // for each word, split it into doubles using a stringstream
+  for (const auto& word : tokens) {
+    // If the string word is F or T then the row is {0,1} or {1,0} respectively
+    if (word == "F") {
+      table.push_back(ParseFalseRow());
+    } else if (word == "T") {
+      table.push_back(ParseTrueRow());
+    } else {
+      // Expect something like a/b/c
+      std::vector<double> row;
+      if (!ParseConditional(word, row)) {
+        // stop parsing if we encounter an error
+        return;
+      }
+      table.push_back(row);
+    }
+  }
+}
+
+std::vector<std::string> static Tokenize(const std::string& str) {
+  std::istringstream iss(str);
+  std::vector<std::string> tokens;
+  for (std::string s; iss >> s;) {
+    tokens.push_back(s);
+  }
+  return tokens;
+}
+
+bool SignatureParser::parse(const std::string& str, Table& table) {
+  // check if string is just whitespace
+  if (std::all_of(str.begin(), str.end(), isspace)) {
+    return false;
+  }
+
+  // return false if the string is empty
+  if (str.empty()) {
+    return false;
+  }
+
+  // tokenize the str on whitespace
+  std::vector<std::string> tokens = Tokenize(str);
+
+  // if the first token is "OR", return the OR table
+  if (tokens[0] == "OR") {
+    // if there are more tokens, return false
+    if (tokens.size() > 1) {
+      return false;
+    }
+    table = ParseOr();
+    return true;
+  }
+
+  // if the first token is "AND", return the AND table
+  if (tokens[0] == "AND") {
+    // if there are more tokens, return false
+    if (tokens.size() > 1) {
+      return false;
+    }
+    table = ParseAnd();
+    return true;
+  }
+
+  // otherwise then parse the conditional table
+  ParseConditionalTable(tokens, table);
+  // return false if the table is empty
+  if (table.empty()) {
+    return false;
+  }
+  // the boost::phoenix parser did not return an error if we could not fully parse a string
+  // it just returned whatever it could parse
+  return true;
+}
+}  // namespace gtsam

--- a/gtsam/discrete/SignatureParser.h
+++ b/gtsam/discrete/SignatureParser.h
@@ -17,7 +17,8 @@
  */
 
 #pragma once
-#include <iostream>
+
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -38,18 +39,18 @@ namespace gtsam {
  *   "1/2/3 2/3/4 1/2/3 2/3/4 1/2/3 2/3/4 1/2/3 2/3/4 1/2/3" :
  *      {{1,2,3},{2,3,4},{1,2,3},{2,3,4},{1,2,3},{2,3,4},{1,2,3},{2,3,4},{1,2,3}}
  *
- * If the string has un-parsable elements, should parse whatever it can:
- *   "1/2 sdf" : {{1,2}}
+ * If the string has un-parsable elements the parser will fail with nullopt:
+ *   "1/2 sdf" : nullopt !
  *
- * It should return false if the string is empty:
- *   "": false
+ * It also fails if the string is empty:
+ *   "": nullopt !
  *
- * We should return false if the rows are not of the same size.
+ * Also fails if the rows are not of the same size.
  */
-namespace SignatureParser {
-typedef std::vector<double> Row;
-typedef std::vector<Row> Table;
+struct SignatureParser {
+  using Row = std::vector<double>;
+  using Table = std::vector<Row>;
 
-bool parse(const std::string& str, Table& table);
-};  // namespace SignatureParser
+  static std::optional<Table> Parse(const std::string& str);
+};
 }  // namespace gtsam

--- a/gtsam/discrete/SignatureParser.h
+++ b/gtsam/discrete/SignatureParser.h
@@ -1,0 +1,30 @@
+/**
+ * This is a simple parser that replaces the boost spirit parser. It is
+ * meant to parse strings like "1/1 2/3 1/4". Every word of the form "a/b/c/..."
+ * should be parsed as a row, and the rows should be stored in a table.
+ * The elements of the row will be doubles.
+ * The table is a vector of rows. The row is a vector of doubles.
+ * The parser should be able to parse the following strings:
+ * "1/1 2/3 1/4": {{1,1},{2,3},{1,4}}
+ * "1/1 2/3 1/4 1/1 2/3 1/4" : {{1,1},{2,3},{1,4},{1,1},{2,3},{1,4}}
+ * "1/2/3 2/3/4 1/2/3 2/3/4 1/2/3 2/3/4 1/2/3 2/3/4 1/2/3" : {{1,2,3},{2,3,4},{1,2,3},{2,3,4},{1,2,3},{2,3,4},{1,2,3},{2,3,4},{1,2,3}}
+ * If the string has unparseable elements, the parser should parse whatever it can
+ * "1/2 sdf" : {{1,2}}
+ * It should return false if the string is empty.
+ * "": false
+ * We should return false if the rows are not of the same size.
+ */
+
+#pragma once
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace gtsam {
+namespace SignatureParser {
+typedef std::vector<double> Row;
+typedef std::vector<Row> Table;
+
+bool parse(const std::string& str, Table& table);
+};  // namespace SignatureParser
+}  // namespace gtsam

--- a/gtsam/discrete/SignatureParser.h
+++ b/gtsam/discrete/SignatureParser.h
@@ -1,18 +1,19 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
 /**
- * This is a simple parser that replaces the boost spirit parser. It is
- * meant to parse strings like "1/1 2/3 1/4". Every word of the form "a/b/c/..."
- * should be parsed as a row, and the rows should be stored in a table.
- * The elements of the row will be doubles.
- * The table is a vector of rows. The row is a vector of doubles.
- * The parser should be able to parse the following strings:
- * "1/1 2/3 1/4": {{1,1},{2,3},{1,4}}
- * "1/1 2/3 1/4 1/1 2/3 1/4" : {{1,1},{2,3},{1,4},{1,1},{2,3},{1,4}}
- * "1/2/3 2/3/4 1/2/3 2/3/4 1/2/3 2/3/4 1/2/3 2/3/4 1/2/3" : {{1,2,3},{2,3,4},{1,2,3},{2,3,4},{1,2,3},{2,3,4},{1,2,3},{2,3,4},{1,2,3}}
- * If the string has unparseable elements, the parser should parse whatever it can
- * "1/2 sdf" : {{1,2}}
- * It should return false if the string is empty.
- * "": false
- * We should return false if the rows are not of the same size.
+ * @file SignatureParser.h
+ * @brief Parser for conditional distribution signatures.
+ * @author Kartik Arcot
+ * @date January 2023
  */
 
 #pragma once
@@ -21,6 +22,30 @@
 #include <vector>
 
 namespace gtsam {
+/**
+ * @brief A simple parser that replaces the boost spirit parser.
+ *
+ * It is meant to parse strings like "1/1 2/3 1/4". Every word of the form
+ * "a/b/c/..." is parsed as a row, and the rows are stored in a table.
+ *
+ * A `Row` is a vector of doubles, and a `Table` is a vector of rows.
+ *
+ * Examples: the parser is able to parse the following strings:
+ *   "1/1 2/3 1/4":
+ *      {{1,1},{2,3},{1,4}}
+ *   "1/1 2/3 1/4 1/1 2/3 1/4" :
+ *      {{1,1},{2,3},{1,4},{1,1},{2,3},{1,4}}
+ *   "1/2/3 2/3/4 1/2/3 2/3/4 1/2/3 2/3/4 1/2/3 2/3/4 1/2/3" :
+ *      {{1,2,3},{2,3,4},{1,2,3},{2,3,4},{1,2,3},{2,3,4},{1,2,3},{2,3,4},{1,2,3}}
+ *
+ * If the string has un-parsable elements, should parse whatever it can:
+ *   "1/2 sdf" : {{1,2}}
+ *
+ * It should return false if the string is empty:
+ *   "": false
+ *
+ * We should return false if the rows are not of the same size.
+ */
 namespace SignatureParser {
 typedef std::vector<double> Row;
 typedef std::vector<Row> Table;

--- a/gtsam/discrete/tests/testSignature.cpp
+++ b/gtsam/discrete/tests/testSignature.cpp
@@ -29,7 +29,7 @@ using namespace gtsam;
 DiscreteKey X(0, 2), Y(1, 3), Z(2, 2);
 
 /* ************************************************************************* */
-TEST(testSignature, simple_conditional) {
+TEST(testSignature, SimpleConditional) {
   Signature sig(X, {Y}, "1/1 2/3 1/4");
   CHECK(sig.table());
   Signature::Table table = *sig.table();
@@ -54,7 +54,7 @@ TEST(testSignature, simple_conditional) {
 }
 
 /* ************************************************************************* */
-TEST(testSignature, simple_conditional_nonparser) {
+TEST(testSignature, SimpleConditionalNonparser) {
   Signature::Row row1{1, 1}, row2{2, 3}, row3{1, 4};
   Signature::Table table{row1, row2, row3};
 
@@ -77,7 +77,7 @@ TEST(testSignature, simple_conditional_nonparser) {
 DiscreteKey A(0, 2), S(1, 2), T(2, 2), L(3, 2), B(4, 2), E(5, 2), D(7, 2);
 
 // Make sure we can create all signatures for Asia network with constructor.
-TEST(testSignature, all_examples) {
+TEST(testSignature, AllExamples) {
   DiscreteKey X(6, 2);
   Signature a(A, {}, "99/1");
   Signature s(S, {}, "50/50");
@@ -89,7 +89,7 @@ TEST(testSignature, all_examples) {
 }
 
 // Make sure we can create all signatures for Asia network with operator magic.
-TEST(testSignature, all_examples_magic) {
+TEST(testSignature, AllExamplesMagic) {
   DiscreteKey X(6, 2);
   Signature a(A % "99/1");
   Signature s(S % "50/50");
@@ -101,7 +101,7 @@ TEST(testSignature, all_examples_magic) {
 }
 
 // Check example from docs.
-TEST(testSignature, doxygen_example) {
+TEST(testSignature, DoxygenExample) {
   Signature::Table table{{0.9, 0.1}, {0.2, 0.8}, {0.3, 0.7}, {0.1, 0.9}};
   Signature d1(D, {E, B}, table);
   Signature d2((D | E, B) = "9/1 2/8 3/7 1/9");

--- a/gtsam/discrete/tests/testSignatureParser.cpp
+++ b/gtsam/discrete/tests/testSignatureParser.cpp
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for the SimpleParser class.
+ * @file testSimpleParser.cpp
+ */
+
+#include <gtsam/base/TestableAssertions.h>
+#include <gtsam/discrete/SignatureParser.h>
+#include <CppUnitLite/TestHarness.h>
+
+bool compare_tables(const gtsam::SignatureParser::Table& table1,
+                    const gtsam::SignatureParser::Table& table2) {
+  if (table1.size() != table2.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < table1.size(); ++i) {
+    if (table1[i].size() != table2[i].size()) {
+      return false;
+    }
+    for (size_t j = 0; j < table1[i].size(); ++j) {
+      if (table1[i][j] != table2[i][j]) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+// Simple test case
+TEST(SimpleParser, simple) {
+  gtsam::SignatureParser::Table table, expectedTable;
+  expectedTable = {{1, 1}, {2, 3}, {1, 4}};
+  bool ret = gtsam::SignatureParser::parse("1/1 2/3 1/4", table);
+  EXPECT(ret);
+  // compare the tables
+  EXPECT(compare_tables(table, expectedTable));
+}
+
+// Test case with each row having 3 elements
+TEST(SimpleParser, three_elements) {
+  gtsam::SignatureParser::Table table, expectedTable;
+  expectedTable = {{1, 1, 1}, {2, 3, 2}, {1, 4, 3}};
+  bool ret = gtsam::SignatureParser::parse("1/1/1 2/3/2 1/4/3", table);
+  EXPECT(ret);
+  // compare the tables
+  EXPECT(compare_tables(table, expectedTable));
+}
+
+// A test case to check if we can parse a signarue with 'T' and 'F'
+TEST(SimpleParser, TandF) {
+  gtsam::SignatureParser::Table table, expectedTable;
+  expectedTable = {{1,0}, {1,0}, {1,0}, {0,1}};
+  bool ret = gtsam::SignatureParser::parse("F F F T", table);
+  EXPECT(ret);
+  // compare the tables
+  EXPECT(compare_tables(table, expectedTable));
+}
+
+// A test to parse {F F F 1}
+TEST(SimpleParser, FFF1) {
+  gtsam::SignatureParser::Table table, expectedTable;
+  expectedTable = {{1,0}, {1,0}, {1,0}};
+  // should ignore the last 1
+  bool ret = gtsam::SignatureParser::parse("F F F 1", table);
+  EXPECT(ret);
+  // compare the tables
+  EXPECT(compare_tables(table, expectedTable));
+}
+
+// Expect false if the string is empty
+TEST(SimpleParser, empty_string) {
+  gtsam::SignatureParser::Table table;
+  bool ret = gtsam::SignatureParser::parse("", table);
+  EXPECT(!ret);
+}
+
+
+// Expect false if jibberish
+TEST(SimpleParser, jibberish) {
+  gtsam::SignatureParser::Table table;
+  bool ret = gtsam::SignatureParser::parse("sdf 22/3", table);
+  EXPECT(!ret);
+}
+
+// If jibberish is in the middle, it should still parse the rest
+TEST(SimpleParser, jibberish_in_middle) {
+  gtsam::SignatureParser::Table table, expectedTable;
+  expectedTable = {{1, 1}, {2, 3}};
+  bool ret = gtsam::SignatureParser::parse("1/1 2/3 sdf 1/4", table);
+  EXPECT(ret);
+  // compare the tables
+  EXPECT(compare_tables(table, expectedTable));
+}
+
+int main() {
+  TestResult tr;
+  return TestRegistry::runAllTests(tr);
+}

--- a/gtsam/discrete/tests/testSignatureParser.cpp
+++ b/gtsam/discrete/tests/testSignatureParser.cpp
@@ -32,72 +32,62 @@ bool compareTables(const SignatureParser::Table& table1,
 /* ************************************************************************* */
 // Simple test case
 TEST(SimpleParser, Simple) {
-  SignatureParser::Table table, expectedTable;
-  expectedTable = {{1, 1}, {2, 3}, {1, 4}};
-  bool ret = SignatureParser::parse("1/1 2/3 1/4", table);
-  EXPECT(ret);
+  SignatureParser::Table expectedTable{{1, 1}, {2, 3}, {1, 4}};
+  const auto table = SignatureParser::Parse("1/1 2/3 1/4");
+  CHECK(table);
   // compare the tables
-  EXPECT(compareTables(table, expectedTable));
+  EXPECT(compareTables(*table, expectedTable));
 }
 
 /* ************************************************************************* */
 // Test case with each row having 3 elements
 TEST(SimpleParser, ThreeElements) {
-  SignatureParser::Table table, expectedTable;
-  expectedTable = {{1, 1, 1}, {2, 3, 2}, {1, 4, 3}};
-  bool ret = SignatureParser::parse("1/1/1 2/3/2 1/4/3", table);
-  EXPECT(ret);
+  SignatureParser::Table expectedTable{{1, 1, 1}, {2, 3, 2}, {1, 4, 3}};
+  const auto table = SignatureParser::Parse("1/1/1 2/3/2 1/4/3");
+  CHECK(table);
   // compare the tables
-  EXPECT(compareTables(table, expectedTable));
+  EXPECT(compareTables(*table, expectedTable));
 }
 
 /* ************************************************************************* */
 // A test case to check if we can parse a signature with 'T' and 'F'
 TEST(SimpleParser, TAndF) {
-  SignatureParser::Table table, expectedTable;
-  expectedTable = {{1, 0}, {1, 0}, {1, 0}, {0, 1}};
-  bool ret = SignatureParser::parse("F F F T", table);
-  EXPECT(ret);
+  SignatureParser::Table expectedTable{{1, 0}, {1, 0}, {1, 0}, {0, 1}};
+  const auto table = SignatureParser::Parse("F F F T");
+  CHECK(table);
   // compare the tables
-  EXPECT(compareTables(table, expectedTable));
+  EXPECT(compareTables(*table, expectedTable));
 }
 
 /* ************************************************************************* */
 // A test to parse {F F F 1}
 TEST(SimpleParser, FFF1) {
-  SignatureParser::Table table, expectedTable;
-  expectedTable = {{1, 0}, {1, 0}, {1, 0}};
-  // should ignore the last 1
-  bool ret = SignatureParser::parse("F F F 1", table);
-  EXPECT(ret);
+  SignatureParser::Table expectedTable{{1, 0}, {1, 0}, {1, 0}};
+  const auto table = SignatureParser::Parse("F F F");
+  CHECK(table);
   // compare the tables
-  EXPECT(compareTables(table, expectedTable));
+  EXPECT(compareTables(*table, expectedTable));
 }
 
 /* ************************************************************************* */
 // Expect false if the string is empty
 TEST(SimpleParser, emptyString) {
-  SignatureParser::Table table;
-  bool ret = SignatureParser::parse("", table);
-  EXPECT(!ret);
+  const auto table = SignatureParser::Parse("");
+  EXPECT(!table);
 }
 
 /* ************************************************************************* */
 // Expect false if gibberish
 TEST(SimpleParser, Gibberish) {
-  SignatureParser::Table table;
-  bool ret = SignatureParser::parse("sdf 22/3", table);
-  EXPECT(!ret);
+  const auto table = SignatureParser::Parse("sdf 22/3");
+  EXPECT(!table);
 }
 
-// If Gibberish is in the middle, it should still parse the rest
+// If Gibberish is in the middle, it should not parse.
 TEST(SimpleParser, GibberishInMiddle) {
-  SignatureParser::Table table, expectedTable;
-  expectedTable = {{1, 1}, {2, 3}};
-  bool ret = SignatureParser::parse("1/1 2/3 sdf 1/4", table);
-  EXPECT(ret);
-  // compare the tables
-  EXPECT(compareTables(table, expectedTable));
+  SignatureParser::Table expectedTable{{1, 1}, {2, 3}};
+  const auto table = SignatureParser::Parse("1/1 2/3 sdf 1/4");
+  EXPECT(!table);
 }
 
 /* ************************************************************************* */

--- a/gtsam/discrete/tests/testSignatureParser.cpp
+++ b/gtsam/discrete/tests/testSignatureParser.cpp
@@ -3,12 +3,16 @@
  * @file testSimpleParser.cpp
  */
 
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/TestableAssertions.h>
 #include <gtsam/discrete/SignatureParser.h>
-#include <CppUnitLite/TestHarness.h>
 
-bool compare_tables(const gtsam::SignatureParser::Table& table1,
-                    const gtsam::SignatureParser::Table& table2) {
+using namespace gtsam;
+
+/* ************************************************************************* */
+// Simple test case
+bool compareTables(const SignatureParser::Table& table1,
+                   const SignatureParser::Table& table2) {
   if (table1.size() != table2.size()) {
     return false;
   }
@@ -25,71 +29,78 @@ bool compare_tables(const gtsam::SignatureParser::Table& table1,
   return true;
 }
 
+/* ************************************************************************* */
 // Simple test case
-TEST(SimpleParser, simple) {
-  gtsam::SignatureParser::Table table, expectedTable;
+TEST(SimpleParser, Simple) {
+  SignatureParser::Table table, expectedTable;
   expectedTable = {{1, 1}, {2, 3}, {1, 4}};
-  bool ret = gtsam::SignatureParser::parse("1/1 2/3 1/4", table);
+  bool ret = SignatureParser::parse("1/1 2/3 1/4", table);
   EXPECT(ret);
   // compare the tables
-  EXPECT(compare_tables(table, expectedTable));
+  EXPECT(compareTables(table, expectedTable));
 }
 
+/* ************************************************************************* */
 // Test case with each row having 3 elements
-TEST(SimpleParser, three_elements) {
-  gtsam::SignatureParser::Table table, expectedTable;
+TEST(SimpleParser, ThreeElements) {
+  SignatureParser::Table table, expectedTable;
   expectedTable = {{1, 1, 1}, {2, 3, 2}, {1, 4, 3}};
-  bool ret = gtsam::SignatureParser::parse("1/1/1 2/3/2 1/4/3", table);
+  bool ret = SignatureParser::parse("1/1/1 2/3/2 1/4/3", table);
   EXPECT(ret);
   // compare the tables
-  EXPECT(compare_tables(table, expectedTable));
+  EXPECT(compareTables(table, expectedTable));
 }
 
-// A test case to check if we can parse a signarue with 'T' and 'F'
-TEST(SimpleParser, TandF) {
-  gtsam::SignatureParser::Table table, expectedTable;
-  expectedTable = {{1,0}, {1,0}, {1,0}, {0,1}};
-  bool ret = gtsam::SignatureParser::parse("F F F T", table);
+/* ************************************************************************* */
+// A test case to check if we can parse a signature with 'T' and 'F'
+TEST(SimpleParser, TAndF) {
+  SignatureParser::Table table, expectedTable;
+  expectedTable = {{1, 0}, {1, 0}, {1, 0}, {0, 1}};
+  bool ret = SignatureParser::parse("F F F T", table);
   EXPECT(ret);
   // compare the tables
-  EXPECT(compare_tables(table, expectedTable));
+  EXPECT(compareTables(table, expectedTable));
 }
 
+/* ************************************************************************* */
 // A test to parse {F F F 1}
 TEST(SimpleParser, FFF1) {
-  gtsam::SignatureParser::Table table, expectedTable;
-  expectedTable = {{1,0}, {1,0}, {1,0}};
+  SignatureParser::Table table, expectedTable;
+  expectedTable = {{1, 0}, {1, 0}, {1, 0}};
   // should ignore the last 1
-  bool ret = gtsam::SignatureParser::parse("F F F 1", table);
+  bool ret = SignatureParser::parse("F F F 1", table);
   EXPECT(ret);
   // compare the tables
-  EXPECT(compare_tables(table, expectedTable));
+  EXPECT(compareTables(table, expectedTable));
 }
 
+/* ************************************************************************* */
 // Expect false if the string is empty
-TEST(SimpleParser, empty_string) {
-  gtsam::SignatureParser::Table table;
-  bool ret = gtsam::SignatureParser::parse("", table);
+TEST(SimpleParser, emptyString) {
+  SignatureParser::Table table;
+  bool ret = SignatureParser::parse("", table);
   EXPECT(!ret);
 }
 
-
-// Expect false if jibberish
-TEST(SimpleParser, jibberish) {
-  gtsam::SignatureParser::Table table;
-  bool ret = gtsam::SignatureParser::parse("sdf 22/3", table);
+/* ************************************************************************* */
+// Expect false if gibberish
+TEST(SimpleParser, Gibberish) {
+  SignatureParser::Table table;
+  bool ret = SignatureParser::parse("sdf 22/3", table);
   EXPECT(!ret);
 }
 
-// If jibberish is in the middle, it should still parse the rest
-TEST(SimpleParser, jibberish_in_middle) {
-  gtsam::SignatureParser::Table table, expectedTable;
+// If Gibberish is in the middle, it should still parse the rest
+TEST(SimpleParser, GibberishInMiddle) {
+  SignatureParser::Table table, expectedTable;
   expectedTable = {{1, 1}, {2, 3}};
-  bool ret = gtsam::SignatureParser::parse("1/1 2/3 sdf 1/4", table);
+  bool ret = SignatureParser::parse("1/1 2/3 sdf 1/4", table);
   EXPECT(ret);
   // compare the tables
-  EXPECT(compare_tables(table, expectedTable));
+  EXPECT(compareTables(table, expectedTable));
 }
+
+/* ************************************************************************* */
 
 int main() {
   TestResult tr;


### PR DESCRIPTION
Thanks a lot @kartikarcot for this new parser that replaces the boost phoenix parser. 
I refactored a bit, I don;t like to use non-const references so using std::optional now.

@varunagrawal this is not as quick but Kartik added a bunch of tests and all hybrid tests work as well.