### PR TITLE
Reverted ill-advised concepts, attempt 2

### DIFF
--- a/gtsam/base/Group.h
+++ b/gtsam/base/Group.h
@@ -139,8 +139,8 @@ compose_pow(const G& g, size_t n) {
 /// Assumes nothing except group structure and Testable from G and H
 template<typename G, typename H>
 class DirectProduct: public std::pair<G, H> {
-  GTSAM_CONCEPT_ASSERT1(IsGroup<G>);
-  GTSAM_CONCEPT_ASSERT2(IsGroup<H>);
+  GTSAM_CONCEPT_ASSERT(IsGroup<G>);
+  GTSAM_CONCEPT_ASSERT(IsGroup<H>);
 
 public:
   /// Default constructor yields identity
@@ -170,8 +170,8 @@ struct traits<DirectProduct<G, H> > :
 /// Assumes existence of three additive operators for both groups
 template<typename G, typename H>
 class DirectSum: public std::pair<G, H> {
-  GTSAM_CONCEPT_ASSERT1(IsGroup<G>);  // TODO(frank): check additive
-  GTSAM_CONCEPT_ASSERT2(IsGroup<H>);  // TODO(frank): check additive
+  GTSAM_CONCEPT_ASSERT(IsGroup<G>);  // TODO(frank): check additive
+  GTSAM_CONCEPT_ASSERT(IsGroup<H>);  // TODO(frank): check additive
 
   const G& g() const { return this->first; }
   const H& h() const { return this->second;}

--- a/gtsam/base/ProductLieGroup.h
+++ b/gtsam/base/ProductLieGroup.h
@@ -27,8 +27,8 @@ namespace gtsam {
 /// Assumes Lie group structure for G and H
 template<typename G, typename H>
 class ProductLieGroup: public std::pair<G, H> {
-  GTSAM_CONCEPT_ASSERT1(IsLieGroup<G>);
-  GTSAM_CONCEPT_ASSERT2(IsLieGroup<H>);
+  GTSAM_CONCEPT_ASSERT(IsLieGroup<G>);
+  GTSAM_CONCEPT_ASSERT(IsLieGroup<H>);
   typedef std::pair<G, H> Base;
 
 protected:

--- a/gtsam/base/concepts.h
+++ b/gtsam/base/concepts.h
@@ -14,21 +14,12 @@
 #include <boost/concept/requires.hpp>
 #include <boost/concept_check.hpp>
 #define GTSAM_CONCEPT_ASSERT(concept) BOOST_CONCEPT_ASSERT((concept))
-#define GTSAM_CONCEPT_ASSERT1(concept) BOOST_CONCEPT_ASSERT((concept))
-#define GTSAM_CONCEPT_ASSERT2(concept) BOOST_CONCEPT_ASSERT((concept))
-#define GTSAM_CONCEPT_ASSERT3(concept) BOOST_CONCEPT_ASSERT((concept))
-#define GTSAM_CONCEPT_ASSERT4(concept) BOOST_CONCEPT_ASSERT((concept))
 #define GTSAM_CONCEPT_REQUIRES(concept, return_type) BOOST_CONCEPT_REQUIRES(((concept)), (return_type))
 #else 
-// These do something sensible:
+// This does something sensible:
 #define BOOST_CONCEPT_USAGE(concept) void check##concept()
-// TODO(dellaert): would be nice if it was a single macro...
-#define GTSAM_CONCEPT_ASSERT(concept) concept checkConcept [[maybe_unused]]
-#define GTSAM_CONCEPT_ASSERT1(concept) concept checkConcept1 [[maybe_unused]]
-#define GTSAM_CONCEPT_ASSERT2(concept) concept checkConcept2 [[maybe_unused]]
-#define GTSAM_CONCEPT_ASSERT3(concept) concept checkConcept3 [[maybe_unused]]
-#define GTSAM_CONCEPT_ASSERT4(concept) concept checkConcept4 [[maybe_unused]]
-// This one just ignores concept for now:
+// These just ignore the concept checking for now:
+#define GTSAM_CONCEPT_ASSERT(concept)
 #define GTSAM_CONCEPT_REQUIRES(concept, return_type) return_type
 #endif
 

--- a/gtsam/base/tests/testMatrix.cpp
+++ b/gtsam/base/tests/testMatrix.cpp
@@ -1151,8 +1151,10 @@ TEST(Matrix, Matrix24IsVectorSpace) {
 }
 
 TEST(Matrix, RowMajorIsVectorSpace) {
+#ifdef GTSAM_USE_BOOST_FEATURES
   typedef Eigen::Matrix<double, 2, 3, Eigen::RowMajor> RowMajor;
   GTSAM_CONCEPT_ASSERT(IsVectorSpace<RowMajor>);
+#endif
 }
 
 TEST(Matrix, MatrixIsVectorSpace) {
@@ -1164,9 +1166,11 @@ TEST(Matrix, VectorIsVectorSpace) {
 }
 
 TEST(Matrix, RowVectorIsVectorSpace) {
+#ifdef GTSAM_USE_BOOST_FEATURES
   typedef Eigen::Matrix<double, 1, -1> RowVector;
   GTSAM_CONCEPT_ASSERT(IsVectorSpace<RowVector>);
   GTSAM_CONCEPT_ASSERT(IsVectorSpace<Vector5>);
+#endif
 }
 
 //******************************************************************************

--- a/gtsam/base/tests/testMatrix.cpp
+++ b/gtsam/base/tests/testMatrix.cpp
@@ -1165,8 +1165,8 @@ TEST(Matrix, VectorIsVectorSpace) {
 
 TEST(Matrix, RowVectorIsVectorSpace) {
   typedef Eigen::Matrix<double, 1, -1> RowVector;
-  GTSAM_CONCEPT_ASSERT1(IsVectorSpace<RowVector>);
-  GTSAM_CONCEPT_ASSERT2(IsVectorSpace<Vector5>);
+  GTSAM_CONCEPT_ASSERT(IsVectorSpace<RowVector>);
+  GTSAM_CONCEPT_ASSERT(IsVectorSpace<Vector5>);
 }
 
 //******************************************************************************

--- a/gtsam/base/tests/testVector.cpp
+++ b/gtsam/base/tests/testVector.cpp
@@ -272,8 +272,10 @@ TEST(Vector, VectorIsVectorSpace) {
 }
 
 TEST(Vector, RowVectorIsVectorSpace) {
+#ifdef GTSAM_USE_BOOST_FEATURES
   typedef Eigen::Matrix<double,1,-1> RowVector;
   GTSAM_CONCEPT_ASSERT(IsVectorSpace<RowVector>);
+#endif
 }
 
 /* ************************************************************************* */

--- a/gtsam/base/tests/testVector.cpp
+++ b/gtsam/base/tests/testVector.cpp
@@ -267,8 +267,8 @@ TEST(Vector, linear_dependent3 )
 
 //******************************************************************************
 TEST(Vector, VectorIsVectorSpace) {
-  GTSAM_CONCEPT_ASSERT1(IsVectorSpace<Vector5>);
-  GTSAM_CONCEPT_ASSERT2(IsVectorSpace<Vector>);
+  GTSAM_CONCEPT_ASSERT(IsVectorSpace<Vector5>);
+  GTSAM_CONCEPT_ASSERT(IsVectorSpace<Vector>);
 }
 
 TEST(Vector, RowVectorIsVectorSpace) {

--- a/gtsam/geometry/tests/testCyclic.cpp
+++ b/gtsam/geometry/tests/testCyclic.cpp
@@ -107,8 +107,8 @@ struct traits<K4> : internal::AdditiveGroupTraits<K4> {
 TEST(Cyclic , DirectSum) {
   // The Direct sum of Z2 and Z2 is *not* Cyclic<4>, but the
   // smallest non-cyclic group called the Klein four-group:
-  GTSAM_CONCEPT_ASSERT1(IsGroup<K4>);
-  GTSAM_CONCEPT_ASSERT2(IsTestable<K4>);
+  GTSAM_CONCEPT_ASSERT(IsGroup<K4>);
+  GTSAM_CONCEPT_ASSERT(IsTestable<K4>);
 
   // Refer to http://en.wikipedia.org/wiki/Klein_four-group
   K4 e(0,0), a(0, 1), b(1, 0), c(1, 1);

--- a/gtsam/geometry/tests/testPoint2.cpp
+++ b/gtsam/geometry/tests/testPoint2.cpp
@@ -34,9 +34,9 @@ TEST(Point2 , Constructor) {
 
 //******************************************************************************
 TEST(Double , Concept) {
-  GTSAM_CONCEPT_ASSERT1(IsGroup<double>);
-  GTSAM_CONCEPT_ASSERT2(IsManifold<double>);
-  GTSAM_CONCEPT_ASSERT3(IsVectorSpace<double>);
+  GTSAM_CONCEPT_ASSERT(IsGroup<double>);
+  GTSAM_CONCEPT_ASSERT(IsManifold<double>);
+  GTSAM_CONCEPT_ASSERT(IsVectorSpace<double>);
 }
 
 //******************************************************************************
@@ -48,9 +48,9 @@ TEST(Double , Invariants) {
 
 //******************************************************************************
 TEST(Point2 , Concept) {
-  GTSAM_CONCEPT_ASSERT1(IsGroup<Point2>);
-  GTSAM_CONCEPT_ASSERT2(IsManifold<Point2>);
-  GTSAM_CONCEPT_ASSERT3(IsVectorSpace<Point2>);
+  GTSAM_CONCEPT_ASSERT(IsGroup<Point2>);
+  GTSAM_CONCEPT_ASSERT(IsManifold<Point2>);
+  GTSAM_CONCEPT_ASSERT(IsVectorSpace<Point2>);
 }
 
 //******************************************************************************

--- a/gtsam/geometry/tests/testPoint3.cpp
+++ b/gtsam/geometry/tests/testPoint3.cpp
@@ -34,9 +34,9 @@ TEST(Point3 , Constructor) {
 
 //******************************************************************************
 TEST(Point3 , Concept) {
-  GTSAM_CONCEPT_ASSERT1(IsGroup<Point3>);
-  GTSAM_CONCEPT_ASSERT2(IsManifold<Point3>);
-  GTSAM_CONCEPT_ASSERT3(IsVectorSpace<Point3>);
+  GTSAM_CONCEPT_ASSERT(IsGroup<Point3>);
+  GTSAM_CONCEPT_ASSERT(IsManifold<Point3>);
+  GTSAM_CONCEPT_ASSERT(IsVectorSpace<Point3>);
 }
 
 //******************************************************************************

--- a/gtsam/geometry/tests/testPose2.cpp
+++ b/gtsam/geometry/tests/testPose2.cpp
@@ -35,9 +35,9 @@ GTSAM_CONCEPT_LIE_INST(Pose2)
 
 //******************************************************************************
 TEST(Pose2 , Concept) {
-  GTSAM_CONCEPT_ASSERT1(IsGroup<Pose2 >);
-  GTSAM_CONCEPT_ASSERT2(IsManifold<Pose2 >);
-  GTSAM_CONCEPT_ASSERT3(IsLieGroup<Pose2 >);
+  GTSAM_CONCEPT_ASSERT(IsGroup<Pose2 >);
+  GTSAM_CONCEPT_ASSERT(IsManifold<Pose2 >);
+  GTSAM_CONCEPT_ASSERT(IsLieGroup<Pose2 >);
 }
 
 /* ************************************************************************* */

--- a/gtsam/geometry/tests/testQuaternion.cpp
+++ b/gtsam/geometry/tests/testQuaternion.cpp
@@ -29,9 +29,9 @@ typedef traits<Q>::ChartJacobian QuaternionJacobian;
 
 //******************************************************************************
 TEST(Quaternion , Concept) {
-  GTSAM_CONCEPT_ASSERT1(IsGroup<Quaternion >);
-  GTSAM_CONCEPT_ASSERT2(IsManifold<Quaternion >);
-  GTSAM_CONCEPT_ASSERT3(IsLieGroup<Quaternion >);
+  GTSAM_CONCEPT_ASSERT(IsGroup<Quaternion >);
+  GTSAM_CONCEPT_ASSERT(IsManifold<Quaternion >);
+  GTSAM_CONCEPT_ASSERT(IsLieGroup<Quaternion >);
 }
 
 //******************************************************************************

--- a/gtsam/geometry/tests/testRot3.cpp
+++ b/gtsam/geometry/tests/testRot3.cpp
@@ -38,9 +38,9 @@ static double error = 1e-9, epsilon = 0.001;
 
 //******************************************************************************
 TEST(Rot3 , Concept) {
-  GTSAM_CONCEPT_ASSERT1(IsGroup<Rot3 >);
-  GTSAM_CONCEPT_ASSERT2(IsManifold<Rot3 >);
-  GTSAM_CONCEPT_ASSERT3(IsLieGroup<Rot3 >);
+  GTSAM_CONCEPT_ASSERT(IsGroup<Rot3 >);
+  GTSAM_CONCEPT_ASSERT(IsManifold<Rot3 >);
+  GTSAM_CONCEPT_ASSERT(IsLieGroup<Rot3 >);
 }
 
 /* ************************************************************************* */

--- a/gtsam/geometry/tests/testSO3.cpp
+++ b/gtsam/geometry/tests/testSO3.cpp
@@ -36,9 +36,9 @@ TEST(SO3, Identity) {
 
 //******************************************************************************
 TEST(SO3, Concept) {
-  GTSAM_CONCEPT_ASSERT1(IsGroup<SO3>);
-  GTSAM_CONCEPT_ASSERT2(IsManifold<SO3>);
-  GTSAM_CONCEPT_ASSERT3(IsLieGroup<SO3>);
+  GTSAM_CONCEPT_ASSERT(IsGroup<SO3>);
+  GTSAM_CONCEPT_ASSERT(IsManifold<SO3>);
+  GTSAM_CONCEPT_ASSERT(IsLieGroup<SO3>);
 }
 
 //******************************************************************************

--- a/gtsam/geometry/tests/testSO4.cpp
+++ b/gtsam/geometry/tests/testSO4.cpp
@@ -42,9 +42,9 @@ TEST(SO4, Identity) {
 
 //******************************************************************************
 TEST(SO4, Concept) {
-  GTSAM_CONCEPT_ASSERT1(IsGroup<SO4>);
-  GTSAM_CONCEPT_ASSERT2(IsManifold<SO4>);
-  GTSAM_CONCEPT_ASSERT3(IsLieGroup<SO4>);
+  GTSAM_CONCEPT_ASSERT(IsGroup<SO4>);
+  GTSAM_CONCEPT_ASSERT(IsManifold<SO4>);
+  GTSAM_CONCEPT_ASSERT(IsLieGroup<SO4>);
 }
 
 //******************************************************************************

--- a/gtsam/geometry/tests/testSOn.cpp
+++ b/gtsam/geometry/tests/testSOn.cpp
@@ -84,9 +84,9 @@ TEST(SOn, SO5) {
 
 //******************************************************************************
 TEST(SOn, Concept) {
-  GTSAM_CONCEPT_ASSERT1(IsGroup<SOn>);
-  GTSAM_CONCEPT_ASSERT2(IsManifold<SOn>);
-  GTSAM_CONCEPT_ASSERT3(IsLieGroup<SOn>);
+  GTSAM_CONCEPT_ASSERT(IsGroup<SOn>);
+  GTSAM_CONCEPT_ASSERT(IsManifold<SOn>);
+  GTSAM_CONCEPT_ASSERT(IsLieGroup<SOn>);
 }
 
 //******************************************************************************

--- a/gtsam/geometry/tests/testSimilarity2.cpp
+++ b/gtsam/geometry/tests/testSimilarity2.cpp
@@ -35,9 +35,9 @@ static const double s = 4;
 
 //******************************************************************************
 TEST(Similarity2, Concepts) {
-  GTSAM_CONCEPT_ASSERT1(IsGroup<Similarity2>);
-  GTSAM_CONCEPT_ASSERT2(IsManifold<Similarity2>);
-  GTSAM_CONCEPT_ASSERT3(IsLieGroup<Similarity2>);
+  GTSAM_CONCEPT_ASSERT(IsGroup<Similarity2>);
+  GTSAM_CONCEPT_ASSERT(IsManifold<Similarity2>);
+  GTSAM_CONCEPT_ASSERT(IsLieGroup<Similarity2>);
 }
 
 //******************************************************************************

--- a/gtsam/geometry/tests/testSimilarity3.cpp
+++ b/gtsam/geometry/tests/testSimilarity3.cpp
@@ -54,9 +54,9 @@ const double degree = M_PI / 180;
 
 //******************************************************************************
 TEST(Similarity3, Concepts) {
-  GTSAM_CONCEPT_ASSERT1(IsGroup<Similarity3 >);
-  GTSAM_CONCEPT_ASSERT2(IsManifold<Similarity3 >);
-  GTSAM_CONCEPT_ASSERT3(IsLieGroup<Similarity3 >);
+  GTSAM_CONCEPT_ASSERT(IsGroup<Similarity3 >);
+  GTSAM_CONCEPT_ASSERT(IsManifold<Similarity3 >);
+  GTSAM_CONCEPT_ASSERT(IsLieGroup<Similarity3 >);
 }
 
 //******************************************************************************

--- a/gtsam/geometry/tests/testStereoPoint2.cpp
+++ b/gtsam/geometry/tests/testStereoPoint2.cpp
@@ -31,9 +31,9 @@ GTSAM_CONCEPT_TESTABLE_INST(StereoPoint2)
 
 //******************************************************************************
 TEST(StereoPoint2 , Concept) {
-  GTSAM_CONCEPT_ASSERT1(IsGroup<StereoPoint2>);
-  GTSAM_CONCEPT_ASSERT2(IsManifold<StereoPoint2 >);
-  GTSAM_CONCEPT_ASSERT3(IsVectorSpace<StereoPoint2>);
+  GTSAM_CONCEPT_ASSERT(IsGroup<StereoPoint2>);
+  GTSAM_CONCEPT_ASSERT(IsManifold<StereoPoint2 >);
+  GTSAM_CONCEPT_ASSERT(IsVectorSpace<StereoPoint2>);
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/VectorValues.cpp
+++ b/gtsam/linear/VectorValues.cpp
@@ -130,7 +130,7 @@ namespace gtsam {
   GTSAM_EXPORT std::ostream& operator<<(std::ostream& os, const VectorValues& v) {
     // Change print depending on whether we are using TBB
 #ifdef GTSAM_USE_TBB
-    map<Key, Vector> sorted;
+    std::map<Key, Vector> sorted;
     for (const auto& [key,value] : v) {
       sorted.emplace(key, value);
     }

--- a/gtsam/nonlinear/ExtendedKalmanFilter.h
+++ b/gtsam/nonlinear/ExtendedKalmanFilter.h
@@ -44,8 +44,8 @@ namespace gtsam {
 template <class VALUE>
 class ExtendedKalmanFilter {
   // Check that VALUE type is a testable Manifold
-  GTSAM_CONCEPT_ASSERT1(IsTestable<VALUE>);
-  GTSAM_CONCEPT_ASSERT2(IsManifold<VALUE>);
+  GTSAM_CONCEPT_ASSERT(IsTestable<VALUE>);
+  GTSAM_CONCEPT_ASSERT(IsManifold<VALUE>);
 
  public:
   typedef std::shared_ptr<ExtendedKalmanFilter<VALUE> > shared_ptr;

--- a/gtsam/slam/BetweenFactor.h
+++ b/gtsam/slam/BetweenFactor.h
@@ -40,8 +40,8 @@ namespace gtsam {
   class BetweenFactor: public NoiseModelFactorN<VALUE, VALUE> {
 
     // Check that VALUE type is a testable Lie group
-    GTSAM_CONCEPT_ASSERT1(IsTestable<VALUE>);
-    GTSAM_CONCEPT_ASSERT2(IsLieGroup<VALUE>);
+    GTSAM_CONCEPT_ASSERT(IsTestable<VALUE>);
+    GTSAM_CONCEPT_ASSERT(IsLieGroup<VALUE>);
 
   public:
 

--- a/tests/testLie.cpp
+++ b/tests/testLie.cpp
@@ -47,9 +47,9 @@ template<> struct traits<Product> : internal::LieGroupTraits<Product> {
 
 //******************************************************************************
 TEST(Lie, ProductLieGroup) {
-  GTSAM_CONCEPT_ASSERT1(IsGroup<Product>);
-  GTSAM_CONCEPT_ASSERT2(IsManifold<Product>);
-  GTSAM_CONCEPT_ASSERT3(IsLieGroup<Product>);
+  GTSAM_CONCEPT_ASSERT(IsGroup<Product>);
+  GTSAM_CONCEPT_ASSERT(IsManifold<Product>);
+  GTSAM_CONCEPT_ASSERT(IsLieGroup<Product>);
   Product pair1;
   Vector5 d;
   d << 1, 2, 0.1, 0.2, 0.3;

--- a/tests/testManifold.cpp
+++ b/tests/testManifold.cpp
@@ -38,26 +38,26 @@ typedef PinholeCamera<Cal3Bundler> Camera;
 //******************************************************************************
 TEST(Manifold, SomeManifoldsGTSAM) {
   //GTSAM_CONCEPT_ASSERT(IsManifold<int>); // integer is not a manifold
-  GTSAM_CONCEPT_ASSERT1(IsManifold<Camera>);
-  GTSAM_CONCEPT_ASSERT2(IsManifold<Cal3_S2>);
-  GTSAM_CONCEPT_ASSERT3(IsManifold<Cal3Bundler>);
-  GTSAM_CONCEPT_ASSERT4(IsManifold<Camera>);
+  GTSAM_CONCEPT_ASSERT(IsManifold<Camera>);
+  GTSAM_CONCEPT_ASSERT(IsManifold<Cal3_S2>);
+  GTSAM_CONCEPT_ASSERT(IsManifold<Cal3Bundler>);
+  GTSAM_CONCEPT_ASSERT(IsManifold<Camera>);
 }
 
 //******************************************************************************
 TEST(Manifold, SomeLieGroupsGTSAM) {
-  GTSAM_CONCEPT_ASSERT1(IsLieGroup<Rot2>);
-  GTSAM_CONCEPT_ASSERT2(IsLieGroup<Pose2>);
-  GTSAM_CONCEPT_ASSERT3(IsLieGroup<Rot3>);
-  GTSAM_CONCEPT_ASSERT4(IsLieGroup<Pose3>);
+  GTSAM_CONCEPT_ASSERT(IsLieGroup<Rot2>);
+  GTSAM_CONCEPT_ASSERT(IsLieGroup<Pose2>);
+  GTSAM_CONCEPT_ASSERT(IsLieGroup<Rot3>);
+  GTSAM_CONCEPT_ASSERT(IsLieGroup<Pose3>);
 }
 
 //******************************************************************************
 TEST(Manifold, SomeVectorSpacesGTSAM) {
-  GTSAM_CONCEPT_ASSERT1(IsVectorSpace<double>);
-  GTSAM_CONCEPT_ASSERT2(IsVectorSpace<float>);
-  GTSAM_CONCEPT_ASSERT3(IsVectorSpace<Point2>);
-  GTSAM_CONCEPT_ASSERT4(IsVectorSpace<Matrix24>);
+  GTSAM_CONCEPT_ASSERT(IsVectorSpace<double>);
+  GTSAM_CONCEPT_ASSERT(IsVectorSpace<float>);
+  GTSAM_CONCEPT_ASSERT(IsVectorSpace<Point2>);
+  GTSAM_CONCEPT_ASSERT(IsVectorSpace<Matrix24>);
 }
 
 //******************************************************************************


### PR DESCRIPTION
My attempt at quickly hacking a replacement was rather ill-advised, as in debugging expression storage I found it added a large overhead to every data structure including the concepts. I have made GTSAM_CONCEPT_ASSERT a no-op for now, and reverted the semicolon change done in fix/warnings.