### PR TITLE
cmake: explicitly specifying the linker language for gtsam

### DIFF
--- a/gtsam/CMakeLists.txt
+++ b/gtsam/CMakeLists.txt
@@ -133,7 +133,8 @@ set_target_properties(gtsam PROPERTIES
     OUTPUT_NAME         gtsam
     CLEAN_DIRECT_OUTPUT 1
     VERSION             ${gtsam_version}
-    SOVERSION           ${gtsam_soversion})
+    SOVERSION           ${gtsam_soversion}
+    LINKER_LANGUAGE     CXX)
 
 # Append Eigen include path to either
 # system-eigen, or GTSAM eigen path


### PR DESCRIPTION
Integrating upstream from: https://salsa.debian.org/science-team/gtsam/-/blob/master/debian/patches/0004-I-m-explicitly-specifying-the-linker-language-for-gt.patch

cc: original author @dkogan