### PR TITLE
GTSAM_CONCEPT_CHECK Fix

### DIFF
--- a/CppUnitLite/Test.h
+++ b/CppUnitLite/Test.h
@@ -80,7 +80,7 @@ protected:
 #define TEST_UNSAFE(testGroup, testName)\
   class testGroup##testName##Test : public Test \
   { public: testGroup##testName##Test () : Test (#testName "Test", __FILE__, __LINE__, false) {} \
-            virtual ~testGroup##testName##Test () {};\
+            virtual ~testGroup##testName##Test () {} \
             void run (TestResult& result_) override;} \
     testGroup##testName##Instance; \
   void testGroup##testName##Test::run (TestResult& result_)

--- a/gtsam/base/concepts.h
+++ b/gtsam/base/concepts.h
@@ -19,7 +19,7 @@
 // This does something sensible:
 #define BOOST_CONCEPT_USAGE(concept) void check##concept()
 // These just ignore the concept checking for now:
-#define GTSAM_CONCEPT_ASSERT(concept) void*(concept)
+#define GTSAM_CONCEPT_ASSERT(concept) static_assert(true, "")
 #define GTSAM_CONCEPT_REQUIRES(concept, return_type) return_type
 #endif
 

--- a/gtsam/navigation/PreintegrationCombinedParams.h
+++ b/gtsam/navigation/PreintegrationCombinedParams.h
@@ -24,7 +24,6 @@
 
 /* GTSAM includes */
 #include <gtsam/base/Matrix.h>
-#include <gtsam/base/serialization.h>
 #include <gtsam/navigation/ManifoldPreintegration.h>
 #include <gtsam/navigation/PreintegrationCombinedParams.h>
 #include <gtsam/navigation/TangentPreintegration.h>

--- a/gtsam_unstable/nonlinear/ConcurrentBatchSmoother.h
+++ b/gtsam_unstable/nonlinear/ConcurrentBatchSmoother.h
@@ -43,7 +43,7 @@ public:
     double error; ///< The final factor graph error
 
     /// Constructor
-    Result() : iterations(0), lambdas(0), nonlinearVariables(0), linearVariables(0), error(0) {};
+    Result() : iterations(0), lambdas(0), nonlinearVariables(0), linearVariables(0), error(0) {}
 
     /// Getter methods
     size_t getIterations() const { return iterations; }
@@ -54,10 +54,10 @@ public:
   };
 
   /** Default constructor */
-  ConcurrentBatchSmoother(const LevenbergMarquardtParams& parameters = LevenbergMarquardtParams()) : parameters_(parameters) {};
+  ConcurrentBatchSmoother(const LevenbergMarquardtParams& parameters = LevenbergMarquardtParams()) : parameters_(parameters) {}
 
   /** Default destructor */
-  ~ConcurrentBatchSmoother() override {};
+  ~ConcurrentBatchSmoother() override {}
 
   /** Implement a GTSAM standard 'print' function */
   void print(const std::string& s = "Concurrent Batch Smoother:\n", const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override;

--- a/gtsam_unstable/nonlinear/ConcurrentIncrementalFilter.h
+++ b/gtsam_unstable/nonlinear/ConcurrentIncrementalFilter.h
@@ -51,7 +51,7 @@ public:
     double error; ///< The final factor graph error
 
     /// Constructor
-    Result() : iterations(0), nonlinearVariables(0), linearVariables(0), error(0) {};
+    Result() : iterations(0), nonlinearVariables(0), linearVariables(0), error(0) {}
 
     /// Getter methods
     size_t getIterations() const { return iterations; }
@@ -61,10 +61,10 @@ public:
   };
 
   /** Default constructor */
-  ConcurrentIncrementalFilter(const ISAM2Params& parameters = ISAM2Params()) : isam2_(parameters) {};
+  ConcurrentIncrementalFilter(const ISAM2Params& parameters = ISAM2Params()) : isam2_(parameters) {}
 
   /** Default destructor */
-  ~ConcurrentIncrementalFilter() override {};
+  ~ConcurrentIncrementalFilter() override {}
 
   /** Implement a GTSAM standard 'print' function */
   void print(const std::string& s = "Concurrent Incremental Filter:\n", const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override;

--- a/gtsam_unstable/nonlinear/ConcurrentIncrementalSmoother.h
+++ b/gtsam_unstable/nonlinear/ConcurrentIncrementalSmoother.h
@@ -41,7 +41,7 @@ public:
     double error; ///< The final factor graph error
 
     /// Constructor
-    Result() : iterations(0), nonlinearVariables(0), linearVariables(0), error(0) {};
+    Result() : iterations(0), nonlinearVariables(0), linearVariables(0), error(0) {}
 
     /// Getter methods
     size_t getIterations() const { return iterations; }
@@ -51,10 +51,10 @@ public:
   };
 
   /** Default constructor */
-  ConcurrentIncrementalSmoother(const ISAM2Params& parameters = ISAM2Params()) : isam2_(parameters) {};
+  ConcurrentIncrementalSmoother(const ISAM2Params& parameters = ISAM2Params()) : isam2_(parameters) {}
 
   /** Default destructor */
-  ~ConcurrentIncrementalSmoother() override {};
+  ~ConcurrentIncrementalSmoother() override {}
 
   /** Implement a GTSAM standard 'print' function */
   void print(const std::string& s = "Concurrent Incremental Smoother:\n", const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override;


### PR DESCRIPTION
This PR fixes #1490.

Instead of `void*(concept)`, I use `static_assert(true, "")` as a no-op.

I also went ahead and removed extra semi-colons, cleaning up a bunch of warnings that popped up, and removed an unnecessary header from `PreintergratedCombinedParams` that throws errors when Boost is disabled.