### PR TITLE
Fix Windows CI

### DIFF
--- a/cmake/GtsamBuildTypes.cmake
+++ b/cmake/GtsamBuildTypes.cmake
@@ -150,7 +150,7 @@ if (NOT CMAKE_VERSION VERSION_LESS 3.8)
     set(CMAKE_CXX_EXTENSIONS OFF)
     if (MSVC)
       # NOTE(jlblanco): seems to be required in addition to the cxx_std_17 above?
-      list_append_cache(GTSAM_COMPILE_OPTIONS_PUBLIC /std:c++latest)
+      list_append_cache(GTSAM_COMPILE_OPTIONS_PUBLIC /std:c++17)
     endif()
 else()
   # Old cmake versions:


### PR DESCRIPTION
This PR fixes the CI issue with Windows by changing from `/std:c++latest` to `/std:c++17` for Visual Studio.

From my online reading, `/std:c++latest` uses the latest standard for C++ on Windows and this may cause unexpected issues as we experienced. Setting to the C++17 standard explicitly makes things more predictable.