### PR TITLE
Fix JacobianFactor and HessianFactor on platforms where Eigen::Index is not the same size as gtsam::Key  Eigen::Index is defined as std::ptrdiff_t (size_t), which is not always the same size as gtsam::Key (uint64)

### DIFF
--- a/gtsam/linear/HessianFactor.cpp
+++ b/gtsam/linear/HessianFactor.cpp
@@ -38,7 +38,7 @@ using namespace std;
 namespace gtsam {
 
 // Typedefs used in constructors below.
-using Dims = std::vector<Eigen::Index>;
+using Dims = std::vector<Key>;
 
 /* ************************************************************************* */
 void HessianFactor::Allocate(const Scatter& scatter) {

--- a/gtsam/linear/HessianFactor.cpp
+++ b/gtsam/linear/HessianFactor.cpp
@@ -72,7 +72,7 @@ HessianFactor::HessianFactor() :
 
 /* ************************************************************************* */
 HessianFactor::HessianFactor(Key j, const Matrix& G, const Vector& g, double f)
-    : GaussianFactor(KeyVector{j}), info_(Dims{G.cols(), 1}) {
+    : GaussianFactor(KeyVector{j}), info_(Dims{static_cast<Key>(G.cols()), 1}) {
   if (G.rows() != G.cols() || G.rows() != g.size())
     throw invalid_argument(
         "Attempting to construct HessianFactor with inconsistent matrix and/or vector dimensions");
@@ -85,7 +85,7 @@ HessianFactor::HessianFactor(Key j, const Matrix& G, const Vector& g, double f)
 // error is 0.5*(x-mu)'*inv(Sigma)*(x-mu) = 0.5*(x'*G*x - 2*x'*G*mu + mu'*G*mu)
 // where G = inv(Sigma), g = G*mu, f = mu'*G*mu = mu'*g
 HessianFactor::HessianFactor(Key j, const Vector& mu, const Matrix& Sigma)
-    : GaussianFactor(KeyVector{j}), info_(Dims{Sigma.cols(), 1}) {
+    : GaussianFactor(KeyVector{j}), info_(Dims{static_cast<Key>(Sigma.cols()), 1}) {
   if (Sigma.rows() != Sigma.cols() || Sigma.rows() != mu.size())
     throw invalid_argument(
         "Attempting to construct HessianFactor with inconsistent matrix and/or vector dimensions");
@@ -99,7 +99,7 @@ HessianFactor::HessianFactor(Key j1, Key j2, const Matrix& G11,
     const Matrix& G12, const Vector& g1, const Matrix& G22, const Vector& g2,
     double f) :
     GaussianFactor(KeyVector{j1,j2}), info_(
-        Dims{G11.cols(),G22.cols(),1}) {
+        Dims{static_cast<Key>(G11.cols()),static_cast<Key>(G22.cols()),1}) {
   info_.setDiagonalBlock(0, G11);
   info_.setOffDiagonalBlock(0, 1, G12);
   info_.setDiagonalBlock(1, G22);
@@ -113,7 +113,7 @@ HessianFactor::HessianFactor(Key j1, Key j2, Key j3, const Matrix& G11,
     const Matrix& G23, const Vector& g2, const Matrix& G33, const Vector& g3,
     double f) :
     GaussianFactor(KeyVector{j1,j2,j3}), info_(
-        Dims{G11.cols(),G22.cols(),G33.cols(),1}) {
+        Dims{static_cast<Key>(G11.cols()),static_cast<Key>(G22.cols()),static_cast<Key>(G33.cols()),1}) {
   if (G11.rows() != G11.cols() || G11.rows() != G12.rows()
       || G11.rows() != G13.rows() || G11.rows() != g1.size()
       || G22.cols() != G12.cols() || G33.cols() != G13.cols()

--- a/gtsam/linear/JacobianFactor.cpp
+++ b/gtsam/linear/JacobianFactor.cpp
@@ -40,8 +40,8 @@ using namespace std;
 namespace gtsam {
 
 // Typedefs used in constructors below.
-using Dims = std::vector<Eigen::Index>;
-using Pairs = std::vector<std::pair<Eigen::Index, Matrix>>;
+using Dims = std::vector<Key>;
+using Pairs = std::vector<std::pair<Key, Matrix>>;
 
 /* ************************************************************************* */
 JacobianFactor::JacobianFactor() :


### PR DESCRIPTION
Fix JacobianFactor and HessianFactor on platforms where Eigen::Index is not the same size as gtsam::Key

Eigen::Index is defined as std::ptrdiff_t (size_t), which is not always the same size as gtsam::Key (uint64)

On platform where they are different, buildDamped for example will add Factors with wrong keys which dangles and cannot be eliminate, causing solver to fail.

Leaving tests unchanged since they have their own private definition using Dims = std::vector<Eigen::Index>; which doesn't break.