### PR TITLE
Wapper Update

### DIFF
--- a/matlab/gtsam_tests/testEnum.m
+++ b/matlab/gtsam_tests/testEnum.m
@@ -1,0 +1,12 @@
+% test Enum
+import gtsam.*;
+
+params = GncLMParams();
+
+EXPECT('Get lossType',params.lossType==GncLossType.TLS);
+
+params.lossType = GncLossType.GM;
+EXPECT('Set lossType',params.lossType==GncLossType.GM);
+
+params.setLossType(GncLossType.TLS);
+EXPECT('setLossType',params.lossType==GncLossType.TLS);

--- a/wrap/.github/workflows/linux-ci.yml
+++ b/wrap/.github/workflows/linux-ci.yml
@@ -5,12 +5,12 @@ on: [pull_request]
 jobs:
   build:
     name: Tests for 🐍 ${{ matrix.python-version }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - name: Checkout
@@ -19,7 +19,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get -y update
-          sudo apt install cmake build-essential pkg-config libpython-dev python-numpy libboost-all-dev
+          sudo apt install cmake build-essential pkg-config libpython3-dev python3-numpy libboost-all-dev
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/wrap/.github/workflows/macos-ci.yml
+++ b/wrap/.github/workflows/macos-ci.yml
@@ -5,12 +5,12 @@ on: [pull_request]
 jobs:
   build:
     name: Tests for 🐍 ${{ matrix.python-version }}
-    runs-on: macos-10.15
+    runs-on: macos-12
 
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - name: Checkout

--- a/wrap/gtwrap/matlab_wrapper/mixins.py
+++ b/wrap/gtwrap/matlab_wrapper/mixins.py
@@ -60,6 +60,11 @@ class CheckMixin:
                arg_type.typename.name not in self.not_ptr_type and \
                arg_type.is_ref
 
+    def is_class_enum(self, arg_type: parser.Type, class_: parser.Class):
+        """Check if `arg_type` is an enum in the class `class_`."""
+        enums = (enum.name for enum in class_.enums)
+        return arg_type.ctype.typename.name in enums
+
 
 class FormatMixin:
     """Mixin to provide formatting utilities."""

--- a/wrap/gtwrap/matlab_wrapper/templates.py
+++ b/wrap/gtwrap/matlab_wrapper/templates.py
@@ -1,3 +1,5 @@
+"""Code generation templates for the Matlab wrapper."""
+
 import textwrap
 
 

--- a/wrap/tests/expected/matlab/+Pet/Kind.m
+++ b/wrap/tests/expected/matlab/+Pet/Kind.m
@@ -1,0 +1,6 @@
+classdef Kind < uint32
+    enumeration
+        Dog(0)
+        Cat(1)
+    end
+end

--- a/wrap/tests/expected/matlab/+gtsam/+MCU/Avengers.m
+++ b/wrap/tests/expected/matlab/+gtsam/+MCU/Avengers.m
@@ -1,0 +1,9 @@
+classdef Avengers < uint32
+    enumeration
+        CaptainAmerica(0)
+        IronMan(1)
+        Hulk(2)
+        Hawkeye(3)
+        Thor(4)
+    end
+end

--- a/wrap/tests/expected/matlab/+gtsam/+MCU/GotG.m
+++ b/wrap/tests/expected/matlab/+gtsam/+MCU/GotG.m
@@ -1,0 +1,9 @@
+classdef GotG < uint32
+    enumeration
+        Starlord(0)
+        Gamorra(1)
+        Rocket(2)
+        Drax(3)
+        Groot(4)
+    end
+end

--- a/wrap/tests/expected/matlab/+gtsam/+OptimizerGaussNewtonParams/Verbosity.m
+++ b/wrap/tests/expected/matlab/+gtsam/+OptimizerGaussNewtonParams/Verbosity.m
@@ -1,0 +1,7 @@
+classdef Verbosity < uint32
+    enumeration
+        SILENT(0)
+        SUMMARY(1)
+        VERBOSE(2)
+    end
+end

--- a/wrap/tests/expected/matlab/+gtsam/VerbosityLM.m
+++ b/wrap/tests/expected/matlab/+gtsam/VerbosityLM.m
@@ -1,0 +1,12 @@
+classdef VerbosityLM < uint32
+    enumeration
+        SILENT(0)
+        SUMMARY(1)
+        TERMINATION(2)
+        LAMBDA(3)
+        TRYLAMBDA(4)
+        TRYCONFIG(5)
+        DAMPED(6)
+        TRYDELTA(7)
+    end
+end

--- a/wrap/tests/expected/matlab/Color.m
+++ b/wrap/tests/expected/matlab/Color.m
@@ -1,0 +1,7 @@
+classdef Color < uint32
+    enumeration
+        Red(0)
+        Green(1)
+        Blue(2)
+    end
+end

--- a/wrap/tests/expected/matlab/enum_wrapper.cpp
+++ b/wrap/tests/expected/matlab/enum_wrapper.cpp
@@ -1,0 +1,266 @@
+#include <gtwrap/matlab.h>
+#include <map>
+
+
+
+typedef gtsam::Optimizer<gtsam::GaussNewtonParams> OptimizerGaussNewtonParams;
+
+typedef std::set<std::shared_ptr<Pet>*> Collector_Pet;
+static Collector_Pet collector_Pet;
+typedef std::set<std::shared_ptr<gtsam::MCU>*> Collector_gtsamMCU;
+static Collector_gtsamMCU collector_gtsamMCU;
+typedef std::set<std::shared_ptr<OptimizerGaussNewtonParams>*> Collector_gtsamOptimizerGaussNewtonParams;
+static Collector_gtsamOptimizerGaussNewtonParams collector_gtsamOptimizerGaussNewtonParams;
+
+
+void _deleteAllObjects()
+{
+  mstream mout;
+  std::streambuf *outbuf = std::cout.rdbuf(&mout);
+
+  bool anyDeleted = false;
+  { for(Collector_Pet::iterator iter = collector_Pet.begin();
+      iter != collector_Pet.end(); ) {
+    delete *iter;
+    collector_Pet.erase(iter++);
+    anyDeleted = true;
+  } }
+  { for(Collector_gtsamMCU::iterator iter = collector_gtsamMCU.begin();
+      iter != collector_gtsamMCU.end(); ) {
+    delete *iter;
+    collector_gtsamMCU.erase(iter++);
+    anyDeleted = true;
+  } }
+  { for(Collector_gtsamOptimizerGaussNewtonParams::iterator iter = collector_gtsamOptimizerGaussNewtonParams.begin();
+      iter != collector_gtsamOptimizerGaussNewtonParams.end(); ) {
+    delete *iter;
+    collector_gtsamOptimizerGaussNewtonParams.erase(iter++);
+    anyDeleted = true;
+  } }
+
+  if(anyDeleted)
+    cout <<
+      "WARNING:  Wrap modules with variables in the workspace have been reloaded due to\n"
+      "calling destructors, call 'clear all' again if you plan to now recompile a wrap\n"
+      "module, so that your recompiled module is used instead of the old one." << endl;
+  std::cout.rdbuf(outbuf);
+}
+
+void _enum_RTTIRegister() {
+  const mxArray *alreadyCreated = mexGetVariablePtr("global", "gtsam_enum_rttiRegistry_created");
+  if(!alreadyCreated) {
+    std::map<std::string, std::string> types;
+
+
+
+    mxArray *registry = mexGetVariable("global", "gtsamwrap_rttiRegistry");
+    if(!registry)
+      registry = mxCreateStructMatrix(1, 1, 0, NULL);
+    typedef std::pair<std::string, std::string> StringPair;
+    for(const StringPair& rtti_matlab: types) {
+      int fieldId = mxAddField(registry, rtti_matlab.first.c_str());
+      if(fieldId < 0) {
+        mexErrMsgTxt("gtsam wrap:  Error indexing RTTI types, inheritance will not work correctly");
+      }
+      mxArray *matlabName = mxCreateString(rtti_matlab.second.c_str());
+      mxSetFieldByNumber(registry, 0, fieldId, matlabName);
+    }
+    if(mexPutVariable("global", "gtsamwrap_rttiRegistry", registry) != 0) {
+      mexErrMsgTxt("gtsam wrap:  Error indexing RTTI types, inheritance will not work correctly");
+    }
+    mxDestroyArray(registry);
+
+    mxArray *newAlreadyCreated = mxCreateNumericMatrix(0, 0, mxINT8_CLASS, mxREAL);
+    if(mexPutVariable("global", "gtsam_enum_rttiRegistry_created", newAlreadyCreated) != 0) {
+      mexErrMsgTxt("gtsam wrap:  Error indexing RTTI types, inheritance will not work correctly");
+    }
+    mxDestroyArray(newAlreadyCreated);
+  }
+}
+
+void Pet_collectorInsertAndMakeBase_0(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mexAtExit(&_deleteAllObjects);
+  typedef std::shared_ptr<Pet> Shared;
+
+  Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
+  collector_Pet.insert(self);
+}
+
+void Pet_constructor_1(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mexAtExit(&_deleteAllObjects);
+  typedef std::shared_ptr<Pet> Shared;
+
+  string& name = *unwrap_shared_ptr< string >(in[0], "ptr_string");
+  std::shared_ptr<Pet::Kind> type = unwrap_enum<Pet::Kind>(in[1]);
+  Shared *self = new Shared(new Pet(name,*type));
+  collector_Pet.insert(self);
+  out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
+  *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
+}
+
+void Pet_deconstructor_2(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  typedef std::shared_ptr<Pet> Shared;
+  checkArguments("delete_Pet",nargout,nargin,1);
+  Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
+  Collector_Pet::iterator item;
+  item = collector_Pet.find(self);
+  if(item != collector_Pet.end()) {
+    collector_Pet.erase(item);
+  }
+  delete self;
+}
+
+void Pet_get_name_3(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("name",nargout,nargin-1,0);
+  auto obj = unwrap_shared_ptr<Pet>(in[0], "ptr_Pet");
+  out[0] = wrap< string >(obj->name);
+}
+
+void Pet_set_name_4(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("name",nargout,nargin-1,1);
+  auto obj = unwrap_shared_ptr<Pet>(in[0], "ptr_Pet");
+  string name = unwrap< string >(in[1]);
+  obj->name = name;
+}
+
+void Pet_get_type_5(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("type",nargout,nargin-1,0);
+  auto obj = unwrap_shared_ptr<Pet>(in[0], "ptr_Pet");
+  out[0] = wrap_enum(obj->type,"Pet.Kind");
+}
+
+void Pet_set_type_6(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("type",nargout,nargin-1,1);
+  auto obj = unwrap_shared_ptr<Pet>(in[0], "ptr_Pet");
+  std::shared_ptr<Pet::Kind> type = unwrap_enum<Pet::Kind>(in[1]);
+  obj->type = *type;
+}
+
+void gtsamMCU_collectorInsertAndMakeBase_7(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mexAtExit(&_deleteAllObjects);
+  typedef std::shared_ptr<gtsam::MCU> Shared;
+
+  Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
+  collector_gtsamMCU.insert(self);
+}
+
+void gtsamMCU_constructor_8(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mexAtExit(&_deleteAllObjects);
+  typedef std::shared_ptr<gtsam::MCU> Shared;
+
+  Shared *self = new Shared(new gtsam::MCU());
+  collector_gtsamMCU.insert(self);
+  out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
+  *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
+}
+
+void gtsamMCU_deconstructor_9(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  typedef std::shared_ptr<gtsam::MCU> Shared;
+  checkArguments("delete_gtsamMCU",nargout,nargin,1);
+  Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
+  Collector_gtsamMCU::iterator item;
+  item = collector_gtsamMCU.find(self);
+  if(item != collector_gtsamMCU.end()) {
+    collector_gtsamMCU.erase(item);
+  }
+  delete self;
+}
+
+void gtsamOptimizerGaussNewtonParams_collectorInsertAndMakeBase_10(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mexAtExit(&_deleteAllObjects);
+  typedef std::shared_ptr<gtsam::Optimizer<gtsam::GaussNewtonParams>> Shared;
+
+  Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
+  collector_gtsamOptimizerGaussNewtonParams.insert(self);
+}
+
+void gtsamOptimizerGaussNewtonParams_deconstructor_11(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  typedef std::shared_ptr<gtsam::Optimizer<gtsam::GaussNewtonParams>> Shared;
+  checkArguments("delete_gtsamOptimizerGaussNewtonParams",nargout,nargin,1);
+  Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
+  Collector_gtsamOptimizerGaussNewtonParams::iterator item;
+  item = collector_gtsamOptimizerGaussNewtonParams.find(self);
+  if(item != collector_gtsamOptimizerGaussNewtonParams.end()) {
+    collector_gtsamOptimizerGaussNewtonParams.erase(item);
+  }
+  delete self;
+}
+
+void gtsamOptimizerGaussNewtonParams_setVerbosity_12(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("setVerbosity",nargout,nargin-1,1);
+  auto obj = unwrap_shared_ptr<gtsam::Optimizer<gtsam::GaussNewtonParams>>(in[0], "ptr_gtsamOptimizerGaussNewtonParams");
+  std::shared_ptr<Optimizer<gtsam::GaussNewtonParams>::Verbosity> value = unwrap_enum<Optimizer<gtsam::GaussNewtonParams>::Verbosity>(in[1]);
+  obj->setVerbosity(*value);
+}
+
+
+void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mstream mout;
+  std::streambuf *outbuf = std::cout.rdbuf(&mout);
+
+  _enum_RTTIRegister();
+
+  int id = unwrap<int>(in[0]);
+
+  try {
+    switch(id) {
+    case 0:
+      Pet_collectorInsertAndMakeBase_0(nargout, out, nargin-1, in+1);
+      break;
+    case 1:
+      Pet_constructor_1(nargout, out, nargin-1, in+1);
+      break;
+    case 2:
+      Pet_deconstructor_2(nargout, out, nargin-1, in+1);
+      break;
+    case 3:
+      Pet_get_name_3(nargout, out, nargin-1, in+1);
+      break;
+    case 4:
+      Pet_set_name_4(nargout, out, nargin-1, in+1);
+      break;
+    case 5:
+      Pet_get_type_5(nargout, out, nargin-1, in+1);
+      break;
+    case 6:
+      Pet_set_type_6(nargout, out, nargin-1, in+1);
+      break;
+    case 7:
+      gtsamMCU_collectorInsertAndMakeBase_7(nargout, out, nargin-1, in+1);
+      break;
+    case 8:
+      gtsamMCU_constructor_8(nargout, out, nargin-1, in+1);
+      break;
+    case 9:
+      gtsamMCU_deconstructor_9(nargout, out, nargin-1, in+1);
+      break;
+    case 10:
+      gtsamOptimizerGaussNewtonParams_collectorInsertAndMakeBase_10(nargout, out, nargin-1, in+1);
+      break;
+    case 11:
+      gtsamOptimizerGaussNewtonParams_deconstructor_11(nargout, out, nargin-1, in+1);
+      break;
+    case 12:
+      gtsamOptimizerGaussNewtonParams_setVerbosity_12(nargout, out, nargin-1, in+1);
+      break;
+    }
+  } catch(const std::exception& e) {
+    mexErrMsgTxt(("Exception from gtsam:\n" + std::string(e.what()) + "\n").c_str());
+  }
+
+  std::cout.rdbuf(outbuf);
+}

--- a/wrap/tests/expected/matlab/special_cases_wrapper.cpp
+++ b/wrap/tests/expected/matlab/special_cases_wrapper.cpp
@@ -204,14 +204,14 @@ void gtsamGeneralSFMFactorCal3Bundler_get_verbosity_11(int nargout, mxArray *out
 {
   checkArguments("verbosity",nargout,nargin-1,0);
   auto obj = unwrap_shared_ptr<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>>(in[0], "ptr_gtsamGeneralSFMFactorCal3Bundler");
-  out[0] = wrap_shared_ptr(std::make_shared<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>::Verbosity>(obj->verbosity),"gtsam.GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>.Verbosity", false);
+  out[0] = wrap_enum(obj->verbosity,"gtsam.GeneralSFMFactorCal3Bundler.Verbosity");
 }
 
 void gtsamGeneralSFMFactorCal3Bundler_set_verbosity_12(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("verbosity",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>>(in[0], "ptr_gtsamGeneralSFMFactorCal3Bundler");
-  std::shared_ptr<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>::Verbosity> verbosity = unwrap_shared_ptr< gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>::Verbosity >(in[1], "ptr_gtsamGeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>Verbosity");
+  std::shared_ptr<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>::Verbosity> verbosity = unwrap_enum<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>::Verbosity>(in[1]);
   obj->verbosity = *verbosity;
 }
 

--- a/wrap/tests/test_matlab_wrapper.py
+++ b/wrap/tests/test_matlab_wrapper.py
@@ -141,6 +141,32 @@ class TestWrap(unittest.TestCase):
             actual = osp.join(self.MATLAB_ACTUAL_DIR, file)
             self.compare_and_diff(file, actual)
 
+    def test_enum(self):
+        """Test interface file with only enum info."""
+        file = osp.join(self.INTERFACE_DIR, 'enum.i')
+
+        wrapper = MatlabWrapper(
+            module_name='enum',
+            top_module_namespace=['gtsam'],
+            ignore_classes=[''],
+        )
+
+        wrapper.wrap([file], path=self.MATLAB_ACTUAL_DIR)
+
+        files = [
+            'enum_wrapper.cpp',
+            'Color.m',
+            '+Pet/Kind.m',
+            '+gtsam/VerbosityLM.m',
+            '+gtsam/+MCU/Avengers.m',
+            '+gtsam/+MCU/GotG.m',
+            '+gtsam/+OptimizerGaussNewtonParams/Verbosity.m',
+        ]
+
+        for file in files:
+            actual = osp.join(self.MATLAB_ACTUAL_DIR, file)
+            self.compare_and_diff(file, actual)
+
     def test_templates(self):
         """Test interface file with template info."""
         file = osp.join(self.INTERFACE_DIR, 'templates.i')


### PR DESCRIPTION
Update the Matlab wrapper with enum support.

520dbca0f Merge pull request #158 from borglab/matlab-enum-support
661daf0dd fix python version specification
6f9111ddb fix python install
691e47734 update CI to newer OS versions
579539b1c finish wrapping
474aece68 fix issue in _collector_return
660c21bcc wrap enum types in cpp
1fa5c2756 begin updating generated cpp for enums
7b156a3f5 add wrap_enum and unwrap_enum helper functions
2a5423061 finish wrapping every part of enum.i
68cfa8a51 wrap enums inside classes
ce734fa9f wrap enums declared on their own
66c84e5cb unit test for enum wrapping in matlab
1cc126669 module docstring for matlab_wrapper/templates.py

git-subtree-dir: wrap
git-subtree-split: 520dbca0f2c3db4d30f0a0fd020a729cc0caa7b7