### PR TITLE
4.2: Fix an invalid include, restore C++11 compatibility

### DIFF
--- a/gtsam/sfm/DsfTrackGenerator.h
+++ b/gtsam/sfm/DsfTrackGenerator.h
@@ -20,9 +20,10 @@
 #include <gtsam/base/DSFMap.h>
 #include <gtsam/sfm/SfmTrack.h>
 
+#include <boost/optional.hpp>
+
 #include <Eigen/Core>
 #include <map>
-#include <optional>
 #include <vector>
 
 namespace gtsam {


### PR DESCRIPTION
C++11 compatibility in 4.2a9 is currently broken due to this single minor bug.

Cropped up in https://github.com/conan-io/conan-center-index/pull/17933