### PR TITLE
Make Basis factors dynamic

### DIFF
--- a/gtsam/basis/Basis.cpp
+++ b/gtsam/basis/Basis.cpp
@@ -1,0 +1,33 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file Basis.cpp
+ * @brief Compute an interpolating basis
+ * @author Varun Agrawal
+ * @date June 20, 2023
+ */
+
+#include <gtsam/basis/Basis.h>
+
+namespace gtsam {
+
+Matrix kroneckerProductIdentity(size_t M, const Weights& w) {
+  Matrix result(M, w.cols() * M);
+  result.setZero();
+
+  for (int i = 0; i < w.cols(); i++) {
+    result.block(0, i * M, M, M).diagonal().array() = w(i);
+  }
+  return result;
+}
+
+}  // namespace gtsam

--- a/gtsam/basis/Basis.h
+++ b/gtsam/basis/Basis.h
@@ -81,16 +81,7 @@ using Weights = Eigen::Matrix<double, 1, -1>; /* 1xN vector */
  *
  * @ingroup basis
  */
-template <size_t M>
-Matrix kroneckerProductIdentity(const Weights& w) {
-  Matrix result(M, w.cols() * M);
-  result.setZero();
-
-  for (int i = 0; i < w.cols(); i++) {
-    result.block(0, i * M, M, M).diagonal().array() = w(i);
-  }
-  return result;
-}
+Matrix kroneckerProductIdentity(size_t M, const Weights& w);
 
 /**
  * CRTP Base class for function bases
@@ -174,12 +165,12 @@ class Basis {
    * value x. When given a specific M*N parameters, returns an M-vector the M
    * corresponding functions at x, possibly with Jacobians wrpt the parameters.
    */
-  template <int M>
   class VectorEvaluationFunctor : protected EvaluationFunctor {
    protected:
-    using VectorM = Eigen::Matrix<double, M, 1>;
-    using Jacobian = Eigen::Matrix<double, /*MxMN*/ M, -1>;
+    using Jacobian = Eigen::Matrix<double, /*MxMN*/ -1, -1>;
     Jacobian H_;
+
+    size_t M_;
 
     /**
      * Calculate the `M*(M*N)` Jacobian of this functor with respect to
@@ -190,7 +181,7 @@ class Basis {
      * i.e., the Kronecker product of weights_ with the MxM identity matrix.
      */
     void calculateJacobian() {
-      H_ = kroneckerProductIdentity<M>(this->weights_);
+      H_ = kroneckerProductIdentity(M_, this->weights_);
     }
 
    public:
@@ -200,26 +191,27 @@ class Basis {
     VectorEvaluationFunctor() {}
 
     /// Default Constructor
-    VectorEvaluationFunctor(size_t N, double x) : EvaluationFunctor(N, x) {
+    VectorEvaluationFunctor(size_t M, size_t N, double x)
+        : EvaluationFunctor(N, x), M_(M) {
       calculateJacobian();
     }
 
     /// Constructor, with interval [a,b]
-    VectorEvaluationFunctor(size_t N, double x, double a, double b)
-        : EvaluationFunctor(N, x, a, b) {
+    VectorEvaluationFunctor(size_t M, size_t N, double x, double a, double b)
+        : EvaluationFunctor(N, x, a, b), M_(M) {
       calculateJacobian();
     }
 
     /// M-dimensional evaluation
-    VectorM apply(const ParameterMatrix& P,
-                  OptionalJacobian</*MxN*/ -1, -1> H = {}) const {
+    Vector apply(const ParameterMatrix& P,
+                 OptionalJacobian</*MxN*/ -1, -1> H = {}) const {
       if (H) *H = H_;
       return P.matrix() * this->weights_.transpose();
     }
 
     /// c++ sugar
-    VectorM operator()(const ParameterMatrix& P,
-                       OptionalJacobian</*MxN*/ -1, -1> H = {}) const {
+    Vector operator()(const ParameterMatrix& P,
+                      OptionalJacobian</*MxN*/ -1, -1> H = {}) const {
       return apply(P, H);
     }
   };
@@ -231,12 +223,13 @@ class Basis {
    *
    * This component is specified by the row index i, with 0<i<M.
    */
-  template <int M>
   class VectorComponentFunctor : public EvaluationFunctor {
    protected:
     using Jacobian = Eigen::Matrix<double, /*1xMN*/ 1, -1>;
-    size_t rowIndex_;
     Jacobian H_;
+
+    size_t M_;
+    size_t rowIndex_;
 
     /*
      * Calculate the `1*(M*N)` Jacobian of this functor with respect to
@@ -248,9 +241,9 @@ class Basis {
      * MxM identity matrix. See also VectorEvaluationFunctor.
      */
     void calculateJacobian(size_t N) {
-      H_.setZero(1, M * N);
+      H_.setZero(1, M_ * N);
       for (int j = 0; j < EvaluationFunctor::weights_.size(); j++)
-        H_(0, rowIndex_ + j * M) = EvaluationFunctor::weights_(j);
+        H_(0, rowIndex_ + j * M_) = EvaluationFunctor::weights_(j);
     }
 
    public:
@@ -258,14 +251,15 @@ class Basis {
     VectorComponentFunctor() {}
 
     /// Construct with row index
-    VectorComponentFunctor(size_t N, size_t i, double x)
-        : EvaluationFunctor(N, x), rowIndex_(i) {
+    VectorComponentFunctor(size_t M, size_t N, size_t i, double x)
+        : EvaluationFunctor(N, x), M_(M), rowIndex_(i) {
       calculateJacobian(N);
     }
 
     /// Construct with row index and interval
-    VectorComponentFunctor(size_t N, size_t i, double x, double a, double b)
-        : EvaluationFunctor(N, x, a, b), rowIndex_(i) {
+    VectorComponentFunctor(size_t M, size_t N, size_t i, double x, double a,
+                           double b)
+        : EvaluationFunctor(N, x, a, b), M_(M), rowIndex_(i) {
       calculateJacobian(N);
     }
 
@@ -297,21 +291,20 @@ class Basis {
    * 3D rotation.
    */
   template <class T>
-  class ManifoldEvaluationFunctor
-      : public VectorEvaluationFunctor<traits<T>::dimension> {
+  class ManifoldEvaluationFunctor : public VectorEvaluationFunctor {
     enum { M = traits<T>::dimension };
-    using Base = VectorEvaluationFunctor<M>;
+    using Base = VectorEvaluationFunctor;
 
    public:
     /// For serialization
     ManifoldEvaluationFunctor() {}
 
     /// Default Constructor
-    ManifoldEvaluationFunctor(size_t N, double x) : Base(N, x) {}
+    ManifoldEvaluationFunctor(size_t N, double x) : Base(M, N, x) {}
 
     /// Constructor, with interval [a,b]
     ManifoldEvaluationFunctor(size_t N, double x, double a, double b)
-        : Base(N, x, a, b) {}
+        : Base(M, N, x, a, b) {}
 
     /// Manifold evaluation
     T apply(const ParameterMatrix& P,
@@ -396,12 +389,12 @@ class Basis {
    * returns an M-vector the M corresponding function derivatives at x, possibly
    * with Jacobians wrpt the parameters.
    */
-  template <int M>
   class VectorDerivativeFunctor : protected DerivativeFunctorBase {
    protected:
-    using VectorM = Eigen::Matrix<double, M, 1>;
-    using Jacobian = Eigen::Matrix<double, /*MxMN*/ M, -1>;
+    using Jacobian = Eigen::Matrix<double, /*MxMN*/ -1, -1>;
     Jacobian H_;
+
+    size_t M_;
 
     /**
      * Calculate the `M*(M*N)` Jacobian of this functor with respect to
@@ -412,7 +405,7 @@ class Basis {
      * i.e., the Kronecker product of weights_ with the MxM identity matrix.
      */
     void calculateJacobian() {
-      H_ = kroneckerProductIdentity<M>(this->weights_);
+      H_ = kroneckerProductIdentity(M_, this->weights_);
     }
 
    public:
@@ -422,24 +415,25 @@ class Basis {
     VectorDerivativeFunctor() {}
 
     /// Default Constructor
-    VectorDerivativeFunctor(size_t N, double x) : DerivativeFunctorBase(N, x) {
+    VectorDerivativeFunctor(size_t M, size_t N, double x)
+        : DerivativeFunctorBase(N, x), M_(M) {
       calculateJacobian();
     }
 
     /// Constructor, with optional interval [a,b]
-    VectorDerivativeFunctor(size_t N, double x, double a, double b)
-        : DerivativeFunctorBase(N, x, a, b) {
+    VectorDerivativeFunctor(size_t M, size_t N, double x, double a, double b)
+        : DerivativeFunctorBase(N, x, a, b), M_(M) {
       calculateJacobian();
     }
 
-    VectorM apply(const ParameterMatrix& P,
-                  OptionalJacobian</*MxMN*/ -1, -1> H = {}) const {
+    Vector apply(const ParameterMatrix& P,
+                 OptionalJacobian</*MxMN*/ -1, -1> H = {}) const {
       if (H) *H = H_;
       return P.matrix() * this->weights_.transpose();
     }
     /// c++ sugar
-    VectorM operator()(const ParameterMatrix& P,
-                       OptionalJacobian</*MxMN*/ -1, -1> H = {}) const {
+    Vector operator()(const ParameterMatrix& P,
+                      OptionalJacobian</*MxMN*/ -1, -1> H = {}) const {
       return apply(P, H);
     }
   };
@@ -451,12 +445,13 @@ class Basis {
    *
    * This component is specified by the row index i, with 0<i<M.
    */
-  template <int M>
   class ComponentDerivativeFunctor : protected DerivativeFunctorBase {
    protected:
     using Jacobian = Eigen::Matrix<double, /*1xMN*/ 1, -1>;
-    size_t rowIndex_;
     Jacobian H_;
+
+    size_t M_;
+    size_t rowIndex_;
 
     /*
      * Calculate the `1*(M*N)` Jacobian of this functor with respect to
@@ -468,9 +463,9 @@ class Basis {
      * MxM identity matrix. See also VectorDerivativeFunctor.
      */
     void calculateJacobian(size_t N) {
-      H_.setZero(1, M * N);
+      H_.setZero(1, M_ * N);
       for (int j = 0; j < this->weights_.size(); j++)
-        H_(0, rowIndex_ + j * M) = this->weights_(j);
+        H_(0, rowIndex_ + j * M_) = this->weights_(j);
     }
 
    public:
@@ -478,14 +473,15 @@ class Basis {
     ComponentDerivativeFunctor() {}
 
     /// Construct with row index
-    ComponentDerivativeFunctor(size_t N, size_t i, double x)
-        : DerivativeFunctorBase(N, x), rowIndex_(i) {
+    ComponentDerivativeFunctor(size_t M, size_t N, size_t i, double x)
+        : DerivativeFunctorBase(N, x), M_(M), rowIndex_(i) {
       calculateJacobian(N);
     }
 
     /// Construct with row index and interval
-    ComponentDerivativeFunctor(size_t N, size_t i, double x, double a, double b)
-        : DerivativeFunctorBase(N, x, a, b), rowIndex_(i) {
+    ComponentDerivativeFunctor(size_t M, size_t N, size_t i, double x, double a,
+                               double b)
+        : DerivativeFunctorBase(N, x, a, b), M_(M), rowIndex_(i) {
       calculateJacobian(N);
     }
     /// Calculate derivative of component rowIndex_ of F

--- a/gtsam/basis/Basis.h
+++ b/gtsam/basis/Basis.h
@@ -169,7 +169,7 @@ class Basis {
   };
 
   /**
-   * VectorEvaluationFunctor at a given x, applied to ParameterMatrix<M>.
+   * VectorEvaluationFunctor at a given x, applied to ParameterMatrix.
    * This functor is used to evaluate a parameterized function at a given scalar
    * value x. When given a specific M*N parameters, returns an M-vector the M
    * corresponding functions at x, possibly with Jacobians wrpt the parameters.
@@ -211,14 +211,14 @@ class Basis {
     }
 
     /// M-dimensional evaluation
-    VectorM apply(const ParameterMatrix<M>& P,
+    VectorM apply(const ParameterMatrix& P,
                   OptionalJacobian</*MxN*/ -1, -1> H = {}) const {
       if (H) *H = H_;
       return P.matrix() * this->weights_.transpose();
     }
 
     /// c++ sugar
-    VectorM operator()(const ParameterMatrix<M>& P,
+    VectorM operator()(const ParameterMatrix& P,
                        OptionalJacobian</*MxN*/ -1, -1> H = {}) const {
       return apply(P, H);
     }
@@ -270,21 +270,21 @@ class Basis {
     }
 
     /// Calculate component of component rowIndex_ of P
-    double apply(const ParameterMatrix<M>& P,
+    double apply(const ParameterMatrix& P,
                  OptionalJacobian</*1xMN*/ -1, -1> H = {}) const {
       if (H) *H = H_;
       return P.row(rowIndex_) * EvaluationFunctor::weights_.transpose();
     }
 
     /// c++ sugar
-    double operator()(const ParameterMatrix<M>& P,
+    double operator()(const ParameterMatrix& P,
                       OptionalJacobian</*1xMN*/ -1, -1> H = {}) const {
       return apply(P, H);
     }
   };
 
   /**
-   * Manifold EvaluationFunctor at a given x, applied to ParameterMatrix<M>.
+   * Manifold EvaluationFunctor at a given x, applied to ParameterMatrix.
    * This functor is used to evaluate a parameterized function at a given scalar
    * value x. When given a specific M*N parameters, returns an M-vector the M
    * corresponding functions at x, possibly with Jacobians wrpt the parameters.
@@ -314,7 +314,7 @@ class Basis {
         : Base(N, x, a, b) {}
 
     /// Manifold evaluation
-    T apply(const ParameterMatrix<M>& P,
+    T apply(const ParameterMatrix& P,
             OptionalJacobian</*MxMN*/ -1, -1> H = {}) const {
       // Interpolate the M-dimensional vector to yield a vector in tangent space
       Eigen::Matrix<double, M, 1> xi = Base::operator()(P, H);
@@ -333,7 +333,7 @@ class Basis {
     }
 
     /// c++ sugar
-    T operator()(const ParameterMatrix<M>& P,
+    T operator()(const ParameterMatrix& P,
                  OptionalJacobian</*MxN*/ -1, -1> H = {}) const {
       return apply(P, H);  // might call apply in derived
     }
@@ -389,7 +389,7 @@ class Basis {
   };
 
   /**
-   * VectorDerivativeFunctor at a given x, applied to ParameterMatrix<M>.
+   * VectorDerivativeFunctor at a given x, applied to ParameterMatrix.
    *
    * This functor is used to evaluate the derivatives of a parameterized
    * function at a given scalar value x. When given a specific M*N parameters,
@@ -432,15 +432,14 @@ class Basis {
       calculateJacobian();
     }
 
-    VectorM apply(const ParameterMatrix<M>& P,
+    VectorM apply(const ParameterMatrix& P,
                   OptionalJacobian</*MxMN*/ -1, -1> H = {}) const {
       if (H) *H = H_;
       return P.matrix() * this->weights_.transpose();
     }
     /// c++ sugar
-    VectorM operator()(
-        const ParameterMatrix<M>& P,
-        OptionalJacobian</*MxMN*/ -1, -1> H = {}) const {
+    VectorM operator()(const ParameterMatrix& P,
+                       OptionalJacobian</*MxMN*/ -1, -1> H = {}) const {
       return apply(P, H);
     }
   };
@@ -490,18 +489,17 @@ class Basis {
       calculateJacobian(N);
     }
     /// Calculate derivative of component rowIndex_ of F
-    double apply(const ParameterMatrix<M>& P,
+    double apply(const ParameterMatrix& P,
                  OptionalJacobian</*1xMN*/ -1, -1> H = {}) const {
       if (H) *H = H_;
       return P.row(rowIndex_) * this->weights_.transpose();
     }
     /// c++ sugar
-    double operator()(const ParameterMatrix<M>& P,
+    double operator()(const ParameterMatrix& P,
                       OptionalJacobian</*1xMN*/ -1, -1> H = {}) const {
       return apply(P, H);
     }
   };
-
 };
 
 }  // namespace gtsam

--- a/gtsam/basis/BasisFactors.h
+++ b/gtsam/basis/BasisFactors.h
@@ -87,11 +87,10 @@ class EvaluationFactor : public FunctorizedFactor<double, Vector> {
  * measurement prediction function.
  *
  * @param BASIS: The basis class to use e.g. Chebyshev2
- * @param M: Size of the evaluated state vector.
  *
  * @ingroup basis
  */
-template <class BASIS, int M>
+template <class BASIS>
 class VectorEvaluationFactor
     : public FunctorizedFactor<Vector, ParameterMatrix> {
  private:
@@ -107,14 +106,14 @@ class VectorEvaluationFactor
    * polynomial.
    * @param z The measurement value.
    * @param model The noise model.
+   * @param M Size of the evaluated state vector.
    * @param N The degree of the polynomial.
    * @param x The point at which to evaluate the basis polynomial.
    */
   VectorEvaluationFactor(Key key, const Vector &z,
-                         const SharedNoiseModel &model, const size_t N,
-                         double x)
-      : Base(key, z, model,
-             typename BASIS::template VectorEvaluationFunctor<M>(N, x)) {}
+                         const SharedNoiseModel &model, const size_t M,
+                         const size_t N, double x)
+      : Base(key, z, model, typename BASIS::VectorEvaluationFunctor(M, N, x)) {}
 
   /**
    * @brief Construct a new VectorEvaluationFactor object.
@@ -123,16 +122,17 @@ class VectorEvaluationFactor
    * polynomial.
    * @param z The measurement value.
    * @param model The noise model.
+   * @param M Size of the evaluated state vector.
    * @param N The degree of the polynomial.
    * @param x The point at which to evaluate the basis polynomial.
    * @param a Lower bound for the polynomial.
    * @param b Upper bound for the polynomial.
    */
   VectorEvaluationFactor(Key key, const Vector &z,
-                         const SharedNoiseModel &model, const size_t N,
-                         double x, double a, double b)
+                         const SharedNoiseModel &model, const size_t M,
+                         const size_t N, double x, double a, double b)
       : Base(key, z, model,
-             typename BASIS::template VectorEvaluationFunctor<M>(N, x, a, b)) {}
+             typename BASIS::VectorEvaluationFunctor(M, N, x, a, b)) {}
 
   virtual ~VectorEvaluationFactor() {}
 };
@@ -147,17 +147,15 @@ class VectorEvaluationFactor
  * indexed by `i`.
  *
  * @param BASIS: The basis class to use e.g. Chebyshev2
- * @param P: Size of the fixed-size vector.
  *
  * Example:
- *  VectorComponentFactor<BASIS, P> controlPrior(key, measured, model,
- *                                               N, i, t, a, b);
+ *  VectorComponentFactor<BASIS> controlPrior(key, measured, model,
+ *                                            N, i, t, a, b);
  *  where N is the degree and i is the component index.
  *
  * @ingroup basis
  */
-// TODO(Varun) remove template P
-template <class BASIS, size_t P>
+template <class BASIS>
 class VectorComponentFactor
     : public FunctorizedFactor<double, ParameterMatrix> {
  private:
@@ -174,15 +172,16 @@ class VectorComponentFactor
    * @param z The scalar value at a specified index `i` of the full measurement
    * vector.
    * @param model The noise model.
+   * @param P Size of the fixed-size vector.
    * @param N The degree of the polynomial.
    * @param i The index for the evaluated vector to give us the desired scalar
    * value.
    * @param x The point at which to evaluate the basis polynomial.
    */
   VectorComponentFactor(Key key, const double &z, const SharedNoiseModel &model,
-                        const size_t N, size_t i, double x)
+                        const size_t P, const size_t N, size_t i, double x)
       : Base(key, z, model,
-             typename BASIS::template VectorComponentFunctor<P>(N, i, x)) {}
+             typename BASIS::VectorComponentFunctor(P, N, i, x)) {}
 
   /**
    * @brief Construct a new VectorComponentFactor object.
@@ -192,6 +191,7 @@ class VectorComponentFactor
    * @param z The scalar value at a specified index `i` of the full measurement
    * vector.
    * @param model The noise model.
+   * @param P Size of the fixed-size vector.
    * @param N The degree of the polynomial.
    * @param i The index for the evaluated vector to give us the desired scalar
    * value.
@@ -200,11 +200,10 @@ class VectorComponentFactor
    * @param b Upper bound for the polynomial.
    */
   VectorComponentFactor(Key key, const double &z, const SharedNoiseModel &model,
-                        const size_t N, size_t i, double x, double a, double b)
-      : Base(
-            key, z, model,
-            typename BASIS::template VectorComponentFunctor<P>(N, i, x, a, b)) {
-  }
+                        const size_t P, const size_t N, size_t i, double x,
+                        double a, double b)
+      : Base(key, z, model,
+             typename BASIS::VectorComponentFunctor(P, N, i, x, a, b)) {}
 
   virtual ~VectorComponentFactor() {}
 };
@@ -324,15 +323,13 @@ class DerivativeFactor
  * polynomial at a specified point `x` is equal to the vector value `z`.
  *
  * @param BASIS: The basis class to use e.g. Chebyshev2
- * @param M: Size of the evaluated state vector derivative.
  */
-//TODO(Varun) remove template M
-template <class BASIS, int M>
+template <class BASIS>
 class VectorDerivativeFactor
     : public FunctorizedFactor<Vector, ParameterMatrix> {
  private:
   using Base = FunctorizedFactor<Vector, ParameterMatrix>;
-  using Func = typename BASIS::template VectorDerivativeFunctor<M>;
+  using Func = typename BASIS::VectorDerivativeFunctor;
 
  public:
   VectorDerivativeFactor() {}
@@ -344,13 +341,14 @@ class VectorDerivativeFactor
    * polynomial.
    * @param z The measurement value.
    * @param model The noise model.
+   * @param M Size of the evaluated state vector derivative.
    * @param N The degree of the polynomial.
    * @param x The point at which to evaluate the basis polynomial.
    */
   VectorDerivativeFactor(Key key, const Vector &z,
-                         const SharedNoiseModel &model, const size_t N,
-                         double x)
-      : Base(key, z, model, Func(N, x)) {}
+                         const SharedNoiseModel &model, const size_t M,
+                         const size_t N, double x)
+      : Base(key, z, model, Func(M, N, x)) {}
 
   /**
    * @brief Construct a new VectorDerivativeFactor object.
@@ -359,15 +357,16 @@ class VectorDerivativeFactor
    * polynomial.
    * @param z The measurement value.
    * @param model The noise model.
+   * @param M Size of the evaluated state vector derivative.
    * @param N The degree of the polynomial.
    * @param x The point at which to evaluate the basis polynomial.
    * @param a Lower bound for the polynomial.
    * @param b Upper bound for the polynomial.
    */
   VectorDerivativeFactor(Key key, const Vector &z,
-                         const SharedNoiseModel &model, const size_t N,
-                         double x, double a, double b)
-      : Base(key, z, model, Func(N, x, a, b)) {}
+                         const SharedNoiseModel &model, const size_t M,
+                         const size_t N, double x, double a, double b)
+      : Base(key, z, model, Func(M, N, x, a, b)) {}
 
   virtual ~VectorDerivativeFactor() {}
 };
@@ -378,15 +377,13 @@ class VectorDerivativeFactor
  * vector-valued measurement `z`.
  *
  * @param BASIS: The basis class to use e.g. Chebyshev2
- * @param P: Size of the control component derivative.
  */
-// TODO(Varun) remove template P
-template <class BASIS, int P>
+template <class BASIS>
 class ComponentDerivativeFactor
     : public FunctorizedFactor<double, ParameterMatrix> {
  private:
   using Base = FunctorizedFactor<double, ParameterMatrix>;
-  using Func = typename BASIS::template ComponentDerivativeFunctor<P>;
+  using Func = typename BASIS::ComponentDerivativeFunctor;
 
  public:
   ComponentDerivativeFactor() {}
@@ -399,15 +396,16 @@ class ComponentDerivativeFactor
    * @param z The scalar measurement value at a specific index `i` of the full
    * measurement vector.
    * @param model The degree of the polynomial.
+   * @param P: Size of the control component derivative.
    * @param N The degree of the polynomial.
    * @param i The index for the evaluated vector to give us the desired scalar
    * value.
    * @param x The point at which to evaluate the basis polynomial.
    */
   ComponentDerivativeFactor(Key key, const double &z,
-                            const SharedNoiseModel &model, const size_t N,
-                            size_t i, double x)
-      : Base(key, z, model, Func(N, i, x)) {}
+                            const SharedNoiseModel &model, const size_t P,
+                            const size_t N, size_t i, double x)
+      : Base(key, z, model, Func(P, N, i, x)) {}
 
   /**
    * @brief Construct a new ComponentDerivativeFactor object.
@@ -417,6 +415,7 @@ class ComponentDerivativeFactor
    * @param z The scalar measurement value at a specific index `i` of the full
    * measurement vector.
    * @param model The degree of the polynomial.
+   * @param P: Size of the control component derivative.
    * @param N The degree of the polynomial.
    * @param i The index for the evaluated vector to give us the desired scalar
    * value.
@@ -425,9 +424,10 @@ class ComponentDerivativeFactor
    * @param b Upper bound for the polynomial.
    */
   ComponentDerivativeFactor(Key key, const double &z,
-                            const SharedNoiseModel &model, const size_t N,
-                            size_t i, double x, double a, double b)
-      : Base(key, z, model, Func(N, i, x, a, b)) {}
+                            const SharedNoiseModel &model, const size_t P,
+                            const size_t N, size_t i, double x, double a,
+                            double b)
+      : Base(key, z, model, Func(P, N, i, x, a, b)) {}
 
   virtual ~ComponentDerivativeFactor() {}
 };

--- a/gtsam/basis/BasisFactors.h
+++ b/gtsam/basis/BasisFactors.h
@@ -93,9 +93,9 @@ class EvaluationFactor : public FunctorizedFactor<double, Vector> {
  */
 template <class BASIS, int M>
 class VectorEvaluationFactor
-    : public FunctorizedFactor<Vector, ParameterMatrix<M>> {
+    : public FunctorizedFactor<Vector, ParameterMatrix> {
  private:
-  using Base = FunctorizedFactor<Vector, ParameterMatrix<M>>;
+  using Base = FunctorizedFactor<Vector, ParameterMatrix>;
 
  public:
   VectorEvaluationFactor() {}
@@ -156,11 +156,12 @@ class VectorEvaluationFactor
  *
  * @ingroup basis
  */
+// TODO(Varun) remove template P
 template <class BASIS, size_t P>
 class VectorComponentFactor
-    : public FunctorizedFactor<double, ParameterMatrix<P>> {
+    : public FunctorizedFactor<double, ParameterMatrix> {
  private:
-  using Base = FunctorizedFactor<double, ParameterMatrix<P>>;
+  using Base = FunctorizedFactor<double, ParameterMatrix>;
 
  public:
   VectorComponentFactor() {}
@@ -226,10 +227,9 @@ class VectorComponentFactor
  * where `x` is the value (e.g. timestep) at which the rotation was evaluated.
  */
 template <class BASIS, typename T>
-class ManifoldEvaluationFactor
-    : public FunctorizedFactor<T, ParameterMatrix<traits<T>::dimension>> {
+class ManifoldEvaluationFactor : public FunctorizedFactor<T, ParameterMatrix> {
  private:
-  using Base = FunctorizedFactor<T, ParameterMatrix<traits<T>::dimension>>;
+  using Base = FunctorizedFactor<T, ParameterMatrix>;
 
  public:
   ManifoldEvaluationFactor() {}
@@ -326,11 +326,12 @@ class DerivativeFactor
  * @param BASIS: The basis class to use e.g. Chebyshev2
  * @param M: Size of the evaluated state vector derivative.
  */
+//TODO(Varun) remove template M
 template <class BASIS, int M>
 class VectorDerivativeFactor
-    : public FunctorizedFactor<Vector, ParameterMatrix<M>> {
+    : public FunctorizedFactor<Vector, ParameterMatrix> {
  private:
-  using Base = FunctorizedFactor<Vector, ParameterMatrix<M>>;
+  using Base = FunctorizedFactor<Vector, ParameterMatrix>;
   using Func = typename BASIS::template VectorDerivativeFunctor<M>;
 
  public:
@@ -379,11 +380,12 @@ class VectorDerivativeFactor
  * @param BASIS: The basis class to use e.g. Chebyshev2
  * @param P: Size of the control component derivative.
  */
+// TODO(Varun) remove template P
 template <class BASIS, int P>
 class ComponentDerivativeFactor
-    : public FunctorizedFactor<double, ParameterMatrix<P>> {
+    : public FunctorizedFactor<double, ParameterMatrix> {
  private:
-  using Base = FunctorizedFactor<double, ParameterMatrix<P>>;
+  using Base = FunctorizedFactor<double, ParameterMatrix>;
   using Func = typename BASIS::template ComponentDerivativeFunctor<P>;
 
  public:

--- a/gtsam/basis/basis.i
+++ b/gtsam/basis/basis.i
@@ -71,7 +71,8 @@ virtual class EvaluationFactor : gtsam::NoiseModelFactor {
                    double x, double a, double b);
 };
 
-template <BASIS = {gtsam::Chebyshev2}>
+template <BASIS = {gtsam::FourierBasis, gtsam::Chebyshev1Basis,
+                   gtsam::Chebyshev2Basis, gtsam::Chebyshev2}>
 virtual class VectorEvaluationFactor : gtsam::NoiseModelFactor {
   VectorEvaluationFactor();
   VectorEvaluationFactor(gtsam::Key key, const Vector& z,
@@ -82,7 +83,8 @@ virtual class VectorEvaluationFactor : gtsam::NoiseModelFactor {
                          const size_t N, double x, double a, double b);
 };
 
-template <BASIS = {gtsam::Chebyshev2}>
+template <BASIS = {gtsam::FourierBasis, gtsam::Chebyshev1Basis,
+                   gtsam::Chebyshev2Basis, gtsam::Chebyshev2}>
 virtual class VectorComponentFactor : gtsam::NoiseModelFactor {
   VectorComponentFactor();
   VectorComponentFactor(gtsam::Key key, const double z,
@@ -93,7 +95,12 @@ virtual class VectorComponentFactor : gtsam::NoiseModelFactor {
                         const size_t N, size_t i, double x, double a, double b);
 };
 
-template <BASIS, T>
+#include <gtsam/geometry/Pose2.h>
+#include <gtsam/geometry/Pose3.h>
+
+template <BASIS = {gtsam::FourierBasis, gtsam::Chebyshev1Basis,
+                   gtsam::Chebyshev2Basis, gtsam::Chebyshev2},
+          T = {gtsam::Rot2, gtsam::Rot3, gtsam::Pose2, gtsam::Pose3}>
 virtual class ManifoldEvaluationFactor : gtsam::NoiseModelFactor {
   ManifoldEvaluationFactor();
   ManifoldEvaluationFactor(gtsam::Key key, const T& z,
@@ -104,14 +111,8 @@ virtual class ManifoldEvaluationFactor : gtsam::NoiseModelFactor {
                            double x, double a, double b);
 };
 
-#include <gtsam/geometry/Pose3.h>
-
-typedef gtsam::ManifoldEvaluationFactor<gtsam::Chebyshev2, gtsam::Rot3>
-    ManifoldEvaluationFactorChebyshev2Rot3;
-typedef gtsam::ManifoldEvaluationFactor<gtsam::Chebyshev2, gtsam::Pose3>
-    ManifoldEvaluationFactorChebyshev2Pose3;
-
-template <BASIS = {gtsam::Chebyshev2}>
+template <BASIS = {gtsam::FourierBasis, gtsam::Chebyshev1Basis,
+                   gtsam::Chebyshev2Basis, gtsam::Chebyshev2}>
 virtual class DerivativeFactor : gtsam::NoiseModelFactor {
   DerivativeFactor();
   DerivativeFactor(gtsam::Key key, const double z,
@@ -122,7 +123,8 @@ virtual class DerivativeFactor : gtsam::NoiseModelFactor {
                    double x, double a, double b);
 };
 
-template <BASIS = {gtsam::Chebyshev2}>
+template <BASIS = {gtsam::FourierBasis, gtsam::Chebyshev1Basis,
+                   gtsam::Chebyshev2Basis, gtsam::Chebyshev2}>
 virtual class VectorDerivativeFactor : gtsam::NoiseModelFactor {
   VectorDerivativeFactor();
   VectorDerivativeFactor(gtsam::Key key, const Vector& z,
@@ -133,7 +135,8 @@ virtual class VectorDerivativeFactor : gtsam::NoiseModelFactor {
                          const size_t N, double x, double a, double b);
 };
 
-template <BASIS = {gtsam::Chebyshev2}>
+template <BASIS = {gtsam::FourierBasis, gtsam::Chebyshev1Basis,
+                   gtsam::Chebyshev2Basis, gtsam::Chebyshev2}>
 virtual class ComponentDerivativeFactor : gtsam::NoiseModelFactor {
   ComponentDerivativeFactor();
   ComponentDerivativeFactor(gtsam::Key key, const double z,

--- a/gtsam/basis/basis.i
+++ b/gtsam/basis/basis.i
@@ -71,43 +71,27 @@ virtual class EvaluationFactor : gtsam::NoiseModelFactor {
                    double x, double a, double b);
 };
 
-template <BASIS, M>
+template <BASIS = {gtsam::Chebyshev2}>
 virtual class VectorEvaluationFactor : gtsam::NoiseModelFactor {
   VectorEvaluationFactor();
   VectorEvaluationFactor(gtsam::Key key, const Vector& z,
-                         const gtsam::noiseModel::Base* model, const size_t N,
-                         double x);
+                         const gtsam::noiseModel::Base* model, const size_t M,
+                         const size_t N, double x);
   VectorEvaluationFactor(gtsam::Key key, const Vector& z,
-                         const gtsam::noiseModel::Base* model, const size_t N,
-                         double x, double a, double b);
+                         const gtsam::noiseModel::Base* model, const size_t M,
+                         const size_t N, double x, double a, double b);
 };
 
-// TODO(Varun) Better way to support arbitrary dimensions?
-// Especially if users mainly do `pip install gtsam` for the Python wrapper.
-typedef gtsam::VectorEvaluationFactor<gtsam::Chebyshev2, 3>
-    VectorEvaluationFactorChebyshev2D3;
-typedef gtsam::VectorEvaluationFactor<gtsam::Chebyshev2, 4>
-    VectorEvaluationFactorChebyshev2D4;
-typedef gtsam::VectorEvaluationFactor<gtsam::Chebyshev2, 12>
-    VectorEvaluationFactorChebyshev2D12;
-
-template <BASIS, P>
+template <BASIS = {gtsam::Chebyshev2}>
 virtual class VectorComponentFactor : gtsam::NoiseModelFactor {
   VectorComponentFactor();
   VectorComponentFactor(gtsam::Key key, const double z,
-                        const gtsam::noiseModel::Base* model, const size_t N,
-                        size_t i, double x);
+                        const gtsam::noiseModel::Base* model, const size_t M,
+                        const size_t N, size_t i, double x);
   VectorComponentFactor(gtsam::Key key, const double z,
-                        const gtsam::noiseModel::Base* model, const size_t N,
-                        size_t i, double x, double a, double b);
+                        const gtsam::noiseModel::Base* model, const size_t M,
+                        const size_t N, size_t i, double x, double a, double b);
 };
-
-typedef gtsam::VectorComponentFactor<gtsam::Chebyshev2, 3>
-    VectorComponentFactorChebyshev2D3;
-typedef gtsam::VectorComponentFactor<gtsam::Chebyshev2, 4>
-    VectorComponentFactorChebyshev2D4;
-typedef gtsam::VectorComponentFactor<gtsam::Chebyshev2, 12>
-    VectorComponentFactorChebyshev2D12;
 
 template <BASIS, T>
 virtual class ManifoldEvaluationFactor : gtsam::NoiseModelFactor {
@@ -127,8 +111,39 @@ typedef gtsam::ManifoldEvaluationFactor<gtsam::Chebyshev2, gtsam::Rot3>
 typedef gtsam::ManifoldEvaluationFactor<gtsam::Chebyshev2, gtsam::Pose3>
     ManifoldEvaluationFactorChebyshev2Pose3;
 
-// TODO(gerry): Add `DerivativeFactor`, `VectorDerivativeFactor`, and
-// `ComponentDerivativeFactor`
+template <BASIS = {gtsam::Chebyshev2}>
+virtual class DerivativeFactor : gtsam::NoiseModelFactor {
+  DerivativeFactor();
+  DerivativeFactor(gtsam::Key key, const double z,
+                   const gtsam::noiseModel::Base* model, const size_t N,
+                   double x);
+  DerivativeFactor(gtsam::Key key, const double z,
+                   const gtsam::noiseModel::Base* model, const size_t N,
+                   double x, double a, double b);
+};
+
+template <BASIS = {gtsam::Chebyshev2}>
+virtual class VectorDerivativeFactor : gtsam::NoiseModelFactor {
+  VectorDerivativeFactor();
+  VectorDerivativeFactor(gtsam::Key key, const Vector& z,
+                         const gtsam::noiseModel::Base* model, const size_t M,
+                         const size_t N, double x);
+  VectorDerivativeFactor(gtsam::Key key, const Vector& z,
+                         const gtsam::noiseModel::Base* model, const size_t M,
+                         const size_t N, double x, double a, double b);
+};
+
+template <BASIS = {gtsam::Chebyshev2}>
+virtual class ComponentDerivativeFactor : gtsam::NoiseModelFactor {
+  ComponentDerivativeFactor();
+  ComponentDerivativeFactor(gtsam::Key key, const double z,
+                            const gtsam::noiseModel::Base* model,
+                            const size_t P, const size_t N, size_t i, double x);
+  ComponentDerivativeFactor(gtsam::Key key, const double z,
+                            const gtsam::noiseModel::Base* model,
+                            const size_t P, const size_t N, size_t i, double x,
+                            double a, double b);
+};
 
 #include <gtsam/basis/FitBasis.h>
 template <BASIS = {gtsam::FourierBasis, gtsam::Chebyshev1Basis,

--- a/gtsam/basis/basis.i
+++ b/gtsam/basis/basis.i
@@ -48,9 +48,8 @@ class Chebyshev2 {
 
 #include <gtsam/basis/ParameterMatrix.h>
 
-template <M = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}>
 class ParameterMatrix {
-  ParameterMatrix(const size_t N);
+  ParameterMatrix(const size_t M, const size_t N);
   ParameterMatrix(const Matrix& matrix);
 
   Matrix matrix() const;

--- a/gtsam/basis/tests/testBasisFactors.cpp
+++ b/gtsam/basis/tests/testBasisFactors.cpp
@@ -17,30 +17,29 @@
  * @brief unit tests for factors in BasisFactors.h
  */
 
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/Testable.h>
+#include <gtsam/base/TestableAssertions.h>
+#include <gtsam/base/Vector.h>
 #include <gtsam/basis/Basis.h>
 #include <gtsam/basis/BasisFactors.h>
 #include <gtsam/basis/Chebyshev2.h>
 #include <gtsam/geometry/Pose2.h>
+#include <gtsam/inference/Symbol.h>
 #include <gtsam/nonlinear/FunctorizedFactor.h>
 #include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
 #include <gtsam/nonlinear/factorTesting.h>
-#include <gtsam/inference/Symbol.h>
-#include <gtsam/base/Testable.h>
-#include <gtsam/base/TestableAssertions.h>
-#include <gtsam/base/Vector.h>
 
-#include <CppUnitLite/TestHarness.h>
-
-using gtsam::noiseModel::Isotropic;
-using gtsam::Pose2;
-using gtsam::Vector;
-using gtsam::Values;
 using gtsam::Chebyshev2;
-using gtsam::ParameterMatrix;
-using gtsam::LevenbergMarquardtParams;
 using gtsam::LevenbergMarquardtOptimizer;
+using gtsam::LevenbergMarquardtParams;
 using gtsam::NonlinearFactorGraph;
 using gtsam::NonlinearOptimizerParams;
+using gtsam::ParameterMatrix;
+using gtsam::Pose2;
+using gtsam::Values;
+using gtsam::Vector;
+using gtsam::noiseModel::Isotropic;
 
 constexpr size_t N = 2;
 
@@ -86,10 +85,10 @@ TEST(BasisFactors, VectorEvaluationFactor) {
   NonlinearFactorGraph graph;
   graph.add(factor);
 
-  ParameterMatrix<M> stateMatrix(N);
+  ParameterMatrix stateMatrix(M, N);
 
   Values initial;
-  initial.insert<ParameterMatrix<M>>(key, stateMatrix);
+  initial.insert<ParameterMatrix>(key, stateMatrix);
 
   LevenbergMarquardtParams parameters;
   parameters.setMaxIterations(20);
@@ -128,16 +127,16 @@ TEST(BasisFactors, VectorComponentFactor) {
   const size_t i = 2;
   const double measured = 0.0, t = 3.0, a = 2.0, b = 4.0;
   auto model = Isotropic::Sigma(1, 1.0);
-  VectorComponentFactor<Chebyshev2, P> factor(key, measured, model, N, i,
-                                                    t, a, b);
+  VectorComponentFactor<Chebyshev2, P> factor(key, measured, model, N, i, t, a,
+                                              b);
 
   NonlinearFactorGraph graph;
   graph.add(factor);
 
-  ParameterMatrix<P> stateMatrix(N);
+  ParameterMatrix stateMatrix(P, N);
 
   Values initial;
-  initial.insert<ParameterMatrix<P>>(key, stateMatrix);
+  initial.insert<ParameterMatrix>(key, stateMatrix);
 
   LevenbergMarquardtParams parameters;
   parameters.setMaxIterations(20);
@@ -153,16 +152,16 @@ TEST(BasisFactors, ManifoldEvaluationFactor) {
   const Pose2 measured;
   const double t = 3.0, a = 2.0, b = 4.0;
   auto model = Isotropic::Sigma(3, 1.0);
-  ManifoldEvaluationFactor<Chebyshev2, Pose2> factor(key, measured, model, N,
-                                                     t, a, b);
+  ManifoldEvaluationFactor<Chebyshev2, Pose2> factor(key, measured, model, N, t,
+                                                     a, b);
 
   NonlinearFactorGraph graph;
   graph.add(factor);
 
-  ParameterMatrix<3> stateMatrix(N);
+  ParameterMatrix stateMatrix(3, N);
 
   Values initial;
-  initial.insert<ParameterMatrix<3>>(key, stateMatrix);
+  initial.insert<ParameterMatrix>(key, stateMatrix);
 
   LevenbergMarquardtParams parameters;
   parameters.setMaxIterations(20);
@@ -186,10 +185,10 @@ TEST(BasisFactors, VecDerivativePrior) {
   NonlinearFactorGraph graph;
   graph.add(vecDPrior);
 
-  ParameterMatrix<M> stateMatrix(N);
+  ParameterMatrix stateMatrix(M, N);
 
   Values initial;
-  initial.insert<ParameterMatrix<M>>(key, stateMatrix);
+  initial.insert<ParameterMatrix>(key, stateMatrix);
 
   LevenbergMarquardtParams parameters;
   parameters.setMaxIterations(20);
@@ -213,8 +212,8 @@ TEST(BasisFactors, ComponentDerivativeFactor) {
   graph.add(controlDPrior);
 
   Values initial;
-  ParameterMatrix<M> stateMatrix(N);
-  initial.insert<ParameterMatrix<M>>(key, stateMatrix);
+  ParameterMatrix stateMatrix(M, N);
+  initial.insert<ParameterMatrix>(key, stateMatrix);
 
   LevenbergMarquardtParams parameters;
   parameters.setMaxIterations(20);

--- a/gtsam/basis/tests/testBasisFactors.cpp
+++ b/gtsam/basis/tests/testBasisFactors.cpp
@@ -80,7 +80,7 @@ TEST(BasisFactors, VectorEvaluationFactor) {
   const Vector measured = Vector::Zero(M);
 
   auto model = Isotropic::Sigma(M, 1.0);
-  VectorEvaluationFactor<Chebyshev2, M> factor(key, measured, model, N, 0);
+  VectorEvaluationFactor<Chebyshev2> factor(key, measured, model, M, N, 0);
 
   NonlinearFactorGraph graph;
   graph.add(factor);
@@ -106,7 +106,7 @@ TEST(BasisFactors, Print) {
   const Vector measured = Vector::Ones(M) * 42;
 
   auto model = Isotropic::Sigma(M, 1.0);
-  VectorEvaluationFactor<Chebyshev2, M> factor(key, measured, model, N, 0);
+  VectorEvaluationFactor<Chebyshev2> factor(key, measured, model, M, N, 0);
 
   std::string expected =
       "  keys = { X0 }\n"
@@ -127,8 +127,8 @@ TEST(BasisFactors, VectorComponentFactor) {
   const size_t i = 2;
   const double measured = 0.0, t = 3.0, a = 2.0, b = 4.0;
   auto model = Isotropic::Sigma(1, 1.0);
-  VectorComponentFactor<Chebyshev2, P> factor(key, measured, model, N, i, t, a,
-                                              b);
+  VectorComponentFactor<Chebyshev2> factor(key, measured, model, P, N, i, t, a,
+                                           b);
 
   NonlinearFactorGraph graph;
   graph.add(factor);
@@ -180,7 +180,7 @@ TEST(BasisFactors, VecDerivativePrior) {
 
   const Vector measured = Vector::Zero(M);
   auto model = Isotropic::Sigma(M, 1.0);
-  VectorDerivativeFactor<Chebyshev2, M> vecDPrior(key, measured, model, N, 0);
+  VectorDerivativeFactor<Chebyshev2> vecDPrior(key, measured, model, M, N, 0);
 
   NonlinearFactorGraph graph;
   graph.add(vecDPrior);
@@ -205,8 +205,8 @@ TEST(BasisFactors, ComponentDerivativeFactor) {
 
   double measured = 0;
   auto model = Isotropic::Sigma(1, 1.0);
-  ComponentDerivativeFactor<Chebyshev2, M> controlDPrior(key, measured, model,
-                                                         N, 0, 0);
+  ComponentDerivativeFactor<Chebyshev2> controlDPrior(key, measured, model, M,
+                                                      N, 0, 0);
 
   NonlinearFactorGraph graph;
   graph.add(controlDPrior);

--- a/gtsam/basis/tests/testChebyshev2.cpp
+++ b/gtsam/basis/tests/testChebyshev2.cpp
@@ -116,12 +116,12 @@ TEST(Chebyshev2, InterpolateVector) {
   expected << t, 0;
   Eigen::Matrix<double, /*2x2N*/ -1, -1> actualH(2, 2 * N);
 
-  Chebyshev2::VectorEvaluationFunctor<2> fx(N, t, a, b);
+  Chebyshev2::VectorEvaluationFunctor fx(2, N, t, a, b);
   EXPECT(assert_equal(expected, fx(X, actualH), 1e-9));
 
   // Check derivative
   std::function<Vector2(ParameterMatrix)> f =
-      std::bind(&Chebyshev2::VectorEvaluationFunctor<2>::operator(), fx,
+      std::bind(&Chebyshev2::VectorEvaluationFunctor::operator(), fx,
                 std::placeholders::_1, nullptr);
   Matrix numericalH =
       numericalDerivative11<Vector2, ParameterMatrix, 2 * N>(f, X);
@@ -413,8 +413,8 @@ TEST(Chebyshev2, Derivative6_03) {
 TEST(Chebyshev2, VectorDerivativeFunctor) {
   const size_t N = 3, M = 2;
   const double x = 0.2;
-  using VecD = Chebyshev2::VectorDerivativeFunctor<M>;
-  VecD fx(N, x, 0, 3);
+  using VecD = Chebyshev2::VectorDerivativeFunctor;
+  VecD fx(M, N, x, 0, 3);
   ParameterMatrix X(M, N);
   Matrix actualH(M, M * N);
   EXPECT(assert_equal(Vector::Zero(M), (Vector)fx(X, actualH), 1e-8));
@@ -429,7 +429,7 @@ TEST(Chebyshev2, VectorDerivativeFunctor) {
 // Test VectorDerivativeFunctor with polynomial function
 TEST(Chebyshev2, VectorDerivativeFunctor2) {
   const size_t N = 64, M = 1, T = 15;
-  using VecD = Chebyshev2::VectorDerivativeFunctor<M>;
+  using VecD = Chebyshev2::VectorDerivativeFunctor;
 
   const Vector points = Chebyshev2::Points(N, 0, T);
 
@@ -443,14 +443,14 @@ TEST(Chebyshev2, VectorDerivativeFunctor2) {
   // Evaluate the derivative at the chebyshev points using
   // VectorDerivativeFunctor.
   for (size_t i = 0; i < N; ++i) {
-    VecD d(N, points(i), 0, T);
+    VecD d(M, N, points(i), 0, T);
     Vector1 Dx = d(X);
     EXPECT_DOUBLES_EQUAL(fprime(points(i)), Dx(0), 1e-6);
   }
 
   // Test Jacobian at the first chebyshev point.
   Matrix actualH(M, M * N);
-  VecD vecd(N, points(0), 0, T);
+  VecD vecd(M, N, points(0), 0, T);
   vecd(X, actualH);
   Matrix expectedH = numericalDerivative11<Vector1, ParameterMatrix, M * N>(
       std::bind(&VecD::operator(), vecd, std::placeholders::_1, nullptr), X);
@@ -462,9 +462,9 @@ TEST(Chebyshev2, VectorDerivativeFunctor2) {
 TEST(Chebyshev2, ComponentDerivativeFunctor) {
   const size_t N = 6, M = 2;
   const double x = 0.2;
-  using CompFunc = Chebyshev2::ComponentDerivativeFunctor<M>;
+  using CompFunc = Chebyshev2::ComponentDerivativeFunctor;
   size_t row = 1;
-  CompFunc fx(N, row, x, 0, 3);
+  CompFunc fx(M, N, row, x, 0, 3);
   ParameterMatrix X(M, N);
   Matrix actualH(1, M * N);
   EXPECT_DOUBLES_EQUAL(0, fx(X, actualH), 1e-8);

--- a/gtsam/basis/tests/testFourier.cpp
+++ b/gtsam/basis/tests/testFourier.cpp
@@ -180,13 +180,13 @@ TEST(Basis, Derivative7) {
 
 //******************************************************************************
 TEST(Basis, VecDerivativeFunctor) {
-  using DotShape = typename FourierBasis::VectorDerivativeFunctor<2>;
+  using DotShape = typename FourierBasis::VectorDerivativeFunctor;
   const size_t N = 3;
 
   // MATLAB example, Dec 27 2019, commit 014eded5
   double h = 2 * M_PI / 16;
   Vector2 dotShape(0.5556, -0.8315);  // at h/2
-  DotShape dotShapeFunction(N, h / 2);
+  DotShape dotShapeFunction(2, N, h / 2);
   Matrix23 theta_mat = (Matrix32() << 0, 0, 0.7071, 0.7071, 0.7071, -0.7071)
                            .finished()
                            .transpose();

--- a/gtsam/basis/tests/testFourier.cpp
+++ b/gtsam/basis/tests/testFourier.cpp
@@ -190,7 +190,7 @@ TEST(Basis, VecDerivativeFunctor) {
   Matrix23 theta_mat = (Matrix32() << 0, 0, 0.7071, 0.7071, 0.7071, -0.7071)
                            .finished()
                            .transpose();
-  ParameterMatrix<2> theta(theta_mat);
+  ParameterMatrix theta(theta_mat);
   EXPECT(assert_equal(Vector(dotShape), dotShapeFunction(theta), 1e-4));
 }
 

--- a/gtsam/basis/tests/testParameterMatrix.cpp
+++ b/gtsam/basis/tests/testParameterMatrix.cpp
@@ -32,19 +32,19 @@ const size_t M = 2, N = 5;
 
 //******************************************************************************
 TEST(ParameterMatrix, Constructor) {
-  ParameterMatrix<2> actual1(3);
-  ParameterMatrix<2> expected1(Matrix::Zero(2, 3));
+  ParameterMatrix actual1(2, 3);
+  ParameterMatrix expected1(Matrix::Zero(2, 3));
   EXPECT(assert_equal(expected1, actual1));
 
-  ParameterMatrix<2> actual2(Matrix::Ones(2, 3));
-  ParameterMatrix<2> expected2(Matrix::Ones(2, 3));
+  ParameterMatrix actual2(Matrix::Ones(2, 3));
+  ParameterMatrix expected2(Matrix::Ones(2, 3));
   EXPECT(assert_equal(expected2, actual2));
   EXPECT(assert_equal(expected2.matrix(), actual2.matrix()));
 }
 
 //******************************************************************************
 TEST(ParameterMatrix, Dimensions) {
-  ParameterMatrix<M> params(N);
+  ParameterMatrix params(M, N);
   EXPECT_LONGS_EQUAL(params.rows(), M);
   EXPECT_LONGS_EQUAL(params.cols(), N);
   EXPECT_LONGS_EQUAL(params.dim(), M * N);
@@ -52,7 +52,7 @@ TEST(ParameterMatrix, Dimensions) {
 
 //******************************************************************************
 TEST(ParameterMatrix, Getters) {
-  ParameterMatrix<M> params(N);
+  ParameterMatrix params(M, N);
 
   Matrix expectedMatrix = Matrix::Zero(2, 5);
   EXPECT(assert_equal(expectedMatrix, params.matrix()));
@@ -60,13 +60,13 @@ TEST(ParameterMatrix, Getters) {
   Matrix expectedMatrixTranspose = Matrix::Zero(5, 2);
   EXPECT(assert_equal(expectedMatrixTranspose, params.transpose()));
 
-  ParameterMatrix<M> p2(Matrix::Ones(M, N));
+  ParameterMatrix p2(Matrix::Ones(M, N));
   Vector expectedRowVector = Vector::Ones(N);
   for (size_t r = 0; r < M; ++r) {
     EXPECT(assert_equal(p2.row(r), expectedRowVector));
   }
 
-  ParameterMatrix<M> p3(2 * Matrix::Ones(M, N));
+  ParameterMatrix p3(2 * Matrix::Ones(M, N));
   Vector expectedColVector = 2 * Vector::Ones(M);
   for (size_t c = 0; c < M; ++c) {
     EXPECT(assert_equal(p3.col(c), expectedColVector));
@@ -75,7 +75,7 @@ TEST(ParameterMatrix, Getters) {
 
 //******************************************************************************
 TEST(ParameterMatrix, Setters) {
-  ParameterMatrix<M> params(Matrix::Zero(M, N));
+  ParameterMatrix params(Matrix::Zero(M, N));
   Matrix expected = Matrix::Zero(M, N);
 
   // row
@@ -97,31 +97,31 @@ TEST(ParameterMatrix, Setters) {
 
 //******************************************************************************
 TEST(ParameterMatrix, Addition) {
-  ParameterMatrix<M> params(Matrix::Ones(M, N));
-  ParameterMatrix<M> expected(2 * Matrix::Ones(M, N));
+  ParameterMatrix params(Matrix::Ones(M, N));
+  ParameterMatrix expected(2 * Matrix::Ones(M, N));
 
   // Add vector
   EXPECT(assert_equal(expected, params + Vector::Ones(M * N)));
   // Add another ParameterMatrix
-  ParameterMatrix<M> actual = params + ParameterMatrix<M>(Matrix::Ones(M, N));
+  ParameterMatrix actual = params + ParameterMatrix(Matrix::Ones(M, N));
   EXPECT(assert_equal(expected, actual));
 }
 
 //******************************************************************************
 TEST(ParameterMatrix, Subtraction) {
-  ParameterMatrix<M> params(2 * Matrix::Ones(M, N));
-  ParameterMatrix<M> expected(Matrix::Ones(M, N));
+  ParameterMatrix params(2 * Matrix::Ones(M, N));
+  ParameterMatrix expected(Matrix::Ones(M, N));
 
   // Subtract vector
   EXPECT(assert_equal(expected, params - Vector::Ones(M * N)));
   // Subtract another ParameterMatrix
-  ParameterMatrix<M> actual = params - ParameterMatrix<M>(Matrix::Ones(M, N));
+  ParameterMatrix actual = params - ParameterMatrix(Matrix::Ones(M, N));
   EXPECT(assert_equal(expected, actual));
 }
 
 //******************************************************************************
 TEST(ParameterMatrix, Multiplication) {
-  ParameterMatrix<M> params(Matrix::Ones(M, N));
+  ParameterMatrix params(Matrix::Ones(M, N));
   Matrix multiplier = 2 * Matrix::Ones(N, 2);
   Matrix expected = 2 * N * Matrix::Ones(M, 2);
   EXPECT(assert_equal(expected, params * multiplier));
@@ -129,12 +129,12 @@ TEST(ParameterMatrix, Multiplication) {
 
 //******************************************************************************
 TEST(ParameterMatrix, VectorSpace) {
-  ParameterMatrix<M> params(Matrix::Ones(M, N));
+  ParameterMatrix params(Matrix::Ones(M, N));
   // vector
   EXPECT(assert_equal(Vector::Ones(M * N), params.vector()));
   // identity
-  EXPECT(assert_equal(ParameterMatrix<M>::Identity(),
-                      ParameterMatrix<M>(Matrix::Zero(M, 0))));
+  EXPECT(assert_equal(ParameterMatrix::Identity(M),
+                      ParameterMatrix(Matrix::Zero(M, 0))));
 }
 
 //******************************************************************************

--- a/gtsam/nonlinear/values.i
+++ b/gtsam/nonlinear/values.i
@@ -96,21 +96,7 @@ class Values {
   void insert(size_t j, const gtsam::imuBias::ConstantBias& constant_bias);
   void insert(size_t j, const gtsam::NavState& nav_state);
   void insert(size_t j, double c);
-  void insert(size_t j, const gtsam::ParameterMatrix<1>& X);
-  void insert(size_t j, const gtsam::ParameterMatrix<2>& X);
-  void insert(size_t j, const gtsam::ParameterMatrix<3>& X);
-  void insert(size_t j, const gtsam::ParameterMatrix<4>& X);
-  void insert(size_t j, const gtsam::ParameterMatrix<5>& X);
-  void insert(size_t j, const gtsam::ParameterMatrix<6>& X);
-  void insert(size_t j, const gtsam::ParameterMatrix<7>& X);
-  void insert(size_t j, const gtsam::ParameterMatrix<8>& X);
-  void insert(size_t j, const gtsam::ParameterMatrix<9>& X);
-  void insert(size_t j, const gtsam::ParameterMatrix<10>& X);
-  void insert(size_t j, const gtsam::ParameterMatrix<11>& X);
-  void insert(size_t j, const gtsam::ParameterMatrix<12>& X);
-  void insert(size_t j, const gtsam::ParameterMatrix<13>& X);
-  void insert(size_t j, const gtsam::ParameterMatrix<14>& X);
-  void insert(size_t j, const gtsam::ParameterMatrix<15>& X);
+  void insert(size_t j, const gtsam::ParameterMatrix& X);
 
   template <T = {gtsam::Point2, gtsam::Point3}>
   void insert(size_t j, const T& val);
@@ -144,21 +130,7 @@ class Values {
   void update(size_t j, Vector vector);
   void update(size_t j, Matrix matrix);
   void update(size_t j, double c);
-  void update(size_t j, const gtsam::ParameterMatrix<1>& X);
-  void update(size_t j, const gtsam::ParameterMatrix<2>& X);
-  void update(size_t j, const gtsam::ParameterMatrix<3>& X);
-  void update(size_t j, const gtsam::ParameterMatrix<4>& X);
-  void update(size_t j, const gtsam::ParameterMatrix<5>& X);
-  void update(size_t j, const gtsam::ParameterMatrix<6>& X);
-  void update(size_t j, const gtsam::ParameterMatrix<7>& X);
-  void update(size_t j, const gtsam::ParameterMatrix<8>& X);
-  void update(size_t j, const gtsam::ParameterMatrix<9>& X);
-  void update(size_t j, const gtsam::ParameterMatrix<10>& X);
-  void update(size_t j, const gtsam::ParameterMatrix<11>& X);
-  void update(size_t j, const gtsam::ParameterMatrix<12>& X);
-  void update(size_t j, const gtsam::ParameterMatrix<13>& X);
-  void update(size_t j, const gtsam::ParameterMatrix<14>& X);
-  void update(size_t j, const gtsam::ParameterMatrix<15>& X);
+  void update(size_t j, const gtsam::ParameterMatrix& X);
 
   void insert_or_assign(size_t j, const gtsam::Point2& point2);
   void insert_or_assign(size_t j, const gtsam::Point3& point3);
@@ -199,21 +171,7 @@ class Values {
   void insert_or_assign(size_t j, Vector vector);
   void insert_or_assign(size_t j, Matrix matrix);
   void insert_or_assign(size_t j, double c);
-  void insert_or_assign(size_t j, const gtsam::ParameterMatrix<1>& X);
-  void insert_or_assign(size_t j, const gtsam::ParameterMatrix<2>& X);
-  void insert_or_assign(size_t j, const gtsam::ParameterMatrix<3>& X);
-  void insert_or_assign(size_t j, const gtsam::ParameterMatrix<4>& X);
-  void insert_or_assign(size_t j, const gtsam::ParameterMatrix<5>& X);
-  void insert_or_assign(size_t j, const gtsam::ParameterMatrix<6>& X);
-  void insert_or_assign(size_t j, const gtsam::ParameterMatrix<7>& X);
-  void insert_or_assign(size_t j, const gtsam::ParameterMatrix<8>& X);
-  void insert_or_assign(size_t j, const gtsam::ParameterMatrix<9>& X);
-  void insert_or_assign(size_t j, const gtsam::ParameterMatrix<10>& X);
-  void insert_or_assign(size_t j, const gtsam::ParameterMatrix<11>& X);
-  void insert_or_assign(size_t j, const gtsam::ParameterMatrix<12>& X);
-  void insert_or_assign(size_t j, const gtsam::ParameterMatrix<13>& X);
-  void insert_or_assign(size_t j, const gtsam::ParameterMatrix<14>& X);
-  void insert_or_assign(size_t j, const gtsam::ParameterMatrix<15>& X);
+  void insert_or_assign(size_t j, const gtsam::ParameterMatrix& X);
 
   template <T = {gtsam::Point2,
                  gtsam::Point3,
@@ -244,21 +202,7 @@ class Values {
                  Vector,
                  Matrix,
                  double,
-                 gtsam::ParameterMatrix<1>,
-                 gtsam::ParameterMatrix<2>,
-                 gtsam::ParameterMatrix<3>,
-                 gtsam::ParameterMatrix<4>,
-                 gtsam::ParameterMatrix<5>,
-                 gtsam::ParameterMatrix<6>,
-                 gtsam::ParameterMatrix<7>,
-                 gtsam::ParameterMatrix<8>,
-                 gtsam::ParameterMatrix<9>,
-                 gtsam::ParameterMatrix<10>,
-                 gtsam::ParameterMatrix<11>,
-                 gtsam::ParameterMatrix<12>,
-                 gtsam::ParameterMatrix<13>,
-                 gtsam::ParameterMatrix<14>,
-                 gtsam::ParameterMatrix<15>}>
+                 gtsam::ParameterMatrix}>
   T at(size_t j);
 };
 


### PR DESCRIPTION
This PR removes the templating from all the Basis factors and functors, instead opting to pass the erstwhile template parameter as a constructor argument.

This will allow a user to define factors for arbitrarily sized vectors and not be limited to what template parameters are specified in the `basis.i` file.

Fixes almost everything in #1163 except for `FitBasis cannot take an interval [a,b]`. This last part I still need to understand how to do (and may not be high up on my current TODO list 😞).