### PR TITLE
Remove boost from TableFactor and added guards to testSerializationSlam

### DIFF
--- a/gtsam/discrete/TableFactor.cpp
+++ b/gtsam/discrete/TableFactor.cpp
@@ -21,7 +21,6 @@
 #include <gtsam/discrete/TableFactor.h>
 #include <gtsam/hybrid/HybridValues.h>
 
-#include <boost/format.hpp>
 #include <utility>
 
 using namespace std;
@@ -203,7 +202,7 @@ void TableFactor::print(const string& s, const KeyFormatter& formatter) const {
   cout << s;
   cout << " f[";
   for (auto&& key : keys())
-    cout << boost::format(" (%1%,%2%),") % formatter(key) % cardinality(key);
+    cout << " (" << formatter(key) << "," << cardinality(key) << "),";
   cout << " ]" << endl;
   for (SparseIt it(sparse_table_); it; ++it) {
     DiscreteValues assignment = findAssignments(it.index());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,7 +13,7 @@ if (NOT GTSAM_USE_BOOST_FEATURES)
 endif()
 
 if (NOT GTSAM_ENABLE_BOOST_SERIALIZATION)
-	list(APPEND excluded_tests "testSerializationSLAM.cpp")
+	list(APPEND excluded_tests "testSerializationSlam.cpp")
 endif()
 
 # Build tests

--- a/tests/testSerializationSlam.cpp
+++ b/tests/testSerializationSlam.cpp
@@ -52,8 +52,6 @@
 #include <gtsam/base/serializationTestHelpers.h>
 #include <gtsam/base/std_optional_serialization.h>
 
-#ifdef GTSAM_USE_BOOST_FEATURES
-
 #include <boost/archive/xml_iarchive.hpp>
 #include <boost/serialization/export.hpp>
 
@@ -675,8 +673,6 @@ TEST(SubgraphSolver, Solves) {
     EXPECT(assert_equal(values_x2.vector(ordering), solveT_x));
   }
 }
-
-#endif
 
 /* ************************************************************************* */
 int main() { TestResult tr; return TestRegistry::runAllTests(tr); }

--- a/tests/testSerializationSlam.cpp
+++ b/tests/testSerializationSlam.cpp
@@ -52,6 +52,8 @@
 #include <gtsam/base/serializationTestHelpers.h>
 #include <gtsam/base/std_optional_serialization.h>
 
+#ifdef GTSAM_USE_BOOST_FEATURES
+
 #include <boost/archive/xml_iarchive.hpp>
 #include <boost/serialization/export.hpp>
 
@@ -673,6 +675,8 @@ TEST(SubgraphSolver, Solves) {
     EXPECT(assert_equal(values_x2.vector(ordering), solveT_x));
   }
 }
+
+#endif
 
 /* ************************************************************************* */
 int main() { TestResult tr; return TestRegistry::runAllTests(tr); }


### PR DESCRIPTION
This PR removes the dependence on boost from the recently added `TableFactor`, and adds some guards to `testSerializationSlam` if boost is disabled. These were currently the only two things preventing gtsam from building and passing all unit tests without boost.

I attempted to maintain the style of the output in TableFactor, but I didn't explicitly test with boost to compare. 