### PR TITLE
Add explanation of the StereoPoint2 constructor

### DIFF
--- a/gtsam/geometry/StereoPoint2.h
+++ b/gtsam/geometry/StereoPoint2.h
@@ -46,7 +46,9 @@ public:
       uL_(0), uR_(0), v_(0) {
   }
 
-  /** constructor */
+  /** uL and uR represent the x-axis value of left and right frame coordinates respectively.
+      v represents the y coordinate value. The y-axis value should be the same under the
+      stereo constraint. */
   StereoPoint2(double uL, double uR, double v) :
       uL_(uL), uR_(uR), v_(v) {
   }


### PR DESCRIPTION
The constructor arguments of StereoPoint2 was unclear for me so I added the explanation.
It would be better to say the assumption that the stereo images are rectified.