### PR TITLE
Update FindTBB.cmake: fix cmake error for TBB 2021

### DIFF
--- a/cmake/FindTBB.cmake
+++ b/cmake/FindTBB.cmake
@@ -182,17 +182,8 @@ if(NOT TBB_FOUND)
   ##################################
 
   if(TBB_INCLUDE_DIRS)
-    set(_tbb_version_file_prior_to_tbb_2021_1 "${TBB_INCLUDE_DIRS}/tbb/tbb_stddef.h")
     set(_tbb_version_file_after_tbb_2021_1 "${TBB_INCLUDE_DIRS}/oneapi/tbb/version.h")
-
-    if (EXISTS "${_tbb_version_file_prior_to_tbb_2021_1}")
-      file(READ "${_tbb_version_file_prior_to_tbb_2021_1}" _tbb_version_file )
-    elseif (EXISTS "${_tbb_version_file_after_tbb_2021_1}")
-      file(READ "${_tbb_version_file_after_tbb_2021_1}" _tbb_version_file )
-    else()
-        message(FATAL_ERROR "Found TBB installation: ${TBB_INCLUDE_DIRS} "
-      "missing version header.")
-    endif()
+    file(READ "${_tbb_version_file_after_tbb_2021_1}" _tbb_version_file )
 
     string(REGEX REPLACE ".*#define TBB_VERSION_MAJOR ([0-9]+).*" "\\1"
         TBB_VERSION_MAJOR "${_tbb_version_file}")


### PR DESCRIPTION
fix file failed to open for reading (No such file or directory): /usr/include/tbb/tbb_stddef.h inside docker build (TBB 2021.5 has removed the tbb_stddef.h)
related to https://github.com/borglab/gtsam/issues/769