### PR TITLE
Fix windows tests

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         build_type: 
           - Debug
-          # - Release
+          - Release
           
         build_unstable: 
           - ON

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -2,6 +2,10 @@ name: Windows CI
 
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: ${{ matrix.name }} ${{ matrix.build_type }}
@@ -16,19 +20,15 @@ jobs:
       BOOST_EXE: boost_1_72_0-msvc-14.2
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        # Github Actions requires a single row to be added to the build matrix.
-        # See https://help.github.com/en/articles/workflow-syntax-for-github-actions.
-        name: [
-            windows-2019-cl,
-          ]
-
-        build_type: [
-            Debug,
-            Release
-          ]
-        build_unstable: [ON]
+        build_type: 
+          - Debug
+          # - Release
+          
+        build_unstable: 
+          - ON
+          # - OFF 
         include:
           - name: windows-2019-cl
             os: windows-2019
@@ -87,10 +87,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Setup msbuild
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x${{ matrix.platform }}
+
       - name: Configuration
         run: |
           cmake -E remove_directory build
-          cmake -B build -S . -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF -DBOOST_ROOT="${env:BOOST_ROOT}" -DBOOST_INCLUDEDIR="${env:BOOST_ROOT}\boost\include" -DBOOST_LIBRARYDIR="${env:BOOST_ROOT}\lib"
+          cmake -G Ninja -B build -S . -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF -DBOOST_ROOT="${env:BOOST_ROOT}" -DBOOST_INCLUDEDIR="${env:BOOST_ROOT}\boost\include" -DBOOST_LIBRARYDIR="${env:BOOST_ROOT}\lib"
 
       - name: Build
         run: |

--- a/gtsam/basis/Basis.h
+++ b/gtsam/basis/Basis.h
@@ -80,7 +80,7 @@ using Weights = Eigen::Matrix<double, 1, -1>; /* 1xN vector */
  *
  * @ingroup basis
  */
-Matrix kroneckerProductIdentity(size_t M, const Weights& w);
+Matrix GTSAM_EXPORT kroneckerProductIdentity(size_t M, const Weights& w);
 
 /**
  * CRTP Base class for function bases

--- a/gtsam/discrete/SignatureParser.h
+++ b/gtsam/discrete/SignatureParser.h
@@ -47,7 +47,7 @@ namespace gtsam {
  *
  * Also fails if the rows are not of the same size.
  */
-struct SignatureParser {
+struct GTSAM_EXPORT SignatureParser {
   using Row = std::vector<double>;
   using Table = std::vector<Row>;
 

--- a/gtsam/geometry/CameraSet.h
+++ b/gtsam/geometry/CameraSet.h
@@ -270,7 +270,7 @@ class CameraSet : public std::vector<CAMERA, Eigen::aligned_allocator<CAMERA>> {
 
       // Get map from key to location in the new augmented Hessian matrix (the
       // one including only unique keys).
-      std::map<Key, size_t> keyToSlotMap;
+      std::map<Key, uint32_t> keyToSlotMap;
       for (size_t k = 0; k < nrUniqueKeys; k++) {
         keyToSlotMap[hessianKeys[k]] = k;
       }

--- a/gtsam/geometry/Pose2.h
+++ b/gtsam/geometry/Pose2.h
@@ -36,7 +36,7 @@ namespace gtsam {
  * @ingroup geometry
  * \nosubgrouping
  */
-class Pose2: public LieGroup<Pose2, 3> {
+class GTSAM_EXPORT Pose2: public LieGroup<Pose2, 3> {
 
 public:
 
@@ -112,10 +112,10 @@ public:
   /// @{
 
   /** print with optional string */
-  GTSAM_EXPORT void print(const std::string& s = "") const;
+  void print(const std::string& s = "") const;
 
   /** assert equality up to a tolerance */
-  GTSAM_EXPORT bool equals(const Pose2& pose, double tol = 1e-9) const;
+  bool equals(const Pose2& pose, double tol = 1e-9) const;
 
   /// @}
   /// @name Group
@@ -125,7 +125,7 @@ public:
   inline static Pose2 Identity() { return Pose2(); }
 
   /// inverse
-  GTSAM_EXPORT Pose2 inverse() const;
+  Pose2 inverse() const;
 
   /// compose syntactic sugar
   inline Pose2 operator*(const Pose2& p2) const {
@@ -137,16 +137,16 @@ public:
   /// @{
 
   ///Exponential map at identity - create a rotation from canonical coordinates \f$ [T_x,T_y,\theta] \f$
-  GTSAM_EXPORT static Pose2 Expmap(const Vector3& xi, ChartJacobian H = {});
+  static Pose2 Expmap(const Vector3& xi, ChartJacobian H = {});
 
   ///Log map at identity - return the canonical coordinates \f$ [T_x,T_y,\theta] \f$ of this rotation
-  GTSAM_EXPORT static Vector3 Logmap(const Pose2& p, ChartJacobian H = {});
+  static Vector3 Logmap(const Pose2& p, ChartJacobian H = {});
 
   /**
    * Calculate Adjoint map
    * Ad_pose is 3*3 matrix that when applied to twist xi \f$ [T_x,T_y,\theta] \f$, returns Ad_pose(xi)
    */
-  GTSAM_EXPORT Matrix3 AdjointMap() const;
+  Matrix3 AdjointMap() const;
 
   /// Apply AdjointMap to twist xi
   inline Vector3 Adjoint(const Vector3& xi) const {
@@ -156,7 +156,7 @@ public:
   /**
    * Compute the [ad(w,v)] operator for SE2 as in [Kobilarov09siggraph], pg 19
    */
-  GTSAM_EXPORT static Matrix3 adjointMap(const Vector3& v);
+  static Matrix3 adjointMap(const Vector3& v);
 
   /**
    * Action of the adjointMap on a Lie-algebra vector y, with optional derivatives
@@ -192,15 +192,15 @@ public:
   }
 
   /// Derivative of Expmap
-  GTSAM_EXPORT static Matrix3 ExpmapDerivative(const Vector3& v);
+  static Matrix3 ExpmapDerivative(const Vector3& v);
 
   /// Derivative of Logmap
-  GTSAM_EXPORT static Matrix3 LogmapDerivative(const Pose2& v);
+  static Matrix3 LogmapDerivative(const Pose2& v);
 
   // Chart at origin, depends on compile-time flag SLOW_BUT_CORRECT_EXPMAP
-  struct ChartAtOrigin {
-	GTSAM_EXPORT static Pose2 Retract(const Vector3& v, ChartJacobian H = {});
-	GTSAM_EXPORT static Vector3 Local(const Pose2& r, ChartJacobian H = {});
+  struct GTSAM_EXPORT ChartAtOrigin {
+    static Pose2 Retract(const Vector3& v, ChartJacobian H = {});
+    static Vector3 Local(const Pose2& r, ChartJacobian H = {});
   };
 
   using LieGroup<Pose2, 3>::inverse; // version with derivative
@@ -210,7 +210,7 @@ public:
   /// @{
 
   /** Return point coordinates in pose coordinate frame */
-  GTSAM_EXPORT Point2 transformTo(const Point2& point,
+  Point2 transformTo(const Point2& point,
       OptionalJacobian<2, 3> Dpose = {},
       OptionalJacobian<2, 2> Dpoint = {}) const;
 
@@ -222,7 +222,7 @@ public:
   Matrix transformTo(const Matrix& points) const;
 
   /** Return point coordinates in global frame */
-  GTSAM_EXPORT Point2 transformFrom(const Point2& point,
+  Point2 transformFrom(const Point2& point,
       OptionalJacobian<2, 3> Dpose = {},
       OptionalJacobian<2, 2> Dpoint = {}) const;
 
@@ -273,14 +273,14 @@ public:
   }
 
   //// return transformation matrix
-  GTSAM_EXPORT Matrix3 matrix() const;
+  Matrix3 matrix() const;
 
   /**
    * Calculate bearing to a landmark
    * @param point 2D location of landmark
    * @return 2D rotation \f$ \in SO(2) \f$
    */
-  GTSAM_EXPORT Rot2 bearing(const Point2& point,
+  Rot2 bearing(const Point2& point,
                OptionalJacobian<1, 3> H1={}, OptionalJacobian<1, 2> H2={}) const;
 
   /**
@@ -288,7 +288,7 @@ public:
    * @param point SO(2) location of other pose
    * @return 2D rotation \f$ \in SO(2) \f$
    */
-  GTSAM_EXPORT Rot2 bearing(const Pose2& pose,
+  Rot2 bearing(const Pose2& pose,
                OptionalJacobian<1, 3> H1={}, OptionalJacobian<1, 3> H2={}) const;
 
   /**
@@ -296,7 +296,7 @@ public:
    * @param point 2D location of landmark
    * @return range (double)
    */
-  GTSAM_EXPORT double range(const Point2& point,
+  double range(const Point2& point,
       OptionalJacobian<1, 3> H1={},
       OptionalJacobian<1, 2> H2={}) const;
 
@@ -305,7 +305,7 @@ public:
    * @param point 2D location of other pose
    * @return range (double)
    */
-  GTSAM_EXPORT double range(const Pose2& point,
+  double range(const Pose2& point,
       OptionalJacobian<1, 3> H1={},
       OptionalJacobian<1, 3> H2={}) const;
 

--- a/gtsam/geometry/Pose3.h
+++ b/gtsam/geometry/Pose3.h
@@ -204,7 +204,7 @@ public:
   static Matrix6 LogmapDerivative(const Pose3& xi);
 
   // Chart at origin, depends on compile-time flag GTSAM_POSE3_EXPMAP
-  struct ChartAtOrigin {
+  struct GTSAM_EXPORT ChartAtOrigin {
     static Pose3 Retract(const Vector6& xi, ChartJacobian Hxi = {});
     static Vector6 Local(const Pose3& pose, ChartJacobian Hpose = {});
   };

--- a/gtsam/geometry/Rot2.h
+++ b/gtsam/geometry/Rot2.h
@@ -141,7 +141,7 @@ namespace gtsam {
     }
 
     // Chart at origin simply uses exponential map and its inverse
-    struct ChartAtOrigin {
+    struct GTSAM_EXPORT ChartAtOrigin {
       static Rot2 Retract(const Vector1& v, ChartJacobian H = {}) {
         return Expmap(v, H);
       }

--- a/gtsam/geometry/Rot3.h
+++ b/gtsam/geometry/Rot3.h
@@ -396,7 +396,7 @@ class GTSAM_EXPORT Rot3 : public LieGroup<Rot3, 3> {
     Matrix3 AdjointMap() const { return matrix(); }
 
     // Chart at origin, depends on compile-time flag ROT3_DEFAULT_COORDINATES_MODE
-    struct ChartAtOrigin {
+    struct GTSAM_EXPORT ChartAtOrigin {
       static Rot3 Retract(const Vector3& v, ChartJacobian H = {});
       static Vector3 Local(const Rot3& r, ChartJacobian H = {});
     };

--- a/gtsam/geometry/Similarity2.h
+++ b/gtsam/geometry/Similarity2.h
@@ -150,7 +150,7 @@ class GTSAM_EXPORT Similarity2 : public LieGroup<Similarity2, 4> {
                             OptionalJacobian<4, 4> Hm = {});
 
   /// Chart at the origin
-  struct ChartAtOrigin {
+  struct GTSAM_EXPORT ChartAtOrigin {
     static Similarity2 Retract(const Vector4& v,
                                ChartJacobian H = {}) {
       return Similarity2::Expmap(v, H);

--- a/gtsam/geometry/Similarity3.h
+++ b/gtsam/geometry/Similarity3.h
@@ -150,7 +150,7 @@ class GTSAM_EXPORT Similarity3 : public LieGroup<Similarity3, 7> {
                             OptionalJacobian<7, 7> Hm = {});
 
   /// Chart at the origin
-  struct ChartAtOrigin {
+  struct GTSAM_EXPORT ChartAtOrigin {
     static Similarity3 Retract(const Vector7& v,
                                ChartJacobian H = {}) {
       return Similarity3::Expmap(v, H);

--- a/gtsam/inference/Ordering.h
+++ b/gtsam/inference/Ordering.h
@@ -34,7 +34,7 @@
 
 namespace gtsam {
 
-class Ordering: public KeyVector {
+class GTSAM_EXPORT Ordering: public KeyVector {
 protected:
   typedef KeyVector Base;
 
@@ -48,8 +48,7 @@ public:
   typedef Ordering This; ///< Typedef to this class
   typedef std::shared_ptr<This> shared_ptr; ///< shared_ptr to this class
 
-  /// Create an empty ordering
-  GTSAM_EXPORT
+  /// Create an empty ordering  
   Ordering() {
   }
 
@@ -105,7 +104,7 @@ public:
   }
 
   /// Compute a fill-reducing ordering using COLAMD from a VariableIndex.
-  static GTSAM_EXPORT Ordering Colamd(const VariableIndex& variableIndex);
+  static Ordering Colamd(const VariableIndex& variableIndex);
 
   /// Compute a fill-reducing ordering using constrained COLAMD from a factor graph (see details
   /// for note on performance).  This internally builds a VariableIndex so if you already have a
@@ -130,7 +129,7 @@ public:
   /// variables in \c constrainLast will be ordered in the same order specified in the KeyVector
   /// \c constrainLast.   If \c forceOrder is false, the variables in \c constrainLast will be
   /// ordered after all the others, but will be rearranged by CCOLAMD to reduce fill-in as well.
-  static GTSAM_EXPORT Ordering ColamdConstrainedLast(
+  static Ordering ColamdConstrainedLast(
       const VariableIndex& variableIndex, const KeyVector& constrainLast,
       bool forceOrder = false);
 
@@ -158,7 +157,7 @@ public:
   /// KeyVector \c constrainFirst.   If \c forceOrder is false, the variables in \c
   /// constrainFirst will be ordered before all the others, but will be rearranged by CCOLAMD to
   /// reduce fill-in as well.
-  static GTSAM_EXPORT Ordering ColamdConstrainedFirst(
+  static Ordering ColamdConstrainedFirst(
       const VariableIndex& variableIndex,
       const KeyVector& constrainFirst, bool forceOrder = false);
 
@@ -187,7 +186,7 @@ public:
   /// appear in \c groups in arbitrary order.  Any variables not present in \c groups will be
   /// assigned to group 0.  This function simply fills the \c cmember argument to CCOLAMD with the
   /// supplied indices, see the CCOLAMD documentation for more information.
-  static GTSAM_EXPORT Ordering ColamdConstrained(
+  static Ordering ColamdConstrained(
       const VariableIndex& variableIndex, const FastMap<Key, int>& groups);
 
   /// Return a natural Ordering. Typically used by iterative solvers
@@ -201,11 +200,11 @@ public:
 
   /// METIS Formatting function
   template<class FACTOR_GRAPH>
-  static GTSAM_EXPORT void CSRFormat(std::vector<int>& xadj,
+  static void CSRFormat(std::vector<int>& xadj,
       std::vector<int>& adj, const FACTOR_GRAPH& graph);
 
   /// Compute an ordering determined by METIS from a VariableIndex
-  static GTSAM_EXPORT Ordering Metis(const MetisIndex& met);
+  static Ordering Metis(const MetisIndex& met);
 
   template<class FACTOR_GRAPH>
   static Ordering Metis(const FACTOR_GRAPH& graph) {
@@ -246,19 +245,17 @@ public:
 
   /// @name Testable
   /// @{
-
-  GTSAM_EXPORT
+  
   void print(const std::string& str = "", const KeyFormatter& keyFormatter =
       DefaultKeyFormatter) const;
-
-  GTSAM_EXPORT
+  
   bool equals(const Ordering& other, double tol = 1e-9) const;
 
   /// @}
 
 private:
   /// Internal COLAMD function
-  static GTSAM_EXPORT Ordering ColamdConstrained(
+  static Ordering ColamdConstrained(
       const VariableIndex& variableIndex, std::vector<int>& cmember);
 
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION

--- a/gtsam_unstable/linear/LP.h
+++ b/gtsam_unstable/linear/LP.h
@@ -29,7 +29,7 @@ namespace gtsam {
 using namespace std;
 
 /// Mapping between variable's key and its corresponding dimensionality
-using KeyDimMap = std::map<Key, size_t>;
+using KeyDimMap = std::map<Key, uint32_t>;
 /*
  * Iterates through every factor in a linear graph and generates a
  * mapping between every factor key and it's corresponding dimensionality.


### PR DESCRIPTION
Fix windows tests:

1. compile with ninja
2. Add fix for compilation in Visual Studio. This seems to be a weird issue with how size_t is interpreted since the multiple symbols defined error comes from additional declarations of std::map<Key, size_t>. This might be a bug in MSVC 16. from #1553
3. GTSAM_EXPORT  on functions.
4. GTSAM_EXPORT  on nested structs / classes.