### PR TITLE
Fix windows tests

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -118,9 +118,9 @@ jobs:
           cmake --build build -j4 --config ${{ matrix.build_type }} --target check.sam
           cmake --build build -j4 --config ${{ matrix.build_type }} --target check.sfm
           cmake --build build -j4 --config ${{ matrix.build_type }} --target check.symbolic
-          # cmake --build build -j4 --config ${{ matrix.build_type }} --target check.hybrid
-          # cmake --build build -j4 --config ${{ matrix.build_type }} --target check.nonlinear
-          # cmake --build build -j4 --config ${{ matrix.build_type }} --target check.slam
+          cmake --build build -j4 --config ${{ matrix.build_type }} --target check.hybrid
+          cmake --build build -j4 --config ${{ matrix.build_type }} --target check.nonlinear
+          cmake --build build -j4 --config ${{ matrix.build_type }} --target check.slam
 
           # Run GTSAM_UNSTABLE tests
           cmake --build build -j4 --config ${{ matrix.build_type }} --target check.base_unstable

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -123,11 +123,11 @@ jobs:
           cmake --build build -j4 --config ${{ matrix.build_type }} --target check.slam
 
           # Run GTSAM_UNSTABLE tests
+          cmake --build build -j4 --config ${{ matrix.build_type }} --target check.geometry_unstable
+          cmake --build build -j4 --config ${{ matrix.build_type }} --target check.linear_unstable
+          cmake --build build -j4 --config ${{ matrix.build_type }} --target check.discrete_unstable
+          cmake --build build -j4 --config ${{ matrix.build_type }} --target check.dynamics_unstable
+          cmake --build build -j4 --config ${{ matrix.build_type }} --target check.nonlinear_unstable
+          cmake --build build -j4 --config ${{ matrix.build_type }} --target check.slam_unstable
+          cmake --build build -j4 --config ${{ matrix.build_type }} --target check.partition
           cmake --build build -j4 --config ${{ matrix.build_type }} --target check.base_unstable
-          # cmake --build build -j4 --config ${{ matrix.build_type }} --target check.geometry_unstable
-          # cmake --build build -j4 --config ${{ matrix.build_type }} --target check.linear_unstable
-          # cmake --build build -j4 --config ${{ matrix.build_type }} --target check.discrete_unstable
-          # cmake --build build -j4 --config ${{ matrix.build_type }} --target check.dynamics_unstable
-          # cmake --build build -j4 --config ${{ matrix.build_type }} --target check.nonlinear_unstable
-          # cmake --build build -j4 --config ${{ matrix.build_type }} --target check.slam_unstable
-          # cmake --build build -j4 --config ${{ matrix.build_type }} --target check.partition

--- a/gtsam/hybrid/HybridFactorGraph.h
+++ b/gtsam/hybrid/HybridFactorGraph.h
@@ -35,7 +35,7 @@ using SharedFactor = std::shared_ptr<Factor>;
  * Hybrid Factor Graph
  * Factor graph with utilities for hybrid factors.
  */
-class HybridFactorGraph : public FactorGraph<Factor> {
+class GTSAM_EXPORT HybridFactorGraph : public FactorGraph<Factor> {
  public:
   using Base = FactorGraph<Factor>;
   using This = HybridFactorGraph;              ///< this class

--- a/gtsam/hybrid/HybridSmoother.h
+++ b/gtsam/hybrid/HybridSmoother.h
@@ -24,7 +24,7 @@
 
 namespace gtsam {
 
-class HybridSmoother {
+class GTSAM_EXPORT HybridSmoother {
  private:
   HybridBayesNet hybridBayesNet_;
   HybridGaussianFactorGraph remainingFactorGraph_;

--- a/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
@@ -43,6 +43,7 @@
 #include <iostream>
 #include <iterator>
 #include <vector>
+#include <numeric>
 
 #include "Switching.h"
 #include "TinyHybridExample.h"


### PR DESCRIPTION
Fix windows tests:
I open more tests. also did internal check with `cmake --build build -j4 --config ${{ matrix.build_type }} --target check` That compile all tests.
There a few errors remain. 
One of the error is miss use of 3rd party metis on gtsam repo. The code is taken only for linux/osx but not for windows.
This is bad practice. You should create a download scrip for 3rd parties and compile it separately or use vcpkg that do the same.
I will past all the remain errors that you should deal with them in the following comments. 