### PR TITLE
Hybrid Elimination Improvements

### DIFF
--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -93,7 +93,7 @@ namespace gtsam {
     /// print
     void print(const std::string& s, const LabelFormatter& labelFormatter,
                const ValueFormatter& valueFormatter) const override {
-      std::cout << s << " Leaf [" << nrAssignments() << "]"
+      std::cout << s << " Leaf [" << nrAssignments() << "] "
                 << valueFormatter(constant_) << std::endl;
     }
 

--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -93,7 +93,8 @@ namespace gtsam {
     /// print
     void print(const std::string& s, const LabelFormatter& labelFormatter,
                const ValueFormatter& valueFormatter) const override {
-      std::cout << s << " Leaf " << valueFormatter(constant_) << std::endl;
+      std::cout << s << " Leaf [" << nrAssignments() << "]"
+                << valueFormatter(constant_) << std::endl;
     }
 
     /** Write graphviz format to stream `os`. */
@@ -825,6 +826,16 @@ namespace gtsam {
     size_t total = 0;
     visit([&total](const Y& node) { total += 1; });
     return total;
+  }
+
+  /****************************************************************************/
+  template <typename L, typename Y>
+  size_t DecisionTree<L, Y>::nrAssignments() const {
+    size_t n = 0;
+    this->visitLeaf([&n](const DecisionTree<L, Y>::Leaf& leaf) {
+      n += leaf.nrAssignments();
+    });
+    return n;
   }
 
   /****************************************************************************/

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -300,6 +300,42 @@ namespace gtsam {
     size_t nrLeaves() const;
 
     /**
+     * @brief This is a convenience function which returns the total number of
+     * leaf assignments in the decision tree.
+     * This function is not used for anymajor operations within the discrete
+     * factor graph framework.
+     *
+     * Leaf assignments represent the cardinality of each leaf node, e.g. in a
+     * binary tree each leaf has 2 assignments. This includes counts removed
+     * from implicit pruning hence, it will always be >= nrLeaves().
+     *
+     * E.g. we have a decision tree as below, where each node has 2 branches:
+     *
+     * Choice(m1)
+     * 0 Choice(m0)
+     * 0 0 Leaf 0.0
+     * 0 1 Leaf 0.0
+     * 1 Choice(m0)
+     * 1 0 Leaf 1.0
+     * 1 1 Leaf 2.0
+     *
+     * In the unpruned form, the tree will have 4 assignments, 2 for each key,
+     * and 4 leaves.
+     *
+     * In the pruned form, the number of assignments is still 4 but the number
+     * of leaves is now 3, as below:
+     *
+     * Choice(m1)
+     * 0 Leaf 0.0
+     * 1 Choice(m0)
+     * 1 0 Leaf 1.0
+     * 1 1 Leaf 2.0
+     *
+     * @return size_t
+     */
+    size_t nrAssignments() const;
+
+    /**
      * @brief Fold a binary function over the tree, returning accumulator.
      *
      * @tparam X type for accumulator.

--- a/gtsam/discrete/DecisionTreeFactor.cpp
+++ b/gtsam/discrete/DecisionTreeFactor.cpp
@@ -102,6 +102,14 @@ namespace gtsam {
   }
 
   /* ************************************************************************ */
+  DecisionTreeFactor DecisionTreeFactor::apply(ADT::UnaryAssignment op) const {
+    // apply operand
+    ADT result = ADT::apply(op);
+    // Make a new factor
+    return DecisionTreeFactor(discreteKeys(), result);
+  }
+
+  /* ************************************************************************ */
   DecisionTreeFactor::shared_ptr DecisionTreeFactor::combine(
       size_t nrFrontals, ADT::Binary op) const {
     if (nrFrontals > size()) {

--- a/gtsam/discrete/DecisionTreeFactor.h
+++ b/gtsam/discrete/DecisionTreeFactor.h
@@ -147,6 +147,9 @@ namespace gtsam {
     /// @name Advanced Interface
     /// @{
 
+    /// Inherit all the `apply` methods from AlgebraicDecisionTree
+    using ADT::apply;
+
     /**
      * Apply binary operator (*this) "op" f
      * @param f the second argument for op

--- a/gtsam/discrete/DecisionTreeFactor.h
+++ b/gtsam/discrete/DecisionTreeFactor.h
@@ -147,8 +147,11 @@ namespace gtsam {
     /// @name Advanced Interface
     /// @{
 
-    /// Inherit all the `apply` methods from AlgebraicDecisionTree
-    using ADT::apply;
+    /**
+     * Apply unary operator (*this) "op" f
+     * @param op a unary operator that operates on AlgebraicDecisionTree
+     */
+    DecisionTreeFactor apply(ADT::UnaryAssignment op) const;
 
     /**
      * Apply binary operator (*this) "op" f

--- a/gtsam/discrete/tests/testDecisionTree.cpp
+++ b/gtsam/discrete/tests/testDecisionTree.cpp
@@ -531,6 +531,38 @@ TEST(DecisionTree, ApplyWithAssignment) {
   EXPECT_LONGS_EQUAL(5, count);
 }
 
+/* ************************************************************************** */
+// Test number of assignments.
+TEST(DecisionTree, NrAssignments2) {
+  using gtsam::symbol_shorthand::M;
+
+  std::vector<double> probs = {0, 0, 1, 2};
+
+  /* Create the decision tree
+    Choice(m1)
+    0 Leaf 0.000000
+    1 Choice(m0)
+    1 0 Leaf 1.000000
+    1 1 Leaf 2.000000
+  */
+  DiscreteKeys keys{{M(1), 2}, {M(0), 2}};
+  DecisionTree<Key, double> dt1(keys, probs);
+  EXPECT_LONGS_EQUAL(4, dt1.nrAssignments());
+
+  /* Create the DecisionTree
+    Choice(m1)
+    0 Choice(m0)
+    0 0 Leaf 0.000000
+    0 1 Leaf 1.000000
+    1 Choice(m0)
+    1 0 Leaf 0.000000
+    1 1 Leaf 2.000000
+  */
+  DiscreteKeys keys2{{M(0), 2}, {M(1), 2}};
+  DecisionTree<Key, double> dt2(keys2, probs);
+  EXPECT_LONGS_EQUAL(4, dt2.nrAssignments());
+}
+
 /* ************************************************************************* */
 int main() {
   TestResult tr;

--- a/gtsam/discrete/tests/testDecisionTree.cpp
+++ b/gtsam/discrete/tests/testDecisionTree.cpp
@@ -25,6 +25,7 @@
 #include <gtsam/base/serializationTestHelpers.h>
 #include <gtsam/discrete/DecisionTree-inl.h>
 #include <gtsam/discrete/Signature.h>
+#include <gtsam/inference/Symbol.h>
 
 #include <iomanip>
 
@@ -529,38 +530,6 @@ TEST(DecisionTree, ApplyWithAssignment) {
 
   // Check if apply doesn't enumerate all leaves.
   EXPECT_LONGS_EQUAL(5, count);
-}
-
-/* ************************************************************************** */
-// Test number of assignments.
-TEST(DecisionTree, NrAssignments2) {
-  using gtsam::symbol_shorthand::M;
-
-  std::vector<double> probs = {0, 0, 1, 2};
-
-  /* Create the decision tree
-    Choice(m1)
-    0 Leaf 0.000000
-    1 Choice(m0)
-    1 0 Leaf 1.000000
-    1 1 Leaf 2.000000
-  */
-  DiscreteKeys keys{{M(1), 2}, {M(0), 2}};
-  DecisionTree<Key, double> dt1(keys, probs);
-  EXPECT_LONGS_EQUAL(4, dt1.nrAssignments());
-
-  /* Create the DecisionTree
-    Choice(m1)
-    0 Choice(m0)
-    0 0 Leaf 0.000000
-    0 1 Leaf 1.000000
-    1 Choice(m0)
-    1 0 Leaf 0.000000
-    1 1 Leaf 2.000000
-  */
-  DiscreteKeys keys2{{M(0), 2}, {M(1), 2}};
-  DecisionTree<Key, double> dt2(keys2, probs);
-  EXPECT_LONGS_EQUAL(4, dt2.nrAssignments());
 }
 
 /* ************************************************************************* */

--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -155,18 +155,18 @@ void HybridBayesNet::updateDiscreteConditionals(
       auto discrete = conditional->asDiscrete();
 
       // Convert pointer from conditional to factor
-      auto discreteTree =
-          std::dynamic_pointer_cast<DecisionTreeFactor::ADT>(discrete);
+      auto discreteFactor =
+          std::dynamic_pointer_cast<DecisionTreeFactor>(discrete);
       // Apply prunerFunc to the underlying AlgebraicDecisionTree
-      DecisionTreeFactor::ADT prunedDiscreteTree =
-          discreteTree->apply(prunerFunc(prunedDiscreteProbs, *conditional));
+      DecisionTreeFactor::ADT prunedDiscreteFactor =
+          discreteFactor->apply(prunerFunc(prunedDiscreteProbs, *conditional));
 
       gttic_(HybridBayesNet_MakeConditional);
       // Create the new (hybrid) conditional
       KeyVector frontals(discrete->frontals().begin(),
                          discrete->frontals().end());
       auto prunedDiscrete = std::make_shared<DiscreteLookupTable>(
-          frontals.size(), conditional->discreteKeys(), prunedDiscreteTree);
+          frontals.size(), conditional->discreteKeys(), prunedDiscreteFactor);
       conditional = std::make_shared<HybridConditional>(prunedDiscrete);
       gttoc_(HybridBayesNet_MakeConditional);
 

--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -146,8 +146,7 @@ std::function<double(const Assignment<Key> &, double)> prunerFunc(
 /* ************************************************************************* */
 void HybridBayesNet::updateDiscreteConditionals(
     const DecisionTreeFactor &prunedDiscreteProbs) {
-  KeyVector prunedTreeKeys = prunedDiscreteProbs.keys();
-
+  //TODO(Varun) Should prune the joint conditional, maybe during elimination?
   // Loop with index since we need it later.
   for (size_t i = 0; i < this->size(); i++) {
     HybridConditional::shared_ptr conditional = this->at(i);

--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -38,21 +38,17 @@ bool HybridBayesNet::equals(const This &bn, double tol) const {
 }
 
 /* ************************************************************************* */
-DecisionTreeFactor::shared_ptr HybridBayesNet::discreteConditionals() const {
-  AlgebraicDecisionTree<Key> discreteProbs;
-
+DiscreteConditional::shared_ptr HybridBayesNet::discreteConditionals() const {
   // The canonical decision tree factor which will get
   // the discrete conditionals added to it.
-  DecisionTreeFactor discreteProbsFactor;
+  DiscreteConditional discreteProbs;
 
   for (auto &&conditional : *this) {
     if (conditional->isDiscrete()) {
-      // Convert to a DecisionTreeFactor and add it to the main factor.
-      DecisionTreeFactor f(*conditional->asDiscrete());
-      discreteProbsFactor = discreteProbsFactor * f;
+      discreteProbs = discreteProbs * (*conditional->asDiscrete());
     }
   }
-  return std::make_shared<DecisionTreeFactor>(discreteProbsFactor);
+  return std::make_shared<DiscreteConditional>(discreteProbs);
 }
 
 /* ************************************************************************* */
@@ -146,8 +142,8 @@ std::function<double(const Assignment<Key> &, double)> prunerFunc(
 /* ************************************************************************* */
 void HybridBayesNet::updateDiscreteConditionals(
     const DecisionTreeFactor &prunedDiscreteProbs) {
-  //TODO(Varun) Should prune the joint conditional, maybe during elimination?
-  // Loop with index since we need it later.
+  // TODO(Varun) Should prune the joint conditional, maybe during elimination?
+  //  Loop with index since we need it later.
   for (size_t i = 0; i < this->size(); i++) {
     HybridConditional::shared_ptr conditional = this->at(i);
     if (conditional->isDiscrete()) {
@@ -179,7 +175,7 @@ void HybridBayesNet::updateDiscreteConditionals(
 HybridBayesNet HybridBayesNet::prune(size_t maxNrLeaves) {
   // Get the decision tree of only the discrete keys
   gttic_(HybridBayesNet_PruneDiscreteConditionals);
-  DecisionTreeFactor::shared_ptr discreteConditionals =
+  DiscreteConditional::shared_ptr discreteConditionals =
       this->discreteConditionals();
   const DecisionTreeFactor prunedDiscreteProbs =
       discreteConditionals->prune(maxNrLeaves);

--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -39,8 +39,7 @@ bool HybridBayesNet::equals(const This &bn, double tol) const {
 
 /* ************************************************************************* */
 DiscreteConditional::shared_ptr HybridBayesNet::discreteConditionals() const {
-  // The canonical decision tree factor which will get
-  // the discrete conditionals added to it.
+  // The joint discrete probability.
   DiscreteConditional discreteProbs;
 
   for (auto &&conditional : *this) {
@@ -152,7 +151,7 @@ void HybridBayesNet::updateDiscreteConditionals(
       // Convert pointer from conditional to factor
       auto discreteFactor =
           std::dynamic_pointer_cast<DecisionTreeFactor>(discrete);
-      // Apply prunerFunc to the underlying AlgebraicDecisionTree
+      // Apply prunerFunc to the underlying conditional
       DecisionTreeFactor::ADT prunedDiscreteFactor =
           discreteFactor->apply(prunerFunc(prunedDiscreteProbs, *conditional));
 
@@ -173,7 +172,7 @@ void HybridBayesNet::updateDiscreteConditionals(
 
 /* ************************************************************************* */
 HybridBayesNet HybridBayesNet::prune(size_t maxNrLeaves) {
-  // Get the decision tree of only the discrete keys
+  // Get the joint distribution of only the discrete keys
   gttic_(HybridBayesNet_PruneDiscreteConditionals);
   DiscreteConditional::shared_ptr discreteConditionals =
       this->discreteConditionals();

--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -38,19 +38,6 @@ bool HybridBayesNet::equals(const This &bn, double tol) const {
 }
 
 /* ************************************************************************* */
-DiscreteConditional::shared_ptr HybridBayesNet::discreteConditionals() const {
-  // The joint discrete probability.
-  DiscreteConditional discreteProbs;
-
-  for (auto &&conditional : *this) {
-    if (conditional->isDiscrete()) {
-      discreteProbs = discreteProbs * (*conditional->asDiscrete());
-    }
-  }
-  return std::make_shared<DiscreteConditional>(discreteProbs);
-}
-
-/* ************************************************************************* */
 /**
  * @brief Helper function to get the pruner functional.
  *
@@ -139,52 +126,52 @@ std::function<double(const Assignment<Key> &, double)> prunerFunc(
 }
 
 /* ************************************************************************* */
-void HybridBayesNet::updateDiscreteConditionals(
-    const DecisionTreeFactor &prunedDiscreteProbs) {
-  // TODO(Varun) Should prune the joint conditional, maybe during elimination?
-  //  Loop with index since we need it later.
+DecisionTreeFactor HybridBayesNet::pruneDiscreteConditionals(
+    size_t maxNrLeaves) {
+  // Get the joint distribution of only the discrete keys
+  gttic_(HybridBayesNet_PruneDiscreteConditionals);
+  // The joint discrete probability.
+  DiscreteConditional discreteProbs;
+
+  std::vector<size_t> discrete_factor_idxs;
+  // Record frontal keys so we can maintain ordering
+  Ordering discrete_frontals;
+
   for (size_t i = 0; i < this->size(); i++) {
-    HybridConditional::shared_ptr conditional = this->at(i);
+    auto conditional = this->at(i);
     if (conditional->isDiscrete()) {
-      auto discrete = conditional->asDiscrete();
+      discreteProbs = discreteProbs * (*conditional->asDiscrete());
 
-      // Convert pointer from conditional to factor
-      auto discreteFactor =
-          std::dynamic_pointer_cast<DecisionTreeFactor>(discrete);
-      // Apply prunerFunc to the underlying conditional
-      DecisionTreeFactor::ADT prunedDiscreteFactor =
-          discreteFactor->apply(prunerFunc(prunedDiscreteProbs, *conditional));
-
-      gttic_(HybridBayesNet_MakeConditional);
-      // Create the new (hybrid) conditional
-      KeyVector frontals(discrete->frontals().begin(),
-                         discrete->frontals().end());
-      auto prunedDiscrete = std::make_shared<DiscreteLookupTable>(
-          frontals.size(), conditional->discreteKeys(), prunedDiscreteFactor);
-      conditional = std::make_shared<HybridConditional>(prunedDiscrete);
-      gttoc_(HybridBayesNet_MakeConditional);
-
-      // Add it back to the BayesNet
-      this->at(i) = conditional;
+      Ordering conditional_keys(conditional->frontals());
+      discrete_frontals += conditional_keys;
+      discrete_factor_idxs.push_back(i);
     }
   }
+  const DecisionTreeFactor prunedDiscreteProbs =
+      discreteProbs.prune(maxNrLeaves);
+  gttoc_(HybridBayesNet_PruneDiscreteConditionals);
+
+  // Eliminate joint probability back into conditionals
+  gttic_(HybridBayesNet_UpdateDiscreteConditionals);
+  DiscreteFactorGraph dfg{prunedDiscreteProbs};
+  DiscreteBayesNet::shared_ptr dbn = dfg.eliminateSequential(discrete_frontals);
+
+  // Assign pruned discrete conditionals back at the correct indices.
+  for (size_t i = 0; i < discrete_factor_idxs.size(); i++) {
+    size_t idx = discrete_factor_idxs.at(i);
+    this->at(idx) = std::make_shared<HybridConditional>(dbn->at(i));
+  }
+  gttoc_(HybridBayesNet_UpdateDiscreteConditionals);
+
+  return prunedDiscreteProbs;
 }
 
 /* ************************************************************************* */
 HybridBayesNet HybridBayesNet::prune(size_t maxNrLeaves) {
-  // Get the joint distribution of only the discrete keys
-  gttic_(HybridBayesNet_PruneDiscreteConditionals);
-  DiscreteConditional::shared_ptr discreteConditionals =
-      this->discreteConditionals();
-  const DecisionTreeFactor prunedDiscreteProbs =
-      discreteConditionals->prune(maxNrLeaves);
-  gttoc_(HybridBayesNet_PruneDiscreteConditionals);
+  DecisionTreeFactor prunedDiscreteProbs =
+      this->pruneDiscreteConditionals(maxNrLeaves);
 
-  gttic_(HybridBayesNet_UpdateDiscreteConditionals);
-  this->updateDiscreteConditionals(prunedDiscreteProbs);
-  gttoc_(HybridBayesNet_UpdateDiscreteConditionals);
-
-  /* To Prune, we visitWith every leaf in the GaussianMixture.
+  /* To prune, we visitWith every leaf in the GaussianMixture.
    * For each leaf, using the assignment we can check the discrete decision tree
    * for 0.0 probability, then just set the leaf to a nullptr.
    *

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -137,13 +137,6 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
   VectorValues optimize(const DiscreteValues &assignment) const;
 
   /**
-   * @brief Get all the discrete conditionals as a decision tree factor.
-   *
-   * @return DiscreteConditional::shared_ptr
-   */
-  DiscreteConditional::shared_ptr discreteConditionals() const;
-
-  /**
    * @brief Sample from an incomplete BayesNet, given missing variables.
    *
    * Example:
@@ -222,11 +215,11 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
 
  private:
   /**
-   * @brief Update the discrete conditionals with the pruned versions.
+   * @brief Prune all the discrete conditionals.
    *
-   * @param prunedDiscreteProbs
+   * @param maxNrLeaves
    */
-  void updateDiscreteConditionals(const DecisionTreeFactor &prunedDiscreteProbs);
+  DecisionTreeFactor pruneDiscreteConditionals(size_t maxNrLeaves);
 
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -139,9 +139,9 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
   /**
    * @brief Get all the discrete conditionals as a decision tree factor.
    *
-   * @return DecisionTreeFactor::shared_ptr
+   * @return DiscreteConditional::shared_ptr
    */
-  DecisionTreeFactor::shared_ptr discreteConditionals() const;
+  DiscreteConditional::shared_ptr discreteConditionals() const;
 
   /**
    * @brief Sample from an incomplete BayesNet, given missing variables.

--- a/gtsam/hybrid/HybridFactor.h
+++ b/gtsam/hybrid/HybridFactor.h
@@ -20,6 +20,7 @@
 #include <gtsam/base/Testable.h>
 #include <gtsam/discrete/DecisionTree.h>
 #include <gtsam/discrete/DiscreteKey.h>
+#include <gtsam/discrete/TableFactor.h>
 #include <gtsam/inference/Factor.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
 #include <gtsam/nonlinear/Values.h>

--- a/gtsam/hybrid/HybridFactorGraph.cpp
+++ b/gtsam/hybrid/HybridFactorGraph.cpp
@@ -17,7 +17,6 @@
  * @date   January, 2023
  */
 
-#include <gtsam/discrete/DecisionTreeFactor.h>
 #include <gtsam/hybrid/HybridFactorGraph.h>
 
 namespace gtsam {
@@ -26,7 +25,7 @@ namespace gtsam {
 std::set<DiscreteKey> HybridFactorGraph::discreteKeys() const {
   std::set<DiscreteKey> keys;
   for (auto& factor : factors_) {
-    if (auto p = std::dynamic_pointer_cast<DecisionTreeFactor>(factor)) {
+    if (auto p = std::dynamic_pointer_cast<DiscreteFactor>(factor)) {
       for (const DiscreteKey& key : p->discreteKeys()) {
         keys.insert(key);
       }

--- a/gtsam/hybrid/HybridFactorGraph.cpp
+++ b/gtsam/hybrid/HybridFactorGraph.cpp
@@ -67,6 +67,8 @@ const KeySet HybridFactorGraph::continuousKeySet() const {
       for (const Key& key : p->continuousKeys()) {
         keys.insert(key);
       }
+    } else if (auto p = std::dynamic_pointer_cast<GaussianFactor>(factor)) {
+      keys.insert(p->keys().begin(), p->keys().end());
     }
   }
   return keys;

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -261,12 +261,9 @@ hybridElimination(const HybridGaussianFactorGraph &factors,
 
     DecisionTree<Key, double> probabilities(eliminationResults, probability);
 
-    auto dtf =
-        std::make_shared<DecisionTreeFactor>(discreteSeparator, probabilities);
-
     return {
         std::make_shared<HybridConditional>(gaussianMixture),
-        std::make_shared<TableFactor>(discreteSeparator, dtf->probabilities())};
+        std::make_shared<DecisionTreeFactor>(discreteSeparator, probabilities)};
   } else {
     // Otherwise, we create a resulting GaussianMixtureFactor on the separator,
     // taking care to correct for conditional constant.

--- a/gtsam/hybrid/HybridGaussianFactorGraph.h
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.h
@@ -40,6 +40,7 @@ class HybridEliminationTree;
 class HybridBayesTree;
 class HybridJunctionTree;
 class DecisionTreeFactor;
+class TableFactor;
 class JacobianFactor;
 class HybridValues;
 

--- a/gtsam/hybrid/HybridJunctionTree.cpp
+++ b/gtsam/hybrid/HybridJunctionTree.cpp
@@ -66,7 +66,7 @@ struct HybridConstructorTraversalData {
         for (auto& k : hf->discreteKeys()) {
           data.discreteKeys.insert(k.first);
         }
-      } else if (auto hf = std::dynamic_pointer_cast<DecisionTreeFactor>(f)) {
+      } else if (auto hf = std::dynamic_pointer_cast<DiscreteFactor>(f)) {
         for (auto& k : hf->discreteKeys()) {
           data.discreteKeys.insert(k.first);
         }
@@ -161,7 +161,7 @@ HybridJunctionTree::HybridJunctionTree(
   Data rootData(0);
   rootData.junctionTreeNode =
       std::make_shared<typename Base::Node>();  // Make a dummy node to gather
-                                                  // the junction tree roots
+                                                // the junction tree roots
   treeTraversal::DepthFirstForest(eliminationTree, rootData,
                                   Data::ConstructorTraversalVisitorPre,
                                   Data::ConstructorTraversalVisitorPost);

--- a/gtsam/hybrid/HybridNonlinearFactorGraph.cpp
+++ b/gtsam/hybrid/HybridNonlinearFactorGraph.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <gtsam/discrete/DecisionTreeFactor.h>
+#include <gtsam/discrete/TableFactor.h>
 #include <gtsam/hybrid/GaussianMixture.h>
 #include <gtsam/hybrid/HybridGaussianFactorGraph.h>
 #include <gtsam/hybrid/HybridNonlinearFactorGraph.h>
@@ -67,7 +68,7 @@ HybridGaussianFactorGraph::shared_ptr HybridNonlinearFactorGraph::linearize(
     } else if (auto nlf = dynamic_pointer_cast<NonlinearFactor>(f)) {
       const GaussianFactor::shared_ptr& gf = nlf->linearize(continuousValues);
       linearFG->push_back(gf);
-    } else if (dynamic_pointer_cast<DecisionTreeFactor>(f)) {
+    } else if (dynamic_pointer_cast<DiscreteFactor>(f)) {
       // If discrete-only: doesn't need linearization.
       linearFG->push_back(f);
     } else if (auto gmf = dynamic_pointer_cast<GaussianMixtureFactor>(f)) {

--- a/gtsam/hybrid/HybridSmoother.cpp
+++ b/gtsam/hybrid/HybridSmoother.cpp
@@ -72,7 +72,8 @@ void HybridSmoother::update(HybridGaussianFactorGraph graph,
       addConditionals(graph, hybridBayesNet_, ordering);
 
   // Eliminate.
-  auto bayesNetFragment = graph.eliminateSequential(ordering);
+  HybridBayesNet::shared_ptr bayesNetFragment =
+      graph.eliminateSequential(ordering);
 
   /// Prune
   if (maxNrLeaves) {

--- a/gtsam/hybrid/HybridSmoother.cpp
+++ b/gtsam/hybrid/HybridSmoother.cpp
@@ -97,7 +97,8 @@ HybridSmoother::addConditionals(const HybridGaussianFactorGraph &originalGraph,
   HybridGaussianFactorGraph graph(originalGraph);
   HybridBayesNet hybridBayesNet(originalHybridBayesNet);
 
-  // If we are not at the first iteration, means we have conditionals to add.
+  // If hybridBayesNet is not empty,
+  // it means we have conditionals to add to the factor graph.
   if (!hybridBayesNet.empty()) {
     // We add all relevant conditional mixtures on the last continuous variable
     // in the previous `hybridBayesNet` to the graph

--- a/gtsam/hybrid/tests/Switching.h
+++ b/gtsam/hybrid/tests/Switching.h
@@ -202,31 +202,16 @@ struct Switching {
    * @brief Add "mode chain" to HybridNonlinearFactorGraph from M(0) to M(K-2).
    * E.g. if K=4, we want M0, M1 and M2.
    *
-   * @param fg The nonlinear factor graph to which the mode chain is added.
+   * @param fg The factor graph to which the mode chain is added.
    */
-  void addModeChain(HybridNonlinearFactorGraph *fg,
+  template <typename FACTORGRAPH>
+  void addModeChain(FACTORGRAPH *fg,
                     std::string discrete_transition_prob = "1/2 3/2") {
-    fg->emplace_shared<DiscreteDistribution>(modes[0], "1/1");
+    fg->template emplace_shared<DiscreteDistribution>(modes[0], "1/1");
     for (size_t k = 0; k < K - 2; k++) {
       auto parents = {modes[k]};
-      fg->emplace_shared<DiscreteConditional>(modes[k + 1], parents,
-                                              discrete_transition_prob);
-    }
-  }
-
-  /**
-   * @brief Add "mode chain" to HybridGaussianFactorGraph from M(0) to M(K-2).
-   * E.g. if K=4, we want M0, M1 and M2.
-   *
-   * @param fg The gaussian factor graph to which the mode chain is added.
-   */
-  void addModeChain(HybridGaussianFactorGraph *fg,
-                    std::string discrete_transition_prob = "1/2 3/2") {
-    fg->emplace_shared<DiscreteDistribution>(modes[0], "1/1");
-    for (size_t k = 0; k < K - 2; k++) {
-      auto parents = {modes[k]};
-      fg->emplace_shared<DiscreteConditional>(modes[k + 1], parents,
-                                              discrete_transition_prob);
+      fg->template emplace_shared<DiscreteConditional>(
+          modes[k + 1], parents, discrete_transition_prob);
     }
   }
 };

--- a/gtsam/hybrid/tests/testGaussianMixtureFactor.cpp
+++ b/gtsam/hybrid/tests/testGaussianMixtureFactor.cpp
@@ -108,7 +108,7 @@ TEST(GaussianMixtureFactor, Printing) {
   std::string expected =
       R"(Hybrid [x1 x2; 1]{
  Choice(1) 
- 0 Leaf :
+ 0 Leaf [1]:
   A[x1] = [
 	0;
 	0
@@ -120,7 +120,7 @@ TEST(GaussianMixtureFactor, Printing) {
   b = [ 0 0 ]
   No noise model
 
- 1 Leaf :
+ 1 Leaf [1]:
   A[x1] = [
 	0;
 	0

--- a/gtsam/hybrid/tests/testGaussianMixtureFactor.cpp
+++ b/gtsam/hybrid/tests/testGaussianMixtureFactor.cpp
@@ -108,7 +108,7 @@ TEST(GaussianMixtureFactor, Printing) {
   std::string expected =
       R"(Hybrid [x1 x2; 1]{
  Choice(1) 
- 0 Leaf [1]:
+ 0 Leaf [1] :
   A[x1] = [
 	0;
 	0
@@ -120,7 +120,7 @@ TEST(GaussianMixtureFactor, Printing) {
   b = [ 0 0 ]
   No noise model
 
- 1 Leaf [1]:
+ 1 Leaf [1] :
   A[x1] = [
 	0;
 	0

--- a/gtsam/hybrid/tests/testHybridBayesTree.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesTree.cpp
@@ -146,7 +146,7 @@ TEST(HybridBayesTree, Optimize) {
 
   DiscreteFactorGraph dfg;
   for (auto&& f : *remainingFactorGraph) {
-    auto discreteFactor = dynamic_pointer_cast<DecisionTreeFactor>(f);
+    auto discreteFactor = dynamic_pointer_cast<DiscreteFactor>(f);
     assert(discreteFactor);
     dfg.push_back(discreteFactor);
   }

--- a/gtsam/hybrid/tests/testHybridFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridFactorGraph.cpp
@@ -18,7 +18,9 @@
 #include <gtsam/base/TestableAssertions.h>
 #include <gtsam/base/utilities.h>
 #include <gtsam/hybrid/HybridFactorGraph.h>
+#include <gtsam/hybrid/HybridGaussianFactorGraph.h>
 #include <gtsam/inference/Symbol.h>
+#include <gtsam/linear/JacobianFactor.h>
 #include <gtsam/nonlinear/PriorFactor.h>
 
 using namespace std;
@@ -35,6 +37,32 @@ using symbol_shorthand::X;
 TEST(HybridFactorGraph, Constructor) {
   // Initialize the hybrid factor graph
   HybridFactorGraph fg;
+}
+
+/* ************************************************************************* */
+// Test if methods to get keys work as expected.
+TEST(HybridFactorGraph, Keys) {
+  HybridGaussianFactorGraph hfg;
+
+  // Add prior on x0
+  hfg.add(JacobianFactor(X(0), I_3x3, Z_3x1));
+
+  // Add factor between x0 and x1
+  hfg.add(JacobianFactor(X(0), I_3x3, X(1), -I_3x3, Z_3x1));
+
+  // Add a gaussian mixture factor ϕ(x1, c1)
+  DiscreteKey m1(M(1), 2);
+  DecisionTree<Key, GaussianFactor::shared_ptr> dt(
+      M(1), std::make_shared<JacobianFactor>(X(1), I_3x3, Z_3x1),
+      std::make_shared<JacobianFactor>(X(1), I_3x3, Vector3::Ones()));
+  hfg.add(GaussianMixtureFactor({X(1)}, {m1}, dt));
+
+  KeySet expected_continuous{X(0), X(1)};
+  EXPECT(
+      assert_container_equality(expected_continuous, hfg.continuousKeySet()));
+
+  KeySet expected_discrete{M(1)};
+  EXPECT(assert_container_equality(expected_discrete, hfg.discreteKeySet()));
 }
 
 /* ************************************************************************* */

--- a/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
@@ -902,7 +902,7 @@ TEST(HybridGaussianFactorGraph, EliminateSwitchingNetwork) {
   // Test resulting posterior Bayes net has correct size:
   EXPECT_LONGS_EQUAL(8, posterior->size());
 
-  // TODO(dellaert): this test fails - no idea why.
+  // Ratio test
   EXPECT(ratioTest(bn, measurements, *posterior));
 }
 

--- a/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
@@ -492,7 +492,7 @@ factor 0:
 factor 1: 
 Hybrid [x0 x1; m0]{
  Choice(m0) 
- 0 Leaf :
+ 0 Leaf [1]:
   A[x0] = [
 	-1
 ]
@@ -502,7 +502,7 @@ Hybrid [x0 x1; m0]{
   b = [ -1 ]
   No noise model
 
- 1 Leaf :
+ 1 Leaf [1]:
   A[x0] = [
 	-1
 ]
@@ -516,7 +516,7 @@ Hybrid [x0 x1; m0]{
 factor 2: 
 Hybrid [x1 x2; m1]{
  Choice(m1) 
- 0 Leaf :
+ 0 Leaf [1]:
   A[x1] = [
 	-1
 ]
@@ -526,7 +526,7 @@ Hybrid [x1 x2; m1]{
   b = [ -1 ]
   No noise model
 
- 1 Leaf :
+ 1 Leaf [1]:
   A[x1] = [
 	-1
 ]
@@ -550,16 +550,16 @@ factor 4:
   b = [ -10 ]
   No noise model
 factor 5:  P( m0 ):
- Leaf  0.5
+ Leaf [2] 0.5
 
 factor 6:  P( m1 | m0 ):
  Choice(m1) 
  0 Choice(m0) 
- 0 0 Leaf 0.33333333
- 0 1 Leaf  0.6
+ 0 0 Leaf [1]0.33333333
+ 0 1 Leaf [1] 0.6
  1 Choice(m0) 
- 1 0 Leaf 0.66666667
- 1 1 Leaf  0.4
+ 1 0 Leaf [1]0.66666667
+ 1 1 Leaf [1] 0.4
 
 )";
   EXPECT(assert_print_equal(expected_hybridFactorGraph, linearizedFactorGraph));
@@ -570,13 +570,13 @@ size: 3
 conditional 0: Hybrid  P( x0 | x1 m0)
  Discrete Keys = (m0, 2), 
  Choice(m0) 
- 0 Leaf  p(x0 | x1)
+ 0 Leaf [1] p(x0 | x1)
   R = [ 10.0499 ]
   S[x1] = [ -0.0995037 ]
   d = [ -9.85087 ]
   No noise model
 
- 1 Leaf  p(x0 | x1)
+ 1 Leaf [1] p(x0 | x1)
   R = [ 10.0499 ]
   S[x1] = [ -0.0995037 ]
   d = [ -9.95037 ]
@@ -586,26 +586,26 @@ conditional 1: Hybrid  P( x1 | x2 m0 m1)
  Discrete Keys = (m0, 2), (m1, 2), 
  Choice(m1) 
  0 Choice(m0) 
- 0 0 Leaf  p(x1 | x2)
+ 0 0 Leaf [1] p(x1 | x2)
   R = [ 10.099 ]
   S[x2] = [ -0.0990196 ]
   d = [ -9.99901 ]
   No noise model
 
- 0 1 Leaf  p(x1 | x2)
+ 0 1 Leaf [1] p(x1 | x2)
   R = [ 10.099 ]
   S[x2] = [ -0.0990196 ]
   d = [ -9.90098 ]
   No noise model
 
  1 Choice(m0) 
- 1 0 Leaf  p(x1 | x2)
+ 1 0 Leaf [1] p(x1 | x2)
   R = [ 10.099 ]
   S[x2] = [ -0.0990196 ]
   d = [ -10.098 ]
   No noise model
 
- 1 1 Leaf  p(x1 | x2)
+ 1 1 Leaf [1] p(x1 | x2)
   R = [ 10.099 ]
   S[x2] = [ -0.0990196 ]
   d = [ -10 ]
@@ -615,14 +615,14 @@ conditional 2: Hybrid  P( x2 | m0 m1)
  Discrete Keys = (m0, 2), (m1, 2), 
  Choice(m1) 
  0 Choice(m0) 
- 0 0 Leaf  p(x2)
+ 0 0 Leaf [1] p(x2)
   R = [ 10.0494 ]
   d = [ -10.1489 ]
   mean: 1 elements
   x2: -1.0099
   No noise model
 
- 0 1 Leaf  p(x2)
+ 0 1 Leaf [1] p(x2)
   R = [ 10.0494 ]
   d = [ -10.1479 ]
   mean: 1 elements
@@ -630,14 +630,14 @@ conditional 2: Hybrid  P( x2 | m0 m1)
   No noise model
 
  1 Choice(m0) 
- 1 0 Leaf  p(x2)
+ 1 0 Leaf [1] p(x2)
   R = [ 10.0494 ]
   d = [ -10.0504 ]
   mean: 1 elements
   x2: -1.0001
   No noise model
 
- 1 1 Leaf  p(x2)
+ 1 1 Leaf [1] p(x2)
   R = [ 10.0494 ]
   d = [ -10.0494 ]
   mean: 1 elements

--- a/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
@@ -492,7 +492,7 @@ factor 0:
 factor 1: 
 Hybrid [x0 x1; m0]{
  Choice(m0) 
- 0 Leaf [1]:
+ 0 Leaf [1] :
   A[x0] = [
 	-1
 ]
@@ -502,7 +502,7 @@ Hybrid [x0 x1; m0]{
   b = [ -1 ]
   No noise model
 
- 1 Leaf [1]:
+ 1 Leaf [1] :
   A[x0] = [
 	-1
 ]
@@ -516,7 +516,7 @@ Hybrid [x0 x1; m0]{
 factor 2: 
 Hybrid [x1 x2; m1]{
  Choice(m1) 
- 0 Leaf [1]:
+ 0 Leaf [1] :
   A[x1] = [
 	-1
 ]
@@ -526,7 +526,7 @@ Hybrid [x1 x2; m1]{
   b = [ -1 ]
   No noise model
 
- 1 Leaf [1]:
+ 1 Leaf [1] :
   A[x1] = [
 	-1
 ]
@@ -550,16 +550,16 @@ factor 4:
   b = [ -10 ]
   No noise model
 factor 5:  P( m0 ):
- Leaf [2] 0.5
+ Leaf [2]  0.5
 
 factor 6:  P( m1 | m0 ):
  Choice(m1) 
  0 Choice(m0) 
- 0 0 Leaf [1]0.33333333
- 0 1 Leaf [1] 0.6
+ 0 0 Leaf [1] 0.33333333
+ 0 1 Leaf [1]  0.6
  1 Choice(m0) 
- 1 0 Leaf [1]0.66666667
- 1 1 Leaf [1] 0.4
+ 1 0 Leaf [1] 0.66666667
+ 1 1 Leaf [1]  0.4
 
 )";
   EXPECT(assert_print_equal(expected_hybridFactorGraph, linearizedFactorGraph));

--- a/gtsam/hybrid/tests/testMixtureFactor.cpp
+++ b/gtsam/hybrid/tests/testMixtureFactor.cpp
@@ -63,8 +63,8 @@ TEST(MixtureFactor, Printing) {
       R"(Hybrid [x1 x2; 1]
 MixtureFactor
  Choice(1) 
- 0 Leaf [1]Nonlinear factor on 2 keys
- 1 Leaf [1]Nonlinear factor on 2 keys
+ 0 Leaf [1] Nonlinear factor on 2 keys
+ 1 Leaf [1] Nonlinear factor on 2 keys
 )";
   EXPECT(assert_print_equal(expected, mixtureFactor));
 }

--- a/gtsam/hybrid/tests/testMixtureFactor.cpp
+++ b/gtsam/hybrid/tests/testMixtureFactor.cpp
@@ -63,8 +63,8 @@ TEST(MixtureFactor, Printing) {
       R"(Hybrid [x1 x2; 1]
 MixtureFactor
  Choice(1) 
- 0 Leaf Nonlinear factor on 2 keys
- 1 Leaf Nonlinear factor on 2 keys
+ 0 Leaf [1]Nonlinear factor on 2 keys
+ 1 Leaf [1]Nonlinear factor on 2 keys
 )";
   EXPECT(assert_print_equal(expected, mixtureFactor));
 }

--- a/gtsam/linear/GaussianConditional.cpp
+++ b/gtsam/linear/GaussianConditional.cpp
@@ -99,7 +99,7 @@ namespace gtsam {
 
   /* ************************************************************************ */
   void GaussianConditional::print(const string &s, const KeyFormatter& formatter) const {
-    cout << s << " p(";
+    cout << (s.empty() ? "" : s + " ") << "p(";
     for (const_iterator it = beginFrontals(); it != endFrontals(); ++it) {
       cout << formatter(*it) << (nrFrontals() > 1 ? " " : "");
     }


### PR DESCRIPTION
- Override `apply` with `UnaryAssignment` for `DecisionTreeFactor`.
- Improve discrete elimination by eliminating the joint distribution and re-segregating back into original conditionals.
- Make hybrid code use common parent `DiscreteFactor` where applicable.
- Update the eliminate method to check the factors as mentioned in @dellaert's TODO.
- Templetize methods in `Switching.h` to remove duplication.