### PR TITLE
fixes issues with TBB not being found when building downstream packages

### DIFF
--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -21,6 +21,10 @@ else()
 find_dependency(Boost @BOOST_FIND_MINIMUM_VERSION@ COMPONENTS @BOOST_FIND_MINIMUM_COMPONENTS@)
 endif()
 
+if(@GTSAM_USE_TBB@)
+    find_dependency(TBB 4.4 COMPONENTS tbb tbbmalloc)
+endif()
+
 if(@GTSAM_USE_SYSTEM_EIGEN@)
 find_dependency(Eigen3 REQUIRED)
 endif()


### PR DESCRIPTION
Hi! I noticed that #1567 broke downstream packages that build against GTSAM (e.g., Kimera-RPGO) as it switches to linking against TBB interface/alias libraries which aren't declared as a dependency. Regardless, TBB should probably be added via `find_dependency` in GTSAM's cmake config if it's being publicly linked against.

This at least fixes the issue for me when TBB is found, but I'm not entirely sure if:
1) it would be preferable to have a TBB version set in `HandleTBB.cmake` that GTSAM's config could use
2) this works when TBB isn't present on the system