### PR TITLE
Simplify scripts

### DIFF
--- a/.github/scripts/python.sh
+++ b/.github/scripts/python.sh
@@ -9,14 +9,13 @@ set -x -e
 # install TBB with _debug.so files
 function install_tbb()
 {
+  echo install_tbb
   if [ "$(uname)" == "Linux" ]; then
     sudo apt-get -y install libtbb-dev
 
   elif [ "$(uname)" == "Darwin" ]; then
     brew install tbb
-
   fi
-
 }
 
 if [ -z ${PYTHON_VERSION+x} ]; then
@@ -37,19 +36,19 @@ function install_dependencies()
 
   export PATH=$PATH:$($PYTHON -c "import site; print(site.USER_BASE)")/bin
 
-  [ "${GTSAM_WITH_TBB:-OFF}" = "ON" ] && install_tbb
+  if [ "${GTSAM_WITH_TBB:-OFF}" == "ON" ]; then
+    install_tbb
+  fi
 
   $PYTHON -m pip install -r $GITHUB_WORKSPACE/python/requirements.txt
 }
 
 function build()
 {
-  mkdir $GITHUB_WORKSPACE/build
-  cd $GITHUB_WORKSPACE/build
-
   BUILD_PYBIND="ON"
-
-  cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
+  cmake $GITHUB_WORKSPACE \
+      -B build \
+      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
       -DGTSAM_BUILD_TESTS=OFF \
       -DGTSAM_BUILD_UNSTABLE=${GTSAM_BUILD_UNSTABLE:-ON} \
       -DGTSAM_USE_QUATERNIONS=OFF \
@@ -65,16 +64,16 @@ function build()
 
 
   # Set to 2 cores so that Actions does not error out during resource provisioning.
-  make -j2 install
+  cmake --build build -j2
 
-  cd $GITHUB_WORKSPACE/build/python
-  $PYTHON -m pip install --user .
+  $PYTHON -m pip install --user build/python
 }
 
 function test()
 {
   cd $GITHUB_WORKSPACE/python/gtsam/tests
   $PYTHON -m unittest discover -v
+  cd $GITHUB_WORKSPACE
 }
 
 # select between build or test

--- a/.github/scripts/unix.sh
+++ b/.github/scripts/unix.sh
@@ -5,33 +5,30 @@
 # Specifically Linux and macOS.
 ##########################################################
 
+set -e   # Make sure any error makes the script to return an error code
+set -x   # echo
+
 # install TBB with _debug.so files
 function install_tbb()
 {
+  echo install_tbb  
   if [ "$(uname)" == "Linux" ]; then
     sudo apt-get -y install libtbb-dev
 
   elif [ "$(uname)" == "Darwin" ]; then
     brew install tbb
-
   fi
-
 }
 
 # common tasks before either build or test
 function configure()
 {
-  set -e   # Make sure any error makes the script to return an error code
-  set -x   # echo
+  # delete old build
+  rm -rf build
 
-  SOURCE_DIR=$GITHUB_WORKSPACE
-  BUILD_DIR=$GITHUB_WORKSPACE/build
-
-  #env
-  rm -fr $BUILD_DIR || true
-  mkdir $BUILD_DIR && cd $BUILD_DIR
-
-  [ "${GTSAM_WITH_TBB:-OFF}" = "ON" ] && install_tbb
+  if [ "${GTSAM_WITH_TBB:-OFF}" == "ON" ]; then
+    install_tbb
+  fi
 
   if [ ! -z "$GCC_VERSION" ]; then
     export CC=gcc-$GCC_VERSION
@@ -40,7 +37,8 @@ function configure()
 
   # GTSAM_BUILD_WITH_MARCH_NATIVE=OFF: to avoid crashes in builder VMs
   # CMAKE_CXX_FLAGS="-w": Suppress warnings to avoid IO latency in CI logs
-  cmake $SOURCE_DIR \
+  cmake $GITHUB_WORKSPACE \
+      -B build \
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-Debug} \
       -DCMAKE_CXX_FLAGS="-w" \
       -DGTSAM_BUILD_TESTS=${GTSAM_BUILD_TESTS:-OFF} \
@@ -62,9 +60,9 @@ function configure()
 function finish ()
 {
   # Print ccache stats
-  [ -x "$(command -v ccache)" ] && ccache -s
-
-  cd $SOURCE_DIR
+  if [ -x "$(command -v ccache)" ]; then
+    ccache -s
+  fi
 }
 
 # compile the code with the intent of populating the cache
@@ -77,12 +75,12 @@ function build ()
 
   if [ "$(uname)" == "Linux" ]; then
     if (($(nproc) > 2)); then
-      make -j4
+      cmake --build build -j4
     else
-      make -j2
+      cmake --build build -j2
     fi
   elif [ "$(uname)" == "Darwin" ]; then
-    make -j$(sysctl -n hw.physicalcpu)
+    cmake --build build -j$(sysctl -n hw.physicalcpu)
   fi
 
   finish
@@ -99,12 +97,12 @@ function test ()
   # Actual testing
   if [ "$(uname)" == "Linux" ]; then
     if (($(nproc) > 2)); then
-      make -j$(nproc) check
+      cmake --build build -j$(nproc) --target check
     else
-      make -j2 check
+      cmake --build build -j2 --target check
     fi
   elif [ "$(uname)" == "Darwin" ]; then
-    make -j$(sysctl -n hw.physicalcpu) check
+    cmake --build build -j$(sysctl -n hw.physicalcpu) --target check
   fi
 
   finish


### PR DESCRIPTION
Simplify scripts:
- Minimize the need of change directory (cd) command. It better to have all command from source code directory if possible.
- Evoke cmake build instead of make. It make it more general approach. cmake will invoke make or other build system he was generated for. 
- Change conditional command to be more correctly in the ci. Some of the conditional create error return. If you edit the scripts it can lead that it fail the CI. Also it more readable that it conditional. 
- The script is now independently from the environment variable: `GITHUB_WORKSPACE`. It mean you can also run it locally on your machine and test it. Also work on the CI. 

@dellaert Can you take a look on it? 