### PR TITLE
Add a custom loss function for Robust, fix a bug in Asymmetric

### DIFF
--- a/gtsam/linear/LossFunctions.h
+++ b/gtsam/linear/LossFunctions.h
@@ -544,6 +544,50 @@ class GTSAM_EXPORT AsymmetricCauchy : public Base {
 #endif
 };
 
+// Type alias for the custom loss and weight functions
+using CustomLossFunction = std::function<double(double)>;
+using CustomWeightFunction = std::function<double(double)>;
+
+/** Implementation of the "Custom" robust error model.
+ *
+ *  This model just takes two functions as input, one for the loss and one for the weight.
+ */
+class GTSAM_EXPORT Custom : public Base {
+ protected:
+  std::function<double(double)> weight_, loss_;
+  std::string name_;
+
+ public:
+  typedef std::shared_ptr<Custom> shared_ptr;
+
+  Custom(CustomWeightFunction weight, CustomLossFunction loss,
+         const ReweightScheme reweight = Block, std::string name = "Custom");
+  double weight(double distance) const override;
+  double loss(double distance) const override;
+  void print(const std::string &s) const override;
+  bool equals(const Base &expected, double tol = 1e-8) const override;
+  static shared_ptr Create(std::function<double(double)> weight, std::function<double(double)> loss,
+                           const ReweightScheme reweight = Block, const std::string &name = "Custom");
+  inline std::string& name() { return name_; }
+
+  inline std::function<double(double)>& weightFunction() { return weight_; }
+  inline std::function<double(double)>& lossFunction() { return loss_; }
+
+  // Default constructor for serialization
+  inline Custom() = default;
+
+ private:
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
+  friend class boost::serialization::access;
+  template <class ARCHIVE>
+  void serialize(ARCHIVE &ar, const unsigned int /*version*/) {
+    ar &BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
+    ar &BOOST_SERIALIZATION_NVP(name_);
+  }
+#endif
+};
+
 }  // namespace mEstimator
 }  // namespace noiseModel
 }  // namespace gtsam

--- a/gtsam/linear/linear.i
+++ b/gtsam/linear/linear.i
@@ -203,6 +203,24 @@ virtual class AsymmetricTukey: gtsam::noiseModel::mEstimator::Base {
   double loss(double error) const;
 };
 
+virtual class Custom: gtsam::noiseModel::mEstimator::Base {
+  Custom(gtsam::noiseModel::mEstimator::CustomWeightFunction weight,
+         gtsam::noiseModel::mEstimator::CustomLossFunction loss,
+         gtsam::noiseModel::mEstimator::Base::ReweightScheme reweight,
+         std::string name);
+  static gtsam::noiseModel::mEstimator::Custom* Create(
+      gtsam::noiseModel::mEstimator::CustomWeightFunction weight,
+      gtsam::noiseModel::mEstimator::CustomLossFunction loss,
+      gtsam::noiseModel::mEstimator::Base::ReweightScheme reweight,
+      std::string name);
+
+  // enabling serialization functionality
+  void serializable() const;
+
+  double weight(double error) const;
+  double loss(double error) const;
+};
+
 
 }///\namespace mEstimator
 

--- a/python/gtsam/tests/test_Robust.py
+++ b/python/gtsam/tests/test_Robust.py
@@ -1,0 +1,43 @@
+"""
+GTSAM Copyright 2010-2019, Georgia Tech Research Corporation,
+Atlanta, Georgia 30332-0415
+All Rights Reserved
+
+See LICENSE for the license information
+
+Simple unit test for custom robust noise model.
+Author: Fan Jiang
+"""
+import unittest
+
+import gtsam
+import numpy as np
+from gtsam.utils.test_case import GtsamTestCase
+
+
+class TestRobust(GtsamTestCase):
+
+    def test_RobustLossAndWeight(self):
+        k = 10.0
+
+        def custom_weight(e):
+            abs_e = abs(e)
+            return 1.0 if abs_e <= k else k / abs_e
+
+        def custom_loss(e):
+            abs_e = abs(e)
+            return abs_e * abs_e / 2.0 if abs_e <= k else k * abs_e - k * k / 2.0
+
+        custom_robust = gtsam.noiseModel.Robust.Create(
+            gtsam.noiseModel.mEstimator.Custom(custom_weight, custom_loss,
+                                               gtsam.noiseModel.mEstimator.Base.ReweightScheme.Scalar,
+                                               "huber"),
+            gtsam.noiseModel.Isotropic.Sigma(1, 2.0))
+        f = gtsam.PriorFactorDouble(0, 1.0, custom_robust)
+        v = gtsam.Values()
+        v.insert(0, 0.0)
+
+        self.assertAlmostEquals(f.error(v), 0.125)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add a way to use a custom loss function without changing GTSAM code