### PR TITLE
Add Lie group capabilities to NavState

### DIFF
--- a/gtsam/geometry/Pose3.h
+++ b/gtsam/geometry/Pose3.h
@@ -135,10 +135,10 @@ public:
   /// @name Lie Group
   /// @{
 
-  /// Exponential map at identity - create a rotation from canonical coordinates \f$ [R_x,R_y,R_z,T_x,T_y,T_z] \f$
+  /// Exponential map at identity - create a pose from canonical coordinates \f$ [R_x,R_y,R_z,T_x,T_y,T_z] \f$
   static Pose3 Expmap(const Vector6& xi, OptionalJacobian<6, 6> Hxi = {});
 
-  /// Log map at identity - return the canonical coordinates \f$ [R_x,R_y,R_z,T_x,T_y,T_z] \f$ of this rotation
+  /// Log map at identity - return the canonical coordinates \f$ [R_x,R_y,R_z,T_x,T_y,T_z] \f$ of this pose
   static Vector6 Logmap(const Pose3& pose, OptionalJacobian<6, 6> Hpose = {});
 
   /**

--- a/gtsam/geometry/Rot3.cpp
+++ b/gtsam/geometry/Rot3.cpp
@@ -120,7 +120,7 @@ Unit3 Rot3::unrotate(const Unit3& p,
     OptionalJacobian<2,3> HR, OptionalJacobian<2,2> Hp) const {
   Matrix32 Dp;
   Unit3 q = Unit3(unrotate(p.point3(Dp)));
-  if (Hp) *Hp = q.basis().transpose() * matrix().transpose () * Dp;
+  if (Hp) *Hp = q.basis().transpose() * matrix().transpose() * Dp;
   if (HR) *HR = q.basis().transpose() * q.skew();
   return q;
 }

--- a/gtsam/navigation/NavState.h
+++ b/gtsam/navigation/NavState.h
@@ -71,11 +71,14 @@ public:
   }
   /// Named constructor with derivatives
   static NavState Create(const Rot3& R, const Point3& t, const Velocity3& v,
-      OptionalJacobian<9, 3> H1, OptionalJacobian<9, 3> H2,
-      OptionalJacobian<9, 3> H3);
+                         OptionalJacobian<9, 3> H1 = {},
+                         OptionalJacobian<9, 3> H2 = {},
+                         OptionalJacobian<9, 3> H3 = {});
+
   /// Named constructor with derivatives
   static NavState FromPoseVelocity(const Pose3& pose, const Vector3& vel,
-      OptionalJacobian<9, 6> H1, OptionalJacobian<9, 3> H2);
+                                   OptionalJacobian<9, 6> H1 = {},
+                                   OptionalJacobian<9, 3> H2 = {});
 
   /// @}
   /// @name Component Access
@@ -264,8 +267,9 @@ public:
   /// Integrate forward in time given angular velocity and acceleration in body frame
   /// Uses second order integration for position, returns derivatives except dt.
   NavState update(const Vector3& b_acceleration, const Vector3& b_omega,
-      const double dt, OptionalJacobian<9, 9> F, OptionalJacobian<9, 3> G1,
-      OptionalJacobian<9, 3> G2) const;
+                  const double dt, OptionalJacobian<9, 9> F = {},
+                  OptionalJacobian<9, 3> G1 = {},
+                  OptionalJacobian<9, 3> G2 = {}) const;
 
   /// Compute tangent space contribution due to Coriolis forces
   Vector9 coriolis(double dt, const Vector3& omega, bool secondOrder = false,

--- a/gtsam/navigation/NavState.h
+++ b/gtsam/navigation/NavState.h
@@ -25,14 +25,18 @@
 namespace gtsam {
 
 /// Velocity is currently typedef'd to Vector3
-typedef Vector3 Velocity3;
+using Velocity3 = Vector3;
 
 /**
  * Navigation state: Pose (rotation, translation) + velocity
- * NOTE(frank): it does not make sense to make this a Lie group, but it is a 9D manifold
+ * Following Barrau20icra, this class belongs to the Lie group SE_2(3).
+ * This group is also called "double direct isometries”.
+ *
+ * NOTE: While Barrau20icra follow a R,v,t order,
+ * we use a R,t,v order to maintain backwards compatibility.
  */
-class GTSAM_EXPORT NavState {
-private:
+class GTSAM_EXPORT NavState : public LieGroup<NavState, 9> {
+ private:
 
   // TODO(frank):
   // - should we rename t_ to p_? if not, we should rename dP do dT
@@ -45,8 +49,6 @@ public:
   enum {
     dimension = 9
   };
-
-  typedef std::pair<Point3, Velocity3> PositionAndVelocity;
 
   /// @name Constructors
   /// @{
@@ -87,6 +89,9 @@ public:
     return Pose3(attitude(), position());
   }
 
+  /// Syntactic sugar
+  const Rot3& rotation() const { return attitude(); };
+
   /// @}
   /// @name Derived quantities
   /// @{
@@ -111,9 +116,8 @@ public:
   Velocity3 bodyVelocity(OptionalJacobian<3, 9> H = {}) const;
 
   /// Return matrix group representation, in MATLAB notation:
-  /// nTb = [nRb 0 n_t; 0 nRb n_v; 0 0 1]
-  /// With this embedding in GL(3), matrix product agrees with compose
-  Matrix7 matrix() const;
+  /// nTb = [nRb n_v, n_t; 0_1x3 1 0; 0_1x3 0 1]
+  Matrix5 matrix() const;
 
   /// @}
   /// @name Testable
@@ -130,7 +134,24 @@ public:
   bool equals(const NavState& other, double tol = 1e-8) const;
 
   /// @}
-  /// @name Manifold
+  /// @name Group
+  /// @{
+
+  /// identity for group operation
+  static NavState Identity() {
+    return NavState();
+  }
+
+  /// inverse transformation with derivatives
+  NavState inverse() const;
+
+  /// compose syntactic sugar
+  NavState operator*(const NavState& T) const {
+    return NavState(R_ * T.R_, t_ + R_ * T.t_, v_ + R_ * T.v_);
+  }
+
+  /// @}
+  /// @name Lie Group
   /// @{
 
   // Tangent space sugar.
@@ -163,6 +184,78 @@ public:
   Vector9 localCoordinates(const NavState& g, //
       OptionalJacobian<9, 9> H1 = {}, OptionalJacobian<9, 9> H2 =
           {}) const;
+
+  /**
+   * Exponential map at identity - create a NavState from canonical coordinates
+   * \f$ [R_x,R_y,R_z,T_x,T_y,T_z,V_x,V_y,V_z] \f$
+   */
+  static NavState Expmap(const Vector9& xi, OptionalJacobian<9, 9> Hxi = {});
+
+  /**
+   * Log map at identity - return the canonical coordinates \f$
+   * [R_x,R_y,R_z,T_x,T_y,T_z,V_x,V_y,V_z] \f$ of this NavState
+   */
+  static Vector9 Logmap(const NavState& pose, OptionalJacobian<9, 9> Hpose = {});
+
+  /**
+   * Calculate Adjoint map, transforming a twist in this pose's (i.e, body)
+   * frame to the world spatial frame.
+   */
+  Matrix9 AdjointMap() const;
+
+  /**
+   * Apply this NavState's AdjointMap Ad_g to a twist \f$ \xi_b \f$, i.e. a
+   * body-fixed velocity, transforming it to the spatial frame
+   * \f$ \xi^s = g*\xi^b*g^{-1} = Ad_g * \xi^b \f$
+   * Note that H_xib = AdjointMap()
+   */
+  Vector9 Adjoint(const Vector9& xi_b,
+                  OptionalJacobian<9, 9> H_this = {},
+                  OptionalJacobian<9, 9> H_xib = {}) const;
+  
+  /// The dual version of Adjoint
+  Vector9 AdjointTranspose(const Vector9& x,
+                           OptionalJacobian<9, 9> H_this = {},
+                           OptionalJacobian<9, 9> H_x = {}) const;
+
+  /**
+   * Compute the [ad(w,v)] operator as defined in [Kobilarov09siggraph], pg 11
+   * but for the NavState [ad(w,v)] = [w^, zero3; v^, w^]
+   */
+  static Matrix9 adjointMap(const Vector9& xi);
+
+  /**
+   * Action of the adjointMap on a Lie-algebra vector y, with optional derivatives
+   */
+  static Vector9 adjoint(const Vector9& xi, const Vector9& y,
+                         OptionalJacobian<9, 9> Hxi = {},
+                         OptionalJacobian<9, 9> H_y = {});
+
+  /**
+   * The dual version of adjoint action, acting on the dual space of the Lie-algebra vector space.
+   */
+  static Vector9 adjointTranspose(const Vector9& xi, const Vector9& y,
+                                  OptionalJacobian<9, 9> Hxi = {},
+                                  OptionalJacobian<9, 9> H_y = {});
+
+  /// Derivative of Expmap
+  static Matrix9 ExpmapDerivative(const Vector9& xi);
+
+  /// Derivative of Logmap
+  static Matrix9 LogmapDerivative(const NavState& xi);
+
+  // Chart at origin, depends on compile-time flag GTSAM_POSE3_EXPMAP
+  struct GTSAM_EXPORT ChartAtOrigin {
+    static NavState Retract(const Vector9& xi, ChartJacobian Hxi = {});
+    static Vector9 Local(const NavState& state, ChartJacobian Hstate = {});
+  };
+
+  /**
+   * Compute the 6x3 bottom-left block Qs of the SE_2(3) Expmap derivative
+   * matrix
+   */
+  static Matrix63 ComputeQforExpmapDerivative(const Vector9& xi,
+                                              double nearZeroThreshold = 1e-5);
 
   /// @}
   /// @name Dynamics
@@ -203,8 +296,10 @@ private:
 };
 
 // Specialize NavState traits to use a Retract/Local that agrees with IMUFactors
-template<>
-struct traits<NavState> : internal::Manifold<NavState> {
-};
+template <>
+struct traits<NavState> : public internal::LieGroup<NavState> {};
+
+template <>
+struct traits<const NavState> : public internal::LieGroup<NavState> {};
 
 } // namespace gtsam


### PR DESCRIPTION
This PR makes `NavState` the $SE_2(3)$ Lie Group as defined in [Barrau20icra](https://arxiv.org/abs/2003.03908).

There are some things that need to be completed before this PR can land:
- [ ] Jacobians for `AdjointTranspose`.
- [ ] Verify computation of `retract` and `localCoordinates`. Specifically, need to derive the jacobians and verify they are the same as Barrau20icra.
- [ ] If we remove the custom `retract` and `localCoordinates`, lots of unit tests fail, so it is important to check this too.