### PR TITLE
Fix Matlab compilation for discrete.i

### DIFF
--- a/gtsam/discrete/discrete.i
+++ b/gtsam/discrete/discrete.i
@@ -280,11 +280,11 @@ class DiscreteLookupDAG {
 };
 
 #include <gtsam/discrete/DiscreteFactorGraph.h>
-std::pair<gtsam::DiscreteConditional*, gtsam::DecisionTreeFactor*>
+pair<gtsam::DiscreteConditional*, gtsam::DecisionTreeFactor*>
 EliminateDiscrete(const gtsam::DiscreteFactorGraph& factors,
                   const gtsam::Ordering& frontalKeys);
 
-std::pair<gtsam::DiscreteConditional*, gtsam::DecisionTreeFactor*>
+pair<gtsam::DiscreteConditional*, gtsam::DecisionTreeFactor*>
 EliminateForMPE(const gtsam::DiscreteFactorGraph& factors,
                 const gtsam::Ordering& frontalKeys);
 


### PR DESCRIPTION
This PR fixes #1614 

Unfortunately, the Matlab wrapper has a bug where if the return type is a `std::pair` then it fails to compile, since the expected return type is `pair` (without the `std::`). I'll add a fix to the matlab wrapper, but this PR should fix the issue in the meantime.