### PR TITLE
Remove setting CMAKE_MACOSX_RPATH to 0 by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
 
-# new feature to Cmake Version > 2.8.12
-# Mac ONLY. Define Relative Path on Mac OS
-if(NOT DEFINED CMAKE_MACOSX_RPATH)
-  set(CMAKE_MACOSX_RPATH 0)
-endif()
-
 # Set the version number for the library
 set (GTSAM_VERSION_MAJOR 4)
 set (GTSAM_VERSION_MINOR 3)


### PR DESCRIPTION
In https://github.com/conda-forge/gtsam-feedstock/pull/15#issuecomment-1712518197, setting CMAKE_MACOSX_RPATH to `0` (combined with the fact that the build system uses the `gtsam.cpython-311-darwin.so` in the build directory to copy in `lib/python3.11/site-packages/gtsam/gtsam.cpython-311-darwin.so` instead of installing it) lead to a quite difficult to debug strange behaviour. 

As CMAKE_MACOSX_RPATH is set to 1 since CMake 3.0 , I wanted to see it the upstream CI fails. If setting CMAKE_MACOSX_RPATH to 0 make the CI fails and it is necessary to disable RPATH for some reason, the following CMake variable are the one currently suggested by CMake, and so I would try to set them instead of tweaking `CMAKE_MACOSX_RPATH` :
* [`CMAKE_SKIP_RPATH`](https://cmake.org/cmake/help/latest/variable/CMAKE_SKIP_RPATH.html): to disable both build and install rpath
* [`CMAKE_SKIP_BUILD_RPATH`](https://cmake.org/cmake/help/latest/variable/CMAKE_SKIP_BUILD_RPATH.html): to disable build rpath
* [`CMAKE_SKIP_INSTALL_RPATH`](https://cmake.org/cmake/help/latest/variable/CMAKE_SKIP_INSTALL_RPATH.html): to disable install rpath