### PR TITLE
Fix CMake variable in doc folder

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -56,7 +56,7 @@ if (GTSAM_BUILD_DOCS)
     if (GTSAM_BUILD_UNSTABLE)
         list(APPEND doc_subdirs ${gtsam_unstable_doc_subdirs})
     endif()
-    if (GTSAM_BUILD_EXAMPLES)
+    if (GTSAM_BUILD_EXAMPLES_ALWAYS)
         list(APPEND doc_subdirs examples)
     endif()
     


### PR DESCRIPTION
The variable `GTSAM_BUILD_EXAMPLES_ALWAYS` was incorrectly specified as `GTSAM_BUILD_EXAMPLES`.

Fixes #1608 