### PR TITLE
Mark current clique affected.

### DIFF
--- a/gtsam_unstable/nonlinear/IncrementalFixedLagSmoother.cpp
+++ b/gtsam_unstable/nonlinear/IncrementalFixedLagSmoother.cpp
@@ -119,9 +119,8 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
   for(Key key: marginalizableKeys) {
     ISAM2Clique::shared_ptr clique = isam_[key];
     // Mark all frontal keys of the current clique.
-    for(Key i: clique->conditional()->frontals()) {
-      additionalKeys.insert(i);
-    }
+    additionalKeys.insert(clique->conditional()->frontals().begin(),
+                          clique->conditional()->frontals().end());
     // Recursively mark all of the children key that contain the marginal key.
     for(const ISAM2Clique::shared_ptr& child: clique->children) {
       recursiveMarkAffectedKeys(key, child, additionalKeys);

--- a/gtsam_unstable/nonlinear/IncrementalFixedLagSmoother.cpp
+++ b/gtsam_unstable/nonlinear/IncrementalFixedLagSmoother.cpp
@@ -118,6 +118,11 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
   std::set<Key> additionalKeys;
   for(Key key: marginalizableKeys) {
     ISAM2Clique::shared_ptr clique = isam_[key];
+    // Mark all frontal keys of the current clique.
+    for(Key i: clique->conditional()->frontals()) {
+      additionalKeys.insert(i);
+    }
+    // Recursively mark all of the children key that contain the marginal key.
     for(const ISAM2Clique::shared_ptr& child: clique->children) {
       recursiveMarkAffectedKeys(key, child, additionalKeys);
     }


### PR DESCRIPTION
This PR fixes the issue where the `IncrementalFixedLagSmoother` fails to marginalize a key that is located in the middle of the tree as described here: https://github.com/borglab/gtsam/issues/1638

I'm open for suggestions on how to write a unit test for this problem. 

Please also let me know, if 
- marking the marginalized variable itself affected is potentially dangerous or 
- this PR is just covering up a problem in ISAM2. 