### PR TITLE
Fix precompiled_header.h on MSVC when boost is disabled

### DIFF
--- a/gtsam/base/serialization.h
+++ b/gtsam/base/serialization.h
@@ -16,6 +16,7 @@
  * @author Richard Roberts
  * @date Feb 7, 2012
  */
+
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #pragma once
 

--- a/gtsam/base/serialization.h
+++ b/gtsam/base/serialization.h
@@ -16,7 +16,7 @@
  * @author Richard Roberts
  * @date Feb 7, 2012
  */
-
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #pragma once
 
 #include <Eigen/Core>
@@ -270,3 +270,4 @@ void deserializeBinary(const std::string& serialized, T& output,
 ///@}
 
 }  // namespace gtsam
+#endif

--- a/gtsam/precompiled_header.h
+++ b/gtsam/precompiled_header.h
@@ -42,8 +42,10 @@
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/OptionalJacobian.h>
 #include <gtsam/base/ProductLieGroup.h>
+#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <gtsam/base/serialization.h>
 #include <gtsam/base/serializationTestHelpers.h>
+#endif
 #include <gtsam/base/SymmetricBlockMatrix.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/TestableAssertions.h>

--- a/gtsam/precompiled_header.h
+++ b/gtsam/precompiled_header.h
@@ -42,10 +42,8 @@
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/OptionalJacobian.h>
 #include <gtsam/base/ProductLieGroup.h>
-#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <gtsam/base/serialization.h>
 #include <gtsam/base/serializationTestHelpers.h>
-#endif
 #include <gtsam/base/SymmetricBlockMatrix.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/TestableAssertions.h>


### PR DESCRIPTION
Fix precompiled_header.h on MSVC when boost is disabled