### PR TITLE
CMake Cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,19 +42,19 @@ set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
 include(GtsamMakeConfigFile)
 include(GNUInstallDirs)
 
-# Load build type flags and default to Debug mode
-include(GtsamBuildTypes)
-
-# Use macros for creating tests/timing scripts
-include(GtsamTesting)
-include(GtsamPrinting)
-
 # guard against in-source builds
 if(${GTSAM_SOURCE_DIR} STREQUAL ${GTSAM_BINARY_DIR})
   message(FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there. You may need to remove CMakeCache.txt. ")
 endif()
 
 include(cmake/HandleGeneralOptions.cmake)   # CMake build options
+
+# Load build type flags and default to Debug mode
+include(GtsamBuildTypes)
+
+# Use macros for creating tests/timing scripts
+include(GtsamTesting)
+include(GtsamPrinting)
 
 ############### Decide on BOOST ######################################
 # Enable or disable serialization with GTSAM_ENABLE_BOOST_SERIALIZATION

--- a/cmake/GtsamBuildTypes.cmake
+++ b/cmake/GtsamBuildTypes.cmake
@@ -55,9 +55,6 @@ if(NOT CMAKE_BUILD_TYPE AND NOT MSVC AND NOT XCODE_VERSION)
       "Choose the type of build, options are: None Debug Release Timing Profiling RelWithDebInfo." FORCE)
 endif()
 
-# Add option for using build type postfixes to allow installing multiple build modes
-option(GTSAM_BUILD_TYPE_POSTFIXES        "Enable/Disable appending the build type to the name of compiled libraries" ON)
-
 # Define all cache variables, to be populated below depending on the OS/compiler:
 set(GTSAM_COMPILE_OPTIONS_PRIVATE        "" CACHE INTERNAL "(Do not edit) Private compiler flags for all build configurations." FORCE)
 set(GTSAM_COMPILE_OPTIONS_PUBLIC         "" CACHE INTERNAL "(Do not edit) Public compiler flags (exported to user projects) for all build configurations."  FORCE)
@@ -82,6 +79,13 @@ set(GTSAM_COMPILE_DEFINITIONS_PRIVATE_RELWITHDEBINFO  "NDEBUG" CACHE STRING "(Us
 set(GTSAM_COMPILE_DEFINITIONS_PRIVATE_RELEASE         "NDEBUG" CACHE STRING "(User editable) Private preprocessor macros for Release configuration.")
 set(GTSAM_COMPILE_DEFINITIONS_PRIVATE_PROFILING       "NDEBUG" CACHE STRING "(User editable) Private preprocessor macros for Profiling configuration.")
 set(GTSAM_COMPILE_DEFINITIONS_PRIVATE_TIMING          "NDEBUG;ENABLE_TIMING" CACHE STRING "(User editable) Private preprocessor macros for Timing configuration.")
+
+mark_as_advanced(GTSAM_COMPILE_DEFINITIONS_PRIVATE_DEBUG)
+mark_as_advanced(GTSAM_COMPILE_DEFINITIONS_PRIVATE_RELWITHDEBINFO)
+mark_as_advanced(GTSAM_COMPILE_DEFINITIONS_PRIVATE_RELEASE)
+mark_as_advanced(GTSAM_COMPILE_DEFINITIONS_PRIVATE_PROFILING)
+mark_as_advanced(GTSAM_COMPILE_DEFINITIONS_PRIVATE_TIMING)
+
 if(MSVC)
   # Common to all configurations:
   list_append_cache(GTSAM_COMPILE_DEFINITIONS_PRIVATE
@@ -143,6 +147,13 @@ else()
   set(GTSAM_COMPILE_OPTIONS_PRIVATE_TIMING          -g -O3  CACHE STRING "(User editable) Private compiler flags for Timing configuration.")
 endif()
 
+mark_as_advanced(GTSAM_COMPILE_OPTIONS_PRIVATE_COMMON)
+mark_as_advanced(GTSAM_COMPILE_OPTIONS_PRIVATE_DEBUG)
+mark_as_advanced(GTSAM_COMPILE_OPTIONS_PRIVATE_RELWITHDEBINFO)
+mark_as_advanced(GTSAM_COMPILE_OPTIONS_PRIVATE_RELEASE)
+mark_as_advanced(GTSAM_COMPILE_OPTIONS_PRIVATE_PROFILING)
+mark_as_advanced(GTSAM_COMPILE_OPTIONS_PRIVATE_TIMING)
+
 # Enable C++17:
 if (NOT CMAKE_VERSION VERSION_LESS 3.8)
     set(GTSAM_COMPILE_FEATURES_PUBLIC "cxx_std_17" CACHE STRING "CMake compile features property for all gtsam targets.")
@@ -198,7 +209,6 @@ if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
 endif()
 
 if (NOT MSVC)
-  option(GTSAM_BUILD_WITH_MARCH_NATIVE  "Enable/Disable building with all instructions supported by native architecture (binary may not be portable!)" OFF)
   if(GTSAM_BUILD_WITH_MARCH_NATIVE)
     # Check if Apple OS and compiler is [Apple]Clang
     if(APPLE AND (${CMAKE_CXX_COMPILER_ID} MATCHES "^(Apple)?Clang$"))

--- a/cmake/GtsamTesting.cmake
+++ b/cmake/GtsamTesting.cmake
@@ -42,7 +42,7 @@ endmacro()
 # GTSAM_BUILD_EXAMPLES_ALWAYS is enabled.  They may also be built with 'make examples'.
 #
 # Usage example:
-#   gtsamAddExamplesGlob("*.cpp" "BrokenExample.cpp" "gtsam;GeographicLib")
+#   gtsamAddExamplesGlob("*.cpp" "BrokenExample.cpp" "gtsam;GeographicLib" ON)
 #
 # Arguments:
 #   globPatterns:  The list of files or glob patterns from which to create examples, with
@@ -51,12 +51,9 @@ endmacro()
 #   excludedFiles: A list of files or globs to exclude, e.g. "C*.cpp;BrokenExample.cpp".  Pass
 #                  an empty string "" if nothing needs to be excluded.
 #   linkLibraries: The list of libraries to link to.
-macro(gtsamAddExamplesGlob globPatterns excludedFiles linkLibraries)
-	if(NOT DEFINED GTSAM_BUILD_EXAMPLES_ALWAYS)
-		set(GTSAM_BUILD_EXAMPLES_ALWAYS OFF)
-	endif()
-
-	gtsamAddExesGlob_impl("${globPatterns}" "${excludedFiles}" "${linkLibraries}" "examples" ${GTSAM_BUILD_EXAMPLES_ALWAYS})
+#   buildWithAll: Build examples with `make` and/or `make all`
+macro(gtsamAddExamplesGlob globPatterns excludedFiles linkLibraries buildWithAll)
+	gtsamAddExesGlob_impl("${globPatterns}" "${excludedFiles}" "${linkLibraries}" "examples" ${buildWithAll})
 endmacro()
 
 
@@ -80,8 +77,9 @@ endmacro()
 #   excludedFiles: A list of files or globs to exclude, e.g. "C*.cpp;BrokenExample.cpp".  Pass
 #                  an empty string "" if nothing needs to be excluded.
 #   linkLibraries: The list of libraries to link to.
-macro(gtsamAddTimingGlob globPatterns excludedFiles linkLibraries)
-	gtsamAddExesGlob_impl("${globPatterns}" "${excludedFiles}" "${linkLibraries}" "timing" ${GTSAM_BUILD_TIMING_ALWAYS})
+#   buildWithAll: Build examples with `make` and/or `make all`
+macro(gtsamAddTimingGlob globPatterns excludedFiles linkLibraries buildWithAll)
+	gtsamAddExesGlob_impl("${globPatterns}" "${excludedFiles}" "${linkLibraries}" "timing" ${buildWithAll})
 endmacro()
 
 

--- a/cmake/GtsamTesting.cmake
+++ b/cmake/GtsamTesting.cmake
@@ -91,12 +91,12 @@ enable_testing()
 #TODO(Varun) Move to HandlePrintConfiguration.cmake. This will require additional changes.
 option(GTSAM_BUILD_TESTS                 "Enable/Disable building of tests"          ON)	
 
-# Add option for combining unit tests	
-if(MSVC OR XCODE_VERSION)	
-	option(GTSAM_SINGLE_TEST_EXE "Combine unit tests into single executable (faster compile)" ON)	
-else()	
-	option(GTSAM_SINGLE_TEST_EXE "Combine unit tests into single executable (faster compile)" OFF)	
-endif()	
+# Add option for combining unit tests
+if(MSVC OR XCODE_VERSION)
+	option(GTSAM_SINGLE_TEST_EXE "Combine unit tests into single executable (faster compile)" ON)
+else()
+	option(GTSAM_SINGLE_TEST_EXE "Combine unit tests into single executable (faster compile)" OFF)
+endif()
 mark_as_advanced(GTSAM_SINGLE_TEST_EXE)
 
 # Enable make check (http://www.cmake.org/Wiki/CMakeEmulateMakeCheck)

--- a/cmake/GtsamTesting.cmake
+++ b/cmake/GtsamTesting.cmake
@@ -52,6 +52,10 @@ endmacro()
 #                  an empty string "" if nothing needs to be excluded.
 #   linkLibraries: The list of libraries to link to.
 macro(gtsamAddExamplesGlob globPatterns excludedFiles linkLibraries)
+	if(NOT DEFINED GTSAM_BUILD_EXAMPLES_ALWAYS)
+		set(GTSAM_BUILD_EXAMPLES_ALWAYS OFF)
+	endif()
+
 	gtsamAddExesGlob_impl("${globPatterns}" "${excludedFiles}" "${linkLibraries}" "examples" ${GTSAM_BUILD_EXAMPLES_ALWAYS})
 endmacro()
 
@@ -85,18 +89,6 @@ endmacro()
 
 # Build macros for using tests
 enable_testing()
-
-option(GTSAM_BUILD_TESTS                 "Enable/Disable building of tests"          ON)
-option(GTSAM_BUILD_EXAMPLES_ALWAYS       "Build examples with 'make all' (build with 'make examples' if not)"       ON)
-option(GTSAM_BUILD_TIMING_ALWAYS         "Build timing scripts with 'make all' (build with 'make timing' if not"    OFF)
-
-# Add option for combining unit tests
-if(MSVC OR XCODE_VERSION)
-	option(GTSAM_SINGLE_TEST_EXE "Combine unit tests into single executable (faster compile)" ON)
-else()
-	option(GTSAM_SINGLE_TEST_EXE "Combine unit tests into single executable (faster compile)" OFF)
-endif()
-mark_as_advanced(GTSAM_SINGLE_TEST_EXE)
 
 # Enable make check (http://www.cmake.org/Wiki/CMakeEmulateMakeCheck)
 if(GTSAM_BUILD_TESTS)

--- a/cmake/GtsamTesting.cmake
+++ b/cmake/GtsamTesting.cmake
@@ -88,6 +88,17 @@ endmacro()
 # Build macros for using tests
 enable_testing()
 
+#TODO(Varun) Move to HandlePrintConfiguration.cmake. This will require additional changes.
+option(GTSAM_BUILD_TESTS                 "Enable/Disable building of tests"          ON)	
+
+# Add option for combining unit tests	
+if(MSVC OR XCODE_VERSION)	
+	option(GTSAM_SINGLE_TEST_EXE "Combine unit tests into single executable (faster compile)" ON)	
+else()	
+	option(GTSAM_SINGLE_TEST_EXE "Combine unit tests into single executable (faster compile)" OFF)	
+endif()	
+mark_as_advanced(GTSAM_SINGLE_TEST_EXE)
+
 # Enable make check (http://www.cmake.org/Wiki/CMakeEmulateMakeCheck)
 if(GTSAM_BUILD_TESTS)
 	add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIGURATION> --output-on-failure)
@@ -113,6 +124,7 @@ add_custom_target(timing)
 # Implementations of this file's macros:
 
 macro(gtsamAddTestsGlob_impl groupName globPatterns excludedFiles linkLibraries)
+	#TODO(Varun) Building of tests should not depend on global gtsam flag
 	if(GTSAM_BUILD_TESTS)
 		# Add group target if it doesn't already exist
 		if(NOT TARGET check.${groupName})

--- a/cmake/HandleGeneralOptions.cmake
+++ b/cmake/HandleGeneralOptions.cmake
@@ -9,17 +9,8 @@ else()
 endif()
 
 ### GtsamTesting related options
-option(GTSAM_BUILD_TESTS                 "Enable/Disable building of tests"          ON)
 option(GTSAM_BUILD_EXAMPLES_ALWAYS       "Build examples with 'make all' (build with 'make examples' if not)"       ON)
 option(GTSAM_BUILD_TIMING_ALWAYS         "Build timing scripts with 'make all' (build with 'make timing' if not"    OFF)
-
-# Add option for combining unit tests
-if(MSVC OR XCODE_VERSION)
-    option(GTSAM_SINGLE_TEST_EXE "Combine unit tests into single executable (faster compile)" ON)
-else()
-    option(GTSAM_SINGLE_TEST_EXE "Combine unit tests into single executable (faster compile)" OFF)
-endif()
-mark_as_advanced(GTSAM_SINGLE_TEST_EXE)
 ###
 
 # Add option for using build type postfixes to allow installing multiple build modes

--- a/cmake/HandleGeneralOptions.cmake
+++ b/cmake/HandleGeneralOptions.cmake
@@ -8,6 +8,27 @@ else()
     set(GTSAM_UNSTABLE_AVAILABLE 0)
 endif()
 
+### GtsamTesting related options
+option(GTSAM_BUILD_TESTS                 "Enable/Disable building of tests"          ON)
+option(GTSAM_BUILD_EXAMPLES_ALWAYS       "Build examples with 'make all' (build with 'make examples' if not)"       ON)
+option(GTSAM_BUILD_TIMING_ALWAYS         "Build timing scripts with 'make all' (build with 'make timing' if not"    OFF)
+
+# Add option for combining unit tests
+if(MSVC OR XCODE_VERSION)
+    option(GTSAM_SINGLE_TEST_EXE "Combine unit tests into single executable (faster compile)" ON)
+else()
+    option(GTSAM_SINGLE_TEST_EXE "Combine unit tests into single executable (faster compile)" OFF)
+endif()
+mark_as_advanced(GTSAM_SINGLE_TEST_EXE)
+###
+
+# Add option for using build type postfixes to allow installing multiple build modes
+option(GTSAM_BUILD_TYPE_POSTFIXES        "Enable/Disable appending the build type to the name of compiled libraries" ON)
+
+if (NOT MSVC)
+    option(GTSAM_BUILD_WITH_MARCH_NATIVE  "Enable/Disable building with all instructions supported by native architecture (binary may not be portable!)" OFF)
+endif()
+
 # Configurable Options
 if(GTSAM_UNSTABLE_AVAILABLE)
     option(GTSAM_BUILD_UNSTABLE              "Enable/Disable libgtsam_unstable"          ON)

--- a/cmake/README.html
+++ b/cmake/README.html
@@ -47,9 +47,9 @@ linkLibraries: The list of libraries to link to in addition to CppUnitLite.
 </code></pre>
 </li>
 <li>
-<p><code>gtsamAddExamplesGlob(globPatterns excludedFiles linkLibraries)</code> Add scripts that will serve as examples of how to use the library.  A list of files or glob patterns is specified, and one executable will be created for each matching .cpp file.  These executables will not be installed.  They are build with 'make all' if GTSAM_BUILD_EXAMPLES_ALWAYS is enabled.  They may also be built with 'make examples'.</p>
+<p><code>gtsamAddExamplesGlob(globPatterns excludedFiles linkLibraries buildWithAll)</code> Add scripts that will serve as examples of how to use the library.  A list of files or glob patterns is specified, and one executable will be created for each matching .cpp file.  These executables will not be installed.  They are build with 'make all' if GTSAM_BUILD_EXAMPLES_ALWAYS is enabled.  They may also be built with 'make examples'.</p>
 <p>Usage example:</p>
-<pre><code>gtsamAddExamplesGlob("*.cpp" "BrokenExample.cpp" "gtsam;GeographicLib")
+<pre><code>gtsamAddExamplesGlob("*.cpp" "BrokenExample.cpp" "gtsam;GeographicLib" ON)
 </code></pre>
 <p>Arguments:</p>
 <pre><code>globPatterns:  The list of files or glob patterns from which to create unit tests, with
@@ -58,6 +58,7 @@ linkLibraries: The list of libraries to link to in addition to CppUnitLite.
 excludedFiles: A list of files or globs to exclude, e.g. "C*.cpp;BrokenExample.cpp".  Pass
                an empty string "" if nothing needs to be excluded.
 linkLibraries: The list of libraries to link to.
+buildWithAll: Build examples with `make` and/or `make all`
 </code></pre>
 </li>
 </ul>

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -52,11 +52,11 @@ Defines two useful functions for creating CTest unit tests.  Also immediately cr
                        Pass an empty string "" if nothing needs to be excluded.
         linkLibraries: The list of libraries to link to in addition to CppUnitLite.
         
-*   `gtsamAddExamplesGlob(globPatterns excludedFiles linkLibraries)` Add scripts that will serve as examples of how to use the library.  A list of files or glob patterns is specified, and one executable will be created for each matching .cpp file.  These executables will not be installed.  They are build with 'make all' if GTSAM_BUILD_EXAMPLES_ALWAYS is enabled.  They may also be built with 'make examples'.
+*   `gtsamAddExamplesGlob(globPatterns excludedFiles linkLibraries buildWithAll)` Add scripts that will serve as examples of how to use the library.  A list of files or glob patterns is specified, and one executable will be created for each matching .cpp file.  These executables will not be installed.  They are build with 'make all' if GTSAM_BUILD_EXAMPLES_ALWAYS is enabled.  They may also be built with 'make examples'.
 
     Usage example:
 
-        gtsamAddExamplesGlob("*.cpp" "BrokenExample.cpp" "gtsam;GeographicLib")
+        gtsamAddExamplesGlob("*.cpp" "BrokenExample.cpp" "gtsam;GeographicLib" ON)
 
     Arguments:
 
@@ -66,6 +66,7 @@ Defines two useful functions for creating CTest unit tests.  Also immediately cr
         excludedFiles: A list of files or globs to exclude, e.g. "C*.cpp;BrokenExample.cpp".  Pass
                        an empty string "" if nothing needs to be excluded.
         linkLibraries: The list of libraries to link to.
+        buildWithAll: Build examples with `make` and/or `make all`
 
 ## GtsamMakeConfigFile
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -20,4 +20,4 @@ if (NOT GTSAM_USE_BOOST_FEATURES)
       )
 endif()
 
-gtsamAddExamplesGlob("*.cpp" "${excluded_examples}" "gtsam;${Boost_PROGRAM_OPTIONS_LIBRARY}")
+gtsamAddExamplesGlob("*.cpp" "${excluded_examples}" "gtsam;${Boost_PROGRAM_OPTIONS_LIBRARY}" ${GTSAM_BUILD_EXAMPLES_ALWAYS})

--- a/gtsam_unstable/discrete/examples/CMakeLists.txt
+++ b/gtsam_unstable/discrete/examples/CMakeLists.txt
@@ -12,4 +12,4 @@ endif()
 
 
 
-gtsamAddExamplesGlob("*.cpp" "${excluded_examples}" "gtsam_unstable")
+gtsamAddExamplesGlob("*.cpp" "${excluded_examples}" "gtsam_unstable" ${GTSAM_BUILD_EXAMPLES_ALWAYS})

--- a/gtsam_unstable/examples/CMakeLists.txt
+++ b/gtsam_unstable/examples/CMakeLists.txt
@@ -9,4 +9,4 @@ if (NOT GTSAM_USE_BOOST_FEATURES)
 endif()
 
 
-gtsamAddExamplesGlob("*.cpp" "${excluded_examples}" "gtsam_unstable")
+gtsamAddExamplesGlob("*.cpp" "${excluded_examples}" "gtsam_unstable" ${GTSAM_BUILD_EXAMPLES_ALWAYS})

--- a/gtsam_unstable/timing/CMakeLists.txt
+++ b/gtsam_unstable/timing/CMakeLists.txt
@@ -1,1 +1,1 @@
-gtsamAddTimingGlob("*.cpp" "" "gtsam_unstable")
+gtsamAddTimingGlob("*.cpp" "" "gtsam_unstable" ${GTSAM_BUILD_TIMING_ALWAYS})

--- a/timing/CMakeLists.txt
+++ b/timing/CMakeLists.txt
@@ -14,6 +14,6 @@ if (NOT GTSAM_USE_BOOST_FEATURES)
       )
 endif()
 
-gtsamAddTimingGlob("*.cpp" "${excluded_scripts}" "gtsam")
+gtsamAddTimingGlob("*.cpp" "${excluded_scripts}" "gtsam" ${GTSAM_BUILD_TIMING_ALWAYS})
 
 target_link_libraries(timeGaussianFactorGraph CppUnitLite)


### PR DESCRIPTION
Updated the GTSAM cmake so that GTSAM specific flags are not exposed in downstream applications. The benefit is that configuring downstream applications becomes easier and more legible, without all the extra variables involved.

For example, this is the ccmake output of GTDynamics before:

<img width="732" alt="Screen Shot 2023-10-08 at 11 27 17 AM" src="https://github.com/borglab/gtsam/assets/975964/4ee026e2-4e34-47f2-9d53-1040d6749962">
<img width="732" alt="Screen Shot 2023-10-08 at 11 27 34 AM" src="https://github.com/borglab/gtsam/assets/975964/9e866bfe-c344-4709-8ee8-51295fea309d">


<hr/>

and after:
<img width="732" alt="Screen Shot 2023-10-08 at 11 25 53 AM" src="https://github.com/borglab/gtsam/assets/975964/ef4eeed3-cf44-4bb2-bba8-b7d4cd1850ba">
<img width="732" alt="Screen Shot 2023-10-08 at 11 28 54 AM" src="https://github.com/borglab/gtsam/assets/975964/570c8a4b-c332-4f3a-9129-7df4c79c6938">
