### PR TITLE
Global DefaultKeyFormatter Assignment

### DIFF
--- a/gtsam/inference/Key.cpp
+++ b/gtsam/inference/Key.cpp
@@ -26,7 +26,7 @@ using namespace std;
 
 namespace gtsam {
 
-// KeyFormatter DefaultKeyFormatter = &_dynamicsKeyFormatter;
+/// Assign default key formatter
 KeyFormatter DefaultKeyFormatter = &_defaultKeyFormatter;
 
 /* ************************************************************************* */

--- a/gtsam/inference/Key.cpp
+++ b/gtsam/inference/Key.cpp
@@ -10,7 +10,7 @@
  * -------------------------------------------------------------------------- */
 
 /**
- * @file Key.h
+ * @file Key.cpp
  * @brief
  * @author Richard Roberts
  * @author Alex Cunningham
@@ -25,6 +25,9 @@
 using namespace std;
 
 namespace gtsam {
+
+// KeyFormatter DefaultKeyFormatter = &_dynamicsKeyFormatter;
+KeyFormatter DefaultKeyFormatter = &_defaultKeyFormatter;
 
 /* ************************************************************************* */
 string _defaultKeyFormatter(Key key) {

--- a/gtsam/inference/Key.h
+++ b/gtsam/inference/Key.h
@@ -37,10 +37,16 @@ using KeyFormatter = std::function<std::string(Key)>;
 // Helper function for DefaultKeyFormatter
 GTSAM_EXPORT std::string _defaultKeyFormatter(Key key);
 
-/// The default KeyFormatter, which is used if no KeyFormatter is passed to
-/// a nonlinear 'print' function.  Automatically detects plain integer keys
-/// and Symbol keys.
-static const KeyFormatter DefaultKeyFormatter = &_defaultKeyFormatter;
+/**
+ * The default KeyFormatter, which is used if no KeyFormatter is passed
+ * to a 'print' function.
+ *
+ * Automatically detects plain integer keys and Symbol keys.
+ * 
+ * Marked as `extern` so that it can be updated by external libraries.
+ *
+ */
+extern KeyFormatter DefaultKeyFormatter;
 
 // Helper function for Multi-robot Key Formatter
 GTSAM_EXPORT std::string _multirobotKeyFormatter(gtsam::Key key);
@@ -124,7 +130,3 @@ struct traits<Key> {
 };
 
 } // namespace gtsam
-
-
-
-

--- a/gtsam/inference/Key.h
+++ b/gtsam/inference/Key.h
@@ -46,7 +46,7 @@ GTSAM_EXPORT std::string _defaultKeyFormatter(Key key);
  * Marked as `extern` so that it can be updated by external libraries.
  *
  */
-extern KeyFormatter DefaultKeyFormatter;
+extern GTSAM_EXPORT KeyFormatter DefaultKeyFormatter;
 
 // Helper function for Multi-robot Key Formatter
 GTSAM_EXPORT std::string _multirobotKeyFormatter(gtsam::Key key);


### PR DESCRIPTION
This PR makes `gtsam::DefaultKeyFormatter` an extern variable so it can be updated in downstream applications.

For example, in a project that uses both GTSAM and GTDynamics, I want the graph to print the keys in the GTDynamics format.

If I **don't** call `print` as `.print("", gtdynamics::GTDKeyFormatter);`, I get
```bash
calling estimator.update()
: (F21673568, 1)(F21673568, 1)(F23362418, 1)(F23362418, 1)(R21673568, 1)(R21673568, 1)(R23362418, 1)(R23362418, 1)
```

However, if I define the following at the top of the file (or the config.h file):
```cpp
gtsam::KeyFormatter gtsam::DefaultKeyFormatter = gtdynamics::GTDKeyFormatter;
```

I get the output as
```bash
calling estimator.update()
: (FL0, 1)(FL1, 1)(FR0, 1)(FR1, 1)(RL0, 1)(RL1, 1)(RR0, 1)(RR1, 1)
```

which is much cleaner.

This would allow custom definition of keys and key formatters and easy global assignment in 3rd party libraries.