### PR TITLE
Re-enable Debug CI for Linux

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -31,7 +31,7 @@ jobs:
           ubuntu-22.04-clang-14,
         ]
 
-        build_type: [Release]
+        build_type: [Debug, Release]
         build_unstable: [ON]
         include:
           - name: ubuntu-20.04-gcc-9


### PR DESCRIPTION
The Debug build was removed in a previous PR for some reason, so I am reintroducing it here to cover all our bases.

Currently, the Linux CI takes [39m 38s](https://github.com/borglab/gtsam/actions/runs/6551953149?pr=1640) to run. I will update this comment with the time taken when the Debug build has completed running to provide evidence that adding the Debug build doesn't add significant more CI time.