### PR TITLE
Compile gtsam python for windows

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -18,9 +18,11 @@ jobs:
       CTEST_PARALLEL_LEVEL: 2
       CMAKE_BUILD_TYPE: ${{ matrix.build_type }}
       PYTHON_VERSION: ${{ matrix.python_version }}
+      BOOST_VERSION: 1.72.0
+      BOOST_EXE: boost_1_72_0-msvc-14.2      
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         # Github Actions requires a single row to be added to the build matrix.
         # See https://help.github.com/en/articles/workflow-syntax-for-github-actions.
@@ -30,6 +32,7 @@ jobs:
             ubuntu-20.04-gcc-9-tbb,
             ubuntu-20.04-clang-9,
             macOS-11-xcode-13.4.1,
+            windows-2019-msbuild,
           ]
 
         build_type: [Release]
@@ -55,6 +58,10 @@ jobs:
             os: macOS-11
             compiler: xcode
             version: "13.4.1"
+
+          - name: windows-2019-msbuild
+            os: windows-2019
+            platform: 64
 
     steps:
       - name: Checkout
@@ -97,29 +104,68 @@ jobs:
           echo "CC=clang" >> $GITHUB_ENV
           echo "CXX=clang++" >> $GITHUB_ENV
 
+      - name: Setup msbuild (Windows)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x${{matrix.platform}}
+
+      - name: Setup python (Windows)
+        uses: actions/setup-python@v4
+        if: runner.os == 'Windows'
+        with:
+          python-version: ${{ matrix.python_version }}
+
+      - name: Install ninja (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          choco install ninja
+          ninja --version
+          where ninja
+
+      - name: Install Boost (Windows)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          # Snippet from: https://github.com/actions/virtual-environments/issues/2667
+          $BOOST_PATH = "C:\hostedtoolcache\windows\Boost\$env:BOOST_VERSION\x86_64"
+
+          # Use the prebuilt binary for Windows
+          $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/$env:BOOST_VERSION/$env:BOOST_EXE-${{matrix.platform}}.exe"
+          (New-Object System.Net.WebClient).DownloadFile($Url, "$env:TEMP\boost.exe")
+          Start-Process -Wait -FilePath "$env:TEMP\boost.exe" "/SILENT","/SP-","/SUPPRESSMSGBOXES","/DIR=$BOOST_PATH"
+
+          # Set the BOOST_ROOT variable
+          echo "BOOST_ROOT=$BOOST_PATH" >> $env:GITHUB_ENV
+
       - name: Set GTSAM_WITH_TBB Flag
         if: matrix.flag == 'tbb'
         run: |
           echo "GTSAM_WITH_TBB=ON" >> $GITHUB_ENV
           echo "GTSAM Uses TBB"
 
-      - name: Set Swap Space
+      - name: Set Swap Space (Linux)
         if: runner.os == 'Linux'
         uses: pierotofy/set-swap-space@master
         with:
           swap-size-gb: 6
 
-      - name: Install System Dependencies
+      - name: Install System Dependencies (Linux, macOS)
+        if: runner.os != 'Windows'
         run: |
           bash .github/scripts/python.sh -d
 
       - name: Install Python Dependencies
+        shell: bash
         run: python$PYTHON_VERSION -m pip install -r python/dev_requirements.txt
 
       - name: Build
+        shell: bash
         run: |
           bash .github/scripts/python.sh -b
 
       - name: Test
+        shell: bash
         run: |
           bash .github/scripts/python.sh -t

--- a/gtsam/base/utilities.h
+++ b/gtsam/base/utilities.h
@@ -4,6 +4,8 @@
 #include <iostream>
 #include <sstream>
 
+#include <gtsam/dllexport.h>
+
 namespace gtsam {
 /**
  * For Python __str__().
@@ -11,7 +13,7 @@ namespace gtsam {
  * of an object when it prints to cout.
  * https://stackoverflow.com/questions/5419356/redirect-stdout-stderr-to-a-string
  */
-struct RedirectCout {
+struct GTSAM_EXPORT RedirectCout {
   /// constructor -- redirect stdout buffer to a stringstream buffer
   RedirectCout() : ssBuffer_(), coutBuffer_(std::cout.rdbuf(ssBuffer_.rdbuf())) {}
 

--- a/gtsam/discrete/DiscreteValues.h
+++ b/gtsam/discrete/DiscreteValues.h
@@ -126,12 +126,12 @@ inline std::vector<DiscreteValues> cartesianProduct(const DiscreteKeys& keys) {
 }
 
 /// Free version of markdown.
-std::string markdown(const DiscreteValues& values,
+std::string GTSAM_EXPORT markdown(const DiscreteValues& values,
                      const KeyFormatter& keyFormatter = DefaultKeyFormatter,
                      const DiscreteValues::Names& names = {});
 
 /// Free version of html.
-std::string html(const DiscreteValues& values,
+std::string GTSAM_EXPORT html(const DiscreteValues& values,
                  const KeyFormatter& keyFormatter = DefaultKeyFormatter,
                  const DiscreteValues::Names& names = {});
 

--- a/gtsam/geometry/Rot3.h
+++ b/gtsam/geometry/Rot3.h
@@ -396,7 +396,7 @@ class GTSAM_EXPORT Rot3 : public LieGroup<Rot3, 3> {
     Matrix3 AdjointMap() const { return matrix(); }
 
     // Chart at origin, depends on compile-time flag ROT3_DEFAULT_COORDINATES_MODE
-    struct ChartAtOrigin {
+    struct GTSAM_EXPORT ChartAtOrigin {
       static Rot3 Retract(const Vector3& v, ChartJacobian H = {});
       static Vector3 Local(const Rot3& r, ChartJacobian H = {});
     };

--- a/gtsam/nonlinear/CustomFactor.h
+++ b/gtsam/nonlinear/CustomFactor.h
@@ -42,7 +42,7 @@ using CustomErrorFunction = std::function<Vector(const CustomFactor &, const Val
  *
  * This factor is mainly for creating a custom factor in Python.
  */
-class CustomFactor: public NoiseModelFactor {
+class GTSAM_EXPORT CustomFactor: public NoiseModelFactor {
 protected:
   CustomErrorFunction error_function_;
 

--- a/gtsam/sfm/DsfTrackGenerator.h
+++ b/gtsam/sfm/DsfTrackGenerator.h
@@ -69,7 +69,7 @@ using MatchIndicesMap = std::map<IndexPair, CorrespondenceIndices>;
  *        correspondence indices, from each image.
  * @param Length-N list of keypoints, for N images/cameras.
  */
-std::vector<SfmTrack2d> tracksFromPairwiseMatches(
+std::vector<SfmTrack2d> GTSAM_EXPORT tracksFromPairwiseMatches(
     const MatchIndicesMap& matches, const KeypointsVector& keypoints,
     bool verbose = false);
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -94,14 +94,21 @@ set(interface_headers
 set(GTSAM_PYTHON_TARGET gtsam_py)
 set(GTSAM_PYTHON_UNSTABLE_TARGET gtsam_unstable_py)
 
+set(GTSAM_OUTPUT_NAME "gtsam")
+set(GTSAM_UNSTABLE_OUTPUT_NAME "gtsam_unstable")
+if(MSVC)
+        set(GTSAM_OUTPUT_NAME "py_gtsam")
+        set(GTSAM_UNSTABLE_OUTPUT_NAME "py_gtsam_unstable")
+endif()
+
 pybind_wrap(${GTSAM_PYTHON_TARGET} # target
             "${interface_headers}" # interface_headers
             "gtsam.cpp" # generated_cpp
             "gtsam" # module_name
             "gtsam" # top_namespace
             "${ignore}" # ignore_classes
-            ${PROJECT_PYTHON_SOURCE_DIR}/gtsam/gtsam.tpl
-            gtsam # libs
+            "${PROJECT_PYTHON_SOURCE_DIR}/gtsam/gtsam.tpl"
+            "gtsam" # libs
             "gtsam;gtsam_header" # dependencies
             ${GTSAM_ENABLE_BOOST_SERIALIZATION} # use_boost_serialization
             )
@@ -109,7 +116,7 @@ pybind_wrap(${GTSAM_PYTHON_TARGET} # target
 set_target_properties(${GTSAM_PYTHON_TARGET} PROPERTIES
     INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
     INSTALL_RPATH_USE_LINK_PATH TRUE
-    OUTPUT_NAME "gtsam"
+    OUTPUT_NAME "${GTSAM_OUTPUT_NAME}"
     LIBRARY_OUTPUT_DIRECTORY "${GTSAM_PYTHON_BUILD_DIRECTORY}/gtsam"
     DEBUG_POSTFIX "" # Otherwise you will have a wrong name
     RELWITHDEBINFO_POSTFIX "" # Otherwise you will have a wrong name
@@ -188,7 +195,7 @@ if(GTSAM_UNSTABLE_BUILD_PYTHON)
     set_target_properties(${GTSAM_PYTHON_UNSTABLE_TARGET} PROPERTIES
             INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
             INSTALL_RPATH_USE_LINK_PATH TRUE
-            OUTPUT_NAME "gtsam_unstable"
+            OUTPUT_NAME "${GTSAM_UNSTABLE_OUTPUT_NAME}"
             LIBRARY_OUTPUT_DIRECTORY "${GTSAM_PYTHON_BUILD_DIRECTORY}/gtsam_unstable"
             DEBUG_POSTFIX "" # Otherwise you will have a wrong name
             RELWITHDEBINFO_POSTFIX "" # Otherwise you will have a wrong name


### PR DESCRIPTION
Compile gtsam python for windows

I manage to create a ci worker that compile gtsam python for windows.

There is an error when the OUTPUT_NAME of python target is the same name of the linkage lib on windows only.
```
LINK : fatal error LNK1149: output filename matches input filename 'D:\a\gtsam\gtsam\build\lib\gtsam.lib'
```
https://github.com/talregev/gtsam/actions/runs/7093971320/job/19308372633#step:13:1092

It still fail because I change the OUTPUT_NAME . I am not sure how to solve it, but I solve the other compilation errors. 

@dellaert Can you take a look on it? 