### PR TITLE
libcephes only needs 3.10, allowing build on ubuntu 18.04

### DIFF
--- a/gtsam/3rdparty/cephes/CMakeLists.txt
+++ b/gtsam/3rdparty/cephes/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.10)
 enable_testing()
 project(
   cephes


### PR DESCRIPTION
This PR changes the cmake requirements for libcephes from 3.12 to 3.10. This allows building on Ubuntu 18.04 (bionic), which only has cmake v 3.10.2.
This PR addresses issue #1710

I tested that GTSAM builds correctly on my local machine (which is Ubuntu 22.04, cmake 3.22.1).

