### PR TITLE
Remove swap from python ci

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -145,12 +145,6 @@ jobs:
           echo "GTSAM_WITH_TBB=ON" >> $GITHUB_ENV
           echo "GTSAM Uses TBB"
 
-      - name: Set Swap Space (Linux)
-        if: runner.os == 'Linux'
-        uses: pierotofy/set-swap-space@master
-        with:
-          swap-size-gb: 6
-
       - name: Install System Dependencies (Linux, macOS)
         if: runner.os != 'Windows'
         run: |


### PR DESCRIPTION
Remove swap from python ci
It not needed for the ci.
Also may fix the hang problem.