### PR TITLE
Ubuntu 22.04 for python tbb. hopefully will solve the hang problem.

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -29,7 +29,7 @@ jobs:
         name:
           [
             ubuntu-20.04-gcc-9,
-            ubuntu-20.04-gcc-9-tbb,
+            ubuntu-22.04-gcc-9-tbb,
             ubuntu-20.04-clang-9,
             macOS-11-xcode-13.4.1,
             windows-2019-msbuild,
@@ -43,8 +43,8 @@ jobs:
             compiler: gcc
             version: "9"
 
-          - name: ubuntu-20.04-gcc-9-tbb
-            os: ubuntu-20.04
+          - name: ubuntu-22.04-gcc-9-tbb
+            os: ubuntu-22.04
             compiler: gcc
             version: "9"
             flag: tbb


### PR DESCRIPTION
Change the os for python + tbb to be ubuntu 22.04. 
It may solve the hang problem.
The hang problem, is a know problem as we can see in this issue:
https://github.com/actions/runner/issues/1326
https://github.com/actions/runner/issues/2454

I am not sure what cause the hang problem. Maybe gtsam code, maybe the machine itself, or maybe python version.

But I want to try change the os. Better then to stay on this state. We can always revert this PR. 
I didn't do much tests (I run the CI on my end) or I don't have any prove, but I think the ubuntu 22.04 machine are stronger. Also maybe the os image github action is using for this os is better. 

Eventually the ci moving forward with the os version, and delete old version and get new one.
This can be tested only on python tbb to see his behavior for long run. 
