### PR TITLE
Fixing std::optional handling being redundant in Boost version > 1.80

### DIFF
--- a/gtsam/base/std_optional_serialization.h
+++ b/gtsam/base/std_optional_serialization.h
@@ -11,6 +11,8 @@
 
 // Defined only if boost serialization is enabled
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+// Only for old boost
+#if BOOST_VERSION < 108000
 #pragma once
 #include <optional>
 #include <boost/config.hpp>
@@ -98,4 +100,5 @@ void serialize(Archive& ar, std::optional<T>& t, const unsigned int version) {
 
 }  // namespace serialization
 }  // namespace boost
+#endif
 #endif


### PR DESCRIPTION
In macos vm, recently we get a newer version of boost (1.84).
They already implemented in the new version the function that gtsam implemented.
So I am not sure the correct version of boost that it begin to happen, so I put version 1.80.
We can tune the version later (when we have another issue similar to that in different boost version).

@varunagrawal @ProfFan
Thank you for your time and effort for review this PR.