### PR TITLE
Close unmatched endif

### DIFF
--- a/gtsam/base/std_optional_serialization.h
+++ b/gtsam/base/std_optional_serialization.h
@@ -12,8 +12,6 @@
 
 // Defined only if boost serialization is enabled
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
-// Only for old boost
-#if BOOST_VERSION < 108000
 #include <optional>
 #include <boost/config.hpp>
 
@@ -108,5 +106,4 @@ void serialize(Archive& ar, std::optional<T>& t, const unsigned int version) {
 }  // namespace serialization
 }  // namespace boost
 #endif // BOOST_VERSION < 108400
-#endif // BOOST_VERSION < 108000
 #endif // GTSAM_ENABLE_BOOST_SERIALIZATION

--- a/gtsam/base/std_optional_serialization.h
+++ b/gtsam/base/std_optional_serialization.h
@@ -8,12 +8,12 @@
 * Functionality to serialize std::optional<T> to boost::archive
 * Inspired from this PR: https://github.com/boostorg/serialization/pull/163
 * ---------------------------------------------------------------------------- */
+#pragma once
 
 // Defined only if boost serialization is enabled
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
 // Only for old boost
 #if BOOST_VERSION < 108000
-#pragma once
 #include <optional>
 #include <boost/config.hpp>
 
@@ -107,5 +107,6 @@ void serialize(Archive& ar, std::optional<T>& t, const unsigned int version) {
 
 }  // namespace serialization
 }  // namespace boost
-#endif
-#endif
+#endif // BOOST_VERSION < 108400
+#endif // BOOST_VERSION < 108000
+#endif // GTSAM_ENABLE_BOOST_SERIALIZATION


### PR DESCRIPTION
Building with arguments:

CMAKE_BUILD_TYPE=Release
GTSAM_ENABLE_BOOST_SERIALIZATION=FALSE
GTSAM_THROW_CHEIRALITY_EXCEPTION=FALSE
GTSAM_BUILD_EXAMPLES_ALWAYS=FALSE
-Wno-dev

Was failing on MacOS with clang with an unmatched ifdef error on head of devel. This PR makes the appropriate simple fix.