### PR TITLE
Fixing strength of bias constraints in IMUKittiExampleGPS.cpp

### DIFF
--- a/examples/IMUKittiExampleGPS.cpp
+++ b/examples/IMUKittiExampleGPS.cpp
@@ -241,7 +241,6 @@ int main(int argc, char* argv[]) {
       "-- Starting main loop: inference is performed at each time step, but we "
       "plot trajectory every 10 steps\n");
   size_t j = 0;
-  size_t included_imu_measurement_count = 0;
 
   for (size_t i = first_gps_pose; i < gps_measurements.size() - 1; i++) {
     // At each non=IMU measurement we initialize a new node in the graph
@@ -249,6 +248,7 @@ int main(int argc, char* argv[]) {
     auto current_vel_key = V(i);
     auto current_bias_key = B(i);
     double t = gps_measurements[i].time;
+    size_t included_imu_measurement_count = 0;
 
     if (i == first_gps_pose) {
       // Create initial estimate and prior on initial pose, velocity, and biases


### PR DESCRIPTION
This is a follow-up of a question at gtsam's Google [group](https://groups.google.com/g/gtsam-users/c/cc56DoPbxSA).

`included_imu_measurement_count` variable was not zeroed making each consecutive bias constraint weaker. This PR zeroes it when a new node is placed in the graph. For default parameters, `included_imu_measurement_count` is equal to 100 for all added bias constraints.

This change impacts the final estimate, which I am not sure if was ever compared to ground truth.

Previously, State at 469:
`t:   43.0073055   74.1530101 -0.426735268`

Currently, State at 469:
`t:  44.1523951  74.9626438 0.170519702`
