### PR TITLE
Correctly deal with sensor rotation in AHRS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ CMakeLists.txt.user*
 xcode/
 /Dockerfile
 /python/gtsam/notebooks/.ipynb_checkpoints/ellipses-checkpoint.ipynb
+.cache/

--- a/gtsam/navigation/AHRSFactor.cpp
+++ b/gtsam/navigation/AHRSFactor.cpp
@@ -54,8 +54,10 @@ void PreintegratedAhrsMeasurements::integrateMeasurement(
   PreintegratedRotation::integrateMeasurement(measuredOmega,
       biasHat_, deltaT, &D_incrR_integratedOmega, &Fr);
 
-  // first order uncertainty propagation
-  // the deltaT allows to pass from continuous time noise to discrete time noise
+  // First order uncertainty propagation
+  // The deltaT allows to pass from continuous time noise to discrete time
+  // noise. Comparing with the IMUFactor.cpp implementation, the latter is an
+  // approximation for C * (wCov / dt) * C.transpose(), with C \approx I * dt.
   preintMeasCov_ = Fr * preintMeasCov_ * Fr.transpose() + p().gyroscopeCovariance * deltaT;
 }
 

--- a/gtsam/navigation/AHRSFactor.cpp
+++ b/gtsam/navigation/AHRSFactor.cpp
@@ -49,10 +49,9 @@ void PreintegratedAhrsMeasurements::resetIntegration() {
 //------------------------------------------------------------------------------
 void PreintegratedAhrsMeasurements::integrateMeasurement(
     const Vector3& measuredOmega, double deltaT) {
-
-  Matrix3 D_incrR_integratedOmega, Fr;
-  PreintegratedRotation::integrateMeasurement(measuredOmega,
-      biasHat_, deltaT, &D_incrR_integratedOmega, &Fr);
+  Matrix3 Fr;
+  PreintegratedRotation::integrateGyroMeasurement(measuredOmega, biasHat_,
+                                                  deltaT, &Fr);
 
   // First order uncertainty propagation
   // The deltaT allows to pass from continuous time noise to discrete time

--- a/gtsam/navigation/PreintegratedRotation.cpp
+++ b/gtsam/navigation/PreintegratedRotation.cpp
@@ -68,7 +68,8 @@ bool PreintegratedRotation::equals(const PreintegratedRotation& other,
       && equal_with_abs_tol(delRdelBiasOmega_, other.delRdelBiasOmega_, tol);
 }
 
-Rot3 PreintegratedRotation::IncrementalRotation::operator()(
+namespace internal {
+Rot3 IncrementalRotation::operator()(
     const Vector3& bias, OptionalJacobian<3, 3> H_bias) const {
   // First we compensate the measurements for the bias
   Vector3 correctedOmega = measuredOmega - bias;
@@ -93,12 +94,13 @@ Rot3 PreintegratedRotation::IncrementalRotation::operator()(
   }
   return incrR;
 }
+}  // namespace internal
 
 void PreintegratedRotation::integrateGyroMeasurement(
     const Vector3& measuredOmega, const Vector3& biasHat, double deltaT,
     OptionalJacobian<3, 3> F) {
   Matrix3 H_bias;
-  IncrementalRotation f{measuredOmega, deltaT, p_->body_P_sensor};
+  internal::IncrementalRotation f{measuredOmega, deltaT, p_->body_P_sensor};
   const Rot3 incrR = f(biasHat, H_bias);
 
   // Update deltaTij and rotation

--- a/gtsam/navigation/PreintegratedRotation.cpp
+++ b/gtsam/navigation/PreintegratedRotation.cpp
@@ -95,11 +95,11 @@ Rot3 PreintegratedRotation::IncrementalRotation::operator()(
 }
 
 void PreintegratedRotation::integrateGyroMeasurement(
-    const Vector3& measuredOmega, const Vector3& bias, double deltaT,
+    const Vector3& measuredOmega, const Vector3& biasHat, double deltaT,
     OptionalJacobian<3, 3> F) {
   Matrix3 H_bias;
   IncrementalRotation f{measuredOmega, deltaT, p_->body_P_sensor};
-  const Rot3 incrR = f(bias, H_bias);
+  const Rot3 incrR = f(biasHat, H_bias);
 
   // Update deltaTij and rotation
   deltaTij_ += deltaT;
@@ -112,16 +112,16 @@ void PreintegratedRotation::integrateGyroMeasurement(
 
 // deprecated!
 void PreintegratedRotation::integrateMeasurement(
-    const Vector3& measuredOmega, const Vector3& bias, double deltaT,
+    const Vector3& measuredOmega, const Vector3& biasHat, double deltaT,
     OptionalJacobian<3, 3> optional_D_incrR_integratedOmega,
     OptionalJacobian<3, 3> F) {
-  integrateGyroMeasurement(measuredOmega, bias, deltaT, F);
+  integrateGyroMeasurement(measuredOmega, biasHat, deltaT, F);
 
   // If asked, pass obsolete Jacobians as well
   if (optional_D_incrR_integratedOmega) {
     Matrix3 H_bias;
     IncrementalRotation f{measuredOmega, deltaT, p_->body_P_sensor};
-    const Rot3 incrR = f(bias, H_bias);
+    const Rot3 incrR = f(biasHat, H_bias);
     *optional_D_incrR_integratedOmega << H_bias / -deltaT;
   }
 }

--- a/gtsam/navigation/PreintegratedRotation.cpp
+++ b/gtsam/navigation/PreintegratedRotation.cpp
@@ -89,13 +89,13 @@ Rot3 PreintegratedRotation::incrementalRotation(const Vector3& measuredOmega,
   return Rot3::Expmap(integratedOmega, D_incrR_integratedOmega); // expensive !!
 }
 
-void PreintegratedRotation::integrateMeasurement(const Vector3& measuredOmega,
-    const Vector3& biasHat, double deltaT,
+void PreintegratedRotation::integrateMeasurement(
+    const Vector3& measuredOmega, const Vector3& biasHat, double deltaT,
     OptionalJacobian<3, 3> optional_D_incrR_integratedOmega,
     OptionalJacobian<3, 3> F) {
   Matrix3 D_incrR_integratedOmega;
   const Rot3 incrR = incrementalRotation(measuredOmega, biasHat, deltaT,
-      D_incrR_integratedOmega);
+                                         D_incrR_integratedOmega);
 
   // If asked, pass first derivative as well
   if (optional_D_incrR_integratedOmega) {
@@ -108,8 +108,8 @@ void PreintegratedRotation::integrateMeasurement(const Vector3& measuredOmega,
 
   // Update Jacobian
   const Matrix3 incrRt = incrR.transpose();
-  delRdelBiasOmega_ = incrRt * delRdelBiasOmega_
-      - D_incrR_integratedOmega * deltaT;
+  delRdelBiasOmega_ =
+      incrRt * delRdelBiasOmega_ - D_incrR_integratedOmega * deltaT;
 }
 
 Rot3 PreintegratedRotation::biascorrectedDeltaRij(const Vector3& biasOmegaIncr,

--- a/gtsam/navigation/PreintegratedRotation.cpp
+++ b/gtsam/navigation/PreintegratedRotation.cpp
@@ -122,7 +122,7 @@ void PreintegratedRotation::integrateMeasurement(
   // If asked, pass obsolete Jacobians as well
   if (optional_D_incrR_integratedOmega) {
     Matrix3 H_bias;
-    IncrementalRotation f{measuredOmega, deltaT, p_->body_P_sensor};
+    internal::IncrementalRotation f{measuredOmega, deltaT, p_->body_P_sensor};
     const Rot3 incrR = f(biasHat, H_bias);
     *optional_D_incrR_integratedOmega << H_bias / -deltaT;
   }

--- a/gtsam/navigation/PreintegratedRotation.cpp
+++ b/gtsam/navigation/PreintegratedRotation.cpp
@@ -110,7 +110,7 @@ void PreintegratedRotation::integrateGyroMeasurement(
   delRdelBiasOmega_ = incrRt * delRdelBiasOmega_ + H_bias;
 }
 
-// deprecated!
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
 void PreintegratedRotation::integrateMeasurement(
     const Vector3& measuredOmega, const Vector3& biasHat, double deltaT,
     OptionalJacobian<3, 3> optional_D_incrR_integratedOmega,
@@ -125,6 +125,7 @@ void PreintegratedRotation::integrateMeasurement(
     *optional_D_incrR_integratedOmega << H_bias / -deltaT;
   }
 }
+#endif
 
 Rot3 PreintegratedRotation::biascorrectedDeltaRij(const Vector3& biasOmegaIncr,
     OptionalJacobian<3, 3> H) const {

--- a/gtsam/navigation/PreintegratedRotation.h
+++ b/gtsam/navigation/PreintegratedRotation.h
@@ -176,32 +176,6 @@ class GTSAM_EXPORT PreintegratedRotation {
 
   /// @}
 
-  /// @name Internal, exposed for testing only
-  /// @{
-
-  /**
-   * @brief Function object for incremental rotation.
-   * @param measuredOmega The measured angular velocity (as given by the sensor)
-   * @param deltaT The time interval over which the rotation is integrated.
-   * @param body_P_sensor Optional transform between body and IMU.
-   */
-  struct IncrementalRotation {
-    const Vector3& measuredOmega;
-    const double deltaT;
-    const std::optional<Pose3>& body_P_sensor;
-
-    /**
-     * @brief Integrate angular velocity, but corrected by bias.
-     * @param bias The bias estimate
-     * @param H_bias Jacobian of the rotation w.r.t. bias.
-     * @return The incremental rotation
-     */
-    Rot3 operator()(const Vector3& bias,
-                    OptionalJacobian<3, 3> H_bias = {}) const;
-  };
-
-  /// @}
-
   /// @name Deprecated API
   /// @{
 
@@ -249,5 +223,29 @@ class GTSAM_EXPORT PreintegratedRotation {
 
 template <>
 struct traits<PreintegratedRotation> : public Testable<PreintegratedRotation> {};
+
+namespace internal {
+/**
+ * @brief Function object for incremental rotation.
+ * @param measuredOmega The measured angular velocity (as given by the sensor)
+ * @param deltaT The time interval over which the rotation is integrated.
+ * @param body_P_sensor Optional transform between body and IMU.
+ */
+struct IncrementalRotation {
+  const Vector3& measuredOmega;
+  const double deltaT;
+  const std::optional<Pose3>& body_P_sensor;
+
+  /**
+   * @brief Integrate angular velocity, but corrected by bias.
+   * @param bias The bias estimate
+   * @param H_bias Jacobian of the rotation w.r.t. bias.
+   * @return The incremental rotation
+   */
+  Rot3 operator()(const Vector3& bias,
+                  OptionalJacobian<3, 3> H_bias = {}) const;
+};
+
+}  // namespace internal
 
 }  /// namespace gtsam

--- a/gtsam/navigation/PreintegratedRotation.h
+++ b/gtsam/navigation/PreintegratedRotation.h
@@ -65,7 +65,6 @@ struct GTSAM_EXPORT PreintegratedRotationParams {
   friend class boost::serialization::access;
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
-    namespace bs = ::boost::serialization;
     ar & BOOST_SERIALIZATION_NVP(gyroscopeCovariance);
     ar & BOOST_SERIALIZATION_NVP(body_P_sensor);
 
@@ -159,15 +158,34 @@ class GTSAM_EXPORT PreintegratedRotation {
   /// @name Main functionality
   /// @{
 
-  /// Take the gyro measurement, correct it using the (constant) bias estimate
-  /// and possibly the sensor pose, and then integrate it forward in time to yield
-  /// an incremental rotation.
-  Rot3 incrementalRotation(const Vector3& measuredOmega, const Vector3& biasHat, double deltaT,
-                           OptionalJacobian<3, 3> D_incrR_integratedOmega) const;
+  /**
+   * @brief Take the gyro measurement, correct it using the (constant) bias
+   * estimate and possibly the sensor pose, and then integrate it forward in
+   * time to yield an incremental rotation.
+   * @param measuredOmega The measured angular velocity (as given by the sensor)
+   * @param biasHat The bias estimate
+   * @param deltaT The time interval
+   * @param D_incrR_integratedOmega Jacobian of the incremental rotation w.r.t.
+   * delta_T * (measuredOmega - biasHat), possibly rotated by body_R_sensor.
+   * @return The incremental rotation
+   */
+  Rot3 incrementalRotation(
+      const Vector3& measuredOmega, const Vector3& biasHat, double deltaT,
+      OptionalJacobian<3, 3> D_incrR_integratedOmega) const;
 
-  /// Calculate an incremental rotation given the gyro measurement and a time interval,
-  /// and update both deltaTij_ and deltaRij_.
-  void integrateMeasurement(const Vector3& measuredOmega, const Vector3& biasHat, double deltaT,
+  /**
+   * @brief Calculate an incremental rotation given the gyro measurement and a
+   * time interval, and update both deltaTij_ and deltaRij_.
+   * @param measuredOmega The measured angular velocity (as given by the sensor)
+   * @param biasHat The bias estimate
+   * @param deltaT The time interval
+   * @param D_incrR_integratedOmega Optional Jacobian of the incremental
+   * rotation w.r.t. the integrated angular velocity
+   * @param F Optional Jacobian of the incremental rotation w.r.t. the bias
+   * estimate
+   */
+  void integrateMeasurement(const Vector3& measuredOmega,
+                            const Vector3& biasHat, double deltaT,
                             OptionalJacobian<3, 3> D_incrR_integratedOmega = {},
                             OptionalJacobian<3, 3> F = {});
 

--- a/gtsam/navigation/PreintegratedRotation.h
+++ b/gtsam/navigation/PreintegratedRotation.h
@@ -181,7 +181,7 @@ class GTSAM_EXPORT PreintegratedRotation {
    * @param measuredOmega The measured angular velocity (as given by the sensor)
    * @param bias The biasHat estimate
    * @param deltaT The time interval
-   * @param F Jacobian of internal compose, used in AhrsFactor.
+   * @param F optional Jacobian of internal compose, used in AhrsFactor.
    */
   void integrateGyroMeasurement(const Vector3& measuredOmega,
                                 const Vector3& biasHat, double deltaT,
@@ -190,7 +190,7 @@ class GTSAM_EXPORT PreintegratedRotation {
   /**
    * @brief Return a bias corrected version of the integrated rotation.
    * @param biasOmegaIncr An increment with respect to biasHat used above.
-   * @param H Jacobian of the correction w.r.t. the bias increment.
+   * @param H optional Jacobian of the correction w.r.t. the bias increment.
    * @note The *key* functionality of this class used in optimizing the bias.
    */
   Rot3 biascorrectedDeltaRij(const Vector3& biasOmegaIncr,

--- a/gtsam/navigation/PreintegratedRotation.h
+++ b/gtsam/navigation/PreintegratedRotation.h
@@ -24,6 +24,7 @@
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/std_optional_serialization.h>
 #include <gtsam/geometry/Pose3.h>
+#include "gtsam/dllexport.h"
 
 namespace gtsam {
 
@@ -34,7 +35,7 @@ namespace internal {
  * @param deltaT The time interval over which the rotation is integrated.
  * @param body_P_sensor Optional transform between body and IMU.
  */
-struct IncrementalRotation {
+struct GTSAM_EXPORT IncrementalRotation {
   const Vector3& measuredOmega;
   const double deltaT;
   const std::optional<Pose3>& body_P_sensor;

--- a/gtsam/navigation/tests/testAHRSFactor.cpp
+++ b/gtsam/navigation/tests/testAHRSFactor.cpp
@@ -302,29 +302,6 @@ TEST(AHRSFactor, FirstOrderPreIntegratedMeasurements) {
 }
 
 //******************************************************************************
-// TEST(AHRSFactor, PimWithBodyDisplacement) {
-//   Vector3 bias(0, 0, 0.3);
-//   Vector3 measuredOmega(0, 0, M_PI / 10.0 + 0.3);
-//   double deltaT = 1.0;
-
-//   auto p = std::make_shared<PreintegratedAhrsMeasurements::Params>();
-//   p->gyroscopeCovariance = kMeasuredOmegaCovariance;
-//   p->body_P_sensor = Pose3(Rot3::Roll(M_PI_2), Point3(0, 0, 0));
-//   PreintegratedAhrsMeasurements pim(p, Vector3::Zero());
-
-//   pim.integrateMeasurement(measuredOmega, deltaT);
-
-//   Vector3 biasOmegaIncr(0.01, 0.0, 0.0);
-//   Matrix3 actualH;
-//   pim.biascorrectedDeltaRij(biasOmegaIncr, actualH);
-
-//   // Numerical derivative using a lambda function:
-//   auto f = [&](const Vector3& bias) { return pim.biascorrectedDeltaRij(bias); };
-//   Matrix3 expectedH = numericalDerivative11<Rot3, Vector3>(f, bias);
-//   EXPECT(assert_equal(expectedH, actualH));
-// }
-
-//******************************************************************************
 TEST(AHRSFactor, ErrorWithBiasesAndSensorBodyDisplacement) {
   Vector3 bias(0, 0, 0.3);
   Rot3 Ri(Rot3::Expmap(Vector3(0, 0, M_PI / 4.0)));

--- a/gtsam/navigation/tests/testAHRSFactor.cpp
+++ b/gtsam/navigation/tests/testAHRSFactor.cpp
@@ -30,6 +30,7 @@
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/factorTesting.h>
 
+#include <cmath>
 #include <list>
 
 using namespace std::placeholders;
@@ -301,6 +302,29 @@ TEST(AHRSFactor, FirstOrderPreIntegratedMeasurements) {
 }
 
 //******************************************************************************
+// TEST(AHRSFactor, PimWithBodyDisplacement) {
+//   Vector3 bias(0, 0, 0.3);
+//   Vector3 measuredOmega(0, 0, M_PI / 10.0 + 0.3);
+//   double deltaT = 1.0;
+
+//   auto p = std::make_shared<PreintegratedAhrsMeasurements::Params>();
+//   p->gyroscopeCovariance = kMeasuredOmegaCovariance;
+//   p->body_P_sensor = Pose3(Rot3::Roll(M_PI_2), Point3(0, 0, 0));
+//   PreintegratedAhrsMeasurements pim(p, Vector3::Zero());
+
+//   pim.integrateMeasurement(measuredOmega, deltaT);
+
+//   Vector3 biasOmegaIncr(0.01, 0.0, 0.0);
+//   Matrix3 actualH;
+//   pim.biascorrectedDeltaRij(biasOmegaIncr, actualH);
+
+//   // Numerical derivative using a lambda function:
+//   auto f = [&](const Vector3& bias) { return pim.biascorrectedDeltaRij(bias); };
+//   Matrix3 expectedH = numericalDerivative11<Rot3, Vector3>(f, bias);
+//   EXPECT(assert_equal(expectedH, actualH));
+// }
+
+//******************************************************************************
 TEST(AHRSFactor, ErrorWithBiasesAndSensorBodyDisplacement) {
   Vector3 bias(0, 0, 0.3);
   Rot3 Ri(Rot3::Expmap(Vector3(0, 0, M_PI / 4.0)));
@@ -312,10 +336,10 @@ TEST(AHRSFactor, ErrorWithBiasesAndSensorBodyDisplacement) {
   Vector3 measuredOmega(0, 0, M_PI / 10.0 + 0.3);
   double deltaT = 1.0;
 
-  const Pose3 body_P_sensor(Rot3::Expmap(Vector3(0, 0.10, 0.10)),
-                            Point3(1, 0, 0));
-
-  PreintegratedAhrsMeasurements pim(Vector3::Zero(), kMeasuredOmegaCovariance);
+  auto p = std::make_shared<PreintegratedAhrsMeasurements::Params>();
+  p->gyroscopeCovariance = kMeasuredOmegaCovariance;
+  p->body_P_sensor = Pose3(Rot3::Expmap(Vector3(1, 2, 3)), Point3(1, 0, 0));
+  PreintegratedAhrsMeasurements pim(p, Vector3::Zero());
 
   pim.integrateMeasurement(measuredOmega, deltaT);
 

--- a/gtsam/navigation/tests/testPreintegratedRotation.cpp
+++ b/gtsam/navigation/tests/testPreintegratedRotation.cpp
@@ -52,8 +52,7 @@ TEST(PreintegratedRotation, integrateGyroMeasurement) {
 
   // Check the value.
   Matrix3 H_bias;
-  PreintegratedRotation::IncrementalRotation f{measuredOmega, deltaT,
-                                               p->getBodyPSensor()};
+  internal::IncrementalRotation f{measuredOmega, deltaT, p->getBodyPSensor()};
   const Rot3 incrR = f(bias, H_bias);
   Rot3 expected = Rot3::Roll(omega * deltaT);
   EXPECT(assert_equal(expected, incrR, 1e-9));
@@ -98,8 +97,7 @@ TEST(PreintegratedRotation, integrateGyroMeasurementWithTransform) {
 
   // Check the value.
   Matrix3 H_bias;
-  PreintegratedRotation::IncrementalRotation f{measuredOmega, deltaT,
-                                               p->getBodyPSensor()};
+  internal::IncrementalRotation f{measuredOmega, deltaT, p->getBodyPSensor()};
   Rot3 expected = Rot3::Pitch(omega * deltaT);
   EXPECT(assert_equal(expected, f(bias, H_bias), 1e-9));
 

--- a/gtsam/navigation/tests/testPreintegratedRotation.cpp
+++ b/gtsam/navigation/tests/testPreintegratedRotation.cpp
@@ -1,0 +1,122 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file   testPreintegratedRotation.cpp
+ * @brief  Unit test for PreintegratedRotation
+ * @author Frank Dellaert
+ */
+
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/numericalDerivative.h>
+#include <gtsam/navigation/PreintegratedRotation.h>
+
+#include <memory>
+
+#include "gtsam/base/Matrix.h"
+#include "gtsam/base/Vector.h"
+
+using namespace gtsam;
+
+//******************************************************************************
+namespace simple_roll {
+auto p = std::make_shared<PreintegratedRotationParams>();
+PreintegratedRotation pim(p);
+const double roll = 0.1;
+const Vector3 measuredOmega(roll, 0, 0);
+const Vector3 biasHat(0, 0, 0);
+const double deltaT = 0.5;
+}  // namespace simple_roll
+
+//******************************************************************************
+TEST(PreintegratedRotation, incrementalRotation) {
+  using namespace simple_roll;
+
+  // Check the value.
+  Matrix3 D_incrR_integratedOmega;
+  const Rot3 incrR = pim.incrementalRotation(measuredOmega, biasHat, deltaT,
+                                             D_incrR_integratedOmega);
+  Rot3 expected = Rot3::Roll(roll * deltaT);
+  EXPECT(assert_equal(expected, incrR, 1e-9));
+
+  // Lambda for numerical derivative:
+  auto f = [&](const Vector3& x, const Vector3& y) {
+    return pim.incrementalRotation(x, y, deltaT, {});
+  };
+
+  // NOTE(frank): these derivatives as computed by the function violate the
+  // "Jacobian contract". We should refactor this. It's not clear that the
+  // deltaT factor is actually understood in calling code.
+
+  // Check derivative with respect to measuredOmega
+  EXPECT(assert_equal<Matrix3>(
+      numericalDerivative21<Rot3, Vector3, Vector3>(f, measuredOmega, biasHat),
+      deltaT * D_incrR_integratedOmega));
+
+  // Check derivative with respect to biasHat
+  EXPECT(assert_equal<Matrix3>(
+      numericalDerivative22<Rot3, Vector3, Vector3>(f, measuredOmega, biasHat),
+      -deltaT * D_incrR_integratedOmega));
+}
+
+//******************************************************************************
+static std::shared_ptr<PreintegratedRotationParams> paramsWithTransform() {
+  auto p = std::make_shared<PreintegratedRotationParams>();
+  p->setBodyPSensor({Rot3::Yaw(M_PI_2), {0, 0, 0}});
+  return p;
+}
+
+namespace roll_in_rotated_frame {
+auto p = paramsWithTransform();
+PreintegratedRotation pim(p);
+const double roll = 0.1;
+const Vector3 measuredOmega(roll, 0, 0);
+const Vector3 biasHat(0, 0, 0);
+const double deltaT = 0.5;
+}  // namespace roll_in_rotated_frame
+
+//******************************************************************************
+TEST(PreintegratedRotation, incrementalRotationWithTransform) {
+  using namespace roll_in_rotated_frame;
+
+  // Check the value.
+  Matrix3 D_incrR_integratedOmega;
+  const Rot3 incrR = pim.incrementalRotation(measuredOmega, biasHat, deltaT,
+                                             D_incrR_integratedOmega);
+  Rot3 expected = Rot3::Pitch(roll * deltaT);
+  EXPECT(assert_equal(expected, incrR, 1e-9));
+
+  // Lambda for numerical derivative:
+  auto f = [&](const Vector3& x, const Vector3& y) {
+    return pim.incrementalRotation(x, y, deltaT, {});
+  };
+
+  // NOTE(frank): Here, once again, the derivatives are weird, as they do not
+  // take the rotation into account. They *are* the derivatives of the rotated
+  // omegas, but not the derivatives with respect to the function arguments.
+
+  // Check derivative with respect to measuredOmega
+  EXPECT(assert_equal<Matrix3>(
+      numericalDerivative21<Rot3, Vector3, Vector3>(f, measuredOmega, biasHat),
+      deltaT * D_incrR_integratedOmega));
+
+  // Check derivative with respect to biasHat
+  EXPECT(assert_equal<Matrix3>(
+      numericalDerivative22<Rot3, Vector3, Vector3>(f, measuredOmega, biasHat),
+      -deltaT * D_incrR_integratedOmega));
+}
+
+//******************************************************************************
+int main() {
+  TestResult tr;
+  return TestRegistry::runAllTests(tr);
+}
+//******************************************************************************


### PR DESCRIPTION
Sensor ~displacement~ rotation was not handled correctly in the AHRS factors. I spent a day tracking it down and fixed it:

- Significantly cleaned up `testAHRSFactor.cpp`, now uses `FactorTesting.h` macros
- To try and debug, deprecated two methods in `PreintegratedRotation` with hard-to-understand Jacobians
- Instead, added a function object with sane Jacobians, and fixed bug in Jacobians (missing chain rule).
- End-result is still not exactly how I'd like it ("insane" Jacobian in `biascorrectedDeltaRij`) but fixes bug

Tested:
- add `testPreintegratedRotation.cpp`, all tests pass
- Added new end-to-end integration test in `testAHRSFactor.cpp`, inspired by `testImuFactor.cpp`
- added a test in `testManifoldPreintegration.cpp` to establish equivalence
- added tests on deprecated methods, work, but deleted them in commit 1ac286f97a6fb482c26d4a9c9d042c4fd065e74d