### PR TITLE
gtsam ros pkg not propagating dependencies for downstream ros pkgs

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -23,9 +23,9 @@
 
   <buildtool_depend>cmake</buildtool_depend>
 
-  <build_depend>boost</build_depend>
-  <build_depend>eigen</build_depend>
-  <build_depend>tbb</build_depend>
+  <depend>boost</depend>
+  <depend>eigen</depend>
+  <depend>tbb</depend>
 
   <export>
     <!-- Specify that this is not really a Catkin package-->


### PR DESCRIPTION
This would fix https://github.com/borglab/gtsam/issues/1769