### PR TITLE
correct Linux CI platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ matrices.
 
 The current support matrix is:
 
-| Platform     | Compiler  | Build Status  |
-|:------------:|:---------:|:-------------:|
-| Ubuntu 18.04 | gcc/clang | ![Linux CI](https://github.com/borglab/gtsam/workflows/Linux%20CI/badge.svg) |
-| macOS        | clang     | ![macOS CI](https://github.com/borglab/gtsam/workflows/macOS%20CI/badge.svg) |
-| Windows      | MSVC      | ![Windows CI](https://github.com/borglab/gtsam/workflows/Windows%20CI/badge.svg) |
+| Platform           | Compiler  | Build Status                                                                     |
+|:------------------:|:---------:|:--------------------------------------------------------------------------------:|
+| Ubuntu 20.04/22.04 | gcc/clang | ![Linux CI](https://github.com/borglab/gtsam/workflows/Linux%20CI/badge.svg)     |
+| macOS              | clang     | ![macOS CI](https://github.com/borglab/gtsam/workflows/macOS%20CI/badge.svg)     |
+| Windows            | MSVC      | ![Windows CI](https://github.com/borglab/gtsam/workflows/Windows%20CI/badge.svg) |
 
 
 On top of the C++ library, GTSAM includes [wrappers for MATLAB & Python](#wrappers).


### PR DESCRIPTION
follow up of https://github.com/borglab/gtsam/pull/1276 and https://github.com/borglab/gtsam/commit/42182c85ffeeeffeda8fdc4cdd7358d3cbaafe4d

tidy up support matrix markdown table format

Hope everyone has been doing great!

This is just a small PR to update the support matrix with the correct Ubuntu versions that the Linux CI badge represents. We currently test against 20.04/22.04 and have dropped testing for 18.04.