### PR TITLE
Fix `geometry.i` namespace issue

### DIFF
--- a/gtsam/geometry/geometry.i
+++ b/gtsam/geometry/geometry.i
@@ -856,7 +856,7 @@ class Cal3_S2Stereo {
   gtsam::Matrix K() const;
   gtsam::Point2 principalPoint() const;
   double baseline() const;
-  Vector6 vector() const;
+  gtsam::Vector6 vector() const;
   gtsam::Matrix inverse() const;
 };
 


### PR DESCRIPTION
I forgot to update the namespace for a method in `geometry.i` which is leading to the Matlab wrapper not compiling.
Fixes #1799.