### PR TITLE
Fix return type of EliminateQR in wrapper

### DIFF
--- a/gtsam/linear/linear.i
+++ b/gtsam/linear/linear.i
@@ -375,7 +375,8 @@ virtual class JacobianFactor : gtsam::GaussianFactor {
   void serialize() const;
 };
 
-pair<gtsam::GaussianConditional, gtsam::JacobianFactor*> EliminateQR(const gtsam::GaussianFactorGraph& factors, const gtsam::Ordering& keys);
+pair<gtsam::GaussianConditional*, gtsam::JacobianFactor*> EliminateQR(
+    const gtsam::GaussianFactorGraph& factors, const gtsam::Ordering& keys);
 
 #include <gtsam/linear/HessianFactor.h>
 virtual class HessianFactor : gtsam::GaussianFactor {


### PR DESCRIPTION
This fixes the matlab compilation issue we're seeing since the return type is actually a `GaussianConditional` pointer.