### PR TITLE
fix C++ version issue of CppUnitLite

### DIFF
--- a/CppUnitLite/CMakeLists.txt
+++ b/CppUnitLite/CMakeLists.txt
@@ -6,6 +6,7 @@ file(GLOB cppunitlite_src "*.cpp")
 add_library(CppUnitLite STATIC ${cppunitlite_src} ${cppunitlite_headers})
 list(APPEND GTSAM_EXPORTED_TARGETS CppUnitLite)
 set(GTSAM_EXPORTED_TARGETS "${GTSAM_EXPORTED_TARGETS}" PARENT_SCOPE)
+target_compile_features(CppUnitLite PUBLIC ${GTSAM_COMPILE_FEATURES_PUBLIC})
 
 gtsam_assign_source_folders("${cppunitlite_headers};${cppunitlite_src}") # MSVC project structure
 


### PR DESCRIPTION
Will not build as `boost/lexical_cast` (CppUnitLite's dependency) requires C++11 and newer.

Partially fixes #1815 