### PR TITLE
Fix warnings and add M1 runner

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -26,6 +26,7 @@ jobs:
         # See https://help.github.com/en/articles/workflow-syntax-for-github-actions.
         name: [
           macos-12-xcode-14.2,
+          macos-14-xcode-15.4,
         ]
 
         build_type: [Debug, Release]
@@ -35,6 +36,11 @@ jobs:
             os: macos-12
             compiler: xcode
             version: "14.2"
+
+          - name: macos-14-xcode-15.4
+            os: macos-14
+            compiler: xcode
+            version: "15.4"
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -110,11 +110,6 @@ jobs:
           echo "CC=clang" >> $GITHUB_ENV
           echo "CXX=clang++" >> $GITHUB_ENV
 
-          python$PYTHON_VERSION -m venv venv
-          source venv/bin/activate
-          echo "PATH=$(pwd)/venv/bin:$PATH" >> $GITHUB_ENV
-          python -m pip install --upgrade pip
-
       - name: Setup msbuild (Windows)
         if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1
@@ -175,7 +170,7 @@ jobs:
 
       - name: Install Python Dependencies
         shell: bash
-        run: python$PYTHON_VERSION -m pip install -r python/dev_requirements.txt
+        run: python$PYTHON_VERSION -m pip install --break-system-packages --user -r python/dev_requirements.txt
 
       - name: Build
         shell: bash

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -32,6 +32,7 @@ jobs:
             ubuntu-20.04-gcc-9-tbb,
             ubuntu-20.04-clang-9,
             macos-12-xcode-14.2,
+            macos-14-xcode-15.4,
             windows-2022-msbuild,
           ]
 
@@ -58,6 +59,11 @@ jobs:
             os: macos-12
             compiler: xcode
             version: "14.2"
+
+          - name: macos-14-xcode-15.4
+            os: macos-14
+            compiler: xcode
+            version: "15.4"
 
           - name: windows-2022-msbuild
             os: windows-2022

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -174,7 +174,11 @@ jobs:
 
       - name: Install Python Dependencies
         shell: bash
-        run: python$PYTHON_VERSION -m pip install -r python/dev_requirements.txt
+        run: |
+          if [ "${{ runner.os }}" == "macOS" ]; then
+            source venv/bin/activate
+          fi
+          python$PYTHON_VERSION -m pip install -r python/dev_requirements.txt
 
       - name: Build
         shell: bash

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -110,6 +110,10 @@ jobs:
           echo "CC=clang" >> $GITHUB_ENV
           echo "CXX=clang++" >> $GITHUB_ENV
 
+          python$PYTHON_VERSION -m venv venv
+          source venv/bin/activate
+          python -m pip install --upgrade pip
+
       - name: Setup msbuild (Windows)
         if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -168,9 +168,17 @@ jobs:
         run: |
           bash .github/scripts/python.sh -d
 
+      - name: Create virtual on MacOS
+        if: runner.os == 'macOS'
+        run: |
+          python$PYTHON_VERSION -m venv venv
+          source venv/bin/activate
+          echo "PATH=$(pwd)/venv/bin:$PATH" >> $GITHUB_ENV
+          python -m pip install --upgrade pip
+
       - name: Install Python Dependencies
         shell: bash
-        run: python$PYTHON_VERSION -m pip install --break-system-packages --user -r python/dev_requirements.txt
+        run: python$PYTHON_VERSION -m pip install -r python/dev_requirements.txt
 
       - name: Build
         shell: bash

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -112,6 +112,7 @@ jobs:
 
           python$PYTHON_VERSION -m venv venv
           source venv/bin/activate
+          echo "PATH=$(pwd)/venv/bin:$PATH" >> $GITHUB_ENV
           python -m pip install --upgrade pip
 
       - name: Setup msbuild (Windows)
@@ -174,11 +175,7 @@ jobs:
 
       - name: Install Python Dependencies
         shell: bash
-        run: |
-          if [ "${{ runner.os }}" == "macOS" ]; then
-            source venv/bin/activate
-          fi
-          python$PYTHON_VERSION -m pip install -r python/dev_requirements.txt
+        run: python$PYTHON_VERSION -m pip install -r python/dev_requirements.txt
 
       - name: Build
         shell: bash

--- a/.github/workflows/build-special.yml
+++ b/.github/workflows/build-special.yml
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup msbuild
         uses: ilammy/msvc-dev-cmd@v1

--- a/gtsam/3rdparty/Eigen/Eigen/src/SparseCore/TriangularSolver.h
+++ b/gtsam/3rdparty/Eigen/Eigen/src/SparseCore/TriangularSolver.h
@@ -270,11 +270,9 @@ struct sparse_solve_triangular_sparse_selector<Lhs,Rhs,Mode,UpLo,ColMajor>
       }
 
 
-      Index count = 0;
       // FIXME compute a reference value to filter zeros
       for (typename AmbiVector<Scalar,StorageIndex>::Iterator it(tempVector/*,1e-12*/); it; ++it)
       {
-        ++ count;
 //         std::cerr << "fill " << it.index() << ", " << col << "\n";
 //         std::cout << it.value() << "  ";
         // FIXME use insertBack

--- a/gtsam/3rdparty/Eigen/Eigen/src/SparseLU/SparseLU_heap_relax_snode.h
+++ b/gtsam/3rdparty/Eigen/Eigen/src/SparseLU/SparseLU_heap_relax_snode.h
@@ -75,8 +75,6 @@ void SparseLUImpl<Scalar,StorageIndex>::heap_relax_snode (const Index n, IndexVe
   // Identify the relaxed supernodes by postorder traversal of the etree
   Index snode_start; // beginning of a snode 
   StorageIndex k;
-  Index nsuper_et_post = 0; // Number of relaxed snodes in postordered etree 
-  Index nsuper_et = 0; // Number of relaxed snodes in the original etree 
   StorageIndex l; 
   for (j = 0; j < n; )
   {
@@ -88,7 +86,6 @@ void SparseLUImpl<Scalar,StorageIndex>::heap_relax_snode (const Index n, IndexVe
       parent = et(j);
     }
     // Found a supernode in postordered etree, j is the last column 
-    ++nsuper_et_post;
     k = StorageIndex(n);
     for (Index i = snode_start; i <= j; ++i)
       k = (std::min)(k, inv_post(i));
@@ -97,7 +94,6 @@ void SparseLUImpl<Scalar,StorageIndex>::heap_relax_snode (const Index n, IndexVe
     {
       // This is also a supernode in the original etree
       relax_end(k) = l; // Record last column 
-      ++nsuper_et; 
     }
     else 
     {
@@ -107,7 +103,6 @@ void SparseLUImpl<Scalar,StorageIndex>::heap_relax_snode (const Index n, IndexVe
         if (descendants(i) == 0) 
         {
           relax_end(l) = l;
-          ++nsuper_et;
         }
       }
     }

--- a/gtsam/3rdparty/metis/GKlib/pdb.c
+++ b/gtsam/3rdparty/metis/GKlib/pdb.c
@@ -131,7 +131,7 @@ that structure.
 /************************************************************************/
 pdbf *gk_readpdbfile(char *fname) { /* {{{ */
 	int i=0, res=0; 
-	char linetype[6];
+	char linetype[7];
 	int  aserial;
 	char aname[5] = "    \0";
 	char altLoc   = ' ';

--- a/gtsam/discrete/tests/testDiscreteConditional.cpp
+++ b/gtsam/discrete/tests/testDiscreteConditional.cpp
@@ -292,7 +292,7 @@ TEST(DiscreteConditional, choose) {
 /* ************************************************************************* */
 // Check argmax on P(C|D) and P(D), plus tie-breaking for P(B)
 TEST(DiscreteConditional, Argmax) {
-  DiscreteKey B(2, 2), C(2, 2), D(4, 2);
+  DiscreteKey C(2, 2), D(4, 2);
   DiscreteConditional B_prior(D, "1/1");
   DiscreteConditional D_prior(D, "1/3");
   DiscreteConditional C_given_D((C | D) = "1/4 1/1");

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -266,7 +266,7 @@ endif()
 # Add custom target so we can install with `make python-install`
 set(GTSAM_PYTHON_INSTALL_TARGET python-install)
 add_custom_target(${GTSAM_PYTHON_INSTALL_TARGET}
-        COMMAND ${PYTHON_EXECUTABLE} -m pip install --break-system-packages --user .
+        COMMAND ${PYTHON_EXECUTABLE} -m pip install $(if [ -z "$VIRTUAL_ENV" ]; then echo "--user"; fi) .
         DEPENDS ${GTSAM_PYTHON_DEPENDENCIES}
         WORKING_DIRECTORY ${GTSAM_PYTHON_BUILD_DIRECTORY})
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -266,7 +266,7 @@ endif()
 # Add custom target so we can install with `make python-install`
 set(GTSAM_PYTHON_INSTALL_TARGET python-install)
 add_custom_target(${GTSAM_PYTHON_INSTALL_TARGET}
-        COMMAND ${PYTHON_EXECUTABLE} -m pip install $(if [ -z "$VIRTUAL_ENV" ]; then echo "--user"; fi) .
+        COMMAND ${PYTHON_EXECUTABLE} -m pip install `if [ -z "$VIRTUAL_ENV" ]; then echo --user; fi` .
         DEPENDS ${GTSAM_PYTHON_DEPENDENCIES}
         WORKING_DIRECTORY ${GTSAM_PYTHON_BUILD_DIRECTORY})
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -266,7 +266,7 @@ endif()
 # Add custom target so we can install with `make python-install`
 set(GTSAM_PYTHON_INSTALL_TARGET python-install)
 add_custom_target(${GTSAM_PYTHON_INSTALL_TARGET}
-        COMMAND ${PYTHON_EXECUTABLE} -m pip install --user .
+        COMMAND ${PYTHON_EXECUTABLE} -m pip install --break-system-packages --user .
         DEPENDS ${GTSAM_PYTHON_DEPENDENCIES}
         WORKING_DIRECTORY ${GTSAM_PYTHON_BUILD_DIRECTORY})
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -266,7 +266,7 @@ endif()
 # Add custom target so we can install with `make python-install`
 set(GTSAM_PYTHON_INSTALL_TARGET python-install)
 add_custom_target(${GTSAM_PYTHON_INSTALL_TARGET}
-        COMMAND ${PYTHON_EXECUTABLE} -m pip install `if [ -z "$VIRTUAL_ENV" ]; then echo --user; fi` .
+        COMMAND ${PYTHON_EXECUTABLE} -c "import sys, subprocess; cmd = [sys.executable, '-m', 'pip', 'install']; if not hasattr(sys, 'real_prefix') and not (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix): cmd.append('--user'); cmd.append('.'); subprocess.check_call(cmd)"
         DEPENDS ${GTSAM_PYTHON_DEPENDENCIES}
         WORKING_DIRECTORY ${GTSAM_PYTHON_BUILD_DIRECTORY})
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -264,11 +264,13 @@ if(GTSAM_UNSTABLE_BUILD_PYTHON)
 endif()
 
 # Add custom target so we can install with `make python-install`
+# Note below we make sure to install with --user iff not in a virtualenv
 set(GTSAM_PYTHON_INSTALL_TARGET python-install)
 add_custom_target(${GTSAM_PYTHON_INSTALL_TARGET}
-        COMMAND ${PYTHON_EXECUTABLE} -c "import sys, subprocess; cmd = [sys.executable, '-m', 'pip', 'install']; if not hasattr(sys, 'real_prefix') and not (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix): cmd.append('--user'); cmd.append('.'); subprocess.check_call(cmd)"
+        COMMAND ${PYTHON_EXECUTABLE} -c "import sys, subprocess; cmd = [sys.executable, '-m', 'pip', 'install']; has_venv = hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix); cmd.append('--user' if not has_venv else ''); cmd.append('.'); subprocess.check_call([c for c in cmd if c])"
         DEPENDS ${GTSAM_PYTHON_DEPENDENCIES}
-        WORKING_DIRECTORY ${GTSAM_PYTHON_BUILD_DIRECTORY})
+        WORKING_DIRECTORY ${GTSAM_PYTHON_BUILD_DIRECTORY}
+        VERBATIM)
 
 # Custom make command to run all GTSAM Python tests
 add_custom_target(


### PR DESCRIPTION
- fixed some c++ warnings in vendored libraries and one of our tests
- updated checkout actions
- added an M1 action for python to see whether segfaults are reproducible in CI (they are not!)
- made sure make python-install also works in a virtual env (which is used for Mac in CI)
- added an M1 action for regular GTSAM