### PR TITLE
Use bundled `pybind11` for Python wrapper

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -30,7 +30,7 @@ if(POLICY CMP0057)
 endif()
 
 # Use bundled pybind11 version
-find_package(pybind11 CONFIG QUIET PATHS "${PROJECT_SOURCE_DIR}/wrap/pybind11")
+add_subdirectory(${PROJECT_SOURCE_DIR}/wrap/pybind11 pybind11)
 
 # Set the wrapping script variable
 set(PYBIND_WRAP_SCRIPT "${PROJECT_SOURCE_DIR}/wrap/scripts/pybind_wrap.py")

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -29,11 +29,8 @@ if(POLICY CMP0057)
   cmake_policy(SET CMP0057 NEW)
 endif()
 
-# Prefer system pybind11 first, if not found, rely on bundled version:
-find_package(pybind11 CONFIG QUIET)
-if (NOT pybind11_FOUND)
-        add_subdirectory(${PROJECT_SOURCE_DIR}/wrap/pybind11 pybind11)
-endif()
+# Use bundled pybind11 version
+find_package(pybind11 CONFIG QUIET PATHS "${PROJECT_SOURCE_DIR}/wrap/pybind11")
 
 # Set the wrapping script variable
 set(PYBIND_WRAP_SCRIPT "${PROJECT_SOURCE_DIR}/wrap/scripts/pybind_wrap.py")


### PR DESCRIPTION
Force the use of the bundled `pybind11` directory when compiling the Python wrapper.
This should hopefully fix issues like in #1720.