### PR TITLE
Generate Python type hints during build

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -265,12 +265,18 @@ endif()
 
 # Add custom target so we can install with `make python-install`
 set(GTSAM_PYTHON_INSTALL_TARGET python-install)
-add_custom_target(${GTSAM_PYTHON_INSTALL_TARGET}
-        COMMAND stubgen -q -p gtsam &&
-                rsync -a "out/gtsam/" gtsam &&
-                ${PYTHON_EXECUTABLE} -m pip install --user .
+if (NOT WIN32)
+    add_custom_target(${GTSAM_PYTHON_INSTALL_TARGET}
+        COMMAND stubgen -q -p gtsam && rsync -a \"out/gtsam/\" gtsam && ${PYTHON_EXECUTABLE} -m pip install --user .
         DEPENDS ${GTSAM_PYTHON_DEPENDENCIES}
         WORKING_DIRECTORY ${GTSAM_PYTHON_BUILD_DIRECTORY})
+elseif()
+    #TODO(Varun) Find rsync equivalent on Windows
+    add_custom_target(${GTSAM_PYTHON_INSTALL_TARGET}
+        COMMAND ${PYTHON_EXECUTABLE} -m pip install --user .
+        DEPENDS ${GTSAM_PYTHON_DEPENDENCIES}
+        WORKING_DIRECTORY ${GTSAM_PYTHON_BUILD_DIRECTORY})
+endif()
 
 # Custom make command to run all GTSAM Python tests
 add_custom_target(

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -264,15 +264,14 @@ if(GTSAM_UNSTABLE_BUILD_PYTHON)
 endif()
 
 # Add custom target so we can install with `make python-install`
-set(GTSAM_PYTHON_INSTALL_TARGET python-install)
 if (NOT WIN32)
-    add_custom_target(${GTSAM_PYTHON_INSTALL_TARGET}
+    add_custom_target(python-install
         COMMAND stubgen -q -p gtsam && rsync -a \"out/gtsam/\" gtsam && ${PYTHON_EXECUTABLE} -m pip install --user .
         DEPENDS ${GTSAM_PYTHON_DEPENDENCIES}
         WORKING_DIRECTORY ${GTSAM_PYTHON_BUILD_DIRECTORY})
 elseif()
     #TODO(Varun) Find rsync equivalent on Windows
-    add_custom_target(${GTSAM_PYTHON_INSTALL_TARGET}
+    add_custom_target(python-install
         COMMAND ${PYTHON_EXECUTABLE} -m pip install --user .
         DEPENDS ${GTSAM_PYTHON_DEPENDENCIES}
         WORKING_DIRECTORY ${GTSAM_PYTHON_BUILD_DIRECTORY})

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -266,11 +266,11 @@ endif()
 # Add custom target so we can install with `make python-install`
 if (NOT WIN32) # WIN32=1 is target platform is Windows
     add_custom_target(python-install
-        COMMAND stubgen -q -p gtsam && rsync -a \"out/gtsam/\" gtsam && ${PYTHON_EXECUTABLE} -m pip install --user .
+        COMMAND stubgen -q -p gtsam -o ./stubs && cp -a stubs/gtsam/ gtsam && ${PYTHON_EXECUTABLE} -m pip install --user .
         DEPENDS ${GTSAM_PYTHON_DEPENDENCIES}
         WORKING_DIRECTORY ${GTSAM_PYTHON_BUILD_DIRECTORY})
 else()
-    #TODO(Varun) Find rsync equivalent on Windows
+    #TODO(Varun) Find equivalent cp on Windows
     add_custom_target(python-install
         COMMAND ${PYTHON_EXECUTABLE} -m pip install --user .
         DEPENDS ${GTSAM_PYTHON_DEPENDENCIES}

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -281,12 +281,3 @@ add_custom_target(
           ${PYTHON_EXECUTABLE} -m unittest discover -v -s .
           DEPENDS ${GTSAM_PYTHON_DEPENDENCIES} ${GTSAM_PYTHON_TEST_FILES}
           WORKING_DIRECTORY "${GTSAM_PYTHON_BUILD_DIRECTORY}/gtsam/tests")
-
-add_custom_target(
-        python-test-unstable
-        COMMAND
-          ${CMAKE_COMMAND} -E env # add package to python path so no need to install
-          "PYTHONPATH=${GTSAM_PYTHON_BUILD_DIRECTORY}/$ENV{PYTHONPATH}"
-          ${PYTHON_EXECUTABLE} -m unittest discover -v -s .
-          DEPENDS ${GTSAM_PYTHON_DEPENDENCIES} ${GTSAM_PYTHON_TEST_FILES}
-          WORKING_DIRECTORY "${GTSAM_PYTHON_BUILD_DIRECTORY}/gtsam_unstable/tests")

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -266,7 +266,9 @@ endif()
 # Add custom target so we can install with `make python-install`
 set(GTSAM_PYTHON_INSTALL_TARGET python-install)
 add_custom_target(${GTSAM_PYTHON_INSTALL_TARGET}
-        COMMAND ${PYTHON_EXECUTABLE} -m pip install --user .
+        COMMAND stubgen -q -p gtsam &&
+                rsync -a "out/gtsam/" gtsam &&
+                ${PYTHON_EXECUTABLE} -m pip install --user .
         DEPENDS ${GTSAM_PYTHON_DEPENDENCIES}
         WORKING_DIRECTORY ${GTSAM_PYTHON_BUILD_DIRECTORY})
 
@@ -279,3 +281,12 @@ add_custom_target(
           ${PYTHON_EXECUTABLE} -m unittest discover -v -s .
           DEPENDS ${GTSAM_PYTHON_DEPENDENCIES} ${GTSAM_PYTHON_TEST_FILES}
           WORKING_DIRECTORY "${GTSAM_PYTHON_BUILD_DIRECTORY}/gtsam/tests")
+
+add_custom_target(
+        python-test-unstable
+        COMMAND
+          ${CMAKE_COMMAND} -E env # add package to python path so no need to install
+          "PYTHONPATH=${GTSAM_PYTHON_BUILD_DIRECTORY}/$ENV{PYTHONPATH}"
+          ${PYTHON_EXECUTABLE} -m unittest discover -v -s .
+          DEPENDS ${GTSAM_PYTHON_DEPENDENCIES} ${GTSAM_PYTHON_TEST_FILES}
+          WORKING_DIRECTORY "${GTSAM_PYTHON_BUILD_DIRECTORY}/gtsam_unstable/tests")

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -264,12 +264,12 @@ if(GTSAM_UNSTABLE_BUILD_PYTHON)
 endif()
 
 # Add custom target so we can install with `make python-install`
-if (NOT WIN32)
+if (NOT WIN32) # WIN32=1 is target platform is Windows
     add_custom_target(python-install
         COMMAND stubgen -q -p gtsam && rsync -a \"out/gtsam/\" gtsam && ${PYTHON_EXECUTABLE} -m pip install --user .
         DEPENDS ${GTSAM_PYTHON_DEPENDENCIES}
         WORKING_DIRECTORY ${GTSAM_PYTHON_BUILD_DIRECTORY})
-elseif()
+else()
     #TODO(Varun) Find rsync equivalent on Windows
     add_custom_target(python-install
         COMMAND ${PYTHON_EXECUTABLE} -m pip install --user .

--- a/python/dev_requirements.txt
+++ b/python/dev_requirements.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
 pyparsing>=2.4.2
+mypy>=1.11.2

--- a/python/dev_requirements.txt
+++ b/python/dev_requirements.txt
@@ -1,3 +1,3 @@
 -r requirements.txt
 pyparsing>=2.4.2
-mypy>=1.11.2
+mypy==1.4.1  #TODO(Varun) A bug in mypy>=1.5.0 causes an unresolved placeholder error when importing numpy>=2.0.0 (https://github.com/python/mypy/issues/17396)

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -13,6 +13,7 @@ package_data = {
         "./*.so",
         "./*.dll",
         "./*.pyd",
+        "*.pyi", "**/*.pyi",  # Add the type hints
     ]
 }
 


### PR DESCRIPTION
This PR leverages stubgen to generate typehint `.pyi` files which then get packaged along with the binaries.
What this means is that we now get **much better** autocomplete in VSCode and other IDEs that read the pyi files.

Below are screenshots of the autocomplete we get as a result:

<img width="573" alt="Screen Shot 2024-08-25 at 4 14 34 PM" src="https://github.com/user-attachments/assets/d94329fc-d3e6-4f97-98a4-232e4179c7cc">
<img width="673" alt="Screen Shot 2024-08-25 at 4 14 48 PM" src="https://github.com/user-attachments/assets/4fdaa898-d638-4a5d-be58-23301be7d73e">
