### PR TITLE
Use pybind11-stubgen for generating stubs

### DIFF
--- a/gtsam/inference/Factor.h
+++ b/gtsam/inference/Factor.h
@@ -25,6 +25,7 @@
 #include <boost/serialization/nvp.hpp>
 #endif
 #include <memory>
+#include <algorithm>
 
 #include <gtsam/base/types.h>
 #include <gtsam/base/FastVector.h>

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -171,6 +171,7 @@ file(COPY "${GTSAM_SOURCE_DIR}/examples/Data" DESTINATION "${GTSAM_MODULE_PATH}"
 # Add gtsam as a dependency to the install target
 set(GTSAM_PYTHON_DEPENDENCIES ${GTSAM_PYTHON_TARGET})
 
+set(GTSAM_PYTHON_INSTALL_EXTRA "")
 
 if(GTSAM_UNSTABLE_BUILD_PYTHON)
     set(ignore
@@ -250,6 +251,22 @@ if(GTSAM_UNSTABLE_BUILD_PYTHON)
             VERBATIM            
         )
     endif()
+
+    add_custom_target(
+        python-unstable-stubs
+        COMMAND
+        ${CMAKE_COMMAND} -E env
+        "PYTHONPATH=${GTSAM_PYTHON_BUILD_DIRECTORY}/$ENV{PYTHONPATH}"
+        pybind11-stubgen -o . --enum-class-locations \"KernelFunctionType|NoiseFormat:gtsam.gtsam\" --enum-class-locations \"OrderingType:gtsam.gtsam.Ordering\" gtsam_unstable
+        DEPENDS ${GTSAM_PYTHON_DEPENDENCIES} ${GTSAM_PYTHON_TEST_FILES} ${GTSAM_PYTHON_UNSTABLE_TARGET}
+        WORKING_DIRECTORY "${GTSAM_PYTHON_BUILD_DIRECTORY}/"
+    )
+
+    if(NOT WIN32)
+        # Add the stubgen target as a dependency to the install target
+        list(APPEND GTSAM_PYTHON_INSTALL_EXTRA python-unstable-stubs)
+    endif()
+
     # Custom make command to run all GTSAM_UNSTABLE Python tests
     add_custom_target(
         python-test-unstable
@@ -262,26 +279,30 @@ if(GTSAM_UNSTABLE_BUILD_PYTHON)
     )
 endif()
 
+add_custom_target(
+        python-stubs
+        COMMAND
+        ${CMAKE_COMMAND} -E env
+        "PYTHONPATH=${GTSAM_PYTHON_BUILD_DIRECTORY}/$ENV{PYTHONPATH}"
+        pybind11-stubgen -o . --enum-class-locations \"KernelFunctionType|NoiseFormat:gtsam.gtsam\" --enum-class-locations \"OrderingType:gtsam.gtsam.Ordering\" gtsam
+        DEPENDS ${GTSAM_PYTHON_DEPENDENCIES} ${GTSAM_PYTHON_TEST_FILES} ${GTSAM_PYTHON_TARGET}
+        WORKING_DIRECTORY "${GTSAM_PYTHON_BUILD_DIRECTORY}/"
+)
+
+if(NOT WIN32)
+    # Add the stubgen target as a dependency to the install target
+    list(APPEND GTSAM_PYTHON_INSTALL_EXTRA python-stubs)
+endif()
+
 # Add custom target so we can install with `make python-install`
 # Note below we make sure to install with --user iff not in a virtualenv
 set(GTSAM_PYTHON_INSTALL_TARGET python-install)
-#TODO(Varun) Maybe move the long command to script?
-# https://stackoverflow.com/questions/49053544/how-do-i-run-a-python-script-every-time-in-a-cmake-build
-if (NOT WIN32) # WIN32=1 is target platform is Windows
-    add_custom_target(${GTSAM_PYTHON_INSTALL_TARGET}
-        COMMAND stubgen -q -p gtsam && cp -a out/gtsam/ gtsam && ${PYTHON_EXECUTABLE} -c "import sys, subprocess; cmd = [sys.executable, '-m', 'pip', 'install']; has_venv = hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix); cmd.append('--user' if not has_venv else ''); cmd.append('.'); subprocess.check_call([c for c in cmd if c])"
-        DEPENDS ${GTSAM_PYTHON_DEPENDENCIES}
-        WORKING_DIRECTORY ${GTSAM_PYTHON_BUILD_DIRECTORY}
-        VERBATIM)
-else()
-    #TODO(Varun) Find equivalent cp on Windows
-    add_custom_target(${GTSAM_PYTHON_INSTALL_TARGET}
-        COMMAND ${PYTHON_EXECUTABLE} -c "import sys, subprocess; cmd = [sys.executable, '-m', 'pip', 'install']; has_venv = hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix); cmd.append('--user' if not has_venv else ''); cmd.append('.'); subprocess.check_call([c for c in cmd if c])"
-        DEPENDS ${GTSAM_PYTHON_DEPENDENCIES}
-        WORKING_DIRECTORY ${GTSAM_PYTHON_BUILD_DIRECTORY}
-        VERBATIM)
-endif()
 
+add_custom_target(${GTSAM_PYTHON_INSTALL_TARGET}
+        COMMAND ${PYTHON_EXECUTABLE} -c "import sys, subprocess; cmd = [sys.executable, '-m', 'pip', 'install']; has_venv = hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix); cmd.append('--user' if not has_venv else ''); cmd.append('.'); subprocess.check_call([c for c in cmd if c])"
+        DEPENDS ${GTSAM_PYTHON_DEPENDENCIES} ${GTSAM_PYTHON_INSTALL_EXTRA}
+        WORKING_DIRECTORY ${GTSAM_PYTHON_BUILD_DIRECTORY}
+        VERBATIM)
 
 # Custom make command to run all GTSAM Python tests
 add_custom_target(

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -257,7 +257,7 @@ if(GTSAM_UNSTABLE_BUILD_PYTHON)
         COMMAND
         ${CMAKE_COMMAND} -E env
         "PYTHONPATH=${GTSAM_PYTHON_BUILD_DIRECTORY}/$ENV{PYTHONPATH}"
-        pybind11-stubgen -o . --enum-class-locations \"KernelFunctionType|NoiseFormat:gtsam.gtsam\" --enum-class-locations \"OrderingType:gtsam.gtsam.Ordering\" gtsam_unstable
+        pybind11-stubgen -o . --enum-class-locations \"KernelFunctionType|NoiseFormat:gtsam.gtsam\" --enum-class-locations \"OrderingType:gtsam.gtsam.Ordering\" --numpy-array-use-type-var gtsam_unstable
         DEPENDS ${GTSAM_PYTHON_DEPENDENCIES} ${GTSAM_PYTHON_TEST_FILES} ${GTSAM_PYTHON_UNSTABLE_TARGET}
         WORKING_DIRECTORY "${GTSAM_PYTHON_BUILD_DIRECTORY}/"
     )
@@ -284,7 +284,7 @@ add_custom_target(
         COMMAND
         ${CMAKE_COMMAND} -E env
         "PYTHONPATH=${GTSAM_PYTHON_BUILD_DIRECTORY}/$ENV{PYTHONPATH}"
-        pybind11-stubgen -o . --enum-class-locations \"KernelFunctionType|NoiseFormat:gtsam.gtsam\" --enum-class-locations \"OrderingType:gtsam.gtsam.Ordering\" gtsam
+        pybind11-stubgen -o . --enum-class-locations \"KernelFunctionType|NoiseFormat:gtsam.gtsam\" --enum-class-locations \"OrderingType:gtsam.gtsam.Ordering\" --numpy-array-use-type-var gtsam
         DEPENDS ${GTSAM_PYTHON_DEPENDENCIES} ${GTSAM_PYTHON_TEST_FILES} ${GTSAM_PYTHON_TARGET}
         WORKING_DIRECTORY "${GTSAM_PYTHON_BUILD_DIRECTORY}/"
 )

--- a/python/dev_requirements.txt
+++ b/python/dev_requirements.txt
@@ -1,3 +1,3 @@
 -r requirements.txt
 pyparsing>=2.4.2
-mypy==1.4.1  #TODO(Varun) A bug in mypy>=1.5.0 causes an unresolved placeholder error when importing numpy>=2.0.0 (https://github.com/python/mypy/issues/17396)
+pybind11-stubgen>=2.5.1

--- a/python/gtsam/gtsam.tpl
+++ b/python/gtsam/gtsam.tpl
@@ -39,12 +39,12 @@ namespace py = pybind11;
 {module_def} {{
     m_.doc() = "pybind11 wrapper of {module_name}";
 
+// Specializations for STL classes
+#include "python/gtsam/specializations/{module_name}.h"
+
 {submodules_init}
 
 {wrapped_namespace}
-
-// Specializations for STL classes
-#include "python/gtsam/specializations/{module_name}.h"
 
 }}
 


### PR DESCRIPTION
Use `pybind11-stubgen` to generate the stubs, which is a stub generator specifically built for `pybind11` types.

Also changed the way stub is generated. Should hopefully fix the issues with `mypy`'s generator.

Tested locally on both VSCode and JupyterLab (macOS M1):

<img width="914" alt="image" src="https://github.com/user-attachments/assets/8575dc82-e936-40d4-a6ec-a783cab3cfba">
