### PR TITLE
HybridNonlinearFactor Relinearization

### DIFF
--- a/gtsam/hybrid/HybridGaussianConditional.cpp
+++ b/gtsam/hybrid/HybridGaussianConditional.cpp
@@ -56,6 +56,15 @@ HybridGaussianConditional::conditionals() const {
 }
 
 /* *******************************************************************************/
+HybridGaussianConditional::HybridGaussianConditional(
+    const KeyVector &continuousFrontals, const KeyVector &continuousParents,
+    const DiscreteKeys &discreteParents,
+    const std::vector<GaussianConditional::shared_ptr> &conditionals)
+    : HybridGaussianConditional(continuousFrontals, continuousParents,
+                                discreteParents,
+                                Conditionals(discreteParents, conditionals)) {}
+
+/* *******************************************************************************/
 // TODO(dellaert): This is copy/paste: HybridGaussianConditional should be
 // derived from HybridGaussianFactor, no?
 GaussianFactorGraphTree HybridGaussianConditional::add(

--- a/gtsam/hybrid/HybridGaussianConditional.cpp
+++ b/gtsam/hybrid/HybridGaussianConditional.cpp
@@ -220,22 +220,19 @@ std::shared_ptr<HybridGaussianFactor> HybridGaussianConditional::likelihood(
   const DiscreteKeys discreteParentKeys = discreteKeys();
   const KeyVector continuousParentKeys = continuousParents();
   const HybridGaussianFactor::Factors likelihoods(
-      conditionals_, [&](const GaussianConditional::shared_ptr &conditional) {
-        const auto likelihood_m = conditional->likelihood(given);
+      conditionals_,
+      [&](const GaussianConditional::shared_ptr &conditional)
+          -> std::pair<GaussianFactor::shared_ptr, double> {
+        auto likelihood_m = conditional->likelihood(given);
         const double Cgm_Kgcm =
             logConstant_ - conditional->logNormalizationConstant();
         if (Cgm_Kgcm == 0.0) {
-          return likelihood_m;
+          return {likelihood_m, 0.0};
         } else {
           // Add a constant factor to the likelihood in case the noise models
           // are not all equal.
-          GaussianFactorGraph gfg;
-          gfg.push_back(likelihood_m);
-          Vector c(1);
-          c << std::sqrt(2.0 * Cgm_Kgcm);
-          auto constantFactor = std::make_shared<JacobianFactor>(c);
-          gfg.push_back(constantFactor);
-          return std::make_shared<JacobianFactor>(gfg);
+          double c = std::sqrt(2.0 * Cgm_Kgcm);
+          return {likelihood_m, c};
         }
       });
   return std::make_shared<HybridGaussianFactor>(

--- a/gtsam/hybrid/HybridGaussianConditional.cpp
+++ b/gtsam/hybrid/HybridGaussianConditional.cpp
@@ -222,8 +222,8 @@ std::shared_ptr<HybridGaussianFactor> HybridGaussianConditional::likelihood(
   const HybridGaussianFactor::Factors likelihoods(
       conditionals_,
       [&](const GaussianConditional::shared_ptr &conditional)
-          -> std::pair<GaussianFactor::shared_ptr, double> {
-        auto likelihood_m = conditional->likelihood(given);
+          -> GaussianFactorValuePair {
+        const auto likelihood_m = conditional->likelihood(given);
         const double Cgm_Kgcm =
             logConstant_ - conditional->logNormalizationConstant();
         if (Cgm_Kgcm == 0.0) {
@@ -231,8 +231,13 @@ std::shared_ptr<HybridGaussianFactor> HybridGaussianConditional::likelihood(
         } else {
           // Add a constant factor to the likelihood in case the noise models
           // are not all equal.
-          double c = std::sqrt(2.0 * Cgm_Kgcm);
-          return {likelihood_m, c};
+          GaussianFactorGraph gfg;
+          gfg.push_back(likelihood_m);
+          Vector c(1);
+          c << std::sqrt(2.0 * Cgm_Kgcm);
+          auto constantFactor = std::make_shared<JacobianFactor>(c);
+          gfg.push_back(constantFactor);
+          return {std::make_shared<JacobianFactor>(gfg), 0.0};
         }
       });
   return std::make_shared<HybridGaussianFactor>(

--- a/gtsam/hybrid/HybridGaussianConditional.cpp
+++ b/gtsam/hybrid/HybridGaussianConditional.cpp
@@ -58,11 +58,11 @@ HybridGaussianConditional::conditionals() const {
 /* *******************************************************************************/
 HybridGaussianConditional::HybridGaussianConditional(
     const KeyVector &continuousFrontals, const KeyVector &continuousParents,
-    const DiscreteKeys &discreteParents,
+    const DiscreteKey &discreteParent,
     const std::vector<GaussianConditional::shared_ptr> &conditionals)
     : HybridGaussianConditional(continuousFrontals, continuousParents,
-                                discreteParents,
-                                Conditionals(discreteParents, conditionals)) {}
+                                DiscreteKeys{discreteParent},
+                                Conditionals({discreteParent}, conditionals)) {}
 
 /* *******************************************************************************/
 // TODO(dellaert): This is copy/paste: HybridGaussianConditional should be

--- a/gtsam/hybrid/HybridGaussianConditional.cpp
+++ b/gtsam/hybrid/HybridGaussianConditional.cpp
@@ -219,7 +219,7 @@ std::shared_ptr<HybridGaussianFactor> HybridGaussianConditional::likelihood(
 
   const DiscreteKeys discreteParentKeys = discreteKeys();
   const KeyVector continuousParentKeys = continuousParents();
-  const HybridGaussianFactor::Factors likelihoods(
+  const HybridGaussianFactor::FactorValuePairs likelihoods(
       conditionals_,
       [&](const GaussianConditional::shared_ptr &conditional)
           -> GaussianFactorValuePair {

--- a/gtsam/hybrid/HybridGaussianConditional.cpp
+++ b/gtsam/hybrid/HybridGaussianConditional.cpp
@@ -229,15 +229,10 @@ std::shared_ptr<HybridGaussianFactor> HybridGaussianConditional::likelihood(
         if (Cgm_Kgcm == 0.0) {
           return {likelihood_m, 0.0};
         } else {
-          // Add a constant factor to the likelihood in case the noise models
+          // Add a constant to the likelihood in case the noise models
           // are not all equal.
-          GaussianFactorGraph gfg;
-          gfg.push_back(likelihood_m);
-          Vector c(1);
-          c << std::sqrt(2.0 * Cgm_Kgcm);
-          auto constantFactor = std::make_shared<JacobianFactor>(c);
-          gfg.push_back(constantFactor);
-          return {std::make_shared<JacobianFactor>(gfg), 0.0};
+          double c = 2.0 * Cgm_Kgcm;
+          return {likelihood_m, c};
         }
       });
   return std::make_shared<HybridGaussianFactor>(

--- a/gtsam/hybrid/HybridGaussianConditional.cpp
+++ b/gtsam/hybrid/HybridGaussianConditional.cpp
@@ -56,24 +56,6 @@ HybridGaussianConditional::conditionals() const {
 }
 
 /* *******************************************************************************/
-HybridGaussianConditional::HybridGaussianConditional(
-    KeyVector &&continuousFrontals, KeyVector &&continuousParents,
-    DiscreteKeys &&discreteParents,
-    std::vector<GaussianConditional::shared_ptr> &&conditionals)
-    : HybridGaussianConditional(continuousFrontals, continuousParents,
-                                discreteParents,
-                                Conditionals(discreteParents, conditionals)) {}
-
-/* *******************************************************************************/
-HybridGaussianConditional::HybridGaussianConditional(
-    const KeyVector &continuousFrontals, const KeyVector &continuousParents,
-    const DiscreteKeys &discreteParents,
-    const std::vector<GaussianConditional::shared_ptr> &conditionals)
-    : HybridGaussianConditional(continuousFrontals, continuousParents,
-                                discreteParents,
-                                Conditionals(discreteParents, conditionals)) {}
-
-/* *******************************************************************************/
 // TODO(dellaert): This is copy/paste: HybridGaussianConditional should be
 // derived from HybridGaussianFactor, no?
 GaussianFactorGraphTree HybridGaussianConditional::add(

--- a/gtsam/hybrid/HybridGaussianConditional.h
+++ b/gtsam/hybrid/HybridGaussianConditional.h
@@ -106,32 +106,6 @@ class GTSAM_EXPORT HybridGaussianConditional
                             const DiscreteKeys &discreteParents,
                             const Conditionals &conditionals);
 
-  /**
-   * @brief Make a Gaussian Mixture from a list of Gaussian conditionals
-   *
-   * @param continuousFrontals The continuous frontal variables
-   * @param continuousParents The continuous parent variables
-   * @param discreteParents Discrete parents variables
-   * @param conditionals List of conditionals
-   */
-  HybridGaussianConditional(
-      KeyVector &&continuousFrontals, KeyVector &&continuousParents,
-      DiscreteKeys &&discreteParents,
-      std::vector<GaussianConditional::shared_ptr> &&conditionals);
-
-  /**
-   * @brief Make a Gaussian Mixture from a list of Gaussian conditionals
-   *
-   * @param continuousFrontals The continuous frontal variables
-   * @param continuousParents The continuous parent variables
-   * @param discreteParents Discrete parents variables
-   * @param conditionals List of conditionals
-   */
-  HybridGaussianConditional(
-      const KeyVector &continuousFrontals, const KeyVector &continuousParents,
-      const DiscreteKeys &discreteParents,
-      const std::vector<GaussianConditional::shared_ptr> &conditionals);
-
   /// @}
   /// @name Testable
   /// @{
@@ -273,7 +247,7 @@ class GTSAM_EXPORT HybridGaussianConditional
 #endif
 };
 
-/// Return the DiscreteKey vector as a set.
+/// Return the DiscreteKeys vector as a set.
 std::set<DiscreteKey> DiscreteKeysAsSet(const DiscreteKeys &discreteKeys);
 
 // traits

--- a/gtsam/hybrid/HybridGaussianConditional.h
+++ b/gtsam/hybrid/HybridGaussianConditional.h
@@ -112,12 +112,13 @@ class GTSAM_EXPORT HybridGaussianConditional
    *
    * @param continuousFrontals The continuous frontal variables
    * @param continuousParents The continuous parent variables
-   * @param discreteParents Discrete parents variables
-   * @param conditionals Vector of conditionals
+   * @param discreteParent Single discrete parent variable
+   * @param conditionals Vector of conditionals with the same size as the
+   * cardinality of the discrete parent.
    */
   HybridGaussianConditional(
       const KeyVector &continuousFrontals, const KeyVector &continuousParents,
-      const DiscreteKeys &discreteParents,
+      const DiscreteKey &discreteParent,
       const std::vector<GaussianConditional::shared_ptr> &conditionals);
 
   /// @}

--- a/gtsam/hybrid/HybridGaussianConditional.h
+++ b/gtsam/hybrid/HybridGaussianConditional.h
@@ -106,6 +106,20 @@ class GTSAM_EXPORT HybridGaussianConditional
                             const DiscreteKeys &discreteParents,
                             const Conditionals &conditionals);
 
+  /**
+   * @brief Make a Gaussian Mixture from a vector of Gaussian conditionals.
+   * The DecisionTree-based constructor is preferred over this one.
+   *
+   * @param continuousFrontals The continuous frontal variables
+   * @param continuousParents The continuous parent variables
+   * @param discreteParents Discrete parents variables
+   * @param conditionals Vector of conditionals
+   */
+  HybridGaussianConditional(
+      const KeyVector &continuousFrontals, const KeyVector &continuousParents,
+      const DiscreteKeys &discreteParents,
+      const std::vector<GaussianConditional::shared_ptr> &conditionals);
+
   /// @}
   /// @name Testable
   /// @{
@@ -247,7 +261,7 @@ class GTSAM_EXPORT HybridGaussianConditional
 #endif
 };
 
-/// Return the DiscreteKeys vector as a set.
+/// Return the DiscreteKey vector as a set.
 std::set<DiscreteKey> DiscreteKeysAsSet(const DiscreteKeys &discreteKeys);
 
 // traits

--- a/gtsam/hybrid/HybridGaussianFactor.cpp
+++ b/gtsam/hybrid/HybridGaussianFactor.cpp
@@ -42,9 +42,11 @@ HybridGaussianFactor::Factors augment(
     const HybridGaussianFactor::FactorValuePairs &factors) {
   // Find the minimum value so we can "proselytize" to positive values.
   // Done because we can't have sqrt of negative numbers.
-  auto unzipped_pair = unzip(factors);
-  const HybridGaussianFactor::Factors gaussianFactors = unzipped_pair.first;
-  const AlgebraicDecisionTree<Key> valueTree = unzipped_pair.second;
+  HybridGaussianFactor::Factors gaussianFactors;
+  AlgebraicDecisionTree<Key> valueTree;
+  std::tie(gaussianFactors, valueTree) = unzip(factors);
+
+  // Normalize
   double min_value = valueTree.min();
   AlgebraicDecisionTree<Key> values =
       valueTree.apply([&min_value](double n) { return n - min_value; });

--- a/gtsam/hybrid/HybridGaussianFactor.cpp
+++ b/gtsam/hybrid/HybridGaussianFactor.cpp
@@ -163,20 +163,4 @@ double HybridGaussianFactor::error(const HybridValues &values) const {
   return gf->error(values.continuous());
 }
 
-/* *******************************************************************************/
-double ComputeLogNormalizer(
-    const noiseModel::Gaussian::shared_ptr &noise_model) {
-  // Since noise models are Gaussian, we can get the logDeterminant using
-  // the same trick as in GaussianConditional
-  double logDetR = noise_model->R()
-                       .diagonal()
-                       .unaryExpr([](double x) { return log(x); })
-                       .sum();
-  double logDeterminantSigma = -2.0 * logDetR;
-
-  size_t n = noise_model->dim();
-  constexpr double log2pi = 1.8378770664093454835606594728112;
-  return n * log2pi + logDeterminantSigma;
-}
-
 }  // namespace gtsam

--- a/gtsam/hybrid/HybridGaussianFactor.h
+++ b/gtsam/hybrid/HybridGaussianFactor.h
@@ -96,15 +96,15 @@ class GTSAM_EXPORT HybridGaussianFactor : public HybridFactor {
    * GaussianFactor shared pointers.
    *
    * @param continuousKeys Vector of keys for continuous factors.
-   * @param discreteKeys Vector of discrete keys.
+   * @param discreteKey The discrete key to index each component.
    * @param factors Vector of gaussian factor shared pointers
-   *  and arbitrary scalars.
+   *  and arbitrary scalars. Same size as the cardinality of discreteKey.
    */
   HybridGaussianFactor(const KeyVector &continuousKeys,
-                       const DiscreteKeys &discreteKeys,
+                       const DiscreteKey &discreteKey,
                        const std::vector<GaussianFactorValuePair> &factors)
-      : HybridGaussianFactor(continuousKeys, discreteKeys,
-                             FactorValuePairs(discreteKeys, factors)) {}
+      : HybridGaussianFactor(continuousKeys, {discreteKey},
+                             FactorValuePairs({discreteKey}, factors)) {}
 
   /// @}
   /// @name Testable

--- a/gtsam/hybrid/HybridGaussianFactor.h
+++ b/gtsam/hybrid/HybridGaussianFactor.h
@@ -175,16 +175,4 @@ class GTSAM_EXPORT HybridGaussianFactor : public HybridFactor {
 template <>
 struct traits<HybridGaussianFactor> : public Testable<HybridGaussianFactor> {};
 
-/**
- * @brief Helper function to compute the sqrt(|2πΣ|) normalizer values
- * for a Gaussian noise model.
- * We compute this in the log-space for numerical accuracy.
- *
- * @param noise_model The Gaussian noise model
- * whose normalizer we wish to compute.
- * @return double
- */
-GTSAM_EXPORT double ComputeLogNormalizer(
-    const noiseModel::Gaussian::shared_ptr &noise_model);
-
 }  // namespace gtsam

--- a/gtsam/hybrid/HybridGaussianFactor.h
+++ b/gtsam/hybrid/HybridGaussianFactor.h
@@ -119,7 +119,7 @@ class GTSAM_EXPORT HybridGaussianFactor : public HybridFactor {
   /// @name Standard API
   /// @{
 
-  /// Get the factor and scalar at a given discrete assignment.
+  /// Get factor at a given discrete assignment.
   sharedFactor operator()(const DiscreteValues &assignment) const;
 
   /**

--- a/gtsam/hybrid/HybridGaussianFactor.h
+++ b/gtsam/hybrid/HybridGaussianFactor.h
@@ -33,6 +33,9 @@ class HybridValues;
 class DiscreteValues;
 class VectorValues;
 
+/// Alias for pair of GaussianFactor::shared_pointer and a double value.
+using GaussianFactorValuePair = std::pair<GaussianFactor::shared_ptr, double>;
+
 /**
  * @brief Implementation of a discrete conditional mixture factor.
  * Implements a joint discrete-continuous factor where the discrete variable
@@ -53,7 +56,7 @@ class GTSAM_EXPORT HybridGaussianFactor : public HybridFactor {
   using sharedFactor = std::shared_ptr<GaussianFactor>;
 
   /// typedef for Decision Tree of Gaussian factors and log-constant.
-  using Factors = DecisionTree<Key, std::pair<sharedFactor, double>>;
+  using Factors = DecisionTree<Key, GaussianFactorValuePair>;
 
  private:
   /// Decision tree of Gaussian factors indexed by discrete keys.
@@ -95,9 +98,9 @@ class GTSAM_EXPORT HybridGaussianFactor : public HybridFactor {
    * @param factors Vector of gaussian factor shared pointers
    *  and arbitrary scalars.
    */
-  HybridGaussianFactor(
-      const KeyVector &continuousKeys, const DiscreteKeys &discreteKeys,
-      const std::vector<std::pair<sharedFactor, double>> &factors)
+  HybridGaussianFactor(const KeyVector &continuousKeys,
+                       const DiscreteKeys &discreteKeys,
+                       const std::vector<GaussianFactorValuePair> &factors)
       : HybridGaussianFactor(continuousKeys, discreteKeys,
                              Factors(discreteKeys, factors)) {}
 
@@ -115,8 +118,7 @@ class GTSAM_EXPORT HybridGaussianFactor : public HybridFactor {
   /// @{
 
   /// Get the factor and scalar at a given discrete assignment.
-  std::pair<sharedFactor, double> operator()(
-      const DiscreteValues &assignment) const;
+  GaussianFactorValuePair operator()(const DiscreteValues &assignment) const;
 
   /**
    * @brief Combine the Gaussian Factor Graphs in `sum` and `this` while

--- a/gtsam/hybrid/HybridGaussianFactor.h
+++ b/gtsam/hybrid/HybridGaussianFactor.h
@@ -53,7 +53,7 @@ class GTSAM_EXPORT HybridGaussianFactor : public HybridFactor {
   using sharedFactor = std::shared_ptr<GaussianFactor>;
 
   /// typedef for Decision Tree of Gaussian factors and log-constant.
-  using Factors = DecisionTree<Key, sharedFactor>;
+  using Factors = DecisionTree<Key, std::pair<sharedFactor, double>>;
 
  private:
   /// Decision tree of Gaussian factors indexed by discrete keys.
@@ -80,8 +80,7 @@ class GTSAM_EXPORT HybridGaussianFactor : public HybridFactor {
    * @param continuousKeys A vector of keys representing continuous variables.
    * @param discreteKeys A vector of keys representing discrete variables and
    * their cardinalities.
-   * @param factors The decision tree of Gaussian factors stored
-   * as the mixture density.
+   * @param factors The decision tree of Gaussian factors and arbitrary scalars.
    */
   HybridGaussianFactor(const KeyVector &continuousKeys,
                        const DiscreteKeys &discreteKeys,
@@ -93,11 +92,12 @@ class GTSAM_EXPORT HybridGaussianFactor : public HybridFactor {
    *
    * @param continuousKeys Vector of keys for continuous factors.
    * @param discreteKeys Vector of discrete keys.
-   * @param factors Vector of gaussian factor shared pointers.
+   * @param factors Vector of gaussian factor shared pointers
+   *  and arbitrary scalars.
    */
-  HybridGaussianFactor(const KeyVector &continuousKeys,
-                       const DiscreteKeys &discreteKeys,
-                       const std::vector<sharedFactor> &factors)
+  HybridGaussianFactor(
+      const KeyVector &continuousKeys, const DiscreteKeys &discreteKeys,
+      const std::vector<std::pair<sharedFactor, double>> &factors)
       : HybridGaussianFactor(continuousKeys, discreteKeys,
                              Factors(discreteKeys, factors)) {}
 
@@ -114,8 +114,9 @@ class GTSAM_EXPORT HybridGaussianFactor : public HybridFactor {
   /// @name Standard API
   /// @{
 
-  /// Get factor at a given discrete assignment.
-  sharedFactor operator()(const DiscreteValues &assignment) const;
+  /// Get the factor and scalar at a given discrete assignment.
+  std::pair<sharedFactor, double> operator()(
+      const DiscreteValues &assignment) const;
 
   /**
    * @brief Combine the Gaussian Factor Graphs in `sum` and `this` while

--- a/gtsam/hybrid/HybridGaussianFactor.h
+++ b/gtsam/hybrid/HybridGaussianFactor.h
@@ -55,8 +55,10 @@ class GTSAM_EXPORT HybridGaussianFactor : public HybridFactor {
 
   using sharedFactor = std::shared_ptr<GaussianFactor>;
 
-  /// typedef for Decision Tree of Gaussian factors and log-constant.
-  using Factors = DecisionTree<Key, GaussianFactorValuePair>;
+  /// typedef for Decision Tree of Gaussian factors and arbitrary value.
+  using FactorValuePairs = DecisionTree<Key, GaussianFactorValuePair>;
+  /// typedef for Decision Tree of Gaussian factors.
+  using Factors = DecisionTree<Key, sharedFactor>;
 
  private:
   /// Decision tree of Gaussian factors indexed by discrete keys.
@@ -87,7 +89,7 @@ class GTSAM_EXPORT HybridGaussianFactor : public HybridFactor {
    */
   HybridGaussianFactor(const KeyVector &continuousKeys,
                        const DiscreteKeys &discreteKeys,
-                       const Factors &factors);
+                       const FactorValuePairs &factors);
 
   /**
    * @brief Construct a new HybridGaussianFactor object using a vector of
@@ -102,7 +104,7 @@ class GTSAM_EXPORT HybridGaussianFactor : public HybridFactor {
                        const DiscreteKeys &discreteKeys,
                        const std::vector<GaussianFactorValuePair> &factors)
       : HybridGaussianFactor(continuousKeys, discreteKeys,
-                             Factors(discreteKeys, factors)) {}
+                             FactorValuePairs(discreteKeys, factors)) {}
 
   /// @}
   /// @name Testable
@@ -118,7 +120,7 @@ class GTSAM_EXPORT HybridGaussianFactor : public HybridFactor {
   /// @{
 
   /// Get the factor and scalar at a given discrete assignment.
-  GaussianFactorValuePair operator()(const DiscreteValues &assignment) const;
+  sharedFactor operator()(const DiscreteValues &assignment) const;
 
   /**
    * @brief Combine the Gaussian Factor Graphs in `sum` and `this` while
@@ -172,5 +174,17 @@ class GTSAM_EXPORT HybridGaussianFactor : public HybridFactor {
 // traits
 template <>
 struct traits<HybridGaussianFactor> : public Testable<HybridGaussianFactor> {};
+
+/**
+ * @brief Helper function to compute the sqrt(|2πΣ|) normalizer values
+ * for a Gaussian noise model.
+ * We compute this in the log-space for numerical accuracy.
+ *
+ * @param noise_model The Gaussian noise model
+ * whose normalizer we wish to compute.
+ * @return double
+ */
+GTSAM_EXPORT double ComputeLogNormalizer(
+    const noiseModel::Gaussian::shared_ptr &noise_model);
 
 }  // namespace gtsam

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -92,13 +92,15 @@ void HybridGaussianFactorGraph::printErrors(
     // Clear the stringstream
     ss.str(std::string());
 
-    if (auto gmf = std::dynamic_pointer_cast<HybridGaussianFactor>(factor)) {
+    if (auto hgf = std::dynamic_pointer_cast<HybridGaussianFactor>(factor)) {
       if (factor == nullptr) {
         std::cout << "nullptr"
                   << "\n";
       } else {
-        gmf->operator()(values.discrete())->print(ss.str(), keyFormatter);
-        std::cout << "error = " << gmf->error(values) << std::endl;
+        auto [factor, val] = hgf->operator()(values.discrete());
+        factor->print(ss.str(), keyFormatter);
+        std::cout << "value: " << val << std::endl;
+        std::cout << "error = " << factor->error(values) << std::endl;
       }
     } else if (auto hc = std::dynamic_pointer_cast<HybridConditional>(factor)) {
       if (factor == nullptr) {
@@ -262,9 +264,12 @@ discreteElimination(const HybridGaussianFactorGraph &factors,
       // Case where we have a HybridGaussianFactor with no continuous keys.
       // In this case, compute discrete probabilities.
       auto logProbability =
-          [&](const GaussianFactor::shared_ptr &factor) -> double {
-        if (!factor) return 0.0;
-        return -factor->error(VectorValues());
+          [&](const std::pair<GaussianFactor::shared_ptr, double> &fv)
+          -> double {
+        auto [factor, val] = fv;
+        double v = 0.5 * val * val;
+        if (!factor) return -v;
+        return -(factor->error(VectorValues()) + v);
       };
       AlgebraicDecisionTree<Key> logProbabilities =
           DecisionTree<Key, double>(gmf->factors(), logProbability);
@@ -348,7 +353,8 @@ static std::shared_ptr<Factor> createHybridGaussianFactor(
     const KeyVector &continuousSeparator,
     const DiscreteKeys &discreteSeparator) {
   // Correct for the normalization constant used up by the conditional
-  auto correct = [&](const Result &pair) -> GaussianFactor::shared_ptr {
+  auto correct =
+      [&](const Result &pair) -> std::pair<GaussianFactor::shared_ptr, double> {
     const auto &[conditional, factor] = pair;
     if (factor) {
       auto hf = std::dynamic_pointer_cast<HessianFactor>(factor);
@@ -357,10 +363,10 @@ static std::shared_ptr<Factor> createHybridGaussianFactor(
       // as per the Hessian definition
       hf->constantTerm() += 2.0 * conditional->logNormalizationConstant();
     }
-    return factor;
+    return {factor, 0.0};
   };
-  DecisionTree<Key, GaussianFactor::shared_ptr> newFactors(eliminationResults,
-                                                           correct);
+  DecisionTree<Key, std::pair<GaussianFactor::shared_ptr, double>> newFactors(
+      eliminationResults, correct);
 
   return std::make_shared<HybridGaussianFactor>(continuousSeparator,
                                                 discreteSeparator, newFactors);
@@ -597,10 +603,10 @@ GaussianFactorGraph HybridGaussianFactorGraph::operator()(
       gfg.push_back(gf);
     } else if (auto gc = std::dynamic_pointer_cast<GaussianConditional>(f)) {
       gfg.push_back(gf);
-    } else if (auto gmf = std::dynamic_pointer_cast<HybridGaussianFactor>(f)) {
-      gfg.push_back((*gmf)(assignment));
-    } else if (auto gm = dynamic_pointer_cast<HybridGaussianConditional>(f)) {
-      gfg.push_back((*gm)(assignment));
+    } else if (auto hgf = std::dynamic_pointer_cast<HybridGaussianFactor>(f)) {
+      gfg.push_back((*hgf)(assignment).first);
+    } else if (auto hgc = dynamic_pointer_cast<HybridGaussianConditional>(f)) {
+      gfg.push_back((*hgc)(assignment));
     } else {
       continue;
     }

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -263,9 +263,7 @@ discreteElimination(const HybridGaussianFactorGraph &factors,
     } else if (auto gmf = dynamic_pointer_cast<HybridGaussianFactor>(f)) {
       // Case where we have a HybridGaussianFactor with no continuous keys.
       // In this case, compute discrete probabilities.
-      auto logProbability =
-          [&](const std::pair<GaussianFactor::shared_ptr, double> &fv)
-          -> double {
+      auto logProbability = [&](const GaussianFactorValuePair &fv) -> double {
         auto [factor, val] = fv;
         double v = 0.5 * val * val;
         if (!factor) return -v;
@@ -353,8 +351,7 @@ static std::shared_ptr<Factor> createHybridGaussianFactor(
     const KeyVector &continuousSeparator,
     const DiscreteKeys &discreteSeparator) {
   // Correct for the normalization constant used up by the conditional
-  auto correct =
-      [&](const Result &pair) -> std::pair<GaussianFactor::shared_ptr, double> {
+  auto correct = [&](const Result &pair) -> GaussianFactorValuePair {
     const auto &[conditional, factor] = pair;
     if (factor) {
       auto hf = std::dynamic_pointer_cast<HessianFactor>(factor);
@@ -365,8 +362,8 @@ static std::shared_ptr<Factor> createHybridGaussianFactor(
     }
     return {factor, 0.0};
   };
-  DecisionTree<Key, std::pair<GaussianFactor::shared_ptr, double>> newFactors(
-      eliminationResults, correct);
+  DecisionTree<Key, GaussianFactorValuePair> newFactors(eliminationResults,
+                                                        correct);
 
   return std::make_shared<HybridGaussianFactor>(continuousSeparator,
                                                 discreteSeparator, newFactors);

--- a/gtsam/hybrid/HybridNonlinearFactor.h
+++ b/gtsam/hybrid/HybridNonlinearFactor.h
@@ -92,17 +92,18 @@ class HybridNonlinearFactor : public HybridFactor {
    * @tparam FACTOR The type of the factor shared pointers being passed in.
    * Will be typecast to NonlinearFactor shared pointers.
    * @param keys Vector of keys for continuous factors.
-   * @param discreteKeys Vector of discrete keys.
+   * @param discreteKey The discrete key indexing each component factor.
    * @param factors Vector of nonlinear factor and scalar pairs.
+   * Same size as the cardinality of discreteKey.
    * @param normalized Flag indicating if the factor error is already
    * normalized.
    */
   template <typename FACTOR>
   HybridNonlinearFactor(
-      const KeyVector& keys, const DiscreteKeys& discreteKeys,
+      const KeyVector& keys, const DiscreteKey& discreteKey,
       const std::vector<std::pair<std::shared_ptr<FACTOR>, double>>& factors,
       bool normalized = false)
-      : Base(keys, discreteKeys), normalized_(normalized) {
+      : Base(keys, {discreteKey}), normalized_(normalized) {
     std::vector<NonlinearFactorValuePair> nonlinear_factors;
     KeySet continuous_keys_set(keys.begin(), keys.end());
     KeySet factor_keys_set;
@@ -118,7 +119,7 @@ class HybridNonlinearFactor : public HybridFactor {
             "Factors passed into HybridNonlinearFactor need to be nonlinear!");
       }
     }
-    factors_ = Factors(discreteKeys, nonlinear_factors);
+    factors_ = Factors({discreteKey}, nonlinear_factors);
 
     if (continuous_keys_set != factor_keys_set) {
       throw std::runtime_error(

--- a/gtsam/hybrid/HybridNonlinearFactor.h
+++ b/gtsam/hybrid/HybridNonlinearFactor.h
@@ -245,10 +245,11 @@ class HybridNonlinearFactor : public HybridFactor {
       const Values& continuousValues) const {
     // functional to linearize each factor in the decision tree
     auto linearizeDT =
-        [continuousValues](const std::pair<sharedFactor, double>& f) {
-          auto [factor, val] = f;
-          return {factor->linearize(continuousValues), val};
-        };
+        [continuousValues](const std::pair<sharedFactor, double>& f)
+        -> std::pair<GaussianFactor::shared_ptr, double> {
+      auto [factor, val] = f;
+      return {factor->linearize(continuousValues), val};
+    };
 
     DecisionTree<Key, std::pair<GaussianFactor::shared_ptr, double>>
         linearized_factors(factors_, linearizeDT);

--- a/gtsam/hybrid/HybridNonlinearFactor.h
+++ b/gtsam/hybrid/HybridNonlinearFactor.h
@@ -236,7 +236,7 @@ class HybridNonlinearFactor : public HybridFactor {
   GaussianFactor::shared_ptr linearize(
       const Values& continuousValues,
       const DiscreteValues& discreteValues) const {
-    auto [factor, val] = factors_(discreteValues);
+    auto factor = factors_(discreteValues).first;
     return factor->linearize(continuousValues);
   }
 

--- a/gtsam/hybrid/HybridNonlinearFactor.h
+++ b/gtsam/hybrid/HybridNonlinearFactor.h
@@ -140,7 +140,7 @@ class HybridNonlinearFactor : public HybridFactor {
     auto errorFunc =
         [continuousValues](const std::pair<sharedFactor, double>& f) {
           auto [factor, val] = f;
-          return factor->error(continuousValues) + (0.5 * val * val);
+          return factor->error(continuousValues) + (0.5 * val);
         };
     DecisionTree<Key, double> result(factors_, errorFunc);
     return result;
@@ -159,7 +159,7 @@ class HybridNonlinearFactor : public HybridFactor {
     auto [factor, val] = factors_(discreteValues);
     // Compute the error for the selected factor
     const double factorError = factor->error(continuousValues);
-    return factorError + (0.5 * val * val);
+    return factorError + (0.5 * val);
   }
 
   /**

--- a/gtsam/hybrid/HybridNonlinearFactor.h
+++ b/gtsam/hybrid/HybridNonlinearFactor.h
@@ -246,7 +246,7 @@ class HybridNonlinearFactor : public HybridFactor {
     // functional to linearize each factor in the decision tree
     auto linearizeDT =
         [continuousValues](const std::pair<sharedFactor, double>& f)
-        -> std::pair<GaussianFactor::shared_ptr, double> {
+        -> GaussianFactorValuePair {
       auto [factor, val] = f;
       return {factor->linearize(continuousValues), val};
     };

--- a/gtsam/hybrid/HybridNonlinearFactor.h
+++ b/gtsam/hybrid/HybridNonlinearFactor.h
@@ -110,7 +110,7 @@ class HybridNonlinearFactor : public HybridFactor {
                 std::inserter(factor_keys_set, factor_keys_set.end()));
 
       if (auto nf = std::dynamic_pointer_cast<NonlinearFactor>(f)) {
-        nonlinear_factors.push_back(std::make_pair(nf, val));
+        nonlinear_factors.emplace_back(nf, val);
       } else {
         throw std::runtime_error(
             "Factors passed into HybridNonlinearFactor need to be nonlinear!");

--- a/gtsam/hybrid/HybridNonlinearFactor.h
+++ b/gtsam/hybrid/HybridNonlinearFactor.h
@@ -33,6 +33,9 @@
 
 namespace gtsam {
 
+/// Alias for a NonlinearFactor shared pointer and double scalar pair.
+using NonlinearFactorValuePair = std::pair<NonlinearFactor::shared_ptr, double>;
+
 /**
  * @brief Implementation of a discrete conditional mixture factor.
  *
@@ -55,7 +58,7 @@ class HybridNonlinearFactor : public HybridFactor {
    * @brief typedef for DecisionTree which has Keys as node labels and
    * pairs of NonlinearFactor & an arbitrary scalar as leaf nodes.
    */
-  using Factors = DecisionTree<Key, std::pair<sharedFactor, double>>;
+  using Factors = DecisionTree<Key, NonlinearFactorValuePair>;
 
  private:
   /// Decision tree of Gaussian factors indexed by discrete keys.
@@ -100,8 +103,7 @@ class HybridNonlinearFactor : public HybridFactor {
       const std::vector<std::pair<std::shared_ptr<FACTOR>, double>>& factors,
       bool normalized = false)
       : Base(keys, discreteKeys), normalized_(normalized) {
-    std::vector<std::pair<NonlinearFactor::shared_ptr, double>>
-        nonlinear_factors;
+    std::vector<NonlinearFactorValuePair> nonlinear_factors;
     KeySet continuous_keys_set(keys.begin(), keys.end());
     KeySet factor_keys_set;
     for (auto&& [f, val] : factors) {

--- a/gtsam/hybrid/HybridNonlinearFactor.h
+++ b/gtsam/hybrid/HybridNonlinearFactor.h
@@ -138,7 +138,7 @@ class HybridNonlinearFactor : public HybridFactor {
     auto errorFunc =
         [continuousValues](const std::pair<sharedFactor, double>& f) {
           auto [factor, val] = f;
-          return factor->error(continuousValues) + val;
+          return factor->error(continuousValues) + (0.5 * val * val);
         };
     DecisionTree<Key, double> result(factors_, errorFunc);
     return result;
@@ -157,7 +157,7 @@ class HybridNonlinearFactor : public HybridFactor {
     auto [factor, val] = factors_(discreteValues);
     // Compute the error for the selected factor
     const double factorError = factor->error(continuousValues);
-    return factorError + val;
+    return factorError + (0.5 * val * val);
   }
 
   /**

--- a/gtsam/hybrid/hybrid.i
+++ b/gtsam/hybrid/hybrid.i
@@ -77,7 +77,8 @@ class HybridGaussianFactor : gtsam::HybridFactor {
   HybridGaussianFactor(
       const gtsam::KeyVector& continuousKeys,
       const gtsam::DiscreteKeys& discreteKeys,
-      const std::vector<gtsam::GaussianFactor::shared_ptr>& factorsList);
+      const std::vector<std::pair<gtsam::GaussianFactor::shared_ptr, double>>&
+          factorsList);
 
   void print(string s = "HybridGaussianFactor\n",
              const gtsam::KeyFormatter& keyFormatter =
@@ -242,14 +243,14 @@ class HybridNonlinearFactorGraph {
 class HybridNonlinearFactor : gtsam::HybridFactor {
   HybridNonlinearFactor(
       const gtsam::KeyVector& keys, const gtsam::DiscreteKeys& discreteKeys,
-      const gtsam::DecisionTree<gtsam::Key, gtsam::NonlinearFactor*>& factors,
+      const gtsam::DecisionTree<
+          gtsam::Key, std::pair<gtsam::NonlinearFactor*, double>>& factors,
       bool normalized = false);
 
-  template <FACTOR = {gtsam::NonlinearFactor}>
-  HybridNonlinearFactor(const gtsam::KeyVector& keys,
-                        const gtsam::DiscreteKeys& discreteKeys,
-                        const std::vector<FACTOR*>& factors,
-                        bool normalized = false);
+  HybridNonlinearFactor(
+      const gtsam::KeyVector& keys, const gtsam::DiscreteKeys& discreteKeys,
+      const std::vector<std::pair<gtsam::NonlinearFactor*, double>>& factors,
+      bool normalized = false);
 
   double error(const gtsam::Values& continuousValues,
                const gtsam::DiscreteValues& discreteValues) const;

--- a/gtsam/hybrid/hybrid.i
+++ b/gtsam/hybrid/hybrid.i
@@ -92,6 +92,11 @@ class HybridGaussianConditional : gtsam::HybridFactor {
       const gtsam::KeyVector& continuousParents,
       const gtsam::DiscreteKeys& discreteParents,
       const gtsam::HybridGaussianConditional::Conditionals& conditionals);
+  HybridGaussianConditional(
+      const gtsam::KeyVector& continuousFrontals,
+      const gtsam::KeyVector& continuousParents,
+      const gtsam::DiscreteKeys& discreteParents,
+      const std::vector<gtsam::GaussianConditional::shared_ptr>& conditionals);
 
   gtsam::HybridGaussianFactor* likelihood(
       const gtsam::VectorValues& frontals) const;

--- a/gtsam/hybrid/hybrid.i
+++ b/gtsam/hybrid/hybrid.i
@@ -76,7 +76,7 @@ virtual class HybridConditional {
 class HybridGaussianFactor : gtsam::HybridFactor {
   HybridGaussianFactor(
       const gtsam::KeyVector& continuousKeys,
-      const gtsam::DiscreteKeys& discreteKeys,
+      const gtsam::DiscreteKey& discreteKey,
       const std::vector<std::pair<gtsam::GaussianFactor::shared_ptr, double>>&
           factorsList);
 
@@ -91,8 +91,7 @@ class HybridGaussianConditional : gtsam::HybridFactor {
       const gtsam::KeyVector& continuousFrontals,
       const gtsam::KeyVector& continuousParents,
       const gtsam::DiscreteKeys& discreteParents,
-      const std::vector<gtsam::GaussianConditional::shared_ptr>&
-          conditionalsList);
+      const gtsam::HybridGaussianConditional::Conditionals& conditionals);
 
   gtsam::HybridGaussianFactor* likelihood(
       const gtsam::VectorValues& frontals) const;
@@ -248,7 +247,7 @@ class HybridNonlinearFactor : gtsam::HybridFactor {
       bool normalized = false);
 
   HybridNonlinearFactor(
-      const gtsam::KeyVector& keys, const gtsam::DiscreteKeys& discreteKeys,
+      const gtsam::KeyVector& keys, const gtsam::DiscreteKey& discreteKey,
       const std::vector<std::pair<gtsam::NonlinearFactor*, double>>& factors,
       bool normalized = false);
 

--- a/gtsam/hybrid/hybrid.i
+++ b/gtsam/hybrid/hybrid.i
@@ -95,7 +95,7 @@ class HybridGaussianConditional : gtsam::HybridFactor {
   HybridGaussianConditional(
       const gtsam::KeyVector& continuousFrontals,
       const gtsam::KeyVector& continuousParents,
-      const gtsam::DiscreteKeys& discreteParents,
+      const gtsam::DiscreteKey& discreteParent,
       const std::vector<gtsam::GaussianConditional::shared_ptr>& conditionals);
 
   gtsam::HybridGaussianFactor* likelihood(

--- a/gtsam/hybrid/tests/Switching.h
+++ b/gtsam/hybrid/tests/Switching.h
@@ -57,15 +57,16 @@ inline HybridGaussianFactorGraph::shared_ptr makeSwitchingChain(
 
   // keyFunc(1) to keyFunc(n+1)
   for (size_t t = 1; t < n; t++) {
-    std::vector<GaussianFactorValuePair> components = {
-        {std::make_shared<JacobianFactor>(keyFunc(t), I_3x3, keyFunc(t + 1),
-                                          I_3x3, Z_3x1),
-         0.0},
-        {std::make_shared<JacobianFactor>(keyFunc(t), I_3x3, keyFunc(t + 1),
-                                          I_3x3, Vector3::Ones()),
-         0.0}};
-    hfg.add(HybridGaussianFactor({keyFunc(t), keyFunc(t + 1)},
-                                 {{dKeyFunc(t), 2}}, components));
+    DiscreteKeys dKeys{{dKeyFunc(t), 2}};
+    HybridGaussianFactor::FactorValuePairs components(
+        dKeys, {{std::make_shared<JacobianFactor>(keyFunc(t), I_3x3,
+                                                  keyFunc(t + 1), I_3x3, Z_3x1),
+                 0.0},
+                {std::make_shared<JacobianFactor>(
+                     keyFunc(t), I_3x3, keyFunc(t + 1), I_3x3, Vector3::Ones()),
+                 0.0}});
+    hfg.add(
+        HybridGaussianFactor({keyFunc(t), keyFunc(t + 1)}, dKeys, components));
 
     if (t > 1) {
       hfg.add(DecisionTreeFactor({{dKeyFunc(t - 1), 2}, {dKeyFunc(t), 2}},

--- a/gtsam/hybrid/tests/Switching.h
+++ b/gtsam/hybrid/tests/Switching.h
@@ -168,8 +168,8 @@ struct Switching {
         components.push_back(
             {std::dynamic_pointer_cast<NonlinearFactor>(f), 0.0});
       }
-      nonlinearFactorGraph.emplace_shared<HybridNonlinearFactor>(
-          keys, DiscreteKeys{modes[k]}, components);
+      nonlinearFactorGraph.emplace_shared<HybridNonlinearFactor>(keys, modes[k],
+                                                                 components);
     }
 
     // Add measurement factors

--- a/gtsam/hybrid/tests/Switching.h
+++ b/gtsam/hybrid/tests/Switching.h
@@ -57,12 +57,15 @@ inline HybridGaussianFactorGraph::shared_ptr makeSwitchingChain(
 
   // keyFunc(1) to keyFunc(n+1)
   for (size_t t = 1; t < n; t++) {
-    hfg.add(HybridGaussianFactor(
-        {keyFunc(t), keyFunc(t + 1)}, {{dKeyFunc(t), 2}},
+    std::vector<GaussianFactorValuePair> components = {
         {std::make_shared<JacobianFactor>(keyFunc(t), I_3x3, keyFunc(t + 1),
                                           I_3x3, Z_3x1),
-         std::make_shared<JacobianFactor>(keyFunc(t), I_3x3, keyFunc(t + 1),
-                                          I_3x3, Vector3::Ones())}));
+         0.0},
+        {std::make_shared<JacobianFactor>(keyFunc(t), I_3x3, keyFunc(t + 1),
+                                          I_3x3, Vector3::Ones()),
+         0.0}};
+    hfg.add(HybridGaussianFactor({keyFunc(t), keyFunc(t + 1)},
+                                 {{dKeyFunc(t), 2}}, components));
 
     if (t > 1) {
       hfg.add(DecisionTreeFactor({{dKeyFunc(t - 1), 2}, {dKeyFunc(t), 2}},

--- a/gtsam/hybrid/tests/Switching.h
+++ b/gtsam/hybrid/tests/Switching.h
@@ -159,9 +159,10 @@ struct Switching {
     for (size_t k = 0; k < K - 1; k++) {
       KeyVector keys = {X(k), X(k + 1)};
       auto motion_models = motionModels(k, between_sigma);
-      std::vector<NonlinearFactor::shared_ptr> components;
+      std::vector<std::pair<NonlinearFactor::shared_ptr, double>> components;
       for (auto &&f : motion_models) {
-        components.push_back(std::dynamic_pointer_cast<NonlinearFactor>(f));
+        components.push_back(
+            {std::dynamic_pointer_cast<NonlinearFactor>(f), 0.0});
       }
       nonlinearFactorGraph.emplace_shared<HybridNonlinearFactor>(
           keys, DiscreteKeys{modes[k]}, components);

--- a/gtsam/hybrid/tests/Switching.h
+++ b/gtsam/hybrid/tests/Switching.h
@@ -162,7 +162,7 @@ struct Switching {
     for (size_t k = 0; k < K - 1; k++) {
       KeyVector keys = {X(k), X(k + 1)};
       auto motion_models = motionModels(k, between_sigma);
-      std::vector<std::pair<NonlinearFactor::shared_ptr, double>> components;
+      std::vector<NonlinearFactorValuePair> components;
       for (auto &&f : motion_models) {
         components.push_back(
             {std::dynamic_pointer_cast<NonlinearFactor>(f), 0.0});

--- a/gtsam/hybrid/tests/TinyHybridExample.h
+++ b/gtsam/hybrid/tests/TinyHybridExample.h
@@ -43,12 +43,13 @@ inline HybridBayesNet createHybridBayesNet(size_t num_measurements = 1,
   // Create Gaussian mixture z_i = x0 + noise for each measurement.
   for (size_t i = 0; i < num_measurements; i++) {
     const auto mode_i = manyModes ? DiscreteKey{M(i), 2} : mode;
+    DiscreteKeys modes{mode_i};
+    std::vector<GaussianConditional::shared_ptr> conditionals{
+        GaussianConditional::sharedMeanAndStddev(Z(i), I_1x1, X(0), Z_1x1, 0.5),
+        GaussianConditional::sharedMeanAndStddev(Z(i), I_1x1, X(0), Z_1x1, 3)};
     bayesNet.emplace_shared<HybridGaussianConditional>(
         KeyVector{Z(i)}, KeyVector{X(0)}, DiscreteKeys{mode_i},
-        std::vector{GaussianConditional::sharedMeanAndStddev(Z(i), I_1x1, X(0),
-                                                             Z_1x1, 0.5),
-                    GaussianConditional::sharedMeanAndStddev(Z(i), I_1x1, X(0),
-                                                             Z_1x1, 3)});
+        HybridGaussianConditional::Conditionals(modes, conditionals));
   }
 
   // Create prior on X(0).

--- a/gtsam/hybrid/tests/TinyHybridExample.h
+++ b/gtsam/hybrid/tests/TinyHybridExample.h
@@ -43,13 +43,11 @@ inline HybridBayesNet createHybridBayesNet(size_t num_measurements = 1,
   // Create Gaussian mixture z_i = x0 + noise for each measurement.
   for (size_t i = 0; i < num_measurements; i++) {
     const auto mode_i = manyModes ? DiscreteKey{M(i), 2} : mode;
-    DiscreteKeys modes{mode_i};
     std::vector<GaussianConditional::shared_ptr> conditionals{
         GaussianConditional::sharedMeanAndStddev(Z(i), I_1x1, X(0), Z_1x1, 0.5),
         GaussianConditional::sharedMeanAndStddev(Z(i), I_1x1, X(0), Z_1x1, 3)};
     bayesNet.emplace_shared<HybridGaussianConditional>(
-        KeyVector{Z(i)}, KeyVector{X(0)}, DiscreteKeys{mode_i},
-        HybridGaussianConditional::Conditionals(modes, conditionals));
+        KeyVector{Z(i)}, KeyVector{X(0)}, mode_i, conditionals);
   }
 
   // Create prior on X(0).

--- a/gtsam/hybrid/tests/testHybridBayesNet.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesNet.cpp
@@ -383,15 +383,17 @@ TEST(HybridBayesNet, Sampling) {
   HybridNonlinearFactorGraph nfg;
 
   auto noise_model = noiseModel::Diagonal::Sigmas(Vector1(1.0));
+  nfg.emplace_shared<PriorFactor<double>>(X(0), 0.0, noise_model);
+
   auto zero_motion =
       std::make_shared<BetweenFactor<double>>(X(0), X(1), 0, noise_model);
   auto one_motion =
       std::make_shared<BetweenFactor<double>>(X(0), X(1), 1, noise_model);
-  std::vector<NonlinearFactorValuePair> factors = {{zero_motion, 0.0},
-                                                   {one_motion, 0.0}};
-  nfg.emplace_shared<PriorFactor<double>>(X(0), 0.0, noise_model);
-  nfg.emplace_shared<HybridNonlinearFactor>(
-      KeyVector{X(0), X(1)}, DiscreteKeys{DiscreteKey(M(0), 2)}, factors);
+  DiscreteKeys discreteKeys{DiscreteKey(M(0), 2)};
+  HybridNonlinearFactor::Factors factors(
+      discreteKeys, {{zero_motion, 0.0}, {one_motion, 0.0}});
+  nfg.emplace_shared<HybridNonlinearFactor>(KeyVector{X(0), X(1)}, discreteKeys,
+                                            factors);
 
   DiscreteKey mode(M(0), 2);
   nfg.emplace_shared<DiscreteDistribution>(mode, "1/1");

--- a/gtsam/hybrid/tests/testHybridBayesNet.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesNet.cpp
@@ -387,8 +387,8 @@ TEST(HybridBayesNet, Sampling) {
       std::make_shared<BetweenFactor<double>>(X(0), X(1), 0, noise_model);
   auto one_motion =
       std::make_shared<BetweenFactor<double>>(X(0), X(1), 1, noise_model);
-  std::vector<std::pair<NonlinearFactor::shared_ptr, double>> factors = {
-      {zero_motion, 0.0}, {one_motion, 0.0}};
+  std::vector<NonlinearFactorValuePair> factors = {{zero_motion, 0.0},
+                                                   {one_motion, 0.0}};
   nfg.emplace_shared<PriorFactor<double>>(X(0), 0.0, noise_model);
   nfg.emplace_shared<HybridNonlinearFactor>(
       KeyVector{X(0), X(1)}, DiscreteKeys{DiscreteKey(M(0), 2)}, factors);

--- a/gtsam/hybrid/tests/testHybridBayesNet.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesNet.cpp
@@ -107,11 +107,9 @@ TEST(HybridBayesNet, evaluateHybrid) {
   // Create hybrid Bayes net.
   HybridBayesNet bayesNet;
   bayesNet.push_back(continuousConditional);
-  DiscreteKeys discreteParents{Asia};
   bayesNet.emplace_shared<HybridGaussianConditional>(
-      KeyVector{X(1)}, KeyVector{}, discreteParents,
-      HybridGaussianConditional::Conditionals(
-          discreteParents, std::vector{conditional0, conditional1}));
+      KeyVector{X(1)}, KeyVector{}, Asia,
+      std::vector{conditional0, conditional1});
   bayesNet.emplace_shared<DiscreteConditional>(Asia, "99/1");
 
   // Create values at which to evaluate.
@@ -170,11 +168,9 @@ TEST(HybridBayesNet, Error) {
              conditional1 = std::make_shared<GaussianConditional>(
                  X(1), Vector1::Constant(2), I_1x1, model1);
 
-  DiscreteKeys discreteParents{Asia};
   auto gm = std::make_shared<HybridGaussianConditional>(
-      KeyVector{X(1)}, KeyVector{}, discreteParents,
-      HybridGaussianConditional::Conditionals(
-          discreteParents, std::vector{conditional0, conditional1}));
+      KeyVector{X(1)}, KeyVector{}, Asia,
+      std::vector{conditional0, conditional1});
   // Create hybrid Bayes net.
   HybridBayesNet bayesNet;
   bayesNet.push_back(continuousConditional);
@@ -393,11 +389,10 @@ TEST(HybridBayesNet, Sampling) {
       std::make_shared<BetweenFactor<double>>(X(0), X(1), 0, noise_model);
   auto one_motion =
       std::make_shared<BetweenFactor<double>>(X(0), X(1), 1, noise_model);
-  DiscreteKeys discreteKeys{DiscreteKey(M(0), 2)};
-  HybridNonlinearFactor::Factors factors(
-      discreteKeys, {{zero_motion, 0.0}, {one_motion, 0.0}});
-  nfg.emplace_shared<HybridNonlinearFactor>(KeyVector{X(0), X(1)}, discreteKeys,
-                                            factors);
+  nfg.emplace_shared<HybridNonlinearFactor>(
+      KeyVector{X(0), X(1)}, DiscreteKey(M(0), 2),
+      std::vector<NonlinearFactorValuePair>{{zero_motion, 0.0},
+                                            {one_motion, 0.0}});
 
   DiscreteKey mode(M(0), 2);
   nfg.emplace_shared<DiscreteDistribution>(mode, "1/1");

--- a/gtsam/hybrid/tests/testHybridBayesNet.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesNet.cpp
@@ -107,9 +107,11 @@ TEST(HybridBayesNet, evaluateHybrid) {
   // Create hybrid Bayes net.
   HybridBayesNet bayesNet;
   bayesNet.push_back(continuousConditional);
+  DiscreteKeys discreteParents{Asia};
   bayesNet.emplace_shared<HybridGaussianConditional>(
-      KeyVector{X(1)}, KeyVector{}, DiscreteKeys{Asia},
-      std::vector{conditional0, conditional1});
+      KeyVector{X(1)}, KeyVector{}, discreteParents,
+      HybridGaussianConditional::Conditionals(
+          discreteParents, std::vector{conditional0, conditional1}));
   bayesNet.emplace_shared<DiscreteConditional>(Asia, "99/1");
 
   // Create values at which to evaluate.
@@ -168,9 +170,11 @@ TEST(HybridBayesNet, Error) {
              conditional1 = std::make_shared<GaussianConditional>(
                  X(1), Vector1::Constant(2), I_1x1, model1);
 
+  DiscreteKeys discreteParents{Asia};
   auto gm = std::make_shared<HybridGaussianConditional>(
-      KeyVector{X(1)}, KeyVector{}, DiscreteKeys{Asia},
-      std::vector{conditional0, conditional1});
+      KeyVector{X(1)}, KeyVector{}, discreteParents,
+      HybridGaussianConditional::Conditionals(
+          discreteParents, std::vector{conditional0, conditional1}));
   // Create hybrid Bayes net.
   HybridBayesNet bayesNet;
   bayesNet.push_back(continuousConditional);

--- a/gtsam/hybrid/tests/testHybridBayesNet.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesNet.cpp
@@ -387,7 +387,8 @@ TEST(HybridBayesNet, Sampling) {
       std::make_shared<BetweenFactor<double>>(X(0), X(1), 0, noise_model);
   auto one_motion =
       std::make_shared<BetweenFactor<double>>(X(0), X(1), 1, noise_model);
-  std::vector<NonlinearFactor::shared_ptr> factors = {zero_motion, one_motion};
+  std::vector<std::pair<NonlinearFactor::shared_ptr, double>> factors = {
+      {zero_motion, 0.0}, {one_motion, 0.0}};
   nfg.emplace_shared<PriorFactor<double>>(X(0), 0.0, noise_model);
   nfg.emplace_shared<HybridNonlinearFactor>(
       KeyVector{X(0), X(1)}, DiscreteKeys{DiscreteKey(M(0), 2)}, factors);

--- a/gtsam/hybrid/tests/testHybridEstimation.cpp
+++ b/gtsam/hybrid/tests/testHybridEstimation.cpp
@@ -435,8 +435,8 @@ static HybridNonlinearFactorGraph createHybridNonlinearFactorGraph() {
       std::make_shared<BetweenFactor<double>>(X(0), X(1), 0, noise_model);
   const auto one_motion =
       std::make_shared<BetweenFactor<double>>(X(0), X(1), 1, noise_model);
-  std::vector<std::pair<NonlinearFactor::shared_ptr, double>> components = {
-      {zero_motion, 0.0}, {one_motion, 0.0}};
+  std::vector<NonlinearFactorValuePair> components = {{zero_motion, 0.0},
+                                                      {one_motion, 0.0}};
   nfg.emplace_shared<HybridNonlinearFactor>(KeyVector{X(0), X(1)},
                                             DiscreteKeys{m}, components);
 
@@ -595,8 +595,8 @@ TEST(HybridEstimation, ModeSelection) {
        model1 = std::make_shared<MotionModel>(
            X(0), X(1), 0.0, noiseModel::Isotropic::Sigma(d, noise_tight));
 
-  std::vector<std::pair<NonlinearFactor::shared_ptr, double>> components = {
-      {model0, 0.0}, {model1, 0.0}};
+  std::vector<NonlinearFactorValuePair> components = {{model0, 0.0},
+                                                      {model1, 0.0}};
 
   KeyVector keys = {X(0), X(1)};
   HybridNonlinearFactor mf(keys, modes, components);
@@ -687,8 +687,8 @@ TEST(HybridEstimation, ModeSelection2) {
        model1 = std::make_shared<BetweenFactor<Vector3>>(
            X(0), X(1), Z_3x1, noiseModel::Isotropic::Sigma(d, noise_tight));
 
-  std::vector<std::pair<NonlinearFactor::shared_ptr, double>> components = {
-      {model0, 0.0}, {model1, 0.0}};
+  std::vector<NonlinearFactorValuePair> components = {{model0, 0.0},
+                                                      {model1, 0.0}};
 
   KeyVector keys = {X(0), X(1)};
   HybridNonlinearFactor mf(keys, modes, components);

--- a/gtsam/hybrid/tests/testHybridEstimation.cpp
+++ b/gtsam/hybrid/tests/testHybridEstimation.cpp
@@ -437,8 +437,8 @@ static HybridNonlinearFactorGraph createHybridNonlinearFactorGraph() {
       std::make_shared<BetweenFactor<double>>(X(0), X(1), 1, noise_model);
   std::vector<NonlinearFactorValuePair> components = {{zero_motion, 0.0},
                                                       {one_motion, 0.0}};
-  nfg.emplace_shared<HybridNonlinearFactor>(KeyVector{X(0), X(1)},
-                                            DiscreteKeys{m}, components);
+  nfg.emplace_shared<HybridNonlinearFactor>(KeyVector{X(0), X(1)}, m,
+                                            components);
 
   return nfg;
 }
@@ -583,9 +583,6 @@ TEST(HybridEstimation, ModeSelection) {
   graph.emplace_shared<PriorFactor<double>>(X(0), 0.0, measurement_model);
   graph.emplace_shared<PriorFactor<double>>(X(1), 0.0, measurement_model);
 
-  DiscreteKeys modes;
-  modes.emplace_back(M(0), 2);
-
   // The size of the noise model
   size_t d = 1;
   double noise_tight = 0.5, noise_loose = 5.0;
@@ -594,11 +591,11 @@ TEST(HybridEstimation, ModeSelection) {
            X(0), X(1), 0.0, noiseModel::Isotropic::Sigma(d, noise_loose)),
        model1 = std::make_shared<MotionModel>(
            X(0), X(1), 0.0, noiseModel::Isotropic::Sigma(d, noise_tight));
-
   std::vector<NonlinearFactorValuePair> components = {{model0, 0.0},
                                                       {model1, 0.0}};
 
   KeyVector keys = {X(0), X(1)};
+  DiscreteKey modes(M(0), 2);
   HybridNonlinearFactor mf(keys, modes, components);
 
   initial.insert(X(0), 0.0);
@@ -617,7 +614,7 @@ TEST(HybridEstimation, ModeSelection) {
 
   /**************************************************************/
   HybridBayesNet bn;
-  const DiscreteKey mode{M(0), 2};
+  const DiscreteKey mode(M(0), 2);
 
   bn.push_back(
       GaussianConditional::sharedMeanAndStddev(Z(0), -I_1x1, X(0), Z_1x1, 0.1));
@@ -648,7 +645,7 @@ TEST(HybridEstimation, ModeSelection2) {
   double noise_tight = 0.5, noise_loose = 5.0;
 
   HybridBayesNet bn;
-  const DiscreteKey mode{M(0), 2};
+  const DiscreteKey mode(M(0), 2);
 
   bn.push_back(
       GaussianConditional::sharedMeanAndStddev(Z(0), -I_3x3, X(0), Z_3x1, 0.1));
@@ -679,18 +676,15 @@ TEST(HybridEstimation, ModeSelection2) {
   graph.emplace_shared<PriorFactor<Vector3>>(X(0), Z_3x1, measurement_model);
   graph.emplace_shared<PriorFactor<Vector3>>(X(1), Z_3x1, measurement_model);
 
-  DiscreteKeys modes;
-  modes.emplace_back(M(0), 2);
-
   auto model0 = std::make_shared<BetweenFactor<Vector3>>(
            X(0), X(1), Z_3x1, noiseModel::Isotropic::Sigma(d, noise_loose)),
        model1 = std::make_shared<BetweenFactor<Vector3>>(
            X(0), X(1), Z_3x1, noiseModel::Isotropic::Sigma(d, noise_tight));
-
   std::vector<NonlinearFactorValuePair> components = {{model0, 0.0},
                                                       {model1, 0.0}};
 
   KeyVector keys = {X(0), X(1)};
+  DiscreteKey modes(M(0), 2);
   HybridNonlinearFactor mf(keys, modes, components);
 
   initial.insert<Vector3>(X(0), Z_3x1);

--- a/gtsam/hybrid/tests/testHybridEstimation.cpp
+++ b/gtsam/hybrid/tests/testHybridEstimation.cpp
@@ -544,8 +544,7 @@ std::shared_ptr<HybridGaussianFactor> mixedVarianceFactor(
 
   auto func =
       [&](const Assignment<Key>& assignment,
-          const GaussianFactorValuePair& gfv) -> GaussianFactorValuePair {
-    auto [gf, val] = gfv;
+          const GaussianFactor::shared_ptr& gf) -> GaussianFactorValuePair {
     if (assignment.at(mode) != tight_index) {
       double factor_log_constant = -0.5 * d * log2pi + log(1.0 / noise_loose);
 

--- a/gtsam/hybrid/tests/testHybridEstimation.cpp
+++ b/gtsam/hybrid/tests/testHybridEstimation.cpp
@@ -435,9 +435,10 @@ static HybridNonlinearFactorGraph createHybridNonlinearFactorGraph() {
       std::make_shared<BetweenFactor<double>>(X(0), X(1), 0, noise_model);
   const auto one_motion =
       std::make_shared<BetweenFactor<double>>(X(0), X(1), 1, noise_model);
-  nfg.emplace_shared<HybridNonlinearFactor>(
-      KeyVector{X(0), X(1)}, DiscreteKeys{m},
-      std::vector<NonlinearFactor::shared_ptr>{zero_motion, one_motion});
+  std::vector<std::pair<NonlinearFactor::shared_ptr, double>> components = {
+      {zero_motion, 0.0}, {one_motion, 0.0}};
+  nfg.emplace_shared<HybridNonlinearFactor>(KeyVector{X(0), X(1)},
+                                            DiscreteKeys{m}, components);
 
   return nfg;
 }
@@ -589,7 +590,8 @@ TEST(HybridEstimation, ModeSelection) {
        model1 = std::make_shared<MotionModel>(
            X(0), X(1), 0.0, noiseModel::Isotropic::Sigma(d, noise_tight));
 
-  std::vector<NonlinearFactor::shared_ptr> components = {model0, model1};
+  std::vector<std::pair<NonlinearFactor::shared_ptr, double>> components = {
+      {model0, 0.0}, {model1, 0.0}};
 
   KeyVector keys = {X(0), X(1)};
   HybridNonlinearFactor mf(keys, modes, components);
@@ -680,7 +682,8 @@ TEST(HybridEstimation, ModeSelection2) {
        model1 = std::make_shared<BetweenFactor<Vector3>>(
            X(0), X(1), Z_3x1, noiseModel::Isotropic::Sigma(d, noise_tight));
 
-  std::vector<NonlinearFactor::shared_ptr> components = {model0, model1};
+  std::vector<std::pair<NonlinearFactor::shared_ptr, double>> components = {
+      {model0, 0.0}, {model1, 0.0}};
 
   KeyVector keys = {X(0), X(1)};
   HybridNonlinearFactor mf(keys, modes, components);

--- a/gtsam/hybrid/tests/testHybridEstimation.cpp
+++ b/gtsam/hybrid/tests/testHybridEstimation.cpp
@@ -620,12 +620,16 @@ TEST(HybridEstimation, ModeSelection) {
       GaussianConditional::sharedMeanAndStddev(Z(0), -I_1x1, X(0), Z_1x1, 0.1));
   bn.push_back(
       GaussianConditional::sharedMeanAndStddev(Z(0), -I_1x1, X(1), Z_1x1, 0.1));
+
+  std::vector<GaussianConditional::shared_ptr> conditionals{
+      GaussianConditional::sharedMeanAndStddev(Z(0), I_1x1, X(0), -I_1x1, X(1),
+                                               Z_1x1, noise_loose),
+      GaussianConditional::sharedMeanAndStddev(Z(0), I_1x1, X(0), -I_1x1, X(1),
+                                               Z_1x1, noise_tight)};
   bn.emplace_shared<HybridGaussianConditional>(
       KeyVector{Z(0)}, KeyVector{X(0), X(1)}, DiscreteKeys{mode},
-      std::vector{GaussianConditional::sharedMeanAndStddev(
-                      Z(0), I_1x1, X(0), -I_1x1, X(1), Z_1x1, noise_loose),
-                  GaussianConditional::sharedMeanAndStddev(
-                      Z(0), I_1x1, X(0), -I_1x1, X(1), Z_1x1, noise_tight)});
+      HybridGaussianConditional::Conditionals(DiscreteKeys{mode},
+                                              conditionals));
 
   VectorValues vv;
   vv.insert(Z(0), Z_1x1);
@@ -651,12 +655,16 @@ TEST(HybridEstimation, ModeSelection2) {
       GaussianConditional::sharedMeanAndStddev(Z(0), -I_3x3, X(0), Z_3x1, 0.1));
   bn.push_back(
       GaussianConditional::sharedMeanAndStddev(Z(0), -I_3x3, X(1), Z_3x1, 0.1));
+
+  std::vector<GaussianConditional::shared_ptr> conditionals{
+      GaussianConditional::sharedMeanAndStddev(Z(0), I_3x3, X(0), -I_3x3, X(1),
+                                               Z_3x1, noise_loose),
+      GaussianConditional::sharedMeanAndStddev(Z(0), I_3x3, X(0), -I_3x3, X(1),
+                                               Z_3x1, noise_tight)};
   bn.emplace_shared<HybridGaussianConditional>(
       KeyVector{Z(0)}, KeyVector{X(0), X(1)}, DiscreteKeys{mode},
-      std::vector{GaussianConditional::sharedMeanAndStddev(
-                      Z(0), I_3x3, X(0), -I_3x3, X(1), Z_3x1, noise_loose),
-                  GaussianConditional::sharedMeanAndStddev(
-                      Z(0), I_3x3, X(0), -I_3x3, X(1), Z_3x1, noise_tight)});
+      HybridGaussianConditional::Conditionals(DiscreteKeys{mode},
+                                              conditionals));
 
   VectorValues vv;
   vv.insert(Z(0), Z_3x1);

--- a/gtsam/hybrid/tests/testHybridEstimation.cpp
+++ b/gtsam/hybrid/tests/testHybridEstimation.cpp
@@ -542,8 +542,10 @@ std::shared_ptr<HybridGaussianFactor> mixedVarianceFactor(
   double logNormalizationConstant = log(1.0 / noise_tight);
   double logConstant = -0.5 * d * log2pi + logNormalizationConstant;
 
-  auto func = [&](const Assignment<Key>& assignment,
-                  const GaussianFactor::shared_ptr& gf) {
+  auto func =
+      [&](const Assignment<Key>& assignment,
+          const GaussianFactorValuePair& gfv) -> GaussianFactorValuePair {
+    auto [gf, val] = gfv;
     if (assignment.at(mode) != tight_index) {
       double factor_log_constant = -0.5 * d * log2pi + log(1.0 / noise_loose);
 
@@ -555,9 +557,9 @@ std::shared_ptr<HybridGaussianFactor> mixedVarianceFactor(
       }
 
       _gfg.emplace_shared<JacobianFactor>(c);
-      return std::make_shared<JacobianFactor>(_gfg);
+      return {std::make_shared<JacobianFactor>(_gfg), 0.0};
     } else {
-      return dynamic_pointer_cast<JacobianFactor>(gf);
+      return {dynamic_pointer_cast<JacobianFactor>(gf), 0.0};
     }
   };
   auto updated_components = gmf->factors().apply(func);

--- a/gtsam/hybrid/tests/testHybridFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridFactorGraph.cpp
@@ -52,9 +52,9 @@ TEST(HybridFactorGraph, Keys) {
 
   // Add a gaussian mixture factor ϕ(x1, c1)
   DiscreteKey m1(M(1), 2);
-  DecisionTree<Key, GaussianFactor::shared_ptr> dt(
-      M(1), std::make_shared<JacobianFactor>(X(1), I_3x3, Z_3x1),
-      std::make_shared<JacobianFactor>(X(1), I_3x3, Vector3::Ones()));
+  DecisionTree<Key, GaussianFactorValuePair> dt(
+      M(1), {std::make_shared<JacobianFactor>(X(1), I_3x3, Z_3x1), 0.0},
+      {std::make_shared<JacobianFactor>(X(1), I_3x3, Vector3::Ones()), 0.0});
   hfg.add(HybridGaussianFactor({X(1)}, {m1}, dt));
 
   KeySet expected_continuous{X(0), X(1)};

--- a/gtsam/hybrid/tests/testHybridGaussianConditional.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianConditional.cpp
@@ -183,7 +183,7 @@ TEST(HybridGaussianConditional, Likelihood2) {
   // Check the detailed JacobianFactor calculation for mode==1.
   {
     // We have a JacobianFactor
-    const auto gf1 = (*likelihood)(assignment1);
+    const auto gf1 = (*likelihood)(assignment1).first;
     const auto jf1 = std::dynamic_pointer_cast<JacobianFactor>(gf1);
     CHECK(jf1);
 

--- a/gtsam/hybrid/tests/testHybridGaussianConditional.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianConditional.cpp
@@ -52,7 +52,9 @@ const std::vector<GaussianConditional::shared_ptr> conditionals{
                                              commonSigma),
     GaussianConditional::sharedMeanAndStddev(Z(0), I_1x1, X(0), Vector1(0.0),
                                              commonSigma)};
-const HybridGaussianConditional mixture({Z(0)}, {X(0)}, {mode}, conditionals);
+const HybridGaussianConditional mixture(
+    {Z(0)}, {X(0)}, {mode},
+    HybridGaussianConditional::Conditionals({mode}, conditionals));
 }  // namespace equal_constants
 
 /* ************************************************************************* */
@@ -153,7 +155,9 @@ const std::vector<GaussianConditional::shared_ptr> conditionals{
                                              0.5),
     GaussianConditional::sharedMeanAndStddev(Z(0), I_1x1, X(0), Vector1(0.0),
                                              3.0)};
-const HybridGaussianConditional mixture({Z(0)}, {X(0)}, {mode}, conditionals);
+const HybridGaussianConditional mixture(
+    {Z(0)}, {X(0)}, {mode},
+    HybridGaussianConditional::Conditionals({mode}, conditionals));
 }  // namespace mode_dependent_constants
 
 /* ************************************************************************* */

--- a/gtsam/hybrid/tests/testHybridGaussianConditional.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianConditional.cpp
@@ -183,7 +183,7 @@ TEST(HybridGaussianConditional, Likelihood2) {
   // Check the detailed JacobianFactor calculation for mode==1.
   {
     // We have a JacobianFactor
-    const auto gf1 = (*likelihood)(assignment1).first;
+    const auto gf1 = (*likelihood)(assignment1);
     const auto jf1 = std::dynamic_pointer_cast<JacobianFactor>(gf1);
     CHECK(jf1);
 

--- a/gtsam/hybrid/tests/testHybridGaussianFactor.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactor.cpp
@@ -129,7 +129,6 @@ Hybrid [x1 x2; 1]{
 ]
   b = [ 0 0 ]
   No noise model
-value: 0
 
  1 Leaf :
   A[x1] = [
@@ -142,7 +141,6 @@ value: 0
 ]
   b = [ 0 0 ]
   No noise model
-value: 0
 
 }
 )";

--- a/gtsam/hybrid/tests/testHybridGaussianFactor.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactor.cpp
@@ -71,8 +71,10 @@ TEST(HybridGaussianFactor, Sum) {
   auto f20 = std::make_shared<JacobianFactor>(X(1), A1, X(3), A3, b);
   auto f21 = std::make_shared<JacobianFactor>(X(1), A1, X(3), A3, b);
   auto f22 = std::make_shared<JacobianFactor>(X(1), A1, X(3), A3, b);
-  std::vector<GaussianFactor::shared_ptr> factorsA{f10, f11};
-  std::vector<GaussianFactor::shared_ptr> factorsB{f20, f21, f22};
+  std::vector<std::pair<GaussianFactor::shared_ptr, double>> factorsA{
+      {f10, 0.0}, {f11, 0.0}};
+  std::vector<std::pair<GaussianFactor::shared_ptr, double>> factorsB{
+      {f20, 0.0}, {f21, 0.0}, {f22, 0.0}};
 
   // TODO(Frank): why specify keys at all? And: keys in factor should be *all*
   // keys, deviating from Kevin's scheme. Should we index DT on DiscreteKey?
@@ -109,7 +111,8 @@ TEST(HybridGaussianFactor, Printing) {
   auto b = Matrix::Zero(2, 1);
   auto f10 = std::make_shared<JacobianFactor>(X(1), A1, X(2), A2, b);
   auto f11 = std::make_shared<JacobianFactor>(X(1), A1, X(2), A2, b);
-  std::vector<GaussianFactor::shared_ptr> factors{f10, f11};
+  std::vector<std::pair<GaussianFactor::shared_ptr, double>> factors{
+      {f10, 0.0}, {f11, 0.0}};
 
   HybridGaussianFactor mixtureFactor({X(1), X(2)}, {m1}, factors);
 
@@ -128,6 +131,7 @@ Hybrid [x1 x2; 1]{
 ]
   b = [ 0 0 ]
   No noise model
+value: 0
 
  1 Leaf :
   A[x1] = [
@@ -140,6 +144,7 @@ Hybrid [x1 x2; 1]{
 ]
   b = [ 0 0 ]
   No noise model
+value: 0
 
 }
 )";
@@ -178,7 +183,8 @@ TEST(HybridGaussianFactor, Error) {
 
   auto f0 = std::make_shared<JacobianFactor>(X(1), A01, X(2), A02, b);
   auto f1 = std::make_shared<JacobianFactor>(X(1), A11, X(2), A12, b);
-  std::vector<GaussianFactor::shared_ptr> factors{f0, f1};
+  std::vector<std::pair<GaussianFactor::shared_ptr, double>> factors{{f0, 0.0},
+                                                                     {f1, 0.0}};
 
   HybridGaussianFactor mixtureFactor({X(1), X(2)}, {m1}, factors);
 

--- a/gtsam/hybrid/tests/testHybridGaussianFactor.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactor.cpp
@@ -616,15 +616,15 @@ TEST(HybridGaussianFactor, TwoStateModel2) {
 
 /* ************************************************************************* */
 /**
- * Test a model P(z0|x0)P(x1|x0,m1)P(z1|x1)P(m1).
+ * Test a model p(z0|x0)p(x1|x0,m1)p(z1|x1)p(m1).
  *
- * P(x1|x0,m1) has the same means but different covariances.
+ * p(x1|x0,m1) has the same means but different covariances.
  *
  * Converting to a factor graph gives us
- * ϕ(x0)ϕ(x1,x0,m1)ϕ(x1)P(m1)
+ * ϕ(x0)ϕ(x1,x0,m1)ϕ(x1)p(m1)
  *
  * If we only have a measurement on z0, then
- * the P(m1) should be 0.5/0.5.
+ * the p(m1) should be 0.5/0.5.
  * Getting a measurement on z1 gives use more information.
  */
 TEST(HybridGaussianFactor, TwoStateModel3) {

--- a/gtsam/hybrid/tests/testHybridGaussianFactor.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactor.cpp
@@ -233,8 +233,11 @@ static HybridBayesNet GetGaussianMixtureModel(double mu0, double mu1,
        c1 = make_shared<GaussianConditional>(z, Vector1(mu1), I_1x1, model1);
 
   HybridBayesNet hbn;
+  DiscreteKeys discreteParents{m};
   hbn.emplace_shared<HybridGaussianConditional>(
-      KeyVector{z}, KeyVector{}, DiscreteKeys{m}, std::vector{c0, c1});
+      KeyVector{z}, KeyVector{}, discreteParents,
+      HybridGaussianConditional::Conditionals(discreteParents,
+                                              std::vector{c0, c1}));
 
   auto mixing = make_shared<DiscreteConditional>(m, "50/50");
   hbn.push_back(mixing);
@@ -408,8 +411,11 @@ static HybridGaussianConditional::shared_ptr CreateHybridMotionModel(
                                              -I_1x1, model0),
        c1 = make_shared<GaussianConditional>(X(1), Vector1(mu1), I_1x1, X(0),
                                              -I_1x1, model1);
+  DiscreteKeys discreteParents{m1};
   return std::make_shared<HybridGaussianConditional>(
-      KeyVector{X(1)}, KeyVector{X(0)}, DiscreteKeys{m1}, std::vector{c0, c1});
+      KeyVector{X(1)}, KeyVector{X(0)}, discreteParents,
+      HybridGaussianConditional::Conditionals(discreteParents,
+                                              std::vector{c0, c1}));
 }
 
 /// Create two state Bayes network with 1 or two measurement models

--- a/gtsam/hybrid/tests/testHybridGaussianFactor.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactor.cpp
@@ -526,7 +526,7 @@ TEST(HybridGaussianFactor, TwoStateModel) {
 /**
  * Test a model P(z0|x0)P(x1|x0,m1)P(z1|x1)P(m1).
  *
- * P(f01|x1,x0,m1) has different means and different covariances.
+ * P(x1|x0,m1) has different means and different covariances.
  *
  * Converting to a factor graph gives us
  * ϕ(x0)ϕ(x1,x0,m1)ϕ(x1)P(m1)
@@ -618,11 +618,105 @@ TEST(HybridGaussianFactor, TwoStateModel2) {
 
 /* ************************************************************************* */
 /**
+ * Test a model P(z0|x0)P(x1|x0,m1)P(z1|x1)P(m1).
+ *
+ * P(x1|x0,m1) has the same means but different covariances.
+ *
+ * Converting to a factor graph gives us
+ * ϕ(x0)ϕ(x1,x0,m1)ϕ(x1)P(m1)
+ *
+ * If we only have a measurement on z0, then
+ * the P(m1) should be 0.5/0.5.
+ * Getting a measurement on z1 gives use more information.
+ */
+TEST(HybridGaussianFactor, TwoStateModel3) {
+  using namespace test_two_state_estimation;
+
+  double mu = 1.0;
+  double sigma0 = 0.5, sigma1 = 2.0;
+  auto hybridMotionModel = CreateHybridMotionModel(mu, mu, sigma0, sigma1);
+
+  // Start with no measurement on x1, only on x0
+  const Vector1 z0(0.5);
+  VectorValues given;
+  given.insert(Z(0), z0);
+
+  {
+    HybridBayesNet hbn = CreateBayesNet(hybridMotionModel);
+    HybridGaussianFactorGraph gfg = hbn.toFactorGraph(given);
+
+    // Check that ratio of Bayes net and factor graph for different modes is
+    // equal for several values of {x0,x1}.
+    for (VectorValues vv :
+         {VectorValues{{X(0), Vector1(0.0)}, {X(1), Vector1(1.0)}},
+          VectorValues{{X(0), Vector1(0.5)}, {X(1), Vector1(3.0)}}}) {
+      vv.insert(given);  // add measurements for HBN
+      HybridValues hv0(vv, {{M(1), 0}}), hv1(vv, {{M(1), 1}});
+      EXPECT_DOUBLES_EQUAL(gfg.error(hv0) / hbn.error(hv0),
+                           gfg.error(hv1) / hbn.error(hv1), 1e-9);
+    }
+
+    HybridBayesNet::shared_ptr bn = gfg.eliminateSequential();
+
+    // Importance sampling run with 100k samples gives 50.095/49.905
+    // approximateDiscreteMarginal(hbn, hybridMotionModel, given);
+
+    // Since no measurement on x1, we a 50/50 probability
+    auto p_m = bn->at(2)->asDiscrete();
+    EXPECT_DOUBLES_EQUAL(0.5, p_m->operator()({{M(1), 0}}), 1e-9);
+    EXPECT_DOUBLES_EQUAL(0.5, p_m->operator()({{M(1), 1}}), 1e-9);
+  }
+
+  {
+    // Now we add a measurement z1 on x1
+    const Vector1 z1(4.0);  // favors m==1
+    given.insert(Z(1), z1);
+
+    HybridBayesNet hbn = CreateBayesNet(hybridMotionModel, true);
+    HybridGaussianFactorGraph gfg = hbn.toFactorGraph(given);
+
+    // Check that ratio of Bayes net and factor graph for different modes is
+    // equal for several values of {x0,x1}.
+    for (VectorValues vv :
+         {VectorValues{{X(0), Vector1(0.0)}, {X(1), Vector1(1.0)}},
+          VectorValues{{X(0), Vector1(0.5)}, {X(1), Vector1(3.0)}}}) {
+      vv.insert(given);  // add measurements for HBN
+      HybridValues hv0(vv, {{M(1), 0}}), hv1(vv, {{M(1), 1}});
+      EXPECT_DOUBLES_EQUAL(gfg.error(hv0) / hbn.error(hv0),
+                           gfg.error(hv1) / hbn.error(hv1), 1e-9);
+    }
+
+    HybridBayesNet::shared_ptr bn = gfg.eliminateSequential();
+
+    // Values taken from an importance sampling run with 100k samples:
+    // approximateDiscreteMarginal(hbn, hybridMotionModel, given);
+    DiscreteConditional expected(m1, "51.7762/48.2238");
+    EXPECT(assert_equal(expected, *(bn->at(2)->asDiscrete()), 0.002));
+  }
+
+  {
+    // Add a different measurement z1 on x1 that favors m==1
+    const Vector1 z1(7.0);
+    given.insert_or_assign(Z(1), z1);
+
+    HybridBayesNet hbn = CreateBayesNet(hybridMotionModel, true);
+    HybridGaussianFactorGraph gfg = hbn.toFactorGraph(given);
+    HybridBayesNet::shared_ptr bn = gfg.eliminateSequential();
+
+    // Values taken from an importance sampling run with 100k samples:
+    // approximateDiscreteMarginal(hbn, hybridMotionModel, given);
+    DiscreteConditional expected(m1, "49.0762/50.9238");
+    EXPECT(assert_equal(expected, *(bn->at(2)->asDiscrete()), 0.005));
+  }
+}
+
+/* ************************************************************************* */
+/**
  * Same model, P(z0|x0)P(x1|x0,m1)P(z1|x1)P(m1), but now with very informative
  * measurements and vastly different motion model: either stand still or move
  * far. This yields a very informative posterior.
  */
-TEST(HybridGaussianFactor, TwoStateModel3) {
+TEST(HybridGaussianFactor, TwoStateModel4) {
   using namespace test_two_state_estimation;
 
   double mu0 = 0.0, mu1 = 10.0;

--- a/gtsam/hybrid/tests/testHybridGaussianFactor.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactor.cpp
@@ -71,9 +71,8 @@ TEST(HybridGaussianFactor, Sum) {
   auto f20 = std::make_shared<JacobianFactor>(X(1), A1, X(3), A3, b);
   auto f21 = std::make_shared<JacobianFactor>(X(1), A1, X(3), A3, b);
   auto f22 = std::make_shared<JacobianFactor>(X(1), A1, X(3), A3, b);
-  std::vector<std::pair<GaussianFactor::shared_ptr, double>> factorsA{
-      {f10, 0.0}, {f11, 0.0}};
-  std::vector<std::pair<GaussianFactor::shared_ptr, double>> factorsB{
+  std::vector<GaussianFactorValuePair> factorsA{{f10, 0.0}, {f11, 0.0}};
+  std::vector<GaussianFactorValuePair> factorsB{
       {f20, 0.0}, {f21, 0.0}, {f22, 0.0}};
 
   // TODO(Frank): why specify keys at all? And: keys in factor should be *all*
@@ -111,8 +110,7 @@ TEST(HybridGaussianFactor, Printing) {
   auto b = Matrix::Zero(2, 1);
   auto f10 = std::make_shared<JacobianFactor>(X(1), A1, X(2), A2, b);
   auto f11 = std::make_shared<JacobianFactor>(X(1), A1, X(2), A2, b);
-  std::vector<std::pair<GaussianFactor::shared_ptr, double>> factors{
-      {f10, 0.0}, {f11, 0.0}};
+  std::vector<GaussianFactorValuePair> factors{{f10, 0.0}, {f11, 0.0}};
 
   HybridGaussianFactor mixtureFactor({X(1), X(2)}, {m1}, factors);
 
@@ -183,8 +181,7 @@ TEST(HybridGaussianFactor, Error) {
 
   auto f0 = std::make_shared<JacobianFactor>(X(1), A01, X(2), A02, b);
   auto f1 = std::make_shared<JacobianFactor>(X(1), A11, X(2), A12, b);
-  std::vector<std::pair<GaussianFactor::shared_ptr, double>> factors{{f0, 0.0},
-                                                                     {f1, 0.0}};
+  std::vector<GaussianFactorValuePair> factors{{f0, 0.0}, {f1, 0.0}};
 
   HybridGaussianFactor mixtureFactor({X(1), X(2)}, {m1}, factors);
 

--- a/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
@@ -127,9 +127,9 @@ TEST(HybridGaussianFactorGraph, eliminateFullSequentialEqualChance) {
 
   // Add a gaussian mixture factor ϕ(x1, c1)
   DiscreteKey m1(M(1), 2);
-  DecisionTree<Key, GaussianFactor::shared_ptr> dt(
-      M(1), std::make_shared<JacobianFactor>(X(1), I_3x3, Z_3x1),
-      std::make_shared<JacobianFactor>(X(1), I_3x3, Vector3::Ones()));
+  DecisionTree<Key, GaussianFactorValuePair> dt(
+      M(1), {std::make_shared<JacobianFactor>(X(1), I_3x3, Z_3x1), 0.0},
+      {std::make_shared<JacobianFactor>(X(1), I_3x3, Vector3::Ones()), 0.0});
   hfg.add(HybridGaussianFactor({X(1)}, {m1}, dt));
 
   auto result = hfg.eliminateSequential();
@@ -153,9 +153,9 @@ TEST(HybridGaussianFactorGraph, eliminateFullSequentialSimple) {
   // Add factor between x0 and x1
   hfg.add(JacobianFactor(X(0), I_3x3, X(1), -I_3x3, Z_3x1));
 
-  std::vector<GaussianFactor::shared_ptr> factors = {
-      std::make_shared<JacobianFactor>(X(1), I_3x3, Z_3x1),
-      std::make_shared<JacobianFactor>(X(1), I_3x3, Vector3::Ones())};
+  std::vector<GaussianFactorValuePair> factors = {
+      {std::make_shared<JacobianFactor>(X(1), I_3x3, Z_3x1), 0.0},
+      {std::make_shared<JacobianFactor>(X(1), I_3x3, Vector3::Ones()), 0.0}};
   hfg.add(HybridGaussianFactor({X(1)}, {m1}, factors));
 
   // Discrete probability table for c1
@@ -178,10 +178,10 @@ TEST(HybridGaussianFactorGraph, eliminateFullMultifrontalSimple) {
   hfg.add(JacobianFactor(X(0), I_3x3, Z_3x1));
   hfg.add(JacobianFactor(X(0), I_3x3, X(1), -I_3x3, Z_3x1));
 
-  hfg.add(HybridGaussianFactor(
-      {X(1)}, {{M(1), 2}},
-      {std::make_shared<JacobianFactor>(X(1), I_3x3, Z_3x1),
-       std::make_shared<JacobianFactor>(X(1), I_3x3, Vector3::Ones())}));
+  std::vector<GaussianFactorValuePair> factors = {
+      {std::make_shared<JacobianFactor>(X(1), I_3x3, Z_3x1), 0.0},
+      {std::make_shared<JacobianFactor>(X(1), I_3x3, Vector3::Ones()), 0.0}};
+  hfg.add(HybridGaussianFactor({X(1)}, {{M(1), 2}}, factors));
 
   hfg.add(DecisionTreeFactor(m1, {2, 8}));
   // TODO(Varun) Adding extra discrete variable not connected to continuous
@@ -208,9 +208,9 @@ TEST(HybridGaussianFactorGraph, eliminateFullMultifrontalCLG) {
   hfg.add(JacobianFactor(X(0), I_3x3, X(1), -I_3x3, Z_3x1));
 
   // Decision tree with different modes on x1
-  DecisionTree<Key, GaussianFactor::shared_ptr> dt(
-      M(1), std::make_shared<JacobianFactor>(X(1), I_3x3, Z_3x1),
-      std::make_shared<JacobianFactor>(X(1), I_3x3, Vector3::Ones()));
+  DecisionTree<Key, GaussianFactorValuePair> dt(
+      M(1), {std::make_shared<JacobianFactor>(X(1), I_3x3, Z_3x1), 0.0},
+      {std::make_shared<JacobianFactor>(X(1), I_3x3, Vector3::Ones()), 0.0});
 
   // Hybrid factor P(x1|c1)
   hfg.add(HybridGaussianFactor({X(1)}, {m}, dt));
@@ -238,14 +238,14 @@ TEST(HybridGaussianFactorGraph, eliminateFullMultifrontalTwoClique) {
   hfg.add(JacobianFactor(X(1), I_3x3, X(2), -I_3x3, Z_3x1));
 
   {
-    hfg.add(HybridGaussianFactor(
-        {X(0)}, {{M(0), 2}},
-        {std::make_shared<JacobianFactor>(X(0), I_3x3, Z_3x1),
-         std::make_shared<JacobianFactor>(X(0), I_3x3, Vector3::Ones())}));
+    std::vector<GaussianFactorValuePair> factors = {
+        {std::make_shared<JacobianFactor>(X(0), I_3x3, Z_3x1), 0.0},
+        {std::make_shared<JacobianFactor>(X(0), I_3x3, Vector3::Ones()), 0.0}};
+    hfg.add(HybridGaussianFactor({X(0)}, {{M(0), 2}}, factors));
 
-    DecisionTree<Key, GaussianFactor::shared_ptr> dt1(
-        M(1), std::make_shared<JacobianFactor>(X(2), I_3x3, Z_3x1),
-        std::make_shared<JacobianFactor>(X(2), I_3x3, Vector3::Ones()));
+    DecisionTree<Key, GaussianFactorValuePair> dt1(
+        M(1), {std::make_shared<JacobianFactor>(X(2), I_3x3, Z_3x1), 0.0},
+        {std::make_shared<JacobianFactor>(X(2), I_3x3, Vector3::Ones()), 0.0});
 
     hfg.add(HybridGaussianFactor({X(2)}, {{M(1), 2}}, dt1));
   }
@@ -256,15 +256,15 @@ TEST(HybridGaussianFactorGraph, eliminateFullMultifrontalTwoClique) {
   hfg.add(JacobianFactor(X(4), I_3x3, X(5), -I_3x3, Z_3x1));
 
   {
-    DecisionTree<Key, GaussianFactor::shared_ptr> dt(
-        M(3), std::make_shared<JacobianFactor>(X(3), I_3x3, Z_3x1),
-        std::make_shared<JacobianFactor>(X(3), I_3x3, Vector3::Ones()));
+    DecisionTree<Key, GaussianFactorValuePair> dt(
+        M(3), {std::make_shared<JacobianFactor>(X(3), I_3x3, Z_3x1), 0.0},
+        {std::make_shared<JacobianFactor>(X(3), I_3x3, Vector3::Ones()), 0.0});
 
     hfg.add(HybridGaussianFactor({X(3)}, {{M(3), 2}}, dt));
 
-    DecisionTree<Key, GaussianFactor::shared_ptr> dt1(
-        M(2), std::make_shared<JacobianFactor>(X(5), I_3x3, Z_3x1),
-        std::make_shared<JacobianFactor>(X(5), I_3x3, Vector3::Ones()));
+    DecisionTree<Key, GaussianFactorValuePair> dt1(
+        M(2), {std::make_shared<JacobianFactor>(X(5), I_3x3, Z_3x1), 0.0},
+        {std::make_shared<JacobianFactor>(X(5), I_3x3, Vector3::Ones()), 0.0});
 
     hfg.add(HybridGaussianFactor({X(5)}, {{M(2), 2}}, dt1));
   }
@@ -552,9 +552,9 @@ TEST(HybridGaussianFactorGraph, optimize) {
   hfg.add(JacobianFactor(X(0), I_3x3, Z_3x1));
   hfg.add(JacobianFactor(X(0), I_3x3, X(1), -I_3x3, Z_3x1));
 
-  DecisionTree<Key, GaussianFactor::shared_ptr> dt(
-      C(1), std::make_shared<JacobianFactor>(X(1), I_3x3, Z_3x1),
-      std::make_shared<JacobianFactor>(X(1), I_3x3, Vector3::Ones()));
+  DecisionTree<Key, GaussianFactorValuePair> dt(
+      C(1), {std::make_shared<JacobianFactor>(X(1), I_3x3, Z_3x1), 0.0},
+      {std::make_shared<JacobianFactor>(X(1), I_3x3, Vector3::Ones()), 0.0});
 
   hfg.add(HybridGaussianFactor({X(1)}, {c1}, dt));
 
@@ -734,8 +734,8 @@ TEST(HybridGaussianFactorGraph, assembleGraphTree) {
   // Expected decision tree with two factor graphs:
   // f(x0;mode=0)P(x0) and f(x0;mode=1)P(x0)
   GaussianFactorGraphTree expected{
-      M(0), GaussianFactorGraph(std::vector<GF>{(*mixture)(d0), prior}),
-      GaussianFactorGraph(std::vector<GF>{(*mixture)(d1), prior})};
+      M(0), GaussianFactorGraph(std::vector<GF>{(*mixture)(d0).first, prior}),
+      GaussianFactorGraph(std::vector<GF>{(*mixture)(d1).first, prior})};
 
   EXPECT(assert_equal(expected(d0), actual(d0), 1e-5));
   EXPECT(assert_equal(expected(d1), actual(d1), 1e-5));

--- a/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
@@ -734,8 +734,8 @@ TEST(HybridGaussianFactorGraph, assembleGraphTree) {
   // Expected decision tree with two factor graphs:
   // f(x0;mode=0)P(x0) and f(x0;mode=1)P(x0)
   GaussianFactorGraphTree expected{
-      M(0), GaussianFactorGraph(std::vector<GF>{(*mixture)(d0).first, prior}),
-      GaussianFactorGraph(std::vector<GF>{(*mixture)(d1).first, prior})};
+      M(0), GaussianFactorGraph(std::vector<GF>{(*mixture)(d0), prior}),
+      GaussianFactorGraph(std::vector<GF>{(*mixture)(d1), prior})};
 
   EXPECT(assert_equal(expected(d0), actual(d0), 1e-5));
   EXPECT(assert_equal(expected(d1), actual(d1), 1e-5));

--- a/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
@@ -181,7 +181,7 @@ TEST(HybridGaussianFactorGraph, eliminateFullMultifrontalSimple) {
   std::vector<GaussianFactorValuePair> factors = {
       {std::make_shared<JacobianFactor>(X(1), I_3x3, Z_3x1), 0.0},
       {std::make_shared<JacobianFactor>(X(1), I_3x3, Vector3::Ones()), 0.0}};
-  hfg.add(HybridGaussianFactor({X(1)}, {{M(1), 2}}, factors));
+  hfg.add(HybridGaussianFactor({X(1)}, {M(1), 2}, factors));
 
   hfg.add(DecisionTreeFactor(m1, {2, 8}));
   // TODO(Varun) Adding extra discrete variable not connected to continuous
@@ -241,7 +241,7 @@ TEST(HybridGaussianFactorGraph, eliminateFullMultifrontalTwoClique) {
     std::vector<GaussianFactorValuePair> factors = {
         {std::make_shared<JacobianFactor>(X(0), I_3x3, Z_3x1), 0.0},
         {std::make_shared<JacobianFactor>(X(0), I_3x3, Vector3::Ones()), 0.0}};
-    hfg.add(HybridGaussianFactor({X(0)}, {{M(0), 2}}, factors));
+    hfg.add(HybridGaussianFactor({X(0)}, {M(0), 2}, factors));
 
     DecisionTree<Key, GaussianFactorValuePair> dt1(
         M(1), {std::make_shared<JacobianFactor>(X(2), I_3x3, Z_3x1), 0.0},

--- a/gtsam/hybrid/tests/testHybridGaussianISAM.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianISAM.cpp
@@ -423,7 +423,7 @@ TEST(HybridGaussianISAM, NonTrivial) {
   std::vector<std::pair<PlanarMotionModel::shared_ptr, double>> components = {
       {moving, 0.0}, {still, 0.0}};
   auto mixtureFactor = std::make_shared<HybridNonlinearFactor>(
-      contKeys, DiscreteKeys{gtsam::DiscreteKey(M(1), 2)}, components);
+      contKeys, gtsam::DiscreteKey(M(1), 2), components);
   fg.push_back(mixtureFactor);
 
   // Add equivalent of ImuFactor
@@ -463,7 +463,7 @@ TEST(HybridGaussianISAM, NonTrivial) {
       std::make_shared<PlanarMotionModel>(W(1), W(2), odometry, noise_model);
   components = {{moving, 0.0}, {still, 0.0}};
   mixtureFactor = std::make_shared<HybridNonlinearFactor>(
-      contKeys, DiscreteKeys{gtsam::DiscreteKey(M(2), 2)}, components);
+      contKeys, gtsam::DiscreteKey(M(2), 2), components);
   fg.push_back(mixtureFactor);
 
   // Add equivalent of ImuFactor
@@ -506,7 +506,7 @@ TEST(HybridGaussianISAM, NonTrivial) {
       std::make_shared<PlanarMotionModel>(W(2), W(3), odometry, noise_model);
   components = {{moving, 0.0}, {still, 0.0}};
   mixtureFactor = std::make_shared<HybridNonlinearFactor>(
-      contKeys, DiscreteKeys{gtsam::DiscreteKey(M(3), 2)}, components);
+      contKeys, gtsam::DiscreteKey(M(3), 2), components);
   fg.push_back(mixtureFactor);
 
   // Add equivalent of ImuFactor

--- a/gtsam/hybrid/tests/testHybridGaussianISAM.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianISAM.cpp
@@ -420,7 +420,8 @@ TEST(HybridGaussianISAM, NonTrivial) {
                                                    noise_model),
        moving = std::make_shared<PlanarMotionModel>(W(0), W(1), odometry,
                                                     noise_model);
-  std::vector<PlanarMotionModel::shared_ptr> components = {moving, still};
+  std::vector<std::pair<PlanarMotionModel::shared_ptr, double>> components = {
+      {moving, 0.0}, {still, 0.0}};
   auto mixtureFactor = std::make_shared<HybridNonlinearFactor>(
       contKeys, DiscreteKeys{gtsam::DiscreteKey(M(1), 2)}, components);
   fg.push_back(mixtureFactor);
@@ -460,7 +461,7 @@ TEST(HybridGaussianISAM, NonTrivial) {
                                               noise_model);
   moving =
       std::make_shared<PlanarMotionModel>(W(1), W(2), odometry, noise_model);
-  components = {moving, still};
+  components = {{moving, 0.0}, {still, 0.0}};
   mixtureFactor = std::make_shared<HybridNonlinearFactor>(
       contKeys, DiscreteKeys{gtsam::DiscreteKey(M(2), 2)}, components);
   fg.push_back(mixtureFactor);
@@ -503,7 +504,7 @@ TEST(HybridGaussianISAM, NonTrivial) {
                                               noise_model);
   moving =
       std::make_shared<PlanarMotionModel>(W(2), W(3), odometry, noise_model);
-  components = {moving, still};
+  components = {{moving, 0.0}, {still, 0.0}};
   mixtureFactor = std::make_shared<HybridNonlinearFactor>(
       contKeys, DiscreteKeys{gtsam::DiscreteKey(M(3), 2)}, components);
   fg.push_back(mixtureFactor);

--- a/gtsam/hybrid/tests/testHybridNonlinearFactor.cpp
+++ b/gtsam/hybrid/tests/testHybridNonlinearFactor.cpp
@@ -58,8 +58,7 @@ TEST(HybridNonlinearFactor, Printing) {
       std::make_shared<BetweenFactor<double>>(X(1), X(2), between0, model);
   auto f1 =
       std::make_shared<BetweenFactor<double>>(X(1), X(2), between1, model);
-  std::vector<std::pair<NonlinearFactor::shared_ptr, double>> factors{
-      {f0, 0.0}, {f1, 0.0}};
+  std::vector<NonlinearFactorValuePair> factors{{f0, 0.0}, {f1, 0.0}};
 
   HybridNonlinearFactor mixtureFactor({X(1), X(2)}, {m1}, factors);
 
@@ -87,8 +86,7 @@ static HybridNonlinearFactor getHybridNonlinearFactor() {
       std::make_shared<BetweenFactor<double>>(X(1), X(2), between0, model);
   auto f1 =
       std::make_shared<BetweenFactor<double>>(X(1), X(2), between1, model);
-  std::vector<std::pair<NonlinearFactor::shared_ptr, double>> factors{
-      {f0, 0.0}, {f1, 0.0}};
+  std::vector<NonlinearFactorValuePair> factors{{f0, 0.0}, {f1, 0.0}};
 
   return HybridNonlinearFactor({X(1), X(2)}, {m1}, factors);
 }

--- a/gtsam/hybrid/tests/testHybridNonlinearFactor.cpp
+++ b/gtsam/hybrid/tests/testHybridNonlinearFactor.cpp
@@ -58,7 +58,8 @@ TEST(HybridNonlinearFactor, Printing) {
       std::make_shared<BetweenFactor<double>>(X(1), X(2), between0, model);
   auto f1 =
       std::make_shared<BetweenFactor<double>>(X(1), X(2), between1, model);
-  std::vector<NonlinearFactor::shared_ptr> factors{f0, f1};
+  std::vector<std::pair<NonlinearFactor::shared_ptr, double>> factors{
+      {f0, 0.0}, {f1, 0.0}};
 
   HybridNonlinearFactor mixtureFactor({X(1), X(2)}, {m1}, factors);
 
@@ -86,7 +87,8 @@ static HybridNonlinearFactor getHybridNonlinearFactor() {
       std::make_shared<BetweenFactor<double>>(X(1), X(2), between0, model);
   auto f1 =
       std::make_shared<BetweenFactor<double>>(X(1), X(2), between1, model);
-  std::vector<NonlinearFactor::shared_ptr> factors{f0, f1};
+  std::vector<std::pair<NonlinearFactor::shared_ptr, double>> factors{
+      {f0, 0.0}, {f1, 0.0}};
 
   return HybridNonlinearFactor({X(1), X(2)}, {m1}, factors);
 }

--- a/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
@@ -526,6 +526,7 @@ Hybrid [x0 x1; m0]{
 ]
   b = [ -1 ]
   No noise model
+value: 0
 
  1 Leaf :
   A[x0] = [
@@ -536,6 +537,7 @@ Hybrid [x0 x1; m0]{
 ]
   b = [ -0 ]
   No noise model
+value: 0
 
 }
 factor 2: 
@@ -551,6 +553,7 @@ Hybrid [x1 x2; m1]{
 ]
   b = [ -1 ]
   No noise model
+value: 0
 
  1 Leaf :
   A[x1] = [
@@ -561,6 +564,7 @@ Hybrid [x1 x2; m1]{
 ]
   b = [ -0 ]
   No noise model
+value: 0
 
 }
 factor 3: 
@@ -609,6 +613,7 @@ Hybrid [x0 x1; m0]{
 ]
   b = [ -1 ]
   No noise model
+value: 0
 
  1 Leaf:
   A[x0] = [
@@ -619,6 +624,7 @@ Hybrid [x0 x1; m0]{
 ]
   b = [ -0 ]
   No noise model
+value: 0
 
 }
 factor 2: 
@@ -633,6 +639,7 @@ Hybrid [x1 x2; m1]{
 ]
   b = [ -1 ]
   No noise model
+value: 0
 
  1 Leaf:
   A[x1] = [
@@ -643,6 +650,7 @@ Hybrid [x1 x2; m1]{
 ]
   b = [ -0 ]
   No noise model
+value: 0
 
 }
 factor 3: 

--- a/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
@@ -27,6 +27,7 @@
 #include <gtsam/hybrid/HybridNonlinearFactorGraph.h>
 #include <gtsam/linear/GaussianBayesNet.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/linear/NoiseModel.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/PriorFactor.h>
 #include <gtsam/sam/BearingRangeFactor.h>
@@ -867,7 +868,7 @@ static HybridNonlinearFactorGraph CreateFactorGraph(
       std::make_shared<BetweenFactor<double>>(X(0), X(1), means[1], model1);
 
   // Create HybridNonlinearFactor
-  std::vector<std::pair<NonlinearFactor::shared_ptr, double>> factors{
+  std::vector<NonlinearFactorValuePair> factors{
       {f0, ComputeLogNormalizer(model0)}, {f1, ComputeLogNormalizer(model1)}};
 
   HybridNonlinearFactor mixtureFactor({X(0), X(1)}, {m1}, factors);

--- a/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
@@ -131,7 +131,8 @@ TEST(HybridGaussianFactorGraph, Resize) {
   auto still = std::make_shared<MotionModel>(X(0), X(1), 0.0, noise_model),
        moving = std::make_shared<MotionModel>(X(0), X(1), 1.0, noise_model);
 
-  std::vector<MotionModel::shared_ptr> components = {still, moving};
+  std::vector<std::pair<MotionModel::shared_ptr, double>> components = {
+      {still, 0.0}, {moving, 0.0}};
   auto dcFactor = std::make_shared<HybridNonlinearFactor>(
       contKeys, DiscreteKeys{gtsam::DiscreteKey(M(1), 2)}, components);
   nhfg.push_back(dcFactor);
@@ -162,7 +163,8 @@ TEST(HybridGaussianFactorGraph, HybridNonlinearFactor) {
   auto still = std::make_shared<MotionModel>(X(0), X(1), 0.0, noise_model),
        moving = std::make_shared<MotionModel>(X(0), X(1), 1.0, noise_model);
 
-  std::vector<MotionModel::shared_ptr> components = {still, moving};
+  std::vector<std::pair<MotionModel::shared_ptr, double>> components = {
+      {still, 0.0}, {moving, 0.0}};
 
   // Check for exception when number of continuous keys are under-specified.
   KeyVector contKeys = {X(0)};
@@ -801,7 +803,8 @@ TEST(HybridFactorGraph, DefaultDecisionTree) {
                                                    noise_model),
        moving = std::make_shared<PlanarMotionModel>(X(0), X(1), odometry,
                                                     noise_model);
-  std::vector<PlanarMotionModel::shared_ptr> motion_models = {still, moving};
+  std::vector<std::pair<PlanarMotionModel::shared_ptr, double>> motion_models =
+      {{still, 0.0}, {moving, 0.0}};
   fg.emplace_shared<HybridNonlinearFactor>(
       contKeys, DiscreteKeys{gtsam::DiscreteKey(M(1), 2)}, motion_models);
 

--- a/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
@@ -135,7 +135,7 @@ TEST(HybridGaussianFactorGraph, Resize) {
   std::vector<std::pair<MotionModel::shared_ptr, double>> components = {
       {still, 0.0}, {moving, 0.0}};
   auto dcFactor = std::make_shared<HybridNonlinearFactor>(
-      contKeys, DiscreteKeys{gtsam::DiscreteKey(M(1), 2)}, components);
+      contKeys, gtsam::DiscreteKey(M(1), 2), components);
   nhfg.push_back(dcFactor);
 
   Values linearizationPoint;
@@ -170,12 +170,12 @@ TEST(HybridGaussianFactorGraph, HybridNonlinearFactor) {
   // Check for exception when number of continuous keys are under-specified.
   KeyVector contKeys = {X(0)};
   THROWS_EXCEPTION(std::make_shared<HybridNonlinearFactor>(
-      contKeys, DiscreteKeys{gtsam::DiscreteKey(M(1), 2)}, components));
+      contKeys, gtsam::DiscreteKey(M(1), 2), components));
 
   // Check for exception when number of continuous keys are too many.
   contKeys = {X(0), X(1), X(2)};
   THROWS_EXCEPTION(std::make_shared<HybridNonlinearFactor>(
-      contKeys, DiscreteKeys{gtsam::DiscreteKey(M(1), 2)}, components));
+      contKeys, gtsam::DiscreteKey(M(1), 2), components));
 }
 
 /*****************************************************************************
@@ -807,7 +807,7 @@ TEST(HybridFactorGraph, DefaultDecisionTree) {
   std::vector<std::pair<PlanarMotionModel::shared_ptr, double>> motion_models =
       {{still, 0.0}, {moving, 0.0}};
   fg.emplace_shared<HybridNonlinearFactor>(
-      contKeys, DiscreteKeys{gtsam::DiscreteKey(M(1), 2)}, motion_models);
+      contKeys, gtsam::DiscreteKey(M(1), 2), motion_models);
 
   // Add Range-Bearing measurements to from X0 to L0 and X1 to L1.
   // create a noise model for the landmark measurements

--- a/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
@@ -442,7 +442,7 @@ TEST(HybridFactorGraph, Full_Elimination) {
 
     DiscreteFactorGraph discrete_fg;
     // TODO(Varun) Make this a function of HybridGaussianFactorGraph?
-    for (auto& factor : (*remainingFactorGraph_partial)) {
+    for (auto &factor : (*remainingFactorGraph_partial)) {
       auto df = dynamic_pointer_cast<DiscreteFactor>(factor);
       assert(df);
       discrete_fg.push_back(df);
@@ -526,7 +526,6 @@ Hybrid [x0 x1; m0]{
 ]
   b = [ -1 ]
   No noise model
-value: 0
 
  1 Leaf :
   A[x0] = [
@@ -537,7 +536,6 @@ value: 0
 ]
   b = [ -0 ]
   No noise model
-value: 0
 
 }
 factor 2: 
@@ -553,7 +551,6 @@ Hybrid [x1 x2; m1]{
 ]
   b = [ -1 ]
   No noise model
-value: 0
 
  1 Leaf :
   A[x1] = [
@@ -564,7 +561,6 @@ value: 0
 ]
   b = [ -0 ]
   No noise model
-value: 0
 
 }
 factor 3: 
@@ -613,7 +609,6 @@ Hybrid [x0 x1; m0]{
 ]
   b = [ -1 ]
   No noise model
-value: 0
 
  1 Leaf:
   A[x0] = [
@@ -624,7 +619,6 @@ value: 0
 ]
   b = [ -0 ]
   No noise model
-value: 0
 
 }
 factor 2: 
@@ -639,7 +633,6 @@ Hybrid [x1 x2; m1]{
 ]
   b = [ -1 ]
   No noise model
-value: 0
 
  1 Leaf:
   A[x1] = [
@@ -650,7 +643,6 @@ value: 0
 ]
   b = [ -0 ]
   No noise model
-value: 0
 
 }
 factor 3: 

--- a/gtsam/hybrid/tests/testHybridNonlinearISAM.cpp
+++ b/gtsam/hybrid/tests/testHybridNonlinearISAM.cpp
@@ -439,7 +439,8 @@ TEST(HybridNonlinearISAM, NonTrivial) {
                                                    noise_model),
        moving = std::make_shared<PlanarMotionModel>(W(0), W(1), odometry,
                                                     noise_model);
-  std::vector<PlanarMotionModel::shared_ptr> components = {moving, still};
+  std::vector<std::pair<PlanarMotionModel::shared_ptr, double>> components = {
+      {moving, 0.0}, {still, 0.0}};
   auto mixtureFactor = std::make_shared<HybridNonlinearFactor>(
       contKeys, DiscreteKeys{gtsam::DiscreteKey(M(1), 2)}, components);
   fg.push_back(mixtureFactor);
@@ -479,7 +480,7 @@ TEST(HybridNonlinearISAM, NonTrivial) {
                                               noise_model);
   moving =
       std::make_shared<PlanarMotionModel>(W(1), W(2), odometry, noise_model);
-  components = {moving, still};
+  components = {{moving, 0.0}, {still, 0.0}};
   mixtureFactor = std::make_shared<HybridNonlinearFactor>(
       contKeys, DiscreteKeys{gtsam::DiscreteKey(M(2), 2)}, components);
   fg.push_back(mixtureFactor);
@@ -522,7 +523,7 @@ TEST(HybridNonlinearISAM, NonTrivial) {
                                               noise_model);
   moving =
       std::make_shared<PlanarMotionModel>(W(2), W(3), odometry, noise_model);
-  components = {moving, still};
+  components = {{moving, 0.0}, {still, 0.0}};
   mixtureFactor = std::make_shared<HybridNonlinearFactor>(
       contKeys, DiscreteKeys{gtsam::DiscreteKey(M(3), 2)}, components);
   fg.push_back(mixtureFactor);

--- a/gtsam/hybrid/tests/testHybridNonlinearISAM.cpp
+++ b/gtsam/hybrid/tests/testHybridNonlinearISAM.cpp
@@ -442,7 +442,7 @@ TEST(HybridNonlinearISAM, NonTrivial) {
   std::vector<std::pair<PlanarMotionModel::shared_ptr, double>> components = {
       {moving, 0.0}, {still, 0.0}};
   auto mixtureFactor = std::make_shared<HybridNonlinearFactor>(
-      contKeys, DiscreteKeys{gtsam::DiscreteKey(M(1), 2)}, components);
+      contKeys, gtsam::DiscreteKey(M(1), 2), components);
   fg.push_back(mixtureFactor);
 
   // Add equivalent of ImuFactor
@@ -482,7 +482,7 @@ TEST(HybridNonlinearISAM, NonTrivial) {
       std::make_shared<PlanarMotionModel>(W(1), W(2), odometry, noise_model);
   components = {{moving, 0.0}, {still, 0.0}};
   mixtureFactor = std::make_shared<HybridNonlinearFactor>(
-      contKeys, DiscreteKeys{gtsam::DiscreteKey(M(2), 2)}, components);
+      contKeys, gtsam::DiscreteKey(M(2), 2), components);
   fg.push_back(mixtureFactor);
 
   // Add equivalent of ImuFactor
@@ -525,7 +525,7 @@ TEST(HybridNonlinearISAM, NonTrivial) {
       std::make_shared<PlanarMotionModel>(W(2), W(3), odometry, noise_model);
   components = {{moving, 0.0}, {still, 0.0}};
   mixtureFactor = std::make_shared<HybridNonlinearFactor>(
-      contKeys, DiscreteKeys{gtsam::DiscreteKey(M(3), 2)}, components);
+      contKeys, gtsam::DiscreteKey(M(3), 2), components);
   fg.push_back(mixtureFactor);
 
   // Add equivalent of ImuFactor

--- a/gtsam/hybrid/tests/testSerializationHybrid.cpp
+++ b/gtsam/hybrid/tests/testSerializationHybrid.cpp
@@ -116,7 +116,8 @@ TEST(HybridSerialization, HybridGaussianConditional) {
   const auto conditional1 = std::make_shared<GaussianConditional>(
       GaussianConditional::FromMeanAndStddev(Z(0), I, X(0), Vector1(0), 3));
   const HybridGaussianConditional gm({Z(0)}, {X(0)}, {mode},
-                                     {conditional0, conditional1});
+                                     HybridGaussianConditional::Conditionals(
+                                         {mode}, {conditional0, conditional1}));
 
   EXPECT(equalsObj<HybridGaussianConditional>(gm));
   EXPECT(equalsXML<HybridGaussianConditional>(gm));

--- a/gtsam/hybrid/tests/testSerializationHybrid.cpp
+++ b/gtsam/hybrid/tests/testSerializationHybrid.cpp
@@ -83,7 +83,7 @@ TEST(HybridSerialization, HybridGaussianFactor) {
   auto b1 = Matrix::Ones(2, 1);
   auto f0 = std::make_shared<JacobianFactor>(X(0), A, b0);
   auto f1 = std::make_shared<JacobianFactor>(X(0), A, b1);
-  std::vector<GaussianFactor::shared_ptr> factors{f0, f1};
+  std::vector<GaussianFactorValuePair> factors{{f0, 0.0}, {f1, 0.0}};
 
   const HybridGaussianFactor factor(continuousKeys, discreteKeys, factors);
 

--- a/gtsam/hybrid/tests/testSerializationHybrid.cpp
+++ b/gtsam/hybrid/tests/testSerializationHybrid.cpp
@@ -76,7 +76,7 @@ BOOST_CLASS_EXPORT_GUID(HybridBayesNet, "gtsam_HybridBayesNet");
 // Test HybridGaussianFactor serialization.
 TEST(HybridSerialization, HybridGaussianFactor) {
   KeyVector continuousKeys{X(0)};
-  DiscreteKeys discreteKeys{{M(0), 2}};
+  DiscreteKey discreteKey{M(0), 2};
 
   auto A = Matrix::Zero(2, 1);
   auto b0 = Matrix::Zero(2, 1);
@@ -85,7 +85,7 @@ TEST(HybridSerialization, HybridGaussianFactor) {
   auto f1 = std::make_shared<JacobianFactor>(X(0), A, b1);
   std::vector<GaussianFactorValuePair> factors{{f0, 0.0}, {f1, 0.0}};
 
-  const HybridGaussianFactor factor(continuousKeys, discreteKeys, factors);
+  const HybridGaussianFactor factor(continuousKeys, discreteKey, factors);
 
   EXPECT(equalsObj<HybridGaussianFactor>(factor));
   EXPECT(equalsXML<HybridGaussianFactor>(factor));

--- a/gtsam/linear/NoiseModel.cpp
+++ b/gtsam/linear/NoiseModel.cpp
@@ -706,6 +706,22 @@ const RobustModel::shared_ptr &robust, const NoiseModel::shared_ptr noise){
   return shared_ptr(new Robust(robust,noise));
 }
 
+/* *******************************************************************************/
+double ComputeLogNormalizer(
+    const noiseModel::Gaussian::shared_ptr& noise_model) {
+  // Since noise models are Gaussian, we can get the logDeterminant using
+  // the same trick as in GaussianConditional
+  double logDetR = noise_model->R()
+                       .diagonal()
+                       .unaryExpr([](double x) { return log(x); })
+                       .sum();
+  double logDeterminantSigma = -2.0 * logDetR;
+
+  size_t n = noise_model->dim();
+  constexpr double log2pi = 1.8378770664093454835606594728112;
+  return n * log2pi + logDeterminantSigma;
+}
+
 /* ************************************************************************* */
 
 }

--- a/gtsam/linear/NoiseModel.cpp
+++ b/gtsam/linear/NoiseModel.cpp
@@ -714,6 +714,9 @@ double ComputeLogNormalizer(
     const noiseModel::Gaussian::shared_ptr& noise_model) {
   // Since noise models are Gaussian, we can get the logDeterminant using
   // the same trick as in GaussianConditional
+  // Sigma = (R'R)^{-1}, det(Sigma) = det((R'R)^{-1}) = det(R'R)^{-1}
+  // log det(Sigma) = -log(det(R'R)) = -2*log(det(R))
+  // Hence, log det(Sigma)) = -2.0 * logDetR()
   double logDetR = noise_model->R()
                        .diagonal()
                        .unaryExpr([](double x) { return log(x); })

--- a/gtsam/linear/NoiseModel.cpp
+++ b/gtsam/linear/NoiseModel.cpp
@@ -706,6 +706,9 @@ const RobustModel::shared_ptr &robust, const NoiseModel::shared_ptr noise){
   return shared_ptr(new Robust(robust,noise));
 }
 
+/* ************************************************************************* */
+}  // namespace noiseModel
+
 /* *******************************************************************************/
 double ComputeLogNormalizer(
     const noiseModel::Gaussian::shared_ptr& noise_model) {
@@ -722,7 +725,4 @@ double ComputeLogNormalizer(
   return n * log2pi + logDeterminantSigma;
 }
 
-/* ************************************************************************* */
-
-}
 } // gtsam

--- a/gtsam/linear/NoiseModel.h
+++ b/gtsam/linear/NoiseModel.h
@@ -751,6 +751,18 @@ namespace gtsam {
   template<> struct traits<noiseModel::Isotropic> : public Testable<noiseModel::Isotropic> {};
   template<> struct traits<noiseModel::Unit> : public Testable<noiseModel::Unit> {};
 
+  /**
+   * @brief Helper function to compute the sqrt(|2πΣ|) normalizer values
+   * for a Gaussian noise model.
+   * We compute this in the log-space for numerical accuracy.
+   *
+   * @param noise_model The Gaussian noise model
+   * whose normalizer we wish to compute.
+   * @return double
+   */
+  GTSAM_EXPORT double ComputeLogNormalizer(
+      const noiseModel::Gaussian::shared_ptr& noise_model);
+
 } //\ namespace gtsam
 
 

--- a/gtsam/linear/NoiseModel.h
+++ b/gtsam/linear/NoiseModel.h
@@ -752,7 +752,7 @@ namespace gtsam {
   template<> struct traits<noiseModel::Unit> : public Testable<noiseModel::Unit> {};
 
   /**
-   * @brief Helper function to compute the sqrt(|2πΣ|) normalizer values
+   * @brief Helper function to compute the log(|2πΣ|) normalizer values
    * for a Gaussian noise model.
    * We compute this in the log-space for numerical accuracy.
    *

--- a/gtsam/linear/tests/testNoiseModel.cpp
+++ b/gtsam/linear/tests/testNoiseModel.cpp
@@ -807,6 +807,26 @@ TEST(NoiseModel, NonDiagonalGaussian)
   }
 }
 
+TEST(NoiseModel, ComputeLogNormalizer) {
+  // Very simple 1D noise model, which we can compute by hand.
+  double sigma = 0.1;
+  auto noise_model = Isotropic::Sigma(1, sigma);
+  double actual_value = ComputeLogNormalizer(noise_model);
+  // Compute log(|2πΣ|) by hand.
+  // = log(2π) + log(Σ) (since it is 1D)
+  constexpr double log2pi = 1.8378770664093454835606594728112;
+  double expected_value = log2pi + log(sigma * sigma);
+  EXPECT_DOUBLES_EQUAL(expected_value, actual_value, 1e-9);
+
+  // Similar situation in the 3D case
+  size_t n = 3;
+  auto noise_model2 = Isotropic::Sigma(n, sigma);
+  double actual_value2 = ComputeLogNormalizer(noise_model2);
+  // We multiply by 3 due to the determinant
+  double expected_value2 = n * (log2pi + log(sigma * sigma));
+  EXPECT_DOUBLES_EQUAL(expected_value2, actual_value2, 1e-9);
+}
+
 /* ************************************************************************* */
 int main() {  TestResult tr; return TestRegistry::runAllTests(tr); }
 /* ************************************************************************* */

--- a/python/gtsam/tests/test_HybridBayesNet.py
+++ b/python/gtsam/tests/test_HybridBayesNet.py
@@ -43,14 +43,12 @@ class TestHybridBayesNet(GtsamTestCase):
         # Create the conditionals
         conditional0 = GaussianConditional(X(1), [5], I_1x1, model0)
         conditional1 = GaussianConditional(X(1), [2], I_1x1, model1)
-        discrete_keys = DiscreteKeys()
-        discrete_keys.push_back(Asia)
 
         # Create hybrid Bayes net.
         bayesNet = HybridBayesNet()
         bayesNet.push_back(conditional)
         bayesNet.push_back(
-            HybridGaussianConditional([X(1)], [], discrete_keys,
+            HybridGaussianConditional([X(1)], [], Asia,
                                       [conditional0, conditional1]))
         bayesNet.push_back(DiscreteConditional(Asia, "99/1"))
 

--- a/python/gtsam/tests/test_HybridFactorGraph.py
+++ b/python/gtsam/tests/test_HybridFactorGraph.py
@@ -101,10 +101,8 @@ class TestHybridGaussianFactorGraph(GtsamTestCase):
                                                                  I_1x1,
                                                                  X(0), [0],
                                                                  sigma=3)
-            discreteParents = DiscreteKeys()
-            discreteParents.push_back(mode)
             bayesNet.push_back(
-                HybridGaussianConditional([Z(i)], [X(0)], discreteParents,
+                HybridGaussianConditional([Z(i)], [X(0)], mode,
                                           [conditional0, conditional1]))
 
         # Create prior on X(0).

--- a/python/gtsam/tests/test_HybridFactorGraph.py
+++ b/python/gtsam/tests/test_HybridFactorGraph.py
@@ -20,7 +20,7 @@ import gtsam
 from gtsam import (DiscreteConditional, DiscreteKeys, GaussianConditional,
                    HybridBayesNet, HybridGaussianConditional,
                    HybridGaussianFactor, HybridGaussianFactorGraph,
-                   HybridValues, JacobianFactor, Ordering, noiseModel)
+                   HybridValues, JacobianFactor, noiseModel)
 
 DEBUG_MARGINALS = False
 
@@ -31,13 +31,11 @@ class TestHybridGaussianFactorGraph(GtsamTestCase):
     def test_create(self):
         """Test construction of hybrid factor graph."""
         model = noiseModel.Unit.Create(3)
-        dk = DiscreteKeys()
-        dk.push_back((C(0), 2))
 
         jf1 = JacobianFactor(X(0), np.eye(3), np.zeros((3, 1)), model)
         jf2 = JacobianFactor(X(0), np.eye(3), np.ones((3, 1)), model)
 
-        gmf = HybridGaussianFactor([X(0)], dk, [(jf1, 0), (jf2, 0)])
+        gmf = HybridGaussianFactor([X(0)], (C(0), 2), [(jf1, 0), (jf2, 0)])
 
         hfg = HybridGaussianFactorGraph()
         hfg.push_back(jf1)
@@ -58,13 +56,11 @@ class TestHybridGaussianFactorGraph(GtsamTestCase):
     def test_optimize(self):
         """Test construction of hybrid factor graph."""
         model = noiseModel.Unit.Create(3)
-        dk = DiscreteKeys()
-        dk.push_back((C(0), 2))
 
         jf1 = JacobianFactor(X(0), np.eye(3), np.zeros((3, 1)), model)
         jf2 = JacobianFactor(X(0), np.eye(3), np.ones((3, 1)), model)
 
-        gmf = HybridGaussianFactor([X(0)], dk, [(jf1, 0), (jf2, 0)])
+        gmf = HybridGaussianFactor([X(0)], (C(0), 2), [(jf1, 0), (jf2, 0)])
 
         hfg = HybridGaussianFactorGraph()
         hfg.push_back(jf1)
@@ -96,8 +92,6 @@ class TestHybridGaussianFactorGraph(GtsamTestCase):
 
         # Create Gaussian mixture Z(0) = X(0) + noise for each measurement.
         I_1x1 = np.eye(1)
-        keys = DiscreteKeys()
-        keys.push_back(mode)
         for i in range(num_measurements):
             conditional0 = GaussianConditional.FromMeanAndStddev(Z(i),
                                                                  I_1x1,
@@ -107,8 +101,10 @@ class TestHybridGaussianFactorGraph(GtsamTestCase):
                                                                  I_1x1,
                                                                  X(0), [0],
                                                                  sigma=3)
+            discreteParents = DiscreteKeys()
+            discreteParents.push_back(mode)
             bayesNet.push_back(
-                HybridGaussianConditional([Z(i)], [X(0)], keys,
+                HybridGaussianConditional([Z(i)], [X(0)], discreteParents,
                                           [conditional0, conditional1]))
 
         # Create prior on X(0).

--- a/python/gtsam/tests/test_HybridFactorGraph.py
+++ b/python/gtsam/tests/test_HybridFactorGraph.py
@@ -37,7 +37,7 @@ class TestHybridGaussianFactorGraph(GtsamTestCase):
         jf1 = JacobianFactor(X(0), np.eye(3), np.zeros((3, 1)), model)
         jf2 = JacobianFactor(X(0), np.eye(3), np.ones((3, 1)), model)
 
-        gmf = HybridGaussianFactor([X(0)], dk, [jf1, jf2])
+        gmf = HybridGaussianFactor([X(0)], dk, [(jf1, 0), (jf2, 0)])
 
         hfg = HybridGaussianFactorGraph()
         hfg.push_back(jf1)
@@ -64,7 +64,7 @@ class TestHybridGaussianFactorGraph(GtsamTestCase):
         jf1 = JacobianFactor(X(0), np.eye(3), np.zeros((3, 1)), model)
         jf2 = JacobianFactor(X(0), np.eye(3), np.ones((3, 1)), model)
 
-        gmf = HybridGaussianFactor([X(0)], dk, [jf1, jf2])
+        gmf = HybridGaussianFactor([X(0)], dk, [(jf1, 0), (jf2, 0)])
 
         hfg = HybridGaussianFactorGraph()
         hfg.push_back(jf1)

--- a/python/gtsam/tests/test_HybridNonlinearFactorGraph.py
+++ b/python/gtsam/tests/test_HybridNonlinearFactorGraph.py
@@ -27,8 +27,6 @@ class TestHybridGaussianFactorGraph(GtsamTestCase):
 
     def test_nonlinear_hybrid(self):
         nlfg = gtsam.HybridNonlinearFactorGraph()
-        dk = gtsam.DiscreteKeys()
-        dk.push_back((10, 2))
         nlfg.push_back(
             BetweenFactorPoint3(1, 2, Point3(1, 2, 3),
                                 noiseModel.Diagonal.Variances([1, 1, 1])))
@@ -40,7 +38,7 @@ class TestHybridGaussianFactorGraph(GtsamTestCase):
                                       noiseModel.Unit.Create(3)), 0.0),
                    (PriorFactorPoint3(1, Point3(1, 2, 1),
                                       noiseModel.Unit.Create(3)), 0.0)]
-        nlfg.push_back(gtsam.HybridNonlinearFactor([1], dk, factors))
+        nlfg.push_back(gtsam.HybridNonlinearFactor([1], (10, 2), factors))
         nlfg.push_back(gtsam.DecisionTreeFactor((10, 2), "1 3"))
         values = gtsam.Values()
         values.insert_point3(1, Point3(0, 0, 0))

--- a/python/gtsam/tests/test_HybridNonlinearFactorGraph.py
+++ b/python/gtsam/tests/test_HybridNonlinearFactorGraph.py
@@ -35,13 +35,12 @@ class TestHybridGaussianFactorGraph(GtsamTestCase):
         nlfg.push_back(
             PriorFactorPoint3(2, Point3(1, 2, 3),
                               noiseModel.Diagonal.Variances([0.5, 0.5, 0.5])))
-        nlfg.push_back(
-            gtsam.HybridNonlinearFactor([1], dk, [
-                PriorFactorPoint3(1, Point3(0, 0, 0),
-                                  noiseModel.Unit.Create(3)),
-                PriorFactorPoint3(1, Point3(1, 2, 1),
-                                  noiseModel.Unit.Create(3))
-            ]))
+
+        factors = [(PriorFactorPoint3(1, Point3(0, 0, 0),
+                                      noiseModel.Unit.Create(3)), 0.0),
+                   (PriorFactorPoint3(1, Point3(1, 2, 1),
+                                      noiseModel.Unit.Create(3)), 0.0)]
+        nlfg.push_back(gtsam.HybridNonlinearFactor([1], dk, factors))
         nlfg.push_back(gtsam.DecisionTreeFactor((10, 2), "1 3"))
         values = gtsam.Values()
         values.insert_point3(1, Point3(0, 0, 0))


### PR DESCRIPTION
`HybridNonlinearFactor` and `HybridGaussianFactor` now take a DecisionTree of factor and scalar pairs. This allows us to specify arbitrary values which will be used within the definition of the factors, allowing for relinearization.