### PR TITLE
HybridGaussianConditional inherits from HybridGaussianFactor

### DIFF
--- a/gtsam/hybrid/HybridGaussianConditional.cpp
+++ b/gtsam/hybrid/HybridGaussianConditional.cpp
@@ -35,8 +35,8 @@ HybridGaussianFactor::FactorValuePairs GetFactorValuePairs(
     double value = 0.0;
     // Check if conditional is pruned
     if (conditional) {
-      // Assign log(|2πΣ|) = -2*log(1 / sqrt(|2πΣ|))
-      value = -2.0 * conditional->logNormalizationConstant();
+      // Assign log(\sqrt(|2πΣ|)) = -log(1 / sqrt(|2πΣ|))
+      value = -conditional->logNormalizationConstant();
     }
     return {std::dynamic_pointer_cast<GaussianFactor>(conditional), value};
   };

--- a/gtsam/hybrid/HybridGaussianConditional.cpp
+++ b/gtsam/hybrid/HybridGaussianConditional.cpp
@@ -79,21 +79,6 @@ HybridGaussianConditional::HybridGaussianConditional(
                                 Conditionals({discreteParent}, conditionals)) {}
 
 /* *******************************************************************************/
-// TODO(dellaert): This is copy/paste: HybridGaussianConditional should be
-// derived from HybridGaussianFactor, no?
-GaussianFactorGraphTree HybridGaussianConditional::add(
-    const GaussianFactorGraphTree &sum) const {
-  using Y = GaussianFactorGraph;
-  auto add = [](const Y &graph1, const Y &graph2) {
-    auto result = graph1;
-    result.push_back(graph2);
-    return result;
-  };
-  const auto tree = asGaussianFactorGraphTree();
-  return sum.empty() ? tree : sum.apply(tree, add);
-}
-
-/* *******************************************************************************/
 GaussianFactorGraphTree HybridGaussianConditional::asGaussianFactorGraphTree()
     const {
   auto wrap = [this](const GaussianConditional::shared_ptr &gc) {

--- a/gtsam/hybrid/HybridGaussianConditional.h
+++ b/gtsam/hybrid/HybridGaussianConditional.h
@@ -108,8 +108,9 @@ class GTSAM_EXPORT HybridGaussianConditional
                             const Conditionals &conditionals);
 
   /**
-   * @brief Make a Hybrid Gaussian Conditional from a vector of Gaussian conditionals.
-   * The DecisionTree-based constructor is preferred over this one.
+   * @brief Make a Hybrid Gaussian Conditional from a vector of Gaussian
+   * conditionals. The DecisionTree-based constructor is preferred over this
+   * one.
    *
    * @param continuousFrontals The continuous frontal variables
    * @param continuousParents The continuous parent variables
@@ -233,14 +234,6 @@ class GTSAM_EXPORT HybridGaussianConditional
    */
   void prune(const DecisionTreeFactor &discreteProbs);
 
-  /**
-   * @brief Merge the Gaussian Factor Graphs in `this` and `sum` while
-   * maintaining the decision tree structure.
-   *
-   * @param sum Decision Tree of Gaussian Factor Graphs
-   * @return GaussianFactorGraphTree
-   */
-  GaussianFactorGraphTree add(const GaussianFactorGraphTree &sum) const;
   /// @}
 
  private:

--- a/gtsam/hybrid/HybridGaussianConditional.h
+++ b/gtsam/hybrid/HybridGaussianConditional.h
@@ -51,13 +51,13 @@ class HybridValues;
  * @ingroup hybrid
  */
 class GTSAM_EXPORT HybridGaussianConditional
-    : public HybridFactor,
-      public Conditional<HybridFactor, HybridGaussianConditional> {
+    : public HybridGaussianFactor,
+      public Conditional<HybridGaussianFactor, HybridGaussianConditional> {
  public:
   using This = HybridGaussianConditional;
-  using shared_ptr = std::shared_ptr<HybridGaussianConditional>;
-  using BaseFactor = HybridFactor;
-  using BaseConditional = Conditional<HybridFactor, HybridGaussianConditional>;
+  using shared_ptr = std::shared_ptr<This>;
+  using BaseFactor = HybridGaussianFactor;
+  using BaseConditional = Conditional<BaseFactor, HybridGaussianConditional>;
 
   /// typedef for Decision Tree of Gaussian Conditionals
   using Conditionals = DecisionTree<Key, GaussianConditional::shared_ptr>;

--- a/gtsam/hybrid/HybridGaussianConditional.h
+++ b/gtsam/hybrid/HybridGaussianConditional.h
@@ -64,7 +64,8 @@ class GTSAM_EXPORT HybridGaussianConditional
 
  private:
   Conditionals conditionals_;  ///< a decision tree of Gaussian conditionals.
-  double logConstant_;         ///< log of the normalization constant.
+  double logNormalizer_;       ///< log of the normalization constant
+                               ///< (log(\sqrt(|2πΣ|))).
 
   /**
    * @brief Convert a HybridGaussianConditional of conditionals into
@@ -149,7 +150,7 @@ class GTSAM_EXPORT HybridGaussianConditional
 
   /// The log normalization constant is max of the the individual
   /// log-normalization constants.
-  double logNormalizationConstant() const override { return logConstant_; }
+  double logNormalizationConstant() const override { return -logNormalizer_; }
 
   /**
    * Create a likelihood factor for a hybrid Gaussian conditional,

--- a/gtsam/hybrid/HybridGaussianConditional.h
+++ b/gtsam/hybrid/HybridGaussianConditional.h
@@ -64,8 +64,9 @@ class GTSAM_EXPORT HybridGaussianConditional
 
  private:
   Conditionals conditionals_;  ///< a decision tree of Gaussian conditionals.
-  double logNormalizer_;       ///< log of the normalization constant
-                               ///< (log(\sqrt(|2πΣ|))).
+  ///< Negative-log of the normalization constant (log(\sqrt(|2πΣ|))).
+  ///< Take advantage of the neg-log space so everything is a minimization
+  double logConstant_;
 
   /**
    * @brief Convert a HybridGaussianConditional of conditionals into
@@ -151,7 +152,7 @@ class GTSAM_EXPORT HybridGaussianConditional
 
   /// The log normalization constant is max of the the individual
   /// log-normalization constants.
-  double logNormalizationConstant() const override { return -logNormalizer_; }
+  double logNormalizationConstant() const override { return -logConstant_; }
 
   /**
    * Create a likelihood factor for a hybrid Gaussian conditional,

--- a/gtsam/hybrid/tests/testHybridGaussianConditional.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianConditional.cpp
@@ -100,7 +100,7 @@ TEST(HybridGaussianConditional, Error) {
   auto actual = hybrid_conditional.errorTree(vv);
 
   // Check result.
-  std::vector<DiscreteKey> discrete_keys = {mode};
+  DiscreteKeys discrete_keys{mode};
   std::vector<double> leaves = {conditionals[0]->error(vv),
                                 conditionals[1]->error(vv)};
   AlgebraicDecisionTree<Key> expected(discrete_keys, leaves);
@@ -170,6 +170,37 @@ TEST(HybridGaussianConditional, ContinuousParents) {
   // Check that the continuous parent keys are correct:
   EXPECT(continuousParentKeys.size() == 1);
   EXPECT(continuousParentKeys[0] == X(0));
+}
+
+/* ************************************************************************* */
+/// Check error with mode dependent constants.
+TEST(HybridGaussianConditional, Error2) {
+  using namespace mode_dependent_constants;
+  auto actual = mixture.errorTree(vv);
+
+  // Check result.
+  DiscreteKeys discrete_keys{mode};
+  double logNormalizer0 = -conditionals[0]->logNormalizationConstant();
+  double logNormalizer1 = -conditionals[1]->logNormalizationConstant();
+  double minLogNormalizer = std::min(logNormalizer0, logNormalizer1);
+
+  // Expected error is e(X) + log(|2πΣ|).
+  // We normalize log(|2πΣ|) with min(logNormalizers) so it is non-negative.
+  std::vector<double> leaves = {
+      conditionals[0]->error(vv) + logNormalizer0 - minLogNormalizer,
+      conditionals[1]->error(vv) + logNormalizer1 - minLogNormalizer};
+  AlgebraicDecisionTree<Key> expected(discrete_keys, leaves);
+
+  EXPECT(assert_equal(expected, actual, 1e-6));
+
+  // Check for non-tree version.
+  for (size_t mode : {0, 1}) {
+    const HybridValues hv{vv, {{M(0), mode}}};
+    EXPECT_DOUBLES_EQUAL(conditionals[mode]->error(vv) -
+                             conditionals[mode]->logNormalizationConstant() -
+                             minLogNormalizer,
+                         mixture.error(hv), 1e-8);
+  }
 }
 
 /* ************************************************************************* */

--- a/gtsam/hybrid/tests/testHybridGaussianConditional.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianConditional.cpp
@@ -176,7 +176,7 @@ TEST(HybridGaussianConditional, ContinuousParents) {
 /// Check error with mode dependent constants.
 TEST(HybridGaussianConditional, Error2) {
   using namespace mode_dependent_constants;
-  auto actual = mixture.errorTree(vv);
+  auto actual = hybrid_conditional.errorTree(vv);
 
   // Check result.
   DiscreteKeys discrete_keys{mode};
@@ -199,7 +199,7 @@ TEST(HybridGaussianConditional, Error2) {
     EXPECT_DOUBLES_EQUAL(conditionals[mode]->error(vv) -
                              conditionals[mode]->logNormalizationConstant() -
                              minLogNormalizer,
-                         mixture.error(hv), 1e-8);
+                         hybrid_conditional.error(hv), 1e-8);
   }
 }
 


### PR DESCRIPTION
Analogous to `GaussianConditional` and `GaussianFactor`, make `HybridGaussianConditional` inherit from `HybridGaussianFactor` so we can reduce code duplication.

I also changed `logConstant_` to be defined in the negative logspace, letting us lower bound the values at 0.0 instead of $-\infty$. I'll be updating the `Hybrid.pdf` file to reflect this for synergy.

One of a bunch of small PRs to improve the hybrid API and functionality.