### PR TITLE
More refactoring

### DIFF
--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -44,8 +44,13 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
   /// @name Standard Constructors
   /// @{
 
-  /** Construct empty Bayes net */
+  /// Construct empty Bayes net.
   HybridBayesNet() = default;
+
+  /// Constructor that takes an initializer list of shared pointers.
+  HybridBayesNet(
+      std::initializer_list<HybridConditional::shared_ptr> conditionals)
+      : Base(conditionals) {}
 
   /// @}
   /// @name Testable

--- a/gtsam/hybrid/HybridGaussianConditional.cpp
+++ b/gtsam/hybrid/HybridGaussianConditional.cpp
@@ -51,7 +51,7 @@ struct HybridGaussianConditional::Helper {
     std::vector<GC::shared_ptr> gcs;
     fvs.reserve(p.size());
     gcs.reserve(p.size());
-    for (const auto &[mean, sigma] : p) {
+    for (auto &&[mean, sigma] : p) {
       auto gaussianConditional =
           GC::sharedMeanAndStddev(std::forward<Args>(args)..., mean, sigma);
       double value = gaussianConditional->negLogConstant();
@@ -96,38 +96,34 @@ HybridGaussianConditional::HybridGaussianConditional(
       conditionals_(helper.conditionals),
       negLogConstant_(helper.minNegLogConstant) {}
 
-/* *******************************************************************************/
 HybridGaussianConditional::HybridGaussianConditional(
-    const DiscreteKey &mode,
+    const DiscreteKey &discreteParent,
     const std::vector<GaussianConditional::shared_ptr> &conditionals)
-    : HybridGaussianConditional(DiscreteKeys{mode},
-                                Conditionals({mode}, conditionals)) {}
+    : HybridGaussianConditional(DiscreteKeys{discreteParent},
+                                Conditionals({discreteParent}, conditionals)) {}
 
-/* *******************************************************************************/
 HybridGaussianConditional::HybridGaussianConditional(
-    const DiscreteKey &mode, Key key,  //
+    const DiscreteKey &discreteParent, Key key,  //
     const std::vector<std::pair<Vector, double>> &parameters)
-    : HybridGaussianConditional(DiscreteKeys{mode},
-                                Helper(mode, parameters, key)) {}
+    : HybridGaussianConditional(DiscreteKeys{discreteParent},
+                                Helper(discreteParent, parameters, key)) {}
 
-/* *******************************************************************************/
 HybridGaussianConditional::HybridGaussianConditional(
-    const DiscreteKey &mode, Key key,  //
+    const DiscreteKey &discreteParent, Key key,  //
     const Matrix &A, Key parent,
     const std::vector<std::pair<Vector, double>> &parameters)
-    : HybridGaussianConditional(DiscreteKeys{mode},
-                                Helper(mode, parameters, key, A, parent)) {}
+    : HybridGaussianConditional(
+          DiscreteKeys{discreteParent},
+          Helper(discreteParent, parameters, key, A, parent)) {}
 
-/* *******************************************************************************/
 HybridGaussianConditional::HybridGaussianConditional(
-    const DiscreteKey &mode, Key key,  //
+    const DiscreteKey &discreteParent, Key key,  //
     const Matrix &A1, Key parent1, const Matrix &A2, Key parent2,
     const std::vector<std::pair<Vector, double>> &parameters)
     : HybridGaussianConditional(
-          DiscreteKeys{mode},
-          Helper(mode, parameters, key, A1, parent1, A2, parent2)) {}
+          DiscreteKeys{discreteParent},
+          Helper(discreteParent, parameters, key, A1, parent1, A2, parent2)) {}
 
-/* *******************************************************************************/
 HybridGaussianConditional::HybridGaussianConditional(
     const DiscreteKeys &discreteParents,
     const HybridGaussianConditional::Conditionals &conditionals)

--- a/gtsam/hybrid/HybridGaussianConditional.cpp
+++ b/gtsam/hybrid/HybridGaussianConditional.cpp
@@ -96,18 +96,21 @@ HybridGaussianConditional::HybridGaussianConditional(
       conditionals_(helper.conditionals),
       negLogConstant_(helper.minNegLogConstant) {}
 
+/* *******************************************************************************/
 HybridGaussianConditional::HybridGaussianConditional(
     const DiscreteKey &mode,
     const std::vector<GaussianConditional::shared_ptr> &conditionals)
     : HybridGaussianConditional(DiscreteKeys{mode},
                                 Conditionals({mode}, conditionals)) {}
 
+/* *******************************************************************************/
 HybridGaussianConditional::HybridGaussianConditional(
     const DiscreteKey &mode, Key key,  //
     const std::vector<std::pair<Vector, double>> &parameters)
     : HybridGaussianConditional(DiscreteKeys{mode},
                                 Helper(mode, parameters, key)) {}
 
+/* *******************************************************************************/
 HybridGaussianConditional::HybridGaussianConditional(
     const DiscreteKey &mode, Key key,  //
     const Matrix &A, Key parent,
@@ -115,6 +118,7 @@ HybridGaussianConditional::HybridGaussianConditional(
     : HybridGaussianConditional(DiscreteKeys{mode},
                                 Helper(mode, parameters, key, A, parent)) {}
 
+/* *******************************************************************************/
 HybridGaussianConditional::HybridGaussianConditional(
     const DiscreteKey &mode, Key key,  //
     const Matrix &A1, Key parent1, const Matrix &A2, Key parent2,
@@ -123,6 +127,7 @@ HybridGaussianConditional::HybridGaussianConditional(
           DiscreteKeys{mode},
           Helper(mode, parameters, key, A1, parent1, A2, parent2)) {}
 
+/* *******************************************************************************/
 HybridGaussianConditional::HybridGaussianConditional(
     const DiscreteKeys &discreteParents,
     const HybridGaussianConditional::Conditionals &conditionals)

--- a/gtsam/hybrid/HybridGaussianConditional.cpp
+++ b/gtsam/hybrid/HybridGaussianConditional.cpp
@@ -62,21 +62,6 @@ struct HybridGaussianConditional::ConstructorHelper {
     }
   }
 
-  /// Construct from means and a single sigma.
-  ConstructorHelper(Key x, const DiscreteKey mode,
-                    const std::vector<Vector> &means, double sigma)
-      : nrFrontals(1), minNegLogConstant(0) {
-    std::vector<GaussianConditional::shared_ptr> gcs;
-    for (const auto &mean : means) {
-      auto c = GaussianConditional::sharedMeanAndStddev(x, mean, sigma);
-      gcs.push_back(c);
-    }
-    conditionals = Conditionals({mode}, gcs);
-    pairs = FactorValuePairs(conditionals, [](const auto &c) {
-      return GaussianFactorValuePair{c, 0.0};
-    });
-  }
-
   /// Construct from means and a sigmas.
   ConstructorHelper(Key x, const DiscreteKey mode,
                     const std::vector<std::pair<Vector, double>> &parameters)
@@ -109,12 +94,6 @@ HybridGaussianConditional::HybridGaussianConditional(
     const std::vector<GaussianConditional::shared_ptr> &conditionals)
     : HybridGaussianConditional(DiscreteKeys{mode},
                                 Conditionals({mode}, conditionals)) {}
-
-HybridGaussianConditional::HybridGaussianConditional(
-    Key x, const DiscreteKey mode, const std::vector<Vector> &means,
-    double sigma)
-    : HybridGaussianConditional(DiscreteKeys{mode},
-                                ConstructorHelper(x, mode, means, sigma)) {}
 
 HybridGaussianConditional::HybridGaussianConditional(
     Key x, const DiscreteKey mode,

--- a/gtsam/hybrid/HybridGaussianConditional.h
+++ b/gtsam/hybrid/HybridGaussianConditional.h
@@ -88,17 +88,6 @@ class GTSAM_EXPORT HybridGaussianConditional
       const std::vector<GaussianConditional::shared_ptr> &conditionals);
 
   /**
-   * @brief Construct from vector of means and a single sigma.
-   *
-   * @param x The continuous key.
-   * @param mode The discrete key.
-   * @param means The means for the Gaussian conditionals.
-   * @param sigma The standard deviation for the Gaussian conditionals.
-   */
-  HybridGaussianConditional(Key x, const DiscreteKey mode,
-                            const std::vector<Vector> &means, double sigma);
-
-  /**
    * @brief Construct from vector of means and sigmas.
    *
    * @param x The continuous key.

--- a/gtsam/hybrid/HybridGaussianConditional.h
+++ b/gtsam/hybrid/HybridGaussianConditional.h
@@ -87,15 +87,21 @@ class GTSAM_EXPORT HybridGaussianConditional
       const DiscreteKey &mode,
       const std::vector<GaussianConditional::shared_ptr> &conditionals);
 
-  /**
-   * @brief Construct from vector of means and sigmas.
-   *
-   * @param x The continuous key.
-   * @param mode The discrete key.
-   * @param parameters The means and sigmas for the Gaussian conditionals.
-   */
+  /// Construct from mean `mu_i` and `sigma_i`.
   HybridGaussianConditional(
-      Key x, const DiscreteKey mode,
+      const DiscreteKey mode, Key key,  //
+      const std::vector<std::pair<Vector, double>> &parameters);
+
+  /// Construct from conditional mean `A1 p1 + b_i` and `sigma_i`.
+  HybridGaussianConditional(
+      const DiscreteKey mode, Key key,  //
+      const Matrix &A, Key parent,
+      const std::vector<std::pair<Vector, double>> &parameters);
+
+  /// Construct from conditional mean `A1 p1 + A2 p2 + b_i` and `sigma_i`.
+  HybridGaussianConditional(
+      const DiscreteKey mode, Key key,  //
+      const Matrix &A1, Key parent1, const Matrix &A2, Key parent2,
       const std::vector<std::pair<Vector, double>> &parameters);
 
   /**
@@ -194,11 +200,11 @@ class GTSAM_EXPORT HybridGaussianConditional
 
  private:
   /// Helper struct for private constructor.
-  struct ConstructorHelper;
+  struct Helper;
 
   /// Private constructor that uses helper struct above.
   HybridGaussianConditional(const DiscreteKeys &discreteParents,
-                            const ConstructorHelper &helper);
+                            const Helper &helper);
 
   /// Convert to a DecisionTree of Gaussian factor graphs.
   GaussianFactorGraphTree asGaussianFactorGraphTree() const;

--- a/gtsam/hybrid/HybridGaussianConditional.h
+++ b/gtsam/hybrid/HybridGaussianConditional.h
@@ -79,13 +79,35 @@ class GTSAM_EXPORT HybridGaussianConditional
   /**
    * @brief Construct from one discrete key and vector of conditionals.
    *
-   * @param discreteParent Single discrete parent variable
+   * @param mode Single discrete parent variable
    * @param conditionals Vector of conditionals with the same size as the
    * cardinality of the discrete parent.
    */
   HybridGaussianConditional(
-      const DiscreteKey &discreteParent,
+      const DiscreteKey &mode,
       const std::vector<GaussianConditional::shared_ptr> &conditionals);
+
+  /**
+   * @brief Construct from vector of means and a single sigma.
+   *
+   * @param x The continuous key.
+   * @param mode The discrete key.
+   * @param means The means for the Gaussian conditionals.
+   * @param sigma The standard deviation for the Gaussian conditionals.
+   */
+  HybridGaussianConditional(Key x, const DiscreteKey mode,
+                            const std::vector<Vector> &means, double sigma);
+
+  /**
+   * @brief Construct from vector of means and sigmas.
+   *
+   * @param x The continuous key.
+   * @param mode The discrete key.
+   * @param parameters The means and sigmas for the Gaussian conditionals.
+   */
+  HybridGaussianConditional(
+      Key x, const DiscreteKey mode,
+      const std::vector<std::pair<Vector, double>> &parameters);
 
   /**
    * @brief Construct from multiple discrete keys and conditional tree.
@@ -186,10 +208,8 @@ class GTSAM_EXPORT HybridGaussianConditional
   struct ConstructorHelper;
 
   /// Private constructor that uses helper struct above.
-  HybridGaussianConditional(
-      const DiscreteKeys &discreteParents,
-      const HybridGaussianConditional::Conditionals &conditionals,
-      const ConstructorHelper &helper);
+  HybridGaussianConditional(const DiscreteKeys &discreteParents,
+                            const ConstructorHelper &helper);
 
   /// Convert to a DecisionTree of Gaussian factor graphs.
   GaussianFactorGraphTree asGaussianFactorGraphTree() const;

--- a/gtsam/hybrid/HybridGaussianConditional.h
+++ b/gtsam/hybrid/HybridGaussianConditional.h
@@ -89,18 +89,18 @@ class GTSAM_EXPORT HybridGaussianConditional
 
   /// Construct from mean `mu_i` and `sigma_i`.
   HybridGaussianConditional(
-      const DiscreteKey mode, Key key,  //
+      const DiscreteKey &mode, Key key,  //
       const std::vector<std::pair<Vector, double>> &parameters);
 
   /// Construct from conditional mean `A1 p1 + b_i` and `sigma_i`.
   HybridGaussianConditional(
-      const DiscreteKey mode, Key key,  //
+      const DiscreteKey &mode, Key key,  //
       const Matrix &A, Key parent,
       const std::vector<std::pair<Vector, double>> &parameters);
 
   /// Construct from conditional mean `A1 p1 + A2 p2 + b_i` and `sigma_i`.
   HybridGaussianConditional(
-      const DiscreteKey mode, Key key,  //
+      const DiscreteKey &mode, Key key,  //
       const Matrix &A1, Key parent1, const Matrix &A2, Key parent2,
       const std::vector<std::pair<Vector, double>> &parameters);
 

--- a/gtsam/hybrid/HybridGaussianConditional.h
+++ b/gtsam/hybrid/HybridGaussianConditional.h
@@ -79,45 +79,45 @@ class GTSAM_EXPORT HybridGaussianConditional
   /**
    * @brief Construct from one discrete key and vector of conditionals.
    *
-   * @param mode Single discrete parent variable
+   * @param discreteParent Single discrete parent variable
    * @param conditionals Vector of conditionals with the same size as the
    * cardinality of the discrete parent.
    */
   HybridGaussianConditional(
-      const DiscreteKey &mode,
+      const DiscreteKey &discreteParent,
       const std::vector<GaussianConditional::shared_ptr> &conditionals);
 
   /**
    * @brief Constructs a HybridGaussianConditional with means mu_i and
    * standard deviations sigma_i.
    *
-   * @param mode The discrete mode key.
+   * @param discreteParent The discrete parent or "mode" key.
    * @param key The key for this conditional variable.
    * @param parameters A vector of pairs (mu_i, sigma_i).
    */
   HybridGaussianConditional(
-      const DiscreteKey &mode, Key key,
+      const DiscreteKey &discreteParent, Key key,
       const std::vector<std::pair<Vector, double>> &parameters);
 
   /**
    * @brief Constructs a HybridGaussianConditional with conditional means
    * A × parent + b_i and standard deviations sigma_i.
    *
-   * @param mode The discrete mode key.
+   * @param discreteParent The discrete parent or "mode" key.
    * @param key The key for this conditional variable.
    * @param A The matrix A.
    * @param parent The key of the parent variable.
    * @param parameters A vector of pairs (b_i, sigma_i).
    */
   HybridGaussianConditional(
-      const DiscreteKey &mode, Key key, const Matrix &A, Key parent,
+      const DiscreteKey &discreteParent, Key key, const Matrix &A, Key parent,
       const std::vector<std::pair<Vector, double>> &parameters);
 
   /**
    * @brief Constructs a HybridGaussianConditional with conditional means
    * A1 × parent1 + A2 × parent2 + b_i and standard deviations sigma_i.
    *
-   * @param mode The discrete mode key.
+   * @param discreteParent The discrete parent or "mode" key.
    * @param key The key for this conditional variable.
    * @param A1 The first matrix.
    * @param parent1 The key of the first parent variable.
@@ -126,7 +126,7 @@ class GTSAM_EXPORT HybridGaussianConditional
    * @param parameters A vector of pairs (b_i, sigma_i).
    */
   HybridGaussianConditional(
-      const DiscreteKey &mode, Key key,  //
+      const DiscreteKey &discreteParent, Key key,  //
       const Matrix &A1, Key parent1, const Matrix &A2, Key parent2,
       const std::vector<std::pair<Vector, double>> &parameters);
 

--- a/gtsam/hybrid/HybridGaussianConditional.h
+++ b/gtsam/hybrid/HybridGaussianConditional.h
@@ -87,18 +87,44 @@ class GTSAM_EXPORT HybridGaussianConditional
       const DiscreteKey &mode,
       const std::vector<GaussianConditional::shared_ptr> &conditionals);
 
-  /// Construct from mean `mu_i` and `sigma_i`.
+  /**
+   * @brief Constructs a HybridGaussianConditional with means mu_i and
+   * standard deviations sigma_i.
+   *
+   * @param mode The discrete mode key.
+   * @param key The key for this conditional variable.
+   * @param parameters A vector of pairs (mu_i, sigma_i).
+   */
   HybridGaussianConditional(
-      const DiscreteKey &mode, Key key,  //
+      const DiscreteKey &mode, Key key,
       const std::vector<std::pair<Vector, double>> &parameters);
 
-  /// Construct from conditional mean `A1 p1 + b_i` and `sigma_i`.
+  /**
+   * @brief Constructs a HybridGaussianConditional with conditional means
+   * A × parent + b_i and standard deviations sigma_i.
+   *
+   * @param mode The discrete mode key.
+   * @param key The key for this conditional variable.
+   * @param A The matrix A.
+   * @param parent The key of the parent variable.
+   * @param parameters A vector of pairs (b_i, sigma_i).
+   */
   HybridGaussianConditional(
-      const DiscreteKey &mode, Key key,  //
-      const Matrix &A, Key parent,
+      const DiscreteKey &mode, Key key, const Matrix &A, Key parent,
       const std::vector<std::pair<Vector, double>> &parameters);
 
-  /// Construct from conditional mean `A1 p1 + A2 p2 + b_i` and `sigma_i`.
+  /**
+   * @brief Constructs a HybridGaussianConditional with conditional means
+   * A1 × parent1 + A2 × parent2 + b_i and standard deviations sigma_i.
+   *
+   * @param mode The discrete mode key.
+   * @param key The key for this conditional variable.
+   * @param A1 The first matrix.
+   * @param parent1 The key of the first parent variable.
+   * @param A2 The second matrix.
+   * @param parent2 The key of the second parent variable.
+   * @param parameters A vector of pairs (b_i, sigma_i).
+   */
   HybridGaussianConditional(
       const DiscreteKey &mode, Key key,  //
       const Matrix &A1, Key parent1, const Matrix &A2, Key parent2,

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -366,18 +366,17 @@ static std::shared_ptr<Factor> createHybridGaussianFactor(
   return std::make_shared<HybridGaussianFactor>(discreteSeparator, newFactors);
 }
 
-static std::pair<HybridConditional::shared_ptr, std::shared_ptr<Factor>>
-hybridElimination(const HybridGaussianFactorGraph &factors,
-                  const Ordering &frontalKeys,
-                  const std::set<DiscreteKey> &discreteSeparatorSet) {
-  // NOTE: since we use the special JunctionTree,
-  // only possibility is continuous conditioned on discrete.
-  DiscreteKeys discreteSeparator(discreteSeparatorSet.begin(),
-                                 discreteSeparatorSet.end());
+std::pair<HybridConditional::shared_ptr, std::shared_ptr<Factor>>
+HybridGaussianFactorGraph::eliminate(const Ordering &keys) const {
+  // Since we eliminate all continuous variables first,
+  // the discrete separator will be *all* the discrete keys.
+  const std::set<DiscreteKey> keysForDiscreteVariables = discreteKeys();
+  DiscreteKeys discreteSeparator(keysForDiscreteVariables.begin(),
+                                 keysForDiscreteVariables.end());
 
   // Collect all the factors to create a set of Gaussian factor graphs in a
   // decision tree indexed by all discrete keys involved.
-  GaussianFactorGraphTree factorGraphTree = factors.assembleGraphTree();
+  GaussianFactorGraphTree factorGraphTree = assembleGraphTree();
 
   // Convert factor graphs with a nullptr to an empty factor graph.
   // This is done after assembly since it is non-trivial to keep track of which
@@ -392,7 +391,7 @@ hybridElimination(const HybridGaussianFactorGraph &factors,
     }
 
     // Expensive elimination of product factor.
-    auto result = EliminatePreferCholesky(graph, frontalKeys);
+    auto result = EliminatePreferCholesky(graph, keys);
 
     // Record whether there any continuous variables left
     someContinuousLeft |= !result.second->empty();
@@ -436,7 +435,7 @@ hybridElimination(const HybridGaussianFactorGraph &factors,
  */
 std::pair<HybridConditional::shared_ptr, std::shared_ptr<Factor>>  //
 EliminateHybrid(const HybridGaussianFactorGraph &factors,
-                const Ordering &frontalKeys) {
+                const Ordering &keys) {
   // NOTE: Because we are in the Conditional Gaussian regime there are only
   // a few cases:
   // 1. continuous variable, make a hybrid Gaussian conditional if there are
@@ -510,20 +509,13 @@ EliminateHybrid(const HybridGaussianFactorGraph &factors,
 
   if (only_discrete) {
     // Case 1: we are only dealing with discrete
-    return discreteElimination(factors, frontalKeys);
+    return discreteElimination(factors, keys);
   } else if (only_continuous) {
     // Case 2: we are only dealing with continuous
-    return continuousElimination(factors, frontalKeys);
+    return continuousElimination(factors, keys);
   } else {
     // Case 3: We are now in the hybrid land!
-    KeySet frontalKeysSet(frontalKeys.begin(), frontalKeys.end());
-
-    // Find all discrete keys.
-    // Since we eliminate all continuous variables first,
-    // the discrete separator will be *all* the discrete keys.
-    std::set<DiscreteKey> discreteSeparator = factors.discreteKeys();
-
-    return hybridElimination(factors, frontalKeys, discreteSeparator);
+    return factors.eliminate(keys);
   }
 }
 

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -366,6 +366,7 @@ static std::shared_ptr<Factor> createHybridGaussianFactor(
   return std::make_shared<HybridGaussianFactor>(discreteSeparator, newFactors);
 }
 
+/* *******************************************************************************/
 std::pair<HybridConditional::shared_ptr, std::shared_ptr<Factor>>
 HybridGaussianFactorGraph::eliminate(const Ordering &keys) const {
   // Since we eliminate all continuous variables first,

--- a/gtsam/hybrid/HybridGaussianFactorGraph.h
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.h
@@ -217,6 +217,14 @@ class GTSAM_EXPORT HybridGaussianFactorGraph
    */
   GaussianFactorGraphTree assembleGraphTree() const;
 
+  /**
+   * @brief Eliminate the given continuous keys.
+   *
+   * @param keys The continuous keys to eliminate.
+   * @return The conditional on the  keys and a factor on the separator.
+   */
+  std::pair<std::shared_ptr<HybridConditional>, std::shared_ptr<Factor>>
+  eliminate(const Ordering& keys) const;
   /// @}
 
   /// Get the GaussianFactorGraph at a given discrete assignment.

--- a/gtsam/hybrid/tests/Switching.h
+++ b/gtsam/hybrid/tests/Switching.h
@@ -24,16 +24,15 @@
 #include <gtsam/hybrid/HybridNonlinearFactor.h>
 #include <gtsam/hybrid/HybridNonlinearFactorGraph.h>
 #include <gtsam/inference/Symbol.h>
+#include <gtsam/linear/GaussianFactor.h>
+#include <gtsam/linear/GaussianFactorGraph.h>
 #include <gtsam/linear/JacobianFactor.h>
 #include <gtsam/linear/NoiseModel.h>
+#include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/PriorFactor.h>
 #include <gtsam/slam/BetweenFactor.h>
 
 #include <vector>
-
-#include "gtsam/linear/GaussianFactor.h"
-#include "gtsam/linear/GaussianFactorGraph.h"
-#include "gtsam/nonlinear/NonlinearFactor.h"
 
 #pragma once
 

--- a/gtsam/hybrid/tests/TinyHybridExample.h
+++ b/gtsam/hybrid/tests/TinyHybridExample.h
@@ -41,12 +41,12 @@ inline HybridBayesNet createHybridBayesNet(size_t num_measurements = 1,
   HybridBayesNet bayesNet;
 
   // Create hybrid Gaussian factor z_i = x0 + noise for each measurement.
+  std::vector<std::pair<Vector, double>> measurementModels{{Z_1x1, 0.5},
+                                                           {Z_1x1, 3.0}};
   for (size_t i = 0; i < num_measurements; i++) {
     const auto mode_i = manyModes ? DiscreteKey{M(i), 2} : mode;
-    std::vector<GaussianConditional::shared_ptr> conditionals{
-        GaussianConditional::sharedMeanAndStddev(Z(i), I_1x1, X(0), Z_1x1, 0.5),
-        GaussianConditional::sharedMeanAndStddev(Z(i), I_1x1, X(0), Z_1x1, 3)};
-    bayesNet.emplace_shared<HybridGaussianConditional>(mode_i, conditionals);
+    bayesNet.emplace_shared<HybridGaussianConditional>(mode_i, Z(i), I_1x1,
+                                                       X(0), measurementModels);
   }
 
   // Create prior on X(0).

--- a/gtsam/hybrid/tests/testGaussianMixture.cpp
+++ b/gtsam/hybrid/tests/testGaussianMixture.cpp
@@ -80,8 +80,9 @@ TEST(GaussianMixture, GaussianMixtureModel) {
   double sigma = 2.0;
 
   HybridBayesNet hbn;
-  std::vector<Vector> means{Vector1(mu0), Vector1(mu1)};
-  hbn.emplace_shared<HybridGaussianConditional>(Z(0), m, means, sigma);
+  std::vector<std::pair<Vector, double>> parameters{{Vector1(mu0), sigma},
+                                                    {Vector1(mu1), sigma}};
+  hbn.emplace_shared<HybridGaussianConditional>(Z(0), m, parameters);
   hbn.push_back(mixing);
 
   // At the halfway point between the means, we should get P(m|z)=0.5

--- a/gtsam/hybrid/tests/testGaussianMixture.cpp
+++ b/gtsam/hybrid/tests/testGaussianMixture.cpp
@@ -79,15 +79,16 @@ TEST(GaussianMixture, GaussianMixtureModel) {
   double mu0 = 1.0, mu1 = 3.0;
   double sigma = 2.0;
 
-  HybridBayesNet hbn;
+  // Create a Gaussian mixture model p(z|m) with same sigma.
+  HybridBayesNet gmm;
   std::vector<std::pair<Vector, double>> parameters{{Vector1(mu0), sigma},
                                                     {Vector1(mu1), sigma}};
-  hbn.emplace_shared<HybridGaussianConditional>(m, Z(0), parameters);
-  hbn.push_back(mixing);
+  gmm.emplace_shared<HybridGaussianConditional>(m, Z(0), parameters);
+  gmm.push_back(mixing);
 
   // At the halfway point between the means, we should get P(m|z)=0.5
   double midway = mu1 - mu0;
-  auto pMid = SolveHBN(hbn, midway);
+  auto pMid = SolveHBN(gmm, midway);
   EXPECT(assert_equal(DiscreteConditional(m, "60/40"), pMid));
 
   // Everywhere else, the result should be a sigmoid.
@@ -96,7 +97,7 @@ TEST(GaussianMixture, GaussianMixtureModel) {
     const double expected = prob_m_z(mu0, mu1, sigma, sigma, z);
 
     // Workflow 1: convert HBN to HFG and solve
-    auto posterior1 = SolveHBN(hbn, z);
+    auto posterior1 = SolveHBN(gmm, z);
     EXPECT_DOUBLES_EQUAL(expected, posterior1(m1Assignment), 1e-8);
 
     // Workflow 2: directly specify HFG and solve
@@ -117,16 +118,17 @@ TEST(GaussianMixture, GaussianMixtureModel2) {
   double mu0 = 1.0, mu1 = 3.0;
   double sigma0 = 8.0, sigma1 = 4.0;
 
-  HybridBayesNet hbn;
+  // Create a Gaussian mixture model p(z|m) with same sigma.
+  HybridBayesNet gmm;
   std::vector<std::pair<Vector, double>> parameters{{Vector1(mu0), sigma0},
                                                     {Vector1(mu1), sigma1}};
-  hbn.emplace_shared<HybridGaussianConditional>(m, Z(0), parameters);
-  hbn.push_back(mixing);
+  gmm.emplace_shared<HybridGaussianConditional>(m, Z(0), parameters);
+  gmm.push_back(mixing);
 
   // We get zMax=3.1333 by finding the maximum value of the function, at which
   // point the mode m==1 is about twice as probable as m==0.
   double zMax = 3.133;
-  auto pMax = SolveHBN(hbn, zMax);
+  auto pMax = SolveHBN(gmm, zMax);
   EXPECT(assert_equal(DiscreteConditional(m, "42/58"), pMax, 1e-4));
 
   // Everywhere else, the result should be a bell curve like function.
@@ -135,7 +137,7 @@ TEST(GaussianMixture, GaussianMixtureModel2) {
     const double expected = prob_m_z(mu0, mu1, sigma0, sigma1, z);
 
     // Workflow 1: convert HBN to HFG and solve
-    auto posterior1 = SolveHBN(hbn, z);
+    auto posterior1 = SolveHBN(gmm, z);
     EXPECT_DOUBLES_EQUAL(expected, posterior1(m1Assignment), 1e-8);
 
     // Workflow 2: directly specify HFG and solve

--- a/gtsam/hybrid/tests/testGaussianMixture.cpp
+++ b/gtsam/hybrid/tests/testGaussianMixture.cpp
@@ -82,7 +82,7 @@ TEST(GaussianMixture, GaussianMixtureModel) {
   HybridBayesNet hbn;
   std::vector<std::pair<Vector, double>> parameters{{Vector1(mu0), sigma},
                                                     {Vector1(mu1), sigma}};
-  hbn.emplace_shared<HybridGaussianConditional>(Z(0), m, parameters);
+  hbn.emplace_shared<HybridGaussianConditional>(m, Z(0), parameters);
   hbn.push_back(mixing);
 
   // At the halfway point between the means, we should get P(m|z)=0.5
@@ -120,7 +120,7 @@ TEST(GaussianMixture, GaussianMixtureModel2) {
   HybridBayesNet hbn;
   std::vector<std::pair<Vector, double>> parameters{{Vector1(mu0), sigma0},
                                                     {Vector1(mu1), sigma1}};
-  hbn.emplace_shared<HybridGaussianConditional>(Z(0), m, parameters);
+  hbn.emplace_shared<HybridGaussianConditional>(m, Z(0), parameters);
   hbn.push_back(mixing);
 
   // We get zMax=3.1333 by finding the maximum value of the function, at which

--- a/gtsam/hybrid/tests/testHybridBayesNet.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesNet.cpp
@@ -20,11 +20,11 @@
 
 #include <gtsam/hybrid/HybridBayesNet.h>
 #include <gtsam/hybrid/HybridBayesTree.h>
+#include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 
 #include "Switching.h"
 #include "TinyHybridExample.h"
-#include "gtsam/nonlinear/NonlinearFactor.h"
 
 // Include for test suite
 #include <CppUnitLite/TestHarness.h>

--- a/gtsam/hybrid/tests/testHybridBayesNet.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesNet.cpp
@@ -20,6 +20,7 @@
 
 #include <gtsam/hybrid/HybridBayesNet.h>
 #include <gtsam/hybrid/HybridBayesTree.h>
+#include <gtsam/hybrid/HybridConditional.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 
@@ -32,7 +33,6 @@
 using namespace std;
 using namespace gtsam;
 
-using noiseModel::Isotropic;
 using symbol_shorthand::M;
 using symbol_shorthand::X;
 using symbol_shorthand::Z;
@@ -92,37 +92,49 @@ TEST(HybridBayesNet, Tiny) {
 }
 
 /* ****************************************************************************/
+// Hybrid Bayes net P(X0|X1) P(X1|Asia) P(Asia).
+namespace different_sigmas {
+const auto gc = GaussianConditional::sharedMeanAndStddev(X(0), 2 * I_1x1, X(1),
+                                                         Vector1(-4.0), 5.0);
+
+const std::vector<std::pair<Vector, double>> parms{{Vector1(5), 2.0},
+                                                   {Vector1(2), 3.0}};
+const auto hgc = std::make_shared<HybridGaussianConditional>(X(1), Asia, parms);
+
+const auto prior = std::make_shared<DiscreteConditional>(Asia, "99/1");
+auto wrap = [](const auto& c) {
+  return std::make_shared<HybridConditional>(c);
+};
+const HybridBayesNet bayesNet{wrap(gc), wrap(hgc), wrap(prior)};
+
+// Create values at which to evaluate.
+HybridValues values{{{X(0), Vector1(-6)}, {X(1), Vector1(1)}}, {{asiaKey, 0}}};
+}  // namespace different_sigmas
+
+/* ****************************************************************************/
 // Test evaluate for a hybrid Bayes net P(X0|X1) P(X1|Asia) P(Asia).
 TEST(HybridBayesNet, evaluateHybrid) {
-  const auto continuousConditional = GaussianConditional::sharedMeanAndStddev(
-      X(0), 2 * I_1x1, X(1), Vector1(-4.0), 5.0);
+  using namespace different_sigmas;
 
-  const SharedDiagonal model0 = noiseModel::Diagonal::Sigmas(Vector1(2.0)),
-                       model1 = noiseModel::Diagonal::Sigmas(Vector1(3.0));
-
-  const auto conditional0 = std::make_shared<GaussianConditional>(
-                 X(1), Vector1::Constant(5), I_1x1, model0),
-             conditional1 = std::make_shared<GaussianConditional>(
-                 X(1), Vector1::Constant(2), I_1x1, model1);
-
-  // Create hybrid Bayes net.
-  HybridBayesNet bayesNet;
-  bayesNet.push_back(continuousConditional);
-  bayesNet.emplace_shared<HybridGaussianConditional>(
-      Asia, std::vector{conditional0, conditional1});
-  bayesNet.emplace_shared<DiscreteConditional>(Asia, "99/1");
-
-  // Create values at which to evaluate.
-  HybridValues values;
-  values.insert(asiaKey, 0);
-  values.insert(X(0), Vector1(-6));
-  values.insert(X(1), Vector1(1));
-
-  const double conditionalProbability =
-      continuousConditional->evaluate(values.continuous());
-  const double mixtureProbability = conditional0->evaluate(values.continuous());
+  const double conditionalProbability = gc->evaluate(values.continuous());
+  const double mixtureProbability = hgc->evaluate(values);
   EXPECT_DOUBLES_EQUAL(conditionalProbability * mixtureProbability * 0.99,
                        bayesNet.evaluate(values), 1e-9);
+}
+
+/* ****************************************************************************/
+// Test error for a hybrid Bayes net P(X0|X1) P(X1|Asia) P(Asia).
+TEST(HybridBayesNet, Error) {
+  using namespace different_sigmas;
+
+  AlgebraicDecisionTree<Key> actual = bayesNet.errorTree(values.continuous());
+
+  // Regression.
+  // Manually added all the error values from the 3 conditional types.
+  AlgebraicDecisionTree<Key> expected(
+      {Asia}, std::vector<double>{2.33005033585, 5.38619084965});
+
+  EXPECT(assert_equal(expected, actual));
 }
 
 /* ****************************************************************************/
@@ -152,45 +164,6 @@ TEST(HybridBayesNet, Choose) {
                       *gbn.at(2)));
   EXPECT(assert_equal(*(*hybridBayesNet->at(3)->asHybrid())(assignment),
                       *gbn.at(3)));
-}
-
-/* ****************************************************************************/
-// Test error for a hybrid Bayes net P(X0|X1) P(X1|Asia) P(Asia).
-TEST(HybridBayesNet, Error) {
-  const auto continuousConditional = GaussianConditional::sharedMeanAndStddev(
-      X(0), 2 * I_1x1, X(1), Vector1(-4.0), 5.0);
-
-  const SharedDiagonal model0 = noiseModel::Diagonal::Sigmas(Vector1(2.0)),
-                       model1 = noiseModel::Diagonal::Sigmas(Vector1(3.0));
-
-  const auto conditional0 = std::make_shared<GaussianConditional>(
-                 X(1), Vector1::Constant(5), I_1x1, model0),
-             conditional1 = std::make_shared<GaussianConditional>(
-                 X(1), Vector1::Constant(2), I_1x1, model1);
-
-  auto gm = std::make_shared<HybridGaussianConditional>(
-      Asia, std::vector{conditional0, conditional1});
-  // Create hybrid Bayes net.
-  HybridBayesNet bayesNet;
-  bayesNet.push_back(continuousConditional);
-  bayesNet.push_back(gm);
-  bayesNet.emplace_shared<DiscreteConditional>(Asia, "99/1");
-
-  // Create values at which to evaluate.
-  HybridValues values;
-  values.insert(asiaKey, 0);
-  values.insert(X(0), Vector1(-6));
-  values.insert(X(1), Vector1(1));
-
-  AlgebraicDecisionTree<Key> actual_errors =
-      bayesNet.errorTree(values.continuous());
-
-  // Regression.
-  // Manually added all the error values from the 3 conditional types.
-  AlgebraicDecisionTree<Key> expected_errors(
-      {Asia}, std::vector<double>{2.33005033585, 5.38619084965});
-
-  EXPECT(assert_equal(expected_errors, actual_errors));
 }
 
 /* ****************************************************************************/

--- a/gtsam/hybrid/tests/testHybridBayesNet.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesNet.cpp
@@ -21,7 +21,6 @@
 #include <gtsam/hybrid/HybridBayesNet.h>
 #include <gtsam/hybrid/HybridBayesTree.h>
 #include <gtsam/hybrid/HybridConditional.h>
-#include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 
 #include "Switching.h"

--- a/gtsam/hybrid/tests/testHybridBayesNet.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesNet.cpp
@@ -99,7 +99,7 @@ const auto gc = GaussianConditional::sharedMeanAndStddev(X(0), 2 * I_1x1, X(1),
 
 const std::vector<std::pair<Vector, double>> parms{{Vector1(5), 2.0},
                                                    {Vector1(2), 3.0}};
-const auto hgc = std::make_shared<HybridGaussianConditional>(X(1), Asia, parms);
+const auto hgc = std::make_shared<HybridGaussianConditional>(Asia, X(1), parms);
 
 const auto prior = std::make_shared<DiscreteConditional>(Asia, "99/1");
 auto wrap = [](const auto& c) {

--- a/gtsam/hybrid/tests/testHybridBayesNet.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesNet.cpp
@@ -444,6 +444,57 @@ TEST(HybridBayesNet, Sampling) {
   // num_samples)));
 }
 
+/* ****************************************************************************/
+// Test hybrid gaussian factor graph errorTree when
+// there is a HybridConditional in the graph
+TEST(HybridBayesNet, ErrorTreeWithConditional) {
+  using symbol_shorthand::F;
+
+  Key z0 = Z(0), f01 = F(0);
+  Key x0 = X(0), x1 = X(1);
+
+  HybridBayesNet hbn;
+
+  auto prior_model = noiseModel::Isotropic::Sigma(1, 1e-1);
+  auto measurement_model = noiseModel::Isotropic::Sigma(1, 2.0);
+
+  // Set a prior P(x0) at x0=0
+  hbn.emplace_shared<GaussianConditional>(x0, Vector1(0.0), I_1x1, prior_model);
+
+  // Add measurement P(z0 | x0)
+  hbn.emplace_shared<GaussianConditional>(z0, Vector1(0.0), -I_1x1, x0, I_1x1,
+                                          measurement_model);
+
+  // Add hybrid motion model
+  double mu = 0.0;
+  double sigma0 = 1e2, sigma1 = 1e-2;
+  auto model0 = noiseModel::Isotropic::Sigma(1, sigma0);
+  auto model1 = noiseModel::Isotropic::Sigma(1, sigma1);
+  auto c0 = make_shared<GaussianConditional>(f01, Vector1(mu), I_1x1, x1, I_1x1,
+                                             x0, -I_1x1, model0),
+       c1 = make_shared<GaussianConditional>(f01, Vector1(mu), I_1x1, x1, I_1x1,
+                                             x0, -I_1x1, model1);
+  DiscreteKey m1(M(2), 2);
+  hbn.emplace_shared<HybridGaussianConditional>(m1, std::vector{c0, c1});
+
+  // Discrete uniform prior.
+  hbn.emplace_shared<DiscreteConditional>(m1, "0.5/0.5");
+
+  VectorValues given;
+  given.insert(z0, Vector1(0.0));
+  given.insert(f01, Vector1(0.0));
+  auto gfg = hbn.toFactorGraph(given);
+
+  VectorValues vv;
+  vv.insert(x0, Vector1(1.0));
+  vv.insert(x1, Vector1(2.0));
+  AlgebraicDecisionTree<Key> errorTree = gfg.errorTree(vv);
+
+  // regression
+  AlgebraicDecisionTree<Key> expected(m1, 59.335390372, 5050.125);
+  EXPECT(assert_equal(expected, errorTree, 1e-9));
+}
+
 /* ************************************************************************* */
 int main() {
   TestResult tr;

--- a/gtsam/hybrid/tests/testHybridEstimation.cpp
+++ b/gtsam/hybrid/tests/testHybridEstimation.cpp
@@ -30,7 +30,6 @@
 #include <gtsam/linear/GaussianFactorGraph.h>
 #include <gtsam/linear/JacobianFactor.h>
 #include <gtsam/linear/NoiseModel.h>
-#include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/PriorFactor.h>
 #include <gtsam/slam/BetweenFactor.h>

--- a/gtsam/hybrid/tests/testHybridEstimation.cpp
+++ b/gtsam/hybrid/tests/testHybridEstimation.cpp
@@ -19,6 +19,7 @@
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/hybrid/HybridBayesNet.h>
+#include <gtsam/hybrid/HybridGaussianFactor.h>
 #include <gtsam/hybrid/HybridNonlinearFactor.h>
 #include <gtsam/hybrid/HybridNonlinearFactorGraph.h>
 #include <gtsam/hybrid/HybridNonlinearISAM.h>
@@ -29,6 +30,7 @@
 #include <gtsam/linear/GaussianFactorGraph.h>
 #include <gtsam/linear/JacobianFactor.h>
 #include <gtsam/linear/NoiseModel.h>
+#include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/PriorFactor.h>
 #include <gtsam/slam/BetweenFactor.h>
@@ -39,7 +41,6 @@
 #include <bitset>
 
 #include "Switching.h"
-#include "gtsam/nonlinear/NonlinearFactor.h"
 
 using namespace std;
 using namespace gtsam;

--- a/gtsam/hybrid/tests/testHybridEstimation.cpp
+++ b/gtsam/hybrid/tests/testHybridEstimation.cpp
@@ -573,12 +573,10 @@ TEST(HybridEstimation, ModeSelection) {
   bn.push_back(
       GaussianConditional::sharedMeanAndStddev(Z(0), -I_1x1, X(1), Z_1x1, 0.1));
 
-  std::vector<GaussianConditional::shared_ptr> conditionals{
-      GaussianConditional::sharedMeanAndStddev(Z(0), I_1x1, X(0), -I_1x1, X(1),
-                                               Z_1x1, noise_loose),
-      GaussianConditional::sharedMeanAndStddev(Z(0), I_1x1, X(0), -I_1x1, X(1),
-                                               Z_1x1, noise_tight)};
-  bn.emplace_shared<HybridGaussianConditional>(mode, conditionals);
+  std::vector<std::pair<Vector, double>> parameters{{Z_1x1, noise_loose},
+                                                    {Z_1x1, noise_tight}};
+  bn.emplace_shared<HybridGaussianConditional>(mode, Z(0), I_1x1, X(0), -I_1x1,
+                                               X(1), parameters);
 
   VectorValues vv;
   vv.insert(Z(0), Z_1x1);
@@ -605,12 +603,10 @@ TEST(HybridEstimation, ModeSelection2) {
   bn.push_back(
       GaussianConditional::sharedMeanAndStddev(Z(0), -I_3x3, X(1), Z_3x1, 0.1));
 
-  std::vector<GaussianConditional::shared_ptr> conditionals{
-      GaussianConditional::sharedMeanAndStddev(Z(0), I_3x3, X(0), -I_3x3, X(1),
-                                               Z_3x1, noise_loose),
-      GaussianConditional::sharedMeanAndStddev(Z(0), I_3x3, X(0), -I_3x3, X(1),
-                                               Z_3x1, noise_tight)};
-  bn.emplace_shared<HybridGaussianConditional>(mode, conditionals);
+  std::vector<std::pair<Vector, double>> parameters{{Z_3x1, noise_loose},
+                                                    {Z_3x1, noise_tight}};
+  bn.emplace_shared<HybridGaussianConditional>(mode, Z(0), I_3x3, X(0), -I_3x3,
+                                               X(1), parameters);
 
   VectorValues vv;
   vv.insert(Z(0), Z_3x1);

--- a/gtsam/hybrid/tests/testHybridGaussianISAM.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianISAM.cpp
@@ -24,13 +24,13 @@
 #include <gtsam/hybrid/HybridGaussianISAM.h>
 #include <gtsam/linear/GaussianBayesNet.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/PriorFactor.h>
 #include <gtsam/sam/BearingRangeFactor.h>
 
 #include <numeric>
 
 #include "Switching.h"
-#include "gtsam/nonlinear/NonlinearFactor.h"
 
 // Include for test suite
 #include <CppUnitLite/TestHarness.h>

--- a/gtsam/hybrid/tests/testHybridGaussianISAM.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianISAM.cpp
@@ -24,7 +24,6 @@
 #include <gtsam/hybrid/HybridGaussianISAM.h>
 #include <gtsam/linear/GaussianBayesNet.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
-#include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/PriorFactor.h>
 #include <gtsam/sam/BearingRangeFactor.h>
 

--- a/gtsam/hybrid/tests/testHybridMotionModel.cpp
+++ b/gtsam/hybrid/tests/testHybridMotionModel.cpp
@@ -55,13 +55,10 @@ void addMeasurement(HybridBayesNet &hbn, Key z_key, Key x_key, double sigma) {
 /// Create hybrid motion model p(x1 | x0, m1)
 static HybridGaussianConditional::shared_ptr CreateHybridMotionModel(
     double mu0, double mu1, double sigma0, double sigma1) {
-  auto model0 = noiseModel::Isotropic::Sigma(1, sigma0);
-  auto model1 = noiseModel::Isotropic::Sigma(1, sigma1);
-  auto c0 = make_shared<GaussianConditional>(X(1), Vector1(mu0), I_1x1, X(0),
-                                             -I_1x1, model0),
-       c1 = make_shared<GaussianConditional>(X(1), Vector1(mu1), I_1x1, X(0),
-                                             -I_1x1, model1);
-  return std::make_shared<HybridGaussianConditional>(m1, std::vector{c0, c1});
+  std::vector<std::pair<Vector, double>> motionModels{{Vector1(mu0), sigma0},
+                                                      {Vector1(mu1), sigma1}};
+  return std::make_shared<HybridGaussianConditional>(m1, X(1), I_1x1, X(0),
+                                                     motionModels);
 }
 
 /// Create two state Bayes network with 1 or two measurement models

--- a/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
@@ -28,15 +28,13 @@
 #include <gtsam/linear/GaussianBayesNet.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
 #include <gtsam/linear/NoiseModel.h>
+#include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/PriorFactor.h>
 #include <gtsam/sam/BearingRangeFactor.h>
 #include <gtsam/slam/BetweenFactor.h>
 
-#include <numeric>
-
 #include "Switching.h"
-#include "gtsam/nonlinear/NonlinearFactor.h"
 
 // Include for test suite
 #include <CppUnitLite/TestHarness.h>

--- a/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
@@ -28,7 +28,6 @@
 #include <gtsam/linear/GaussianBayesNet.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
 #include <gtsam/linear/NoiseModel.h>
-#include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/PriorFactor.h>
 #include <gtsam/sam/BearingRangeFactor.h>

--- a/gtsam/hybrid/tests/testHybridNonlinearISAM.cpp
+++ b/gtsam/hybrid/tests/testHybridNonlinearISAM.cpp
@@ -24,13 +24,13 @@
 #include <gtsam/hybrid/HybridNonlinearISAM.h>
 #include <gtsam/linear/GaussianBayesNet.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/PriorFactor.h>
 #include <gtsam/sam/BearingRangeFactor.h>
 
 #include <numeric>
 
 #include "Switching.h"
-#include "gtsam/nonlinear/NonlinearFactor.h"
 
 // Include for test suite
 #include <CppUnitLite/TestHarness.h>

--- a/gtsam/hybrid/tests/testHybridNonlinearISAM.cpp
+++ b/gtsam/hybrid/tests/testHybridNonlinearISAM.cpp
@@ -24,7 +24,6 @@
 #include <gtsam/hybrid/HybridNonlinearISAM.h>
 #include <gtsam/linear/GaussianBayesNet.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
-#include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/PriorFactor.h>
 #include <gtsam/sam/BearingRangeFactor.h>
 


### PR DESCRIPTION
- added eliminate as method of HGFG to test in isolation
- moved HBN test to right place
- added three "bougie" constructors that considerably simplify tests and later examples:
```c++
/// Construct from mean `mu_i` and `sigma_i`.
  HybridGaussianConditional(
      const DiscreteKey mode, Key key,  //
      const std::vector<std::pair<Vector, double>> &parameters);

  /// Construct from conditional mean `A1 p1 + b_i` and `sigma_i`.
  HybridGaussianConditional(
      const DiscreteKey mode, Key key,  //
      const Matrix &A, Key parent,
      const std::vector<std::pair<Vector, double>> &parameters);

  /// Construct from conditional mean `A1 p1 + A2 p2 + b_i` and `sigma_i`.
  HybridGaussianConditional(
      const DiscreteKey mode, Key key,  //
      const Matrix &A1, Key parent1, const Matrix &A2, Key parent2,
      const std::vector<std::pair<Vector, double>> &parameters);
 ```