### PR TITLE
Fix hybrid bug, double performance

### DIFF
--- a/gtsam/discrete/AlgebraicDecisionTree.h
+++ b/gtsam/discrete/AlgebraicDecisionTree.h
@@ -70,6 +70,7 @@ namespace gtsam {
         return a / b;
       }
       static inline double id(const double& x) { return x; }
+      static inline double negate(const double& x) { return -x; }
     };
 
     AlgebraicDecisionTree(double leaf = 1.0) : Base(leaf) {}
@@ -184,6 +185,16 @@ namespace gtsam {
     /** sum */
     AlgebraicDecisionTree operator+(const AlgebraicDecisionTree& g) const {
       return this->apply(g, &Ring::add);
+    }
+
+    /** negation */
+    AlgebraicDecisionTree operator-() const {
+      return this->apply(&Ring::negate);
+    }
+
+    /** subtract */
+    AlgebraicDecisionTree operator-(const AlgebraicDecisionTree& g) const {
+      return *this + (-g);
     }
 
     /** product */

--- a/gtsam/discrete/DecisionTreeFactor.h
+++ b/gtsam/discrete/DecisionTreeFactor.h
@@ -131,7 +131,7 @@ namespace gtsam {
 
     /// Calculate probability for given values `x`, 
     /// is just look up in AlgebraicDecisionTree.
-    double evaluate(const DiscreteValues& values) const  {
+    double evaluate(const Assignment<Key>& values) const  {
       return ADT::operator()(values);
     }
 
@@ -155,7 +155,7 @@ namespace gtsam {
       return apply(f, safe_div);
     }
 
-    /// Convert into a decisiontree
+    /// Convert into a decision tree
     DecisionTreeFactor toDecisionTreeFactor() const override { return *this; }
 
     /// Create new factor by summing all values with the same separator values

--- a/gtsam/discrete/tests/testAlgebraicDecisionTree.cpp
+++ b/gtsam/discrete/tests/testAlgebraicDecisionTree.cpp
@@ -10,10 +10,10 @@
  * -------------------------------------------------------------------------- */
 
 /*
- * @file    testDecisionTree.cpp
- * @brief    Develop DecisionTree
- * @author  Frank Dellaert
- * @date  Mar 6, 2011
+ * @file   testAlgebraicDecisionTree.cpp
+ * @brief  Unit tests for Algebraic decision tree
+ * @author Frank Dellaert
+ * @date   Mar 6, 2011
  */
 
 #include <gtsam/base/Testable.h>
@@ -46,23 +46,35 @@ void dot(const T& f, const string& filename) {
 #endif
 }
 
-/** I can't get this to work !
- class Mul: std::function<double(const double&, const double&)> {
- inline double operator()(const double& a, const double& b) {
- return a * b;
- }
- };
+/* ************************************************************************** */
+// Test arithmetic:
+TEST(ADT, arithmetic) {
+  DiscreteKey A(0, 2), B(1, 2);
+  ADT zero{0}, one{1};
+  ADT a(A, 1, 2);
+  ADT b(B, 3, 4);
 
- // If second argument of binary op is Leaf
- template<typename L>
- typename DecisionTree<L, double>::Node::Ptr DecisionTree<L,
- double>::Choice::apply_fC_op_gL( Cache& cache, const Leaf& gL, Mul op) const {
- Ptr h(new Choice(label(), cardinality()));
- for(const NodePtr& branch: branches_)
- h->push_back(branch->apply_f_op_g(cache, gL, op));
- return Unique(cache, h);
- }
- */
+  // Addition
+  CHECK(assert_equal(a, zero + a));
+
+  // Negate and subtraction
+  CHECK(assert_equal(-a, zero - a));
+  CHECK(assert_equal({zero}, a - a));
+  CHECK(assert_equal(a + b, b + a));
+  CHECK(assert_equal({A, 3, 4}, a + 2));
+  CHECK(assert_equal({B, 1, 2}, b - 2));
+
+  // Multiplication
+  CHECK(assert_equal(zero, zero * a));
+  CHECK(assert_equal(zero, a * zero));
+  CHECK(assert_equal(a, one * a));
+  CHECK(assert_equal(a, a * one));
+  CHECK(assert_equal(a * b, b * a));
+
+  // division
+  // CHECK(assert_equal(a, (a * b) / b)); // not true because no pruning
+  CHECK(assert_equal(b, (a * b) / a));
+}
 
 /* ************************************************************************** */
 // instrumented operators

--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -195,40 +195,6 @@ HybridValues HybridBayesNet::sample() const {
 }
 
 /* ************************************************************************* */
-AlgebraicDecisionTree<Key> HybridBayesNet::errorTree(
-    const VectorValues &continuousValues) const {
-  AlgebraicDecisionTree<Key> result(0.0);
-
-  // Iterate over each conditional.
-  for (auto &&conditional : *this) {
-    if (auto gm = conditional->asHybrid()) {
-      // If conditional is hybrid, compute error for all assignments.
-      result = result + gm->errorTree(continuousValues);
-
-    } else if (auto gc = conditional->asGaussian()) {
-      // If continuous, get the error and add it to the result
-      double error = gc->error(continuousValues);
-      // Add the computed error to every leaf of the result tree.
-      result = result.apply(
-          [error](double leaf_value) { return leaf_value + error; });
-
-    } else if (auto dc = conditional->asDiscrete()) {
-      // If discrete, add the discrete error in the right branch
-      if (result.nrLeaves() == 1) {
-        result = dc->errorTree();
-      } else {
-        result = result.apply(
-            [dc](const Assignment<Key> &assignment, double leaf_value) {
-              return leaf_value + dc->error(DiscreteValues(assignment));
-            });
-      }
-    }
-  }
-
-  return result;
-}
-
-/* ************************************************************************* */
 AlgebraicDecisionTree<Key> HybridBayesNet::logDiscretePosteriorPrime(
     const VectorValues &continuousValues) const {
   AlgebraicDecisionTree<Key> result(0.0);

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -211,16 +211,6 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
   HybridBayesNet prune(size_t maxNrLeaves) const;
 
   /**
-   * @brief Compute conditional error for each discrete assignment,
-   * and return as a tree.
-   *
-   * @param continuousValues Continuous values at which to compute the error.
-   * @return AlgebraicDecisionTree<Key>
-   */
-  AlgebraicDecisionTree<Key> errorTree(
-      const VectorValues &continuousValues) const;
-
-  /**
    * @brief Error method using HybridValues which returns specific error for
    * assignment.
    */

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <gtsam/discrete/DecisionTreeFactor.h>
+#include <gtsam/discrete/DiscreteBayesNet.h>
 #include <gtsam/global_includes.h>
 #include <gtsam/hybrid/HybridConditional.h>
 #include <gtsam/hybrid/HybridValues.h>
@@ -77,16 +78,11 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
   }
 
   /**
-   * Add a conditional using a shared_ptr, using implicit conversion to
-   * a HybridConditional.
-   *
-   * This is useful when you create a conditional shared pointer as you need it
-   * somewhere else.
-   *
+   * Move a HybridConditional into a shared pointer and add.
+
    * Example:
-   *   auto shared_ptr_to_a_conditional =
-   *     std::make_shared<HybridGaussianConditional>(...);
-   *  hbn.push_back(shared_ptr_to_a_conditional);
+   *   HybridGaussianConditional conditional(...);
+   *   hbn.push_back(conditional); // loses the original conditional
    */
   void push_back(HybridConditional &&conditional) {
     factors_.push_back(
@@ -124,14 +120,21 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
   }
 
   /**
-   * @brief Get the Gaussian Bayes Net which corresponds to a specific discrete
-   * value assignment. Note this corresponds to the Gaussian posterior p(X|M=m)
-   * of the continuous variables given the discrete assignment M=m.
+   * @brief Get the discrete Bayes Net P(M). As the hybrid Bayes net defines
+   * P(X,M) = P(X|M) P(M), this method returns the marginal distribution on the
+   * discrete variables.
    *
-   * @note Be careful, as any factors not Gaussian are ignored.
+   * @return discrete marginal as a DiscreteBayesNet.
+   */
+  DiscreteBayesNet discreteMarginal() const;
+
+  /**
+   * @brief Get the Gaussian Bayes net P(X|M=m) corresponding to a specific
+   * assignment m for the discrete variables M. As the hybrid Bayes net defines
+   * P(X,M) = P(X|M) P(M), this method returns the **posterior** p(X|M=m).
    *
    * @param assignment The discrete value assignment for the discrete keys.
-   * @return Gaussian posterior as a GaussianBayesNet
+   * @return Gaussian posterior P(X|M=m) as a GaussianBayesNet.
    */
   GaussianBayesNet choose(const DiscreteValues &assignment) const;
 
@@ -222,7 +225,7 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
    *
    * @note The joint P(X,M) is p(X|M) P(M)
    * Then the posterior on M given X=x is is P(M|x) = p(x|M) P(M) / p(x).
-   * Ideally we want log P(M|x) = log p(x|M) + log P(M) - log P(x), but
+   * Ideally we want log P(M|x) = log p(x|M) + log P(M) - log p(x), but
    * unfortunately log p(x) is expensive, so we compute the log of the
    * unnormalized posterior log P'(M|x) = log p(x|M) + log P(M)
    *
@@ -255,13 +258,6 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
   /// @}
 
  private:
-  /**
-   * @brief Prune all the discrete conditionals.
-   *
-   * @param maxNrLeaves
-   */
-  DecisionTreeFactor pruneDiscreteConditionals(size_t maxNrLeaves);
-
 #ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -201,8 +201,13 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
    */
   HybridValues sample() const;
 
-  /// Prune the Hybrid Bayes Net such that we have at most maxNrLeaves leaves.
-  HybridBayesNet prune(size_t maxNrLeaves);
+  /**
+   * @brief Prune the Bayes Net such that we have at most maxNrLeaves leaves.
+   *
+   * @param maxNrLeaves Continuous values at which to compute the error.
+   * @return A pruned HybridBayesNet
+   */
+  HybridBayesNet prune(size_t maxNrLeaves) const;
 
   /**
    * @brief Compute conditional error for each discrete assignment,

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -128,7 +128,7 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
    * value assignment. Note this corresponds to the Gaussian posterior p(X|M=m)
    * of the continuous variables given the discrete assignment M=m.
    *
-   * @note Any pure discrete factors are ignored.
+   * @note Be careful, as any factors not Gaussian are ignored.
    *
    * @param assignment The discrete value assignment for the discrete keys.
    * @return Gaussian posterior as a GaussianBayesNet

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -217,8 +217,8 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
   using Base::error;
 
   /**
-   * @brief Compute the log posterior log P'(M|x) of all assignments up to a
-   * constant, returning the result as an algebraic decision tree.
+   * @brief Compute the negative log posterior log P'(M|x) of all assignments up
+   * to a constant, returning the result as an algebraic decision tree.
    *
    * @note The joint P(X,M) is p(X|M) P(M)
    * Then the posterior on M given X=x is is P(M|x) = p(x|M) P(M) / p(x).
@@ -229,7 +229,7 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
    * @param continuousValues Continuous values x at which to compute log P'(M|x)
    * @return AlgebraicDecisionTree<Key>
    */
-  AlgebraicDecisionTree<Key> logDiscretePosteriorPrime(
+  AlgebraicDecisionTree<Key> errorTree(
       const VectorValues &continuousValues) const;
 
   using BayesNet::logProbability;  // expose HybridValues version

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -125,12 +125,13 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
 
   /**
    * @brief Get the Gaussian Bayes Net which corresponds to a specific discrete
-   * value assignment.
+   * value assignment. Note this corresponds to the Gaussian posterior p(X|M=m)
+   * of the continuous variables given the discrete assignment M=m.
    *
    * @note Any pure discrete factors are ignored.
    *
    * @param assignment The discrete value assignment for the discrete keys.
-   * @return GaussianBayesNet
+   * @return Gaussian posterior as a GaussianBayesNet
    */
   GaussianBayesNet choose(const DiscreteValues &assignment) const;
 
@@ -226,29 +227,33 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
   using Base::error;
 
   /**
-   * @brief Compute log probability for each discrete assignment,
-   * and return as a tree.
+   * @brief Compute the log posterior log P'(M|x) of all assignments up to a
+   * constant, returning the result as an algebraic decision tree.
    *
-   * @param continuousValues Continuous values at which
-   * to compute the log probability.
+   * @note The joint P(X,M) is p(X|M) P(M)
+   * Then the posterior on M given X=x is is P(M|x) = p(x|M) P(M) / p(x).
+   * Ideally we want log P(M|x) = log p(x|M) + log P(M) - log P(x), but
+   * unfortunately log p(x) is expensive, so we compute the log of the
+   * unnormalized posterior log P'(M|x) = log p(x|M) + log P(M)
+   *
+   * @param continuousValues Continuous values x at which to compute log P'(M|x)
    * @return AlgebraicDecisionTree<Key>
    */
-  AlgebraicDecisionTree<Key> logProbability(
+  AlgebraicDecisionTree<Key> logDiscretePosteriorPrime(
       const VectorValues &continuousValues) const;
 
   using BayesNet::logProbability;  // expose HybridValues version
 
   /**
-   * @brief Compute unnormalized probability q(μ|M),
-   * for each discrete assignment, and return as a tree.
-   * q(μ|M) is the unnormalized probability at the MLE point μ,
-   * conditioned on the discrete variables.
+   * @brief Compute normalized posterior P(M|X=x) and return as a tree.
    *
-   * @param continuousValues Continuous values at which to compute the
-   * probability.
+   * @note Not a DiscreteConditional as the cardinalities of the DiscreteKeys,
+   * which we would need, are hard to recover.
+   *
+   * @param continuousValues Continuous values x to condition P(M|X=x) on.
    * @return AlgebraicDecisionTree<Key>
    */
-  AlgebraicDecisionTree<Key> evaluate(
+  AlgebraicDecisionTree<Key> discretePosterior(
       const VectorValues &continuousValues) const;
 
   /**

--- a/gtsam/hybrid/HybridBayesTree.cpp
+++ b/gtsam/hybrid/HybridBayesTree.cpp
@@ -26,6 +26,10 @@
 #include <gtsam/inference/BayesTreeCliqueBase-inst.h>
 #include <gtsam/linear/GaussianJunctionTree.h>
 
+#include <memory>
+
+#include "gtsam/hybrid/HybridConditional.h"
+
 namespace gtsam {
 
 // Instantiate base class
@@ -207,7 +211,9 @@ void HybridBayesTree::prune(const size_t maxNrLeaves) {
       if (conditional->isHybrid()) {
         auto hybridGaussianCond = conditional->asHybrid();
 
-        hybridGaussianCond->prune(parentData.prunedDiscreteProbs);
+        // Imperative
+        clique->conditional() = std::make_shared<HybridConditional>(
+            hybridGaussianCond->prune(parentData.prunedDiscreteProbs));
       }
       return parentData;
     }

--- a/gtsam/hybrid/HybridConditional.cpp
+++ b/gtsam/hybrid/HybridConditional.cpp
@@ -64,7 +64,6 @@ void HybridConditional::print(const std::string &s,
 
   if (inner_) {
     inner_->print("", formatter);
-
   } else {
     if (isContinuous()) std::cout << "Continuous ";
     if (isDiscrete()) std::cout << "Discrete ";
@@ -100,79 +99,68 @@ bool HybridConditional::equals(const HybridFactor &other, double tol) const {
   if (auto gm = asHybrid()) {
     auto other = e->asHybrid();
     return other != nullptr && gm->equals(*other, tol);
-  }
-  if (auto gc = asGaussian()) {
+  } else if (auto gc = asGaussian()) {
     auto other = e->asGaussian();
     return other != nullptr && gc->equals(*other, tol);
-  }
-  if (auto dc = asDiscrete()) {
+  } else if (auto dc = asDiscrete()) {
     auto other = e->asDiscrete();
     return other != nullptr && dc->equals(*other, tol);
-  }
-
-  return inner_ ? (e->inner_ ? inner_->equals(*(e->inner_), tol) : false)
-                : !(e->inner_);
+  } else
+    return inner_ ? (e->inner_ ? inner_->equals(*(e->inner_), tol) : false)
+                  : !(e->inner_);
 }
 
 /* ************************************************************************ */
 double HybridConditional::error(const HybridValues &values) const {
   if (auto gc = asGaussian()) {
     return gc->error(values.continuous());
-  }
-  if (auto gm = asHybrid()) {
+  } else if (auto gm = asHybrid()) {
     return gm->error(values);
-  }
-  if (auto dc = asDiscrete()) {
+  } else if (auto dc = asDiscrete()) {
     return dc->error(values.discrete());
-  }
-  throw std::runtime_error(
-      "HybridConditional::error: conditional type not handled");
+  } else
+    throw std::runtime_error(
+        "HybridConditional::error: conditional type not handled");
 }
 
 /* ************************************************************************ */
 AlgebraicDecisionTree<Key> HybridConditional::errorTree(
     const VectorValues &values) const {
   if (auto gc = asGaussian()) {
-    return AlgebraicDecisionTree<Key>(gc->error(values));
-  }
-  if (auto gm = asHybrid()) {
+    return {gc->error(values)};  // NOTE: a "constant" tree
+  } else if (auto gm = asHybrid()) {
     return gm->errorTree(values);
-  }
-  if (auto dc = asDiscrete()) {
-    return AlgebraicDecisionTree<Key>(0.0);
-  }
-  throw std::runtime_error(
-      "HybridConditional::error: conditional type not handled");
+  } else if (auto dc = asDiscrete()) {
+    return dc->errorTree();
+  } else
+    throw std::runtime_error(
+        "HybridConditional::error: conditional type not handled");
 }
 
 /* ************************************************************************ */
 double HybridConditional::logProbability(const HybridValues &values) const {
   if (auto gc = asGaussian()) {
     return gc->logProbability(values.continuous());
-  }
-  if (auto gm = asHybrid()) {
+  } else if (auto gm = asHybrid()) {
     return gm->logProbability(values);
-  }
-  if (auto dc = asDiscrete()) {
+  } else if (auto dc = asDiscrete()) {
     return dc->logProbability(values.discrete());
-  }
-  throw std::runtime_error(
-      "HybridConditional::logProbability: conditional type not handled");
+  } else
+    throw std::runtime_error(
+        "HybridConditional::logProbability: conditional type not handled");
 }
 
 /* ************************************************************************ */
 double HybridConditional::negLogConstant() const {
   if (auto gc = asGaussian()) {
     return gc->negLogConstant();
-  }
-  if (auto gm = asHybrid()) {
-    return gm->negLogConstant();  // 0.0!
-  }
-  if (auto dc = asDiscrete()) {
+  } else if (auto gm = asHybrid()) {
+    return gm->negLogConstant();
+  } else if (auto dc = asDiscrete()) {
     return dc->negLogConstant();  // 0.0!
-  }
-  throw std::runtime_error(
-      "HybridConditional::negLogConstant: conditional type not handled");
+  } else
+    throw std::runtime_error(
+        "HybridConditional::negLogConstant: conditional type not handled");
 }
 
 /* ************************************************************************ */

--- a/gtsam/hybrid/HybridGaussianConditional.cpp
+++ b/gtsam/hybrid/HybridGaussianConditional.cpp
@@ -338,24 +338,6 @@ HybridGaussianConditional::shared_ptr HybridGaussianConditional::prune(
 }
 
 /* *******************************************************************************/
-AlgebraicDecisionTree<Key> HybridGaussianConditional::logProbability(
-    const VectorValues &continuousValues) const {
-  // functor to calculate (double) logProbability value from
-  // GaussianConditional.
-  auto probFunc =
-      [continuousValues](const GaussianConditional::shared_ptr &conditional) {
-        if (conditional) {
-          return conditional->logProbability(continuousValues);
-        } else {
-          // Return arbitrarily small logProbability if conditional is null
-          // Conditional is null if it is pruned out.
-          return -1e20;
-        }
-      };
-  return DecisionTree<Key, double>(conditionals_, probFunc);
-}
-
-/* *******************************************************************************/
 double HybridGaussianConditional::logProbability(
     const HybridValues &values) const {
   auto conditional = conditionals_(values.discrete());

--- a/gtsam/hybrid/HybridGaussianConditional.h
+++ b/gtsam/hybrid/HybridGaussianConditional.h
@@ -195,16 +195,6 @@ class GTSAM_EXPORT HybridGaussianConditional
   const Conditionals &conditionals() const;
 
   /**
-   * @brief Compute logProbability of the HybridGaussianConditional as a tree.
-   *
-   * @param continuousValues The continuous VectorValues.
-   * @return AlgebraicDecisionTree<Key> A decision tree with the same keys
-   * as the conditionals, and leaf values as the logProbability.
-   */
-  AlgebraicDecisionTree<Key> logProbability(
-      const VectorValues &continuousValues) const;
-
-  /**
    * @brief Compute the logProbability of this hybrid Gaussian conditional.
    *
    * @param values Continuous values and discrete assignment.

--- a/gtsam/hybrid/HybridGaussianConditional.h
+++ b/gtsam/hybrid/HybridGaussianConditional.h
@@ -225,8 +225,10 @@ class GTSAM_EXPORT HybridGaussianConditional
    * `discreteProbs`.
    *
    * @param discreteProbs A pruned set of probabilities for the discrete keys.
+   * @return Shared pointer to possibly a pruned HybridGaussianConditional
    */
-  void prune(const DecisionTreeFactor &discreteProbs);
+  HybridGaussianConditional::shared_ptr prune(
+      const DecisionTreeFactor &discreteProbs) const;
 
   /// @}
 

--- a/gtsam/hybrid/HybridGaussianConditional.h
+++ b/gtsam/hybrid/HybridGaussianConditional.h
@@ -14,6 +14,7 @@
  * @brief  A hybrid conditional in the Conditional Linear Gaussian scheme
  * @author Fan Jiang
  * @author Varun Agrawal
+ * @author Frank Dellaert
  * @date   Mar 12, 2022
  */
 

--- a/gtsam/hybrid/HybridGaussianConditional.h
+++ b/gtsam/hybrid/HybridGaussianConditional.h
@@ -243,17 +243,6 @@ class GTSAM_EXPORT HybridGaussianConditional
   /// Convert to a DecisionTree of Gaussian factor graphs.
   GaussianFactorGraphTree asGaussianFactorGraphTree() const;
 
-  /**
-   * @brief Get the pruner function from discrete probabilities.
-   *
-   * @param discreteProbs The probabilities of only discrete keys.
-   * @return std::function<GaussianConditional::shared_ptr(
-   * const Assignment<Key> &, const GaussianConditional::shared_ptr &)>
-   */
-  std::function<GaussianConditional::shared_ptr(
-      const Assignment<Key> &, const GaussianConditional::shared_ptr &)>
-  prunerFunc(const DecisionTreeFactor &prunedProbabilities);
-
   /// Check whether `given` has values for all frontal keys.
   bool allFrontalsGiven(const VectorValues &given) const;
 

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -542,7 +542,7 @@ AlgebraicDecisionTree<Key> HybridGaussianFactorGraph::discretePosterior(
 }
 
 /* ************************************************************************ */
-GaussianFactorGraph HybridGaussianFactorGraph::operator()(
+GaussianFactorGraph HybridGaussianFactorGraph::choose(
     const DiscreteValues &assignment) const {
   GaussianFactorGraph gfg;
   for (auto &&f : *this) {

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -508,16 +508,16 @@ AlgebraicDecisionTree<Key> HybridGaussianFactorGraph::errorTree(
   AlgebraicDecisionTree<Key> result(0.0);
   // Iterate over each factor.
   for (auto &factor : factors_) {
-    if (auto f = std::dynamic_pointer_cast<HybridFactor>(factor)) {
-      // Check for HybridFactor, and call errorTree
-      result = result + f->errorTree(continuousValues);
-    } else if (auto f = std::dynamic_pointer_cast<DiscreteFactor>(factor)) {
-      // Skip discrete factors
-      continue;
+    if (auto hf = std::dynamic_pointer_cast<HybridFactor>(factor)) {
+      // Add errorTree for hybrid factors, includes HybridGaussianConditionals!
+      result = result + hf->errorTree(continuousValues);
+    } else if (auto df = std::dynamic_pointer_cast<DiscreteFactor>(factor)) {
+      // If discrete, just add its errorTree as well
+      result = result + df->errorTree();
     } else {
       // Everything else is a continuous only factor
       HybridValues hv(continuousValues, DiscreteValues());
-      result = result + AlgebraicDecisionTree<Key>(factor->error(hv));
+      result = result + factor->error(hv);  // NOTE: yes, you can add constants
     }
   }
   return result;

--- a/gtsam/hybrid/HybridGaussianFactorGraph.h
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <gtsam/discrete/DiscreteKey.h>
 #include <gtsam/hybrid/HybridFactor.h>
 #include <gtsam/hybrid/HybridFactorGraph.h>
 #include <gtsam/hybrid/HybridGaussianFactor.h>
@@ -188,23 +189,32 @@ class GTSAM_EXPORT HybridGaussianFactorGraph
       const VectorValues& continuousValues) const;
 
   /**
-   * @brief Compute unnormalized probability \f$ P(X | M, Z) \f$
-   * for each discrete assignment, and return as a tree.
-   *
-   * @param continuousValues Continuous values at which to compute the
-   * probability.
-   * @return AlgebraicDecisionTree<Key>
-   */
-  AlgebraicDecisionTree<Key> probPrime(
-      const VectorValues& continuousValues) const;
-
-  /**
    * @brief Compute the unnormalized posterior probability for a continuous
    * vector values given a specific assignment.
    *
    * @return double
    */
   double probPrime(const HybridValues& values) const;
+
+  /**
+   * @brief Compute unnormalized probability \f$ P(X | M, Z) \f$
+   * for each discrete assignment, and return as a tree.
+   *
+   * @param continuousValues Continuous values at which to compute probability.
+   * @return DecisionTreeFactor
+   */
+  DecisionTreeFactor probPrime(const VectorValues& continuousValues) const;
+
+  /**
+   * @brief Computer posterior P(M|X=x) when all continuous values X are given.
+   * This is very efficient as this simply probPrime normalized into a
+   * conditional.
+   *
+   * @param continuousValues Continuous values x to condition on.
+   * @return DecisionTreeFactor
+   */
+  DiscreteConditional discretePosterior(
+      const VectorValues& continuousValues) const;
 
   /**
    * @brief Create a decision tree of factor graphs out of this hybrid factor

--- a/gtsam/hybrid/HybridGaussianFactorGraph.h
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.h
@@ -230,8 +230,23 @@ class GTSAM_EXPORT HybridGaussianFactorGraph
   eliminate(const Ordering& keys) const;
   /// @}
 
-  /// Get the GaussianFactorGraph at a given discrete assignment.
-  GaussianFactorGraph operator()(const DiscreteValues& assignment) const;
+  /**
+   @brief Get the GaussianFactorGraph at a given discrete assignment. Note this
+   * corresponds to the Gaussian posterior p(X|M=m, Z=z) of the continuous
+   * variables X given the discrete assignment M=m and whatever measurements z
+   * where assumed in the creation of the factor Graph.
+   *
+   * @note Be careful, as any factors not Gaussian are ignored.
+   *
+   * @param assignment The discrete value assignment for the discrete keys.
+   * @return Gaussian factors as a GaussianFactorGraph
+   */
+  GaussianFactorGraph choose(const DiscreteValues& assignment) const;
+
+  /// Syntactic sugar for choose
+  GaussianFactorGraph operator()(const DiscreteValues& assignment) const {
+    return choose(assignment);
+  }
 };
 
 // traits

--- a/gtsam/hybrid/HybridGaussianFactorGraph.h
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.h
@@ -197,23 +197,16 @@ class GTSAM_EXPORT HybridGaussianFactorGraph
   double probPrime(const HybridValues& values) const;
 
   /**
-   * @brief Compute unnormalized probability \f$ P(X | M, Z) \f$
-   * for each discrete assignment, and return as a tree.
-   *
-   * @param continuousValues Continuous values at which to compute probability.
-   * @return DecisionTreeFactor
-   */
-  DecisionTreeFactor probPrime(const VectorValues& continuousValues) const;
-
-  /**
    * @brief Computer posterior P(M|X=x) when all continuous values X are given.
-   * This is very efficient as this simply probPrime normalized into a
-   * conditional.
+   * This is efficient as this simply probPrime normalized.
+   *
+   * @note Not a DiscreteConditional as the cardinalities of the DiscreteKeys,
+   * which we would need, are hard to recover.
    *
    * @param continuousValues Continuous values x to condition on.
    * @return DecisionTreeFactor
    */
-  DiscreteConditional discretePosterior(
+  AlgebraicDecisionTree<Key> discretePosterior(
       const VectorValues& continuousValues) const;
 
   /**

--- a/gtsam/hybrid/HybridSmoother.cpp
+++ b/gtsam/hybrid/HybridSmoother.cpp
@@ -72,21 +72,17 @@ void HybridSmoother::update(HybridGaussianFactorGraph graph,
       addConditionals(graph, hybridBayesNet_, ordering);
 
   // Eliminate.
-  HybridBayesNet::shared_ptr bayesNetFragment =
-      graph.eliminateSequential(ordering);
+  HybridBayesNet bayesNetFragment = *graph.eliminateSequential(ordering);
 
   /// Prune
   if (maxNrLeaves) {
     // `pruneBayesNet` sets the leaves with 0 in discreteFactor to nullptr in
     // all the conditionals with the same keys in bayesNetFragment.
-    HybridBayesNet prunedBayesNetFragment =
-        bayesNetFragment->prune(*maxNrLeaves);
-    // Set the bayes net fragment to the pruned version
-    bayesNetFragment = std::make_shared<HybridBayesNet>(prunedBayesNetFragment);
+    bayesNetFragment = bayesNetFragment.prune(*maxNrLeaves);
   }
 
   // Add the partial bayes net to the posterior bayes net.
-  hybridBayesNet_.add(*bayesNetFragment);
+  hybridBayesNet_.add(bayesNetFragment);
 }
 
 /* ************************************************************************* */

--- a/gtsam/hybrid/HybridSmoother.h
+++ b/gtsam/hybrid/HybridSmoother.h
@@ -39,7 +39,7 @@ class GTSAM_EXPORT HybridSmoother {
    * discrete factor on all discrete keys, plus all discrete factors in the
    * original graph.
    *
-   * \note If maxComponents is given, we look at the discrete factor resulting
+   * \note If maxNrLeaves is given, we look at the discrete factor resulting
    * from this elimination, and prune it and the Gaussian components
    * corresponding to the pruned choices.
    *

--- a/gtsam/hybrid/tests/testHybridBayesNet.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesNet.cpp
@@ -168,8 +168,6 @@ TEST(HybridBayesNet, Tiny) {
   const double error1 = chosen1.error(vv) + gc1->negLogConstant() -
                         px->negLogConstant() - log(0.6);
   // print errors:
-  std::cout << "error0 = " << error0 << std::endl;
-  std::cout << "error1 = " << error1 << std::endl;
   EXPECT_DOUBLES_EQUAL(error0, bayesNet.error(zero), 1e-9);
   EXPECT_DOUBLES_EQUAL(error1, bayesNet.error(one), 1e-9);
   EXPECT_DOUBLES_EQUAL(error0 + logP0, error1 + logP1, 1e-9);
@@ -196,16 +194,13 @@ TEST(HybridBayesNet, Tiny) {
   ratio[1] = std::exp(-fg.error(one)) / bayesNet.evaluate(one);
   EXPECT_DOUBLES_EQUAL(ratio[0], ratio[1], 1e-8);
 
-  // TODO(Frank): Better test: check if discretePosteriors agree !
-  // Since ϕ(M, x) \propto P(M,x|z)
-  // q0 = std::exp(-fg.error(zero));
-  // q1 = std::exp(-fg.error(one));
-  // sum = q0 + q1;
-  // AlgebraicDecisionTree<Key> fgPosterior(M(0), q0 / sum, q1 / sum);
+  // Better and more general test:
+  // Since ϕ(M, x) \propto P(M,x|z) the discretePosteriors should agree
+  q0 = std::exp(-fg.error(zero));
+  q1 = std::exp(-fg.error(one));
+  sum = q0 + q1;
+  EXPECT(assert_equal(expectedPosterior, {M(0), q0 / sum, q1 / sum}));
   VectorValues xv{{X(0), Vector1(5.0)}};
-  fg.printErrors(zero);
-  fg.printErrors(one);
-  GTSAM_PRINT(fg.errorTree(xv));
   auto fgPosterior = fg.discretePosterior(xv);
   EXPECT(assert_equal(expectedPosterior, fgPosterior));
 }

--- a/gtsam/hybrid/tests/testHybridEstimation.cpp
+++ b/gtsam/hybrid/tests/testHybridEstimation.cpp
@@ -109,6 +109,7 @@ TEST(HybridEstimation, IncrementalSmoother) {
 
   HybridGaussianFactorGraph linearized;
 
+  constexpr size_t maxNrLeaves = 3;
   for (size_t k = 1; k < K; k++) {
     // Motion Model
     graph.push_back(switching.nonlinearFactorGraph.at(k));
@@ -120,8 +121,12 @@ TEST(HybridEstimation, IncrementalSmoother) {
     linearized = *graph.linearize(initial);
     Ordering ordering = smoother.getOrdering(linearized);
 
-    smoother.update(linearized, 3, ordering);
+    smoother.update(linearized, maxNrLeaves, ordering);
     graph.resize(0);
+
+    // Uncomment to print out pruned discrete marginal:
+    // smoother.hybridBayesNet().at(0)->asDiscrete()->dot("smoother_" +
+    //                                                    std::to_string(k));
   }
 
   HybridValues delta = smoother.hybridBayesNet().optimize();

--- a/gtsam/hybrid/tests/testHybridGaussianConditional.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianConditional.cpp
@@ -25,7 +25,11 @@
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/linear/GaussianConditional.h>
 
+#include <memory>
 #include <vector>
+
+#include "gtsam/discrete/DecisionTree.h"
+#include "gtsam/discrete/DiscreteKey.h"
 
 // Include for test suite
 #include <CppUnitLite/TestHarness.h>
@@ -250,8 +254,60 @@ TEST(HybridGaussianConditional, Likelihood2) {
 }
 
 /* ************************************************************************* */
+// Test pruning a HybridGaussianConditional with two discrete keys, based on a
+// DecisionTreeFactor with 3 keys:
+TEST(HybridGaussianConditional, Prune) {
+  // Create a two key conditional:
+  DiscreteKeys modes{{M(1), 2}, {M(2), 2}};
+  std::vector<GaussianConditional::shared_ptr> gcs;
+  for (size_t i = 0; i < 4; i++) {
+    gcs.push_back(
+        GaussianConditional::sharedMeanAndStddev(Z(0), Vector1(i + 1), i + 1));
+  }
+  auto empty = std::make_shared<GaussianConditional>();
+  HybridGaussianConditional::Conditionals conditionals(modes, gcs);
+  HybridGaussianConditional hgc(modes, conditionals);
+
+  DiscreteKeys keys = modes;
+  keys.push_back({M(3), 2});
+  {
+    for (size_t i = 0; i < 8; i++) {
+      std::vector<double> potentials{0, 0, 0, 0, 0, 0, 0, 0};
+      potentials[i] = 1;
+      const DecisionTreeFactor decisionTreeFactor(keys, potentials);
+      // Prune the HybridGaussianConditional
+      const auto pruned = hgc.prune(decisionTreeFactor);
+      // Check that the pruned HybridGaussianConditional has 1 conditional
+      EXPECT_LONGS_EQUAL(1, pruned->nrComponents());
+    }
+  }
+  {
+    const std::vector<double> potentials{0, 0, 0.5, 0,  //
+                                         0, 0, 0.5, 0};
+    const DecisionTreeFactor decisionTreeFactor(keys, potentials);
+
+    const auto pruned = hgc.prune(decisionTreeFactor);
+
+    // Check that the pruned HybridGaussianConditional has 2 conditionals
+    EXPECT_LONGS_EQUAL(2, pruned->nrComponents());
+  }
+  {
+    const std::vector<double> potentials{0.2, 0, 0.3, 0,  //
+                                         0,   0, 0.5, 0};
+    const DecisionTreeFactor decisionTreeFactor(keys, potentials);
+
+    const auto pruned = hgc.prune(decisionTreeFactor);
+
+    // Check that the pruned HybridGaussianConditional has 3 conditionals
+    EXPECT_LONGS_EQUAL(3, pruned->nrComponents());
+  }
+}
+
+/* *************************************************************************
+ */
 int main() {
   TestResult tr;
   return TestRegistry::runAllTests(tr);
 }
-/* ************************************************************************* */
+/* *************************************************************************
+ */

--- a/gtsam/hybrid/tests/testHybridGaussianConditional.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianConditional.cpp
@@ -74,17 +74,6 @@ TEST(HybridGaussianConditional, Invariants) {
 /// Check LogProbability.
 TEST(HybridGaussianConditional, LogProbability) {
   using namespace equal_constants;
-  auto actual = hybrid_conditional.logProbability(vv);
-
-  // Check result.
-  std::vector<DiscreteKey> discrete_keys = {mode};
-  std::vector<double> leaves = {conditionals[0]->logProbability(vv),
-                                conditionals[1]->logProbability(vv)};
-  AlgebraicDecisionTree<Key> expected(discrete_keys, leaves);
-
-  EXPECT(assert_equal(expected, actual, 1e-6));
-
-  // Check for non-tree version.
   for (size_t mode : {0, 1}) {
     const HybridValues hv{vv, {{M(0), mode}}};
     EXPECT_DOUBLES_EQUAL(conditionals[mode]->logProbability(vv),

--- a/gtsam/hybrid/tests/testHybridGaussianFactor.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactor.cpp
@@ -357,15 +357,8 @@ TEST(HybridGaussianFactor, DifferentCovariancesFG) {
   cv.insert(X(0), Vector1(0.0));
   cv.insert(X(1), Vector1(0.0));
 
-  // Check that the error values at the MLE point μ.
-  AlgebraicDecisionTree<Key> errorTree = hbn->errorTree(cv);
-
   DiscreteValues dv0{{M(1), 0}};
   DiscreteValues dv1{{M(1), 1}};
-
-  // regression
-  EXPECT_DOUBLES_EQUAL(9.90348755254, errorTree(dv0), 1e-9);
-  EXPECT_DOUBLES_EQUAL(0.69314718056, errorTree(dv1), 1e-9);
 
   DiscreteConditional expected_m1(m1, "0.5/0.5");
   DiscreteConditional actual_m1 = *(hbn->at(2)->asDiscrete());

--- a/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
@@ -614,21 +614,20 @@ TEST(HybridGaussianFactorGraph, ErrorAndProbPrimeTree) {
   const HybridValues delta = hybridBayesNet->optimize();
 
   // regression test for errorTree
-  std::vector<double> leaves = {0.9998558, 0.4902432, 0.5193694, 0.0097568};
+  std::vector<double> leaves = {2.7916153, 1.5888555, 1.7233422, 1.6191947};
   AlgebraicDecisionTree<Key> expectedErrors(s.modes, leaves);
   const auto error_tree = graph.errorTree(delta.continuous());
   EXPECT(assert_equal(expectedErrors, error_tree, 1e-7));
 
   // regression test for discretePosterior
   const AlgebraicDecisionTree<Key> expectedPosterior(
-      s.modes, std::vector{0.14341014, 0.23872714, 0.23187421, 0.38598852});
+      s.modes, std::vector{0.095516068, 0.31800092, 0.27798511, 0.3084979});
   auto posterior = graph.discretePosterior(delta.continuous());
   EXPECT(assert_equal(expectedPosterior, posterior, 1e-7));
 }
 
 /* ****************************************************************************/
-// Test hybrid gaussian factor graph errorTree during
-// incremental operation
+// Test hybrid gaussian factor graph errorTree during incremental operation
 TEST(HybridGaussianFactorGraph, IncrementalErrorTree) {
   Switching s(4);
 
@@ -648,8 +647,7 @@ TEST(HybridGaussianFactorGraph, IncrementalErrorTree) {
   auto error_tree = graph.errorTree(delta.continuous());
 
   std::vector<DiscreteKey> discrete_keys = {{M(0), 2}, {M(1), 2}};
-  std::vector<double> leaves = {0.99985581, 0.4902432, 0.51936941,
-                                0.0097568009};
+  std::vector<double> leaves = {2.7916153, 1.5888555, 1.7233422, 1.6191947};
   AlgebraicDecisionTree<Key> expected_error(discrete_keys, leaves);
 
   // regression
@@ -666,12 +664,10 @@ TEST(HybridGaussianFactorGraph, IncrementalErrorTree) {
   delta = hybridBayesNet->optimize();
   auto error_tree2 = graph.errorTree(delta.continuous());
 
-  discrete_keys = {{M(0), 2}, {M(1), 2}, {M(2), 2}};
+  // regression
   leaves = {0.50985198, 0.0097577296, 0.50009425, 0,
             0.52922138, 0.029127133,  0.50985105, 0.0097567964};
-  AlgebraicDecisionTree<Key> expected_error2(discrete_keys, leaves);
-
-  // regression
+  AlgebraicDecisionTree<Key> expected_error2(s.modes, leaves);
   EXPECT(assert_equal(expected_error, error_tree, 1e-7));
 }
 

--- a/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
@@ -619,16 +619,9 @@ TEST(HybridGaussianFactorGraph, ErrorAndProbPrimeTree) {
   const auto error_tree = graph.errorTree(delta.continuous());
   EXPECT(assert_equal(expectedErrors, error_tree, 1e-7));
 
-  // regression test for probPrime
-  const DecisionTreeFactor expectedFactor(
-      s.modes, std::vector{0.36793249, 0.61247742, 0.59489556, 0.99029064});
-  auto probabilities = graph.probPrime(delta.continuous());
-  EXPECT(assert_equal(expectedFactor, probabilities, 1e-7));
-
   // regression test for discretePosterior
-  const DecisionTreeFactor normalized(
+  const AlgebraicDecisionTree<Key> expectedPosterior(
       s.modes, std::vector{0.14341014, 0.23872714, 0.23187421, 0.38598852});
-  DiscreteConditional expectedPosterior(2, normalized);
   auto posterior = graph.discretePosterior(delta.continuous());
   EXPECT(assert_equal(expectedPosterior, posterior, 1e-7));
 }

--- a/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
@@ -994,15 +994,8 @@ TEST(HybridNonlinearFactorGraph, DifferentCovariances) {
   cv.insert(X(0), Vector1(0.0));
   cv.insert(X(1), Vector1(0.0));
 
-  // Check that the error values at the MLE point μ.
-  AlgebraicDecisionTree<Key> errorTree = hbn->errorTree(cv);
-
   DiscreteValues dv0{{M(1), 0}};
   DiscreteValues dv1{{M(1), 1}};
-
-  // regression
-  EXPECT_DOUBLES_EQUAL(9.90348755254, errorTree(dv0), 1e-9);
-  EXPECT_DOUBLES_EQUAL(0.69314718056, errorTree(dv1), 1e-9);
 
   DiscreteConditional expected_m1(m1, "0.5/0.5");
   DiscreteConditional actual_m1 = *(hbn->at(2)->asDiscrete());

--- a/gtsam/inference/BayesTreeCliqueBase.h
+++ b/gtsam/inference/BayesTreeCliqueBase.h
@@ -140,6 +140,9 @@ namespace gtsam {
     /** Access the conditional */
     const sharedConditional& conditional() const { return conditional_; }
 
+    /** Write access to the conditional */
+    sharedConditional& conditional() { return conditional_; }
+
     /// Return true if this clique is the root of a Bayes tree. 
     inline bool isRoot() const { return parent_.expired(); }
 


### PR DESCRIPTION
I could not really separate the functional pruning PR from this one. Here's everything in this PR:

## Fixing the bug
- BIG: fix bug in HybridConditional::errorTree and HGFG::errorTree
- made errorTree much faster by calling polymorphic errorTree and using AlgebraicDecisionTree operators

## `discretePosterior`
- renamed both `HBN::evaluate` and `HGFG::probPrime` that take VectorValues to `discretePosterior`: these are very powerful. 

## Simplified API 
- removed `HBN::logProbability`: errorTree is all we need and this one has confusing semantics
- removed `HGC::logProbability` that takes continuous values: very problematic name and only used in one place: again, errorTree is all we need.

## Functional pruning
- pruning is now functional
- got rid of duplicate (unused) prunerFunc
- added a write-access conditional to allow iSAM versions to be still imperative

## Update Oct 1:
- Reworked `HGC::prune` to use `ADT::max`
- Rewrote `HybridBayesNet::prune` completely

Looking at pruned trees for testHybridEstimation is very informative: it seems that the ordering of the keys is working against us in terms of pruning: we have large duplicate trees:

step 2:
<img width="544" alt="image" src="https://github.com/user-attachments/assets/80343094-b4f1-4e8b-baa8-732d3ae8050d">

step 5:
<img width="483" alt="image" src="https://github.com/user-attachments/assets/cbd2851f-3bae-4d3b-af8c-7b1b1ef1850e">

...

step 14:
<img width="352" alt="image" src="https://github.com/user-attachments/assets/0441f8ec-4adf-4c00-a571-619854ec811e">
