### PR TITLE
Fix Pruning

### DIFF
--- a/gtsam/discrete/DecisionTreeFactor.cpp
+++ b/gtsam/discrete/DecisionTreeFactor.cpp
@@ -385,6 +385,16 @@ namespace gtsam {
     // Now threshold the decision tree
     size_t total = 0;
     auto thresholdFunc = [threshold, &total, N](const double& value) {
+      // There is a possible case where the `threshold` is equal to 0.0
+      // In that case `(value < threshold) == false`
+      // which increases the leaf total erroneously.
+      // Hence we check for 0.0 explicitly.
+      if (fpEqual(value, 0.0, 1e-12)) {
+        return 0.0;
+      }
+
+      // Check if value is less than the threshold and
+      // we haven't exceeded the maximum number of leaves.
       if (value < threshold || total >= N) {
         return 0.0;
       } else {

--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -73,7 +73,7 @@ HybridBayesNet HybridBayesNet::prune(size_t maxNrLeaves) const {
   // per pruned Discrete joint.
   for (auto &&conditional : *this) {
     if (auto hgc = conditional->asHybrid()) {
-      // Make a copy of the hybrid Gaussian conditional and prune it!
+      // Prune the hybrid Gaussian conditional!
       auto prunedHybridGaussianConditional = hgc->prune(pruned);
 
       // Type-erase and add to the pruned Bayes Net fragment.

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -240,7 +240,9 @@ discreteElimination(const HybridGaussianFactorGraph &factors,
       // In this case, compute discrete probabilities.
       auto logProbability =
           [&](const GaussianFactor::shared_ptr &factor) -> double {
-        if (!factor) return 0.0;
+        // If the factor is null, it is has been pruned hence return ∞
+        // so that the exp(-∞)=0.
+        if (!factor) return std::numeric_limits<double>::infinity();
         return factor->error(VectorValues());
       };
       AlgebraicDecisionTree<Key> logProbabilities =
@@ -300,8 +302,9 @@ static std::shared_ptr<Factor> createDiscreteFactor(
   auto negLogProbability = [&](const Result &pair) -> double {
     const auto &[conditional, factor] = pair;
     static const VectorValues kEmpty;
-    // If the factor is not null, it has no keys, just contains the residual.
-    if (!factor) return 1.0;  // TODO(dellaert): not loving this.
+    // If the factor is null, it has been pruned, hence return ∞
+    // so that the exp(-∞)=0.
+    if (!factor) return std::numeric_limits<double>::infinity();
 
     // Negative logspace version of:
     // exp(-factor->error(kEmpty)) / conditional->normalizationConstant();

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -305,6 +305,9 @@ static std::shared_ptr<Factor> createDiscreteFactor(
 
     // Negative logspace version of:
     // exp(-factor->error(kEmpty)) / conditional->normalizationConstant();
+    // = exp(-factor->error(kEmpty)) * \sqrt{|2πΣ|};
+    // log = -(-factor->error(kEmpty) + log(\sqrt{|2πΣ|}))
+    // = factor->error(kEmpty) - log(\sqrt{|2πΣ|})
     // negLogConstant gives `-log(k)`
     // which is `-log(k) = log(1/k) = log(\sqrt{|2πΣ|})`.
     return factor->error(kEmpty) - conditional->negLogConstant();


### PR DESCRIPTION
Update the return value of pruned factors/conditionals to return ∞ as the error in negative log space.

This way, when we normalize (by subtracting the minimum value) and take the exponential negative `exp(-e)`, we get `p=0` for pruned assignments, valid probabilities everywhere else.

With this fix, we can now run hybrid legged state estimation for 16 timesteps in 3.8 seconds, down from 13 minutes.