### PR TITLE
Fix machine precision bug in DoglegOptimizerImpl::ComputeBlend

### DIFF
--- a/gtsam/nonlinear/DoglegOptimizerImpl.cpp
+++ b/gtsam/nonlinear/DoglegOptimizerImpl.cpp
@@ -67,12 +67,14 @@ VectorValues DoglegOptimizerImpl::ComputeBlend(double delta, const VectorValues&
   double tau1 = (-b + sqrt_b_m4ac) / (2.*a);
   double tau2 = (-b - sqrt_b_m4ac) / (2.*a);
 
+  // Determine correct solution accounting for machine precision
   double tau;
-  if(0.0 <= tau1 && tau1 <= 1.0) {
-    assert(!(0.0 <= tau2 && tau2 <= 1.0));
+  const double eps = std::numeric_limits<double>::epsilon();
+  if(-eps <= tau1 && tau1 <= 1.0 + eps) {
+    assert(!(-eps <= tau2 && tau2 <= 1.0 + eps));
     tau = tau1;
   } else {
-    assert(0.0 <= tau2 && tau2 <= 1.0);
+    assert(-eps <= tau2 && tau2 <= 1.0 + eps);
     tau = tau2;
   }
 

--- a/tests/testDoglegOptimizer.cpp
+++ b/tests/testDoglegOptimizer.cpp
@@ -73,6 +73,24 @@ TEST(DoglegOptimizer, ComputeBlend) {
 }
 
 /* ************************************************************************* */
+TEST(DoglegOptimizer, ComputeBlendEdgeCases) {
+  // Test Derived from Issue #1861
+  // Evaluate ComputeBlend Behavior for edge cases where the trust region
+  // is equal in size to that of the newton step or the gradient step.
+
+  // Simulated Newton (n) and Gradient Descent (u) step vectors w/ ||n|| > ||u||
+  VectorValues::Dims dims;
+  dims[0] = 3;
+  VectorValues n(Vector3(0.3233546123, -0.2133456123, 0.3664345632), dims);
+  VectorValues u(Vector3(0.0023456342, -0.04535687, 0.087345661212), dims);
+  
+  // Test upper edge case where trust region is equal to magnitude of newton step
+  EXPECT(assert_equal(n, DoglegOptimizerImpl::ComputeBlend(n.norm(), u, n, false)));
+  // Test lower edge case where trust region is equal to magnitude of gradient step 
+  EXPECT(assert_equal(u, DoglegOptimizerImpl::ComputeBlend(u.norm(), u, n, false)));
+}
+
+/* ************************************************************************* */
 TEST(DoglegOptimizer, ComputeDoglegPoint) {
   // Create an arbitrary Bayes Net
   GaussianBayesNet gbn;


### PR DESCRIPTION
Fixes #1861

This commit fixes a bug that could cause the incorrect solution to be returned from `DoglegOptimizerImpl::ComputeBlend` that is documented in Issue #1861.

The fix incorporates machine precision epsilon using `std::numeric_limits` into the bounds checks that determine which solution is returned from the quadratic documented in `doc/trustregion.pdf`. This should ensure that the correct solution is returned regardless of machine prevision errors.

This PR also adds a test for the edgecases that are know to cause the bug on some machines.