### PR TITLE
Record cardinalities in DecisionTree

### DIFF
--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -583,10 +583,16 @@ namespace gtsam {
   template <typename L, typename Y>
   template <typename M, typename X, typename Func>
   DecisionTree<L, Y>::DecisionTree(const DecisionTree<M, X>& other,
-                                   const std::map<M, L>& map, Func Y_of_X)
-      : cardinalities_map_(other.allCardinalities()) {
+                                   const std::map<M, L>& map, Func Y_of_X) {
     auto L_of_M = [&map](const M& label) -> L { return map.at(label); };
     root_ = convertFrom<M, X>(other.root_, L_of_M, Y_of_X);
+
+    // Fill in cardinalities
+    std::map<M, size_t> otherCardinalities = other.allCardinalities();
+    for (auto&& it = otherCardinalities.begin(); it != otherCardinalities.end();
+         it++) {
+      cardinalities_map_[L_of_M(it->first)] = it->second;
+    }
   }
 
   /****************************************************************************/

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -67,6 +67,9 @@ namespace gtsam {
       return a == b;
     }
 
+    /// Map of Keys and their cardinalities.
+    std::map<L, size_t> cardinalities_map_;
+
    public:
     using LabelFormatter = std::function<std::string(L)>;
     using ValueFormatter = std::function<std::string(Y)>;
@@ -274,6 +277,12 @@ namespace gtsam {
     /** evaluate */
     const Y& operator()(const Assignment<L>& x) const;
 
+    /// Get the cardinalities for all the labels.
+    std::map<L, size_t> allCardinalities() const { return cardinalities_map_; }
+
+    /// Get cardinality for a specific label.
+    size_t nrChoices(L j) const { return cardinalities_map_.at(j); }
+
     /**
      * @brief Visit all leaves in depth-first fashion.
      *
@@ -413,6 +422,7 @@ namespace gtsam {
     template <class ARCHIVE>
     void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
       ar& BOOST_SERIALIZATION_NVP(root_);
+      ar& BOOST_SERIALIZATION_NVP(cardinalities_map_);
     }
 #endif
   };  // DecisionTree


### PR DESCRIPTION
This PR updates `DecisionTree` to store the cardinalities of the nodes so we can recover them easily later.

Note that I had to settle for strange naming conventions to avoid collisions when a class inherits from both `DiscreteFactor` and `DecisionTree`.