### PR TITLE
precompiled_header.h: remove chartTesting.h

### DIFF
--- a/gtsam/precompiled_header.h
+++ b/gtsam/precompiled_header.h
@@ -23,7 +23,6 @@
 // numericalDerivative.h : includes things in linear, nonlinear :-(
 // testLie.h: includes numericalDerivative
 #include <gtsam/base/Lie.h>
-#include <gtsam/base/chartTesting.h>
 #include <gtsam/base/cholesky.h>
 #include <gtsam/base/concepts.h>
 #include <gtsam/base/ConcurrentMap.h>


### PR DESCRIPTION
The [chartTesting.h](https://github.com/borglab/gtsam/blob/develop/gtsam/base/chartTesting.h) header is no longer used anywhere in the codebase, but it causes a compilation error on MSVC when building with C++20 or newer:
```
C:\Users\martin\.conan2\p\b\gtsam83ef710337281\b\src\gtsam\base\chartTesting.h(42,3): error C3878: syntax error: unexpected token ')' following 'expression_statement' [C:\Users\martin\.conan2\p\b\gtsam83ef710337281\b\build\gtsam 
\gtsam.vcxproj]
  (compiling source file '../../src/gtsam/precompiled_header.cpp')
```

This PR removes it from the list of precompiled headers as a fix. Should the chartTesting.h header be removed altogether, perhaps?

Fixes #1788.