### PR TITLE
Faster DecisionTree

### DIFF
--- a/gtsam/discrete/AlgebraicDecisionTree.h
+++ b/gtsam/discrete/AlgebraicDecisionTree.h
@@ -22,10 +22,12 @@
 #include <gtsam/discrete/DecisionTree-inl.h>
 
 #include <algorithm>
+#include <limits>
 #include <map>
 #include <string>
 #include <iomanip>
 #include <vector>
+
 namespace gtsam {
 
   /**

--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -650,7 +650,7 @@ namespace gtsam {
   template<typename L, typename Y>
   template<typename It, typename ValueIt>
   typename DecisionTree<L, Y>::NodePtr DecisionTree<L, Y>::build(
-      It begin, It end, ValueIt beginY, ValueIt endY) const {
+      It begin, It end, ValueIt beginY, ValueIt endY) {
     // get crucial counts
     size_t nrChoices = begin->second;
     size_t size = endY - beginY;
@@ -692,7 +692,7 @@ namespace gtsam {
   template<typename L, typename Y>
   template<typename It, typename ValueIt>
   typename DecisionTree<L, Y>::NodePtr DecisionTree<L, Y>::create(
-      It begin, It end, ValueIt beginY, ValueIt endY) const {
+      It begin, It end, ValueIt beginY, ValueIt endY) {
     auto node = build(begin, end, beginY, endY);
     if (auto choice = std::dynamic_pointer_cast<const Choice>(node)) {
       return Choice::Unique(choice);

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -176,9 +176,9 @@ namespace gtsam {
      * @return NodePtr 
      */
     template <typename M, typename X>
-    NodePtr convertFrom(const typename DecisionTree<M, X>::NodePtr& f,
-                        std::function<L(const M&)> L_of_M,
-                        std::function<Y(const X&)> Y_of_X) const;
+    static NodePtr convertFrom(const typename DecisionTree<M, X>::NodePtr& f,
+                               std::function<L(const M&)> L_of_M,
+                               std::function<Y(const X&)> Y_of_X);
 
    public:
     /// @name Standard Constructors
@@ -402,7 +402,7 @@ namespace gtsam {
 
     // internal use only
     template<typename Iterator> NodePtr
-    compose(Iterator begin, Iterator end, const L& label) const;
+    static compose(Iterator begin, Iterator end, const L& label);
 
     /// @}
 

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -154,7 +154,7 @@ namespace gtsam {
      * and Y values 
      */
     template <typename It, typename ValueIt>
-    NodePtr build(It begin, It end, ValueIt beginY, ValueIt endY) const;
+    static NodePtr build(It begin, It end, ValueIt beginY, ValueIt endY);
 
     /** Internal helper function to create from
      * keys, cardinalities, and Y values.
@@ -162,7 +162,7 @@ namespace gtsam {
      * before we prune in a top-down fashion.
      */
     template <typename It, typename ValueIt>
-    NodePtr create(It begin, It end, ValueIt beginY, ValueIt endY) const;
+    static NodePtr create(It begin, It end, ValueIt beginY, ValueIt endY);
 
     /**
      * @brief Convert from a DecisionTree<L, X> to DecisionTree<L, Y>.

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -166,6 +166,19 @@ namespace gtsam {
     NodePtr create(It begin, It end, ValueIt beginY, ValueIt endY) const;
 
     /**
+     * @brief Convert from a DecisionTree<L, X> to DecisionTree<L, Y>.
+     *
+     * @tparam M The previous label type.
+     * @tparam X The previous value type.
+     * @param f The node pointer to the root of the previous DecisionTree.
+     * @param Y_of_X Functor to convert from value type X to type Y.
+     * @return NodePtr
+     */
+    template <typename X>
+    static NodePtr convertFrom(const typename DecisionTree<L, X>::NodePtr& f,
+                               std::function<Y(const X&)> Y_of_X);
+
+    /**
      * @brief Convert from a DecisionTree<M, X> to DecisionTree<L, Y>.
      * 
      * @tparam M The previous label type.

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -31,7 +31,6 @@
 #include <iostream>
 #include <map>
 #include <set>
-#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
Several improvements yield maybe 5% speedup in hybrid (I thought it'd be more, mileage may vary):
- Make several methods static
- Add a convertFrom that does not do "Shannon expansion" as labels are not changed
- Make `push_back` take an r-value and use std::move where used
