### PR TITLE
Significant speedup

### DIFF
--- a/gtsam/discrete/DecisionTree-inl.h
+++ b/gtsam/discrete/DecisionTree-inl.h
@@ -1060,7 +1060,7 @@ namespace gtsam {
   template <typename L, typename Y>
   template <typename A, typename B>
   std::pair<DecisionTree<L, A>, DecisionTree<L, B>> DecisionTree<L, Y>::split(
-      std::function<std::pair<A, B>(const Y&)> AB_of_Y) {
+      std::function<std::pair<A, B>(const Y&)> AB_of_Y) const {
     using AB = std::pair<A, B>;
     const DecisionTree<L, AB> ab(*this, AB_of_Y);
     const DecisionTree<L, A> a(ab, [](const AB& p) { return p.first; });

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -156,10 +156,10 @@ namespace gtsam {
     template <typename It, typename ValueIt>
     static NodePtr build(It begin, It end, ValueIt beginY, ValueIt endY);
 
-    /** Internal helper function to create from
-     * keys, cardinalities, and Y values.
-     * Calls `build` which builds thetree bottom-up,
-     * before we prune in a top-down fashion.
+    /**
+     * Internal helper function to create a tree from keys, cardinalities, and Y
+     * values. Calls `build` which builds the tree bottom-up, before we prune in
+     * a top-down fashion.
      */
     template <typename It, typename ValueIt>
     static NodePtr create(It begin, It end, ValueIt beginY, ValueIt endY);
@@ -239,7 +239,7 @@ namespace gtsam {
     DecisionTree(const DecisionTree<L, X>& other, Func Y_of_X);
 
     /**
-     * @brief Convert from a different value type X to value type Y, also transate
+     * @brief Convert from a different value type X to value type Y, also translate
      * labels via map from type M to L.
      *
      * @tparam M Previous label type.
@@ -405,6 +405,18 @@ namespace gtsam {
     std::string dot(const LabelFormatter& labelFormatter,
                     const ValueFormatter& valueFormatter,
                     bool showZero = true) const;
+
+    /**
+     * @brief Convert into two trees with value types A and B.
+     *
+     * @tparam A First new value type.
+     * @tparam B Second new value type.
+     * @param AB_of_Y Functor to convert from type X to std::pair<A, B>.
+     * @return A pair of DecisionTrees with value types A and B respectively.
+     */
+    template <typename A, typename B>
+    std::pair<DecisionTree<L, A>, DecisionTree<L, B>> split(
+        std::function<std::pair<A, B>(const Y&)> AB_of_Y);
 
     /// @name Advanced Interface
     /// @{

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -416,7 +416,7 @@ namespace gtsam {
      */
     template <typename A, typename B>
     std::pair<DecisionTree<L, A>, DecisionTree<L, B>> split(
-        std::function<std::pair<A, B>(const Y&)> AB_of_Y);
+        std::function<std::pair<A, B>(const Y&)> AB_of_Y) const;
 
     /// @name Advanced Interface
     /// @{

--- a/gtsam/discrete/DecisionTree.h
+++ b/gtsam/discrete/DecisionTree.h
@@ -85,7 +85,7 @@ namespace gtsam {
 
     /** ------------------------ Node base class --------------------------- */
     struct Node {
-      using Ptr = std::shared_ptr<const Node>;
+      using Ptr = std::shared_ptr<Node>;
 
 #ifdef DT_DEBUG_MEMORY
       static int nrNodes;
@@ -227,6 +227,15 @@ namespace gtsam {
     /** Create DecisionTree from two others */
     DecisionTree(const L& label, const DecisionTree& f0,
                  const DecisionTree& f1);
+
+    /**
+     * @brief Move constructor for DecisionTree. Very efficient as does not
+     * allocate anything, just changes in-place. But `other` is consumed.
+     *
+     * @param op The unary operation to apply to the moved DecisionTree.
+     * @param other The DecisionTree to move from, will be empty afterwards.
+     */
+    DecisionTree(const Unary& op, DecisionTree&& other) noexcept;
 
     /**
      * @brief Convert from a different value type.

--- a/gtsam/discrete/tests/testDecisionTree.cpp
+++ b/gtsam/discrete/tests/testDecisionTree.cpp
@@ -11,7 +11,7 @@
 
 /*
  * @file    testDecisionTree.cpp
- * @brief    Develop DecisionTree
+ * @brief   DecisionTree unit tests
  * @author  Frank Dellaert
  * @author  Can Erdogan
  * @date    Jan 30, 2012
@@ -270,6 +270,37 @@ TEST(DecisionTree, Example) {
   LONGS_EQUAL(125, acnotb(x101))
   DOT(acnotb);
 }
+
+/* ************************************************************************** */
+// Test that we can create two trees out of one, using a function that returns a pair.
+TEST(DecisionTree, Split) {
+  // Create labels
+  string A("A"), B("B");
+
+  // Create a decision tree
+  DT original(A, DT(B, 1, 2), DT(B, 3, 4));
+
+  // Define a function that returns an int/bool pair
+  auto split_function = [](const int& value) -> std::pair<int, bool> {
+    return {value*3, value*3 % 2 == 0};
+  };
+
+  // Split the original tree into two new trees
+  auto [la,lb] = original.split<int,bool>(split_function);
+
+  // Check the first resulting tree
+  EXPECT_LONGS_EQUAL(3, la(Assignment<string>{{A, 0}, {B, 0}}));
+  EXPECT_LONGS_EQUAL(6, la(Assignment<string>{{A, 0}, {B, 1}}));
+  EXPECT_LONGS_EQUAL(9, la(Assignment<string>{{A, 1}, {B, 0}}));
+  EXPECT_LONGS_EQUAL(12, la(Assignment<string>{{A, 1}, {B, 1}}));
+
+  // Check the second resulting tree
+  EXPECT(!lb(Assignment<string>{{A, 0}, {B, 0}}));
+  EXPECT(lb(Assignment<string>{{A, 0}, {B, 1}}));
+  EXPECT(!lb(Assignment<string>{{A, 1}, {B, 0}}));
+  EXPECT(lb(Assignment<string>{{A, 1}, {B, 1}}));
+}
+
 
 /* ************************************************************************** */
 // test Conversion of values

--- a/gtsam/discrete/tests/testDecisionTree.cpp
+++ b/gtsam/discrete/tests/testDecisionTree.cpp
@@ -108,6 +108,7 @@ struct DT : public DecisionTree<string, int> {
     std::cout << s;
     Base::print("", keyFormatter, valueFormatter);
   }
+
   /// Equality method customized to int node type
   bool equals(const Base& other, double tol = 1e-9) const {
     auto compare = [](const int& v, const int& w) { return v == w; };
@@ -301,6 +302,27 @@ TEST(DecisionTree, Split) {
   EXPECT(lb(Assignment<string>{{A, 1}, {B, 1}}));
 }
 
+
+/* ************************************************************************** */
+// Test that we can create a tree by modifying an rvalue.
+TEST(DecisionTree, Consume) {
+  // Create labels
+  string A("A"), B("B");
+
+  // Create a decision tree
+  DT original(A, DT(B, 1, 2), DT(B, 3, 4));
+
+  DT modified([](int i){return i*2;}, std::move(original));
+
+  // Check the first resulting tree
+  EXPECT_LONGS_EQUAL(2, modified(Assignment<string>{{A, 0}, {B, 0}}));
+  EXPECT_LONGS_EQUAL(4, modified(Assignment<string>{{A, 0}, {B, 1}}));
+  EXPECT_LONGS_EQUAL(6, modified(Assignment<string>{{A, 1}, {B, 0}}));
+  EXPECT_LONGS_EQUAL(8, modified(Assignment<string>{{A, 1}, {B, 1}}));
+
+  // Check original was moved
+  EXPECT(original.root_ == nullptr);
+}
 
 /* ************************************************************************** */
 // test Conversion of values

--- a/gtsam/hybrid/HybridGaussianConditional.cpp
+++ b/gtsam/hybrid/HybridGaussianConditional.cpp
@@ -110,15 +110,15 @@ struct HybridGaussianConditional::Helper {
 
 /* *******************************************************************************/
 HybridGaussianConditional::HybridGaussianConditional(
-    const DiscreteKeys &discreteParents, const Helper &helper)
+    const DiscreteKeys &discreteParents, Helper &&helper)
     : BaseFactor(discreteParents,
-                 FactorValuePairs(helper.pairs,
-                                  [&](const GaussianFactorValuePair &
-                                          pair) {  // subtract minNegLogConstant
-                                    return GaussianFactorValuePair{
-                                        pair.first,
-                                        pair.second - helper.minNegLogConstant};
-                                  })),
+                 FactorValuePairs(
+                     [&](const GaussianFactorValuePair
+                             &pair) {  // subtract minNegLogConstant
+                       return GaussianFactorValuePair{
+                           pair.first, pair.second - helper.minNegLogConstant};
+                     },
+                     std::move(helper.pairs))),
       BaseConditional(*helper.nrFrontals),
       negLogConstant_(helper.minNegLogConstant) {}
 

--- a/gtsam/hybrid/HybridGaussianConditional.cpp
+++ b/gtsam/hybrid/HybridGaussianConditional.cpp
@@ -275,9 +275,7 @@ std::shared_ptr<HybridGaussianFactor> HybridGaussianConditional::likelihood(
         if (auto conditional =
                 std::dynamic_pointer_cast<GaussianConditional>(pair.first)) {
           const auto likelihood_m = conditional->likelihood(given);
-          // scalar is already correct.
-          assert(pair.second ==
-                 conditional->negLogConstant() - negLogConstant_);
+          // pair.second == conditional->negLogConstant() - negLogConstant_
           return {likelihood_m, pair.second};
         } else {
           return {nullptr, std::numeric_limits<double>::infinity()};
@@ -320,8 +318,7 @@ HybridGaussianConditional::shared_ptr HybridGaussianConditional::prune(
   };
 
   FactorValuePairs prunedConditionals = factors().apply(pruner);
-  return std::shared_ptr<HybridGaussianConditional>(
-      new HybridGaussianConditional(discreteKeys(), prunedConditionals));
+  return std::make_shared<HybridGaussianConditional>(discreteKeys(), prunedConditionals);
 }
 
 /* *******************************************************************************/

--- a/gtsam/hybrid/HybridGaussianConditional.h
+++ b/gtsam/hybrid/HybridGaussianConditional.h
@@ -141,6 +141,19 @@ class GTSAM_EXPORT HybridGaussianConditional
   HybridGaussianConditional(const DiscreteKeys &discreteParents,
                             const Conditionals &conditionals);
 
+  /**
+   * @brief Construct from multiple discrete keys M and a tree of
+   * factor/scalar pairs, where the scalar is assumed to be the
+   * the negative log constant for each assignment m, up to a constant.
+   *
+   * @note Will throw if factors are not actually conditionals.
+   *
+   * @param discreteParents the discrete parents. Will be placed last.
+   * @param conditionalPairs Decision tree of GaussianFactor/scalar pairs.
+   */
+  HybridGaussianConditional(const DiscreteKeys &discreteParents,
+                            const FactorValuePairs &pairs);
+
   /// @}
   /// @name Testable
   /// @{
@@ -229,14 +242,6 @@ class GTSAM_EXPORT HybridGaussianConditional
   /// Private constructor that uses helper struct above.
   HybridGaussianConditional(const DiscreteKeys &discreteParents,
                             const Helper &helper);
-
-  /// Private constructor used when constants have already been calculated.
-  HybridGaussianConditional(const DiscreteKeys &discreteKeys, int nrFrontals,
-                            const FactorValuePairs &factors,
-                            double negLogConstant)
-      : BaseFactor(discreteKeys, factors),
-        BaseConditional(nrFrontals),
-        negLogConstant_(negLogConstant) {}
 
   /// Check whether `given` has values for all frontal keys.
   bool allFrontalsGiven(const VectorValues &given) const;

--- a/gtsam/hybrid/HybridGaussianConditional.h
+++ b/gtsam/hybrid/HybridGaussianConditional.h
@@ -64,8 +64,6 @@ class GTSAM_EXPORT HybridGaussianConditional
   using Conditionals = DecisionTree<Key, GaussianConditional::shared_ptr>;
 
  private:
-  Conditionals conditionals_;  ///< a decision tree of Gaussian conditionals.
-
   ///< Negative-log of the normalization constant (log(\sqrt(|2πΣ|))).
   ///< Take advantage of the neg-log space so everything is a minimization
   double negLogConstant_;
@@ -192,8 +190,8 @@ class GTSAM_EXPORT HybridGaussianConditional
   std::shared_ptr<HybridGaussianFactor> likelihood(
       const VectorValues &given) const;
 
-  /// Getter for the underlying Conditionals DecisionTree
-  const Conditionals &conditionals() const;
+  /// Get Conditionals DecisionTree (dynamic cast from factors)
+  const Conditionals conditionals() const;
 
   /**
    * @brief Compute the logProbability of this hybrid Gaussian conditional.
@@ -241,7 +239,6 @@ class GTSAM_EXPORT HybridGaussianConditional
   void serialize(Archive &ar, const unsigned int /*version*/) {
     ar &BOOST_SERIALIZATION_BASE_OBJECT_NVP(BaseFactor);
     ar &BOOST_SERIALIZATION_BASE_OBJECT_NVP(BaseConditional);
-    ar &BOOST_SERIALIZATION_NVP(conditionals_);
   }
 #endif
 };

--- a/gtsam/hybrid/HybridGaussianConditional.h
+++ b/gtsam/hybrid/HybridGaussianConditional.h
@@ -241,7 +241,7 @@ class GTSAM_EXPORT HybridGaussianConditional
 
   /// Private constructor that uses helper struct above.
   HybridGaussianConditional(const DiscreteKeys &discreteParents,
-                            const Helper &helper);
+                            Helper &&helper);
 
   /// Check whether `given` has values for all frontal keys.
   bool allFrontalsGiven(const VectorValues &given) const;

--- a/gtsam/hybrid/HybridGaussianConditional.h
+++ b/gtsam/hybrid/HybridGaussianConditional.h
@@ -191,6 +191,7 @@ class GTSAM_EXPORT HybridGaussianConditional
       const VectorValues &given) const;
 
   /// Get Conditionals DecisionTree (dynamic cast from factors)
+  /// @note Slow: avoid using in favor of factors(), which uses existing tree.
   const Conditionals conditionals() const;
 
   /**
@@ -228,6 +229,14 @@ class GTSAM_EXPORT HybridGaussianConditional
   /// Private constructor that uses helper struct above.
   HybridGaussianConditional(const DiscreteKeys &discreteParents,
                             const Helper &helper);
+
+  /// Private constructor used when constants have already been calculated.
+  HybridGaussianConditional(const DiscreteKeys &discreteKeys, int nrFrontals,
+                            const FactorValuePairs &factors,
+                            double negLogConstant)
+      : BaseFactor(discreteKeys, factors),
+        BaseConditional(nrFrontals),
+        negLogConstant_(negLogConstant) {}
 
   /// Check whether `given` has values for all frontal keys.
   bool allFrontalsGiven(const VectorValues &given) const;

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -20,6 +20,7 @@
 
 #include <gtsam/base/utilities.h>
 #include <gtsam/discrete/Assignment.h>
+#include <gtsam/discrete/DecisionTreeFactor.h>
 #include <gtsam/discrete/DiscreteEliminationTree.h>
 #include <gtsam/discrete/DiscreteFactorGraph.h>
 #include <gtsam/discrete/DiscreteJunctionTree.h>
@@ -47,8 +48,6 @@
 #include <stdexcept>
 #include <utility>
 #include <vector>
-
-#include "gtsam/discrete/DecisionTreeFactor.h"
 
 namespace gtsam {
 
@@ -367,6 +366,7 @@ HybridGaussianFactorGraph::eliminate(const Ordering &keys) const {
   // any difference in noise models used.
   HybridGaussianProductFactor productFactor = collectProductFactor();
 
+  // Check if a factor is null
   auto isNull = [](const GaussianFactor::shared_ptr &ptr) { return !ptr; };
 
   // This is the elimination method on the leaf nodes

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -367,7 +367,7 @@ HybridGaussianFactorGraph::eliminate(const Ordering &keys) const {
   // any difference in noise models used.
   HybridGaussianProductFactor productFactor = collectProductFactor();
 
-  auto isNull = [](const GaussianFactor::shared_ptr& ptr) { return !ptr; };
+  auto isNull = [](const GaussianFactor::shared_ptr &ptr) { return !ptr; };
 
   // This is the elimination method on the leaf nodes
   bool someContinuousLeft = false;
@@ -375,6 +375,8 @@ HybridGaussianFactorGraph::eliminate(const Ordering &keys) const {
       [&](const std::pair<GaussianFactorGraph, double> &pair) -> Result {
     const auto &[graph, scalar] = pair;
 
+    // If any product contains a pruned factor, prune it here. Done here as it's
+    // non non-trivial to do within collectProductFactor.
     if (graph.empty() || std::any_of(graph.begin(), graph.end(), isNull)) {
       return {nullptr, 0.0, nullptr, 0.0};
     }

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -390,7 +390,7 @@ HybridGaussianFactorGraph::eliminate(const Ordering &keys) const {
   };
 
   // Perform elimination!
-  ResultTree eliminationResults(prunedProductFactor, eliminate);
+  const ResultTree eliminationResults(prunedProductFactor, eliminate);
 
   // If there are no more continuous parents we create a DiscreteFactor with the
   // error for each discrete choice. Otherwise, create a HybridGaussianFactor


### PR DESCRIPTION
# Speedups across the board
## In DT:
- speed up DT conversion if labels stay 

## In HGC
- remove double storage: just one tree in HGF base class
- special constructor straight from this base class storage

## In HGFG
- prune empty graphs on the fly
- new `Result` struct to eliminate double compute of negLogK
- use new HGC constructor

## Extra
- DT method `split` : unused for now but could speed up if split could build only two trees instead of three; in that case, we could try building ResultTree as two trees instead, and one of them could be used to create the HGCs directly
