### PR TITLE
Some Hybrid iSAM cleanup

### DIFF
--- a/gtsam/hybrid/HybridGaussianFactorGraph.h
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.h
@@ -133,6 +133,14 @@ class GTSAM_EXPORT HybridGaussianFactorGraph
       : Base(factors) {}
 
   /**
+   * Construct from an initializer lists of GaussianFactor shared pointers.
+   * Example:
+   *   HybridGaussianFactorGraph graph = { factor1, factor2, factor3 };
+   */
+  HybridGaussianFactorGraph(std::initializer_list<sharedFactor> factors)
+      : Base(factors) {}
+
+  /**
    * Implicit copy/downcast constructor to override explicit template container
    * constructor. In BayesTree this is used for:
    * `cachedSeparatorMarginal_.reset(*separatorMarginal)`

--- a/gtsam/hybrid/HybridGaussianISAM.cpp
+++ b/gtsam/hybrid/HybridGaussianISAM.cpp
@@ -10,7 +10,7 @@
  * -------------------------------------------------------------------------- */
 
 /**
- * @file HybridGaussianISAM.h
+ * @file HybridGaussianISAM.cpp
  * @date March 31, 2022
  * @author Fan Jiang
  * @author Frank Dellaert

--- a/gtsam/hybrid/HybridNonlinearISAM.cpp
+++ b/gtsam/hybrid/HybridNonlinearISAM.cpp
@@ -39,8 +39,8 @@ void HybridNonlinearISAM::update(const HybridNonlinearFactorGraph& newFactors,
   if (newFactors.size() > 0) {
     // Reorder and relinearize every reorderInterval updates
     if (reorderInterval_ > 0 && ++reorderCounter_ >= reorderInterval_) {
-      // TODO(Varun) Relinearization doesn't take into account pruning
-      reorder_relinearize();
+      // TODO(Varun) Re-linearization doesn't take into account pruning
+      reorderRelinearize();
       reorderCounter_ = 0;
     }
 
@@ -60,7 +60,7 @@ void HybridNonlinearISAM::update(const HybridNonlinearFactorGraph& newFactors,
 }
 
 /* ************************************************************************* */
-void HybridNonlinearISAM::reorder_relinearize() {
+void HybridNonlinearISAM::reorderRelinearize() {
   if (factors_.size() > 0) {
     // Obtain the new linearization point
     const Values newLinPoint = estimate();
@@ -69,7 +69,7 @@ void HybridNonlinearISAM::reorder_relinearize() {
 
     // Just recreate the whole BayesTree
     // TODO: allow for constrained ordering here
-    // TODO: decouple relinearization and reordering to avoid
+    // TODO: decouple re-linearization and reordering to avoid
     isam_.update(*factors_.linearize(newLinPoint), {}, {},
                  eliminationFunction_);
 

--- a/gtsam/hybrid/HybridNonlinearISAM.h
+++ b/gtsam/hybrid/HybridNonlinearISAM.h
@@ -37,7 +37,7 @@ class GTSAM_EXPORT HybridNonlinearISAM {
   /// The discrete assignment
   DiscreteValues assignment_;
 
-  /** The original factors, used when relinearizing */
+  /** The original factors, used when re-linearizing */
   HybridNonlinearFactorGraph factors_;
 
   /** The reordering interval and counter */
@@ -52,8 +52,8 @@ class GTSAM_EXPORT HybridNonlinearISAM {
   /// @{
 
   /**
-   * Periodically reorder and relinearize
-   * @param reorderInterval is the number of updates between reorderings,
+   * Periodically reorder and re-linearize
+   * @param reorderInterval is the number of updates between re-orderings,
    *   0 never reorders (and is dangerous for memory consumption)
    *  1 (default) reorders every time, in worse case is batch every update
    *  typical values are 50 or 100
@@ -124,8 +124,8 @@ class GTSAM_EXPORT HybridNonlinearISAM {
               const std::optional<size_t>& maxNrLeaves = {},
               const std::optional<Ordering>& ordering = {});
 
-  /** Relinearization and reordering of variables */
-  void reorder_relinearize();
+  /** Re-linearization and reordering of variables */
+  void reorderRelinearize();
 
   /// @}
 };

--- a/gtsam/hybrid/tests/testHybridEstimation.cpp
+++ b/gtsam/hybrid/tests/testHybridEstimation.cpp
@@ -37,6 +37,8 @@
 // Include for test suite
 #include <CppUnitLite/TestHarness.h>
 
+#include <string>
+
 #include "Switching.h"
 
 using namespace std;
@@ -55,13 +57,16 @@ std::vector<size_t> discrete_seq = {1, 1, 0, 0, 0, 1, 1, 1, 1, 0,
 Switching InitializeEstimationProblem(
     const size_t K, const double between_sigma, const double measurement_sigma,
     const std::vector<double>& measurements,
-    const std::string& discrete_transition_prob,
+    const std::string& transitionProbabilityTable,
     HybridNonlinearFactorGraph& graph, Values& initial) {
   Switching switching(K, between_sigma, measurement_sigma, measurements,
-                      discrete_transition_prob);
+                      transitionProbabilityTable);
+
+  // Add prior on M(0)
+  graph.push_back(switching.modeChain.at(0));
 
   // Add the X(0) prior
-  graph.push_back(switching.nonlinearFactorGraph.at(0));
+  graph.push_back(switching.unaryFactors.at(0));
   initial.insert(X(0), switching.linearizationPoint.at<double>(X(0)));
 
   return switching;
@@ -128,10 +133,9 @@ TEST(HybridEstimation, IncrementalSmoother) {
 
   constexpr size_t maxNrLeaves = 3;
   for (size_t k = 1; k < K; k++) {
-    // Motion Model
-    graph.push_back(switching.nonlinearFactorGraph.at(k));
-    // Measurement
-    graph.push_back(switching.nonlinearFactorGraph.at(k + K - 1));
+    if (k > 1) graph.push_back(switching.modeChain.at(k - 1));  // Mode chain
+    graph.push_back(switching.binaryFactors.at(k - 1));         // Motion Model
+    graph.push_back(switching.unaryFactors.at(k));              // Measurement
 
     initial.insert(X(k), switching.linearizationPoint.at<double>(X(k)));
 
@@ -176,10 +180,9 @@ TEST(HybridEstimation, ValidPruningError) {
 
   constexpr size_t maxNrLeaves = 3;
   for (size_t k = 1; k < K; k++) {
-    // Motion Model
-    graph.push_back(switching.nonlinearFactorGraph.at(k));
-    // Measurement
-    graph.push_back(switching.nonlinearFactorGraph.at(k + K - 1));
+    if (k > 1) graph.push_back(switching.modeChain.at(k - 1));  // Mode chain
+    graph.push_back(switching.binaryFactors.at(k - 1));         // Motion Model
+    graph.push_back(switching.unaryFactors.at(k));              // Measurement
 
     initial.insert(X(k), switching.linearizationPoint.at<double>(X(k)));
 
@@ -225,15 +228,17 @@ TEST(HybridEstimation, ISAM) {
 
   HybridGaussianFactorGraph linearized;
 
+  const size_t maxNrLeaves = 3;
   for (size_t k = 1; k < K; k++) {
-    // Motion Model
-    graph.push_back(switching.nonlinearFactorGraph.at(k));
-    // Measurement
-    graph.push_back(switching.nonlinearFactorGraph.at(k + K - 1));
+    if (k > 1) graph.push_back(switching.modeChain.at(k - 1));  // Mode chain
+    graph.push_back(switching.binaryFactors.at(k - 1));         // Motion Model
+    graph.push_back(switching.unaryFactors.at(k));              // Measurement
 
     initial.insert(X(k), switching.linearizationPoint.at<double>(X(k)));
 
-    isam.update(graph, initial, 3);
+    isam.update(graph, initial, maxNrLeaves);
+    // isam.saveGraph("NLiSAM" + std::to_string(k) + ".dot");
+    // GTSAM_PRINT(isam);
 
     graph.resize(0);
     initial.clear();

--- a/gtsam/hybrid/tests/testHybridEstimation.cpp
+++ b/gtsam/hybrid/tests/testHybridEstimation.cpp
@@ -339,12 +339,8 @@ TEST(HybridEstimation, Probability) {
   HybridValues hybrid_values = bayesNet->optimize();
 
   // This is the correct sequence as designed
-  DiscreteValues discrete_seq;
-  discrete_seq[M(0)] = 1;
-  discrete_seq[M(1)] = 1;
-  discrete_seq[M(2)] = 0;
-
-  EXPECT(assert_equal(discrete_seq, hybrid_values.discrete()));
+  DiscreteValues expectedSequence{{M(0), 1}, {M(1), 1}, {M(2), 0}};
+  EXPECT(assert_equal(expectedSequence, hybrid_values.discrete()));
 }
 
 /****************************************************************************/
@@ -411,12 +407,8 @@ TEST(HybridEstimation, ProbabilityMultifrontal) {
   HybridValues hybrid_values = discreteBayesTree->optimize();
 
   // This is the correct sequence as designed
-  DiscreteValues discrete_seq;
-  discrete_seq[M(0)] = 1;
-  discrete_seq[M(1)] = 1;
-  discrete_seq[M(2)] = 0;
-
-  EXPECT(assert_equal(discrete_seq, hybrid_values.discrete()));
+  DiscreteValues expectedSequence{{M(0), 1}, {M(1), 1}, {M(2), 0}};
+  EXPECT(assert_equal(expectedSequence, hybrid_values.discrete()));
 }
 
 /*********************************************************************************

--- a/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridNonlinearFactorGraph.cpp
@@ -216,8 +216,8 @@ TEST(HybridNonlinearFactorGraph, PushBack) {
 TEST(HybridNonlinearFactorGraph, ErrorTree) {
   Switching s(3);
 
-  HybridNonlinearFactorGraph graph = s.nonlinearFactorGraph;
-  Values values = s.linearizationPoint;
+  const HybridNonlinearFactorGraph &graph = s.nonlinearFactorGraph();
+  const Values &values = s.linearizationPoint;
 
   auto error_tree = graph.errorTree(s.linearizationPoint);
 
@@ -248,7 +248,7 @@ TEST(HybridNonlinearFactorGraph, ErrorTree) {
 TEST(HybridNonlinearFactorGraph, Switching) {
   Switching self(3);
 
-  EXPECT_LONGS_EQUAL(7, self.nonlinearFactorGraph.size());
+  EXPECT_LONGS_EQUAL(7, self.nonlinearFactorGraph().size());
   EXPECT_LONGS_EQUAL(7, self.linearizedFactorGraph.size());
 }
 
@@ -260,7 +260,7 @@ TEST(HybridNonlinearFactorGraph, Linearization) {
 
   // Linearize here:
   HybridGaussianFactorGraph actualLinearized =
-      *self.nonlinearFactorGraph.linearize(self.linearizationPoint);
+      *self.nonlinearFactorGraph().linearize(self.linearizationPoint);
 
   EXPECT_LONGS_EQUAL(7, actualLinearized.size());
 }
@@ -409,7 +409,7 @@ TEST(HybridNonlinearFactorGraph, Partial_Elimination) {
 /* ****************************************************************************/
 TEST(HybridNonlinearFactorGraph, Error) {
   Switching self(3);
-  HybridNonlinearFactorGraph fg = self.nonlinearFactorGraph;
+  HybridNonlinearFactorGraph fg = self.nonlinearFactorGraph();
 
   {
     HybridValues values(VectorValues(), DiscreteValues{{M(0), 0}, {M(1), 0}},
@@ -441,8 +441,9 @@ TEST(HybridNonlinearFactorGraph, Error) {
 TEST(HybridNonlinearFactorGraph, PrintErrors) {
   Switching self(3);
 
-  // Get nonlinear factor graph and add linear factors to be holistic
-  HybridNonlinearFactorGraph fg = self.nonlinearFactorGraph;
+  // Get nonlinear factor graph and add linear factors to be holistic.
+  // TODO(Frank): ???
+  HybridNonlinearFactorGraph fg = self.nonlinearFactorGraph();
   fg.add(self.linearizedFactorGraph);
 
   // Optimize to get HybridValues


### PR DESCRIPTION
- some naming conventions and spelling
- Made a more robust interface to Switching
- changed HybridGaussianISAM tests to reuse update graphs
- kept HybridNonlinearISAM tests the same but modernized them a bit
- in both cases, kept some regression but made tests have real teeth
- Added chain factors in testHybridEstimation

PS, ISAM test in latter produces BayesTrees like this, which seems right:

<img width="345" alt="image" src="https://github.com/user-attachments/assets/3fd3e115-d025-4602-b0d2-be46bb092593">
