### PR TITLE
Allow parent project to override options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.0)
 
+# allow parent project to override options
+if (POLICY CMP0077)
+  cmake_policy(SET CMP0077 NEW)
+endif(POLICY CMP0077)
+
+
 # Set the version number for the library
 set (GTSAM_VERSION_MAJOR 4)
 set (GTSAM_VERSION_MINOR 3)


### PR DESCRIPTION
I needed to depend on gtsam without boost, but when using fetch content I couldn't override the options relating to boost usage to disable it

I fixed this by setting polity CMP0077