### PR TITLE
Fix warning: ‘beta’ may be used uninitialized in this function

### DIFF
--- a/gtsam/nonlinear/NonlinearConjugateGradientOptimizer.h
+++ b/gtsam/nonlinear/NonlinearConjugateGradientOptimizer.h
@@ -21,6 +21,8 @@
 #include <gtsam/base/Manifold.h>
 #include <gtsam/nonlinear/NonlinearOptimizer.h>
 
+#include <stdexcept>
+
 namespace gtsam {
 
 /// Fletcher-Reeves formula for computing β, the direction of steepest descent.
@@ -247,6 +249,9 @@ std::tuple<V, int> nonlinearConjugateGradient(
         case DirectionMethod::DaiYuan:
           beta = DaiYuan(currentGradient, prevGradient, direction);
           break;
+        default:
+          throw std::runtime_error(
+              "NonlinearConjugateGradientOptimizer: Invalid directionMethod");
       }
 
       direction = currentGradient + (beta * direction);


### PR DESCRIPTION
Simple change. Trying to make ROS builds quieter...