### PR TITLE
Fix `minNegLogConstant` after pruning

### DIFF
--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -198,6 +198,35 @@ AlgebraicDecisionTree<Key> HybridBayesNet::errorTree(
 }
 
 /* ************************************************************************* */
+double HybridBayesNet::negLogConstant() const {
+  double negLogNormConst = 0.0;
+  // Iterate over each conditional.
+  for (auto &&conditional : *this) {
+    negLogNormConst += conditional->negLogConstant();
+  }
+  return negLogNormConst;
+}
+
+/* ************************************************************************* */
+double HybridBayesNet::negLogConstant(const DiscreteValues &discrete) const {
+  double negLogNormConst = 0.0;
+  // Iterate over each conditional.
+  for (auto &&conditional : *this) {
+    if (auto gm = conditional->asHybrid()) {
+      negLogNormConst += gm->choose(discrete)->negLogConstant();
+    } else if (auto gc = conditional->asGaussian()) {
+      negLogNormConst += gc->negLogConstant();
+    } else if (auto dc = conditional->asDiscrete()) {
+      negLogNormConst += dc->choose(discrete)->negLogConstant();
+    } else {
+      throw std::runtime_error(
+          "Unknown conditional type when computing negLogConstant");
+    }
+  }
+  return negLogNormConst;
+}
+
+/* ************************************************************************* */
 AlgebraicDecisionTree<Key> HybridBayesNet::discretePosterior(
     const VectorValues &continuousValues) const {
   AlgebraicDecisionTree<Key> errors = this->errorTree(continuousValues);

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -238,6 +238,23 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
   using BayesNet::logProbability;  // expose HybridValues version
 
   /**
+   * @brief Get the negative log of the normalization constant corresponding
+   * to the joint density represented by this Bayes net.
+   *
+   * @return double
+   */
+  double negLogConstant() const;
+
+  /**
+   * @brief Get the negative log of the normalization constant
+   * corresponding to the joint Gaussian density represented by
+   * this Bayes net indexed by `discrete`.
+   *
+   * @return double
+   */
+  double negLogConstant(const DiscreteValues &discrete) const;
+
+  /**
    * @brief Compute normalized posterior P(M|X=x) and return as a tree.
    *
    * @note Not a DiscreteConditional as the cardinalities of the DiscreteKeys,

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -238,21 +238,14 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
   using BayesNet::logProbability;  // expose HybridValues version
 
   /**
-   * @brief Get the negative log of the normalization constant corresponding
-   * to the joint density represented by this Bayes net.
-   *
-   * @return double
-   */
-  double negLogConstant() const;
-
-  /**
    * @brief Get the negative log of the normalization constant
-   * corresponding to the joint Gaussian density represented by
-   * this Bayes net indexed by `discrete`.
+   * corresponding to the joint density represented by this Bayes net.
+   * Optionally index by `discrete`.
    *
+   * @param discrete Optional DiscreteValues
    * @return double
    */
-  double negLogConstant(const DiscreteValues &discrete) const;
+  double negLogConstant(const std::optional<DiscreteValues> &discrete) const;
 
   /**
    * @brief Compute normalized posterior P(M|X=x) and return as a tree.

--- a/gtsam/hybrid/HybridGaussianConditional.cpp
+++ b/gtsam/hybrid/HybridGaussianConditional.cpp
@@ -322,8 +322,11 @@ HybridGaussianConditional::shared_ptr HybridGaussianConditional::prune(
           const GaussianFactorValuePair &pair) -> GaussianFactorValuePair {
     if (max->evaluate(choices) == 0.0)
       return {nullptr, std::numeric_limits<double>::infinity()};
-    else
-      return pair;
+    else {
+      // Add negLogConstant_ back so that the minimum negLogConstant in the
+      // HybridGaussianConditional is set correctly.
+      return {pair.first, pair.second + negLogConstant_};
+    }
   };
 
   FactorValuePairs prunedConditionals = factors().apply(pruner);

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -59,10 +59,11 @@ using OrphanWrapper = BayesTreeOrphanWrapper<HybridBayesTree::Clique>;
 
 /// Result from elimination.
 struct Result {
+  // Gaussian conditional resulting from elimination.
   GaussianConditional::shared_ptr conditional;
-  double negLogK;
-  GaussianFactor::shared_ptr factor;
-  double scalar;
+  double negLogK;  // Negative log of the normalization constant K.
+  GaussianFactor::shared_ptr factor;  // Leftover factor 𝜏.
+  double scalar;                      // Scalar value associated with factor 𝜏.
 
   bool operator==(const Result &other) const {
     return conditional == other.conditional && negLogK == other.negLogK &&

--- a/gtsam/hybrid/tests/testHybridGaussianConditional.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianConditional.cpp
@@ -275,6 +275,11 @@ TEST(HybridGaussianConditional, Prune) {
 
     // Check that the pruned HybridGaussianConditional has 2 conditionals
     EXPECT_LONGS_EQUAL(2, pruned->nrComponents());
+
+    // Check that the minimum negLogConstant is set correctly
+    EXPECT_DOUBLES_EQUAL(
+        hgc.conditionals()({{M(1), 0}, {M(2), 1}})->negLogConstant(),
+        pruned->negLogConstant(), 1e-9);
   }
   {
     const std::vector<double> potentials{0.2, 0, 0.3, 0,  //
@@ -285,6 +290,9 @@ TEST(HybridGaussianConditional, Prune) {
 
     // Check that the pruned HybridGaussianConditional has 3 conditionals
     EXPECT_LONGS_EQUAL(3, pruned->nrComponents());
+
+    // Check that the minimum negLogConstant is correct
+    EXPECT_DOUBLES_EQUAL(hgc.negLogConstant(), pruned->negLogConstant(), 1e-9);
   }
 }
 


### PR DESCRIPTION
I identified a bug where the `minNegLogConstant` was being set to 0 instead of the minimum of the possible negative log constants. This PR fixes that.

On the heels of that fix, I added some extra methods to `HybridBayesNet` and got two tests which were marked as failing to pass.