### PR TITLE
Update MacOS Images for CI

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -25,20 +25,32 @@ jobs:
         # Github Actions requires a single row to be added to the build matrix.
         # See https://help.github.com/en/articles/workflow-syntax-for-github-actions.
         name: [
-          macos-12-xcode-14.2,
+          macos-13-xcode-14.2,
+          macos-13-arm64-xcode-14.2,
           macos-14-xcode-15.4,
+          macos-14-arm64-xcode-15.4,
         ]
 
         build_type: [Debug, Release]
         build_unstable: [ON]
         include:
-          - name: macos-12-xcode-14.2
-            os: macos-12
+          - name: macos-13-xcode-14.2
+            os: macos-13
+            compiler: xcode
+            version: "14.2"
+
+            - name: macos-13-arm64-xcode-14.2
+            os: macos-13-xlarge
             compiler: xcode
             version: "14.2"
 
           - name: macos-14-xcode-15.4
             os: macos-14
+            compiler: xcode
+            version: "15.4"
+
+            - name: macos-14-arm64-xcode-15.4
+            os: macos-14-xlarge
             compiler: xcode
             version: "15.4"
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -26,9 +26,7 @@ jobs:
         # See https://help.github.com/en/articles/workflow-syntax-for-github-actions.
         name: [
           macos-13-xcode-14.2,
-          macos-13-arm64-xcode-14.2,
           macos-14-xcode-15.4,
-          macos-14-arm64-xcode-15.4,
         ]
 
         build_type: [Debug, Release]
@@ -39,18 +37,8 @@ jobs:
             compiler: xcode
             version: "14.2"
 
-          - name: macos-13-arm64-xcode-14.2
-            os: macos-13-xlarge
-            compiler: xcode
-            version: "14.2"
-
           - name: macos-14-xcode-15.4
             os: macos-14
-            compiler: xcode
-            version: "15.4"
-
-          - name: macos-14-arm64-xcode-15.4
-            os: macos-14-xlarge
             compiler: xcode
             version: "15.4"
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -39,7 +39,7 @@ jobs:
             compiler: xcode
             version: "14.2"
 
-            - name: macos-13-arm64-xcode-14.2
+          - name: macos-13-arm64-xcode-14.2
             os: macos-13-xlarge
             compiler: xcode
             version: "14.2"
@@ -49,7 +49,7 @@ jobs:
             compiler: xcode
             version: "15.4"
 
-            - name: macos-14-arm64-xcode-15.4
+          - name: macos-14-arm64-xcode-15.4
             os: macos-14-xlarge
             compiler: xcode
             version: "15.4"

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -30,7 +30,6 @@ jobs:
           [
             ubuntu-20.04-gcc-9,
             ubuntu-20.04-clang-9,
-            macos-14-arm64-xcode-15.4,
             macos-14-xcode-15.4,
             windows-2022-msbuild,
           ]
@@ -47,11 +46,6 @@ jobs:
             os: ubuntu-20.04
             compiler: clang
             version: "9"
-
-          - name: macos-14-arm64-xcode-15.4
-            os: macos-14-xlarge
-            compiler: xcode
-            version: "15.4"
 
           - name: macos-14-xcode-15.4
             os: macos-14

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -30,6 +30,7 @@ jobs:
           [
             ubuntu-20.04-gcc-9,
             ubuntu-20.04-clang-9,
+            macos-13-xcode-14.2,
             macos-14-xcode-15.4,
             windows-2022-msbuild,
           ]
@@ -46,6 +47,11 @@ jobs:
             os: ubuntu-20.04
             compiler: clang
             version: "9"
+
+          - name: macos-13-xcode-14.2
+            os: macos-13
+            compiler: xcode
+            version: "14.2"
 
           - name: macos-14-xcode-15.4
             os: macos-14

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -30,7 +30,7 @@ jobs:
           [
             ubuntu-20.04-gcc-9,
             ubuntu-20.04-clang-9,
-            macos-12-xcode-14.2,
+            macos-14-arm64-xcode-15.4,
             macos-14-xcode-15.4,
             windows-2022-msbuild,
           ]
@@ -48,10 +48,10 @@ jobs:
             compiler: clang
             version: "9"
 
-          - name: macos-12-xcode-14.2
-            os: macos-12
+          - name: macos-14-arm64-xcode-15.4
+            os: macos-14-xlarge
             compiler: xcode
-            version: "14.2"
+            version: "15.4"
 
           - name: macos-14-xcode-15.4
             os: macos-14


### PR DESCRIPTION
Github Actions has [deprecated macos-12](https://github.com/actions/runner-images), so upgrading to macos-13.

Additionally, adding support for Mac ARM64 processors in the CI.