### PR TITLE
Reduce memory consumption during discrete pruning

### DIFF
--- a/gtsam/discrete/DecisionTreeFactor.cpp
+++ b/gtsam/discrete/DecisionTreeFactor.cpp
@@ -363,13 +363,15 @@ namespace gtsam {
     /// Push value onto the heap
     void push(double x) {
       v_.push_back(x);
-      std::make_heap(v_.begin(), v_.end(), std::greater<double>{});
+      std::push_heap(v_.begin(), v_.end(), std::greater<double>{});
     }
 
     /// Push value `x`, `n` number of times.
     void push(double x, size_t n) {
-      v_.insert(v_.end(), n, x);
-      std::make_heap(v_.begin(), v_.end(), std::greater<double>{});
+      for (size_t i = 0; i < n; ++i) {
+        v_.push_back(x);
+        std::push_heap(v_.begin(), v_.end(), std::greater<double>{});
+      }
     }
 
     /// Pop the top value of the heap.
@@ -390,10 +392,11 @@ namespace gtsam {
      */
     void print(const std::string& s = "") {
       std::cout << (s.empty() ? "" : s + " ");
-      for (size_t i = 0; i < v_.size() - 1; i++) {
-        std::cout << v_.at(i) << ",";
+      for (size_t i = 0; i < v_.size(); i++) {
+        std::cout << v_.at(i);
+        if (v_.size() > 1 && i < v_.size() - 1) std::cout << ", ";
       }
-      std::cout << v_.at(v_.size() - 1) << std::endl;
+      std::cout << std::endl;
     }
 
     /// Return true if heap is empty.

--- a/gtsam/discrete/DecisionTreeFactor.cpp
+++ b/gtsam/discrete/DecisionTreeFactor.cpp
@@ -239,7 +239,7 @@ namespace gtsam {
     };
 
     // Go through the tree
-    this->apply(op);
+    this->visitWith(op);
 
     return probs;
   }


### PR DESCRIPTION
When running pruning, especially when we have a large number of discrete variables, the code would try to collect all the values in a `std::vector`. In the case we had >20 discrete variables with cardinality 2 each, this would lead to vectors of size greater than a million, thus taking up a large amount of memory.
Once the allocated heap memory exceeded a limit, the OS would automatically kill the process.

To address this, I implemented a simple `MinHeap` class and used it to maintain at most `maxNrAssignments` values in the heap, popping smaller values as necessary.

This successfully addresses the memory issue, and on profiling with gperftools, the heap profile **drops from 25 GB to less than 1 MB**. Consequently, I have been able to run the hybrid estimator to **over 120 timesteps, up from a limit of 28**.

The estimator is still struggling once we go beyond 150 due to the large number of discrete variables at that point. This would seem like a good candidate for some sort of marginalization scheme, since the initial 50 discrete variables shouldn't be affected much.