### PR TITLE
Bump min required cmake version to 3.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.9)
 if (POLICY CMP0082)
     cmake_policy(SET CMP0082 NEW) # install from sub-directories immediately
 endif()


### PR DESCRIPTION
In the top-level cmake file. It was 3.5 and recent cmake versions complain about it becoming deprecate.
Also, the wrap directory already required 3.9 anyhow.

PS: This is only an issue to users of Ubuntu 16.04 or older...