### PR TITLE
Add GNC threshold parameter

### DIFF
--- a/examples/GNCExample.cpp
+++ b/examples/GNCExample.cpp
@@ -63,7 +63,8 @@ int main() {
 
   // Set GNC-specific options
   GncParams<LevenbergMarquardtParams> gncParams(lmParams);
-  gncParams.setLossType(GncLossType::TLS);
+  gncParams.setLossType(GncLossType::TLS);  // Truncated Least Squares or Geman-McClure 
+  gncParams.setBarc(1.0);                   // Parameter $c$ in Truncated Least Squares or Geman-McClure
 
   // Optimize the graph and print results
   GncOptimizer<GncParams<LevenbergMarquardtParams>> optimizer(graph, initial, gncParams);

--- a/gtsam/nonlinear/GncOptimizer.h
+++ b/gtsam/nonlinear/GncOptimizer.h
@@ -128,7 +128,7 @@ class GncOptimizer {
    * alpha that the inlier residuals are smaller than that threshold
    * */
   void setInlierCostThresholdsAtProbability(const double alpha) {
-    barcSq_  = Vector::Ones(nfg_.size()); // initialize
+    barcSq_  = (params_.barc * params_.barc) * Vector::Ones(nfg_.size()); // initialize threshold to $bar{c}^2$
     for (size_t k = 0; k < nfg_.size(); k++) {
       if (nfg_[k]) {
         barcSq_[k] = 0.5 * Chi2inv(alpha, nfg_[k]->dim()); // 0.5 derives from the error definition in gtsam

--- a/gtsam/nonlinear/GncParams.h
+++ b/gtsam/nonlinear/GncParams.h
@@ -71,6 +71,8 @@ class GncParams {
   double muStep = 1.4;  ///< Multiplicative factor to reduce/increase the mu in gnc
   double relativeCostTol = 1e-5;  ///< If relative cost change is below this threshold, stop iterating
   double weightsTol = 1e-4;  ///< If the weights are within weightsTol from being binary, stop iterating (only for TLS)
+  double barc = 1.0; ///< Default inlier threshold $\bar{c}$ = 1
+
   Verbosity verbosity = SILENT;  ///< Verbosity level
 
   /// Use IndexVector for inliers and outliers since it is fast
@@ -106,6 +108,11 @@ class GncParams {
   /// Set the maximum difference between the weights and their rounding in {0,1} to stop iterating.
   void setWeightsTol(double value) {
     weightsTol = value;
+  }
+
+  /// Set the inlier threshold $\bar{c}$.
+  void setBarc(double value) {
+    barc = value;
   }
 
   /// Set the verbosity level.


### PR DESCRIPTION
This PR adds the ability to change $\bar{c}$ in the TLS/GM function.

$$
\rho_\text{TLS}(r, \bar{c})=\min(r^2, \bar{c}^2)\ ;\ \ \rho_\text{GM}(r, \bar{c})=\frac{\bar{c}^2r^2}{\bar{c}^2+r^2}
$$

---

Originally, in `gtsam/nonlinear/GncOptimizer.h`, $\bar{c}$ is always set to 1.
```c++
void setInlierCostThresholdsAtProbability(const double alpha) {
  barcSq_  = Vector::Ones(nfg_.size()); // initialize <- THIS LINE
  for (size_t k = 0; k < nfg_.size(); k++) {
    if (nfg_[k]) {
      barcSq_[k] = 0.5 * Chi2inv(alpha, nfg_[k]->dim()); // 0.5 derives from the error definition in gtsam
    }
  }
}
```

We add a `barc` parameter to `gtsam/nonlinear/GncParams.h`, thereby we can set `barcSq` with respect to `barc`
```c++
void setInlierCostThresholdsAtProbability(const double alpha) {
  barcSq_  = (params_.barc * params_.barc) * Vector::Ones(nfg_.size()); // initialize threshold to $bar{c}^2$
  for (size_t k = 0; k < nfg_.size(); k++) {
    if (nfg_[k]) {
      barcSq_[k] = 0.5 * Chi2inv(alpha, nfg_[k]->dim()); // 0.5 derives from the error definition in gtsam
    }
  }
}
```

We also tested it in `examples/GNCExample.cpp`
```c++
// Set GNC-specific options
GncParams<LevenbergMarquardtParams> gncParams(lmParams);
gncParams.setLossType(GncLossType::TLS);  // Truncated Least Squares or Geman-McClure 
gncParams.setBarc(1.0);                   // Parameter $c$ in Truncated Least Squares or Geman-McClure
```

---

In addition, there are other ways to set `barcSq` in `gtsam/nonlinear/GncOptimizer.h`
```c++
void setInlierCostThresholds(const double inth) {
  barcSq_ = inth * Vector::Ones(nfg_.size());
}

void setInlierCostThresholds(const Vector& inthVec) {
  barcSq_ = inthVec;
}
```

These two functions are not used in the origin GNC implementation, thus I am not sure what `inth` is. It seems like `inth` is $\bar{c}^2$ in `gtsam/test/testGncOptimizer.cpp` and is meant to set to $\bar{c}^2$ directly if known, so I left it unchanged.