### PR TITLE
fix CHECK_EQUAL

### DIFF
--- a/CppUnitLite/Test.h
+++ b/CppUnitLite/Test.h
@@ -129,7 +129,7 @@ protected:
     result_.addFailure(Failure(name_, __FILE__, __LINE__, #expected, #actual)); }
 
 #define CHECK_EQUAL(expected,actual)\
-{ if ((expected) == (actual)) return; result_.addFailure(Failure(name_, __FILE__, __LINE__, std::to_string(expected), std::to_string(actual))); }
+{ if (!((expected) == (actual))) { result_.addFailure(Failure(name_, __FILE__, __LINE__, std::to_string(expected), std::to_string(actual))); } }
 
 #define LONGS_EQUAL(expected,actual)\
 { long actualTemp = actual; \


### PR DESCRIPTION
Previously, CHECK_EQUAL returned upon success, skipping the rest of the test.  :-)