### PR TITLE
Fix conversion from `DecisionTree` to `TableFactor`

### DIFF
--- a/gtsam/discrete/tests/testTableFactor.cpp
+++ b/gtsam/discrete/tests/testTableFactor.cpp
@@ -148,6 +148,36 @@ TEST(TableFactor, constructors) {
 }
 
 /* ************************************************************************* */
+// Check conversion from DecisionTreeFactor.
+TEST(TableFactor, Conversion) {
+  /* This is the DecisionTree we are using
+  Choice(m2)
+  0 Choice(m1)
+  0 0 Leaf    0
+  0 1 Choice(m0)
+  0 1 0 Leaf    0
+  0 1 1 Leaf 0.14649446  // 3
+  1 Choice(m1)
+  1 0 Choice(m0)
+  1 0 0 Leaf    0
+  1 0 1 Leaf 0.14648756  // 5
+  1 1 Choice(m0)
+  1 1 0 Leaf 0.14649446  // 6
+  1 1 1 Leaf 0.23918345  // 7
+  */
+  DiscreteKeys dkeys = {{0, 2}, {1, 2}, {2, 2}};
+  DecisionTreeFactor dtf(
+      dkeys, std::vector<double>{0, 0, 0, 0.14649446, 0, 0.14648756, 0.14649446,
+                                 0.23918345});
+
+  // dtf.print();
+  TableFactor tf(dtf.discreteKeys(), dtf);
+  // tf.print();
+  // tf.toDecisionTreeFactor().print();
+  EXPECT(assert_equal(dtf, tf.toDecisionTreeFactor()));
+}
+
+/* ************************************************************************* */
 // Check multiplication between two TableFactors.
 TEST(TableFactor, multiplication) {
   DiscreteKey v0(0, 2), v1(1, 2), v2(2, 2);

--- a/gtsam/discrete/tests/testTableFactor.cpp
+++ b/gtsam/discrete/tests/testTableFactor.cpp
@@ -170,10 +170,8 @@ TEST(TableFactor, Conversion) {
       dkeys, std::vector<double>{0, 0, 0, 0.14649446, 0, 0.14648756, 0.14649446,
                                  0.23918345});
 
-  // dtf.print();
   TableFactor tf(dtf.discreteKeys(), dtf);
-  // tf.print();
-  // tf.toDecisionTreeFactor().print();
+
   EXPECT(assert_equal(dtf, tf.toDecisionTreeFactor()));
 }
 


### PR DESCRIPTION
I recently discovered a bug in the way we are converting a `DecisionTree` (and its derivatives such as `DecisionTreeFactor`) into a `TableFactor`, where the leaf value ordering is incorrect.
I have added a test that showcases this error, called `Conversion`.

## Issue Description

The issue stems from the fact that the DecisionTree is structured with the highest label first, so a DecisionTreeFactor with keys `(x0, x1, x2)` will have a leaf visiting scheme where x0 is the fast moving index and x2 is the slowest moving one.
This results in a different ordering of the resulting vector of leaf values than what the TableFactor expects (where x0 is the slowest moving index and x2 is the fastest), and thus incorrect sparse table construction.

Currently I can't seem to figure out what the correct approach is to "invert" this sequencing. For example, for a tree with leaves `0.5 0.4 0.2 0.5 0.6 0.8` (from the `TableFactor::constructors` test), the output of `DecisionTreeFactor::probabilities` is `0.5, 0.5, 0.4, 0.6, 0.2, 0.8` which gives the ordering as `[0, 4, 2, 6, 1, 5, 3, 7]`.

I spent all day yesterday trying to figure out the mapping between the ordering but there is always some test case that fails. If there is a formula/algorithm for this conversion of orderings, please let me know so I can use that instead of the current approach.

## Proposed Fix

To address the above issue in a general fashion, I updated `ComputeLeafOrdering` to visit the leaves of the tree and generate the `SparseVector` index from the corresponding `Assignment` of discrete keys. This allows us to directly construct the sparse table with the correct indexing and structure, circumventing 2 issues:

1. The need to perform the mapping from highest label first to lowest label first (or any other scheme) ordering.
2. `DecisionTree::probabilities` constructs a **dense** vector which can cause exponential blowup in memory. The proposed approach in this fix prevents the need to ever construct this vector. Of course this means that performance is predicated on the fact that the DecisionTree is "sparse" to begin with.

The major drawback though is that based on a benchmarking test I wrote, this scheme is slower than the current approach, but premature optimization is the root of all evil so we will cross that bridge when we come to it.