### PR TITLE
Left and Right SO(3) Jacobians

### DIFF
--- a/gtsam/geometry/Point3.cpp
+++ b/gtsam/geometry/Point3.cpp
@@ -69,6 +69,16 @@ Point3 cross(const Point3 &p, const Point3 &q, OptionalJacobian<3, 3> H1,
                 p.x() * q.y() - p.y() * q.x());
 }
 
+Point3 doubleCross(const Point3 &p, const Point3 &q,  //
+                   OptionalJacobian<3, 3> H1, OptionalJacobian<3, 3> H2) {
+  if (H1) *H1 = q.dot(p) * I_3x3 + p * q.transpose() - 2 * q * p.transpose();
+  if (H2) {
+    const Matrix3 W = skewSymmetric(p);
+    *H2 = W * W;
+  }
+  return gtsam::cross(p, gtsam::cross(p, q));
+}
+
 double dot(const Point3 &p, const Point3 &q, OptionalJacobian<1, 3> H1,
            OptionalJacobian<1, 3> H2) {
   if (H1) *H1 << q.x(), q.y(), q.z();

--- a/gtsam/geometry/Point3.h
+++ b/gtsam/geometry/Point3.h
@@ -61,9 +61,9 @@ GTSAM_EXPORT Point3 cross(const Point3& p, const Point3& q,
                           OptionalJacobian<3, 3> H_q = {});
 
 /// double cross product @return p x (p x q)
-Point3 doubleCross(const Point3& p, const Point3& q,
-                   OptionalJacobian<3, 3> H1 = {},
-                   OptionalJacobian<3, 3> H2 = {});
+GTSAM_EXPORT Point3 doubleCross(const Point3& p, const Point3& q,
+                                OptionalJacobian<3, 3> H1 = {},
+                                OptionalJacobian<3, 3> H2 = {});
 
 /// dot product
 GTSAM_EXPORT double dot(const Point3& p, const Point3& q,

--- a/gtsam/geometry/Point3.h
+++ b/gtsam/geometry/Point3.h
@@ -55,10 +55,15 @@ GTSAM_EXPORT double norm3(const Point3& p, OptionalJacobian<1, 3> H = {});
 /// normalize, with optional Jacobian
 GTSAM_EXPORT Point3 normalize(const Point3& p, OptionalJacobian<3, 3> H = {});
 
-/// cross product @return this x q
+/// cross product @return p x q
 GTSAM_EXPORT Point3 cross(const Point3& p, const Point3& q,
                           OptionalJacobian<3, 3> H_p = {},
                           OptionalJacobian<3, 3> H_q = {});
+
+/// double cross product @return p x (p x q)
+Point3 doubleCross(const Point3& p, const Point3& q,
+                   OptionalJacobian<3, 3> H1 = {},
+                   OptionalJacobian<3, 3> H2 = {});
 
 /// dot product
 GTSAM_EXPORT double dot(const Point3& p, const Point3& q,

--- a/gtsam/geometry/Pose3.cpp
+++ b/gtsam/geometry/Pose3.cpp
@@ -240,12 +240,10 @@ Vector6 Pose3::ChartAtOrigin::Local(const Pose3& pose, ChartJacobian Hpose) {
 
 /* ************************************************************************* */
 namespace pose3 {
-class GTSAM_EXPORT ExpmapFunctor : public so3::DexpFunctor {
- protected:
+struct GTSAM_EXPORT ExpmapFunctor : public so3::DexpFunctor {
   // Constant used in computeQ
   double F;  // (B - 0.5) / theta2 or -1/24 for theta->0
 
- public:
   ExpmapFunctor(const Vector3& omega, bool nearZeroApprox = false)
       : so3::DexpFunctor(omega, nearZeroApprox) {
     F = nearZero ? _one_twenty_fourth : (B - 0.5) / theta2;
@@ -253,7 +251,7 @@ class GTSAM_EXPORT ExpmapFunctor : public so3::DexpFunctor {
 
   // Compute the bottom-left 3x3 block of the SE(3) Expmap derivative
   // TODO(Frank): t = applyLeftJacobian(v), it would be nice to understand
-  // how to compute mess below from its derivatives in w and v.
+  // how to compute mess below from applyLeftJacobian derivatives in w and v.
   Matrix3 computeQ(const Vector3& v) const {
     const Matrix3 V = skewSymmetric(v);
     const Matrix3 WVW = W * V * W;
@@ -261,7 +259,6 @@ class GTSAM_EXPORT ExpmapFunctor : public so3::DexpFunctor {
            F * (WW * V + V * WW - 3 * WVW) - 0.5 * E * (WVW * W + W * WVW);
   }
 
- protected:
   static constexpr double _one_twenty_fourth = - 1.0 / 24.0;
 };
 }  // namespace pose3

--- a/gtsam/geometry/Pose3.cpp
+++ b/gtsam/geometry/Pose3.cpp
@@ -240,18 +240,16 @@ Vector6 Pose3::ChartAtOrigin::Local(const Pose3& pose, ChartJacobian Hpose) {
 
 /* ************************************************************************* */
 namespace pose3 {
-class ExpmapFunctor : public so3::DexpFunctor {
- private:
-  static constexpr double one_twenty_fourth = 1.0 / 24.0;
-
+class GTSAM_EXPORT ExpmapFunctor : public so3::DexpFunctor {
+ protected:
   // Constant used in computeQ
   double F;  // (B - 0.5) / theta2 or -1/24 for theta->0
 
  public:
   ExpmapFunctor(const Vector3& omega, bool nearZeroApprox = false)
       : so3::DexpFunctor(omega, nearZeroApprox) {
-        F = nearZero ? - one_twenty_fourth : (B - 0.5) / theta2;
-      }
+    F = nearZero ? _one_twenty_fourth : (B - 0.5) / theta2;
+  }
 
   // Compute the bottom-left 3x3 block of the SE(3) Expmap derivative
   // TODO(Frank): t = applyLeftJacobian(v), it would be nice to understand
@@ -262,6 +260,9 @@ class ExpmapFunctor : public so3::DexpFunctor {
     return -0.5 * V + C * (W * V + V * W - WVW) +
            F * (WW * V + V * WW - 3 * WVW) - 0.5 * E * (WVW * W + W * WVW);
   }
+
+ protected:
+  static constexpr double _one_twenty_fourth = - 1.0 / 24.0;
 };
 }  // namespace pose3
 

--- a/gtsam/geometry/SO3.h
+++ b/gtsam/geometry/SO3.h
@@ -26,7 +26,6 @@
 #include <gtsam/base/Matrix.h>
 #include <gtsam/dllexport.h>
 
-#include <cmath>
 #include <vector>
 
 namespace gtsam {
@@ -160,7 +159,6 @@ class DexpFunctor : public ExpmapFunctor {
   static constexpr double one_sixth = 1.0 / 6.0;
   const Vector3 omega;
   double C;  // Ethan Eade's C constant
-  Matrix3 rightJacobian_;
 
  public:
   /// Constructor with element of Lie algebra so(3)
@@ -172,8 +170,11 @@ class DexpFunctor : public ExpmapFunctor {
   // Information Theory, and Lie Groups", Volume 2, 2008.
   //   expmap(omega + v) \approx expmap(omega) * expmap(dexp * v)
   // This maps a perturbation v in the tangent space to
-  // a perturbation on the manifold Expmap(dexp * v) */
-  const Matrix3& dexp() const { return rightJacobian_; }
+  // a perturbation on the manifold Expmap(dexp * v)
+  GTSAM_EXPORT Matrix3 rightJacobian() const;
+
+  /// differential of expmap == right Jacobian
+  GTSAM_EXPORT Matrix3 dexp() const { return rightJacobian(); }
 
   /// Multiplies with dexp(), with optional derivatives
   GTSAM_EXPORT Vector3 applyDexp(const Vector3& v,
@@ -186,8 +187,12 @@ class DexpFunctor : public ExpmapFunctor {
                                     OptionalJacobian<3, 3> H2 = {}) const;
 
   // Compute the left Jacobian for Exponential map in SO(3)
-  // Note precomputed, as not used as much
-  Matrix3 leftJacobian() const;
+  GTSAM_EXPORT Matrix3 leftJacobian() const;
+
+  /// Multiplies with leftJacobian(), with optional derivatives
+  GTSAM_EXPORT Vector3 applyLeftJacobian(const Vector3& v,
+                                         OptionalJacobian<3, 3> H1 = {},
+                                         OptionalJacobian<3, 3> H2 = {}) const;
 };
 }  //  namespace so3
 

--- a/gtsam/geometry/SO3.h
+++ b/gtsam/geometry/SO3.h
@@ -160,6 +160,12 @@ class DexpFunctor : public ExpmapFunctor {
   const Vector3 omega;
   double C;  // Ethan Eade's C constant
 
+  /// Computes B * (omega x v).
+  Vector3 cross(const Vector3& v, OptionalJacobian<3, 3> H = {}) const;
+
+  /// Computes C * (omega x (omega x v)).
+  Vector3 doubleCross(const Vector3& v, OptionalJacobian<3, 3> H = {}) const;
+
  public:
   /// Constructor with element of Lie algebra so(3)
   GTSAM_EXPORT explicit DexpFunctor(const Vector3& omega,

--- a/gtsam/geometry/SO3.h
+++ b/gtsam/geometry/SO3.h
@@ -155,7 +155,7 @@ class GTSAM_EXPORT ExpmapFunctor {
 };
 
 /// Functor that implements Exponential map *and* its derivatives
-class DexpFunctor : public ExpmapFunctor {
+class GTSAM_EXPORT DexpFunctor : public ExpmapFunctor {
  protected:
   const Vector3 omega;
   double C;  // Ethan's C constant: (1 - A) / theta^2 or 1/6 for theta->0
@@ -164,15 +164,8 @@ class DexpFunctor : public ExpmapFunctor {
   double E;  // (B - 3.0 * C) / theta2 or -1/60 for theta->0
 
  public:
-  /// Computes B * (omega x v).
-  Vector3 cross(const Vector3& v, OptionalJacobian<3, 3> H = {}) const;
-
-  /// Computes C * (omega x (omega x v)).
-  Vector3 doubleCross(const Vector3& v, OptionalJacobian<3, 3> H = {}) const;
-
   /// Constructor with element of Lie algebra so(3)
-  GTSAM_EXPORT explicit DexpFunctor(const Vector3& omega,
-                                    bool nearZeroApprox = false);
+  explicit DexpFunctor(const Vector3& omega, bool nearZeroApprox = false);
 
   // NOTE(luca): Right Jacobian for Exponential map in SO(3) - equation
   // (10.86) and following equations in G.S. Chirikjian, "Stochastic Models,
@@ -180,28 +173,31 @@ class DexpFunctor : public ExpmapFunctor {
   //   expmap(omega + v) \approx expmap(omega) * expmap(dexp * v)
   // This maps a perturbation v in the tangent space to
   // a perturbation on the manifold Expmap(dexp * v)
-  GTSAM_EXPORT Matrix3 rightJacobian() const;
-
-  /// differential of expmap == right Jacobian
-  GTSAM_EXPORT Matrix3 dexp() const { return rightJacobian(); }
-
-  /// Multiplies with dexp(), with optional derivatives
-  GTSAM_EXPORT Vector3 applyDexp(const Vector3& v,
-                                 OptionalJacobian<3, 3> H1 = {},
-                                 OptionalJacobian<3, 3> H2 = {}) const;
-
-  /// Multiplies with dexp().inverse(), with optional derivatives
-  GTSAM_EXPORT Vector3 applyInvDexp(const Vector3& v,
-                                    OptionalJacobian<3, 3> H1 = {},
-                                    OptionalJacobian<3, 3> H2 = {}) const;
+  Matrix3 rightJacobian() const { return I_3x3 - B * W + C * WW; }
 
   // Compute the left Jacobian for Exponential map in SO(3)
-  GTSAM_EXPORT Matrix3 leftJacobian() const;
+  Matrix3 leftJacobian() const { return I_3x3 + B * W + C * WW; }
+
+  /// differential of expmap == right Jacobian
+  inline Matrix3 dexp() const { return rightJacobian(); }
+
+  /// Computes B * (omega x v).
+  Vector3 crossB(const Vector3& v, OptionalJacobian<3, 3> H = {}) const;
+
+  /// Computes C * (omega x (omega x v)).
+  Vector3 doubleCrossC(const Vector3& v, OptionalJacobian<3, 3> H = {}) const;
+
+  /// Multiplies with dexp(), with optional derivatives
+  Vector3 applyDexp(const Vector3& v, OptionalJacobian<3, 3> H1 = {},
+                    OptionalJacobian<3, 3> H2 = {}) const;
+
+  /// Multiplies with dexp().inverse(), with optional derivatives
+  Vector3 applyInvDexp(const Vector3& v, OptionalJacobian<3, 3> H1 = {},
+                       OptionalJacobian<3, 3> H2 = {}) const;
 
   /// Multiplies with leftJacobian(), with optional derivatives
-  GTSAM_EXPORT Vector3 applyLeftJacobian(const Vector3& v,
-                                         OptionalJacobian<3, 3> H1 = {},
-                                         OptionalJacobian<3, 3> H2 = {}) const;
+  Vector3 applyLeftJacobian(const Vector3& v, OptionalJacobian<3, 3> H1 = {},
+                            OptionalJacobian<3, 3> H2 = {}) const;
 
  protected:
   static constexpr double one_sixth = 1.0 / 6.0;

--- a/gtsam/geometry/tests/testPoint3.cpp
+++ b/gtsam/geometry/tests/testPoint3.cpp
@@ -18,6 +18,8 @@
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/geometry/Point3.h>
+#include "gtsam/base/Matrix.h"
+#include "gtsam/base/OptionalJacobian.h"
 
 using namespace std::placeholders;
 using namespace gtsam;
@@ -152,6 +154,17 @@ TEST( Point3, cross2) {
     EXPECT(assert_equal(numericalDerivative21<Point3,Point3>(f, p, r), H1, 1e-9));
     EXPECT(assert_equal(numericalDerivative22<Point3,Point3>(f, p, r), H2, 1e-9));
   }
+}
+
+/* ************************************************************************* */
+TEST(Point3, doubleCross) {
+  Matrix aH1, aH2;
+  std::function<Point3(const Point3&, const Point3&)> f =
+      [](const Point3& p, const Point3& q) { return doubleCross(p, q); };
+  const Point3 omega(1, 2, 3), theta(4, 5, 6);
+  doubleCross(omega, theta, aH1, aH2);
+  EXPECT(assert_equal(numericalDerivative21(f, omega, theta), aH1));
+  EXPECT(assert_equal(numericalDerivative22(f, omega, theta), aH2));
 }
 
 //*************************************************************************

--- a/gtsam/geometry/tests/testPoint3.cpp
+++ b/gtsam/geometry/tests/testPoint3.cpp
@@ -18,8 +18,6 @@
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/geometry/Point3.h>
-#include "gtsam/base/Matrix.h"
-#include "gtsam/base/OptionalJacobian.h"
 
 using namespace std::placeholders;
 using namespace gtsam;

--- a/gtsam/geometry/tests/testPose3.cpp
+++ b/gtsam/geometry/tests/testPose3.cpp
@@ -845,7 +845,28 @@ TEST( Pose3, ExpmapDerivative1) {
 }
 
 /* ************************************************************************* */
-TEST(Pose3, ExpmapDerivative2) {
+TEST( Pose3, ExpmapDerivative2) {
+  Matrix6 actualH;
+  Vector6 w; w << 1.0, -2.0, 3.0, -10.0, -20.0, 30.0;
+  Pose3::Expmap(w,actualH);
+  Matrix expectedH = numericalDerivative21<Pose3, Vector6,
+      OptionalJacobian<6, 6> >(&Pose3::Expmap, w, {});
+  EXPECT(assert_equal(expectedH, actualH));
+}
+
+/* ************************************************************************* */
+TEST( Pose3, ExpmapDerivative3) {
+  Matrix6 actualH;
+  Vector6 w; w << 0.0, 0.0, 0.0, -10.0, -20.0, 30.0;
+  Pose3::Expmap(w,actualH);
+  Matrix expectedH = numericalDerivative21<Pose3, Vector6,
+      OptionalJacobian<6, 6> >(&Pose3::Expmap, w, {});
+  // Small angle approximation is not as precise as numerical derivative?
+  EXPECT(assert_equal(expectedH, actualH, 1e-5));
+}
+
+/* ************************************************************************* */
+TEST(Pose3, ExpmapDerivative4) {
   // Iserles05an (Lie-group Methods) says:
   // scalar is easy: d exp(a(t)) / dt = exp(a(t)) a'(t)
   // matrix is hard: d exp(A(t)) / dt = exp(A(t)) dexp[-A(t)] A'(t)

--- a/gtsam/geometry/tests/testSO3.cpp
+++ b/gtsam/geometry/tests/testSO3.cpp
@@ -19,7 +19,6 @@
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/testLie.h>
 #include <gtsam/geometry/SO3.h>
-#include <iostream>
 
 using namespace std::placeholders;
 using namespace std;


### PR DESCRIPTION
Attempt at getting a simpler expression for $Q$, as t in $SE(3)$ and $SE_2(3)$ can be calculated just as JL*v, where JL is the left Jacobian of $SO(3)$. To do this, I
- simplified SO(3) functor
- added leftJacobian
- added applyLeftJacobian
- added doubleCross and verified its derivatives
- add `pose3::ExpmapFunctor` to compute Q block.

But, I asw of yet don't understand (anymore) the expmap derivative and why it does not work out by using ApplyLeftJacobian derivatives. Still, this PR adds a lot of goodies and simplifies code for right and left jacobian opertations in SO3.