### PR TITLE
Faster `TableFactor::toDecisionTreeFactor`

### DIFF
--- a/gtsam/discrete/TableFactor.cpp
+++ b/gtsam/discrete/TableFactor.cpp
@@ -262,16 +262,21 @@ DecisionTreeFactor TableFactor::toDecisionTreeFactor() const {
     // k will be in reverse key order already
     uint64_t k;
     ss >> k;
-    std::cout << "ss: " << ss.str() << ", k=" << k << std::endl;
+    std::cout << "ss: " << ss.str() << ", k=" << k
+              << ", v=" << sparse_table_.coeff(i) << std::endl;
     pair_table.push_back(std::make_pair(k, sparse_table_.coeff(i)));
   }
 
-  // Sort based on key so we get values in reverse key order.
+  // Sort based on key assignment so we get values in reverse key order.
   std::sort(
       pair_table.begin(), pair_table.end(),
       [](const std::pair<uint64_t, double>& a,
          const std::pair<uint64_t, double>& b) { return a.first <= b.first; });
 
+  std::cout << "Sorted pair_table:" << std::endl;
+  for (auto&& [k, v] : pair_table) {
+    std::cout << "k=" << k << ", v=" << v << std::endl;
+  }
   // Create the table vector
   std::vector<double> table;
   std::for_each(pair_table.begin(), pair_table.end(),

--- a/gtsam/discrete/TableFactor.cpp
+++ b/gtsam/discrete/TableFactor.cpp
@@ -260,7 +260,7 @@ DecisionTreeFactor TableFactor::toDecisionTreeFactor() const {
       ss << keyValueForIndex(key, i);
     }
     // k will be in reverse key order already
-    uint64_t k = std::strtoull(ss.str().c_str(), NULL, 10);
+    uint64_t k = std::stoll(ss.str().c_str());
     pair_table.push_back(std::make_pair(k, sparse_table_.coeff(i)));
   }
 

--- a/gtsam/discrete/TableFactor.cpp
+++ b/gtsam/discrete/TableFactor.cpp
@@ -252,6 +252,11 @@ DecisionTreeFactor TableFactor::operator*(const DecisionTreeFactor& f) const {
 DecisionTreeFactor TableFactor::toDecisionTreeFactor() const {
   DiscreteKeys dkeys = discreteKeys();
 
+  // Record key assignment and value pairs in pair_table.
+  // The assignments are stored in descending order of keys so that the order of
+  // the values matches what is expected by a DecisionTree.
+  // This is why we reverse the keys and then
+  // query for the key value/assignment.
   DiscreteKeys rdkeys(dkeys.rbegin(), dkeys.rend());
   std::vector<std::pair<uint64_t, double>> pair_table;
   for (auto i = 0; i < sparse_table_.size(); i++) {
@@ -265,13 +270,16 @@ DecisionTreeFactor TableFactor::toDecisionTreeFactor() const {
     pair_table.push_back(std::make_pair(k, sparse_table_.coeff(i)));
   }
 
-  // Sort based on key assignment so we get values in reverse key order.
+  // Sort the pair_table (of assignment-value pairs) based on assignment so we
+  // get values in reverse key order.
   std::sort(
       pair_table.begin(), pair_table.end(),
       [](const std::pair<uint64_t, double>& a,
          const std::pair<uint64_t, double>& b) { return a.first < b.first; });
 
-  // Create the table vector
+  // Create the table vector by extracting the values from pair_table.
+  // The pair_table has already been sorted in the desired order,
+  // so the values will be in descending key order.
   std::vector<double> table;
   std::for_each(pair_table.begin(), pair_table.end(),
                 [&table](const std::pair<uint64_t, double>& pair) {

--- a/gtsam/discrete/TableFactor.cpp
+++ b/gtsam/discrete/TableFactor.cpp
@@ -260,7 +260,9 @@ DecisionTreeFactor TableFactor::toDecisionTreeFactor() const {
       ss << keyValueForIndex(key, i);
     }
     // k will be in reverse key order already
-    uint64_t k = std::stoll(ss.str().c_str());
+    uint64_t k;
+    ss >> k;
+    std::cout << "ss: " << ss.str() << ", k=" << k << std::endl;
     pair_table.push_back(std::make_pair(k, sparse_table_.coeff(i)));
   }
 

--- a/gtsam/discrete/TableFactor.cpp
+++ b/gtsam/discrete/TableFactor.cpp
@@ -262,8 +262,6 @@ DecisionTreeFactor TableFactor::toDecisionTreeFactor() const {
     // k will be in reverse key order already
     uint64_t k;
     ss >> k;
-    std::cout << "ss: " << ss.str() << ", k=" << k
-              << ", v=" << sparse_table_.coeff(i) << std::endl;
     pair_table.push_back(std::make_pair(k, sparse_table_.coeff(i)));
   }
 
@@ -273,10 +271,6 @@ DecisionTreeFactor TableFactor::toDecisionTreeFactor() const {
       [](const std::pair<uint64_t, double>& a,
          const std::pair<uint64_t, double>& b) { return a.first < b.first; });
 
-  std::cout << "Sorted pair_table:" << std::endl;
-  for (auto&& [k, v] : pair_table) {
-    std::cout << "k=" << k << ", v=" << v << std::endl;
-  }
   // Create the table vector
   std::vector<double> table;
   std::for_each(pair_table.begin(), pair_table.end(),

--- a/gtsam/discrete/TableFactor.cpp
+++ b/gtsam/discrete/TableFactor.cpp
@@ -271,7 +271,7 @@ DecisionTreeFactor TableFactor::toDecisionTreeFactor() const {
   std::sort(
       pair_table.begin(), pair_table.end(),
       [](const std::pair<uint64_t, double>& a,
-         const std::pair<uint64_t, double>& b) { return a.first <= b.first; });
+         const std::pair<uint64_t, double>& b) { return a.first < b.first; });
 
   std::cout << "Sorted pair_table:" << std::endl;
   for (auto&& [k, v] : pair_table) {

--- a/gtsam/discrete/TableFactor.cpp
+++ b/gtsam/discrete/TableFactor.cpp
@@ -153,8 +153,7 @@ TableFactor::TableFactor(const DiscreteKeys& dkeys,
 
 /* ************************************************************************ */
 TableFactor::TableFactor(const DecisionTreeFactor& dtf)
-    : TableFactor(dtf.discreteKeys(),
-                  ComputeSparseTable(dtf.discreteKeys(), dtf)) {}
+    : TableFactor(dtf.discreteKeys(), dtf) {}
 
 /* ************************************************************************ */
 TableFactor::TableFactor(const DiscreteConditional& c)
@@ -278,7 +277,8 @@ DecisionTreeFactor TableFactor::toDecisionTreeFactor() const {
                   table.push_back(pair.second);
                 });
 
-  DecisionTreeFactor f(rdkeys, table);
+  AlgebraicDecisionTree<Key> tree(rdkeys, table);
+  DecisionTreeFactor f(dkeys, tree);
   return f;
 }
 

--- a/gtsam/discrete/TableFactor.h
+++ b/gtsam/discrete/TableFactor.h
@@ -99,7 +99,6 @@ class GTSAM_EXPORT TableFactor : public DiscreteFactor {
   typedef Eigen::SparseVector<double>::InnerIterator SparseIt;
   typedef std::vector<std::pair<DiscreteValues, double>> AssignValList;
 
- public:
   /// @name Standard Constructors
   /// @{
 
@@ -155,6 +154,9 @@ class GTSAM_EXPORT TableFactor : public DiscreteFactor {
   // /// @}
   // /// @name Standard Interface
   // /// @{
+
+  /// Getter for the underlying sparse vector
+  Eigen::SparseVector<double> sparseTable() const { return sparse_table_; }
 
   /// Evaluate probability distribution, is just look up in TableFactor.
   double evaluate(const Assignment<Key>& values) const override;


### PR DESCRIPTION
I remembered that `DecisionTree` prefers the keys being ordered highest to lowest for faster speed. This PR updates the vector passed to the DecisionTree constructor such that the ordering matches the key ordering which is highest to lowest.

This update results in `toDecisionTreeFactor` going from taking 2.95 seconds to 0.81 seconds for a tree with 17 keys, which means `2^17 = 131,072` values.
It's still not great, since 17 can be hit pretty quickly, but it is a step forward.

Perhaps avoiding conversions altogether would be the way forward? Maybe subclass `DiscreteConditional` from the `TableFactor`?