### PR TITLE
Better SE(3) and SE2(3) Jacobians

### DIFF
--- a/gtsam/geometry/Pose3.cpp
+++ b/gtsam/geometry/Pose3.cpp
@@ -11,19 +11,18 @@
 
 /**
  * @file  Pose3.cpp
- * @brief 3D Pose
+ * @brief 3D Pose manifold SO(3) x R^3 and group SE(3)
  */
 
-#include <gtsam/geometry/Pose3.h>
-#include <gtsam/geometry/Pose2.h>
-#include <gtsam/geometry/concepts.h>
 #include <gtsam/base/concepts.h>
+#include <gtsam/geometry/Pose2.h>
+#include <gtsam/geometry/Pose3.h>
+#include <gtsam/geometry/Rot3.h>
+#include <gtsam/geometry/concepts.h>
 
 #include <cmath>
 #include <iostream>
 #include <string>
-
-#include "gtsam/geometry/Rot3.h"
 
 namespace gtsam {
 
@@ -164,6 +163,8 @@ Pose3 Pose3::interpolateRt(const Pose3& T, double t) const {
 }
 
 /* ************************************************************************* */
+// Expmap is implemented in so3::ExpmapFunctor::expmap, based on Ethan Eade's
+// elegant Lie group document, at https://www.ethaneade.org/lie.pdf.
 Pose3 Pose3::Expmap(const Vector6& xi, OptionalJacobian<6, 6> Hxi) {
   // Get angular velocity omega and translational velocity v from twist xi
   const Vector3 w = xi.head<3>(), v = xi.tail<3>();

--- a/gtsam/geometry/Pose3.h
+++ b/gtsam/geometry/Pose3.h
@@ -223,17 +223,19 @@ public:
       const Vector6& xi, double nearZeroThreshold = 1e-5);
 
   /**
-   * Compute the translation part of the exponential map, with derivative.
+   * Compute the translation part of the exponential map, with Jacobians.
    * @param w 3D angular velocity
    * @param v 3D velocity
    * @param Q Optionally, compute 3x3 Jacobian wrpt w
-   * @param R Optionally, precomputed as Rot3::Expmap(w)
+   * @param J Optionally, compute 3x3 Jacobian wrpt v = right Jacobian of SO(3)
    * @param nearZeroThreshold threshold for small values
-   * Note Q is 3x3 bottom-left block of SE3 Expmap right derivative matrix
+   * @note This function returns Jacobians Q and J corresponding to the bottom
+   * blocks of the SE(3) exponential, and translated from left to right from the
+   * applyLeftJacobian Jacobians.
    */
   static Vector3 ExpmapTranslation(const Vector3& w, const Vector3& v,
                                    OptionalJacobian<3, 3> Q = {},
-                                   const std::optional<Rot3>& R = {},
+                                   OptionalJacobian<3, 3> J = {},
                                    double nearZeroThreshold = 1e-5);
 
   using LieGroup<Pose3, 6>::inverse; // version with derivative

--- a/gtsam/geometry/Pose3.h
+++ b/gtsam/geometry/Pose3.h
@@ -11,7 +11,7 @@
 
 /**
  *@file  Pose3.h
- *@brief 3D Pose
+ * @brief 3D Pose manifold SO(3) x R^3 and group SE(3)
  */
 
 // \callgraph

--- a/gtsam/geometry/SO3.cpp
+++ b/gtsam/geometry/SO3.cpp
@@ -33,6 +33,15 @@ namespace gtsam {
 //******************************************************************************
 namespace so3 {
 
+static constexpr double one_6th = 1.0 / 6.0;
+static constexpr double one_12th = 1.0 / 12.0;
+static constexpr double one_24th = 1.0 / 24.0;
+static constexpr double one_60th = 1.0 / 60.0;
+static constexpr double one_120th = 1.0 / 120.0;
+static constexpr double one_180th = 1.0 / 180.0;
+static constexpr double one_720th = 1.0 / 720.0;
+static constexpr double one_1260th = 1.0 / 1260.0;
+
 GTSAM_EXPORT Matrix99 Dcompose(const SO3& Q) {
   Matrix99 H;
   auto R = Q.matrix();
@@ -60,9 +69,9 @@ void ExpmapFunctor::init(bool nearZeroApprox) {
         2.0 * s2 * s2;  // numerically better than [1 - cos(theta)]
     B = one_minus_cos / theta2;
   } else {
-    // Limits as theta -> 0:
-    A = 1.0;
-    B = 0.5;
+    // Taylor expansion at 0
+    A = 1.0 - theta2 * one_6th;
+    B = 0.5 - theta2 * one_24th;
   }
 }
 
@@ -93,12 +102,12 @@ DexpFunctor::DexpFunctor(const Vector3& omega, bool nearZeroApprox)
     E = (2.0 * B - A) / theta2;
     F = (3.0 * C - B) / theta2;
   } else {
-    // Limit as theta -> 0
+    // Taylor expansion at 0
     // TODO(Frank): flipping signs here does not trigger any tests: harden!
-    C = one_sixth;
-    D = one_twelfth;
-    E = one_twelfth;
-    F = one_sixtieth;
+    C = one_6th - theta2 * one_120th;
+    D = one_12th + theta2 * one_720th;
+    E = one_12th - theta2 * one_180th;
+    F = one_60th - theta2 * one_1260th;
   }
 }
 

--- a/gtsam/geometry/SO3.cpp
+++ b/gtsam/geometry/SO3.cpp
@@ -142,14 +142,14 @@ Vector3 DexpFunctor::applyDexp(const Vector3& v, OptionalJacobian<3, 3> H1,
 
 Vector3 DexpFunctor::applyInvDexp(const Vector3& v, OptionalJacobian<3, 3> H1,
                                   OptionalJacobian<3, 3> H2) const {
-  const Matrix3 invDexp = rightJacobian().inverse();
-  const Vector3 c = invDexp * v;
+  const Matrix3 invJr = rightJacobianInverse();
+  const Vector3 c = invJr * v;
   if (H1) {
-    Matrix3 D_dexpv_w;
-    applyDexp(c, D_dexpv_w);  // get derivative H of forward mapping
-    *H1 = -invDexp * D_dexpv_w;
+    Matrix3 H;
+    applyDexp(c, H);  // get derivative H of forward mapping
+    *H1 = -invJr * H;
   }
-  if (H2) *H2 = invDexp;
+  if (H2) *H2 = invJr;
   return c;
 }
 
@@ -162,6 +162,20 @@ Vector3 DexpFunctor::applyLeftJacobian(const Vector3& v,
   if (H1) *H1 = D_BWv_w + D_CWWv_w;
   if (H2) *H2 = leftJacobian();
   return v + BWv + CWWv;
+}
+
+Vector3 DexpFunctor::applyLeftJacobianInverse(const Vector3& v,
+                                              OptionalJacobian<3, 3> H1,
+                                              OptionalJacobian<3, 3> H2) const {
+  const Matrix3 invJl = leftJacobianInverse();
+  const Vector3 c = invJl * v;
+  if (H1) {
+    Matrix3 H;
+    applyLeftJacobian(c, H);  // get derivative H of forward mapping
+    *H1 = -invJl * H;
+  }
+  if (H2) *H2 = invJl;
+  return c;
 }
 
 }  // namespace so3

--- a/gtsam/geometry/SO3.h
+++ b/gtsam/geometry/SO3.h
@@ -138,8 +138,8 @@ struct GTSAM_EXPORT ExpmapFunctor {
   bool nearZero;
 
   // Ethan Eade's constants:
-  double A;  // A = sin(theta) / theta or 1 for theta->0
-  double B;  // B = (1 - cos(theta)) / theta^2 or 0.5 for theta->0
+  double A;  // A = sin(theta) / theta
+  double B;  // B = (1 - cos(theta))
 
   /// Constructor with element of Lie algebra so(3)
   explicit ExpmapFunctor(const Vector3& omega, bool nearZeroApprox = false);
@@ -159,14 +159,14 @@ struct GTSAM_EXPORT DexpFunctor : public ExpmapFunctor {
   const Vector3 omega;
 
   // Ethan's C constant used in Jacobians
-  double C;  // (1 - A) / theta^2 or 1/6 for theta->0
+  double C;  // (1 - A) / theta^2
 
   // Constant used in inverse Jacobians
-  double D;  // (1 - A/2B) / theta2 or 1/12 for theta->0
+  double D;  // (1 - A/2B) / theta2
 
   // Constants used in cross and doubleCross
-  double E;  // (A - 2.0 * B) / theta2 or -1/12 for theta->0
-  double F;  // (B - 3.0 * C) / theta2 or -1/60 for theta->0
+  double E;  // (2B - A) / theta2
+  double F;  // (3C - B) / theta2
 
   /// Constructor with element of Lie algebra so(3)
   explicit DexpFunctor(const Vector3& omega, bool nearZeroApprox = false);
@@ -216,10 +216,6 @@ struct GTSAM_EXPORT DexpFunctor : public ExpmapFunctor {
   Vector3 applyLeftJacobianInverse(const Vector3& v,
                                    OptionalJacobian<3, 3> H1 = {},
                                    OptionalJacobian<3, 3> H2 = {}) const;
-
-  static constexpr double one_sixth = 1.0 / 6.0;
-  static constexpr double one_twelfth = 1.0 / 12.0;
-  static constexpr double one_sixtieth = 1.0 / 60.0;
 };
 }  //  namespace so3
 

--- a/gtsam/geometry/SO3.h
+++ b/gtsam/geometry/SO3.h
@@ -132,6 +132,8 @@ GTSAM_EXPORT Matrix99 Dcompose(const SO3& R);
 // functor also implements dedicated methods to apply dexp and/or inv(dexp).
 
 /// Functor implementing Exponential map
+/// Math is based on Ethan Eade's elegant Lie group document, at
+/// https://www.ethaneade.org/lie.pdf.
 struct GTSAM_EXPORT ExpmapFunctor {
   const double theta2, theta;
   const Matrix3 W, WW;
@@ -155,6 +157,8 @@ struct GTSAM_EXPORT ExpmapFunctor {
 };
 
 /// Functor that implements Exponential map *and* its derivatives
+/// Math extends Ethan theme of elegant I + aW + bWW expressions.
+/// See https://www.ethaneade.org/lie.pdf expmap (82) and left Jacobian (83).
 struct GTSAM_EXPORT DexpFunctor : public ExpmapFunctor {
   const Vector3 omega;
 

--- a/gtsam/geometry/SO3.h
+++ b/gtsam/geometry/SO3.h
@@ -162,7 +162,7 @@ struct GTSAM_EXPORT DexpFunctor : public ExpmapFunctor {
   double C;  // (1 - A) / theta^2 or 1/6 for theta->0
 
   // Constant used in inverse Jacobians
-  double D;  // 1.0 - A / (2.0 * B)) / theta2 or 1/12 for theta->0
+  double D;  // (1 - A/2B) / theta2 or 1/12 for theta->0
 
   // Constants used in cross and doubleCross
   double E;  // (A - 2.0 * B) / theta2 or -1/12 for theta->0
@@ -211,6 +211,11 @@ struct GTSAM_EXPORT DexpFunctor : public ExpmapFunctor {
   /// Multiplies with leftJacobian(), with optional derivatives
   Vector3 applyLeftJacobian(const Vector3& v, OptionalJacobian<3, 3> H1 = {},
                             OptionalJacobian<3, 3> H2 = {}) const;
+
+  /// Multiplies with leftJacobianInverse(), with optional derivatives
+  Vector3 applyLeftJacobianInverse(const Vector3& v,
+                                   OptionalJacobian<3, 3> H1 = {},
+                                   OptionalJacobian<3, 3> H2 = {}) const;
 
   static constexpr double one_sixth = 1.0 / 6.0;
   static constexpr double one_twelfth = 1.0 / 12.0;

--- a/gtsam/geometry/SO3.h
+++ b/gtsam/geometry/SO3.h
@@ -157,10 +157,16 @@ struct GTSAM_EXPORT ExpmapFunctor {
 /// Functor that implements Exponential map *and* its derivatives
 struct GTSAM_EXPORT DexpFunctor : public ExpmapFunctor {
   const Vector3 omega;
-  double C;  // Ethan's C constant: (1 - A) / theta^2 or 1/6 for theta->0
+
+  // Ethan's C constant used in Jacobians
+  double C;  // (1 - A) / theta^2 or 1/6 for theta->0
+
+  // Constant used in inverse Jacobians
+  double D;  // 1.0 - A / (2.0 * B)) / theta2 or 1/12 for theta->0
+
   // Constants used in cross and doubleCross
-  double D;  // (A - 2.0 * B) / theta2 or -1/12 for theta->0
-  double E;  // (B - 3.0 * C) / theta2 or -1/60 for theta->0
+  double E;  // (A - 2.0 * B) / theta2 or -1/12 for theta->0
+  double F;  // (B - 3.0 * C) / theta2 or -1/60 for theta->0
 
   /// Constructor with element of Lie algebra so(3)
   explicit DexpFunctor(const Vector3& omega, bool nearZeroApprox = false);
@@ -178,6 +184,15 @@ struct GTSAM_EXPORT DexpFunctor : public ExpmapFunctor {
 
   /// Differential of expmap == right Jacobian
   inline Matrix3 dexp() const { return rightJacobian(); }
+
+  /// Inverse of right Jacobian
+  Matrix3 rightJacobianInverse() const { return I_3x3 + 0.5 * W + D * WW; }
+
+  // Inverse of left Jacobian
+  Matrix3 leftJacobianInverse() const { return I_3x3 - 0.5 * W + D * WW; }
+
+  /// Synonym for rightJacobianInverse
+  inline Matrix3 invDexp() const { return rightJacobianInverse(); }
 
   /// Computes B * (omega x v).
   Vector3 crossB(const Vector3& v, OptionalJacobian<3, 3> H = {}) const;
@@ -198,8 +213,8 @@ struct GTSAM_EXPORT DexpFunctor : public ExpmapFunctor {
                             OptionalJacobian<3, 3> H2 = {}) const;
 
   static constexpr double one_sixth = 1.0 / 6.0;
-  static constexpr double _one_twelfth = -1.0 / 12.0;
-  static constexpr double _one_sixtieth = -1.0 / 60.0;
+  static constexpr double one_twelfth = 1.0 / 12.0;
+  static constexpr double one_sixtieth = 1.0 / 60.0;
 };
 }  //  namespace so3
 

--- a/gtsam/geometry/tests/testPose3.cpp
+++ b/gtsam/geometry/tests/testPose3.cpp
@@ -906,7 +906,7 @@ TEST(Pose3, Logmap) {
     for (Vector3 v : test_cases::vs) {
       const Vector6 xi = (Vector6() << w, v).finished();
       Pose3 pose = Pose3::Expmap(xi);
-      EXPECT(assert_equal(xi, Pose3::Logmap(pose), 1e-5));
+      EXPECT(assert_equal(xi, Pose3::Logmap(pose)));
     }
   }
 }
@@ -924,7 +924,13 @@ TEST(Pose3, LogmapDerivatives) {
                 &Pose3::Logmap, pose, {});
         Matrix actualH;
         Pose3::Logmap(pose, actualH);
+#ifdef GTSAM_USE_QUATERNIONS
+        // TODO(Frank): Figure out why quaternions are not as accurate.
+        // Hint: 6 cases fail on Ubuntu 22.04, but none on MacOS.
+        EXPECT(assert_equal(expectedH, actualH, 1e-7));
+#else
         EXPECT(assert_equal(expectedH, actualH));
+#endif
       }
     }
   }

--- a/gtsam/geometry/tests/testPose3.cpp
+++ b/gtsam/geometry/tests/testPose3.cpp
@@ -900,17 +900,6 @@ TEST(Pose3, ExpmapDerivative4) {
   }
 }
 
-TEST( Pose3, ExpmapDerivativeQr) {
-  Vector6 w = Vector6::Random();
-  w.head<3>().normalize();
-  w.head<3>() = w.head<3>() * 0.9e-2;
-  Matrix3 actualQr = Pose3::ComputeQforExpmapDerivative(w, 0.01);
-  Matrix expectedH = numericalDerivative21<Pose3, Vector6,
-      OptionalJacobian<6, 6> >(&Pose3::Expmap, w, {});
-  Matrix3 expectedQr = expectedH.bottomLeftCorner<3, 3>();
-  EXPECT(assert_equal(expectedQr, actualQr, 1e-6));
-}
-
 /* ************************************************************************* */
 TEST( Pose3, LogmapDerivative) {
   Matrix6 actualH;

--- a/gtsam/geometry/tests/testSO3.cpp
+++ b/gtsam/geometry/tests/testSO3.cpp
@@ -19,7 +19,6 @@
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/testLie.h>
 #include <gtsam/geometry/SO3.h>
-#include <iostream>
 
 using namespace std::placeholders;
 using namespace std;

--- a/gtsam/geometry/tests/testSO3.cpp
+++ b/gtsam/geometry/tests/testSO3.cpp
@@ -304,6 +304,7 @@ TEST(SO3, JacobianLogmap) {
   EXPECT(assert_equal(Jexpected, Jactual));
 }
 
+//******************************************************************************
 namespace test_cases {
 std::vector<Vector3> small{{0, 0, 0},                                 //
                            {1e-5, 0, 0}, {0, 1e-5, 0}, {0, 0, 1e-5},  //,

--- a/gtsam/geometry/tests/testSO3.cpp
+++ b/gtsam/geometry/tests/testSO3.cpp
@@ -19,6 +19,7 @@
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/testLie.h>
 #include <gtsam/geometry/SO3.h>
+#include <iostream>
 
 using namespace std::placeholders;
 using namespace std;
@@ -304,12 +305,28 @@ TEST(SO3, JacobianLogmap) {
 }
 
 namespace test_cases {
-std::vector<Vector3> small{{0, 0, 0}, {1e-5, 0, 0}, {0, 1e-5, 0}, {0, 0, 1e-5}};
+std::vector<Vector3> small{{0, 0, 0},                                 //
+                           {1e-5, 0, 0}, {0, 1e-5, 0}, {0, 0, 1e-5},  //,
+                           {1e-4, 0, 0}, {0, 1e-4, 0}, {0, 0, 1e-4}};
 std::vector<Vector3> large{
     {0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {0, 0, 1}, {0.1, 0.2, 0.3}};
 auto omegas = [](bool nearZero) { return nearZero ? small : large; };
 std::vector<Vector3> vs{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}, {0.4, 0.3, 0.2}};
 }  // namespace test_cases
+
+//******************************************************************************
+TEST(SO3, JacobianInverses) {
+  Matrix HR, HL;
+  for (bool nearZero : {true, false}) {
+    for (const Vector3& omega : test_cases::omegas(nearZero)) {
+      so3::DexpFunctor local(omega, nearZero);
+      EXPECT(assert_equal<Matrix3>(local.rightJacobian().inverse(),
+                                   local.rightJacobianInverse()));
+      EXPECT(assert_equal<Matrix3>(local.leftJacobian().inverse(),
+                                   local.leftJacobianInverse()));
+    }
+  }
+}
 
 //******************************************************************************
 TEST(SO3, CrossB) {

--- a/gtsam/navigation/NavState.cpp
+++ b/gtsam/navigation/NavState.cpp
@@ -114,7 +114,7 @@ NavState NavState::inverse() const {
 
 //------------------------------------------------------------------------------
 NavState NavState::Expmap(const Vector9& xi, OptionalJacobian<9, 9> Hxi) {
-  // Get angular velocity w and components rho and nu from xi
+  // Get angular velocity w and components rho (for t) and nu (for v) from xi
   Vector3 w = xi.head<3>(), rho = xi.segment<3>(3), nu = xi.tail<3>();
 
   // Compute rotation using Expmap


### PR DESCRIPTION
Implements ExpmapTranslation with SO3::applyLeftJacobian and simplifies the Expmap jacobians in a way that also provides insight in how they relate to the applyLeftJacobian Jacobians. The key piece of code is this:
```c++
  Matrix3 H;
  Vector t = local.applyLeftJacobian(v, H); // = J_l * v !

  // We return Jacobians for use in Expmap, so we multiply with X, that
  // translates from left to right for our right expmap convention:
  Matrix3 X = local.rightJacobian() * local.leftJacobianInverse();
  Q = X * H;
```
This does three things:
- replaces very complicated expression $-0.5 * V + C * (W * V + V * W - WVW) + F * (WW * V + V * WW - 3 * WVW) - 0.5 * E * (WVW * W + W * WVW)$ from before
- explains why the bottom-right block of the Expmap Jacobian was $J_r$, not $J_l$
- functor in Pose3 is now no longer needed.

Smaller things:
- added applyLeftJacobianInverse and tested
- ExpmapTranslation no longer needs R
- Changed sign of D and E "constants" and renamed them to E and F.
- New D "constant" for use in inverses