### PR TITLE
[cephes] use GTSAM_LIBRARY_TYPE

### DIFF
--- a/gtsam/3rdparty/cephes/CMakeLists.txt
+++ b/gtsam/3rdparty/cephes/CMakeLists.txt
@@ -89,7 +89,7 @@ set(CEPHES_SOURCES
     cephes/zetac.c)
 
 # Add library source files
-add_library(cephes-gtsam SHARED ${CEPHES_SOURCES})
+add_library(cephes-gtsam ${GTSAM_LIBRARY_TYPE} ${CEPHES_SOURCES})
 
 # Add include directory (aka headers)
 target_include_directories(


### PR DESCRIPTION
Previously, when building GTSAM statically, my binaries still depended on `libcephes-gtsamRelWithDebInfo.so.1 `

```
matt@photonvision:~/Documents/GitHub/thirdparty-gtsam/build$ ldd meme
        linux-vdso.so.1 (0x00007ffcf8ff9000)
        libtbb.so.12 => /lib/x86_64-linux-gnu/libtbb.so.12 (0x000076020ab8f000)
        libtbbmalloc.so.2 => /lib/x86_64-linux-gnu/libtbbmalloc.so.2 (0x000076020ab4f000)
        libcephes-gtsamRelWithDebInfo.so.1 => /home/matt/Documents/GitHub/thirdparty-gtsam/build/_deps/gtsam-build/gtsam/3rdparty/cephes/libcephes-gtsamRelWithDebInfo.so.1 (0x000076020ab1d000)
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x000076020a800000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x000076020aa36000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x000076020a7e0000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x000076020a400000)
        /lib64/ld-linux-x86-64.so.2 (0x000076020af08000)
```

This PR would change cephes to use GTSAM_LIBRARY_TYPE, instead of hard-coding to SHARED. Not sure if there was a technical reason it was previously always SHARED - going back through the blame i dont see anything super obvious