### PR TITLE
Fix BilinearAngleTranslationFactor part of TranslationFactor

### DIFF
--- a/gtsam/sfm/TranslationFactor.h
+++ b/gtsam/sfm/TranslationFactor.h
@@ -134,7 +134,7 @@ class BilinearAngleTranslationFactor
                        OptionalMatrixType H1, OptionalMatrixType H2,
                        OptionalMatrixType H3) const override {
     // Ideally we should use a positive real valued scalar datatype for scale.
-    const double abs_scale = abs(scale[0]);
+    const double abs_scale = std::abs(scale[0]);
     const Point3 predicted = (Tb - Ta) * abs_scale;
     if (H1) {
       *H1 = -Matrix3::Identity() * abs_scale;


### PR DESCRIPTION
When compiling for a 32-bit armhf system this fails the tests as the abs is implicit converting the double into an int. I looked through the rest of the code as well for potential oversights on this part, but this seemed to be the only place it was missing the usage of std::abs