### PR TITLE
Add cassert include to Chebyshev2.cpp

### DIFF
--- a/gtsam/basis/Chebyshev2.cpp
+++ b/gtsam/basis/Chebyshev2.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <gtsam/basis/Chebyshev2.h>
+#include <cassert>
 
 namespace gtsam {
 


### PR DESCRIPTION
With gcc 11.4.0-1ubuntu1~22.04, I'm seeing this include missing from Chebyshev2.cpp. I haven't yet dug into why this isn't something we see in our CI on borglab/gtsam