### PR TITLE
Add missing test include for assert_inequal()

### DIFF
--- a/gtsam/discrete/tests/testDecisionTreeFactor.cpp
+++ b/gtsam/discrete/tests/testDecisionTreeFactor.cpp
@@ -19,6 +19,7 @@
 
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/Testable.h>
+#include <gtsam/base/TestableAssertions.h>
 #include <gtsam/base/serializationTestHelpers.h>
 #include <gtsam/discrete/DecisionTreeFactor.h>
 #include <gtsam/discrete/DiscreteDistribution.h>

--- a/gtsam/discrete/tests/testTableFactor.cpp
+++ b/gtsam/discrete/tests/testTableFactor.cpp
@@ -18,6 +18,7 @@
 
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/Testable.h>
+#include <gtsam/base/TestableAssertions.h>
 #include <gtsam/base/serializationTestHelpers.h>
 #include <gtsam/discrete/DiscreteConditional.h>
 #include <gtsam/discrete/DiscreteDistribution.h>


### PR DESCRIPTION
Here's the compilation errors I got without it. The other tests compile.
```
In file included from /home/tav/git/gtsam/CppUnitLite/TestHarness.h:23,
                 from /home/tav/git/gtsam/gtsam/discrete/tests/testDecisionTreeFactor.cpp:20:
/home/tav/git/gtsam/gtsam/discrete/tests/testDecisionTreeFactor.cpp: In member function ‘virtual void DecisionTreeFactorDivideTest::run(TestResult&)’:
/home/tav/git/gtsam/gtsam/discrete/tests/testDecisionTreeFactor.cpp:123:25: error: invalid initialization of reference of type ‘const gtsam::Vector&’ {aka ‘const Eigen::Matrix<double, -1, 1>&’} from expression of type ‘gtsam::DecisionTreeFactor’
  123 |   EXPECT(assert_inequal(pS, s));
      |                         ^~
/home/tav/git/gtsam/CppUnitLite/Test.h:151:9: note: in definition of macro ‘EXPECT’
  151 | { if (!(condition)) \
      |         ^~~~~~~~~
In file included from /home/tav/git/gtsam/gtsam/inference/DotWriter.h:22,
                 from /home/tav/git/gtsam/gtsam/inference/FactorGraph.h:25,
                 from /home/tav/git/gtsam/gtsam/inference/MetisIndex.h:21,
                 from /home/tav/git/gtsam/gtsam/inference/Ordering.h:25,
                 from /home/tav/git/gtsam/gtsam/discrete/DiscreteFactor.h:25,
                 from /home/tav/git/gtsam/gtsam/discrete/DecisionTreeFactor.h:22,
                 from /home/tav/git/gtsam/gtsam/discrete/tests/testDecisionTreeFactor.cpp:23:
/home/tav/git/gtsam/gtsam/base/Vector.h:163:48: note: in passing argument 1 of ‘bool gtsam::assert_inequal(const Vector&, const Vector&, double)’
  163 | GTSAM_EXPORT bool assert_inequal(const Vector& vec1, const Vector& vec2, double tol=1e-9);
      |                                  ~~~~~~~~~~~~~~^~~~
/home/tav/git/gtsam/gtsam/discrete/tests/testDecisionTreeFactor.cpp:131:25: error: invalid initialization of reference of type ‘const gtsam::Vector&’ {aka ‘const Eigen::Matrix<double, -1, 1>&’} from expression of type ‘gtsam::KeySet’ {aka ‘gtsam::FastSet<long unsigned int>’}
  131 |   EXPECT(assert_inequal(KeySet(pS.keys()), keys));
      |                         ^~~~~~~~~~~~~~~~~
/home/tav/git/gtsam/CppUnitLite/Test.h:151:9: note: in definition of macro ‘EXPECT’
  151 | { if (!(condition)) \
      |         ^~~~~~~~~
/home/tav/git/gtsam/gtsam/base/Vector.h:163:48: note: in passing argument 1 of ‘bool gtsam::assert_inequal(const Vector&, const Vector&, double)’
  163 | GTSAM_EXPORT bool assert_inequal(const Vector& vec1, const Vector& vec2, double tol=1e-9);
      |                                  ~~~~~~~~~~~~~~^~~~
```
```
In file included from /home/tav/git/gtsam/CppUnitLite/TestHarness.h:23,
                 from /home/tav/git/gtsam/gtsam/discrete/tests/testTableFactor.cpp:19:
/home/tav/git/gtsam/gtsam/discrete/tests/testTableFactor.cpp: In member function ‘virtual void TableFactorconstructorsTest::run(TestResult&)’:
/home/tav/git/gtsam/gtsam/discrete/tests/testTableFactor.cpp:147:25: error: invalid initialization of reference of type ‘const gtsam::Vector&’ {aka ‘const Eigen::Matrix<double, -1, 1>&’} from expression of type ‘gtsam::TableFactor’
  147 |   EXPECT(assert_inequal(f5_with_wrong_keys, f5, 1e-9));
      |                         ^~~~~~~~~~~~~~~~~~
/home/tav/git/gtsam/CppUnitLite/Test.h:151:9: note: in definition of macro ‘EXPECT’
  151 | { if (!(condition)) \
      |         ^~~~~~~~~
In file included from /home/tav/git/gtsam/gtsam/inference/DotWriter.h:22,
                 from /home/tav/git/gtsam/gtsam/inference/FactorGraph.h:25,
                 from /home/tav/git/gtsam/gtsam/inference/MetisIndex.h:21,
                 from /home/tav/git/gtsam/gtsam/inference/Ordering.h:25,
                 from /home/tav/git/gtsam/gtsam/discrete/DiscreteFactor.h:25,
                 from /home/tav/git/gtsam/gtsam/discrete/DecisionTreeFactor.h:22,
                 from /home/tav/git/gtsam/gtsam/discrete/DiscreteConditional.h:21,
                 from /home/tav/git/gtsam/gtsam/discrete/tests/testTableFactor.cpp:22:
/home/tav/git/gtsam/gtsam/base/Vector.h:163:48: note: in passing argument 1 of ‘bool gtsam::assert_inequal(const Vector&, const Vector&, double)’
  163 | GTSAM_EXPORT bool assert_inequal(const Vector& vec1, const Vector& vec2, double tol=1e-9);
      |                                  ~~~~~~~~~~~~~~^~~~
```