### PR TITLE
Adding lever-arm to GPS factors

### DIFF
--- a/gtsam/navigation/GPSFactor.cpp
+++ b/gtsam/navigation/GPSFactor.cpp
@@ -117,7 +117,7 @@ Vector GPSFactor2::evaluateError(const NavState& p,
 
 //***************************************************************************
 void GPSFactor2Arm::print(const string& s, const KeyFormatter& keyFormatter) const {
-  cout << s << "GPSFactorArm on " << keyFormatter(key()) << "\n";
+  cout << s << "GPSFactor2Arm on " << keyFormatter(key()) << "\n";
   cout << "  GPS measurement: " << nT_.transpose() << "\n";
   cout << "  Lever arm: " << bL_.transpose() << "\n";
   noiseModel_->print("  noise model: ");

--- a/gtsam/navigation/GPSFactor.cpp
+++ b/gtsam/navigation/GPSFactor.cpp
@@ -26,31 +26,20 @@ namespace gtsam {
 void GPSFactor::print(const string& s, const KeyFormatter& keyFormatter) const {
   cout << (s.empty() ? "" : s + " ") << "GPSFactor on " << keyFormatter(key())
        << "\n";
-  cout << "  GPS measurement: " << nT_.transpose() << "\n";
-  cout << "  Lever arm: " << B_t_BG_.transpose() << "\n";
+  cout << "  GPS measurement: " << nT_ << "\n";
   noiseModel_->print("  noise model: ");
 }
 
 //***************************************************************************
 bool GPSFactor::equals(const NonlinearFactor& expected, double tol) const {
   const This* e = dynamic_cast<const This*>(&expected);
-  return e != nullptr && Base::equals(*e, tol) &&
-         traits<Point3>::Equals(nT_, e->nT_, tol) &&
-         traits<Point3>::Equals(B_t_BG_, e->B_t_BG_, tol);
+  return e != nullptr && Base::equals(*e, tol) && traits<Point3>::Equals(nT_, e->nT_, tol);
 }
 
 //***************************************************************************
 Vector GPSFactor::evaluateError(const Pose3& p,
     OptionalMatrixType H) const {
-  const Matrix3 rot = p.rotation().matrix();
-  if (H) {
-    H->resize(3, 6);
-
-    H->block<3, 3>(0, 0) = -rot * skewSymmetric(B_t_BG_);
-    H->block<3, 3>(0, 3) = rot;
-  }
-
-  return p.translation() - (nT_ - rot * B_t_BG_);
+  return p.translation(H) -nT_;
 }
 
 //***************************************************************************
@@ -78,8 +67,7 @@ pair<Pose3, Vector3> GPSFactor::EstimateState(double t1, const Point3& NED1,
 //***************************************************************************
 void GPSFactor2::print(const string& s, const KeyFormatter& keyFormatter) const {
   cout << s << "GPSFactor2 on " << keyFormatter(key()) << "\n";
-  cout << "  GPS measurement: " << nT_.transpose() << "\n";
-  cout << "  Lever arm: " << B_t_BG_.transpose() << "\n";
+  cout << "  GPS measurement: " << nT_.transpose() << endl;
   noiseModel_->print("  noise model: ");
 }
 
@@ -87,23 +75,13 @@ void GPSFactor2::print(const string& s, const KeyFormatter& keyFormatter) const 
 bool GPSFactor2::equals(const NonlinearFactor& expected, double tol) const {
   const This* e = dynamic_cast<const This*>(&expected);
   return e != nullptr && Base::equals(*e, tol) &&
-         traits<Point3>::Equals(nT_, e->nT_, tol) &&
-         traits<Point3>::Equals(B_t_BG_, e->B_t_BG_, tol);
+         traits<Point3>::Equals(nT_, e->nT_, tol);
 }
 
 //***************************************************************************
 Vector GPSFactor2::evaluateError(const NavState& p,
     OptionalMatrixType H) const {
-  const Matrix3 rot = p.attitude().matrix();
-  if (H) {
-    H->resize(3, 9);
-
-    H->block<3, 3>(0, 0) = -rot * skewSymmetric(B_t_BG_);
-    H->block<3, 3>(0, 3) = rot;
-    H->block<3, 3>(0, 6).setZero();
-  }
-
-  return p.position() - (nT_ - rot * B_t_BG_);
+  return p.position(H) -nT_;
 }
 
 //***************************************************************************

--- a/gtsam/navigation/GPSFactor.h
+++ b/gtsam/navigation/GPSFactor.h
@@ -39,6 +39,7 @@ private:
   typedef NoiseModelFactorN<Pose3> Base;
 
   Point3 nT_; ///< Position measurement in cartesian coordinates
+  Point3 B_t_BG_; ///< Lever arm between GPS and BODY frame
 
 public:
 
@@ -52,7 +53,7 @@ public:
   typedef GPSFactor This;
 
   /** default constructor - only use for serialization */
-  GPSFactor(): nT_(0, 0, 0) {}
+  GPSFactor(): nT_(0, 0, 0), B_t_BG_(0, 0, 0) {}
 
   ~GPSFactor() override {}
 
@@ -63,8 +64,8 @@ public:
    * @param gpsIn measurement already in correct coordinates
    * @param model Gaussian noise model
    */
-  GPSFactor(Key key, const Point3& gpsIn, const SharedNoiseModel& model) :
-      Base(model, key), nT_(gpsIn) {
+  GPSFactor(Key key, const Point3& gpsIn, const SharedNoiseModel& model, const Point3& leverArm) :
+      Base(model, key), nT_(gpsIn), B_t_BG_(leverArm) {
   }
 
   /// @return a deep copy of this factor
@@ -85,6 +86,10 @@ public:
 
   inline const Point3 & measurementIn() const {
     return nT_;
+  }
+
+  inline const Point3 & leverArm() const {
+    return B_t_BG_;
   }
 
   /**
@@ -122,6 +127,7 @@ private:
   typedef NoiseModelFactorN<NavState> Base;
 
   Point3 nT_; ///< Position measurement in cartesian coordinates
+  Point3 B_t_BG_; ///< Lever arm between GPS and BODY frame
 
 public:
 
@@ -135,13 +141,13 @@ public:
   typedef GPSFactor2 This;
 
   /// default constructor - only use for serialization
-  GPSFactor2():nT_(0, 0, 0) {}
+  GPSFactor2():nT_(0, 0, 0), B_t_BG_(0, 0, 0) {}
 
   ~GPSFactor2() override {}
 
   /// Constructor from a measurement in a Cartesian frame.
-  GPSFactor2(Key key, const Point3& gpsIn, const SharedNoiseModel& model) :
-      Base(model, key), nT_(gpsIn) {
+  GPSFactor2(Key key, const Point3& gpsIn, const SharedNoiseModel& model, const Point3& leverArm) :
+      Base(model, key), nT_(gpsIn), B_t_BG_(leverArm) {
   }
 
   /// @return a deep copy of this factor
@@ -162,6 +168,10 @@ public:
 
   inline const Point3 & measurementIn() const {
     return nT_;
+  }
+
+  inline const Point3 & leverArm() const {
+    return B_t_BG_;
   }
 
 private:

--- a/gtsam/navigation/GPSFactor.h
+++ b/gtsam/navigation/GPSFactor.h
@@ -85,6 +85,7 @@ public:
   /// vector of errors
   Vector evaluateError(const Pose3& p, OptionalMatrixType H) const override;
 
+  /// return the measurement, in the navigation frame
   inline const Point3 & measurementIn() const {
     return nT_;
   }
@@ -146,7 +147,12 @@ public:
 
   ~GPSFactorArm() override {}
 
-  /// Constructor from a measurement in a Cartesian frame.
+  /** Constructor from a measurement in a Cartesian frame.
+   * @param key       key of the Pose3 variable related to this measurement
+   * @param gpsIn     gps measurement, in Cartesian navigation frame
+   * @param leverArm  translation from the body frame origin to the gps antenna, in body frame
+   * @param model     Gaussian noise model
+  */
   GPSFactorArm(Key key, const Point3& gpsIn, const Point3& leverArm, const SharedNoiseModel& model) :
       Base(model, key), nT_(gpsIn), bL_(leverArm) {
   }
@@ -167,10 +173,12 @@ public:
   /// vector of errors
   Vector evaluateError(const Pose3& p, OptionalMatrixType H) const override;
 
+  /// return the measurement, in the navigation frame
   inline const Point3 & measurementIn() const {
     return nT_;
   }
 
+  /// return the lever arm, a position in the body frame
   inline const Point3 & leverArm() const {
     return bL_;
   }
@@ -207,7 +215,11 @@ public:
 
   ~GPSFactor2() override {}
 
-  /// Constructor from a measurement in a Cartesian frame.
+  /** Constructor from a measurement in a Cartesian frame.
+   * @param key       key of the NavState variable related to this measurement
+   * @param gpsIn     gps measurement, in Cartesian navigation frame
+   * @param model     Gaussian noise model
+  */
   GPSFactor2(Key key, const Point3& gpsIn, const SharedNoiseModel& model) :
       Base(model, key), nT_(gpsIn) {
   }
@@ -228,6 +240,7 @@ public:
   /// vector of errors
   Vector evaluateError(const NavState& p, OptionalMatrixType H) const override;
 
+  /// return the measurement, in the navigation frame
   inline const Point3 & measurementIn() const {
     return nT_;
   }
@@ -281,7 +294,12 @@ public:
 
   ~GPSFactor2Arm() override {}
 
-  /// Constructor from a measurement in a Cartesian frame.
+  /** Constructor from a measurement in a Cartesian frame.
+   * @param key       key of the NavState variable related to this measurement
+   * @param gpsIn     gps measurement, in Cartesian navigation frame
+   * @param leverArm  translation from the body frame origin to the gps antenna, in body frame
+   * @param model     noise model for the factor's residual
+  */
   GPSFactor2Arm(Key key, const Point3& gpsIn, const Point3& leverArm, const SharedNoiseModel& model) :
       Base(model, key), nT_(gpsIn), bL_(leverArm) {
   }
@@ -302,10 +320,12 @@ public:
   /// vector of errors
   Vector evaluateError(const NavState& p, OptionalMatrixType H) const override;
 
+  /// return the measurement, in the navigation frame
   inline const Point3 & measurementIn() const {
     return nT_;
   }
 
+  /// return the lever arm, a position in the body frame
   inline const Point3 & leverArm() const {
     return bL_;
   }

--- a/gtsam/navigation/GPSFactor.h
+++ b/gtsam/navigation/GPSFactor.h
@@ -176,14 +176,6 @@ public:
     return bL_;
   }
 
-  /**
-   *  Convenience function to estimate state at time t, given two GPS
-   *  readings (in local NED Cartesian frame) bracketing t
-   *  Assumes roll is zero, calculates yaw and pitch from NED1->NED2 vector.
-   */
-  static std::pair<Pose3, Vector3> EstimateState(double t1, const Point3& NED1,
-      double t2, const Point3& NED2, double timestamp);
-
 };
 
 /**

--- a/gtsam/navigation/GPSFactor.h
+++ b/gtsam/navigation/GPSFactor.h
@@ -112,6 +112,7 @@ private:
         & boost::serialization::make_nvp("NoiseModelFactor1",
             boost::serialization::base_object<Base>(*this));
     ar & BOOST_SERIALIZATION_NVP(nT_);
+    ar & BOOST_SERIALIZATION_NVP(B_t_BG_);
   }
 #endif
 };
@@ -186,6 +187,7 @@ private:
         & boost::serialization::make_nvp("NoiseModelFactor1",
             boost::serialization::base_object<Base>(*this));
     ar & BOOST_SERIALIZATION_NVP(nT_);
+    ar & BOOST_SERIALIZATION_NVP(B_t_BG_);
   }
 #endif
 };

--- a/gtsam/navigation/GPSFactor.h
+++ b/gtsam/navigation/GPSFactor.h
@@ -24,8 +24,7 @@
 namespace gtsam {
 
 /**
- * Prior on position in a Cartesian frame, assuming position prior is in body
- * frame.
+ * Prior on position in a Cartesian frame.
  * If there exists a non-zero lever arm between body frame and GPS
  * antenna, instead use GPSFactorArm.
  * Possibilities include:
@@ -41,7 +40,7 @@ private:
 
   typedef NoiseModelFactorN<Pose3> Base;
 
-  Point3 nT_; ///< Position measurement in cartesian coordinates
+  Point3 nT_; ///< Position measurement in cartesian coordinates (navigation frame)
 
 public:
 
@@ -127,7 +126,7 @@ private:
 
   typedef NoiseModelFactorN<Pose3> Base;
 
-  Point3 nT_;  ///< Position measurement in cartesian coordinates
+  Point3 nT_;  ///< Position measurement in cartesian coordinates (navigation frame)
   Point3 bL_;  ///< bL_ is a lever arm in the body frame, denoting the 3D
                ///< position of the GPS antenna in the body frame
 
@@ -190,7 +189,7 @@ private:
 
   typedef NoiseModelFactorN<NavState> Base;
 
-  Point3 nT_; ///< Position measurement in cartesian coordinates
+  Point3 nT_; ///< Position measurement in cartesian coordinates (navigation frame)
 
 public:
 
@@ -262,7 +261,7 @@ private:
 
   typedef NoiseModelFactorN<NavState> Base;
 
-  Point3 nT_;  ///< Position measurement in cartesian coordinates
+  Point3 nT_;  ///< Position measurement in cartesian coordinates (navigation frame)
   Point3 bL_;  ///< bL_ is a lever arm in the body frame, denoting the 3D
                ///< position of the GPS antenna in the body frame
 

--- a/gtsam/navigation/GPSFactor.h
+++ b/gtsam/navigation/GPSFactor.h
@@ -39,7 +39,6 @@ private:
   typedef NoiseModelFactorN<Pose3> Base;
 
   Point3 nT_; ///< Position measurement in cartesian coordinates
-  Point3 B_t_BG_; ///< Lever arm between GPS and BODY frame
 
 public:
 
@@ -53,7 +52,7 @@ public:
   typedef GPSFactor This;
 
   /** default constructor - only use for serialization */
-  GPSFactor(): nT_(0, 0, 0), B_t_BG_(0, 0, 0) {}
+  GPSFactor(): nT_(0, 0, 0) {}
 
   ~GPSFactor() override {}
 
@@ -64,8 +63,8 @@ public:
    * @param gpsIn measurement already in correct coordinates
    * @param model Gaussian noise model
    */
-  GPSFactor(Key key, const Point3& gpsIn, const SharedNoiseModel& model, const Point3& leverArm) :
-      Base(model, key), nT_(gpsIn), B_t_BG_(leverArm) {
+  GPSFactor(Key key, const Point3& gpsIn, const SharedNoiseModel& model) :
+      Base(model, key), nT_(gpsIn) {
   }
 
   /// @return a deep copy of this factor
@@ -88,10 +87,6 @@ public:
     return nT_;
   }
 
-  inline const Point3 & leverArm() const {
-    return B_t_BG_;
-  }
-
   /**
    *  Convenience function to estimate state at time t, given two GPS
    *  readings (in local NED Cartesian frame) bracketing t
@@ -112,7 +107,6 @@ private:
         & boost::serialization::make_nvp("NoiseModelFactor1",
             boost::serialization::base_object<Base>(*this));
     ar & BOOST_SERIALIZATION_NVP(nT_);
-    ar & BOOST_SERIALIZATION_NVP(B_t_BG_);
   }
 #endif
 };
@@ -128,7 +122,6 @@ private:
   typedef NoiseModelFactorN<NavState> Base;
 
   Point3 nT_; ///< Position measurement in cartesian coordinates
-  Point3 B_t_BG_; ///< Lever arm between GPS and BODY frame
 
 public:
 
@@ -142,13 +135,13 @@ public:
   typedef GPSFactor2 This;
 
   /// default constructor - only use for serialization
-  GPSFactor2():nT_(0, 0, 0), B_t_BG_(0, 0, 0) {}
+  GPSFactor2():nT_(0, 0, 0) {}
 
   ~GPSFactor2() override {}
 
   /// Constructor from a measurement in a Cartesian frame.
-  GPSFactor2(Key key, const Point3& gpsIn, const SharedNoiseModel& model, const Point3& leverArm) :
-      Base(model, key), nT_(gpsIn), B_t_BG_(leverArm) {
+  GPSFactor2(Key key, const Point3& gpsIn, const SharedNoiseModel& model) :
+      Base(model, key), nT_(gpsIn) {
   }
 
   /// @return a deep copy of this factor
@@ -171,10 +164,6 @@ public:
     return nT_;
   }
 
-  inline const Point3 & leverArm() const {
-    return B_t_BG_;
-  }
-
 private:
 
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
@@ -187,7 +176,6 @@ private:
         & boost::serialization::make_nvp("NoiseModelFactor1",
             boost::serialization::base_object<Base>(*this));
     ar & BOOST_SERIALIZATION_NVP(nT_);
-    ar & BOOST_SERIALIZATION_NVP(B_t_BG_);
   }
 #endif
 };

--- a/gtsam/navigation/navigation.i
+++ b/gtsam/navigation/navigation.i
@@ -329,7 +329,8 @@ virtual class Pose3AttitudeFactor : gtsam::NoiseModelFactor {
 #include <gtsam/navigation/GPSFactor.h>
 virtual class GPSFactor : gtsam::NonlinearFactor{
   GPSFactor(size_t key, const gtsam::Point3& gpsIn,
-            const gtsam::noiseModel::Base* model);
+            const gtsam::noiseModel::Base* model,
+            const gtsam::Point3& leverArm);
 
   // Testable
   void print(string s = "", const gtsam::KeyFormatter& keyFormatter =
@@ -338,6 +339,7 @@ virtual class GPSFactor : gtsam::NonlinearFactor{
 
   // Standard Interface
   gtsam::Point3 measurementIn() const;
+  gtsam::Point3 leverArm() const;
 
   // enable serialization functionality
   void serialize() const;
@@ -345,7 +347,8 @@ virtual class GPSFactor : gtsam::NonlinearFactor{
 
 virtual class GPSFactor2 : gtsam::NonlinearFactor {
   GPSFactor2(size_t key, const gtsam::Point3& gpsIn,
-            const gtsam::noiseModel::Base* model);
+            const gtsam::noiseModel::Base* model,
+            const gtsam::Point3& leverArm);
 
   // Testable
   void print(string s = "", const gtsam::KeyFormatter& keyFormatter =
@@ -354,6 +357,7 @@ virtual class GPSFactor2 : gtsam::NonlinearFactor {
 
   // Standard Interface
   gtsam::Point3 measurementIn() const;
+  gtsam::Point3 leverArm() const;
 
   // enable serialization functionality
   void serialize() const;

--- a/gtsam/navigation/navigation.i
+++ b/gtsam/navigation/navigation.i
@@ -329,8 +329,7 @@ virtual class Pose3AttitudeFactor : gtsam::NoiseModelFactor {
 #include <gtsam/navigation/GPSFactor.h>
 virtual class GPSFactor : gtsam::NonlinearFactor{
   GPSFactor(size_t key, const gtsam::Point3& gpsIn,
-            const gtsam::noiseModel::Base* model,
-            const gtsam::Point3& leverArm);
+            const gtsam::noiseModel::Base* model);
 
   // Testable
   void print(string s = "", const gtsam::KeyFormatter& keyFormatter =
@@ -339,7 +338,6 @@ virtual class GPSFactor : gtsam::NonlinearFactor{
 
   // Standard Interface
   gtsam::Point3 measurementIn() const;
-  gtsam::Point3 leverArm() const;
 
   // enable serialization functionality
   void serialize() const;
@@ -347,8 +345,7 @@ virtual class GPSFactor : gtsam::NonlinearFactor{
 
 virtual class GPSFactor2 : gtsam::NonlinearFactor {
   GPSFactor2(size_t key, const gtsam::Point3& gpsIn,
-            const gtsam::noiseModel::Base* model,
-            const gtsam::Point3& leverArm);
+            const gtsam::noiseModel::Base* model);
 
   // Testable
   void print(string s = "", const gtsam::KeyFormatter& keyFormatter =
@@ -357,7 +354,6 @@ virtual class GPSFactor2 : gtsam::NonlinearFactor {
 
   // Standard Interface
   gtsam::Point3 measurementIn() const;
-  gtsam::Point3 leverArm() const;
 
   // enable serialization functionality
   void serialize() const;

--- a/gtsam/navigation/tests/testGPSFactor.cpp
+++ b/gtsam/navigation/tests/testGPSFactor.cpp
@@ -45,9 +45,6 @@ LocalCartesian origin_ENU(lat0, lon0, h0, kWGS84);
 
 // Dekalb-Peachtree Airport runway 2L
 const double lat = 33.87071, lon = -84.30482, h = 274;
-
-// Random lever arm
-const Point3 leverArm(0.1, 0.2, 0.3);
 }
 
 // *************************************************************************
@@ -64,12 +61,10 @@ TEST( GPSFactor, Constructor ) {
   // Factor
   Key key(1);
   SharedNoiseModel model = noiseModel::Isotropic::Sigma(3, 0.25);
-  GPSFactor factor(key, Point3(E, N, U), model, leverArm);
+  GPSFactor factor(key, Point3(E, N, U), model);
 
   // Create a linearization point at zero error
-  const Rot3 rot = Rot3::RzRyRx(0.15, -0.30, 0.45);
-  const Point3 p = Point3(E, N, U) - rot * leverArm;
-  Pose3 T(rot, p);
+  Pose3 T(Rot3::RzRyRx(0.15, -0.30, 0.45), Point3(E, N, U));
   EXPECT(assert_equal(Z_3x1,factor.evaluateError(T),1e-5));
 
   // Calculate numerical derivatives
@@ -95,12 +90,10 @@ TEST( GPSFactor2, Constructor ) {
   // Factor
   Key key(1);
   SharedNoiseModel model = noiseModel::Isotropic::Sigma(3, 0.25);
-  GPSFactor2 factor(key, Point3(E, N, U), model, leverArm);
+  GPSFactor2 factor(key, Point3(E, N, U), model);
 
   // Create a linearization point at zero error
-  const Rot3 rot = Rot3::RzRyRx(0.15, -0.30, 0.45);
-  const Point3 p = Point3(E, N, U) - rot * leverArm;
-  NavState T(rot, p, Vector3::Zero());
+  NavState T(Rot3::RzRyRx(0.15, -0.30, 0.45), Point3(E, N, U), Vector3::Zero());
   EXPECT(assert_equal(Z_3x1,factor.evaluateError(T),1e-5));
 
   // Calculate numerical derivatives

--- a/gtsam/navigation/tests/testGPSFactor.cpp
+++ b/gtsam/navigation/tests/testGPSFactor.cpp
@@ -45,6 +45,9 @@ LocalCartesian origin_ENU(lat0, lon0, h0, kWGS84);
 
 // Dekalb-Peachtree Airport runway 2L
 const double lat = 33.87071, lon = -84.30482, h = 274;
+
+// Random lever arm
+const Point3 leverArm(0.1, 0.2, 0.3);
 }
 
 // *************************************************************************
@@ -61,10 +64,12 @@ TEST( GPSFactor, Constructor ) {
   // Factor
   Key key(1);
   SharedNoiseModel model = noiseModel::Isotropic::Sigma(3, 0.25);
-  GPSFactor factor(key, Point3(E, N, U), model);
+  GPSFactor factor(key, Point3(E, N, U), model, leverArm);
 
   // Create a linearization point at zero error
-  Pose3 T(Rot3::RzRyRx(0.15, -0.30, 0.45), Point3(E, N, U));
+  const Rot3 rot = Rot3::RzRyRx(0.15, -0.30, 0.45);
+  const Point3 p = Point3(E, N, U) - rot * leverArm;
+  Pose3 T(rot, p);
   EXPECT(assert_equal(Z_3x1,factor.evaluateError(T),1e-5));
 
   // Calculate numerical derivatives
@@ -90,10 +95,12 @@ TEST( GPSFactor2, Constructor ) {
   // Factor
   Key key(1);
   SharedNoiseModel model = noiseModel::Isotropic::Sigma(3, 0.25);
-  GPSFactor2 factor(key, Point3(E, N, U), model);
+  GPSFactor2 factor(key, Point3(E, N, U), model, leverArm);
 
   // Create a linearization point at zero error
-  NavState T(Rot3::RzRyRx(0.15, -0.30, 0.45), Point3(E, N, U), Vector3::Zero());
+  const Rot3 rot = Rot3::RzRyRx(0.15, -0.30, 0.45);
+  const Point3 p = Point3(E, N, U) - rot * leverArm;
+  NavState T(rot, p, Vector3::Zero());
   EXPECT(assert_equal(Z_3x1,factor.evaluateError(T),1e-5));
 
   // Calculate numerical derivatives


### PR DESCRIPTION
I noticed the GPS factors had no option for a non-zero lever arm, the feature became necessary for me so I figured I would make this PR.

Of course similar behavior is possible with `setBodyPSensor` but this comes at the cost of additional linearization error I believe ([ref](https://groups.google.com/g/gtsam-users/c/nG_B_-5VDxA/m/Ob3r82J5AQAJ)). As a result the performance is actually different.