### PR TITLE
Faster SE(3) and SE_2(3) exponential maps

### DIFF
--- a/gtsam/geometry/Pose3.cpp
+++ b/gtsam/geometry/Pose3.cpp
@@ -189,7 +189,7 @@ Pose3 Pose3::Expmap(const Vector6& xi, OptionalJacobian<6, 6> Hxi) {
 
   // Compute rotation using Expmap
 #ifdef GTSAM_USE_QUATERNIONS
-  const Rot3 R = traits<gtsam::Quaternion>::Expmap(v);
+  const Rot3 R = traits<gtsam::Quaternion>::Expmap(w);
 #else
   const Rot3 R(local.expmap());
 #endif

--- a/gtsam/geometry/Pose3.cpp
+++ b/gtsam/geometry/Pose3.cpp
@@ -209,11 +209,9 @@ Pose3 Pose3::Expmap(const Vector6& xi, OptionalJacobian<6, 6> Hxi) {
   if (Hxi) {
     // The Jacobian of expmap is given by the right Jacobian of SO(3):
     const Matrix3 Jr = local.rightJacobian();
-    // We multiply H, the derivative of applyLeftJacobian in omega, with
-    //   X = Jr * Jl^{-1},
-    // which translates from left to right for our right expmap convention:
-    const Matrix3 X = Jr * local.leftJacobianInverse();
-    const Matrix3 Q = X * H;
+    // We multiply H, the derivative of applyLeftJacobian in omega, with R^T
+    // to translate from left to right for our right expmap convention:
+    const Matrix3 Q = R.matrix().transpose() * H;
     *Hxi << Jr, Z_3x3,  //
         Q, Jr;
   }
@@ -290,9 +288,8 @@ Matrix3 Pose3::ComputeQforExpmapDerivative(const Vector6& xi,
   Matrix3 H;
   local.applyLeftJacobian(v, H);
 
-  // Multiply with X, translates from left to right for our expmap convention:
-  const Matrix3 X = local.rightJacobian() * local.leftJacobianInverse();
-  return X * H;
+  // Multiply with R^T, translates from left to right for our expmap convention:
+  return local.expmap().transpose() * H;
 }
 
 /* ************************************************************************* */

--- a/gtsam/geometry/Pose3.cpp
+++ b/gtsam/geometry/Pose3.cpp
@@ -209,8 +209,8 @@ Pose3 Pose3::Expmap(const Vector6& xi, OptionalJacobian<6, 6> Hxi) {
   if (Hxi) {
     // The Jacobian of expmap is given by the right Jacobian of SO(3):
     const Matrix3 Jr = local.rightJacobian();
-    // We multiply H, the derivative of applyLeftJacobian in omega, with R^T
-    // to translate from left to right for our right expmap convention:
+    // We are creating a Pose3, so we still need to chain H with R^T, the
+    // Jacobian of Pose3::Create with respect to t.
     const Matrix3 Q = R.matrix().transpose() * H;
     *Hxi << Jr, Z_3x3,  //
         Q, Jr;
@@ -288,8 +288,9 @@ Matrix3 Pose3::ComputeQforExpmapDerivative(const Vector6& xi,
   Matrix3 H;
   local.applyLeftJacobian(v, H);
 
-  // Multiply with R^T, translates from left to right for our expmap convention:
-  return local.expmap().transpose() * H;
+  // Multiply with R^T to account for the Pose3::Create Jacobian.
+  const Matrix3 R = local.expmap();
+  return R.transpose() * H;
 }
 
 /* ************************************************************************* */

--- a/gtsam/geometry/Pose3.cpp
+++ b/gtsam/geometry/Pose3.cpp
@@ -212,8 +212,8 @@ Pose3 Pose3::Expmap(const Vector6& xi, OptionalJacobian<6, 6> Hxi) {
     // We are creating a Pose3, so we still need to chain H with R^T, the
     // Jacobian of Pose3::Create with respect to t.
     const Matrix3 Q = R.matrix().transpose() * H;
-    *Hxi << Jr, Z_3x3,  //
-        Q, Jr;
+    *Hxi << Jr, Z_3x3,  // Jr here *is* the Jacobian of expmap
+        Q, Jr;  // Here Jr = R^T * J_l, with J_l the Jacobian of t in v.
   }
 
   return Pose3(R, t);

--- a/gtsam/geometry/Pose3.h
+++ b/gtsam/geometry/Pose3.h
@@ -220,26 +220,9 @@ public:
   *  (see Chirikjian11book2, pg 44, eq 10.95.
   *  The closed-form formula is identical to formula 102 in Barfoot14tro where
   *  Q_l of the SE3 Expmap left derivative matrix is given.
-  *  This is the Jacobian of ExpmapTranslation and computed there.
   */
   static Matrix3 ComputeQforExpmapDerivative(
       const Vector6& xi, double nearZeroThreshold = 1e-5);
-
-  /**
-   * Compute the translation part of the exponential map, with Jacobians.
-   * @param w 3D angular velocity
-   * @param v 3D velocity
-   * @param Q Optionally, compute 3x3 Jacobian wrpt w
-   * @param J Optionally, compute 3x3 Jacobian wrpt v = right Jacobian of SO(3)
-   * @param nearZeroThreshold threshold for small values
-   * @note This function returns Jacobians Q and J corresponding to the bottom
-   * blocks of the SE(3) exponential, and translated from left to right from the
-   * applyLeftJacobian Jacobians.
-   */
-  static Vector3 ExpmapTranslation(const Vector3& w, const Vector3& v,
-                                   OptionalJacobian<3, 3> Q = {},
-                                   OptionalJacobian<3, 3> J = {},
-                                   double nearZeroThreshold = 1e-5);
 
   using LieGroup<Pose3, 6>::inverse; // version with derivative
 

--- a/gtsam/geometry/SO3.cpp
+++ b/gtsam/geometry/SO3.cpp
@@ -92,7 +92,7 @@ ExpmapFunctor::ExpmapFunctor(const Vector3& axis, double angle,
   init(nearZeroApprox);
 }
 
-SO3 ExpmapFunctor::expmap() const { return SO3(I_3x3 + A * W + B * WW); }
+Matrix3 ExpmapFunctor::expmap() const { return I_3x3 + A * W + B * WW; }
 
 DexpFunctor::DexpFunctor(const Vector3& omega, bool nearZeroApprox)
     : ExpmapFunctor(omega, nearZeroApprox), omega(omega) {
@@ -193,7 +193,7 @@ Vector3 DexpFunctor::applyLeftJacobianInverse(const Vector3& v,
 template <>
 GTSAM_EXPORT
 SO3 SO3::AxisAngle(const Vector3& axis, double theta) {
-  return so3::ExpmapFunctor(axis, theta).expmap();
+  return SO3(so3::ExpmapFunctor(axis, theta).expmap());
 }
 
 //******************************************************************************
@@ -251,11 +251,11 @@ template <>
 GTSAM_EXPORT
 SO3 SO3::Expmap(const Vector3& omega, ChartJacobian H) {
   if (H) {
-    so3::DexpFunctor impl(omega);
-    *H = impl.dexp();
-    return impl.expmap();
+    so3::DexpFunctor local(omega);
+    *H = local.dexp();
+    return SO3(local.expmap());
   } else {
-    return so3::ExpmapFunctor(omega).expmap();
+    return SO3(so3::ExpmapFunctor(omega).expmap());
   }
 }
 

--- a/gtsam/geometry/SO3.h
+++ b/gtsam/geometry/SO3.h
@@ -150,7 +150,7 @@ struct GTSAM_EXPORT ExpmapFunctor {
   ExpmapFunctor(const Vector3& axis, double angle, bool nearZeroApprox = false);
 
   /// Rodrigues formula
-  SO3 expmap() const;
+  Matrix3 expmap() const;
 
  protected:
   void init(bool nearZeroApprox = false);

--- a/gtsam/geometry/tests/testSO3.cpp
+++ b/gtsam/geometry/tests/testSO3.cpp
@@ -163,22 +163,22 @@ TEST(SO3, ExpmapFunctor) {
 
   // axis angle version
   so3::ExpmapFunctor f1(axis, angle);
-  SO3 actual1 = f1.expmap();
+  SO3 actual1(f1.expmap());
   CHECK(assert_equal(expected, actual1.matrix(), 1e-5));
 
   // axis angle version, negative angle
   so3::ExpmapFunctor f2(axis, angle - 2*M_PI);
-  SO3 actual2 = f2.expmap();
+  SO3 actual2(f2.expmap());
   CHECK(assert_equal(expected, actual2.matrix(), 1e-5));
 
   // omega version
   so3::ExpmapFunctor f3(axis * angle);
-  SO3 actual3 = f3.expmap();
+  SO3 actual3(f3.expmap());
   CHECK(assert_equal(expected, actual3.matrix(), 1e-5));
 
   // omega version, negative angle
   so3::ExpmapFunctor f4(axis * (angle - 2*M_PI));
-  SO3 actual4 = f4.expmap();
+  SO3 actual4(f4.expmap());
   CHECK(assert_equal(expected, actual4.matrix(), 1e-5));
 }
 

--- a/gtsam/navigation/NavState.cpp
+++ b/gtsam/navigation/NavState.cpp
@@ -136,10 +136,10 @@ NavState NavState::Expmap(const Vector9& xi, OptionalJacobian<9, 9> Hxi) {
   if (Hxi) {
     // See Pose3::Expamp for explanation of the Jacobians
     const Matrix3 Jr = local.rightJacobian();
-    const Matrix3 X = Jr * local.leftJacobianInverse();
+    const Matrix3 M = R.matrix();
     *Hxi << Jr, Z_3x3, Z_3x3,  //
-        X * H_t_w, Jr, Z_3x3,  //
-        X * H_v_w, Z_3x3, Jr;
+        M.transpose() * H_t_w, Jr, Z_3x3,  //
+        M.transpose() * H_v_w, Z_3x3, Jr;
   }
 
   return NavState(R, t, v);
@@ -250,10 +250,10 @@ Matrix9 NavState::LogmapDerivative(const NavState& state) {
   local.applyLeftJacobian(rho, H_t_w);
   local.applyLeftJacobian(nu, H_v_w);
 
-  // Multiply with X, translates from left to right for our expmap convention:
-  const Matrix3 X = local.rightJacobian() * local.leftJacobianInverse();
-  const Matrix3 Qt = X * H_t_w;
-  const Matrix3 Qv = X * H_v_w;
+  // Multiply with R^T, translates from left to right for our expmap convention:
+  const Matrix3 R = local.expmap();
+  const Matrix3 Qt = R.transpose() * H_t_w;
+  const Matrix3 Qv = R.transpose() * H_v_w;
 
   const Matrix3 Jw = Rot3::LogmapDerivative(w);
   const Matrix3 Qt2 = -Jw * Qt * Jw;

--- a/gtsam/navigation/NavState.cpp
+++ b/gtsam/navigation/NavState.cpp
@@ -123,7 +123,7 @@ NavState NavState::Expmap(const Vector9& xi, OptionalJacobian<9, 9> Hxi) {
 
   // Compute rotation using Expmap
 #ifdef GTSAM_USE_QUATERNIONS
-  const Rot3 R = traits<gtsam::Quaternion>::Expmap(v);
+  const Rot3 R = traits<gtsam::Quaternion>::Expmap(w);
 #else
   const Rot3 R(local.expmap());
 #endif

--- a/gtsam/navigation/NavState.cpp
+++ b/gtsam/navigation/NavState.cpp
@@ -138,9 +138,11 @@ NavState NavState::Expmap(const Vector9& xi, OptionalJacobian<9, 9> Hxi) {
     // We are creating a NavState, so we still need to chain H_t_w and H_v_w
     // with R^T, the Jacobian of Navstate::Create with respect to both t and v.
     const Matrix3 M = R.matrix();
-    *Hxi << Jr, Z_3x3, Z_3x3,  //
+    *Hxi << Jr, Z_3x3, Z_3x3,   // Jr here *is* the Jacobian of expmap
         M.transpose() * H_t_w, Jr, Z_3x3,  //
         M.transpose() * H_v_w, Z_3x3, Jr;
+        // In the last two rows, Jr = R^T * J_l, see Barfoot eq. (8.83).
+        // J_l is the Jacobian of applyLeftJacobian in the second argument.
   }
 
   return NavState(R, t, v);


### PR DESCRIPTION
`DexpFunctor` was instantiated several times:
  - for computing R via `SO3::Expmap`
  - for `ExmapTranslation`, *twice* so in `NavState`
 
This PR 
- gets rid of `ExpmapTranslation` and inlines it in the 4 places it was used;
- in the `Pose3` and `Navstate` `Expmaps`, we also now use the *one* instantiated `DexpFunctor` to compute the rotation;
- according to Barfoot Eq 8.83, X = J_r * inv(J_l) = R^T, so substitute that wherever we used X before: another big saving!
- in addition, I realized why R^T: it's the jacobian of Pose3::Create !

This PR saves a bunch of compute (many sines and cosines, and computation of skew W and W*W) and is more "transparent" about what is going on. In addition, the X=R^T saves even more on top of that.