### PR TITLE
Reduce smart pointer copies in destructors

### DIFF
--- a/gtsam/base/timing.cpp
+++ b/gtsam/base/timing.cpp
@@ -109,7 +109,7 @@ void TimingOutline::print(const std::string& outline) const {
 
 /* ************************************************************************* */
 void TimingOutline::printCsvHeader(bool addLineBreak) const {
-#ifdef GTSAM_USE_BOOST_FEATURES
+#if GTSAM_USE_BOOST_FEATURES
   // Order is (CPU time, number of times, wall time, time + children in seconds,
   // min time, max time)
   std::cout << label_ + " cpu time (s)" << "," << label_ + " #calls" << ","
@@ -134,7 +134,7 @@ void TimingOutline::printCsvHeader(bool addLineBreak) const {
 
 /* ************************************************************************* */
 void TimingOutline::printCsv(bool addLineBreak) const {
-#ifdef GTSAM_USE_BOOST_FEATURES
+#if GTSAM_USE_BOOST_FEATURES
   // Order is (CPU time, number of times, wall time, time + children in seconds,
   // min time, max time)
   std::cout << self() << "," << n_ << "," << wall() << "," << secs() << ","

--- a/gtsam/constrained/NonlinearConstraint.h
+++ b/gtsam/constrained/NonlinearConstraint.h
@@ -21,7 +21,7 @@
 #include <gtsam/inference/FactorGraph.h>
 #include <gtsam/inference/FactorGraph-inst.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
-#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/base_object.hpp>
 #endif
 
@@ -77,7 +77,7 @@ class GTSAM_EXPORT NonlinearConstraint : public NoiseModelFactor {
   }
 
  private:
-#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>

--- a/gtsam/constrained/NonlinearEqualityConstraint.h
+++ b/gtsam/constrained/NonlinearEqualityConstraint.h
@@ -39,7 +39,7 @@ class GTSAM_EXPORT NonlinearEqualityConstraint : public NonlinearConstraint {
   virtual ~NonlinearEqualityConstraint() {}
 
  private:
-#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -85,7 +85,7 @@ class ExpressionEqualityConstraint : public NonlinearEqualityConstraint {
   }
 
  private:
-#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -131,7 +131,7 @@ class GTSAM_EXPORT ZeroCostConstraint : public NonlinearEqualityConstraint {
   }
 
  private:
-#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -166,7 +166,7 @@ class GTSAM_EXPORT NonlinearEqualityConstraints : public FactorGraph<NonlinearEq
   NonlinearFactorGraph penaltyGraph(const double mu = 1.0) const;
 
  private:
-#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>

--- a/gtsam/constrained/NonlinearInequalityConstraint.h
+++ b/gtsam/constrained/NonlinearInequalityConstraint.h
@@ -61,7 +61,7 @@ class GTSAM_EXPORT NonlinearInequalityConstraint : public NonlinearConstraint {
   virtual NoiseModelFactor::shared_ptr penaltyFactorEquality(const double mu = 1.0) const;
 
  private:
-#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -129,7 +129,7 @@ class GTSAM_EXPORT ScalarExpressionInequalityConstraint : public NonlinearInequa
   }
 
  private:
-#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -169,7 +169,7 @@ class GTSAM_EXPORT NonlinearInequalityConstraints
                                           const double mu = 1.0) const;
 
  private:
-#ifdef GTSAM_ENABLE_BOOST_SERIALIZATION
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>

--- a/gtsam/inference/BayesTree-inst.h
+++ b/gtsam/inference/BayesTree-inst.h
@@ -196,21 +196,20 @@ namespace gtsam {
     for (auto&& root: roots_) {
       std::queue<sharedClique> bfs_queue;
       
-      // first, move the root to the queue
-      bfs_queue.push(root);
-      root = nullptr; // now the root node is owned by the queue
+      // first, steal the root and move it to the queue. This invalidates root
+      bfs_queue.push(std::move(root));
 
       // do a BFS on the tree, for each node, add its children to the queue, and then delete it from the queue
       // So if the reference count of the node is 1, it will be deleted, and because its children are in the queue,
       // the deletion of the node will not trigger a recursive deletion of the children.
       while (!bfs_queue.empty()) {
-        // move the ownership of the front node from the queue to the current variable
-        auto current = bfs_queue.front();
+        // move the ownership of the front node from the queue to the current variable, invalidating the sharedClique at the front of the queue
+        auto current = std::move(bfs_queue.front());
         bfs_queue.pop();
 
         // add the children of the current node to the queue, so that the queue will also own the children nodes.
         for (auto child: current->children) {
-          bfs_queue.push(child);
+          bfs_queue.push(std::move(child));
         } // leaving the scope of current will decrease the reference count of the current node by 1, and if the reference count is 0,
           // the node will be deleted. Because the children are in the queue, the deletion of the node will not trigger a recursive
           // deletion of the children.

--- a/gtsam/inference/ClusterTree.h
+++ b/gtsam/inference/ClusterTree.h
@@ -166,9 +166,9 @@ class ClusterTree {
 
   /// @}
 
+ protected:
   ~ClusterTree();
 
- protected:
   /// @name Details
   /// @{
 

--- a/gtsam/inference/EliminationTree-inst.h
+++ b/gtsam/inference/EliminationTree-inst.h
@@ -197,20 +197,19 @@ namespace gtsam {
     for (auto&& root : roots_) {
       std::queue<sharedNode> bfs_queue;
 
-      // first, move the root to the queue
-      bfs_queue.push(root);
-      root = nullptr; // now the root node is owned by the queue
+      // first, steal the root and move it to the queue. This invalidates root
+      bfs_queue.push(std::move(root));
 
       // for each node iterated, if its reference count is 1, it will be deleted while its children are still in the queue.
       // so that the recursive deletion will not happen.
       while (!bfs_queue.empty()) {
-        // move the ownership of the front node from the queue to the current variable
-        auto node = bfs_queue.front();
+        // move the ownership of the front node from the queue to the current variable, invalidating the sharedClique at the front of the queue
+        auto node = std::move(bfs_queue.front());
         bfs_queue.pop();
 
         // add the children of the current node to the queue, so that the queue will also own the children nodes.
         for (auto&& child : node->children) {
-          bfs_queue.push(child);
+          bfs_queue.push(std::move(child));
         } // leaving the scope of current will decrease the reference count of the current node by 1, and if the reference count is 0,
           // the node will be deleted. Because the children are in the queue, the deletion of the node will not trigger a recursive
           // deletion of the children.

--- a/gtsam/inference/EliminationTree.h
+++ b/gtsam/inference/EliminationTree.h
@@ -117,8 +117,10 @@ namespace gtsam {
 
     /// @}
 
-  public:
+  protected:
     ~EliminationTree(); 
+
+  public:
     /// @name Standard Interface
     /// @{
 


### PR DESCRIPTION
https://github.com/borglab/gtsam/pull/1441/ introduced a new recursive destructor to avoid stack overflows. We can improve runtime a bit by avoiding copying shared pointers around when we don't need to. I tested this using a robot stationary at 0,0,0 looking at an apriltag 2.5 meters in front of me a total of 50,000 observations, updating ISAM with each observation. This decreases mean runtime by 17% in this particular toy problem (see below).

With this optimization applied and for this -particular- toy problem, I'm still seeing ~half my runtime spent in the BayesTree destructor (see attached perf data from a release build):

![image](https://github.com/user-attachments/assets/0e592e0c-80e2-4b5d-9e29-db048e04fcdc)
[perf.zip](https://github.com/user-attachments/files/18472488/perf.zip)

IsamBenchmark.cpp (program that generates the output below): https://github.com/mcm001/gtsam/blob/44d36c1e173fe9c9c3752eb0dab376059610272e/examples/IsamBenchmark.cpp

|                         | Without patch                            | With patch |
| ----------------------- | ---------------------------------------- | ---------- |
| Run times, microseconds | 6.01E+07                                 | 6.28E+07   |
|                         | 8.22E+07                                 | 7.07E+07   |
|                         | 8.02E+07                                 | 8.14E+07   |
|                         | 8.32E+07                                 | 7.25E+07   |
|                         | 8.24E+07                                 | 6.72E+07   |
|                         | 8.61E+07                                 | 5.99E+07   |
|                         | 8.39E+07                                 | 6.51E+07   |
|                         | 8.28E+07                                 | 6.29E+07   |
|                         | 8.44E+07                                 | 6.27E+07   |
|                         | 8.49E+07                                 | 6.34E+07   |
| Mean, seconds           | 81.01                                    | 66.86      |
|                         | p-value, 2-tailed t-test, equal variance | 2.62E-04   |

I suspect that there's further opportunities for optimization in these destructors, but I'll leave that to people smarter than I :)

Also fixes some stray ifdef/ifs for boost builds that squeaked in in MR https://github.com/borglab/gtsam/pull/1948 and https://github.com/borglab/gtsam/pull/1789 (see 6697452954a9b8676d9d33d4ec9294cac5e74dc4 ). Perhaps this is an indication that we need to add a no-boost build without boost installed in CI?

```
-- ===============================================================	
-- ================  Configuration Options  ======================	
--  CMAKE_CXX_COMPILER_ID type                       : GNU	
--  CMAKE_CXX_COMPILER_VERSION                       : 11.4.0	
--  CMake version                                    : 3.31.4	
--  CMake generator                                  : Ninja	
--  CMake build tool                                 : /usr/bin/ninja	
-- Build flags	
--  Build Tests                                      : Enabled	
--  Build examples with 'make all'                   : Enabled	
--  Build timing scripts with 'make all'             : Disabled	
--  Build shared GTSAM libraries                     : Enabled	
--  Put build type in library name                   : Enabled	
--  Build libgtsam_unstable                          : Enabled	
--  Build GTSAM unstable Python                      : Enabled	
--  Build MATLAB Toolbox for unstable                : Disabled	
--  Build for native architecture                    : Disabled	
--  Build type                                       : Release	
--  C compilation flags                              :  -O3 -DNDEBUG	
--  C++ compilation flags                            :  -O3 -DNDEBUG	
--  Enable Boost serialization                       : OFF	
--  GTSAM_COMPILE_FEATURES_PUBLIC                    : cxx_std_17	
--  GTSAM_COMPILE_OPTIONS_PUBLIC                     :	
--  GTSAM_COMPILE_DEFINITIONS_PUBLIC                 :	
--  GTSAM_COMPILE_OPTIONS_PUBLIC_RELEASE             :	
--  GTSAM_COMPILE_DEFINITIONS_PUBLIC_RELEASE         :	
--  Use System Eigen                                 : OFF (Using version: 3.4.0)	
--  Use System Metis                                 : OFF	
--  Using Boost version                              :	
--  Use Intel TBB                                    : Yes (Version: 2021.5.0)	
--  Eigen will use MKL                               : MKL not found	
--  Eigen will use MKL and OpenMP                    : OpenMP found but GTSAM_WITH_EIGEN_MKL is disabled	
--  Default allocator                                : TBB	
--  Cheirality exceptions enabled                    : YES	
--  Build with ccache                                : Yes	
-- Packaging flags	
--  CPack Source Generator                           : TGZ	
--  CPack Generator                                  : TGZ	
-- GTSAM flags	
--  Quaternions as default Rot3                      : Disabled	
--  Runtime consistency checking                     : Disabled	
--  Build with Memory Sanitizer                      : Disabled	
--  Rot3 retract is full ExpMap                      : Enabled	
--  Pose3 retract is full ExpMap                     : Enabled	
--  Enable branch merging in DecisionTree            : Enabled	
--  Enable timing machinery                          : Disabled	
--  Allow features deprecated in GTSAM 4.3           : Enabled	
--  Metis-based Nested Dissection                    : Enabled	
--  Use tangent-space preintegration                 : Enabled	
-- MATLAB toolbox flags	
--  Install MATLAB toolbox                           : Disabled	
-- Python toolbox flags	
--  Build Python module with pybind                  : Disabled	
-- ===============================================================	
```

