### PR TITLE
fix: add GTSAM_USE_BOOST_FEATURES to definitions

### DIFF
--- a/gtsam/base/concepts.h
+++ b/gtsam/base/concepts.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <gtsam/config.h>
+
 #if GTSAM_USE_BOOST_FEATURES
 #include <boost/concept_check.hpp>
 #include <boost/concept/assert.hpp>


### PR DESCRIPTION
This fixes the issue #1994 and some issues mentioned in #1967 and  #1981.

The change defines the proper identifier if `GTSAM_USE_BOOST_FEATURES` option is set in CMakeLists.txt.
It's used in:
https://github.com/borglab/gtsam/blob/7b56d6689ce685de9c5d88c0fd35c9e5338844a1/gtsam/base/concepts.h#L11-L24
...and without it the compiler throws `BOOST_CONCEPT_USAGE` redefinition error.