### PR TITLE
Better `HybridSmoother`

### DIFF
--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -63,7 +63,7 @@ HybridBayesNet HybridBayesNet::prune(size_t maxNrLeaves, bool removeDeadModes,
 
   // Prune the joint. NOTE: imperative and, again, possibly quite expensive.
   DiscreteConditional pruned = joint;
-  joint.prune(maxNrLeaves);
+  pruned.prune(maxNrLeaves);
 
   DiscreteValues deadModesValues;
   if (removeDeadModes) {
@@ -115,7 +115,7 @@ HybridBayesNet HybridBayesNet::prune(size_t maxNrLeaves, bool removeDeadModes,
    */
 
   // Go through all the Gaussian conditionals in the Bayes Net and prune them as
-  // per pruned Discrete joint.
+  // per pruned discrete joint.
   for (auto &&conditional : *this) {
     if (auto hgc = conditional->asHybrid()) {
       // Prune the hybrid Gaussian conditional!

--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -47,8 +47,8 @@ bool HybridBayesNet::equals(const This &bn, double tol) const {
 // TODO(Frank): This can be quite expensive *unless* the factors have already
 // been pruned before. Another, possibly faster approach is branch and bound
 // search to find the K-best leaves and then create a single pruned conditional.
-HybridBayesNet HybridBayesNet::prune(size_t maxNrLeaves,
-                                     bool removeDeadModes) const {
+HybridBayesNet HybridBayesNet::prune(size_t maxNrLeaves, bool removeDeadModes,
+                                     double deadModeThreshold) const {
   // Collect all the discrete conditionals. Could be small if already pruned.
   const DiscreteBayesNet marginal = discreteMarginal();
 

--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -72,7 +72,7 @@ HybridBayesNet HybridBayesNet::prune(size_t maxNrLeaves, bool removeDeadModes,
       Vector probabilities = marginals.marginalProbabilities(dkey);
 
       int index = -1;
-      auto threshold = (probabilities.array() > 0.99);
+      auto threshold = (probabilities.array() > deadModeThreshold);
       // If atleast 1 value is non-zero, then we can find the index
       // Else if all are zero, index would be set to 0 which is incorrect
       if (!threshold.isZero()) {

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -217,15 +217,15 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
    * @brief Prune the Bayes Net such that we have at most maxNrLeaves leaves.
    *
    * @param maxNrLeaves Continuous values at which to compute the error.
-   * @param removeDeadModes Flag to enable removal of modes which only have a
-   * single possible assignment.
    * @param deadModeThreshold The threshold to check the mode marginals against.
    * If greater than this threshold, the mode gets assigned that value and is
    * considered "dead" for hybrid elimination.
+   * The mode can then be removed since it only has a single possible
+   * assignment.
    * @return A pruned HybridBayesNet
    */
-  HybridBayesNet prune(size_t maxNrLeaves, bool removeDeadModes = false,
-                       double deadModeThreshold = 0.99) const;
+  HybridBayesNet prune(size_t maxNrLeaves,
+                       const std::optional<double> &deadModeThreshold) const;
 
   /**
    * @brief Error method using HybridValues which returns specific error for

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -224,8 +224,9 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
    * assignment.
    * @return A pruned HybridBayesNet
    */
-  HybridBayesNet prune(size_t maxNrLeaves,
-                       const std::optional<double> &deadModeThreshold) const;
+  HybridBayesNet prune(
+      size_t maxNrLeaves,
+      const std::optional<double> &deadModeThreshold = {}) const;
 
   /**
    * @brief Error method using HybridValues which returns specific error for

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -219,9 +219,13 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
    * @param maxNrLeaves Continuous values at which to compute the error.
    * @param removeDeadModes Flag to enable removal of modes which only have a
    * single possible assignment.
+   * @param deadModeThreshold The threshold to check the mode marginals against.
+   * If greater than this threshold, the mode gets assigned that value and is
+   * considered "dead" for hybrid elimination.
    * @return A pruned HybridBayesNet
    */
-  HybridBayesNet prune(size_t maxNrLeaves, bool removeDeadModes = false) const;
+  HybridBayesNet prune(size_t maxNrLeaves, bool removeDeadModes = false,
+                       double deadModeThreshold = 0.99) const;
 
   /**
    * @brief Error method using HybridValues which returns specific error for

--- a/gtsam/hybrid/HybridSmoother.cpp
+++ b/gtsam/hybrid/HybridSmoother.cpp
@@ -81,8 +81,7 @@ void HybridSmoother::update(const HybridGaussianFactorGraph &graph,
   if (maxNrLeaves) {
     // `pruneBayesNet` sets the leaves with 0 in discreteFactor to nullptr in
     // all the conditionals with the same keys in bayesNetFragment.
-    bayesNetFragment = bayesNetFragment.prune(*maxNrLeaves, removeDeadModes_,
-                                              deadModeThreshold_);
+    bayesNetFragment = bayesNetFragment.prune(*maxNrLeaves, deadModeThreshold_);
   }
 
   // Add the partial bayes net to the posterior bayes net.

--- a/gtsam/hybrid/HybridSmoother.cpp
+++ b/gtsam/hybrid/HybridSmoother.cpp
@@ -74,6 +74,11 @@ void HybridSmoother::update(const HybridGaussianFactorGraph &graph,
     ordering = *given_ordering;
   }
 
+  // graph.print("Original GRAPH");
+  // GTSAM_PRINT(updatedGraph);
+  // GTSAM_PRINT(hybridBayesNet_);
+  // GTSAM_PRINT(ordering);
+
   // Eliminate.
   HybridBayesNet bayesNetFragment = *updatedGraph.eliminateSequential(ordering);
 
@@ -81,7 +86,8 @@ void HybridSmoother::update(const HybridGaussianFactorGraph &graph,
   if (maxNrLeaves) {
     // `pruneBayesNet` sets the leaves with 0 in discreteFactor to nullptr in
     // all the conditionals with the same keys in bayesNetFragment.
-    bayesNetFragment = bayesNetFragment.prune(*maxNrLeaves, removeDeadModes_);
+    bayesNetFragment = bayesNetFragment.prune(*maxNrLeaves, removeDeadModes_,
+                                              deadModeThreshold_);
   }
 
   // Add the partial bayes net to the posterior bayes net.

--- a/gtsam/hybrid/HybridSmoother.cpp
+++ b/gtsam/hybrid/HybridSmoother.cpp
@@ -74,11 +74,6 @@ void HybridSmoother::update(const HybridGaussianFactorGraph &graph,
     ordering = *given_ordering;
   }
 
-  // graph.print("Original GRAPH");
-  // GTSAM_PRINT(updatedGraph);
-  // GTSAM_PRINT(hybridBayesNet_);
-  // GTSAM_PRINT(ordering);
-
   // Eliminate.
   HybridBayesNet bayesNetFragment = *updatedGraph.eliminateSequential(ordering);
 

--- a/gtsam/hybrid/HybridSmoother.cpp
+++ b/gtsam/hybrid/HybridSmoother.cpp
@@ -116,6 +116,14 @@ HybridSmoother::addConditionals(const HybridGaussianFactorGraph &originalGraph,
             factorKeys.end()) {
           newConditionals.push_back(conditional);
 
+          // Add the conditional parents to factorKeys
+          // so we add those conditionals too.
+          // NOTE: This assumes we have a structure where
+          // variables depend on those in the future.
+          for (auto &&parentKey : conditional->parents()) {
+            factorKeys.insert(parentKey);
+          }
+
           // Remove the conditional from the updated Bayes net
           auto it = find(updatedHybridBayesNet.begin(),
                          updatedHybridBayesNet.end(), conditional);

--- a/gtsam/hybrid/HybridSmoother.cpp
+++ b/gtsam/hybrid/HybridSmoother.cpp
@@ -81,7 +81,7 @@ void HybridSmoother::update(const HybridGaussianFactorGraph &graph,
   if (maxNrLeaves) {
     // `pruneBayesNet` sets the leaves with 0 in discreteFactor to nullptr in
     // all the conditionals with the same keys in bayesNetFragment.
-    bayesNetFragment = bayesNetFragment.prune(*maxNrLeaves);
+    bayesNetFragment = bayesNetFragment.prune(*maxNrLeaves, removeDeadModes_);
   }
 
   // Add the partial bayes net to the posterior bayes net.

--- a/gtsam/hybrid/HybridSmoother.h
+++ b/gtsam/hybrid/HybridSmoother.h
@@ -66,7 +66,7 @@ class GTSAM_EXPORT HybridSmoother {
    */
   std::pair<HybridGaussianFactorGraph, HybridBayesNet> addConditionals(
       const HybridGaussianFactorGraph& graph,
-      const HybridBayesNet& hybridBayesNet, const Ordering& ordering) const;
+      const HybridBayesNet& hybridBayesNet) const;
 
   /**
    * @brief Get the hybrid Gaussian conditional from

--- a/gtsam/hybrid/HybridSmoother.h
+++ b/gtsam/hybrid/HybridSmoother.h
@@ -29,10 +29,8 @@ class GTSAM_EXPORT HybridSmoother {
   HybridBayesNet hybridBayesNet_;
   HybridGaussianFactorGraph remainingFactorGraph_;
 
-  /// Flag indicating that we should remove dead discrete modes.
-  bool removeDeadModes_;
   /// The threshold above which we make a decision about a mode.
-  double deadModeThreshold_;
+  std::optional<double> deadModeThreshold_;
 
  public:
   /**
@@ -40,11 +38,10 @@ class GTSAM_EXPORT HybridSmoother {
    *
    * @param removeDeadModes Flag indicating whether to remove dead modes.
    * @param deadModeThreshold The threshold above which a mode gets assigned a
-   * value and is considered "dead".
+   * value and is considered "dead". 0.99 is a good starting value.
    */
-  HybridSmoother(bool removeDeadModes = false, double deadModeThreshold = 0.99)
-      : removeDeadModes_(removeDeadModes),
-        deadModeThreshold_(deadModeThreshold) {}
+  HybridSmoother(const std::optional<double> deadModeThreshold)
+      : deadModeThreshold_(deadModeThreshold) {}
 
   /**
    * Given new factors, perform an incremental update.

--- a/gtsam/hybrid/HybridSmoother.h
+++ b/gtsam/hybrid/HybridSmoother.h
@@ -70,17 +70,6 @@ class GTSAM_EXPORT HybridSmoother {
               const std::optional<Ordering> given_ordering = {});
 
   /**
-   * @brief Get an elimination ordering which eliminates continuous and then
-   * discrete.
-   *
-   * Expects `newFactors` to already have the necessary conditionals connected
-   * to the
-   *
-   * @param factors
-   * @return Ordering
-   */
-
-  /**
    * @brief Get an elimination ordering which eliminates continuous
    * and then discrete.
    *

--- a/gtsam/hybrid/HybridSmoother.h
+++ b/gtsam/hybrid/HybridSmoother.h
@@ -49,11 +49,35 @@ class GTSAM_EXPORT HybridSmoother {
    * @param given_ordering The (optional) ordering for elimination, only
    * continuous variables are allowed
    */
-  void update(HybridGaussianFactorGraph graph,
+  void update(const HybridGaussianFactorGraph& graph,
               std::optional<size_t> maxNrLeaves = {},
               const std::optional<Ordering> given_ordering = {});
 
-  Ordering getOrdering(const HybridGaussianFactorGraph& newFactors);
+  /**
+   * @brief Get an elimination ordering which eliminates continuous and then
+   * discrete.
+   *
+   * Expects `newFactors` to already have the necessary conditionals connected
+   * to the
+   *
+   * @param factors
+   * @return Ordering
+   */
+
+  /**
+   * @brief Get an elimination ordering which eliminates continuous
+   * and then discrete.
+   *
+   * Expects `factors` to already have the necessary conditionals
+   * which were connected to the variables in the newly added factors.
+   * Those variables should be in `newFactorKeys`.
+   *
+   * @param factors All the new factors and connected conditionals.
+   * @param newFactorKeys The keys/variables in the newly added factors.
+   * @return Ordering
+   */
+  Ordering getOrdering(const HybridGaussianFactorGraph& factors,
+                       const KeySet& newFactorKeys);
 
   /**
    * @brief Add conditionals from previous timestep as part of liquefication.

--- a/gtsam/hybrid/HybridSmoother.h
+++ b/gtsam/hybrid/HybridSmoother.h
@@ -29,7 +29,23 @@ class GTSAM_EXPORT HybridSmoother {
   HybridBayesNet hybridBayesNet_;
   HybridGaussianFactorGraph remainingFactorGraph_;
 
+  /// Flag indicating that we should remove dead discrete modes.
+  bool removeDeadModes_;
+  /// The threshold above which we make a decision about a mode.
+  double deadModeThreshold_;
+
  public:
+  /**
+   * @brief Constructor
+   *
+   * @param removeDeadModes Flag indicating whether to remove dead modes.
+   * @param deadModeThreshold The threshold above which a mode gets assigned a
+   * value and is considered "dead".
+   */
+  HybridSmoother(bool removeDeadModes = false, double deadModeThreshold = 0.99)
+      : removeDeadModes_(removeDeadModes),
+        deadModeThreshold_(deadModeThreshold) {}
+
   /**
    * Given new factors, perform an incremental update.
    * The relevant densities in the `hybridBayesNet` will be added to the input

--- a/gtsam/hybrid/HybridSmoother.h
+++ b/gtsam/hybrid/HybridSmoother.h
@@ -40,7 +40,7 @@ class GTSAM_EXPORT HybridSmoother {
    * @param deadModeThreshold The threshold above which a mode gets assigned a
    * value and is considered "dead". 0.99 is a good starting value.
    */
-  HybridSmoother(const std::optional<double> deadModeThreshold)
+  HybridSmoother(const std::optional<double> deadModeThreshold = {})
       : deadModeThreshold_(deadModeThreshold) {}
 
   /**

--- a/gtsam/hybrid/tests/testHybridBayesNet.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesNet.cpp
@@ -434,7 +434,7 @@ TEST(HybridBayesNet, RemoveDeadNodes) {
   HybridValues delta = posterior->optimize();
 
   // Prune the Bayes net
-  const bool pruneDeadVariables = true;
+  const double pruneDeadVariables = 0.99;
   auto prunedBayesNet = posterior->prune(2, pruneDeadVariables);
 
   // Check that discrete joint only has M0 and not (M0, M1)
@@ -445,11 +445,12 @@ TEST(HybridBayesNet, RemoveDeadNodes) {
   // Check that hybrid conditionals that only depend on M1
   // are now Gaussian and not Hybrid
   EXPECT(prunedBayesNet.at(0)->isDiscrete());
-  EXPECT(prunedBayesNet.at(1)->isHybrid());
+  EXPECT(prunedBayesNet.at(1)->isDiscrete());
+  EXPECT(prunedBayesNet.at(2)->isHybrid());
   // Only P(X2 | X1, M1) depends on M1,
   // so it gets convert to a Gaussian P(X2 | X1)
-  EXPECT(prunedBayesNet.at(2)->isContinuous());
-  EXPECT(prunedBayesNet.at(3)->isHybrid());
+  EXPECT(prunedBayesNet.at(3)->isContinuous());
+  EXPECT(prunedBayesNet.at(4)->isHybrid());
 }
 
 /* ****************************************************************************/

--- a/gtsam/hybrid/tests/testHybridSmoother.cpp
+++ b/gtsam/hybrid/tests/testHybridSmoother.cpp
@@ -95,16 +95,15 @@ TEST(HybridSmoother, IncrementalSmoother) {
     initial.insert(X(k), switching.linearizationPoint.at<double>(X(k)));
 
     HybridGaussianFactorGraph linearized = *graph.linearize(initial);
-    Ordering ordering = smoother.getOrdering(linearized);
 
-    smoother.update(linearized, maxNrLeaves, ordering);
+    smoother.update(linearized, maxNrLeaves);
 
     // Clear all the factors from the graph
     graph.resize(0);
   }
 
   EXPECT_LONGS_EQUAL(11,
-                     smoother.hybridBayesNet().at(0)->asDiscrete()->nrValues());
+                     smoother.hybridBayesNet().at(3)->asDiscrete()->nrValues());
 
   // Get the continuous delta update as well as
   // the optimal discrete assignment.
@@ -150,16 +149,15 @@ TEST(HybridSmoother, ValidPruningError) {
     initial.insert(X(k), switching.linearizationPoint.at<double>(X(k)));
 
     HybridGaussianFactorGraph linearized = *graph.linearize(initial);
-    Ordering ordering = smoother.getOrdering(linearized);
 
-    smoother.update(linearized, maxNrLeaves, ordering);
+    smoother.update(linearized, maxNrLeaves);
 
     // Clear all the factors from the graph
     graph.resize(0);
   }
 
   EXPECT_LONGS_EQUAL(14,
-                     smoother.hybridBayesNet().at(0)->asDiscrete()->nrValues());
+                     smoother.hybridBayesNet().at(6)->asDiscrete()->nrValues());
 
   // Get the continuous delta update as well as
   // the optimal discrete assignment.

--- a/gtsam/hybrid/tests/testHybridSmoother.cpp
+++ b/gtsam/hybrid/tests/testHybridSmoother.cpp
@@ -194,8 +194,6 @@ TEST(HybridSmoother, DeadModeRemoval) {
 
     HybridGaussianFactorGraph linearized = *graph.linearize(initial);
 
-    // std::cout << "\n\n\nk" << std::endl;
-    // GTSAM_PRINT(linearized);
     smoother.update(linearized, maxNrLeaves);
 
     // Clear all the factors from the graph


### PR DESCRIPTION
Updated the `HybridSmoother` to
1. Only use conditionals connected to the variables which are connected to the new factors being added.
2. Improve the `getOrdering` method to give orderings that **don't include all the variables**.
3. Removed extra loops and made the whole things a bit more efficient.