### PR TITLE
Fix Dead Mode Removal

### DIFF
--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -63,7 +63,7 @@ HybridBayesNet HybridBayesNet::prune(size_t maxNrLeaves, bool removeDeadModes,
 
   // Prune the joint. NOTE: imperative and, again, possibly quite expensive.
   DiscreteConditional pruned = joint;
-  joint.prune(maxNrLeaves);
+  pruned.prune(maxNrLeaves);
 
   DiscreteValues deadModesValues;
   if (removeDeadModes) {
@@ -115,7 +115,7 @@ HybridBayesNet HybridBayesNet::prune(size_t maxNrLeaves, bool removeDeadModes,
    */
 
   // Go through all the Gaussian conditionals in the Bayes Net and prune them as
-  // per pruned Discrete joint.
+  // per pruned discrete joint.
   for (auto &&conditional : *this) {
     if (auto hgc = conditional->asHybrid()) {
       // Prune the hybrid Gaussian conditional!

--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -47,8 +47,8 @@ bool HybridBayesNet::equals(const This &bn, double tol) const {
 // TODO(Frank): This can be quite expensive *unless* the factors have already
 // been pruned before. Another, possibly faster approach is branch and bound
 // search to find the K-best leaves and then create a single pruned conditional.
-HybridBayesNet HybridBayesNet::prune(size_t maxNrLeaves,
-                                     bool removeDeadModes) const {
+HybridBayesNet HybridBayesNet::prune(size_t maxNrLeaves, bool removeDeadModes,
+                                     double deadModeThreshold) const {
   // Collect all the discrete conditionals. Could be small if already pruned.
   const DiscreteBayesNet marginal = discreteMarginal();
 

--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -72,7 +72,7 @@ HybridBayesNet HybridBayesNet::prune(size_t maxNrLeaves, bool removeDeadModes,
       Vector probabilities = marginals.marginalProbabilities(dkey);
 
       int index = -1;
-      auto threshold = (probabilities.array() > 0.99);
+      auto threshold = (probabilities.array() > deadModeThreshold);
       // If atleast 1 value is non-zero, then we can find the index
       // Else if all are zero, index would be set to 0 which is incorrect
       if (!threshold.isZero()) {

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -217,15 +217,15 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
    * @brief Prune the Bayes Net such that we have at most maxNrLeaves leaves.
    *
    * @param maxNrLeaves Continuous values at which to compute the error.
-   * @param removeDeadModes Flag to enable removal of modes which only have a
-   * single possible assignment.
    * @param deadModeThreshold The threshold to check the mode marginals against.
    * If greater than this threshold, the mode gets assigned that value and is
    * considered "dead" for hybrid elimination.
+   * The mode can then be removed since it only has a single possible
+   * assignment.
    * @return A pruned HybridBayesNet
    */
-  HybridBayesNet prune(size_t maxNrLeaves, bool removeDeadModes = false,
-                       double deadModeThreshold = 0.99) const;
+  HybridBayesNet prune(size_t maxNrLeaves,
+                       const std::optional<double> &deadModeThreshold) const;
 
   /**
    * @brief Error method using HybridValues which returns specific error for

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -224,8 +224,9 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
    * assignment.
    * @return A pruned HybridBayesNet
    */
-  HybridBayesNet prune(size_t maxNrLeaves,
-                       const std::optional<double> &deadModeThreshold) const;
+  HybridBayesNet prune(
+      size_t maxNrLeaves,
+      const std::optional<double> &deadModeThreshold = {}) const;
 
   /**
    * @brief Error method using HybridValues which returns specific error for

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -219,9 +219,13 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<HybridConditional> {
    * @param maxNrLeaves Continuous values at which to compute the error.
    * @param removeDeadModes Flag to enable removal of modes which only have a
    * single possible assignment.
+   * @param deadModeThreshold The threshold to check the mode marginals against.
+   * If greater than this threshold, the mode gets assigned that value and is
+   * considered "dead" for hybrid elimination.
    * @return A pruned HybridBayesNet
    */
-  HybridBayesNet prune(size_t maxNrLeaves, bool removeDeadModes = false) const;
+  HybridBayesNet prune(size_t maxNrLeaves, bool removeDeadModes = false,
+                       double deadModeThreshold = 0.99) const;
 
   /**
    * @brief Error method using HybridValues which returns specific error for

--- a/gtsam/hybrid/HybridSmoother.cpp
+++ b/gtsam/hybrid/HybridSmoother.cpp
@@ -81,8 +81,7 @@ void HybridSmoother::update(const HybridGaussianFactorGraph &graph,
   if (maxNrLeaves) {
     // `pruneBayesNet` sets the leaves with 0 in discreteFactor to nullptr in
     // all the conditionals with the same keys in bayesNetFragment.
-    bayesNetFragment = bayesNetFragment.prune(*maxNrLeaves, removeDeadModes_,
-                                              deadModeThreshold_);
+    bayesNetFragment = bayesNetFragment.prune(*maxNrLeaves, deadModeThreshold_);
   }
 
   // Add the partial bayes net to the posterior bayes net.

--- a/gtsam/hybrid/HybridSmoother.cpp
+++ b/gtsam/hybrid/HybridSmoother.cpp
@@ -74,6 +74,11 @@ void HybridSmoother::update(const HybridGaussianFactorGraph &graph,
     ordering = *given_ordering;
   }
 
+  // graph.print("Original GRAPH");
+  // GTSAM_PRINT(updatedGraph);
+  // GTSAM_PRINT(hybridBayesNet_);
+  // GTSAM_PRINT(ordering);
+
   // Eliminate.
   HybridBayesNet bayesNetFragment = *updatedGraph.eliminateSequential(ordering);
 
@@ -81,7 +86,8 @@ void HybridSmoother::update(const HybridGaussianFactorGraph &graph,
   if (maxNrLeaves) {
     // `pruneBayesNet` sets the leaves with 0 in discreteFactor to nullptr in
     // all the conditionals with the same keys in bayesNetFragment.
-    bayesNetFragment = bayesNetFragment.prune(*maxNrLeaves, removeDeadModes_);
+    bayesNetFragment = bayesNetFragment.prune(*maxNrLeaves, removeDeadModes_,
+                                              deadModeThreshold_);
   }
 
   // Add the partial bayes net to the posterior bayes net.

--- a/gtsam/hybrid/HybridSmoother.cpp
+++ b/gtsam/hybrid/HybridSmoother.cpp
@@ -74,11 +74,6 @@ void HybridSmoother::update(const HybridGaussianFactorGraph &graph,
     ordering = *given_ordering;
   }
 
-  // graph.print("Original GRAPH");
-  // GTSAM_PRINT(updatedGraph);
-  // GTSAM_PRINT(hybridBayesNet_);
-  // GTSAM_PRINT(ordering);
-
   // Eliminate.
   HybridBayesNet bayesNetFragment = *updatedGraph.eliminateSequential(ordering);
 

--- a/gtsam/hybrid/HybridSmoother.h
+++ b/gtsam/hybrid/HybridSmoother.h
@@ -29,10 +29,8 @@ class GTSAM_EXPORT HybridSmoother {
   HybridBayesNet hybridBayesNet_;
   HybridGaussianFactorGraph remainingFactorGraph_;
 
-  /// Flag indicating that we should remove dead discrete modes.
-  bool removeDeadModes_;
   /// The threshold above which we make a decision about a mode.
-  double deadModeThreshold_;
+  std::optional<double> deadModeThreshold_;
 
  public:
   /**
@@ -40,11 +38,10 @@ class GTSAM_EXPORT HybridSmoother {
    *
    * @param removeDeadModes Flag indicating whether to remove dead modes.
    * @param deadModeThreshold The threshold above which a mode gets assigned a
-   * value and is considered "dead".
+   * value and is considered "dead". 0.99 is a good starting value.
    */
-  HybridSmoother(bool removeDeadModes = false, double deadModeThreshold = 0.99)
-      : removeDeadModes_(removeDeadModes),
-        deadModeThreshold_(deadModeThreshold) {}
+  HybridSmoother(const std::optional<double> deadModeThreshold)
+      : deadModeThreshold_(deadModeThreshold) {}
 
   /**
    * Given new factors, perform an incremental update.

--- a/gtsam/hybrid/HybridSmoother.h
+++ b/gtsam/hybrid/HybridSmoother.h
@@ -40,7 +40,7 @@ class GTSAM_EXPORT HybridSmoother {
    * @param deadModeThreshold The threshold above which a mode gets assigned a
    * value and is considered "dead". 0.99 is a good starting value.
    */
-  HybridSmoother(const std::optional<double> deadModeThreshold)
+  HybridSmoother(const std::optional<double> deadModeThreshold = {})
       : deadModeThreshold_(deadModeThreshold) {}
 
   /**

--- a/gtsam/hybrid/tests/testHybridBayesNet.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesNet.cpp
@@ -434,7 +434,7 @@ TEST(HybridBayesNet, RemoveDeadNodes) {
   HybridValues delta = posterior->optimize();
 
   // Prune the Bayes net
-  const bool pruneDeadVariables = true;
+  const double pruneDeadVariables = 0.99;
   auto prunedBayesNet = posterior->prune(2, pruneDeadVariables);
 
   // Check that discrete joint only has M0 and not (M0, M1)
@@ -445,11 +445,12 @@ TEST(HybridBayesNet, RemoveDeadNodes) {
   // Check that hybrid conditionals that only depend on M1
   // are now Gaussian and not Hybrid
   EXPECT(prunedBayesNet.at(0)->isDiscrete());
-  EXPECT(prunedBayesNet.at(1)->isHybrid());
+  EXPECT(prunedBayesNet.at(1)->isDiscrete());
+  EXPECT(prunedBayesNet.at(2)->isHybrid());
   // Only P(X2 | X1, M1) depends on M1,
   // so it gets convert to a Gaussian P(X2 | X1)
-  EXPECT(prunedBayesNet.at(2)->isContinuous());
-  EXPECT(prunedBayesNet.at(3)->isHybrid());
+  EXPECT(prunedBayesNet.at(3)->isContinuous());
+  EXPECT(prunedBayesNet.at(4)->isHybrid());
 }
 
 /* ****************************************************************************/

--- a/gtsam/hybrid/tests/testHybridSmoother.cpp
+++ b/gtsam/hybrid/tests/testHybridSmoother.cpp
@@ -194,8 +194,6 @@ TEST(HybridSmoother, DeadModeRemoval) {
 
     HybridGaussianFactorGraph linearized = *graph.linearize(initial);
 
-    // std::cout << "\n\n\nk" << std::endl;
-    // GTSAM_PRINT(linearized);
     smoother.update(linearized, maxNrLeaves);
 
     // Clear all the factors from the graph


### PR DESCRIPTION
Currently, I am encountering an issue where if we remove a dead mode and then we add a factor which has the mode key in it, the elimination algorithm errors out in the construction of the elimination tree. This is particularly true if we add a discrete chain, where we have conditionals like $P(m_{k+1} | m_k)$ and $m_k$ was the dead mode removed.

The simplest fix is to add the mode marginals to the `HybridBayesNet` when we remove the mode from the joint so that any future factors that get added referencing those modes don't complain during elimination.

I also added a check for the joint discrete conditional being empty (aka no keys) and we no longer add it. A new unit test was added to confirm this works, but failed before.