### PR TITLE
Fix for loop copy warning

### DIFF
--- a/gtsam/discrete/Assignment.h
+++ b/gtsam/discrete/Assignment.h
@@ -90,7 +90,7 @@ class Assignment : public std::map<L, size_t> {
       const std::vector<std::pair<L, size_t>>& keys) {
     std::vector<AssignmentType> allPossValues;
     AssignmentType assignment;
-    for (const auto [idx, _] : keys) assignment[idx] = 0;  // Initialize from 0
+    for (const auto& [idx, _] : keys) assignment[idx] = 0;  // Initialize from 0
 
     const size_t nrKeys = keys.size();
     while (true) {


### PR DESCRIPTION
This fixes a warning seen building on Ubuntu 24.04.

Warning:
```
gtsam/gtsam/discrete/Assignment.h:93:21: error: loop variable ‘<structured bindings>’ creates a copy from type ‘const std::pair<long unsigned int, long unsigned int>’ [-Werror=range-loop-construct]
   93 |     for (const auto [idx, _] : keys) assignment[idx] = 0;  // Initialize from 0
```

This change uses a reference to avoid the copy.