### PR TITLE
move constructors

### DIFF
--- a/gtsam/base/SymmetricBlockMatrix.h
+++ b/gtsam/base/SymmetricBlockMatrix.h
@@ -256,9 +256,14 @@ namespace gtsam {
       full().triangularView<Eigen::Upper>() = xpr.template triangularView<Eigen::Upper>();
     }
 
-    /// Set the entire active matrix zero.
+    /// Set the entire *active* matrix zero.
     void setZero() {
       full().triangularView<Eigen::Upper>().setZero();
+    }
+
+    /// Set entire matrix zero.
+    void setAllZero() {
+      matrix_.setZero();
     }
 
     /// Negate the entire active matrix.

--- a/gtsam/base/VerticalBlockMatrix.h
+++ b/gtsam/base/VerticalBlockMatrix.h
@@ -57,13 +57,46 @@ namespace gtsam {
     DenseIndex blockStart_; ///< Changes apparent matrix view, see main class comment.
 
   public:
-
     /** Construct an empty VerticalBlockMatrix */
-    VerticalBlockMatrix() :
-      rowStart_(0), rowEnd_(0), blockStart_(0)
-    {
+    VerticalBlockMatrix() : rowStart_(0), rowEnd_(0), blockStart_(0) {
       variableColOffsets_.push_back(0);
-      assertInvariants();
+    }
+
+    // Destructor
+    ~VerticalBlockMatrix() = default;
+
+    // Copy constructor (default)
+    VerticalBlockMatrix(const VerticalBlockMatrix& other) = default;
+
+    // Copy assignment operator (default)
+    VerticalBlockMatrix& operator=(const VerticalBlockMatrix& other) = default;
+
+    // Move constructor
+    VerticalBlockMatrix(VerticalBlockMatrix&& other) noexcept
+      : matrix_(std::move(other.matrix_)),
+        variableColOffsets_(std::move(other.variableColOffsets_)),
+        rowStart_(other.rowStart_),
+        rowEnd_(other.rowEnd_),
+        blockStart_(other.blockStart_) {
+      other.rowStart_ = 0;
+      other.rowEnd_ = 0;
+      other.blockStart_ = 0;
+    }
+
+    // Move assignment operator
+    VerticalBlockMatrix& operator=(VerticalBlockMatrix&& other) noexcept {
+      if (this != &other) {
+        matrix_ = std::move(other.matrix_);
+        variableColOffsets_ = std::move(other.variableColOffsets_);
+        rowStart_ = other.rowStart_;
+        rowEnd_ = other.rowEnd_;
+        blockStart_ = other.blockStart_;
+
+        other.rowStart_ = 0;
+        other.rowEnd_ = 0;
+        other.blockStart_ = 0;
+      }
+      return *this;
     }
 
     /** Construct from a container of the sizes of each vertical block. */

--- a/gtsam/linear/GaussianConditional-inl.h
+++ b/gtsam/linear/GaussianConditional-inl.h
@@ -33,4 +33,10 @@ namespace gtsam {
     const KEYS& keys, size_t nrFrontals, const VerticalBlockMatrix& augmentedMatrix, const SharedDiagonal& sigmas) :
   BaseFactor(keys, augmentedMatrix, sigmas), BaseConditional(nrFrontals) {}
 
+  /* ************************************************************************* */
+  template<typename KEYS>
+  GaussianConditional::GaussianConditional(
+    const KEYS& keys, size_t nrFrontals, VerticalBlockMatrix&& augmentedMatrix, const SharedDiagonal& sigmas) :
+  BaseFactor(keys, std::move(augmentedMatrix), sigmas), BaseConditional(nrFrontals) {}
+
 } // gtsam

--- a/gtsam/linear/GaussianConditional.h
+++ b/gtsam/linear/GaussianConditional.h
@@ -75,14 +75,35 @@ namespace gtsam {
       size_t nrFrontals, const Vector& d,
       const SharedDiagonal& sigmas = SharedDiagonal());
 
-    /** Constructor with arbitrary number keys, and where the augmented matrix is given all together
-     *  instead of in block terms.  Note that only the active view of the provided augmented matrix
-     *  is used, and that the matrix data is copied into a newly-allocated matrix in the constructed
-     *  factor. */
-    template<typename KEYS>
-    GaussianConditional(
-      const KEYS& keys, size_t nrFrontals, const VerticalBlockMatrix& augmentedMatrix,
-      const SharedDiagonal& sigmas = SharedDiagonal());
+    /**
+     * @brief Constructor with an arbitrary number of keys, where the augmented matrix
+     * is given all together instead of in block terms.
+     *
+     * @tparam KEYS Type of the keys container.
+     * @param keys Container of keys.
+     * @param nrFrontals Number of frontal variables.
+     * @param augmentedMatrix The augmented matrix containing the coefficients.
+     * @param sigmas Optional noise model (default is an empty SharedDiagonal).
+     */
+    template <typename KEYS>
+    GaussianConditional(const KEYS& keys, size_t nrFrontals,
+                        const VerticalBlockMatrix& augmentedMatrix,
+                        const SharedDiagonal& sigmas = SharedDiagonal());
+
+    /**
+     * @brief Constructor with an arbitrary number of keys, where the augmented matrix
+     * is given all together instead of in block terms, using move semantics for efficiency.
+     *
+     * @tparam KEYS Type of the keys container.
+     * @param keys Container of keys.
+     * @param nrFrontals Number of frontal variables.
+     * @param augmentedMatrix The augmented matrix containing the coefficients (moved).
+     * @param sigmas Optional noise model (default is an empty SharedDiagonal).
+     */
+    template <typename KEYS>
+    GaussianConditional(const KEYS& keys, size_t nrFrontals,
+                        VerticalBlockMatrix&& augmentedMatrix,
+                        const SharedDiagonal& sigmas = SharedDiagonal());
 
     /// Construct from mean `mu` and standard deviation `sigma`.
     static GaussianConditional FromMeanAndStddev(Key key, const Vector& mu,

--- a/gtsam/linear/HessianFactor.cpp
+++ b/gtsam/linear/HessianFactor.cpp
@@ -470,7 +470,7 @@ std::shared_ptr<GaussianConditional> HessianFactor::eliminateCholesky(const Orde
 
     // TODO(frank): pre-allocate GaussianConditional and write into it
     const VerticalBlockMatrix Ab = info_.split(nFrontals);
-    conditional = std::make_shared<GaussianConditional>(keys_, nFrontals, Ab);
+    conditional = std::make_shared<GaussianConditional>(keys_, nFrontals, std::move(Ab));
 
     // Erase the eliminated keys in this factor
     keys_.erase(begin(), begin() + nFrontals);

--- a/gtsam/linear/HessianFactor.cpp
+++ b/gtsam/linear/HessianFactor.cpp
@@ -245,7 +245,7 @@ HessianFactor::HessianFactor(const GaussianFactorGraph& factors,
 
   // Form A' * A
   gttic(update);
-  info_.setZero();
+  info_.setAllZero();
   for(const auto& factor: factors)
     if (factor)
       factor->updateHessian(keys_, &info_);

--- a/gtsam/linear/JacobianFactor-inl.h
+++ b/gtsam/linear/JacobianFactor-inl.h
@@ -30,26 +30,43 @@ namespace gtsam {
   }
 
   /* ************************************************************************* */
-  template<typename KEYS>
-  JacobianFactor::JacobianFactor(
-    const KEYS& keys, const VerticalBlockMatrix& augmentedMatrix, const SharedDiagonal& model) :
-  Base(keys), Ab_(augmentedMatrix)
-  {
+  template <typename KEYS>
+  JacobianFactor::JacobianFactor(const KEYS& keys,
+                                 const VerticalBlockMatrix& augmentedMatrix,
+                                 const SharedDiagonal& model)
+      : Base(keys), Ab_(augmentedMatrix) {
+    checkAndAssignModel(model, augmentedMatrix);
+  }
+
+  /* ************************************************************************* */
+  template <typename KEYS>
+  JacobianFactor::JacobianFactor(const KEYS& keys,
+                                 VerticalBlockMatrix&& augmentedMatrix,
+                                 const SharedDiagonal& model)
+      : Base(keys), Ab_(std::move(augmentedMatrix)) {
+    checkAndAssignModel(model, Ab_);
+  }
+
+  /* ************************************************************************* */
+  void JacobianFactor::checkAndAssignModel(
+      const SharedDiagonal& model, const VerticalBlockMatrix& augmentedMatrix) {
     // Check noise model dimension
-    if(model && (DenseIndex)model->dim() != augmentedMatrix.rows())
+    if (model && (DenseIndex)model->dim() != augmentedMatrix.rows())
       throw InvalidNoiseModel(augmentedMatrix.rows(), model->dim());
 
     // Check number of variables
-    if((DenseIndex)Base::keys_.size() != augmentedMatrix.nBlocks() - 1)
+    if ((DenseIndex)Base::keys_.size() != augmentedMatrix.nBlocks() - 1)
       throw std::invalid_argument(
-      "Error in JacobianFactor constructor input.  Number of provided keys plus\n"
-      "one for the RHS vector must equal the number of provided matrix blocks.");
+          "Error in JacobianFactor constructor input. Number of provided keys "
+          "plus one for the RHS vector must equal the number of provided "
+          "matrix blocks.");
 
     // Check RHS dimension
-    if(augmentedMatrix(augmentedMatrix.nBlocks() - 1).cols() != 1)
+    if (augmentedMatrix(augmentedMatrix.nBlocks() - 1).cols() != 1)
       throw std::invalid_argument(
-      "Error in JacobianFactor constructor input.  The last provided matrix block\n"
-      "must be the RHS vector, but the last provided block had more than one column.");
+          "Error in JacobianFactor constructor input. The last provided "
+          "matrix block must be the RHS vector, but the last provided block "
+          "had more than one column.");
 
     // Take noise model
     model_ = model;

--- a/gtsam/linear/JacobianFactor-inl.h
+++ b/gtsam/linear/JacobianFactor-inl.h
@@ -23,9 +23,9 @@
 namespace gtsam {
 
   /* ************************************************************************* */
-  template<typename TERMS>
-  JacobianFactor::JacobianFactor(const TERMS&terms, const Vector &b, const SharedDiagonal& model)
-  {
+  template <typename TERMS>
+  JacobianFactor::JacobianFactor(const TERMS& terms, const Vector& b,
+                                const SharedDiagonal& model) {
     fillTerms(terms, b, model);
   }
 
@@ -34,8 +34,8 @@ namespace gtsam {
   JacobianFactor::JacobianFactor(const KEYS& keys,
                                  const VerticalBlockMatrix& augmentedMatrix,
                                  const SharedDiagonal& model)
-      : Base(keys), Ab_(augmentedMatrix) {
-    checkAndAssignModel(model, augmentedMatrix);
+      : Base(keys), Ab_(augmentedMatrix), model_(model) {
+    checkAb(model, augmentedMatrix);
   }
 
   /* ************************************************************************* */
@@ -43,33 +43,8 @@ namespace gtsam {
   JacobianFactor::JacobianFactor(const KEYS& keys,
                                  VerticalBlockMatrix&& augmentedMatrix,
                                  const SharedDiagonal& model)
-      : Base(keys), Ab_(std::move(augmentedMatrix)) {
-    checkAndAssignModel(model, Ab_);
-  }
-
-  /* ************************************************************************* */
-  void JacobianFactor::checkAndAssignModel(
-      const SharedDiagonal& model, const VerticalBlockMatrix& augmentedMatrix) {
-    // Check noise model dimension
-    if (model && (DenseIndex)model->dim() != augmentedMatrix.rows())
-      throw InvalidNoiseModel(augmentedMatrix.rows(), model->dim());
-
-    // Check number of variables
-    if ((DenseIndex)Base::keys_.size() != augmentedMatrix.nBlocks() - 1)
-      throw std::invalid_argument(
-          "Error in JacobianFactor constructor input. Number of provided keys "
-          "plus one for the RHS vector must equal the number of provided "
-          "matrix blocks.");
-
-    // Check RHS dimension
-    if (augmentedMatrix(augmentedMatrix.nBlocks() - 1).cols() != 1)
-      throw std::invalid_argument(
-          "Error in JacobianFactor constructor input. The last provided "
-          "matrix block must be the RHS vector, but the last provided block "
-          "had more than one column.");
-
-    // Take noise model
-    model_ = model;
+      : Base(keys), Ab_(std::move(augmentedMatrix)), model_(model) {
+    checkAb(model, Ab_);
   }
 
   /* ************************************************************************* */

--- a/gtsam/linear/JacobianFactor.cpp
+++ b/gtsam/linear/JacobianFactor.cpp
@@ -112,6 +112,28 @@ JacobianFactor::JacobianFactor(const HessianFactor& factor)
   }
 }
 
+  /* ************************************************************************* */
+void JacobianFactor::checkAb(const SharedDiagonal& model,
+                             const VerticalBlockMatrix& augmentedMatrix) const {
+  // Check noise model dimension
+  if (model && (DenseIndex)model->dim() != augmentedMatrix.rows())
+    throw InvalidNoiseModel(augmentedMatrix.rows(), model->dim());
+
+  // Check number of variables
+  if ((DenseIndex)Base::keys_.size() != augmentedMatrix.nBlocks() - 1)
+    throw std::invalid_argument(
+        "Error in JacobianFactor constructor input. Number of provided keys "
+        "plus one for the RHS vector must equal the number of provided "
+        "matrix blocks.");
+
+  // Check RHS dimension
+  if (augmentedMatrix(augmentedMatrix.nBlocks() - 1).cols() != 1)
+    throw std::invalid_argument(
+        "Error in JacobianFactor constructor input. The last provided "
+        "matrix block must be the RHS vector, but the last provided block "
+        "had more than one column.");
+}
+
 /* ************************************************************************* */
 // Helper functions for combine constructor
 namespace {

--- a/gtsam/linear/JacobianFactor.h
+++ b/gtsam/linear/JacobianFactor.h
@@ -403,10 +403,10 @@ namespace gtsam {
     void fillTerms(const TERMS& terms, const Vector& b, const SharedDiagonal& noiseModel);
 
     /// Common code between VerticalBlockMatrix constructors
-    void checkAndAssignModel(const SharedDiagonal& model,
-                             const VerticalBlockMatrix& augmentedMatrix);
+    void checkAb(const SharedDiagonal& model,
+                 const VerticalBlockMatrix& augmentedMatrix) const;
 
-  private:
+   private:
 
     /**
      * Helper function for public constructors:

--- a/gtsam/linear/JacobianFactor.h
+++ b/gtsam/linear/JacobianFactor.h
@@ -145,13 +145,17 @@ namespace gtsam {
     template<typename TERMS>
     JacobianFactor(const TERMS& terms, const Vector& b, const SharedDiagonal& model = SharedDiagonal());
 
-    /** Constructor with arbitrary number keys, and where the augmented matrix is given all together
-     *  instead of in block terms.  Note that only the active view of the provided augmented matrix
-     *  is used, and that the matrix data is copied into a newly-allocated matrix in the constructed
-     *  factor. */
-    template<typename KEYS>
-    JacobianFactor(
-      const KEYS& keys, const VerticalBlockMatrix& augmentedMatrix, const SharedDiagonal& sigmas = SharedDiagonal());
+    /** Constructor with arbitrary number keys, and where the augmented matrix
+     * is given all together instead of in block terms.
+     */
+    template <typename KEYS>
+    JacobianFactor(const KEYS& keys, const VerticalBlockMatrix& augmentedMatrix,
+                   const SharedDiagonal& sigmas = SharedDiagonal());
+
+    /** Construct with an rvalue VerticalBlockMatrix, to allow std::move. */
+    template <typename KEYS>
+    JacobianFactor(const KEYS& keys, VerticalBlockMatrix&& augmentedMatrix,
+                   const SharedDiagonal& model);
 
     /**
      * Build a dense joint factor from all the factors in a factor graph.  If a VariableSlots
@@ -397,6 +401,10 @@ namespace gtsam {
     /// Internal function to fill blocks and set dimensions
     template<typename TERMS>
     void fillTerms(const TERMS& terms, const Vector& b, const SharedDiagonal& noiseModel);
+
+    /// Common code between VerticalBlockMatrix constructors
+    void checkAndAssignModel(const SharedDiagonal& model,
+                             const VerticalBlockMatrix& augmentedMatrix);
 
   private:
 


### PR DESCRIPTION
I added move constructors for GaussianConditional, JacobianFactor, and VerticalBlockMatrix, hoping to see a performance difference, but if anything it made it worse. Below are timings for timeBatch and timeSFMBAL, where 
- `Before` is without any move constructors
- `After` is without VerticalBlockMatrix move constructors (just GaussianConditional, JacobianFactor)
- `After2` is with VerticalBlockMatrix move constructors

<img width="325" alt="image" src="https://github.com/user-attachments/assets/8b955cff-0c83-4332-979b-dcf88016cef5" />

`After` is 2% *more* expensive, and `After2` restores that to "about the same".

Any ideas, e.g., @ProfFan ?


























































