### PR TITLE
Search for K-best solutions

### DIFF
--- a/gtsam/discrete/DiscreteSearch.cpp
+++ b/gtsam/discrete/DiscreteSearch.cpp
@@ -241,7 +241,6 @@ std::vector<double> DiscreteSearch::computeCostToGo(
   for (const auto& conditional : conditionals) {
     Ordering ordering(conditional->begin(), conditional->end());
     auto maxx = conditional->max(ordering);
-    assert(maxx->size() == 1);
     error -= std::log(maxx->evaluate({}));
     costToGo.push_back(error);
   }

--- a/gtsam/discrete/DiscreteSearch.cpp
+++ b/gtsam/discrete/DiscreteSearch.cpp
@@ -20,8 +20,6 @@
 
 namespace gtsam {
 
-using Value = size_t;
-
 /**
  * @brief Represents a node in the search tree for discrete search algorithms.
  *

--- a/gtsam/discrete/DiscreteSearch.cpp
+++ b/gtsam/discrete/DiscreteSearch.cpp
@@ -20,6 +20,8 @@
 
 namespace gtsam {
 
+using Solution = DiscreteSearch::Solution;
+
 /**
  * @brief Represents a node in the search tree for discrete search algorithms.
  *

--- a/gtsam/discrete/DiscreteSearch.cpp
+++ b/gtsam/discrete/DiscreteSearch.cpp
@@ -1,0 +1,178 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/*
+ * DiscreteSearch.cpp
+ *
+ * @date January, 2025
+ * @author Frank Dellaert
+ */
+
+#include <gtsam/discrete/DiscreteSearch.h>
+
+namespace gtsam {
+
+SearchNode SearchNode::Root(size_t numConditionals, double bound) {
+  return {.assignment = DiscreteValues(),
+          .error = 0.0,
+          .bound = bound,
+          .nextConditional = static_cast<int>(numConditionals) - 1};
+}
+
+SearchNode SearchNode::expand(const DiscreteConditional& conditional,
+                              const DiscreteValues& fa) const {
+  // Combine the new frontal assignment with the current partial assignment
+  DiscreteValues newAssignment = assignment;
+  for (auto& kv : fa) {
+    newAssignment[kv.first] = kv.second;
+  }
+
+  return {.assignment = newAssignment,
+          .error = error + conditional.error(newAssignment),
+          .bound = 0.0,
+          .nextConditional = nextConditional - 1};
+}
+
+bool Solutions::maybeAdd(double error, const DiscreteValues& assignment) {
+  const bool full = pq_.size() == maxSize_;
+  if (full && error >= pq_.top().error) return false;
+  if (full) pq_.pop();
+  pq_.emplace(error, assignment);
+  return true;
+}
+
+std::ostream& operator<<(std::ostream& os, const Solutions& sn) {
+  auto pq = sn.pq_;
+  while (!pq.empty()) {
+    const Solution& best = pq.top();
+    os << "Error: " << best.error << ", Values: " << best.assignment
+       << std::endl;
+    pq.pop();
+  }
+  return os;
+}
+
+bool Solutions::prune(double bound) const {
+  if (pq_.size() < maxSize_) return false;
+  double worstError = pq_.top().error;
+  return (bound >= worstError);
+}
+
+std::vector<Solution> Solutions::extractSolutions() {
+  std::vector<Solution> result;
+  while (!pq_.empty()) {
+    result.push_back(pq_.top());
+    pq_.pop();
+  }
+  std::sort(
+      result.begin(), result.end(),
+      [](const Solution& a, const Solution& b) { return a.error < b.error; });
+  return result;
+}
+
+DiscreteSearch::DiscreteSearch(const DiscreteBayesNet& bayesNet, size_t K)
+    : solutions_(K) {
+  // Copy out the conditionals
+  for (auto& factor : bayesNet) {
+    conditionals_.push_back(factor);
+  }
+
+  // Calculate the cost-to-go for each conditional
+  costToGo_ = computeCostToGo(conditionals_);
+
+  // Create the root node and push it to the expansions queue
+  expansions_.push(SearchNode::Root(
+      conditionals_.size(), costToGo_.empty() ? 0.0 : costToGo_.back()));
+}
+
+DiscreteSearch::DiscreteSearch(const DiscreteBayesTree& bayesTree, size_t K)
+    : solutions_(K) {
+  using CliquePtr = DiscreteBayesTree::sharedClique;
+  std::function<void(const CliquePtr&)> collectConditionals =
+      [&](const CliquePtr& clique) -> void {
+    if (!clique) return;
+
+    // Recursive post-order traversal: process children first
+    for (const auto& child : clique->children) {
+      collectConditionals(child);
+    }
+
+    // Then add the current clique's conditional
+    conditionals_.push_back(clique->conditional());
+  };
+
+  // Start traversal from each root in the tree
+  for (const auto& root : bayesTree.roots()) collectConditionals(root);
+
+  // Calculate the cost-to-go for each conditional
+  costToGo_ = computeCostToGo(conditionals_);
+
+  // Create the root node and push it to the expansions queue
+  expansions_.push(SearchNode::Root(
+      conditionals_.size(), costToGo_.empty() ? 0.0 : costToGo_.back()));
+}
+
+std::vector<Solution> DiscreteSearch::run() {
+  while (!expansions_.empty()) {
+    numExpansions++;
+    expandNextNode();
+  }
+
+  // Extract solutions from bestSolutions in ascending order of error
+  return solutions_.extractSolutions();
+}
+
+std::vector<double> DiscreteSearch::computeCostToGo(
+    const std::vector<DiscreteConditional::shared_ptr>& conditionals) {
+  std::vector<double> costToGo;
+  double error = 0.0;
+  for (const auto& conditional : conditionals) {
+    Ordering ordering(conditional->begin(), conditional->end());
+    auto maxx = conditional->max(ordering);
+    assert(maxx->size() == 1);
+    error -= std::log(maxx->evaluate({}));
+    costToGo.push_back(error);
+  }
+  return costToGo;
+}
+
+void DiscreteSearch::expandNextNode() {
+  // Pop the partial assignment with the smallest bound
+  SearchNode current = expansions_.top();
+  expansions_.pop();
+
+  // If we already have K solutions, prune if we cannot beat the worst one.
+  if (solutions_.prune(current.bound)) {
+    return;
+  }
+
+  // Check if we have a complete assignment
+  if (current.isComplete()) {
+    solutions_.maybeAdd(current.error, current.assignment);
+    return;
+  }
+
+  // Expand on the next factor
+  const auto& conditional = conditionals_[current.nextConditional];
+
+  for (auto& fa : conditional->frontalAssignments()) {
+    auto childNode = current.expand(*conditional, fa);
+    if (childNode.nextConditional >= 0)
+      childNode.bound = childNode.error + costToGo_[childNode.nextConditional];
+
+    // Again, prune if we cannot beat the worst solution
+    if (!solutions_.prune(childNode.bound)) {
+      expansions_.push(childNode);
+    }
+  }
+}
+
+}  // namespace gtsam

--- a/gtsam/discrete/DiscreteSearch.cpp
+++ b/gtsam/discrete/DiscreteSearch.cpp
@@ -165,7 +165,7 @@ DiscreteSearch::DiscreteSearch(const DiscreteBayesTree& bayesTree) {
       };
   for (const auto& root : bayesTree.roots()) collectConditionals(root);
   costToGo_ = computeCostToGo(conditionals_);
-};
+}
 
 struct SearchNodeQueue
     : public std::priority_queue<SearchNode, std::vector<SearchNode>,

--- a/gtsam/discrete/DiscreteSearch.cpp
+++ b/gtsam/discrete/DiscreteSearch.cpp
@@ -20,61 +20,139 @@
 
 namespace gtsam {
 
-SearchNode SearchNode::Root(size_t numConditionals, double bound) {
-  return {.assignment = DiscreteValues(),
-          .error = 0.0,
-          .bound = bound,
-          .nextConditional = static_cast<int>(numConditionals) - 1};
-}
+using Value = size_t;
 
-SearchNode SearchNode::expand(const DiscreteConditional& conditional,
-                              const DiscreteValues& fa) const {
-  // Combine the new frontal assignment with the current partial assignment
-  DiscreteValues newAssignment = assignment;
-  for (auto& [key, value] : fa) {
-    newAssignment[key] = value;
+/**
+ * @brief Represents a node in the search tree for discrete search algorithms.
+ *
+ * @details Each SearchNode contains a partial assignment of discrete variables,
+ * the current error, a bound on the final error, and the index of the next
+ * conditional to be assigned.
+ */
+struct SearchNode {
+  DiscreteValues assignment;  ///< Partial assignment of discrete variables.
+  double error;               ///< Current error for the partial assignment.
+  double bound;  ///< Lower bound on the final error for unassigned variables.
+  int nextConditional;  ///< Index of the next conditional to be assigned.
+
+  /**
+   * @brief Construct the root node for the search.
+   */
+  static SearchNode Root(size_t numConditionals, double bound) {
+    return {.assignment = DiscreteValues(),
+            .error = 0.0,
+            .bound = bound,
+            .nextConditional = static_cast<int>(numConditionals) - 1};
   }
 
-  return {.assignment = newAssignment,
-          .error = error + conditional.error(newAssignment),
-          .bound = 0.0,
-          .nextConditional = nextConditional - 1};
-}
+  struct Compare {
+    bool operator()(const SearchNode& a, const SearchNode& b) const {
+      return a.bound > b.bound;  // smallest bound -> highest priority
+    }
+  };
 
-bool Solutions::maybeAdd(double error, const DiscreteValues& assignment) {
-  const bool full = pq_.size() == maxSize_;
-  if (full && error >= pq_.top().error) return false;
-  if (full) pq_.pop();
-  pq_.emplace(error, assignment);
-  return true;
-}
+  /**
+   * @brief Checks if the node represents a complete assignment.
+   *
+   * @return True if all variables have been assigned, false otherwise.
+   */
+  inline bool isComplete() const { return nextConditional < 0; }
 
-std::ostream& operator<<(std::ostream& os, const Solutions& sn) {
-  os << "Solutions (top " << sn.pq_.size() << "):\n";
-  auto pq = sn.pq_;
-  while (!pq.empty()) {
-    os << pq.top() << "\n";
-    pq.pop();
+  /**
+   * @brief Expands the node by assigning the next variable.
+   *
+   * @param conditional The discrete conditional representing the next variable
+   * to be assigned.
+   * @param fa The frontal assignment for the next variable.
+   * @return A new SearchNode representing the expanded state.
+   */
+  SearchNode expand(const DiscreteConditional& conditional,
+                    const DiscreteValues& fa) const {
+    // Combine the new frontal assignment with the current partial assignment
+    DiscreteValues newAssignment = assignment;
+    for (auto& [key, value] : fa) {
+      newAssignment[key] = value;
+    }
+
+    return {.assignment = newAssignment,
+            .error = error + conditional.error(newAssignment),
+            .bound = 0.0,
+            .nextConditional = nextConditional - 1};
   }
-  return os;
-}
 
-bool Solutions::prune(double bound) const {
-  if (pq_.size() < maxSize_) return false;
-  return bound >= pq_.top().error;
-}
-
-std::vector<Solution> Solutions::extractSolutions() {
-  std::vector<Solution> result;
-  while (!pq_.empty()) {
-    result.push_back(pq_.top());
-    pq_.pop();
+  /**
+   * @brief Prints the SearchNode to an output stream.
+   *
+   * @param os The output stream.
+   * @param node The SearchNode to be printed.
+   * @return The output stream.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const SearchNode& node) {
+    os << "SearchNode(error=" << node.error << ", bound=" << node.bound << ")";
+    return os;
   }
-  std::sort(
-      result.begin(), result.end(),
-      [](const Solution& a, const Solution& b) { return a.error < b.error; });
-  return result;
-}
+};
+
+struct CompareSolution {
+  bool operator()(const Solution& a, const Solution& b) const {
+    return a.error < b.error;
+  }
+};
+
+// Define the Solutions class
+class Solutions {
+ private:
+  size_t maxSize_;
+  std::priority_queue<Solution, std::vector<Solution>, CompareSolution> pq_;
+
+ public:
+  Solutions(size_t maxSize) : maxSize_(maxSize) {}
+
+  /// Add a solution to the priority queue, possibly evicting the worst one.
+  /// Return true if we added the solution.
+  bool maybeAdd(double error, const DiscreteValues& assignment) {
+    const bool full = pq_.size() == maxSize_;
+    if (full && error >= pq_.top().error) return false;
+    if (full) pq_.pop();
+    pq_.emplace(error, assignment);
+    return true;
+  }
+
+  /// Check if we have any solutions
+  bool empty() const { return pq_.empty(); }
+
+  // Method to print all solutions
+  friend std::ostream& operator<<(std::ostream& os, const Solutions& sn) {
+    os << "Solutions (top " << sn.pq_.size() << "):\n";
+    auto pq = sn.pq_;
+    while (!pq.empty()) {
+      os << pq.top() << "\n";
+      pq.pop();
+    }
+    return os;
+  }
+
+  /// Check if (partial) solution with given bound can be pruned. If we have
+  /// room, we never prune. Otherwise, prune if lower bound on error is worse
+  /// than our current worst error.
+  bool prune(double bound) const {
+    if (pq_.size() < maxSize_) return false;
+    return bound >= pq_.top().error;
+  }
+
+  // Method to extract solutions in ascending order of error
+  std::vector<Solution> extractSolutions() {
+    std::vector<Solution> result;
+    while (!pq_.empty()) {
+      result.push_back(pq_.top());
+      pq_.pop();
+    }
+    std::sort(
+        result.begin(), result.end(),
+        [](const Solution& a, const Solution& b) { return a.error < b.error; });
+    return result;
+  }
+};
 
 DiscreteSearch::DiscreteSearch(const DiscreteBayesNet& bayesNet) {
   std::vector<DiscreteConditional::shared_ptr> conditionals;

--- a/gtsam/discrete/DiscreteSearch.cpp
+++ b/gtsam/discrete/DiscreteSearch.cpp
@@ -39,10 +39,8 @@ struct SearchNode {
    * @brief Construct the root node for the search.
    */
   static SearchNode Root(size_t numConditionals, double bound) {
-    return {.assignment = DiscreteValues(),
-            .error = 0.0,
-            .bound = bound,
-            .nextConditional = static_cast<int>(numConditionals) - 1};
+    return {DiscreteValues(), 0.0, bound,
+            static_cast<int>(numConditionals) - 1};
   }
 
   struct Compare {
@@ -74,10 +72,8 @@ struct SearchNode {
       newAssignment[key] = value;
     }
 
-    return {.assignment = newAssignment,
-            .error = error + conditional.error(newAssignment),
-            .bound = 0.0,
-            .nextConditional = nextConditional - 1};
+    return {newAssignment, error + conditional.error(newAssignment), 0.0,
+            nextConditional - 1};
   }
 
   /**

--- a/gtsam/discrete/DiscreteSearch.h
+++ b/gtsam/discrete/DiscreteSearch.h
@@ -23,63 +23,9 @@
 
 namespace gtsam {
 
-using Value = size_t;
-
 /**
- * @brief Represents a node in the search tree for discrete search algorithms.
- *
- * @details Each SearchNode contains a partial assignment of discrete variables,
- * the current error, a bound on the final error, and the index of the next
- * conditional to be assigned.
+ * @brief A solution to a discrete search problem.
  */
-struct SearchNode {
-  DiscreteValues assignment;  ///< Partial assignment of discrete variables.
-  double error;               ///< Current error for the partial assignment.
-  double bound;  ///< Lower bound on the final error for unassigned variables.
-  int nextConditional;  ///< Index of the next conditional to be assigned.
-
-  /**
-   * @brief Construct the root node for the search.
-   */
-  static SearchNode Root(size_t numConditionals, double bound);
-
-  struct Compare {
-    bool operator()(const SearchNode& a, const SearchNode& b) const {
-      return a.bound > b.bound;  // smallest bound -> highest priority
-    }
-  };
-
-  /**
-   * @brief Checks if the node represents a complete assignment.
-   *
-   * @return True if all variables have been assigned, false otherwise.
-   */
-  inline bool isComplete() const { return nextConditional < 0; }
-
-  /**
-   * @brief Expands the node by assigning the next variable.
-   *
-   * @param conditional The discrete conditional representing the next variable
-   * to be assigned.
-   * @param fa The frontal assignment for the next variable.
-   * @return A new SearchNode representing the expanded state.
-   */
-  SearchNode expand(const DiscreteConditional& conditional,
-                    const DiscreteValues& fa) const;
-
-  /**
-   * @brief Prints the SearchNode to an output stream.
-   *
-   * @param os The output stream.
-   * @param node The SearchNode to be printed.
-   * @return The output stream.
-   */
-  friend std::ostream& operator<<(std::ostream& os, const SearchNode& node) {
-    os << "SearchNode(error=" << node.error << ", bound=" << node.bound << ")";
-    return os;
-  }
-};
-
 struct Solution {
   double error;
   DiscreteValues assignment;
@@ -89,40 +35,6 @@ struct Solution {
     os << "[ error=" << sn.error << " assignment={" << sn.assignment << "}]";
     return os;
   }
-
-  struct Compare {
-    bool operator()(const Solution& a, const Solution& b) const {
-      return a.error < b.error;
-    }
-  };
-};
-
-// Define the Solutions class
-class Solutions {
- private:
-  size_t maxSize_;
-  std::priority_queue<Solution, std::vector<Solution>, Solution::Compare> pq_;
-
- public:
-  Solutions(size_t maxSize) : maxSize_(maxSize) {}
-
-  /// Add a solution to the priority queue, possibly evicting the worst one.
-  /// Return true if we added the solution.
-  bool maybeAdd(double error, const DiscreteValues& assignment);
-
-  /// Check if we have any solutions
-  bool empty() const { return pq_.empty(); }
-
-  // Method to print all solutions
-  friend std::ostream& operator<<(std::ostream& os, const Solutions& sn);
-
-  /// Check if (partial) solution with given bound can be pruned. If we have
-  /// room, we never prune. Otherwise, prune if lower bound on error is worse
-  /// than our current worst error.
-  bool prune(double bound) const;
-
-  // Method to extract solutions in ascending order of error
-  std::vector<Solution> extractSolutions();
 };
 
 /**

--- a/gtsam/discrete/DiscreteSearch.h
+++ b/gtsam/discrete/DiscreteSearch.h
@@ -1,0 +1,276 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/*
+ * DiscreteSearch.cpp
+ *
+ * @date January, 2025
+ * @author Frank Dellaert
+ */
+
+#include <gtsam/discrete/DiscreteBayesNet.h>
+
+namespace gtsam {
+
+using Value = size_t;
+
+/**
+ * @brief Represents a node in the search tree for discrete search algorithms.
+ *
+ * @details Each SearchNode contains a partial assignment of discrete variables,
+ * the current error, a bound on the final error, and the index of the next
+ * conditional to be assigned.
+ */
+struct SearchNode {
+  DiscreteValues assignment;  ///< Partial assignment of discrete variables.
+  double error;               ///< Current error for the partial assignment.
+  double bound;  ///< Lower bound on the final error for unassigned variables.
+  int nextConditional;  ///< Index of the next conditional to be assigned.
+
+  struct CompareByBound {
+    bool operator()(const SearchNode& a, const SearchNode& b) const {
+      return a.bound > b.bound;  // smallest bound -> highest priority
+    }
+  };
+
+  /**
+   * @brief Checks if the node represents a complete assignment.
+   *
+   * @return True if all variables have been assigned, false otherwise.
+   */
+  bool isComplete() const { return nextConditional < 0; }
+
+  /**
+   * @brief Computes a lower bound on the final error for unassigned variables.
+   *
+   * @details This is a stub implementation that returns 0. Real implementations
+   * might perform partial factor analysis or use heuristics to compute the
+   * bound.
+   *
+   * @return A lower bound on the final error.
+   */
+  double computeBound() const {
+    // Real code might do partial factor analysis or heuristics.
+    return 0.0;
+  }
+
+  /**
+   * @brief Expands the node by assigning the next variable.
+   *
+   * @param conditional The discrete conditional representing the next variable
+   * to be assigned.
+   * @param fa The frontal assignment for the next variable.
+   * @return A new SearchNode representing the expanded state.
+   */
+  SearchNode expand(const DiscreteConditional& conditional,
+                    const DiscreteValues& fa) const {
+    // Combine the new frontal assignment with the current partial assignment
+    SearchNode child;
+    child.assignment = assignment;
+    for (auto& kv : fa) {
+      child.assignment[kv.first] = kv.second;
+    }
+
+    // Compute the incremental error for this factor
+    child.error = error + conditional.error(child.assignment);
+
+    // Compute new bound
+    child.bound = computeBound();
+
+    // Update the index of the next conditional
+    child.nextConditional = nextConditional - 1;
+
+    return child;
+  }
+
+  /**
+   * @brief Prints the SearchNode to an output stream.
+   *
+   * @param os The output stream.
+   * @param node The SearchNode to be printed.
+   * @return The output stream.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const SearchNode& node) {
+    os << "SearchNode(error=" << node.error << ", bound=" << node.bound << ")";
+    return os;
+  }
+};
+
+struct Solution {
+  double error;
+  DiscreteValues assignment;
+  Solution(double err, const DiscreteValues& assign)
+      : error(err), assignment(assign) {}
+  friend std::ostream& operator<<(std::ostream& os, const Solution& sn) {
+    os << "[ error=" << sn.error << " assignment={" << sn.assignment << "}]";
+    return os;
+  }
+};
+
+struct CompareByError {
+  bool operator()(const Solution& a, const Solution& b) const {
+    return a.error < b.error;
+  }
+};
+
+// Define the Solutions class
+class Solutions {
+ private:
+  size_t maxSize_;
+  std::priority_queue<Solution, std::vector<Solution>, CompareByError> pq_;
+
+ public:
+  Solutions(size_t maxSize) : maxSize_(maxSize) {}
+
+  /// Add a solution to the priority queue, possibly evicting the worst one.
+  /// Return true if we added the solution.
+  bool maybeAdd(double error, const DiscreteValues& assignment) {
+    const bool full = pq_.size() == maxSize_;
+    if (full && error >= pq_.top().error) return false;
+    if (full) pq_.pop();
+    pq_.emplace(error, assignment);
+    return true;
+  }
+
+  /// Check if we have any solutions
+  bool empty() const { return pq_.empty(); }
+
+  // Method to print all solutions
+  friend std::ostream& operator<<(std::ostream& os, const Solutions& sn) {
+    auto pq = sn.pq_;
+    while (!pq.empty()) {
+      const Solution& best = pq.top();
+      os << "Error: " << best.error << ", Values: " << best.assignment
+         << std::endl;
+      pq.pop();
+    }
+    return os;
+  }
+
+  /// Check if (partial) solution with given bound can be pruned. If we have
+  /// room, we never prune. Otherwise, prune if lower bound on error is worse
+  /// than our current worst error.
+  bool prune(double bound) const {
+    if (pq_.size() < maxSize_) return false;
+    double worstError = pq_.top().error;
+    return (bound >= worstError);
+  }
+
+  // Method to extract solutions in ascending order of error
+  std::vector<Solution> extractSolutions() {
+    std::vector<Solution> result;
+    while (!pq_.empty()) {
+      result.push_back(pq_.top());
+      pq_.pop();
+    }
+    std::sort(
+        result.begin(), result.end(),
+        [](const Solution& a, const Solution& b) { return a.error < b.error; });
+    return result;
+  }
+};
+
+/**
+ * DiscreteSearch: Search for the K best solutions.
+ */
+class DiscreteSearch {
+ public:
+  /**
+   * Construct from a DiscreteBayesNet and K.
+   */
+  DiscreteSearch(const DiscreteBayesNet& bayesNet, size_t K) : solutions_(K) {
+    // Copy out the conditionals
+    for (auto& factor : bayesNet) {
+      conditionals_.push_back(factor);
+    }
+
+    // Calculate the cost-to-go for each conditional. If there are n
+    // conditionals, we start with nextConditional = n-1, and the minimum error
+    // obtainable is the sum of all the minimum errors. We start with
+    // 0, and that is the minimum error of the conditional with that index:
+    double error = 0.0;
+    for (const auto& conditional : conditionals_) {
+      Ordering ordering(conditional->begin(), conditional->end());
+      auto maxx = conditional->max(ordering);
+      assert(maxx->size() == 1);
+      error -= std::log(maxx->evaluate({}));
+      costToGo_.push_back(error);
+    }
+
+    // Create the root node: no variables assigned, nextConditional = last.
+    SearchNode root{
+        .assignment = DiscreteValues(),
+        .error = 0.0,
+        .nextConditional = static_cast<int>(conditionals_.size()) - 1};
+    if (!costToGo_.empty()) root.bound = costToGo_.back();
+    expansions_.push(root);
+  }
+
+  /**
+   * @brief Search for the K best solutions.
+   *
+   * This method performs a search to find the K best solutions for the given
+   * DiscreteBayesNet. It uses a priority queue to manage the search nodes,
+   * expanding nodes with the smallest bound first. The search continues until
+   * all possible nodes have been expanded or pruned.
+   *
+   * @return A vector of the K best solutions found during the search.
+   */
+  std::vector<Solution> run() {
+    while (!expansions_.empty()) {
+      expandNextNode();
+    }
+
+    // Extract solutions from bestSolutions in ascending order of error
+    return solutions_.extractSolutions();
+  }
+
+ private:
+  void expandNextNode() {
+    // Pop the partial assignment with the smallest bound
+    SearchNode current = expansions_.top();
+    expansions_.pop();
+
+    // If we already have K solutions, prune if we cannot beat the worst one.
+    if (solutions_.prune(current.bound)) {
+      return;
+    }
+
+    // Check if we have a complete assignment
+    if (current.isComplete()) {
+      solutions_.maybeAdd(current.error, current.assignment);
+      return;
+    }
+
+    // Expand on the next factor
+    const auto& conditional = conditionals_[current.nextConditional];
+
+    for (auto& fa : conditional->frontalAssignments()) {
+      auto childNode = current.expand(*conditional, fa);
+      if (childNode.nextConditional >= 0)
+        childNode.bound =
+            childNode.error + costToGo_[childNode.nextConditional];
+
+      // Again, prune if we cannot beat the worst solution
+      if (!solutions_.prune(childNode.bound)) {
+        expansions_.push(childNode);
+      }
+    }
+  }
+
+  std::vector<std::shared_ptr<DiscreteConditional>> conditionals_;
+  std::vector<double> costToGo_;
+  std::priority_queue<SearchNode, std::vector<SearchNode>,
+                      SearchNode::CompareByBound>
+      expansions_;
+  Solutions solutions_;
+};
+}  // namespace gtsam

--- a/gtsam/discrete/DiscreteSearch.h
+++ b/gtsam/discrete/DiscreteSearch.h
@@ -17,6 +17,7 @@
  */
 
 #include <gtsam/discrete/DiscreteBayesNet.h>
+#include <gtsam/discrete/DiscreteBayesTree.h>
 
 namespace gtsam {
 
@@ -213,6 +214,12 @@ class DiscreteSearch {
     if (!costToGo_.empty()) root.bound = costToGo_.back();
     expansions_.push(root);
   }
+
+  /**
+   * Construct from a DiscreteBayesNet and K.
+   */
+  DiscreteSearch(const DiscreteBayesTree& bayesTree, size_t K)
+      : solutions_(K) {}
 
   /**
    * @brief Search for the K best solutions.

--- a/gtsam/discrete/DiscreteSearch.h
+++ b/gtsam/discrete/DiscreteSearch.h
@@ -130,17 +130,15 @@ class Solutions {
  */
 class DiscreteSearch {
  public:
-  size_t numExpansions = 0;
-
   /**
    * Construct from a DiscreteBayesNet and K.
    */
-  DiscreteSearch(const DiscreteBayesNet& bayesNet, size_t K = 1);
+  DiscreteSearch(const DiscreteBayesNet& bayesNet);
 
   /**
    * Construct from a DiscreteBayesTree and K.
    */
-  DiscreteSearch(const DiscreteBayesTree& bayesTree, size_t K = 1);
+  DiscreteSearch(const DiscreteBayesTree& bayesTree);
 
   /**
    * @brief Search for the K best solutions.
@@ -152,29 +150,17 @@ class DiscreteSearch {
    *
    * @return A vector of the K best solutions found during the search.
    */
-  std::vector<Solution> run();
+  std::vector<Solution> run(size_t K = 1) const;
 
  private:
-  /// Initialize the search with the given conditionals.
-  void initialize(
-      const std::vector<DiscreteConditional::shared_ptr>& conditionals) {
-    conditionals_ = conditionals;
-    costToGo_ = computeCostToGo(conditionals_);
-    expansions_.push(SearchNode::Root(
-        conditionals_.size(), costToGo_.empty() ? 0.0 : costToGo_.back()));
-  }
-
   /// Compute the cumulative cost-to-go for each conditional slot.
   static std::vector<double> computeCostToGo(
       const std::vector<DiscreteConditional::shared_ptr>& conditionals);
 
   /// Expand the next node in the search tree.
-  void expandNextNode();
+  void expandNextNode() const;
 
   std::vector<DiscreteConditional::shared_ptr> conditionals_;
   std::vector<double> costToGo_;
-  std::priority_queue<SearchNode, std::vector<SearchNode>, SearchNode::Compare>
-      expansions_;
-  Solutions solutions_;
 };
 }  // namespace gtsam

--- a/gtsam/discrete/DiscreteSearch.h
+++ b/gtsam/discrete/DiscreteSearch.h
@@ -39,14 +39,9 @@ struct SearchNode {
   /**
    * @brief Construct the root node for the search.
    */
-  static SearchNode Root(size_t numConditionals, double bound) {
-    return {.assignment = DiscreteValues(),
-            .error = 0.0,
-            .bound = bound,
-            .nextConditional = static_cast<int>(numConditionals) - 1};
-  }
+  static SearchNode Root(size_t numConditionals, double bound);
 
-  struct CompareByBound {
+  struct Compare {
     bool operator()(const SearchNode& a, const SearchNode& b) const {
       return a.bound > b.bound;  // smallest bound -> highest priority
     }
@@ -68,18 +63,7 @@ struct SearchNode {
    * @return A new SearchNode representing the expanded state.
    */
   SearchNode expand(const DiscreteConditional& conditional,
-                    const DiscreteValues& fa) const {
-    // Combine the new frontal assignment with the current partial assignment
-    DiscreteValues newAssignment = assignment;
-    for (auto& kv : fa) {
-      newAssignment[kv.first] = kv.second;
-    }
-
-    return {.assignment = newAssignment,
-            .error = error + conditional.error(newAssignment),
-            .bound = 0.0,
-            .nextConditional = nextConditional - 1};
-  }
+                    const DiscreteValues& fa) const;
 
   /**
    * @brief Prints the SearchNode to an output stream.
@@ -103,69 +87,40 @@ struct Solution {
     os << "[ error=" << sn.error << " assignment={" << sn.assignment << "}]";
     return os;
   }
-};
 
-struct CompareByError {
-  bool operator()(const Solution& a, const Solution& b) const {
-    return a.error < b.error;
-  }
+  struct Compare {
+    bool operator()(const Solution& a, const Solution& b) const {
+      return a.error < b.error;
+    }
+  };
 };
 
 // Define the Solutions class
 class Solutions {
  private:
   size_t maxSize_;
-  std::priority_queue<Solution, std::vector<Solution>, CompareByError> pq_;
+  std::priority_queue<Solution, std::vector<Solution>, Solution::Compare> pq_;
 
  public:
   Solutions(size_t maxSize) : maxSize_(maxSize) {}
 
   /// Add a solution to the priority queue, possibly evicting the worst one.
   /// Return true if we added the solution.
-  bool maybeAdd(double error, const DiscreteValues& assignment) {
-    const bool full = pq_.size() == maxSize_;
-    if (full && error >= pq_.top().error) return false;
-    if (full) pq_.pop();
-    pq_.emplace(error, assignment);
-    return true;
-  }
+  bool maybeAdd(double error, const DiscreteValues& assignment);
 
   /// Check if we have any solutions
   bool empty() const { return pq_.empty(); }
 
   // Method to print all solutions
-  friend std::ostream& operator<<(std::ostream& os, const Solutions& sn) {
-    auto pq = sn.pq_;
-    while (!pq.empty()) {
-      const Solution& best = pq.top();
-      os << "Error: " << best.error << ", Values: " << best.assignment
-         << std::endl;
-      pq.pop();
-    }
-    return os;
-  }
+  friend std::ostream& operator<<(std::ostream& os, const Solutions& sn);
 
   /// Check if (partial) solution with given bound can be pruned. If we have
   /// room, we never prune. Otherwise, prune if lower bound on error is worse
   /// than our current worst error.
-  bool prune(double bound) const {
-    if (pq_.size() < maxSize_) return false;
-    double worstError = pq_.top().error;
-    return (bound >= worstError);
-  }
+  bool prune(double bound) const;
 
   // Method to extract solutions in ascending order of error
-  std::vector<Solution> extractSolutions() {
-    std::vector<Solution> result;
-    while (!pq_.empty()) {
-      result.push_back(pq_.top());
-      pq_.pop();
-    }
-    std::sort(
-        result.begin(), result.end(),
-        [](const Solution& a, const Solution& b) { return a.error < b.error; });
-    return result;
-  }
+  std::vector<Solution> extractSolutions();
 };
 
 /**
@@ -178,48 +133,12 @@ class DiscreteSearch {
   /**
    * Construct from a DiscreteBayesNet and K.
    */
-  DiscreteSearch(const DiscreteBayesNet& bayesNet, size_t K) : solutions_(K) {
-    // Copy out the conditionals
-    for (auto& factor : bayesNet) {
-      conditionals_.push_back(factor);
-    }
-
-    // Calculate the cost-to-go for each conditional
-    costToGo_ = computeCostToGo(conditionals_);
-
-    // Create the root node and push it to the expansions queue
-    expansions_.push(SearchNode::Root(
-        conditionals_.size(), costToGo_.empty() ? 0.0 : costToGo_.back()));
-  }
+  DiscreteSearch(const DiscreteBayesNet& bayesNet, size_t K);
 
   /**
    * Construct from a DiscreteBayesTree and K.
    */
-  DiscreteSearch(const DiscreteBayesTree& bayesTree, size_t K) : solutions_(K) {
-    using CliquePtr = DiscreteBayesTree::sharedClique;
-    std::function<void(const CliquePtr&)> collectConditionals =
-        [&](const CliquePtr& clique) -> void {
-      if (!clique) return;
-
-      // Recursive post-order traversal: process children first
-      for (const auto& child : clique->children) {
-        collectConditionals(child);
-      }
-
-      // Then add the current clique's conditional
-      conditionals_.push_back(clique->conditional());
-    };
-
-    // Start traversal from each root in the tree
-    for (const auto& root : bayesTree.roots()) collectConditionals(root);
-
-    // Calculate the cost-to-go for each conditional
-    costToGo_ = computeCostToGo(conditionals_);
-
-    // Create the root node and push it to the expansions queue
-    expansions_.push(SearchNode::Root(
-        conditionals_.size(), costToGo_.empty() ? 0.0 : costToGo_.back()));
-  }
+  DiscreteSearch(const DiscreteBayesTree& bayesTree, size_t K);
 
   /**
    * @brief Search for the K best solutions.
@@ -231,15 +150,7 @@ class DiscreteSearch {
    *
    * @return A vector of the K best solutions found during the search.
    */
-  std::vector<Solution> run() {
-    while (!expansions_.empty()) {
-      numExpansions++;
-      expandNextNode();
-    }
-
-    // Extract solutions from bestSolutions in ascending order of error
-    return solutions_.extractSolutions();
-  }
+  std::vector<Solution> run();
 
  private:
   /**
@@ -249,58 +160,16 @@ class DiscreteSearch {
    * @return A vector of cost-to-go values.
    */
   static std::vector<double> computeCostToGo(
-      const std::vector<DiscreteConditional::shared_ptr>& conditionals) {
-    std::vector<double> costToGo;
-    double error = 0.0;
-    for (const auto& conditional : conditionals) {
-      Ordering ordering(conditional->begin(), conditional->end());
-      auto maxx = conditional->max(ordering);
-      assert(maxx->size() == 1);
-      error -= std::log(maxx->evaluate({}));
-      costToGo.push_back(error);
-    }
-    return costToGo;
-  }
+      const std::vector<DiscreteConditional::shared_ptr>& conditionals);
 
   /**
    * @brief Expand the next node in the search tree.
    */
-  void expandNextNode() {
-    // Pop the partial assignment with the smallest bound
-    SearchNode current = expansions_.top();
-    expansions_.pop();
-
-    // If we already have K solutions, prune if we cannot beat the worst one.
-    if (solutions_.prune(current.bound)) {
-      return;
-    }
-
-    // Check if we have a complete assignment
-    if (current.isComplete()) {
-      solutions_.maybeAdd(current.error, current.assignment);
-      return;
-    }
-
-    // Expand on the next factor
-    const auto& conditional = conditionals_[current.nextConditional];
-
-    for (auto& fa : conditional->frontalAssignments()) {
-      auto childNode = current.expand(*conditional, fa);
-      if (childNode.nextConditional >= 0)
-        childNode.bound =
-            childNode.error + costToGo_[childNode.nextConditional];
-
-      // Again, prune if we cannot beat the worst solution
-      if (!solutions_.prune(childNode.bound)) {
-        expansions_.push(childNode);
-      }
-    }
-  }
+  void expandNextNode();
 
   std::vector<DiscreteConditional::shared_ptr> conditionals_;
   std::vector<double> costToGo_;
-  std::priority_queue<SearchNode, std::vector<SearchNode>,
-                      SearchNode::CompareByBound>
+  std::priority_queue<SearchNode, std::vector<SearchNode>, SearchNode::Compare>
       expansions_;
   Solutions solutions_;
 };

--- a/gtsam/discrete/DiscreteSearch.h
+++ b/gtsam/discrete/DiscreteSearch.h
@@ -24,24 +24,24 @@
 namespace gtsam {
 
 /**
- * @brief A solution to a discrete search problem.
- */
-struct Solution {
-  double error;
-  DiscreteValues assignment;
-  Solution(double err, const DiscreteValues& assign)
-      : error(err), assignment(assign) {}
-  friend std::ostream& operator<<(std::ostream& os, const Solution& sn) {
-    os << "[ error=" << sn.error << " assignment={" << sn.assignment << "}]";
-    return os;
-  }
-};
-
-/**
  * DiscreteSearch: Search for the K best solutions.
  */
-class DiscreteSearch {
+class GTSAM_EXPORT DiscreteSearch {
  public:
+  /**
+   * @brief A solution to a discrete search problem.
+   */
+  struct Solution {
+    double error;
+    DiscreteValues assignment;
+    Solution(double err, const DiscreteValues& assign)
+        : error(err), assignment(assign) {}
+    friend std::ostream& operator<<(std::ostream& os, const Solution& sn) {
+      os << "[ error=" << sn.error << " assignment={" << sn.assignment << "}]";
+      return os;
+    }
+  };
+
   /**
    * Construct from a DiscreteBayesNet and K.
    */

--- a/gtsam/discrete/DiscreteValues.cpp
+++ b/gtsam/discrete/DiscreteValues.cpp
@@ -27,11 +27,23 @@ using std::stringstream;
 namespace gtsam {
 
 /* ************************************************************************ */
+static void stream(std::ostream& os, const DiscreteValues& x,
+                   const KeyFormatter& keyFormatter) {
+  for (const auto& kv : x)
+    os << "(" << keyFormatter(kv.first) << ", " << kv.second << ")";
+}
+
+/* ************************************************************************ */
+std::ostream& operator<<(std::ostream& os, const DiscreteValues& x) {
+  stream(os, x, DefaultKeyFormatter);
+  return os;
+}
+
+/* ************************************************************************ */
 void DiscreteValues::print(const string& s,
                            const KeyFormatter& keyFormatter) const {
   cout << s << ": ";
-  for (auto&& kv : *this)
-    cout << "(" << keyFormatter(kv.first) << ", " << kv.second << ")";
+  stream(cout, *this, keyFormatter);
   cout << endl;
 }
 

--- a/gtsam/discrete/DiscreteValues.h
+++ b/gtsam/discrete/DiscreteValues.h
@@ -64,6 +64,9 @@ class GTSAM_EXPORT DiscreteValues : public Assignment<Key> {
   /// @name Standard Interface
   /// @{
 
+  /// ostream operator:
+  friend std::ostream& operator<<(std::ostream& os, const DiscreteValues& x);
+
   // insert in base class;
   std::pair<iterator, bool> insert( const value_type& value ){
     return Base::insert(value);

--- a/gtsam/discrete/tests/AsiaExample.h
+++ b/gtsam/discrete/tests/AsiaExample.h
@@ -30,7 +30,7 @@ static const DiscreteKey Dyspnea(D, 2), XRay(X, 2), Either(E, 2),
     Bronchitis(B, 2), LungCancer(L, 2), Tuberculosis(T, 2), Smoking(S, 2),
     Asia(A, 2);
 
-// Function to construct the incomplete Asia example
+// Function to construct the Asia priors
 DiscreteBayesNet createPriors() {
   DiscreteBayesNet priors;
   priors.add(Smoking % "50/50");

--- a/gtsam/discrete/tests/AsiaExample.h
+++ b/gtsam/discrete/tests/AsiaExample.h
@@ -1,0 +1,61 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/*
+ * AsiaExample.h
+ *
+ *  @date Jan, 2025
+ *  @author Frank Dellaert
+ */
+
+#include <gtsam/discrete/DiscreteBayesNet.h>
+#include <gtsam/inference/Symbol.h>
+
+namespace gtsam {
+namespace asia_example {
+
+static const Key D = Symbol('D', 1), X = Symbol('X', 2), E = Symbol('E', 3),
+                 B = Symbol('B', 4), L = Symbol('L', 5), T = Symbol('T', 6),
+                 S = Symbol('S', 7), A = Symbol('A', 8);
+
+static const DiscreteKey Dyspnea(D, 2), XRay(X, 2), Either(E, 2),
+    Bronchitis(B, 2), LungCancer(L, 2), Tuberculosis(T, 2), Smoking(S, 2),
+    Asia(A, 2);
+
+// Function to construct the incomplete Asia example
+DiscreteBayesNet createPriors() {
+  DiscreteBayesNet priors;
+  priors.add(Smoking % "50/50");
+  priors.add(Asia, "99/1");
+  return priors;
+}
+
+// Function to construct the incomplete Asia example
+DiscreteBayesNet createFragment() {
+  DiscreteBayesNet fragment;
+  fragment.add((Either | Tuberculosis, LungCancer) = "F T T T");
+  fragment.add(LungCancer | Smoking = "99/1 90/10");
+  fragment.add(Tuberculosis | Asia = "99/1 95/5");
+  for (const auto& factor : createPriors()) fragment.push_back(factor);
+  return fragment;
+}
+
+// Function to construct the Asia example
+DiscreteBayesNet createAsiaExample() {
+  DiscreteBayesNet asia;
+  asia.add((Dyspnea | Either, Bronchitis) = "9/1 2/8 3/7 1/9");
+  asia.add(XRay | Either = "95/5 2/98");
+  asia.add(Bronchitis | Smoking = "70/30 40/60");
+  for (const auto& factor : createFragment()) asia.push_back(factor);
+  return asia;
+}
+}  // namespace asia_example
+}  // namespace gtsam

--- a/gtsam/discrete/tests/testDiscreteSearch.cpp
+++ b/gtsam/discrete/tests/testDiscreteSearch.cpp
@@ -1,0 +1,59 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/*
+ * testDiscreteSearch.cpp
+ *
+ *  @date January, 2025
+ *  @author Frank Dellaert
+ */
+
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/Testable.h>
+#include <gtsam/discrete/DiscreteSearch.h>
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <map>
+#include <queue>
+#include <string>
+#include <vector>
+
+#include "AsiaExample.h"
+
+using namespace gtsam;
+
+TEST(DiscreteBayesNet, EmptyKBest) {
+  DiscreteBayesNet net;  // no factors
+  DiscreteSearch search(net, 3);
+  auto solutions = search.run();
+  // Expect one solution with empty assignment, error=0
+  EXPECT_LONGS_EQUAL(1, solutions.size());
+  EXPECT_DOUBLES_EQUAL(0, std::fabs(solutions[0].error), 1e-9);
+}
+
+TEST(DiscreteBayesNet, AsiaKBest) {
+  using namespace asia_example;
+  DiscreteBayesNet asia = createAsiaExample();
+  DiscreteSearch search(asia, 4);
+  auto solutions = search.run();
+  EXPECT(!solutions.empty());
+  // Regression test: check the first solution
+  EXPECT_DOUBLES_EQUAL(1.236627, std::fabs(solutions[0].error), 1e-5);
+}
+
+/* ************************************************************************* */
+int main() {
+  TestResult tr;
+  return TestRegistry::runAllTests(tr);
+}
+/* ************************************************************************* */

--- a/gtsam/discrete/tests/testDiscreteSearch.cpp
+++ b/gtsam/discrete/tests/testDiscreteSearch.cpp
@@ -35,8 +35,8 @@ using namespace gtsam;
 /* ************************************************************************* */
 TEST(DiscreteBayesNet, EmptyKBest) {
   DiscreteBayesNet net;  // no factors
-  DiscreteSearch search(net, 3);
-  auto solutions = search.run();
+  DiscreteSearch search(net);
+  auto solutions = search.run(3);
   // Expect one solution with empty assignment, error=0
   EXPECT_LONGS_EQUAL(1, solutions.size());
   EXPECT_DOUBLES_EQUAL(0, std::fabs(solutions[0].error), 1e-9);
@@ -46,23 +46,17 @@ TEST(DiscreteBayesNet, EmptyKBest) {
 TEST(DiscreteBayesNet, AsiaKBest) {
   using namespace asia_example;
   DiscreteBayesNet asia = createAsiaExample();
+  DiscreteSearch search(asia);
 
   // Ask for the MPE
-  DiscreteSearch search1(asia);
-  auto mpe = search1.run();
-
-  // print numExpansions
-  std::cout << "Number of expansions: " << search1.numExpansions << std::endl;
+  auto mpe = search.run();
 
   EXPECT_LONGS_EQUAL(1, mpe.size());
   // Regression test: check the MPE solution
   EXPECT_DOUBLES_EQUAL(1.236627, std::fabs(mpe[0].error), 1e-5);
 
-  DiscreteSearch search(asia, 4);
-  auto solutions = search.run();
-
-  // print numExpansions
-  std::cout << "Number of expansions: " << search.numExpansions << std::endl;
+  // Ask for top 4 solutions
+  auto solutions = search.run(4);
 
   EXPECT_LONGS_EQUAL(4, solutions.size());
   // Regression test: check the first and last solution
@@ -74,8 +68,8 @@ TEST(DiscreteBayesNet, AsiaKBest) {
 TEST(DiscreteBayesTree, EmptyTree) {
   DiscreteBayesTree bt;
 
-  DiscreteSearch search(bt, 3);
-  auto solutions = search.run();
+  DiscreteSearch search(bt);
+  auto solutions = search.run(3);
 
   // We expect exactly 1 solution with error = 0.0 (the empty assignment).
   assert(solutions.size() == 1 && "There should be exactly one empty solution");
@@ -89,24 +83,17 @@ TEST(DiscreteBayesTree, AsiaTreeKBest) {
   DiscreteFactorGraph asia(createAsiaExample());
   const Ordering ordering{D, X, B, E, L, T, S, A};
   DiscreteBayesTree::shared_ptr bt = asia.eliminateMultifrontal(ordering);
+  DiscreteSearch search(*bt);
 
-  // Ask for top 4 solutions
-  DiscreteSearch search1(*bt);
-  auto mpe = search1.run();
-
-  // print numExpansions
-  std::cout << "Number of expansions: " << search1.numExpansions << std::endl;
+  // Ask for MPE
+  auto mpe = search.run();
 
   EXPECT_LONGS_EQUAL(1, mpe.size());
   // Regression test: check the MPE solution
   EXPECT_DOUBLES_EQUAL(1.236627, std::fabs(mpe[0].error), 1e-5);
 
   // Ask for top 4 solutions
-  DiscreteSearch search(*bt, 4);
-  auto solutions = search.run();
-
-  // print numExpansions
-  std::cout << "Number of expansions: " << search.numExpansions << std::endl;
+  auto solutions = search.run(4);
 
   EXPECT_LONGS_EQUAL(4, solutions.size());
   // Regression test: check the first and last solution

--- a/gtsam/discrete/tests/testDiscreteSearch.cpp
+++ b/gtsam/discrete/tests/testDiscreteSearch.cpp
@@ -49,8 +49,9 @@ TEST(DiscreteBayesNet, AsiaKBest) {
   DiscreteSearch search(asia, 4);
   auto solutions = search.run();
   EXPECT(!solutions.empty());
-  // Regression test: check the first solution
+  // Regression test: check the first and last solution
   EXPECT_DOUBLES_EQUAL(1.236627, std::fabs(solutions[0].error), 1e-5);
+  EXPECT_DOUBLES_EQUAL(2.201708, std::fabs(solutions[3].error), 1e-5);
 }
 
 /* ************************************************************************* */
@@ -70,16 +71,21 @@ TEST(DiscreteBayesTree, testEmptyTree) {
 TEST(DiscreteBayesTree, testTrivialOneClique) {
   using namespace asia_example;
   DiscreteFactorGraph asia(createAsiaExample());
-  DiscreteBayesTree::shared_ptr bt = asia.eliminateMultifrontal();
+  const Ordering ordering{D, X, B, E, L, T, S, A};
+  DiscreteBayesTree::shared_ptr bt = asia.eliminateMultifrontal(ordering);
   GTSAM_PRINT(*bt);
 
   // Ask for top 4 solutions
   DiscreteSearch search(*bt, 4);
   auto solutions = search.run();
 
+  // print numExpansions
+  std::cout << "Number of expansions: " << search.numExpansions << std::endl;
+
   EXPECT(!solutions.empty());
-  // Regression test: check the first solution
+  // Regression test: check the first and last solution
   EXPECT_DOUBLES_EQUAL(1.236627, std::fabs(solutions[0].error), 1e-5);
+  EXPECT_DOUBLES_EQUAL(2.201708, std::fabs(solutions[3].error), 1e-5);
 }
 
 /* ************************************************************************* */

--- a/gtsam/discrete/tests/testDiscreteSearch.cpp
+++ b/gtsam/discrete/tests/testDiscreteSearch.cpp
@@ -45,8 +45,8 @@ TEST(DiscreteBayesNet, EmptyKBest) {
 /* ************************************************************************* */
 TEST(DiscreteBayesNet, AsiaKBest) {
   using namespace asia_example;
-  DiscreteBayesNet asia = createAsiaExample();
-  DiscreteSearch search(asia);
+  const DiscreteBayesNet asia = createAsiaExample();
+  const DiscreteSearch search(asia);
 
   // Ask for the MPE
   auto mpe = search.run();
@@ -54,6 +54,10 @@ TEST(DiscreteBayesNet, AsiaKBest) {
   EXPECT_LONGS_EQUAL(1, mpe.size());
   // Regression test: check the MPE solution
   EXPECT_DOUBLES_EQUAL(1.236627, std::fabs(mpe[0].error), 1e-5);
+
+  // Check it is equal to MPE via inference
+  const DiscreteFactorGraph asiaFG(asia);
+  EXPECT(assert_equal(mpe[0].assignment, asiaFG.optimize()));
 
   // Ask for top 4 solutions
   auto solutions = search.run(4);
@@ -72,7 +76,6 @@ TEST(DiscreteBayesTree, EmptyTree) {
   auto solutions = search.run(3);
 
   // We expect exactly 1 solution with error = 0.0 (the empty assignment).
-  assert(solutions.size() == 1 && "There should be exactly one empty solution");
   EXPECT_LONGS_EQUAL(1, solutions.size());
   EXPECT_DOUBLES_EQUAL(0, std::fabs(solutions[0].error), 1e-9);
 }
@@ -80,9 +83,9 @@ TEST(DiscreteBayesTree, EmptyTree) {
 /* ************************************************************************* */
 TEST(DiscreteBayesTree, AsiaTreeKBest) {
   using namespace asia_example;
-  DiscreteFactorGraph asia(createAsiaExample());
+  DiscreteFactorGraph asiaFG(createAsiaExample());
   const Ordering ordering{D, X, B, E, L, T, S, A};
-  DiscreteBayesTree::shared_ptr bt = asia.eliminateMultifrontal(ordering);
+  DiscreteBayesTree::shared_ptr bt = asiaFG.eliminateMultifrontal(ordering);
   DiscreteSearch search(*bt);
 
   // Ask for MPE
@@ -91,6 +94,9 @@ TEST(DiscreteBayesTree, AsiaTreeKBest) {
   EXPECT_LONGS_EQUAL(1, mpe.size());
   // Regression test: check the MPE solution
   EXPECT_DOUBLES_EQUAL(1.236627, std::fabs(mpe[0].error), 1e-5);
+
+  // Check it is equal to MPE via inference
+  EXPECT(assert_equal(mpe[0].assignment, asiaFG.optimize()));
 
   // Ask for top 4 solutions
   auto solutions = search.run(4);

--- a/gtsam/discrete/tests/testDiscreteSearch.cpp
+++ b/gtsam/discrete/tests/testDiscreteSearch.cpp
@@ -32,6 +32,7 @@
 
 using namespace gtsam;
 
+/* ************************************************************************* */
 TEST(DiscreteBayesNet, EmptyKBest) {
   DiscreteBayesNet net;  // no factors
   DiscreteSearch search(net, 3);
@@ -41,11 +42,41 @@ TEST(DiscreteBayesNet, EmptyKBest) {
   EXPECT_DOUBLES_EQUAL(0, std::fabs(solutions[0].error), 1e-9);
 }
 
+/* ************************************************************************* */
 TEST(DiscreteBayesNet, AsiaKBest) {
   using namespace asia_example;
   DiscreteBayesNet asia = createAsiaExample();
   DiscreteSearch search(asia, 4);
   auto solutions = search.run();
+  EXPECT(!solutions.empty());
+  // Regression test: check the first solution
+  EXPECT_DOUBLES_EQUAL(1.236627, std::fabs(solutions[0].error), 1e-5);
+}
+
+/* ************************************************************************* */
+TEST(DiscreteBayesTree, testEmptyTree) {
+  DiscreteBayesTree bt;
+
+  DiscreteSearch search(bt, 3);
+  auto solutions = search.run();
+
+  // We expect exactly 1 solution with error = 0.0 (the empty assignment).
+  assert(solutions.size() == 1 && "There should be exactly one empty solution");
+  EXPECT_LONGS_EQUAL(1, solutions.size());
+  EXPECT_DOUBLES_EQUAL(0, std::fabs(solutions[0].error), 1e-9);
+}
+
+/* ************************************************************************* */
+TEST(DiscreteBayesTree, testTrivialOneClique) {
+  using namespace asia_example;
+  DiscreteFactorGraph asia(createAsiaExample());
+  DiscreteBayesTree::shared_ptr bt = asia.eliminateMultifrontal();
+  GTSAM_PRINT(*bt);
+
+  // Ask for top 4 solutions
+  DiscreteSearch search(*bt, 4);
+  auto solutions = search.run();
+
   EXPECT(!solutions.empty());
   // Regression test: check the first solution
   EXPECT_DOUBLES_EQUAL(1.236627, std::fabs(solutions[0].error), 1e-5);

--- a/gtsam/discrete/tests/testDiscreteSearch.cpp
+++ b/gtsam/discrete/tests/testDiscreteSearch.cpp
@@ -46,20 +46,32 @@ TEST(DiscreteBayesNet, EmptyKBest) {
 TEST(DiscreteBayesNet, AsiaKBest) {
   using namespace asia_example;
   DiscreteBayesNet asia = createAsiaExample();
+
+  // Ask for the MPE
+  DiscreteSearch search1(asia);
+  auto mpe = search1.run();
+
+  // print numExpansions
+  std::cout << "Number of expansions: " << search1.numExpansions << std::endl;
+
+  EXPECT_LONGS_EQUAL(1, mpe.size());
+  // Regression test: check the MPE solution
+  EXPECT_DOUBLES_EQUAL(1.236627, std::fabs(mpe[0].error), 1e-5);
+
   DiscreteSearch search(asia, 4);
   auto solutions = search.run();
 
   // print numExpansions
   std::cout << "Number of expansions: " << search.numExpansions << std::endl;
 
-  EXPECT(!solutions.empty());
+  EXPECT_LONGS_EQUAL(4, solutions.size());
   // Regression test: check the first and last solution
   EXPECT_DOUBLES_EQUAL(1.236627, std::fabs(solutions[0].error), 1e-5);
   EXPECT_DOUBLES_EQUAL(2.201708, std::fabs(solutions[3].error), 1e-5);
 }
 
 /* ************************************************************************* */
-TEST(DiscreteBayesTree, testEmptyTree) {
+TEST(DiscreteBayesTree, EmptyTree) {
   DiscreteBayesTree bt;
 
   DiscreteSearch search(bt, 3);
@@ -72,11 +84,22 @@ TEST(DiscreteBayesTree, testEmptyTree) {
 }
 
 /* ************************************************************************* */
-TEST(DiscreteBayesTree, testTrivialOneClique) {
+TEST(DiscreteBayesTree, AsiaTreeKBest) {
   using namespace asia_example;
   DiscreteFactorGraph asia(createAsiaExample());
   const Ordering ordering{D, X, B, E, L, T, S, A};
   DiscreteBayesTree::shared_ptr bt = asia.eliminateMultifrontal(ordering);
+
+  // Ask for top 4 solutions
+  DiscreteSearch search1(*bt);
+  auto mpe = search1.run();
+
+  // print numExpansions
+  std::cout << "Number of expansions: " << search1.numExpansions << std::endl;
+
+  EXPECT_LONGS_EQUAL(1, mpe.size());
+  // Regression test: check the MPE solution
+  EXPECT_DOUBLES_EQUAL(1.236627, std::fabs(mpe[0].error), 1e-5);
 
   // Ask for top 4 solutions
   DiscreteSearch search(*bt, 4);
@@ -85,7 +108,7 @@ TEST(DiscreteBayesTree, testTrivialOneClique) {
   // print numExpansions
   std::cout << "Number of expansions: " << search.numExpansions << std::endl;
 
-  EXPECT(!solutions.empty());
+  EXPECT_LONGS_EQUAL(4, solutions.size());
   // Regression test: check the first and last solution
   EXPECT_DOUBLES_EQUAL(1.236627, std::fabs(solutions[0].error), 1e-5);
   EXPECT_DOUBLES_EQUAL(2.201708, std::fabs(solutions[3].error), 1e-5);

--- a/gtsam/discrete/tests/testDiscreteSearch.cpp
+++ b/gtsam/discrete/tests/testDiscreteSearch.cpp
@@ -48,6 +48,10 @@ TEST(DiscreteBayesNet, AsiaKBest) {
   DiscreteBayesNet asia = createAsiaExample();
   DiscreteSearch search(asia, 4);
   auto solutions = search.run();
+
+  // print numExpansions
+  std::cout << "Number of expansions: " << search.numExpansions << std::endl;
+
   EXPECT(!solutions.empty());
   // Regression test: check the first and last solution
   EXPECT_DOUBLES_EQUAL(1.236627, std::fabs(solutions[0].error), 1e-5);
@@ -73,7 +77,6 @@ TEST(DiscreteBayesTree, testTrivialOneClique) {
   DiscreteFactorGraph asia(createAsiaExample());
   const Ordering ordering{D, X, B, E, L, T, S, A};
   DiscreteBayesTree::shared_ptr bt = asia.eliminateMultifrontal(ordering);
-  GTSAM_PRINT(*bt);
 
   // Ask for top 4 solutions
   DiscreteSearch search(*bt, 4);


### PR DESCRIPTION
A new class that uses branch-and-bound search to find the K-best solutions quickly. Should be much more efficient than forming the product and enumerating all assignments. Works for both DiscreteBayesNets and DiscreteBayesTrees.

## Testing:

> time gtsam/discrete/tests/testDiscreteSearch

Number of expansions: 35  <<  Asia **Bayes net**
Number of expansions: 33  <<  Asia **Bayes tree**
There were no test failures

real    0m0.027s
user    0m0.006s
sys     0m0.010s
