### PR TITLE
fix hybrid uninitialized warning

### DIFF
--- a/examples/Hybrid_City10000.cpp
+++ b/examples/Hybrid_City10000.cpp
@@ -120,7 +120,7 @@ int main(int argc, char* argv[]) {
 
   SmootherUpdate(smoother, graph, init_values, maxNrHypotheses, &results);
 
-  size_t key_s, key_t;
+  size_t key_s, key_t{0};
 
   clock_t start_time = clock();
   std::string str;


### PR DESCRIPTION
There is an error when building on Ubuntu 24.04:
```
gtsam/examples/Hybrid_City10000.cpp:207:16: error: ‘key_t’ may be used uninitialized [-Werror=maybe-uninitialized]
  207 |   write_results(results, (key_t + 1), "HybridISAM_city10000.txt");
```

This solves the error by initializing `key_t` to remove the warning. This was tested by performing a successful build. 