### PR TITLE
Add overviews for existing docs folders on MyST site

### DIFF
--- a/gtsam/geometry/geometry.md
+++ b/gtsam/geometry/geometry.md
@@ -1,0 +1,3 @@
+# Geometry
+
+The geometry folder contains classes that handle fundamental geometric representations and transformations commonly used in applications of GTSAM.

--- a/gtsam/user_guide.md
+++ b/gtsam/user_guide.md
@@ -1,0 +1,3 @@
+# User Guide
+
+This section contains documentation and usage instructions for many classes within GTSAM via Markdown files (`*.md`) and interactive Python notebooks (`*.ipynb`). Python notebooks with an <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/> button near the top can be opened in your browser, where you can run the files yourself and make edits to play with and understand GTSAM.

--- a/myst.yml
+++ b/myst.yml
@@ -8,11 +8,11 @@ project:
   toc:
     - file: README.md
     - file: INSTALL.md
-    - title: User Guide
+    - file: ./gtsam/user_guide.md
       children: 
-      - title: Geometry
+      - file: ./gtsam/geometry/geometry.md
         children:
-        - pattern: './gtsam/geometry/doc/*'
+        - pattern: ./gtsam/geometry/doc/*
 site:
   nav: 
     - title: Getting started


### PR DESCRIPTION
Add overview files on the site for User guide and Geometry as requested @dellaert. Also, as expected, this PR does not run checks now.
Edit: Actually, develop still "requires" a check so it shows up despite not running anything. It doesn't actually waste any compute, so if having "Some checks haven't completed yet" show up on a docs PR isn't undesirable, no changes needed. Otherwise, general settings or specific branch protection settings for develop will need to be changed to remove the required check.