### PR TITLE
Edit required check so that it doesn't hang when only non-code files modified

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,11 +1,9 @@
 name: Linux CI
 
-on:
-  pull_request:
-    paths-ignore:
-      - '**.md'
-      - '**.ipynb' 
-      - 'myst.yml'
+# Since this is a required check, specify paths-ignore in the check-paths job
+# instead of under 'pull_request:'. Otherwise, the check is still required but
+# never runs, and a maintainer must bypass the check in order to merge the PR.
+on: [pull_request]
 
 # Every time you make a push to your PR, it cancel immediately the previous checks,
 # and start a new one. The other runner will be available more quickly to your PR.
@@ -14,7 +12,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Check paths to changed files to see if any are non-ignored.
+  check-paths:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.filter.outputs.changes_detected }}
+    steps:
+      - name: Check modified files
+        id: filter
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            ignored:
+              - '!**.md'
+              - '!**.ipynb' 
+              - '!myst.yml'
   build:
+    # Only run build if relevant files have been modified in this PR.
+    needs: check-paths
+    if: needs.check-paths.outputs.should_run == 'true'
+
     name: ${{ matrix.name }} ${{ matrix.build_type }}
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,9 +1,11 @@
 name: Linux CI
 
-# Since this is a required check, specify paths-ignore in the check-paths job
-# instead of under 'pull_request:'. Otherwise, the check is still required but
-# never runs, and a maintainer must bypass the check in order to merge the PR.
-on: [pull_request]
+on:
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.ipynb' 
+      - 'myst.yml'
 
 # Every time you make a push to your PR, it cancel immediately the previous checks,
 # and start a new one. The other runner will be available more quickly to your PR.
@@ -12,26 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Check paths to changed files to see if any are non-ignored.
-  check-paths:
-    runs-on: ubuntu-latest
-    outputs:
-      should_run: ${{ steps.filter.outputs.changes_detected }}
-    steps:
-      - name: Check modified files
-        id: filter
-        uses: dorny/paths-filter@v2
-        with:
-          filters: |
-            ignored:
-              - '!**.md'
-              - '!**.ipynb' 
-              - '!myst.yml'
   build:
-    # Only run build if relevant files have been modified in this PR.
-    needs: check-paths
-    if: needs.check-paths.outputs.should_run == 'true'
-
     name: ${{ matrix.name }} ${{ matrix.build_type }}
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -1,11 +1,9 @@
 name: Python CI
 
-on:
-  pull_request:
-    paths-ignore:
-      - '**.md'
-      - '**.ipynb' 
-      - 'myst.yml'
+# Since this is a required check, specify paths-ignore in the check-paths job
+# instead of under 'pull_request:'. Otherwise, the check is still required but
+# never runs, and a maintainer must bypass the check in order to merge the PR.
+on: [pull_request]
 
 # Every time you make a push to your PR, it cancel immediately the previous checks,
 # and start a new one. The other runner will be available more quickly to your PR.
@@ -14,7 +12,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Check paths to changed files to see if any are non-ignored.
+  check-paths:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.filter.outputs.relevant_changes }}
+    steps:
+      - name: Check modified files
+        id: filter
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            relevant_changes:
+              - '!**.md'
+              - '!**.ipynb' 
+              - '!myst.yml'
+              - '**' # Match everything else
+              
   build:
+    # Only run build if relevant files have been modified in this PR.
+    needs: check-paths
+    if: needs.check-paths.outputs.should_run == 'true'
+    
     name: ${{ matrix.name }} ${{ matrix.build_type }} Python ${{ matrix.python_version }}
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Fixes issue encountered in #2023 where the check required by the repository rule (Linux CI) does not run when only Markdown files are edited, but it's still "required," so it blocks the PR from being merged because GitHub just waits for the check to run, but it never does.

Works by running a preliminary job to see if relevant files were modified, and only runs the main job if they were. 

The other checks can keep the simpler `paths-ignore` syntax because they are not required under a ruleset.