### PR TITLE
Fix req workflow

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -20,14 +20,14 @@ jobs:
     steps:
       - name: Check modified files
         id: filter
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v3
         with:
+          predicate-quantifier: 'every' # If any changed file matches every filter, proceed with build
           filters: |
             relevant_changes:
               - '!**.md'
               - '!**.ipynb' 
               - '!myst.yml'
-              - '**' # Match everything else
               
   build:
     # Only run build if relevant files have been modified in this PR.


### PR DESCRIPTION
Fixes the rule-required Python CI workflow so that it doesn't run when the ignored files are modified. **Actually works this time**.