### PR TITLE
Updated elaboratePoint2KalmanFilter.cpp example and easyPoint2KF bugfix

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,3 @@
-set (excluded_examples
-    "elaboratePoint2KalmanFilter.cpp"
-)
-
 # if GTSAM_ENABLE_BOOST_SERIALIZATION is not set then SolverComparer.cpp will not compile
 if (NOT GTSAM_ENABLE_BOOST_SERIALIZATION)
     list (APPEND excluded_examples

--- a/examples/easyPoint2KalmanFilter.cpp
+++ b/examples/easyPoint2KalmanFilter.cpp
@@ -100,7 +100,7 @@ int main() {
   Symbol x2('x',2);
   difference = Point2(1,0);
   BetweenFactor<Point2> factor3(x1, x2, difference, Q);
-  Point2 x2_predict = ekf.predict(factor1);
+  Point2 x2_predict = ekf.predict(factor3);
   traits<Point2>::Print(x2_predict, "X2 Predict");
 
   // Update

--- a/gtsam/nonlinear/nonlinear.i
+++ b/gtsam/nonlinear/nonlinear.i
@@ -725,13 +725,5 @@ virtual class BatchFixedLagSmoother : gtsam::FixedLagSmoother {
   VALUE calculateEstimate(size_t key) const;
 };
 
-#include <gtsam/nonlinear/ExtendedKalmanFilter.h>
-template<T = {gtsam::Point2, gtsam::Pose2, gtsam::Pose3}>
-class ExtendedKalmanFilter {
-    ExtendedKalmanFilter(size_t key_initial, T x_initial, gtsam::noiseModel::Gaussian* P_initial);
-    T predict(const gtsam::NoiseModelFactor& motionFactor);
-    T update(const gtsam::NoiseModelFactor& measurementFactor);
-    gtsam::JacobianFactor* Density() const;
-};
 
 }  // namespace gtsam

--- a/gtsam/nonlinear/nonlinear.i
+++ b/gtsam/nonlinear/nonlinear.i
@@ -725,5 +725,13 @@ virtual class BatchFixedLagSmoother : gtsam::FixedLagSmoother {
   VALUE calculateEstimate(size_t key) const;
 };
 
+#include <gtsam/nonlinear/ExtendedKalmanFilter.h>
+template<T = {gtsam::Point2, gtsam::Pose2, gtsam::Pose3}>
+class ExtendedKalmanFilter {
+    ExtendedKalmanFilter(size_t key_initial, T x_initial, gtsam::noiseModel::Gaussian* P_initial);
+    T predict(const gtsam::NoiseModelFactor& motionFactor);
+    T update(const gtsam::NoiseModelFactor& measurementFactor);
+    gtsam::JacobianFactor* Density() const;
+};
 
 }  // namespace gtsam


### PR DESCRIPTION
Fixed the elaboratePoint2KalmanFilter.cpp with:

- Direct JacobianFactor creation
- Updated vector creation 
- Updated data structure management. insert() is now push_back()

Additionally fixed minor bug in easyPoint2KalmanFilter which predicted with wrong factor.

```
X1 Predict[
1;
0
]
X1 Update[
1;
0
]
X2 Predict[
2;
0
]
X2 Update[
2;
0
]
X3 Predict[
3;
0
]
X3 Update[
3;
0
]
```