### PR TITLE
Cleanup eigen svd clang warning. Update svd options usage.

### DIFF
--- a/gtsam/geometry/FundamentalMatrix.cpp
+++ b/gtsam/geometry/FundamentalMatrix.cpp
@@ -9,10 +9,6 @@
 #include <gtsam/geometry/FundamentalMatrix.h>
 #include <gtsam/geometry/Point2.h>
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-
 namespace gtsam {
 
 //*************************************************************************
@@ -39,7 +35,10 @@ FundamentalMatrix::FundamentalMatrix(const Matrix3& U, double s,
 
 FundamentalMatrix::FundamentalMatrix(const Matrix3& F) {
   // Perform SVD
-  Eigen::JacobiSVD<Matrix3> svd(F, Eigen::ComputeFullU | Eigen::ComputeFullV);
+  Eigen::JacobiSVD<Matrix3, Eigen::ComputeFullU | Eigen::ComputeFullV> svd(F);
+  if (svd.info() != Eigen::ComputationInfo::Success) {
+    throw std::runtime_error("FundamentalMatrix::FundamentalMatrix: SVD computation failure.");
+  }
 
   // Extract U and V
   Matrix3 U = svd.matrixU();

--- a/gtsam/geometry/Rot2.cpp
+++ b/gtsam/geometry/Rot2.cpp
@@ -131,7 +131,7 @@ Rot2 Rot2::relativeBearing(const Point2& d, OptionalJacobian<1, 2> H) {
 
 /* ************************************************************************* */
 Rot2 Rot2::ClosestTo(const Matrix2& M) {
-  Eigen::JacobiSVD<Matrix2> svd(M, Eigen::ComputeFullU | Eigen::ComputeFullV);
+  Eigen::JacobiSVD<Matrix2, Eigen::ComputeFullU | Eigen::ComputeFullV> svd(M);
   const Matrix2& U = svd.matrixU();
   const Matrix2& V = svd.matrixV();
   const double det = (U * V.transpose()).determinant();

--- a/gtsam/geometry/SO3.cpp
+++ b/gtsam/geometry/SO3.cpp
@@ -200,7 +200,7 @@ SO3 SO3::AxisAngle(const Vector3& axis, double theta) {
 template <>
 GTSAM_EXPORT
 SO3 SO3::ClosestTo(const Matrix3& M) {
-  Eigen::JacobiSVD<Matrix3> svd(M, Eigen::ComputeFullU | Eigen::ComputeFullV);
+  Eigen::JacobiSVD<Matrix3, Eigen::ComputeFullU | Eigen::ComputeFullV> svd(M);
   const auto& U = svd.matrixU();
   const auto& V = svd.matrixV();
   const double det = (U * V.transpose()).determinant();


### PR DESCRIPTION
This removes the GCC diagnostic handling for svd by checking the svd info. This was made available in Eigen 3.4, which this repository uses. 

This also updates a few of the JacobiSVD to use the templated options. This is the preferred method instead of passing it in as an argument, which will be deprecated in the future. 