### PR TITLE
Fix old eigen builds

### DIFF
--- a/gtsam/geometry/FundamentalMatrix.cpp
+++ b/gtsam/geometry/FundamentalMatrix.cpp
@@ -36,9 +36,11 @@ FundamentalMatrix::FundamentalMatrix(const Matrix3& U, double s,
 FundamentalMatrix::FundamentalMatrix(const Matrix3& F) {
   // Perform SVD
   Eigen::JacobiSVD<Matrix3> svd(F, Eigen::ComputeFullU | Eigen::ComputeFullV);
+  #if EIGEN_VERSION_AT_LEAST(3, 4, 0)
   if (svd.info() != Eigen::ComputationInfo::Success) {
     throw std::runtime_error("FundamentalMatrix::FundamentalMatrix: SVD computation failure");
   }
+  #endif
 
   // Extract U and V
   Matrix3 U = svd.matrixU();


### PR DESCRIPTION
This [PR](https://github.com/borglab/gtsam/pull/2033) used a function in Eigen 3.4. Building with older versions of Eigen would throw an error. This fixes the build for older versions of Eigen. 

This was tested building with Ubuntu 24.04 with Eigen 3.4.0 and with Ubuntu 20.04 with Eigen 3.3.7. 