### PR TITLE
Bugfix Bearing/Range Pose3toPose3 Jacobians

### DIFF
--- a/gtsam/geometry/Pose3.cpp
+++ b/gtsam/geometry/Pose3.cpp
@@ -442,9 +442,11 @@ double Pose3::range(const Point3& point, OptionalJacobian<1, 6> Hself,
 /* ************************************************************************* */
 double Pose3::range(const Pose3& pose, OptionalJacobian<1, 6> Hself,
                     OptionalJacobian<1, 6> Hpose) const {
+  Matrix36 D_point_pose;
   Matrix13 D_local_point;
-  double r = range(pose.translation(), Hself, Hpose ? &D_local_point : 0);
-  if (Hpose) *Hpose << Matrix13::Zero(), D_local_point * pose.rotation().matrix();
+  Point3 point = pose.translation(Hpose ? &D_point_pose : 0);
+  double r = range(point, Hself, Hpose ? &D_local_point : 0);
+  if (Hpose) *Hpose = D_local_point * D_point_pose;
   return r;
 }
 
@@ -467,12 +469,13 @@ Unit3 Pose3::bearing(const Point3& point, OptionalJacobian<2, 6> Hself,
 
 /* ************************************************************************* */
 Unit3 Pose3::bearing(const Pose3& pose, OptionalJacobian<2, 6> Hself,
-                     OptionalJacobian<2, 6> Hpose) const {
-  if (Hpose) {
-    Hpose->setZero();
-    return bearing(pose.translation(), Hself, Hpose.cols<3>(3));
-  }
-  return bearing(pose.translation(), Hself, {});
+  OptionalJacobian<2, 6> Hpose) const {
+  Matrix36 D_point_pose;
+  Matrix23 D_local_point;
+  Point3 point = pose.translation(Hpose ? &D_point_pose : 0);
+  Unit3 b = bearing(point, Hself, Hpose ? &D_local_point : 0);
+  if (Hpose) *Hpose = D_local_point * D_point_pose;
+  return b;
 }
 
 /* ************************************************************************* */

--- a/gtsam/geometry/tests/testPose3.cpp
+++ b/gtsam/geometry/tests/testPose3.cpp
@@ -770,17 +770,7 @@ TEST(Pose3, PoseToPoseBearing) {
 
   // Check numerical derivatives
   expectedH1 = numericalDerivative21(bearing_proxy, xl1, l2);
-
-  // Since the second pose is treated as a point, the value calculated by
-  // numericalDerivative22 only depends on the position of the pose. Here, we
-  // calculate the Jacobian w.r.t. the second pose's position, and then augment
-  // that with zeroes in the block that is w.r.t. the second pose's
-  // orientation.
   H2block = numericalDerivative22(bearing_proxy, xl1, l2);
-  expectedH2 = Matrix(2, 6);
-  expectedH2.setZero();
-  expectedH2.block<2, 3>(0, 3) = H2block;
-
   EXPECT(assert_equal(expectedH1, actualH1, 1e-5));
   EXPECT(assert_equal(expectedH2, actualH2, 1e-5));
 }

--- a/gtsam/geometry/tests/testPose3.cpp
+++ b/gtsam/geometry/tests/testPose3.cpp
@@ -769,8 +769,9 @@ TEST(Pose3, PoseToPoseBearing) {
   EXPECT(assert_equal(Unit3(0,1,0), xl1.bearing(xl2, actualH1, actualH2), 1e-9));
 
   // Check numerical derivatives
-  expectedH1 = numericalDerivative21(bearing_proxy, xl1, l2);
-  H2block = numericalDerivative22(bearing_proxy, xl1, l2);
+  std::function<Unit3(const Pose3&, const Pose3&)> f = [](const Pose3& a, const Pose3& b) { return a.bearing(b); };
+  expectedH1 = numericalDerivative21(f, xl1, xl2);
+  expectedH2 = numericalDerivative22(f, xl1, xl2);
   EXPECT(assert_equal(expectedH1, actualH1, 1e-5));
   EXPECT(assert_equal(expectedH2, actualH2, 1e-5));
 }


### PR DESCRIPTION
Previously the Jacobians for bearing between two Pose3 objects were computed incorrectly as it neglected the Jacobian of a pose's translation wrt its tangent vector. 

The Jacobian for range between two Pose3 objects was computed correctly but in a non-canonical way. (Canonical = using OptionalJacobians for all chain rule computation) 

This commit fixes the bearing Jacobian, and provides a canonical implementation for both Pose3-Pose3 bearing and range Jacobians.

This was discovered while doing testing for multi-robot cases (where robots directly observe each other via bearing-range measurements) and had a significant and detrimental affect on results even causing GaussNewton solvers to completely diverge.

Also based on git this has been hiding for 8 years? So hopefully has not been causing issues for anyone!

Finally, I will note that the deleted comment in the test is just plain wrong since jacobians are of course compute WRT the tangent elements.