### PR TITLE
Fix Pruning Bug

### DIFF
--- a/gtsam/discrete/DecisionTreeFactor.cpp
+++ b/gtsam/discrete/DecisionTreeFactor.cpp
@@ -501,6 +501,10 @@ namespace gtsam {
     };
     this->visitWith(op);
 
+    // If total number of hypotheses is less than N, return 0.0
+    if (min_heap.size() < N) {
+      return 0.0;
+    }
     return min_heap.top();
   }
 

--- a/gtsam/discrete/tests/testDecisionTreeFactor.cpp
+++ b/gtsam/discrete/tests/testDecisionTreeFactor.cpp
@@ -132,7 +132,6 @@ TEST(DecisionTreeFactor, Divide) {
   KeySet keys(joint.keys());
   keys.insert(pA.keys().begin(), pA.keys().end());
   EXPECT(assert_inequal(KeySet(pS.keys()), keys));
-  
 }
 
 /* ************************************************************************* */
@@ -234,6 +233,12 @@ TEST(DecisionTreeFactor, Prune) {
   maxNrAssignments = 5;
   auto pruned3 = factor.prune(maxNrAssignments);
   EXPECT(assert_equal(expected3, pruned3));
+
+  // Edge case where the number of hypotheses are less than maxNrAssignments
+  DecisionTreeFactor f(A, "0.50001 0.49999");
+  auto pruned4 = f.prune(10);
+  DecisionTreeFactor expected4(A, "0.50001 0.49999");
+  EXPECT(assert_equal(expected4, pruned4));
 }
 
 /* ************************************************************************** */


### PR DESCRIPTION
There is a bug in the `computeThreshold` method where it returns the smallest value of the discrete probabilities even if the max number of assignments allowed is greater than the number of discrete probabilities. This was leading to incorrect dead mode removal.

I added a test that fails without the fix and passes with.

This gives us slightly different results.

### Previous 220 steps
![city10000_results_220](https://github.com/user-attachments/assets/84c822b1-7525-4ff9-a9ea-76db90cfd78c)

### New 220 steps
![city10000_results_220_new](https://github.com/user-attachments/assets/67f3d9ac-fcc3-413d-9abd-75b5f512b836)

The final results are a little bit better!

### Previous 6500 steps
![city10000_results_6500](https://github.com/user-attachments/assets/e77c805f-ee32-4940-8187-a17ba3d122b6)

### New 6500 steps
![city10000_results_6500_new](https://github.com/user-attachments/assets/3bfd8ae3-b352-47a8-90af-ad388c185f9d)

