### PR TITLE
Use `GTSAM_CONCEPT_USAGE` in lieu of `BOOST_CONCEPT_USAGE`

### DIFF
--- a/gtsam/base/Group.h
+++ b/gtsam/base/Group.h
@@ -45,7 +45,7 @@ public:
   typedef typename traits<G>::group_flavor flavor_tag;
   //typedef typename traits<G>::identity::value_type identity_value_type;
 
-  BOOST_CONCEPT_USAGE(IsGroup) {
+  GTSAM_CONCEPT_USAGE(IsGroup) {
     static_assert(
         (std::is_base_of<group_tag, structure_category_tag>::value),
         "This type's structure_category trait does not assert it as a group (or derived)");

--- a/gtsam/base/Lie.h
+++ b/gtsam/base/Lie.h
@@ -264,7 +264,7 @@ public:
   typedef typename traits<T>::TangentVector TangentVector;
   typedef typename traits<T>::ChartJacobian ChartJacobian;
 
-  BOOST_CONCEPT_USAGE(IsLieGroup) {
+  GTSAM_CONCEPT_USAGE(IsLieGroup) {
     static_assert(
         (std::is_base_of<lie_group_tag, structure_category_tag>::value),
         "This type's trait does not assert it is a Lie group (or derived)");

--- a/gtsam/base/Manifold.h
+++ b/gtsam/base/Manifold.h
@@ -61,7 +61,7 @@ struct HasManifoldPrereqs {
   Eigen::Matrix<double, dim, 1> v;
   OptionalJacobian<dim, dim> Hp, Hq, Hv;
 
-  BOOST_CONCEPT_USAGE(HasManifoldPrereqs) {
+  GTSAM_CONCEPT_USAGE(HasManifoldPrereqs) {
     v = p.localCoordinates(q);
     q = p.retract(v);
   }
@@ -139,7 +139,7 @@ public:
   typedef typename traits<T>::ManifoldType ManifoldType;
   typedef typename traits<T>::TangentVector TangentVector;
 
-  BOOST_CONCEPT_USAGE(IsManifold) {
+  GTSAM_CONCEPT_USAGE(IsManifold) {
     static_assert(
         (std::is_base_of<manifold_tag, structure_category_tag>::value),
         "This type's structure_category trait does not assert it as a manifold (or derived)");

--- a/gtsam/base/Testable.h
+++ b/gtsam/base/Testable.h
@@ -61,7 +61,7 @@ namespace gtsam {
     bool r1,r2;
   public:
 
-    BOOST_CONCEPT_USAGE(IsTestable) {
+    GTSAM_CONCEPT_USAGE(IsTestable) {
       // check print function, with optional string
       traits<T>::Print(t, std::string());
       traits<T>::Print(t);
@@ -134,7 +134,7 @@ namespace gtsam {
   template<typename T>
   struct HasTestablePrereqs {
 
-    BOOST_CONCEPT_USAGE(HasTestablePrereqs) {
+    GTSAM_CONCEPT_USAGE(HasTestablePrereqs) {
       t->print(str);
       b = t->equals(*s,tol);
     }

--- a/gtsam/base/VectorSpace.h
+++ b/gtsam/base/VectorSpace.h
@@ -168,7 +168,7 @@ struct HasVectorSpacePrereqs {
   Class p, q;
   Vector v;
 
-  BOOST_CONCEPT_USAGE(HasVectorSpacePrereqs) {
+  GTSAM_CONCEPT_USAGE(HasVectorSpacePrereqs) {
     p = Class::Identity();  // identity
     q = p + p;              // addition
     q = p - p;              // subtraction
@@ -472,7 +472,7 @@ public:
 
   typedef typename traits<T>::structure_category structure_category_tag;
 
-  BOOST_CONCEPT_USAGE(IsVectorSpace) {
+  GTSAM_CONCEPT_USAGE(IsVectorSpace) {
     static_assert(
         (std::is_base_of<vector_space_tag, structure_category_tag>::value),
         "This type's trait does not assert it as a vector space (or derived)");

--- a/gtsam/base/concepts.h
+++ b/gtsam/base/concepts.h
@@ -17,9 +17,10 @@
 #include <boost/concept_check.hpp>
 #define GTSAM_CONCEPT_ASSERT(concept) BOOST_CONCEPT_ASSERT((concept))
 #define GTSAM_CONCEPT_REQUIRES(concept, return_type) BOOST_CONCEPT_REQUIRES(((concept)), (return_type))
+#define GTSAM_CONCEPT_USAGE BOOST_CONCEPT_USAGE
 #else 
 // This does something sensible:
-#define BOOST_CONCEPT_USAGE(concept) void check##concept()
+#define GTSAM_CONCEPT_USAGE(concept) void check##concept()
 // These just ignore the concept checking for now:
 #define GTSAM_CONCEPT_ASSERT(concept) static_assert(true, "")
 #define GTSAM_CONCEPT_REQUIRES(concept, return_type) return_type


### PR DESCRIPTION
In an effort to have less Boost influence on the code base, this PR updates `BOOST_CONCEPT_USAGE` with `GTSAM_CONCEPT_USAGE`.