### PR TITLE
Fix Sim(2) Expmap and Logmap

### DIFF
--- a/gtsam/geometry/Similarity2.h
+++ b/gtsam/geometry/Similarity2.h
@@ -141,6 +141,9 @@ class GTSAM_EXPORT Similarity2 : public LieGroup<Similarity2, 4> {
 
   using LieAlgebra = Matrix3;
 
+  /// Calculate expmap and logmap coefficients.
+  static Matrix2 GetV(double theta, double lambda);
+
   /**
    * Log map at the identity
    * \f$ [t_x, t_y, \delta, \lambda] \f$

--- a/gtsam/geometry/tests/testSimilarity2.cpp
+++ b/gtsam/geometry/tests/testSimilarity2.cpp
@@ -79,7 +79,7 @@ TEST(Similarity2, HatAndVee) {
 
 /* ************************************************************************* */
 // Checks correct exponential map (Expmap) with brute force matrix exponential
-TEST_DISABLED(Similarity2, BruteForceExpmap) {
+TEST(Similarity2, BruteForceExpmap) {
   const Vector4 xi(0.1, 0.2, 0.3, 0.4);
   EXPECT(assert_equal(Similarity2::Expmap(xi), expm<Similarity2>(xi), 1e-4));
 }


### PR DESCRIPTION
Using the reference [here](https://ethaneade.com/lie_groups.pdf), I fixed the Expmap and Logmap implementations for `Similarity2`.

Fixes #2046.