### PR TITLE
Nonlinear Hybrid Smoother

### DIFF
--- a/gtsam/hybrid/HybridSmoother.cpp
+++ b/gtsam/hybrid/HybridSmoother.cpp
@@ -101,6 +101,12 @@ void HybridSmoother::update(const HybridNonlinearFactorGraph &newFactors,
                             std::optional<size_t> maxNrLeaves,
                             const std::optional<Ordering> given_ordering) {
   HybridGaussianFactorGraph linearizedFactors = *newFactors.linearize(initial);
+
+  // Record the new nonlinear factors and
+  // linearization point for relinearization
+  allFactors_.push_back(newFactors);
+  linearizationPoint_.insert_or_assign(initial);
+
   const KeySet originalNewFactorKeys = newFactors.keys();
 #ifdef DEBUG_SMOOTHER
   std::cout << "hybridBayesNet_ size before: " << hybridBayesNet_.size()

--- a/gtsam/hybrid/HybridSmoother.cpp
+++ b/gtsam/hybrid/HybridSmoother.cpp
@@ -291,4 +291,20 @@ HybridValues HybridSmoother::optimize() const {
   return HybridValues(continuous, mpe);
 }
 
+/* ************************************************************************* */
+void HybridSmoother::relinearize() {
+  allFactors_ = allFactors_.restrict(fixedValues_);
+  HybridGaussianFactorGraph::shared_ptr linearized =
+      allFactors_.linearize(linearizationPoint_);
+  HybridBayesNet::shared_ptr bayesNet = linearized->eliminateSequential();
+  HybridValues delta = bayesNet->optimize();
+  linearizationPoint_ = linearizationPoint_.retract(delta.continuous());
+  reInitialize(*bayesNet);
+}
+
+/* ************************************************************************* */
+Values HybridSmoother::linearizationPoint() const {
+  return linearizationPoint_;
+}
+
 }  // namespace gtsam

--- a/gtsam/hybrid/HybridSmoother.cpp
+++ b/gtsam/hybrid/HybridSmoother.cpp
@@ -307,4 +307,9 @@ Values HybridSmoother::linearizationPoint() const {
   return linearizationPoint_;
 }
 
+/* ************************************************************************* */
+HybridNonlinearFactorGraph HybridSmoother::allFactors() const {
+  return allFactors_;
+}
+
 }  // namespace gtsam

--- a/gtsam/hybrid/HybridSmoother.cpp
+++ b/gtsam/hybrid/HybridSmoother.cpp
@@ -96,9 +96,11 @@ void HybridSmoother::removeFixedValues(
 }
 
 /* ************************************************************************* */
-void HybridSmoother::update(const HybridGaussianFactorGraph &newFactors,
+void HybridSmoother::update(const HybridNonlinearFactorGraph &newFactors,
+                            const Values &initial,
                             std::optional<size_t> maxNrLeaves,
                             const std::optional<Ordering> given_ordering) {
+  HybridGaussianFactorGraph linearizedFactors = *newFactors.linearize(initial);
   const KeySet originalNewFactorKeys = newFactors.keys();
 #ifdef DEBUG_SMOOTHER
   std::cout << "hybridBayesNet_ size before: " << hybridBayesNet_.size()
@@ -108,7 +110,7 @@ void HybridSmoother::update(const HybridGaussianFactorGraph &newFactors,
   HybridGaussianFactorGraph updatedGraph;
   // Add the necessary conditionals from the previous timestep(s).
   std::tie(updatedGraph, hybridBayesNet_) =
-      addConditionals(newFactors, hybridBayesNet_);
+      addConditionals(linearizedFactors, hybridBayesNet_);
 #ifdef DEBUG_SMOOTHER
   // print size of newFactors, updatedGraph, hybridBayesNet_
   std::cout << "updatedGraph size: " << updatedGraph.size() << std::endl;

--- a/gtsam/hybrid/HybridSmoother.h
+++ b/gtsam/hybrid/HybridSmoother.h
@@ -19,6 +19,7 @@
 #include <gtsam/discrete/DiscreteFactorGraph.h>
 #include <gtsam/hybrid/HybridBayesNet.h>
 #include <gtsam/hybrid/HybridGaussianFactorGraph.h>
+#include <gtsam/hybrid/HybridNonlinearFactorGraph.h>
 
 #include <optional>
 
@@ -26,8 +27,9 @@ namespace gtsam {
 
 class GTSAM_EXPORT HybridSmoother {
  private:
-  HybridBayesNet hybridBayesNet_;
+  HybridNonlinearFactorGraph allFactors_;
 
+  HybridBayesNet hybridBayesNet_;
   /// The threshold above which we make a decision about a mode.
   std::optional<double> marginalThreshold_;
   DiscreteValues fixedValues_;
@@ -73,12 +75,12 @@ class GTSAM_EXPORT HybridSmoother {
    * @param graph The new factors, should be linear only
    * @param maxNrLeaves The maximum number of leaves in the new discrete factor,
    * if applicable
-   * @param given_ordering The (optional) ordering for elimination, only
+   * @param givenOrdering The (optional) ordering for elimination, only
    * continuous variables are allowed
    */
-  void update(const HybridGaussianFactorGraph& graph,
+  void update(const HybridNonlinearFactorGraph& graph, const Values& initial,
               std::optional<size_t> maxNrLeaves = {},
-              const std::optional<Ordering> given_ordering = {});
+              const std::optional<Ordering> givenOrdering = {});
 
   /**
    * @brief Get an elimination ordering which eliminates continuous

--- a/gtsam/hybrid/HybridSmoother.h
+++ b/gtsam/hybrid/HybridSmoother.h
@@ -126,15 +126,12 @@ class GTSAM_EXPORT HybridSmoother {
   /// Optimize the hybrid Bayes Net, taking into accound fixed values.
   HybridValues optimize() const;
 
-  void relinearize() {
-    allFactors_ = allFactors_.restrict(fixedValues_);
-    HybridGaussianFactorGraph::shared_ptr linearized =
-        allFactors_.linearize(linearizationPoint_);
-    HybridBayesNet::shared_ptr bayesNet = linearized->eliminateSequential();
-    HybridValues delta = bayesNet->optimize();
-    linearizationPoint_ = linearizationPoint_.retract(delta.continuous());
-    reInitialize(*bayesNet);
-  }
+  /// Relinearize the nonlinear factor graph
+  /// with the latest linearization point.
+  void relinearize();
+
+  /// Return the current linearization point.
+  Values linearizationPoint() const;
 
  private:
   /// Helper to compute the ordering if ordering is not given.

--- a/gtsam/hybrid/HybridSmoother.h
+++ b/gtsam/hybrid/HybridSmoother.h
@@ -133,6 +133,9 @@ class GTSAM_EXPORT HybridSmoother {
   /// Return the current linearization point.
   Values linearizationPoint() const;
 
+  /// Return all the recorded nonlinear factors
+  HybridNonlinearFactorGraph allFactors() const;
+
  private:
   /// Helper to compute the ordering if ordering is not given.
   Ordering maybeComputeOrdering(const HybridGaussianFactorGraph& updatedGraph,

--- a/gtsam/hybrid/hybrid.i
+++ b/gtsam/hybrid/hybrid.i
@@ -287,6 +287,8 @@ class HybridSmoother {
       std::optional<size_t> maxNrLeaves = std::nullopt,
       const std::optional<gtsam::Ordering> given_ordering = std::nullopt);
 
+  void relinearize();
+
   gtsam::Ordering getOrdering(const gtsam::HybridGaussianFactorGraph& factors,
                               const gtsam::KeySet& newFactorKeys);
 

--- a/gtsam/hybrid/hybrid.i
+++ b/gtsam/hybrid/hybrid.i
@@ -283,7 +283,7 @@ class HybridSmoother {
   void reInitialize(gtsam::HybridBayesNet& hybridBayesNet);
 
   void update(
-      const gtsam::HybridGaussianFactorGraph& graph,
+      const gtsam::HybridNonlinearFactorGraph& graph, const Values& initial,
       std::optional<size_t> maxNrLeaves = std::nullopt,
       const std::optional<gtsam::Ordering> given_ordering = std::nullopt);
 

--- a/gtsam/hybrid/hybrid.i
+++ b/gtsam/hybrid/hybrid.i
@@ -291,6 +291,7 @@ class HybridSmoother {
   void relinearize();
 
   gtsam::Values linearizationPoint() const;
+  gtsam::HybridNonlinearFactorGraph allFactors() const;
 
   gtsam::Ordering getOrdering(const gtsam::HybridGaussianFactorGraph& factors,
                               const gtsam::KeySet& newFactorKeys);

--- a/gtsam/hybrid/hybrid.i
+++ b/gtsam/hybrid/hybrid.i
@@ -283,11 +283,14 @@ class HybridSmoother {
   void reInitialize(gtsam::HybridBayesNet& hybridBayesNet);
 
   void update(
-      const gtsam::HybridNonlinearFactorGraph& graph, const Values& initial,
+      const gtsam::HybridNonlinearFactorGraph& graph,
+      const gtsam::Values& initial,
       std::optional<size_t> maxNrLeaves = std::nullopt,
       const std::optional<gtsam::Ordering> given_ordering = std::nullopt);
 
   void relinearize();
+
+  gtsam::Values linearizationPoint() const;
 
   gtsam::Ordering getOrdering(const gtsam::HybridGaussianFactorGraph& factors,
                               const gtsam::KeySet& newFactorKeys);

--- a/gtsam/hybrid/tests/testHybridSmoother.cpp
+++ b/gtsam/hybrid/tests/testHybridSmoother.cpp
@@ -94,9 +94,7 @@ TEST(HybridSmoother, IncrementalSmoother) {
 
     initial.insert(X(k), switching.linearizationPoint.at<double>(X(k)));
 
-    HybridGaussianFactorGraph linearized = *graph.linearize(initial);
-
-    smoother.update(linearized, maxNrLeaves);
+    smoother.update(graph, initial, maxNrLeaves);
 
     // Clear all the factors from the graph
     graph.resize(0);
@@ -152,9 +150,7 @@ TEST(HybridSmoother, ValidPruningError) {
 
     initial.insert(X(k), switching.linearizationPoint.at<double>(X(k)));
 
-    HybridGaussianFactorGraph linearized = *graph.linearize(initial);
-
-    smoother.update(linearized, maxNrLeaves);
+    smoother.update(graph, initial, maxNrLeaves);
 
     // Clear all the factors from the graph
     graph.resize(0);
@@ -200,9 +196,7 @@ TEST(HybridSmoother, DeadModeRemoval) {
 
     initial.insert(X(k), switching.linearizationPoint.at<double>(X(k)));
 
-    HybridGaussianFactorGraph linearized = *graph.linearize(initial);
-
-    smoother.update(linearized, maxNrLeaves);
+    smoother.update(graph, initial, maxNrLeaves);
 
     // Clear all the factors from the graph
     graph.resize(0);


### PR DESCRIPTION
Updated the `HybridSmoother` to accept nonlinear hybrid factor graphs as well as perform relinearization.

To confirm, I re-ran the `HybridCity10000.py` script for 6500 iterations and got the following, which is the same as the previous version of the script.

![city10000_results_6500](https://github.com/user-attachments/assets/c0e74077-eb9c-4f29-8fa8-f181e1d615fc)
