### PR TITLE
Fix the build for example Hybrid City 10000

### DIFF
--- a/examples/Hybrid_City10000.cpp
+++ b/examples/Hybrid_City10000.cpp
@@ -110,7 +110,7 @@ class Experiment {
     gttic_(SmootherUpdate);
     clock_t beforeUpdate = clock();
     auto linearized = newFactors_.linearize(initial_);
-    smoother_.update(*linearized, maxNrHypotheses);
+    smoother_.update(*linearized, initial_);
     allFactors_.push_back(newFactors_);
     newFactors_.resize(0);
     clock_t afterUpdate = clock();


### PR DESCRIPTION
# Issue:
When building, I get the following error:
```
gtsam/examples/Hybrid_City10000.cpp:113:35: error: cannot convert ‘size_t’ {aka ‘long unsigned int’} to ‘const gtsam::Values&’
  113 |     smoother_.update(*linearized, maxNrHypotheses);
      |                                   ^~~~~~~~~~~~~~~
      |                                   |
      |                                   size_t {aka long unsigned int}

```

Instead of using the size_t, this changes it to use the Values called `initial_`. 