### PR TITLE
Update Metis' cmake_minimum_required to 3.5

### DIFF
--- a/gtsam/3rdparty/metis/CMakeLists.txt
+++ b/gtsam/3rdparty/metis/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(METIS)
 
 # Add flags for currect directory and below


### PR DESCRIPTION
Currently, the Windows CI is erroring out since the version of CMake used there has deprecated CMake before version 3.5.

Since we vendor Metis, this fix should not affect the build process for anyone working with a version of CMake released in the last 5 years.