### PR TITLE
Fix Matlab wrapper

### DIFF
--- a/gtsam/discrete/discrete.i
+++ b/gtsam/discrete/discrete.i
@@ -288,7 +288,7 @@ class DiscreteBayesTree {
   const DiscreteBayesTreeClique* clique(size_t j) const;
   size_t numCachedSeparatorMarginals() const;
 
-  gtsam::DiscreteConditional marginalFactor(size_t key) const;
+  gtsam::DiscreteConditional* marginalFactor(size_t key) const;
   gtsam::DiscreteFactorGraph* joint(size_t j1, size_t j2) const;
   gtsam::DiscreteBayesNet* jointBayesNet(size_t j1, size_t j2) const;
 

--- a/gtsam/discrete/discrete.i
+++ b/gtsam/discrete/discrete.i
@@ -369,7 +369,7 @@ class DiscreteFactorGraph {
   void print(string s = "") const;
   bool equals(const gtsam::DiscreteFactorGraph& fg, double tol = 1e-9) const;
 
-  gtsam::DecisionTreeFactor product() const;
+  gtsam::DiscreteFactor* product() const;
   double operator()(const gtsam::DiscreteValues& values) const;
   gtsam::DiscreteValues optimize() const;
 


### PR DESCRIPTION
Some return types were outdated or incorrect (returning object instead of shared pointer), fixing them allows the wrapper to compile.

Fixes #2057 