### PR TITLE
Release/4.2 python ctor wrapper stereo

### DIFF
--- a/gtsam/slam/slam.i
+++ b/gtsam/slam/slam.i
@@ -167,6 +167,18 @@ virtual class GenericStereoFactor : gtsam::NoiseModelFactor {
   GenericStereoFactor(const gtsam::StereoPoint2& measured,
                       const gtsam::noiseModel::Base* noiseModel, size_t poseKey,
                       size_t landmarkKey, const gtsam::Cal3_S2Stereo* K);
+  GenericStereoFactor(const gtsam::StereoPoint2& measured,
+                      const gtsam::noiseModel::Base* noiseModel,
+                      size_t poseKey, size_t landmarkKey,
+                      const gtsam::Cal3_S2Stereo* K,
+                      const POSE& body_P_sensor);
+  GenericStereoFactor(const gtsam::StereoPoint2& measured,
+                      const gtsam::noiseModel::Base* noiseModel,
+                      size_t poseKey, size_t landmarkKey,
+                      const gtsam::Cal3_S2Stereo* K,
+                      bool throwCheirality, bool verboseCheirality,
+                      const POSE& body_P_sensor);
+  
   gtsam::StereoPoint2 measured() const;
   gtsam::Cal3_S2Stereo* calibration() const;
 


### PR DESCRIPTION
This MR exposes `body_P_sensor` parameter in Python wrapper for `GenericStereoFactor3D`.

I am working on a stereo vision application for a robot where the camera frame differs from the body link. I cannot prototype in Python because the `body_P_sensor` parameter for `GenericStereoFactor3D` constructor is not exposed.

After the MR:
```
graph.push_back(GenericStereoFactor3D(
    StereoPoint2(uL, uR, v), noise_model, 1, 3, K, body_to_camera)
```