### PR TITLE
Bump minimum Ubuntu runner version to 22.04

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -30,9 +30,9 @@ jobs:
         # Github Actions requires a single row to be added to the build matrix.
         # See https://help.github.com/en/articles/workflow-syntax-for-github-actions.
         name: [
-            # "Bracket" the versions from GCC [9-14] and Clang [9-16]
+            # "Bracket" the versions from GCC [9-14] and Clang [11-16]
             ubuntu-22.04-gcc-9,
-            ubuntu-22.04-clang-9,
+            ubuntu-22.04-clang-11,
             ubuntu-24.04-gcc-14,
             ubuntu-24.04-clang-16,
           ]
@@ -45,10 +45,10 @@ jobs:
             compiler: gcc
             version: "9"
 
-          - name: ubuntu-22.04-clang-9
+          - name: ubuntu-22.04-clang-11
             os: ubuntu-22.04
             compiler: clang
-            version: "9"
+            version: "11"
 
           - name: ubuntu-24.04-gcc-14
             os: ubuntu-24.04

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -3,9 +3,9 @@ name: Linux CI
 on:
   pull_request:
     paths-ignore:
-      - '**.md'
-      - '**.ipynb' 
-      - 'myst.yml'
+      - "**.md"
+      - "**.ipynb"
+      - "myst.yml"
 
 # Every time you make a push to your PR, it cancel immediately the previous checks,
 # and start a new one. The other runner will be available more quickly to your PR.
@@ -31,8 +31,8 @@ jobs:
         # See https://help.github.com/en/articles/workflow-syntax-for-github-actions.
         name: [
             # "Bracket" the versions from GCC [9-14] and Clang [9-16]
-            ubuntu-20.04-gcc-9,
-            ubuntu-20.04-clang-9,
+            ubuntu-22.04-gcc-9,
+            ubuntu-22.04-clang-9,
             ubuntu-24.04-gcc-14,
             ubuntu-24.04-clang-16,
           ]
@@ -40,13 +40,13 @@ jobs:
         build_type: [Debug, Release]
         build_unstable: [ON]
         include:
-          - name: ubuntu-20.04-gcc-9
-            os: ubuntu-20.04
+          - name: ubuntu-22.04-gcc-9
+            os: ubuntu-22.04
             compiler: gcc
             version: "9"
 
-          - name: ubuntu-20.04-clang-9
-            os: ubuntu-20.04
+          - name: ubuntu-22.04-clang-9
+            os: ubuntu-22.04
             compiler: clang
             version: "9"
 

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -22,18 +22,18 @@ jobs:
         id: filter
         uses: dorny/paths-filter@v3
         with:
-          predicate-quantifier: 'every' # If any changed file matches every filter, proceed with build
+          predicate-quantifier: "every" # If any changed file matches every filter, proceed with build
           filters: |
             relevant_changes:
               - '!**.md'
               - '!**.ipynb' 
               - '!myst.yml'
-              
+
   build:
     # Only run build if relevant files have been modified in this PR.
     needs: check-paths
     if: needs.check-paths.outputs.should_run == 'true'
-    
+
     name: ${{ matrix.name }} ${{ matrix.build_type }} Python ${{ matrix.python_version }}
     runs-on: ${{ matrix.os }}
 
@@ -52,8 +52,8 @@ jobs:
         # See https://help.github.com/en/articles/workflow-syntax-for-github-actions.
         name:
           [
-            ubuntu-20.04-gcc-9,
-            ubuntu-20.04-clang-9,
+            ubuntu-22.04-gcc-9,
+            ubuntu-22.04-clang-11,
             macos-13-xcode-14.2,
             macos-14-xcode-15.4,
             windows-2022-msbuild,
@@ -62,15 +62,15 @@ jobs:
         build_type: [Release]
         python_version: [3]
         include:
-          - name: ubuntu-20.04-gcc-9
+          - name: ubuntu-22.04-gcc-9
             os: ubuntu-20.04
             compiler: gcc
             version: "9"
 
-          - name: ubuntu-20.04-clang-9
+          - name: ubuntu-22.04-clang-11
             os: ubuntu-20.04
             compiler: clang
-            version: "9"
+            version: "11"
 
           - name: macos-13-xcode-14.2
             os: macos-13

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -63,12 +63,12 @@ jobs:
         python_version: [3]
         include:
           - name: ubuntu-22.04-gcc-9
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             compiler: gcc
             version: "9"
 
           - name: ubuntu-22.04-clang-11
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             compiler: clang
             version: "11"
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ matrices.
 
 The current support matrix is:
 
-| Platform           | Compiler  | Build Status                                                                     |
-|:------------------:|:---------:|:--------------------------------------------------------------------------------:|
-| Ubuntu 20.04/22.04 | gcc/clang | ![Linux CI](https://github.com/borglab/gtsam/workflows/Linux%20CI/badge.svg)     |
-| macOS              | clang     | ![macOS CI](https://github.com/borglab/gtsam/workflows/macOS%20CI/badge.svg)     |
-| Windows            | MSVC      | ![Windows CI](https://github.com/borglab/gtsam/workflows/Windows%20CI/badge.svg) |
+|   Platform   | Compiler  |                                   Build Status                                   |
+| :----------: | :-------: | :------------------------------------------------------------------------------: |
+| Ubuntu 22.04 | gcc/clang |   ![Linux CI](https://github.com/borglab/gtsam/workflows/Linux%20CI/badge.svg)   |
+|    macOS     |   clang   |   ![macOS CI](https://github.com/borglab/gtsam/workflows/macOS%20CI/badge.svg)   |
+|   Windows    |   MSVC    | ![Windows CI](https://github.com/borglab/gtsam/workflows/Windows%20CI/badge.svg) |
 
 
 On top of the C++ library, GTSAM includes [wrappers for MATLAB & Python](#wrappers).

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ matrices.
 
 The current support matrix is:
 
-|   Platform   | Compiler  |                                   Build Status                                   |
-| :----------: | :-------: | :------------------------------------------------------------------------------: |
-| Ubuntu 22.04 | gcc/clang |   ![Linux CI](https://github.com/borglab/gtsam/workflows/Linux%20CI/badge.svg)   |
-|    macOS     |   clang   |   ![macOS CI](https://github.com/borglab/gtsam/workflows/macOS%20CI/badge.svg)   |
-|   Windows    |   MSVC    | ![Windows CI](https://github.com/borglab/gtsam/workflows/Windows%20CI/badge.svg) |
+|      Platform      | Compiler  |                                   Build Status                                   |
+| :----------------: | :-------: | :------------------------------------------------------------------------------: |
+| Ubuntu 22.04/24.04 | gcc/clang |   ![Linux CI](https://github.com/borglab/gtsam/workflows/Linux%20CI/badge.svg)   |
+|       macOS        |   clang   |   ![macOS CI](https://github.com/borglab/gtsam/workflows/macOS%20CI/badge.svg)   |
+|      Windows       |   MSVC    | ![Windows CI](https://github.com/borglab/gtsam/workflows/Windows%20CI/badge.svg) |
 
 
 On top of the C++ library, GTSAM includes [wrappers for MATLAB & Python](#wrappers).


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/11101 and https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/?utm_source=chatgpt.com. Ubuntu 20.04 runner images are deprecated as of April 15, 2025.

This PR bumps the minimum Ubuntu version in our CI to 22.04 in various places.