### PR TITLE
Update navbar

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -33,7 +33,7 @@ site:
     - title: C++ reference
       url: https://gtsam.org/doxygen/
   options:
-    logo_text: GTSAM
+    logo_text: GTSAM 
   template: book-theme
 
   # TODO: Graphics for favicon, site logo

--- a/myst.yml
+++ b/myst.yml
@@ -28,17 +28,15 @@ project:
     - file: ./doc/expressions.md
 site:
   nav: 
-    - title: Getting started
-      children:
-      - title: Overview
-        url: /readme
-      - title: Install guide
-        url: /install
+    - title: GTSAM.org
+      url: https://gtsam.org
     - title: C++ reference
       url: https://gtsam.org/doxygen/
+  options:
+    logo_text: GTSAM
   template: book-theme
 
-  # TODO: Graphics for favicon and to replace "Made with MyST" in the top left
+  # TODO: Graphics for favicon, site logo
   # options:
   #   favicon: favicon.ico
   #   logo: site_logo.png


### PR DESCRIPTION
**Current navbar:**
![image](https://github.com/user-attachments/assets/0bf185e4-8164-4532-bd01-5929e7b1507c)
**Updated navbar:**
![image](https://github.com/user-attachments/assets/a6d1c28b-30b2-4545-920e-615de48437a3)
"Getting started" removed because it was redundant; the links are in the sidebar.