### PR TITLE
Add `cibuildwheel` targets for MacOS Silicon

### DIFF
--- a/.github/workflows/build-cibw.yml
+++ b/.github/workflows/build-cibw.yml
@@ -93,6 +93,24 @@ jobs:
             cibw_python_version: 313
             platform_id: macosx_x86_64
 
+          # MacOS arm64
+          - os: macos-14
+            python_version: "3.10"
+            cibw_python_version: 310
+            platform_id: macosx_arm64
+          - os: macos-14
+            python_version: "3.11"
+            cibw_python_version: 311
+            platform_id: macosx_arm64
+          - os: macos-14
+            python_version: "3.12"
+            cibw_python_version: 312
+            platform_id: macosx_arm64
+          - os: macos-14
+            python_version: "3.13"
+            cibw_python_version: 313
+            platform_id: macosx_arm64
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR adds targets in the `cibuildwheel` workflow for MacOS ARM64. This will support M-series Macs.