### PR TITLE
Allow for dynamic M/G in new EKF variants

### DIFF
--- a/gtsam/base/VectorSpace.h
+++ b/gtsam/base/VectorSpace.h
@@ -35,7 +35,7 @@ struct VectorSpaceImpl {
       ChartJacobian H1 = {}, ChartJacobian H2 = {}) {
     if (H1) *H1 = - Jacobian::Identity();
     if (H2) *H2 = Jacobian::Identity();
-    Class v = other-origin;
+    Class v = other - origin;
     return v.vector();
   }
 
@@ -82,12 +82,12 @@ struct VectorSpaceImpl {
     return -v;
   }
 
-  static LieAlgebra Hat(const TangentVector& v) {
-    return v;
-  }
+  static LieAlgebra Hat(const TangentVector& v) { return v; }
 
-  static TangentVector Vee(const LieAlgebra& X) {
-    return X;
+  static TangentVector Vee(const LieAlgebra& X) { return X; }
+
+  static Jacobian AdjointMap(const Class& /*m*/) {
+    return Jacobian::Identity();
   }
   /// @}
 };
@@ -118,7 +118,7 @@ struct VectorSpaceImpl<Class,Eigen::Dynamic> {
       ChartJacobian H1 = {}, ChartJacobian H2 = {}) {
     if (H1) *H1 = - Eye(origin);
     if (H2) *H2 = Eye(other);
-    Class v = other-origin;
+    Class v = other - origin;
     return v.vector();
   }
 
@@ -141,8 +141,7 @@ struct VectorSpaceImpl<Class,Eigen::Dynamic> {
 
   static Class Expmap(const TangentVector& v, ChartJacobian Hv = {}) {
     Class result(v);
-    if (Hv)
-      *Hv = Eye(v);
+    if (Hv) *Hv = Eye(v);
     return result;
   }
 
@@ -165,6 +164,7 @@ struct VectorSpaceImpl<Class,Eigen::Dynamic> {
     return -v;
   }
 
+  static Eigen::MatrixXd AdjointMap(const Class& m) { return Eye(m); }
   /// @}
 };
 
@@ -273,8 +273,8 @@ struct ScalarTraits : VectorSpaceImpl<Scalar, 1> {
     if (H) (*H)[0] = 1.0;
     return v[0];
   }
+  // AdjointMap for ScalarTraits is inherited from VectorSpaceImpl<Scalar, 1>
   /// @}
-
 };
 
 } // namespace internal
@@ -352,6 +352,9 @@ struct traits<Eigen::Matrix<double, M, N, Options, MaxRows, MaxCols> > :
     if (H) *H = Jacobian::Identity();
     return m + Eigen::Map<const Fixed>(v.data());
   }
+
+  // AdjointMap for fixed-size Eigen matrices is inherited from
+  // internal::VectorSpaceImpl< Eigen::Matrix<double, M, N, ...> , M*N >
   /// @}
 };
 
@@ -404,7 +407,7 @@ struct DynamicTraits {
   static TangentVector Local(const Dynamic& m, const Dynamic& other, //
       ChartJacobian H1 = {}, ChartJacobian H2 = {}) {
     if (H1) *H1 = -Eye(m);
-    if (H2) *H2 =  Eye(m);
+    if (H2) *H2 = Eye(m);
     TangentVector v(GetDimension(m));
     Eigen::Map<Dynamic>(v.data(), m.rows(), m.cols()) = other - m;
     return v;
@@ -425,7 +428,7 @@ struct DynamicTraits {
   static TangentVector Logmap(const Dynamic& m, ChartJacobian H = {}) {
     if (H) *H = Eye(m);
     TangentVector result(GetDimension(m));
-    Eigen::Map<Dynamic>(result.data(), m.cols(), m.rows()) = m;
+    Eigen::Map<Dynamic>(result.data(), m.rows(), m.cols()) = m;
     return result;
   }
 
@@ -460,7 +463,8 @@ struct DynamicTraits {
   static TangentVector Vee(const LieAlgebra& X) {
     return X;
   }
-  
+
+  static Jacobian AdjointMap(const Dynamic& m) { return Eye(m); }
   /// @}
 
 };
@@ -505,5 +509,4 @@ private:
   T p, q, r;
 };
 
-} // namespace gtsam
-
+}  // namespace gtsam

--- a/gtsam/navigation/InvariantEKF.h
+++ b/gtsam/navigation/InvariantEKF.h
@@ -77,9 +77,9 @@ namespace gtsam {
      * @param Q Process noise covariance.
      */
     void predict(const G& U, const Covariance& Q) {
-      this->X_ = this->X_.compose(U);
-      // TODO(dellaert): traits<G>::AdjointMap should exist
-      const Jacobian A = traits<G>::Inverse(U).AdjointMap();
+      this->X_ = traits<G>::Compose(this->X_, U);
+      const G U_inv = traits<G>::Inverse(U);
+      const Jacobian A = traits<G>::AdjointMap(U_inv);
       // P_ is Covariance. A is Jacobian. Q is Covariance.
       // All are Eigen::Matrix<double,Dim,Dim>.
       this->P_ = A * this->P_ * A.transpose() + Q;

--- a/gtsam/navigation/InvariantEKF.h
+++ b/gtsam/navigation/InvariantEKF.h
@@ -97,6 +97,7 @@ namespace gtsam {
     void predict(const TangentVector& u, double dt, const Covariance& Q) {
       G U;
       if constexpr (std::is_same_v<G, Matrix>) {
+        // Specialize to Matrix case as its Expmap is not defined.
         const Matrix& X = static_cast<const Matrix&>(this->X_);
         U.resize(X.rows(), X.cols());
         Eigen::Map<Vector>(static_cast<Matrix&>(U).data(), U.size()) = u * dt;

--- a/gtsam/navigation/InvariantEKF.h
+++ b/gtsam/navigation/InvariantEKF.h
@@ -43,7 +43,8 @@ namespace gtsam {
    *
    * The state-dependent prediction methods from LieGroupEKF are hidden.
    * The update step remains the same as in ManifoldEKF/LieGroupEKF.
-   * Covariances (P, Q) are `Eigen::Matrix<double, Dim, Dim>`.
+   * For details on how static and dynamic dimensions are handled, please refer to
+   * the `ManifoldEKF` class documentation.
    */
   template <typename G>
   class InvariantEKF : public LieGroupEKF<G> {
@@ -59,9 +60,9 @@ namespace gtsam {
     /**
      * Constructor: forwards to LieGroupEKF constructor.
      * @param X0 Initial state on Lie group G.
-     * @param P0_input Initial covariance in the tangent space at X0 (dynamic gtsam::Matrix).
+     * @param P0 Initial covariance in the tangent space at X0.
      */
-    InvariantEKF(const G& X0, const Matrix& P0_input) : Base(X0, P0_input) {}
+    InvariantEKF(const G& X0, const Covariance& P0) : Base(X0, P0) {}
 
     // We hide state-dependent predict methods from LieGroupEKF by only providing the
     // invariant predict methods below.
@@ -73,7 +74,7 @@ namespace gtsam {
      * where Ad_{U^{-1}} is the Adjoint map of U^{-1}.
      *
      * @param U Lie group element representing the motion increment.
-     * @param Q Process noise covariance (Eigen::Matrix<double, Dim, Dim>).
+     * @param Q Process noise covariance.
      */
     void predict(const G& U, const Covariance& Q) {
       this->X_ = this->X_.compose(U);
@@ -91,7 +92,7 @@ namespace gtsam {
      *
      * @param u Tangent space control vector.
      * @param dt Time interval.
-     * @param Q Process noise covariance matrix (Eigen::Matrix<double, Dim, Dim>).
+     * @param Q Process noise covariance matrix.
      */
     void predict(const TangentVector& u, double dt, const Covariance& Q) {
       const G U = traits<G>::Expmap(u * dt);

--- a/gtsam/navigation/InvariantEKF.h
+++ b/gtsam/navigation/InvariantEKF.h
@@ -95,7 +95,15 @@ namespace gtsam {
      * @param Q Process noise covariance matrix.
      */
     void predict(const TangentVector& u, double dt, const Covariance& Q) {
-      const G U = traits<G>::Expmap(u * dt);
+      G U;
+      if constexpr (std::is_same_v<G, Matrix>) {
+        const Matrix& X = static_cast<const Matrix&>(this->X_);
+        U.resize(X.rows(), X.cols());
+        Eigen::Map<Vector>(static_cast<Matrix&>(U).data(), U.size()) = u * dt;
+      }
+      else {
+        U = traits<G>::Expmap(u * dt);
+      }
       predict(U, Q); // Call the group composition predict
     }
 

--- a/gtsam/navigation/ManifoldEKF.h
+++ b/gtsam/navigation/ManifoldEKF.h
@@ -18,6 +18,9 @@
   * differentiable manifold. It relies on the manifold's retract and
   * localCoordinates operations.
   *
+  * Works with manifolds M that may have fixed or dynamic tangent space dimensions.
+  * Covariances and Jacobians are handled as `Matrix` (dynamic-size Eigen matrices).
+  *
   * @date    April 24, 2025
   * @authors Scott Baker, Matt Kielo, Frank Dellaert
   */
@@ -27,9 +30,11 @@
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/OptionalJacobian.h>
 #include <gtsam/base/Vector.h>
-#include <gtsam/base/Manifold.h> // Include for traits
+#include <gtsam/base/Manifold.h> // Include for traits and IsManifold
 
 #include <Eigen/Dense>
+#include <string>
+#include <stdexcept>
 #include <type_traits>
 
 namespace gtsam {
@@ -39,41 +44,59 @@ namespace gtsam {
      * @brief Extended Kalman Filter on a generic manifold M
      *
      * @tparam M  Manifold type providing:
-     *           - static int dimension = tangent dimension
-     *           - using TangentVector = Eigen::Vector...
-     *           - A `retract(const TangentVector&)` method (member or static)
-     *           - A `localCoordinates(const M&)` method (member or static)
-     *           - `gtsam::traits<M>` specialization must exist.
+     *           - `traits<M>` specialization must exist, defining
+     *             `dimension` (compile-time or Eigen::Dynamic),
+     *             `TangentVector`, `Retract`, and `LocalCoordinates`.
+     *             If `dimension` is Eigen::Dynamic, `GetDimension(const M&)`
+     *             must be provided by traits.
      *
      * This filter maintains a state X in the manifold M and covariance P in the
-     * tangent space at X. Prediction requires providing the predicted next state
-     * and the state transition Jacobian F. Updates apply a measurement function h
-     * and correct the state using the tangent space error.
+     * tangent space at X. The covariance P is always stored as a gtsam::Matrix.
+     * Prediction requires providing the predicted next state and the state transition Jacobian F.
+     * Updates apply a measurement function h and correct the state using the tangent space error.
      */
   template <typename M>
   class ManifoldEKF {
   public:
-    /// Manifold dimension (tangent space dimension)
-    static constexpr int n = traits<M>::dimension;
-
-    /// Tangent vector type for the manifold M
+    /// Tangent vector type for the manifold M, as defined by its traits.
     using TangentVector = typename traits<M>::TangentVector;
 
-    /// Square matrix of size n for covariance and Jacobians
-    using MatrixN = Eigen::Matrix<double, n, n>;
+    /**
+     * Constructor: initialize with state and covariance.
+     * @param X0 Initial state on manifold M.
+     * @param P0 Initial covariance in the tangent space at X0. Must be a square
+     *           Matrix whose dimensions match the tangent space dimension of X0.
+     */
+    ManifoldEKF(const M& X0, const Matrix& P0) : X_(X0), P_(P0) {
+      static_assert(IsManifold<M>::value,
+        "Template parameter M must be a GTSAM Manifold.");
 
-    /// Constructor: initialize with state and covariance
-    ManifoldEKF(const M& X0, const MatrixN& P0) : X_(X0), P_(P0) {
-      static_assert(IsManifold<M>::value, "Template parameter M must be a GTSAM Manifold");
+      // Determine tangent space dimension n_ at runtime.
+      if constexpr (traits<M>::dimension == Eigen::Dynamic) {
+        // If M::dimension is dynamic, traits<M>::GetDimension(M) must exist.
+        n_ = traits<M>::GetDimension(X0);
+      }
+      else {
+        n_ = traits<M>::dimension;
+      }
+
+      // Validate dimensions of initial covariance P0.
+      if (P0.rows() != n_ || P0.cols() != n_) {
+        throw std::invalid_argument(
+          "ManifoldEKF: Initial covariance P0 dimensions (" +
+          std::to_string(P0.rows()) + "x" + std::to_string(P0.cols()) +
+          ") do not match state's tangent space dimension (" +
+          std::to_string(n_) + ").");
+      }
     }
 
-    virtual ~ManifoldEKF() = default; // Add virtual destructor for base class
+    virtual ~ManifoldEKF() = default;
 
-    /// @return current state estimate
+    /// @return current state estimate on manifold M.
     const M& state() const { return X_; }
 
-    /// @return current covariance estimate
-    const MatrixN& covariance() const { return P_; }
+    /// @return current covariance estimate in the tangent space (always a Matrix).
+    const Matrix& covariance() const { return P_; }
 
     /**
      * Basic predict step: Updates state and covariance given the predicted
@@ -83,11 +106,23 @@ namespace gtsam {
      * where F = d(local(X_{k+1})) / d(local(X_k)) is the Jacobian of the
      * state transition in local coordinates around X_k.
      *
-     * @param X_next The predicted state at time k+1.
+     * @param X_next The predicted state at time k+1 on manifold M.
      * @param F The state transition Jacobian (size nxn).
      * @param Q Process noise covariance matrix in the tangent space (size nxn).
      */
-    void predict(const M& X_next, const MatrixN& F, const Matrix& Q) {
+    void predict(const M& X_next, const Matrix& F, const Matrix& Q) {
+      if (F.rows() != n_ || F.cols() != n_) {
+        throw std::invalid_argument(
+          "ManifoldEKF::predict: Jacobian F dimensions (" +
+          std::to_string(F.rows()) + "x" + std::to_string(F.cols()) +
+          ") must be " + std::to_string(n_) + "x" + std::to_string(n_) + ".");
+      }
+      if (Q.rows() != n_ || Q.cols() != n_) {
+        throw std::invalid_argument(
+          "ManifoldEKF::predict: Noise Q dimensions (" +
+          std::to_string(Q.rows()) + "x" + std::to_string(Q.cols()) +
+          ") must be " + std::to_string(n_) + "x" + std::to_string(n_) + ".");
+      }
       X_ = X_next;
       P_ = F * P_ * F.transpose() + Q;
     }
@@ -96,7 +131,7 @@ namespace gtsam {
      * Measurement update: Corrects the state and covariance using a pre-calculated
      * predicted measurement and its Jacobian.
      *
-     * @tparam Measurement Type of the measurement vector (e.g., VectorN<m>).
+     * @tparam Measurement Type of the measurement vector (e.g., VectorN<m>, Vector).
      * @param prediction Predicted measurement.
      * @param H Jacobian of the measurement function h w.r.t. local(X), H = dh/dlocal(X).
      *          Its dimensions must be m x n.
@@ -105,56 +140,99 @@ namespace gtsam {
      */
     template <typename Measurement>
     void update(const Measurement& prediction,
-      const Eigen::Matrix<double, traits<Measurement>::dimension, n>& H,
-      const Measurement& z, const Matrix& R) {
-      // Innovation z \ominus prediction
-      Vector innovation = traits<Measurement>::Local(z, prediction);
+      const Matrix& H,
+      const Measurement& z,
+      const Matrix& R) {
 
-      // Innovation covariance and Kalman Gain
-      auto S = H * P_ * H.transpose() + R; // S is m x m
-      Matrix K = P_ * H.transpose() * S.inverse(); // K = P H^T S^-1 (size n x m)
+      static_assert(IsManifold<Measurement>::value,
+        "Template parameter Measurement must be a GTSAM Manifold for LocalCoordinates.");
 
-      // Correction vector in tangent space
-      TangentVector delta_xi = -K * innovation; // delta_xi is n x 1
+      int m; // Measurement dimension
+      if constexpr (traits<Measurement>::dimension == Eigen::Dynamic) {
+        m = traits<Measurement>::GetDimension(z);
+        if (traits<Measurement>::GetDimension(prediction) != m) {
+          throw std::invalid_argument(
+            "ManifoldEKF::update: Dynamic measurement 'prediction' and 'z' have different dimensions.");
+        }
+      }
+      else {
+        m = traits<Measurement>::dimension;
+      }
 
-      // Update state using retract
+      if (H.rows() != m || H.cols() != n_) {
+        throw std::invalid_argument(
+          "ManifoldEKF::update: Jacobian H dimensions (" +
+          std::to_string(H.rows()) + "x" + std::to_string(H.cols()) +
+          ") must be " + std::to_string(m) + "x" + std::to_string(n_) + ".");
+      }
+      if (R.rows() != m || R.cols() != m) {
+        throw std::invalid_argument(
+          "ManifoldEKF::update: Noise R dimensions (" +
+          std::to_string(R.rows()) + "x" + std::to_string(R.cols()) +
+          ") must be " + std::to_string(m) + "x" + std::to_string(m) + ".");
+      }
+
+      // Innovation: y = z - h(x_pred). In tangent space: local(h(x_pred), z)
+      // This is `log(prediction.inverse() * z)` if Measurement is a Lie group.
+      typename traits<Measurement>::TangentVector innovation =
+        traits<Measurement>::Local(prediction, z);
+
+      // Innovation covariance: S = H P H^T + R
+      const Matrix S = H * P_ * H.transpose() + R; // S is m x m
+
+      // Kalman Gain: K = P H^T S^-1
+      const Matrix K = P_ * H.transpose() * S.inverse(); // K is n_ x m
+
+      // Correction vector in tangent space of M: delta_xi = K * innovation
+      const TangentVector delta_xi = K * innovation; // delta_xi is n_ x 1
+
+      // Update state using retract: X_new = retract(X_old, delta_xi)
       X_ = traits<M>::Retract(X_, delta_xi);
 
       // Update covariance using Joseph form for numerical stability
-      MatrixN I_KH = I_n - K * H; // I_KH is n x n
+      const auto I_n = Matrix::Identity(n_, n_);
+      const Matrix I_KH = I_n - K * H; // I_KH is n x n
       P_ = I_KH * P_ * I_KH.transpose() + K * R * K.transpose();
     }
 
     /**
-     * Measurement update: Corrects the state and covariance using a measurement.
+     * Measurement update: Corrects the state and covariance using a measurement
+     * model function.
      *
-     * @tparam Measurement Type of the measurement vector (e.g., VectorN<m>)
-     * @tparam Prediction Functor signature: Measurement h(const M&, OptionalJacobian<m,n>&)
-     * @param h Measurement model functor returning predicted measurement prediction
-     *          and its Jacobian H = d(h)/d(local(X)).
+     * @tparam Measurement Type of the measurement vector (e.g., VectorN<m>, Vector).
+     * @tparam MeasurementFunction Functor/lambda with signature compatible with:
+     *        `Measurement h(const M& x, Jac& H_jacobian)`
+     *        where `Jac` can be `Matrix&` or `OptionalJacobian<m, n_>&`.
+     *        The Jacobian H should be d(h)/d(local(X)).
+     * @param h Measurement model function.
      * @param z Observed measurement.
-     * @param R Measurement noise covariance (size m x m).
+     * @param R Measurement noise covariance (must be an m x m Matrix).
      */
-    template <typename Measurement, typename Prediction>
-    void update(Prediction&& h, const Measurement& z, const Matrix& R) {
-      constexpr int m = traits<Measurement>::dimension;
+    template <typename Measurement, typename MeasurementFunction>
+    void update(MeasurementFunction&& h, const Measurement& z, const Matrix& R) {
+      static_assert(IsManifold<Measurement>::value,
+        "Template parameter Measurement must be a GTSAM Manifold.");
+
+      int m; // Measurement dimension
+      if constexpr (traits<Measurement>::dimension == Eigen::Dynamic) {
+        m = traits<Measurement>::GetDimension(z);
+      }
+      else {
+        m = traits<Measurement>::dimension;
+      }
+
       // Predict measurement and get Jacobian H = dh/dlocal(X)
-      Eigen::Matrix<double, m, n> H;
+      Matrix H(m, n_);
       Measurement prediction = h(X_, H);
-      update(prediction, H, z, R); // Call the other update function
+
+      // Call the other update function
+      update(prediction, H, z, R);
     }
 
   protected:
-    M X_;      ///< manifold state estimate
-    MatrixN P_; ///< covariance in tangent space at X_
-
-  private:
-    /// Identity matrix of size n
-    static const MatrixN I_n;
+    M X_;      ///< Manifold state estimate.
+    Matrix P_; ///< Covariance in tangent space at X_ (always a dynamic Matrix).
+    int n_;    ///< Tangent space dimension of M, determined at construction.
   };
-
-  // Define static identity I_n
-  template <typename M>
-  const typename ManifoldEKF<M>::MatrixN ManifoldEKF<M>::I_n = ManifoldEKF<M>::MatrixN::Identity();
 
 }  // namespace gtsam

--- a/gtsam/navigation/tests/testInvariantEKF.cpp
+++ b/gtsam/navigation/tests/testInvariantEKF.cpp
@@ -119,6 +119,99 @@ TEST(IEKF_Pose2, PredictUpdateSequence) {
 
 }
 
+// Define simple dynamics and measurement for a 2x2 Matrix state
+namespace exampleDynamicMatrix {
+  // Predicts the next state given current state (Matrix), tangent "velocity" (Vector), and dt.
+  // This is mainly for verification; IEKF predict will use tangent vector directly.
+  Matrix predictNextStateManually(const Matrix& p, const Vector& vTangent, double dt) {
+    return traits<Matrix>::Retract(p, vTangent * dt);
+  }
+  // Define a measurement model: measure the trace of the Matrix (assumed 2x2 here)
+  double measureTrace(const Matrix& p, OptionalJacobian<-1, -1> H = {}) {
+    if (H) {
+      // p_flat (col-major for Eigen) for a 2x2 matrix p = [[p00,p01],[p10,p11]] is [p00, p10, p01, p11]
+      // trace = p(0,0) + p(1,1)
+      // H = d(trace)/d(p_flat) = [1, 0, 0, 1]
+      // The Jacobian H will be 1x4 for a 2x2 matrix.
+      H->resize(1, p.size()); // p.size() is rows*cols
+      (*H) << 1.0, 0.0, 0.0, 1.0; // Assuming 2x2, so 1x4
+    }
+    return p(0, 0) + p(1, 1);
+  }
+} // namespace exampleDynamicMatrix
+
+// Test fixture for InvariantEKF with a 2x2 Matrix state
+struct DynamicMatrixEKFTest {
+  Matrix p0Matrix; // Initial state (as 2x2 Matrix)
+  Matrix p0Covariance; // Initial covariance (dynamic Matrix, 4x4)
+  Vector velocityTangent; // Control input in tangent space (Vector4 for 2x2 matrix)
+  double dt;
+  Matrix processNoiseCovariance; // Process noise covariance (dynamic Matrix, 4x4)
+  Matrix measurementNoiseCovariance; // Measurement noise covariance (dynamic Matrix, 1x1)
+  DynamicMatrixEKFTest() :
+    p0Matrix((Matrix(2, 2) << 1.0, 2.0, 3.0, 4.0).finished()),
+    p0Covariance(I_4x4 * 0.01),
+    velocityTangent((Vector(4) << 0.5, 0.1, -0.1, -0.5).finished()), // [dp00, dp10, dp01, dp11]/sec
+    dt(0.1),
+    processNoiseCovariance(I_4x4 * 0.001),
+    measurementNoiseCovariance(Matrix::Identity(1, 1) * 0.005) {
+  }
+};
+
+TEST(InvariantEKF_DynamicMatrix, Predict) {
+  DynamicMatrixEKFTest data;
+  InvariantEKF<Matrix> ekf(data.p0Matrix, data.p0Covariance);
+  // For a 2x2 Matrix, tangent space dimension is 2*2=4.
+  EXPECT_LONGS_EQUAL(4, ekf.state().size());
+  EXPECT_LONGS_EQUAL(data.p0Matrix.rows() * data.p0Matrix.cols(), ekf.state().size());
+  EXPECT_LONGS_EQUAL(4, ekf.dimension());
+  // --- Perform EKF prediction using InvariantEKF::predict(tangentVector, dt, Q) ---
+  ekf.predict(data.velocityTangent, data.dt, data.processNoiseCovariance);
+  // --- Verification ---
+  // 1. Calculate expected next state
+  Matrix pNextExpected = exampleDynamicMatrix::predictNextStateManually(data.p0Matrix, data.velocityTangent, data.dt);
+  EXPECT(assert_equal(pNextExpected, ekf.state(), 1e-9));
+  // 2. Calculate expected covariance
+  // For VectorSpace, AdjointMap is Identity. So P_next = P_prev + Q.
+  Matrix pCovarianceExpected = data.p0Covariance + data.processNoiseCovariance;
+  EXPECT(assert_equal(pCovarianceExpected, ekf.covariance(), 1e-9));
+}
+
+TEST(InvariantEKF_DynamicMatrix, Update) {
+  DynamicMatrixEKFTest data;
+  Matrix pStartMatrix = (Matrix(2, 2) << 1.5, -0.5, 0.8, 2.5).finished();
+  Matrix pStartCovariance = I_4x4 * 0.02;
+  InvariantEKF<Matrix> ekf(pStartMatrix, pStartCovariance);
+  EXPECT_LONGS_EQUAL(4, ekf.state().size());
+  EXPECT_LONGS_EQUAL(4, ekf.dimension());
+  // Simulate a measurement (true trace of pStartMatrix is 1.5 + 2.5 = 4.0)
+  double zTrue = exampleDynamicMatrix::measureTrace(pStartMatrix); // No Jacobian needed here
+  double zObserved = zTrue - 0.03; // Add some "error"
+  // --- Perform EKF update ---
+  // The update method is inherited from ManifoldEKF.
+  ekf.update(exampleDynamicMatrix::measureTrace, zObserved, data.measurementNoiseCovariance);
+  // --- Verification (Manual Kalman Update Steps) ---
+  // 1. Predict measurement and get Jacobian H
+  Matrix H_manual(1, 4); // This will be 1x4 for a 2x2 matrix measurement
+  double zPredictionManual = exampleDynamicMatrix::measureTrace(pStartMatrix, H_manual);
+  // 2. Innovation and Innovation Covariance
+  // EKF calculates innovation_tangent = traits<Measurement>::Local(prediction, zObserved)
+  // For double (a VectorSpace), Local(A,B) is B-A. So, zObserved - zPredictionManual.
+  double innovationY_tangent = zObserved - zPredictionManual;
+  Matrix innovationCovarianceS = H_manual * pStartCovariance * H_manual.transpose() + data.measurementNoiseCovariance;
+  // 3. Kalman Gain K
+  Matrix kalmanGainK = pStartCovariance * H_manual.transpose() * innovationCovarianceS.inverse(); // K is 4x1
+  // 4. State Correction (in tangent space of Matrix)
+  Vector deltaXiTangent = kalmanGainK * innovationY_tangent; // deltaXi is 4x1 Vector
+  // 5. Expected Updated State and Covariance (using Joseph form)
+  Matrix pUpdatedExpected = traits<Matrix>::Retract(pStartMatrix, deltaXiTangent);
+  Matrix I_KH = I_4x4 - kalmanGainK * H_manual;
+  Matrix pUpdatedCovarianceExpected = I_KH * pStartCovariance * I_KH.transpose() + kalmanGainK * data.measurementNoiseCovariance * kalmanGainK.transpose();
+  // --- Compare EKF result with manual calculation ---
+  EXPECT(assert_equal(pUpdatedExpected, ekf.state(), 1e-9));
+  EXPECT(assert_equal(pUpdatedCovarianceExpected, ekf.covariance(), 1e-9));
+}
+
 int main() {
   TestResult tr;
   return TestRegistry::runAllTests(tr);

--- a/gtsam/navigation/tests/testLieGroupEKF.cpp
+++ b/gtsam/navigation/tests/testLieGroupEKF.cpp
@@ -126,19 +126,17 @@ namespace exampleLieGroupDynamicMatrix {
     return kFixedVelocityTangent;
   }
 
-  // Measurement function h(X, H_p)
-  // H_p is D(h)/D(X_local)
-  double h(const Matrix& p, OptionalJacobian<-1, -1> H_p = {}) {
-    if (p.size() == 0) {
-      if (H_p) H_p->resize(1, 0); // Jacobian dh/dX_local is 1x0
-      return 0.0; // Define trace of empty matrix as 0 for consistency
+  // Measurement function h(X, H)
+  double h(const Matrix& p, OptionalJacobian<-1, -1> H = {}) {
+    // Specialized for a 2x2 matrix!
+    if (p.rows() != 2 || p.cols() != 2) {
+      throw std::invalid_argument("Matrix must be 2x2.");
     }
-    // This test specifically uses 2x2 matrices (size 4)
-    if (H_p) {
-      H_p->resize(1, p.size()); // p.size() is 4
-      (*H_p) << 1.0, 0.0, 0.0, 1.0; // d(trace)/d(p_flat) for p_flat = [p00,p10,p01,p11]
+    if (H) {
+      H->resize(1, p.size());
+      *H << 1.0, 0.0, 0.0, 1.0; // d(trace)/dp00, d(trace)/dp01, d(trace)/dp10, d(trace)/dp11
     }
-    return p(0, 0) + p(1, 1); // trace
+    return p(0, 0) + p(1, 1); // Trace of the matrix
   }
 } // namespace exampleLieGroupDynamicMatrix
 

--- a/gtsam/navigation/tests/testLieGroupEKF.cpp
+++ b/gtsam/navigation/tests/testLieGroupEKF.cpp
@@ -108,6 +108,94 @@ TEST(GroupeEKF, StateAndControl) {
   EXPECT(assert_equal(expectedH, actualH));
 }
 
+// Namespace for dynamic Matrix LieGroupEKF test
+namespace exampleLieGroupDynamicMatrix {
+  // Constant tangent vector for dynamics (same as "velocityTangent" in IEKF test)
+  const Vector kFixedVelocityTangent = (Vector(4) << 0.5, 0.1, -0.1, -0.5).finished();
+
+  // Dynamics function: xi = f(X, H_X)
+  // Returns a constant tangent vector, so Df_DX = 0.
+  // H_X is D(xi)/D(X_local), where X_local is the tangent space perturbation of X.
+  Vector f(const Matrix& X, OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H_X = {}) {
+    if (H_X) {
+      size_t state_dim = X.size();
+      size_t tangent_dim = kFixedVelocityTangent.size();
+      // Ensure Jacobian dimensions are consistent even if state or tangent is 0-dim
+      H_X->setZero(tangent_dim, state_dim);
+    }
+    return kFixedVelocityTangent;
+  }
+
+  // Measurement function h(X, H_p)
+  // H_p is D(h)/D(X_local)
+  double h(const Matrix& p, OptionalJacobian<-1, -1> H_p = {}) {
+    if (p.size() == 0) {
+      if (H_p) H_p->resize(1, 0); // Jacobian dh/dX_local is 1x0
+      return 0.0; // Define trace of empty matrix as 0 for consistency
+    }
+    // This test specifically uses 2x2 matrices (size 4)
+    if (H_p) {
+      H_p->resize(1, p.size()); // p.size() is 4
+      (*H_p) << 1.0, 0.0, 0.0, 1.0; // d(trace)/d(p_flat) for p_flat = [p00,p10,p01,p11]
+    }
+    return p(0, 0) + p(1, 1); // trace
+  }
+} // namespace exampleLieGroupDynamicMatrix
+
+TEST(LieGroupEKF_DynamicMatrix, PredictAndUpdate) {
+  // --- Setup ---
+  Matrix p0Matrix = (Matrix(2, 2) << 1.0, 2.0, 3.0, 4.0).finished();
+  Matrix p0Covariance = I_4x4 * 0.01;
+  double dt = 0.1;
+  Matrix process_noise_Q = I_4x4 * 0.001;
+  Matrix measurement_noise_R = Matrix::Identity(1, 1) * 0.005;
+
+  LieGroupEKF<Matrix> ekf(p0Matrix, p0Covariance);
+  EXPECT_LONGS_EQUAL(4, ekf.state().size());
+  EXPECT_LONGS_EQUAL(4, ekf.dimension());
+
+  // --- Predict ---
+  // ekf.predict takes f(X, H_X), dt, process_noise_Q
+  ekf.predict(exampleLieGroupDynamicMatrix::f, dt, process_noise_Q);
+
+  // Verification for Predict
+  // For f, Df_DXk = 0 (Jacobian of xi w.r.t X_local is Zero).
+  // State transition Jacobian A = Ad_Uinv + Dexp * Df_DXk * dt.
+  // For Matrix (VectorSpace): Ad_Uinv = I, Dexp = I.
+  // So, A = I + I * 0 * dt = I.
+  // Covariance update: P_next = A * P_current * A.transpose() + Q = I * P_current * I + Q = P_current + Q.
+  Matrix pPredictedExpected = traits<Matrix>::Retract(p0Matrix, exampleLieGroupDynamicMatrix::kFixedVelocityTangent * dt);
+  Matrix pCovariancePredictedExpected = p0Covariance + process_noise_Q;
+
+  EXPECT(assert_equal(pPredictedExpected, ekf.state(), 1e-9));
+  EXPECT(assert_equal(pCovariancePredictedExpected, ekf.covariance(), 1e-9));
+
+  // --- Update ---
+  Matrix pStateBeforeUpdate = ekf.state();
+  Matrix pCovarianceBeforeUpdate = ekf.covariance();
+
+  double zTrue = exampleLieGroupDynamicMatrix::h(pStateBeforeUpdate);
+  double zObserved = zTrue - 0.03; // Simulated measurement with some error
+
+  ekf.update(exampleLieGroupDynamicMatrix::h, zObserved, measurement_noise_R);
+
+  // Verification for Update (Manual Kalman Steps)
+  Matrix H_update(1, 4); // Measurement Jacobian: 1x4 for 2x2 matrix, trace measurement
+  double zPredictionManual = exampleLieGroupDynamicMatrix::h(pStateBeforeUpdate, H_update);
+  // Innovation: y_tangent = traits<Measurement>::Local(prediction, observation)
+  // For double (scalar), Local(A,B) is B-A.
+  double innovationY_tangent = zObserved - zPredictionManual;
+  Matrix S_innovation_cov = H_update * pCovarianceBeforeUpdate * H_update.transpose() + measurement_noise_R;
+  Matrix K_gain = pCovarianceBeforeUpdate * H_update.transpose() * S_innovation_cov.inverse();
+  Vector deltaXiTangent = K_gain * innovationY_tangent; // Tangent space correction for Matrix state
+  Matrix pUpdatedExpected = traits<Matrix>::Retract(pStateBeforeUpdate, deltaXiTangent);
+  Matrix I_KH = I_4x4 - K_gain * H_update; // I_4x4 because state dimension is 4
+  Matrix pUpdatedCovarianceExpected = I_KH * pCovarianceBeforeUpdate * I_KH.transpose() + K_gain * measurement_noise_R * K_gain.transpose();
+
+  EXPECT(assert_equal(pUpdatedExpected, ekf.state(), 1e-9));
+  EXPECT(assert_equal(pUpdatedCovarianceExpected, ekf.covariance(), 1e-9));
+}
+
 int main() {
   TestResult tr;
   return TestRegistry::runAllTests(tr);

--- a/gtsam/navigation/tests/testManifoldEKF.cpp
+++ b/gtsam/navigation/tests/testManifoldEKF.cpp
@@ -30,7 +30,7 @@ using namespace gtsam;
 namespace exampleUnit3 {
 
   // Predicts the next state given current state, tangent velocity, and dt
-  Unit3 predictNextState(const Unit3& p, const Vector2& v, double dt) {
+  Unit3 f(const Unit3& p, const Vector2& v, double dt) {
     return p.retract(v * dt);
   }
 
@@ -76,13 +76,13 @@ TEST(ManifoldEKF_Unit3, Predict) {
 
   // --- Prepare inputs for ManifoldEKF::predict ---
   // 1. Compute expected next state
-  Unit3 p_next_expected = exampleUnit3::predictNextState(data.p0, data.velocity, data.dt);
+  Unit3 p_next_expected = exampleUnit3::f(data.p0, data.velocity, data.dt);
 
   // 2. Compute state transition Jacobian F = d(local(p_next)) / d(local(p))
-  //    We can compute this numerically using the predictNextState function.
+  //    We can compute this numerically using the f function.
   //    GTSAM's numericalDerivative handles derivatives *between* manifolds.
   auto predict_wrapper = [&](const Unit3& p) -> Unit3 {
-    return exampleUnit3::predictNextState(p, data.velocity, data.dt);
+    return exampleUnit3::f(p, data.velocity, data.dt);
     };
   Matrix2 F = numericalDerivative11<Unit3, Unit3>(predict_wrapper, data.p0);
 
@@ -100,7 +100,7 @@ TEST(ManifoldEKF_Unit3, Predict) {
   // Check F manually for a simple case (e.g., zero velocity should give Identity)
   Vector2 zero_velocity = Vector2::Zero();
   auto predict_wrapper_zero = [&](const Unit3& p) -> Unit3 {
-    return exampleUnit3::predictNextState(p, zero_velocity, data.dt);
+    return exampleUnit3::f(p, zero_velocity, data.dt);
     };
   Matrix2 F_zero = numericalDerivative11<Unit3, Unit3>(predict_wrapper_zero, data.p0);
   EXPECT(assert_equal<Matrix2>(I_2x2, F_zero, 1e-8));
@@ -152,23 +152,19 @@ namespace exampleDynamicMatrix {
 
   // Predicts the next state given current state (Matrix), tangent "velocity" (Vector), and dt.
   // For Matrix (a VectorSpace type), Retract(M, v) is typically M + v.
-  Matrix predictNextState(const Matrix& p, const Vector& vTangent, double dt) {
+  Matrix f(const Matrix& p, const Vector& vTangent, double dt) {
     return traits<Matrix>::Retract(p, vTangent * dt);
   }
 
   // Define a measurement model: measure the trace of the Matrix (assumed 2x2 here)
   // H is the Jacobian dh/d(flatten(p))
-  double measureTrace(const Matrix& p, OptionalJacobian<-1, -1> H_opt = {}) {
-    if (H_opt) {
+  double h(const Matrix& p, OptionalJacobian<-1, -1> H = {}) {
+    if (H) {
       // The Jacobian H = d(trace)/d(flatten(p)) will be 1xN, where N is p.size().
       // For a 2x2 matrix, N=4, so H is 1x4: [1, 0, 0, 1].
-      Matrix H = Matrix::Zero(1, p.size());
-      if (p.rows() >= 2 && p.cols() >= 2) { // Ensure it's at least 2x2 for trace definition
-        H(0, 0) = 1.0; // d(trace)/dp00
-        H(0, p.rows() * (p.cols() - 1) + (p.rows() - 1)) = 1.0; // d(trace)/dp11 (for col-major)
-        // For 2x2: H(0, 2*1 + 1) = H(0,3)
-      }
-      *H_opt = H;
+      H->resize(1, p.size());
+      (*H)(0, 0) = 1.0; // d(trace)/dp00
+      (*H)(0, p.rows() * (p.cols() - 1) + (p.rows() - 1)) = 1.0; // d(trace)/dp11 (for col-major)
     }
     if (p.rows() < 1 || p.cols() < 1) return 0.0; // Or throw error
     double trace = 0.0;
@@ -181,69 +177,63 @@ namespace exampleDynamicMatrix {
 } // namespace exampleDynamicMatrix
 
 TEST(ManifoldEKF_DynamicMatrix, CombinedPredictAndUpdate) {
-  Matrix p_initial = (Matrix(2, 2) << 1.0, 2.0, 3.0, 4.0).finished();
-  Matrix P_initial = I_4x4 * 0.01; // Covariance for 2x2 matrix (4x4)
-  Vector v_tangent = (Vector(4) << 0.5, 0.1, -0.1, -0.5).finished(); // [dp00, dp10, dp01, dp11]/sec
-  double dt = 0.1;
-  Matrix Q = I_4x4 * 0.001; // Process noise covariance (4x4)
-  Matrix R = Matrix::Identity(1, 1) * 0.005; // Measurement noise covariance (1x1)
+  Matrix pInitial = (Matrix(2, 2) << 1.0, 2.0, 3.0, 4.0).finished();
+  Matrix pInitialCovariance = I_4x4 * 0.01; // Covariance for 2x2 matrix (4x4)
+  Vector vTangent = (Vector(4) << 0.5, 0.1, -0.1, -0.5).finished(); // [dp00, dp10, dp01, dp11]/sec
+  double deltaTime = 0.1;
+  Matrix processNoiseCovariance = I_4x4 * 0.001; // Process noise covariance (4x4)
+  Matrix measurementNoiseCovariance = Matrix::Identity(1, 1) * 0.005; // Measurement noise covariance (1x1)
 
-  ManifoldEKF<Matrix> ekf(p_initial, P_initial);
+  ManifoldEKF<Matrix> ekf(pInitial, pInitialCovariance);
   // For a 2x2 Matrix, tangent space dimension is 2*2=4.
   EXPECT_LONGS_EQUAL(4, ekf.state().size());
-  EXPECT_LONGS_EQUAL(p_initial.rows() * p_initial.cols(), ekf.state().size());
+  EXPECT_LONGS_EQUAL(pInitial.rows() * pInitial.cols(), ekf.state().size());
 
   // Predict Step
-  Matrix p_predicted_mean = exampleDynamicMatrix::predictNextState(p_initial, v_tangent, dt);
+  Matrix pPredictedMean = exampleDynamicMatrix::f(pInitial, vTangent, deltaTime);
 
-  // For this linear prediction model (p_next = p_current + V*dt in tangent space),
-  // Derivative w.r.t delta_xi is Identity.
-  Matrix F = I_4x4;
+  // For this linear prediction model (pNext = pCurrent + V*dt in tangent space),
+  // Derivative w.r.t deltaXi is Identity.
+  Matrix fJacobian = I_4x4;
 
-  ekf.predict(p_predicted_mean, F, Q);
+  ekf.predict(pPredictedMean, fJacobian, processNoiseCovariance);
 
-  EXPECT(assert_equal(p_predicted_mean, ekf.state(), 1e-9));
-  Matrix P_predicted_expected = F * P_initial * F.transpose() + Q;
-  EXPECT(assert_equal(P_predicted_expected, ekf.covariance(), 1e-9));
+  EXPECT(assert_equal(pPredictedMean, ekf.state(), 1e-9));
+  Matrix pPredictedCovarianceExpected = fJacobian * pInitialCovariance * fJacobian.transpose() + processNoiseCovariance;
+  EXPECT(assert_equal(pPredictedCovarianceExpected, ekf.covariance(), 1e-9));
 
   // Update Step
-  Matrix p_current_for_update = ekf.state();
-  Matrix P_current_for_update = ekf.covariance();
+  Matrix pCurrentForUpdate = ekf.state();
+  Matrix pCurrentCovarianceForUpdate = ekf.covariance();
 
-  // True trace of p_current_for_update (which is p_predicted_mean)
-  // p_predicted_mean = p_initial + v_tangent*dt
-  // = [1.0, 2.0; 3.0, 4.0] + [0.05, -0.01; 0.01, -0.05] (v_tangent reshaped to 2x2 col-major)
-  // Trace = 1.05 + 3.95 = 5.0
-  double z_true = exampleDynamicMatrix::measureTrace(p_current_for_update);
-  EXPECT_DOUBLES_EQUAL(5.0, z_true, 1e-9);
-  double z_observed = z_true - 0.03;
+  // True trace of pCurrentForUpdate (which is pPredictedMean)
+  double zTrue = exampleDynamicMatrix::h(pCurrentForUpdate);
+  EXPECT_DOUBLES_EQUAL(5.0, zTrue, 1e-9);
+  double zObserved = zTrue - 0.03;
 
-  ekf.update(exampleDynamicMatrix::measureTrace, z_observed, R);
+  ekf.update(exampleDynamicMatrix::h, zObserved, measurementNoiseCovariance);
 
   // Manual Kalman Update Steps for Verification
-  Matrix H(1, 4); // Measurement Jacobian H (1x4 for 2x2 matrix, trace measurement)
-  double z_prediction_manual = exampleDynamicMatrix::measureTrace(p_current_for_update, H);
-  Matrix H_expected = (Matrix(1, 4) << 1.0, 0.0, 0.0, 1.0).finished();
-  EXPECT(assert_equal(H_expected, H, 1e-9));
+  Matrix hJacobian(1, 4); // Measurement Jacobian H (1x4 for 2x2 matrix, trace measurement)
+  double zPredictionManual = exampleDynamicMatrix::h(pCurrentForUpdate, hJacobian);
+  Matrix hJacobianExpected = (Matrix(1, 4) << 1.0, 0.0, 0.0, 1.0).finished();
+  EXPECT(assert_equal(hJacobianExpected, hJacobian, 1e-9));
 
+  // Innovation: y = zObserved - zPredictionManual (since measurement is double)
+  double yInnovation = zObserved - zPredictionManual;
+  Matrix innovationCovariance = hJacobian * pCurrentCovarianceForUpdate * hJacobian.transpose() + measurementNoiseCovariance;
 
-  // Innovation: y = z_observed - z_prediction_manual (since measurement is double)
-  double y_innovation = z_observed - z_prediction_manual;
-  Matrix S = H * P_current_for_update * H.transpose() + R; // S is 1x1
-
-  Matrix K_gain = P_current_for_update * H.transpose() * S.inverse(); // K is 4x1
+  Matrix kalmanGain = pCurrentCovarianceForUpdate * hJacobian.transpose() * innovationCovariance.inverse(); // K is 4x1
 
   // State Correction (in tangent space of Matrix)
-  Vector delta_xi_tangent = K_gain * y_innovation; // delta_xi is 4x1 Vector
+  Vector deltaXiTangent = kalmanGain * yInnovation; // deltaXi is 4x1 Vector
 
-  Matrix p_updated_manual_expected = traits<Matrix>::Retract(p_current_for_update, delta_xi_tangent);
-  Matrix P_updated_manual_expected = (I_4x4 - K_gain * H) * P_current_for_update;
+  Matrix pUpdatedManualExpected = traits<Matrix>::Retract(pCurrentForUpdate, deltaXiTangent);
+  Matrix pUpdatedCovarianceManualExpected = (I_4x4 - kalmanGain * hJacobian) * pCurrentCovarianceForUpdate;
 
-  EXPECT(assert_equal(p_updated_manual_expected, ekf.state(), 1e-9));
-  EXPECT(assert_equal(P_updated_manual_expected, ekf.covariance(), 1e-9));
+  EXPECT(assert_equal(pUpdatedManualExpected, ekf.state(), 1e-9));
+  EXPECT(assert_equal(pUpdatedCovarianceManualExpected, ekf.covariance(), 1e-9));
 }
-
-
 
 int main() {
   TestResult tr;


### PR DESCRIPTION
- made ManifoldEKF, LieGroupEKF, and InvariantEKF work with dynamic types, e.g. Matrix
- added 3 tests to make sure it works
- open: tests for Manifold and LieGroup would be better if vector of Manifolds, real Lie Groups rather than VectorSpace.