### PR TITLE
Hybrid Improvements

### DIFF
--- a/gtsam/discrete/DiscreteBayesNet.cpp
+++ b/gtsam/discrete/DiscreteBayesNet.cpp
@@ -71,7 +71,7 @@ DiscreteValues DiscreteBayesNet::sample(DiscreteValues result) const {
 
 /* ************************************************************************* */
 // The implementation is: build the entire joint into one factor and then prune.
-// NOTE: This can be quite expensive *unless* the factors have already
+// NOTE(Frank): This can be quite expensive *unless* the factors have already
 // been pruned before. Another, possibly faster approach is branch and bound
 // search to find the K-best leaves and then create a single pruned conditional.
 DiscreteBayesNet DiscreteBayesNet::prune(

--- a/gtsam/discrete/DiscreteBayesNet.cpp
+++ b/gtsam/discrete/DiscreteBayesNet.cpp
@@ -71,16 +71,14 @@ DiscreteValues DiscreteBayesNet::sample(DiscreteValues result) const {
 
 /* ************************************************************************* */
 // The implementation is: build the entire joint into one factor and then prune.
-// TODO(Frank): This can be quite expensive *unless* the factors have already
+// NOTE: This can be quite expensive *unless* the factors have already
 // been pruned before. Another, possibly faster approach is branch and bound
 // search to find the K-best leaves and then create a single pruned conditional.
 DiscreteBayesNet DiscreteBayesNet::prune(
     size_t maxNrLeaves, const std::optional<double>& marginalThreshold,
     DiscreteValues* fixedValues) const {
   // Multiply into one big conditional. NOTE: possibly quite expensive.
-  DiscreteConditional joint;
-  for (const DiscreteConditional::shared_ptr& conditional : *this)
-    joint = joint * (*conditional);
+  DiscreteConditional joint = this->joint();
 
   // Prune the joint. NOTE: imperative and, again, possibly quite expensive.
   DiscreteConditional pruned = joint;
@@ -120,6 +118,15 @@ DiscreteBayesNet DiscreteBayesNet::prune(
   DiscreteBayesNet result;
   if (pruned.keys().size() > 0) result.push_back(pruned);
   return result;
+}
+
+/* *********************************************************************** */
+DiscreteConditional DiscreteBayesNet::joint() const {
+  DiscreteConditional joint;
+  for (const DiscreteConditional::shared_ptr& conditional : *this)
+    joint = joint * (*conditional);
+
+  return joint;
 }
 
 /* *********************************************************************** */

--- a/gtsam/discrete/DiscreteBayesNet.h
+++ b/gtsam/discrete/DiscreteBayesNet.h
@@ -136,6 +136,16 @@ class GTSAM_EXPORT DiscreteBayesNet: public BayesNet<DiscreteConditional> {
                            const std::optional<double>& marginalThreshold = {},
                            DiscreteValues* fixedValues = nullptr) const;
 
+    /**
+     * @brief Multiply all conditionals into one big joint conditional
+     * and return it.
+     *
+     * NOTE: possibly quite expensive.
+     *
+     * @return DiscreteConditional
+     */
+    DiscreteConditional joint() const;
+
     ///@}
     /// @name Wrapper support
     /// @{

--- a/gtsam/discrete/TableFactor.cpp
+++ b/gtsam/discrete/TableFactor.cpp
@@ -108,7 +108,9 @@ static Eigen::SparseVector<double> ComputeSparseTable(
    *
    */
   auto op = [&](const Assignment<Key>& assignment, double p) {
-    if (p > 0) {
+    // Check if greater than 1e-11 because we consider
+    // smaller than that as numerically 0
+    if (p > 1e-11) {
       // Get all the keys involved in this assignment
       KeySet assignmentKeys;
       for (auto&& [k, _] : assignment) {

--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -53,11 +53,11 @@ HybridBayesNet HybridBayesNet::prune(
 
   // Prune discrete Bayes net
   DiscreteValues fixed;
-  auto prunedBN = marginal.prune(maxNrLeaves, marginalThreshold, &fixed);
+  DiscreteBayesNet prunedBN =
+      marginal.prune(maxNrLeaves, marginalThreshold, &fixed);
 
   // Multiply into one big conditional. NOTE: possibly quite expensive.
-  DiscreteConditional pruned;
-  for (auto &&conditional : prunedBN) pruned = pruned * (*conditional);
+  DiscreteConditional pruned = prunedBN.joint();
 
   // Set the fixed values if requested.
   if (marginalThreshold && fixedValues) {

--- a/gtsam/hybrid/HybridSmoother.h
+++ b/gtsam/hybrid/HybridSmoother.h
@@ -145,8 +145,19 @@ class GTSAM_EXPORT HybridSmoother {
   Ordering maybeComputeOrdering(const HybridGaussianFactorGraph& updatedGraph,
                                 const std::optional<Ordering> givenOrdering);
 
-  /// Remove fixed discrete values for discrete keys introduced in `newFactors`.
-  void removeFixedValues(const HybridGaussianFactorGraph& newFactors);
+  /**
+   * @brief Remove fixed discrete values for discrete keys
+   * introduced in `newFactors`, and reintroduce discrete factors
+   * with marginalThreshold_ as the probability value.
+   *
+   * @param graph The factor graph with previous conditionals added in.
+   * @param newFactors The new factors added to the smoother,
+   * used to check if a fixed discrete value has been reintroduced.
+   * @return HybridGaussianFactorGraph
+   */
+  HybridGaussianFactorGraph removeFixedValues(
+      const HybridGaussianFactorGraph& graph,
+      const HybridGaussianFactorGraph& newFactors);
 };
 
 }  // namespace gtsam

--- a/gtsam/hybrid/hybrid.i
+++ b/gtsam/hybrid/hybrid.i
@@ -152,6 +152,7 @@ class HybridBayesNet {
   gtsam::HybridGaussianFactorGraph toFactorGraph(
       const gtsam::VectorValues& measurements) const;
 
+  gtsam::DiscreteBayesNet discreteMarginal() const;
   gtsam::GaussianBayesNet choose(const gtsam::DiscreteValues& assignment) const;
 
   gtsam::HybridValues optimize() const;


### PR DESCRIPTION
1. Add a factor with the Dead Mode Removal marginal threshold when a discrete variable which was removed is added back again. This helps to get back information which improves the performance in later steps by allowing for Dead Mode Removal to operate better.
2. Update `TableFactor` to only record probabilities above 1e-11. This helps keep the TableFactor smaller and improve sparsity.
3. Added `DiscreteBayesNet::joint` as a new method since it is a common operation.

Here is an illustrative example:
Say we have a HybridBayesNet with the conditionals
$BN = P(X(0) | M(0))P(M(0))$
where `X(0)` is a continuous variable and `M(0)` is a discrete variable. Assuming `P(M(0))` was `0.1, 0.9`, then DMR (with threshold 0.85) would remove this conditional and assign `M(0)=1`.

In the next update step, we add the factor $\phi(X(1), M(0))$, and the discrete measurement $\phi(M(0))$. Note that we have reintroduced `M(0)` again and there is new information.
From our previous step, `M(0) = 1`, but the new factors might make it such that `M(0)=0` is the better assignment.
The way I handle that is to reintroduce `P(M(0)) = {0.15, 0.85}` so we get the graph:
$FG = \phi(X(1), M(0)) \phi(M(0)) P(M(0))$.
This way, when we eliminate the information from the previous and current steps are fused giving us a better estimate of `M(0)`.