### PR TITLE
Add Multi RobotKeyFormatter as an external variable (Windows)

### DIFF
--- a/gtsam/inference/Key.cpp
+++ b/gtsam/inference/Key.cpp
@@ -28,6 +28,7 @@ namespace gtsam {
 
 /// Assign default key formatter
 KeyFormatter DefaultKeyFormatter = &_defaultKeyFormatter;
+KeyFormatter MultiRobotKeyFormatter = &_multirobotKeyFormatter;
 
 /* ************************************************************************* */
 string _defaultKeyFormatter(Key key) {

--- a/gtsam/inference/Key.h
+++ b/gtsam/inference/Key.h
@@ -57,8 +57,7 @@ GTSAM_EXPORT std::string _multirobotKeyFormatter(gtsam::Key key);
 /// formatter in print functions.
 ///
 /// Checks for LabeledSymbol, Symbol and then plain keys, in order.
-static const gtsam::KeyFormatter MultiRobotKeyFormatter =
-    &_multirobotKeyFormatter;
+extern GTSAM_EXPORT KeyFormatter MultiRobotKeyFormatter; 
 
 /// To use the key_formatter on Keys, they must be wrapped in a StreamedKey.
 struct StreamedKey {


### PR DESCRIPTION
This PR is a fix for Windows users, just like the default formatter was exported, MultiRobotKeyFormatter also needs to be exported in order to compile correctly.

P.S.: I would like to thank you prof. Frank Dellaert and your group, your work is a treasure.

```diff
- static const gtsam::KeyFormatter MultiRobotKeyFormatter = &_multirobotKeyFormatter;
+ extern GTSAM_EXPORT KeyFormatter MultiRobotKeyFormatter; 
```