### PR TITLE
Updated wrapper for HybridValues

### DIFF
--- a/.github/workflows/build-special.yml
+++ b/.github/workflows/build-special.yml
@@ -201,20 +201,23 @@ jobs:
         if: runner.os == 'Linux'
         shell: bash
         run: |
+          # Attempts to create and enable a swap file at /mnt/swapfile.
+          # It tries different sizes (8G, 4G, 2G, 1G) until successful.
           set -euo pipefail
           SWAP=/mnt/swapfile
           sudo swapoff $SWAP 2>/dev/null || true
           sudo rm -f $SWAP
-
+          
           for SIZE in 8 4 2 1; do
             if sudo fallocate -l ${SIZE}G $SWAP; then
               sudo chmod 600 $SWAP
               sudo mkswap $SWAP
               sudo swapon $SWAP && break
-            fi
-            sudo rm -f $SWAP
-          done
-
+              fi
+              sudo rm -f $SWAP
+              done
+              
+          # Displays active swap spaces at the end.
           swapon --show
 
       - name: Build & Test

--- a/.github/workflows/build-special.yml
+++ b/.github/workflows/build-special.yml
@@ -197,11 +197,25 @@ jobs:
           echo "GTSAM_BUILD_UNSTABLE=OFF" >> $GITHUB_ENV
           echo "GTSAM 'unstable' will not be built."
 
-      - name: Set Swap Space
+      - name: Create swap (Linux only)
         if: runner.os == 'Linux'
-        uses: pierotofy/set-swap-space@master
-        with:
-          swap-size-gb: 8
+        shell: bash
+        run: |
+          set -euo pipefail
+          SWAP=/mnt/swapfile
+          sudo swapoff $SWAP 2>/dev/null || true
+          sudo rm -f $SWAP
+
+          for SIZE in 8 4 2 1; do
+            if sudo fallocate -l ${SIZE}G $SWAP; then
+              sudo chmod 600 $SWAP
+              sudo mkswap $SWAP
+              sudo swapon $SWAP && break
+            fi
+            sudo rm -f $SWAP
+          done
+
+          swapon --show
 
       - name: Build & Test
         run: |

--- a/gtsam/hybrid/HybridValues.cpp
+++ b/gtsam/hybrid/HybridValues.cpp
@@ -27,7 +27,6 @@ namespace gtsam {
 HybridValues::HybridValues(const VectorValues& cv, const DiscreteValues& dv)
     : continuous_(cv), discrete_(dv) {}
 
-/* ************************************************************************* */
 HybridValues::HybridValues(const VectorValues& cv, const DiscreteValues& dv,
                            const Values& v)
     : continuous_(cv), discrete_(dv), nonlinear_(v) {}
@@ -44,7 +43,6 @@ void HybridValues::print(const std::string& s,
   nonlinear_.print("  Nonlinear", keyFormatter);
 }
 
-/* ************************************************************************* */
 bool HybridValues::equals(const HybridValues& other, double tol) const {
   return continuous_.equals(other.continuous_, tol) &&
          discrete_.equals(other.discrete_, tol);
@@ -53,24 +51,19 @@ bool HybridValues::equals(const HybridValues& other, double tol) const {
 /* ************************************************************************* */
 const VectorValues& HybridValues::continuous() const { return continuous_; }
 
-/* ************************************************************************* */
 const DiscreteValues& HybridValues::discrete() const { return discrete_; }
 
-/* ************************************************************************* */
 const Values& HybridValues::nonlinear() const { return nonlinear_; }
 
 /* ************************************************************************* */
 bool HybridValues::existsVector(Key j) { return continuous_.exists(j); }
 
-/* ************************************************************************* */
 bool HybridValues::existsDiscrete(Key j) {
   return (discrete_.find(j) != discrete_.end());
 }
 
-/* ************************************************************************* */
 bool HybridValues::existsNonlinear(Key j) { return nonlinear_.exists(j); }
 
-/* ************************************************************************* */
 bool HybridValues::exists(Key j) {
   return existsVector(j) || existsDiscrete(j) || existsNonlinear(j);
 }
@@ -82,42 +75,31 @@ HybridValues HybridValues::retract(const VectorValues& delta) const {
 }
 
 /* ************************************************************************* */
-void HybridValues::insert(Key j, const Vector& value) {
+HybridValues& HybridValues::insert(Key j, const Vector& value) {
   continuous_.insert(j, value);
+  return *this;
 }
 
-/* ************************************************************************* */
-void HybridValues::insert(Key j, size_t value) { discrete_[j] = value; }
-
-/* ************************************************************************* */
-void HybridValues::insert_or_assign(Key j, const Vector& value) {
-  continuous_.insert_or_assign(j, value);
-}
-
-/* ************************************************************************* */
-void HybridValues::insert_or_assign(Key j, size_t value) {
+HybridValues& HybridValues::insert(Key j, size_t value) { 
   discrete_[j] = value;
+  return *this;
 }
 
-/* ************************************************************************* */
 HybridValues& HybridValues::insert(const VectorValues& values) {
   continuous_.insert(values);
   return *this;
 }
 
-/* ************************************************************************* */
 HybridValues& HybridValues::insert(const DiscreteValues& values) {
   discrete_.insert(values);
   return *this;
 }
 
-/* ************************************************************************* */
 HybridValues& HybridValues::insert(const Values& values) {
   nonlinear_.insert(values);
   return *this;
 }
 
-/* ************************************************************************* */
 HybridValues& HybridValues::insert(const HybridValues& values) {
   continuous_.insert(values.continuous());
   discrete_.insert(values.discrete());
@@ -126,9 +108,17 @@ HybridValues& HybridValues::insert(const HybridValues& values) {
 }
 
 /* ************************************************************************* */
-Vector& HybridValues::at(Key j) { return continuous_.at(j); }
+void HybridValues::insert_or_assign(Key j, const Vector& value) {
+  continuous_.insert_or_assign(j, value);
+}
+
+void HybridValues::insert_or_assign(Key j, size_t value) {
+  discrete_[j] = value;
+}
 
 /* ************************************************************************* */
+Vector& HybridValues::at(Key j) { return continuous_.at(j); }
+
 size_t& HybridValues::atDiscrete(Key j) { return discrete_.at(j); }
 
 /* ************************************************************************* */
@@ -137,13 +127,16 @@ HybridValues& HybridValues::update(const VectorValues& values) {
   return *this;
 }
 
-/* ************************************************************************* */
 HybridValues& HybridValues::update(const DiscreteValues& values) {
   discrete_.update(values);
   return *this;
 }
 
-/* ************************************************************************* */
+HybridValues& HybridValues::update(const Values& values) {
+  nonlinear_.update(values);
+  return *this;
+}
+
 HybridValues& HybridValues::update(const HybridValues& values) {
   continuous_.update(values.continuous());
   discrete_.update(values.discrete());

--- a/gtsam/hybrid/HybridValues.h
+++ b/gtsam/hybrid/HybridValues.h
@@ -95,20 +95,38 @@ class GTSAM_EXPORT HybridValues {
   /// Check whether a variable with key \c j exists.
   bool exists(Key j);
 
-  /** Add a delta config to current config and returns a new config */
+  /**
+   * Add a delta config to current config and returns a new config.
+   * @param delta The delta to be added.
+   * @note This function applies the delta to the  nonlinear values, while keeping
+   * the continuous and discrete values unchanged.
+   */
   HybridValues retract(const VectorValues& delta) const;
 
   /** Insert a vector \c value with key \c j.  Throws an invalid_argument
    * exception if the key \c j is already used.
    * @param value The vector to be inserted.
    * @param j The index with which the value will be associated. */
-  void insert(Key j, const Vector& value);
+  HybridValues& insert(Key j, const Vector& value);
 
   /** Insert a discrete \c value with key \c j.  Replaces the existing value if
    * the key \c j is already used.
    * @param value The vector to be inserted.
    * @param j The index with which the value will be associated. */
-  void insert(Key j, size_t value);
+  HybridValues& insert(Key j, size_t value);
+
+  /**
+   * Insert a nonlinear value with key \c j. Throws an invalid_argument
+   * exception if the key \c j is already used.
+   * @tparam T The type of value to insert.
+   * @param j The index with which the value will be associated.
+   * @param value The value to be inserted.
+   */
+  template <typename T>
+  HybridValues& insertNonlinear(Key j, const T& value) {
+    nonlinear_.insert<T>(j, value);
+    return *this;
+  }
 
   /// insert_or_assign() , similar to Values.h
   void insert_or_assign(Key j, const Vector& value);
@@ -155,6 +173,12 @@ class GTSAM_EXPORT HybridValues {
    * std::out_of_range if any keys in \c values are not present in this object.
    */
   HybridValues& update(const DiscreteValues& values);
+
+  /** For all key/value pairs in \c values, replace nonlinear values with
+   * corresponding keys in this object with those in \c values.  Throws
+   * std::out_of_range if any keys in \c values are not present in this object.
+   */
+  HybridValues& update(const Values& values);
 
   /** For all key/value pairs in \c values, replace all values with
    * corresponding keys in this object with those in \c values.  Throws

--- a/gtsam/hybrid/doc/HybridValues.ipynb
+++ b/gtsam/hybrid/doc/HybridValues.ipynb
@@ -1,0 +1,358 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# HybridValues"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/hybrid/doc/HybridValues.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "id": "a7158ed5",
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      },
+      "outputs": [],
+      "source": [
+        "try:\n",
+        "    import google.colab\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "except ImportError:\n",
+        "    pass  # Not running on Colab, do nothing"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "5dfef865",
+      "metadata": {},
+      "source": [
+        "`HybridValues` is a container class in GTSAM designed to hold results from hybrid inference. It stores three types of variable assignments simultaneously:\n",
+        "\n",
+        "1.  **Continuous `VectorValues`**: Stores vector-valued assignments for continuous variables, typically used with Gaussian factors/conditionals (`gtsam.GaussianFactor`, `gtsam.GaussianConditional`).\n",
+        "2.  **Discrete `DiscreteValues`**: Stores assignments (unsigned integers) for discrete variables (`gtsam.DiscreteKey`, `gtsam.DiscreteFactor`).\n",
+        "3.  **Nonlinear `Values`**: Stores assignments for variables living on manifolds, used with nonlinear factors (`gtsam.NonlinearFactor`).\n",
+        "\n",
+        "It provides a unified way to represent the complete state (or solution) in a hybrid system."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "id": "7788e3ad",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "\n",
+        "from gtsam import (\n",
+        "    HybridValues, VectorValues, DiscreteValues, Values, Pose2\n",
+        ")\n",
+        "from gtsam.symbol_shorthand import X, D"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "ccd7fac8",
+      "metadata": {},
+      "source": [
+        "## Initialization"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "id": "f3f164e1",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Empty HybridValues:\n",
+            "HybridValues: \n",
+            "  Continuous: 0 elements\n",
+            "  Discrete: \n",
+            "  Nonlinear\n",
+            "Values with 0 values:\n",
+            "\n",
+            "HybridValues from VectorValues and DiscreteValues:\n",
+            "HybridValues: \n",
+            "  Continuous: 2 elements\n",
+            "  x0: 1 2\n",
+            "  x1: 3\n",
+            "  Discrete: (d0, 1)(d1, 0)\n",
+            "  Nonlinear\n",
+            "Values with 0 values:\n",
+            "\n",
+            "HybridValues from all three types:\n",
+            "HybridValues: \n",
+            "  Continuous: 2 elements\n",
+            "  x0: 1 2\n",
+            "  x1: 3\n",
+            "  Discrete: (d0, 1)(d1, 0)\n",
+            "  Nonlinear\n",
+            "Values with 1 values:\n",
+            "Value x5: (class gtsam::Pose2)\n",
+            "(1, 2, 0.3)\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "# 1. Default constructor (empty)\n",
+        "hybrid_values_empty = HybridValues()\n",
+        "print(\"Empty HybridValues:\")\n",
+        "hybrid_values_empty.print()\n",
+        "\n",
+        "# 2. From VectorValues and DiscreteValues\n",
+        "vec_vals = VectorValues()\n",
+        "vec_vals.insert(X(0), np.array([1.0, 2.0]))\n",
+        "vec_vals.insert(X(1), np.array([3.0]))\n",
+        "\n",
+        "disc_vals = DiscreteValues()\n",
+        "disc_vals[D(0)] = 1\n",
+        "disc_vals[D(1)] = 0\n",
+        "\n",
+        "hybrid_values_vd = HybridValues(vec_vals, disc_vals)\n",
+        "print(\"\\nHybridValues from VectorValues and DiscreteValues:\")\n",
+        "hybrid_values_vd.print()\n",
+        "\n",
+        "# 3. From VectorValues, DiscreteValues, and Nonlinear Values\n",
+        "nonlinear_vals = Values()\n",
+        "nonlinear_vals.insert(X(5), Pose2(1, 2, 0.3)) # Example nonlinear type\n",
+        "\n",
+        "hybrid_values_all = HybridValues(vec_vals, disc_vals, nonlinear_vals)\n",
+        "print(\"\\nHybridValues from all three types:\")\n",
+        "hybrid_values_all.print()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "5d32a2ba",
+      "metadata": {},
+      "source": [
+        "## Accessing Values\n",
+        "\n",
+        "Methods are provided to access the underlying containers and check for key existence."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "id": "1f0cac8e",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "Accessed Continuous Values size: 2\n",
+            "Accessed Discrete Values size: 2\n",
+            "Accessed Nonlinear Values size: 1\n",
+            "\n",
+            "Exists Vector X(0)? True\n",
+            "Exists Discrete D(1)? True\n",
+            "Exists Nonlinear X(5)? True\n",
+            "Exists Vector D(0)? False\n",
+            "Exists X(0)? True\n",
+            "Exists D(0)? True\n",
+            "Exists X(5)? True\n",
+            "\n",
+            "Value at X(0): [1. 2.]\n",
+            "Value at D(0): 1\n",
+            "Value at X(5): (1, 2, 0.3)\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Access underlying containers\n",
+        "cont_vals = hybrid_values_all.continuous()\n",
+        "disc_vals_acc = hybrid_values_all.discrete()\n",
+        "nonlin_vals_acc = hybrid_values_all.nonlinear()\n",
+        "\n",
+        "print(f\"\\nAccessed Continuous Values size: {cont_vals.size()}\")\n",
+        "print(f\"Accessed Discrete Values size: {len(disc_vals_acc)}\") # DiscreteValues acts like dict\n",
+        "print(f\"Accessed Nonlinear Values size: {nonlin_vals_acc.size()}\")\n",
+        "\n",
+        "# Check existence\n",
+        "print(f\"\\nExists Vector X(0)? {hybrid_values_all.existsVector(X(0))}\")\n",
+        "print(f\"Exists Discrete D(1)? {hybrid_values_all.existsDiscrete(D(1))}\")\n",
+        "print(f\"Exists Nonlinear X(5)? {hybrid_values_all.existsNonlinear(X(5))}\")\n",
+        "print(f\"Exists Vector D(0)? {hybrid_values_all.existsVector(D(0))}\") # False\n",
+        "\n",
+        "# exists() checks across all types (nonlinear checked first)\n",
+        "print(f\"Exists X(0)? {hybrid_values_all.exists(X(0))}\") # Checks VectorValues\n",
+        "print(f\"Exists D(0)? {hybrid_values_all.exists(D(0))}\") # Checks DiscreteValues\n",
+        "print(f\"Exists X(5)? {hybrid_values_all.exists(X(5))}\") # Checks Nonlinear Values\n",
+        "\n",
+        "# Access specific values\n",
+        "print(f\"\\nValue at X(0): {hybrid_values_all.at(X(0))}\")\n",
+        "print(f\"Value at D(0): {hybrid_values_all.discrete()[D(0)]}\")\n",
+        "print(f\"Value at X(5): {hybrid_values_all.nonlinear().atPose2(X(5))}\") # Use type-specific getter"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "2d60d49e",
+      "metadata": {},
+      "source": [
+        "## Modifying Values (Insert, Update, Retract)\n",
+        "\n",
+        "Values can be inserted individually or from other containers. `update` modifies existing keys, while `insert` adds new keys. `retract` applies a delta to the continuous VectorValues part."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "id": "a7214ff6",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "After individual inserts:\n",
+            "HybridValues: \n",
+            "  Continuous: 1 elements\n",
+            "  x10: 1\n",
+            "  Discrete: (d10, 1)\n",
+            "  Nonlinear\n",
+            "Values with 0 values:\n",
+            "\n",
+            "After container inserts:\n",
+            "HybridValues: \n",
+            "  Continuous: 2 elements\n",
+            "  x10: 1\n",
+            "  x12: 5\n",
+            "  Discrete: (d10, 1)(d11, 0)\n",
+            "  Nonlinear\n",
+            "Values with 0 values:\n",
+            "\n",
+            "After update:\n",
+            "HybridValues: \n",
+            "  Continuous: 2 elements\n",
+            "  x10: 99\n",
+            "  x12: 5\n",
+            "  Discrete: (d10, 2)(d11, 0)\n",
+            "  Nonlinear\n",
+            "Values with 0 values:\n",
+            "\n",
+            "After retract:\n",
+            "HybridValues: \n",
+            "  Continuous: 2 elements\n",
+            "  x10: 99\n",
+            "  x12: 5\n",
+            "  Discrete: (d10, 2)(d11, 0)\n",
+            "  Nonlinear\n",
+            "Values with 0 values:\n",
+            "\n",
+            "Original (unchanged by retract):\n",
+            "HybridValues: \n",
+            "  Continuous: 2 elements\n",
+            "  x10: 99\n",
+            "  x12: 5\n",
+            "  Discrete: (d10, 2)(d11, 0)\n",
+            "  Nonlinear\n",
+            "Values with 0 values:\n",
+            "\n",
+            "After insert_or_assign:\n",
+            "HybridValues: \n",
+            "  Continuous: 3 elements\n",
+            "  x10: 100\n",
+            "  x12: 5\n",
+            "  x13: 13\n",
+            "  Discrete: (d10, 2)(d11, 0)(d12, 1)\n",
+            "  Nonlinear\n",
+            "Values with 0 values:\n"
+          ]
+        }
+      ],
+      "source": [
+        "hv = HybridValues()\n",
+        "\n",
+        "# Insert individual values\n",
+        "hv.insert(X(10), np.array([1.0])) # Vector value\n",
+        "hv.insert(D(10), 1)             # Discrete value\n",
+        "\n",
+        "print(\"After individual inserts:\")\n",
+        "hv.print()\n",
+        "\n",
+        "# Insert from containers\n",
+        "new_vec = VectorValues()\n",
+        "new_vec.insert(X(12), np.array([5.0]))\n",
+        "new_disc = DiscreteValues()\n",
+        "new_disc[D(11)] = 0\n",
+        "\n",
+        "hv.insert(new_vec)\n",
+        "hv.insert(new_disc)\n",
+        "print(\"\\nAfter container inserts:\")\n",
+        "hv.print()\n",
+        "\n",
+        "# Update existing values\n",
+        "update_vec = VectorValues()\n",
+        "update_vec.insert(X(10), np.array([99.0]))\n",
+        "update_disc = DiscreteValues()\n",
+        "update_disc[D(10)] = 2\n",
+        "\n",
+        "hv.update(update_vec)\n",
+        "hv.update(update_disc)\n",
+        "print(\"\\nAfter update:\")\n",
+        "hv.print()\n",
+        "\n",
+        "# Retract (applies delta to VectorValues part)\n",
+        "delta = VectorValues()\n",
+        "delta.insert(X(10), np.array([-1.0]))\n",
+        "delta.insert(X(12), np.array([0.5]))\n",
+        "\n",
+        "hv_retracted = hv.retract(delta)\n",
+        "print(\"\\nAfter retract:\")\n",
+        "hv_retracted.print()\n",
+        "print(\"\\nOriginal (unchanged by retract):\")\n",
+        "hv.print() # Original is not modified\n",
+        "\n",
+        "# Insert or assign\n",
+        "# Replaces if exists, inserts if not.\n",
+        "hv.insert_or_assign(X(10), np.array([100.0])) # Overwrites X(10)\n",
+        "hv.insert_or_assign(D(12), 1) # Inserts D(12)\n",
+        "hv.insert_or_assign(X(13), np.array([13.0])) # Inserts X(13)\n",
+        "print(\"\\nAfter insert_or_assign:\")\n",
+        "hv.print()"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "gtsam",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.13.1"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/gtsam/hybrid/doc/HybridValues.ipynb
+++ b/gtsam/hybrid/doc/HybridValues.ipynb
@@ -17,7 +17,6 @@
     {
       "cell_type": "code",
       "execution_count": 1,
-      "id": "a7158ed5",
       "metadata": {
         "tags": [
           "remove-cell"
@@ -34,37 +33,35 @@
     },
     {
       "cell_type": "markdown",
-      "id": "5dfef865",
+      "id": "9c1d5e4c",
       "metadata": {},
       "source": [
         "`HybridValues` is a container class in GTSAM designed to hold results from hybrid inference. It stores three types of variable assignments simultaneously:\n",
         "\n",
-        "1.  **Continuous `VectorValues`**: Stores vector-valued assignments for continuous variables, typically used with Gaussian factors/conditionals (`gtsam.GaussianFactor`, `gtsam.GaussianConditional`).\n",
-        "2.  **Discrete `DiscreteValues`**: Stores assignments (unsigned integers) for discrete variables (`gtsam.DiscreteKey`, `gtsam.DiscreteFactor`).\n",
-        "3.  **Nonlinear `Values`**: Stores assignments for variables living on manifolds, used with nonlinear factors (`gtsam.NonlinearFactor`).\n",
+        "1.  **Continuous `VectorValues`**: Stores vector-valued assignments for continuous variables, typically used with Gaussian factors/conditionals (`gtsam.GaussianFactor`, `gtsam.GaussianConditional`). Keys are often denoted with `V(index)`.\n",
+        "2.  **Discrete `DiscreteValues`**: Stores assignments (unsigned integers) for discrete variables (`gtsam.DiscreteKey`, `gtsam.DiscreteFactor`). Keys are often denoted with `D(index)`.\n",
+        "3.  **Nonlinear `Values`**: Stores assignments for variables living on manifolds, used with nonlinear factors (`gtsam.NonlinearFactor`). Keys are often denoted with `M(index)` (or other symbols like `X` if more generic).\n",
         "\n",
         "It provides a unified way to represent the complete state (or solution) in a hybrid system."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
-      "id": "7788e3ad",
+      "execution_count": null,
+      "id": "f649cde1",
       "metadata": {},
       "outputs": [],
       "source": [
         "import gtsam\n",
         "import numpy as np\n",
         "\n",
-        "from gtsam import (\n",
-        "    HybridValues, VectorValues, DiscreteValues, Values, Pose2\n",
-        ")\n",
-        "from gtsam.symbol_shorthand import X, D"
+        "from gtsam import HybridValues, VectorValues, DiscreteValues, Values, Pose2\n",
+        "from gtsam.symbol_shorthand import V, D, M  # Use V, D, M for keys"
       ]
     },
     {
       "cell_type": "markdown",
-      "id": "ccd7fac8",
+      "id": "1f06af85",
       "metadata": {},
       "source": [
         "## Initialization"
@@ -73,7 +70,7 @@
     {
       "cell_type": "code",
       "execution_count": 3,
-      "id": "f3f164e1",
+      "id": "2d0c69ee",
       "metadata": {},
       "outputs": [
         {
@@ -90,8 +87,8 @@
             "HybridValues from VectorValues and DiscreteValues:\n",
             "HybridValues: \n",
             "  Continuous: 2 elements\n",
-            "  x0: 1 2\n",
-            "  x1: 3\n",
+            "  v0: 1 2\n",
+            "  v1: 3\n",
             "  Discrete: (d0, 1)(d1, 0)\n",
             "  Nonlinear\n",
             "Values with 0 values:\n",
@@ -99,12 +96,12 @@
             "HybridValues from all three types:\n",
             "HybridValues: \n",
             "  Continuous: 2 elements\n",
-            "  x0: 1 2\n",
-            "  x1: 3\n",
+            "  v0: 1 2\n",
+            "  v1: 3\n",
             "  Discrete: (d0, 1)(d1, 0)\n",
             "  Nonlinear\n",
             "Values with 1 values:\n",
-            "Value x5: (class gtsam::Pose2)\n",
+            "Value m5: (gtsam::Pose2)\n",
             "(1, 2, 0.3)\n",
             "\n"
           ]
@@ -118,8 +115,8 @@
         "\n",
         "# 2. From VectorValues and DiscreteValues\n",
         "vec_vals = VectorValues()\n",
-        "vec_vals.insert(X(0), np.array([1.0, 2.0]))\n",
-        "vec_vals.insert(X(1), np.array([3.0]))\n",
+        "vec_vals.insert(V(0), np.array([1.0, 2.0]))\n",
+        "vec_vals.insert(V(1), np.array([3.0]))\n",
         "\n",
         "disc_vals = DiscreteValues()\n",
         "disc_vals[D(0)] = 1\n",
@@ -131,7 +128,7 @@
         "\n",
         "# 3. From VectorValues, DiscreteValues, and Nonlinear Values\n",
         "nonlinear_vals = Values()\n",
-        "nonlinear_vals.insert(X(5), Pose2(1, 2, 0.3)) # Example nonlinear type\n",
+        "nonlinear_vals.insert(M(5), Pose2(1, 2, 0.3)) # Example nonlinear type\n",
         "\n",
         "hybrid_values_all = HybridValues(vec_vals, disc_vals, nonlinear_vals)\n",
         "print(\"\\nHybridValues from all three types:\")\n",
@@ -140,7 +137,7 @@
     },
     {
       "cell_type": "markdown",
-      "id": "5d32a2ba",
+      "id": "3c78f991",
       "metadata": {},
       "source": [
         "## Accessing Values\n",
@@ -151,7 +148,7 @@
     {
       "cell_type": "code",
       "execution_count": 4,
-      "id": "1f0cac8e",
+      "id": "0a5e1fbe",
       "metadata": {},
       "outputs": [
         {
@@ -160,21 +157,31 @@
           "text": [
             "\n",
             "Accessed Continuous Values size: 2\n",
+            "Accessed Continuous Values:: 2 elements\n",
+            "  v0: 1 2\n",
+            "  v1: 3\n",
             "Accessed Discrete Values size: 2\n",
             "Accessed Nonlinear Values size: 1\n",
+            "Accessed Nonlinear Values:\n",
+            "Values with 1 values:\n",
+            "Value m5: (gtsam::Pose2)\n",
+            "(1, 2, 0.3)\n",
             "\n",
-            "Exists Vector X(0)? True\n",
+            "\n",
+            "Exists Vector V(0)? True\n",
             "Exists Discrete D(1)? True\n",
-            "Exists Nonlinear X(5)? True\n",
+            "Exists Nonlinear M(5)? True\n",
             "Exists Vector D(0)? False\n",
-            "Exists X(0)? True\n",
-            "Exists D(0)? True\n",
-            "Exists X(5)? True\n",
+            "Exists V(0) (any type)? True\n",
+            "Exists D(0) (any type)? True\n",
+            "Exists M(5) (any type)? True\n",
             "\n",
-            "Value at X(0): [1. 2.]\n",
-            "Value at D(0): 1\n",
-            "Value at X(5): (1, 2, 0.3)\n",
-            "\n"
+            "Value at V(0): [1. 2.]\n",
+            "Value at D(0) (via atDiscrete): 1\n",
+            "Value at D(0) (via discrete() dict access): 1\n",
+            "Value at M(5): (1, 2, 0.3)\n",
+            "\n",
+            "Accessed Discrete Values:: (d0, 1)(d1, 0)\n"
           ]
         }
       ],
@@ -185,40 +192,44 @@
         "nonlin_vals_acc = hybrid_values_all.nonlinear()\n",
         "\n",
         "print(f\"\\nAccessed Continuous Values size: {cont_vals.size()}\")\n",
+        "cont_vals.print(\"Accessed Continuous Values:\")\n",
         "print(f\"Accessed Discrete Values size: {len(disc_vals_acc)}\") # DiscreteValues acts like dict\n",
+        "gtsam.PrintDiscreteValues(disc_vals_acc,\"Accessed Discrete Values:\")\n",
         "print(f\"Accessed Nonlinear Values size: {nonlin_vals_acc.size()}\")\n",
+        "nonlin_vals_acc.print(\"Accessed Nonlinear Values:\")\n",
         "\n",
         "# Check existence\n",
-        "print(f\"\\nExists Vector X(0)? {hybrid_values_all.existsVector(X(0))}\")\n",
+        "print(f\"\\nExists Vector V(0)? {hybrid_values_all.existsVector(V(0))}\")\n",
         "print(f\"Exists Discrete D(1)? {hybrid_values_all.existsDiscrete(D(1))}\")\n",
-        "print(f\"Exists Nonlinear X(5)? {hybrid_values_all.existsNonlinear(X(5))}\")\n",
-        "print(f\"Exists Vector D(0)? {hybrid_values_all.existsVector(D(0))}\") # False\n",
+        "print(f\"Exists Nonlinear M(5)? {hybrid_values_all.existsNonlinear(M(5))}\")\n",
+        "print(f\"Exists Vector D(0)? {hybrid_values_all.existsVector(D(0))}\") # False, D(0) is a discrete key\n",
         "\n",
-        "# exists() checks across all types (nonlinear checked first)\n",
-        "print(f\"Exists X(0)? {hybrid_values_all.exists(X(0))}\") # Checks VectorValues\n",
-        "print(f\"Exists D(0)? {hybrid_values_all.exists(D(0))}\") # Checks DiscreteValues\n",
-        "print(f\"Exists X(5)? {hybrid_values_all.exists(X(5))}\") # Checks Nonlinear Values\n",
+        "# exists() checks across all types (nonlinear, then vector, then discrete)\n",
+        "print(f\"Exists V(0) (any type)? {hybrid_values_all.exists(V(0))}\") # Checks VectorValues\n",
+        "print(f\"Exists D(0) (any type)? {hybrid_values_all.exists(D(0))}\") # Checks DiscreteValues\n",
+        "print(f\"Exists M(5) (any type)? {hybrid_values_all.exists(M(5))}\") # Checks Nonlinear Values\n",
         "\n",
         "# Access specific values\n",
-        "print(f\"\\nValue at X(0): {hybrid_values_all.at(X(0))}\")\n",
-        "print(f\"Value at D(0): {hybrid_values_all.discrete()[D(0)]}\")\n",
-        "print(f\"Value at X(5): {hybrid_values_all.nonlinear().atPose2(X(5))}\") # Use type-specific getter"
+        "print(f\"\\nValue at V(0): {hybrid_values_all.at(V(0))}\")\n",
+        "print(f\"Value at D(0) (via atDiscrete): {hybrid_values_all.atDiscrete(D(0))}\") \n",
+        "print(f\"Value at D(0) (via discrete() dict access): {hybrid_values_all.discrete()[D(0)]}\")\n",
+        "print(f\"Value at M(5): {hybrid_values_all.nonlinear().atPose2(M(5))}\") # Use type-specific getter from nonlinear() part"
       ]
     },
     {
       "cell_type": "markdown",
-      "id": "2d60d49e",
+      "id": "2f4c779c",
       "metadata": {},
       "source": [
         "## Modifying Values (Insert, Update, Retract)\n",
         "\n",
-        "Values can be inserted individually or from other containers. `update` modifies existing keys, while `insert` adds new keys. `retract` applies a delta to the continuous VectorValues part."
+        "Values can be inserted individually or from other containers. `update` modifies existing keys if they exist, while `insert` typically adds new keys (or might error/overwrite for some specific insert methods if key already exists). `insert_or_assign` will update if the key exists, or insert if it's new. `retract` applies a delta primarily to the `nonlinearValues_` part."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
-      "id": "a7214ff6",
+      "execution_count": 5,
+      "id": "25c0a8da",
       "metadata": {},
       "outputs": [
         {
@@ -228,56 +239,28 @@
             "After individual inserts:\n",
             "HybridValues: \n",
             "  Continuous: 1 elements\n",
-            "  x10: 1\n",
+            "  v10: 1 2\n",
             "  Discrete: (d10, 1)\n",
             "  Nonlinear\n",
-            "Values with 0 values:\n",
+            "Values with 1 values:\n",
+            "Value m11: (gtsam::Pose2)\n",
+            "(0.1, 0.2, 0.03)\n",
+            "\n",
             "\n",
             "After container inserts:\n",
             "HybridValues: \n",
             "  Continuous: 2 elements\n",
-            "  x10: 1\n",
-            "  x12: 5\n",
+            "  v10: 1 2\n",
+            "  v12: 5\n",
             "  Discrete: (d10, 1)(d11, 0)\n",
             "  Nonlinear\n",
-            "Values with 0 values:\n",
+            "Values with 2 values:\n",
+            "Value m11: (gtsam::Pose2)\n",
+            "(0.1, 0.2, 0.03)\n",
             "\n",
-            "After update:\n",
-            "HybridValues: \n",
-            "  Continuous: 2 elements\n",
-            "  x10: 99\n",
-            "  x12: 5\n",
-            "  Discrete: (d10, 2)(d11, 0)\n",
-            "  Nonlinear\n",
-            "Values with 0 values:\n",
-            "\n",
-            "After retract:\n",
-            "HybridValues: \n",
-            "  Continuous: 2 elements\n",
-            "  x10: 99\n",
-            "  x12: 5\n",
-            "  Discrete: (d10, 2)(d11, 0)\n",
-            "  Nonlinear\n",
-            "Values with 0 values:\n",
-            "\n",
-            "Original (unchanged by retract):\n",
-            "HybridValues: \n",
-            "  Continuous: 2 elements\n",
-            "  x10: 99\n",
-            "  x12: 5\n",
-            "  Discrete: (d10, 2)(d11, 0)\n",
-            "  Nonlinear\n",
-            "Values with 0 values:\n",
-            "\n",
-            "After insert_or_assign:\n",
-            "HybridValues: \n",
-            "  Continuous: 3 elements\n",
-            "  x10: 100\n",
-            "  x12: 5\n",
-            "  x13: 13\n",
-            "  Discrete: (d10, 2)(d11, 0)(d12, 1)\n",
-            "  Nonlinear\n",
-            "Values with 0 values:\n"
+            "Value m15: (gtsam::Pose2)\n",
+            "(1, 1, 0)\n",
+            "\n"
           ]
         }
       ],
@@ -285,58 +268,160 @@
         "hv = HybridValues()\n",
         "\n",
         "# Insert individual values\n",
-        "hv.insert(X(10), np.array([1.0])) # Vector value\n",
-        "hv.insert(D(10), 1)             # Discrete value\n",
+        "hv.insert(V(10), np.array([1.0, 2.0])) # Vector value, goes into hv.continuous()\n",
+        "hv.insert(D(10), 1)                    # Discrete value, goes into hv.discrete()\n",
+        "hv.insertNonlinear(M(11), Pose2(0.1, 0.2, 0.03)) # Nonlinear value, goes into hv.nonlinear()\n",
         "\n",
         "print(\"After individual inserts:\")\n",
         "hv.print()\n",
         "\n",
         "# Insert from containers\n",
         "new_vec = VectorValues()\n",
-        "new_vec.insert(X(12), np.array([5.0]))\n",
+        "new_vec.insert(V(12), np.array([5.0]))\n",
         "new_disc = DiscreteValues()\n",
         "new_disc[D(11)] = 0\n",
+        "new_nonlin = Values()\n",
+        "new_nonlin.insert(M(15), Pose2(1,1,0))\n",
         "\n",
-        "hv.insert(new_vec)\n",
-        "hv.insert(new_disc)\n",
+        "hv.insert(new_vec)      # Merges into hv.continuous()\n",
+        "hv.insert(new_disc)     # Merges into hv.discrete()\n",
+        "hv.insert(new_nonlin)   # Merges into hv.nonlinear()\n",
         "print(\"\\nAfter container inserts:\")\n",
-        "hv.print()\n",
-        "\n",
+        "hv.print()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "id": "00eeee4e",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "After update:\n",
+            "HybridValues: \n",
+            "  Continuous: 2 elements\n",
+            "  v10: 99 98\n",
+            "  v12: 5\n",
+            "  Discrete: (d10, 2)(d11, 0)\n",
+            "  Nonlinear\n",
+            "Values with 2 values:\n",
+            "Value m11: (gtsam::Pose2)\n",
+            "(0.5, 0.6, 0.07)\n",
+            "\n",
+            "Value m15: (gtsam::Pose2)\n",
+            "(1, 1, 0)\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
         "# Update existing values\n",
         "update_vec = VectorValues()\n",
-        "update_vec.insert(X(10), np.array([99.0]))\n",
+        "update_vec.insert(V(10), np.array([99.0, 98.0]))\n",
         "update_disc = DiscreteValues()\n",
         "update_disc[D(10)] = 2\n",
+        "update_nonlin = Values()\n",
+        "update_nonlin.insert(M(11), Pose2(0.5,0.6,0.07))\n",
         "\n",
         "hv.update(update_vec)\n",
         "hv.update(update_disc)\n",
+        "hv.update(update_nonlin)\n",
         "print(\"\\nAfter update:\")\n",
-        "hv.print()\n",
+        "hv.print()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "id": "e5b10c13",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "After retract (M(11) should change, V(10) should not):\n",
+            "HybridValues: \n",
+            "  Continuous: 2 elements\n",
+            "  v10: 99 98\n",
+            "  v12: 5\n",
+            "  Discrete: (d10, 2)(d11, 0)\n",
+            "  Nonlinear\n",
+            "Values with 2 values:\n",
+            "Value m11: (gtsam::Pose2)\n",
+            "(0.553375, 0.55362, 0.08)\n",
+            "\n",
+            "Value m15: (gtsam::Pose2)\n",
+            "(1, 1, 0)\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Retract (applies delta to the nonlinearValues_ part of HybridValues)\n",
+        "# Note: The continuous_ (VectorValues) part is NOT retracted by HybridValues.retract itself.\n",
+        "delta_nl = VectorValues() # Deltas are always VectorValues\n",
+        "# Create a delta for the Pose2 at M(11). M(11) current value: Pose2(0.5,0.6,0.07)\n",
+        "delta_pose2_M11 = np.array([0.05, -0.05, 0.01]) # dx, dy, dtheta\n",
+        "delta_nl.insert(M(11), delta_pose2_M11)\n",
         "\n",
-        "# Retract (applies delta to VectorValues part)\n",
-        "delta = VectorValues()\n",
-        "delta.insert(X(10), np.array([-1.0]))\n",
-        "delta.insert(X(12), np.array([0.5]))\n",
-        "\n",
-        "hv_retracted = hv.retract(delta)\n",
-        "print(\"\\nAfter retract:\")\n",
-        "hv_retracted.print()\n",
-        "print(\"\\nOriginal (unchanged by retract):\")\n",
-        "hv.print() # Original is not modified\n",
-        "\n",
+        "hv_retracted = hv.retract(delta_nl)\n",
+        "print(\"\\nAfter retract (M(11) should change, V(10) should not):\")\n",
+        "hv_retracted.print()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "id": "263a8269",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "After insert_or_assign (for V and D keys):\n",
+            "HybridValues: \n",
+            "  Continuous: 3 elements\n",
+            "  v10: 100 101\n",
+            "  v12: 5\n",
+            "  v13: 13\n",
+            "  Discrete: (d10, 2)(d11, 0)(d12, 1)\n",
+            "  Nonlinear\n",
+            "Values with 2 values:\n",
+            "Value m11: (gtsam::Pose2)\n",
+            "(0.5, 0.6, 0.07)\n",
+            "\n",
+            "Value m15: (gtsam::Pose2)\n",
+            "(1, 1, 0)\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
         "# Insert or assign\n",
         "# Replaces if exists, inserts if not.\n",
-        "hv.insert_or_assign(X(10), np.array([100.0])) # Overwrites X(10)\n",
-        "hv.insert_or_assign(D(12), 1) # Inserts D(12)\n",
-        "hv.insert_or_assign(X(13), np.array([13.0])) # Inserts X(13)\n",
-        "print(\"\\nAfter insert_or_assign:\")\n",
+        "hv.insert_or_assign(V(10), np.array([100.0, 101.0])) # Overwrites V(10) in continuous_\n",
+        "hv.insert_or_assign(D(12), 1) # Inserts D(12) in discrete_\n",
+        "hv.insert_or_assign(V(13), np.array([13.0])) # Inserts V(13) in continuous_\n",
+        "# Note: insert_or_assign for nonlinear types is not directly on HybridValues.\n",
+        "# You would typically do this on the underlying Values container:\n",
+        "# hv.nonlinear().insert_or_assign(M(11), Pose2(...)) # if Values had insert_or_assign\n",
+        "# Or, more commonly, for nonlinear: hv.nonlinear().update(M(11), Pose2(...))\n",
+        "print(\"\\nAfter insert_or_assign (for V and D keys):\")\n",
         "hv.print()"
       ]
     }
   ],
   "metadata": {
     "kernelspec": {
-      "display_name": "gtsam",
+      "display_name": "py312",
       "language": "python",
       "name": "python3"
     },
@@ -350,7 +435,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.13.1"
+      "version": "3.12.6"
     }
   },
   "nbformat": 4,

--- a/gtsam/hybrid/doc/HybridValues.ipynb
+++ b/gtsam/hybrid/doc/HybridValues.ipynb
@@ -47,7 +47,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 2,
       "id": "f649cde1",
       "metadata": {},
       "outputs": [],
@@ -166,7 +166,7 @@
             "Values with 1 values:\n",
             "Value m5: (gtsam::Pose2)\n",
             "(1, 2, 0.3)\n",
-            "\n",
+            "Accessed Discrete Values:: (d0, 1)\n",
             "\n",
             "Exists Vector V(0)? True\n",
             "Exists Discrete D(1)? True\n",
@@ -181,7 +181,7 @@
             "Value at D(0) (via discrete() dict access): 1\n",
             "Value at M(5): (1, 2, 0.3)\n",
             "\n",
-            "Accessed Discrete Values:: (d0, 1)(d1, 0)\n"
+            "(d1, 0)\n"
           ]
         }
       ],

--- a/gtsam/hybrid/hybrid.i
+++ b/gtsam/hybrid/hybrid.i
@@ -4,6 +4,32 @@
 
 namespace gtsam {
 
+#include <gtsam/geometry/Cal3_S2.h>
+#include <gtsam/geometry/Cal3Bundler.h>
+#include <gtsam/geometry/Cal3DS2.h>
+#include <gtsam/geometry/Cal3f.h>
+#include <gtsam/geometry/Cal3Fisheye.h>
+#include <gtsam/geometry/Cal3Unified.h>
+#include <gtsam/geometry/EssentialMatrix.h>
+#include <gtsam/geometry/FundamentalMatrix.h>
+#include <gtsam/geometry/OrientedPlane3.h>
+#include <gtsam/geometry/PinholeCamera.h>
+#include <gtsam/geometry/Point2.h>
+#include <gtsam/geometry/Point3.h>
+#include <gtsam/geometry/Pose2.h>
+#include <gtsam/geometry/Pose3.h>
+#include <gtsam/geometry/Similarity2.h>
+#include <gtsam/geometry/Similarity3.h>
+#include <gtsam/geometry/Rot2.h>
+#include <gtsam/geometry/Rot3.h>
+#include <gtsam/geometry/SO3.h>
+#include <gtsam/geometry/SO4.h>
+#include <gtsam/geometry/SOn.h>
+#include <gtsam/geometry/StereoPoint2.h>
+#include <gtsam/geometry/Unit3.h>
+#include <gtsam/navigation/ImuBias.h>
+#include <gtsam/navigation/NavState.h>
+
 #include <gtsam/hybrid/HybridValues.h>
 class HybridValues {
   gtsam::VectorValues continuous() const;
@@ -18,16 +44,58 @@ class HybridValues {
 
   void insert(gtsam::Key j, int value);
   void insert(gtsam::Key j, const gtsam::Vector& value);
-
-  void insert_or_assign(gtsam::Key j, const gtsam::Vector& value);
-  void insert_or_assign(gtsam::Key j, size_t value);
+  
+  // Use same (important) order as in values.i
+  void insertNonlinear(size_t j, gtsam::Vector vector);
+  void insertNonlinear(size_t j, gtsam::Matrix matrix);
+  void insertNonlinear(size_t j, const gtsam::Point2& point2);
+  void insertNonlinear(size_t j, const gtsam::Point3& point3);
+  void insertNonlinear(size_t j, const gtsam::Rot2& rot2);
+  void insertNonlinear(size_t j, const gtsam::Pose2& pose2);
+  void insertNonlinear(size_t j, const gtsam::SO3& R);
+  void insertNonlinear(size_t j, const gtsam::SO4& Q);
+  void insertNonlinear(size_t j, const gtsam::SOn& P);
+  void insertNonlinear(size_t j, const gtsam::Rot3& rot3);
+  void insertNonlinear(size_t j, const gtsam::Pose3& pose3);
+  void insertNonlinear(size_t j, const gtsam::Similarity2& similarity2);
+  void insertNonlinear(size_t j, const gtsam::Similarity3& similarity3);
+  void insertNonlinear(size_t j, const gtsam::Unit3& unit3);
+  void insertNonlinear(size_t j, const gtsam::Cal3Bundler& cal3bundler);
+  void insertNonlinear(size_t j, const gtsam::Cal3f& cal3f);
+  void insertNonlinear(size_t j, const gtsam::Cal3_S2& cal3_s2);
+  void insertNonlinear(size_t j, const gtsam::Cal3DS2& cal3ds2);
+  void insertNonlinear(size_t j, const gtsam::Cal3Fisheye& cal3fisheye);
+  void insertNonlinear(size_t j, const gtsam::Cal3Unified& cal3unified);
+  void insertNonlinear(size_t j, const gtsam::EssentialMatrix& E);
+  void insertNonlinear(size_t j, const gtsam::FundamentalMatrix& F);
+  void insertNonlinear(size_t j, const gtsam::SimpleFundamentalMatrix& F);
+  void insertNonlinear(size_t j, const gtsam::OrientedPlane3& plane);
+  void insertNonlinear(size_t j, const gtsam::PinholeCamera<gtsam::Cal3Bundler>& camera);
+  void insertNonlinear(size_t j, const gtsam::PinholeCamera<gtsam::Cal3f>& camera);
+  void insertNonlinear(size_t j, const gtsam::PinholeCamera<gtsam::Cal3_S2>& camera);
+  void insertNonlinear(size_t j, const gtsam::PinholeCamera<gtsam::Cal3DS2>& camera);
+  void insertNonlinear(size_t j, const gtsam::PinholeCamera<gtsam::Cal3Fisheye>& camera);
+  void insertNonlinear(size_t j, const gtsam::PinholeCamera<gtsam::Cal3Unified>& camera);
+  void insertNonlinear(size_t j, const gtsam::PinholePose<gtsam::Cal3Bundler>& camera);
+  void insertNonlinear(size_t j, const gtsam::PinholePose<gtsam::Cal3f>& camera);
+  void insertNonlinear(size_t j, const gtsam::PinholePose<gtsam::Cal3_S2>& camera);
+  void insertNonlinear(size_t j, const gtsam::PinholePose<gtsam::Cal3DS2>& camera);
+  void insertNonlinear(size_t j, const gtsam::PinholePose<gtsam::Cal3Fisheye>& camera);
+  void insertNonlinear(size_t j, const gtsam::PinholePose<gtsam::Cal3Unified>& camera);
+  void insertNonlinear(size_t j, const gtsam::imuBias::ConstantBias& constant_bias);
+  void insertNonlinear(size_t j, const gtsam::NavState& nav_state);
+  void insertNonlinear(size_t j, double c);
 
   void insert(const gtsam::VectorValues& values);
   void insert(const gtsam::DiscreteValues& values);
   void insert(const gtsam::HybridValues& values);
 
+  void insert_or_assign(gtsam::Key j, const gtsam::Vector& value);
+  void insert_or_assign(gtsam::Key j, size_t value);
+
   void update(const gtsam::VectorValues& values);
   void update(const gtsam::DiscreteValues& values);
+  void update(const gtsam::Values& values);
   void update(const gtsam::HybridValues& values);
 
   size_t& atDiscrete(gtsam::Key j);

--- a/gtsam/hybrid/hybrid.i
+++ b/gtsam/hybrid/hybrid.i
@@ -34,9 +34,12 @@ namespace gtsam {
 class HybridValues {
   gtsam::VectorValues continuous() const;
   gtsam::DiscreteValues discrete() const;
+  gtsam::Values& nonlinear() const;
 
   HybridValues();
   HybridValues(const gtsam::VectorValues& cv, const gtsam::DiscreteValues& dv);
+  HybridValues(const gtsam::VectorValues& cv, const gtsam::DiscreteValues& dv, const gtsam::Values& v);
+
   void print(string s = "HybridValues",
              const gtsam::KeyFormatter& keyFormatter =
                  gtsam::DefaultKeyFormatter) const;
@@ -44,6 +47,8 @@ class HybridValues {
 
   void insert(gtsam::Key j, int value);
   void insert(gtsam::Key j, const gtsam::Vector& value);
+  void insert_or_assign(gtsam::Key j, const gtsam::Vector& value);
+  void insert_or_assign(gtsam::Key j, size_t value);
   
   // Use same (important) order as in values.i
   void insertNonlinear(size_t j, gtsam::Vector vector);
@@ -88,15 +93,21 @@ class HybridValues {
 
   void insert(const gtsam::VectorValues& values);
   void insert(const gtsam::DiscreteValues& values);
+  void insert(const gtsam::Values& values);
   void insert(const gtsam::HybridValues& values);
 
-  void insert_or_assign(gtsam::Key j, const gtsam::Vector& value);
-  void insert_or_assign(gtsam::Key j, size_t value);
 
   void update(const gtsam::VectorValues& values);
   void update(const gtsam::DiscreteValues& values);
   void update(const gtsam::Values& values);
   void update(const gtsam::HybridValues& values);
+
+  bool existsVector(gtsam::Key j);
+  bool existsDiscrete(gtsam::Key j);
+  bool existsNonlinear(gtsam::Key j);
+  bool exists(gtsam::Key j);
+
+  gtsam::HybridValues retract(const gtsam::VectorValues& delta) const;
 
   size_t& atDiscrete(gtsam::Key j);
   gtsam::Vector& at(gtsam::Key j);

--- a/gtsam/hybrid/hybrid.md
+++ b/gtsam/hybrid/hybrid.md
@@ -1,0 +1,38 @@
+# Hybrid
+
+The `hybrid` module provides classes and algorithms designed for inference in probabilistic graphical models involving **both discrete and continuous variables**. It extends the core concepts from the `inference` module to handle these mixed variable types, enabling the modeling and solving of systems with discrete modes, decisions, or states alongside continuous states.
+
+## Core Hybrid Concepts
+
+-   [HybridValues](doc/HybridValues.ipynb): Container holding assignments for discrete (`DiscreteValues`), continuous (`VectorValues`), and nonlinear (`Values`) variables simultaneously.
+-   [HybridFactor](doc/HybridFactor.ipynb): Abstract base class for factors involving discrete and/or continuous variables.
+-   [HybridConditional](doc/HybridConditional.ipynb): Type-erased wrapper for conditionals (Gaussian, Discrete, HybridGaussian) resulting from hybrid elimination.
+
+## Hybrid Factor Types
+
+-   [HybridNonlinearFactor](doc/HybridNonlinearFactor.ipynb): Represents a factor where a discrete choice selects among different `NonlinearFactor` (NoiseModelFactor) components, potentially with associated scalar energies.
+-   [HybridGaussianFactor](doc/HybridGaussianFactor.ipynb): Represents a factor where a discrete choice selects among different Gaussian factor components, potentially with associated scalar energies.
+-   [HybridGaussianProductFactor](doc/HybridGaussianProductFactor.ipynb): Internal decision tree structure holding pairs of `GaussianFactorGraph` and `double` scalars, used during hybrid elimination.
+
+## Hybrid Factor Graphs
+
+-   [HybridFactorGraph](doc/HybridFactorGraph.ipynb): Base class for factor graphs designed to hold hybrid factors.
+-   [HybridNonlinearFactorGraph](doc/HybridNonlinearFactorGraph.ipynb): A factor graph containing Nonlinear, Discrete, and/or `HybridNonlinearFactor` types, used to model nonlinear hybrid systems.
+-   [HybridGaussianFactorGraph](doc/HybridGaussianFactorGraph.ipynb): A factor graph containing Gaussian, Discrete, and/or `HybridGaussianFactor` types, typically resulting from linearization. Supports hybrid elimination.
+
+## Hybrid Bayes Nets and Bayes Trees
+
+-   [HybridGaussianConditional](doc/HybridGaussianConditional.ipynb): Represents a conditional density $P(X | M, Z)$ where continuous variables $X$ depend on discrete parents $M$ and continuous parents $Z$, implemented as a decision tree of `GaussianConditional`s.
+-   [HybridBayesNet](doc/HybridBayesNet.ipynb): Represents the result of sequential variable elimination on a `HybridGaussianFactorGraph` as a DAG of `HybridConditional`s.
+-   [HybridBayesTree](doc/HybridBayesTree.ipynb): Represents the result of multifrontal variable elimination on a `HybridGaussianFactorGraph` as a tree of cliques, each containing a `HybridConditional`.
+
+## Incremental Hybrid Inference
+
+-   [HybridGaussianISAM](doc/HybridGaussianISAM.ipynb): Incremental Smoothing and Mapping (ISAM) algorithm for `HybridGaussianFactorGraph`s, based on updating a `HybridBayesTree`.
+-   [HybridNonlinearISAM](doc/HybridNonlinearISAM.ipynb): Wrapper providing an ISAM interface for nonlinear hybrid problems, managing linearization and an underlying `HybridGaussianISAM`.
+-   [HybridSmoother](doc/HybridSmoother.ipynb): An incremental fixed-lag smoother interface for hybrid systems, managing updates to a `HybridBayesNet` posterior.
+
+## Hybrid Elimination Intermediates
+
+-   [HybridEliminationTree](doc/HybridEliminationTree.ipynb): Tree structure representing the dependencies during sequential elimination of a `HybridGaussianFactorGraph`.
+-   [HybridJunctionTree](doc/HybridJunctionTree.ipynb): Intermediate cluster tree structure used in multifrontal elimination, holding original factors within cliques before elimination.

--- a/gtsam/hybrid/tests/testHybridValues.cpp
+++ b/gtsam/hybrid/tests/testHybridValues.cpp
@@ -25,6 +25,7 @@
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/linear/VectorValues.h>
 #include <gtsam/nonlinear/Values.h>
+#include <gtsam/geometry/Pose2.h>
 
 // Include for test suite
 #include <CppUnitLite/TestHarness.h>
@@ -32,13 +33,14 @@
 using namespace std;
 using namespace gtsam;
 
-static const HybridValues kExample{{{99, Vector2(2, 3)}}, {{100, 3}}};
+static const HybridValues kExample{ {{99, Vector2(2, 3)}}, {{100, 3}}, Values{{22, genericValue(Pose2(1,2,3))}} };
 
 /* ************************************************************************* */
 TEST(HybridValues, Basics) {
   HybridValues values;
   values.insert(99, Vector2(2, 3));
   values.insert(100, 3);
+  values.insertNonlinear(22, Pose2(1, 2, 3));
   EXPECT(assert_equal(kExample, values));
   EXPECT(assert_equal(values.at(99), Vector2(2, 3)));
   EXPECT(assert_equal(values.atDiscrete(100), int(3)));
@@ -57,6 +59,8 @@ TEST(HybridValues, Insert) {
                       actual.insert(DiscreteValues{{100, 3}})));
   EXPECT(assert_equal(kExample,  //
                       actual.insert(VectorValues{{99, Vector2(2, 3)}})));
+  EXPECT(assert_equal(kExample,  //
+            actual.insert(Values{{22, genericValue(Pose2(1, 2, 3))}})));
   HybridValues actual2;
   EXPECT(assert_equal(kExample, actual2.insert(kExample)));
 }
@@ -69,6 +73,8 @@ TEST(HybridValues, Update) {
                       actual.update(DiscreteValues{{100, 2}})));
   EXPECT(assert_equal({{{99, Vector1(4)}}, {{100, 2}}},
                       actual.update(VectorValues{{99, Vector1(4)}})));
+  EXPECT(assert_equal({{{99, Vector1(4)}}, {{100, 2}}, Values{{22, genericValue(Pose2(4, 5, 6))}}},
+            actual.update(Values{{22, genericValue(Pose2(4, 5, 6))}})));
   HybridValues actual2(kExample);
   EXPECT(assert_equal(kExample, actual2.update(kExample)));
 }

--- a/myst.yml
+++ b/myst.yml
@@ -16,6 +16,9 @@ project:
       - file: ./gtsam/inference/inference.md
         children:
         - pattern: ./gtsam/inference/doc/*
+      - file: ./gtsam/hybrid/hybrid.md
+        children:
+        - pattern: ./gtsam/hybrid/doc/*
       - file: ./gtsam/nonlinear/nonlinear.md
         children:
         - pattern: ./gtsam/nonlinear/doc/*

--- a/python/gtsam/tests/test_HybridValues.py
+++ b/python/gtsam/tests/test_HybridValues.py
@@ -6,16 +6,15 @@ All Rights Reserved
 See LICENSE for the license information
 
 Unit tests for Hybrid Values.
-Author: Shangjie Xue
+Author: Shangjie Xue, Varun Agrawal, Frank Dellaert
 """
-# pylint: disable=invalid-name, no-name-in-module, no-member
 
-from __future__ import print_function
+# pylint: disable=invalid-name, no-name-in-module, no-member
 
 import unittest
 
 import numpy as np
-from gtsam.symbol_shorthand import C, X
+from gtsam.symbol_shorthand import D, V, M
 from gtsam.utils.test_case import GtsamTestCase
 
 import gtsam
@@ -24,19 +23,216 @@ import gtsam
 class TestHybridValues(GtsamTestCase):
     """Unit tests for HybridValues."""
 
-    def test_basic(self):
-        """Test construction and basic methods of hybrid values."""
+    def setUp(self):
+        """Set up common objects for tests."""
+        self.vector_values = gtsam.VectorValues()
+        self.vector_values.insert(V(0), np.array([1.0, 2.0]))
+        self.vector_values.insert(V(1), np.array([3.0]))
 
-        hv1 = gtsam.HybridValues()
-        hv1.insert(X(0), np.ones((3, 1)))
-        hv1.insert(C(0), 2)
+        self.discrete_values = gtsam.DiscreteValues()
+        self.discrete_values[D(0)] = 1
+        self.discrete_values[D(1)] = 0
 
-        hv2 = gtsam.HybridValues()
-        hv2.insert(C(0), 2)
-        hv2.insert(X(0), np.ones((3, 1)))
+        self.nonlinear_values = gtsam.Values()
+        self.nonlinear_values.insert(M(5), gtsam.Pose2(1, 2, 0.3))
 
-        self.assertEqual(hv1.atDiscrete(C(0)), 2)
-        self.assertEqual(hv1.at(X(0))[0], np.ones((3, 1))[0])
+    def test_constructors(self):
+        """Test various constructors."""
+        hv_empty = gtsam.HybridValues()
+        self.assertEqual(hv_empty.continuous().size(), 0)
+        self.assertEqual(len(hv_empty.discrete()), 0)
+        self.assertEqual(hv_empty.nonlinear().size(), 0)
+
+        hv_vd = gtsam.HybridValues(self.vector_values, self.discrete_values)
+        self.assertEqual(hv_vd.continuous().size(), 2)
+        self.assertEqual(len(hv_vd.discrete()), 2)
+        self.assertEqual(hv_vd.nonlinear().size(), 0)
+        self.assertTrue(hv_vd.continuous().equals(self.vector_values, 1e-9))
+        # DiscreteValues comparison needs to be element-wise or via string
+        self.assertEqual(hv_vd.discrete()[D(0)], self.discrete_values[D(0)])
+
+        hv_all = gtsam.HybridValues(
+            self.vector_values, self.discrete_values, self.nonlinear_values
+        )
+        self.assertEqual(hv_all.continuous().size(), 2)
+        self.assertEqual(len(hv_all.discrete()), 2)
+        self.assertEqual(hv_all.nonlinear().size(), 1)
+        self.assertTrue(hv_all.nonlinear().equals(self.nonlinear_values, 1e-9))
+
+    def test_accessors(self):
+        """Test accessing underlying containers."""
+        hv_all = gtsam.HybridValues(
+            self.vector_values, self.discrete_values, self.nonlinear_values
+        )
+
+        self.assertTrue(hv_all.continuous().equals(self.vector_values, 1e-9))
+        # Compare DiscreteValues content
+        retrieved_dv = hv_all.discrete()
+        self.assertEqual(len(retrieved_dv), len(self.discrete_values))
+        for k, v in self.discrete_values.items():
+            self.assertEqual(retrieved_dv[k], v)
+        self.assertTrue(hv_all.nonlinear().equals(self.nonlinear_values, 1e-9))
+
+        # Test at methods
+        self.gtsamAssertEquals(hv_all.at(V(0)), self.vector_values.at(V(0)), 1e-9)
+        self.assertEqual(hv_all.atDiscrete(D(0)), self.discrete_values[D(0)])
+        # For nonlinear, access via nonlinear().atTYPE()
+        self.assertTrue(
+            hv_all.nonlinear()
+            .atPose2(M(5))
+            .equals(self.nonlinear_values.atPose2(M(5)), 1e-9)
+        )
+
+    def test_exists(self):
+        """Test existence checks."""
+        hv_all = gtsam.HybridValues(
+            self.vector_values, self.discrete_values, self.nonlinear_values
+        )
+
+        self.assertTrue(hv_all.existsVector(V(0)))
+        self.assertFalse(hv_all.existsVector(D(0)))  # Key for discrete
+        self.assertFalse(hv_all.existsVector(M(5)))  # Key for nonlinear
+
+        self.assertTrue(hv_all.existsDiscrete(D(1)))
+        self.assertFalse(hv_all.existsDiscrete(V(0)))  # Key for vector
+
+        self.assertTrue(hv_all.existsNonlinear(M(5)))
+        self.assertFalse(hv_all.existsNonlinear(V(0)))  # Key for vector
+
+        # General exists (checks nonlinear, then vector, then discrete)
+        self.assertTrue(hv_all.exists(V(0)))  # Vector
+        self.assertTrue(hv_all.exists(D(0)))  # Discrete
+        self.assertTrue(hv_all.exists(M(5)))  # Nonlinear
+        self.assertFalse(hv_all.exists(D(7)))  # Non-existent key
+
+    def test_equals(self):
+        """Test equals method."""
+        hv1 = gtsam.HybridValues(
+            self.vector_values, self.discrete_values, self.nonlinear_values
+        )
+        hv2 = gtsam.HybridValues(
+            self.vector_values, self.discrete_values, self.nonlinear_values
+        )
+
+        self.assertTrue(hv1.equals(hv2, 1e-9))
+
+    def test_insert_individual(self):
+        """Test inserting individual values."""
+        hv = gtsam.HybridValues()
+        hv.insert(V(10), np.array([1.0]))
+        hv.insert(D(10), 1)
+        hv.insertNonlinear(M(11), gtsam.Pose2())
+
+        self.assertTrue(hv.existsVector(V(10)))
+        self.gtsamAssertEquals(hv.at(V(10)), np.array([1.0]))
+        self.assertTrue(hv.existsDiscrete(D(10)))
+        self.assertEqual(hv.atDiscrete(D(10)), 1)
+
+    def test_insert_containers(self):
+        """Test inserting from other Values containers."""
+        hv = gtsam.HybridValues()
+
+        hv.insert(self.vector_values)
+        self.assertEqual(hv.continuous().size(), 2)
+        self.assertTrue(hv.continuous().equals(self.vector_values, 1e-9))
+
+        hv.insert(self.discrete_values)
+        self.assertEqual(len(hv.discrete()), 2)
+        # Check discrete values equality
+        retrieved_dv = hv.discrete()
+        for k, v in self.discrete_values.items():
+            self.assertEqual(retrieved_dv[k], v)
+
+        hv.insert(self.nonlinear_values)
+        self.assertEqual(hv.nonlinear().size(), 1)
+        self.assertTrue(hv.nonlinear().equals(self.nonlinear_values, 1e-9))
+
+        hv_copy = gtsam.HybridValues()
+        hv_copy.insert(hv)  # Test insert(HybridValues)
+        self.assertTrue(hv_copy.equals(hv, 1e-9))
+
+    def test_insert_or_assign(self):
+        """Test insert_or_assign method."""
+        hv = gtsam.HybridValues()
+        hv.insert(V(0), np.array([1.0]))
+        hv.insert(D(0), 0)
+
+        # Test insert_or_assign for vector
+        hv.insert_or_assign(V(0), np.array([2.0]))  # Update existing
+        self.gtsamAssertEquals(hv.at(V(0)), np.array([2.0]))
+        hv.insert_or_assign(V(1), np.array([3.0]))  # Insert new
+        self.gtsamAssertEquals(hv.at(V(1)), np.array([3.0]))
+
+        # Test insert_or_assign for discrete
+        hv.insert_or_assign(D(0), 1)  # Update existing
+        self.assertEqual(hv.atDiscrete(D(0)), 1)
+        hv.insert_or_assign(D(1), 2)  # Insert new
+        self.assertEqual(hv.atDiscrete(D(1)), 2)
+
+    def test_update(self):
+        """Test update methods."""
+        hv = gtsam.HybridValues(
+            self.vector_values, self.discrete_values, self.nonlinear_values
+        )
+
+        # Update VectorValues
+        vv_update = gtsam.VectorValues()
+        vv_update.insert(V(0), np.array([10.0, 20.0]))  # Existing key
+        hv.update(vv_update)
+        self.gtsamAssertEquals(hv.at(V(0)), np.array([10.0, 20.0]))
+        self.assertEqual(hv.continuous().size(), 2)  # X0, X1
+
+        # Update DiscreteValues
+        dv_update = gtsam.DiscreteValues()
+        dv_update[D(0)] = 5  # Existing key
+        hv.update(dv_update)
+        self.assertEqual(hv.atDiscrete(D(0)), 5)
+        self.assertEqual(len(hv.discrete()), 2)  # C0, C1
+
+        # Update NonlinearValues
+        nv_update = gtsam.Values()
+        nv_update.insert(M(5), gtsam.Pose2(3, 4, 0.5))
+        hv.update(nv_update)
+        self.assertTrue(
+            hv.nonlinear().atPose2(M(5)).equals(gtsam.Pose2(3, 4, 0.5), 1e-9)
+        )
+        self.assertEqual(hv.nonlinear().size(), 1)
+
+        # Update HybridValues (only continuous and discrete parts for now)
+        hv_update_source = gtsam.HybridValues()
+        vv_source = gtsam.VectorValues()
+        vv_source.insert(V(0), np.array([-1.0, -2.0]))
+        dv_source = gtsam.DiscreteValues()
+        dv_source[D(0)] = 100
+        hv_update_source.insert(vv_source)
+        hv_update_source.insert(dv_source)
+
+        hv.update(hv_update_source)
+        self.gtsamAssertEquals(hv.at(V(0)), np.array([-1.0, -2.0]))
+        self.assertEqual(hv.atDiscrete(D(0)), 100)
+
+    def test_retract(self):
+        """Test retract method."""
+        hv = gtsam.HybridValues(
+            self.vector_values, self.discrete_values, self.nonlinear_values
+        )
+
+        delta = gtsam.VectorValues()
+        deltaM5 = np.array([0.5, 0.5, -1.0])
+        delta.insert(M(5), deltaM5)
+
+        hv_retracted = hv.retract(delta)
+
+        # Original should be unchanged
+        self.assertTrue(hv.continuous().equals(self.vector_values, 1e-9))
+
+        # Check retracted values
+        expected_M5 = hv.nonlinear().atPose2(M(5)).retract(deltaM5)
+        self.gtsamAssertEquals(hv_retracted.nonlinear().atPose2(M(5)), expected_M5)
+
+        # Check that discrete and continuous parts are copied
+        self.assertEqual(len(hv_retracted.discrete()), len(self.discrete_values))
+        self.assertEqual(hv_retracted.continuous().size(), self.vector_values.size())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Added `insertNonlinear`
- Updated wrapper for HybridValues and added docs.
- Links in Markdown currently don't work yet, should work after #2120 lands.