### PR TITLE
Fixed SLAM Example link in Pose2 Doc

### DIFF
--- a/gtsam/geometry/doc/Pose2.ipynb
+++ b/gtsam/geometry/doc/Pose2.ipynb
@@ -767,7 +767,7 @@
       },
       "source": [
         "## Example: SLAM\n",
-        "`Pose2` can be used as the basis to perform simultaneous localization and mapping (SLAM), as seen in the example [here](https://github.com/borglab/gtsam/blob/develop/python/gtsam/examples/Pose2SLAMExample.py).\n"
+        "`Pose2` can be used as the basis to perform simultaneous localization and mapping (SLAM), as seen in the example [here](https://github.com/borglab/gtsam/blob/develop/python/gtsam/examples/Pose2SLAMExample.ipynb).\n"
       ]
     }
   ],


### PR DESCRIPTION
Noticed that the link to the SLAM example in the Pose2 documentation was not working.
Fixed the path to direct to `Pose2SLAMExample.ipynb`.

Test: opened link in new tab, no more file not found error.