### PR TITLE
Add template for IMU backend selection to move away from compiler flag

### DIFF
--- a/examples/CombinedImuFactorsExample.cpp
+++ b/examples/CombinedImuFactorsExample.cpp
@@ -185,7 +185,7 @@ int main(int argc, char* argv[]) {
 
   auto p = imuParams();
 
-  std::shared_ptr<PreintegrationType> preintegrated =
+  std::shared_ptr<DefaultPreintegrationType> preintegrated =
       std::make_shared<PreintegratedCombinedMeasurements>(p, prior_imu_bias);
 
   assert(preintegrated);

--- a/examples/ImuFactorsExample.cpp
+++ b/examples/ImuFactorsExample.cpp
@@ -192,7 +192,7 @@ int main(int argc, char* argv[]) {
 
   auto p = imuParams();
 
-  std::shared_ptr<PreintegrationType> preintegrated =
+  std::shared_ptr<DefaultPreintegrationType> preintegrated =
       std::make_shared<PreintegratedImuMeasurements>(p, prior_imu_bias);
 
   assert(preintegrated);

--- a/gtsam/navigation/CombinedImuFactor.cpp
+++ b/gtsam/navigation/CombinedImuFactor.cpp
@@ -21,6 +21,8 @@
  **/
 
 #include <gtsam/navigation/CombinedImuFactor.h>
+#include <gtsam/navigation/ManifoldPreintegration.h>
+#include <gtsam/navigation/TangentPreintegration.h>
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/export.hpp>
 #endif
@@ -58,33 +60,37 @@ bool PreintegrationCombinedParams::equals(const PreintegratedRotationParams& oth
 }
 
 //------------------------------------------------------------------------------
-// Inner class PreintegratedCombinedMeasurements
+// Inner class PreintegratedCombinedMeasurementsT
 //------------------------------------------------------------------------------
-void PreintegratedCombinedMeasurements::print(const string& s) const {
-  PreintegrationType::print(s);
+template <class PreintegrationBackend>
+void PreintegratedCombinedMeasurementsT<PreintegrationBackend>::print(const string& s) const {
+  PreintegrationBackend::print(s);
   cout << "  preintMeasCov [ " << preintMeasCov_ << " ]" << endl;
 }
 
 //------------------------------------------------------------------------------
-bool PreintegratedCombinedMeasurements::equals(
-    const PreintegratedCombinedMeasurements& other, double tol) const {
-  return PreintegrationType::equals(other, tol)
+template <class PreintegrationBackend>
+bool PreintegratedCombinedMeasurementsT<PreintegrationBackend>::equals(
+    const PreintegratedCombinedMeasurementsT<PreintegrationBackend>& other, double tol) const {
+  return PreintegrationBackend::equals(other, tol)
       && equal_with_abs_tol(preintMeasCov_, other.preintMeasCov_, tol);
 }
 
 //------------------------------------------------------------------------------
-void PreintegratedCombinedMeasurements::resetIntegration() {
+template <class PreintegrationBackend>
+void PreintegratedCombinedMeasurementsT<PreintegrationBackend>::resetIntegration() {
   // Base class method to reset the preintegrated measurements
-  PreintegrationType::resetIntegration();
+  PreintegrationBackend::resetIntegration();
   preintMeasCov_.setZero();
 }
 
 //------------------------------------------------------------------------------
-void PreintegratedCombinedMeasurements::resetIntegration(
+template <class PreintegrationBackend>
+void PreintegratedCombinedMeasurementsT<PreintegrationBackend>::resetIntegration(
     const gtsam::Matrix6& Q_init) {
   // Base class method to reset the preintegrated measurements
-  PreintegrationType::resetIntegration();
-  p().biasAccOmegaInt = Q_init;
+  PreintegrationBackend::resetIntegration();
+  this->p().biasAccOmegaInt = Q_init;
   preintMeasCov_.setZero();
 }
 
@@ -103,7 +109,8 @@ void PreintegratedCombinedMeasurements::resetIntegration(
 #define D_g_g(H) (H)->block<3,3>(12,12)
 
 //------------------------------------------------------------------------------
-void PreintegratedCombinedMeasurements::integrateMeasurement(
+template <class PreintegrationBackend>
+void PreintegratedCombinedMeasurementsT<PreintegrationBackend>::integrateMeasurement(
     const Vector3& measuredAcc, const Vector3& measuredOmega, double dt) {
   if (dt <= 0) {
     throw std::runtime_error(
@@ -113,7 +120,7 @@ void PreintegratedCombinedMeasurements::integrateMeasurement(
   // Update preintegrated measurements.
   Matrix9 A; // Jacobian wrt preintegrated measurements without bias (df/dx)
   Matrix93 B, C;  // Jacobian of state wrpt accel bias and omega bias respectively.
-  PreintegrationType::update(measuredAcc, measuredOmega, dt, &A, &B, &C);
+  PreintegrationBackend::update(measuredAcc, measuredOmega, dt, &A, &B, &C);
 
   // Update preintegrated measurements covariance: as in [2] we consider a first
   // order propagation that can be seen as a prediction phase in an EKF
@@ -144,10 +151,10 @@ void PreintegratedCombinedMeasurements::integrateMeasurement(
 
   // propagate uncertainty
   // TODO(frank): use noiseModel routine so we can have arbitrary noise models.
-  const Matrix3& aCov = p().accelerometerCovariance;
-  const Matrix3& wCov = p().gyroscopeCovariance;
-  const Matrix3& iCov = p().integrationCovariance;
-  const Matrix6& bInitCov = p().biasAccOmegaInt;
+  const Matrix3& aCov = this->p().accelerometerCovariance;
+  const Matrix3& wCov = this->p().gyroscopeCovariance;
+  const Matrix3& iCov = this->p().integrationCovariance;
+  const Matrix6& bInitCov = this->p().biasAccOmegaInt;
 
   // first order uncertainty propagation
   // Optimized matrix mult: (1/dt) * G * measurementCovariance * G.transpose()
@@ -174,8 +181,8 @@ void PreintegratedCombinedMeasurements::integrateMeasurement(
       (vel_H_acc * (aCov / dt) * vel_H_acc.transpose())  //
       + (vel_H_biasAccInit * bInitCov11 * vel_H_biasAccInit.transpose());
 
-  D_a_a(&G_measCov_Gt) = dt * p().biasAccCovariance;
-  D_g_g(&G_measCov_Gt) = dt * p().biasOmegaCovariance;
+  D_a_a(&G_measCov_Gt) = dt * this->p().biasAccCovariance;
+  D_g_g(&G_measCov_Gt) = dt * this->p().biasOmegaCovariance;
 
   // OFF BLOCK DIAGONAL TERMS
   D_R_t(&G_measCov_Gt) =
@@ -197,23 +204,10 @@ void PreintegratedCombinedMeasurements::integrateMeasurement(
 }
 
 //------------------------------------------------------------------------------
-// CombinedImuFactor methods
+// CombinedImuFactorT methods
 //------------------------------------------------------------------------------
-CombinedImuFactor::CombinedImuFactor(Key pose_i, Key vel_i, Key pose_j,
-    Key vel_j, Key bias_i, Key bias_j,
-    const PreintegratedCombinedMeasurements& pim) :
-    Base(noiseModel::Gaussian::Covariance(pim.preintMeasCov_), pose_i, vel_i,
-        pose_j, vel_j, bias_i, bias_j), _PIM_(pim) {
-}
-
-//------------------------------------------------------------------------------
-gtsam::NonlinearFactor::shared_ptr CombinedImuFactor::clone() const {
-  return std::static_pointer_cast<gtsam::NonlinearFactor>(
-      gtsam::NonlinearFactor::shared_ptr(new This(*this)));
-}
-
-//------------------------------------------------------------------------------
-void CombinedImuFactor::print(const string& s,
+template <class PIMType_>
+void CombinedImuFactorT<PIMType_>::print(const string& s,
     const KeyFormatter& keyFormatter) const {
   cout << (s.empty() ? s : s + "\n") << "CombinedImuFactor("
        << keyFormatter(this->key<1>()) << "," << keyFormatter(this->key<2>()) << ","
@@ -225,13 +219,15 @@ void CombinedImuFactor::print(const string& s,
 }
 
 //------------------------------------------------------------------------------
-bool CombinedImuFactor::equals(const NonlinearFactor& other, double tol) const {
+template <class PIMType_>
+bool CombinedImuFactorT<PIMType_>::equals(const NonlinearFactor& other, double tol) const {
   const This* e = dynamic_cast<const This*>(&other);
   return e != nullptr && Base::equals(*e, tol) && _PIM_.equals(e->_PIM_, tol);
 }
 
 //------------------------------------------------------------------------------
-Vector CombinedImuFactor::evaluateError(const Pose3& pose_i,
+template <class PIMType_>
+Vector CombinedImuFactorT<PIMType_>::evaluateError(const Pose3& pose_i,
     const Vector3& vel_i, const Pose3& pose_j, const Vector3& vel_j,
     const imuBias::ConstantBias& bias_i, const imuBias::ConstantBias& bias_j,
     OptionalMatrixType H1, OptionalMatrixType H2,
@@ -296,10 +292,40 @@ Vector CombinedImuFactor::evaluateError(const Pose3& pose_i,
 }
 
 //------------------------------------------------------------------------------
-std::ostream& operator<<(std::ostream& os, const CombinedImuFactor& f) {
-  f._PIM_.print("combined preintegrated measurements:\n");
-  os << "  noise model sigmas: " << f.noiseModel_->sigmas().transpose();
+template <class PIMType_>
+std::ostream& operator<<(std::ostream& os, const CombinedImuFactorT<PIMType_>& f) {
+  f.preintegratedMeasurements().print("combined preintegrated measurements:\n");
+  os << "  noise model sigmas: " << f.noiseModel()->sigmas().transpose();
   return os;
 }
 
+//------------------------------------------------------------------------------
+// Explicit instantiations
+//------------------------------------------------------------------------------
+template class GTSAM_EXPORT PreintegratedCombinedMeasurementsT<ManifoldPreintegration>;
+template class GTSAM_EXPORT PreintegratedCombinedMeasurementsT<TangentPreintegration>;
+
+template class GTSAM_EXPORT CombinedImuFactorT<PreintegratedCombinedMeasurementsT<ManifoldPreintegration>>;
+template class GTSAM_EXPORT CombinedImuFactorT<PreintegratedCombinedMeasurementsT<TangentPreintegration>>;
+
+// Instantiate operator<<
+template GTSAM_EXPORT std::ostream& operator<<<PreintegratedCombinedMeasurementsT<ManifoldPreintegration>>(
+    std::ostream& os, const CombinedImuFactorT<PreintegratedCombinedMeasurementsT<ManifoldPreintegration>>& f);
+template GTSAM_EXPORT std::ostream& operator<<<PreintegratedCombinedMeasurementsT<TangentPreintegration>>(
+    std::ostream& os, const CombinedImuFactorT<PreintegratedCombinedMeasurementsT<TangentPreintegration>>& f);
+
+
 }  // namespace gtsam
+
+// Undefine macros to prevent scope leakage
+#undef D_R_R
+#undef D_R_t
+#undef D_R_v
+#undef D_t_R
+#undef D_t_t
+#undef D_t_v
+#undef D_v_R
+#undef D_v_t
+#undef D_v_v
+#undef D_a_a
+#undef D_g_g

--- a/gtsam/navigation/CombinedImuFactor.cpp
+++ b/gtsam/navigation/CombinedImuFactor.cpp
@@ -214,7 +214,7 @@ void CombinedImuFactorT<PIM>::print(const string& s,
        << keyFormatter(this->template key<3>()) << "," << keyFormatter(this->template key<4>()) << ","
        << keyFormatter(this->template key<5>()) << "," << keyFormatter(this->template key<6>())
        << ")\n";
-  _PIM_.print("  preintegrated measurements:");
+  pim_.print("  preintegrated measurements:");
   this->noiseModel_->print("  noise model: ");
 }
 
@@ -222,7 +222,7 @@ void CombinedImuFactorT<PIM>::print(const string& s,
 template <class PIM>
 bool CombinedImuFactorT<PIM>::equals(const NonlinearFactor& other, double tol) const {
   const This* e = dynamic_cast<const This*>(&other);
-  return e != nullptr && Base::equals(*e, tol) && _PIM_.equals(e->_PIM_, tol);
+  return e != nullptr && Base::equals(*e, tol) && pim_.equals(e->pim_, tol);
 }
 
 //------------------------------------------------------------------------------
@@ -243,7 +243,7 @@ Vector CombinedImuFactorT<PIM>::evaluateError(const Pose3& pose_i,
   Matrix93 D_r_vel_i, D_r_vel_j;
 
   // error wrt preintegrated measurements
-  Vector9 r_Rpv = _PIM_.computeErrorAndJacobians(pose_i, vel_i, pose_j, vel_j,
+  Vector9 r_Rpv = pim_.computeErrorAndJacobians(pose_i, vel_i, pose_j, vel_j,
       bias_i, H1 ? &D_r_pose_i : 0, H2 ? &D_r_vel_i : 0, H3 ? &D_r_pose_j : 0,
       H4 ? &D_r_vel_j : 0, H5 ? &D_r_bias_i : 0);
 

--- a/gtsam/navigation/CombinedImuFactor.cpp
+++ b/gtsam/navigation/CombinedImuFactor.cpp
@@ -206,8 +206,8 @@ void PreintegratedCombinedMeasurementsT<PreintegrationType>::integrateMeasuremen
 //------------------------------------------------------------------------------
 // CombinedImuFactorT methods
 //------------------------------------------------------------------------------
-template <class PIMType_>
-void CombinedImuFactorT<PIMType_>::print(const string& s,
+template <class PIM>
+void CombinedImuFactorT<PIM>::print(const string& s,
     const KeyFormatter& keyFormatter) const {
   cout << (s.empty() ? s : s + "\n") << "CombinedImuFactor("
        << keyFormatter(this->template key<1>()) << "," << keyFormatter(this->template key<2>()) << ","
@@ -219,15 +219,15 @@ void CombinedImuFactorT<PIMType_>::print(const string& s,
 }
 
 //------------------------------------------------------------------------------
-template <class PIMType_>
-bool CombinedImuFactorT<PIMType_>::equals(const NonlinearFactor& other, double tol) const {
+template <class PIM>
+bool CombinedImuFactorT<PIM>::equals(const NonlinearFactor& other, double tol) const {
   const This* e = dynamic_cast<const This*>(&other);
   return e != nullptr && Base::equals(*e, tol) && _PIM_.equals(e->_PIM_, tol);
 }
 
 //------------------------------------------------------------------------------
-template <class PIMType_>
-Vector CombinedImuFactorT<PIMType_>::evaluateError(const Pose3& pose_i,
+template <class PIM>
+Vector CombinedImuFactorT<PIM>::evaluateError(const Pose3& pose_i,
     const Vector3& vel_i, const Pose3& pose_j, const Vector3& vel_j,
     const imuBias::ConstantBias& bias_i, const imuBias::ConstantBias& bias_j,
     OptionalMatrixType H1, OptionalMatrixType H2,
@@ -292,8 +292,8 @@ Vector CombinedImuFactorT<PIMType_>::evaluateError(const Pose3& pose_i,
 }
 
 //------------------------------------------------------------------------------
-template <class PIMType_>
-std::ostream& operator<<(std::ostream& os, const CombinedImuFactorT<PIMType_>& f) {
+template <class PIM>
+std::ostream& operator<<(std::ostream& os, const CombinedImuFactorT<PIM>& f) {
   f.preintegratedMeasurements().print("combined preintegrated measurements:\n");
   os << "  noise model sigmas: " << f.noiseModel()->sigmas().transpose();
   return os;

--- a/gtsam/navigation/CombinedImuFactor.cpp
+++ b/gtsam/navigation/CombinedImuFactor.cpp
@@ -210,9 +210,9 @@ template <class PIMType_>
 void CombinedImuFactorT<PIMType_>::print(const string& s,
     const KeyFormatter& keyFormatter) const {
   cout << (s.empty() ? s : s + "\n") << "CombinedImuFactor("
-       << keyFormatter(this->key<1>()) << "," << keyFormatter(this->key<2>()) << ","
-       << keyFormatter(this->key<3>()) << "," << keyFormatter(this->key<4>()) << ","
-       << keyFormatter(this->key<5>()) << "," << keyFormatter(this->key<6>())
+       << keyFormatter(this->template key<1>()) << "," << keyFormatter(this->template key<2>()) << ","
+       << keyFormatter(this->template key<3>()) << "," << keyFormatter(this->template key<4>()) << ","
+       << keyFormatter(this->template key<5>()) << "," << keyFormatter(this->template key<6>())
        << ")\n";
   _PIM_.print("  preintegrated measurements:");
   this->noiseModel_->print("  noise model: ");

--- a/gtsam/navigation/CombinedImuFactor.cpp
+++ b/gtsam/navigation/CombinedImuFactor.cpp
@@ -316,16 +316,3 @@ template GTSAM_EXPORT std::ostream& operator<<<PreintegratedCombinedMeasurements
 
 
 }  // namespace gtsam
-
-// Undefine macros to prevent scope leakage
-#undef D_R_R
-#undef D_R_t
-#undef D_R_v
-#undef D_t_R
-#undef D_t_t
-#undef D_t_v
-#undef D_v_R
-#undef D_v_t
-#undef D_v_v
-#undef D_a_a
-#undef D_g_g

--- a/gtsam/navigation/CombinedImuFactor.cpp
+++ b/gtsam/navigation/CombinedImuFactor.cpp
@@ -62,34 +62,34 @@ bool PreintegrationCombinedParams::equals(const PreintegratedRotationParams& oth
 //------------------------------------------------------------------------------
 // Inner class PreintegratedCombinedMeasurementsT
 //------------------------------------------------------------------------------
-template <class PreintegrationBackend>
-void PreintegratedCombinedMeasurementsT<PreintegrationBackend>::print(const string& s) const {
-  PreintegrationBackend::print(s);
+template <class PreintegrationType>
+void PreintegratedCombinedMeasurementsT<PreintegrationType>::print(const string& s) const {
+  PreintegrationType::print(s);
   cout << "  preintMeasCov [ " << preintMeasCov_ << " ]" << endl;
 }
 
 //------------------------------------------------------------------------------
-template <class PreintegrationBackend>
-bool PreintegratedCombinedMeasurementsT<PreintegrationBackend>::equals(
-    const PreintegratedCombinedMeasurementsT<PreintegrationBackend>& other, double tol) const {
-  return PreintegrationBackend::equals(other, tol)
+template <class PreintegrationType>
+bool PreintegratedCombinedMeasurementsT<PreintegrationType>::equals(
+    const PreintegratedCombinedMeasurementsT<PreintegrationType>& other, double tol) const {
+  return PreintegrationType::equals(other, tol)
       && equal_with_abs_tol(preintMeasCov_, other.preintMeasCov_, tol);
 }
 
 //------------------------------------------------------------------------------
-template <class PreintegrationBackend>
-void PreintegratedCombinedMeasurementsT<PreintegrationBackend>::resetIntegration() {
+template <class PreintegrationType>
+void PreintegratedCombinedMeasurementsT<PreintegrationType>::resetIntegration() {
   // Base class method to reset the preintegrated measurements
-  PreintegrationBackend::resetIntegration();
+  PreintegrationType::resetIntegration();
   preintMeasCov_.setZero();
 }
 
 //------------------------------------------------------------------------------
-template <class PreintegrationBackend>
-void PreintegratedCombinedMeasurementsT<PreintegrationBackend>::resetIntegration(
+template <class PreintegrationType>
+void PreintegratedCombinedMeasurementsT<PreintegrationType>::resetIntegration(
     const gtsam::Matrix6& Q_init) {
   // Base class method to reset the preintegrated measurements
-  PreintegrationBackend::resetIntegration();
+  PreintegrationType::resetIntegration();
   this->p().biasAccOmegaInt = Q_init;
   preintMeasCov_.setZero();
 }
@@ -109,8 +109,8 @@ void PreintegratedCombinedMeasurementsT<PreintegrationBackend>::resetIntegration
 #define D_g_g(H) (H)->block<3,3>(12,12)
 
 //------------------------------------------------------------------------------
-template <class PreintegrationBackend>
-void PreintegratedCombinedMeasurementsT<PreintegrationBackend>::integrateMeasurement(
+template <class PreintegrationType>
+void PreintegratedCombinedMeasurementsT<PreintegrationType>::integrateMeasurement(
     const Vector3& measuredAcc, const Vector3& measuredOmega, double dt) {
   if (dt <= 0) {
     throw std::runtime_error(
@@ -120,7 +120,7 @@ void PreintegratedCombinedMeasurementsT<PreintegrationBackend>::integrateMeasure
   // Update preintegrated measurements.
   Matrix9 A; // Jacobian wrt preintegrated measurements without bias (df/dx)
   Matrix93 B, C;  // Jacobian of state wrpt accel bias and omega bias respectively.
-  PreintegrationBackend::update(measuredAcc, measuredOmega, dt, &A, &B, &C);
+  PreintegrationType::update(measuredAcc, measuredOmega, dt, &A, &B, &C);
 
   // Update preintegrated measurements covariance: as in [2] we consider a first
   // order propagation that can be seen as a prediction phase in an EKF

--- a/gtsam/navigation/CombinedImuFactor.h
+++ b/gtsam/navigation/CombinedImuFactor.h
@@ -28,9 +28,9 @@
 namespace gtsam {
 
 #ifdef GTSAM_TANGENT_PREINTEGRATION
-typedef TangentPreintegration PreintegrationType;
+typedef TangentPreintegration DefaultPreintegrationBackend;
 #else
-typedef ManifoldPreintegration PreintegrationType;
+typedef ManifoldPreintegration DefaultPreintegrationBackend;
 #endif
 
 /*
@@ -63,8 +63,8 @@ typedef ManifoldPreintegration PreintegrationType;
  *
  * @ingroup navigation
  */
-class GTSAM_EXPORT PreintegratedCombinedMeasurements
-    : public PreintegrationType {
+template <class PreintegrationBackend>
+class GTSAM_EXPORT PreintegratedCombinedMeasurementsT : public PreintegrationBackend {
  public:
   typedef PreintegrationCombinedParams Params;
 
@@ -77,45 +77,44 @@ class GTSAM_EXPORT PreintegratedCombinedMeasurements
    */
   Eigen::Matrix<double, 15, 15> preintMeasCov_;
 
-  friend class CombinedImuFactor;
+  template <class PIMType_> friend class CombinedImuFactorT;
 
  public:
   /// @name Constructors
   /// @{
 
   /// Default constructor only for serialization and wrappers
-  PreintegratedCombinedMeasurements() { resetIntegration(); }
-
+  PreintegratedCombinedMeasurementsT() { this->resetIntegration(); } 
   /**
    *  Default constructor, initializes the class with no measurements
    *  @param p Parameters, typically fixed in a single application
    *  @param biasHat Current estimate of acceleration and rotation rate biases
    *  @param preintMeasCov Covariance matrix used in noise model.
    */
-  PreintegratedCombinedMeasurements(
+  PreintegratedCombinedMeasurementsT(
       const std::shared_ptr<Params>& p,
       const imuBias::ConstantBias& biasHat = imuBias::ConstantBias(),
       const Eigen::Matrix<double, 15, 15>& preintMeasCov =
           Eigen::Matrix<double, 15, 15>::Zero())
-      : PreintegrationType(p, biasHat), preintMeasCov_(preintMeasCov) {
-    PreintegrationType::resetIntegration();
+      : PreintegrationBackend(p, biasHat), preintMeasCov_(preintMeasCov) {
+    this->resetIntegration();
   }
 
   /**
    *  Construct preintegrated directly from members: base class and
    * preintMeasCov
-   *  @param base               PreintegrationType instance
+   *  @param base               PreintegrationBackend instance
    *  @param preintMeasCov      Covariance matrix used in noise model.
    */
-  PreintegratedCombinedMeasurements(
-      const PreintegrationType& base,
+  PreintegratedCombinedMeasurementsT(
+      const PreintegrationBackend& base,
       const Eigen::Matrix<double, 15, 15>& preintMeasCov)
-      : PreintegrationType(base), preintMeasCov_(preintMeasCov) {
-    PreintegrationType::resetIntegration();
+      : PreintegrationBackend(base), preintMeasCov_(preintMeasCov) {
+    this->PreintegrationBackend::resetIntegration();
   }
 
   /// Virtual destructor
-  ~PreintegratedCombinedMeasurements() override {}
+  ~PreintegratedCombinedMeasurementsT() override {}
 
   /// @}
 
@@ -149,7 +148,7 @@ class GTSAM_EXPORT PreintegratedCombinedMeasurements
   void print(
       const std::string& s = "Preintegrated Measurements:") const override;
   /// equals
-  bool equals(const PreintegratedCombinedMeasurements& expected,
+  bool equals(const PreintegratedCombinedMeasurementsT<PreintegrationBackend>& expected,
               double tol = 1e-9) const;
   /// @}
 
@@ -179,7 +178,7 @@ class GTSAM_EXPORT PreintegratedCombinedMeasurements
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
     namespace bs = ::boost::serialization;
-    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(PreintegrationType);
+    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(PreintegrationBackend);
     ar& BOOST_SERIALIZATION_NVP(preintMeasCov_);
   }
 #endif
@@ -187,6 +186,9 @@ class GTSAM_EXPORT PreintegratedCombinedMeasurements
  public:
   GTSAM_MAKE_ALIGNED_OPERATOR_NEW
 };
+
+// For backward compatibility:
+typedef PreintegratedCombinedMeasurementsT<DefaultPreintegrationBackend> PreintegratedCombinedMeasurements;
 
 /**
  * CombinedImuFactor is a 6-ways factor involving previous state (pose and
@@ -206,31 +208,28 @@ class GTSAM_EXPORT PreintegratedCombinedMeasurements
  *
  * @ingroup navigation
  */
-class GTSAM_EXPORT CombinedImuFactor
+template <class PIMType_ = PreintegratedCombinedMeasurements>
+class GTSAM_EXPORT CombinedImuFactorT
     : public NoiseModelFactorN<Pose3, Vector3, Pose3, Vector3,
                                imuBias::ConstantBias, imuBias::ConstantBias> {
  public:
  private:
-  typedef CombinedImuFactor This;
+  typedef CombinedImuFactorT<PIMType_> This;
   typedef NoiseModelFactorN<Pose3, Vector3, Pose3, Vector3,
                             imuBias::ConstantBias, imuBias::ConstantBias>
       Base;
 
-  PreintegratedCombinedMeasurements _PIM_;
+  PIMType_ _PIM_;
 
  public:
   // Provide access to Matrix& version of evaluateError:
   using Base::evaluateError;
 
   /** Shorthand for a smart pointer to a factor */
-#if !defined(_MSC_VER) && __GNUC__ == 4 && __GNUC_MINOR__ > 5
-  typedef typename std::shared_ptr<CombinedImuFactor> shared_ptr;
-#else
-  typedef std::shared_ptr<CombinedImuFactor> shared_ptr;
-#endif
+  typedef std::shared_ptr<This> shared_ptr;
 
   /** Default constructor - only use for serialization */
-  CombinedImuFactor() {}
+  CombinedImuFactorT() {}
 
   /**
    * Constructor
@@ -242,21 +241,24 @@ class GTSAM_EXPORT CombinedImuFactor
    * @param bias_j Current bias key
    * @param PreintegratedCombinedMeasurements Combined IMU measurements
    */
-  CombinedImuFactor(
+  CombinedImuFactorT(
       Key pose_i, Key vel_i, Key pose_j, Key vel_j, Key bias_i, Key bias_j,
-      const PreintegratedCombinedMeasurements& preintegratedMeasurements);
+      const PIMType_& preintegratedMeasurements)
+      : Base(noiseModel::Gaussian::Covariance(preintegratedMeasurements.preintMeasCov()),
+             pose_i, vel_i, pose_j, vel_j, bias_i, bias_j),
+        _PIM_(preintegratedMeasurements) {}
 
-  ~CombinedImuFactor() override {}
+  ~CombinedImuFactorT() override {}
 
   /// @return a deep copy of this factor
-  gtsam::NonlinearFactor::shared_ptr clone() const override;
+  gtsam::NonlinearFactor::shared_ptr clone() const override {
+    return std::make_shared<This>(*this);
+  }
 
   /** implement functions needed for Testable */
 
   /// @name Testable
   /// @{
-  GTSAM_EXPORT friend std::ostream& operator<<(std::ostream& os,
-                                               const CombinedImuFactor&);
   /// print
   void print(const std::string& s = "", const KeyFormatter& keyFormatter =
                                             DefaultKeyFormatter) const override;
@@ -268,7 +270,7 @@ class GTSAM_EXPORT CombinedImuFactor
 
   /** Access the preintegrated measurements. */
 
-  const PreintegratedCombinedMeasurements& preintegratedMeasurements() const {
+  const PIMType_& preintegratedMeasurements() const {
     return _PIM_;
   }
 
@@ -300,17 +302,24 @@ class GTSAM_EXPORT CombinedImuFactor
  public:
   GTSAM_MAKE_ALIGNED_OPERATOR_NEW
 };
-// class CombinedImuFactor
+// class CombinedImuFactorT
+
+// For backward compatibility:
+typedef CombinedImuFactorT<> CombinedImuFactor;
+
+// operator<< for CombinedImuFactorT
+template <class PIMType_>
+GTSAM_EXPORT std::ostream& operator<<(std::ostream& os, const CombinedImuFactorT<PIMType_>& f);
 
 template <>
 struct traits<PreintegrationCombinedParams>
     : public Testable<PreintegrationCombinedParams> {};
 
-template <>
-struct traits<PreintegratedCombinedMeasurements>
-    : public Testable<PreintegratedCombinedMeasurements> {};
-
-template <>
-struct traits<CombinedImuFactor> : public Testable<CombinedImuFactor> {};
+template <class PreintegrationBackend>
+struct traits<PreintegratedCombinedMeasurementsT<PreintegrationBackend>>
+    : public Testable<PreintegratedCombinedMeasurementsT<PreintegrationBackend>> {};
+ 
+template <class PIMType_>
+struct traits<CombinedImuFactorT<PIMType_>> : public Testable<CombinedImuFactorT<PIMType_>> {};
 
 }  // namespace gtsam

--- a/gtsam/navigation/CombinedImuFactor.h
+++ b/gtsam/navigation/CombinedImuFactor.h
@@ -219,7 +219,7 @@ class GTSAM_EXPORT CombinedImuFactorT
                             imuBias::ConstantBias, imuBias::ConstantBias>
       Base;
 
-  PIM _PIM_;
+  PIM pim_;
 
  public:
   // Provide access to Matrix& version of evaluateError:
@@ -246,7 +246,7 @@ class GTSAM_EXPORT CombinedImuFactorT
       const PIM& preintegratedMeasurements)
       : Base(noiseModel::Gaussian::Covariance(preintegratedMeasurements.preintMeasCov()),
              pose_i, vel_i, pose_j, vel_j, bias_i, bias_j),
-        _PIM_(preintegratedMeasurements) {}
+        pim_(preintegratedMeasurements) {}
 
   ~CombinedImuFactorT() override {}
 
@@ -271,7 +271,7 @@ class GTSAM_EXPORT CombinedImuFactorT
   /** Access the preintegrated measurements. */
 
   const PIM& preintegratedMeasurements() const {
-    return _PIM_;
+    return pim_;
   }
 
   /** implement functions needed to derive from Factor */
@@ -295,7 +295,7 @@ class GTSAM_EXPORT CombinedImuFactorT
     // NoiseModelFactor6 instead of NoiseModelFactorN for backward compatibility
     ar& boost::serialization::make_nvp(
         "NoiseModelFactor6", boost::serialization::base_object<Base>(*this));
-    ar& BOOST_SERIALIZATION_NVP(_PIM_);
+    ar& BOOST_SERIALIZATION_NVP(pim_);
   }
 #endif
 

--- a/gtsam/navigation/CombinedImuFactor.h
+++ b/gtsam/navigation/CombinedImuFactor.h
@@ -305,7 +305,7 @@ class GTSAM_EXPORT CombinedImuFactorT
 // class CombinedImuFactorT
 
 // For backward compatibility:
-using CombinedImuFactor CombinedImuFactorT<>;
+using CombinedImuFactor = CombinedImuFactorT<>;
 
 // operator<< for CombinedImuFactorT
 template <class PIMType_>

--- a/gtsam/navigation/CombinedImuFactor.h
+++ b/gtsam/navigation/CombinedImuFactor.h
@@ -188,7 +188,7 @@ class GTSAM_EXPORT PreintegratedCombinedMeasurementsT : public PreintegrationBac
 };
 
 // For backward compatibility:
-typedef PreintegratedCombinedMeasurementsT<DefaultPreintegrationBackend> PreintegratedCombinedMeasurements;
+using PreintegratedCombinedMeasurements = PreintegratedCombinedMeasurementsT<DefaultPreintegrationBackend>;
 
 /**
  * CombinedImuFactor is a 6-ways factor involving previous state (pose and
@@ -305,7 +305,7 @@ class GTSAM_EXPORT CombinedImuFactorT
 // class CombinedImuFactorT
 
 // For backward compatibility:
-typedef CombinedImuFactorT<> CombinedImuFactor;
+using CombinedImuFactor CombinedImuFactorT<>;
 
 // operator<< for CombinedImuFactorT
 template <class PIMType_>

--- a/gtsam/navigation/CombinedImuFactor.h
+++ b/gtsam/navigation/CombinedImuFactor.h
@@ -77,7 +77,7 @@ class GTSAM_EXPORT PreintegratedCombinedMeasurementsT : public PreintegrationBac
    */
   Eigen::Matrix<double, 15, 15> preintMeasCov_;
 
-  template <class PIMType_> friend class CombinedImuFactorT;
+  template <class PIM> friend class CombinedImuFactorT;
 
  public:
   /// @name Constructors

--- a/gtsam/navigation/CombinedImuFactor.h
+++ b/gtsam/navigation/CombinedImuFactor.h
@@ -208,18 +208,18 @@ using PreintegratedCombinedMeasurements = PreintegratedCombinedMeasurementsT<Def
  *
  * @ingroup navigation
  */
-template <class PIMType_ = PreintegratedCombinedMeasurements>
+template <class PIM = PreintegratedCombinedMeasurements>
 class GTSAM_EXPORT CombinedImuFactorT
     : public NoiseModelFactorN<Pose3, Vector3, Pose3, Vector3,
                                imuBias::ConstantBias, imuBias::ConstantBias> {
  public:
  private:
-  typedef CombinedImuFactorT<PIMType_> This;
+  typedef CombinedImuFactorT<PIM> This;
   typedef NoiseModelFactorN<Pose3, Vector3, Pose3, Vector3,
                             imuBias::ConstantBias, imuBias::ConstantBias>
       Base;
 
-  PIMType_ _PIM_;
+  PIM _PIM_;
 
  public:
   // Provide access to Matrix& version of evaluateError:
@@ -243,7 +243,7 @@ class GTSAM_EXPORT CombinedImuFactorT
    */
   CombinedImuFactorT(
       Key pose_i, Key vel_i, Key pose_j, Key vel_j, Key bias_i, Key bias_j,
-      const PIMType_& preintegratedMeasurements)
+      const PIM& preintegratedMeasurements)
       : Base(noiseModel::Gaussian::Covariance(preintegratedMeasurements.preintMeasCov()),
              pose_i, vel_i, pose_j, vel_j, bias_i, bias_j),
         _PIM_(preintegratedMeasurements) {}
@@ -270,7 +270,7 @@ class GTSAM_EXPORT CombinedImuFactorT
 
   /** Access the preintegrated measurements. */
 
-  const PIMType_& preintegratedMeasurements() const {
+  const PIM& preintegratedMeasurements() const {
     return _PIM_;
   }
 
@@ -308,8 +308,8 @@ class GTSAM_EXPORT CombinedImuFactorT
 using CombinedImuFactor = CombinedImuFactorT<>;
 
 // operator<< for CombinedImuFactorT
-template <class PIMType_>
-GTSAM_EXPORT std::ostream& operator<<(std::ostream& os, const CombinedImuFactorT<PIMType_>& f);
+template <class PIM>
+GTSAM_EXPORT std::ostream& operator<<(std::ostream& os, const CombinedImuFactorT<PIM>& f);
 
 template <>
 struct traits<PreintegrationCombinedParams>
@@ -319,7 +319,7 @@ template <class PreintegrationType>
 struct traits<PreintegratedCombinedMeasurementsT<PreintegrationType>>
     : public Testable<PreintegratedCombinedMeasurementsT<PreintegrationType>> {};
  
-template <class PIMType_>
-struct traits<CombinedImuFactorT<PIMType_>> : public Testable<CombinedImuFactorT<PIMType_>> {};
+template <class PIM>
+struct traits<CombinedImuFactorT<PIM>> : public Testable<CombinedImuFactorT<PIM>> {};
 
 }  // namespace gtsam

--- a/gtsam/navigation/CombinedImuFactor.h
+++ b/gtsam/navigation/CombinedImuFactor.h
@@ -28,9 +28,9 @@
 namespace gtsam {
 
 #ifdef GTSAM_TANGENT_PREINTEGRATION
-typedef TangentPreintegration DefaultPreintegrationBackend;
+typedef TangentPreintegration DefaultPreintegrationType;
 #else
-typedef ManifoldPreintegration DefaultPreintegrationBackend;
+typedef ManifoldPreintegration DefaultPreintegrationType;
 #endif
 
 /*
@@ -63,8 +63,8 @@ typedef ManifoldPreintegration DefaultPreintegrationBackend;
  *
  * @ingroup navigation
  */
-template <class PreintegrationBackend>
-class GTSAM_EXPORT PreintegratedCombinedMeasurementsT : public PreintegrationBackend {
+template <class PreintegrationType>
+class GTSAM_EXPORT PreintegratedCombinedMeasurementsT : public PreintegrationType {
  public:
   typedef PreintegrationCombinedParams Params;
 
@@ -96,21 +96,21 @@ class GTSAM_EXPORT PreintegratedCombinedMeasurementsT : public PreintegrationBac
       const imuBias::ConstantBias& biasHat = imuBias::ConstantBias(),
       const Eigen::Matrix<double, 15, 15>& preintMeasCov =
           Eigen::Matrix<double, 15, 15>::Zero())
-      : PreintegrationBackend(p, biasHat), preintMeasCov_(preintMeasCov) {
+      : PreintegrationType(p, biasHat), preintMeasCov_(preintMeasCov) {
     this->resetIntegration();
   }
 
   /**
    *  Construct preintegrated directly from members: base class and
    * preintMeasCov
-   *  @param base               PreintegrationBackend instance
+   *  @param base               PreintegrationType instance
    *  @param preintMeasCov      Covariance matrix used in noise model.
    */
   PreintegratedCombinedMeasurementsT(
-      const PreintegrationBackend& base,
+      const PreintegrationType& base,
       const Eigen::Matrix<double, 15, 15>& preintMeasCov)
-      : PreintegrationBackend(base), preintMeasCov_(preintMeasCov) {
-    this->PreintegrationBackend::resetIntegration();
+      : PreintegrationType(base), preintMeasCov_(preintMeasCov) {
+    this->PreintegrationType::resetIntegration();
   }
 
   /// Virtual destructor
@@ -148,7 +148,7 @@ class GTSAM_EXPORT PreintegratedCombinedMeasurementsT : public PreintegrationBac
   void print(
       const std::string& s = "Preintegrated Measurements:") const override;
   /// equals
-  bool equals(const PreintegratedCombinedMeasurementsT<PreintegrationBackend>& expected,
+  bool equals(const PreintegratedCombinedMeasurementsT<PreintegrationType>& expected,
               double tol = 1e-9) const;
   /// @}
 
@@ -178,7 +178,7 @@ class GTSAM_EXPORT PreintegratedCombinedMeasurementsT : public PreintegrationBac
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
     namespace bs = ::boost::serialization;
-    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(PreintegrationBackend);
+    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(PreintegrationType);
     ar& BOOST_SERIALIZATION_NVP(preintMeasCov_);
   }
 #endif
@@ -188,7 +188,7 @@ class GTSAM_EXPORT PreintegratedCombinedMeasurementsT : public PreintegrationBac
 };
 
 // For backward compatibility:
-using PreintegratedCombinedMeasurements = PreintegratedCombinedMeasurementsT<DefaultPreintegrationBackend>;
+using PreintegratedCombinedMeasurements = PreintegratedCombinedMeasurementsT<DefaultPreintegrationType>;
 
 /**
  * CombinedImuFactor is a 6-ways factor involving previous state (pose and
@@ -315,9 +315,9 @@ template <>
 struct traits<PreintegrationCombinedParams>
     : public Testable<PreintegrationCombinedParams> {};
 
-template <class PreintegrationBackend>
-struct traits<PreintegratedCombinedMeasurementsT<PreintegrationBackend>>
-    : public Testable<PreintegratedCombinedMeasurementsT<PreintegrationBackend>> {};
+template <class PreintegrationType>
+struct traits<PreintegratedCombinedMeasurementsT<PreintegrationType>>
+    : public Testable<PreintegratedCombinedMeasurementsT<PreintegrationType>> {};
  
 template <class PIMType_>
 struct traits<CombinedImuFactorT<PIMType_>> : public Testable<CombinedImuFactorT<PIMType_>> {};

--- a/gtsam/navigation/ImuFactor.cpp
+++ b/gtsam/navigation/ImuFactor.cpp
@@ -131,7 +131,7 @@ template <class PIM>
 bool ImuFactorT<PIM>::equals(const NonlinearFactor& other, double tol) const {
   const This *e = dynamic_cast<const This*>(&other);
   const bool base = Base::equals(*e, tol);
-  const bool pim = _PIM_.equals(e->_PIM_, tol);
+  const bool pim = pim_.equals(e->pim_, tol);
   return e != nullptr && base && pim;
 }
 
@@ -142,7 +142,7 @@ Vector ImuFactorT<PIM>::evaluateError(const Pose3& pose_i, const Vector3& vel_i,
     const imuBias::ConstantBias& bias_i, OptionalMatrixType H1,
     OptionalMatrixType H2, OptionalMatrixType H3,
     OptionalMatrixType H4, OptionalMatrixType H5) const {
-  return _PIM_.computeErrorAndJacobians(pose_i, vel_i, pose_j, vel_j, bias_i,
+  return pim_.computeErrorAndJacobians(pose_i, vel_i, pose_j, vel_j, bias_i,
       H1, H2, H3, H4, H5);
 }
 
@@ -171,7 +171,7 @@ template <class PIM>
 bool ImuFactor2T<PIM>::equals(const NonlinearFactor& other, double tol) const {
   const This *e = dynamic_cast<const This*>(&other);
   const bool base = Base::equals(*e, tol);
-  const bool pim = _PIM_.equals(e->_PIM_, tol);
+  const bool pim = pim_.equals(e->pim_, tol);
   return e != nullptr && base && pim;
 }
 
@@ -182,7 +182,7 @@ Vector ImuFactor2T<PIM>::evaluateError(const NavState& state_i,
     const imuBias::ConstantBias& bias_i, //
     OptionalMatrixType H1, OptionalMatrixType H2,
     OptionalMatrixType H3) const {
-  return _PIM_.computeError(state_i, state_j, bias_i, H1, H2, H3);
+  return pim_.computeError(state_i, state_j, bias_i, H1, H2, H3);
 }
 
 //------------------------------------------------------------------------------

--- a/gtsam/navigation/ImuFactor.cpp
+++ b/gtsam/navigation/ImuFactor.cpp
@@ -34,30 +34,30 @@ using namespace std;
 //------------------------------------------------------------------------------
 // Inner class PreintegratedImuMeasurementsT
 //------------------------------------------------------------------------------
-template <class PreintegrationBackend>
-void PreintegratedImuMeasurementsT<PreintegrationBackend>::print(const string& s) const {
-  PreintegrationBackend::print(s);
+template <class PreintegrationType>
+void PreintegratedImuMeasurementsT<PreintegrationType>::print(const string& s) const {
+  PreintegrationType::print(s);
   cout << "    preintMeasCov \n[" << preintMeasCov_ << "]" << endl;
 }
 
 //------------------------------------------------------------------------------
-template <class PreintegrationBackend>
-bool PreintegratedImuMeasurementsT<PreintegrationBackend>::equals(
-    const PreintegratedImuMeasurementsT<PreintegrationBackend>& other, double tol) const {
-  return PreintegrationBackend::equals(other, tol)
+template <class PreintegrationType>
+bool PreintegratedImuMeasurementsT<PreintegrationType>::equals(
+    const PreintegratedImuMeasurementsT<PreintegrationType>& other, double tol) const {
+  return PreintegrationType::equals(other, tol)
       && equal_with_abs_tol(preintMeasCov_, other.preintMeasCov_, tol);
 }
 
 //------------------------------------------------------------------------------
-template <class PreintegrationBackend>
-void PreintegratedImuMeasurementsT<PreintegrationBackend>::resetIntegration() {
-  PreintegrationBackend::resetIntegration();
+template <class PreintegrationType>
+void PreintegratedImuMeasurementsT<PreintegrationType>::resetIntegration() {
+  PreintegrationType::resetIntegration();
   preintMeasCov_.setZero();
 }
 
 //------------------------------------------------------------------------------
-template <class PreintegrationBackend>
-void PreintegratedImuMeasurementsT<PreintegrationBackend>::integrateMeasurement(
+template <class PreintegrationType>
+void PreintegratedImuMeasurementsT<PreintegrationType>::integrateMeasurement(
     const Vector3& measuredAcc, const Vector3& measuredOmega, double dt) {
   if (dt <= 0) {
     throw std::runtime_error(
@@ -67,7 +67,7 @@ void PreintegratedImuMeasurementsT<PreintegrationBackend>::integrateMeasurement(
   // Update preintegrated measurements (also get Jacobian)
   Matrix9 A;  // overall Jacobian wrt preintegrated measurements (df/dx)
   Matrix93 B, C;  // Jacobian of state wrpt accel bias and omega bias respectively.
-  PreintegrationBackend::update(measuredAcc, measuredOmega, dt, &A, &B, &C);
+  PreintegrationType::update(measuredAcc, measuredOmega, dt, &A, &B, &C);
 
   // first order covariance propagation:
   // as in [2] we consider a first order propagation that can be seen as a
@@ -91,8 +91,8 @@ void PreintegratedImuMeasurementsT<PreintegrationBackend>::integrateMeasurement(
 }
 
 //------------------------------------------------------------------------------
-template <class PreintegrationBackend>
-void PreintegratedImuMeasurementsT<PreintegrationBackend>::integrateMeasurements(
+template <class PreintegrationType>
+void PreintegratedImuMeasurementsT<PreintegrationType>::integrateMeasurements(
     const Matrix& measuredAccs, const Matrix& measuredOmegas,
     const Matrix& dts) {
   assert(

--- a/gtsam/navigation/ImuFactor.cpp
+++ b/gtsam/navigation/ImuFactor.cpp
@@ -20,6 +20,8 @@
  **/
 
 #include <gtsam/navigation/ImuFactor.h>
+#include <gtsam/navigation/ManifoldPreintegration.h>
+#include <gtsam/navigation/TangentPreintegration.h>
 
 /* External or standard includes */
 #include <ostream>
@@ -30,28 +32,32 @@ namespace gtsam {
 using namespace std;
 
 //------------------------------------------------------------------------------
-// Inner class PreintegratedImuMeasurements
+// Inner class PreintegratedImuMeasurementsT
 //------------------------------------------------------------------------------
-void PreintegratedImuMeasurements::print(const string& s) const {
-  PreintegrationType::print(s);
+template <class PreintegrationBackend>
+void PreintegratedImuMeasurementsT<PreintegrationBackend>::print(const string& s) const {
+  PreintegrationBackend::print(s);
   cout << "    preintMeasCov \n[" << preintMeasCov_ << "]" << endl;
 }
 
 //------------------------------------------------------------------------------
-bool PreintegratedImuMeasurements::equals(
-    const PreintegratedImuMeasurements& other, double tol) const {
-  return PreintegrationType::equals(other, tol)
+template <class PreintegrationBackend>
+bool PreintegratedImuMeasurementsT<PreintegrationBackend>::equals(
+    const PreintegratedImuMeasurementsT<PreintegrationBackend>& other, double tol) const {
+  return PreintegrationBackend::equals(other, tol)
       && equal_with_abs_tol(preintMeasCov_, other.preintMeasCov_, tol);
 }
 
 //------------------------------------------------------------------------------
-void PreintegratedImuMeasurements::resetIntegration() {
-  PreintegrationType::resetIntegration();
+template <class PreintegrationBackend>
+void PreintegratedImuMeasurementsT<PreintegrationBackend>::resetIntegration() {
+  PreintegrationBackend::resetIntegration();
   preintMeasCov_.setZero();
 }
 
 //------------------------------------------------------------------------------
-void PreintegratedImuMeasurements::integrateMeasurement(
+template <class PreintegrationBackend>
+void PreintegratedImuMeasurementsT<PreintegrationBackend>::integrateMeasurement(
     const Vector3& measuredAcc, const Vector3& measuredOmega, double dt) {
   if (dt <= 0) {
     throw std::runtime_error(
@@ -61,7 +67,7 @@ void PreintegratedImuMeasurements::integrateMeasurement(
   // Update preintegrated measurements (also get Jacobian)
   Matrix9 A;  // overall Jacobian wrt preintegrated measurements (df/dx)
   Matrix93 B, C;  // Jacobian of state wrpt accel bias and omega bias respectively.
-  PreintegrationType::update(measuredAcc, measuredOmega, dt, &A, &B, &C);
+  PreintegrationBackend::update(measuredAcc, measuredOmega, dt, &A, &B, &C);
 
   // first order covariance propagation:
   // as in [2] we consider a first order propagation that can be seen as a
@@ -69,9 +75,9 @@ void PreintegratedImuMeasurements::integrateMeasurement(
 
   // propagate uncertainty
   // TODO(frank): use noiseModel routine so we can have arbitrary noise models.
-  const Matrix3& aCov = p().accelerometerCovariance;
-  const Matrix3& wCov = p().gyroscopeCovariance;
-  const Matrix3& iCov = p().integrationCovariance;
+  const Matrix3& aCov = this->p().accelerometerCovariance;
+  const Matrix3& wCov = this->p().gyroscopeCovariance;
+  const Matrix3& iCov = this->p().integrationCovariance;
 
   // (1/dt) allows to pass from continuous time noise to discrete time noise
   // Update the uncertainty on the state (matrix A in [4]).
@@ -85,7 +91,8 @@ void PreintegratedImuMeasurements::integrateMeasurement(
 }
 
 //------------------------------------------------------------------------------
-void PreintegratedImuMeasurements::integrateMeasurements(
+template <class PreintegrationBackend>
+void PreintegratedImuMeasurementsT<PreintegrationBackend>::integrateMeasurements(
     const Matrix& measuredAccs, const Matrix& measuredOmegas,
     const Matrix& dts) {
   assert(
@@ -100,40 +107,18 @@ void PreintegratedImuMeasurements::integrateMeasurements(
 }
 
 //------------------------------------------------------------------------------
-#ifdef GTSAM_TANGENT_PREINTEGRATION
-void PreintegratedImuMeasurements::mergeWith(const PreintegratedImuMeasurements& pim12, //
-    Matrix9* H1, Matrix9* H2) {
-  PreintegrationType::mergeWith(pim12, H1, H2);
-  // NOTE(gareth): Temporary P is needed as of Eigen 3.3
-  const Matrix9 P = *H1 * preintMeasCov_ * H1->transpose();
-  preintMeasCov_ = P + *H2 * pim12.preintMeasCov_ * H2->transpose();
-}
-#endif
-
+// ImuFactorT methods
 //------------------------------------------------------------------------------
-// ImuFactor methods
-//------------------------------------------------------------------------------
-ImuFactor::ImuFactor(Key pose_i, Key vel_i, Key pose_j, Key vel_j, Key bias,
-    const PreintegratedImuMeasurements& pim) :
-    Base(noiseModel::Gaussian::Covariance(pim.preintMeasCov_), pose_i, vel_i,
-        pose_j, vel_j, bias), _PIM_(pim) {
-}
-
-//------------------------------------------------------------------------------
-NonlinearFactor::shared_ptr ImuFactor::clone() const {
-  return std::static_pointer_cast<NonlinearFactor>(
-      NonlinearFactor::shared_ptr(new This(*this)));
-}
-
-//------------------------------------------------------------------------------
-std::ostream& operator<<(std::ostream& os, const ImuFactor& f) {
-  f._PIM_.print("preintegrated measurements:\n");
-  os << "  noise model sigmas: " << f.noiseModel_->sigmas().transpose();
+template <class PIMType_>
+std::ostream& operator<<(std::ostream& os, const ImuFactorT<PIMType_>& f) {
+  f.preintegratedMeasurements().print("preintegrated measurements:\n");
+  os << "  noise model sigmas: " << f.noiseModel()->sigmas().transpose();
   return os;
 }
 
 //------------------------------------------------------------------------------
-void ImuFactor::print(const string& s, const KeyFormatter& keyFormatter) const {
+template <class PIMType_>
+void ImuFactorT<PIMType_>::print(const string& s, const KeyFormatter& keyFormatter) const {
   cout << (s.empty() ? s : s + "\n") << "ImuFactor(" << keyFormatter(this->key<1>())
        << "," << keyFormatter(this->key<2>()) << "," << keyFormatter(this->key<3>())
        << "," << keyFormatter(this->key<4>()) << "," << keyFormatter(this->key<5>())
@@ -142,7 +127,8 @@ void ImuFactor::print(const string& s, const KeyFormatter& keyFormatter) const {
 }
 
 //------------------------------------------------------------------------------
-bool ImuFactor::equals(const NonlinearFactor& other, double tol) const {
+template <class PIMType_>
+bool ImuFactorT<PIMType_>::equals(const NonlinearFactor& other, double tol) const {
   const This *e = dynamic_cast<const This*>(&other);
   const bool base = Base::equals(*e, tol);
   const bool pim = _PIM_.equals(e->_PIM_, tol);
@@ -150,7 +136,8 @@ bool ImuFactor::equals(const NonlinearFactor& other, double tol) const {
 }
 
 //------------------------------------------------------------------------------
-Vector ImuFactor::evaluateError(const Pose3& pose_i, const Vector3& vel_i,
+template <class PIMType_>
+Vector ImuFactorT<PIMType_>::evaluateError(const Pose3& pose_i, const Vector3& vel_i,
     const Pose3& pose_j, const Vector3& vel_j,
     const imuBias::ConstantBias& bias_i, OptionalMatrixType H1,
     OptionalMatrixType H2, OptionalMatrixType H3,
@@ -160,75 +147,18 @@ Vector ImuFactor::evaluateError(const Pose3& pose_i, const Vector3& vel_i,
 }
 
 //------------------------------------------------------------------------------
-#ifdef GTSAM_TANGENT_PREINTEGRATION
-PreintegratedImuMeasurements ImuFactor::Merge(
-    const PreintegratedImuMeasurements& pim01,
-    const PreintegratedImuMeasurements& pim12) {
-  if (!pim01.matchesParamsWith(pim12))
-  throw std::domain_error(
-      "Cannot merge PreintegratedImuMeasurements with different params");
-
-  if (pim01.params()->body_P_sensor)
-  throw std::domain_error(
-      "Cannot merge PreintegratedImuMeasurements with sensor pose yet");
-
-  // the bias for the merged factor will be the bias from 01
-  PreintegratedImuMeasurements pim02 = pim01;
-
-  Matrix9 H1, H2;
-  pim02.mergeWith(pim12, &H1, &H2);
-
-  return pim02;
-}
-
+// ImuFactor2T methods
 //------------------------------------------------------------------------------
-ImuFactor::shared_ptr ImuFactor::Merge(const shared_ptr& f01,
-    const shared_ptr& f12) {
-  // IMU bias keys must be the same.
-  if (f01->key<5>() != f12->key<5>())
-  throw std::domain_error("ImuFactor::Merge: IMU bias keys must be the same");
-
-  // expect intermediate pose, velocity keys to matchup.
-  if (f01->key<3>() != f12->key<1>() || f01->key<4>() != f12->key<2>())
-  throw std::domain_error(
-      "ImuFactor::Merge: intermediate pose, velocity keys need to match up");
-
-  // return new factor
-  auto pim02 =
-  Merge(f01->preintegratedMeasurements(), f12->preintegratedMeasurements());
-  return std::make_shared<ImuFactor>(f01->key<1>(),  // P0
-      f01->key<2>(),  // V0
-      f12->key<3>(),  // P2
-      f12->key<4>(),  // V2
-      f01->key<5>(),  // B
-      pim02);
-}
-#endif
-
-//------------------------------------------------------------------------------
-// ImuFactor2 methods
-//------------------------------------------------------------------------------
-ImuFactor2::ImuFactor2(Key state_i, Key state_j, Key bias,
-    const PreintegratedImuMeasurements& pim) :
-    Base(noiseModel::Gaussian::Covariance(pim.preintMeasCov_), state_i, state_j,
-        bias), _PIM_(pim) {
-}
-
-//------------------------------------------------------------------------------
-NonlinearFactor::shared_ptr ImuFactor2::clone() const {
-  return std::static_pointer_cast<NonlinearFactor>(
-      NonlinearFactor::shared_ptr(new This(*this)));
-}
-
-//------------------------------------------------------------------------------
-std::ostream& operator<<(std::ostream& os, const ImuFactor2& f) {
-  f._PIM_.print("preintegrated measurements:\n");
-  os << "  noise model sigmas: " << f.noiseModel_->sigmas().transpose();
+template <class PIMType_>
+std::ostream& operator<<(std::ostream& os, const ImuFactor2T<PIMType_>& f) {
+  f.preintegratedMeasurements().print("preintegrated measurements:\n");
+  os << "  noise model sigmas: " << f.noiseModel()->sigmas().transpose();
   return os;
 }
 
 //------------------------------------------------------------------------------
-void ImuFactor2::print(const string& s,
+template <class PIMType_>
+void ImuFactor2T<PIMType_>::print(const string& s,
     const KeyFormatter& keyFormatter) const {
   cout << (s.empty() ? s : s + "\n") << "ImuFactor2("
        << keyFormatter(this->key<1>()) << "," << keyFormatter(this->key<2>()) << ","
@@ -237,7 +167,8 @@ void ImuFactor2::print(const string& s,
 }
 
 //------------------------------------------------------------------------------
-bool ImuFactor2::equals(const NonlinearFactor& other, double tol) const {
+template <class PIMType_>
+bool ImuFactor2T<PIMType_>::equals(const NonlinearFactor& other, double tol) const {
   const This *e = dynamic_cast<const This*>(&other);
   const bool base = Base::equals(*e, tol);
   const bool pim = _PIM_.equals(e->_PIM_, tol);
@@ -245,7 +176,8 @@ bool ImuFactor2::equals(const NonlinearFactor& other, double tol) const {
 }
 
 //------------------------------------------------------------------------------
-Vector ImuFactor2::evaluateError(const NavState& state_i,
+template <class PIMType_>
+Vector ImuFactor2T<PIMType_>::evaluateError(const NavState& state_i,
     const NavState& state_j,
     const imuBias::ConstantBias& bias_i, //
     OptionalMatrixType H1, OptionalMatrixType H2,
@@ -254,6 +186,29 @@ Vector ImuFactor2::evaluateError(const NavState& state_i,
 }
 
 //------------------------------------------------------------------------------
+// Explicit instantiations
+//------------------------------------------------------------------------------
+template class GTSAM_EXPORT PreintegratedImuMeasurementsT<ManifoldPreintegration>;
+template class GTSAM_EXPORT PreintegratedImuMeasurementsT<TangentPreintegration>;
+
+// ImuFactorT instantiations
+template class GTSAM_EXPORT ImuFactorT<PreintegratedImuMeasurementsT<ManifoldPreintegration>>;
+template class GTSAM_EXPORT ImuFactorT<PreintegratedImuMeasurementsT<TangentPreintegration>>;
+
+// ImuFactor2T instantiations
+template class GTSAM_EXPORT ImuFactor2T<PreintegratedImuMeasurementsT<ManifoldPreintegration>>;
+template class GTSAM_EXPORT ImuFactor2T<PreintegratedImuMeasurementsT<TangentPreintegration>>;
+
+// operator<< instantiations
+template GTSAM_EXPORT std::ostream& operator<<<PreintegratedImuMeasurementsT<ManifoldPreintegration>>(
+    std::ostream& os, const ImuFactorT<PreintegratedImuMeasurementsT<ManifoldPreintegration>>& f);
+template GTSAM_EXPORT std::ostream& operator<<<PreintegratedImuMeasurementsT<TangentPreintegration>>(
+    std::ostream& os, const ImuFactorT<PreintegratedImuMeasurementsT<TangentPreintegration>>& f);
+
+template GTSAM_EXPORT std::ostream& operator<<<PreintegratedImuMeasurementsT<ManifoldPreintegration>>(
+    std::ostream& os, const ImuFactor2T<PreintegratedImuMeasurementsT<ManifoldPreintegration>>& f);
+template GTSAM_EXPORT std::ostream& operator<<<PreintegratedImuMeasurementsT<TangentPreintegration>>(
+    std::ostream& os, const ImuFactor2T<PreintegratedImuMeasurementsT<TangentPreintegration>>& f);
 
 }
 // namespace gtsam

--- a/gtsam/navigation/ImuFactor.cpp
+++ b/gtsam/navigation/ImuFactor.cpp
@@ -119,9 +119,9 @@ std::ostream& operator<<(std::ostream& os, const ImuFactorT<PIMType_>& f) {
 //------------------------------------------------------------------------------
 template <class PIMType_>
 void ImuFactorT<PIMType_>::print(const string& s, const KeyFormatter& keyFormatter) const {
-  cout << (s.empty() ? s : s + "\n") << "ImuFactor(" << keyFormatter(this->key<1>())
-       << "," << keyFormatter(this->key<2>()) << "," << keyFormatter(this->key<3>())
-       << "," << keyFormatter(this->key<4>()) << "," << keyFormatter(this->key<5>())
+  cout << (s.empty() ? s : s + "\n") << "ImuFactor(" << keyFormatter(this->template key<1>())
+       << "," << keyFormatter(this->template key<2>()) << "," << keyFormatter(this->template key<3>())
+       << "," << keyFormatter(this->template key<4>()) << "," << keyFormatter(this->template key<5>())
        << ")\n";
   cout << *this << endl;
 }
@@ -161,7 +161,7 @@ template <class PIMType_>
 void ImuFactor2T<PIMType_>::print(const string& s,
     const KeyFormatter& keyFormatter) const {
   cout << (s.empty() ? s : s + "\n") << "ImuFactor2("
-       << keyFormatter(this->key<1>()) << "," << keyFormatter(this->key<2>()) << ","
+       << keyFormatter(this->template key<1>()) << "," << keyFormatter(this->template key<2>()) << ","
        << keyFormatter(this->key<3>()) << ")\n";
   cout << *this << endl;
 }

--- a/gtsam/navigation/ImuFactor.cpp
+++ b/gtsam/navigation/ImuFactor.cpp
@@ -109,16 +109,16 @@ void PreintegratedImuMeasurementsT<PreintegrationType>::integrateMeasurements(
 //------------------------------------------------------------------------------
 // ImuFactorT methods
 //------------------------------------------------------------------------------
-template <class PIMType_>
-std::ostream& operator<<(std::ostream& os, const ImuFactorT<PIMType_>& f) {
+template <class PIM>
+std::ostream& operator<<(std::ostream& os, const ImuFactorT<PIM>& f) {
   f.preintegratedMeasurements().print("preintegrated measurements:\n");
   os << "  noise model sigmas: " << f.noiseModel()->sigmas().transpose();
   return os;
 }
 
 //------------------------------------------------------------------------------
-template <class PIMType_>
-void ImuFactorT<PIMType_>::print(const string& s, const KeyFormatter& keyFormatter) const {
+template <class PIM>
+void ImuFactorT<PIM>::print(const string& s, const KeyFormatter& keyFormatter) const {
   cout << (s.empty() ? s : s + "\n") << "ImuFactor(" << keyFormatter(this->template key<1>())
        << "," << keyFormatter(this->template key<2>()) << "," << keyFormatter(this->template key<3>())
        << "," << keyFormatter(this->template key<4>()) << "," << keyFormatter(this->template key<5>())
@@ -127,8 +127,8 @@ void ImuFactorT<PIMType_>::print(const string& s, const KeyFormatter& keyFormatt
 }
 
 //------------------------------------------------------------------------------
-template <class PIMType_>
-bool ImuFactorT<PIMType_>::equals(const NonlinearFactor& other, double tol) const {
+template <class PIM>
+bool ImuFactorT<PIM>::equals(const NonlinearFactor& other, double tol) const {
   const This *e = dynamic_cast<const This*>(&other);
   const bool base = Base::equals(*e, tol);
   const bool pim = _PIM_.equals(e->_PIM_, tol);
@@ -136,8 +136,8 @@ bool ImuFactorT<PIMType_>::equals(const NonlinearFactor& other, double tol) cons
 }
 
 //------------------------------------------------------------------------------
-template <class PIMType_>
-Vector ImuFactorT<PIMType_>::evaluateError(const Pose3& pose_i, const Vector3& vel_i,
+template <class PIM>
+Vector ImuFactorT<PIM>::evaluateError(const Pose3& pose_i, const Vector3& vel_i,
     const Pose3& pose_j, const Vector3& vel_j,
     const imuBias::ConstantBias& bias_i, OptionalMatrixType H1,
     OptionalMatrixType H2, OptionalMatrixType H3,
@@ -149,16 +149,16 @@ Vector ImuFactorT<PIMType_>::evaluateError(const Pose3& pose_i, const Vector3& v
 //------------------------------------------------------------------------------
 // ImuFactor2T methods
 //------------------------------------------------------------------------------
-template <class PIMType_>
-std::ostream& operator<<(std::ostream& os, const ImuFactor2T<PIMType_>& f) {
+template <class PIM>
+std::ostream& operator<<(std::ostream& os, const ImuFactor2T<PIM>& f) {
   f.preintegratedMeasurements().print("preintegrated measurements:\n");
   os << "  noise model sigmas: " << f.noiseModel()->sigmas().transpose();
   return os;
 }
 
 //------------------------------------------------------------------------------
-template <class PIMType_>
-void ImuFactor2T<PIMType_>::print(const string& s,
+template <class PIM>
+void ImuFactor2T<PIM>::print(const string& s,
     const KeyFormatter& keyFormatter) const {
   cout << (s.empty() ? s : s + "\n") << "ImuFactor2("
        << keyFormatter(this->template key<1>()) << "," << keyFormatter(this->template key<2>()) << ","
@@ -167,8 +167,8 @@ void ImuFactor2T<PIMType_>::print(const string& s,
 }
 
 //------------------------------------------------------------------------------
-template <class PIMType_>
-bool ImuFactor2T<PIMType_>::equals(const NonlinearFactor& other, double tol) const {
+template <class PIM>
+bool ImuFactor2T<PIM>::equals(const NonlinearFactor& other, double tol) const {
   const This *e = dynamic_cast<const This*>(&other);
   const bool base = Base::equals(*e, tol);
   const bool pim = _PIM_.equals(e->_PIM_, tol);
@@ -176,8 +176,8 @@ bool ImuFactor2T<PIMType_>::equals(const NonlinearFactor& other, double tol) con
 }
 
 //------------------------------------------------------------------------------
-template <class PIMType_>
-Vector ImuFactor2T<PIMType_>::evaluateError(const NavState& state_i,
+template <class PIM>
+Vector ImuFactor2T<PIM>::evaluateError(const NavState& state_i,
     const NavState& state_j,
     const imuBias::ConstantBias& bias_i, //
     OptionalMatrixType H1, OptionalMatrixType H2,

--- a/gtsam/navigation/ImuFactor.h
+++ b/gtsam/navigation/ImuFactor.h
@@ -193,7 +193,7 @@ private:
   typedef NoiseModelFactorN<Pose3, Vector3, Pose3, Vector3,
       imuBias::ConstantBias> Base;
 
-  PIM _PIM_;
+  PIM pim_;
 
 public:
 
@@ -221,7 +221,7 @@ public:
       const PIM& preintegratedMeasurements)
       : Base(noiseModel::Gaussian::Covariance(preintegratedMeasurements.preintMeasCov()),
              pose_i, vel_i, pose_j, vel_j, bias),
-        _PIM_(preintegratedMeasurements) {}
+        pim_(preintegratedMeasurements) {}
 
   ~ImuFactorT() override {
   }
@@ -241,7 +241,7 @@ public:
   /** Access the preintegrated measurements. */
 
   const PIM& preintegratedMeasurements() const {
-    return _PIM_;
+    return pim_;
   }
 
   /** implement functions needed to derive from Factor */
@@ -335,7 +335,7 @@ public:
     // NoiseModelFactor5 instead of NoiseModelFactorN for backward compatibility
     ar & boost::serialization::make_nvp("NoiseModelFactor5",
          boost::serialization::base_object<Base>(*this));
-    ar & BOOST_SERIALIZATION_NVP(_PIM_);
+    ar & BOOST_SERIALIZATION_NVP(pim_);
   }
 #endif
 };
@@ -359,7 +359,7 @@ private:
   typedef ImuFactor2T<PIM> This;
   typedef NoiseModelFactorN<NavState, NavState, imuBias::ConstantBias> Base;
 
-  PIM _PIM_;
+  PIM pim_;
 
 public:
 
@@ -379,7 +379,7 @@ public:
              const PIM& preintegratedMeasurements)
       : Base(noiseModel::Gaussian::Covariance(preintegratedMeasurements.preintMeasCov()),
              state_i, state_j, bias),
-        _PIM_(preintegratedMeasurements) {}
+        pim_(preintegratedMeasurements) {}
 
 
   ~ImuFactor2T() override {
@@ -401,7 +401,7 @@ public:
   /** Access the preintegrated measurements. */
 
   const PIM& preintegratedMeasurements() const {
-    return _PIM_;
+    return pim_;
   }
 
   /** implement functions needed to derive from Factor */
@@ -422,7 +422,7 @@ private:
     // NoiseModelFactor3 instead of NoiseModelFactorN for backward compatibility
     ar & boost::serialization::make_nvp("NoiseModelFactor3",
          boost::serialization::base_object<Base>(*this));
-    ar & BOOST_SERIALIZATION_NVP(_PIM_);
+    ar & BOOST_SERIALIZATION_NVP(pim_);
   }
 #endif
 };

--- a/gtsam/navigation/ImuFactor.h
+++ b/gtsam/navigation/ImuFactor.h
@@ -27,12 +27,15 @@
 #include <gtsam/navigation/TangentPreintegration.h>
 #include <gtsam/base/debug.h>
 
+#include <type_traits> // For std::is_same, std::enable_if
+ 
 namespace gtsam {
 
+// Determine default preintegration backend
 #ifdef GTSAM_TANGENT_PREINTEGRATION
-typedef TangentPreintegration PreintegrationType;
+typedef TangentPreintegration DefaultPreintegrationBackend;
 #else
-typedef ManifoldPreintegration PreintegrationType;
+typedef ManifoldPreintegration DefaultPreintegrationBackend;
 #endif
 
 /*
@@ -65,10 +68,11 @@ typedef ManifoldPreintegration PreintegrationType;
  *
  * @ingroup navigation
  */
-class GTSAM_EXPORT PreintegratedImuMeasurements: public PreintegrationType {
-
-  friend class ImuFactor;
-  friend class ImuFactor2;
+template <class PreintegrationBackend>
+class GTSAM_EXPORT PreintegratedImuMeasurementsT: public PreintegrationBackend {
+ 
+  template <class PIMType_> friend class ImuFactorT;
+  template <class PIMType_> friend class ImuFactor2T;
 
 protected:
 
@@ -78,8 +82,8 @@ protected:
 public:
 
   /// Default constructor for serialization and wrappers
-  PreintegratedImuMeasurements() {
-    resetIntegration();
+  PreintegratedImuMeasurementsT() {
+    this->resetIntegration();
   }
 
  /**
@@ -87,32 +91,32 @@ public:
    *  @param p       Parameters, typically fixed in a single application
    *  @param biasHat Current estimate of acceleration and rotation rate biases
    */
-  PreintegratedImuMeasurements(const std::shared_ptr<PreintegrationParams>& p,
+  PreintegratedImuMeasurementsT(const std::shared_ptr<PreintegrationParams>& p,
       const imuBias::ConstantBias& biasHat = imuBias::ConstantBias()) :
-      PreintegrationType(p, biasHat) {
-    resetIntegration();
+      PreintegrationBackend(p, biasHat) {
+    this->resetIntegration();
   }
 
 /**
   *  Construct preintegrated directly from members: base class and preintMeasCov
-  *  @param base               PreintegrationType instance
+  *  @param base               PreintegrationBackend instance
   *  @param preintMeasCov      Covariance matrix used in noise model.
   */
-  PreintegratedImuMeasurements(const PreintegrationType& base, const Matrix9& preintMeasCov)
-     : PreintegrationType(base),
+  PreintegratedImuMeasurementsT(const PreintegrationBackend& base, const Matrix9& preintMeasCov)
+     : PreintegrationBackend(base),
        preintMeasCov_(preintMeasCov) {
-    PreintegrationType::resetIntegration();
+    this->PreintegrationBackend::resetIntegration();
   }
-
+ 
   /// Virtual destructor
-  ~PreintegratedImuMeasurements() override {
+  ~PreintegratedImuMeasurementsT() override {
   }
 
   /// print
   void print(const std::string& s = "Preintegrated Measurements:") const override;
 
   /// equals
-  bool equals(const PreintegratedImuMeasurements& expected, double tol = 1e-9) const;
+  bool equals(const PreintegratedImuMeasurementsT<PreintegrationBackend>& expected, double tol = 1e-9) const;
 
   /// Re-initialize PreintegratedImuMeasurements
   void resetIntegration() override;
@@ -137,10 +141,19 @@ public:
   /// Return pre-integrated measurement covariance
   Matrix preintMeasCov() const { return preintMeasCov_; }
 
-#ifdef GTSAM_TANGENT_PREINTEGRATION
   /// Merge in a different set of measurements and update bias derivatives accordingly
-  void mergeWith(const PreintegratedImuMeasurements& pim, Matrix9* H1, Matrix9* H2);
-#endif
+  /// This method is specific to TangentPreintegration backend.
+  template <typename PB = PreintegrationBackend,
+             // This method is only callable when PreintegrationBackend is TangentPreintegration.
+             typename = typename std::enable_if<std::is_same<PB, TangentPreintegration>::value>::type>
+  void mergeWith(const PreintegratedImuMeasurementsT<TangentPreintegration>& pim12, Matrix9* H1, Matrix9* H2) {
+    // The `this->PreintegrationBackend::mergeWith` implies calling TangentPreintegration's mergeWith.
+    // Since pim12 is PreintegratedImuMeasurementsT<TangentPreintegration>, it is a TangentPreintegration.
+    this->PreintegrationBackend::mergeWith(pim12, H1, H2);
+    // NOTE(gareth): Temporary P is needed as of Eigen 3.3
+    const Matrix9 P = *H1 * preintMeasCov_ * H1->transpose();
+    preintMeasCov_ = P + *H2 * pim12.preintMeasCov_ * H2->transpose();
+  }
 
  private:
 #if GTSAM_ENABLE_BOOST_SERIALIZATION  ///
@@ -149,11 +162,15 @@ public:
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
     namespace bs = ::boost::serialization;
-    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(PreintegrationType);
+    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(PreintegrationBackend);
     ar & BOOST_SERIALIZATION_NVP(preintMeasCov_);
   }
 #endif
 };
+
+// For backward compatibility (so that the compiler flag GTSAM_TANGENT_PREINTEGRATION still
+// controls which class PreintegratedImuMeasurements uses):
+typedef PreintegratedImuMeasurementsT<DefaultPreintegrationBackend> PreintegratedImuMeasurements;
 
 /**
  * ImuFactor is a 5-ways factor involving previous state (pose and velocity of
@@ -167,15 +184,16 @@ public:
  *
  * @ingroup navigation
  */
-class GTSAM_EXPORT ImuFactor: public NoiseModelFactorN<Pose3, Vector3, Pose3, Vector3,
+template <class PIMType_ = PreintegratedImuMeasurements>
+class GTSAM_EXPORT ImuFactorT: public NoiseModelFactorN<Pose3, Vector3, Pose3, Vector3,
     imuBias::ConstantBias> {
 private:
 
-  typedef ImuFactor This;
+  typedef ImuFactorT<PIMType_> This;
   typedef NoiseModelFactorN<Pose3, Vector3, Pose3, Vector3,
       imuBias::ConstantBias> Base;
 
-  PreintegratedImuMeasurements _PIM_;
+  PIMType_ _PIM_;
 
 public:
 
@@ -183,14 +201,11 @@ public:
   using Base::evaluateError;
 
   /** Shorthand for a smart pointer to a factor */
-#if !defined(_MSC_VER) && __GNUC__ == 4 && __GNUC_MINOR__ > 5
-  typedef typename std::shared_ptr<ImuFactor> shared_ptr;
-#else
-  typedef std::shared_ptr<ImuFactor> shared_ptr;
-#endif
+  typedef std::shared_ptr<This> shared_ptr;
+
 
   /** Default constructor - only use for serialization */
-  ImuFactor() {}
+  ImuFactorT() {}
 
   /**
    * Constructor
@@ -202,18 +217,22 @@ public:
    * @param preintegratedMeasurements The preintegreated measurements since the
    * last pose.
    */
-  ImuFactor(Key pose_i, Key vel_i, Key pose_j, Key vel_j, Key bias,
-      const PreintegratedImuMeasurements& preintegratedMeasurements);
+  ImuFactorT(Key pose_i, Key vel_i, Key pose_j, Key vel_j, Key bias,
+      const PIMType_& preintegratedMeasurements)
+      : Base(noiseModel::Gaussian::Covariance(preintegratedMeasurements.preintMeasCov()),
+             pose_i, vel_i, pose_j, vel_j, bias),
+        _PIM_(preintegratedMeasurements) {}
 
-  ~ImuFactor() override {
+  ~ImuFactorT() override {
   }
 
   /// @return a deep copy of this factor
-  gtsam::NonlinearFactor::shared_ptr clone() const override;
+  gtsam::NonlinearFactor::shared_ptr clone() const override {
+    return std::make_shared<This>(*this);
+  }
 
   /// @name Testable
   /// @{
-  GTSAM_EXPORT friend std::ostream& operator<<(std::ostream& os, const ImuFactor&);
   void print(const std::string& s = "", const KeyFormatter& keyFormatter =
                                             DefaultKeyFormatter) const override;
   bool equals(const NonlinearFactor& expected, double tol = 1e-9) const override;
@@ -221,7 +240,7 @@ public:
 
   /** Access the preintegrated measurements. */
 
-  const PreintegratedImuMeasurements& preintegratedMeasurements() const {
+  const PIMType_& preintegratedMeasurements() const {
     return _PIM_;
   }
 
@@ -233,15 +252,79 @@ public:
       const imuBias::ConstantBias& bias_i, OptionalMatrixType H1, OptionalMatrixType H2,
       OptionalMatrixType H3, OptionalMatrixType H4, OptionalMatrixType H5) const override;
 
-#ifdef GTSAM_TANGENT_PREINTEGRATION
   /// Merge two pre-integrated measurement classes
-  static PreintegratedImuMeasurements Merge(
-      const PreintegratedImuMeasurements& pim01,
-      const PreintegratedImuMeasurements& pim12);
+  template <typename MethodPIMArg = PIMType_,
+    // This method is only callable when PIMType_ is PreintegratedImuMeasurementsT<TangentPreintegration>.
+    typename = typename std::enable_if<
+        std::is_same<MethodPIMArg, PreintegratedImuMeasurementsT<TangentPreintegration>>::value
+    >::type
+  >
+  static MethodPIMArg Merge(
+    const MethodPIMArg& pim01,
+    const MethodPIMArg& pim12
+  ) {
+    // When this template is instantiated:
+    // 1. MethodPIMArg = PIMType_. It's mirrored to avoid error C7637 from strict compilers.
+    // 2. The SFINAE condition ensures MethodPIMArg IS PreintegratedImuMeasurementsT<TangentPreintegration>.
+    // So, arguments are const PreintegratedImuMeasurementsT<TangentPreintegration>&
+    // and return is PreintegratedImuMeasurementsT<TangentPreintegration>.
+
+    if (!pim01.matchesParamsWith(pim12))
+      throw std::domain_error(
+          "Cannot merge PreintegratedImuMeasurements with different params");
+
+    if (pim01.p_->body_P_sensor)
+      throw std::domain_error(
+          "Cannot merge PreintegratedImuMeasurements with sensor pose yet");
+
+    // the bias for the merged factor will be the bias from 01
+    MethodPIMArg pim02 = pim01;
+
+    Matrix9 H1, H2;
+    pim02.mergeWith(pim12, &H1, &H2);
+
+    return pim02;
+  }
 
   /// Merge two factors
-  static shared_ptr Merge(const shared_ptr& f01, const shared_ptr& f12);
-#endif
+  template <
+    typename MethodPIMArg = PIMType_,
+    // This method is only callable when PIMType_ is PreintegratedImuMeasurementsT<TangentPreintegration>.
+    typename = typename std::enable_if<
+        std::is_same<MethodPIMArg, PreintegratedImuMeasurementsT<TangentPreintegration>>::value
+    >::type
+  >
+  static typename ImuFactorT<MethodPIMArg>::shared_ptr Merge(
+    const typename ImuFactorT<MethodPIMArg>::shared_ptr& f01,
+    const typename ImuFactorT<MethodPIMArg>::shared_ptr& f12
+  ) {
+    // When this template is instantiated:
+    // 1. MethodPIMArg = PIMType_. It's mirrored to avoid error C7637 from strict compilers.
+    // 2. The SFINAE condition ensures MethodPIMArg IS PreintegratedImuMeasurementsT<TangentPreintegration>.
+    // So, ImuFactorT<MethodPIMArg> is effectively ImuFactorT<PIMType_>, which is `This`.
+    // The signature effectively becomes:
+    // static typename This::shared_ptr Merge(const typename This::shared_ptr&, const typename This::shared_ptr&)
+
+  // IMU bias keys must be the same.
+  if (f01->key<5>() != f12->key<5>())
+    throw std::domain_error("ImuFactor::Merge: IMU bias keys must be the same");
+
+  // expect intermediate pose, velocity keys to matchup.
+  if (f01->key<3>() != f12->key<1>() || f01->key<4>() != f12->key<2>())
+    throw std::domain_error(
+        "ImuFactor::Merge: intermediate pose, velocity keys need to match up");
+
+  // return new factor
+  auto pim02 = This::Merge(f01->preintegratedMeasurements(), f12->preintegratedMeasurements());
+
+  return std::make_shared<This>( // `This` is ImuFactorT<MethodPIMArg> (i.e. ImuFactorT<PIMType_>)
+      f01->key<1>(),  // P0
+      f01->key<2>(),  // V0
+      f12->key<3>(),  // P2
+      f12->key<4>(),  // V2
+      f01->key<5>(),  // B
+      pim02);
+  }
 
  private:
   /** Serialization function */
@@ -256,19 +339,27 @@ public:
   }
 #endif
 };
-// class ImuFactor
+// class ImuFactorT
+
+// For backward compatibility:
+typedef ImuFactorT<> ImuFactor;
+ 
+// operator<< for ImuFactorT
+template <class PIMType_>
+GTSAM_EXPORT std::ostream& operator<<(std::ostream& os, const ImuFactorT<PIMType_>& f);
 
 /**
  * ImuFactor2 is a ternary factor that uses NavStates rather than Pose/Velocity.
  * @ingroup navigation
  */
-class GTSAM_EXPORT ImuFactor2 : public NoiseModelFactorN<NavState, NavState, imuBias::ConstantBias> {
+template <class PIMType_ = PreintegratedImuMeasurements>
+class GTSAM_EXPORT ImuFactor2T : public NoiseModelFactorN<NavState, NavState, imuBias::ConstantBias> {
 private:
 
-  typedef ImuFactor2 This;
+  typedef ImuFactor2T<PIMType_> This;
   typedef NoiseModelFactorN<NavState, NavState, imuBias::ConstantBias> Base;
 
-  PreintegratedImuMeasurements _PIM_;
+  PIMType_ _PIM_;
 
 public:
 
@@ -276,7 +367,7 @@ public:
   using Base::evaluateError;
 
   /** Default constructor - only use for serialization */
-  ImuFactor2() {}
+  ImuFactor2T() {}
 
   /**
    * Constructor
@@ -284,18 +375,24 @@ public:
    * @param state_j Current state key
    * @param bias    Previous bias key
    */
-  ImuFactor2(Key state_i, Key state_j, Key bias,
-             const PreintegratedImuMeasurements& preintegratedMeasurements);
+  ImuFactor2T(Key state_i, Key state_j, Key bias,
+             const PIMType_& preintegratedMeasurements)
+      : Base(noiseModel::Gaussian::Covariance(preintegratedMeasurements.preintMeasCov()),
+             state_i, state_j, bias),
+        _PIM_(preintegratedMeasurements) {}
 
-  ~ImuFactor2() override {
+
+  ~ImuFactor2T() override {
   }
 
   /// @return a deep copy of this factor
-  gtsam::NonlinearFactor::shared_ptr clone() const override;
+  gtsam::NonlinearFactor::shared_ptr clone() const override {
+    return std::make_shared<This>(*this);
+  }
+
 
   /// @name Testable
   /// @{
-  GTSAM_EXPORT friend std::ostream& operator<<(std::ostream& os, const ImuFactor2&);
   void print(const std::string& s = "", const KeyFormatter& keyFormatter =
                                             DefaultKeyFormatter) const override;
   bool equals(const NonlinearFactor& expected, double tol = 1e-9) const override;
@@ -303,7 +400,7 @@ public:
 
   /** Access the preintegrated measurements. */
 
-  const PreintegratedImuMeasurements& preintegratedMeasurements() const {
+  const PIMType_& preintegratedMeasurements() const {
     return _PIM_;
   }
 
@@ -329,15 +426,22 @@ private:
   }
 #endif
 };
-// class ImuFactor2
+// class ImuFactor2T
 
-template <>
-struct traits<PreintegratedImuMeasurements> : public Testable<PreintegratedImuMeasurements> {};
+// For backward compatibility:
+typedef ImuFactor2T<> ImuFactor2;
 
-template <>
-struct traits<ImuFactor> : public Testable<ImuFactor> {};
+// operator<< for ImuFactor2T
+template <class PIMType_>
+GTSAM_EXPORT std::ostream& operator<<(std::ostream& os, const ImuFactor2T<PIMType_>& f);
 
-template <>
-struct traits<ImuFactor2> : public Testable<ImuFactor2> {};
+template <class PreintegrationBackend>
+struct traits<PreintegratedImuMeasurementsT<PreintegrationBackend>> : public Testable<PreintegratedImuMeasurementsT<PreintegrationBackend>> {};
+
+template <class PIMType_>
+struct traits<ImuFactorT<PIMType_>> : public Testable<ImuFactorT<PIMType_>> {};
+
+template <class PIMType_>
+struct traits<ImuFactor2T<PIMType_>> : public Testable<ImuFactor2T<PIMType_>> {};
 
 } /// namespace gtsam

--- a/gtsam/navigation/ImuFactor.h
+++ b/gtsam/navigation/ImuFactor.h
@@ -170,7 +170,7 @@ public:
 
 // For backward compatibility (so that the compiler flag GTSAM_TANGENT_PREINTEGRATION still
 // controls which class PreintegratedImuMeasurements uses):
-typedef PreintegratedImuMeasurementsT<DefaultPreintegrationBackend> PreintegratedImuMeasurements;
+using PreintegratedImuMeasurements = PreintegratedImuMeasurementsT<DefaultPreintegrationBackend>;
 
 /**
  * ImuFactor is a 5-ways factor involving previous state (pose and velocity of
@@ -342,7 +342,7 @@ public:
 // class ImuFactorT
 
 // For backward compatibility:
-typedef ImuFactorT<> ImuFactor;
+using ImuFactor = ImuFactorT<>;
  
 // operator<< for ImuFactorT
 template <class PIMType_>
@@ -429,7 +429,7 @@ private:
 // class ImuFactor2T
 
 // For backward compatibility:
-typedef ImuFactor2T<> ImuFactor2;
+using ImuFactor2 = ImuFactor2T<>;
 
 // operator<< for ImuFactor2T
 template <class PIMType_>

--- a/gtsam/navigation/ImuFactor.h
+++ b/gtsam/navigation/ImuFactor.h
@@ -184,16 +184,16 @@ using PreintegratedImuMeasurements = PreintegratedImuMeasurementsT<DefaultPreint
  *
  * @ingroup navigation
  */
-template <class PIMType_ = PreintegratedImuMeasurements>
+template <class PIM = PreintegratedImuMeasurements>
 class GTSAM_EXPORT ImuFactorT: public NoiseModelFactorN<Pose3, Vector3, Pose3, Vector3,
     imuBias::ConstantBias> {
 private:
 
-  typedef ImuFactorT<PIMType_> This;
+  typedef ImuFactorT<PIM> This;
   typedef NoiseModelFactorN<Pose3, Vector3, Pose3, Vector3,
       imuBias::ConstantBias> Base;
 
-  PIMType_ _PIM_;
+  PIM _PIM_;
 
 public:
 
@@ -218,7 +218,7 @@ public:
    * last pose.
    */
   ImuFactorT(Key pose_i, Key vel_i, Key pose_j, Key vel_j, Key bias,
-      const PIMType_& preintegratedMeasurements)
+      const PIM& preintegratedMeasurements)
       : Base(noiseModel::Gaussian::Covariance(preintegratedMeasurements.preintMeasCov()),
              pose_i, vel_i, pose_j, vel_j, bias),
         _PIM_(preintegratedMeasurements) {}
@@ -240,7 +240,7 @@ public:
 
   /** Access the preintegrated measurements. */
 
-  const PIMType_& preintegratedMeasurements() const {
+  const PIM& preintegratedMeasurements() const {
     return _PIM_;
   }
 
@@ -253,8 +253,8 @@ public:
       OptionalMatrixType H3, OptionalMatrixType H4, OptionalMatrixType H5) const override;
 
   /// Merge two pre-integrated measurement classes
-  template <typename MethodPIMArg = PIMType_,
-    // This method is only callable when PIMType_ is PreintegratedImuMeasurementsT<TangentPreintegration>.
+  template <typename MethodPIMArg = PIM,
+    // This method is only callable when PIM is PreintegratedImuMeasurementsT<TangentPreintegration>.
     typename = typename std::enable_if<
         std::is_same<MethodPIMArg, PreintegratedImuMeasurementsT<TangentPreintegration>>::value
     >::type
@@ -264,7 +264,7 @@ public:
     const MethodPIMArg& pim12
   ) {
     // When this template is instantiated:
-    // 1. MethodPIMArg = PIMType_. It's mirrored to avoid error C7637 from strict compilers.
+    // 1. MethodPIMArg = PIM. It's mirrored to avoid error C7637 from strict compilers.
     // 2. The SFINAE condition ensures MethodPIMArg IS PreintegratedImuMeasurementsT<TangentPreintegration>.
     // So, arguments are const PreintegratedImuMeasurementsT<TangentPreintegration>&
     // and return is PreintegratedImuMeasurementsT<TangentPreintegration>.
@@ -288,8 +288,8 @@ public:
 
   /// Merge two factors
   template <
-    typename MethodPIMArg = PIMType_,
-    // This method is only callable when PIMType_ is PreintegratedImuMeasurementsT<TangentPreintegration>.
+    typename MethodPIMArg = PIM,
+    // This method is only callable when PIM is PreintegratedImuMeasurementsT<TangentPreintegration>.
     typename = typename std::enable_if<
         std::is_same<MethodPIMArg, PreintegratedImuMeasurementsT<TangentPreintegration>>::value
     >::type
@@ -299,9 +299,9 @@ public:
     const typename ImuFactorT<MethodPIMArg>::shared_ptr& f12
   ) {
     // When this template is instantiated:
-    // 1. MethodPIMArg = PIMType_. It's mirrored to avoid error C7637 from strict compilers.
+    // 1. MethodPIMArg = PIM. It's mirrored to avoid error C7637 from strict compilers.
     // 2. The SFINAE condition ensures MethodPIMArg IS PreintegratedImuMeasurementsT<TangentPreintegration>.
-    // So, ImuFactorT<MethodPIMArg> is effectively ImuFactorT<PIMType_>, which is `This`.
+    // So, ImuFactorT<MethodPIMArg> is effectively ImuFactorT<PIM>, which is `This`.
     // The signature effectively becomes:
     // static typename This::shared_ptr Merge(const typename This::shared_ptr&, const typename This::shared_ptr&)
 
@@ -317,7 +317,7 @@ public:
   // return new factor
   auto pim02 = This::Merge(f01->preintegratedMeasurements(), f12->preintegratedMeasurements());
 
-  return std::make_shared<This>( // `This` is ImuFactorT<MethodPIMArg> (i.e. ImuFactorT<PIMType_>)
+  return std::make_shared<This>( // `This` is ImuFactorT<MethodPIMArg> (i.e. ImuFactorT<PIM>)
       f01->template key<1>(),  // P0
       f01->template key<2>(),  // V0
       f12->template key<3>(),  // P2
@@ -345,21 +345,21 @@ public:
 using ImuFactor = ImuFactorT<>;
  
 // operator<< for ImuFactorT
-template <class PIMType_>
-GTSAM_EXPORT std::ostream& operator<<(std::ostream& os, const ImuFactorT<PIMType_>& f);
+template <class PIM>
+GTSAM_EXPORT std::ostream& operator<<(std::ostream& os, const ImuFactorT<PIM>& f);
 
 /**
  * ImuFactor2 is a ternary factor that uses NavStates rather than Pose/Velocity.
  * @ingroup navigation
  */
-template <class PIMType_ = PreintegratedImuMeasurements>
+template <class PIM = PreintegratedImuMeasurements>
 class GTSAM_EXPORT ImuFactor2T : public NoiseModelFactorN<NavState, NavState, imuBias::ConstantBias> {
 private:
 
-  typedef ImuFactor2T<PIMType_> This;
+  typedef ImuFactor2T<PIM> This;
   typedef NoiseModelFactorN<NavState, NavState, imuBias::ConstantBias> Base;
 
-  PIMType_ _PIM_;
+  PIM _PIM_;
 
 public:
 
@@ -376,7 +376,7 @@ public:
    * @param bias    Previous bias key
    */
   ImuFactor2T(Key state_i, Key state_j, Key bias,
-             const PIMType_& preintegratedMeasurements)
+             const PIM& preintegratedMeasurements)
       : Base(noiseModel::Gaussian::Covariance(preintegratedMeasurements.preintMeasCov()),
              state_i, state_j, bias),
         _PIM_(preintegratedMeasurements) {}
@@ -400,7 +400,7 @@ public:
 
   /** Access the preintegrated measurements. */
 
-  const PIMType_& preintegratedMeasurements() const {
+  const PIM& preintegratedMeasurements() const {
     return _PIM_;
   }
 
@@ -432,16 +432,16 @@ private:
 using ImuFactor2 = ImuFactor2T<>;
 
 // operator<< for ImuFactor2T
-template <class PIMType_>
-GTSAM_EXPORT std::ostream& operator<<(std::ostream& os, const ImuFactor2T<PIMType_>& f);
+template <class PIM>
+GTSAM_EXPORT std::ostream& operator<<(std::ostream& os, const ImuFactor2T<PIM>& f);
 
 template <class PreintegrationType>
 struct traits<PreintegratedImuMeasurementsT<PreintegrationType>> : public Testable<PreintegratedImuMeasurementsT<PreintegrationType>> {};
 
-template <class PIMType_>
-struct traits<ImuFactorT<PIMType_>> : public Testable<ImuFactorT<PIMType_>> {};
+template <class PIM>
+struct traits<ImuFactorT<PIM>> : public Testable<ImuFactorT<PIM>> {};
 
-template <class PIMType_>
-struct traits<ImuFactor2T<PIMType_>> : public Testable<ImuFactor2T<PIMType_>> {};
+template <class PIM>
+struct traits<ImuFactor2T<PIM>> : public Testable<ImuFactor2T<PIM>> {};
 
 } /// namespace gtsam

--- a/gtsam/navigation/ImuFactor.h
+++ b/gtsam/navigation/ImuFactor.h
@@ -33,9 +33,9 @@ namespace gtsam {
 
 // Determine default preintegration backend
 #ifdef GTSAM_TANGENT_PREINTEGRATION
-typedef TangentPreintegration DefaultPreintegrationBackend;
+typedef TangentPreintegration DefaultPreintegrationType;
 #else
-typedef ManifoldPreintegration DefaultPreintegrationBackend;
+typedef ManifoldPreintegration DefaultPreintegrationType;
 #endif
 
 /*
@@ -68,8 +68,8 @@ typedef ManifoldPreintegration DefaultPreintegrationBackend;
  *
  * @ingroup navigation
  */
-template <class PreintegrationBackend>
-class GTSAM_EXPORT PreintegratedImuMeasurementsT: public PreintegrationBackend {
+template <class PreintegrationType>
+class GTSAM_EXPORT PreintegratedImuMeasurementsT: public PreintegrationType {
  
   template <class PIM> friend class ImuFactorT;
   template <class PIM> friend class ImuFactor2T;
@@ -93,19 +93,19 @@ public:
    */
   PreintegratedImuMeasurementsT(const std::shared_ptr<PreintegrationParams>& p,
       const imuBias::ConstantBias& biasHat = imuBias::ConstantBias()) :
-      PreintegrationBackend(p, biasHat) {
+      PreintegrationType(p, biasHat) {
     this->resetIntegration();
   }
 
 /**
   *  Construct preintegrated directly from members: base class and preintMeasCov
-  *  @param base               PreintegrationBackend instance
+  *  @param base               PreintegrationType instance
   *  @param preintMeasCov      Covariance matrix used in noise model.
   */
-  PreintegratedImuMeasurementsT(const PreintegrationBackend& base, const Matrix9& preintMeasCov)
-     : PreintegrationBackend(base),
+  PreintegratedImuMeasurementsT(const PreintegrationType& base, const Matrix9& preintMeasCov)
+     : PreintegrationType(base),
        preintMeasCov_(preintMeasCov) {
-    this->PreintegrationBackend::resetIntegration();
+    this->PreintegrationType::resetIntegration();
   }
  
   /// Virtual destructor
@@ -116,7 +116,7 @@ public:
   void print(const std::string& s = "Preintegrated Measurements:") const override;
 
   /// equals
-  bool equals(const PreintegratedImuMeasurementsT<PreintegrationBackend>& expected, double tol = 1e-9) const;
+  bool equals(const PreintegratedImuMeasurementsT<PreintegrationType>& expected, double tol = 1e-9) const;
 
   /// Re-initialize PreintegratedImuMeasurements
   void resetIntegration() override;
@@ -143,13 +143,13 @@ public:
 
   /// Merge in a different set of measurements and update bias derivatives accordingly
   /// This method is specific to TangentPreintegration backend.
-  template <typename PB = PreintegrationBackend,
-             // This method is only callable when PreintegrationBackend is TangentPreintegration.
+  template <typename PB = PreintegrationType,
+             // This method is only callable when PreintegrationType is TangentPreintegration.
              typename = typename std::enable_if<std::is_same<PB, TangentPreintegration>::value>::type>
   void mergeWith(const PreintegratedImuMeasurementsT<TangentPreintegration>& pim12, Matrix9* H1, Matrix9* H2) {
-    // The `this->PreintegrationBackend::mergeWith` implies calling TangentPreintegration's mergeWith.
+    // The `this->PreintegrationType::mergeWith` implies calling TangentPreintegration's mergeWith.
     // Since pim12 is PreintegratedImuMeasurementsT<TangentPreintegration>, it is a TangentPreintegration.
-    this->PreintegrationBackend::mergeWith(pim12, H1, H2);
+    this->PreintegrationType::mergeWith(pim12, H1, H2);
     // NOTE(gareth): Temporary P is needed as of Eigen 3.3
     const Matrix9 P = *H1 * preintMeasCov_ * H1->transpose();
     preintMeasCov_ = P + *H2 * pim12.preintMeasCov_ * H2->transpose();
@@ -162,7 +162,7 @@ public:
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
     namespace bs = ::boost::serialization;
-    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(PreintegrationBackend);
+    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(PreintegrationType);
     ar & BOOST_SERIALIZATION_NVP(preintMeasCov_);
   }
 #endif
@@ -170,7 +170,7 @@ public:
 
 // For backward compatibility (so that the compiler flag GTSAM_TANGENT_PREINTEGRATION still
 // controls which class PreintegratedImuMeasurements uses):
-using PreintegratedImuMeasurements = PreintegratedImuMeasurementsT<DefaultPreintegrationBackend>;
+using PreintegratedImuMeasurements = PreintegratedImuMeasurementsT<DefaultPreintegrationType>;
 
 /**
  * ImuFactor is a 5-ways factor involving previous state (pose and velocity of
@@ -435,8 +435,8 @@ using ImuFactor2 = ImuFactor2T<>;
 template <class PIMType_>
 GTSAM_EXPORT std::ostream& operator<<(std::ostream& os, const ImuFactor2T<PIMType_>& f);
 
-template <class PreintegrationBackend>
-struct traits<PreintegratedImuMeasurementsT<PreintegrationBackend>> : public Testable<PreintegratedImuMeasurementsT<PreintegrationBackend>> {};
+template <class PreintegrationType>
+struct traits<PreintegratedImuMeasurementsT<PreintegrationType>> : public Testable<PreintegratedImuMeasurementsT<PreintegrationType>> {};
 
 template <class PIMType_>
 struct traits<ImuFactorT<PIMType_>> : public Testable<ImuFactorT<PIMType_>> {};

--- a/gtsam/navigation/ImuFactor.h
+++ b/gtsam/navigation/ImuFactor.h
@@ -306,11 +306,11 @@ public:
     // static typename This::shared_ptr Merge(const typename This::shared_ptr&, const typename This::shared_ptr&)
 
   // IMU bias keys must be the same.
-  if (f01->key<5>() != f12->key<5>())
+  if (f01->template key<5>() != f12->template key<5>())
     throw std::domain_error("ImuFactor::Merge: IMU bias keys must be the same");
 
   // expect intermediate pose, velocity keys to matchup.
-  if (f01->key<3>() != f12->key<1>() || f01->key<4>() != f12->key<2>())
+  if (f01->template key<3>() != f12->template key<1>() || f01->template key<4>() != f12->template key<2>())
     throw std::domain_error(
         "ImuFactor::Merge: intermediate pose, velocity keys need to match up");
 
@@ -318,11 +318,11 @@ public:
   auto pim02 = This::Merge(f01->preintegratedMeasurements(), f12->preintegratedMeasurements());
 
   return std::make_shared<This>( // `This` is ImuFactorT<MethodPIMArg> (i.e. ImuFactorT<PIMType_>)
-      f01->key<1>(),  // P0
-      f01->key<2>(),  // V0
-      f12->key<3>(),  // P2
-      f12->key<4>(),  // V2
-      f01->key<5>(),  // B
+      f01->template key<1>(),  // P0
+      f01->template key<2>(),  // V0
+      f12->template key<3>(),  // P2
+      f12->template key<4>(),  // V2
+      f01->template key<5>(),  // B
       pim02);
   }
 

--- a/gtsam/navigation/ImuFactor.h
+++ b/gtsam/navigation/ImuFactor.h
@@ -71,8 +71,8 @@ typedef ManifoldPreintegration DefaultPreintegrationBackend;
 template <class PreintegrationBackend>
 class GTSAM_EXPORT PreintegratedImuMeasurementsT: public PreintegrationBackend {
  
-  template <class PIMType_> friend class ImuFactorT;
-  template <class PIMType_> friend class ImuFactor2T;
+  template <class PIM> friend class ImuFactorT;
+  template <class PIM> friend class ImuFactor2T;
 
 protected:
 

--- a/gtsam/navigation/doc/CombinedImuFactor.ipynb
+++ b/gtsam/navigation/doc/CombinedImuFactor.ipynb
@@ -208,6 +208,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Custom Preintegration Type\n",
+    "\n",
+    "- Which implementation is used for the `DefaultPreintegrationType` used by `ImuFactor`s and `Preintegrated*Measurements` depends on the compile flag `GTSAM_TANGENT_PREINTEGRATION`, which is true by default.\n",
+    "    - If false, `ManifoldPreintegration` is used. Please use this setting to get the exact implementation from `https://doi.org/10.1109/TRO.2016.2597321`.\n",
+    "    - If true, `TangentPreintegration` is used. This does the integration on the tangent space of the NavState manifold.\n",
+    "- In C++, if you wish to use any preintegration type other than the default, you must template your PIMs and factors on the desired preintegration type using the template-supporting classes `PreintegratedImuMeasurementsT`, `ImuFactorT`, `ImuFactor2T`, `PreintegratedCombinedMeasurementsT`, or `CombinedImuFactorT`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Source\n",
     "- [CombinedImuFactor.h](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/CombinedImuFactor.h)\n",
     "- [CombinedImuFactor.cpp](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/CombinedImuFactor.cpp)"

--- a/gtsam/navigation/doc/ImuFactor.ipynb
+++ b/gtsam/navigation/doc/ImuFactor.ipynb
@@ -41,23 +41,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-cell"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[31mERROR: Could not find a version that satisfies the requirement gtsam-develop (from versions: none)\u001b[0m\u001b[31m\n",
-      "\u001b[0m\u001b[31mERROR: No matching distribution found for gtsam-develop\u001b[0m\u001b[31m\n",
-      "\u001b[0mNote: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%pip install --quiet gtsam-develop"
    ]
@@ -273,6 +263,18 @@
     "error_vector = imu_factor2.evaluateError(nav_state_i, nav_state_j, bias_i)\n",
     "print(\"\\nError vector (should be near zero):\", error_vector)\n",
     "print(\"Factor error (0.5 * ||error||^2_Sigma):\", graph.error(values))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Custom Preintegration Type\n",
+    "\n",
+    "- Which implementation is used for the `DefaultPreintegrationType` used by `ImuFactor`s and `Preintegrated*Measurements` depends on the compile flag `GTSAM_TANGENT_PREINTEGRATION`, which is true by default.\n",
+    "    - If false, `ManifoldPreintegration` is used. Please use this setting to get the exact implementation from `https://doi.org/10.1109/TRO.2016.2597321`.\n",
+    "    - If true, `TangentPreintegration` is used. This does the integration on the tangent space of the NavState manifold.\n",
+    "- In C++, if you wish to use any preintegration type other than the default, you must template your PIMs and factors on the desired preintegration type using the template-supporting classes `PreintegratedImuMeasurementsT`, `ImuFactorT`, `ImuFactor2T`, `PreintegratedCombinedMeasurementsT`, or `CombinedImuFactorT`."
    ]
   },
   {

--- a/gtsam/navigation/doc/PreintegratedCombinedMeasurements.ipynb
+++ b/gtsam/navigation/doc/PreintegratedCombinedMeasurements.ipynb
@@ -21,23 +21,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-cell"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[31mERROR: Could not find a version that satisfies the requirement gtsam-develop (from versions: none)\u001b[0m\u001b[31m\n",
-      "\u001b[0m\u001b[31mERROR: No matching distribution found for gtsam-develop\u001b[0m\u001b[31m\n",
-      "\u001b[0mNote: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%pip install --quiet gtsam-develop"
    ]
@@ -152,6 +142,18 @@
    "metadata": {},
    "source": [
     "This `pim` object is then passed to the `CombinedImuFactor` constructor."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Custom Preintegration Type\n",
+    "\n",
+    "- Which implementation is used for the `DefaultPreintegrationType` used by `ImuFactor`s and `Preintegrated*Measurements` depends on the compile flag `GTSAM_TANGENT_PREINTEGRATION`, which is true by default.\n",
+    "    - If false, `ManifoldPreintegration` is used. Please use this setting to get the exact implementation from `https://doi.org/10.1109/TRO.2016.2597321`.\n",
+    "    - If true, `TangentPreintegration` is used. This does the integration on the tangent space of the NavState manifold.\n",
+    "- In C++, if you wish to use any preintegration type other than the default, you must template your PIMs and factors on the desired preintegration type using the template-supporting classes `PreintegratedImuMeasurementsT`, `ImuFactorT`, `ImuFactor2T`, `PreintegratedCombinedMeasurementsT`, or `CombinedImuFactorT`."
    ]
   },
   {

--- a/gtsam/navigation/doc/PreintegratedImuMeasurements.ipynb
+++ b/gtsam/navigation/doc/PreintegratedImuMeasurements.ipynb
@@ -25,15 +25,7 @@
      "remove-cell"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%pip install --quiet gtsam-develop"
    ]
@@ -172,6 +164,18 @@
    "metadata": {},
    "source": [
     "The `pim` object is then passed to the `ImuFactor` or `ImuFactor2` constructor."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Custom Preintegration Type\n",
+    "\n",
+    "- Which implementation is used for the `DefaultPreintegrationType` used by `ImuFactor`s and `Preintegrated*Measurements` depends on the compile flag `GTSAM_TANGENT_PREINTEGRATION`, which is true by default.\n",
+    "    - If false, `ManifoldPreintegration` is used. Please use this setting to get the exact implementation from `https://doi.org/10.1109/TRO.2016.2597321`.\n",
+    "    - If true, `TangentPreintegration` is used. This does the integration on the tangent space of the NavState manifold.\n",
+    "- In C++, if you wish to use any preintegration type other than the default, you must template your PIMs and factors on the desired preintegration type using the template-supporting classes `PreintegratedImuMeasurementsT`, `ImuFactorT`, `ImuFactor2T`, `PreintegratedCombinedMeasurementsT`, or `CombinedImuFactorT`."
    ]
   },
   {

--- a/gtsam/navigation/navigation.md
+++ b/gtsam/navigation/navigation.md
@@ -200,9 +200,9 @@ The key components are:
     * [CombinedImuFactor](doc/CombinedImuFactor.ipynb): A 6-way factor connecting previous pose/velocity, current pose/velocity, previous bias, and current bias. *Includes* a model for bias random walk evolution between the two bias states.
 
 ### Important notes
-- Which implementation is used for `PreintegrationType` depends on the compile flag `GTSAM_TANGENT_PREINTEGRATION`, which is true by default.
+- Which implementation is used for the `DefaultPreintegrationType` used by `ImuFactor`s and `Preintegrated*Measurements` depends on the compile flag `GTSAM_TANGENT_PREINTEGRATION`, which is true by default.
     - If false, `ManifoldPreintegration` is used. Please use this setting to get the exact implementation from {cite:t}`https://doi.org/10.1109/TRO.2016.2597321`.
     - If true, `TangentPreintegration` is used. This does the integration on the tangent space of the NavState manifold.
+- If you wish to use any preintegration type other than the default, you must template your PIMs and factors on the desired preintegration type using the template-supporting classes `PreintegratedImuMeasurementsT`, `ImuFactorT`, `ImuFactor2T`, `PreintegratedCombinedMeasurementsT`, or `CombinedImuFactorT`.
 - Using the combined IMU factor is not recommended. Typically biases evolve slowly, and hence a separate, lower frequency Markov chain on the bias is more appropriate.
 - For short-duration experiments it is even recommended to use a single constant bias. Bias estimation is notoriously hard to tune/debug, and also acts as a "sink" for any modeling errors. Hence, starting with a constant bias is a good idea to get the rest of the pipeline working.
-


### PR DESCRIPTION
## Description

This PR refactors `ImuFactor`, `ImuFactor2`, `CombinedImuFactor`, and their associated `Preintegrated*Measurements` classes to use a template-based approach for selecting the underlying preintegration method (Manifold or Tangent). This change allows  users to choose a preintegration backend without requiring GTSAM to be recompiled with different flags, while maintaining full backward compatibility.

## Motivation & Background

Previously, the choice between `ManifoldPreintegration` and `TangentPreintegration` was controlled by the `GTSAM_TANGENT_PREINTEGRATION` preprocessor flag at GTSAM compile time.

This refactor addresses this limitation by:
1.  Introducing templated versions of the IMU factor and preintegrated measurements classes
2.  Parameterizing these templates by the preintegration backend type via the preintegrated measurements class
3.  Maintaining backward compatibility by providing `typedef`s for the original class names (e.g., `ImuFactor`) which default to the backend selected by the `GTSAM_TANGENT_PREINTEGRATION` flag (via `DefaultPreintegrationBackend`).

## Key Changes

*   **Templated Classes:**
    *   `PreintegratedImuMeasurements` -> `PreintegratedImuMeasurementsT<PreintegrationBackend>`
    *   `PreintegratedCombinedMeasurements` -> `PreintegratedCombinedMeasurementsT<PreintegrationBackend>`
    *   `ImuFactor` -> `ImuFactorT<PIMType_ = PreintegratedImuMeasurements>`
    *   `ImuFactor2` -> `ImuFactor2T<PIMType_ = PreintegratedImuMeasurements>`
    *   `CombinedImuFactor` -> `CombinedImuFactorT<PIMType_ = PreintegratedCombinedMeasurements>`
*   **Backward Compatibility Typedefs:**
    *   `typedef PreintegratedImuMeasurementsT<DefaultPreintegrationBackend> PreintegratedImuMeasurements;` (and similar for Combined)
    *   `typedef ImuFactorT<> ImuFactor;` (and similar for ImuFactor2, CombinedImuFactor), which use the default `PIMType_` that in turn uses `DefaultPreintegrationBackend`.
*   **SFINAE for Backend-Specific Methods:** Methods like `mergeWith` and static `Merge` functions, previously guarded by `#ifdef GTSAM_TANGENT_PREINTEGRATION`, are now enabled using SFINAE (substitution failure is not an error, a C++ paradigm) only for `TangentPreintegration`-based instantiations. These are also now defined in the header files instead of the .cpp files.
*   **Explicit Instantiations:** Explicit template instantiations for both `ManifoldPreintegration` and `TangentPreintegration` backends are provided in the `.cpp` files. This ensures that:
    *   Implementations can reside in `.cpp` files.
    *   Commonly used instantiations are pre-compiled and exported from the GTSAM library.
    *   Users linking against GTSAM can use these common instantiations without needing the full template method definitions.
*   **Robustness for Dependent Names:** `this->` is used consistently when accessing members of templated base classes (`PreintegrationBackend`) to ensure correct name lookup in dependent contexts, particularly for portability across compilers.

## How to Use

**1. Backward Compatible Usage (no code change needed):**
Existing code using `gtsam::ImuFactor`, `gtsam::PreintegratedImuMeasurements`, etc., will continue to work as before. The preintegration backend will be determined by how GTSAM was compiled (i.e., the `GTSAM_TANGENT_PREINTEGRATION` flag).

```cpp
// Old code - still works, uses GTSAM's compiled default backend
gtsam::PreintegratedImuMeasurements pim(params, bias);
// ... integrate measurements ...
gtsam::ImuFactor factor(keyPose1, keyVel1, keyPose2, keyVel2, keyBias, pim);
```

**2. Explicit Backend Selection (new):**
Users can now explicitly choose the preintegration backend at their own compile time, regardless of GTSAM's compilation flags.

**Example: Explicitly using `ManifoldPreintegration`**
```cpp
#include <gtsam/navigation/ImuFactor.h>
#include <gtsam/navigation/ManifoldPreintegration.h>

// Define the PIM type using ManifoldPreintegration as the backend
typedef gtsam::PreintegratedImuMeasurementsT<gtsam::ManifoldPreintegration> MyManifoldPim;

// Create an ImuFactor that uses this PIM type
typedef gtsam::ImuFactorT<MyManifoldPim> MyManifoldImuFactor;

// --- Usage ---
std::shared_ptr<gtsam::PreintegrationParams> params = /* ... initialize ... */;
gtsam::imuBias::ConstantBias bias; // Or your estimated bias

MyManifoldPim pim(params, bias);
// ... pim.integrateMeasurement(...) ...

gtsam::Key keyPose1(1), keyVel1(2), keyPose2(3), keyVel2(4), keyBias(5);
MyManifoldImuFactor factor(keyPose1, keyVel1, keyPose2, keyVel2, keyBias, pim);
```

**Example: Explicitly using `TangentPreintegration`**
```cpp
#include <gtsam/navigation/ImuFactor.h>
#include <gtsam/navigation/TangentPreintegration.h>

// Define the PIM type using TangentPreintegration as the backend
typedef gtsam::PreintegratedImuMeasurementsT<gtsam::TangentPreintegration> MyTangentPim;

// Create an ImuFactor that uses this PIM type
typedef gtsam::ImuFactorT<MyTangentPim> MyTangentImuFactor;

// --- Usage (similar to above) ---
std::shared_ptr<gtsam::PreintegrationParams> params = /* ... initialize ... */;
gtsam::imuBias::ConstantBias bias;

MyTangentPim pim(params, bias);
// ... pim.integrateMeasurement(...) ...

gtsam::Key keyPose1(1), keyVel1(2), keyPose2(3), keyVel2(4), keyBias(5);
MyTangentImuFactor factor(keyPose1, keyVel1, keyPose2, keyVel2, keyBias, pim);

// If using TangentPreintegration, Merge methods are available:
// MyTangentPim merged_pim = MyTangentImuFactor::Merge(pim1, pim2);
```

## Note

Code changes generated by Gemini; I went over them with a fine-toothed comb and tested. PR description also partially generated by Gemini for the sake of full coverage of changes.

Please suggest changes, as this is a pretty comprehensive overhaul @varunagrawal @ProfFan @dellaert 