### PR TITLE
Updated `Cal3_S2` User Guide

### DIFF
--- a/gtsam/geometry/doc/Cal3_S2.ipynb
+++ b/gtsam/geometry/doc/Cal3_S2.ipynb
@@ -15,7 +15,7 @@
         "id": "cal3s2-intro"
       },
       "source": [
-        "A `Cal3_S2` represents the simple 5-parameter camera calibration model. This model includes parameters for the focal lengths ($f_x, f_y$), the skew factor ($s$), and the principal point ($u_0, v_0$). It does not model lens distortion. The calibration matrix $K$ is defined as:\n",
+        "A `Cal3_S2` represents the simple 5-parameter camera calibration model {cite:p}`https://doi.org/10.1017/CBO9780511811685`[^f1]. This model includes parameters for the focal lengths ($f_x, f_y$), the skew factor ($s$), and the principal point ($u_0, v_0$). It does not model lens distortion. The calibration matrix $K$ is defined as:\n",
         "\n",
         "$$\n",
         "K = \\begin{bmatrix} f_x & s & u_0 \\\\ 0 & f_y & v_0 \\\\ 0 & 0 & 1 \\end{bmatrix}\n",
@@ -28,7 +28,10 @@
         "u &= f_x\\cdot x + s\\cdot y + u_0 \\\\\n",
         "v &= f_y\\cdot y + v_0\n",
         "\\end{align*}\n",
-        "$$"
+        "$$\n",
+        "\n",
+        "<!-- The following will not be rendered as literal text by MyST -->\n",
+        "[^f1]: See ch. 6 $\\S$ 6.1, pp. 153–157."
       ]
     },
     {
@@ -531,7 +534,11 @@
         "\n",
         "### Video(s)\n",
         "- [\"Linear Camera Model | Camera Calibration\"](https://youtu.be/qByYk6JggQU?si=t8kTo_GRWYjs5f53) by Dr. Shree Nayar from Columbia University\n",
-        "- [\"Computer Vision: The Camera Matrix\"](https://youtu.be/Hz8kz5aeQ44?si=Y823_mlZoJOV0gyW) by Michael Prasthofer"
+        "- [\"Computer Vision: The Camera Matrix\"](https://youtu.be/Hz8kz5aeQ44?si=Y823_mlZoJOV0gyW) by Michael Prasthofer\n",
+        "\n",
+        "## Source\n",
+        "- [Cal3_S2.h](https://github.com/borglab/gtsam/blob/develop/gtsam/geometry/Cal3_S2.h)\n",
+        "- [Cal3_S2.cpp](https://github.com/borglab/gtsam/blob/develop/gtsam/geometry/Cal3_S2.cpp)"
       ]
     }
   ],

--- a/gtsam/geometry/doc/Cal3_S2.ipynb
+++ b/gtsam/geometry/doc/Cal3_S2.ipynb
@@ -15,13 +15,14 @@
         "id": "cal3s2-intro"
       },
       "source": [
-        "A `gtsam.Cal3_S2` represents the simple 5-parameter camera calibration model. This model includes parameters for the focal lengths ($f_x, f_y$), the skew factor ($s$), and the principal point ($u_0, v_0$). It does not model lens distortion. The calibration matrix $K$ is defined as:\n",
+        "A `Cal3_S2` represents the simple 5-parameter camera calibration model. This model includes parameters for the focal lengths ($f_x, f_y$), the skew factor ($s$), and the principal point ($u_0, v_0$). It does not model lens distortion. The calibration matrix $K$ is defined as:\n",
         "\n",
         "$$\n",
         "K = \\begin{bmatrix} f_x & s & u_0 \\\\ 0 & f_y & v_0 \\\\ 0 & 0 & 1 \\end{bmatrix}\n",
         "$$\n",
         "\n",
         "This model is based on the assumption of a pinhole camera model. The main purpose of this model is for instrinsic conversions between image pixel coordinates $(u, v)$ in the image sensor frame and the normalized image coordinates $(x, y)$. The normalized image coordinates (also called intrinsic coordinates) are coordinates on a canonical image plane that is unit focal length away from the aperture point. In other words, given any 3D point $(x_c, y_c, z_c)$ based on the camera frame coordinates, a `Cal3_S2` model can handle conversions between $(x, y) = \\left(\\frac{x_c}{z_c}, \\frac{y_c}{z_c}\\right)$ and $(u, v)$, where\n",
+        "\n",
         "$$\n",
         "\\begin{align*}\n",
         "u &= f_x\\cdot x + s\\cdot y + u_0 \\\\\n",
@@ -41,26 +42,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 21,
+      "execution_count": null,
       "metadata": {
         "id": "cal3s2-pip-install"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Note: you may need to restart the kernel to use updated packages.\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "%pip install --quiet gtsam-develop"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 22,
+      "execution_count": 2,
       "metadata": {
         "id": "cal3s2-imports"
       },
@@ -89,7 +82,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 23,
+      "execution_count": 3,
       "metadata": {
         "id": "cal3s2-initialization-code"
       },
@@ -161,7 +154,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 24,
+      "execution_count": 4,
       "metadata": {},
       "outputs": [
         {
@@ -214,7 +207,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 25,
+      "execution_count": 5,
       "metadata": {},
       "outputs": [
         {
@@ -260,7 +253,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 26,
+      "execution_count": 6,
       "metadata": {
         "id": "cal3s2-accessors-code"
       },
@@ -291,41 +284,23 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## Basic Operations"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### `calibrate()`"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "cal3s2-operations-header"
-      },
-      "source": [
-        "`Cal3_S2` provides member functions to convert points between normalized image coordinates and pixel coordinates."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "cal3s2-calibrate-header"
-      },
-      "source": [
-        "The `calibrate(p)` member function converts a 2D point `p` in image pixel coordinates $(u, v)$ to normalized image coordinates $(x, y)$. This member function effectively implements the formula \n",
+        "## Basic Operations\n",
+        "\n",
+        "### `calibrate()`\n",
+        "\n",
+        "`Cal3_S2` provides member functions to convert points between normalized image coordinates and pixel coordinates.\n",
+        "The `calibrate(p)` member function converts a 2D point `p` in image pixel coordinates $(u, v)$ to normalized image coordinates $(x, y)$. This member function effectively implements the formula\n",
+        "\n",
         "$$\n",
         "p_{\\text{norm}} = K^{-1} \\cdot p_{\\text{pixels}}\n",
         "$$\n",
+        "\n",
         "where $p_{\\text{norm}}$ and $p_{\\text{pixels}}$ are homogeneous representations of $(x, y)$ and $(u, v)$, respectively. "
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 35,
+      "execution_count": 7,
       "metadata": {
         "id": "cal3s2-calibrate-code"
       },
@@ -354,7 +329,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 36,
+      "execution_count": 8,
       "metadata": {},
       "outputs": [
         {
@@ -385,7 +360,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 37,
+      "execution_count": 9,
       "metadata": {},
       "outputs": [
         {
@@ -414,15 +389,8 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "### `uncalibrate()`"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "cal3s2-uncalibrate-header"
-      },
-      "source": [
+        "### `uncalibrate()`\n",
+        "\n",
         "The `uncalibrate(p)` member function converts a 2D point `p` from normalized image coordinates $(u, v)$ back to image pixel coordinates $(u, v)$. This is the inverse operation of `calibrate()` and effectively implements the formula\n",
         "\n",
         "$$\n",
@@ -432,7 +400,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 38,
+      "execution_count": 10,
       "metadata": {
         "id": "cal3s2-uncalibrate-code"
       },
@@ -463,7 +431,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 39,
+      "execution_count": 11,
       "metadata": {
         "id": "cal3s2-jacobian-code"
       },
@@ -492,23 +460,18 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Manifold Operations"
-      ]
-    },
-    {
-      "cell_type": "markdown",
       "metadata": {
         "id": "cal3s2-manifold-header"
       },
       "source": [
-        "`Cal3_S2`, like many geometric types in GTSAM, is treated as a manifold. This means it supports operations like `retract()` (moving on the manifold given a tangent vector) and `localCoordinates()` (finding the tangent vector between two points on the manifold). These operations enable gradient-based optimization by applying updates in the tangent space of the manifold."
+        "### Manifold Operations\n",
+        "\n",
+        "`Cal3_S2`, like many geometric types in GTSAM, is treated as a manifold in order to optimize over it. This means it supports operations like `retract()` (moving on the manifold given a tangent vector) and `localCoordinates()` (finding the tangent vector between two points on the manifold). These operations enable gradient-based optimization by applying updates in the tangent space of the manifold."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 31,
+      "execution_count": 12,
       "metadata": {
         "id": "cal3s2-manifold-code"
       },
@@ -559,28 +522,13 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## Additional Resources"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "The following curated resources provide detailed explanations of the camera calibration process. If you found any parts of this user guide to be confusing, we recommend getting started by reviewing these resources first:"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
+        "## Additional Resources\n",
+        "\n",
+        "The following curated resources provide detailed explanations of the camera calibration process. If you found any parts of this user guide to be confusing, we recommend getting started by reviewing these resources first:\n",
+        "\n",
         "### Article(s)\n",
-        "- [\"Camera Intrinsics: Axis skew\"](https://blog.immenselyhappy.com/post/camera-axis-skew/) by Ashima Athri"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
+        "- [\"Camera Intrinsics: Axis skew\"](https://blog.immenselyhappy.com/post/camera-axis-skew/) by Ashima Athri\n",
+        "\n",
         "### Video(s)\n",
         "- [\"Linear Camera Model | Camera Calibration\"](https://youtu.be/qByYk6JggQU?si=t8kTo_GRWYjs5f53) by Dr. Shree Nayar from Columbia University\n",
         "- [\"Computer Vision: The Camera Matrix\"](https://youtu.be/Hz8kz5aeQ44?si=Y823_mlZoJOV0gyW) by Michael Prasthofer"


### PR DESCRIPTION
Update(s):
- Fixed some minor LaTeX format issue that appeared after being rendered by MyST.
- Added Hartley & Zisserman, 2004 as source for the 5-parameter calibration model.
- Added footnote to the source to detail the chapter and page number of interest.
- Mentioned the reason for manifold is to optimize over it.
- Added a "Source" section with reference to `Cal3_S2.h` and `Cal3_S2.cpp` to conform with other user guides (specifically, those in `gtsam/navigation`