### PR TITLE
ImuFactor de-templated

### DIFF
--- a/gtsam/navigation/CombinedImuFactor.cpp
+++ b/gtsam/navigation/CombinedImuFactor.cpp
@@ -21,6 +21,8 @@
  **/
 
 #include <gtsam/navigation/CombinedImuFactor.h>
+#include <gtsam/navigation/ManifoldPreintegration.h>
+#include <gtsam/navigation/TangentPreintegration.h>
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/export.hpp>
 #endif
@@ -58,33 +60,37 @@ bool PreintegrationCombinedParams::equals(const PreintegratedRotationParams& oth
 }
 
 //------------------------------------------------------------------------------
-// Inner class PreintegratedCombinedMeasurements
+// Inner class PreintegratedCombinedMeasurementsT
 //------------------------------------------------------------------------------
-void PreintegratedCombinedMeasurements::print(const string& s) const {
-  PreintegrationType::print(s);
+template <class PreintegrationBackend>
+void PreintegratedCombinedMeasurementsT<PreintegrationBackend>::print(const string& s) const {
+  PreintegrationBackend::print(s);
   cout << "  preintMeasCov [ " << preintMeasCov_ << " ]" << endl;
 }
 
 //------------------------------------------------------------------------------
-bool PreintegratedCombinedMeasurements::equals(
-    const PreintegratedCombinedMeasurements& other, double tol) const {
-  return PreintegrationType::equals(other, tol)
+template <class PreintegrationBackend>
+bool PreintegratedCombinedMeasurementsT<PreintegrationBackend>::equals(
+    const PreintegratedCombinedMeasurementsT<PreintegrationBackend>& other, double tol) const {
+  return PreintegrationBackend::equals(other, tol)
       && equal_with_abs_tol(preintMeasCov_, other.preintMeasCov_, tol);
 }
 
 //------------------------------------------------------------------------------
-void PreintegratedCombinedMeasurements::resetIntegration() {
+template <class PreintegrationBackend>
+void PreintegratedCombinedMeasurementsT<PreintegrationBackend>::resetIntegration() {
   // Base class method to reset the preintegrated measurements
-  PreintegrationType::resetIntegration();
+  PreintegrationBackend::resetIntegration();
   preintMeasCov_.setZero();
 }
 
 //------------------------------------------------------------------------------
-void PreintegratedCombinedMeasurements::resetIntegration(
+template <class PreintegrationBackend>
+void PreintegratedCombinedMeasurementsT<PreintegrationBackend>::resetIntegration(
     const gtsam::Matrix6& Q_init) {
   // Base class method to reset the preintegrated measurements
-  PreintegrationType::resetIntegration();
-  p().biasAccOmegaInt = Q_init;
+  PreintegrationBackend::resetIntegration();
+  this->p().biasAccOmegaInt = Q_init;
   preintMeasCov_.setZero();
 }
 
@@ -103,7 +109,8 @@ void PreintegratedCombinedMeasurements::resetIntegration(
 #define D_g_g(H) (H)->block<3,3>(12,12)
 
 //------------------------------------------------------------------------------
-void PreintegratedCombinedMeasurements::integrateMeasurement(
+template <class PreintegrationBackend>
+void PreintegratedCombinedMeasurementsT<PreintegrationBackend>::integrateMeasurement(
     const Vector3& measuredAcc, const Vector3& measuredOmega, double dt) {
   if (dt <= 0) {
     throw std::runtime_error(
@@ -113,7 +120,7 @@ void PreintegratedCombinedMeasurements::integrateMeasurement(
   // Update preintegrated measurements.
   Matrix9 A; // Jacobian wrt preintegrated measurements without bias (df/dx)
   Matrix93 B, C;  // Jacobian of state wrpt accel bias and omega bias respectively.
-  PreintegrationType::update(measuredAcc, measuredOmega, dt, &A, &B, &C);
+  PreintegrationBackend::update(measuredAcc, measuredOmega, dt, &A, &B, &C);
 
   // Update preintegrated measurements covariance: as in [2] we consider a first
   // order propagation that can be seen as a prediction phase in an EKF
@@ -144,10 +151,10 @@ void PreintegratedCombinedMeasurements::integrateMeasurement(
 
   // propagate uncertainty
   // TODO(frank): use noiseModel routine so we can have arbitrary noise models.
-  const Matrix3& aCov = p().accelerometerCovariance;
-  const Matrix3& wCov = p().gyroscopeCovariance;
-  const Matrix3& iCov = p().integrationCovariance;
-  const Matrix6& bInitCov = p().biasAccOmegaInt;
+  const Matrix3& aCov = this->p().accelerometerCovariance;
+  const Matrix3& wCov = this->p().gyroscopeCovariance;
+  const Matrix3& iCov = this->p().integrationCovariance;
+  const Matrix6& bInitCov = this->p().biasAccOmegaInt;
 
   // first order uncertainty propagation
   // Optimized matrix mult: (1/dt) * G * measurementCovariance * G.transpose()
@@ -174,8 +181,8 @@ void PreintegratedCombinedMeasurements::integrateMeasurement(
       (vel_H_acc * (aCov / dt) * vel_H_acc.transpose())  //
       + (vel_H_biasAccInit * bInitCov11 * vel_H_biasAccInit.transpose());
 
-  D_a_a(&G_measCov_Gt) = dt * p().biasAccCovariance;
-  D_g_g(&G_measCov_Gt) = dt * p().biasOmegaCovariance;
+  D_a_a(&G_measCov_Gt) = dt * this->p().biasAccCovariance;
+  D_g_g(&G_measCov_Gt) = dt * this->p().biasOmegaCovariance;
 
   // OFF BLOCK DIAGONAL TERMS
   D_R_t(&G_measCov_Gt) =
@@ -197,23 +204,10 @@ void PreintegratedCombinedMeasurements::integrateMeasurement(
 }
 
 //------------------------------------------------------------------------------
-// CombinedImuFactor methods
+// CombinedImuFactorT methods
 //------------------------------------------------------------------------------
-CombinedImuFactor::CombinedImuFactor(Key pose_i, Key vel_i, Key pose_j,
-    Key vel_j, Key bias_i, Key bias_j,
-    const PreintegratedCombinedMeasurements& pim) :
-    Base(noiseModel::Gaussian::Covariance(pim.preintMeasCov_), pose_i, vel_i,
-        pose_j, vel_j, bias_i, bias_j), _PIM_(pim) {
-}
-
-//------------------------------------------------------------------------------
-gtsam::NonlinearFactor::shared_ptr CombinedImuFactor::clone() const {
-  return std::static_pointer_cast<gtsam::NonlinearFactor>(
-      gtsam::NonlinearFactor::shared_ptr(new This(*this)));
-}
-
-//------------------------------------------------------------------------------
-void CombinedImuFactor::print(const string& s,
+template <class PIMType_>
+void CombinedImuFactorT<PIMType_>::print(const string& s,
     const KeyFormatter& keyFormatter) const {
   cout << (s.empty() ? s : s + "\n") << "CombinedImuFactor("
        << keyFormatter(this->key<1>()) << "," << keyFormatter(this->key<2>()) << ","
@@ -225,13 +219,15 @@ void CombinedImuFactor::print(const string& s,
 }
 
 //------------------------------------------------------------------------------
-bool CombinedImuFactor::equals(const NonlinearFactor& other, double tol) const {
+template <class PIMType_>
+bool CombinedImuFactorT<PIMType_>::equals(const NonlinearFactor& other, double tol) const {
   const This* e = dynamic_cast<const This*>(&other);
   return e != nullptr && Base::equals(*e, tol) && _PIM_.equals(e->_PIM_, tol);
 }
 
 //------------------------------------------------------------------------------
-Vector CombinedImuFactor::evaluateError(const Pose3& pose_i,
+template <class PIMType_>
+Vector CombinedImuFactorT<PIMType_>::evaluateError(const Pose3& pose_i,
     const Vector3& vel_i, const Pose3& pose_j, const Vector3& vel_j,
     const imuBias::ConstantBias& bias_i, const imuBias::ConstantBias& bias_j,
     OptionalMatrixType H1, OptionalMatrixType H2,
@@ -296,10 +292,40 @@ Vector CombinedImuFactor::evaluateError(const Pose3& pose_i,
 }
 
 //------------------------------------------------------------------------------
-std::ostream& operator<<(std::ostream& os, const CombinedImuFactor& f) {
-  f._PIM_.print("combined preintegrated measurements:\n");
-  os << "  noise model sigmas: " << f.noiseModel_->sigmas().transpose();
+template <class PIMType_>
+std::ostream& operator<<(std::ostream& os, const CombinedImuFactorT<PIMType_>& f) {
+  f.preintegratedMeasurements().print("combined preintegrated measurements:\n");
+  os << "  noise model sigmas: " << f.noiseModel()->sigmas().transpose();
   return os;
 }
 
+//------------------------------------------------------------------------------
+// Explicit instantiations
+//------------------------------------------------------------------------------
+template class GTSAM_EXPORT PreintegratedCombinedMeasurementsT<ManifoldPreintegration>;
+template class GTSAM_EXPORT PreintegratedCombinedMeasurementsT<TangentPreintegration>;
+
+template class GTSAM_EXPORT CombinedImuFactorT<PreintegratedCombinedMeasurementsT<ManifoldPreintegration>>;
+template class GTSAM_EXPORT CombinedImuFactorT<PreintegratedCombinedMeasurementsT<TangentPreintegration>>;
+
+// Instantiate operator<<
+template GTSAM_EXPORT std::ostream& operator<<<PreintegratedCombinedMeasurementsT<ManifoldPreintegration>>(
+    std::ostream& os, const CombinedImuFactorT<PreintegratedCombinedMeasurementsT<ManifoldPreintegration>>& f);
+template GTSAM_EXPORT std::ostream& operator<<<PreintegratedCombinedMeasurementsT<TangentPreintegration>>(
+    std::ostream& os, const CombinedImuFactorT<PreintegratedCombinedMeasurementsT<TangentPreintegration>>& f);
+
+
 }  // namespace gtsam
+
+// Undefine macros to prevent scope leakage
+#undef D_R_R
+#undef D_R_t
+#undef D_R_v
+#undef D_t_R
+#undef D_t_t
+#undef D_t_v
+#undef D_v_R
+#undef D_v_t
+#undef D_v_v
+#undef D_a_a
+#undef D_g_g

--- a/gtsam/navigation/CombinedImuFactor.cpp
+++ b/gtsam/navigation/CombinedImuFactor.cpp
@@ -210,9 +210,9 @@ template <class PIMType_>
 void CombinedImuFactorT<PIMType_>::print(const string& s,
     const KeyFormatter& keyFormatter) const {
   cout << (s.empty() ? s : s + "\n") << "CombinedImuFactor("
-       << keyFormatter(this->key<1>()) << "," << keyFormatter(this->key<2>()) << ","
-       << keyFormatter(this->key<3>()) << "," << keyFormatter(this->key<4>()) << ","
-       << keyFormatter(this->key<5>()) << "," << keyFormatter(this->key<6>())
+       << keyFormatter(this->template key<1>()) << "," << keyFormatter(this->template key<2>()) << ","
+       << keyFormatter(this->template key<3>()) << "," << keyFormatter(this->template key<4>()) << ","
+       << keyFormatter(this->template key<5>()) << "," << keyFormatter(this->template key<6>())
        << ")\n";
   _PIM_.print("  preintegrated measurements:");
   this->noiseModel_->print("  noise model: ");

--- a/gtsam/navigation/CombinedImuFactor.cpp
+++ b/gtsam/navigation/CombinedImuFactor.cpp
@@ -316,16 +316,3 @@ template GTSAM_EXPORT std::ostream& operator<<<PreintegratedCombinedMeasurements
 
 
 }  // namespace gtsam
-
-// Undefine macros to prevent scope leakage
-#undef D_R_R
-#undef D_R_t
-#undef D_R_v
-#undef D_t_R
-#undef D_t_t
-#undef D_t_v
-#undef D_v_R
-#undef D_v_t
-#undef D_v_v
-#undef D_a_a
-#undef D_g_g

--- a/gtsam/navigation/CombinedImuFactor.h
+++ b/gtsam/navigation/CombinedImuFactor.h
@@ -28,9 +28,9 @@
 namespace gtsam {
 
 #ifdef GTSAM_TANGENT_PREINTEGRATION
-typedef TangentPreintegration PreintegrationType;
+typedef TangentPreintegration DefaultPreintegrationBackend;
 #else
-typedef ManifoldPreintegration PreintegrationType;
+typedef ManifoldPreintegration DefaultPreintegrationBackend;
 #endif
 
 /*
@@ -63,8 +63,8 @@ typedef ManifoldPreintegration PreintegrationType;
  *
  * @ingroup navigation
  */
-class GTSAM_EXPORT PreintegratedCombinedMeasurements
-    : public PreintegrationType {
+template <class PreintegrationBackend>
+class GTSAM_EXPORT PreintegratedCombinedMeasurementsT : public PreintegrationBackend {
  public:
   typedef PreintegrationCombinedParams Params;
 
@@ -77,45 +77,44 @@ class GTSAM_EXPORT PreintegratedCombinedMeasurements
    */
   Eigen::Matrix<double, 15, 15> preintMeasCov_;
 
-  friend class CombinedImuFactor;
+  template <class PIMType_> friend class CombinedImuFactorT;
 
  public:
   /// @name Constructors
   /// @{
 
   /// Default constructor only for serialization and wrappers
-  PreintegratedCombinedMeasurements() { resetIntegration(); }
-
+  PreintegratedCombinedMeasurementsT() { this->resetIntegration(); } 
   /**
    *  Default constructor, initializes the class with no measurements
    *  @param p Parameters, typically fixed in a single application
    *  @param biasHat Current estimate of acceleration and rotation rate biases
    *  @param preintMeasCov Covariance matrix used in noise model.
    */
-  PreintegratedCombinedMeasurements(
+  PreintegratedCombinedMeasurementsT(
       const std::shared_ptr<Params>& p,
       const imuBias::ConstantBias& biasHat = imuBias::ConstantBias(),
       const Eigen::Matrix<double, 15, 15>& preintMeasCov =
           Eigen::Matrix<double, 15, 15>::Zero())
-      : PreintegrationType(p, biasHat), preintMeasCov_(preintMeasCov) {
-    PreintegrationType::resetIntegration();
+      : PreintegrationBackend(p, biasHat), preintMeasCov_(preintMeasCov) {
+    this->resetIntegration();
   }
 
   /**
    *  Construct preintegrated directly from members: base class and
    * preintMeasCov
-   *  @param base               PreintegrationType instance
+   *  @param base               PreintegrationBackend instance
    *  @param preintMeasCov      Covariance matrix used in noise model.
    */
-  PreintegratedCombinedMeasurements(
-      const PreintegrationType& base,
+  PreintegratedCombinedMeasurementsT(
+      const PreintegrationBackend& base,
       const Eigen::Matrix<double, 15, 15>& preintMeasCov)
-      : PreintegrationType(base), preintMeasCov_(preintMeasCov) {
-    PreintegrationType::resetIntegration();
+      : PreintegrationBackend(base), preintMeasCov_(preintMeasCov) {
+    this->PreintegrationBackend::resetIntegration();
   }
 
   /// Virtual destructor
-  ~PreintegratedCombinedMeasurements() override {}
+  ~PreintegratedCombinedMeasurementsT() override {}
 
   /// @}
 
@@ -149,7 +148,7 @@ class GTSAM_EXPORT PreintegratedCombinedMeasurements
   void print(
       const std::string& s = "Preintegrated Measurements:") const override;
   /// equals
-  bool equals(const PreintegratedCombinedMeasurements& expected,
+  bool equals(const PreintegratedCombinedMeasurementsT<PreintegrationBackend>& expected,
               double tol = 1e-9) const;
   /// @}
 
@@ -179,7 +178,7 @@ class GTSAM_EXPORT PreintegratedCombinedMeasurements
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
     namespace bs = ::boost::serialization;
-    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(PreintegrationType);
+    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(PreintegrationBackend);
     ar& BOOST_SERIALIZATION_NVP(preintMeasCov_);
   }
 #endif
@@ -187,6 +186,9 @@ class GTSAM_EXPORT PreintegratedCombinedMeasurements
  public:
   GTSAM_MAKE_ALIGNED_OPERATOR_NEW
 };
+
+// For backward compatibility:
+typedef PreintegratedCombinedMeasurementsT<DefaultPreintegrationBackend> PreintegratedCombinedMeasurements;
 
 /**
  * CombinedImuFactor is a 6-ways factor involving previous state (pose and
@@ -206,31 +208,28 @@ class GTSAM_EXPORT PreintegratedCombinedMeasurements
  *
  * @ingroup navigation
  */
-class GTSAM_EXPORT CombinedImuFactor
+template <class PIMType_ = PreintegratedCombinedMeasurements>
+class GTSAM_EXPORT CombinedImuFactorT
     : public NoiseModelFactorN<Pose3, Vector3, Pose3, Vector3,
                                imuBias::ConstantBias, imuBias::ConstantBias> {
  public:
  private:
-  typedef CombinedImuFactor This;
+  typedef CombinedImuFactorT<PIMType_> This;
   typedef NoiseModelFactorN<Pose3, Vector3, Pose3, Vector3,
                             imuBias::ConstantBias, imuBias::ConstantBias>
       Base;
 
-  PreintegratedCombinedMeasurements _PIM_;
+  PIMType_ _PIM_;
 
  public:
   // Provide access to Matrix& version of evaluateError:
   using Base::evaluateError;
 
   /** Shorthand for a smart pointer to a factor */
-#if !defined(_MSC_VER) && __GNUC__ == 4 && __GNUC_MINOR__ > 5
-  typedef typename std::shared_ptr<CombinedImuFactor> shared_ptr;
-#else
-  typedef std::shared_ptr<CombinedImuFactor> shared_ptr;
-#endif
+  typedef std::shared_ptr<This> shared_ptr;
 
   /** Default constructor - only use for serialization */
-  CombinedImuFactor() {}
+  CombinedImuFactorT() {}
 
   /**
    * Constructor
@@ -242,21 +241,24 @@ class GTSAM_EXPORT CombinedImuFactor
    * @param bias_j Current bias key
    * @param PreintegratedCombinedMeasurements Combined IMU measurements
    */
-  CombinedImuFactor(
+  CombinedImuFactorT(
       Key pose_i, Key vel_i, Key pose_j, Key vel_j, Key bias_i, Key bias_j,
-      const PreintegratedCombinedMeasurements& preintegratedMeasurements);
+      const PIMType_& preintegratedMeasurements)
+      : Base(noiseModel::Gaussian::Covariance(preintegratedMeasurements.preintMeasCov()),
+             pose_i, vel_i, pose_j, vel_j, bias_i, bias_j),
+        _PIM_(preintegratedMeasurements) {}
 
-  ~CombinedImuFactor() override {}
+  ~CombinedImuFactorT() override {}
 
   /// @return a deep copy of this factor
-  gtsam::NonlinearFactor::shared_ptr clone() const override;
+  gtsam::NonlinearFactor::shared_ptr clone() const override {
+    return std::make_shared<This>(*this);
+  }
 
   /** implement functions needed for Testable */
 
   /// @name Testable
   /// @{
-  GTSAM_EXPORT friend std::ostream& operator<<(std::ostream& os,
-                                               const CombinedImuFactor&);
   /// print
   void print(const std::string& s = "", const KeyFormatter& keyFormatter =
                                             DefaultKeyFormatter) const override;
@@ -268,7 +270,7 @@ class GTSAM_EXPORT CombinedImuFactor
 
   /** Access the preintegrated measurements. */
 
-  const PreintegratedCombinedMeasurements& preintegratedMeasurements() const {
+  const PIMType_& preintegratedMeasurements() const {
     return _PIM_;
   }
 
@@ -300,17 +302,24 @@ class GTSAM_EXPORT CombinedImuFactor
  public:
   GTSAM_MAKE_ALIGNED_OPERATOR_NEW
 };
-// class CombinedImuFactor
+// class CombinedImuFactorT
+
+// For backward compatibility:
+typedef CombinedImuFactorT<> CombinedImuFactor;
+
+// operator<< for CombinedImuFactorT
+template <class PIMType_>
+GTSAM_EXPORT std::ostream& operator<<(std::ostream& os, const CombinedImuFactorT<PIMType_>& f);
 
 template <>
 struct traits<PreintegrationCombinedParams>
     : public Testable<PreintegrationCombinedParams> {};
 
-template <>
-struct traits<PreintegratedCombinedMeasurements>
-    : public Testable<PreintegratedCombinedMeasurements> {};
-
-template <>
-struct traits<CombinedImuFactor> : public Testable<CombinedImuFactor> {};
+template <class PreintegrationBackend>
+struct traits<PreintegratedCombinedMeasurementsT<PreintegrationBackend>>
+    : public Testable<PreintegratedCombinedMeasurementsT<PreintegrationBackend>> {};
+ 
+template <class PIMType_>
+struct traits<CombinedImuFactorT<PIMType_>> : public Testable<CombinedImuFactorT<PIMType_>> {};
 
 }  // namespace gtsam

--- a/gtsam/navigation/ImuFactor.cpp
+++ b/gtsam/navigation/ImuFactor.cpp
@@ -20,6 +20,8 @@
  **/
 
 #include <gtsam/navigation/ImuFactor.h>
+#include <gtsam/navigation/ManifoldPreintegration.h>
+#include <gtsam/navigation/TangentPreintegration.h>
 
 /* External or standard includes */
 #include <ostream>
@@ -30,28 +32,32 @@ namespace gtsam {
 using namespace std;
 
 //------------------------------------------------------------------------------
-// Inner class PreintegratedImuMeasurements
+// Inner class PreintegratedImuMeasurementsT
 //------------------------------------------------------------------------------
-void PreintegratedImuMeasurements::print(const string& s) const {
-  PreintegrationType::print(s);
+template <class PreintegrationBackend>
+void PreintegratedImuMeasurementsT<PreintegrationBackend>::print(const string& s) const {
+  PreintegrationBackend::print(s);
   cout << "    preintMeasCov \n[" << preintMeasCov_ << "]" << endl;
 }
 
 //------------------------------------------------------------------------------
-bool PreintegratedImuMeasurements::equals(
-    const PreintegratedImuMeasurements& other, double tol) const {
-  return PreintegrationType::equals(other, tol)
+template <class PreintegrationBackend>
+bool PreintegratedImuMeasurementsT<PreintegrationBackend>::equals(
+    const PreintegratedImuMeasurementsT<PreintegrationBackend>& other, double tol) const {
+  return PreintegrationBackend::equals(other, tol)
       && equal_with_abs_tol(preintMeasCov_, other.preintMeasCov_, tol);
 }
 
 //------------------------------------------------------------------------------
-void PreintegratedImuMeasurements::resetIntegration() {
-  PreintegrationType::resetIntegration();
+template <class PreintegrationBackend>
+void PreintegratedImuMeasurementsT<PreintegrationBackend>::resetIntegration() {
+  PreintegrationBackend::resetIntegration();
   preintMeasCov_.setZero();
 }
 
 //------------------------------------------------------------------------------
-void PreintegratedImuMeasurements::integrateMeasurement(
+template <class PreintegrationBackend>
+void PreintegratedImuMeasurementsT<PreintegrationBackend>::integrateMeasurement(
     const Vector3& measuredAcc, const Vector3& measuredOmega, double dt) {
   if (dt <= 0) {
     throw std::runtime_error(
@@ -61,7 +67,7 @@ void PreintegratedImuMeasurements::integrateMeasurement(
   // Update preintegrated measurements (also get Jacobian)
   Matrix9 A;  // overall Jacobian wrt preintegrated measurements (df/dx)
   Matrix93 B, C;  // Jacobian of state wrpt accel bias and omega bias respectively.
-  PreintegrationType::update(measuredAcc, measuredOmega, dt, &A, &B, &C);
+  PreintegrationBackend::update(measuredAcc, measuredOmega, dt, &A, &B, &C);
 
   // first order covariance propagation:
   // as in [2] we consider a first order propagation that can be seen as a
@@ -69,9 +75,9 @@ void PreintegratedImuMeasurements::integrateMeasurement(
 
   // propagate uncertainty
   // TODO(frank): use noiseModel routine so we can have arbitrary noise models.
-  const Matrix3& aCov = p().accelerometerCovariance;
-  const Matrix3& wCov = p().gyroscopeCovariance;
-  const Matrix3& iCov = p().integrationCovariance;
+  const Matrix3& aCov = this->p().accelerometerCovariance;
+  const Matrix3& wCov = this->p().gyroscopeCovariance;
+  const Matrix3& iCov = this->p().integrationCovariance;
 
   // (1/dt) allows to pass from continuous time noise to discrete time noise
   // Update the uncertainty on the state (matrix A in [4]).
@@ -85,7 +91,8 @@ void PreintegratedImuMeasurements::integrateMeasurement(
 }
 
 //------------------------------------------------------------------------------
-void PreintegratedImuMeasurements::integrateMeasurements(
+template <class PreintegrationBackend>
+void PreintegratedImuMeasurementsT<PreintegrationBackend>::integrateMeasurements(
     const Matrix& measuredAccs, const Matrix& measuredOmegas,
     const Matrix& dts) {
   assert(
@@ -100,40 +107,18 @@ void PreintegratedImuMeasurements::integrateMeasurements(
 }
 
 //------------------------------------------------------------------------------
-#ifdef GTSAM_TANGENT_PREINTEGRATION
-void PreintegratedImuMeasurements::mergeWith(const PreintegratedImuMeasurements& pim12, //
-    Matrix9* H1, Matrix9* H2) {
-  PreintegrationType::mergeWith(pim12, H1, H2);
-  // NOTE(gareth): Temporary P is needed as of Eigen 3.3
-  const Matrix9 P = *H1 * preintMeasCov_ * H1->transpose();
-  preintMeasCov_ = P + *H2 * pim12.preintMeasCov_ * H2->transpose();
-}
-#endif
-
+// ImuFactorT methods
 //------------------------------------------------------------------------------
-// ImuFactor methods
-//------------------------------------------------------------------------------
-ImuFactor::ImuFactor(Key pose_i, Key vel_i, Key pose_j, Key vel_j, Key bias,
-    const PreintegratedImuMeasurements& pim) :
-    Base(noiseModel::Gaussian::Covariance(pim.preintMeasCov_), pose_i, vel_i,
-        pose_j, vel_j, bias), _PIM_(pim) {
-}
-
-//------------------------------------------------------------------------------
-NonlinearFactor::shared_ptr ImuFactor::clone() const {
-  return std::static_pointer_cast<NonlinearFactor>(
-      NonlinearFactor::shared_ptr(new This(*this)));
-}
-
-//------------------------------------------------------------------------------
-std::ostream& operator<<(std::ostream& os, const ImuFactor& f) {
-  f._PIM_.print("preintegrated measurements:\n");
-  os << "  noise model sigmas: " << f.noiseModel_->sigmas().transpose();
+template <class PIMType_>
+std::ostream& operator<<(std::ostream& os, const ImuFactorT<PIMType_>& f) {
+  f.preintegratedMeasurements().print("preintegrated measurements:\n");
+  os << "  noise model sigmas: " << f.noiseModel()->sigmas().transpose();
   return os;
 }
 
 //------------------------------------------------------------------------------
-void ImuFactor::print(const string& s, const KeyFormatter& keyFormatter) const {
+template <class PIMType_>
+void ImuFactorT<PIMType_>::print(const string& s, const KeyFormatter& keyFormatter) const {
   cout << (s.empty() ? s : s + "\n") << "ImuFactor(" << keyFormatter(this->key<1>())
        << "," << keyFormatter(this->key<2>()) << "," << keyFormatter(this->key<3>())
        << "," << keyFormatter(this->key<4>()) << "," << keyFormatter(this->key<5>())
@@ -142,7 +127,8 @@ void ImuFactor::print(const string& s, const KeyFormatter& keyFormatter) const {
 }
 
 //------------------------------------------------------------------------------
-bool ImuFactor::equals(const NonlinearFactor& other, double tol) const {
+template <class PIMType_>
+bool ImuFactorT<PIMType_>::equals(const NonlinearFactor& other, double tol) const {
   const This *e = dynamic_cast<const This*>(&other);
   const bool base = Base::equals(*e, tol);
   const bool pim = _PIM_.equals(e->_PIM_, tol);
@@ -150,7 +136,8 @@ bool ImuFactor::equals(const NonlinearFactor& other, double tol) const {
 }
 
 //------------------------------------------------------------------------------
-Vector ImuFactor::evaluateError(const Pose3& pose_i, const Vector3& vel_i,
+template <class PIMType_>
+Vector ImuFactorT<PIMType_>::evaluateError(const Pose3& pose_i, const Vector3& vel_i,
     const Pose3& pose_j, const Vector3& vel_j,
     const imuBias::ConstantBias& bias_i, OptionalMatrixType H1,
     OptionalMatrixType H2, OptionalMatrixType H3,
@@ -160,75 +147,18 @@ Vector ImuFactor::evaluateError(const Pose3& pose_i, const Vector3& vel_i,
 }
 
 //------------------------------------------------------------------------------
-#ifdef GTSAM_TANGENT_PREINTEGRATION
-PreintegratedImuMeasurements ImuFactor::Merge(
-    const PreintegratedImuMeasurements& pim01,
-    const PreintegratedImuMeasurements& pim12) {
-  if (!pim01.matchesParamsWith(pim12))
-  throw std::domain_error(
-      "Cannot merge PreintegratedImuMeasurements with different params");
-
-  if (pim01.params()->body_P_sensor)
-  throw std::domain_error(
-      "Cannot merge PreintegratedImuMeasurements with sensor pose yet");
-
-  // the bias for the merged factor will be the bias from 01
-  PreintegratedImuMeasurements pim02 = pim01;
-
-  Matrix9 H1, H2;
-  pim02.mergeWith(pim12, &H1, &H2);
-
-  return pim02;
-}
-
+// ImuFactor2T methods
 //------------------------------------------------------------------------------
-ImuFactor::shared_ptr ImuFactor::Merge(const shared_ptr& f01,
-    const shared_ptr& f12) {
-  // IMU bias keys must be the same.
-  if (f01->key<5>() != f12->key<5>())
-  throw std::domain_error("ImuFactor::Merge: IMU bias keys must be the same");
-
-  // expect intermediate pose, velocity keys to matchup.
-  if (f01->key<3>() != f12->key<1>() || f01->key<4>() != f12->key<2>())
-  throw std::domain_error(
-      "ImuFactor::Merge: intermediate pose, velocity keys need to match up");
-
-  // return new factor
-  auto pim02 =
-  Merge(f01->preintegratedMeasurements(), f12->preintegratedMeasurements());
-  return std::make_shared<ImuFactor>(f01->key<1>(),  // P0
-      f01->key<2>(),  // V0
-      f12->key<3>(),  // P2
-      f12->key<4>(),  // V2
-      f01->key<5>(),  // B
-      pim02);
-}
-#endif
-
-//------------------------------------------------------------------------------
-// ImuFactor2 methods
-//------------------------------------------------------------------------------
-ImuFactor2::ImuFactor2(Key state_i, Key state_j, Key bias,
-    const PreintegratedImuMeasurements& pim) :
-    Base(noiseModel::Gaussian::Covariance(pim.preintMeasCov_), state_i, state_j,
-        bias), _PIM_(pim) {
-}
-
-//------------------------------------------------------------------------------
-NonlinearFactor::shared_ptr ImuFactor2::clone() const {
-  return std::static_pointer_cast<NonlinearFactor>(
-      NonlinearFactor::shared_ptr(new This(*this)));
-}
-
-//------------------------------------------------------------------------------
-std::ostream& operator<<(std::ostream& os, const ImuFactor2& f) {
-  f._PIM_.print("preintegrated measurements:\n");
-  os << "  noise model sigmas: " << f.noiseModel_->sigmas().transpose();
+template <class PIMType_>
+std::ostream& operator<<(std::ostream& os, const ImuFactor2T<PIMType_>& f) {
+  f.preintegratedMeasurements().print("preintegrated measurements:\n");
+  os << "  noise model sigmas: " << f.noiseModel()->sigmas().transpose();
   return os;
 }
 
 //------------------------------------------------------------------------------
-void ImuFactor2::print(const string& s,
+template <class PIMType_>
+void ImuFactor2T<PIMType_>::print(const string& s,
     const KeyFormatter& keyFormatter) const {
   cout << (s.empty() ? s : s + "\n") << "ImuFactor2("
        << keyFormatter(this->key<1>()) << "," << keyFormatter(this->key<2>()) << ","
@@ -237,7 +167,8 @@ void ImuFactor2::print(const string& s,
 }
 
 //------------------------------------------------------------------------------
-bool ImuFactor2::equals(const NonlinearFactor& other, double tol) const {
+template <class PIMType_>
+bool ImuFactor2T<PIMType_>::equals(const NonlinearFactor& other, double tol) const {
   const This *e = dynamic_cast<const This*>(&other);
   const bool base = Base::equals(*e, tol);
   const bool pim = _PIM_.equals(e->_PIM_, tol);
@@ -245,7 +176,8 @@ bool ImuFactor2::equals(const NonlinearFactor& other, double tol) const {
 }
 
 //------------------------------------------------------------------------------
-Vector ImuFactor2::evaluateError(const NavState& state_i,
+template <class PIMType_>
+Vector ImuFactor2T<PIMType_>::evaluateError(const NavState& state_i,
     const NavState& state_j,
     const imuBias::ConstantBias& bias_i, //
     OptionalMatrixType H1, OptionalMatrixType H2,
@@ -254,6 +186,29 @@ Vector ImuFactor2::evaluateError(const NavState& state_i,
 }
 
 //------------------------------------------------------------------------------
+// Explicit instantiations
+//------------------------------------------------------------------------------
+template class GTSAM_EXPORT PreintegratedImuMeasurementsT<ManifoldPreintegration>;
+template class GTSAM_EXPORT PreintegratedImuMeasurementsT<TangentPreintegration>;
+
+// ImuFactorT instantiations
+template class GTSAM_EXPORT ImuFactorT<PreintegratedImuMeasurementsT<ManifoldPreintegration>>;
+template class GTSAM_EXPORT ImuFactorT<PreintegratedImuMeasurementsT<TangentPreintegration>>;
+
+// ImuFactor2T instantiations
+template class GTSAM_EXPORT ImuFactor2T<PreintegratedImuMeasurementsT<ManifoldPreintegration>>;
+template class GTSAM_EXPORT ImuFactor2T<PreintegratedImuMeasurementsT<TangentPreintegration>>;
+
+// operator<< instantiations
+template GTSAM_EXPORT std::ostream& operator<<<PreintegratedImuMeasurementsT<ManifoldPreintegration>>(
+    std::ostream& os, const ImuFactorT<PreintegratedImuMeasurementsT<ManifoldPreintegration>>& f);
+template GTSAM_EXPORT std::ostream& operator<<<PreintegratedImuMeasurementsT<TangentPreintegration>>(
+    std::ostream& os, const ImuFactorT<PreintegratedImuMeasurementsT<TangentPreintegration>>& f);
+
+template GTSAM_EXPORT std::ostream& operator<<<PreintegratedImuMeasurementsT<ManifoldPreintegration>>(
+    std::ostream& os, const ImuFactor2T<PreintegratedImuMeasurementsT<ManifoldPreintegration>>& f);
+template GTSAM_EXPORT std::ostream& operator<<<PreintegratedImuMeasurementsT<TangentPreintegration>>(
+    std::ostream& os, const ImuFactor2T<PreintegratedImuMeasurementsT<TangentPreintegration>>& f);
 
 }
 // namespace gtsam

--- a/gtsam/navigation/ImuFactor.cpp
+++ b/gtsam/navigation/ImuFactor.cpp
@@ -119,9 +119,9 @@ std::ostream& operator<<(std::ostream& os, const ImuFactorT<PIMType_>& f) {
 //------------------------------------------------------------------------------
 template <class PIMType_>
 void ImuFactorT<PIMType_>::print(const string& s, const KeyFormatter& keyFormatter) const {
-  cout << (s.empty() ? s : s + "\n") << "ImuFactor(" << keyFormatter(this->key<1>())
-       << "," << keyFormatter(this->key<2>()) << "," << keyFormatter(this->key<3>())
-       << "," << keyFormatter(this->key<4>()) << "," << keyFormatter(this->key<5>())
+  cout << (s.empty() ? s : s + "\n") << "ImuFactor(" << keyFormatter(this->template key<1>())
+       << "," << keyFormatter(this->template key<2>()) << "," << keyFormatter(this->template key<3>())
+       << "," << keyFormatter(this->template key<4>()) << "," << keyFormatter(this->template key<5>())
        << ")\n";
   cout << *this << endl;
 }
@@ -161,7 +161,7 @@ template <class PIMType_>
 void ImuFactor2T<PIMType_>::print(const string& s,
     const KeyFormatter& keyFormatter) const {
   cout << (s.empty() ? s : s + "\n") << "ImuFactor2("
-       << keyFormatter(this->key<1>()) << "," << keyFormatter(this->key<2>()) << ","
+       << keyFormatter(this->template key<1>()) << "," << keyFormatter(this->template key<2>()) << ","
        << keyFormatter(this->key<3>()) << ")\n";
   cout << *this << endl;
 }

--- a/gtsam/navigation/ImuFactor.cpp
+++ b/gtsam/navigation/ImuFactor.cpp
@@ -142,9 +142,9 @@ std::ostream& operator<<(std::ostream& os, const ImuFactor& f) {
 
 //------------------------------------------------------------------------------
 void ImuFactor::print(const string& s, const KeyFormatter& keyFormatter) const {
-  cout << (s.empty() ? s : s + "\n") << "ImuFactor(" << keyFormatter(this->template key<1>())
-       << "," << keyFormatter(this->template key<2>()) << "," << keyFormatter(this->template key<3>())
-       << "," << keyFormatter(this->template key<4>()) << "," << keyFormatter(this->template key<5>())
+  cout << (s.empty() ? s : s + "\n") << "ImuFactor(" << keyFormatter(this->key<1>())
+       << "," << keyFormatter(this->key<2>()) << "," << keyFormatter(this->key<3>())
+       << "," << keyFormatter(this->key<4>()) << "," << keyFormatter(this->key<5>())
        << ")\n";
   cout << *this << endl;
 }
@@ -239,7 +239,7 @@ std::ostream& operator<<(std::ostream& os, const ImuFactor2& f) {
 void ImuFactor2::print(const string& s,
     const KeyFormatter& keyFormatter) const {
   cout << (s.empty() ? s : s + "\n") << "ImuFactor2("
-       << keyFormatter(this->template key<1>()) << "," << keyFormatter(this->template key<2>()) << ","
+       << keyFormatter(this->key<1>()) << "," << keyFormatter(this->key<2>()) << ","
        << keyFormatter(this->key<3>()) << ")\n";
   cout << *this << endl;
 }

--- a/gtsam/navigation/ImuFactor.cpp
+++ b/gtsam/navigation/ImuFactor.cpp
@@ -42,10 +42,22 @@ void PreintegratedImuMeasurementsT<PreintegrationBackend>::print(const string& s
 
 //------------------------------------------------------------------------------
 template <class PreintegrationBackend>
-bool PreintegratedImuMeasurementsT<PreintegrationBackend>::equals(
+bool PreintegratedImuMeasurementsT<PreintegrationBackend>::equalsConcrete(
     const PreintegratedImuMeasurementsT<PreintegrationBackend>& other, double tol) const {
   return PreintegrationBackend::equals(other, tol)
       && equal_with_abs_tol(preintMeasCov_, other.preintMeasCov_, tol);
+}
+
+//------------------------------------------------------------------------------
+template <class PreintegrationBackend>
+bool PreintegratedImuMeasurementsT<PreintegrationBackend>::equals(
+    const PreintegratedImuMeasurementsInterface& other_interface, double tol) const {
+  const auto* other_as_this_pim_type =
+      dynamic_cast<const PreintegratedImuMeasurementsT<PreintegrationBackend>*>(&other_interface);
+  if (!other_as_this_pim_type) {
+      return false;
+  }
+  return this->equalsConcrete(*other_as_this_pim_type, tol);
 }
 
 //------------------------------------------------------------------------------
@@ -107,18 +119,29 @@ void PreintegratedImuMeasurementsT<PreintegrationBackend>::integrateMeasurements
 }
 
 //------------------------------------------------------------------------------
-// ImuFactorT methods
+// ImuFactor methods
 //------------------------------------------------------------------------------
-template <class PIMType_>
-std::ostream& operator<<(std::ostream& os, const ImuFactorT<PIMType_>& f) {
-  f.preintegratedMeasurements().print("preintegrated measurements:\n");
+ImuFactor::ImuFactor(Key pose_i, Key vel_i, Key pose_j, Key vel_j, Key bias,
+  const std::shared_ptr<const PreintegratedImuMeasurementsInterface>& pim) :
+  Base(noiseModel::Gaussian::Covariance(pim->preintMeasCov()), pose_i, vel_i,
+      pose_j, vel_j, bias), _PIM_(pim) {
+}
+
+//------------------------------------------------------------------------------
+NonlinearFactor::shared_ptr ImuFactor::clone() const {
+return std::static_pointer_cast<NonlinearFactor>(
+    NonlinearFactor::shared_ptr(new This(*this)));
+}
+
+//------------------------------------------------------------------------------
+std::ostream& operator<<(std::ostream& os, const ImuFactor& f) {
+  f.preintegratedMeasurements()->print("preintegrated measurements:\n");
   os << "  noise model sigmas: " << f.noiseModel()->sigmas().transpose();
   return os;
 }
 
 //------------------------------------------------------------------------------
-template <class PIMType_>
-void ImuFactorT<PIMType_>::print(const string& s, const KeyFormatter& keyFormatter) const {
+void ImuFactor::print(const string& s, const KeyFormatter& keyFormatter) const {
   cout << (s.empty() ? s : s + "\n") << "ImuFactor(" << keyFormatter(this->template key<1>())
        << "," << keyFormatter(this->template key<2>()) << "," << keyFormatter(this->template key<3>())
        << "," << keyFormatter(this->template key<4>()) << "," << keyFormatter(this->template key<5>())
@@ -127,38 +150,93 @@ void ImuFactorT<PIMType_>::print(const string& s, const KeyFormatter& keyFormatt
 }
 
 //------------------------------------------------------------------------------
-template <class PIMType_>
-bool ImuFactorT<PIMType_>::equals(const NonlinearFactor& other, double tol) const {
+bool ImuFactor::equals(const NonlinearFactor& other, double tol) const {
   const This *e = dynamic_cast<const This*>(&other);
   const bool base = Base::equals(*e, tol);
-  const bool pim = _PIM_.equals(e->_PIM_, tol);
+  const bool pim = _PIM_->equals(*(e->_PIM_), tol);
   return e != nullptr && base && pim;
 }
 
 //------------------------------------------------------------------------------
-template <class PIMType_>
-Vector ImuFactorT<PIMType_>::evaluateError(const Pose3& pose_i, const Vector3& vel_i,
+Vector ImuFactor::evaluateError(const Pose3& pose_i, const Vector3& vel_i,
     const Pose3& pose_j, const Vector3& vel_j,
     const imuBias::ConstantBias& bias_i, OptionalMatrixType H1,
     OptionalMatrixType H2, OptionalMatrixType H3,
     OptionalMatrixType H4, OptionalMatrixType H5) const {
-  return _PIM_.computeErrorAndJacobians(pose_i, vel_i, pose_j, vel_j, bias_i,
+  return _PIM_->computeErrorAndJacobians(pose_i, vel_i, pose_j, vel_j, bias_i,
       H1, H2, H3, H4, H5);
 }
 
 //------------------------------------------------------------------------------
-// ImuFactor2T methods
+PreintegratedImuMeasurementsT<TangentPreintegration> ImuFactor::Merge(
+    const PreintegratedImuMeasurementsT<TangentPreintegration>& pim01,
+    const PreintegratedImuMeasurementsT<TangentPreintegration>& pim12) {
+  if (!pim01.matchesParamsWith(pim12))
+  throw std::domain_error(
+      "Cannot merge PreintegratedImuMeasurements with different params");
+
+  if (pim01.params()->body_P_sensor)
+  throw std::domain_error(
+      "Cannot merge PreintegratedImuMeasurements with sensor pose yet");
+
+  // the bias for the merged factor will be the bias from 01
+  PreintegratedImuMeasurementsT<TangentPreintegration> pim02 = pim01;
+
+  Matrix9 H1, H2;
+  pim02.mergeWith(pim12, &H1, &H2);
+
+  return pim02;
+}
+
 //------------------------------------------------------------------------------
-template <class PIMType_>
-std::ostream& operator<<(std::ostream& os, const ImuFactor2T<PIMType_>& f) {
-  f.preintegratedMeasurements().print("preintegrated measurements:\n");
+ImuFactor::shared_ptr ImuFactor::Merge(const shared_ptr& f01,
+    const shared_ptr& f12) {
+  // IMU bias keys must be the same.
+  if (f01->key<5>() != f12->key<5>())
+  throw std::domain_error("ImuFactor::Merge: IMU bias keys must be the same");
+
+  // expect intermediate pose, velocity keys to matchup.
+  if (f01->key<3>() != f12->key<1>() || f01->key<4>() != f12->key<2>())
+  throw std::domain_error(
+      "ImuFactor::Merge: intermediate pose, velocity keys need to match up");
+
+  // return new factor
+  auto pim02 = Merge(
+    *dynamic_cast<const PreintegratedImuMeasurementsT<TangentPreintegration>*>(f01->preintegratedMeasurements().get()), 
+    *dynamic_cast<const PreintegratedImuMeasurementsT<TangentPreintegration>*>(f12->preintegratedMeasurements().get())
+  );
+  return std::make_shared<ImuFactor>(f01->key<1>(),  // P0
+      f01->key<2>(),  // V0
+      f12->key<3>(),  // P2
+      f12->key<4>(),  // V2
+      f01->key<5>(),  // B
+      std::make_shared<const PreintegratedImuMeasurementsT<TangentPreintegration>>(pim02));
+}
+
+//------------------------------------------------------------------------------
+// ImuFactor2 methods
+//------------------------------------------------------------------------------
+ImuFactor2::ImuFactor2(Key state_i, Key state_j, Key bias,
+  std::shared_ptr<const PreintegratedImuMeasurementsInterface> pim) :
+  Base(noiseModel::Gaussian::Covariance(pim->preintMeasCov()), state_i, state_j,
+      bias), _PIM_(pim) {
+}
+
+//------------------------------------------------------------------------------
+NonlinearFactor::shared_ptr ImuFactor2::clone() const {
+return std::static_pointer_cast<NonlinearFactor>(
+    NonlinearFactor::shared_ptr(new This(*this)));
+}
+
+//------------------------------------------------------------------------------
+std::ostream& operator<<(std::ostream& os, const ImuFactor2& f) {
+  f.preintegratedMeasurements()->print("preintegrated measurements:\n");
   os << "  noise model sigmas: " << f.noiseModel()->sigmas().transpose();
   return os;
 }
 
 //------------------------------------------------------------------------------
-template <class PIMType_>
-void ImuFactor2T<PIMType_>::print(const string& s,
+void ImuFactor2::print(const string& s,
     const KeyFormatter& keyFormatter) const {
   cout << (s.empty() ? s : s + "\n") << "ImuFactor2("
        << keyFormatter(this->template key<1>()) << "," << keyFormatter(this->template key<2>()) << ","
@@ -167,22 +245,20 @@ void ImuFactor2T<PIMType_>::print(const string& s,
 }
 
 //------------------------------------------------------------------------------
-template <class PIMType_>
-bool ImuFactor2T<PIMType_>::equals(const NonlinearFactor& other, double tol) const {
+bool ImuFactor2::equals(const NonlinearFactor& other, double tol) const {
   const This *e = dynamic_cast<const This*>(&other);
   const bool base = Base::equals(*e, tol);
-  const bool pim = _PIM_.equals(e->_PIM_, tol);
+  const bool pim = _PIM_->equals(*(e->_PIM_), tol);
   return e != nullptr && base && pim;
 }
 
 //------------------------------------------------------------------------------
-template <class PIMType_>
-Vector ImuFactor2T<PIMType_>::evaluateError(const NavState& state_i,
+Vector ImuFactor2::evaluateError(const NavState& state_i,
     const NavState& state_j,
     const imuBias::ConstantBias& bias_i, //
     OptionalMatrixType H1, OptionalMatrixType H2,
     OptionalMatrixType H3) const {
-  return _PIM_.computeError(state_i, state_j, bias_i, H1, H2, H3);
+  return _PIM_->computeError(state_i, state_j, bias_i, H1, H2, H3);
 }
 
 //------------------------------------------------------------------------------
@@ -190,25 +266,5 @@ Vector ImuFactor2T<PIMType_>::evaluateError(const NavState& state_i,
 //------------------------------------------------------------------------------
 template class GTSAM_EXPORT PreintegratedImuMeasurementsT<ManifoldPreintegration>;
 template class GTSAM_EXPORT PreintegratedImuMeasurementsT<TangentPreintegration>;
-
-// ImuFactorT instantiations
-template class GTSAM_EXPORT ImuFactorT<PreintegratedImuMeasurementsT<ManifoldPreintegration>>;
-template class GTSAM_EXPORT ImuFactorT<PreintegratedImuMeasurementsT<TangentPreintegration>>;
-
-// ImuFactor2T instantiations
-template class GTSAM_EXPORT ImuFactor2T<PreintegratedImuMeasurementsT<ManifoldPreintegration>>;
-template class GTSAM_EXPORT ImuFactor2T<PreintegratedImuMeasurementsT<TangentPreintegration>>;
-
-// operator<< instantiations
-template GTSAM_EXPORT std::ostream& operator<<<PreintegratedImuMeasurementsT<ManifoldPreintegration>>(
-    std::ostream& os, const ImuFactorT<PreintegratedImuMeasurementsT<ManifoldPreintegration>>& f);
-template GTSAM_EXPORT std::ostream& operator<<<PreintegratedImuMeasurementsT<TangentPreintegration>>(
-    std::ostream& os, const ImuFactorT<PreintegratedImuMeasurementsT<TangentPreintegration>>& f);
-
-template GTSAM_EXPORT std::ostream& operator<<<PreintegratedImuMeasurementsT<ManifoldPreintegration>>(
-    std::ostream& os, const ImuFactor2T<PreintegratedImuMeasurementsT<ManifoldPreintegration>>& f);
-template GTSAM_EXPORT std::ostream& operator<<<PreintegratedImuMeasurementsT<TangentPreintegration>>(
-    std::ostream& os, const ImuFactor2T<PreintegratedImuMeasurementsT<TangentPreintegration>>& f);
-
 }
 // namespace gtsam

--- a/gtsam/navigation/ImuFactor.h
+++ b/gtsam/navigation/ImuFactor.h
@@ -27,12 +27,15 @@
 #include <gtsam/navigation/TangentPreintegration.h>
 #include <gtsam/base/debug.h>
 
+#include <type_traits> // For std::is_same, std::enable_if
+ 
 namespace gtsam {
 
+// Determine default preintegration backend
 #ifdef GTSAM_TANGENT_PREINTEGRATION
-typedef TangentPreintegration PreintegrationType;
+typedef TangentPreintegration DefaultPreintegrationBackend;
 #else
-typedef ManifoldPreintegration PreintegrationType;
+typedef ManifoldPreintegration DefaultPreintegrationBackend;
 #endif
 
 /*
@@ -65,10 +68,11 @@ typedef ManifoldPreintegration PreintegrationType;
  *
  * @ingroup navigation
  */
-class GTSAM_EXPORT PreintegratedImuMeasurements: public PreintegrationType {
-
-  friend class ImuFactor;
-  friend class ImuFactor2;
+template <class PreintegrationBackend>
+class GTSAM_EXPORT PreintegratedImuMeasurementsT: public PreintegrationBackend {
+ 
+  template <class PIMType_> friend class ImuFactorT;
+  template <class PIMType_> friend class ImuFactor2T;
 
 protected:
 
@@ -78,8 +82,8 @@ protected:
 public:
 
   /// Default constructor for serialization and wrappers
-  PreintegratedImuMeasurements() {
-    resetIntegration();
+  PreintegratedImuMeasurementsT() {
+    this->resetIntegration();
   }
 
  /**
@@ -87,32 +91,32 @@ public:
    *  @param p       Parameters, typically fixed in a single application
    *  @param biasHat Current estimate of acceleration and rotation rate biases
    */
-  PreintegratedImuMeasurements(const std::shared_ptr<PreintegrationParams>& p,
+  PreintegratedImuMeasurementsT(const std::shared_ptr<PreintegrationParams>& p,
       const imuBias::ConstantBias& biasHat = imuBias::ConstantBias()) :
-      PreintegrationType(p, biasHat) {
-    resetIntegration();
+      PreintegrationBackend(p, biasHat) {
+    this->resetIntegration();
   }
 
 /**
   *  Construct preintegrated directly from members: base class and preintMeasCov
-  *  @param base               PreintegrationType instance
+  *  @param base               PreintegrationBackend instance
   *  @param preintMeasCov      Covariance matrix used in noise model.
   */
-  PreintegratedImuMeasurements(const PreintegrationType& base, const Matrix9& preintMeasCov)
-     : PreintegrationType(base),
+  PreintegratedImuMeasurementsT(const PreintegrationBackend& base, const Matrix9& preintMeasCov)
+     : PreintegrationBackend(base),
        preintMeasCov_(preintMeasCov) {
-    PreintegrationType::resetIntegration();
+    this->PreintegrationBackend::resetIntegration();
   }
-
+ 
   /// Virtual destructor
-  ~PreintegratedImuMeasurements() override {
+  ~PreintegratedImuMeasurementsT() override {
   }
 
   /// print
   void print(const std::string& s = "Preintegrated Measurements:") const override;
 
   /// equals
-  bool equals(const PreintegratedImuMeasurements& expected, double tol = 1e-9) const;
+  bool equals(const PreintegratedImuMeasurementsT<PreintegrationBackend>& expected, double tol = 1e-9) const;
 
   /// Re-initialize PreintegratedImuMeasurements
   void resetIntegration() override;
@@ -137,10 +141,19 @@ public:
   /// Return pre-integrated measurement covariance
   Matrix preintMeasCov() const { return preintMeasCov_; }
 
-#ifdef GTSAM_TANGENT_PREINTEGRATION
   /// Merge in a different set of measurements and update bias derivatives accordingly
-  void mergeWith(const PreintegratedImuMeasurements& pim, Matrix9* H1, Matrix9* H2);
-#endif
+  /// This method is specific to TangentPreintegration backend.
+  template <typename PB = PreintegrationBackend,
+             // This method is only callable when PreintegrationBackend is TangentPreintegration.
+             typename = typename std::enable_if<std::is_same<PB, TangentPreintegration>::value>::type>
+  void mergeWith(const PreintegratedImuMeasurementsT<TangentPreintegration>& pim12, Matrix9* H1, Matrix9* H2) {
+    // The `this->PreintegrationBackend::mergeWith` implies calling TangentPreintegration's mergeWith.
+    // Since pim12 is PreintegratedImuMeasurementsT<TangentPreintegration>, it is a TangentPreintegration.
+    this->PreintegrationBackend::mergeWith(pim12, H1, H2);
+    // NOTE(gareth): Temporary P is needed as of Eigen 3.3
+    const Matrix9 P = *H1 * preintMeasCov_ * H1->transpose();
+    preintMeasCov_ = P + *H2 * pim12.preintMeasCov_ * H2->transpose();
+  }
 
  private:
 #if GTSAM_ENABLE_BOOST_SERIALIZATION  ///
@@ -149,11 +162,15 @@ public:
   template<class ARCHIVE>
   void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
     namespace bs = ::boost::serialization;
-    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(PreintegrationType);
+    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(PreintegrationBackend);
     ar & BOOST_SERIALIZATION_NVP(preintMeasCov_);
   }
 #endif
 };
+
+// For backward compatibility (so that the compiler flag GTSAM_TANGENT_PREINTEGRATION still
+// controls which class PreintegratedImuMeasurements uses):
+typedef PreintegratedImuMeasurementsT<DefaultPreintegrationBackend> PreintegratedImuMeasurements;
 
 /**
  * ImuFactor is a 5-ways factor involving previous state (pose and velocity of
@@ -167,15 +184,16 @@ public:
  *
  * @ingroup navigation
  */
-class GTSAM_EXPORT ImuFactor: public NoiseModelFactorN<Pose3, Vector3, Pose3, Vector3,
+template <class PIMType_ = PreintegratedImuMeasurements>
+class GTSAM_EXPORT ImuFactorT: public NoiseModelFactorN<Pose3, Vector3, Pose3, Vector3,
     imuBias::ConstantBias> {
 private:
 
-  typedef ImuFactor This;
+  typedef ImuFactorT<PIMType_> This;
   typedef NoiseModelFactorN<Pose3, Vector3, Pose3, Vector3,
       imuBias::ConstantBias> Base;
 
-  PreintegratedImuMeasurements _PIM_;
+  PIMType_ _PIM_;
 
 public:
 
@@ -183,14 +201,11 @@ public:
   using Base::evaluateError;
 
   /** Shorthand for a smart pointer to a factor */
-#if !defined(_MSC_VER) && __GNUC__ == 4 && __GNUC_MINOR__ > 5
-  typedef typename std::shared_ptr<ImuFactor> shared_ptr;
-#else
-  typedef std::shared_ptr<ImuFactor> shared_ptr;
-#endif
+  typedef std::shared_ptr<This> shared_ptr;
+
 
   /** Default constructor - only use for serialization */
-  ImuFactor() {}
+  ImuFactorT() {}
 
   /**
    * Constructor
@@ -202,18 +217,22 @@ public:
    * @param preintegratedMeasurements The preintegreated measurements since the
    * last pose.
    */
-  ImuFactor(Key pose_i, Key vel_i, Key pose_j, Key vel_j, Key bias,
-      const PreintegratedImuMeasurements& preintegratedMeasurements);
+  ImuFactorT(Key pose_i, Key vel_i, Key pose_j, Key vel_j, Key bias,
+      const PIMType_& preintegratedMeasurements)
+      : Base(noiseModel::Gaussian::Covariance(preintegratedMeasurements.preintMeasCov()),
+             pose_i, vel_i, pose_j, vel_j, bias),
+        _PIM_(preintegratedMeasurements) {}
 
-  ~ImuFactor() override {
+  ~ImuFactorT() override {
   }
 
   /// @return a deep copy of this factor
-  gtsam::NonlinearFactor::shared_ptr clone() const override;
+  gtsam::NonlinearFactor::shared_ptr clone() const override {
+    return std::make_shared<This>(*this);
+  }
 
   /// @name Testable
   /// @{
-  GTSAM_EXPORT friend std::ostream& operator<<(std::ostream& os, const ImuFactor&);
   void print(const std::string& s = "", const KeyFormatter& keyFormatter =
                                             DefaultKeyFormatter) const override;
   bool equals(const NonlinearFactor& expected, double tol = 1e-9) const override;
@@ -221,7 +240,7 @@ public:
 
   /** Access the preintegrated measurements. */
 
-  const PreintegratedImuMeasurements& preintegratedMeasurements() const {
+  const PIMType_& preintegratedMeasurements() const {
     return _PIM_;
   }
 
@@ -233,15 +252,79 @@ public:
       const imuBias::ConstantBias& bias_i, OptionalMatrixType H1, OptionalMatrixType H2,
       OptionalMatrixType H3, OptionalMatrixType H4, OptionalMatrixType H5) const override;
 
-#ifdef GTSAM_TANGENT_PREINTEGRATION
   /// Merge two pre-integrated measurement classes
-  static PreintegratedImuMeasurements Merge(
-      const PreintegratedImuMeasurements& pim01,
-      const PreintegratedImuMeasurements& pim12);
+  template <typename MethodPIMArg = PIMType_,
+    // This method is only callable when PIMType_ is PreintegratedImuMeasurementsT<TangentPreintegration>.
+    typename = typename std::enable_if<
+        std::is_same<MethodPIMArg, PreintegratedImuMeasurementsT<TangentPreintegration>>::value
+    >::type
+  >
+  static MethodPIMArg Merge(
+    const MethodPIMArg& pim01,
+    const MethodPIMArg& pim12
+  ) {
+    // When this template is instantiated:
+    // 1. MethodPIMArg = PIMType_. It's mirrored to avoid error C7637 from strict compilers.
+    // 2. The SFINAE condition ensures MethodPIMArg IS PreintegratedImuMeasurementsT<TangentPreintegration>.
+    // So, arguments are const PreintegratedImuMeasurementsT<TangentPreintegration>&
+    // and return is PreintegratedImuMeasurementsT<TangentPreintegration>.
+
+    if (!pim01.matchesParamsWith(pim12))
+      throw std::domain_error(
+          "Cannot merge PreintegratedImuMeasurements with different params");
+
+    if (pim01.p_->body_P_sensor)
+      throw std::domain_error(
+          "Cannot merge PreintegratedImuMeasurements with sensor pose yet");
+
+    // the bias for the merged factor will be the bias from 01
+    MethodPIMArg pim02 = pim01;
+
+    Matrix9 H1, H2;
+    pim02.mergeWith(pim12, &H1, &H2);
+
+    return pim02;
+  }
 
   /// Merge two factors
-  static shared_ptr Merge(const shared_ptr& f01, const shared_ptr& f12);
-#endif
+  template <
+    typename MethodPIMArg = PIMType_,
+    // This method is only callable when PIMType_ is PreintegratedImuMeasurementsT<TangentPreintegration>.
+    typename = typename std::enable_if<
+        std::is_same<MethodPIMArg, PreintegratedImuMeasurementsT<TangentPreintegration>>::value
+    >::type
+  >
+  static typename ImuFactorT<MethodPIMArg>::shared_ptr Merge(
+    const typename ImuFactorT<MethodPIMArg>::shared_ptr& f01,
+    const typename ImuFactorT<MethodPIMArg>::shared_ptr& f12
+  ) {
+    // When this template is instantiated:
+    // 1. MethodPIMArg = PIMType_. It's mirrored to avoid error C7637 from strict compilers.
+    // 2. The SFINAE condition ensures MethodPIMArg IS PreintegratedImuMeasurementsT<TangentPreintegration>.
+    // So, ImuFactorT<MethodPIMArg> is effectively ImuFactorT<PIMType_>, which is `This`.
+    // The signature effectively becomes:
+    // static typename This::shared_ptr Merge(const typename This::shared_ptr&, const typename This::shared_ptr&)
+
+  // IMU bias keys must be the same.
+  if (f01->key<5>() != f12->key<5>())
+    throw std::domain_error("ImuFactor::Merge: IMU bias keys must be the same");
+
+  // expect intermediate pose, velocity keys to matchup.
+  if (f01->key<3>() != f12->key<1>() || f01->key<4>() != f12->key<2>())
+    throw std::domain_error(
+        "ImuFactor::Merge: intermediate pose, velocity keys need to match up");
+
+  // return new factor
+  auto pim02 = This::Merge(f01->preintegratedMeasurements(), f12->preintegratedMeasurements());
+
+  return std::make_shared<This>( // `This` is ImuFactorT<MethodPIMArg> (i.e. ImuFactorT<PIMType_>)
+      f01->key<1>(),  // P0
+      f01->key<2>(),  // V0
+      f12->key<3>(),  // P2
+      f12->key<4>(),  // V2
+      f01->key<5>(),  // B
+      pim02);
+  }
 
  private:
   /** Serialization function */
@@ -256,19 +339,27 @@ public:
   }
 #endif
 };
-// class ImuFactor
+// class ImuFactorT
+
+// For backward compatibility:
+typedef ImuFactorT<> ImuFactor;
+ 
+// operator<< for ImuFactorT
+template <class PIMType_>
+GTSAM_EXPORT std::ostream& operator<<(std::ostream& os, const ImuFactorT<PIMType_>& f);
 
 /**
  * ImuFactor2 is a ternary factor that uses NavStates rather than Pose/Velocity.
  * @ingroup navigation
  */
-class GTSAM_EXPORT ImuFactor2 : public NoiseModelFactorN<NavState, NavState, imuBias::ConstantBias> {
+template <class PIMType_ = PreintegratedImuMeasurements>
+class GTSAM_EXPORT ImuFactor2T : public NoiseModelFactorN<NavState, NavState, imuBias::ConstantBias> {
 private:
 
-  typedef ImuFactor2 This;
+  typedef ImuFactor2T<PIMType_> This;
   typedef NoiseModelFactorN<NavState, NavState, imuBias::ConstantBias> Base;
 
-  PreintegratedImuMeasurements _PIM_;
+  PIMType_ _PIM_;
 
 public:
 
@@ -276,7 +367,7 @@ public:
   using Base::evaluateError;
 
   /** Default constructor - only use for serialization */
-  ImuFactor2() {}
+  ImuFactor2T() {}
 
   /**
    * Constructor
@@ -284,18 +375,24 @@ public:
    * @param state_j Current state key
    * @param bias    Previous bias key
    */
-  ImuFactor2(Key state_i, Key state_j, Key bias,
-             const PreintegratedImuMeasurements& preintegratedMeasurements);
+  ImuFactor2T(Key state_i, Key state_j, Key bias,
+             const PIMType_& preintegratedMeasurements)
+      : Base(noiseModel::Gaussian::Covariance(preintegratedMeasurements.preintMeasCov()),
+             state_i, state_j, bias),
+        _PIM_(preintegratedMeasurements) {}
 
-  ~ImuFactor2() override {
+
+  ~ImuFactor2T() override {
   }
 
   /// @return a deep copy of this factor
-  gtsam::NonlinearFactor::shared_ptr clone() const override;
+  gtsam::NonlinearFactor::shared_ptr clone() const override {
+    return std::make_shared<This>(*this);
+  }
+
 
   /// @name Testable
   /// @{
-  GTSAM_EXPORT friend std::ostream& operator<<(std::ostream& os, const ImuFactor2&);
   void print(const std::string& s = "", const KeyFormatter& keyFormatter =
                                             DefaultKeyFormatter) const override;
   bool equals(const NonlinearFactor& expected, double tol = 1e-9) const override;
@@ -303,7 +400,7 @@ public:
 
   /** Access the preintegrated measurements. */
 
-  const PreintegratedImuMeasurements& preintegratedMeasurements() const {
+  const PIMType_& preintegratedMeasurements() const {
     return _PIM_;
   }
 
@@ -329,15 +426,22 @@ private:
   }
 #endif
 };
-// class ImuFactor2
+// class ImuFactor2T
 
-template <>
-struct traits<PreintegratedImuMeasurements> : public Testable<PreintegratedImuMeasurements> {};
+// For backward compatibility:
+typedef ImuFactor2T<> ImuFactor2;
 
-template <>
-struct traits<ImuFactor> : public Testable<ImuFactor> {};
+// operator<< for ImuFactor2T
+template <class PIMType_>
+GTSAM_EXPORT std::ostream& operator<<(std::ostream& os, const ImuFactor2T<PIMType_>& f);
 
-template <>
-struct traits<ImuFactor2> : public Testable<ImuFactor2> {};
+template <class PreintegrationBackend>
+struct traits<PreintegratedImuMeasurementsT<PreintegrationBackend>> : public Testable<PreintegratedImuMeasurementsT<PreintegrationBackend>> {};
+
+template <class PIMType_>
+struct traits<ImuFactorT<PIMType_>> : public Testable<ImuFactorT<PIMType_>> {};
+
+template <class PIMType_>
+struct traits<ImuFactor2T<PIMType_>> : public Testable<ImuFactor2T<PIMType_>> {};
 
 } /// namespace gtsam

--- a/gtsam/navigation/ImuFactor.h
+++ b/gtsam/navigation/ImuFactor.h
@@ -306,11 +306,11 @@ public:
     // static typename This::shared_ptr Merge(const typename This::shared_ptr&, const typename This::shared_ptr&)
 
   // IMU bias keys must be the same.
-  if (f01->key<5>() != f12->key<5>())
+  if (f01->template key<5>() != f12->template key<5>())
     throw std::domain_error("ImuFactor::Merge: IMU bias keys must be the same");
 
   // expect intermediate pose, velocity keys to matchup.
-  if (f01->key<3>() != f12->key<1>() || f01->key<4>() != f12->key<2>())
+  if (f01->template key<3>() != f12->template key<1>() || f01->template key<4>() != f12->template key<2>())
     throw std::domain_error(
         "ImuFactor::Merge: intermediate pose, velocity keys need to match up");
 
@@ -318,11 +318,11 @@ public:
   auto pim02 = This::Merge(f01->preintegratedMeasurements(), f12->preintegratedMeasurements());
 
   return std::make_shared<This>( // `This` is ImuFactorT<MethodPIMArg> (i.e. ImuFactorT<PIMType_>)
-      f01->key<1>(),  // P0
-      f01->key<2>(),  // V0
-      f12->key<3>(),  // P2
-      f12->key<4>(),  // V2
-      f01->key<5>(),  // B
+      f01->template key<1>(),  // P0
+      f01->template key<2>(),  // V0
+      f12->template key<3>(),  // P2
+      f12->template key<4>(),  // V2
+      f01->template key<5>(),  // B
       pim02);
   }
 

--- a/gtsam/navigation/ImuFactor.h
+++ b/gtsam/navigation/ImuFactor.h
@@ -59,6 +59,40 @@ typedef ManifoldPreintegration DefaultPreintegrationBackend;
  */
 
 /**
+ * Interface to support user PIM specification for ImuFactor & ImuFactor2.
+ * This class is the minimum interface required for an ImuFactor to interact
+ * with its underlying PreintegratedImuMeasurements, which may be based on
+ * ManifoldPreintegration, TangentPreintegration, etc.
+ */
+class PreintegratedImuMeasurementsInterface {
+ public:
+  virtual Vector9 computeError(const NavState& state_i, const NavState& state_j,
+    const imuBias::ConstantBias& bias_i,
+    OptionalJacobian<9, 9> H1, OptionalJacobian<9, 9> H2,
+    OptionalJacobian<9, 6> H3) const = 0;
+
+  virtual Vector9 computeErrorAndJacobians(const Pose3& pose_i, const Vector3& vel_i,
+    const Pose3& pose_j, const Vector3& vel_j,
+    const imuBias::ConstantBias& bias_i, 
+    OptionalJacobian<9, 6> H1 = {}, OptionalJacobian<9, 3> H2 = {},
+    OptionalJacobian<9, 6> H3 = {}, OptionalJacobian<9, 3> H4 = {}, 
+    OptionalJacobian<9, 6> H5 = {}) const = 0;
+
+  virtual Matrix preintMeasCov() const = 0;
+
+  virtual void print(const std::string& s) const = 0;
+  virtual bool equals(const PreintegratedImuMeasurementsInterface& expected, double tol) const = 0;
+  
+  virtual ~PreintegratedImuMeasurementsInterface() = default;
+  
+  /**
+  * @brief Create a deep copy of this object and return a shared pointer.
+  * Named deepCopy to avoid conflict with TangentPreintegration.clone().
+  */
+  virtual std::shared_ptr<const PreintegratedImuMeasurementsInterface> deepCopy() const = 0;
+};
+
+/**
  * PreintegratedImuMeasurements accumulates (integrates) the IMU measurements
  * (rotation rates and accelerations) and the corresponding covariance matrix.
  * The measurements are then used to build the Preintegrated IMU factor.
@@ -69,10 +103,11 @@ typedef ManifoldPreintegration DefaultPreintegrationBackend;
  * @ingroup navigation
  */
 template <class PreintegrationBackend>
-class GTSAM_EXPORT PreintegratedImuMeasurementsT: public PreintegrationBackend {
+class GTSAM_EXPORT PreintegratedImuMeasurementsT: public PreintegrationBackend, 
+                                                  public virtual PreintegratedImuMeasurementsInterface {
  
-  template <class PIMType_> friend class ImuFactorT;
-  template <class PIMType_> friend class ImuFactor2T;
+  friend class ImuFactorT;
+  friend class ImuFactor2T;
 
 protected:
 
@@ -116,10 +151,16 @@ public:
   void print(const std::string& s = "Preintegrated Measurements:") const override;
 
   /// equals
-  bool equals(const PreintegratedImuMeasurementsT<PreintegrationBackend>& expected, double tol = 1e-9) const;
+  bool equalsConcrete(const PreintegratedImuMeasurementsT<PreintegrationBackend>& expected, double tol = 1e-9) const;
+  bool equals(const PreintegratedImuMeasurementsInterface& other_interface, double tol = 1e-9) const override;
 
   /// Re-initialize PreintegratedImuMeasurements
   void resetIntegration() override;
+  
+  /// Create a deep copy of this object, wrapped in a shared_ptr.
+  std::shared_ptr<const PreintegratedImuMeasurementsInterface> deepCopy() const override {
+    return std::make_shared<const PreintegratedImuMeasurementsT<PreintegrationBackend>>(*this);
+  }
 
   /**
    * Add a single IMU measurement to the preintegration.
@@ -140,6 +181,24 @@ public:
 
   /// Return pre-integrated measurement covariance
   Matrix preintMeasCov() const { return preintMeasCov_; }
+
+  /// Redeclare compute functions for override
+  Vector9 computeError(const NavState& state_i, const NavState& state_j,
+      const imuBias::ConstantBias& bias_i,
+      OptionalJacobian<9, 9> H1, OptionalJacobian<9, 9> H2,
+      OptionalJacobian<9, 6> H3) const override {
+    return PreintegrationBackend::computeError(
+      state_i, state_j, bias_i, H1, H2, H3);
+  }
+  Vector9 computeErrorAndJacobians(const Pose3& pose_i, const Vector3& vel_i,
+      const Pose3& pose_j, const Vector3& vel_j,
+      const imuBias::ConstantBias& bias_i, 
+      OptionalJacobian<9, 6> H1 = {}, OptionalJacobian<9, 3> H2 = {},
+      OptionalJacobian<9, 6> H3 = {}, OptionalJacobian<9, 3> H4 = {}, 
+      OptionalJacobian<9, 6> H5 = {}) const override {
+    return PreintegrationBackend::computeErrorAndJacobians(
+      pose_i, vel_i, pose_j, vel_j, bias_i, H1, H2, H3, H4, H5);
+  }
 
   /// Merge in a different set of measurements and update bias derivatives accordingly
   /// This method is specific to TangentPreintegration backend.
@@ -184,16 +243,15 @@ typedef PreintegratedImuMeasurementsT<DefaultPreintegrationBackend> Preintegrate
  *
  * @ingroup navigation
  */
-template <class PIMType_ = PreintegratedImuMeasurements>
-class GTSAM_EXPORT ImuFactorT: public NoiseModelFactorN<Pose3, Vector3, Pose3, Vector3,
+class GTSAM_EXPORT ImuFactor: public NoiseModelFactorN<Pose3, Vector3, Pose3, Vector3,
     imuBias::ConstantBias> {
 private:
 
-  typedef ImuFactorT<PIMType_> This;
+  typedef ImuFactor This;
   typedef NoiseModelFactorN<Pose3, Vector3, Pose3, Vector3,
       imuBias::ConstantBias> Base;
 
-  PIMType_ _PIM_;
+  std::shared_ptr<const PreintegratedImuMeasurementsInterface> _PIM_;
 
 public:
 
@@ -201,11 +259,15 @@ public:
   using Base::evaluateError;
 
   /** Shorthand for a smart pointer to a factor */
-  typedef std::shared_ptr<This> shared_ptr;
+#if !defined(_MSC_VER) && __GNUC__ == 4 && __GNUC_MINOR__ > 5
+  typedef typename std::shared_ptr<ImuFactor> shared_ptr;
+#else
+  typedef std::shared_ptr<ImuFactor> shared_ptr;
+#endif
 
 
   /** Default constructor - only use for serialization */
-  ImuFactorT() {}
+  ImuFactor() {}
 
   /**
    * Constructor
@@ -217,30 +279,28 @@ public:
    * @param preintegratedMeasurements The preintegreated measurements since the
    * last pose.
    */
-  ImuFactorT(Key pose_i, Key vel_i, Key pose_j, Key vel_j, Key bias,
-      const PIMType_& preintegratedMeasurements)
-      : Base(noiseModel::Gaussian::Covariance(preintegratedMeasurements.preintMeasCov()),
-             pose_i, vel_i, pose_j, vel_j, bias),
-        _PIM_(preintegratedMeasurements) {}
+  ImuFactor(Key pose_i, Key vel_i, Key pose_j, Key vel_j, Key bias,
+    const std::shared_ptr<const PreintegratedImuMeasurementsInterface>& preintegratedMeasurements);
 
-  ~ImuFactorT() override {
+  ~ImuFactor() override {
   }
 
   /// @return a deep copy of this factor
-  gtsam::NonlinearFactor::shared_ptr clone() const override {
-    return std::make_shared<This>(*this);
-  }
+  gtsam::NonlinearFactor::shared_ptr clone() const override;
 
   /// @name Testable
   /// @{
+  GTSAM_EXPORT friend std::ostream& operator<<(std::ostream& os, const ImuFactor&);
   void print(const std::string& s = "", const KeyFormatter& keyFormatter =
                                             DefaultKeyFormatter) const override;
   bool equals(const NonlinearFactor& expected, double tol = 1e-9) const override;
   /// @}
 
-  /** Access the preintegrated measurements. */
-
-  const PIMType_& preintegratedMeasurements() const {
+  /** 
+   * Access the preintegrated measurements. 
+   * User is responsible for casting to their underlying PIM type.
+   */
+  const std::shared_ptr<const PreintegratedImuMeasurementsInterface> preintegratedMeasurements() const {
     return _PIM_;
   }
 
@@ -253,78 +313,12 @@ public:
       OptionalMatrixType H3, OptionalMatrixType H4, OptionalMatrixType H5) const override;
 
   /// Merge two pre-integrated measurement classes
-  template <typename MethodPIMArg = PIMType_,
-    // This method is only callable when PIMType_ is PreintegratedImuMeasurementsT<TangentPreintegration>.
-    typename = typename std::enable_if<
-        std::is_same<MethodPIMArg, PreintegratedImuMeasurementsT<TangentPreintegration>>::value
-    >::type
-  >
-  static MethodPIMArg Merge(
-    const MethodPIMArg& pim01,
-    const MethodPIMArg& pim12
-  ) {
-    // When this template is instantiated:
-    // 1. MethodPIMArg = PIMType_. It's mirrored to avoid error C7637 from strict compilers.
-    // 2. The SFINAE condition ensures MethodPIMArg IS PreintegratedImuMeasurementsT<TangentPreintegration>.
-    // So, arguments are const PreintegratedImuMeasurementsT<TangentPreintegration>&
-    // and return is PreintegratedImuMeasurementsT<TangentPreintegration>.
-
-    if (!pim01.matchesParamsWith(pim12))
-      throw std::domain_error(
-          "Cannot merge PreintegratedImuMeasurements with different params");
-
-    if (pim01.p_->body_P_sensor)
-      throw std::domain_error(
-          "Cannot merge PreintegratedImuMeasurements with sensor pose yet");
-
-    // the bias for the merged factor will be the bias from 01
-    MethodPIMArg pim02 = pim01;
-
-    Matrix9 H1, H2;
-    pim02.mergeWith(pim12, &H1, &H2);
-
-    return pim02;
-  }
+  static PreintegratedImuMeasurementsT<TangentPreintegration> Merge(
+    const PreintegratedImuMeasurementsT<TangentPreintegration>& pim01,
+    const PreintegratedImuMeasurementsT<TangentPreintegration>& pim12);
 
   /// Merge two factors
-  template <
-    typename MethodPIMArg = PIMType_,
-    // This method is only callable when PIMType_ is PreintegratedImuMeasurementsT<TangentPreintegration>.
-    typename = typename std::enable_if<
-        std::is_same<MethodPIMArg, PreintegratedImuMeasurementsT<TangentPreintegration>>::value
-    >::type
-  >
-  static typename ImuFactorT<MethodPIMArg>::shared_ptr Merge(
-    const typename ImuFactorT<MethodPIMArg>::shared_ptr& f01,
-    const typename ImuFactorT<MethodPIMArg>::shared_ptr& f12
-  ) {
-    // When this template is instantiated:
-    // 1. MethodPIMArg = PIMType_. It's mirrored to avoid error C7637 from strict compilers.
-    // 2. The SFINAE condition ensures MethodPIMArg IS PreintegratedImuMeasurementsT<TangentPreintegration>.
-    // So, ImuFactorT<MethodPIMArg> is effectively ImuFactorT<PIMType_>, which is `This`.
-    // The signature effectively becomes:
-    // static typename This::shared_ptr Merge(const typename This::shared_ptr&, const typename This::shared_ptr&)
-
-  // IMU bias keys must be the same.
-  if (f01->template key<5>() != f12->template key<5>())
-    throw std::domain_error("ImuFactor::Merge: IMU bias keys must be the same");
-
-  // expect intermediate pose, velocity keys to matchup.
-  if (f01->template key<3>() != f12->template key<1>() || f01->template key<4>() != f12->template key<2>())
-    throw std::domain_error(
-        "ImuFactor::Merge: intermediate pose, velocity keys need to match up");
-
-  // return new factor
-  auto pim02 = This::Merge(f01->preintegratedMeasurements(), f12->preintegratedMeasurements());
-
-  return std::make_shared<This>( // `This` is ImuFactorT<MethodPIMArg> (i.e. ImuFactorT<PIMType_>)
-      f01->template key<1>(),  // P0
-      f01->template key<2>(),  // V0
-      f12->template key<3>(),  // P2
-      f12->template key<4>(),  // V2
-      f01->template key<5>(),  // B
-      pim02);
-  }
+  static shared_ptr Merge(const shared_ptr& f01, const shared_ptr& f12);
 
  private:
   /** Serialization function */
@@ -339,27 +333,19 @@ public:
   }
 #endif
 };
-// class ImuFactorT
-
-// For backward compatibility:
-typedef ImuFactorT<> ImuFactor;
- 
-// operator<< for ImuFactorT
-template <class PIMType_>
-GTSAM_EXPORT std::ostream& operator<<(std::ostream& os, const ImuFactorT<PIMType_>& f);
+// class ImuFactor
 
 /**
  * ImuFactor2 is a ternary factor that uses NavStates rather than Pose/Velocity.
  * @ingroup navigation
  */
-template <class PIMType_ = PreintegratedImuMeasurements>
-class GTSAM_EXPORT ImuFactor2T : public NoiseModelFactorN<NavState, NavState, imuBias::ConstantBias> {
+class GTSAM_EXPORT ImuFactor2 : public NoiseModelFactorN<NavState, NavState, imuBias::ConstantBias> {
 private:
 
-  typedef ImuFactor2T<PIMType_> This;
+  typedef ImuFactor2 This;
   typedef NoiseModelFactorN<NavState, NavState, imuBias::ConstantBias> Base;
 
-  PIMType_ _PIM_;
+  std::shared_ptr<const PreintegratedImuMeasurementsInterface> _PIM_;
 
 public:
 
@@ -367,7 +353,7 @@ public:
   using Base::evaluateError;
 
   /** Default constructor - only use for serialization */
-  ImuFactor2T() {}
+  ImuFactor2() {}
 
   /**
    * Constructor
@@ -375,24 +361,18 @@ public:
    * @param state_j Current state key
    * @param bias    Previous bias key
    */
-  ImuFactor2T(Key state_i, Key state_j, Key bias,
-             const PIMType_& preintegratedMeasurements)
-      : Base(noiseModel::Gaussian::Covariance(preintegratedMeasurements.preintMeasCov()),
-             state_i, state_j, bias),
-        _PIM_(preintegratedMeasurements) {}
+  ImuFactor2(Key state_i, Key state_j, Key bias,
+    std::shared_ptr<const PreintegratedImuMeasurementsInterface> preintegratedMeasurements);
 
-
-  ~ImuFactor2T() override {
+  ~ImuFactor2() override {
   }
 
   /// @return a deep copy of this factor
-  gtsam::NonlinearFactor::shared_ptr clone() const override {
-    return std::make_shared<This>(*this);
-  }
-
+  gtsam::NonlinearFactor::shared_ptr clone() const override;
 
   /// @name Testable
   /// @{
+  GTSAM_EXPORT friend std::ostream& operator<<(std::ostream& os, const ImuFactor2&);
   void print(const std::string& s = "", const KeyFormatter& keyFormatter =
                                             DefaultKeyFormatter) const override;
   bool equals(const NonlinearFactor& expected, double tol = 1e-9) const override;
@@ -400,7 +380,7 @@ public:
 
   /** Access the preintegrated measurements. */
 
-  const PIMType_& preintegratedMeasurements() const {
+  const std::shared_ptr<const PreintegratedImuMeasurementsInterface> preintegratedMeasurements() const {
     return _PIM_;
   }
 
@@ -426,22 +406,15 @@ private:
   }
 #endif
 };
-// class ImuFactor2T
-
-// For backward compatibility:
-typedef ImuFactor2T<> ImuFactor2;
-
-// operator<< for ImuFactor2T
-template <class PIMType_>
-GTSAM_EXPORT std::ostream& operator<<(std::ostream& os, const ImuFactor2T<PIMType_>& f);
+// class ImuFactor2
 
 template <class PreintegrationBackend>
 struct traits<PreintegratedImuMeasurementsT<PreintegrationBackend>> : public Testable<PreintegratedImuMeasurementsT<PreintegrationBackend>> {};
 
-template <class PIMType_>
-struct traits<ImuFactorT<PIMType_>> : public Testable<ImuFactorT<PIMType_>> {};
+template <>
+struct traits<ImuFactor> : public Testable<ImuFactor> {};
 
-template <class PIMType_>
-struct traits<ImuFactor2T<PIMType_>> : public Testable<ImuFactor2T<PIMType_>> {};
+template <>
+struct traits<ImuFactor2> : public Testable<ImuFactor2> {};
 
 } /// namespace gtsam

--- a/gtsam/navigation/ManifoldPreintegration.h
+++ b/gtsam/navigation/ManifoldPreintegration.h
@@ -63,6 +63,10 @@ public:
       const imuBias::ConstantBias& biasHat = imuBias::ConstantBias());
 
   /// @}
+  
+  // Declare functions to pass down to PIM
+  using PreintegrationBase::computeError;
+  using PreintegrationBase::computeErrorAndJacobians;
 
   /// @name Basic utilities
   /// @{

--- a/gtsam/navigation/PreintegrationBase.h
+++ b/gtsam/navigation/PreintegrationBase.h
@@ -156,7 +156,7 @@ class GTSAM_EXPORT PreintegrationBase {
                    OptionalJacobian<9, 6> H2 = {}) const;
 
   /// Calculate error given navStates
-  Vector9 computeError(const NavState& state_i, const NavState& state_j,
+  virtual Vector9 computeError(const NavState& state_i, const NavState& state_j,
                        const imuBias::ConstantBias& bias_i,
                        OptionalJacobian<9, 9> H1, OptionalJacobian<9, 9> H2,
                        OptionalJacobian<9, 6> H3) const;
@@ -165,7 +165,7 @@ class GTSAM_EXPORT PreintegrationBase {
    * Compute errors w.r.t. preintegrated measurements and jacobians
    * wrt pose_i, vel_i, bias_i, pose_j, bias_j
    */
-  Vector9 computeErrorAndJacobians(const Pose3& pose_i, const Vector3& vel_i,
+  virtual Vector9 computeErrorAndJacobians(const Pose3& pose_i, const Vector3& vel_i,
       const Pose3& pose_j, const Vector3& vel_j,
       const imuBias::ConstantBias& bias_i, 
       OptionalJacobian<9, 6> H1 = {}, OptionalJacobian<9, 3> H2 = {},

--- a/gtsam/navigation/TangentPreintegration.h
+++ b/gtsam/navigation/TangentPreintegration.h
@@ -59,6 +59,10 @@ public:
 
   /// @}
 
+  // Declare functions to pass down to PIM
+  using PreintegrationBase::computeError;
+  using PreintegrationBase::computeErrorAndJacobians;
+
   /// @name Basic utilities
   /// @{
   /// Re-initialize PreintegratedMeasurements

--- a/gtsam/navigation/navigation.i
+++ b/gtsam/navigation/navigation.i
@@ -148,6 +148,9 @@ virtual class PreintegrationParams : gtsam::PreintegratedRotationParams {
 };
 
 #include <gtsam/navigation/ImuFactor.h>
+class PreintegratedImuMeasurementsInterface {
+};
+
 class PreintegratedImuMeasurements {
   // Constructors
   PreintegratedImuMeasurements(const gtsam::PreintegrationParams* params);
@@ -182,10 +185,10 @@ class PreintegratedImuMeasurements {
 virtual class ImuFactor: gtsam::NonlinearFactor {
   ImuFactor(size_t pose_i, size_t vel_i, size_t pose_j, size_t vel_j,
       size_t bias,
-      const gtsam::PreintegratedImuMeasurements& preintegratedMeasurements);
+      std::shared_ptr<const gtsam::PreintegratedImuMeasurementsInterface> preintegratedMeasurements);
 
   // Standard Interface
-  gtsam::PreintegratedImuMeasurements preintegratedMeasurements() const;
+  std::shared_ptr<const gtsam::PreintegratedImuMeasurementsInterface> preintegratedMeasurements() const;
   gtsam::Vector evaluateError(const gtsam::Pose3& pose_i, gtsam::Vector vel_i,
       const gtsam::Pose3& pose_j, gtsam::Vector vel_j,
       const gtsam::imuBias::ConstantBias& bias);
@@ -198,10 +201,10 @@ virtual class ImuFactor2: gtsam::NonlinearFactor {
   ImuFactor2();
   ImuFactor2(size_t state_i, size_t state_j,
       size_t bias,
-      const gtsam::PreintegratedImuMeasurements& preintegratedMeasurements);
+      std::shared_ptr<const gtsam::PreintegratedImuMeasurementsInterface> preintegratedMeasurements);
 
   // Standard Interface
-  gtsam::PreintegratedImuMeasurements preintegratedMeasurements() const;
+  std::shared_ptr<const gtsam::PreintegratedImuMeasurementsInterface> preintegratedMeasurements() const;
   gtsam::Vector evaluateError(const gtsam::NavState& state_i,
                               gtsam::NavState& state_j,
                               const gtsam::imuBias::ConstantBias& bias_i);


### PR DESCRIPTION
Draft PR showing what the code would look like if ImuFactor switched back to just depending on the passed-in PIM instead of being templated. The result is not great.
- You can't just have a reference to an interface in C++, you need to have a pointer to it (`std::shared_ptr<const PreintegratedImuMeasurementsInterface> _PIM_;` instead of `PreintegratedImuMeasurements _PIM_;`). This creates a whole host of cascading issues that required me to make many more changes than I would have expected to implement this.
- Because of that, it's **no longer backwards compatible.** I had to make changes to some of ImuFactor's function signatures, because C++ has severe limitations on how an interface can be passed around. (`const PreintegratedImuMeasurements& preintegratedMeasurements()` -> `const std::shared_ptr<const PreintegratedImuMeasurementsInterface> preintegratedMeasurements()`). This means some code samples no longer compile and the Python interface has to be changed. And any other external code depending on ImuFactor would stop working.
- Due to the above, you need ugly casts to get the underlying PIM from the interface held by an ImuFactor: `*dynamic_cast<const PreintegratedImuMeasurementsT<TangentPreintegration>*>(factor->preintegratedMeasurements().get())`

This code doesn't compile as-is; there are still one or two issues. I also haven't made the conversion for CombinedImuFactor, that's still templated. But I thought I would put it up so we can make a decision whether to move forward with this... given that the motivation for this method was to keep "this PR - and disruption- small", I don't think it's what we want.