### PR TITLE
Hybrid Fixes

### DIFF
--- a/gtsam/discrete/DiscreteBayesNet.cpp
+++ b/gtsam/discrete/DiscreteBayesNet.cpp
@@ -111,6 +111,12 @@ DiscreteBayesNet DiscreteBayesNet::prune(
 
     // Set the fixed values if requested.
     if (fixedValues) {
+      if (!fixedValues->empty()) {
+        throw std::invalid_argument(
+            "DiscreteBayesNet::prune: fixedValues should be empty since it is "
+            "a purely output argument.");
+      }
+
       *fixedValues = deadModesValues;
     }
   }

--- a/gtsam/discrete/DiscreteFactorGraph.cpp
+++ b/gtsam/discrete/DiscreteFactorGraph.cpp
@@ -71,6 +71,11 @@ namespace gtsam {
         result = result ? result->multiply(factor) : factor;
       }
     }
+    if (result->max() == 0.0 && result->nrValues() == 1) {
+      throw std::runtime_error(
+          "Product factor is 0.0, possibly due to disjointed discrete "
+          "factors.");
+    }
     return result;
   }
 

--- a/gtsam/discrete/DiscreteKey.cpp
+++ b/gtsam/discrete/DiscreteKey.cpp
@@ -51,8 +51,7 @@ namespace gtsam {
                            const KeyFormatter& keyFormatter) const {
     std::cout << (s.empty() ? "" : s + " ") << std::endl;
     for (auto&& dkey : *this) {
-      std::cout << DefaultKeyFormatter(dkey.first) << " " << dkey.second
-                << std::endl;
+      std::cout << keyFormatter(dkey.first) << " " << dkey.second << std::endl;
     }
   }
 

--- a/gtsam/discrete/DiscreteValues.cpp
+++ b/gtsam/discrete/DiscreteValues.cpp
@@ -93,6 +93,14 @@ DiscreteValues& DiscreteValues::update(const DiscreteValues& values) {
 }
 
 /* ************************************************************************ */
+DiscreteValues& DiscreteValues::insert_or_assign(const DiscreteValues& values) {
+  for (auto&& [key, value] : values) {
+    Base::insert_or_assign(key, value);
+  }
+  return *this;
+}
+
+/* ************************************************************************ */
 string DiscreteValues::Translate(const Names& names, Key key, size_t index) {
   if (names.empty()) {
     stringstream ss;

--- a/gtsam/discrete/DiscreteValues.h
+++ b/gtsam/discrete/DiscreteValues.h
@@ -102,6 +102,15 @@ class GTSAM_EXPORT DiscreteValues : public Assignment<Key> {
   DiscreteValues& update(const DiscreteValues& values);
 
   /**
+   * @brief Insert each element of `values` if it does not already exist,
+   * else assign it.
+   * 
+   * @param values DiscreteValues to insert or assign to this.
+   * @return DiscreteValues& 
+   */
+  DiscreteValues& insert_or_assign(const DiscreteValues& values);
+
+  /**
    * @brief Check if the DiscreteValues contains the given key.
    *
    * @param key The key to check for.

--- a/gtsam/discrete/TableFactor.cpp
+++ b/gtsam/discrete/TableFactor.cpp
@@ -108,9 +108,9 @@ static Eigen::SparseVector<double> ComputeSparseTable(
    *
    */
   auto op = [&](const Assignment<Key>& assignment, double p) {
-    // Check if greater than 1e-11 because we consider
+    // Check if greater than a threshold because we consider
     // smaller than that as numerically 0
-    if (p > 1e-11) {
+    if (p > 1e-150) {
       // Get all the keys involved in this assignment
       KeySet assignmentKeys;
       for (auto&& [k, _] : assignment) {

--- a/gtsam/hybrid/DiscreteBoundaryFactor.h
+++ b/gtsam/hybrid/DiscreteBoundaryFactor.h
@@ -116,6 +116,10 @@ class GTSAM_EXPORT DiscreteBoundaryFactor : public DecisionTreeFactor {
    */
   DiscreteBoundaryFactor operator/(const DiscreteBoundaryFactor& f) const;
 
+  /// Unhide base class operators
+  using Base::operator*;
+  using Base::operator/;
+
   /// @}
   /// @name Advanced Interface
   /// @{

--- a/gtsam/hybrid/DiscreteBoundaryFactor.h
+++ b/gtsam/hybrid/DiscreteBoundaryFactor.h
@@ -116,10 +116,6 @@ class GTSAM_EXPORT DiscreteBoundaryFactor : public DecisionTreeFactor {
    */
   DiscreteBoundaryFactor operator/(const DiscreteBoundaryFactor& f) const;
 
-  /// Unhide base class operators
-  using Base::operator*;
-  using Base::operator/;
-
   /// @}
   /// @name Advanced Interface
   /// @{

--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -48,16 +48,25 @@ HybridBayesNet HybridBayesNet::prune(
   // Collect all the discrete conditionals. Could be small if already pruned.
   const DiscreteBayesNet marginal = discreteMarginal();
 
-  // Prune discrete Bayes net
+  // We use a separate value here since we need this to perform `restrict` on
+  // the HybridConditionals later.
   DiscreteValues fixed;
+  // Prune discrete Bayes net
   DiscreteBayesNet prunedBN =
       marginal.prune(maxNrLeaves, marginalThreshold, &fixed);
 
-  // Multiply into one big conditional. NOTE: possibly quite expensive.
+  // Multiply into one big conditional.
+  // NOTE: This is cheap since marginal.prune above creates a
+  // DBN with a single joint conditional.
   DiscreteConditional pruned = prunedBN.joint();
 
   // Set the fixed values if requested.
   if (marginalThreshold && fixedValues) {
+    if (!fixedValues->empty()) {
+      throw std::invalid_argument(
+          "HybridBayesNet::prune: fixedValues should be empty since it is "
+          "a purely output argument.");
+    }
     *fixedValues = fixed;
   }
 

--- a/gtsam/hybrid/HybridGaussianConditional.cpp
+++ b/gtsam/hybrid/HybridGaussianConditional.cpp
@@ -322,8 +322,7 @@ HybridGaussianConditional::shared_ptr HybridGaussianConditional::prune(
                       std::back_inserter(diff));
 
   // Find maximum probability value for every combination of *our* keys.
-  Ordering ordering(diff);
-  auto max = discreteProbs.max(ordering);
+  auto max = discreteProbs.max(Ordering(diff));
 
   // Check the max value for every combination of our keys.
   // If the max value is 0.0, we can prune the corresponding conditional.

--- a/gtsam/hybrid/HybridSmoother.cpp
+++ b/gtsam/hybrid/HybridSmoother.cpp
@@ -99,8 +99,8 @@ HybridGaussianFactorGraph HybridSmoother::removeFixedValues(
       std::vector<double> probabilities(
           dkey.second, (1 - *marginalThreshold_) / dkey.second);
       probabilities[fixedValues_[key]] = *marginalThreshold_;
-      DecisionTreeFactor dtf({dkey}, probabilities);
-      updatedGraph.push_back(dtf);
+      DiscreteConditional dc(dkey, DiscreteKeys{}, probabilities);
+      updatedGraph.push_back(dc);
 
       // Remove fixed value
       fixedValues_.erase(key);

--- a/gtsam/hybrid/HybridSmoother.cpp
+++ b/gtsam/hybrid/HybridSmoother.cpp
@@ -183,7 +183,7 @@ void HybridSmoother::update(const HybridNonlinearFactorGraph &newFactors,
     DiscreteValues newlyFixedValues;
     bayesNetFragment = bayesNetFragment.prune(*maxNrLeaves, marginalThreshold_,
                                               &newlyFixedValues);
-    fixedValues_.insert(newlyFixedValues);
+    fixedValues_.insert_or_assign(newlyFixedValues);
 #if GTSAM_HYBRID_TIMING
     gttoc_(HybridSmootherPrune);
 #endif

--- a/gtsam/hybrid/HybridSmoother.cpp
+++ b/gtsam/hybrid/HybridSmoother.cpp
@@ -183,6 +183,8 @@ void HybridSmoother::update(const HybridNonlinearFactorGraph &newFactors,
     DiscreteValues newlyFixedValues;
     bayesNetFragment = bayesNetFragment.prune(*maxNrLeaves, marginalThreshold_,
                                               &newlyFixedValues);
+    // Insert or assign so it updates existing fixed values
+    // instead of replacing them.
     fixedValues_.insert_or_assign(newlyFixedValues);
 #if GTSAM_HYBRID_TIMING
     gttoc_(HybridSmootherPrune);


### PR DESCRIPTION
A bunch of fixes to help with hybrid estimation and ensure we no longer end up with discrete product factors with only 0.0 values.

The main issue was that setting the cut-off threshold for the `TableFactor` to 1e-11 was a bit too strong, leading to steady pruning away over multiple timesteps. This would eventually cause whole subtrees of discrete conditionals (aka `DiscreteConditional` which inherits from `DecisionTreeFactor`) to be 0, leading to a product factor of 0 when multiplied together during discrete elimination.

Unfortunately, writing a unit test is tricky since this requires a full estimation pipeline to recreate the exact conditions.