### PR TITLE
ROS package.xml: do not depend on boost

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -23,7 +23,6 @@
 
   <buildtool_depend>cmake</buildtool_depend>
 
-  <depend>boost</depend>
   <depend>eigen</depend>
   <depend>tbb</depend>
 


### PR DESCRIPTION
GTSAM could be built now without boost, so let's not propagate the dependency downstream.

LMK if I'm wrong, but boost should be completely optional by now, right? 

If you could also please merge this into the release 4.3 branch, I will create a new ROS release from that to see how it goes... :crossed_fingers: 
