### PR TITLE
Removed `dimension` field from `Cal3`

### DIFF
--- a/gtsam/geometry/Cal3.h
+++ b/gtsam/geometry/Cal3.h
@@ -73,7 +73,6 @@ class GTSAM_EXPORT Cal3 {
   double u0_ = 0.0f, v0_ = 0.0f;  ///< principal point
 
  public:
-  constexpr static auto dimension = 5;
   ///< shared pointer to calibration object
   using shared_ptr = std::shared_ptr<Cal3>;
 
@@ -173,11 +172,9 @@ class GTSAM_EXPORT Cal3 {
   /// Return inverted calibration matrix inv(K)
   Matrix3 inverse() const;
 
-  /// return DOF, dimensionality of tangent space
-  virtual size_t dim() const { return Dim(); }
-
-  /// return DOF, dimensionality of tangent space
-  static size_t Dim() { return dimension; }
+  /// Abstract function that returns DOF, dimensionality of tangent space
+  /// To be overriden in derived classes
+  virtual size_t dim() const = 0;
 
   /// @}
   /// @name Advanced Interface

--- a/gtsam/geometry/Cal3.h
+++ b/gtsam/geometry/Cal3.h
@@ -172,10 +172,6 @@ class GTSAM_EXPORT Cal3 {
   /// Return inverted calibration matrix inv(K)
   Matrix3 inverse() const;
 
-  /// Abstract function that returns DOF, dimensionality of tangent space
-  /// To be overriden in derived classes
-  virtual size_t dim() const = 0;
-
   /// @}
   /// @name Advanced Interface
   /// @{

--- a/gtsam/geometry/Cal3Bundler.h
+++ b/gtsam/geometry/Cal3Bundler.h
@@ -125,7 +125,7 @@ class GTSAM_EXPORT Cal3Bundler : public Cal3f {
   /// @{
 
   /// Return DOF, dimensionality of tangent space
-  size_t dim() const override { return Dim(); }
+  size_t dim() const { return Dim(); }
 
   /// Return DOF, dimensionality of tangent space
   static size_t Dim() { return dimension; }

--- a/gtsam/geometry/Cal3DS2.h
+++ b/gtsam/geometry/Cal3DS2.h
@@ -84,7 +84,7 @@ class GTSAM_EXPORT Cal3DS2 : public Cal3DS2_Base {
   Vector localCoordinates(const Cal3DS2& T2) const;
 
   /// Return dimensions of calibration manifold object
-  size_t dim() const override { return Dim(); }
+  size_t dim() const { return Dim(); }
 
   /// Return dimensions of calibration manifold object
   static size_t Dim() { return dimension; }

--- a/gtsam/geometry/Cal3DS2_Base.h
+++ b/gtsam/geometry/Cal3DS2_Base.h
@@ -136,7 +136,7 @@ class GTSAM_EXPORT Cal3DS2_Base : public Cal3 {
   Matrix29 D2d_calibration(const Point2& p) const;
 
   /// return DOF, dimensionality of tangent space
-  size_t dim() const override { return Dim(); }
+  size_t dim() const { return Dim(); }
 
   /// return DOF, dimensionality of tangent space
   static size_t Dim() { return dimension; }

--- a/gtsam/geometry/Cal3Fisheye.h
+++ b/gtsam/geometry/Cal3Fisheye.h
@@ -154,7 +154,7 @@ class GTSAM_EXPORT Cal3Fisheye : public Cal3 {
   /// @{
 
   /// Return dimensions of calibration manifold object
-  size_t dim() const override { return Dim(); }
+  size_t dim() const { return Dim(); }
 
   /// Return dimensions of calibration manifold object
   static size_t Dim() { return dimension; }

--- a/gtsam/geometry/Cal3Unified.h
+++ b/gtsam/geometry/Cal3Unified.h
@@ -130,7 +130,7 @@ class GTSAM_EXPORT Cal3Unified : public Cal3DS2_Base {
   Vector localCoordinates(const Cal3Unified& T2) const;
 
   /// Return dimensions of calibration manifold object
-  size_t dim() const override { return Dim(); }
+  size_t dim() const { return Dim(); }
 
   /// Return dimensions of calibration manifold object
   static size_t Dim() { return dimension; }

--- a/gtsam/geometry/Cal3_S2.h
+++ b/gtsam/geometry/Cal3_S2.h
@@ -115,6 +115,9 @@ class GTSAM_EXPORT Cal3_S2 : public Cal3 {
   /// @{
 
   /// return DOF, dimensionality of tangent space
+  virtual size_t dim() const { return Dim(); };
+
+  /// return DOF, dimensionality of tangent space
   static size_t Dim() { return dimension; }
 
   /// Given 5-dim tangent vector, create new calibration

--- a/gtsam/geometry/Cal3_S2.h
+++ b/gtsam/geometry/Cal3_S2.h
@@ -115,7 +115,7 @@ class GTSAM_EXPORT Cal3_S2 : public Cal3 {
   /// @{
 
   /// return DOF, dimensionality of tangent space
-  virtual size_t dim() const { return Dim(); };
+  virtual size_t dim() const override { return Dim(); };
 
   /// return DOF, dimensionality of tangent space
   static size_t Dim() { return dimension; }

--- a/gtsam/geometry/Cal3_S2.h
+++ b/gtsam/geometry/Cal3_S2.h
@@ -115,7 +115,7 @@ class GTSAM_EXPORT Cal3_S2 : public Cal3 {
   /// @{
 
   /// return DOF, dimensionality of tangent space
-  virtual size_t dim() const override { return Dim(); };
+  virtual size_t dim() const { return Dim(); };
 
   /// return DOF, dimensionality of tangent space
   static size_t Dim() { return dimension; }

--- a/gtsam/geometry/Cal3f.h
+++ b/gtsam/geometry/Cal3f.h
@@ -102,7 +102,7 @@ class GTSAM_EXPORT Cal3f : public Cal3 {
   /// @{
 
   /// Return DOF, dimensionality of tangent space
-  size_t dim() const override { return Dim(); }
+  size_t dim() const { return Dim(); }
 
   /// Return DOF, dimensionality of tangent space
   static size_t Dim() { return dimension; }

--- a/gtsam/geometry/geometry.i
+++ b/gtsam/geometry/geometry.i
@@ -764,6 +764,11 @@ class EssentialMatrix {
 
 #include <gtsam/geometry/Cal3.h>
 virtual class Cal3 {
+  // Standard Constructors
+  Cal3();
+  Cal3(double fx, double fy, double s, double u0, double v0);
+  Cal3(gtsam::Vector v);
+
   // Testable
   void print(string s = "Cal3") const;
   bool equals(const gtsam::Cal3& K, double tol) const;
@@ -779,9 +784,6 @@ virtual class Cal3 {
   gtsam::Vector vector() const;
   gtsam::Matrix K() const;
   gtsam::Matrix inverse() const;
-
-  // Manifold
-  size_t dim() const;
 };
 
 #include <gtsam/geometry/Cal3_S2.h>

--- a/gtsam/geometry/geometry.i
+++ b/gtsam/geometry/geometry.i
@@ -764,11 +764,6 @@ class EssentialMatrix {
 
 #include <gtsam/geometry/Cal3.h>
 virtual class Cal3 {
-  // Standard Constructors
-  Cal3();
-  Cal3(double fx, double fy, double s, double u0, double v0);
-  Cal3(gtsam::Vector v);
-
   // Testable
   void print(string s = "Cal3") const;
   bool equals(const gtsam::Cal3& K, double tol) const;
@@ -786,7 +781,6 @@ virtual class Cal3 {
   gtsam::Matrix inverse() const;
 
   // Manifold
-  static size_t Dim();
   size_t dim() const;
 };
 


### PR DESCRIPTION
Primary Change(s):
- Removed `dimension` field and `Dim()` from `Cal3.h`
- Made `dim()` a pure virtual function in `Cal3.h`. This made `Cal3` an abstract class. This was done rather than removing the function entirely because derived classes override this function.
- Added an implementation of `dim()` with override keyword so that `Cal3_S2` becomes a concrete class. Not doing so made it abstract, which caused some errors in the unit tests

Check(s) Done:
- Executed `make check`, 100% tests passed

Note(s):
- This is a small PR as I have decided to divide my work based on relevance in order to prevent a backlog of PRs.