### PR TITLE
Ported StereoVOExample

### DIFF
--- a/python/gtsam/examples/README.md
+++ b/python/gtsam/examples/README.md
@@ -11,19 +11,19 @@
 | elaboratePoint2KalmanFilter                           | GaussianSequentialSolver not yet exposed through Python |
 | FisheyeExample                                        |        |
 | HMMExample                                            |        |
-| ImuFactorsExample2                                    | :heavy_check_mark:      |
+| ImuFactorsExample2                                    | :heavy_check_mark: |
 | ImuFactorsExample                                     |        |
 | IMUKittiExampleGPS                                    |        |
 | InverseKinematicsExampleExpressions.cpp               |        |
 | ISAM2Example_SmartFactor                              |        |
 | ISAM2_SmartFactorStereo_IMU                           |        |
-| LocalizationExample                                   | :heavy_check_mark:      |
+| LocalizationExample                                   | :heavy_check_mark: |
 | METISOrderingExample                                  |        |
-| OdometryExample                                       | :heavy_check_mark:      |
-| PlanarSLAMExample                                     | :heavy_check_mark:      |
-| Pose2SLAMExample                                      | :heavy_check_mark:      |
+| OdometryExample                                       | :heavy_check_mark: |
+| PlanarSLAMExample                                     | :heavy_check_mark: |
+| Pose2SLAMExample                                      | :heavy_check_mark: |
 | Pose2SLAMExampleExpressions                           |        |
-| Pose2SLAMExample_g2o                                  | :heavy_check_mark:      |
+| Pose2SLAMExample_g2o                                  | :heavy_check_mark: |
 | Pose2SLAMExample_graph                                |        |
 | Pose2SLAMExample_graphviz                             |        |
 | Pose2SLAMExample_lago                                 | lago not yet exposed through Python |
@@ -32,29 +32,29 @@
 | Pose3Localization                                 |        |
 | Pose3SLAMExample_changeKeys                           |        |
 | Pose3SLAMExampleExpressions_BearingRangeWithTransform |        |
-| Pose3SLAMExample_g2o                                  | :heavy_check_mark:      |
-| Pose3SLAMExample_initializePose3Chordal               | :heavy_check_mark:        |
+| Pose3SLAMExample_g2o                                  | :heavy_check_mark: |
+| Pose3SLAMExample_initializePose3Chordal               | :heavy_check_mark: |
 | Pose3SLAMExample_initializePose3Gradient              |        |
 | RangeISAMExample_plaza2                               |        |
 | SelfCalibrationExample                                |        |
 | SFMdata                                               |        |     
 | SFMExample_bal_COLAMD_METIS                           |        |
-| SFMExample_bal                                        | :heavy_check_mark:      |
-| SFMExample                                            | :heavy_check_mark:      |
+| SFMExample_bal                                        | :heavy_check_mark: |
+| SFMExample                                            | :heavy_check_mark: |
 | SFMExampleExpressions_bal                             |        |
 | SFMExampleExpressions                                 |        |
 | SFMExample_SmartFactor                                |        |
 | SFMExample_SmartFactorPCG                             |        |
-| ShonanAveragingCLI                                    | :heavy_check_mark:       |
-| SimpleRotation                                        | :heavy_check_mark:      |
+| ShonanAveragingCLI                                    | :heavy_check_mark: |
+| SimpleRotation                                        | :heavy_check_mark: |
 | SolverComparer                                        |        |
-| StereoVOExample                                       |        |
+| StereoVOExample                                       | :heavy_check_mark: |
 | StereoVOExample_large                                 |        |
 | TimeTBB                                               |        |
 | UGM_chain                                             | discrete functionality not yet exposed |
 | UGM_small                                             | discrete functionality not yet exposed |
-| VisualISAM2Example                                    | :heavy_check_mark:      |
-| VisualISAMExample                                     | :heavy_check_mark:      |
+| VisualISAM2Example                                    | :heavy_check_mark: |
+| VisualISAMExample                                     | :heavy_check_mark: |
 
 Extra Examples (with no C++ equivalent)
 - DogLegOptimizerExample

--- a/python/gtsam/examples/StereoVOExample.ipynb
+++ b/python/gtsam/examples/StereoVOExample.ipynb
@@ -1,0 +1,375 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "cc72e99e",
+      "metadata": {},
+      "source": [
+        "# Stereo Visual Odometry with GTSAM\n",
+        "\n",
+        "This notebook demonstrates a simple 3D stereo visual odometry problem using the GTSAM Python wrapper. The scenario is as follows:\n",
+        "\n",
+        "1.  A robot starts at the origin (Pose 1: `X(1)`).\n",
+        "2.  The robot moves approximately 1 meter forward (Pose 2: `X(2)`).\n",
+        "3.  From both poses, the robot observes three landmarks (`L(1)`, `L(2)`, `L(3)`) with a stereo camera.\n",
+        "\n",
+        "We will:\n",
+        "*   Define camera calibration and noise models.\n",
+        "*   Create a factor graph representing the problem.\n",
+        "*   Provide initial estimates for poses and landmark positions.\n",
+        "*   Optimize the graph using Levenberg-Marquardt to find the most probable configuration.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "e33e553a",
+      "metadata": {},
+      "source": [
+        "GTSAM Copyright 2010-2025, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "6af0f339",
+      "metadata": {},
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/gtsam-project/gtsam-examples/blob/main/python/StereoVOExample_py.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 19,
+      "id": "ac25f0ee",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "\n",
+        "# For shorthand for common GTSAM types (like X for poses, L for landmarks)\n",
+        "from gtsam.symbol_shorthand import X, L\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "8d3c4fd5",
+      "metadata": {},
+      "source": [
+        "## 1. Setup Factor Graph and Priors\n",
+        "\n",
+        "We start by creating an empty `NonlinearFactorGraph`.\n",
+        "\n",
+        "The first pose `X(1)` is assumed to be at the origin. We'll add a hard constraint (prior) for this using `NonlinearEqualityPose3`. In GTSAM, factor keys are typically integers. We use `X(1)` as a symbolic key for the first pose.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 20,
+      "id": "342a585f",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Graph size after adding prior: 1\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Create an empty nonlinear factor graph\n",
+        "graph = gtsam.NonlinearFactorGraph()\n",
+        "\n",
+        "# Define the first pose at the origin\n",
+        "first_pose = gtsam.Pose3() # Default constructor is identity\n",
+        "\n",
+        "# Add a prior on the first pose (X1). This constraint implies X1 is fixed at the origin.\n",
+        "# NonlinearEqualityPose3 is a factor that enforces X(1) == first_pose.\n",
+        "# It effectively acts as a prior with infinite precision (zero noise).\n",
+        "graph.add(gtsam.NonlinearEqualityPose3(X(1), first_pose))\n",
+        "\n",
+        "print(\"Graph size after adding prior:\", graph.size())\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "4cbc48f7",
+      "metadata": {},
+      "source": [
+        "## 2. Define Camera Calibration and Measurement Noise\n",
+        "\n",
+        "- **Noise Model:** We define an isotropic noise model for the stereo measurements. `Isotropic.Sigma(3, 1.0)` means a 3-dimensional noise (for $u_L, u_R, v$) with a standard deviation of 1 pixel for each dimension.\n",
+        "- **Camera Calibration ([`Cal3_S2Stereo`](/gtsam/geometry/doc/Cal3_S2Stereo.ipynb)):** We define a stereo calibration model with the following properties:\n",
+        "  - $f_x=f_y=1000$\n",
+        "  - $s=0$\n",
+        "  - $(u,v)=(320,\\,240)$\n",
+        "  - $b=0.2$"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 21,
+      "id": "e04b26c7",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Define the stereo measurement noise model (isotropic, 1 pixel standard deviation)\n",
+        "measurement_noise = gtsam.noiseModel.Isotropic.Sigma(3, 1.0)\n",
+        "\n",
+        "# Create stereo camera calibration object\n",
+        "K = gtsam.Cal3_S2Stereo(1000, 1000, 0, 320, 240, 0.2)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "a2f867ed",
+      "metadata": {},
+      "source": [
+        "## 3. Add Stereo Factors\n",
+        "\n",
+        "We now add stereo factors to the graph. Each factor connects a camera pose to a landmark.\n",
+        "The `GenericStereoFactor3D` takes:\n",
+        "*   `measured`: The `StereoPoint2` measurement $(u_L, u_R, v)$.\n",
+        "*   `model`: The noise model for the measurement.\n",
+        "*   `poseKey`: Key for the camera pose.\n",
+        "*   `landmarkKey`: Key for the landmark.\n",
+        "*   `K`: The stereo camera calibration.\n",
+        "\n",
+        "Landmark keys in the C++ example are 3, 4, 5. We'll use `L(1)`, `L(2)`, `L(3)` to map to these.\n",
+        "\n",
+        "**Measurements from Pose 1 (`X(1)`)**\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 22,
+      "id": "e9778bec",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Graph size after adding X(1) factors: 4\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Factors from X(1) to landmarks\n",
+        "# StereoPoint2(uL, uR, v)\n",
+        "graph.add(gtsam.GenericStereoFactor3D(\n",
+        "    gtsam.StereoPoint2(520, 480, 440), measurement_noise, X(1), L(1), K))\n",
+        "graph.add(gtsam.GenericStereoFactor3D(\n",
+        "    gtsam.StereoPoint2(120, 80, 440), measurement_noise, X(1), L(2), K))\n",
+        "graph.add(gtsam.GenericStereoFactor3D(\n",
+        "    gtsam.StereoPoint2(320, 280, 140), measurement_noise, X(1), L(3), K))\n",
+        "\n",
+        "print(\"Graph size after adding X(1) factors:\", graph.size())\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "d0160cf1",
+      "metadata": {},
+      "source": [
+        "**Measurements from Pose 2 (`X(2)`)**\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 23,
+      "id": "495fc44f",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Graph size after adding all factors: 7\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Factors from X(2) to landmarks\n",
+        "graph.add(gtsam.GenericStereoFactor3D(\n",
+        "    gtsam.StereoPoint2(570, 520, 490), measurement_noise, X(2), L(1), K))\n",
+        "graph.add(gtsam.GenericStereoFactor3D(\n",
+        "    gtsam.StereoPoint2(70, 20, 490), measurement_noise, X(2), L(2), K))\n",
+        "graph.add(gtsam.GenericStereoFactor3D(\n",
+        "    gtsam.StereoPoint2(320, 270, 115), measurement_noise, X(2), L(3), K))\n",
+        "\n",
+        "print(\"Graph size after adding all factors:\", graph.size())"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "b6dd7e48",
+      "metadata": {},
+      "source": [
+        "## 4. Create Initial Estimates\n",
+        "\n",
+        "Nonlinear optimization requires initial estimates for all variables (poses and landmarks).\n",
+        "We create a `Values` object to store these.\n",
+        "\n",
+        "*   `X(1)`: At origin (matches the prior).\n",
+        "*   `X(2)`: Robot moves forward, slightly off-axis: `Pose3(Rot3(), Point3(0.1, -0.1, 1.1))`.\n",
+        "*   Landmarks (`L(1)`, `L(2)`, `L(3)` or `3,4,5`): Placed at estimated 3D positions.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 24,
+      "id": "b4be6ab2",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "initial_estimate = gtsam.Values()\n",
+        "\n",
+        "# Initial estimate for X(1)\n",
+        "initial_estimate.insert(X(1), first_pose)\n",
+        "\n",
+        "# Initial estimate for X(2) - robot moved forward ~1m, with some small error\n",
+        "# Pose3(rotation, translation)\n",
+        "# gtsam.Rot3() is identity rotation\n",
+        "initial_pose2 = gtsam.Pose3(gtsam.Rot3(), gtsam.Point3(0.1, -0.1, 1.1))\n",
+        "initial_estimate.insert(X(2), initial_pose2)\n",
+        "\n",
+        "# Initial estimates for landmark positions (Point3)\n",
+        "initial_estimate.insert(L(1), gtsam.Point3(1.0, 1.0, 5.0))\n",
+        "initial_estimate.insert(L(2), gtsam.Point3(-1.0, 1.0, 5.0))\n",
+        "initial_estimate.insert(L(3), gtsam.Point3(0.0, -0.5, 5.0))\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "1c1a5a73",
+      "metadata": {},
+      "source": [
+        "## 5. Optimize the Factor Graph\n",
+        "\n",
+        "We use the Levenberg-Marquardt optimizer to find the solution that minimizes the sum of squared errors defined by the factors in the graph, starting from the `initial_estimate`.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 25,
+      "id": "d0c3a87b",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Create a Levenberg-Marquardt optimizer\n",
+        "optimizer = gtsam.LevenbergMarquardtOptimizer(graph, initial_estimate)\n",
+        "\n",
+        "# Optimize the graph\n",
+        "result = optimizer.optimize()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "3b3685e1",
+      "metadata": {},
+      "source": [
+        "## 6. Analyze Results\n",
+        "\n",
+        "We can extract the optimized poses and landmark positions from the `result` Values object.\n",
+        "\n",
+        "For example, the true second pose (if the robot moved exactly 1m forward along Z from origin) would be `Pose3(Rot3(), Point3(0, 0, 1.0))`.\n",
+        "The true landmark positions can be triangulated from the perfect measurements and true poses.\n",
+        "The example's measurements and initial estimates are designed to be somewhat noisy/imperfect, so the optimizer refines them.\n",
+        "\n",
+        "Let's check the error before and after optimization.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 26,
+      "id": "093fe3dc",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Initial Error: 3434.6236\n",
+            "Final Error  : 0.0000\n",
+            "\n",
+            "Optimized Pose X(1):\n",
+            " R: [\n",
+            "\t1, 0, 0;\n",
+            "\t0, 1, 0;\n",
+            "\t0, 0, 1\n",
+            "]\n",
+            "t: 0 0 0\n",
+            "\n",
+            "\n",
+            "Optimized Pose X(2):\n",
+            " R: [\n",
+            "\t1, -3.03422e-17, -2.0943e-16;\n",
+            "\t3.03422e-17, 1, 1.30264e-15;\n",
+            "\t2.0943e-16, -1.30264e-15, 1\n",
+            "]\n",
+            "t:  6.11092e-13 -6.15462e-13            1\n",
+            "\n",
+            "Translation component of X(2): [ 6.11092279e-13 -6.15461900e-13  1.00000000e+00]\n",
+            "\n",
+            "Optimized Landmark (L(1)):\n",
+            " [1. 1. 5.]\n",
+            "\n",
+            "Optimized Landmark (L(2)):\n",
+            " [-1.  1.  5.]\n",
+            "\n",
+            "Optimized Landmark (L(3)):\n",
+            " [-1.21564099e-16 -5.00000000e-01  5.00000000e+00]\n"
+          ]
+        }
+      ],
+      "source": [
+        "# print(result)\n",
+        "print(f\"Initial Error: {graph.error(initial_estimate):.4f}\")\n",
+        "print(f\"Final Error  : {graph.error(result):.4f}\")\n",
+        "\n",
+        "# Extract and print optimized values for clarity\n",
+        "optimized_pose1 = result.atPose3(X(1))\n",
+        "optimized_pose2 = result.atPose3(X(2))\n",
+        "optimized_lm1 = result.atPoint3(L(1))\n",
+        "optimized_lm2 = result.atPoint3(L(2))\n",
+        "optimized_lm3 = result.atPoint3(L(3))\n",
+        "\n",
+        "print(\"\\nOptimized Pose X(1):\\n\", optimized_pose1)\n",
+        "print(\"\\nOptimized Pose X(2):\\n\", optimized_pose2)\n",
+        "print(f\"Translation component of X(2): {optimized_pose2.translation()}\")\n",
+        "\n",
+        "print(\"\\nOptimized Landmark (L(1)):\\n\", optimized_lm1)\n",
+        "print(\"\\nOptimized Landmark (L(2)):\\n\", optimized_lm2)\n",
+        "print(\"\\nOptimized Landmark (L(3)):\\n\", optimized_lm3)"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "base",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.10"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
Ported the C++ StereoVOExample to a Python Notebook. The new notebook example is functionally the same as the C++ example with some additional explanation spread throughout. 

Check(s):
- Checked the results of the C++ example and the newly ported notebook example, and they match
- Running `make check` passes all tests.

Note: this was originally planned to be part of a larger PR about stereo calibration models and stereo cameras, but I figured that it will be easier for review if I split this particular change into it's own PR. A PR with user guides for both `Cal3_S2Stereo` and `StereoCamera` will come in the near future.