### PR TITLE
MatrixLieGroup implementation and traits

### DIFF
--- a/gtsam/base/Lie.h
+++ b/gtsam/base/Lie.h
@@ -9,16 +9,16 @@
 
  * -------------------------------------------------------------------------- */
 
- /**
-  * @file Lie.h
-  * @brief Base class and basic functions for Lie types
-  * @author Richard Roberts
-  * @author Alex Cunningham
-  * @author Frank Dellaert
-  * @author Mike Bosse
-  * @author Duy Nguyen Ta
-  * @author Yotam Stern
-  */
+/**
+ * @file Lie.h
+ * @brief Base class and basic functions for Lie types
+ * @author Richard Roberts
+ * @author Alex Cunningham
+ * @author Frank Dellaert
+ * @author Mike Bosse
+ * @author Duy Nguyen Ta
+ * @author Yotam Stern
+ */
 
 
 #pragma once
@@ -28,321 +28,319 @@
 
 namespace gtsam {
 
-  /// A CRTP helper class that implements Lie group methods
-  /// Prerequisites: methods operator*, inverse, and AdjointMap, as well as a
-  /// ChartAtOrigin struct that will be used to define the manifold Chart
-  /// To use, simply derive, but also say "using LieGroup<Class,N>::inverse"
-  /// For derivative math, see doc/math.pdf
-  template <class Class, int N>
-  struct LieGroup {
+/// A CRTP helper class that implements Lie group methods
+/// Prerequisites: methods operator*, inverse, and AdjointMap, as well as a
+/// ChartAtOrigin struct that will be used to define the manifold Chart
+/// To use, simply derive, but also say "using LieGroup<Class,N>::inverse"
+/// For derivative math, see doc/math.pdf
+template <class Class, int N>
+struct LieGroup {
 
-    inline constexpr static auto dimension = N;
-    typedef OptionalJacobian<N, N> ChartJacobian;
-    typedef Eigen::Matrix<double, N, N> Jacobian;
-    typedef Eigen::Matrix<double, N, 1> TangentVector;
+  inline constexpr static auto dimension = N;
+  typedef OptionalJacobian<N, N> ChartJacobian;
+  typedef Eigen::Matrix<double, N, N> Jacobian;
+  typedef Eigen::Matrix<double, N, 1> TangentVector;
 
-    const Class& derived() const {
-      return static_cast<const Class&>(*this);
-    }
+  const Class & derived() const {
+    return static_cast<const Class&>(*this);
+  }
 
-    Class compose(const Class& g) const {
-      return derived() * g;
-    }
+  Class compose(const Class& g) const {
+    return derived() * g;
+  }
 
-    Class between(const Class& g) const {
-      return derived().inverse() * g;
-    }
+  Class between(const Class& g) const {
+    return derived().inverse() * g;
+  }
 
-    Class compose(const Class& g, ChartJacobian H1,
+  Class compose(const Class& g, ChartJacobian H1,
       ChartJacobian H2 = {}) const {
-      if (H1) *H1 = g.inverse().AdjointMap();
-      if (H2) *H2 = Eigen::Matrix<double, N, N>::Identity();
-      return derived() * g;
-    }
+    if (H1) *H1 = g.inverse().AdjointMap();
+    if (H2) *H2 = Eigen::Matrix<double, N, N>::Identity();
+    return derived() * g;
+  }
 
-    Class between(const Class& g, ChartJacobian H1,
+  Class between(const Class& g, ChartJacobian H1,
       ChartJacobian H2 = {}) const {
-      Class result = derived().inverse() * g;
-      if (H1) *H1 = -result.inverse().AdjointMap();
-      if (H2) *H2 = Eigen::Matrix<double, N, N>::Identity();
-      return result;
-    }
-
-    Class inverse(ChartJacobian H) const {
-      if (H) *H = -derived().AdjointMap();
-      return derived().inverse();
-    }
-
-    /// expmap as required by manifold concept
-    /// Applies exponential map to v and composes with *this
-    Class expmap(const TangentVector& v) const {
-      return compose(Class::Expmap(v));
-    }
-
-    /// logmap as required by manifold concept
-    /// Applies logarithmic map to group element that takes *this to g
-    TangentVector logmap(const Class& g) const {
-      return Class::Logmap(between(g));
-    }
-
-    /// expmap with optional derivatives
-    Class expmap(const TangentVector& v, //
-      ChartJacobian H1, ChartJacobian H2 = {}) const {
-      Jacobian D_g_v;
-      Class g = Class::Expmap(v, H2 ? &D_g_v : 0);
-      Class h = compose(g); // derivatives inlined below
-      if (H1) *H1 = g.inverse().AdjointMap();
-      if (H2) *H2 = D_g_v;
-      return h;
-    }
-
-    /// logmap with optional derivatives
-    TangentVector logmap(const Class& g, //
-      ChartJacobian H1, ChartJacobian H2 = {}) const {
-      Class h = between(g); // derivatives inlined below
-      Jacobian D_v_h;
-      TangentVector v = Class::Logmap(h, (H1 || H2) ? &D_v_h : 0);
-      if (H1) *H1 = -D_v_h * h.inverse().AdjointMap();
-      if (H2) *H2 = D_v_h;
-      return v;
-    }
-
-    /// Retract at origin: possible in Lie group because it has an identity
-    static Class Retract(const TangentVector& v) {
-      return Class::ChartAtOrigin::Retract(v);
-    }
-
-    /// LocalCoordinates at origin: possible in Lie group because it has an identity
-    static TangentVector LocalCoordinates(const Class& g) {
-      return Class::ChartAtOrigin::Local(g);
-    }
-
-    /// Retract at origin with optional derivative
-    static Class Retract(const TangentVector& v, ChartJacobian H) {
-      return Class::ChartAtOrigin::Retract(v, H);
-    }
-
-    /// LocalCoordinates at origin with optional derivative
-    static TangentVector LocalCoordinates(const Class& g, ChartJacobian H) {
-      return Class::ChartAtOrigin::Local(g, H);
-    }
-
-    /// retract as required by manifold concept: applies v at *this
-    Class retract(const TangentVector& v) const {
-      return compose(Class::ChartAtOrigin::Retract(v));
-    }
-
-    /// localCoordinates as required by manifold concept: finds tangent vector between *this and g
-    TangentVector localCoordinates(const Class& g) const {
-      return Class::ChartAtOrigin::Local(between(g));
-    }
-
-    /// retract with optional derivatives
-    Class retract(const TangentVector& v, //
-      ChartJacobian H1, ChartJacobian H2 = {}) const {
-      Jacobian D_g_v;
-      Class g = Class::ChartAtOrigin::Retract(v, H2 ? &D_g_v : 0);
-      Class h = compose(g); // derivatives inlined below
-      if (H1) *H1 = g.inverse().AdjointMap();
-      if (H2) *H2 = D_g_v;
-      return h;
-    }
-
-    /// localCoordinates with optional derivatives
-    TangentVector localCoordinates(const Class& g, //
-      ChartJacobian H1, ChartJacobian H2 = {}) const {
-      Class h = between(g); // derivatives inlined below
-      Jacobian D_v_h;
-      TangentVector v = Class::ChartAtOrigin::Local(h, (H1 || H2) ? &D_v_h : 0);
-      if (H1) *H1 = -D_v_h * h.inverse().AdjointMap();
-      if (H2) *H2 = D_v_h;
-      return v;
-    }
-  };
-
-  /// tag to assert a type is a Lie group
-  struct lie_group_tag : public manifold_tag, public group_tag {};
-
-  namespace internal {
-
-    /// A helper class that implements the traits interface for GTSAM lie groups.
-    /// To use this for your gtsam type, define:
-    /// template<> struct traits<Class> : public internal::LieGroupTraits<Class> {};
-    /// Assumes existence of: identity, dimension, localCoordinates, retract,
-    /// and additionally Logmap, Expmap, AdjointMap, compose, between, and inverse
-    template<class Class>
-    struct LieGroupTraits : public GetDimensionImpl<Class, Class::dimension> {
-      using structure_category = lie_group_tag;
-
-      /// @name Group
-      /// @{
-      using group_flavor = multiplicative_group_tag;
-      static Class Identity() { return Class::Identity(); }
-      /// @}
-
-      /// @name Manifold
-      /// @{
-      using ManifoldType = Class;
-      // Note: Class::dimension can be an int or Eigen::Dynamic.
-      // GetDimensionImpl handles resolving this to a static value or providing GetDimension(obj).
-      inline constexpr static auto dimension = Class::dimension;
-      using TangentVector = Eigen::Matrix<double, dimension, 1>;
-      using ChartJacobian = OptionalJacobian<dimension, dimension>;
-
-      static TangentVector Local(const Class& origin, const Class& other,
-        ChartJacobian H1 = {}, ChartJacobian H2 = {}) {
-        return origin.localCoordinates(other, H1, H2);
-      }
-
-      static Class Retract(const Class& origin, const TangentVector& v,
-        ChartJacobian H = {}, ChartJacobian Hv = {}) {
-        return origin.retract(v, H, Hv);
-      }
-      /// @}
-
-      /// @name Lie Group
-      /// @{
-      static TangentVector Logmap(const Class& m, ChartJacobian Hm = {}) {
-        return Class::Logmap(m, Hm);
-      }
-
-      static Class Expmap(const TangentVector& v, ChartJacobian Hv = {}) {
-        return Class::Expmap(v, Hv);
-      }
-
-      static Class Compose(const Class& m1, const Class& m2, //
-        ChartJacobian H1 = {}, ChartJacobian H2 = {}) {
-        return m1.compose(m2, H1, H2);
-      }
-
-      static Class Between(const Class& m1, const Class& m2, //
-        ChartJacobian H1 = {}, ChartJacobian H2 = {}) {
-        return m1.between(m2, H1, H2);
-      }
-
-      static Class Inverse(const Class& m, //
-        ChartJacobian H = {}) {
-        return m.inverse(H);
-      }
-
-      static Eigen::Matrix<double, dimension, dimension> AdjointMap(const Class& m) {
-        // This assumes that the Class itself provides a member function `AdjointMap()`
-        // For dynamically-sized types (dimension == Eigen::Dynamic),
-        // m.AdjointMap() must return a gtsam::Matrix of the correct runtime dimensions.
-        return m.AdjointMap();
-      }
-      /// @}
-    };
-
-
-    /// Both LieGroupTraits and Testable
-    template<class Class> struct LieGroup : LieGroupTraits<Class>, Testable<Class> {};
-
-  } // \ namespace internal
-
-  /**
-   * These core global functions can be specialized by new Lie types
-   * for better performance.
-   */
-
-   /** Compute l0 s.t. l2=l1*l0 */
-  template<class Class>
-  inline Class between_default(const Class& l1, const Class& l2) {
-    return l1.inverse().compose(l2);
+    Class result = derived().inverse() * g;
+    if (H1) *H1 = - result.inverse().AdjointMap();
+    if (H2) *H2 = Eigen::Matrix<double, N, N>::Identity();
+    return result;
   }
 
-  /** Log map centered at l0, s.t. exp(l0,log(l0,lp)) = lp */
-  template<class Class>
-  inline Vector logmap_default(const Class& l0, const Class& lp) {
-    return Class::Logmap(l0.between(lp));
+  Class inverse(ChartJacobian H) const {
+    if (H) *H = - derived().AdjointMap();
+    return derived().inverse();
   }
 
-  /** Exponential map centered at l0, s.t. exp(t,d) = t*exp(d) */
-  template<class Class>
-  inline Class expmap_default(const Class& t, const Vector& d) {
-    return t.compose(Class::Expmap(d));
+  /// expmap as required by manifold concept
+  /// Applies exponential map to v and composes with *this
+  Class expmap(const TangentVector& v) const {
+    return compose(Class::Expmap(v));
   }
 
-  /**
-   * Lie Group Concept
-   */
-  template<typename T>
-  class IsLieGroup : public IsGroup<T>, public IsManifold<T> {
-  public:
-    // Concept marker: allows checking IsLieGroup<T>::value in templates
-    static constexpr bool value =
-      std::is_base_of<lie_group_tag, typename traits<T>::structure_category>::value;
+  /// logmap as required by manifold concept
+  /// Applies logarithmic map to group element that takes *this to g
+  TangentVector logmap(const Class& g) const {
+    return Class::Logmap(between(g));
+  }
 
-    typedef typename traits<T>::structure_category structure_category_tag;
-    typedef typename traits<T>::ManifoldType ManifoldType;
-    typedef typename traits<T>::TangentVector TangentVector;
-    typedef typename traits<T>::ChartJacobian ChartJacobian;
+  /// expmap with optional derivatives
+  Class expmap(const TangentVector& v, //
+      ChartJacobian H1, ChartJacobian H2 = {}) const {
+    Jacobian D_g_v;
+    Class g = Class::Expmap(v,H2 ? &D_g_v : 0);
+    Class h = compose(g); // derivatives inlined below
+    if (H1) *H1 = g.inverse().AdjointMap();
+    if (H2) *H2 = D_g_v;
+    return h;
+  }
 
-    GTSAM_CONCEPT_USAGE(IsLieGroup) {
-      static_assert(
+  /// logmap with optional derivatives
+  TangentVector logmap(const Class& g, //
+      ChartJacobian H1, ChartJacobian H2 = {}) const {
+    Class h = between(g); // derivatives inlined below
+    Jacobian D_v_h;
+    TangentVector v = Class::Logmap(h, (H1 || H2) ? &D_v_h : 0);
+    if (H1) *H1 = - D_v_h * h.inverse().AdjointMap();
+    if (H2) *H2 = D_v_h;
+    return v;
+  }
+
+  /// Retract at origin: possible in Lie group because it has an identity
+  static Class Retract(const TangentVector& v) {
+    return Class::ChartAtOrigin::Retract(v);
+  }
+
+  /// LocalCoordinates at origin: possible in Lie group because it has an identity
+  static TangentVector LocalCoordinates(const Class& g) {
+    return Class::ChartAtOrigin::Local(g);
+  }
+
+  /// Retract at origin with optional derivative
+  static Class Retract(const TangentVector& v, ChartJacobian H) {
+    return Class::ChartAtOrigin::Retract(v,H);
+  }
+
+  /// LocalCoordinates at origin with optional derivative
+  static TangentVector LocalCoordinates(const Class& g, ChartJacobian H) {
+    return Class::ChartAtOrigin::Local(g,H);
+  }
+
+  /// retract as required by manifold concept: applies v at *this
+  Class retract(const TangentVector& v) const {
+    return compose(Class::ChartAtOrigin::Retract(v));
+  }
+
+  /// localCoordinates as required by manifold concept: finds tangent vector between *this and g
+  TangentVector localCoordinates(const Class& g) const {
+    return Class::ChartAtOrigin::Local(between(g));
+  }
+
+  /// retract with optional derivatives
+  Class retract(const TangentVector& v, //
+      ChartJacobian H1, ChartJacobian H2 = {}) const {
+    Jacobian D_g_v;
+    Class g = Class::ChartAtOrigin::Retract(v, H2 ? &D_g_v : 0);
+    Class h = compose(g); // derivatives inlined below
+    if (H1) *H1 = g.inverse().AdjointMap();
+    if (H2) *H2 = D_g_v;
+    return h;
+  }
+
+  /// localCoordinates with optional derivatives
+  TangentVector localCoordinates(const Class& g, //
+      ChartJacobian H1, ChartJacobian H2 = {}) const {
+    Class h = between(g); // derivatives inlined below
+    Jacobian D_v_h;
+    TangentVector v = Class::ChartAtOrigin::Local(h, (H1 || H2) ? &D_v_h : 0);
+    if (H1) *H1 = - D_v_h * h.inverse().AdjointMap();
+    if (H2) *H2 = D_v_h;
+    return v;
+  }
+};
+
+/// tag to assert a type is a Lie group
+struct lie_group_tag: public manifold_tag, public group_tag {};
+
+namespace internal {
+
+/// A helper class that implements the traits interface for GTSAM lie groups.
+/// To use this for your gtsam type, define:
+/// template<> struct traits<Class> : public internal::LieGroupTraits<Class> {};
+/// Assumes existence of: identity, dimension, localCoordinates, retract,
+/// and additionally Logmap, Expmap, AdjointMap, compose, between, and inverse
+template<class Class>
+struct LieGroupTraits : public GetDimensionImpl<Class, Class::dimension> {
+  using structure_category = lie_group_tag;
+
+  /// @name Group
+  /// @{
+  using group_flavor = multiplicative_group_tag;
+  static Class Identity() { return Class::Identity(); }
+  /// @}
+
+  /// @name Manifold
+  /// @{
+  using ManifoldType = Class;
+  // Note: Class::dimension can be an int or Eigen::Dynamic.
+  // GetDimensionImpl handles resolving this to a static value or providing GetDimension(obj).
+  inline constexpr static auto dimension = Class::dimension;
+  using TangentVector = Eigen::Matrix<double, dimension, 1>;
+  using ChartJacobian = OptionalJacobian<dimension, dimension>;
+
+  static TangentVector Local(const Class& origin, const Class& other,
+    ChartJacobian H1 = {}, ChartJacobian H2 = {}) {
+    return origin.localCoordinates(other, H1, H2);
+  }
+
+  static Class Retract(const Class& origin, const TangentVector& v,
+    ChartJacobian H = {}, ChartJacobian Hv = {}) {
+    return origin.retract(v, H, Hv);
+  }
+  /// @}
+
+  /// @name Lie Group
+  /// @{
+  static TangentVector Logmap(const Class& m, ChartJacobian Hm = {}) {
+    return Class::Logmap(m, Hm);
+  }
+
+  static Class Expmap(const TangentVector& v, ChartJacobian Hv = {}) {
+    return Class::Expmap(v, Hv);
+  }
+
+  static Class Compose(const Class& m1, const Class& m2, //
+    ChartJacobian H1 = {}, ChartJacobian H2 = {}) {
+    return m1.compose(m2, H1, H2);
+  }
+
+  static Class Between(const Class& m1, const Class& m2, //
+    ChartJacobian H1 = {}, ChartJacobian H2 = {}) {
+    return m1.between(m2, H1, H2);
+  }
+
+  static Class Inverse(const Class& m, //
+    ChartJacobian H = {}) {
+    return m.inverse(H);
+  }
+
+  static Eigen::Matrix<double, dimension, dimension> AdjointMap(const Class& m) {
+    // This assumes that the Class itself provides a member function `AdjointMap()`
+    // For dynamically-sized types (dimension == Eigen::Dynamic),
+    // m.AdjointMap() must return a gtsam::Matrix of the correct runtime dimensions.
+    return m.AdjointMap();
+  }
+  /// @}
+};
+
+
+/// Both LieGroupTraits and Testable
+template<class Class> struct LieGroup: LieGroupTraits<Class>, Testable<Class> {};
+
+} // \ namespace internal
+
+/**
+ * These core global functions can be specialized by new Lie types
+ * for better performance.
+ */
+
+/** Compute l0 s.t. l2=l1*l0 */
+template<class Class>
+inline Class between_default(const Class& l1, const Class& l2) {
+  return l1.inverse().compose(l2);
+}
+
+/** Log map centered at l0, s.t. exp(l0,log(l0,lp)) = lp */
+template<class Class>
+inline Vector logmap_default(const Class& l0, const Class& lp) {
+  return Class::Logmap(l0.between(lp));
+}
+
+/** Exponential map centered at l0, s.t. exp(t,d) = t*exp(d) */
+template<class Class>
+inline Class expmap_default(const Class& t, const Vector& d) {
+  return t.compose(Class::Expmap(d));
+}
+
+/**
+ * Lie Group Concept
+ */
+template<typename T>
+class IsLieGroup: public IsGroup<T>, public IsManifold<T> {
+public:
+  // Concept marker: allows checking IsLieGroup<T>::value in templates
+  static constexpr bool value =
+    std::is_base_of<lie_group_tag, typename traits<T>::structure_category>::value;
+
+  typedef typename traits<T>::structure_category structure_category_tag;
+  typedef typename traits<T>::ManifoldType ManifoldType;
+  typedef typename traits<T>::TangentVector TangentVector;
+  typedef typename traits<T>::ChartJacobian ChartJacobian;
+
+  GTSAM_CONCEPT_USAGE(IsLieGroup) {
+    static_assert(
         value,
         "This type's trait does not assert it is a Lie group (or derived)");
 
-      // group operations with Jacobians
-      g = traits<T>::Compose(g, h, Hg, Hh);
-      g = traits<T>::Between(g, h, Hg, Hh);
-      g = traits<T>::Inverse(g, Hg);
-      // log and exp map without Jacobians
-      g = traits<T>::Expmap(v);
-      v = traits<T>::Logmap(g);
-      // log and exponential map with Jacobians
-      g = traits<T>::Expmap(v, Hg);
-      v = traits<T>::Logmap(g, Hg);
-    }
-  private:
-    T g, h;
-    TangentVector v;
-    ChartJacobian Hg, Hh;
-  };
+    // group operations with Jacobians
+    g = traits<T>::Compose(g, h, Hg, Hh);
+    g = traits<T>::Between(g, h, Hg, Hh);
+    g = traits<T>::Inverse(g, Hg);
+    // log and exp map without Jacobians
+    g = traits<T>::Expmap(v);
+    v = traits<T>::Logmap(g);
+    // log and exponential map with Jacobians
+    g = traits<T>::Expmap(v, Hg);
+    v = traits<T>::Logmap(g, Hg);
+  }
+private:
+  T g, h;
+  TangentVector v;
+  ChartJacobian Hg, Hh;
+};
 
-  /**
-   * Linear interpolation between X and Y by coefficient t. Typically t \in [0,1],
-   * but can also be used to extrapolate before pose X or after pose Y.
-   */
-  template <typename T>
-  T interpolate(const T& X, const T& Y, double t,
-    typename MakeOptionalJacobian<T, T>::type Hx = {},
-    typename MakeOptionalJacobian<T, T>::type Hy = {},
-    typename MakeOptionalJacobian<T, double>::type Ht = {}) {
-    if (Hx || Hy || Ht) {
-      typename MakeJacobian<T, T>::type between_H_x, log_H, exp_H, compose_H_x;
-      const T between =
+/**
+ * Linear interpolation between X and Y by coefficient t. Typically t \in [0,1],
+ * but can also be used to extrapolate before pose X or after pose Y.
+ */
+template <typename T>
+T interpolate(const T& X, const T& Y, double t,
+              typename MakeOptionalJacobian<T, T>::type Hx = {},
+              typename MakeOptionalJacobian<T, T>::type Hy = {},
+              typename MakeOptionalJacobian<T, double>::type Ht = {}) {
+  if (Hx || Hy || Ht) {
+    typename MakeJacobian<T, T>::type between_H_x, log_H, exp_H, compose_H_x;
+    const T between =
         traits<T>::Between(X, Y, between_H_x);  // between_H_y = identity
-      typename traits<T>::TangentVector delta = traits<T>::Logmap(between, log_H);
-      const T Delta = traits<T>::Expmap(t * delta, exp_H);
-      const T result = traits<T>::Compose(
+    typename traits<T>::TangentVector delta = traits<T>::Logmap(between, log_H);
+    const T Delta = traits<T>::Expmap(t * delta, exp_H);
+    const T result = traits<T>::Compose(
         X, Delta, compose_H_x);  // compose_H_xinv_y = identity
 
-      if (Hx) *Hx = compose_H_x + t * exp_H * log_H * between_H_x;
-      if (Hy) *Hy = t * exp_H * log_H;
-      if (Ht) *Ht = delta;
-      return result;
-    }
-    return traits<T>::Compose(
-      X, traits<T>::Expmap(t * traits<T>::Logmap(traits<T>::Between(X, Y))));
+    if (Hx) *Hx = compose_H_x + t * exp_H * log_H * between_H_x;
+    if (Hy) *Hy = t * exp_H * log_H;
+    if (Ht) *Ht = delta;
+    return result;
   }
+  return traits<T>::Compose(
+      X, traits<T>::Expmap(t * traits<T>::Logmap(traits<T>::Between(X, Y))));
+}
 
-  /**
-   * Functor for transforming covariance of T.
-   * T needs to satisfy the Lie group concept.
-   */
-  template<class T>
-  class TransformCovariance
-  {
-  private:
-    typename T::Jacobian adjointMap_;
-  public:
-    explicit TransformCovariance(const T& X) : adjointMap_{ X.AdjointMap() } {}
-    typename T::Jacobian operator()(const typename T::Jacobian& covariance)
-    {
-      return adjointMap_ * covariance * adjointMap_.transpose();
-    }
-  };
+/**
+ * Functor for transforming covariance of T.
+ * T needs to satisfy the Lie group concept.
+ */
+template<class T>
+class TransformCovariance
+{
+private:
+  typename T::Jacobian adjointMap_;
+public:
+  explicit TransformCovariance(const T &X) : adjointMap_{X.AdjointMap()} {}
+  typename T::Jacobian operator()(const typename T::Jacobian &covariance)
+  { return adjointMap_ * covariance * adjointMap_.transpose(); }
+};
 
 } // namespace gtsam
 

--- a/gtsam/base/Lie.h
+++ b/gtsam/base/Lie.h
@@ -9,16 +9,16 @@
 
  * -------------------------------------------------------------------------- */
 
-/**
- * @file Lie.h
- * @brief Base class and basic functions for Lie types
- * @author Richard Roberts
- * @author Alex Cunningham
- * @author Frank Dellaert
- * @author Mike Bosse
- * @author Duy Nguyen Ta
- * @author Yotam Stern
- */
+ /**
+  * @file Lie.h
+  * @brief Base class and basic functions for Lie types
+  * @author Richard Roberts
+  * @author Alex Cunningham
+  * @author Frank Dellaert
+  * @author Mike Bosse
+  * @author Duy Nguyen Ta
+  * @author Yotam Stern
+  */
 
 
 #pragma once
@@ -28,387 +28,389 @@
 
 namespace gtsam {
 
-/// A CRTP helper class that implements Lie group methods
-/// Prerequisites: methods operator*, inverse, and AdjointMap, as well as a
-/// ChartAtOrigin struct that will be used to define the manifold Chart
-/// To use, simply derive, but also say "using LieGroup<Class,N>::inverse"
-/// For derivative math, see doc/math.pdf
-template <class Class, int N>
-struct LieGroup {
+  /// A CRTP helper class that implements Lie group methods
+  /// Prerequisites: methods operator*, inverse, and AdjointMap, as well as a
+  /// ChartAtOrigin struct that will be used to define the manifold Chart
+  /// To use, simply derive, but also say "using LieGroup<Class,N>::inverse"
+  /// For derivative math, see doc/math.pdf
+  template <class Class, int N>
+  struct LieGroup {
 
-  inline constexpr static auto dimension = N;
-  typedef OptionalJacobian<N, N> ChartJacobian;
-  typedef Eigen::Matrix<double, N, N> Jacobian;
-  typedef Eigen::Matrix<double, N, 1> TangentVector;
+    inline constexpr static auto dimension = N;
+    typedef OptionalJacobian<N, N> ChartJacobian;
+    typedef Eigen::Matrix<double, N, N> Jacobian;
+    typedef Eigen::Matrix<double, N, 1> TangentVector;
 
-  const Class & derived() const {
-    return static_cast<const Class&>(*this);
-  }
+    const Class& derived() const {
+      return static_cast<const Class&>(*this);
+    }
 
-  Class compose(const Class& g) const {
-    return derived() * g;
-  }
+    Class compose(const Class& g) const {
+      return derived() * g;
+    }
 
-  Class between(const Class& g) const {
-    return derived().inverse() * g;
-  }
+    Class between(const Class& g) const {
+      return derived().inverse() * g;
+    }
 
-  Class compose(const Class& g, ChartJacobian H1,
+    Class compose(const Class& g, ChartJacobian H1,
       ChartJacobian H2 = {}) const {
-    if (H1) *H1 = g.inverse().AdjointMap();
-    if (H2) *H2 = Eigen::Matrix<double, N, N>::Identity();
-    return derived() * g;
-  }
+      if (H1) *H1 = g.inverse().AdjointMap();
+      if (H2) *H2 = Eigen::Matrix<double, N, N>::Identity();
+      return derived() * g;
+    }
 
-  Class between(const Class& g, ChartJacobian H1,
+    Class between(const Class& g, ChartJacobian H1,
       ChartJacobian H2 = {}) const {
-    Class result = derived().inverse() * g;
-    if (H1) *H1 = - result.inverse().AdjointMap();
-    if (H2) *H2 = Eigen::Matrix<double, N, N>::Identity();
-    return result;
-  }
+      Class result = derived().inverse() * g;
+      if (H1) *H1 = -result.inverse().AdjointMap();
+      if (H2) *H2 = Eigen::Matrix<double, N, N>::Identity();
+      return result;
+    }
 
-  Class inverse(ChartJacobian H) const {
-    if (H) *H = - derived().AdjointMap();
-    return derived().inverse();
-  }
+    Class inverse(ChartJacobian H) const {
+      if (H) *H = -derived().AdjointMap();
+      return derived().inverse();
+    }
 
-  /// expmap as required by manifold concept
-  /// Applies exponential map to v and composes with *this
-  Class expmap(const TangentVector& v) const {
-    return compose(Class::Expmap(v));
-  }
+    /// expmap as required by manifold concept
+    /// Applies exponential map to v and composes with *this
+    Class expmap(const TangentVector& v) const {
+      return compose(Class::Expmap(v));
+    }
 
-  /// logmap as required by manifold concept
-  /// Applies logarithmic map to group element that takes *this to g
-  TangentVector logmap(const Class& g) const {
-    return Class::Logmap(between(g));
-  }
+    /// logmap as required by manifold concept
+    /// Applies logarithmic map to group element that takes *this to g
+    TangentVector logmap(const Class& g) const {
+      return Class::Logmap(between(g));
+    }
 
-  /// expmap with optional derivatives
-  Class expmap(const TangentVector& v, //
+    /// expmap with optional derivatives
+    Class expmap(const TangentVector& v, //
       ChartJacobian H1, ChartJacobian H2 = {}) const {
-    Jacobian D_g_v;
-    Class g = Class::Expmap(v,H2 ? &D_g_v : 0);
-    Class h = compose(g); // derivatives inlined below
-    if (H1) *H1 = g.inverse().AdjointMap();
-    if (H2) *H2 = D_g_v;
-    return h;
-  }
+      Jacobian D_g_v;
+      Class g = Class::Expmap(v, H2 ? &D_g_v : 0);
+      Class h = compose(g); // derivatives inlined below
+      if (H1) *H1 = g.inverse().AdjointMap();
+      if (H2) *H2 = D_g_v;
+      return h;
+    }
 
-  /// logmap with optional derivatives
-  TangentVector logmap(const Class& g, //
+    /// logmap with optional derivatives
+    TangentVector logmap(const Class& g, //
       ChartJacobian H1, ChartJacobian H2 = {}) const {
-    Class h = between(g); // derivatives inlined below
-    Jacobian D_v_h;
-    TangentVector v = Class::Logmap(h, (H1 || H2) ? &D_v_h : 0);
-    if (H1) *H1 = - D_v_h * h.inverse().AdjointMap();
-    if (H2) *H2 = D_v_h;
-    return v;
-  }
+      Class h = between(g); // derivatives inlined below
+      Jacobian D_v_h;
+      TangentVector v = Class::Logmap(h, (H1 || H2) ? &D_v_h : 0);
+      if (H1) *H1 = -D_v_h * h.inverse().AdjointMap();
+      if (H2) *H2 = D_v_h;
+      return v;
+    }
 
-  /// Retract at origin: possible in Lie group because it has an identity
-  static Class Retract(const TangentVector& v) {
-    return Class::ChartAtOrigin::Retract(v);
-  }
+    /// Retract at origin: possible in Lie group because it has an identity
+    static Class Retract(const TangentVector& v) {
+      return Class::ChartAtOrigin::Retract(v);
+    }
 
-  /// LocalCoordinates at origin: possible in Lie group because it has an identity
-  static TangentVector LocalCoordinates(const Class& g) {
-    return Class::ChartAtOrigin::Local(g);
-  }
+    /// LocalCoordinates at origin: possible in Lie group because it has an identity
+    static TangentVector LocalCoordinates(const Class& g) {
+      return Class::ChartAtOrigin::Local(g);
+    }
 
-  /// Retract at origin with optional derivative
-  static Class Retract(const TangentVector& v, ChartJacobian H) {
-    return Class::ChartAtOrigin::Retract(v,H);
-  }
+    /// Retract at origin with optional derivative
+    static Class Retract(const TangentVector& v, ChartJacobian H) {
+      return Class::ChartAtOrigin::Retract(v, H);
+    }
 
-  /// LocalCoordinates at origin with optional derivative
-  static TangentVector LocalCoordinates(const Class& g, ChartJacobian H) {
-    return Class::ChartAtOrigin::Local(g,H);
-  }
+    /// LocalCoordinates at origin with optional derivative
+    static TangentVector LocalCoordinates(const Class& g, ChartJacobian H) {
+      return Class::ChartAtOrigin::Local(g, H);
+    }
 
-  /// retract as required by manifold concept: applies v at *this
-  Class retract(const TangentVector& v) const {
-    return compose(Class::ChartAtOrigin::Retract(v));
-  }
+    /// retract as required by manifold concept: applies v at *this
+    Class retract(const TangentVector& v) const {
+      return compose(Class::ChartAtOrigin::Retract(v));
+    }
 
-  /// localCoordinates as required by manifold concept: finds tangent vector between *this and g
-  TangentVector localCoordinates(const Class& g) const {
-    return Class::ChartAtOrigin::Local(between(g));
-  }
+    /// localCoordinates as required by manifold concept: finds tangent vector between *this and g
+    TangentVector localCoordinates(const Class& g) const {
+      return Class::ChartAtOrigin::Local(between(g));
+    }
 
-  /// retract with optional derivatives
-  Class retract(const TangentVector& v, //
+    /// retract with optional derivatives
+    Class retract(const TangentVector& v, //
       ChartJacobian H1, ChartJacobian H2 = {}) const {
-    Jacobian D_g_v;
-    Class g = Class::ChartAtOrigin::Retract(v, H2 ? &D_g_v : 0);
-    Class h = compose(g); // derivatives inlined below
-    if (H1) *H1 = g.inverse().AdjointMap();
-    if (H2) *H2 = D_g_v;
-    return h;
-  }
+      Jacobian D_g_v;
+      Class g = Class::ChartAtOrigin::Retract(v, H2 ? &D_g_v : 0);
+      Class h = compose(g); // derivatives inlined below
+      if (H1) *H1 = g.inverse().AdjointMap();
+      if (H2) *H2 = D_g_v;
+      return h;
+    }
 
-  /// localCoordinates with optional derivatives
-  TangentVector localCoordinates(const Class& g, //
+    /// localCoordinates with optional derivatives
+    TangentVector localCoordinates(const Class& g, //
       ChartJacobian H1, ChartJacobian H2 = {}) const {
-    Class h = between(g); // derivatives inlined below
-    Jacobian D_v_h;
-    TangentVector v = Class::ChartAtOrigin::Local(h, (H1 || H2) ? &D_v_h : 0);
-    if (H1) *H1 = - D_v_h * h.inverse().AdjointMap();
-    if (H2) *H2 = D_v_h;
-    return v;
+      Class h = between(g); // derivatives inlined below
+      Jacobian D_v_h;
+      TangentVector v = Class::ChartAtOrigin::Local(h, (H1 || H2) ? &D_v_h : 0);
+      if (H1) *H1 = -D_v_h * h.inverse().AdjointMap();
+      if (H2) *H2 = D_v_h;
+      return v;
+    }
+  };
+
+  /// tag to assert a type is a Lie group
+  struct lie_group_tag : public manifold_tag, public group_tag {};
+
+  namespace internal {
+
+    /// A helper class that implements the traits interface for GTSAM lie groups.
+    /// To use this for your gtsam type, define:
+    /// template<> struct traits<Class> : public internal::LieGroupTraits<Class> {};
+    /// Assumes existence of: identity, dimension, localCoordinates, retract,
+    /// and additionally Logmap, Expmap, AdjointMap, compose, between, and inverse
+    template<class Class>
+    struct LieGroupTraits : public GetDimensionImpl<Class, Class::dimension> {
+      using structure_category = lie_group_tag;
+
+      /// @name Group
+      /// @{
+      using group_flavor = multiplicative_group_tag;
+      static Class Identity() { return Class::Identity(); }
+      /// @}
+
+      /// @name Manifold
+      /// @{
+      using ManifoldType = Class;
+      // Note: Class::dimension can be an int or Eigen::Dynamic.
+      // GetDimensionImpl handles resolving this to a static value or providing GetDimension(obj).
+      inline constexpr static auto dimension = Class::dimension;
+      using TangentVector = Eigen::Matrix<double, dimension, 1>;
+      using ChartJacobian = OptionalJacobian<dimension, dimension>;
+
+      static TangentVector Local(const Class& origin, const Class& other,
+        ChartJacobian H1 = {}, ChartJacobian H2 = {}) {
+        return origin.localCoordinates(other, H1, H2);
+      }
+
+      static Class Retract(const Class& origin, const TangentVector& v,
+        ChartJacobian H = {}, ChartJacobian Hv = {}) {
+        return origin.retract(v, H, Hv);
+      }
+      /// @}
+
+      /// @name Lie Group
+      /// @{
+      static TangentVector Logmap(const Class& m, ChartJacobian Hm = {}) {
+        return Class::Logmap(m, Hm);
+      }
+
+      static Class Expmap(const TangentVector& v, ChartJacobian Hv = {}) {
+        return Class::Expmap(v, Hv);
+      }
+
+      static Class Compose(const Class& m1, const Class& m2, //
+        ChartJacobian H1 = {}, ChartJacobian H2 = {}) {
+        return m1.compose(m2, H1, H2);
+      }
+
+      static Class Between(const Class& m1, const Class& m2, //
+        ChartJacobian H1 = {}, ChartJacobian H2 = {}) {
+        return m1.between(m2, H1, H2);
+      }
+
+      static Class Inverse(const Class& m, //
+        ChartJacobian H = {}) {
+        return m.inverse(H);
+      }
+
+      static Eigen::Matrix<double, dimension, dimension> AdjointMap(const Class& m) {
+        // This assumes that the Class itself provides a member function `AdjointMap()`
+        // For dynamically-sized types (dimension == Eigen::Dynamic),
+        // m.AdjointMap() must return a gtsam::Matrix of the correct runtime dimensions.
+        return m.AdjointMap();
+      }
+      /// @}
+    };
+
+
+    /// Both LieGroupTraits and Testable
+    template<class Class> struct LieGroup : LieGroupTraits<Class>, Testable<Class> {};
+
+    /// Adds LieAlgebra, Hat, and Vee to LieGroupTraits
+    template<class Class> struct MatrixLieGroupTraits : LieGroupTraits<Class> {
+      using LieAlgebra = typename Class::LieAlgebra;
+      using TangentVector = typename LieGroupTraits<Class>::TangentVector;
+
+      static LieAlgebra Hat(const TangentVector& v) {
+        return Class::Hat(v);
+      }
+
+      static TangentVector Vee(const LieAlgebra& X) {
+        return Class::Vee(X);
+      }
+    };
+
+    /// Both LieGroupTraits and Testable
+    template<class Class> struct MatrixLieGroup : MatrixLieGroupTraits<Class>, Testable<Class> {};
+
+  } // \ namespace internal
+
+  /**
+   * These core global functions can be specialized by new Lie types
+   * for better performance.
+   */
+
+   /** Compute l0 s.t. l2=l1*l0 */
+  template<class Class>
+  inline Class between_default(const Class& l1, const Class& l2) {
+    return l1.inverse().compose(l2);
   }
-};
 
-/// tag to assert a type is a Lie group
-struct lie_group_tag: public manifold_tag, public group_tag {};
-
-namespace internal {
-
-/// A helper class that implements the traits interface for GTSAM lie groups.
-/// To use this for your gtsam type, define:
-/// template<> struct traits<Class> : public internal::LieGroupTraits<Class> {};
-/// Assumes existence of: identity, dimension, localCoordinates, retract,
-/// and additionally Logmap, Expmap, AdjointMap, compose, between, and inverse
-template<class Class>
-struct LieGroupTraits : public GetDimensionImpl<Class, Class::dimension> {
-  using structure_category = lie_group_tag;
-
-  /// @name Group
-  /// @{
-  using group_flavor = multiplicative_group_tag;
-  static Class Identity() { return Class::Identity(); }
-  /// @}
-
-  /// @name Manifold
-  /// @{
-  using ManifoldType = Class;
-  // Note: Class::dimension can be an int or Eigen::Dynamic.
-  // GetDimensionImpl handles resolving this to a static value or providing GetDimension(obj).
-  inline constexpr static auto dimension = Class::dimension;
-  using TangentVector = Eigen::Matrix<double, dimension, 1>;
-  using ChartJacobian = OptionalJacobian<dimension, dimension>;
-
-  static TangentVector Local(const Class& origin, const Class& other,
-    ChartJacobian H1 = {}, ChartJacobian H2 = {}) {
-    return origin.localCoordinates(other, H1, H2);
+  /** Log map centered at l0, s.t. exp(l0,log(l0,lp)) = lp */
+  template<class Class>
+  inline Vector logmap_default(const Class& l0, const Class& lp) {
+    return Class::Logmap(l0.between(lp));
   }
 
-  static Class Retract(const Class& origin, const TangentVector& v,
-    ChartJacobian H = {}, ChartJacobian Hv = {}) {
-    return origin.retract(v, H, Hv);
-  }
-  /// @}
-
-  /// @name Lie Group
-  /// @{
-  static TangentVector Logmap(const Class& m, ChartJacobian Hm = {}) {
-    return Class::Logmap(m, Hm);
+  /** Exponential map centered at l0, s.t. exp(t,d) = t*exp(d) */
+  template<class Class>
+  inline Class expmap_default(const Class& t, const Vector& d) {
+    return t.compose(Class::Expmap(d));
   }
 
-  static Class Expmap(const TangentVector& v, ChartJacobian Hv = {}) {
-    return Class::Expmap(v, Hv);
-  }
+  /**
+   * Lie Group Concept
+   */
+  template<typename T>
+  class IsLieGroup : public IsGroup<T>, public IsManifold<T> {
+  public:
+    // Concept marker: allows checking IsLieGroup<T>::value in templates
+    static constexpr bool value =
+      std::is_base_of<lie_group_tag, typename traits<T>::structure_category>::value;
 
-  static Class Compose(const Class& m1, const Class& m2, //
-    ChartJacobian H1 = {}, ChartJacobian H2 = {}) {
-    return m1.compose(m2, H1, H2);
-  }
+    typedef typename traits<T>::structure_category structure_category_tag;
+    typedef typename traits<T>::ManifoldType ManifoldType;
+    typedef typename traits<T>::TangentVector TangentVector;
+    typedef typename traits<T>::ChartJacobian ChartJacobian;
 
-  static Class Between(const Class& m1, const Class& m2, //
-    ChartJacobian H1 = {}, ChartJacobian H2 = {}) {
-    return m1.between(m2, H1, H2);
-  }
-
-  static Class Inverse(const Class& m, //
-    ChartJacobian H = {}) {
-    return m.inverse(H);
-  }
-
-  static Eigen::Matrix<double, dimension, dimension> AdjointMap(const Class& m) {
-    // This assumes that the Class itself provides a member function `AdjointMap()`
-    // For dynamically-sized types (dimension == Eigen::Dynamic),
-    // m.AdjointMap() must return a gtsam::Matrix of the correct runtime dimensions.
-    return m.AdjointMap();
-  }
-  /// @}
-};
-
-
-/// Both LieGroupTraits and Testable
-template<class Class> struct LieGroup: LieGroupTraits<Class>, Testable<Class> {};
-
-/// Adds LieAlgebra, Hat, and Vee to LieGroupTraits
-template<class Class> struct MatrixLieGroupTraits: LieGroupTraits<Class> {
-  using LieAlgebra = typename Class::LieAlgebra;
-  using TangentVector = typename LieGroupTraits<Class>::TangentVector;
-
-  static LieAlgebra Hat(const TangentVector& v) {
-    return Class::Hat(v);
-  }
-
-  static TangentVector Vee(const LieAlgebra& X) {
-    return Class::Vee(X);
-  }
-};
-
-/// Both LieGroupTraits and Testable
-template<class Class> struct MatrixLieGroup: MatrixLieGroupTraits<Class>, Testable<Class> {};
-
-} // \ namespace internal
-
-/**
- * These core global functions can be specialized by new Lie types
- * for better performance.
- */
-
-/** Compute l0 s.t. l2=l1*l0 */
-template<class Class>
-inline Class between_default(const Class& l1, const Class& l2) {
-  return l1.inverse().compose(l2);
-}
-
-/** Log map centered at l0, s.t. exp(l0,log(l0,lp)) = lp */
-template<class Class>
-inline Vector logmap_default(const Class& l0, const Class& lp) {
-  return Class::Logmap(l0.between(lp));
-}
-
-/** Exponential map centered at l0, s.t. exp(t,d) = t*exp(d) */
-template<class Class>
-inline Class expmap_default(const Class& t, const Vector& d) {
-  return t.compose(Class::Expmap(d));
-}
-
-/**
- * Lie Group Concept
- */
-template<typename T>
-class IsLieGroup: public IsGroup<T>, public IsManifold<T> {
-public:
-  // Concept marker: allows checking IsLieGroup<T>::value in templates
-  static constexpr bool value =
-    std::is_base_of<lie_group_tag, typename traits<T>::structure_category>::value;
-
-  typedef typename traits<T>::structure_category structure_category_tag;
-  typedef typename traits<T>::ManifoldType ManifoldType;
-  typedef typename traits<T>::TangentVector TangentVector;
-  typedef typename traits<T>::ChartJacobian ChartJacobian;
-
-  GTSAM_CONCEPT_USAGE(IsLieGroup) {
-    static_assert(
+    GTSAM_CONCEPT_USAGE(IsLieGroup) {
+      static_assert(
         value,
         "This type's trait does not assert it is a Lie group (or derived)");
 
-    // group operations with Jacobians
-    g = traits<T>::Compose(g, h, Hg, Hh);
-    g = traits<T>::Between(g, h, Hg, Hh);
-    g = traits<T>::Inverse(g, Hg);
-    // log and exp map without Jacobians
-    g = traits<T>::Expmap(v);
-    v = traits<T>::Logmap(g);
-    // log and exponential map with Jacobians
-    g = traits<T>::Expmap(v, Hg);
-    v = traits<T>::Logmap(g, Hg);
+      // group operations with Jacobians
+      g = traits<T>::Compose(g, h, Hg, Hh);
+      g = traits<T>::Between(g, h, Hg, Hh);
+      g = traits<T>::Inverse(g, Hg);
+      // log and exp map without Jacobians
+      g = traits<T>::Expmap(v);
+      v = traits<T>::Logmap(g);
+      // log and exponential map with Jacobians
+      g = traits<T>::Expmap(v, Hg);
+      v = traits<T>::Logmap(g, Hg);
+    }
+  private:
+    T g, h;
+    TangentVector v;
+    ChartJacobian Hg, Hh;
+  };
+
+  /**
+   * Matrix Lie Group Concept
+   */
+  template<typename T>
+  class IsMatrixLieGroup : public IsLieGroup<T> {
+  public:
+    typedef typename traits<T>::LieAlgebra LieAlgebra;
+    typedef typename traits<T>::TangentVector TangentVector;
+
+    GTSAM_CONCEPT_USAGE(IsMatrixLieGroup) {
+      // hat and vee
+      X = traits<T>::Hat(xi);
+      xi = traits<T>::Vee(X);
+    }
+  private:
+    LieAlgebra X;
+    TangentVector xi;
+  };
+
+  /**
+   *  Three term approximation of the Baker-Campbell-Hausdorff formula
+   *  In non-commutative Lie groups, when composing exp(Z) = exp(X)exp(Y)
+   *  it is not true that Z = X+Y. Instead, Z can be calculated using the BCH
+   *  formula: Z = X + Y + [X,Y]/2 + [X-Y,[X,Y]]/12 - [Y,[X,[X,Y]]]/24
+   *  http://en.wikipedia.org/wiki/Baker-Campbell-Hausdorff_formula
+   */
+   /// AGC: bracket() only appears in Rot3 tests, should this be used elsewhere?
+  template<class T>
+  T BCH(const T& X, const T& Y) {
+    static const double _2 = 1. / 2., _12 = 1. / 12., _24 = 1. / 24.;
+    T X_Y = bracket(X, Y);
+    return T(X + Y + _2 * X_Y + _12 * bracket(X - Y, X_Y) - _24 * bracket(Y, bracket(X, X_Y)));
   }
-private:
-  T g, h;
-  TangentVector v;
-  ChartJacobian Hg, Hh;
-};
-
-/**
- * Matrix Lie Group Concept
- */
-template<typename T>
-class IsMatrixLieGroup: public IsLieGroup<T> {
-public:
-typedef typename traits<T>::LieAlgebra LieAlgebra;
-typedef typename traits<T>::TangentVector TangentVector;
-
-  GTSAM_CONCEPT_USAGE(IsMatrixLieGroup) {
-    // hat and vee
-    X = traits<T>::Hat(xi);
-    xi = traits<T>::Vee(X);
-  }
-private:
-  LieAlgebra X;
-  TangentVector xi;
-};
-
-/**
- *  Three term approximation of the Baker-Campbell-Hausdorff formula
- *  In non-commutative Lie groups, when composing exp(Z) = exp(X)exp(Y)
- *  it is not true that Z = X+Y. Instead, Z can be calculated using the BCH
- *  formula: Z = X + Y + [X,Y]/2 + [X-Y,[X,Y]]/12 - [Y,[X,[X,Y]]]/24
- *  http://en.wikipedia.org/wiki/Baker-Campbell-Hausdorff_formula
- */
-/// AGC: bracket() only appears in Rot3 tests, should this be used elsewhere?
-template<class T>
-T BCH(const T& X, const T& Y) {
-  static const double _2 = 1. / 2., _12 = 1. / 12., _24 = 1. / 24.;
-  T X_Y = bracket(X, Y);
-  return T(X + Y + _2 * X_Y + _12 * bracket(X - Y, X_Y) - _24 * bracket(Y, bracket(X, X_Y)));
-}
 
 #ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
-/// @deprecated: use T::Hat
-template <class T> Matrix wedge(const Vector& x);
+  /// @deprecated: use T::Hat
+  template <class T> Matrix wedge(const Vector& x);
 #endif
 
-/**
- * Exponential map given exponential coordinates
- * class T needs a constructor from Matrix.
- * @param x exponential coordinates, vector of size n
- * @ return a T
- */
-template <class T>
-T expm(const Vector& x, int K = 7) {
-  const Matrix xhat = T::Hat(x);
-  return T(expm(xhat, K));
-}
+  /**
+   * Exponential map given exponential coordinates
+   * class T needs a constructor from Matrix.
+   * @param x exponential coordinates, vector of size n
+   * @ return a T
+   */
+  template <class T>
+  T expm(const Vector& x, int K = 7) {
+    const Matrix xhat = T::Hat(x);
+    return T(expm(xhat, K));
+  }
 
-/**
- * Linear interpolation between X and Y by coefficient t. Typically t \in [0,1],
- * but can also be used to extrapolate before pose X or after pose Y.
- */
-template <typename T>
-T interpolate(const T& X, const T& Y, double t,
-              typename MakeOptionalJacobian<T, T>::type Hx = {},
-              typename MakeOptionalJacobian<T, T>::type Hy = {},
-              typename MakeOptionalJacobian<T, double>::type Ht = {}) {
-  if (Hx || Hy || Ht) {
-    typename MakeJacobian<T, T>::type between_H_x, log_H, exp_H, compose_H_x;
-    const T between =
+  /**
+   * Linear interpolation between X and Y by coefficient t. Typically t \in [0,1],
+   * but can also be used to extrapolate before pose X or after pose Y.
+   */
+  template <typename T>
+  T interpolate(const T& X, const T& Y, double t,
+    typename MakeOptionalJacobian<T, T>::type Hx = {},
+    typename MakeOptionalJacobian<T, T>::type Hy = {},
+    typename MakeOptionalJacobian<T, double>::type Ht = {}) {
+    if (Hx || Hy || Ht) {
+      typename MakeJacobian<T, T>::type between_H_x, log_H, exp_H, compose_H_x;
+      const T between =
         traits<T>::Between(X, Y, between_H_x);  // between_H_y = identity
-    typename traits<T>::TangentVector delta = traits<T>::Logmap(between, log_H);
-    const T Delta = traits<T>::Expmap(t * delta, exp_H);
-    const T result = traits<T>::Compose(
+      typename traits<T>::TangentVector delta = traits<T>::Logmap(between, log_H);
+      const T Delta = traits<T>::Expmap(t * delta, exp_H);
+      const T result = traits<T>::Compose(
         X, Delta, compose_H_x);  // compose_H_xinv_y = identity
 
-    if (Hx) *Hx = compose_H_x + t * exp_H * log_H * between_H_x;
-    if (Hy) *Hy = t * exp_H * log_H;
-    if (Ht) *Ht = delta;
-    return result;
-  }
-  return traits<T>::Compose(
+      if (Hx) *Hx = compose_H_x + t * exp_H * log_H * between_H_x;
+      if (Hy) *Hy = t * exp_H * log_H;
+      if (Ht) *Ht = delta;
+      return result;
+    }
+    return traits<T>::Compose(
       X, traits<T>::Expmap(t * traits<T>::Logmap(traits<T>::Between(X, Y))));
-}
+  }
 
-/**
- * Functor for transforming covariance of T.
- * T needs to satisfy the Lie group concept.
- */
-template<class T>
-class TransformCovariance
-{
-private:
-  typename T::Jacobian adjointMap_;
-public:
-  explicit TransformCovariance(const T &X) : adjointMap_{X.AdjointMap()} {}
-  typename T::Jacobian operator()(const typename T::Jacobian &covariance)
-  { return adjointMap_ * covariance * adjointMap_.transpose(); }
-};
+  /**
+   * Functor for transforming covariance of T.
+   * T needs to satisfy the Lie group concept.
+   */
+  template<class T>
+  class TransformCovariance
+  {
+  private:
+    typename T::Jacobian adjointMap_;
+  public:
+    explicit TransformCovariance(const T& X) : adjointMap_{ X.AdjointMap() } {}
+    typename T::Jacobian operator()(const typename T::Jacobian& covariance)
+    {
+      return adjointMap_ * covariance * adjointMap_.transpose();
+    }
+  };
 
 } // namespace gtsam
 

--- a/gtsam/base/Lie.h
+++ b/gtsam/base/Lie.h
@@ -293,6 +293,8 @@ public:
     // log and exponential map with Jacobians
     g = traits<T>::Expmap(v, Hg);
     v = traits<T>::Logmap(g, Hg);
+    // AdjointMap
+    *Hg = traits<T>::AdjointMap(g);
   }
 private:
   T g, h;

--- a/gtsam/base/Lie.h
+++ b/gtsam/base/Lie.h
@@ -238,23 +238,6 @@ namespace gtsam {
     /// Both LieGroupTraits and Testable
     template<class Class> struct LieGroup : LieGroupTraits<Class>, Testable<Class> {};
 
-    /// Adds LieAlgebra, Hat, and Vee to LieGroupTraits
-    template<class Class> struct MatrixLieGroupTraits : LieGroupTraits<Class> {
-      using LieAlgebra = typename Class::LieAlgebra;
-      using TangentVector = typename LieGroupTraits<Class>::TangentVector;
-
-      static LieAlgebra Hat(const TangentVector& v) {
-        return Class::Hat(v);
-      }
-
-      static TangentVector Vee(const LieAlgebra& X) {
-        return Class::Vee(X);
-      }
-    };
-
-    /// Both LieGroupTraits and Testable
-    template<class Class> struct MatrixLieGroup : MatrixLieGroupTraits<Class>, Testable<Class> {};
-
   } // \ namespace internal
 
   /**
@@ -316,57 +299,6 @@ namespace gtsam {
     TangentVector v;
     ChartJacobian Hg, Hh;
   };
-
-  /**
-   * Matrix Lie Group Concept
-   */
-  template<typename T>
-  class IsMatrixLieGroup : public IsLieGroup<T> {
-  public:
-    typedef typename traits<T>::LieAlgebra LieAlgebra;
-    typedef typename traits<T>::TangentVector TangentVector;
-
-    GTSAM_CONCEPT_USAGE(IsMatrixLieGroup) {
-      // hat and vee
-      X = traits<T>::Hat(xi);
-      xi = traits<T>::Vee(X);
-    }
-  private:
-    LieAlgebra X;
-    TangentVector xi;
-  };
-
-  /**
-   *  Three term approximation of the Baker-Campbell-Hausdorff formula
-   *  In non-commutative Lie groups, when composing exp(Z) = exp(X)exp(Y)
-   *  it is not true that Z = X+Y. Instead, Z can be calculated using the BCH
-   *  formula: Z = X + Y + [X,Y]/2 + [X-Y,[X,Y]]/12 - [Y,[X,[X,Y]]]/24
-   *  http://en.wikipedia.org/wiki/Baker-Campbell-Hausdorff_formula
-   */
-   /// AGC: bracket() only appears in Rot3 tests, should this be used elsewhere?
-  template<class T>
-  T BCH(const T& X, const T& Y) {
-    static const double _2 = 1. / 2., _12 = 1. / 12., _24 = 1. / 24.;
-    T X_Y = bracket(X, Y);
-    return T(X + Y + _2 * X_Y + _12 * bracket(X - Y, X_Y) - _24 * bracket(Y, bracket(X, X_Y)));
-  }
-
-#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
-  /// @deprecated: use T::Hat
-  template <class T> Matrix wedge(const Vector& x);
-#endif
-
-  /**
-   * Exponential map given exponential coordinates
-   * class T needs a constructor from Matrix.
-   * @param x exponential coordinates, vector of size n
-   * @ return a T
-   */
-  template <class T>
-  T expm(const Vector& x, int K = 7) {
-    const Matrix xhat = T::Hat(x);
-    return T(expm(xhat, K));
-  }
 
   /**
    * Linear interpolation between X and Y by coefficient t. Typically t \in [0,1],

--- a/gtsam/base/MatrixLieGroup.h
+++ b/gtsam/base/MatrixLieGroup.h
@@ -23,23 +23,23 @@
 namespace gtsam {
 
   namespace internal {
-    template<class Class, int D, int M>
-    Eigen::Matrix<double, M*M, D> computeVectorizedGenerators() {
-      Eigen::Matrix<double, M*M, D> P_mat;
+    template<class Class, int D, int N>
+    Eigen::Matrix<double, N*N, D> computeVectorizedGenerators() {
+      Eigen::Matrix<double, N*N, D> P_mat;
       for (int i = 0; i < D; ++i) {
         typename Class::TangentVector e_i = Class::TangentVector::Unit(i);
         typename Class::LieAlgebra G_i = Class::Hat(e_i);
-        P_mat.col(i) = Eigen::Map<const Eigen::Matrix<double, M*M, 1>>(G_i.data());
+        P_mat.col(i) = Eigen::Map<const Eigen::Matrix<double, N*N, 1>>(G_i.data());
       }
       return P_mat;
     }
   } // namespace internal
 
   /// A CRTP helper class that implements matrix Lie group methods.
-  /// To use, derive from MatrixLieGroup<Class,D,M> instead of LieGroup<Class,D>.
+  /// To use, derive from MatrixLieGroup<Class,D,N> instead of LieGroup<Class,D>.
   /// Your class must implement a `matrix()` method, static `Hat()/Vee()` methods,
   /// as well as provide a `LieAlgebra` typedef.
-  template<class Class, int D, int M>
+  template<class Class, int D, int N>
   struct MatrixLieGroup : public LieGroup<Class, D> {
     using Base = LieGroup<Class, D>;
     using Base::dimension;
@@ -47,23 +47,20 @@ namespace gtsam {
     using Jacobian = typename Base::Jacobian;
     using TangentVector = typename Base::TangentVector;
 
-    /// The dimension of the matrix representation, e.g., 3 for SO(3).
-    constexpr static int MatrixM = M;
-
     /// Return vectorized matrix representation.
-    Eigen::Matrix<double, M*M, 1> vec(OptionalJacobian<M*M, D> H = {}) const {
+    Eigen::Matrix<double, N*N, 1> vec(OptionalJacobian<N*N, D> H = {}) const {
       const auto& derived = static_cast<const Class&>(*this);
       const auto T = derived.matrix();
       if (H) {
         const auto& P = VectorizedGenerators();
-        // The Jacobian is given by the formula H = (I_M ⊗ T) * P
+        // The Jacobian is given by the formula H = (I_N ⊗ T) * P
         // where P is the matrix of vectorized generators.
         // This can be implemented efficiently with block-wise multiplication.
-        for (int i = 0; i < M; ++i) {
-          H->block(i * M, 0, M, D) = T * P.block(i * M, 0, M, D);
+        for (int i = 0; i < N; ++i) {
+          H->block(i * N, 0, N, D) = T * P.block(i * N, 0, N, D);
         }
       }
-      return Eigen::Map<const Eigen::Matrix<double, M*M, 1>>(T.data());
+      return Eigen::Map<const Eigen::Matrix<double, N*N, 1>>(T.data());
     }
 
     /**
@@ -89,8 +86,8 @@ namespace gtsam {
 
   private:
     /// Pre-compute and store vectorized generators.
-    inline static const Eigen::Matrix<double, M*M, D>& VectorizedGenerators() {
-      static const Eigen::Matrix<double, M*M, D> P = internal::computeVectorizedGenerators<Class, D, M>();
+    inline static const Eigen::Matrix<double, N*N, D>& VectorizedGenerators() {
+      static const Eigen::Matrix<double, N*N, D> P = internal::computeVectorizedGenerators<Class, D, N>();
       return P;
     }
   };
@@ -98,7 +95,7 @@ namespace gtsam {
   namespace internal {
 
     /// Adds LieAlgebra, Hat, Vee, and Vec to LieGroupTraits
-    template <class Class> struct MatrixLieGroupTraits : LieGroupTraits<Class> {
+    template <class Class, int N> struct MatrixLieGroupTraits : LieGroupTraits<Class> {
       using LieAlgebra = typename Class::LieAlgebra;
       using TangentVector = typename LieGroupTraits<Class>::TangentVector;
 
@@ -111,16 +108,16 @@ namespace gtsam {
       }
 
       /// Vectorize the matrix representation of a Lie group element.
-      static Eigen::Matrix<double, Class::MatrixM * Class::MatrixM, 1> Vec(
+      static Eigen::Matrix<double, N * N, 1> Vec(
           const Class& m,
-          OptionalJacobian<Class::MatrixM * Class::MatrixM,
+          OptionalJacobian<N * N,
                            LieGroupTraits<Class>::dimension> H = {}) {
         return m.vec(H);
       }
     };
 
     /// Both LieGroupTraits and Testable
-    template<class Class> struct MatrixLieGroup : MatrixLieGroupTraits<Class>, Testable<Class> {};
+    template<class Class, int N> struct MatrixLieGroup : MatrixLieGroupTraits<Class, N>, Testable<Class> {};
 
   } // \ namespace internal
 

--- a/gtsam/base/MatrixLieGroup.h
+++ b/gtsam/base/MatrixLieGroup.h
@@ -32,7 +32,6 @@ namespace gtsam {
     template<class Class, int D, int N>
     auto computeVectorizedGenerators() {
       // This function is only valid for fixed-size matrices.
-      // Dynamic-size groups should provide their own `VectorizedGenerators(size_t)`.
       static_assert(D != Eigen::Dynamic && N != Eigen::Dynamic,
                     "computeVectorizedGenerators is only for fixed-size Lie groups.");
 
@@ -77,20 +76,31 @@ namespace gtsam {
       } else {  // Dynamic-size case
         const size_t n = T.rows();
         const size_t n2 = n * n;
-        Eigen::Matrix<double, Eigen::Dynamic, 1> result(n2);
-        result = Eigen::Map<const Eigen::Matrix<double, Eigen::Dynamic, 1>>(T.data(), n2);
 
         if (H) {
-          // For dynamic, VectorizedGenerators must take dimension as argument.
-          // It must be a static method on the derived class. SOn has it.
-          const size_t d = derived.dim();
-          auto P = Class::VectorizedGenerators(n);
+          size_t d = D;
+          if constexpr (D == Eigen::Dynamic) {
+            d = derived.dim();
+          }
           H->resize(n2, d);
-          for (size_t i = 0; i < n; i++) {
+
+          // Create P, the matrix of vectorized generators, on the fly.
+          // Column j of P is vec(Hat(e_j)).
+          Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> P(n2, d);
+          for (size_t j = 0; j < d; ++j) {
+            const auto G_j = Class::Hat(TangentVector::Unit(d, j));
+            P.col(j) = Eigen::Map<const Eigen::Matrix<double, Eigen::Dynamic, 1>>(
+                G_j.data(), n2);
+          }
+
+          // The Jacobian is given by the formula H = (I_n ⊗ T) * P
+          // This can be implemented efficiently with block-wise multiplication.
+          for (size_t i = 0; i < n; ++i) {
             H->block(i * n, 0, n, d) = T * P.block(i * n, 0, n, d);
           }
         }
-        return result;
+        return Eigen::Map<const Eigen::Matrix<double, Eigen::Dynamic, 1>>(
+            T.data(), n2);
       }
     }
 
@@ -106,7 +116,9 @@ namespace gtsam {
     Jacobian AdjointMap() const {
       const auto& m = static_cast<const Class&>(*this);
       size_t d = D;
-      if constexpr (D == Eigen::Dynamic)  d = m.dim();
+      if constexpr (D == Eigen::Dynamic) {
+        d = m.dim();
+      }
       Jacobian adj(d, d);
       const auto T_mat = m.matrix();
       const auto T_inv_mat = m.inverse().matrix();
@@ -119,7 +131,7 @@ namespace gtsam {
     }
 
   private:
-    /// Pre-compute and store vectorized generators.
+    /// Pre-compute and store vectorized generators for fixed-size groups.
     inline static const Eigen::Matrix<double, internal::product(N, N), D>& VectorizedGenerators() {
       static_assert(
           N != Eigen::Dynamic && D != Eigen::Dynamic,

--- a/gtsam/base/MatrixLieGroup.h
+++ b/gtsam/base/MatrixLieGroup.h
@@ -47,6 +47,9 @@ namespace gtsam {
     using Jacobian = typename Base::Jacobian;
     using TangentVector = typename Base::TangentVector;
 
+    /// The dimension of the matrix representation, e.g., 3 for SO(3).
+    constexpr static int MatrixM = M;
+
     /// Return vectorized matrix representation.
     Eigen::Matrix<double, M*M, 1> vec(OptionalJacobian<M*M, D> H = {}) const {
       const auto& derived = static_cast<const Class&>(*this);
@@ -63,6 +66,27 @@ namespace gtsam {
       return Eigen::Map<const Eigen::Matrix<double, M*M, 1>>(T.data());
     }
 
+    /**
+     * A generic implementation of AdjointMap for matrix Lie groups.
+     * The Adjoint map is the tangent map of the conjugation `C_g(x) = g*x*g.inverse()`
+     * at the identity. For matrix Lie groups, this is `Ad_g(v) = g*v*g.inverse()`
+     * where v is an element of the Lie algebra. The columns of the Adjoint matrix
+     * are `vee(g * hat(e_i) * g.inverse())` for each basis vector `e_i`.
+     * This method can be overridden by derived classes with a more efficient,
+     * closed-form solution.
+     */
+    Jacobian AdjointMap() const {
+      const auto& m = static_cast<const Class&>(*this);
+      Jacobian adj;
+      const auto T_mat = m.matrix();
+      const auto T_inv_mat = m.inverse().matrix();
+      for (int i = 0; i < D; i++) {
+        const auto G_i = Class::Hat(TangentVector::Unit(i));
+        adj.col(i) = Class::Vee(T_mat * G_i * T_inv_mat);
+      }
+      return adj;
+    }
+
   private:
     /// Pre-compute and store vectorized generators.
     inline static const Eigen::Matrix<double, M*M, D>& VectorizedGenerators() {
@@ -73,8 +97,8 @@ namespace gtsam {
 
   namespace internal {
 
-    /// Adds LieAlgebra, Hat, and Vee to LieGroupTraits
-    template<class Class> struct MatrixLieGroupTraits : LieGroupTraits<Class> {
+    /// Adds LieAlgebra, Hat, Vee, and Vec to LieGroupTraits
+    template <class Class> struct MatrixLieGroupTraits : LieGroupTraits<Class> {
       using LieAlgebra = typename Class::LieAlgebra;
       using TangentVector = typename LieGroupTraits<Class>::TangentVector;
 
@@ -84,6 +108,14 @@ namespace gtsam {
 
       static TangentVector Vee(const LieAlgebra& X) {
         return Class::Vee(X);
+      }
+
+      /// Vectorize the matrix representation of a Lie group element.
+      static Eigen::Matrix<double, Class::MatrixM * Class::MatrixM, 1> Vec(
+          const Class& m,
+          OptionalJacobian<Class::MatrixM * Class::MatrixM,
+                           LieGroupTraits<Class>::dimension> H = {}) {
+        return m.vec(H);
       }
     };
 
@@ -105,8 +137,11 @@ namespace gtsam {
       // hat and vee
       X = traits<T>::Hat(xi);
       xi = traits<T>::Vee(X);
+      // vec
+      (void)traits<T>::Vec(g);
     }
   private:
+    T g;
     LieAlgebra X;
     TangentVector xi;
   };

--- a/gtsam/base/MatrixLieGroup.h
+++ b/gtsam/base/MatrixLieGroup.h
@@ -1,0 +1,161 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+ /**
+  * @file MatrixLieGroup.h
+  * @brief Base class and basic functions for Matrix Lie groups
+  * @author Frank Dellaert
+  */
+
+
+#pragma once
+
+#include <gtsam/base/Lie.h>
+
+namespace gtsam {
+
+  namespace internal {
+    template<class Class, int D, int M>
+    Eigen::Matrix<double, M* M, D> compute_vectorized_generators() {
+      Eigen::Matrix<double, M* M, D> P_mat;
+      for (int i = 0; i < D; ++i) {
+        typename Class::TangentVector e_i = Class::TangentVector::Unit(i);
+        typename Class::LieAlgebra G_i = Class::Hat(e_i);
+        P_mat.col(i) = Eigen::Map<const Eigen::Matrix<double, M* M, 1>>(G_i.data());
+      }
+      return P_mat;
+    }
+  } // namespace internal
+
+  /// A CRTP helper class that implements matrix Lie group methods.
+  /// To use, derive from MatrixLieGroup<Class,D,M> instead of LieGroup<Class,D>.
+  /// Your class must implement a `matrix()` method and a static `Hat()` method,
+  /// as well as provide a `LieAlgebra` typedef.
+  template<class Class, int D, int M>
+  struct MatrixLieGroup : public LieGroup<Class, D> {
+    using Base = LieGroup<Class, D>;
+    using Base::dimension;
+    using ChartJacobian = typename Base::ChartJacobian;
+    using Jacobian = typename Base::Jacobian;
+    using TangentVector = typename Base::TangentVector;
+
+    /// Return vectorized matrix representation.
+    Eigen::Matrix<double, M* M, 1> vec(OptionalJacobian<M* M, D> H = {}) const {
+      const auto& derived = static_cast<const Class&>(*this);
+      const auto T = derived.matrix();
+      if (H) {
+        const auto& P = vectorized_generators();
+        // The Jacobian is given by the formula H = (I_M ⊗ T) * P
+        // where P is the matrix of vectorized generators.
+        // This can be implemented efficiently with block-wise multiplication.
+        for (int i = 0; i < M; ++i) {
+          H->block(i * M, 0, M, D) = T * P.block(i * M, 0, M, D);
+        }
+      }
+      return Eigen::Map<const Eigen::Matrix<double, M* M, 1>>(T.data());
+    }
+
+  private:
+    /// Pre-compute and store vectorized generators.
+    inline static const Eigen::Matrix<double, M* M, D>& vectorized_generators() {
+      static const Eigen::Matrix<double, M* M, D> P = internal::compute_vectorized_generators<Class, D, M>();
+      return P;
+    }
+  };
+
+  namespace internal {
+
+    /// Adds LieAlgebra, Hat, and Vee to LieGroupTraits
+    template<class Class> struct MatrixLieGroupTraits : LieGroupTraits<Class> {
+      using LieAlgebra = typename Class::LieAlgebra;
+      using TangentVector = typename LieGroupTraits<Class>::TangentVector;
+
+      static LieAlgebra Hat(const TangentVector& v) {
+        return Class::Hat(v);
+      }
+
+      static TangentVector Vee(const LieAlgebra& X) {
+        return Class::Vee(X);
+      }
+    };
+
+    /// Both LieGroupTraits and Testable
+    template<class Class> struct MatrixLieGroup : MatrixLieGroupTraits<Class>, Testable<Class> {};
+
+  } // \ namespace internal
+
+  /**
+   * Matrix Lie Group Concept
+   */
+  template<typename T>
+  class IsMatrixLieGroup : public IsLieGroup<T> {
+  public:
+    typedef typename traits<T>::LieAlgebra LieAlgebra;
+    typedef typename traits<T>::TangentVector TangentVector;
+
+    GTSAM_CONCEPT_USAGE(IsMatrixLieGroup) {
+      // hat and vee
+      X = traits<T>::Hat(xi);
+      xi = traits<T>::Vee(X);
+    }
+  private:
+    LieAlgebra X;
+    TangentVector xi;
+  };
+
+  /**
+   *  Three term approximation of the Baker-Campbell-Hausdorff formula
+   *  In non-commutative Lie groups, when composing exp(Z) = exp(X)exp(Y)
+   *  it is not true that Z = X+Y. Instead, Z can be calculated using the BCH
+   *  formula: Z = X + Y + [X,Y]/2 + [X-Y,[X,Y]]/12 - [Y,[X,[X,Y]]]/24
+   *  http://en.wikipedia.org/wiki/Baker-Campbell-Hausdorff_formula
+   */
+   /// AGC: bracket() only appears in Rot3 tests, should this be used elsewhere?
+  template<class T>
+  T BCH(const T& X, const T& Y) {
+    static const double _2 = 1. / 2., _12 = 1. / 12., _24 = 1. / 24.;
+    T X_Y = bracket(X, Y);
+    return T(X + Y + _2 * X_Y + _12 * bracket(X - Y, X_Y) - _24 * bracket(Y, bracket(X, X_Y)));
+  }
+
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
+  /// @deprecated: use T::Hat
+  template <class T>
+  Matrix wedge(const Vector& x) {
+    return T::Hat(x);
+  }
+#endif
+
+  /**
+   * Exponential map given exponential coordinates
+   * class T needs a constructor from Matrix.
+   * @param x exponential coordinates, vector of size n
+   * @ return a T
+   */
+  template <class T>
+  T expm(const Vector& x, int K = 7) {
+    const Matrix xhat = T::Hat(x);
+    return T(expm(xhat, K));
+  }
+
+} // namespace gtsam
+
+
+/**
+ * Macros for using the IsMatrixLieGroup
+ *  - An instantiation for use inside unit tests
+ *  - A typedef for use inside generic algorithms
+ *
+ * NOTE: intentionally not in the gtsam namespace to allow for classes not in
+ * the gtsam namespace to be more easily enforced as testable
+ */
+#define GTSAM_CONCEPT_MATRIX_LIE_GROUP_INST(T) template class gtsam::IsMatrixLieGroup<T>;
+#define GTSAM_CONCEPT_MATRIX_LIE_GROUP_TYPE(T) using _gtsam_IsMatrixLieGroup_##T = gtsam::IsMatrixLieGroup<T>;

--- a/gtsam/base/MatrixLieGroup.h
+++ b/gtsam/base/MatrixLieGroup.h
@@ -29,26 +29,23 @@ namespace gtsam {
       return (a == Eigen::Dynamic || b == Eigen::Dynamic) ? Eigen::Dynamic : a * b;
     }
 
+    // Helper to compute the matrix of vectorized generators for fixed-size groups.
     template<class Class, int D, int N>
     auto computeVectorizedGenerators() {
-      // This function is only valid for fixed-size matrices.
       static_assert(D != Eigen::Dynamic && N != Eigen::Dynamic,
-                    "computeVectorizedGenerators is only for fixed-size Lie groups.");
-
-      Eigen::Matrix<double, N * N, D> P_mat;
+        "This helper is only for fixed-size Lie groups.");
+      Eigen::Matrix<double, N* N, D> P;
       for (int i = 0; i < D; ++i) {
-        typename Class::TangentVector e_i = Class::TangentVector::Unit(i);
-        typename Class::LieAlgebra G_i = Class::Hat(e_i);
-        P_mat.col(i) = Eigen::Map<const Eigen::Matrix<double, N * N, 1>>(G_i.data());
+        const auto G_i = Class::Hat(typename Class::TangentVector::Unit(D, i));
+        P.col(i) = Eigen::Map<const Eigen::Matrix<double, N* N, 1>>(G_i.data());
       }
-      return P_mat;
+      return P;
     }
   } // namespace internal
 
   /// A CRTP helper class that implements matrix Lie group methods.
   /// To use, derive from MatrixLieGroup<Class,D,N> instead of LieGroup<Class,D>.
-  /// Your class must implement a `matrix()` method, static `Hat()/Vee()` methods,
-  /// as well as provide a `LieAlgebra` typedef.
+  /// Your class must implement a `matrix()` method and static `Hat()/Vee()` methods.
   template<class Class, int D, int N>
   struct MatrixLieGroup : public LieGroup<Class, D> {
     using Base = LieGroup<Class, D>;
@@ -57,73 +54,74 @@ namespace gtsam {
     using Jacobian = typename Base::Jacobian;
     using TangentVector = typename Base::TangentVector;
 
-    /// Return vectorized matrix representation.
-    Eigen::Matrix<double, internal::product(N,N), 1> vec(OptionalJacobian<internal::product(N,N), D> H = {}) const {
+    /**
+     * Vectorize the matrix representation of a Lie group element.
+     * The derivative `H` is the `(N*N) x D` Jacobian of this vectorization map.
+     * It is given by the formula `H = (I_N ⊗ T) * P`, where `T` is the `N x N`
+     * matrix of this group element, `⊗` is the Kronecker product, and `P` is
+     * the `(N*N) x D` matrix whose columns are the vectorized Lie algebra
+     * generators `vec(Hat(e_j))`. This can be computed efficiently via
+     * block-wise multiplication.
+     */
+    Eigen::Matrix<double, internal::product(N, N), 1> vec(
+      OptionalJacobian<internal::product(N, N), D> H = {}) const {
       const auto& derived = static_cast<const Class&>(*this);
       const auto& T = derived.matrix();
 
-      if constexpr (N != Eigen::Dynamic) {  // Fixed-size case
-        if (H) {
+      if (H) {
+        if constexpr (N != Eigen::Dynamic && D != Eigen::Dynamic) { // Fixed-size case
           const auto& P = VectorizedGenerators();
-          // The Jacobian is given by the formula H = (I_N ⊗ T) * P
-          // where P is the matrix of vectorized generators.
-          // This can be implemented efficiently with block-wise multiplication.
           for (int i = 0; i < N; ++i) {
             H->block(i * N, 0, N, D) = T * P.block(i * N, 0, N, D);
           }
         }
-        return Eigen::Map<const Eigen::Matrix<double, N * N, 1>>(T.data());
-      } else {  // Dynamic-size case
-        const size_t n = T.rows();
-        const size_t n2 = n * n;
-
-        if (H) {
-          size_t d = D;
-          if constexpr (D == Eigen::Dynamic) {
-            d = derived.dim();
-          }
-          H->resize(n2, d);
+        else { // Dynamic-size case
+          const size_t n = T.rows();
+          const size_t d = derived.dim();
+          H->resize(n * n, d);
 
           // Create P, the matrix of vectorized generators, on the fly.
-          // Column j of P is vec(Hat(e_j)).
-          Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> P(n2, d);
+          Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> P(n * n, d);
           for (size_t j = 0; j < d; ++j) {
             const auto G_j = Class::Hat(TangentVector::Unit(d, j));
             P.col(j) = Eigen::Map<const Eigen::Matrix<double, Eigen::Dynamic, 1>>(
-                G_j.data(), n2);
+              G_j.data(), n * n);
           }
 
-          // The Jacobian is given by the formula H = (I_n ⊗ T) * P
-          // This can be implemented efficiently with block-wise multiplication.
+          // Apply the formula H = (I_n ⊗ T) * P.
           for (size_t i = 0; i < n; ++i) {
             H->block(i * n, 0, n, d) = T * P.block(i * n, 0, n, d);
           }
         }
+      }
+
+      if constexpr (N != Eigen::Dynamic) { // Fixed-size case
+        return Eigen::Map<const Eigen::Matrix<double, N* N, 1>>(T.data());
+      }
+      else { // Dynamic-size case
         return Eigen::Map<const Eigen::Matrix<double, Eigen::Dynamic, 1>>(
-            T.data(), n2);
+          T.data(), T.size());
       }
     }
 
     /**
      * A generic implementation of AdjointMap for matrix Lie groups.
-     * The Adjoint map is the tangent map of the conjugation `C_g(x) = g*x*g.inverse()`
-     * at the identity. For matrix Lie groups, this is `Ad_g(v) = g*v*g.inverse()`
-     * where v is an element of the Lie algebra. The columns of the Adjoint matrix
-     * are `vee(g * hat(e_i) * g.inverse())` for each basis vector `e_i`.
+     * The Adjoint map `Ad_g` is the tangent map of the conjugation `C_g(x) = g*x*g.inverse()`
+     * at the identity. For matrix Lie groups, `Ad_g(v) = g*v*g.inverse()` where `v` is an
+     * element of the Lie algebra. The columns of the Adjoint matrix are
+     * `vee(g * Hat(e_i) * g.inverse())` for each basis vector `e_i`.
      * This method can be overridden by derived classes with a more efficient,
      * closed-form solution.
      */
     Jacobian AdjointMap() const {
       const auto& m = static_cast<const Class&>(*this);
       size_t d = D;
-      if constexpr (D == Eigen::Dynamic) {
-        d = m.dim();
-      }
+      if constexpr (D == Eigen::Dynamic) d = m.dim();
       Jacobian adj(d, d);
       const auto T_mat = m.matrix();
       const auto T_inv_mat = m.inverse().matrix();
       for (size_t i = 0; i < d; i++) {
-        // TangentVector::Unit(d, i) works for both fixed and dynamic size vectors
+        // TangentVector::Unit(d, i) works for both fixed and dynamic size vectors.
         const auto G_i = Class::Hat(TangentVector::Unit(d, i));
         adj.col(i) = Class::Vee(T_mat * G_i * T_inv_mat);
       }
@@ -132,12 +130,10 @@ namespace gtsam {
 
   private:
     /// Pre-compute and store vectorized generators for fixed-size groups.
-    inline static const Eigen::Matrix<double, internal::product(N, N), D>& VectorizedGenerators() {
-      static_assert(
-          N != Eigen::Dynamic && D != Eigen::Dynamic,
-          "VectorizedGenerators without arguments is only for fixed-size Lie groups.");
+    inline static const Eigen::Matrix<double, internal::product(N, N), D>&
+      VectorizedGenerators() {
       static const auto P =
-          internal::computeVectorizedGenerators<Class, D, N>();
+        internal::computeVectorizedGenerators<Class, D, N>();
       return P;
     }
   };
@@ -159,9 +155,9 @@ namespace gtsam {
 
       /// Vectorize the matrix representation of a Lie group element.
       static Eigen::Matrix<double, product(N, N), 1> Vec(
-          const Class& m,
-          OptionalJacobian<product(N, N),
-                           LieGroupTraits<Class>::dimension> H = {}) {
+        const Class& m,
+        OptionalJacobian<product(N, N),
+        LieGroupTraits<Class>::dimension> H = {}) {
         return m.vec(H);
       }
     };

--- a/gtsam/base/MatrixLieGroup.h
+++ b/gtsam/base/MatrixLieGroup.h
@@ -105,7 +105,8 @@ namespace gtsam {
      */
     Jacobian AdjointMap() const {
       const auto& m = static_cast<const Class&>(*this);
-      const size_t d = m.dim();
+      size_t d = D;
+      if constexpr (D == Eigen::Dynamic)  d = m.dim();
       Jacobian adj(d, d);
       const auto T_mat = m.matrix();
       const auto T_inv_mat = m.inverse().matrix();

--- a/gtsam/base/MatrixLieGroup.h
+++ b/gtsam/base/MatrixLieGroup.h
@@ -36,7 +36,7 @@ namespace gtsam {
         "This helper is only for fixed-size Lie groups.");
       Eigen::Matrix<double, N* N, D> P;
       for (int i = 0; i < D; ++i) {
-        const auto G_i = Class::Hat(typename Class::TangentVector::Unit(D, i));
+        const auto G_i = Class::Hat(Class::TangentVector::Unit(D, i));
         P.col(i) = Eigen::Map<const Eigen::Matrix<double, N* N, 1>>(G_i.data());
       }
       return P;

--- a/gtsam/base/MatrixLieGroup.h
+++ b/gtsam/base/MatrixLieGroup.h
@@ -24,12 +24,12 @@ namespace gtsam {
 
   namespace internal {
     template<class Class, int D, int M>
-    Eigen::Matrix<double, M* M, D> compute_vectorized_generators() {
-      Eigen::Matrix<double, M* M, D> P_mat;
+    Eigen::Matrix<double, M*M, D> computeVectorizedGenerators() {
+      Eigen::Matrix<double, M*M, D> P_mat;
       for (int i = 0; i < D; ++i) {
         typename Class::TangentVector e_i = Class::TangentVector::Unit(i);
         typename Class::LieAlgebra G_i = Class::Hat(e_i);
-        P_mat.col(i) = Eigen::Map<const Eigen::Matrix<double, M* M, 1>>(G_i.data());
+        P_mat.col(i) = Eigen::Map<const Eigen::Matrix<double, M*M, 1>>(G_i.data());
       }
       return P_mat;
     }
@@ -37,7 +37,7 @@ namespace gtsam {
 
   /// A CRTP helper class that implements matrix Lie group methods.
   /// To use, derive from MatrixLieGroup<Class,D,M> instead of LieGroup<Class,D>.
-  /// Your class must implement a `matrix()` method and a static `Hat()` method,
+  /// Your class must implement a `matrix()` method, static `Hat()/Vee()` methods,
   /// as well as provide a `LieAlgebra` typedef.
   template<class Class, int D, int M>
   struct MatrixLieGroup : public LieGroup<Class, D> {
@@ -48,11 +48,11 @@ namespace gtsam {
     using TangentVector = typename Base::TangentVector;
 
     /// Return vectorized matrix representation.
-    Eigen::Matrix<double, M* M, 1> vec(OptionalJacobian<M* M, D> H = {}) const {
+    Eigen::Matrix<double, M*M, 1> vec(OptionalJacobian<M*M, D> H = {}) const {
       const auto& derived = static_cast<const Class&>(*this);
       const auto T = derived.matrix();
       if (H) {
-        const auto& P = vectorized_generators();
+        const auto& P = VectorizedGenerators();
         // The Jacobian is given by the formula H = (I_M ⊗ T) * P
         // where P is the matrix of vectorized generators.
         // This can be implemented efficiently with block-wise multiplication.
@@ -60,13 +60,13 @@ namespace gtsam {
           H->block(i * M, 0, M, D) = T * P.block(i * M, 0, M, D);
         }
       }
-      return Eigen::Map<const Eigen::Matrix<double, M* M, 1>>(T.data());
+      return Eigen::Map<const Eigen::Matrix<double, M*M, 1>>(T.data());
     }
 
   private:
     /// Pre-compute and store vectorized generators.
-    inline static const Eigen::Matrix<double, M* M, D>& vectorized_generators() {
-      static const Eigen::Matrix<double, M* M, D> P = internal::compute_vectorized_generators<Class, D, M>();
+    inline static const Eigen::Matrix<double, M*M, D>& VectorizedGenerators() {
+      static const Eigen::Matrix<double, M*M, D> P = internal::computeVectorizedGenerators<Class, D, M>();
       return P;
     }
   };

--- a/gtsam/base/MatrixLieGroup.h
+++ b/gtsam/base/MatrixLieGroup.h
@@ -19,17 +19,28 @@
 #pragma once
 
 #include <gtsam/base/Lie.h>
+#include <type_traits>
 
 namespace gtsam {
 
   namespace internal {
+    // Helper to compute product of compile-time dimensions, returning Dynamic if either is Dynamic.
+    constexpr int product(int a, int b) {
+      return (a == Eigen::Dynamic || b == Eigen::Dynamic) ? Eigen::Dynamic : a * b;
+    }
+
     template<class Class, int D, int N>
-    Eigen::Matrix<double, N*N, D> computeVectorizedGenerators() {
-      Eigen::Matrix<double, N*N, D> P_mat;
+    auto computeVectorizedGenerators() {
+      // This function is only valid for fixed-size matrices.
+      // Dynamic-size groups should provide their own `VectorizedGenerators(size_t)`.
+      static_assert(D != Eigen::Dynamic && N != Eigen::Dynamic,
+                    "computeVectorizedGenerators is only for fixed-size Lie groups.");
+
+      Eigen::Matrix<double, N * N, D> P_mat;
       for (int i = 0; i < D; ++i) {
         typename Class::TangentVector e_i = Class::TangentVector::Unit(i);
         typename Class::LieAlgebra G_i = Class::Hat(e_i);
-        P_mat.col(i) = Eigen::Map<const Eigen::Matrix<double, N*N, 1>>(G_i.data());
+        P_mat.col(i) = Eigen::Map<const Eigen::Matrix<double, N * N, 1>>(G_i.data());
       }
       return P_mat;
     }
@@ -48,19 +59,39 @@ namespace gtsam {
     using TangentVector = typename Base::TangentVector;
 
     /// Return vectorized matrix representation.
-    Eigen::Matrix<double, N*N, 1> vec(OptionalJacobian<N*N, D> H = {}) const {
+    Eigen::Matrix<double, internal::product(N,N), 1> vec(OptionalJacobian<internal::product(N,N), D> H = {}) const {
       const auto& derived = static_cast<const Class&>(*this);
-      const auto T = derived.matrix();
-      if (H) {
-        const auto& P = VectorizedGenerators();
-        // The Jacobian is given by the formula H = (I_N ⊗ T) * P
-        // where P is the matrix of vectorized generators.
-        // This can be implemented efficiently with block-wise multiplication.
-        for (int i = 0; i < N; ++i) {
-          H->block(i * N, 0, N, D) = T * P.block(i * N, 0, N, D);
+      const auto& T = derived.matrix();
+
+      if constexpr (N != Eigen::Dynamic) {  // Fixed-size case
+        if (H) {
+          const auto& P = VectorizedGenerators();
+          // The Jacobian is given by the formula H = (I_N ⊗ T) * P
+          // where P is the matrix of vectorized generators.
+          // This can be implemented efficiently with block-wise multiplication.
+          for (int i = 0; i < N; ++i) {
+            H->block(i * N, 0, N, D) = T * P.block(i * N, 0, N, D);
+          }
         }
+        return Eigen::Map<const Eigen::Matrix<double, N * N, 1>>(T.data());
+      } else {  // Dynamic-size case
+        const size_t n = T.rows();
+        const size_t n2 = n * n;
+        Eigen::Matrix<double, Eigen::Dynamic, 1> result(n2);
+        result = Eigen::Map<const Eigen::Matrix<double, Eigen::Dynamic, 1>>(T.data(), n2);
+
+        if (H) {
+          // For dynamic, VectorizedGenerators must take dimension as argument.
+          // It must be a static method on the derived class. SOn has it.
+          const size_t d = derived.dim();
+          auto P = Class::VectorizedGenerators(n);
+          H->resize(n2, d);
+          for (size_t i = 0; i < n; i++) {
+            H->block(i * n, 0, n, d) = T * P.block(i * n, 0, n, d);
+          }
+        }
+        return result;
       }
-      return Eigen::Map<const Eigen::Matrix<double, N*N, 1>>(T.data());
     }
 
     /**
@@ -74,11 +105,13 @@ namespace gtsam {
      */
     Jacobian AdjointMap() const {
       const auto& m = static_cast<const Class&>(*this);
-      Jacobian adj;
+      const size_t d = m.dim();
+      Jacobian adj(d, d);
       const auto T_mat = m.matrix();
       const auto T_inv_mat = m.inverse().matrix();
-      for (int i = 0; i < D; i++) {
-        const auto G_i = Class::Hat(TangentVector::Unit(i));
+      for (size_t i = 0; i < d; i++) {
+        // TangentVector::Unit(d, i) works for both fixed and dynamic size vectors
+        const auto G_i = Class::Hat(TangentVector::Unit(d, i));
         adj.col(i) = Class::Vee(T_mat * G_i * T_inv_mat);
       }
       return adj;
@@ -86,8 +119,12 @@ namespace gtsam {
 
   private:
     /// Pre-compute and store vectorized generators.
-    inline static const Eigen::Matrix<double, N*N, D>& VectorizedGenerators() {
-      static const Eigen::Matrix<double, N*N, D> P = internal::computeVectorizedGenerators<Class, D, N>();
+    inline static const Eigen::Matrix<double, internal::product(N, N), D>& VectorizedGenerators() {
+      static_assert(
+          N != Eigen::Dynamic && D != Eigen::Dynamic,
+          "VectorizedGenerators without arguments is only for fixed-size Lie groups.");
+      static const auto P =
+          internal::computeVectorizedGenerators<Class, D, N>();
       return P;
     }
   };
@@ -108,9 +145,9 @@ namespace gtsam {
       }
 
       /// Vectorize the matrix representation of a Lie group element.
-      static Eigen::Matrix<double, N * N, 1> Vec(
+      static Eigen::Matrix<double, product(N, N), 1> Vec(
           const Class& m,
-          OptionalJacobian<N * N,
+          OptionalJacobian<product(N, N),
                            LieGroupTraits<Class>::dimension> H = {}) {
         return m.vec(H);
       }

--- a/gtsam/base/ProductLieGroup.h
+++ b/gtsam/base/ProductLieGroup.h
@@ -170,6 +170,15 @@ public:
   TangentVector logmap(const ProductLieGroup& g) const {
     return ProductLieGroup::Logmap(between(g));
   }
+  Jacobian AdjointMap() const {
+    const auto& adjG = traits<G>::AdjointMap(this->first);
+    const auto& adjH = traits<H>::AdjointMap(this->second);
+    size_t d1 = adjG.rows(), d2 = adjH.rows();
+    Matrix adj = Matrix::Zero(d1 + d2, d1 + d2);
+    adj.block(0, 0, d1, d1) = adjG;
+    adj.block(d1, d1, d2, d2) = adjH;
+    return adj;
+  }
   /// @}
 
 };

--- a/gtsam/geometry/Gal3.cpp
+++ b/gtsam/geometry/Gal3.cpp
@@ -52,45 +52,6 @@ namespace { // Anonymous namespace for internal linkage
   Eigen::Block<const Vector10, 3, 1> theta(const Vector10& v) { return v.block<3, 1>(6, 0); }
   Eigen::Block<const Vector10, 1, 1> t_tan(const Vector10& v) { return v.block<1, 1>(9, 0); }
 
-  // The 25x10 matrix of vectorized generators for SGal(3).
-  // The columns correspond to perturbations in [rho, nu, theta, t_tan].
-  // The tangent vector is [rho(3), nu(3), theta(3), t_tan(1)].
-  // P_gal3 = [vec(G_rho), vec(G_nu), vec(G_theta), vec(G_t)]
-  static const Eigen::Matrix<double, 25, 10> P_gal3 =
-      (Eigen::Matrix<double, 25, 10>() <<
-          // rho(0-2), nu(3-5), theta(6-8), t_tan(9)
-          // --- M(i,0) --- rows 0-4
-          0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-          0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
-          0, 0, 0, 0, 0, 0, 0, -1, 0, 0,
-          0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-          0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-          // --- M(i,1) --- rows 5-9
-          0, 0, 0, 0, 0, 0, 0, 0, -1, 0,
-          0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-          0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
-          0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-          0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-          // --- M(i,2) --- rows 10-14
-          0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
-          0, 0, 0, 0, 0, 0, -1, 0, 0, 0,
-          0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-          0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-          0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-          // --- M(i,3) --- rows 15-19
-          0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
-          0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
-          0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
-          0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-          0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-          // --- M(i,4) --- rows 20-24
-          1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-          0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
-          0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
-          0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
-          0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-          ).finished();
-
 } // end anonymous namespace
 
 //------------------------------------------------------------------------------
@@ -212,18 +173,7 @@ Matrix5 Gal3::matrix() const {
 }
 
 //------------------------------------------------------------------------------
-Vector25 Gal3::vec(OptionalJacobian<25, 10> H) const {
-    const Matrix5 T = this->matrix();
-    if (H) {
-        // The Jacobian is given by the formula H = (I_5 ⊗ T) * P_gal3
-        // where P_gal3 is the matrix of vectorized generators.
-        // This can be implemented efficiently with block-wise multiplication.
-        *H << T * P_gal3.block<5, 10>(0, 0), T* P_gal3.block<5, 10>(5, 0),
-            T* P_gal3.block<5, 10>(10, 0), T* P_gal3.block<5, 10>(15, 0),
-            T* P_gal3.block<5, 10>(20, 0);
-    }
-    return Eigen::Map<const Vector25>(T.data());
-}
+
 
 //------------------------------------------------------------------------------
 // Stream operator

--- a/gtsam/geometry/Gal3.cpp
+++ b/gtsam/geometry/Gal3.cpp
@@ -42,15 +42,15 @@ namespace { // Anonymous namespace for internal linkage
   constexpr double kSmallAngleThreshold = 1e-10;
 
   // Helper functions for accessing tangent vector components
-  Eigen::Block<Vector10, 3, 1> rho(Vector10& v) { return v.block<3, 1>(0, 0); }
-  Eigen::Block<Vector10, 3, 1> nu(Vector10& v) { return v.block<3, 1>(3, 0); }
-  Eigen::Block<Vector10, 3, 1> theta(Vector10& v) { return v.block<3, 1>(6, 0); }
-  Eigen::Block<Vector10, 1, 1> t_tan(Vector10& v) { return v.block<1, 1>(9, 0); }
+  Eigen::Block<Gal3::TangentVector, 3, 1> rho(Gal3::TangentVector& v) { return v.block<3, 1>(0, 0); }
+  Eigen::Block<Gal3::TangentVector, 3, 1> nu(Gal3::TangentVector& v) { return v.block<3, 1>(3, 0); }
+  Eigen::Block<Gal3::TangentVector, 3, 1> theta(Gal3::TangentVector& v) { return v.block<3, 1>(6, 0); }
+  Eigen::Block<Gal3::TangentVector, 1, 1> t_tan(Gal3::TangentVector& v) { return v.block<1, 1>(9, 0); }
   // Const versions
-  Eigen::Block<const Vector10, 3, 1> rho(const Vector10& v) { return v.block<3, 1>(0, 0); }
-  Eigen::Block<const Vector10, 3, 1> nu(const Vector10& v) { return v.block<3, 1>(3, 0); }
-  Eigen::Block<const Vector10, 3, 1> theta(const Vector10& v) { return v.block<3, 1>(6, 0); }
-  Eigen::Block<const Vector10, 1, 1> t_tan(const Vector10& v) { return v.block<1, 1>(9, 0); }
+  Eigen::Block<const Gal3::TangentVector, 3, 1> rho(const Gal3::TangentVector& v) { return v.block<3, 1>(0, 0); }
+  Eigen::Block<const Gal3::TangentVector, 3, 1> nu(const Gal3::TangentVector& v) { return v.block<3, 1>(3, 0); }
+  Eigen::Block<const Gal3::TangentVector, 3, 1> theta(const Gal3::TangentVector& v) { return v.block<3, 1>(6, 0); }
+  Eigen::Block<const Gal3::TangentVector, 1, 1> t_tan(const Gal3::TangentVector& v) { return v.block<1, 1>(9, 0); }
 
 } // end anonymous namespace
 
@@ -233,7 +233,7 @@ Gal3 Gal3::operator*(const Gal3& other) const {
 //------------------------------------------------------------------------------
 // Lie Group Static Functions
 //------------------------------------------------------------------------------
-gtsam::Gal3 gtsam::Gal3::Expmap(const Vector10& xi, OptionalJacobian<10, 10> Hxi) {
+gtsam::Gal3 gtsam::Gal3::Expmap(const TangentVector& xi, OptionalJacobian<10, 10> Hxi) {
     // Implements exponential map from Equations 16-19, Pages 7-8
     const Vector3 rho_tan = rho(xi);
     const Vector3 nu_tan = nu(xi);
@@ -268,7 +268,7 @@ gtsam::Gal3 gtsam::Gal3::Expmap(const Vector10& xi, OptionalJacobian<10, 10> Hxi
 }
 
 //------------------------------------------------------------------------------
-Vector10 Gal3::Logmap(const Gal3& g, OptionalJacobian<10, 10> Hg) {
+Gal3::TangentVector Gal3::Logmap(const Gal3& g, OptionalJacobian<10, 10> Hg) {
     // Implements logarithmic map from Equations 20-23, Page 8
     const Vector3 theta_vec = Rot3::Logmap(g.R_);
     const gtsam::so3::DexpFunctor dexp_functor_log(theta_vec);
@@ -293,7 +293,7 @@ Vector10 Gal3::Logmap(const Gal3& g, OptionalJacobian<10, 10> Hg) {
     const Vector3 rho_tan = Jl_theta_inv * (r_vec - E * (t_val * nu_tan));
     const double t_tan_val = t_val;
 
-    Vector10 xi;
+    TangentVector xi;
     rho(xi) = rho_tan;
     nu(xi) = nu_tan;
     theta(xi) = theta_vec;
@@ -307,13 +307,13 @@ Vector10 Gal3::Logmap(const Gal3& g, OptionalJacobian<10, 10> Hg) {
 }
 
 //------------------------------------------------------------------------------
-Matrix10 Gal3::AdjointMap() const {
+Gal3::Jacobian Gal3::AdjointMap() const {
     // Implements adjoint map as in Equation 26, Page 9
     const Matrix3 Rmat = R_.matrix();
     const Vector3 v_vec = v_;
     const Vector3 r_minus_tv = Vector3(r_) - t_ * v_;
 
-    Matrix10 Ad = Matrix10::Zero();
+    Jacobian Ad = Jacobian::Zero();
 
     Ad.block<3,3>(0,0) = Rmat;
     Ad.block<3,3>(0,3) = -t_ * Rmat;
@@ -331,9 +331,9 @@ Matrix10 Gal3::AdjointMap() const {
 }
 
 //------------------------------------------------------------------------------
-Vector10 Gal3::Adjoint(const Vector10& xi, OptionalJacobian<10, 10> H_g, OptionalJacobian<10, 10> H_xi) const {
-    Matrix10 Ad = AdjointMap();
-    Vector10 y = Ad * xi;
+Gal3::TangentVector Gal3::Adjoint(const TangentVector& xi, OptionalJacobian<10, 10> H_g, OptionalJacobian<10, 10> H_xi) const {
+    Jacobian Ad = AdjointMap();
+    TangentVector y = Ad * xi;
 
     if (H_xi) {
         *H_xi = Ad;
@@ -343,8 +343,8 @@ Vector10 Gal3::Adjoint(const Vector10& xi, OptionalJacobian<10, 10> H_g, Optiona
         // NOTE: Using numerical derivative for the Jacobian with respect to
         // the group element instead of deriving the analytical expression.
         // Future work to use analytical instead.
-        std::function<Vector10(const Gal3&, const Vector10&)> adjoint_action_wrt_g =
-          [&](const Gal3& g_in, const Vector10& xi_in) {
+        std::function<TangentVector(const Gal3&, const TangentVector&)> adjoint_action_wrt_g =
+          [&](const Gal3& g_in, const TangentVector& xi_in) {
               return g_in.Adjoint(xi_in);
           };
         *H_g = numericalDerivative21(adjoint_action_wrt_g, *this, xi, 1e-7);
@@ -353,7 +353,7 @@ Vector10 Gal3::Adjoint(const Vector10& xi, OptionalJacobian<10, 10> H_g, Optiona
 }
 
 //------------------------------------------------------------------------------
-Matrix10 Gal3::adjointMap(const Vector10& xi) {
+Gal3::Jacobian Gal3::adjointMap(const TangentVector& xi) {
     // Implements adjoint representation as in Equation 28, Page 10
     const Matrix3 Theta_hat = skewSymmetric(theta(xi));
     const Matrix3 Nu_hat = skewSymmetric(nu(xi));
@@ -361,7 +361,7 @@ Matrix10 Gal3::adjointMap(const Vector10& xi) {
     const double t_val = t_tan(xi)(0);
     const Vector3 nu_vec = nu(xi);
 
-    Matrix10 ad = Matrix10::Zero();
+    Gal3::Jacobian ad = Gal3::Jacobian::Zero();
 
     ad.block<3,3>(0,0) = Theta_hat;
     ad.block<3,3>(0,3) = -t_val * Matrix3::Identity();
@@ -377,8 +377,8 @@ Matrix10 Gal3::adjointMap(const Vector10& xi) {
 }
 
 //------------------------------------------------------------------------------
-Vector10 Gal3::adjoint(const Vector10& xi, const Vector10& y, OptionalJacobian<10, 10> Hxi, OptionalJacobian<10, 10> Hy) {
-    Matrix10 ad_xi = adjointMap(xi);
+Gal3::TangentVector Gal3::adjoint(const TangentVector& xi, const TangentVector& y, OptionalJacobian<10, 10> Hxi, OptionalJacobian<10, 10> Hy) {
+    Jacobian ad_xi = adjointMap(xi);
     if (Hy) *Hy = ad_xi;
     if (Hxi) {
          *Hxi = -adjointMap(y);
@@ -387,34 +387,34 @@ Vector10 Gal3::adjoint(const Vector10& xi, const Vector10& y, OptionalJacobian<1
 }
 
 //------------------------------------------------------------------------------
-Matrix10 Gal3::ExpmapDerivative(const Vector10& xi) {
+Gal3::Jacobian Gal3::ExpmapDerivative(const TangentVector& xi) {
     // Related to the left Jacobian in Equations 31-36, Pages 10-11
     // NOTE: Using numerical approximation instead of implementing the analytical
     // expression for the Jacobian. Future work to replace this
     // with analytical derivative.
-    if (xi.norm() < kSmallAngleThreshold) return Matrix10::Identity();
-    std::function<Gal3(const Vector10&)> fn =
-        [](const Vector10& v) { return Gal3::Expmap(v); };
-    return numericalDerivative11<Gal3, Vector10>(fn, xi, 1e-5);
+    if (xi.norm() < kSmallAngleThreshold) return Jacobian::Identity();
+    std::function<Gal3(const TangentVector&)> fn =
+        [](const TangentVector& v) { return Gal3::Expmap(v); };
+    return numericalDerivative11<Gal3, TangentVector>(fn, xi, 1e-5);
 }
 
 //------------------------------------------------------------------------------
-Matrix10 Gal3::LogmapDerivative(const Gal3& g) {
+Gal3::Jacobian Gal3::LogmapDerivative(const Gal3& g) {
     // Related to the inverse of left Jacobian in Equations 31-36, Pages 10-11
     // NOTE: Using numerical approximation instead of implementing the analytical
     // expression for the inverse Jacobian. Future work to replace this
     // with analytical derivative.
-    Vector10 xi = Gal3::Logmap(g);
-    if (xi.norm() < kSmallAngleThreshold) return Matrix10::Identity();
-    std::function<Vector10(const Gal3&)> fn =
+    TangentVector xi = Gal3::Logmap(g);
+    if (xi.norm() < kSmallAngleThreshold) return Jacobian::Identity();
+    std::function<TangentVector(const Gal3&)> fn =
         [](const Gal3& g_in) { return Gal3::Logmap(g_in); };
-    return numericalDerivative11<Vector10, Gal3>(fn, g, 1e-5);
+    return numericalDerivative11<TangentVector, Gal3>(fn, g, 1e-5);
 }
 
 //------------------------------------------------------------------------------
 // Lie Algebra (Hat/Vee maps)
 //------------------------------------------------------------------------------
-Matrix5 Gal3::Hat(const Vector10& xi) {
+Gal3::LieAlgebra Gal3::Hat(const TangentVector& xi) {
     // Implements hat operator as in Equation 13, Page 6
     const Vector3 rho_tan = rho(xi);
     const Vector3 nu_tan = nu(xi);
@@ -430,13 +430,13 @@ Matrix5 Gal3::Hat(const Vector10& xi) {
 }
 
 //------------------------------------------------------------------------------
-Vector10 Gal3::Vee(const Matrix5& X) {
+Gal3::TangentVector Gal3::Vee(const LieAlgebra& X) {
     // Implements vee operator (inverse of hat operator in Equation 13, Page 6)
     if (X.row(4).norm() > 1e-9 || X.row(3).head(3).norm() > 1e-9 || std::abs(X(3,3)) > 1e-9) {
      throw std::invalid_argument("Matrix is not in sgal(3)");
     }
 
-    Vector10 xi;
+    TangentVector xi;
     rho(xi) = X.block<3, 1>(0, 4);
     nu(xi) = X.block<3, 1>(0, 3);
     const Matrix3& S = X.block<3, 3>(0, 0);
@@ -448,12 +448,12 @@ Vector10 Gal3::Vee(const Matrix5& X) {
 //------------------------------------------------------------------------------
 // ChartAtOrigin
 //------------------------------------------------------------------------------
-Gal3 Gal3::ChartAtOrigin::Retract(const Vector10& xi, ChartJacobian Hxi) {
+Gal3 Gal3::ChartAtOrigin::Retract(const TangentVector& xi, ChartJacobian Hxi) {
   return Gal3::Expmap(xi, Hxi);
 }
 
 //------------------------------------------------------------------------------
-Vector10 Gal3::ChartAtOrigin::Local(const Gal3& g, ChartJacobian Hg) {
+Gal3::TangentVector Gal3::ChartAtOrigin::Local(const Gal3& g, ChartJacobian Hg) {
   return Gal3::Logmap(g, Hg);
 }
 

--- a/gtsam/geometry/Gal3.h
+++ b/gtsam/geometry/Gal3.h
@@ -230,9 +230,9 @@ class GTSAM_EXPORT Gal3 : public MatrixLieGroup<Gal3, 10, 5> {
 
 /// Traits specialization for Gal3
 template <>
-struct traits<Gal3> : public internal::MatrixLieGroup<Gal3> {};
+struct traits<Gal3> : public internal::MatrixLieGroup<Gal3, 5> {};
 
 template <>
-struct traits<const Gal3> : public internal::MatrixLieGroup<Gal3> {};
+struct traits<const Gal3> : public internal::MatrixLieGroup<Gal3, 5> {};
 
 } // namespace gtsam

--- a/gtsam/geometry/Gal3.h
+++ b/gtsam/geometry/Gal3.h
@@ -37,14 +37,12 @@ using Vector10 = Eigen::Matrix<double, 10, 1>;
 using Matrix5 = Eigen::Matrix<double, 5, 5>;
 // Define Matrix10 for Jacobians
 using Matrix10 = Eigen::Matrix<double, 10, 10>;
-// Define Vector25 for vec() method
-using Vector25 = Eigen::Matrix<double, 25, 1>;
 
 /**
  * Represents an element of the 3D Galilean group SGal(3).
  * Internal state: rotation, translation, velocity, time.
  */
-class GTSAM_EXPORT Gal3 : public LieGroup<Gal3, 10> {
+class GTSAM_EXPORT Gal3 : public MatrixLieGroup<Gal3, 10, 5> {
  private:
   Rot3 R_;      ///< Rotation world R body
   Point3 r_;    ///< Position in world frame, n_r_b
@@ -122,8 +120,7 @@ class GTSAM_EXPORT Gal3 : public LieGroup<Gal3, 10> {
   /// Return 5x5 homogeneous matrix representation
   Matrix5 matrix() const;
 
-  /// Vectorize 5x5 matrix into a 25-dim vector.
-  Vector25 vec(OptionalJacobian<25, 10> H = {}) const;
+  
 
   /// @}
   /// @name Testable
@@ -233,9 +230,9 @@ class GTSAM_EXPORT Gal3 : public LieGroup<Gal3, 10> {
 
 /// Traits specialization for Gal3
 template <>
-struct traits<Gal3> : public internal::LieGroup<Gal3> {};
+struct traits<Gal3> : public internal::MatrixLieGroup<Gal3> {};
 
 template <>
-struct traits<const Gal3> : public internal::LieGroup<Gal3> {};
+struct traits<const Gal3> : public internal::MatrixLieGroup<Gal3> {};
 
 } // namespace gtsam

--- a/gtsam/geometry/Gal3.h
+++ b/gtsam/geometry/Gal3.h
@@ -31,12 +31,6 @@ class Gal3;
 
 // Use Vector3 for velocity for consistency with NavState
 using Velocity3 = Vector3;
-// Define Vector10 for tangent space
-using Vector10 = Eigen::Matrix<double, 10, 1>;
-// Define Matrix5 for Lie Algebra matrix representation
-using Matrix5 = Eigen::Matrix<double, 5, 5>;
-// Define Matrix10 for Jacobians
-using Matrix10 = Eigen::Matrix<double, 10, 10>;
 
 /**
  * Represents an element of the 3D Galilean group SGal(3).
@@ -51,9 +45,6 @@ class GTSAM_EXPORT Gal3 : public MatrixLieGroup<Gal3, 10, 5> {
 
  public:
   using LieAlgebra = Matrix5;
-
-  /// The dimension of the tangent space
-  inline static constexpr size_t dimension = 10;
 
   /// @name Constructors
   /// @{
@@ -171,43 +162,43 @@ class GTSAM_EXPORT Gal3 : public MatrixLieGroup<Gal3, 10, 5> {
   /// @{
 
   /// Exponential map at identity: tangent vector xi -> manifold element g
-  static Gal3 Expmap(const Vector10& xi, OptionalJacobian<10, 10> Hxi = {});
+  static Gal3 Expmap(const TangentVector& xi, OptionalJacobian<10, 10> Hxi = {});
 
   /// Logarithmic map at identity: manifold element g -> tangent vector xi
-  static Vector10 Logmap(const Gal3& g, OptionalJacobian<10, 10> Hg = {});
+  static TangentVector Logmap(const Gal3& g, OptionalJacobian<10, 10> Hg = {});
 
   /// Calculate Adjoint map Ad_g
-  Matrix10 AdjointMap() const;
+  Jacobian AdjointMap() const;
 
   /// Apply this element's AdjointMap Ad_g to a tangent vector xi_base at identity
-  Vector10 Adjoint(const Vector10& xi_base, OptionalJacobian<10, 10> H_g = {},
+  TangentVector Adjoint(const TangentVector& xi_base, OptionalJacobian<10, 10> H_g = {},
                   OptionalJacobian<10, 10> H_xi = {}) const;
 
   /// The adjoint action `ad(xi, y)` = `adjointMap(xi) * y`
-  static Vector10 adjoint(const Vector10& xi, const Vector10& y,
+  static TangentVector adjoint(const TangentVector& xi, const TangentVector& y,
                          OptionalJacobian<10, 10> Hxi = {},
                          OptionalJacobian<10, 10> Hy = {});
 
   /// Compute the adjoint map `ad(xi)` associated with tangent vector xi
-  static Matrix10 adjointMap(const Vector10& xi);
+  static Jacobian adjointMap(const TangentVector& xi);
 
   /// Derivative of Expmap(xi) w.r.t. xi evaluated at xi
-  static Matrix10 ExpmapDerivative(const Vector10& xi);
+  static Jacobian ExpmapDerivative(const TangentVector& xi);
 
   /// Derivative of Logmap(g) w.r.t. g
-  static Matrix10 LogmapDerivative(const Gal3& g);
+  static Jacobian LogmapDerivative(const Gal3& g);
 
   /// Chart at origin, uses Expmap/Logmap for Retract/Local
   struct ChartAtOrigin {
-    static Gal3 Retract(const Vector10& xi, ChartJacobian Hxi = {});
-    static Vector10 Local(const Gal3& g, ChartJacobian Hg = {});
+    static Gal3 Retract(const TangentVector& xi, ChartJacobian Hxi = {});
+    static TangentVector Local(const Gal3& g, ChartJacobian Hg = {});
   };
 
   /// Hat operator: maps tangent vector xi to Lie algebra matrix
-  static Matrix5 Hat(const Vector10& xi);
+  static LieAlgebra Hat(const TangentVector& xi);
 
   /// Vee operator: maps Lie algebra matrix to tangent vector xi
-  static Vector10 Vee(const Matrix5& X);
+  static TangentVector Vee(const LieAlgebra& X);
 
   /// @}
 

--- a/gtsam/geometry/Pose2.cpp
+++ b/gtsam/geometry/Pose2.cpp
@@ -325,29 +325,7 @@ double Pose2::range(const Pose2& pose,
 
 /* ************************************************************************* */
 // Compute vectorized Lie algebra generators for SE(2)
-static Matrix93 VectorizedGenerators() {
-  Matrix93 G;
-  for (size_t j = 0; j < 3; j++) {
-    const Matrix3 X = Pose2::Hat(Vector::Unit(3, j));
-    G.col(j) = Eigen::Map<const Vector9>(X.data());
-  }
-  return G;
-}
 
-Vector9 Pose2::vec(OptionalJacobian<9, 3> H) const {
-  // Vectorize
-  const Matrix3 M = matrix();
-  const Vector9 X = Eigen::Map<const Vector9>(M.data());
-
-  // If requested, calculate H as (I_3 \oplus M) * G.
-  if (H) {
-    static const Matrix93 G = VectorizedGenerators(); // static to compute only once
-    for (size_t i = 0; i < 3; i++)
-      H->block(i * 3, 0, 3, dimension) = M * G.block(i * 3, 0, 3, dimension);
-  }
-
-  return X;
-}
 
 /* *************************************************************************
  * Align finds the angle using a linear method:

--- a/gtsam/geometry/Pose2.h
+++ b/gtsam/geometry/Pose2.h
@@ -377,10 +377,10 @@ using Pose2Pair = std::pair<Pose2, Pose2>;
 using Pose2Pairs = std::vector<Pose2Pair>;
 
 template <>
-struct traits<Pose2> : public internal::MatrixLieGroup<Pose2> {};
+struct traits<Pose2> : public internal::MatrixLieGroup<Pose2, 3> {};
 
 template <>
-struct traits<const Pose2> : public internal::MatrixLieGroup<Pose2> {};
+struct traits<const Pose2> : public internal::MatrixLieGroup<Pose2, 3> {};
 
 // bearing and range traits, used in RangeFactor
 template <typename T>

--- a/gtsam/geometry/Pose2.h
+++ b/gtsam/geometry/Pose2.h
@@ -36,7 +36,7 @@ namespace gtsam {
  * @ingroup geometry
  * \nosubgrouping
  */
-class GTSAM_EXPORT Pose2: public LieGroup<Pose2, 3> {
+class GTSAM_EXPORT Pose2: public MatrixLieGroup<Pose2, 3, 3> {
 
 public:
 
@@ -328,8 +328,7 @@ public:
    */
   static std::pair<size_t, size_t> rotationInterval() { return {2, 2}; }
 
-  /// Return vectorized SE(2) matrix in column order.
-  Vector9 vec(OptionalJacobian<9, 3> H = {}) const;
+  
 
   /// Output stream operator
   GTSAM_EXPORT

--- a/gtsam/geometry/Pose3.cpp
+++ b/gtsam/geometry/Pose3.cpp
@@ -527,31 +527,7 @@ Pose3 Pose3::slerp(double t, const Pose3& other, OptionalJacobian<6, 6> Hx, Opti
 
 /* ************************************************************************* */
 // Compute vectorized Lie algebra generators for SE(3)
-using Matrix16x6 = Eigen::Matrix<double, 16, 6>;
-using Vector16 = Eigen::Matrix<double, 16, 1>;
-static Matrix16x6 VectorizedGenerators() {
-  Matrix16x6 G;
-  for (size_t j = 0; j < 6; j++) {
-    const Matrix4 X = Pose3::Hat(Vector::Unit(6, j));
-    G.col(j) = Eigen::Map<const Vector16>(X.data());
-  }
-  return G;
-}
 
-Vector Pose3::vec(OptionalJacobian<16, 6> H) const {
-  // Vectorize
-  const Matrix4 M = matrix();
-  const Vector X = Eigen::Map<const Vector16>(M.data());
-
-  // If requested, calculate H as (I_4 \oplus M) * G.
-  if (H) {
-    static const Matrix16x6 G = VectorizedGenerators(); // static to compute only once
-    for (size_t i = 0; i < 4; i++)
-      H->block(i * 4, 0, 4, dimension) = M * G.block(i * 4, 0, 4, dimension);
-  }
-
-  return X;
-}
 
 /* ************************************************************************* */
 std::ostream &operator<<(std::ostream &os, const Pose3& pose) {

--- a/gtsam/geometry/Pose3.h
+++ b/gtsam/geometry/Pose3.h
@@ -439,10 +439,10 @@ using Pose3Pairs = std::vector<std::pair<Pose3, Pose3> >;
 typedef std::vector<Pose3> Pose3Vector;
 
 template <>
-struct traits<Pose3> : public internal::MatrixLieGroup<Pose3> {};
+struct traits<Pose3> : public internal::MatrixLieGroup<Pose3, 4> {};
 
 template <>
-struct traits<const Pose3> : public internal::MatrixLieGroup<Pose3> {};
+struct traits<const Pose3> : public internal::MatrixLieGroup<Pose3, 4> {};
 
 // bearing and range traits, used in RangeFactor
 template <>

--- a/gtsam/geometry/Pose3.h
+++ b/gtsam/geometry/Pose3.h
@@ -34,7 +34,7 @@ class Pose2;
  * @ingroup geometry
  * \nosubgrouping
  */
-class GTSAM_EXPORT Pose3: public LieGroup<Pose3, 6> {
+class GTSAM_EXPORT Pose3: public MatrixLieGroup<Pose3, 6, 4> {
 public:
 
   /** Pose Concept requirements */
@@ -383,8 +383,7 @@ public:
   Pose3 slerp(double t, const Pose3& other, OptionalJacobian<6, 6> Hx = {},
                                              OptionalJacobian<6, 6> Hy = {}) const;
 
-  /// Return vectorized SE(3) matrix in column order.
-  Vector vec(OptionalJacobian<16, 6> H = {}) const;
+  
 
   /// Output stream operator
   GTSAM_EXPORT

--- a/gtsam/geometry/Quaternion.h
+++ b/gtsam/geometry/Quaternion.h
@@ -152,6 +152,10 @@ struct traits<QUATERNION_TYPE> {
     return SO3::Vee(X);
   }
 
+  static Vector9 Vec(const Q& q, OptionalJacobian<9, 3> H = {}) {
+    return SO3(q.toRotationMatrix()).SO3::vec(H);
+  }
+
   /// @}
   /// @name Manifold traits
   /// @{

--- a/gtsam/geometry/Quaternion.h
+++ b/gtsam/geometry/Quaternion.h
@@ -138,6 +138,10 @@ struct traits<QUATERNION_TYPE> {
     return omega;
   }
 
+  static Matrix3 AdjointMap(const Q &g) {
+    return g.toRotationMatrix();
+  }
+
   using LieAlgebra = Matrix3;
 
   static Matrix3 Hat(const Vector3& v) {

--- a/gtsam/geometry/Rot2.cpp
+++ b/gtsam/geometry/Rot2.cpp
@@ -158,20 +158,7 @@ Rot2 Rot2::ClosestTo(const Matrix2& M) {
 }
 
 /* ************************************************************************* */
-Vector4 Rot2::vec(OptionalJacobian<4, 1> H) const {
-  // Vectorize
-  const Matrix2 M = matrix();
-  const Vector4 X = Eigen::Map<const Vector4>(M.data());
 
-  // If requested, calculate H as (I_3 \oplus M) * G.
-  if (H) {
-    static const Matrix41 G = (Matrix41() << 0, 1, -1, 0).finished();
-    for (size_t i = 0; i < 2; i++)
-      H->block(i * 2, 0, 2, dimension) = M * G.block(i * 2, 0, 2, dimension);
-  }
-
-  return X;
-}
 
 /* ************************************************************************* */
 

--- a/gtsam/geometry/Rot2.h
+++ b/gtsam/geometry/Rot2.h
@@ -240,10 +240,10 @@ namespace gtsam {
 
   };
 
-  template<>
-  struct traits<Rot2> : public internal::MatrixLieGroup<Rot2> {};
+  template <>
+struct traits<Rot2> : public internal::MatrixLieGroup<Rot2, 2> {};
 
-  template<>
-  struct traits<const Rot2> : public internal::MatrixLieGroup<Rot2> {};
+template <>
+struct traits<const Rot2> : public internal::MatrixLieGroup<Rot2, 2> {};
 
 } // gtsam

--- a/gtsam/geometry/Rot2.h
+++ b/gtsam/geometry/Rot2.h
@@ -32,7 +32,7 @@ namespace gtsam {
    * @ingroup geometry
    * \nosubgrouping
    */
-  class GTSAM_EXPORT Rot2 : public LieGroup<Rot2, 1> {
+  class GTSAM_EXPORT Rot2 : public MatrixLieGroup<Rot2, 1, 2> {
     /** we store cos(theta) and sin(theta) */
     double c_, s_;
 
@@ -223,8 +223,7 @@ namespace gtsam {
     /** Find closest valid rotation matrix, given a 2x2 matrix */
     static Rot2 ClosestTo(const Matrix2& M);
 
-    /// Return vectorized SO(2) matrix in column order.
-    Vector4 vec(OptionalJacobian<4, 1> H = {}) const;
+    
 
     /// @}
 

--- a/gtsam/geometry/Rot2.h
+++ b/gtsam/geometry/Rot2.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include <gtsam/geometry/Point2.h>
-#include <gtsam/base/Lie.h>
+#include <gtsam/base/MatrixLieGroup.h>
 
 #include <random>
 

--- a/gtsam/geometry/Rot3.h
+++ b/gtsam/geometry/Rot3.h
@@ -592,11 +592,11 @@ class GTSAM_EXPORT Rot3 : public LieGroup<Rot3, 3> {
   GTSAM_EXPORT std::pair<Matrix3, Vector3> RQ(
       const Matrix3& A, OptionalJacobian<3, 9> H = {});
 
-  template<>
-  struct traits<Rot3> : public internal::MatrixLieGroup<Rot3> {};
+  template <>
+struct traits<Rot3> : public internal::MatrixLieGroup<Rot3, 3> {};
 
-  template<>
-  struct traits<const Rot3> : public internal::MatrixLieGroup<Rot3> {};
+template <>
+struct traits<const Rot3> : public internal::MatrixLieGroup<Rot3, 3> {};
   
 }  // namespace gtsam
 

--- a/gtsam/geometry/Rot3.h
+++ b/gtsam/geometry/Rot3.h
@@ -56,6 +56,8 @@ namespace gtsam {
  * @ingroup geometry
  */
 class GTSAM_EXPORT Rot3 : public LieGroup<Rot3, 3> {
+ public:
+  static constexpr size_t MatrixM = 3;
  private:
 
 #ifdef GTSAM_USE_QUATERNIONS

--- a/gtsam/geometry/SO3.cpp
+++ b/gtsam/geometry/SO3.cpp
@@ -274,13 +274,6 @@ Vector3 SO3::Vee(const Matrix3& X) {
 //******************************************************************************
 template <>
 GTSAM_EXPORT
-Matrix3 SO3::AdjointMap() const {
-  return matrix_;
-}
-
-//******************************************************************************
-template <>
-GTSAM_EXPORT
 SO3 SO3::Expmap(const Vector3& omega, ChartJacobian H) {
   so3::DexpFunctor local(omega);
   if (H) *H = local.rightJacobian();
@@ -393,33 +386,6 @@ Vector3 SO3::ChartAtOrigin::Local(const SO3& R, ChartJacobian H) {
   return Logmap(R, H);
 }
 
-//******************************************************************************
-// local vectorize
-static Vector9 vec3(const Matrix3& R) {
-  return Eigen::Map<const Vector9>(R.data());
-}
-
-// so<3> generators
-static std::vector<Matrix3> G3({SO3::Hat(Vector3::Unit(0)),
-                                SO3::Hat(Vector3::Unit(1)),
-                                SO3::Hat(Vector3::Unit(2))});
-
-// vectorized generators
-static const Matrix93 P3 =
-    (Matrix93() << vec3(G3[0]), vec3(G3[1]), vec3(G3[2])).finished();
-
-//******************************************************************************
-template <>
-GTSAM_EXPORT
-Vector9 SO3::vec(OptionalJacobian<9, 3> H) const {
-  const Matrix3& R = matrix_;
-  if (H) {
-    // As Luca calculated (for SO4), this is (I3 \oplus R) * P3
-    *H << R * P3.block<3, 3>(0, 0), R * P3.block<3, 3>(3, 0),
-        R * P3.block<3, 3>(6, 0);
-  }
-  return gtsam::vec3(R);
-}
 //******************************************************************************
 
 }  // end namespace gtsam

--- a/gtsam/geometry/SO3.h
+++ b/gtsam/geometry/SO3.h
@@ -233,9 +233,9 @@ struct GTSAM_EXPORT DexpFunctor : public ExpmapFunctor {
  */
 
 template <>
-struct traits<SO3> : public internal::MatrixLieGroup<SO3> {};
+struct traits<SO3> : public internal::MatrixLieGroup<SO3, 3> {};
 
 template <>
-struct traits<const SO3> : public internal::MatrixLieGroup<SO3> {};
+struct traits<const SO3> : public internal::MatrixLieGroup<SO3, 3> {};
 
 }  // end namespace gtsam

--- a/gtsam/geometry/SO3.h
+++ b/gtsam/geometry/SO3.h
@@ -59,7 +59,7 @@ Vector3 SO3::Vee(const Matrix3& X);  ///< inverse of Hat
 
 /// Adjoint map
 template <>
-Matrix3 SO3::AdjointMap() const{ return matrix_; }
+inline Matrix3 SO3::AdjointMap() const{ return matrix_; }
 
 /**
  * Exponential map at identity - create a rotation from canonical coordinates

--- a/gtsam/geometry/SO3.h
+++ b/gtsam/geometry/SO3.h
@@ -59,7 +59,7 @@ Vector3 SO3::Vee(const Matrix3& X);  ///< inverse of Hat
 
 /// Adjoint map
 template <>
-Matrix3 SO3::AdjointMap() const;
+Matrix3 SO3::AdjointMap() const{ return matrix_; }
 
 /**
  * Exponential map at identity - create a rotation from canonical coordinates
@@ -95,10 +95,6 @@ SO3 SO3::ChartAtOrigin::Retract(const Vector3& omega, ChartJacobian H);
 template <>
 GTSAM_EXPORT
 Vector3 SO3::ChartAtOrigin::Local(const SO3& R, ChartJacobian H);
-
-template <>
-GTSAM_EXPORT
-Vector9 SO3::vec(OptionalJacobian<9, 3> H) const;
 
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
 template <class Archive>

--- a/gtsam/geometry/SO3.h
+++ b/gtsam/geometry/SO3.h
@@ -39,6 +39,8 @@ template <>
 GTSAM_EXPORT
 SO3 SO3::AxisAngle(const Vector3& axis, double theta);
 
+static constexpr size_t MatrixM = 3;
+
 template <>
 GTSAM_EXPORT
 SO3 SO3::ClosestTo(const Matrix3& M);

--- a/gtsam/geometry/SO4.cpp
+++ b/gtsam/geometry/SO4.cpp
@@ -134,53 +134,6 @@ SO4 SO4::Expmap(const Vector6& xi, ChartJacobian H) {
   }
 }
 
-//******************************************************************************
-// local vectorize
-static SO4::VectorN2 vec4(const Matrix4& Q) {
-  return Eigen::Map<const SO4::VectorN2>(Q.data());
-}
-
-// so<4> generators
-static std::vector<Matrix4, Eigen::aligned_allocator<Matrix4> > G4(
-    {SO4::Hat(Vector6::Unit(0)), SO4::Hat(Vector6::Unit(1)),
-     SO4::Hat(Vector6::Unit(2)), SO4::Hat(Vector6::Unit(3)),
-     SO4::Hat(Vector6::Unit(4)), SO4::Hat(Vector6::Unit(5))});
-
-// vectorized generators
-static const Eigen::Matrix<double, 16, 6> P4 =
-    (Eigen::Matrix<double, 16, 6>() << vec4(G4[0]), vec4(G4[1]), vec4(G4[2]),
-     vec4(G4[3]), vec4(G4[4]), vec4(G4[5]))
-        .finished();
-
-//******************************************************************************
-template <>
-GTSAM_EXPORT
-Matrix6 SO4::AdjointMap() const {
-  // Elaborate way of calculating the AdjointMap
-  // TODO(frank): find a closed form solution. In SO(3) is just R :-/
-  const Matrix4& Q = matrix_;
-  const Matrix4 Qt = Q.transpose();
-  Matrix6 A;
-  for (size_t i = 0; i < 6; i++) {
-    // Calculate column i of linear map for coeffcient of Gi
-    A.col(i) = SO4::Vee(Q * G4[i] * Qt);
-  }
-  return A;
-}
-
-//******************************************************************************
-template <>
-GTSAM_EXPORT
-SO4::VectorN2 SO4::vec(OptionalJacobian<16, 6> H) const {
-  const Matrix& Q = matrix_;
-  if (H) {
-    // As Luca calculated, this is (I4 \oplus Q) * P4
-    *H << Q * P4.block<4, 6>(0, 0), Q * P4.block<4, 6>(4, 0),
-        Q * P4.block<4, 6>(8, 0), Q * P4.block<4, 6>(12, 0);
-  }
-  return gtsam::vec4(Q);
-}
-
 ///******************************************************************************
 template <>
 GTSAM_EXPORT

--- a/gtsam/geometry/SO4.h
+++ b/gtsam/geometry/SO4.h
@@ -110,9 +110,9 @@ void serialize(Archive &ar, SO4 &Q, const unsigned int /*version*/) {
  */
 
 template <>
-struct traits<SO4> : public internal::MatrixLieGroup<SO4> {};
+struct traits<SO4> : public internal::MatrixLieGroup<SO4, 4> {};
 
 template <>
-struct traits<const SO4> : public internal::MatrixLieGroup<SO4> {};
+struct traits<const SO4> : public internal::MatrixLieGroup<SO4, 4> {};
 
 }  // end namespace gtsam

--- a/gtsam/geometry/SO4.h
+++ b/gtsam/geometry/SO4.h
@@ -51,13 +51,6 @@ template <>
 GTSAM_EXPORT
 SO4 SO4::Expmap(const Vector6 &xi, ChartJacobian H);
 
-template <>
-GTSAM_EXPORT
-Matrix6 SO4::AdjointMap() const;
-
-template <>
-GTSAM_EXPORT
-SO4::VectorN2 SO4::vec(OptionalJacobian<16, 6> H) const;
 
 template <>
 GTSAM_EXPORT

--- a/gtsam/geometry/SOn-inl.h
+++ b/gtsam/geometry/SOn-inl.h
@@ -57,13 +57,6 @@ typename SO<N>::TangentVector SO<N>::ChartAtOrigin::Local(const SO& R,
 }
 
 template <int N>
-typename SO<N>::MatrixDD SO<N>::AdjointMap() const {
-  if (N==2) return I_1x1; // SO(2) case
-  throw std::runtime_error(
-      "SO<N>::AdjointMap only implemented for SO2, SO3 and SO4.");
-}
-
-template <int N>
 SO<N> SO<N>::Expmap(const TangentVector& omega, ChartJacobian H) {
   throw std::runtime_error("SO<N>::Expmap only implemented for SO3 and SO4.");
 }

--- a/gtsam/geometry/SOn-inl.h
+++ b/gtsam/geometry/SOn-inl.h
@@ -76,27 +76,6 @@ typename SO<N>::MatrixDD SO<N>::LogmapDerivative(const TangentVector& omega) {
   throw std::runtime_error("O<N>::LogmapDerivative only implemented for SO3.");
 }
 
-// Default fixed size version (but specialized elsewehere for N=2,3,4)
-template <int N>
-typename SO<N>::VectorN2 SO<N>::vec(
-    OptionalJacobian<internal::NSquaredSO(N), dimension> H) const {
-  // Vectorize
-  VectorN2 X = Eigen::Map<const VectorN2>(matrix_.data());
-
-  // If requested, calculate H as (I \oplus Q) * P,
-  // where Q is the N*N rotation matrix, and P is calculated below.
-  if (H) {
-    // Calculate P matrix of vectorized generators
-    // TODO(duy): Should we refactor this as the jacobian of Hat?
-    Matrix P = SO<N>::VectorizedGenerators();
-    for (size_t i = 0; i < N; i++) {
-      H->block(i * N, 0, N, dimension) =
-          matrix_ * P.block(i * N, 0, N, dimension);
-    }
-  }
-  return X;
-}
-
 template <int N>
 void SO<N>::print(const std::string& s) const {
     std::cout << s << matrix_ << std::endl;

--- a/gtsam/geometry/SOn.cpp
+++ b/gtsam/geometry/SOn.cpp
@@ -102,29 +102,4 @@ SOn LieGroup<SOn, Eigen::Dynamic>::between(const SOn& g, DynamicJacobian H1,
   return result;
 }
 
-// Dynamic version of vec
-template <>
-typename SOn::VectorN2 SOn::vec(DynamicJacobian H) const
-{
-  const size_t n = rows(), n2 = n * n;
-
-  // Vectorize
-  VectorN2 X(n2);
-  X << Eigen::Map<const Matrix>(matrix_.data(), n2, 1);
-
-  // If requested, calculate H as (I \oplus Q) * P,
-  // where Q is the N*N rotation matrix, and P is calculated below.
-  if (H) {
-    // Calculate P matrix of vectorized generators
-    // TODO(duy): Should we refactor this as the jacobian of Hat?
-    Matrix P = SOn::VectorizedGenerators(n);
-    const size_t d = dim();
-    H->resize(n2, d);
-    for (size_t i = 0; i < n; i++) {
-      H->block(i * n, 0, n, d) = matrix_ * P.block(i * n, 0, n, d);
-    }
-  }
-  return X;
-}
-
 }  // namespace gtsam

--- a/gtsam/geometry/SOn.h
+++ b/gtsam/geometry/SOn.h
@@ -53,8 +53,6 @@ constexpr int NSquaredSO(int N) { return (N < 0) ? Eigen::Dynamic : N * N; }
 template <int N>
 class SO : public LieGroup<SO<N>, internal::DimensionSO(N)> {
  public:
-  static constexpr size_t MatrixM = N;
- public:
   inline constexpr static auto dimension = internal::DimensionSO(N);
   using MatrixNN = Eigen::Matrix<double, N, N>;
   using VectorN2 = Eigen::Matrix<double, internal::NSquaredSO(N), 1>;
@@ -401,10 +399,10 @@ void serialize(
  */
 
 template <int N>
-struct traits<SO<N>> : public internal::MatrixLieGroup<SO<N>> {};
+struct traits<SO<N>> : public internal::MatrixLieGroup<SO<N>, N> {};
 
 template <int N>
-struct traits<const SO<N>> : public internal::MatrixLieGroup<SO<N>> {};
+struct traits<const SO<N>> : public internal::MatrixLieGroup<SO<N>, N> {};
 
 }  // namespace gtsam
 

--- a/gtsam/geometry/SOn.h
+++ b/gtsam/geometry/SOn.h
@@ -294,14 +294,6 @@ class SO : public MatrixLieGroup<SO<N>, internal::DimensionSO(N), N> {
   /// @name Other methods
   /// @{
 
-  /**
-   * Return vectorized rotation matrix in column order.
-   * Will use dynamic matrices as intermediate results, but returns a fixed size
-   * X and fixed-size Jacobian if dimension is known at compile time.
-   * */
-  VectorN2 vec(OptionalJacobian<internal::NSquaredSO(N), dimension> H =
-                   {}) const;
-
   /// Calculate N^2 x dim matrix of vectorized Lie algebra generators for SO(N)
   template <int N_ = N, typename = IsFixed<N_>>
   static Matrix VectorizedGenerators() {
@@ -376,13 +368,6 @@ template <>
 GTSAM_EXPORT
 SOn LieGroup<SOn, Eigen::Dynamic>::between(const SOn& g, DynamicJacobian H1,
                                            DynamicJacobian H2) const;
-
-/*
- * Specialize dynamic vec.
- */
-template <> 
-GTSAM_EXPORT
-typename SOn::VectorN2 SOn::vec(DynamicJacobian H) const;
 
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
 /** Serialization function */

--- a/gtsam/geometry/SOn.h
+++ b/gtsam/geometry/SOn.h
@@ -18,8 +18,7 @@
 
 #pragma once
 
-#include <gtsam/base/Lie.h>
-#include <gtsam/base/Manifold.h>
+#include <gtsam/base/MatrixLieGroup.h>
 #include <gtsam/base/make_shared.h>
 #include <gtsam/dllexport.h>
 #include <Eigen/Core>

--- a/gtsam/geometry/SOn.h
+++ b/gtsam/geometry/SOn.h
@@ -51,7 +51,7 @@ constexpr int NSquaredSO(int N) { return (N < 0) ? Eigen::Dynamic : N * N; }
  * Template paramater N can be a fixed integer or can be Eigen::Dynamic
  */
 template <int N>
-class SO : public LieGroup<SO<N>, internal::DimensionSO(N)> {
+class SO : public MatrixLieGroup<SO<N>, internal::DimensionSO(N), N> {
  public:
   inline constexpr static auto dimension = internal::DimensionSO(N);
   using MatrixNN = Eigen::Matrix<double, N, N>;
@@ -267,7 +267,9 @@ class SO : public LieGroup<SO<N>, internal::DimensionSO(N)> {
   /// @{
 
   /// Adjoint map
-  MatrixDD AdjointMap() const;
+  MatrixDD AdjointMap() const {
+    return MatrixLieGroup<SO<N>, internal::DimensionSO(N), N>::AdjointMap();
+  }
 
   /**
    * Exponential map at identity - create a rotation from canonical coordinates

--- a/gtsam/geometry/SOn.h
+++ b/gtsam/geometry/SOn.h
@@ -53,6 +53,8 @@ constexpr int NSquaredSO(int N) { return (N < 0) ? Eigen::Dynamic : N * N; }
 template <int N>
 class SO : public LieGroup<SO<N>, internal::DimensionSO(N)> {
  public:
+  static constexpr size_t MatrixM = N;
+ public:
   inline constexpr static auto dimension = internal::DimensionSO(N);
   using MatrixNN = Eigen::Matrix<double, N, N>;
   using VectorN2 = Eigen::Matrix<double, internal::NSquaredSO(N), 1>;

--- a/gtsam/geometry/Similarity2.cpp
+++ b/gtsam/geometry/Similarity2.cpp
@@ -321,38 +321,4 @@ Matrix3 Similarity2::matrix() const {
   return T;
 }
 
-// In Similarity2.cpp, e.g., after the #includes
-
-namespace {
-  // The 9x4 matrix of vectorized generators for Sim(2).
-  // The columns correspond to perturbations in [u_x, u_y, w, lambda].
-  // P_sim2 = [vec(G_ux), vec(G_uy), vec(G_w), vec(G_lambda)]
-  static const Eigen::Matrix<double, 9, 4> P_sim2 =
-    (Eigen::Matrix<double, 9, 4>() <<
-      // u_x u_y w lambda
-      0, 0, 0, 0,  // row 0
-      0, 0, 1, 0,  // row 1
-      0, 0, 0, 0,  // row 2
-      0, 0, -1, 0,  // row 3
-      0, 0, 0, 0,  // row 4
-      0, 0, 0, 0,  // row 5
-      1, 0, 0, 0,  // row 6
-      0, 1, 0, 0,  // row 7
-      0, 0, 0, -1   // row 8
-      ).finished();
-} // namespace
-
-//******************************************************************************
-Vector9 Similarity2::vec(OptionalJacobian<9, 4> H) const {
-  const Matrix3 T = this->matrix();
-  if (H) {
-    // The Jacobian is given by the formula H = (I_3 ⊗ T) * P_sim2
-    // where P_sim2 is the matrix of vectorized generators.
-    // This can be implemented efficiently with block-wise multiplication.
-    *H << T * P_sim2.block<3, 4>(0, 0),
-      T* P_sim2.block<3, 4>(3, 0),
-      T* P_sim2.block<3, 4>(6, 0);
-  }
-  return Eigen::Map<const Vector9>(T.data());
-}
 }  // namespace gtsam

--- a/gtsam/geometry/Similarity2.h
+++ b/gtsam/geometry/Similarity2.h
@@ -9,11 +9,11 @@
 
  * -------------------------------------------------------------------------- */
 
- /**
-  * @file   Similarity2.h
-  * @brief  Implementation of Similarity2 transform
-  * @author John Lambert, Varun Agrawal
-  */
+/**
+ * @file   Similarity2.h
+ * @brief  Implementation of Similarity2 transform
+ * @author John Lambert, Varun Agrawal
+ */
 
 #pragma once
 
@@ -25,200 +25,200 @@
 
 namespace gtsam {
 
-  // Forward declarations
-  class Pose2;
+// Forward declarations
+class Pose2;
+
+/**
+ * 2D similarity transform
+ */
+class GTSAM_EXPORT Similarity2 : public MatrixLieGroup<Similarity2, 4, 3> {
+  /// @name Pose Concept
+  /// @{
+  typedef Rot2 Rotation;
+  typedef Point2 Translation;
+  /// @}
+
+private:
+  Rot2 R_;
+  Point2 t_;
+  double s_;
+
+public:
+  /// @name Constructors
+  /// @{
+
+  /// Default constructor
+  Similarity2();
+
+  /// Construct pure scaling
+  Similarity2(double s);
+
+  /// Construct from GTSAM types
+  Similarity2(const Rot2& R, const Point2& t, double s);
+
+  /// Construct from Eigen types
+  Similarity2(const Matrix2& R, const Vector2& t, double s);
+
+  /// Construct from matrix [R t; 0 s^-1]
+  Similarity2(const Matrix3& T);
+
+  /// @}
+  /// @name Testable
+  /// @{
+
+  /// Compare with tolerance
+  bool equals(const Similarity2& sim, double tol) const;
+
+  /// Exact equality
+  bool operator==(const Similarity2& other) const;
+
+  /// Print with optional string
+  void print(const std::string& s = "") const;
+
+  GTSAM_EXPORT friend std::ostream& operator<<(std::ostream& os,
+                                               const Similarity2& p);
+
+  /// @}
+  /// @name Group
+  /// @{
+
+  /// Return an identity transform
+  static Similarity2 Identity();
+
+  /// Composition
+  Similarity2 operator*(const Similarity2& S) const;
+
+  /// Return the inverse
+  Similarity2 inverse() const;
+
+  /// @}
+  /// @name Group action on Point2
+  /// @{
+
+  /// Action on a point p is s*(R*p+t)
+  Point2 transformFrom(const Point2& p) const;
 
   /**
-   * 2D similarity transform
+   * Action on a pose T.
+   * |Rs  ts|   |R t|   |Rs*R Rs*t+ts|
+   * |0  1/s| * |0 1| = | 0      1/s |, the result is still a Sim2 object.
+   * To retrieve a Pose2, we normalized the scale value into 1.
+   * |Rs*R Rs*t+ts|   |Rs*R s(Rs*t+ts)|
+   * | 0      1/s | = |  0       1    |
+   *
+   * This group action satisfies the compatibility condition.
+   * For more details, refer to: https://en.wikipedia.org/wiki/Group_action
    */
-  class GTSAM_EXPORT Similarity2 : public MatrixLieGroup<Similarity2, 4, 3> {
-    /// @name Pose Concept
-    /// @{
-    typedef Rot2 Rotation;
-    typedef Point2 Translation;
-    /// @}
+  Pose2 transformFrom(const Pose2& T) const;
 
-  private:
-    Rot2 R_;
-    Point2 t_;
-    double s_;
+  /* syntactic sugar for transformFrom */
+  Point2 operator*(const Point2& p) const;
 
-  public:
-    /// @name Constructors
-    /// @{
+  /**
+   *  Create Similarity2 by aligning at least two point pairs
+   */
+  static Similarity2 Align(const Point2Pairs& abPointPairs);
 
-    /// Default constructor
-    Similarity2();
+  /**
+   * Create the Similarity2 object that aligns at least two pose pairs.
+   * Each pair is of the form (aTi, bTi).
+   * Given a list of pairs in frame a, and a list of pairs in frame b,
+   Align()
+   * will compute the best-fit Similarity2 aSb transformation to align them.
+   * First, the rotation aRb will be computed as the average (Karcher mean)
+   of
+   * many estimates aRb (from each pair). Afterwards, the scale factor will
+   be computed
+   * using the algorithm described here:
+   * http://www5.informatik.uni-erlangen.de/Forschung/Publikationen/2005/Zinsser05-PSR.pdf
+   */
+  static Similarity2 Align(const Pose2Pairs& abPosePairs);
 
-    /// Construct pure scaling
-    Similarity2(double s);
+  /// @}
+  /// @name Lie Group
+  /// @{
 
-    /// Construct from GTSAM types
-    Similarity2(const Rot2& R, const Point2& t, double s);
+  using LieAlgebra = Matrix3;
 
-    /// Construct from Eigen types
-    Similarity2(const Matrix2& R, const Vector2& t, double s);
+  /// Calculate expmap and logmap coefficients.
+  static Matrix2 GetV(double theta, double lambda);
 
-    /// Construct from matrix [R t; 0 s^-1]
-    Similarity2(const Matrix3& T);
+  /**
+   * Log map at the identity
+   * \f$ [t_x, t_y, \delta, \lambda] \f$
+   */
+  static Vector4 Logmap(const Similarity2& S,  //
+                        OptionalJacobian<4, 4> Hm = {});
 
-    /// @}
-    /// @name Testable
-    /// @{
+  /// Exponential map at the identity
+  static Similarity2 Expmap(const Vector4& v,  //
+                            OptionalJacobian<4, 4> Hm = {});
 
-    /// Compare with tolerance
-    bool equals(const Similarity2& sim, double tol) const;
+  /// Chart at the origin
+  struct ChartAtOrigin {
+    static Similarity2 Retract(const Vector4& v,
+                               ChartJacobian H = {}) {
+      return Similarity2::Expmap(v, H);
+    }
+    static Vector4 Local(const Similarity2& other,
+                         ChartJacobian H = {}) {
+      return Similarity2::Logmap(other, H);
+    }
+  };
 
-    /// Exact equality
-    bool operator==(const Similarity2& other) const;
+  /// Project from one tangent space to another
+  Matrix4 AdjointMap() const;
 
-    /// Print with optional string
-    void print(const std::string& s = "") const;
+  using LieGroup<Similarity2, 4>::inverse;
 
-    GTSAM_EXPORT friend std::ostream& operator<<(std::ostream& os,
-      const Similarity2& p);
+  /// Hat maps from tangent vector to Lie algebra
+  static Matrix3 Hat(const Vector4& xi);
 
-    /// @}
-    /// @name Group
-    /// @{
+  /// Vee maps from Lie algebra to tangent vector
+  static Vector4 Vee(const Matrix3& X);
 
-    /// Return an identity transform
-    static Similarity2 Identity();
+  /// @}
+  /// @name Standard interface
+  /// @{
 
-    /// Composition
-    Similarity2 operator*(const Similarity2& S) const;
+  /// Calculate 3*3 matrix group equivalent
+  Matrix3 matrix() const;
 
-    /// Return the inverse
-    Similarity2 inverse() const;
+  /// Return a GTSAM rotation
+  Rot2 rotation() const { return R_; }
 
-    /// @}
-    /// @name Group action on Point2
-    /// @{
+  /// Return a GTSAM translation
+  Point2 translation() const { return t_; }
 
-    /// Action on a point p is s*(R*p+t)
-    Point2 transformFrom(const Point2& p) const;
+  /// Return the scale
+  double scale() const { return s_; }
 
-    /**
-     * Action on a pose T.
-     * |Rs  ts|   |R t|   |Rs*R Rs*t+ts|
-     * |0  1/s| * |0 1| = | 0      1/s |, the result is still a Sim2 object.
-     * To retrieve a Pose2, we normalized the scale value into 1.
-     * |Rs*R Rs*t+ts|   |Rs*R s(Rs*t+ts)|
-     * | 0      1/s | = |  0       1    |
-     *
-     * This group action satisfies the compatibility condition.
-     * For more details, refer to: https://en.wikipedia.org/wiki/Group_action
-     */
-    Pose2 transformFrom(const Pose2& T) const;
+  /// Dimensionality of tangent space = 4 DOF - used to autodetect sizes
+  inline static size_t Dim() { return 4; }
 
-    /* syntactic sugar for transformFrom */
-    Point2 operator*(const Point2& p) const;
+  /// Dimensionality of tangent space = 4 DOF
+  inline size_t dim() const { return 4; }
 
-    /**
-     *  Create Similarity2 by aligning at least two point pairs
-     */
-    static Similarity2 Align(const Point2Pairs& abPointPairs);
+ private:
 
-    /**
-     * Create the Similarity2 object that aligns at least two pose pairs.
-     * Each pair is of the form (aTi, bTi).
-     * Given a list of pairs in frame a, and a list of pairs in frame b,
-     Align()
-     * will compute the best-fit Similarity2 aSb transformation to align them.
-     * First, the rotation aRb will be computed as the average (Karcher mean)
-     of
-     * many estimates aRb (from each pair). Afterwards, the scale factor will
-     be computed
-     * using the algorithm described here:
-     * http://www5.informatik.uni-erlangen.de/Forschung/Publikationen/2005/Zinsser05-PSR.pdf
-     */
-    static Similarity2 Align(const Pose2Pairs& abPosePairs);
-
-    /// @}
-    /// @name Lie Group
-    /// @{
-
-    using LieAlgebra = Matrix3;
-
-    /// Calculate expmap and logmap coefficients.
-    static Matrix2 GetV(double theta, double lambda);
-
-    /**
-     * Log map at the identity
-     * \f$ [t_x, t_y, \delta, \lambda] \f$
-     */
-    static Vector4 Logmap(const Similarity2& S,  //
-      OptionalJacobian<4, 4> Hm = {});
-
-    /// Exponential map at the identity
-    static Similarity2 Expmap(const Vector4& v,  //
-      OptionalJacobian<4, 4> Hm = {});
-
-    /// Chart at the origin
-    struct ChartAtOrigin {
-      static Similarity2 Retract(const Vector4& v,
-        ChartJacobian H = {}) {
-        return Similarity2::Expmap(v, H);
-      }
-      static Vector4 Local(const Similarity2& other,
-        ChartJacobian H = {}) {
-        return Similarity2::Logmap(other, H);
-      }
-    };
-
-    /// Project from one tangent space to another
-    Matrix4 AdjointMap() const;
-
-    using LieGroup<Similarity2, 4>::inverse;
-
-    /// Hat maps from tangent vector to Lie algebra
-    static Matrix3 Hat(const Vector4& xi);
-
-    /// Vee maps from Lie algebra to tangent vector
-    static Vector4 Vee(const Matrix3& X);
-
-    /// @}
-    /// @name Standard interface
-    /// @{
-
-    /// Calculate 3*3 matrix group equivalent
-    Matrix3 matrix() const;
-
-    /// Return a GTSAM rotation
-    Rot2 rotation() const { return R_; }
-
-    /// Return a GTSAM translation
-    Point2 translation() const { return t_; }
-
-    /// Return the scale
-    double scale() const { return s_; }
-
-    /// Dimensionality of tangent space = 4 DOF - used to autodetect sizes
-    inline static size_t Dim() { return 4; }
-
-    /// Dimensionality of tangent space = 4 DOF
-    inline size_t dim() const { return 4; }
-
-  private:
-
-#if GTSAM_ENABLE_BOOST_SERIALIZATION
+  #if GTSAM_ENABLE_BOOST_SERIALIZATION
     /** Serialization function */
     friend class boost::serialization::access;
     template<class Archive>
-    void serialize(Archive& ar, const unsigned int /*version*/) {
-      ar& BOOST_SERIALIZATION_NVP(R_);
-      ar& BOOST_SERIALIZATION_NVP(t_);
-      ar& BOOST_SERIALIZATION_NVP(s_);
+    void serialize(Archive & ar, const unsigned int /*version*/) {
+      ar & BOOST_SERIALIZATION_NVP(R_);
+      ar & BOOST_SERIALIZATION_NVP(t_);
+      ar & BOOST_SERIALIZATION_NVP(s_);
     }
-#endif
+  #endif
 
-    /// @}
-  };
+  /// @}
+};
 
-  template <>
-  struct traits<Similarity2> : public internal::MatrixLieGroup<Similarity2> {};
+template <>
+struct traits<Similarity2> : public internal::MatrixLieGroup<Similarity2> {};
 
-  template <>
-  struct traits<const Similarity2> : public internal::MatrixLieGroup<Similarity2> {};
+template <>
+struct traits<const Similarity2> : public internal::MatrixLieGroup<Similarity2> {};
 
 }  // namespace gtsam

--- a/gtsam/geometry/Similarity2.h
+++ b/gtsam/geometry/Similarity2.h
@@ -9,11 +9,11 @@
 
  * -------------------------------------------------------------------------- */
 
-/**
- * @file   Similarity2.h
- * @brief  Implementation of Similarity2 transform
- * @author John Lambert, Varun Agrawal
- */
+ /**
+  * @file   Similarity2.h
+  * @brief  Implementation of Similarity2 transform
+  * @author John Lambert, Varun Agrawal
+  */
 
 #pragma once
 
@@ -26,203 +26,203 @@
 
 namespace gtsam {
 
-// Forward declarations
-class Pose2;
-
-/**
- * 2D similarity transform
- */
-class GTSAM_EXPORT Similarity2 : public LieGroup<Similarity2, 4> {
-  /// @name Pose Concept
-  /// @{
-  typedef Rot2 Rotation;
-  typedef Point2 Translation;
-  /// @}
-
- private:
-  Rot2 R_;
-  Point2 t_;
-  double s_;
-
- public:
-  /// @name Constructors
-  /// @{
-
-  /// Default constructor
-  Similarity2();
-
-  /// Construct pure scaling
-  Similarity2(double s);
-
-  /// Construct from GTSAM types
-  Similarity2(const Rot2& R, const Point2& t, double s);
-
-  /// Construct from Eigen types
-  Similarity2(const Matrix2& R, const Vector2& t, double s);
-
-  /// Construct from matrix [R t; 0 s^-1]
-  Similarity2(const Matrix3& T);
-
-  /// @}
-  /// @name Testable
-  /// @{
-
-  /// Compare with tolerance
-  bool equals(const Similarity2& sim, double tol) const;
-
-  /// Exact equality
-  bool operator==(const Similarity2& other) const;
-
-  /// Print with optional string
-  void print(const std::string& s = "") const;
-
-  GTSAM_EXPORT friend std::ostream& operator<<(std::ostream& os,
-                                               const Similarity2& p);
-
-  /// @}
-  /// @name Group
-  /// @{
-
-  /// Return an identity transform
-  static Similarity2 Identity();
-
-  /// Composition
-  Similarity2 operator*(const Similarity2& S) const;
-
-  /// Return the inverse
-  Similarity2 inverse() const;
-
-  /// @}
-  /// @name Group action on Point2
-  /// @{
-
-  /// Action on a point p is s*(R*p+t)
-  Point2 transformFrom(const Point2& p) const;
+  // Forward declarations
+  class Pose2;
 
   /**
-   * Action on a pose T.
-   * |Rs  ts|   |R t|   |Rs*R Rs*t+ts|
-   * |0  1/s| * |0 1| = | 0      1/s |, the result is still a Sim2 object.
-   * To retrieve a Pose2, we normalized the scale value into 1.
-   * |Rs*R Rs*t+ts|   |Rs*R s(Rs*t+ts)|
-   * | 0      1/s | = |  0       1    |
-   *
-   * This group action satisfies the compatibility condition.
-   * For more details, refer to: https://en.wikipedia.org/wiki/Group_action
+   * 2D similarity transform
    */
-  Pose2 transformFrom(const Pose2& T) const;
+  class GTSAM_EXPORT Similarity2 : public LieGroup<Similarity2, 4> {
+    /// @name Pose Concept
+    /// @{
+    typedef Rot2 Rotation;
+    typedef Point2 Translation;
+    /// @}
 
-  /* syntactic sugar for transformFrom */
-  Point2 operator*(const Point2& p) const;
+  private:
+    Rot2 R_;
+    Point2 t_;
+    double s_;
 
-  /**
-   *  Create Similarity2 by aligning at least two point pairs
-   */
-  static Similarity2 Align(const Point2Pairs& abPointPairs);
+  public:
+    /// @name Constructors
+    /// @{
 
-  /**
-   * Create the Similarity2 object that aligns at least two pose pairs.
-   * Each pair is of the form (aTi, bTi).
-   * Given a list of pairs in frame a, and a list of pairs in frame b,
-   Align()
-   * will compute the best-fit Similarity2 aSb transformation to align them.
-   * First, the rotation aRb will be computed as the average (Karcher mean)
-   of
-   * many estimates aRb (from each pair). Afterwards, the scale factor will
-   be computed
-   * using the algorithm described here:
-   * http://www5.informatik.uni-erlangen.de/Forschung/Publikationen/2005/Zinsser05-PSR.pdf
-   */
-  static Similarity2 Align(const Pose2Pairs& abPosePairs);
+    /// Default constructor
+    Similarity2();
 
-  /// @}
-  /// @name Lie Group
-  /// @{
+    /// Construct pure scaling
+    Similarity2(double s);
 
-  using LieAlgebra = Matrix3;
+    /// Construct from GTSAM types
+    Similarity2(const Rot2& R, const Point2& t, double s);
 
-  /// Calculate expmap and logmap coefficients.
-  static Matrix2 GetV(double theta, double lambda);
+    /// Construct from Eigen types
+    Similarity2(const Matrix2& R, const Vector2& t, double s);
 
-  /**
-   * Log map at the identity
-   * \f$ [t_x, t_y, \delta, \lambda] \f$
-   */
-  static Vector4 Logmap(const Similarity2& S,  //
-                        OptionalJacobian<4, 4> Hm = {});
+    /// Construct from matrix [R t; 0 s^-1]
+    Similarity2(const Matrix3& T);
 
-  /// Exponential map at the identity
-  static Similarity2 Expmap(const Vector4& v,  //
-                            OptionalJacobian<4, 4> Hm = {});
+    /// @}
+    /// @name Testable
+    /// @{
 
-  /// Chart at the origin
-  struct ChartAtOrigin {
-    static Similarity2 Retract(const Vector4& v,
-                               ChartJacobian H = {}) {
-      return Similarity2::Expmap(v, H);
-    }
-    static Vector4 Local(const Similarity2& other,
-                         ChartJacobian H = {}) {
-      return Similarity2::Logmap(other, H);
-    }
-  };
+    /// Compare with tolerance
+    bool equals(const Similarity2& sim, double tol) const;
 
-  /// Project from one tangent space to another
-  Matrix4 AdjointMap() const;
+    /// Exact equality
+    bool operator==(const Similarity2& other) const;
 
-  using LieGroup<Similarity2, 4>::inverse;
+    /// Print with optional string
+    void print(const std::string& s = "") const;
 
-  /// Hat maps from tangent vector to Lie algebra
-  static Matrix3 Hat(const Vector4& xi);
+    GTSAM_EXPORT friend std::ostream& operator<<(std::ostream& os,
+      const Similarity2& p);
 
-  /// Vee maps from Lie algebra to tangent vector
-  static Vector4 Vee(const Matrix3& X);
+    /// @}
+    /// @name Group
+    /// @{
 
-  /// @}
-  /// @name Standard interface
-  /// @{
+    /// Return an identity transform
+    static Similarity2 Identity();
 
-  /// Calculate 4*4 matrix group equivalent
-  Matrix3 matrix() const;
+    /// Composition
+    Similarity2 operator*(const Similarity2& S) const;
 
-  /// Return vectorized Similarity2 matrix in column order
-  Vector9 vec(OptionalJacobian<9, 4> H = {}) const;
+    /// Return the inverse
+    Similarity2 inverse() const;
 
-  /// Return a GTSAM rotation
-  Rot2 rotation() const { return R_; }
+    /// @}
+    /// @name Group action on Point2
+    /// @{
 
-  /// Return a GTSAM translation
-  Point2 translation() const { return t_; }
+    /// Action on a point p is s*(R*p+t)
+    Point2 transformFrom(const Point2& p) const;
 
-  /// Return the scale
-  double scale() const { return s_; }
+    /**
+     * Action on a pose T.
+     * |Rs  ts|   |R t|   |Rs*R Rs*t+ts|
+     * |0  1/s| * |0 1| = | 0      1/s |, the result is still a Sim2 object.
+     * To retrieve a Pose2, we normalized the scale value into 1.
+     * |Rs*R Rs*t+ts|   |Rs*R s(Rs*t+ts)|
+     * | 0      1/s | = |  0       1    |
+     *
+     * This group action satisfies the compatibility condition.
+     * For more details, refer to: https://en.wikipedia.org/wiki/Group_action
+     */
+    Pose2 transformFrom(const Pose2& T) const;
 
-  /// Dimensionality of tangent space = 4 DOF - used to autodetect sizes
-  inline static size_t Dim() { return 4; }
+    /* syntactic sugar for transformFrom */
+    Point2 operator*(const Point2& p) const;
 
-  /// Dimensionality of tangent space = 4 DOF
-  inline size_t dim() const { return 4; }
+    /**
+     *  Create Similarity2 by aligning at least two point pairs
+     */
+    static Similarity2 Align(const Point2Pairs& abPointPairs);
 
- private:
+    /**
+     * Create the Similarity2 object that aligns at least two pose pairs.
+     * Each pair is of the form (aTi, bTi).
+     * Given a list of pairs in frame a, and a list of pairs in frame b,
+     Align()
+     * will compute the best-fit Similarity2 aSb transformation to align them.
+     * First, the rotation aRb will be computed as the average (Karcher mean)
+     of
+     * many estimates aRb (from each pair). Afterwards, the scale factor will
+     be computed
+     * using the algorithm described here:
+     * http://www5.informatik.uni-erlangen.de/Forschung/Publikationen/2005/Zinsser05-PSR.pdf
+     */
+    static Similarity2 Align(const Pose2Pairs& abPosePairs);
 
-  #if GTSAM_ENABLE_BOOST_SERIALIZATION
+    /// @}
+    /// @name Lie Group
+    /// @{
+
+    using LieAlgebra = Matrix3;
+
+    /// Calculate expmap and logmap coefficients.
+    static Matrix2 GetV(double theta, double lambda);
+
+    /**
+     * Log map at the identity
+     * \f$ [t_x, t_y, \delta, \lambda] \f$
+     */
+    static Vector4 Logmap(const Similarity2& S,  //
+      OptionalJacobian<4, 4> Hm = {});
+
+    /// Exponential map at the identity
+    static Similarity2 Expmap(const Vector4& v,  //
+      OptionalJacobian<4, 4> Hm = {});
+
+    /// Chart at the origin
+    struct ChartAtOrigin {
+      static Similarity2 Retract(const Vector4& v,
+        ChartJacobian H = {}) {
+        return Similarity2::Expmap(v, H);
+      }
+      static Vector4 Local(const Similarity2& other,
+        ChartJacobian H = {}) {
+        return Similarity2::Logmap(other, H);
+      }
+    };
+
+    /// Project from one tangent space to another
+    Matrix4 AdjointMap() const;
+
+    using LieGroup<Similarity2, 4>::inverse;
+
+    /// Hat maps from tangent vector to Lie algebra
+    static Matrix3 Hat(const Vector4& xi);
+
+    /// Vee maps from Lie algebra to tangent vector
+    static Vector4 Vee(const Matrix3& X);
+
+    /// @}
+    /// @name Standard interface
+    /// @{
+
+    /// Calculate 4*4 matrix group equivalent
+    Matrix3 matrix() const;
+
+    /// Return vectorized Similarity2 matrix in column order
+    Vector9 vec(OptionalJacobian<9, 4> H = {}) const;
+
+    /// Return a GTSAM rotation
+    Rot2 rotation() const { return R_; }
+
+    /// Return a GTSAM translation
+    Point2 translation() const { return t_; }
+
+    /// Return the scale
+    double scale() const { return s_; }
+
+    /// Dimensionality of tangent space = 4 DOF - used to autodetect sizes
+    inline static size_t Dim() { return 4; }
+
+    /// Dimensionality of tangent space = 4 DOF
+    inline size_t dim() const { return 4; }
+
+  private:
+
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
     /** Serialization function */
     friend class boost::serialization::access;
     template<class Archive>
-    void serialize(Archive & ar, const unsigned int /*version*/) {
-      ar & BOOST_SERIALIZATION_NVP(R_);
-      ar & BOOST_SERIALIZATION_NVP(t_);
-      ar & BOOST_SERIALIZATION_NVP(s_);
+    void serialize(Archive& ar, const unsigned int /*version*/) {
+      ar& BOOST_SERIALIZATION_NVP(R_);
+      ar& BOOST_SERIALIZATION_NVP(t_);
+      ar& BOOST_SERIALIZATION_NVP(s_);
     }
-  #endif
+#endif
 
-  /// @}
-};
+    /// @}
+  };
 
-template <>
-struct traits<Similarity2> : public internal::MatrixLieGroup<Similarity2> {};
+  template <>
+  struct traits<Similarity2> : public internal::MatrixLieGroup<Similarity2> {};
 
-template <>
-struct traits<const Similarity2> : public internal::MatrixLieGroup<Similarity2> {};
+  template <>
+  struct traits<const Similarity2> : public internal::MatrixLieGroup<Similarity2> {};
 
 }  // namespace gtsam

--- a/gtsam/geometry/Similarity2.h
+++ b/gtsam/geometry/Similarity2.h
@@ -216,9 +216,9 @@ public:
 };
 
 template <>
-struct traits<Similarity2> : public internal::MatrixLieGroup<Similarity2> {};
+struct traits<Similarity2> : public internal::MatrixLieGroup<Similarity2, 3> {};
 
 template <>
-struct traits<const Similarity2> : public internal::MatrixLieGroup<Similarity2> {};
+struct traits<const Similarity2> : public internal::MatrixLieGroup<Similarity2, 3> {};
 
 }  // namespace gtsam

--- a/gtsam/geometry/Similarity2.h
+++ b/gtsam/geometry/Similarity2.h
@@ -17,8 +17,7 @@
 
 #pragma once
 
-#include <gtsam/base/Lie.h>
-#include <gtsam/base/Manifold.h>
+#include <gtsam/base/MatrixLieGroup.h>
 #include <gtsam/dllexport.h>
 #include <gtsam/geometry/Point2.h>
 #include <gtsam/geometry/Pose2.h>
@@ -32,7 +31,7 @@ namespace gtsam {
   /**
    * 2D similarity transform
    */
-  class GTSAM_EXPORT Similarity2 : public LieGroup<Similarity2, 4> {
+  class GTSAM_EXPORT Similarity2 : public MatrixLieGroup<Similarity2, 4, 3> {
     /// @name Pose Concept
     /// @{
     typedef Rot2 Rotation;
@@ -182,11 +181,8 @@ namespace gtsam {
     /// @name Standard interface
     /// @{
 
-    /// Calculate 4*4 matrix group equivalent
+    /// Calculate 3*3 matrix group equivalent
     Matrix3 matrix() const;
-
-    /// Return vectorized Similarity2 matrix in column order
-    Vector9 vec(OptionalJacobian<9, 4> H = {}) const;
 
     /// Return a GTSAM rotation
     Rot2 rotation() const { return R_; }

--- a/gtsam/geometry/Similarity3.cpp
+++ b/gtsam/geometry/Similarity3.cpp
@@ -295,42 +295,7 @@ Matrix4 Similarity3::matrix() const {
   return T;
 }
 
-namespace {
-// The 16x7 matrix of vectorized generators for Sim(3).
-// The columns correspond to perturbations in [w_x, w_y, w_z, u_x, u_y, u_z, lambda].
-// P_sim3 = [vec(G_wx), vec(G_wy), vec(G_wz), vec(G_ux), vec(G_uy), vec(G_uz), vec(G_lambda)]
-  static const Eigen::Matrix<double, 16, 7> P_sim3 =
-    (Eigen::Matrix<double, 16, 7>() <<
-      // wx,  wy,  wz,  ux,  uy,  uz,  la
-      0, 0, 0, 0, 0, 0, 0,
-      0, 0, 1, 0, 0, 0, 0,
-      0, -1, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0,
-      0, 0, -1, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0,
-      1, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0,
-      0, 1, 0, 0, 0, 0, 0,
-      -1, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 1, 0, 0, 0,
-      0, 0, 0, 0, 1, 0, 0,
-      0, 0, 0, 0, 0, 1, 0,
-      0, 0, 0, 0, 0, 0, -1
-      ).finished();
-} // namespace
 
-Similarity3::Vector16 Similarity3::vec(OptionalJacobian<16, 7> H) const {
-  const Matrix4 T = this->matrix();
-  if (H) {
-    // The Jacobian is given by the formula H = (I_4 ⊗ T) * P_sim3
-    // where P_sim3 is the matrix of vectorized generators.
-    *H << T * P_sim3.block<4, 7>(0, 0), T* P_sim3.block<4, 7>(4, 0),
-      T* P_sim3.block<4, 7>(8, 0), T* P_sim3.block<4, 7>(12, 0);
-  }
-  return Eigen::Map<const Vector16>(T.data());
-}
 
 
 } // namespace gtsam

--- a/gtsam/geometry/Similarity3.h
+++ b/gtsam/geometry/Similarity3.h
@@ -248,9 +248,9 @@ inline Matrix wedge<Similarity3>(const Vector& xi) {
 }
 #endif
 template <>
-struct traits<Similarity3> : public internal::MatrixLieGroup<Similarity3> {};
+struct traits<Similarity3> : public internal::MatrixLieGroup<Similarity3, 4> {};
 
 template <>
-struct traits<const Similarity3> : public internal::MatrixLieGroup<Similarity3> {};
+struct traits<const Similarity3> : public internal::MatrixLieGroup<Similarity3, 4> {};
 
 }  // namespace gtsam

--- a/gtsam/geometry/Similarity3.h
+++ b/gtsam/geometry/Similarity3.h
@@ -33,7 +33,7 @@ class Pose3;
 /**
  * 3D similarity transform
  */
-class GTSAM_EXPORT Similarity3 : public LieGroup<Similarity3, 7> {
+class GTSAM_EXPORT Similarity3 : public MatrixLieGroup<Similarity3, 7, 4> {
  public:
   /// @name Pose Concept
   /// @{
@@ -67,8 +67,7 @@ class GTSAM_EXPORT Similarity3 : public LieGroup<Similarity3, 7> {
   /// Construct from matrix [R t; 0 s^-1]
   Similarity3(const Matrix4& T);
 
-  /// Vectorize 4x4 matrix into a 16-dim vector.
-  Vector16 vec(OptionalJacobian<16, 7> H = {}) const;
+  
 
   /// @}
   /// @name Testable

--- a/gtsam/geometry/tests/testGal3.cpp
+++ b/gtsam/geometry/tests/testGal3.cpp
@@ -1181,6 +1181,8 @@ TEST(Gal3, vec) {
 
     // 1. Test the Value
     const Matrix5 T = gal3.matrix();
+
+    using Vector25 = Eigen::Matrix<double, 25, 1>;
     const Vector25 expected_vec = Eigen::Map<const Vector25>(T.data());
     Vector25 actual_vec = gal3.vec();
     EXPECT(assert_equal(expected_vec, actual_vec, 1e-9));

--- a/gtsam/geometry/tests/testGal3.cpp
+++ b/gtsam/geometry/tests/testGal3.cpp
@@ -1171,7 +1171,7 @@ TEST(Gal3, ExpLog_NearZero) {
 }
 
 //******************************************************************************
-TEST(Gal3, vec) {
+TEST(Gal3, Vec) {
     // Create a non-trivial Gal3 object
     const Rot3 R_test = Rot3::Rodrigues(0.1, 0.2, 0.3);
     const Point3 r_test(1.0, 2.0, 3.0);

--- a/gtsam/geometry/tests/testGal3.cpp
+++ b/gtsam/geometry/tests/testGal3.cpp
@@ -203,7 +203,7 @@ TEST(Gal3, Expmap) {
     EXPECT(assert_equal(expected_exp_1, custom_exp_1, kTol));
 
     // Check derivatives
-    Matrix10 aH;
+    Gal3::Jacobian aH;
     Gal3::Expmap(tau_vec_1, aH);
     std::function<Gal3(const Vector10&)> expmap_func = [](const Vector10& v){ return Gal3::Expmap(v); };
     Matrix expectedH = numericalDerivative11(expmap_func, tau_vec_1);
@@ -458,7 +458,7 @@ TEST(Gal3, Adjoint) {
     const Gal3 test_g(Rot3(g_R_mat_1), g_r_vec_1, g_v_vec_1, g_t_val_1);
 
     // Expected Adjoint Map
-    Matrix10 expected_adj_matrix = (Matrix10() <<
+    Gal3::Jacobian expected_adj_matrix = (Gal3::Jacobian() <<
         -0.2577418495238488, 0.7767168385303765, 0.5747000015202739, -0.011651451315476903, 0.03511218083817791, 0.025979828658358354, 0.22110620799336958, 0.3876840721487304, -0.42479976201969083, 0.536459189623808,
         -0.6694062876067332, -0.572463082520484, 0.47347781496466923, -0.03026111120383766, -0.025878706730076754, 0.021403988992128208, -0.6381411631187845, 0.6286520658991062, -0.14213043434767314, -0.44445057839362445,
          0.6967527259484512, -0.26267274676776586, 0.6674868290752107, 0.03149733145902263, -0.011874356944831452, 0.03017434036055619, -0.5313038186955878, -0.22369794100291154, 0.4665680546909384, 0.10793991159086103,
@@ -471,7 +471,7 @@ TEST(Gal3, Adjoint) {
          0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0
     ).finished();
 
-    Matrix10 computed_adj = test_g.AdjointMap();
+    Gal3::Jacobian computed_adj = test_g.AdjointMap();
     EXPECT(assert_equal(expected_adj_matrix, computed_adj, kTol * 10)); // Slightly larger tolerance
 
     // Test tangent vector for adjoint action
@@ -537,7 +537,7 @@ TEST(Gal3, Jacobian_Compose) {
     Gal3 g2(Rot3(g2_R_mat), g2_r_vec, g2_v_vec, g2_t_val);
 
     // Expected Jacobians
-    Matrix10 expected_H1 = (Matrix10() <<
+    Gal3::Jacobian expected_H1 = (Gal3::Jacobian() <<
         -0.5204974727334908, 0.773189425449982, 0.3622989004266723, 0.12990890682589473, -0.19297729247761214, -0.09042475048241341, -0.2823811043440715, 0.3598327802048799, -1.1736098322206205, 0.6973186192002845,
          0.7067813015326174, 0.15205374379417114, 0.6908978584436601, -0.17640275132344085, -0.03795049288394836, -0.17243846554606443, -0.650366876876537, 0.542434959867202, 0.5459387038042347, -0.4800290630417764,
          0.4791060140322894, 0.6156766776243058, -0.6256194178153267, -0.11957817625853331, -0.15366430835548997, 0.15614587757865273, 0.652649909196605, -0.5858564732208887, -0.07673941868885611, 0.0008110342596663322,
@@ -549,9 +549,9 @@ TEST(Gal3, Jacobian_Compose) {
          0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.4791060140322894, 0.6156766776243058, -0.6256194178153267, 0.0,
          0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0
     ).finished();
-    Matrix10 expected_H2 = Matrix10::Identity();
+    Gal3::Jacobian expected_H2 = Gal3::Jacobian::Identity();
 
-    Matrix10 H1, H2;
+    Gal3::Jacobian H1, H2;
     g1.compose(g2, H1, H2);
 
     EXPECT(assert_equal(expected_H1, H1, kTol));
@@ -572,7 +572,7 @@ TEST(Gal3, Jacobian_Inverse) {
     Gal3 g(Rot3(g_R_mat), g_r_vec, g_v_vec, g_t_val);
 
     // Expected Jacobian
-    Matrix10 expected_H = (Matrix10() <<
+    Gal3::Jacobian expected_H = (Gal3::Jacobian() <<
         -0.6680516673568877, -0.2740542884848495, 0.6918101016209183, 0.2510022299990406, 0.10296843928652219, -0.2599288149818328, -0.33617296841685484, -0.7460372203093872, -0.6201638436054394, -0.4770686298036335,
         -0.6729369985913887, 0.6193062871756463, -0.4044941514923666, 0.252837760234292, -0.23268748021920607, 0.1519776673080509, 0.04690510412308051, 0.0894976987957895, 0.05899296065652178, -0.2799576331302327,
         0.31758898858193396, 0.7357676057205693, 0.5981498680963873, -0.1193254178566693, -0.27644465064744467, -0.22473853161662533, -0.6077563738775408, -0.3532109665151345, 0.7571646227598928, 0.29190264050471715,
@@ -585,7 +585,7 @@ TEST(Gal3, Jacobian_Inverse) {
         -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -1.0
     ).finished();
 
-    Matrix10 H;
+    Gal3::Jacobian H;
     g.inverse(H);
 
     EXPECT(assert_equal(expected_H, H, kTol));
@@ -613,7 +613,7 @@ TEST(Gal3, Jacobian_Logmap) {
         -0.24958604725524136
     ).finished();
 
-    Matrix10 Hg1_gtsam;
+    Gal3::Jacobian Hg1_gtsam;
     Vector10 log1_gtsam = Gal3::Logmap(g1, Hg1_gtsam);
     EXPECT(assert_equal(expected_log_tau1, log1_gtsam, kTol));
 
@@ -641,7 +641,7 @@ TEST(Gal3, Jacobian_Logmap) {
          0.3757227805330059
     ).finished();
 
-    Matrix10 Hg2_gtsam;
+    Gal3::Jacobian Hg2_gtsam;
     Vector10 log2_gtsam = Gal3::Logmap(g2, Hg2_gtsam);
     EXPECT(assert_equal(expected_log_tau2, log2_gtsam, kTol));
 
@@ -663,7 +663,7 @@ TEST(Gal3, Jacobian_Expmap) {
     ).finished();
 
     // Expected Jacobian
-    Matrix10 expected_H = (Matrix10() <<
+    Gal3::Jacobian expected_H = (Gal3::Jacobian() <<
         0.9844524218735122, -0.1490063714302354, 0.02908427677999133, -0.24094497482047258, 0.04906744369191897, -0.008766606502586993, 0.0010755746403492512, 0.020896120374367614, 0.09422195803906698, -0.032194210151797825,
         0.13700585416694203, 0.9624511801109918, 0.18991633864490795, -0.04463269623239319, -0.23281449603592955, -0.06241249224896669, -0.05013517822202011, -0.011608679508659724, 0.08214064896800377, 0.05141115662809599,
        -0.06540787266535304, -0.1806541475679301, 0.9749387339968734, 0.0221898591040537, 0.05898968326106501, -0.23742922610598202, -0.09935687017740953, -0.06570748233856251, -0.025136525844073204, 0.1253312320983055,
@@ -676,7 +676,7 @@ TEST(Gal3, Jacobian_Expmap) {
         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0
     ).finished();
 
-    Matrix10 H;
+    Gal3::Jacobian H;
     Gal3::Expmap(tau_vec, H);
 
     EXPECT(assert_equal(expected_H, H, kTol));
@@ -706,7 +706,7 @@ TEST(Gal3, Jacobian_Between) {
     double g2_t_val = -0.41496643117394594;
     Gal3 g2(Rot3(g2_R_mat), g2_r_vec, g2_v_vec, g2_t_val);
 
-    Matrix10 H1_analytical, H2_analytical;
+    Gal3::Jacobian H1_analytical, H2_analytical;
     g1.between(g2, H1_analytical, H2_analytical);
 
     std::function<Gal3(const Gal3&, const Gal3&)> between_func =
@@ -738,7 +738,7 @@ TEST(Gal3, Jacobian_AdjointMap) {
     Vector10 xi = (Vector10() << 0.1, -0.2, 0.3, 0.4, -0.5, 0.6, -0.1, 0.15, -0.25, 0.9).finished();
 
     // Analytical Adjoint Map
-    Matrix10 Ad_analytical = g.AdjointMap();
+    Gal3::Jacobian Ad_analytical = g.AdjointMap();
 
     // Numerical derivative of Adjoint action Ad_g(xi) w.r.t xi should equal Adjoint Map
     std::function<Vector10(const Gal3&, const Vector10&)> adjoint_action =
@@ -749,7 +749,7 @@ TEST(Gal3, Jacobian_AdjointMap) {
     EXPECT(assert_equal(Ad_analytical, H_xi_numerical, 1e-7)); // Tolerance for numerical diff
 
     // Verify derivative of Adjoint action Ad_g(xi) w.r.t g
-    Matrix10 H_g_analytical;
+    Gal3::Jacobian H_g_analytical;
     g.Adjoint(xi, H_g_analytical); // Calculate analytical H_g
 
     // Need wrapper that only returns value for numericalDerivative21
@@ -775,7 +775,7 @@ TEST(Gal3, Jacobian_Inverse2) {
     Gal3 g = Gal3(Rot3(g1_R_mat), g1_r_vec, g1_v_vec, g1_t_val);
 
     // Analytical Jacobian H_inv = d(g.inverse()) / d(g)
-    Matrix10 H_inv_analytical;
+    Gal3::Jacobian H_inv_analytical;
     g.inverse(H_inv_analytical);
 
     // Numerical Jacobian
@@ -785,7 +785,7 @@ TEST(Gal3, Jacobian_Inverse2) {
 
     EXPECT(assert_equal(H_inv_numerical, H_inv_analytical, 1e-5));
 
-    Matrix10 expected_adjoint = -g.AdjointMap(); // Check against -Ad(g) for right perturbations
+    Gal3::Jacobian expected_adjoint = -g.AdjointMap(); // Check against -Ad(g) for right perturbations
     EXPECT(assert_equal(expected_adjoint, H_inv_analytical, 1e-8));
 
 }
@@ -814,7 +814,7 @@ TEST(Gal3, Jacobian_Compose2) {
     Gal3 g2(Rot3(g2_R_mat), g2_r_vec, g2_v_vec, g2_t_val);
 
     // Analytical Jacobians
-    Matrix10 H1_analytical, H2_analytical;
+    Gal3::Jacobian H1_analytical, H2_analytical;
     g1.compose(g2, H1_analytical, H2_analytical);
 
     // Numerical Jacobians
@@ -828,7 +828,7 @@ TEST(Gal3, Jacobian_Compose2) {
 
     // Check analytical Jacobians against theoretical formulas
     EXPECT(assert_equal(g2.inverse().AdjointMap(), H1_analytical, 1e-8));
-    EXPECT(assert_equal(gtsam::Matrix10(Matrix10::Identity()), H2_analytical, 1e-8));
+    EXPECT(assert_equal(gtsam::Gal3::Jacobian(Gal3::Jacobian::Identity()), H2_analytical, 1e-8));
 }
 
 /* ************************************************************************* */
@@ -1103,7 +1103,7 @@ TEST(Gal3, StaticAdjoint) {
     Vector10 y = (Vector10() << -0.5, 0.4, -0.3, 0.2, -0.1, 0.0, 0.3, -0.35, 0.45, -0.1).finished();
 
     // Test static adjointMap
-    Matrix10 ad_xi_map = Gal3::adjointMap(xi);
+    Gal3::Jacobian ad_xi_map = Gal3::adjointMap(xi);
     Vector10 ad_xi_map_times_y = ad_xi_map * y;
     Vector10 ad_xi_y_direct = Gal3::adjoint(xi, y);
     EXPECT(assert_equal(ad_xi_map_times_y, ad_xi_y_direct, kTol)); // Check ad(xi)*y == [xi,y]
@@ -1208,10 +1208,10 @@ TEST(Gal3, AdjointMap) {
   const Gal3 gal3(R, r, v, t);
 
   // Call the specialized AdjointMap
-  Matrix10 specialized_Adj = gal3.AdjointMap();
+  Gal3::Jacobian specialized_Adj = gal3.AdjointMap();
 
   // Call the generic AdjointMap from the base class
-  Matrix10 generic_Adj = static_cast<const MatrixLieGroup<Gal3, 10, 5>*>(&gal3)->AdjointMap();
+  Gal3::Jacobian generic_Adj = static_cast<const MatrixLieGroup<Gal3, 10, 5>*>(&gal3)->AdjointMap();
 
   // Assert that they are equal
   EXPECT(assert_equal(specialized_Adj, generic_Adj, kTol));

--- a/gtsam/geometry/tests/testGal3.cpp
+++ b/gtsam/geometry/tests/testGal3.cpp
@@ -1197,6 +1197,26 @@ TEST(Gal3, vec) {
     EXPECT(assert_equal(H_numerical, H_actual, 1e-7));
 }
 
+//******************************************************************************
+
+TEST(Gal3, AdjointMap) {
+  // Create a non-trivial Gal3 object
+  const Rot3 R = Rot3::Rodrigues(0.1, 0.2, 0.3);
+  const Point3 r(1.0, 2.0, 3.0);
+  const Velocity3 v(0.4, 0.5, 0.6);
+  const double t = 0.7;
+  const Gal3 gal3(R, r, v, t);
+
+  // Call the specialized AdjointMap
+  Matrix10 specialized_Adj = gal3.AdjointMap();
+
+  // Call the generic AdjointMap from the base class
+  Matrix10 generic_Adj = static_cast<const MatrixLieGroup<Gal3, 10, 5>*>(&gal3)->AdjointMap();
+
+  // Assert that they are equal
+  EXPECT(assert_equal(specialized_Adj, generic_Adj, kTol));
+}
+
 /* ************************************************************************* */
 int main() {
     TestResult tr;

--- a/gtsam/geometry/tests/testGal3.cpp
+++ b/gtsam/geometry/tests/testGal3.cpp
@@ -34,7 +34,7 @@ static const double kTol = 1e-8;
 
 // Instantiate Testable and Lie concepts for Gal3
 GTSAM_CONCEPT_TESTABLE_INST(gtsam::Gal3)
-GTSAM_CONCEPT_LIE_INST(gtsam::Gal3)
+GTSAM_CONCEPT_MATRIX_LIE_GROUP_INST(gtsam::Gal3)
 
 // Define common test values
 const Rot3 kTestRot = Rot3::RzRyRx(0.1, -0.2, 0.3);

--- a/gtsam/geometry/tests/testPose2.cpp
+++ b/gtsam/geometry/tests/testPose2.cpp
@@ -959,7 +959,7 @@ TEST(Pose2, Print) {
 }
 
 /* ************************************************************************* */
-TEST(Pose2, vec) {
+TEST(Pose2, Vec) {
   // Test a simple pose
   Pose2 pose(Rot2::fromAngle(M_PI / 4), Point2(1, 2));
 
@@ -973,6 +973,22 @@ TEST(Pose2, vec) {
   std::function<Vector9(const Pose2&)> f = [](const Pose2& p) { return p.vec(); };
   Matrix93 numericalH = numericalDerivative11<Vector9, Pose2>(f, pose);
   EXPECT(assert_equal(numericalH, actualH, 1e-9));
+}
+
+/* ************************************************************************* */
+
+TEST(Pose2, AdjointMap) {
+  // Create a non-trivial Pose2 object
+  const Pose2 pose(Rot2::fromAngle(0.5), Point2(1.0, 2.0));
+
+  // Call the specialized AdjointMap
+  Matrix3 specialized_Adj = pose.AdjointMap();
+
+  // Call the generic AdjointMap from the base class
+  Matrix3 generic_Adj = static_cast<const MatrixLieGroup<Pose2, 3, 3>*>(&pose)->AdjointMap();
+
+  // Assert that they are equal
+  EXPECT(assert_equal(specialized_Adj, generic_Adj, 1e-9));
 }
 
 /* ************************************************************************* */

--- a/gtsam/geometry/tests/testPose2.cpp
+++ b/gtsam/geometry/tests/testPose2.cpp
@@ -31,7 +31,7 @@ using namespace gtsam;
 using namespace std;
 
 GTSAM_CONCEPT_TESTABLE_INST(Pose2)
-GTSAM_CONCEPT_LIE_INST(Pose2)
+GTSAM_CONCEPT_MATRIX_LIE_GROUP_INST(Pose2)
 
 //******************************************************************************
 TEST(Pose2 , Concept) {

--- a/gtsam/geometry/tests/testPose3.cpp
+++ b/gtsam/geometry/tests/testPose3.cpp
@@ -31,7 +31,7 @@ using namespace gtsam;
 using namespace std::placeholders;
 
 GTSAM_CONCEPT_TESTABLE_INST(Pose3)
-GTSAM_CONCEPT_LIE_INST(Pose3)
+GTSAM_CONCEPT_MATRIX_LIE_GROUP_INST(Pose3)
 
 static const Point3 P(0.2,0.7,-2);
 static const Rot3 R = Rot3::Rodrigues(0.3,0,0);

--- a/gtsam/geometry/tests/testPose3.cpp
+++ b/gtsam/geometry/tests/testPose3.cpp
@@ -1457,7 +1457,7 @@ TEST(Pose3, ExpmapChainRule) {
 }
 
 /* ************************************************************************* */
-TEST(Pose3, vec) {
+TEST(Pose3, Vec) {
   // Test the 'vec' method
   using Vector16 = Eigen::Matrix<double, 16, 1>;
   Vector16 expected_vec = Eigen::Map<Vector16>(T.matrix().data());
@@ -1469,6 +1469,22 @@ TEST(Pose3, vec) {
   std::function<Vector16(const Pose3&)> f = [](const Pose3& p) { return p.vec(); };
   Matrix numericalH = numericalDerivative11<Vector16, Pose3>(f, T);
   EXPECT(assert_equal(numericalH, actualH, 1e-9));
+}
+
+/* ************************************************************************* */
+
+TEST(Pose3, AdjointMap) {
+  // Create a non-trivial Pose3 object
+  const Pose3 pose(Rot3::Rodrigues(0.1, 0.2, 0.3), Point3(1.0, 2.0, 3.0));
+
+  // Call the specialized AdjointMap
+  Matrix6 specialized_Adj = pose.AdjointMap();
+
+  // Call the generic AdjointMap from the base class
+  Matrix6 generic_Adj = static_cast<const MatrixLieGroup<Pose3, 6, 4>*>(&pose)->AdjointMap();
+
+  // Assert that they are equal
+  EXPECT(assert_equal(specialized_Adj, generic_Adj, 1e-9));
 }
 
 /* ************************************************************************* */

--- a/gtsam/geometry/tests/testQuaternion.cpp
+++ b/gtsam/geometry/tests/testQuaternion.cpp
@@ -27,6 +27,9 @@ using namespace gtsam;
 typedef Quaternion Q; // Typedef
 typedef traits<Q>::ChartJacobian QuaternionJacobian;
 
+GTSAM_CONCEPT_TESTABLE_INST(Quaternion)
+GTSAM_CONCEPT_MATRIX_LIE_GROUP_INST(Quaternion)
+
 //******************************************************************************
 TEST(Quaternion , Concept) {
   GTSAM_CONCEPT_ASSERT(IsGroup<Quaternion >);

--- a/gtsam/geometry/tests/testRot2.cpp
+++ b/gtsam/geometry/tests/testRot2.cpp
@@ -23,7 +23,7 @@
 using namespace gtsam;
 
 GTSAM_CONCEPT_TESTABLE_INST(Rot2)
-GTSAM_CONCEPT_LIE_INST(Rot2)
+GTSAM_CONCEPT_MATRIX_LIE_GROUP_INST(Rot2)
 
 Rot2 R(Rot2::fromAngle(0.1));
 Point2 P(0.2, 0.7);

--- a/gtsam/geometry/tests/testRot3.cpp
+++ b/gtsam/geometry/tests/testRot3.cpp
@@ -30,7 +30,7 @@ using namespace std;
 using namespace gtsam;
 
 GTSAM_CONCEPT_TESTABLE_INST(Rot3)
-GTSAM_CONCEPT_LIE_INST(Rot3)
+GTSAM_CONCEPT_MATRIX_LIE_GROUP_INST(Rot3)
 
 static Rot3 R = Rot3::Rodrigues(0.1, 0.4, 0.2);
 static Point3 P(0.2, 0.7, -2.0);

--- a/gtsam/geometry/tests/testRot3M.cpp
+++ b/gtsam/geometry/tests/testRot3M.cpp
@@ -26,7 +26,7 @@ using namespace std;
 using namespace gtsam;
 
 GTSAM_CONCEPT_TESTABLE_INST(Rot3)
-GTSAM_CONCEPT_LIE_INST(Rot3)
+GTSAM_CONCEPT_MATRIX_LIE_GROUP_INST(Rot3)
 
 static Rot3 R = Rot3::Rodrigues(0.1, 0.4, 0.2);
 static Point3 P(0.2, 0.7, -2.0);

--- a/gtsam/geometry/tests/testSO3.cpp
+++ b/gtsam/geometry/tests/testSO3.cpp
@@ -470,6 +470,23 @@ TEST(Matrix, compose) {
 }
 
 //******************************************************************************
+TEST(SO3, AdjointMap) {
+  // Create a non-trivial SO3
+  const SO3 R = SO3::Expmap(Vector3(0.1, 0.2, 0.3));
+
+  // Call the specialized AdjointMap
+  const Matrix3 specialized_Adj = R.AdjointMap();
+  EXPECT(assert_equal(R.matrix(), specialized_Adj));
+
+  // Call the generic AdjointMap from the base class
+  const Matrix3 generic_Adj =
+    static_cast<const MatrixLieGroup<SO3, 3, 3>*>(&R)->AdjointMap();
+
+  // Assert that they are equal
+  EXPECT(assert_equal(specialized_Adj, generic_Adj, 1e-9));
+}
+
+//******************************************************************************
 int main() {
   TestResult tr;
   return TestRegistry::runAllTests(tr);

--- a/gtsam/geometry/tests/testSimilarity2.cpp
+++ b/gtsam/geometry/tests/testSimilarity2.cpp
@@ -183,7 +183,7 @@ TEST(Similarity2, TransformFrom_Pose2) {
 }
 
 //******************************************************************************
-TEST(Similarity2, vec) {
+TEST(Similarity2, Vec) {
   const double theta = 0.3;
   const Rot2 R_test = Rot2::fromAngle(theta);
   const Point2 t_test(0.2, 0.7);
@@ -217,33 +217,14 @@ TEST(Similarity2, AdjointMap) {
   const double s = 0.5;
   const Similarity2 sim(R, t, s);
 
-  // 1. Calculate the Adjoint map using the fast, closed-form function.
-  // This is the "actual" value we want to test.
-  Matrix4 actual_Adj = sim.AdjointMap();
+  // Call the specialized AdjointMap
+  Matrix4 specialized_Adj = sim.AdjointMap();
 
-  // 2. Calculate the Adjoint map using the general, "brute force" definition.
-  // This is the "expected" ground truth.
-  // Ad_i = Vee(T * Hat(e_i) * T_inv)
+  // Call the generic AdjointMap from the base class
+  Matrix4 generic_Adj = static_cast<const MatrixLieGroup<Similarity2, 4, 3>*>(&sim)->AdjointMap();
 
-  // Get the 4 generators G_i = Hat(e_i) for sim(2)
-  std::vector<Matrix3> G;
-  for (int i = 0; i < 4; ++i) {
-    G.push_back(Similarity2::Hat(Vector4::Unit(i)));
-  }
-
-  // Calculate T and its inverse
-  const Matrix3 T = sim.matrix();
-  const Matrix3 T_inv = sim.inverse().matrix(); // Or calculate analytically
-
-  // Loop through columns to build the expected Adjoint matrix
-  Matrix4 expected_Adj;
-  for (int i = 0; i < 4; ++i) {
-    Matrix3 T_Gi_Tinv = T * G[i] * T_inv;
-    expected_Adj.col(i) = Similarity2::Vee(T_Gi_Tinv);
-  }
-
-  // 3. Assert that the two matrices are equal.
-  EXPECT(assert_equal(expected_Adj, actual_Adj, 1e-9));
+  // Assert that they are equal
+  EXPECT(assert_equal(specialized_Adj, generic_Adj, 1e-9));
 }
 
 //******************************************************************************

--- a/gtsam/geometry/tests/testSimilarity3.cpp
+++ b/gtsam/geometry/tests/testSimilarity3.cpp
@@ -110,34 +110,6 @@ TEST(Similarity3, BruteForceExpmap) {
 }
 
 //******************************************************************************
-TEST(Similarity3, AdjointMap) {
-  // 1. Calculate the Adjoint map using the fast, closed-form function.
-  Matrix7 actual = T2.AdjointMap();
-
-  // 2. Calculate the Adjoint map using the general, "brute force" definition.
-  // Ad_i = Vee(T * Hat(e_i) * T_inv)
-  // Get the 7 generators G_i = Hat(e_i) for sim(3)
-  std::vector<Matrix4> G;
-  for (int i = 0; i < 7; ++i) {
-    G.push_back(Similarity3::Hat(Vector7::Unit(i)));
-  }
-
-  // Calculate T and its inverse
-  const Matrix4 T = T2.matrix();
-  const Matrix4 T_inv = T2.inverse().matrix();
-
-  // Loop through columns to build the expected Adjoint matrix
-  Matrix7 expected;
-  for (int i = 0; i < 7; ++i) {
-    Matrix4 T_Gi_Tinv = T * G[i] * T_inv;
-    expected.col(i) = Similarity3::Vee(T_Gi_Tinv);
-  }
-
-  // 3. Assert that the two matrices are equal.
-  EXPECT(assert_equal(expected, actual));
-}
-
-//******************************************************************************
 TEST(Similarity3, inverse) {
   Similarity3 sim3(Rot3::Ypr(1, 2, 3).inverse(), Point3(4, 5, 6), 7);
   Matrix3 Re; // some values from matlab
@@ -570,7 +542,7 @@ TEST(Similarity3 , LieGroupDerivatives) {
 }
 
 //******************************************************************************
-TEST(Similarity3, vec) {
+TEST(Similarity3, Vec) {
   const Rot3 R_test = Rot3::Rodrigues(0.1, 0.2, 0.3);
   const Point3 t_test(0.4, 0.5, 0.6);
   const double s_test = 0.7;
@@ -594,6 +566,23 @@ TEST(Similarity3, vec) {
   EXPECT(assert_equal(H_numerical, H_actual, 1e-7));
 }
 
+//******************************************************************************
+TEST(Similarity3, AdjointMap) {
+  // Create a non-trivial Similarity3 object
+  const Rot3 R = Rot3::Rodrigues(0.3, 0.2, 0.1);
+  const Point3 t(3.5, -8.2, 4.2);
+  const double s = 1.0;
+  const Similarity3 sim(R, t, s);
+
+  // Call the specialized AdjointMap
+  Matrix7 specialized_Adj = sim.AdjointMap();
+
+  // Call the generic AdjointMap from the base class
+  Matrix7 generic_Adj = static_cast<const MatrixLieGroup<Similarity3, 7, 4>*>(&sim)->AdjointMap();
+
+  // Assert that they are equal
+  EXPECT(assert_equal(specialized_Adj, generic_Adj, 1e-9));
+}
 
 //******************************************************************************
 int main() {

--- a/gtsam/geometry/tests/testStereoPoint2.cpp
+++ b/gtsam/geometry/tests/testStereoPoint2.cpp
@@ -26,7 +26,7 @@ using namespace std;
 using namespace gtsam;
 
 GTSAM_CONCEPT_TESTABLE_INST(StereoPoint2)
-//GTSAM_CONCEPT_LIE_INST(StereoPoint2)
+//GTSAM_CONCEPT_MATRIX_LIE_GROUP_INST(StereoPoint2)
 
 
 //******************************************************************************

--- a/gtsam/navigation/NavState.h
+++ b/gtsam/navigation/NavState.h
@@ -303,9 +303,9 @@ private:
 
 // Specialize NavState traits to use a Retract/Local that agrees with IMUFactors
 template <>
-struct traits<NavState> : public internal::MatrixLieGroup<NavState> {};
+struct traits<NavState> : public internal::MatrixLieGroup<NavState, 5> {};
 
 template <>
-struct traits<const NavState> : public internal::MatrixLieGroup<NavState> {};
+struct traits<const NavState> : public internal::MatrixLieGroup<NavState, 5> {};
 
 } // namespace gtsam

--- a/gtsam/navigation/NavState.h
+++ b/gtsam/navigation/NavState.h
@@ -35,7 +35,7 @@ using Velocity3 = Vector3;
  * NOTE: While Barrau20icra follow a R,v,t order,
  * we use a R,t,v order to maintain backwards compatibility.
  */
-class GTSAM_EXPORT NavState : public LieGroup<NavState, 9> {
+class GTSAM_EXPORT NavState : public MatrixLieGroup<NavState, 9, 5> {
  private:
 
   // TODO(frank):

--- a/gtsam/navigation/tests/testNavState.cpp
+++ b/gtsam/navigation/tests/testNavState.cpp
@@ -30,7 +30,7 @@ using namespace std;
 using namespace gtsam;
 
 GTSAM_CONCEPT_TESTABLE_INST(NavState)
-GTSAM_CONCEPT_LIE_INST(NavState)
+GTSAM_CONCEPT_MATRIX_LIE_GROUP_INST(NavState)
 
 static const Rot3 kAttitude = Rot3::RzRyRx(0.1, 0.2, 0.3);
 static const Point3 kPosition(1.0, 2.0, 3.0);

--- a/gtsam/navigation/tests/testNavState.cpp
+++ b/gtsam/navigation/tests/testNavState.cpp
@@ -746,6 +746,38 @@ TEST(NavState, ChartDerivatives) {
 }
 
 /* ************************************************************************* */
+TEST(NavState, vec) {
+  // Test the 'vec' method
+  using Vector25 = Eigen::Matrix<double, 25, 1>;
+  const NavState navState(Rot3::Rodrigues(0.1, 0.2, 0.3), Point3(1.0, 2.0, 3.0), Velocity3(0.4, 0.5, 0.6));
+
+  Vector25 expected_vec = Eigen::Map<Vector25>(navState.matrix().data());
+  Eigen::Matrix<double, 25, 9> actualH;
+  Vector25 actual_vec = navState.vec(actualH);
+  EXPECT(assert_equal(expected_vec, actual_vec));
+
+  // Verify Jacobian with numerical derivatives
+  std::function<Vector25(const NavState&)> f = [](const NavState& p) { return p.vec(); };
+  Eigen::Matrix<double, 25, 9> numericalH = numericalDerivative11<Vector25, NavState>(f, navState);
+  EXPECT(assert_equal(numericalH, actualH, 1e-9));
+}
+
+/* ************************************************************************* */
+TEST(NavState, AdjointMap_GenericVsSpecialized) {
+  // Create a non-trivial NavState object
+  const NavState navState(Rot3::Rodrigues(0.1, 0.2, 0.3), Point3(1.0, 2.0, 3.0), Velocity3(0.4, 0.5, 0.6));
+
+  // Call the specialized AdjointMap
+  Matrix9 specialized_Adj = navState.AdjointMap();
+
+  // Call the generic AdjointMap from the base class
+  Matrix9 generic_Adj = static_cast<const MatrixLieGroup<NavState, 9, 5>*>(&navState)->AdjointMap();
+
+  // Assert that they are equal
+  EXPECT(assert_equal(specialized_Adj, generic_Adj, 1e-9));
+}
+
+/* ************************************************************************* */
 int main() {
   TestResult tr;
   return TestRegistry::runAllTests(tr);

--- a/gtsam/slam/FrobeniusFactor.h
+++ b/gtsam/slam/FrobeniusFactor.h
@@ -48,6 +48,7 @@ ConvertNoiseModel(const SharedNoiseModel &model, size_t n,
  */
 template <class T>
 class FrobeniusPrior : public NoiseModelFactorN<T> {
+  GTSAM_CONCEPT_ASSERT(IsMatrixLieGroup<T>);
   inline constexpr static auto N = T::LieAlgebra::RowsAtCompileTime;
   inline constexpr static auto Dim = N * N;
   using MatrixNN = Eigen::Matrix<double, N, N>;
@@ -69,7 +70,7 @@ class FrobeniusPrior : public NoiseModelFactorN<T> {
 
   /// Error is just Frobenius norm between T element and vectorized matrix M.
   Vector evaluateError(const T& g, OptionalMatrixType H) const override {
-    return g.vec(H) - vecM_;  // Jacobian is computed only when needed.
+    return traits<T>::Vec(g, H) - vecM_;  // Jacobian is computed only when needed.
   }
 };
 
@@ -79,6 +80,7 @@ class FrobeniusPrior : public NoiseModelFactorN<T> {
  */
 template <class T>
 class FrobeniusFactor : public NoiseModelFactorN<T, T> {
+  GTSAM_CONCEPT_ASSERT(IsMatrixLieGroup<T>);
   inline constexpr static auto N = T::LieAlgebra::RowsAtCompileTime;
   inline constexpr static auto Dim = N * N;
 
@@ -94,7 +96,7 @@ class FrobeniusFactor : public NoiseModelFactorN<T, T> {
   /// Error is just Frobenius norm between rotation matrices.
   Vector evaluateError(const T& T1, const T& T2,
                        OptionalMatrixType H1, OptionalMatrixType H2) const override {
-    Vector error = T2.vec(H2) - T1.vec(H1);
+    Vector error = traits<T>::Vec(T2, H2) - traits<T>::Vec(T1, H1);
     if (H1) *H1 = -*H1;
     return error;
   }
@@ -108,6 +110,7 @@ class FrobeniusFactor : public NoiseModelFactorN<T, T> {
  */
 template <class T>
 class FrobeniusBetweenFactor : public NoiseModelFactorN<T, T> {
+  GTSAM_CONCEPT_ASSERT(IsMatrixLieGroup<T>);
   T T12_;  ///< measured rotation between T1 and T2
   Eigen::Matrix<double, T::dimension, T::dimension>
       T2hat_H_T1_;  ///< fixed derivative of T2hat wrpt T1
@@ -129,7 +132,7 @@ class FrobeniusBetweenFactor : public NoiseModelFactorN<T, T> {
                          const SharedNoiseModel& model = nullptr)
       : NoiseModelFactorN<T, T>(ConvertNoiseModel(model, Dim), j1, j2),
         T12_(T12),
-        T2hat_H_T1_(T12.inverse().AdjointMap()) {}
+        T2hat_H_T1_(traits<T>::AdjointMap(traits<T>::Inverse(T12_))) {}
 
   /// @}
   /// @name Testable
@@ -161,9 +164,9 @@ class FrobeniusBetweenFactor : public NoiseModelFactorN<T, T> {
   /// Error is Frobenius norm between T1*T12 and T2.
   Vector evaluateError(const T& T1, const T& T2,
                        OptionalMatrixType H1, OptionalMatrixType H2) const override {
-    const T T2hat = T1.compose(T12_);
+    const T T2hat = traits<T>::Compose(T1, T12_);
     Eigen::Matrix<double, Dim, T::dimension> vec_H_T2hat;
-    Vector error = T2.vec(H2) - T2hat.vec(H1 ? &vec_H_T2hat : nullptr);
+    Vector error = traits<T>::Vec(T2, H2) - traits<T>::Vec(T2hat, H1 ? &vec_H_T2hat : nullptr);
     if (H1) *H1 = -vec_H_T2hat * T2hat_H_T1_;
     return error;
   }

--- a/gtsam_unstable/dynamics/tests/testPoseRTV.cpp
+++ b/gtsam_unstable/dynamics/tests/testPoseRTV.cpp
@@ -13,7 +13,7 @@
 using namespace gtsam;
 
 GTSAM_CONCEPT_TESTABLE_INST(PoseRTV)
-GTSAM_CONCEPT_LIE_INST(PoseRTV)
+GTSAM_CONCEPT_MATRIX_LIE_GROUP_INST(PoseRTV)
 
 static const Rot3 rot = Rot3::RzRyRx(0.1, 0.2, 0.3);
 static const Point3 pt(1.0, 2.0, 3.0);

--- a/tests/testLie.cpp
+++ b/tests/testLie.cpp
@@ -57,6 +57,9 @@ TEST(Lie, ProductLieGroup) {
   Product pair2 = pair1.expmap(d);
   EXPECT(assert_equal(expected, pair2, 1e-9));
   EXPECT(assert_equal(d, pair1.logmap(pair2), 1e-9));
+  const auto adj = pair1.AdjointMap();
+  EXPECT_LONGS_EQUAL(5, adj.rows());
+  EXPECT_LONGS_EQUAL(5, adj.cols());
 }
 
 /* ************************************************************************* */


### PR DESCRIPTION
**UPDATE**: took timing and new vecs out of this PR for easier review, avoid segafult in #2191 .

This PR introduces a significant refactoring of how matrix Lie groups are handled in GTSAM, aiming to reduce code duplication and improve consistency:
   * New `MatrixLieGroup` Concept: A new CRTP helper class MatrixLieGroup has been introduced in gtsam/base/MatrixLieGroup.h. This class provides generic implementations for common matrix Lie group operations like vec() (vectorization of the matrix representation) and AdjointMap().
   * Refactoring of `Lie.h`: Existing MatrixLieGroup related definitions and functions have been moved from gtsam/base/Lie.h to the new gtsam/base/MatrixLieGroup.h. The AdjointMap assignment in IsLieGroup concept check in Lie.h was also corrected.
   * Migration of Geometry Classes: Numerous geometry classes (e.g., Gal3, Pose2, Pose3, Rot2, SO3, SO4, SO<N>, Similarity2, Similarity3, NavState) have been updated to inherit from MatrixLieGroup instead of LieGroup.
   * Removal of Redundant Implementations: Individual vec() and AdjointMap() implementations in various geometry classes have been removed, as they now leverage the generic implementations provided by MatrixLieGroup.
   * Updated `traits` Specializations: The traits specializations for the migrated classes have been updated to use internal::MatrixLieGroup.
   * New Tests: Added tests verify the correctness of the generic AdjointMap() and vec() implementations for various matrix Lie groups.
   * `FrobeniusFactor` Updates: FrobeniusFactor and FrobeniusBetweenFactor now utilize the generic traits<T>::Vec and traits<T>::AdjointMap methods.
