### PR TITLE
Updated Cal3DS2_Base python wrapper

### DIFF
--- a/gtsam/geometry/geometry.i
+++ b/gtsam/geometry/geometry.i
@@ -829,6 +829,10 @@ virtual class Cal3DS2_Base : gtsam::Cal3 {
   // Standard Interface
   double k1() const;
   double k2() const;
+  double p1() const;
+  double p2() const;
+  gtsam::Vector4 k() const;
+  gtsam::Vector9 vector() const;
 
   // Action on Point2
   gtsam::Point2 uncalibrate(const gtsam::Point2& p) const;


### PR DESCRIPTION
Updated the Python wrapper for `Cal3DS2_Base`. Now, `Cal3DS2` instances should have access to member functions `p1()` and `p2()`, and the member function `vector()` now returns a correct vector with a dimension of 9. This is a direct fixed for issue #2185.

Check(s):
- Ran `make check`, 100% pass.
- Ran `make python-test`, 100% pass.
- Ran `make python-install` and reproduced issue #2185. Problems mentioned were fixed, as shown:
```
>>> import gtsam
>>> k = gtsam.Cal3DS2(7315, 7308, 0, 1920, 1080, -0.32, 0.28, 1.8e-3, 6e-5)
>>> dir(k)
['Dim', 'K', '__class__', '__delattr__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__getstate__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__setstate__', '__sizeof__', '__str__', '__subclasshook__', '_pybind11_conduit_v1_', 'aspectRatio', 'calibrate', 'deserialize', 'dim', 'equals', 'fx', 'fy', 'inverse', 'k', 'k1', 'k2', 'localCoordinates', 'p1', 'p2', 'principalPoint', 'print', 'px', 'py', 'retract', 'serialize', 'skew', 'uncalibrate', 'vector']
>>> k.vector()
array([ 7.315e+03,  7.308e+03,  0.000e+00,  1.920e+03,  1.080e+03,
       -3.200e-01,  2.800e-01,  1.800e-03,  6.000e-05])
```