### PR TITLE
Bespoke vec methods

### DIFF
--- a/gtsam/base/Lie.h
+++ b/gtsam/base/Lie.h
@@ -26,6 +26,8 @@
 #include <gtsam/base/Manifold.h>
 #include <gtsam/base/Group.h>
 
+#include <type_traits>
+
 namespace gtsam {
 
 /// A CRTP helper class that implements Lie group methods
@@ -56,7 +58,7 @@ struct LieGroup {
   Class compose(const Class& g, ChartJacobian H1,
       ChartJacobian H2 = {}) const {
     if (H1) *H1 = g.inverse().AdjointMap();
-    if (H2) *H2 = Eigen::Matrix<double, N, N>::Identity();
+    if (H2) *H2 = identityMatrix();
     return derived() * g;
   }
 
@@ -64,7 +66,7 @@ struct LieGroup {
       ChartJacobian H2 = {}) const {
     Class result = derived().inverse() * g;
     if (H1) *H1 = - result.inverse().AdjointMap();
-    if (H2) *H2 = Eigen::Matrix<double, N, N>::Identity();
+    if (H2) *H2 = identityMatrix();
     return result;
   }
 
@@ -157,6 +159,17 @@ struct LieGroup {
     if (H1) *H1 = - D_v_h * h.inverse().AdjointMap();
     if (H2) *H2 = D_v_h;
     return v;
+  }
+
+ private:
+
+  // Helper to get identity matrix of correct size for static or dynamic N
+  Jacobian identityMatrix() const {
+    if constexpr (N == Eigen::Dynamic) {
+      return Jacobian::Identity(derived().dim(), derived().dim());
+    } else {
+      return Jacobian::Identity();
+    }
   }
 };
 
@@ -271,12 +284,12 @@ class IsLieGroup: public IsGroup<T>, public IsManifold<T> {
 public:
   // Concept marker: allows checking IsLieGroup<T>::value in templates
   static constexpr bool value =
-    std::is_base_of<lie_group_tag, typename traits<T>::structure_category>::value;
+    std::is_base_of_v<lie_group_tag, typename traits<T>::structure_category>;
 
-  typedef typename traits<T>::structure_category structure_category_tag;
-  typedef typename traits<T>::ManifoldType ManifoldType;
-  typedef typename traits<T>::TangentVector TangentVector;
-  typedef typename traits<T>::ChartJacobian ChartJacobian;
+  using structure_category_tag = typename traits<T>::structure_category;
+  using ManifoldType = typename traits<T>::ManifoldType;
+  using TangentVector = typename traits<T>::TangentVector;
+  using ChartJacobian = typename traits<T>::ChartJacobian;
 
   GTSAM_CONCEPT_USAGE(IsLieGroup) {
     static_assert(

--- a/gtsam/base/MatrixLieGroup.h
+++ b/gtsam/base/MatrixLieGroup.h
@@ -173,8 +173,8 @@ namespace gtsam {
   template<typename T>
   class IsMatrixLieGroup : public IsLieGroup<T> {
   public:
-    typedef typename traits<T>::LieAlgebra LieAlgebra;
-    typedef typename traits<T>::TangentVector TangentVector;
+    using LieAlgebra = typename traits<T>::LieAlgebra;
+    using TangentVector = typename traits<T>::TangentVector;
 
     GTSAM_CONCEPT_USAGE(IsMatrixLieGroup) {
       // hat and vee
@@ -207,7 +207,7 @@ namespace gtsam {
 #ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
   /// @deprecated: use T::Hat
   template <class T>
-  Matrix wedge(const Vector& x) {
+  [[deprecated("use T::Hat instead")]] Matrix wedge(const Vector& x) {
     return T::Hat(x);
   }
 #endif

--- a/gtsam/base/timing.h
+++ b/gtsam/base/timing.h
@@ -23,6 +23,9 @@
 
 #if GTSAM_USE_BOOST_FEATURES
 #include <boost/version.hpp>
+#else
+#include <chrono>
+#include <ctime>
 #endif
 
 #include <memory>
@@ -175,6 +178,10 @@ namespace gtsam {
 #ifdef GTSAM_USE_TBB
       tbb::tick_count tbbTimer_;
 #endif
+#else
+      std::chrono::time_point<std::chrono::steady_clock> wall_timer_start_;
+      std::clock_t cpu_timer_start_;
+      bool timer_active_ = false;
 #endif
       void add(size_t usecs, size_t usecsWall);
 
@@ -191,11 +198,11 @@ namespace gtsam {
       double mean() const { return self() / double(n_); } ///< mean self time, in seconds
 #else
       // make them no-ops if not using boost
-      double self() const { return -1.; } ///< self time only, in seconds
-      double wall() const { return -1.; } ///< wall time, in seconds
-      double min()  const { return -1.; } ///< min time, in seconds
-      double max()  const { return -1.; } ///< max time, in seconds
-      double mean() const { return -1.; } ///< mean self time, in seconds
+      double self() const { return double(t_)     / 1000000.0;} ///< self time only, in seconds
+      double wall() const { return double(tWall_) / 1000000.0;} ///< wall time, in seconds
+      double min()  const { return double(tMin_)  / 1000000.0;} ///< min time, in seconds
+      double max()  const { return double(tMax_)  / 1000000.0;} ///< max time, in seconds
+      double mean() const { return n_ > 0 ? self() / double(n_) : 0.0; } ///< mean self time, in seconds
 #endif
       GTSAM_EXPORT void print(const std::string& outline = "") const;
       GTSAM_EXPORT void print2(const std::string& outline = "", const double parentTotal = -1.0) const;

--- a/gtsam/geometry/Gal3.cpp
+++ b/gtsam/geometry/Gal3.cpp
@@ -173,7 +173,24 @@ Matrix5 Gal3::matrix() const {
 }
 
 //------------------------------------------------------------------------------
-
+Gal3::Vector25 Gal3::vec(OptionalJacobian<25, 10> H) const {
+    const Matrix5 T = this->matrix();
+    if (H) {
+        H->setZero();
+        auto R = T.block<3, 3>(0, 0);
+        H->block<3, 1>(0, 6 + 1) = -R.col(2);
+        H->block<3, 1>(0, 6 + 2) = R.col(1);
+        H->block<3, 1>(5, 6 + 0) = R.col(2);
+        H->block<3, 1>(5, 6 + 2) = -R.col(0);
+        H->block<3, 1>(10, 6 + 0) = -R.col(1);
+        H->block<3, 1>(10, 6 + 1) = R.col(0);
+        H->block<3, 3>(15, 3) = R;
+        H->block<3, 3>(20, 0) = R;
+        H->block<3, 1>(20, 9) = T.block<3, 1>(0, 3);
+        (*H)(23, 9) = 1;
+    }
+    return Eigen::Map<const Vector25>(T.data());
+}
 
 //------------------------------------------------------------------------------
 // Stream operator

--- a/gtsam/geometry/Gal3.cpp
+++ b/gtsam/geometry/Gal3.cpp
@@ -178,12 +178,12 @@ Gal3::Vector25 Gal3::vec(OptionalJacobian<25, 10> H) const {
     if (H) {
         H->setZero();
         auto R = T.block<3, 3>(0, 0);
-        H->block<3, 1>(0, 6 + 1) = -R.col(2);
-        H->block<3, 1>(0, 6 + 2) = R.col(1);
-        H->block<3, 1>(5, 6 + 0) = R.col(2);
-        H->block<3, 1>(5, 6 + 2) = -R.col(0);
-        H->block<3, 1>(10, 6 + 0) = -R.col(1);
-        H->block<3, 1>(10, 6 + 1) = R.col(0);
+        H->block<3, 1>(0, 7) = -R.col(2);
+        H->block<3, 1>(0, 8) = R.col(1);
+        H->block<3, 1>(5, 6) = R.col(2);
+        H->block<3, 1>(5, 8) = -R.col(0);
+        H->block<3, 1>(10, 6) = -R.col(1);
+        H->block<3, 1>(10, 7) = R.col(0);
         H->block<3, 3>(15, 3) = R;
         H->block<3, 3>(20, 0) = R;
         H->block<3, 1>(20, 9) = T.block<3, 1>(0, 3);

--- a/gtsam/geometry/Gal3.h
+++ b/gtsam/geometry/Gal3.h
@@ -45,6 +45,7 @@ class GTSAM_EXPORT Gal3 : public MatrixLieGroup<Gal3, 10, 5> {
 
  public:
   using LieAlgebra = Matrix5;
+  using Vector25 = Eigen::Matrix<double, 25, 1>;
 
   /// @name Constructors
   /// @{
@@ -111,7 +112,8 @@ class GTSAM_EXPORT Gal3 : public MatrixLieGroup<Gal3, 10, 5> {
   /// Return 5x5 homogeneous matrix representation
   Matrix5 matrix() const;
 
-  
+  /// Vectorize 5x5 matrix into a 25-dim vector.
+  Vector25 vec(OptionalJacobian<25, 10> H = {}) const;
 
   /// @}
   /// @name Testable

--- a/gtsam/geometry/Pose2.cpp
+++ b/gtsam/geometry/Pose2.cpp
@@ -35,10 +35,16 @@ static const Rot2 R_PI_2(Rot2::fromCosSin(0., 1.));
 
 /* ************************************************************************* */
 Matrix3 Pose2::matrix() const {
-  Matrix3 m = Matrix3::Identity();
-  m.block<2,2>(0,0) = r_.matrix();
-  m.block<2,1>(0,2) = t_;
-  return m;
+  Matrix2 R = r_.matrix();
+  Matrix32 R0;
+  R0.block<2,2>(0,0) = R;
+  R0.block<1,2>(2,0).setZero();
+  Matrix31 T;
+  T <<  t_.x(), t_.y(), 1.0;
+  Matrix3 RT_;
+  RT_.block<3,2>(0,0) = R0;
+  RT_.block<3,1>(0,2) = T;
+  return RT_;
 }
 
 /* ************************************************************************* */

--- a/gtsam/geometry/Pose2.cpp
+++ b/gtsam/geometry/Pose2.cpp
@@ -35,16 +35,28 @@ static const Rot2 R_PI_2(Rot2::fromCosSin(0., 1.));
 
 /* ************************************************************************* */
 Matrix3 Pose2::matrix() const {
-  Matrix2 R = r_.matrix();
-  Matrix32 R0;
-  R0.block<2,2>(0,0) = R;
-  R0.block<1,2>(2,0).setZero();
-  Matrix31 T;
-  T <<  t_.x(), t_.y(), 1.0;
-  Matrix3 RT_;
-  RT_.block<3,2>(0,0) = R0;
-  RT_.block<3,1>(0,2) = T;
-  return RT_;
+  Matrix3 m = Matrix3::Identity();
+  m.block<2,2>(0,0) = r_.matrix();
+  m.block<2,1>(0,2) = t_;
+  return m;
+}
+
+/* ************************************************************************* */
+Vector9 Pose2::vec(OptionalJacobian<9, 3> H) const {
+  // Vectorize
+  const Matrix3 M = matrix();
+  const Vector v = Eigen::Map<const Vector9>(M.data());
+
+  // If requested, calculate H
+  if (H) {
+    H->setZero();
+    auto R = M.block<2, 2>(0, 0);
+    H->block<2, 1>(0, 2) = R.col(1);
+    H->block<2, 1>(3, 2) = -R.col(0);
+    H->block<2, 2>(6, 0) = R;
+  }
+
+  return v;
 }
 
 /* ************************************************************************* */

--- a/gtsam/geometry/Pose2.cpp
+++ b/gtsam/geometry/Pose2.cpp
@@ -51,7 +51,7 @@ Matrix3 Pose2::matrix() const {
 Vector9 Pose2::vec(OptionalJacobian<9, 3> H) const {
   // Vectorize
   const Matrix3 M = matrix();
-  const Vector v = Eigen::Map<const Vector9>(M.data());
+  const Vector9 v = Eigen::Map<const Vector9>(M.data());
 
   // If requested, calculate H
   if (H) {

--- a/gtsam/geometry/Pose2.h
+++ b/gtsam/geometry/Pose2.h
@@ -273,8 +273,11 @@ public:
     return r_;
   }
 
-  //// return transformation matrix
+  /// return transformation matrix
   Matrix3 matrix() const;
+
+  /// Vectorize the rotation matrix into a 9D vector.
+  Vector9 vec(OptionalJacobian<9, 3> H = {}) const;
 
   /**
    * Calculate bearing to a landmark

--- a/gtsam/geometry/Pose3.cpp
+++ b/gtsam/geometry/Pose3.cpp
@@ -526,8 +526,27 @@ Pose3 Pose3::slerp(double t, const Pose3& other, OptionalJacobian<6, 6> Hx, Opti
 }
 
 /* ************************************************************************* */
-// Compute vectorized Lie algebra generators for SE(3)
+Vector Pose3::vec(OptionalJacobian<16, 6> H) const {
+  // Vectorize
+  const Matrix4 M = matrix();
+  using Vector16 = Eigen::Matrix<double, 16, 1>;
+  const Vector X = Eigen::Map<const Vector16>(M.data());
 
+  // If requested, calculate H
+  if (H) {
+    H->setZero();
+    auto R = M.block<3, 3>(0, 0);
+    H->block<3, 1>(0, 1) = -R.col(2);
+    H->block<3, 1>(0, 2) = R.col(1);
+    H->block<3, 1>(4, 0) = R.col(2);
+    H->block<3, 1>(4, 2) = -R.col(0);
+    H->block<3, 1>(8, 0) = -R.col(1);
+    H->block<3, 1>(8, 1) = R.col(0);
+    H->block<3,3>(12,3) = R;
+  }
+
+  return X;
+}
 
 /* ************************************************************************* */
 std::ostream &operator<<(std::ostream &os, const Pose3& pose) {

--- a/gtsam/geometry/Pose3.cpp
+++ b/gtsam/geometry/Pose3.cpp
@@ -361,6 +361,28 @@ Matrix4 Pose3::matrix() const {
 }
 
 /* ************************************************************************* */
+Pose3::Vector16 Pose3::vec(OptionalJacobian<16, 6> H) const {
+  // Vectorize
+  const Matrix4 M = matrix();
+  const Vector v = Eigen::Map<const Vector16>(M.data());
+
+  // If requested, calculate H
+  if (H) {
+    H->setZero();
+    auto R = M.block<3, 3>(0, 0);
+    H->block<3, 1>(0, 1) = -R.col(2);
+    H->block<3, 1>(0, 2) = R.col(1);
+    H->block<3, 1>(4, 0) = R.col(2);
+    H->block<3, 1>(4, 2) = -R.col(0);
+    H->block<3, 1>(8, 0) = -R.col(1);
+    H->block<3, 1>(8, 1) = R.col(0);
+    H->block<3,3>(12,3) = R;
+  }
+
+  return v;
+}
+
+/* ************************************************************************* */
 Pose3 Pose3::transformPoseFrom(const Pose3& aTb, OptionalJacobian<6, 6> Hself,
                                OptionalJacobian<6, 6> HaTb) const {
   const Pose3& wTa = *this;
@@ -523,29 +545,6 @@ std::optional<Pose3> Pose3::Align(const Matrix& a, const Matrix& b) {
 /* ************************************************************************* */
 Pose3 Pose3::slerp(double t, const Pose3& other, OptionalJacobian<6, 6> Hx, OptionalJacobian<6, 6> Hy) const {
   return interpolate(*this, other, t, Hx, Hy);
-}
-
-/* ************************************************************************* */
-Vector Pose3::vec(OptionalJacobian<16, 6> H) const {
-  // Vectorize
-  const Matrix4 M = matrix();
-  using Vector16 = Eigen::Matrix<double, 16, 1>;
-  const Vector X = Eigen::Map<const Vector16>(M.data());
-
-  // If requested, calculate H
-  if (H) {
-    H->setZero();
-    auto R = M.block<3, 3>(0, 0);
-    H->block<3, 1>(0, 1) = -R.col(2);
-    H->block<3, 1>(0, 2) = R.col(1);
-    H->block<3, 1>(4, 0) = R.col(2);
-    H->block<3, 1>(4, 2) = -R.col(0);
-    H->block<3, 1>(8, 0) = -R.col(1);
-    H->block<3, 1>(8, 1) = R.col(0);
-    H->block<3,3>(12,3) = R;
-  }
-
-  return X;
 }
 
 /* ************************************************************************* */

--- a/gtsam/geometry/Pose3.cpp
+++ b/gtsam/geometry/Pose3.cpp
@@ -364,7 +364,7 @@ Matrix4 Pose3::matrix() const {
 Pose3::Vector16 Pose3::vec(OptionalJacobian<16, 6> H) const {
   // Vectorize
   const Matrix4 M = matrix();
-  const Vector v = Eigen::Map<const Vector16>(M.data());
+  const Vector16 v = Eigen::Map<const Vector16>(M.data());
 
   // If requested, calculate H
   if (H) {

--- a/gtsam/geometry/Pose3.h
+++ b/gtsam/geometry/Pose3.h
@@ -383,7 +383,8 @@ public:
   Pose3 slerp(double t, const Pose3& other, OptionalJacobian<6, 6> Hx = {},
                                              OptionalJacobian<6, 6> Hy = {}) const;
 
-  
+  /// Return vectorized SE(3) matrix in column order.
+  Vector vec(OptionalJacobian<16, 6> H = {}) const;
 
   /// Output stream operator
   GTSAM_EXPORT

--- a/gtsam/geometry/Pose3.h
+++ b/gtsam/geometry/Pose3.h
@@ -47,6 +47,7 @@ private:
   Point3 t_; ///< Translation gPp, from global origin to pose frame origin
 
 public:
+  using Vector16 = Eigen::Matrix<double, 16, 1>;
 
   /// @name Standard Constructors
   /// @{
@@ -305,6 +306,9 @@ public:
   /** convert to 4*4 matrix */
   Matrix4 matrix() const;
 
+  /// Return vectorized SE(3) matrix in column order.
+  Vector16 vec(OptionalJacobian<16, 6> H = {}) const;
+
   /** 
     * Assuming self == wTa, takes a pose aTb in local coordinates 
     * and transforms it to world coordinates wTb = wTa * aTb.
@@ -382,9 +386,6 @@ public:
    */
   Pose3 slerp(double t, const Pose3& other, OptionalJacobian<6, 6> Hx = {},
                                              OptionalJacobian<6, 6> Hy = {}) const;
-
-  /// Return vectorized SE(3) matrix in column order.
-  Vector vec(OptionalJacobian<16, 6> H = {}) const;
 
   /// Output stream operator
   GTSAM_EXPORT

--- a/gtsam/geometry/Rot2.cpp
+++ b/gtsam/geometry/Rot2.cpp
@@ -157,9 +157,15 @@ Rot2 Rot2::ClosestTo(const Matrix2& M) {
   return Rot2::fromCosSin(c, s);
 }
 
-/* ************************************************************************* */
-
-
+//******************************************************************************
+Vector4 Rot2::vec(OptionalJacobian<4, 1> H) const {
+  const Matrix2 R = matrix();
+  if (H) {
+    H->block<2, 1>(0, 0) = R.col(1);
+    H->block<2, 1>(2, 0) = -R.col(0);
+  }
+  return Eigen::Map<const Vector4>(R.data());
+}
 /* ************************************************************************* */
 
 } // gtsam

--- a/gtsam/geometry/Rot2.h
+++ b/gtsam/geometry/Rot2.h
@@ -217,14 +217,14 @@ namespace gtsam {
     /** return 2*2 rotation matrix */
     Matrix2 matrix() const;
 
-    /** return 2*2 transpose (inverse) rotation matrix   */
+    /** return 2*2 transpose (inverse) rotation matrix */
     Matrix2 transpose() const;
 
     /** Find closest valid rotation matrix, given a 2x2 matrix */
     static Rot2 ClosestTo(const Matrix2& M);
 
-    
-
+    /** Vectorize the rotation matrix into a 4D vector */
+    Vector4 vec(OptionalJacobian<4, 1> H = {}) const;
     /// @}
 
     private:

--- a/gtsam/geometry/SO3.cpp
+++ b/gtsam/geometry/SO3.cpp
@@ -387,5 +387,21 @@ Vector3 SO3::ChartAtOrigin::Local(const SO3& R, ChartJacobian H) {
 }
 
 //******************************************************************************
+template <>
+GTSAM_EXPORT
+Vector9 SO3::vec(OptionalJacobian<9, 3> H) const {
+  const Matrix3& R = matrix_;
+  if (H) {
+    H->setZero();
+    H->block<3, 1>(0, 1) = -R.col(2);
+    H->block<3, 1>(0, 2) = R.col(1);
+    H->block<3, 1>(3, 0) = R.col(2);
+    H->block<3, 1>(3, 2) = -R.col(0);
+    H->block<3, 1>(6, 0) = -R.col(1);
+    H->block<3, 1>(6, 1) = R.col(0);
+  }
+  return Eigen::Map<const Vector9>(R.data());
+}
+//******************************************************************************
 
 }  // end namespace gtsam

--- a/gtsam/geometry/SO3.h
+++ b/gtsam/geometry/SO3.h
@@ -39,8 +39,6 @@ template <>
 GTSAM_EXPORT
 SO3 SO3::AxisAngle(const Vector3& axis, double theta);
 
-static constexpr size_t MatrixM = 3;
-
 template <>
 GTSAM_EXPORT
 SO3 SO3::ClosestTo(const Matrix3& M);
@@ -95,6 +93,10 @@ SO3 SO3::ChartAtOrigin::Retract(const Vector3& omega, ChartJacobian H);
 template <>
 GTSAM_EXPORT
 Vector3 SO3::ChartAtOrigin::Local(const SO3& R, ChartJacobian H);
+
+template <>
+GTSAM_EXPORT
+Vector9 SO3::vec(OptionalJacobian<9, 3> H) const;
 
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
 template <class Archive>

--- a/gtsam/geometry/SO4.cpp
+++ b/gtsam/geometry/SO4.cpp
@@ -134,6 +134,29 @@ SO4 SO4::Expmap(const Vector6& xi, ChartJacobian H) {
   }
 }
 
+//******************************************************************************
+template <>
+GTSAM_EXPORT
+SO4::VectorN2 SO4::vec(OptionalJacobian<16, 6> H) const {
+  const Matrix& Q = matrix_;
+  if (H) {
+    H->setZero();
+    H->block<4, 1>(0, 2) = -Q.col(3);
+    H->block<4, 1>(0, 4) = -Q.col(2);
+    H->block<4, 1>(0, 5) = Q.col(1);
+    H->block<4, 1>(4, 1) = Q.col(3);
+    H->block<4, 1>(4, 3) = Q.col(2);
+    H->block<4, 1>(4, 5) = -Q.col(0);
+    H->block<4, 1>(8, 0) = -Q.col(3);
+    H->block<4, 1>(8, 3) = -Q.col(1);
+    H->block<4, 1>(8, 4) = Q.col(0);
+    H->block<4, 1>(12, 0) = Q.col(2);
+    H->block<4, 1>(12, 1) = -Q.col(1);
+    H->block<4, 1>(12, 2) = Q.col(0);
+  }
+  return Eigen::Map<const SO4::VectorN2>(Q.data());
+}
+
 ///******************************************************************************
 template <>
 GTSAM_EXPORT

--- a/gtsam/geometry/SO4.h
+++ b/gtsam/geometry/SO4.h
@@ -51,6 +51,9 @@ template <>
 GTSAM_EXPORT
 SO4 SO4::Expmap(const Vector6 &xi, ChartJacobian H);
 
+template <>
+GTSAM_EXPORT
+SO4::VectorN2 SO4::vec(OptionalJacobian<16, 6> H) const;
 
 template <>
 GTSAM_EXPORT

--- a/gtsam/geometry/SOn.h
+++ b/gtsam/geometry/SOn.h
@@ -294,6 +294,12 @@ class SO : public MatrixLieGroup<SO<N>, internal::DimensionSO(N), N> {
   /// @name Other methods
   /// @{
 
+  /// Return vectorized rotation matrix in column order.
+  VectorN2 vec(OptionalJacobian<internal::NSquaredSO(N), dimension> H =
+    {}) const {
+    return MatrixLieGroup<SO<N>, internal::DimensionSO(N), N>::vec(H);
+  }
+
   /// Calculate N^2 x dim matrix of vectorized Lie algebra generators for SO(N)
   template <int N_ = N, typename = IsFixed<N_>>
   static Matrix VectorizedGenerators() {

--- a/gtsam/geometry/tests/testGal3.cpp
+++ b/gtsam/geometry/tests/testGal3.cpp
@@ -1198,7 +1198,6 @@ TEST(Gal3, Vec) {
 }
 
 //******************************************************************************
-
 TEST(Gal3, AdjointMap) {
   // Create a non-trivial Gal3 object
   const Rot3 R = Rot3::Rodrigues(0.1, 0.2, 0.3);

--- a/gtsam/geometry/tests/testPose3.cpp
+++ b/gtsam/geometry/tests/testPose3.cpp
@@ -936,9 +936,7 @@ TEST(Pose3, Logmap) {
 TEST(Pose3, LogmapDerivatives) {
   for (bool nearZero : {true, false}) {
     for (const Vector3& w : test_cases::omegas(nearZero)) {
-      std::cout << "w: " << w.transpose() << std::endl;
       for (Vector3 v : test_cases::vs) {
-        std::cout << "v: " << v.transpose() << std::endl;
         const Vector6 xi = (Vector6() << w, v).finished();
         Pose3 pose = Pose3::Expmap(xi);
         const Matrix6 expectedH =
@@ -1472,7 +1470,6 @@ TEST(Pose3, Vec) {
 }
 
 /* ************************************************************************* */
-
 TEST(Pose3, AdjointMap) {
   // Create a non-trivial Pose3 object
   const Pose3 pose(Rot3::Rodrigues(0.1, 0.2, 0.3), Point3(1.0, 2.0, 3.0));

--- a/gtsam/geometry/tests/testSO4.cpp
+++ b/gtsam/geometry/tests/testSO4.cpp
@@ -147,7 +147,7 @@ TEST(SO4, Invariants) {
 }
 
 //******************************************************************************
-TEST(SO4, compose) {
+TEST(SO4, Compose) {
   SO4 expected = Q1 * Q2;
   Matrix actualH1, actualH2;
   SO4 actual = Q1.compose(Q2, actualH1, actualH2);
@@ -163,7 +163,7 @@ TEST(SO4, compose) {
 }
 
 //******************************************************************************
-TEST(SO4, vec) {
+TEST(SO4, Vec) {
   using Vector16 = SO4::VectorN2;
   const Vector16 expected = Eigen::Map<const Vector16>(Q2.matrix().data());
   Matrix actualH;
@@ -175,7 +175,7 @@ TEST(SO4, vec) {
 }
 
 //******************************************************************************
-TEST(SO4, topLeft) {
+TEST(SO4, TopLeft) {
   const Matrix3 expected = Q3.matrix().topLeftCorner<3, 3>();
   Matrix actualH;
   const Matrix3 actual = topLeft(Q3, actualH);
@@ -188,7 +188,7 @@ TEST(SO4, topLeft) {
 }
 
 //******************************************************************************
-TEST(SO4, stiefel) {
+TEST(SO4, Stiefel) {
   const Matrix43 expected = Q3.matrix().leftCols<3>();
   Matrix actualH;
   const Matrix43 actual = stiefel(Q3, actualH);

--- a/gtsam/navigation/NavState.cpp
+++ b/gtsam/navigation/NavState.cpp
@@ -88,6 +88,24 @@ Matrix5 NavState::matrix() const {
 }
 
 //------------------------------------------------------------------------------
+NavState::Vector25 NavState::vec(OptionalJacobian<25, 9> H) const {
+  const Matrix5 T = this->matrix();
+  if (H) {
+    H->setZero();
+    auto R = T.block<3, 3>(0, 0);
+    H->block<3, 1>(0, 1) = -R.col(2);
+    H->block<3, 1>(0, 2) = R.col(1);
+    H->block<3, 1>(5, 0) = R.col(2);
+    H->block<3, 1>(5, 2) = -R.col(0);
+    H->block<3, 1>(10, 0) = -R.col(1);
+    H->block<3, 1>(10, 1) = R.col(0);
+    H->block<3, 3>(15, 3) = R;
+    H->block<3, 3>(20, 6) = R;
+  }
+  return Eigen::Map<const Vector25>(T.data());
+}
+
+//------------------------------------------------------------------------------
 std::ostream& operator<<(std::ostream& os, const NavState& state) {
   os << "R: " << state.attitude() << "\n";
   os << "p: " << state.position().transpose() << "\n";

--- a/gtsam/navigation/NavState.h
+++ b/gtsam/navigation/NavState.h
@@ -45,9 +45,8 @@ class GTSAM_EXPORT NavState : public MatrixLieGroup<NavState, 9, 5> {
   Velocity3 v_; ///< velocity n_v in nav frame
 
 public:
-
-  inline constexpr static auto dimension = 9;
-
+  using LieAlgebra = Matrix5;
+  using Vector25 = Eigen::Matrix<double, 25, 1>;
 
   /// @name Constructors
   /// @{
@@ -127,6 +126,9 @@ public:
   /// nTb = [nRb n_t n_v; 0_1x3 1 0; 0_1x3 0 1]
   Matrix5 matrix() const;
 
+  /// Vectorize 5x5 matrix into a 25-dim vector.
+  Vector25 vec(OptionalJacobian<25, 9> H = {}) const;
+
   /// @}
   /// @name Testable
   /// @{
@@ -197,8 +199,6 @@ public:
   /// @}
   /// @name Lie Group
   /// @{
-
-  using LieAlgebra = Matrix5;
 
   /**
    * Exponential map at identity - create a NavState from canonical coordinates

--- a/gtsam/navigation/tests/testNavState.cpp
+++ b/gtsam/navigation/tests/testNavState.cpp
@@ -746,8 +746,7 @@ TEST(NavState, ChartDerivatives) {
 }
 
 /* ************************************************************************* */
-TEST(NavState, vec) {
-  // Test the 'vec' method
+TEST(NavState, Vec) {
   using Vector25 = Eigen::Matrix<double, 25, 1>;
   const NavState navState(Rot3::Rodrigues(0.1, 0.2, 0.3), Point3(1.0, 2.0, 3.0), Velocity3(0.4, 0.5, 0.6));
 

--- a/timing/timeFrobeniusFactor.cpp
+++ b/timing/timeFrobeniusFactor.cpp
@@ -1,0 +1,98 @@
+/**
+ * @file    timeFrobeniusFactor.cpp
+ * @brief   Time FrobeniusBetweenFactor::evaluateError with derivatives for various Lie groups.
+ * @author  Frank Dellaert
+ * @date    April 2024
+ */
+
+#include <gtsam/slam/FrobeniusFactor.h>
+#include <gtsam/base/timing.h>
+
+ // Include all Lie Groups to be timed
+#include <gtsam/geometry/Rot2.h>
+#include <gtsam/geometry/Rot3.h>
+#include <gtsam/geometry/Pose2.h>
+#include <gtsam/geometry/Pose3.h>
+#include <gtsam/geometry/SOn.h>
+#include <gtsam/geometry/SO3.h>
+#include <gtsam/geometry/SO4.h>
+#include <gtsam/geometry/Gal3.h>
+#include <gtsam/navigation/NavState.h>
+
+#include <iostream>
+#include <string>
+
+using namespace std;
+using namespace gtsam;
+
+// Define a sufficiently large number of iterations for stable timing.
+#define NUM_ITERATIONS 1000000
+
+// Create CSV file for results
+ofstream os("timeFrobeniusFactor.csv");
+
+/**
+ * @brief Time evaluateError for a given Lie group type.
+ * This function creates a FrobeniusBetweenFactor for a given Lie group type `T`,
+ * and times the `evaluateError` method including Jacobian calculations.
+ * @tparam T The Lie group type (e.g., Rot3, Pose3). It must be a MatrixLieGroup.
+ * @param name A string identifier for the type, used for printing results.
+ */
+template <typename T>
+void timeOne(const std::string& name) {
+  Key key1(1), key2(2);
+
+  // Use random values to avoid any special cases (e.g. identity).
+  // Using ChartAtOrigin::Retract is the modern GTSAM way.
+  T T1 = T::ChartAtOrigin::Retract(Vector::Random(T::dimension));
+  T T2 = T::ChartAtOrigin::Retract(Vector::Random(T::dimension));
+  T T12 = T::ChartAtOrigin::Retract(Vector::Random(T::dimension));
+
+  // Create the factor. The noise model is not important for timing evaluateError.
+  FrobeniusBetweenFactor<T> factor(key1, key2, T12, nullptr);
+
+  // Get dimensions for Jacobian matrices.
+  // N is the matrix dimension (e.g., 3 for SO(3)), Dim is N*N.
+  // D is the dimension of the tangent space.
+  constexpr auto N = T::LieAlgebra::RowsAtCompileTime;
+  constexpr auto Dim = N * N;
+  constexpr auto D = T::dimension;
+  Matrix H1(Dim, D), H2(Dim, D);
+
+  // Warmup call to make sure code and data are in cache.
+  for (int i = 0; i < 100; ++i) {
+    factor.evaluateError(T1, T2, &H1, &H2);
+  }
+
+  // Timed loop.
+  static const size_t id_tic = ::gtsam::internal::getTicTocID(name.c_str());
+  ::gtsam::internal::AutoTicToc obj(id_tic, name.c_str());
+  for (size_t t = 0; t < NUM_ITERATIONS; t++) {
+    // We pass H1 and H2 to ensure Jacobians are computed.
+    factor.evaluateError(T1, T2, &H1, &H2);
+  }
+  obj.stop();
+  auto timer = ::gtsam::internal::gCurrentTimer.lock()->child(id_tic, name.c_str(), ::gtsam::internal::gCurrentTimer);
+  os << timer->secs() / NUM_ITERATIONS << ", ";
+  cout << name << ":\t" << timer->secs() << endl;
+}
+
+/*************************************************************************************/
+int main(void) {
+  // Announce the test and number of iterations.
+  cout << "Timing FrobeniusBetweenFactor::evaluateError with derivatives for " << NUM_ITERATIONS
+    << " iterations." << endl << endl;
+
+  // Time all the specified MatrixLieGroup classes.
+  timeOne<Rot2>("Rot2");
+  timeOne<SO3>("SO3");
+  timeOne<Rot3>("Rot3");
+  timeOne<Pose2>("Pose2");
+  timeOne<SO4>("SO4");
+  timeOne<Pose3>("Pose3");
+  timeOne<Gal3>("Gal3");
+  timeOne<NavState>("NavState");
+
+  return 0;
+}
+/*************************************************************************************/

--- a/timing/timeFrobeniusFactor.cpp
+++ b/timing/timeFrobeniusFactor.cpp
@@ -26,7 +26,7 @@ using namespace std;
 using namespace gtsam;
 
 // Define a sufficiently large number of iterations for stable timing.
-#define NUM_ITERATIONS 1000000
+#define NUM_ITERATIONS 10000000
 
 // Create CSV file for results
 ofstream os("timeFrobeniusFactor.csv");
@@ -74,7 +74,7 @@ void timeOne(const std::string& name) {
   obj.stop();
   auto timer = ::gtsam::internal::gCurrentTimer.lock()->child(id_tic, name.c_str(), ::gtsam::internal::gCurrentTimer);
   os << timer->secs() / NUM_ITERATIONS << ", ";
-  cout << name << ":\t" << timer->secs() << endl;
+  cout << name << ":\t" << timer->secs()*1e9/NUM_ITERATIONS << " ns" << endl;
 }
 
 /*************************************************************************************/
@@ -91,7 +91,6 @@ int main(void) {
   timeOne<SO4>("SO4");
   timeOne<Pose3>("Pose3");
   timeOne<Gal3>("Gal3");
-  timeOne<NavState>("NavState");
 
   return 0;
 }


### PR DESCRIPTION
Added custom vecs for most types, which are faster. Note, timing is with branch in #2191.

| Factor    | Matrix Size | Before (ns) | After (ns) | % Improvement |
|-----------|-------------|-------------|------------|----------------|
| Rot2      | 4x1         | 41          | 24         | 41%            |
| SO3       | 9x3         | 60          | 41         | 31%            |
| Rot3      | 9x3         | 65          | 45         | 30%            |
| Pose2     | 9x3         | 97          | 44         | 54%            |
| SO4       | 16x6         | 729         | 187        | 74%            |
| Pose3     | 16x6         | 414         | 204        | 50%            |
| NavState  | 25x9         | —           | 375        | —              |
| Gal3      | 25x10         | 635         | 427        | 32%            |

Still mostly dominated by  matrix size. ~Note Rot2 and Pose2 still use generic vec~