### PR TITLE
Test both PIM variants

### DIFF
--- a/gtsam/navigation/tests/imuFactorTesting.h
+++ b/gtsam/navigation/tests/imuFactorTesting.h
@@ -76,3 +76,25 @@ struct SomeMeasurements : vector<ImuMeasurement> {
 };
 
 }  // namespace testing
+namespace {
+// Macro to test ImuFactor with both Manifold and Tangent preintegration
+// In the tests below the selected PreintegratedImuMeasurementsT is available
+// as `PIM`, and the combined version as `CombinedPIM`.
+#define TEST_PIM(testGroup, testName)                                           \
+  template <class PIM, class CombinedPIM>                                       \
+  void testGroup##testName##Helper(TestResult& result_,                         \
+                                   const std::string& name_);                   \
+  TEST(testGroup, testName) {                                                   \
+    using M = ManifoldPreintegration;                                           \
+    using PM = PreintegratedImuMeasurementsT<M>;                                \
+    using CM = PreintegratedCombinedMeasurementsT<M>;                           \
+    using T = TangentPreintegration;                                            \
+    using PT = PreintegratedImuMeasurementsT<T>;                                \
+    using CT = PreintegratedCombinedMeasurementsT<T>;                           \
+    testGroup##testName##Helper<PM, CM>(result_, this->name_);                  \
+    testGroup##testName##Helper<PT, CT>(result_, this->name_);                  \
+  }                                                                             \
+  template <class PIM, class CombinedPIM>                                       \
+  void testGroup##testName##Helper(TestResult& result_, const std::string& name_)
+}  // namespace
+

--- a/gtsam/navigation/tests/testCombinedImuFactor.cpp
+++ b/gtsam/navigation/tests/testCombinedImuFactor.cpp
@@ -52,7 +52,23 @@ static std::shared_ptr<PreintegratedCombinedMeasurements::Params> Params(
 }  // namespace testing
 
 /* ************************************************************************* */
-TEST(CombinedImuFactor, PreintegratedMeasurements ) {
+namespace {
+// Macro to test ImuFactor with both Manifold and Tangent preintegration
+// In the tests below, the selected PreintegratedImuMeasurementsT is available as `PIM`.
+#define TEST_PIM(testGroup, testName)                                           \
+  template <class PreintegrationType>                                                          \
+  void testGroup##testName##Helper(TestResult& result_,                         \
+                                   const std::string& name_);                   \
+  TEST(testGroup, testName) {                                                   \
+    testGroup##testName##Helper<ManifoldPreintegration>(result_, this->name_);  \
+    testGroup##testName##Helper<TangentPreintegration>(result_, this->name_);   \
+  }                                                                             \
+  template <class PreintegrationType>                                                          \
+  void testGroup##testName##Helper(TestResult& result_, const std::string& name_)
+}  // namespace
+
+/* ************************************************************************* */
+TEST_PIM(CombinedImuFactor, PreintegratedMeasurements ) {
   // Linearization point
   Bias bias(Vector3(0, 0, 0), Vector3(0, 0, 0)); ///< Current estimate of acceleration and angular rate biases
 
@@ -65,10 +81,10 @@ TEST(CombinedImuFactor, PreintegratedMeasurements ) {
   auto p = testing::Params();
 
   // Actual preintegrated values
-  PreintegratedImuMeasurements expected1(p, bias);
+  PreintegratedImuMeasurementsT<PreintegrationType> expected1(p, bias);
   expected1.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
 
-  PreintegratedCombinedMeasurements actual1(p, bias);
+  PreintegratedCombinedMeasurementsT<PreintegrationType> actual1(p, bias);
 
   actual1.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
 
@@ -80,7 +96,7 @@ TEST(CombinedImuFactor, PreintegratedMeasurements ) {
 
 
 /* ************************************************************************* */
-TEST(CombinedImuFactor, ErrorWithBiases ) {
+TEST_PIM(CombinedImuFactor, ErrorWithBiases ) {
   Bias bias(Vector3(0.2, 0, 0), Vector3(0, 0, 0.3)); // Biases (acc, rot)
   Bias bias2(Vector3(0.2, 0.2, 0), Vector3(1, 0, 0.3)); // Biases (acc, rot)
   Pose3 x1(Rot3::Expmap(Vector3(0, 0, M_PI / 4.0)), Point3(5.0, 1.0, -50.0));
@@ -91,8 +107,8 @@ TEST(CombinedImuFactor, ErrorWithBiases ) {
 
   auto p = testing::Params();
   p->omegaCoriolis = Vector3(0,0.1,0.1);
-  PreintegratedImuMeasurements pim(
-      p, Bias(Vector3(0.2, 0.0, 0.0), Vector3(0.0, 0.0, 0.0)));
+  using PIM = PreintegratedImuMeasurementsT<PreintegrationType>;
+  PIM pim(p, Bias(Vector3(0.2, 0.0, 0.0), Vector3(0.0, 0.0, 0.0)));
 
   // Measurements
   Vector3 measuredOmega;
@@ -104,21 +120,19 @@ TEST(CombinedImuFactor, ErrorWithBiases ) {
 
   pim.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
 
-  PreintegratedCombinedMeasurements combined_pim(p,
-      Bias(Vector3(0.2, 0.0, 0.0), Vector3(0.0, 0.0, 0.0)));
+  using CombinedPIM = PreintegratedCombinedMeasurementsT<PreintegrationType>;
+  CombinedPIM combined_pim(p, Bias(Vector3(0.2, 0.0, 0.0), Vector3(0.0, 0.0, 0.0)));
 
   combined_pim.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
 
   // Create factor
-  ImuFactor imuFactor(X(1), V(1), X(2), V(2), B(1), pim);
+  ImuFactorT<PIM> imuFactor(X(1), V(1), X(2), V(2), B(1), pim);
 
-  noiseModel::Gaussian::shared_ptr Combinedmodel =
-      noiseModel::Gaussian::Covariance(combined_pim.preintMeasCov());
-  CombinedImuFactor combinedfactor(X(1), V(1), X(2), V(2), B(1), B(2),
+  CombinedImuFactorT<CombinedPIM> combinedFactor(X(1), V(1), X(2), V(2), B(1), B(2),
                                    combined_pim);
 
   Vector errorExpected = imuFactor.evaluateError(x1, v1, x2, v2, bias);
-  Vector errorActual = combinedfactor.evaluateError(x1, v1, x2, v2, bias,
+  Vector errorActual = combinedFactor.evaluateError(x1, v1, x2, v2, bias,
       bias2);
   EXPECT(assert_equal(errorExpected, errorActual.head(9), tol));
 
@@ -128,7 +142,7 @@ TEST(CombinedImuFactor, ErrorWithBiases ) {
 
   // Actual Jacobians
   Matrix H1a, H2a, H3a, H4a, H5a, H6a;
-  (void) combinedfactor.evaluateError(x1, v1, x2, v2, bias, bias2, H1a, H2a,
+  (void) combinedFactor.evaluateError(x1, v1, x2, v2, bias, bias2, H1a, H2a,
       H3a, H4a, H5a, H6a);
 
   EXPECT(assert_equal(H1e, H1a.topRows(9)));
@@ -139,7 +153,7 @@ TEST(CombinedImuFactor, ErrorWithBiases ) {
 }
 
 /* ************************************************************************* */
-#ifdef GTSAM_TANGENT_PREINTEGRATION
+// This test only works with tangent preintegration.
 TEST(CombinedImuFactor, FirstOrderPreIntegratedMeasurements) {
   auto p = testing::Params();
   testing::SomeMeasurements measurements;
@@ -151,7 +165,7 @@ TEST(CombinedImuFactor, FirstOrderPreIntegratedMeasurements) {
   };
 
   // Actual pre-integrated values
-  PreintegratedCombinedMeasurements pim(p);
+  PreintegratedCombinedMeasurementsT<TangentPreintegration> pim(p);
   testing::integrateMeasurements(measurements, &pim);
 
   EXPECT(assert_equal(numericalDerivative21<Vector9, Vector3, Vector3>(preintegrated, Z_3x1, Z_3x1),
@@ -159,10 +173,9 @@ TEST(CombinedImuFactor, FirstOrderPreIntegratedMeasurements) {
   EXPECT(assert_equal(numericalDerivative22<Vector9, Vector3, Vector3>(preintegrated, Z_3x1, Z_3x1),
                       pim.preintegrated_H_biasOmega(), 1e-3));
 }
-#endif
 
 /* ************************************************************************* */
-TEST(CombinedImuFactor, PredictPositionAndVelocity) {
+TEST_PIM(CombinedImuFactor, PredictPositionAndVelocity) {
   const Bias bias(Vector3(0, 0.1, 0), Vector3(0, 0.1, 0));  // Biases (acc, rot)
 
   auto p = testing::Params();
@@ -172,7 +185,8 @@ TEST(CombinedImuFactor, PredictPositionAndVelocity) {
   const Vector3 measuredAcc(0, 1.1, -kGravity);
   const double deltaT = 0.01;
 
-  PreintegratedCombinedMeasurements pim(p, bias);
+  using PIM = PreintegratedCombinedMeasurementsT<PreintegrationType>;
+  PIM pim(p, bias);
 
   for (int i = 0; i < 100; ++i)
     pim.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
@@ -180,7 +194,7 @@ TEST(CombinedImuFactor, PredictPositionAndVelocity) {
   // Create factor
   const noiseModel::Gaussian::shared_ptr combinedmodel =
       noiseModel::Gaussian::Covariance(pim.preintMeasCov());
-  const CombinedImuFactor Combinedfactor(X(1), V(1), X(2), V(2), B(1), B(2), pim);
+  const CombinedImuFactorT<PIM> Combinedfactor(X(1), V(1), X(2), V(2), B(1), B(2), pim);
 
   // Predict
   const NavState actual = pim.predict(NavState(), bias);
@@ -191,17 +205,18 @@ TEST(CombinedImuFactor, PredictPositionAndVelocity) {
 }
 
 /* ************************************************************************* */
-TEST(CombinedImuFactor, PredictRotation) {
+TEST_PIM(CombinedImuFactor, PredictRotation) {
   const Bias bias(Vector3(0, 0, 0), Vector3(0, 0, 0)); // Biases (acc, rot)
   auto p = testing::Params();
-  PreintegratedCombinedMeasurements pim(p, bias);
+  using PIM = PreintegratedCombinedMeasurementsT<PreintegrationType>;
+  PIM pim(p, bias);
   const Vector3 measuredAcc = - kGravityAlongNavZDown;
   const Vector3 measuredOmega(0, 0, M_PI / 10.0);
   const double deltaT = 0.01;
   const double tol = 1e-4;
   for (int i = 0; i < 100; ++i)
     pim.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
-  const CombinedImuFactor Combinedfactor(X(1), V(1), X(2), V(2), B(1), B(2), pim);
+  const CombinedImuFactorT<PIM> Combinedfactor(X(1), V(1), X(2), V(2), B(1), B(2), pim);
 
   // Predict
   const Pose3 x(Rot3::Ypr(0, 0, 0), Point3(0, 0, 0)), x2;
@@ -213,7 +228,7 @@ TEST(CombinedImuFactor, PredictRotation) {
 
 /* ************************************************************************* */
 // Testing covariance to check if all the jacobians are accounted for.
-TEST(CombinedImuFactor, CheckCovariance) {
+TEST_PIM(CombinedImuFactor, CheckCovariance) {
   auto params = PreintegrationCombinedParams::MakeSharedU(9.81);
 
   params->setAccelerometerCovariance(pow(0.01, 2) * I_3x3);
@@ -223,7 +238,8 @@ TEST(CombinedImuFactor, CheckCovariance) {
 
   imuBias::ConstantBias currentBias;
 
-  PreintegratedCombinedMeasurements actual(params, currentBias);
+  using PIM = PreintegratedCombinedMeasurementsT<PreintegrationType>;
+  PIM actual(params, currentBias);
 
   // Measurements
   Vector3 measuredAcc(0.1577, -0.8251, 9.6111);
@@ -256,7 +272,7 @@ TEST(CombinedImuFactor, CheckCovariance) {
 /* ************************************************************************* */
 // Test that the covariance values for the ImuFactor and the CombinedImuFactor
 // (top-left 9x9) are the same
-TEST(CombinedImuFactor, SameCovariance) {
+TEST_PIM(CombinedImuFactor, SameCovariance) {
   // IMU measurements and time delta
   Vector3 accMeas(0.1577, -0.8251, 9.6111);
   Vector3 omegaMeas(-0.0210, 0.0311, 0.0145);
@@ -273,7 +289,7 @@ TEST(CombinedImuFactor, SameCovariance) {
   params->setOmegaCoriolis(Vector3::Zero());
 
   // The IMU preintegration object for ImuFactor
-  PreintegratedImuMeasurements pim(params, currentBias);
+  PreintegratedImuMeasurementsT<PreintegrationType> pim(params, currentBias);
   pim.integrateMeasurement(accMeas, omegaMeas, deltaT);
 
   // Define params for CombinedImuFactor
@@ -287,7 +303,7 @@ TEST(CombinedImuFactor, SameCovariance) {
   combined_params->setBiasAccOmegaInit(Z_6x6);
 
   // The IMU preintegration object for CombinedImuFactor
-  PreintegratedCombinedMeasurements cpim(combined_params, currentBias);
+  PreintegratedCombinedMeasurementsT<PreintegrationType> cpim(combined_params, currentBias);
   cpim.integrateMeasurement(accMeas, omegaMeas, deltaT);
 
   // Assert if the noise covariance
@@ -296,6 +312,8 @@ TEST(CombinedImuFactor, SameCovariance) {
 }
 
 /* ************************************************************************* */
+// Runners currently still use the integration type based on the compile flag.
+// So we use the default CombinedScenarioRunner below.
 TEST(CombinedImuFactor, Accelerating) {
   const double a = 0.2, v = 50;
 
@@ -321,6 +339,8 @@ TEST(CombinedImuFactor, Accelerating) {
 }
 
 /* ************************************************************************* */
+// Runners currently still use the integration type based on the compile flag.
+// So we use the default CombinedScenarioRunner below.
 TEST(CombinedImuFactor, ResetIntegration) {
   const double a = 0.2, v = 50;
 

--- a/gtsam/navigation/tests/testCombinedImuFactor.cpp
+++ b/gtsam/navigation/tests/testCombinedImuFactor.cpp
@@ -52,22 +52,6 @@ static std::shared_ptr<PreintegratedCombinedMeasurements::Params> Params(
 }  // namespace testing
 
 /* ************************************************************************* */
-namespace {
-// Macro to test ImuFactor with both Manifold and Tangent preintegration
-// In the tests below, the selected PreintegratedImuMeasurementsT is available as `PIM`.
-#define TEST_PIM(testGroup, testName)                                           \
-  template <class PreintegrationType>                                                          \
-  void testGroup##testName##Helper(TestResult& result_,                         \
-                                   const std::string& name_);                   \
-  TEST(testGroup, testName) {                                                   \
-    testGroup##testName##Helper<ManifoldPreintegration>(result_, this->name_);  \
-    testGroup##testName##Helper<TangentPreintegration>(result_, this->name_);   \
-  }                                                                             \
-  template <class PreintegrationType>                                                          \
-  void testGroup##testName##Helper(TestResult& result_, const std::string& name_)
-}  // namespace
-
-/* ************************************************************************* */
 TEST_PIM(CombinedImuFactor, PreintegratedMeasurements ) {
   // Linearization point
   Bias bias(Vector3(0, 0, 0), Vector3(0, 0, 0)); ///< Current estimate of acceleration and angular rate biases
@@ -81,10 +65,10 @@ TEST_PIM(CombinedImuFactor, PreintegratedMeasurements ) {
   auto p = testing::Params();
 
   // Actual preintegrated values
-  PreintegratedImuMeasurementsT<PreintegrationType> expected1(p, bias);
+  PIM expected1(p, bias);
   expected1.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
 
-  PreintegratedCombinedMeasurementsT<PreintegrationType> actual1(p, bias);
+  CombinedPIM actual1(p, bias);
 
   actual1.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
 
@@ -107,7 +91,6 @@ TEST_PIM(CombinedImuFactor, ErrorWithBiases ) {
 
   auto p = testing::Params();
   p->omegaCoriolis = Vector3(0,0.1,0.1);
-  using PIM = PreintegratedImuMeasurementsT<PreintegrationType>;
   PIM pim(p, Bias(Vector3(0.2, 0.0, 0.0), Vector3(0.0, 0.0, 0.0)));
 
   // Measurements
@@ -120,7 +103,6 @@ TEST_PIM(CombinedImuFactor, ErrorWithBiases ) {
 
   pim.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
 
-  using CombinedPIM = PreintegratedCombinedMeasurementsT<PreintegrationType>;
   CombinedPIM combined_pim(p, Bias(Vector3(0.2, 0.0, 0.0), Vector3(0.0, 0.0, 0.0)));
 
   combined_pim.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
@@ -185,8 +167,7 @@ TEST_PIM(CombinedImuFactor, PredictPositionAndVelocity) {
   const Vector3 measuredAcc(0, 1.1, -kGravity);
   const double deltaT = 0.01;
 
-  using PIM = PreintegratedCombinedMeasurementsT<PreintegrationType>;
-  PIM pim(p, bias);
+  CombinedPIM pim(p, bias);
 
   for (int i = 0; i < 100; ++i)
     pim.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
@@ -194,7 +175,7 @@ TEST_PIM(CombinedImuFactor, PredictPositionAndVelocity) {
   // Create factor
   const noiseModel::Gaussian::shared_ptr combinedmodel =
       noiseModel::Gaussian::Covariance(pim.preintMeasCov());
-  const CombinedImuFactorT<PIM> Combinedfactor(X(1), V(1), X(2), V(2), B(1), B(2), pim);
+  const CombinedImuFactorT<CombinedPIM> Combinedfactor(X(1), V(1), X(2), V(2), B(1), B(2), pim);
 
   // Predict
   const NavState actual = pim.predict(NavState(), bias);
@@ -208,15 +189,14 @@ TEST_PIM(CombinedImuFactor, PredictPositionAndVelocity) {
 TEST_PIM(CombinedImuFactor, PredictRotation) {
   const Bias bias(Vector3(0, 0, 0), Vector3(0, 0, 0)); // Biases (acc, rot)
   auto p = testing::Params();
-  using PIM = PreintegratedCombinedMeasurementsT<PreintegrationType>;
-  PIM pim(p, bias);
+  CombinedPIM pim(p, bias);
   const Vector3 measuredAcc = - kGravityAlongNavZDown;
   const Vector3 measuredOmega(0, 0, M_PI / 10.0);
   const double deltaT = 0.01;
   const double tol = 1e-4;
   for (int i = 0; i < 100; ++i)
     pim.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
-  const CombinedImuFactorT<PIM> Combinedfactor(X(1), V(1), X(2), V(2), B(1), B(2), pim);
+  const CombinedImuFactorT<CombinedPIM> Combinedfactor(X(1), V(1), X(2), V(2), B(1), B(2), pim);
 
   // Predict
   const Pose3 x(Rot3::Ypr(0, 0, 0), Point3(0, 0, 0)), x2;
@@ -238,8 +218,7 @@ TEST_PIM(CombinedImuFactor, CheckCovariance) {
 
   imuBias::ConstantBias currentBias;
 
-  using PIM = PreintegratedCombinedMeasurementsT<PreintegrationType>;
-  PIM actual(params, currentBias);
+  CombinedPIM actual(params, currentBias);
 
   // Measurements
   Vector3 measuredAcc(0.1577, -0.8251, 9.6111);
@@ -289,7 +268,7 @@ TEST_PIM(CombinedImuFactor, SameCovariance) {
   params->setOmegaCoriolis(Vector3::Zero());
 
   // The IMU preintegration object for ImuFactor
-  PreintegratedImuMeasurementsT<PreintegrationType> pim(params, currentBias);
+  PIM pim(params, currentBias);
   pim.integrateMeasurement(accMeas, omegaMeas, deltaT);
 
   // Define params for CombinedImuFactor
@@ -303,7 +282,7 @@ TEST_PIM(CombinedImuFactor, SameCovariance) {
   combined_params->setBiasAccOmegaInit(Z_6x6);
 
   // The IMU preintegration object for CombinedImuFactor
-  PreintegratedCombinedMeasurementsT<PreintegrationType> cpim(combined_params, currentBias);
+  CombinedPIM cpim(combined_params, currentBias);
   cpim.integrateMeasurement(accMeas, omegaMeas, deltaT);
 
   // Assert if the noise covariance

--- a/gtsam/navigation/tests/testImuFactor.cpp
+++ b/gtsam/navigation/tests/testImuFactor.cpp
@@ -49,7 +49,8 @@ static std::shared_ptr<PreintegrationParams> Params() {
 namespace {
 // Auxiliary functions to test evaluate error in ImuFactor
 /* ************************************************************************* */
-Rot3 evaluateRotationError(const ImuFactor& factor, const Pose3& pose_i,
+template <class ImuFactorType>
+Rot3 evaluateRotationError(const ImuFactorType& factor, const Pose3& pose_i,
     const Vector3& vel_i, const Pose3& pose_j, const Vector3& vel_j,
     const Bias& bias) {
   return Rot3::Expmap(
@@ -59,9 +60,25 @@ Rot3 evaluateRotationError(const ImuFactor& factor, const Pose3& pose_i,
 } // namespace
 
 /* ************************************************************************* */
-TEST(ImuFactor, PreintegratedMeasurementsConstruction) {
+namespace {
+// Macro to test ImuFactor with both Manifold and Tangent preintegration
+// In the tests below, the selected PreintegratedImuMeasurementsT is available as `PIM`.
+#define TEST_PIM(testGroup, testName)                                           \
+  template <class PIM>                                                          \
+  void testGroup##testName##Helper(TestResult& result_,                         \
+                                   const std::string& name_);                   \
+  TEST(testGroup, testName) {                                                   \
+    testGroup##testName##Helper<PreintegratedImuMeasurementsT<ManifoldPreintegration>>(result_, this->name_);  \
+    testGroup##testName##Helper<PreintegratedImuMeasurementsT<TangentPreintegration>>(result_, this->name_);   \
+  }                                                                             \
+  template <class PIM>                                                          \
+  void testGroup##testName##Helper(TestResult& result_, const std::string& name_)
+}  // namespace
+
+/* ************************************************************************* */
+TEST_PIM(ImuFactor, PreintegratedMeasurementsConstruction) {
   // Actual pre-integrated values
-  PreintegratedImuMeasurements actual(testing::Params());
+  PIM actual(testing::Params());
   EXPECT(assert_equal(Rot3(), actual.deltaRij()));
   EXPECT(assert_equal(kZero, actual.deltaPij()));
   EXPECT(assert_equal(kZero, actual.deltaVij()));
@@ -69,11 +86,11 @@ TEST(ImuFactor, PreintegratedMeasurementsConstruction) {
 }
 
 /* ************************************************************************* */
-TEST(ImuFactor, PreintegratedMeasurementsReset) {
+TEST_PIM(ImuFactor, PreintegratedMeasurementsReset) {
 
 	auto p = testing::Params();
 	// Create a preintegrated measurement struct and integrate
-	PreintegratedImuMeasurements pimActual(p);
+	PIM pimActual(p);
 	Vector3 measuredAcc(0.5, 1.0, 0.5);
 	Vector3 measuredOmega(0.1, 0.3, 0.1);
 	double deltaT = 1.0;
@@ -81,11 +98,11 @@ TEST(ImuFactor, PreintegratedMeasurementsReset) {
 
 	// reset and make sure that it is the same as a fresh one
 	pimActual.resetIntegration();
-	CHECK(assert_equal(pimActual, PreintegratedImuMeasurements(p)));
+	CHECK(assert_equal(pimActual, PIM(p)));
 
 	// Now create one with a different bias ..
 	Bias nonZeroBias(Vector3(0.2, 0, 0), Vector3(0.1, 0, 0.3));
-	PreintegratedImuMeasurements pimExpected(p, nonZeroBias);
+	PIM pimExpected(p, nonZeroBias);
 
 	// integrate again, then reset to a new bias
 	pimActual.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
@@ -117,7 +134,7 @@ TEST(ImuFactor, Accelerating) {
 }
 
 /* ************************************************************************* */
-TEST(ImuFactor, PreintegratedMeasurements) {
+TEST_PIM(ImuFactor, PreintegratedMeasurements) {
   // Measurements
   const double a = 0.1, w = M_PI / 100.0;
   Vector3 measuredAcc(a, 0.0, 0.0);
@@ -130,7 +147,7 @@ TEST(ImuFactor, PreintegratedMeasurements) {
   Vector3 expectedDeltaV1(0.05, 0.0, 0.0);
 
   // Actual pre-integrated values
-  PreintegratedImuMeasurements actual(testing::Params());
+  PIM actual(testing::Params());
   actual.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
   EXPECT(assert_equal(Rot3::Expmap(expectedDeltaR1), actual.deltaRij()));
   EXPECT(assert_equal(expectedDeltaP1, actual.deltaPij()));
@@ -189,13 +206,13 @@ static const NavState state2(x2, v2);
 } // namespace common
 
 /* ************************************************************************* */
-TEST(ImuFactor, PreintegrationBaseMethods) {
+TEST_PIM(ImuFactor, PreintegrationBaseMethods) {
   using namespace common;
   auto p = testing::Params();
   p->omegaCoriolis = Vector3(0.02, 0.03, 0.04);
   p->use2ndOrderCoriolis = true;
 
-  PreintegratedImuMeasurements pim(p, kZeroBiasHat);
+  PIM pim(p, kZeroBiasHat);
   pim.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
   pim.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
 
@@ -221,10 +238,10 @@ TEST(ImuFactor, PreintegrationBaseMethods) {
 }
 
 /* ************************************************************************* */
-TEST(ImuFactor, MultipleMeasurements) {
+TEST_PIM(ImuFactor, MultipleMeasurements) {
   using namespace common;
 
-  PreintegratedImuMeasurements expected(testing::Params(), kZeroBiasHat);
+  PIM expected(testing::Params(), kZeroBiasHat);
   expected.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
   expected.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
 
@@ -233,22 +250,22 @@ TEST(ImuFactor, MultipleMeasurements) {
   acc << measuredAcc, measuredAcc;
   gyro << measuredOmega, measuredOmega;
   dts << deltaT, deltaT;
-  PreintegratedImuMeasurements actual(testing::Params(), kZeroBiasHat);
+  PIM actual(testing::Params(), kZeroBiasHat);
   actual.integrateMeasurements(acc,gyro,dts);
 
   EXPECT(assert_equal(expected,actual));
 }
 
 /* ************************************************************************* */
-TEST(ImuFactor, ErrorAndJacobians) {
+TEST_PIM(ImuFactor, ErrorAndJacobians) {
   using namespace common;
-  PreintegratedImuMeasurements pim(testing::Params());
+  PIM pim(testing::Params());
 
   pim.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
   EXPECT(assert_equal(state2, pim.predict(state1, kZeroBias)));
 
   // Create factor
-  ImuFactor factor(X(1), V(1), X(2), V(2), B(1), pim);
+  ImuFactorT<PIM> factor(X(1), V(1), X(2), V(2), B(1), pim);
 
   // Expected error
   Vector expectedError(9);
@@ -277,12 +294,12 @@ TEST(ImuFactor, ErrorAndJacobians) {
   // Make sure rotation part is correct when error is interpreted as axis-angle
   // Jacobians are around zero, so the rotation part is the same as:
   Matrix H1Rot3 = numericalDerivative11<Rot3, Pose3>(
-      std::bind(&evaluateRotationError, factor, std::placeholders::_1, v1, x2, v2, kZeroBias),
+      std::bind(&evaluateRotationError<ImuFactorT<PIM>>, factor, std::placeholders::_1, v1, x2, v2, kZeroBias),
       x1);
   EXPECT(assert_equal(H1Rot3, H1a.topRows(3)));
 
   Matrix H3Rot3 = numericalDerivative11<Rot3, Pose3>(
-      std::bind(&evaluateRotationError, factor, x1, v1, std::placeholders::_1, v2, kZeroBias),
+      std::bind(&evaluateRotationError<ImuFactorT<PIM>>, factor, x1, v1, std::placeholders::_1, v2, kZeroBias),
       x2);
   EXPECT(assert_equal(H3Rot3, H3a.topRows(3)));
 
@@ -306,7 +323,7 @@ TEST(ImuFactor, ErrorAndJacobians) {
 }
 
 /* ************************************************************************* */
-TEST(ImuFactor, ErrorAndJacobianWithBiases) {
+TEST_PIM(ImuFactor, ErrorAndJacobianWithBiases) {
   using common::x1;
   using common::v1;
   using common::v2;
@@ -325,7 +342,7 @@ TEST(ImuFactor, ErrorAndJacobianWithBiases) {
   p->omegaCoriolis = kNonZeroOmegaCoriolis;
 
   Bias biasHat(Vector3(0.2, 0.0, 0.0), Vector3(0.0, 0.0, 0.1));
-  PreintegratedImuMeasurements pim(p, biasHat);
+  PIM pim(p, biasHat);
   pim.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
 
   // Make sure of biasCorrectedDelta
@@ -337,7 +354,7 @@ TEST(ImuFactor, ErrorAndJacobianWithBiases) {
   EXPECT(assert_equal(expectedH, actualH));
 
   // Create factor
-  ImuFactor factor(X(1), V(1), X(2), V(2), B(1), pim);
+  ImuFactorT<PIM> factor(X(1), V(1), X(2), V(2), B(1), pim);
 
   Values values;
   values.insert(X(1), x1);
@@ -352,7 +369,7 @@ TEST(ImuFactor, ErrorAndJacobianWithBiases) {
 }
 
 /* ************************************************************************* */
-TEST(ImuFactor, ErrorAndJacobianWith2ndOrderCoriolis) {
+TEST_PIM(ImuFactor, ErrorAndJacobianWith2ndOrderCoriolis) {
   using common::x1;
   using common::v1;
   using common::v2;
@@ -371,12 +388,11 @@ TEST(ImuFactor, ErrorAndJacobianWith2ndOrderCoriolis) {
   p->omegaCoriolis = kNonZeroOmegaCoriolis;
   p->use2ndOrderCoriolis = true;
 
-  PreintegratedImuMeasurements pim(p,
-      Bias(Vector3(0.2, 0.0, 0.0), Vector3(0.0, 0.0, 0.1)));
+  PIM pim(p, Bias(Vector3(0.2, 0.0, 0.0), Vector3(0.0, 0.0, 0.1)));
   pim.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
 
   // Create factor
-  ImuFactor factor(X(1), V(1), X(2), V(2), B(1), pim);
+  ImuFactorT<PIM> factor(X(1), V(1), X(2), V(2), B(1), pim);
 
   Values values;
   values.insert(X(1), x1);
@@ -471,14 +487,7 @@ TEST(ImuFactor, fistOrderExponential) {
 }
 
 /* ************************************************************************* */
-Vector3 correctedAcc(const PreintegratedImuMeasurements& pim,
-    const Vector3& measuredAcc, const Vector3& measuredOmega) {
-  Vector3 correctedAcc = pim.biasHat().correctAccelerometer(measuredAcc);
-  Vector3 correctedOmega = pim.biasHat().correctGyroscope(measuredOmega);
-  return pim.correctMeasurementsBySensorPose(correctedAcc, correctedOmega).first;
-}
-
-TEST(ImuFactor, ErrorWithBiasesAndSensorBodyDisplacement) {
+TEST_PIM(ImuFactor, ErrorWithBiasesAndSensorBodyDisplacement) {
   const Rot3 nRb = Rot3::Expmap(Vector3(0, 0, M_PI / 4.0));
   const Point3 p1(5.0, 1.0, -50.0);
   const Vector3 v1(0.5, 0.0, 0.0);
@@ -497,7 +506,7 @@ TEST(ImuFactor, ErrorWithBiasesAndSensorBodyDisplacement) {
   const double T = 3.0; // seconds
   ScenarioRunner runner(scenario, p, T / 10);
 
-  //  PreintegratedImuMeasurements pim = runner.integrate(T);
+  //  PIM pim = runner.integrate(T);
   //  EXPECT(assert_equal(scenario.pose(T), runner.predict(pim).pose, 1e-9));
   //
   //  Matrix6 estimatedCov = runner.estimatePoseCovariance(T);
@@ -513,51 +522,33 @@ TEST(ImuFactor, ErrorWithBiasesAndSensorBodyDisplacement) {
   // Get mean prediction from "ground truth" measurements
   const Vector3 accNoiseVar2(0.01, 0.02, 0.03);
   const Vector3 omegaNoiseVar2(0.03, 0.01, 0.02);
-  PreintegratedImuMeasurements pim(p, biasHat);
+  PIM pim(p, biasHat);
 
-  // Check updatedDeltaXij derivatives
+  // Check correctMeasurementsBySensorPose derivatives
   Matrix3 D_correctedAcc_measuredOmega = Z_3x3;
   pim.correctMeasurementsBySensorPose(measuredAcc, measuredOmega,
       nullptr, D_correctedAcc_measuredOmega, nullptr);
-  Matrix3 expectedD = numericalDerivative11<Vector3, Vector3>(
-      std::bind(correctedAcc, pim, measuredAcc, std::placeholders::_1),
-      measuredOmega, 1e-6);
+  auto correctedAcc = [&](const Vector3& measuredOmega) -> Vector3 {
+    Vector3 correctedAcc = pim.biasHat().correctAccelerometer(measuredAcc);
+    Vector3 correctedOmega = pim.biasHat().correctGyroscope(measuredOmega);
+    return pim.correctMeasurementsBySensorPose(correctedAcc, correctedOmega).first;
+  };
+  Matrix3 expectedD = numericalDerivative11<Vector3, Vector3>(correctedAcc, measuredOmega, 1e-6);
   EXPECT(assert_equal(expectedD, D_correctedAcc_measuredOmega, 1e-5));
-
-  double dt = 0.1;
-
-// TODO(frank): revive derivative tests
-//  Matrix93 G1, G2;
-//  Vector9 preint =
-//      pim.updatedDeltaXij(measuredAcc, measuredOmega, dt, {}, G1, G2);
-//
-//  Matrix93 expectedG1 = numericalDerivative21<NavState, Vector3, Vector3>(
-//      std::bind(&PreintegratedImuMeasurements::updatedDeltaXij, pim,
-//          std::placeholders::_1, std::placeholders::_2,
-//          dt, {}, {}, {}), measuredAcc,
-//      measuredOmega, 1e-6);
-//  EXPECT(assert_equal(expectedG1, G1, 1e-5));
-//
-//  Matrix93 expectedG2 = numericalDerivative22<NavState, Vector3, Vector3>(
-//      std::bind(&PreintegratedImuMeasurements::updatedDeltaXij, pim,
-//          std::placeholders::_1, std::placeholders::_2,
-//          dt, {}, {}, {}), measuredAcc,
-//      measuredOmega, 1e-6);
-//  EXPECT(assert_equal(expectedG2, G2, 1e-5));
-
-  Bias bias(Vector3(0.2, 0, 0), Vector3(0, 0, 0.3)); // Biases (acc, rot)
 
   // integrate at least twice to get position information
   // otherwise factor cov noise from preint_cov is not positive definite
+  double dt = 0.1;
   pim.integrateMeasurement(measuredAcc, measuredOmega, dt);
   pim.integrateMeasurement(measuredAcc, measuredOmega, dt);
-
+  
   // Create factor
-  ImuFactor factor(X(1), V(1), X(2), V(2), B(1), pim);
-
+  ImuFactorT<PIM> factor(X(1), V(1), X(2), V(2), B(1), pim);
+  
   Pose3 x2(Rot3::Expmap(Vector3(0, 0, M_PI / 4.0 + M_PI / 10.0)),
-      Point3(5.5, 1.0, -50.0));
+  Point3(5.5, 1.0, -50.0));
   Vector3 v2(Vector3(0.5, 0.0, 0.0));
+  Bias bias(Vector3(0.2, 0, 0), Vector3(0, 0, 0.3)); // Biases (acc, rot)
 
   Values values;
   values.insert(X(1), x1);
@@ -572,7 +563,7 @@ TEST(ImuFactor, ErrorWithBiasesAndSensorBodyDisplacement) {
 }
 
 /* ************************************************************************* */
-TEST(ImuFactor, PredictPositionAndVelocity) {
+TEST_PIM(ImuFactor, PredictPositionAndVelocity) {
   gttic(PredictPositionAndVelocity);
   Bias bias(Vector3(0, 0, 0), Vector3(0, 0, 0)); // Biases (acc, rot)
 
@@ -583,14 +574,13 @@ TEST(ImuFactor, PredictPositionAndVelocity) {
   measuredAcc << 0, 1, -kGravity;
   double deltaT = 0.001;
 
-  PreintegratedImuMeasurements pim(testing::Params(),
-      Bias(Vector3(0.2, 0.0, 0.0), Vector3(0.0, 0.0, 0.0)));
+  PIM pim(testing::Params(), Bias(Vector3(0.2, 0.0, 0.0), Vector3(0.0, 0.0, 0.0)));
 
   for (int i = 0; i < 1000; ++i)
     pim.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
 
   // Create factor
-  ImuFactor factor(X(1), V(1), X(2), V(2), B(1), pim);
+  ImuFactorT<PIM> factor(X(1), V(1), X(2), V(2), B(1), pim);
 
   // Predict
   Pose3 x1;
@@ -601,7 +591,7 @@ TEST(ImuFactor, PredictPositionAndVelocity) {
 }
 
 /* ************************************************************************* */
-TEST(ImuFactor, PredictRotation) {
+TEST_PIM(ImuFactor, PredictRotation) {
   gttic(PredictRotation);
   Bias bias(Vector3(0, 0, 0), Vector3(0, 0, 0)); // Biases (acc, rot)
 
@@ -612,14 +602,14 @@ TEST(ImuFactor, PredictRotation) {
   measuredAcc << 0, 0, -kGravity;
   double deltaT = 0.001;
 
-  PreintegratedImuMeasurements pim(testing::Params(),
+  PIM pim(testing::Params(),
       Bias(Vector3(0.2, 0.0, 0.0), Vector3(0.0, 0.0, 0.0)));
 
   for (int i = 0; i < 1000; ++i)
     pim.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
 
   // Create factor
-  ImuFactor factor(X(1), V(1), X(2), V(2), B(1), pim);
+  ImuFactorT<PIM> factor(X(1), V(1), X(2), V(2), B(1), pim);
 
   // Predict
   NavState actual = pim.predict(NavState(), bias);
@@ -628,7 +618,7 @@ TEST(ImuFactor, PredictRotation) {
 }
 
 /* ************************************************************************* */
-TEST(ImuFactor, PredictArbitrary) {
+TEST_PIM(ImuFactor, PredictArbitrary) {
   gttic(PredictArbitrary);
   Pose3 x1;
   const Vector3 v1(0, 0, 0);
@@ -639,7 +629,7 @@ TEST(ImuFactor, PredictArbitrary) {
   const double T = 3.0; // seconds
   ScenarioRunner runner(scenario, testing::Params(), T / 10);
   //
-  //  PreintegratedImuMeasurements pim = runner.integrate(T);
+  //  PIM pim = runner.integrate(T);
   //  EXPECT(assert_equal(scenario.pose(T), runner.predict(pim).pose, 1e-9));
   //
   //  Matrix6 estimatedCov = runner.estimatePoseCovariance(T);
@@ -654,7 +644,7 @@ TEST(ImuFactor, PredictArbitrary) {
 
   auto p = testing::Params();
   p->integrationCovariance = Z_3x3; // MonteCarlo does not sample integration noise
-  PreintegratedImuMeasurements pim(p, biasHat);
+  PIM pim(p, biasHat);
   Bias bias(Vector3(0, 0, 0), Vector3(0, 0, 0));
 //  EXPECT(MonteCarlo(pim, NavState(x1, v1), bias, 0.1, {}, measuredAcc, measuredOmega,
 //                    Vector3::Constant(accNoiseVar), Vector3::Constant(omegaNoiseVar), 100000));
@@ -664,7 +654,7 @@ TEST(ImuFactor, PredictArbitrary) {
     pim.integrateMeasurement(measuredAcc, measuredOmega, dt);
 
   // Create factor
-  ImuFactor factor(X(1), V(1), X(2), V(2), B(1), pim);
+  ImuFactorT<PIM> factor(X(1), V(1), X(2), V(2), B(1), pim);
 
   // Predict
   NavState actual = pim.predict(NavState(x1, v1), bias);
@@ -681,7 +671,7 @@ TEST(ImuFactor, PredictArbitrary) {
 }
 
 /* ************************************************************************* */
-TEST(ImuFactor, bodyPSensorNoBias) {
+TEST_PIM(ImuFactor, bodyPSensorNoBias) {
   gttic(bodyPSensorNoBias);
   Bias bias(Vector3(0, 0, 0), Vector3(0, 0.1, 0)); // Biases (acc, rot)
 
@@ -698,13 +688,13 @@ TEST(ImuFactor, bodyPSensorNoBias) {
   Vector3 s_accMeas(0, 0, -kGravity);
   double dt = 0.001;
 
-  PreintegratedImuMeasurements pim(p, bias);
+  PIM pim(p, bias);
 
   for (int i = 0; i < 1000; ++i)
     pim.integrateMeasurement(s_accMeas, s_omegaMeas_ns, dt);
 
   // Create factor
-  ImuFactor factor(X(1), V(1), X(2), V(2), B(1), pim);
+  ImuFactorT<PIM> factor(X(1), V(1), X(2), V(2), B(1), pim);
 
   // Predict
   NavState actual = pim.predict(NavState(), bias);
@@ -722,7 +712,7 @@ TEST(ImuFactor, bodyPSensorNoBias) {
 #include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
 #include <gtsam/nonlinear/Marginals.h>
 
-TEST(ImuFactor, bodyPSensorWithBias) {
+TEST_PIM(ImuFactor, bodyPSensorWithBias) {
   gttic(bodyPSensorWithBias);
   using noiseModel::Diagonal;
   typedef Bias Bias;
@@ -780,12 +770,13 @@ TEST(ImuFactor, bodyPSensorWithBias) {
   // Now add IMU factors and bias noise models
   Bias zeroBias(Vector3(0, 0, 0), Vector3(0, 0, 0));
   for (int i = 1; i < numPoses; i++) {
-    PreintegratedImuMeasurements pim(p, priorBias);
+    PIM pim(p, priorBias);
     for (int j = 0; j < 200; ++j)
       pim.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
 
     // Create factors
-    graph.emplace_shared<ImuFactor>(X(i - 1), V(i - 1), X(i), V(i), B(i - 1), pim);
+    using FACTOR = ImuFactorT<PIM>;
+    graph.emplace_shared<FACTOR>(X(i - 1), V(i - 1), X(i), V(i), B(i - 1), pim);
     graph.emplace_shared<BetweenFactor<Bias> >(B(i - 1), B(i), zeroBias, biasNoiseModel);
 
     values.insert(X(i), Pose3());
@@ -901,14 +892,14 @@ TEST(ImuFactor, MergeWithCoriolis) {
 
 /* ************************************************************************* */
 // Same values as pre-integration test but now testing covariance
-TEST(ImuFactor, CheckCovariance) {
+TEST_PIM(ImuFactor, CheckCovariance) {
   gttic(CheckCovariance);
   // Measurements
   Vector3 measuredAcc(0.1, 0.0, 0.0);
   Vector3 measuredOmega(M_PI / 100.0, 0.0, 0.0);
   double deltaT = 0.5;
 
-  PreintegratedImuMeasurements actual(testing::Params());
+  PIM actual(testing::Params());
   actual.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
   Matrix9 expected;
   expected << 1.0577e-08, 0, 0, 0, 0, 0, 0, 0, 0,     //

--- a/gtsam/navigation/tests/testImuFactor.cpp
+++ b/gtsam/navigation/tests/testImuFactor.cpp
@@ -46,22 +46,6 @@ static std::shared_ptr<PreintegrationParams> Params() {
 }
 
 /* ************************************************************************* */
-namespace {
-// Macro to test ImuFactor with both Manifold and Tangent preintegration
-// In the tests below, the selected PreintegratedImuMeasurementsT is available as `PIM`.
-#define TEST_PIM(testGroup, testName)                                           \
-  template <class PIM>                                                          \
-  void testGroup##testName##Helper(TestResult& result_,                         \
-                                   const std::string& name_);                   \
-  TEST(testGroup, testName) {                                                   \
-    testGroup##testName##Helper<PreintegratedImuMeasurementsT<ManifoldPreintegration>>(result_, this->name_);  \
-    testGroup##testName##Helper<PreintegratedImuMeasurementsT<TangentPreintegration>>(result_, this->name_);   \
-  }                                                                             \
-  template <class PIM>                                                          \
-  void testGroup##testName##Helper(TestResult& result_, const std::string& name_)
-}  // namespace
-
-/* ************************************************************************* */
 TEST_PIM(ImuFactor, PreintegratedMeasurementsConstruction) {
   // Actual pre-integrated values
   PIM actual(testing::Params());

--- a/gtsam/navigation/tests/testImuFactor.cpp
+++ b/gtsam/navigation/tests/testImuFactor.cpp
@@ -47,20 +47,6 @@ static std::shared_ptr<PreintegrationParams> Params() {
 
 /* ************************************************************************* */
 namespace {
-// Auxiliary functions to test evaluate error in ImuFactor
-/* ************************************************************************* */
-template <class ImuFactorType>
-Rot3 evaluateRotationError(const ImuFactorType& factor, const Pose3& pose_i,
-    const Vector3& vel_i, const Pose3& pose_j, const Vector3& vel_j,
-    const Bias& bias) {
-  return Rot3::Expmap(
-      factor.evaluateError(pose_i, vel_i, pose_j, vel_j, bias).head(3));
-}
-
-} // namespace
-
-/* ************************************************************************* */
-namespace {
 // Macro to test ImuFactor with both Manifold and Tangent preintegration
 // In the tests below, the selected PreintegratedImuMeasurementsT is available as `PIM`.
 #define TEST_PIM(testGroup, testName)                                           \
@@ -294,13 +280,17 @@ TEST_PIM(ImuFactor, ErrorAndJacobians) {
   // Make sure rotation part is correct when error is interpreted as axis-angle
   // Jacobians are around zero, so the rotation part is the same as:
   Matrix H1Rot3 = numericalDerivative11<Rot3, Pose3>(
-      std::bind(&evaluateRotationError<ImuFactorT<PIM>>, factor, std::placeholders::_1, v1, x2, v2, kZeroBias),
-      x1);
+    [&](const Pose3& pose_i) {
+      return Rot3::Expmap(factor.evaluateError(pose_i, v1, x2, v2, kZeroBias).head(3));
+    },
+    x1);
   EXPECT(assert_equal(H1Rot3, H1a.topRows(3)));
 
   Matrix H3Rot3 = numericalDerivative11<Rot3, Pose3>(
-      std::bind(&evaluateRotationError<ImuFactorT<PIM>>, factor, x1, v1, std::placeholders::_1, v2, kZeroBias),
-      x2);
+    [&](const Pose3& pose_j) {
+      return Rot3::Expmap(factor.evaluateError(x1, v1, pose_j, v2, kZeroBias).head(3));
+    },
+    x2);
   EXPECT(assert_equal(H3Rot3, H3a.topRows(3)));
 
   // Evaluate error with wrong values


### PR DESCRIPTION
After @p-zach made the PIM type selectable at run-time, it made sense to make the tests run for all PIM types, especially as we might soon have new integration types. This PR validates that manifold and tangent integration versions behave identically, modulo test coverage.