### PR TITLE
Fix Memory bug in Hybrid Tests

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -116,13 +116,11 @@ jobs:
         run: |
           export CMAKE_GENERATOR=Ninja 
           cmake -E remove_directory build
-          cmake -B build \
-                -S . \
-                -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF \
-                -DGTSAM_ALLOW_DEPRECATED_SINCE_V43=OFF \
-                -DBOOST_ROOT="${BOOST_ROOT}" \
-                -DBOOST_INCLUDEDIR="${BOOST_ROOT}\boost\include" \
-                -DBOOST_LIBRARYDIR="${BOOST_ROOT}\lib"
+          cmake_args="-B build -S . -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF -DGTSAM_ALLOW_DEPRECATED_SINCE_V43=OFF -DBOOST_ROOT=\"${BOOST_ROOT}\" -DBOOST_INCLUDEDIR=\"${BOOST_ROOT}\\boost\\include\" -DBOOST_LIBRARYDIR=\"${BOOST_ROOT}\\lib\""
+          if [ "${{ matrix.build_type }}" == "Debug" ]; then
+            cmake_args="$cmake_args -DGTSAM_ENABLE_ASAN=ON"
+          fi
+          cmake $cmake_args
 
       - name: Build
         shell: bash

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -116,11 +116,13 @@ jobs:
         run: |
           export CMAKE_GENERATOR=Ninja 
           cmake -E remove_directory build
-          cmake_args="-B build -S . -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF -DGTSAM_ALLOW_DEPRECATED_SINCE_V43=OFF -DBOOST_ROOT=\"${BOOST_ROOT}\" -DBOOST_INCLUDEDIR=\"${BOOST_ROOT}\\boost\\include\" -DBOOST_LIBRARYDIR=\"${BOOST_ROOT}\\lib\""
-          if [ "${{ matrix.build_type }}" == "Debug" ]; then
-            cmake_args="$cmake_args -DGTSAM_ENABLE_ASAN=ON"
-          fi
-          cmake $cmake_args
+          cmake -B build \
+                -S . \
+                -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF \
+                -DGTSAM_ALLOW_DEPRECATED_SINCE_V43=OFF \
+                -DBOOST_ROOT="${BOOST_ROOT}" \
+                -DBOOST_INCLUDEDIR="${BOOST_ROOT}\boost\include" \
+                -DBOOST_LIBRARYDIR="${BOOST_ROOT}\lib"
 
       - name: Build
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,37 @@ set (CMAKE_PROJECT_VERSION_PATCH ${GTSAM_VERSION_PATCH})
 ###############################################################################
 # Gather information, perform checks, set defaults
 
+# Option to enable AddressSanitizer
+option(GTSAM_ENABLE_ASAN "Enable AddressSanitizer for memory error detection" OFF)
+
+if (GTSAM_ENABLE_ASAN)
+    message(STATUS "Enabling AddressSanitizer (ASan)")
+    if (MSVC)
+        # MSVC-specific ASan flags
+        # /fsanitize=address enables ASan
+        # /Zi is for debug information (PDB files)
+        # /Od is for disabling optimization (Debug builds)
+        # /MD is for linking with the DLL version of the C runtime library
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fsanitize=address /Zi /Od /MD")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /fsanitize=address /Zi /Od /MD")
+
+        # Linker flags for MSVC ASan
+        # /fsanitize=address enables ASan linking
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /fsanitize=address")
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /fsanitize=address")
+        set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /fsanitize=address")
+    else()
+        # Clang/GCC ASan flags (already there)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
+
+        # Linker flags
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fsanitize=address")
+        set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fsanitize=address")
+    endif()
+endif()
+
 if(MSVC)
   set(MSVC_LINKER_FLAGS "/FORCE:MULTIPLE")
   set(CMAKE_EXE_LINKER_FLAGS ${MSVC_LINKER_FLAGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,8 +51,8 @@ if (GTSAM_ENABLE_ASAN)
         # /Zi is for debug information (PDB files)
         # /Od is for disabling optimization (Debug builds)
         # /MD is for linking with the DLL version of the C runtime library
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fsanitize=address /Zi /Od /MD")
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /fsanitize=address /Zi /Od /MD")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fsanitize=address /Zi /Od")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /fsanitize=address /Zi /Od")
 
         # Linker flags for MSVC ASan
         # /fsanitize=address enables ASan linking

--- a/gtsam/hybrid/tests/DiscreteFixture.h
+++ b/gtsam/hybrid/tests/DiscreteFixture.h
@@ -29,14 +29,32 @@ DiscreteKey dk(D(1), 2);
 Key x1 = X(1);
 
 // Make a factor for non-null hypothesis
-const double loc = 0.0;
-const double sigma1 = 1.0;
-auto prior_noise1 = noiseModel::Isotropic::Sigma(1, sigma1);
-auto f1 = std::make_shared<PriorFactor<double>>(x1, loc, prior_noise1);
+inline std::shared_ptr<gtsam::PriorFactor<double>> f1() {
+  const double loc = 0.0;
+  const double sigma1 = 1.0;
+  static auto prior_noise1 = noiseModel::Isotropic::Sigma(1, sigma1);
+  static auto f = std::make_shared<PriorFactor<double>>(x1, loc, prior_noise1);
+  return f;
+}
 
 // Make a factor for null hypothesis
-const double sigmaNullHypo = 8.0;
-auto prior_noiseNullHypo = noiseModel::Isotropic::Sigma(1, sigmaNullHypo);
-auto fNullHypo =
-    std::make_shared<PriorFactor<double>>(x1, loc, prior_noiseNullHypo);
+inline std::shared_ptr<gtsam::PriorFactor<double>> fNullHypo() {
+  const double loc = 0.0;
+  const double sigmaNullHypo = 8.0;
+  static auto prior_noiseNullHypo = noiseModel::Isotropic::Sigma(1, sigmaNullHypo);
+  static auto f = std::make_shared<PriorFactor<double>>(x1, loc, prior_noiseNullHypo);
+  return f;
+}
+
+inline std::shared_ptr<gtsam::noiseModel::Isotropic> prior_noise1() {
+  const double sigma1 = 1.0;
+  static auto prior_noise1 = noiseModel::Isotropic::Sigma(1, sigma1);
+  return prior_noise1;
+}
+
+inline std::shared_ptr<gtsam::noiseModel::Isotropic> prior_noiseNullHypo() {
+  const double sigmaNullHypo = 8.0;
+  static auto prior_noiseNullHypo = noiseModel::Isotropic::Sigma(1, sigmaNullHypo);
+  return prior_noiseNullHypo;
+}
 }  // namespace discrete_mixture_fixture

--- a/gtsam/hybrid/tests/testDCSAM.cpp
+++ b/gtsam/hybrid/tests/testDCSAM.cpp
@@ -62,8 +62,8 @@ TEST(DCSAM, SimpleMixtureFactor) {
   keys.push_back(x1);
 
   std::vector<NonlinearFactorValuePair> factorComponents{
-      {f1, prior_noise1->negLogConstant()},
-      {fNullHypo, prior_noiseNullHypo->negLogConstant()}};
+      {f1(), prior_noise1()->negLogConstant()},
+      {fNullHypo(), prior_noiseNullHypo()->negLogConstant()}};
 
   HybridNonlinearFactor dcMixture(dk, factorComponents);
 

--- a/gtsam/hybrid/tests/testHybridEstimation.cpp
+++ b/gtsam/hybrid/tests/testHybridEstimation.cpp
@@ -574,7 +574,7 @@ TEST(HybridEstimation, DiscreteMixture) {
   KeyVector keys;
   keys.push_back(x1);
 
-  std::vector<NoiseModelFactor::shared_ptr> factorComponents{f1, fNullHypo};
+  std::vector<NoiseModelFactor::shared_ptr> factorComponents{f1(), fNullHypo()};
 
   HybridNonlinearFactor dcMixture(dk, factorComponents);
   dcfg.push_back(dcMixture);
@@ -662,8 +662,8 @@ TEST(HybridEstimation, ContinuousMixture) {
   keys.push_back(x1);
 
   std::vector<NonlinearFactorValuePair> factorComponents{
-      {f1, prior_noise1->negLogConstant()},
-      {fNullHypo, prior_noiseNullHypo->negLogConstant()}};
+      {f1(), prior_noise1()->negLogConstant()},
+      {fNullHypo(), prior_noiseNullHypo()->negLogConstant()}};
 
   HybridNonlinearFactor dcMixture(dk, factorComponents);
   dcfg.push_back(dcMixture);


### PR DESCRIPTION
There was an intermittent CI failure on Windows/debug flag on. I enabled ASAN on the CI, and lo and behold I got report below. Gemini CLI tracked it down to:
```
Aha! This is excellent news. AddressSanitizer has pinpointed the exact problem: a heap-use-after-free error related to
  discrete_mixture_fixture::fNullHypo.


  Let's break down what the ASan report tells us:


   * Error Type: heap-use-after-free. This means memory was deallocated, and then your program tried to access or modify it again.
   * Location of Use-After-Free: The write occurred at std::_Ref_count_base::_Decref, which is part of std::shared_ptr's internal reference
     counting. This strongly suggests that a shared_ptr is trying to decrement its reference count on an object whose memory has already been
     freed.
   * Culprit Object: The stack trace clearly points to discrete_mixture_fixture::dynamic atexit destructor for 'fNullHypo'. This means 
     fNullHypo` is a global or static object, and the error happens during its destruction when the program exits.
   * Allocation Site: The memory was "previously allocated by thread T0 here: ... discrete_mixture_fixture::dynamic initializer for
     'fNullHypo'' D:\a\gtsam\gtsam\gtsam\hybrid\tests\DiscreteFixture.h:41. This tells us fNullHypo is initialized at DiscreteFixture.h:41`.
   * Free Site: The memory was "freed by thread T0 here: ... discrete_mixture_fixture::dynamic atexit destructor for 'fNullHypo''`. This
     indicates a double-free scenario: the object is being destroyed (and its memory freed) more than once, or its memory is being accessed
     after it has already been freed by a previous destruction.

  The Problem:


  The core issue is a static/global object destruction order problem, specifically a double-free or use-after-free involving fNullHypo,
  which is a std::shared_ptr<gtsam::PriorFactor<double>>. When a program exits, global/static objects are destroyed. If fNullHypo is being
  destroyed by one mechanism (e.g., its shared_ptr destructor) and then another mechanism (e.g., atexit or another static destructor) tries
  to access or destroy it again, you get this error.
```

And suggested the shared pointer fix in gtsam/hybrid/tests/DiscreteFixture.h.

The Address Sanitizer report:
```
│  > Aha!==7648==ERROR: AddressSanitizer: heap-use-after-free on address 0x11f5ee2a1678 at pc 0x7ff79b271383 bp 0x002c9d1df4b0 sp             │
│    0x002c9d1df4b8                                                                                                                           │
│    WRITE of size 4 at 0x11f5ee2a1678 thread T0                                                                                              │
│        #0 0x7ff79b271382 in std::_Ref_count_base::_Decref(void) C:\Program Files\Microsoft Visual                                           │
│    Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory:1159                                                                     │
│        #1 0x7ff79b27096a in std::_Ptr_base<class gtsam::PriorFactor<double>>::_Decref(void) C:\Program Files\Microsoft Visual               │
│    Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory:1385                                                                     │
│        #2 0x7ff79b25ab12 in std::shared_ptr<class gtsam::PriorFactor<double>>::~shared_ptr<class gtsam::PriorFactor<double>>(void)          │
│    C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory:1690                                   │
│        #3 0x7ff79ba3657f in discrete_mixture_fixture::`dynamic atexit destructor for 'fNullHypo''                                           │
│    (D:\a\gtsam\gtsam\build\bin\check_hybrid_program.exe+0x14089657f)                                                                        │
│        #4 0x7ff9a1122b98  (C:\Windows\SYSTEM32\ucrtbased.dll+0x1800a2b98)                                                                   │
│        #5 0x7ff9a11225c4  (C:\Windows\SYSTEM32\ucrtbased.dll+0x1800a25c4)                                                                   │
│        #6 0x7ff9a1122716  (C:\Windows\SYSTEM32\ucrtbased.dll+0x1800a2716)                                                                   │
│        #7 0x7ff9a1122d43  (C:\Windows\SYSTEM32\ucrtbased.dll+0x1800a2d43)                                                                   │
│        #8 0x7ff9a1121f79  (C:\Windows\SYSTEM32\ucrtbased.dll+0x1800a1f79)                                                                   │
│        #9 0x7ff9a1121e0c  (C:\Windows\SYSTEM32\ucrtbased.dll+0x1800a1e0c)                                                                   │
│        #10 0x7ff9a1121e86  (C:\Windows\SYSTEM32\ucrtbased.dll+0x1800a1e86)                                                                  │
│        #11 0x7ff9a112211f  (C:\Windows\SYSTEM32\ucrtbased.dll+0x1800a211f)                                                                  │
│        #12 0x7ff9a1122455  (C:\Windows\SYSTEM32\ucrtbased.dll+0x1800a2455)                                                                  │
│        #13 0x7ff79b9e8a7a in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:295                 │
│        #14 0x7ff79b9e891d in __scrt_common_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:330                     │
│        #15 0x7ff79b9e8b8d in mainCRTStartup D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_main.cpp:16                            │
│        #16 0x7ff9befc4caf  (C:\Windows\System32\KERNEL32.DLL+0x180014caf)                                                                   │
│        #17 0x7ff9bf7dedca  (C:\Windows\SYSTEM32\ntdll.dll+0x18007edca)                                                                      │
│    0x11f5ee2a1678 is located 8 bytes inside of 80-byte region [0x11f5ee2a1670,0x11f5ee2a16c0)                                               │
│    freed by thread T0 here:                                                                                                                 │
│        #0 0x7ff79b9e75b3 in operator delete(void *, unsigned __int64)                                                                       │
│    D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win_delete_scalar_size_thunk.cpp:41                                       │
│        #1 0x7ff79b263800 in std::_Ref_count_obj2<class gtsam::PriorFactor<double>>::`scalar deleting dtor'(unsigned int)                    │
│    (D:\a\gtsam\gtsam\build\bin\check_hybrid_program.exe+0x1400c3800)                                                                        │
│        #2 0x7ff79b272205 in std::_Ref_count_obj2<class gtsam::PriorFactor<double>>::_Delete_this(void) C:\Program Files\Microsoft Visual    │
│    Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory:2122                                                                     │
│        #3 0x7ff79b2714e4 in std::_Ref_count_base::_Decwref(void) C:\Program Files\Microsoft Visual                                          │
│    Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory:1167                                                                     │
│        #4 0x7ff79b2713fd in std::_Ref_count_base::_Decref(void) C:\Program Files\Microsoft Visual                                           │
│    Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory:1161                                                                     │
│        #5 0x7ff79b27096a in std::_Ptr_base<class gtsam::PriorFactor<double>>::_Decref(void) C:\Program Files\Microsoft Visual               │
│    Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory:1385                                                                     │
│        #6 0x7ff79b25ab12 in std::shared_ptr<class gtsam::PriorFactor<double>>::~shared_ptr<class gtsam::PriorFactor<double>>(void)          │
│    C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory:1690                                   │
│        #7 0x7ff79ba36cdf in discrete_mixture_fixture::`dynamic atexit destructor for 'fNullHypo''                                           │
│    (D:\a\gtsam\gtsam\build\bin\check_hybrid_program.exe+0x140896cdf)                                                                        │
│        #8 0x7ff9a1122b98  (C:\Windows\SYSTEM32\ucrtbased.dll+0x1800a2b98)                                                                   │
│        #9 0x7ff9a11225c4  (C:\Windows\SYSTEM32\ucrtbased.dll+0x1800a25c4)                                                                   │
│        #10 0x7ff9a1122716  (C:\Windows\SYSTEM32\ucrtbased.dll+0x1800a2716)                                                                  │
│        #11 0x7ff9a1122d43  (C:\Windows\SYSTEM32\ucrtbased.dll+0x1800a2d43)                                                                  │
│        #12 0x7ff9a1121f79  (C:\Windows\SYSTEM32\ucrtbased.dll+0x1800a1f79)                                                                  │
│        #13 0x7ff9a1121e0c  (C:\Windows\SYSTEM32\ucrtbased.dll+0x1800a1e0c)                                                                  │
│        #14 0x7ff9a1121e86  (C:\Windows\SYSTEM32\ucrtbased.dll+0x1800a1e86)                                                                  │
│        #15 0x7ff9a112211f  (C:\Windows\SYSTEM32\ucrtbased.dll+0x1800a211f)                                                                  │
│        #16 0x7ff9a1122455  (C:\Windows\SYSTEM32\ucrtbased.dll+0x1800a2455)                                                                  │
│        #17 0x7ff79b9e8a7a in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:295                 │
│        #18 0x7ff79b9e891d in __scrt_common_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:330                     │
│        #19 0x7ff79b9e8b8d in mainCRTStartup D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_main.cpp:16                            │
│        #20 0x7ff9befc4caf  (C:\Windows\System32\KERNEL32.DLL+0x180014caf)                                                                   │
│        #21 0x7ff9bf7dedca  (C:\Windows\SYSTEM32\ntdll.dll+0x18007edca)                                                                      │
│    previously allocated by thread T0 here:                                                                                                  │
│        #0 0x7ff79b9e7525 in operator new(unsigned __int64)                                                                                  │
│    D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win_new_scalar_thunk.cpp:40                                               │
│        #1 0x7ff79b20c5c1 in std::make_shared<class gtsam::PriorFactor<double>, unsigned __int64 &, double const &, class                    │
│    std::shared_ptr<class gtsam::noiseModel::Isotropic> &>(unsigned __int64 &, double const &, class std::shared_ptr<class                   │
│    gtsam::noiseModel::Isotropic> &) C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory:2913  │
│        #2 0x7ff79b1a7644 in discrete_mixture_fixture::`dynamic initializer for 'fNullHypo''                                                 │
│    D:\a\gtsam\gtsam\gtsam\hybrid\tests\DiscreteFixture.h:41                                                                                 │
│        #3 0x7ff9a11224f7  (C:\Windows\SYSTEM32\ucrtbased.dll+0x1800a24f7)                                                                   │
│        #4 0x7ff79b9e89ba in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:256                  │
│        #5 0x7ff79b9e891d in __scrt_common_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:330                      │
│        #6 0x7ff79b9e8b8d in mainCRTStartup D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_main.cpp:16                             │
│        #7 0x7ff9befc4caf  (C:\Windows\System32\KERNEL32.DLL+0x180014caf)                                                                    │
│        #8 0x7ff9bf7dedca  (C:\Windows\SYSTEM32\ntdll.dll+0x18007edca)                                                                       │
│    SUMMARY: AddressSanitizer: heap-use-after-free C:\Program Files\Microsoft Visual                                                         │
│    Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory:1159 in std::_Ref_count_base::_Decref(void)                              │
│    Shadow bytes around the buggy address:                                                                                                   │
│      0x11f5ee2a1380: fd fd fd fd fd fa fa fa fa fa fd fd fd fd fd fd                                                                        │
│      0x11f5ee2a1400: fd fd fd fa fa fa fa fa fa fa fa fa fa fa fa fa                                                                        │
│      0x11f5ee2a1480: fa fa fa fa fa fa fd fd fd fd fd fd fd fd fd fa                                                                        │
│      0x11f5ee2a1500: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa                                                                        │
│      0x11f5ee2a1580: fa fa fd fd fd fd fd fd fd fd fd fa fa fa fa fa                                                                        │
│    =>0x11f5ee2a1600: fd fd fd fd fd fd fd fd fd fd fa fa fa fa fd[fd]                                                                       │
│      0x11f5ee2a1680: fd fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa                                                                        │
│      0x11f5ee2a1700: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa                                                                        │
│      0x11f5ee2a1780: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa                                                                        │
│      0x11f5ee2a1800: fa fa fa fa fa fa fd fd fd fd fd fd fd fd fd fa                                                                        │
│      0x11f5ee2a1880: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa                                                                        │
│    Shadow byte legend (one shadow byte represents 8 application bytes):                                                                     │
│      Addressable:           00                                                                                                              │
│      Partially addressable: 01 02 03 04 05 06 07                                                                                            │
│      Heap left redzone:       fa                                                                                                            │
│      Freed heap region:       fd                                                                                                            │
│      Stack left redzone:      f1                                                                                                            │
│      Stack mid redzone:       f2                                                                                                            │
│      Stack right redzone:     f3                                                                                                            │
│      Stack after return:      f5                                                                                                            │
│      Stack use after scope:   f8                                                                                                            │
│      Global redzone:          f9                                                                                                            │
│      Global init order:       f6                                                                                                            │
│      Poisoned by user:        f7                                                                                                            │
│      Container overflow:      fc                                                                                                            │
│      Array cookie:            ac                                                                                                            │
│      Intra object redzone:    bb                                                                                                            │
│      ASan internal:           fe                                                                                                            │
│      Left alloca redzone:     ca                                                                                                            │
│      Right alloca redzone:    cb                                                                                                            │
│    ==7648==ABORTING                                                                                                                         │
│    0% tests passed, 1 tests failed out of 1                                                                                                 │
│    Total Test time (real) =  43.02 sec                                                                                                      │
│    The following tests FAILED:                                                                                                              │
│      1 - check_hybrid_program (Failed)                                                                                                      │
│    Errors while running CTest                                                                                                               │
│    ninja: build stopped: subcommand failed.                                                                                                 │
│    Error: Process completed with exit code 8.                                                                                               │
```