### PR TITLE
Improved Source/Reference Tracking

### DIFF
--- a/gtsam/geometry/doc/Cal3_S2.ipynb
+++ b/gtsam/geometry/doc/Cal3_S2.ipynb
@@ -15,7 +15,7 @@
         "id": "cal3s2-intro"
       },
       "source": [
-        "A `Cal3_S2` represents the simple 5-parameter camera calibration model {cite:p}`https://doi.org/10.1017/CBO9780511811685`[^f1]. This model includes parameters for the focal lengths ($f_x, f_y$), the skew factor ($s$), and the principal point ($u_0, v_0$). It does not model lens distortion. The calibration matrix $K$ is defined as:\n",
+        "A `Cal3_S2` represents the simple 5-parameter camera calibration model [@hartley_multiple_2004]. This model includes parameters for the focal lengths ($f_x, f_y$), the skew factor ($s$), and the principal point ($u_0, v_0$). It does not model lens distortion. The calibration matrix $K$ is defined as:\n",
         "\n",
         "$$\n",
         "K = \\begin{bmatrix} f_x & s & u_0 \\\\ 0 & f_y & v_0 \\\\ 0 & 0 & 1 \\end{bmatrix}\n",
@@ -28,10 +28,7 @@
         "u &= f_x\\cdot x + s\\cdot y + u_0 \\\\\n",
         "v &= f_y\\cdot y + v_0\n",
         "\\end{align*}\n",
-        "$$\n",
-        "\n",
-        "<!-- The following will not be rendered as literal text by MyST -->\n",
-        "[^f1]: See ch. 6 $\\S$ 6.1, pp. 153–157."
+        "$$"
       ]
     },
     {
@@ -547,7 +544,7 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": ".venv",
+      "display_name": "base",
       "language": "python",
       "name": "python3"
     },
@@ -561,7 +558,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.12.3"
+      "version": "3.12.10"
     }
   },
   "nbformat": 4,

--- a/myst.yml
+++ b/myst.yml
@@ -5,6 +5,8 @@ project:
   title: GTSAM Docs
   description: GTSAM is a library of C++ classes that implement smoothing and mapping (SAM) in robotics and vision, using factor graphs and Bayes networks as the underlying computing paradigm rather than sparse matrices.
   github: https://github.com/borglab/gtsam
+  bibliography:
+    - references.bib
   toc:
     - file: README.md
     - file: INSTALL.md

--- a/references.bib
+++ b/references.bib
@@ -1,0 +1,13 @@
+@book{hartley_multiple_2004,
+	edition = {2},
+	title = {Multiple {View} {Geometry} in {Computer} {Vision}},
+	copyright = {https://www.cambridge.org/core/terms},
+	isbn = {978-0-521-54051-3 978-0-511-81168-5},
+	url = {https://www.cambridge.org/core/product/identifier/9780511811685/type/book},
+	urldate = {2025-07-16},
+	publisher = {Cambridge University Press},
+	author = {Hartley, Richard and Zisserman, Andrew},
+	month = mar,
+	year = {2004},
+	doi = {10.1017/cbo9780511811685},
+}


### PR DESCRIPTION
I decided to centralize reference tracking by creating a BibTex file and have MyST look at that file for all references. This makes it easier to keep track of all the references and allows for easy access following the MyST syntax found here: https://mystmd.org/guide/citations#markdown-citations

Note that not all current references are in `references.bib`. I plan on adding existing references to this file gradually.

Update(s):
- Added `references.bib`
- Updated `myst.yml` to have MyST look in `references.bib` for references
- Updated references in `Cal3_S2.ipynb`

Check(s):
- Checked the updated Cal3_S2 page on a local deployment of the MyST site and it appears that references are rendered correctly.