### PR TITLE
Added User Guides for `Cal3_S2Stereo` and `StereoCamera`

### DIFF
--- a/gtsam/geometry/CalibratedCamera.h
+++ b/gtsam/geometry/CalibratedCamera.h
@@ -222,7 +222,7 @@ public:
    * exponential map parameterization
    * @return a pair of [start, end] indices into the tangent space vector
    */
-  static std::pair<size_t, size_t> translationInterval() {
+  static std::pair<size_t, size_t> TranslationInterval() {
     return {3, 5};
   }
 

--- a/gtsam/geometry/CalibratedCamera.h
+++ b/gtsam/geometry/CalibratedCamera.h
@@ -56,15 +56,15 @@ class GTSAM_EXPORT PinholeBase {
 public:
 
   /** Pose Concept requirements */
-  typedef Rot3 Rotation;
-  typedef Point3 Translation;
+  using Rotation = Rot3;
+  using Translation = Point3;
 
   /**
    *  Some classes template on either PinholeCamera or StereoCamera,
    *  and this typedef informs those classes what "project" returns.
    */
-  typedef Point2 Measurement;
-  typedef Point2Vector MeasurementVector;
+  using Measurement = Point2;
+  using MeasurementVector = Point2Vector;
 
 private:
 
@@ -222,7 +222,7 @@ public:
    * exponential map parameterization
    * @return a pair of [start, end] indices into the tangent space vector
    */
-  inline static std::pair<size_t, size_t> translationInterval() {
+  static std::pair<size_t, size_t> translationInterval() {
     return {3, 5};
   }
 

--- a/gtsam/geometry/Point3.h
+++ b/gtsam/geometry/Point3.h
@@ -35,8 +35,8 @@ namespace gtsam {
 
 /// As of GTSAM 4, in order to make GTSAM more lean,
 /// it is now possible to just typedef Point3 to Vector3
-typedef Vector3 Point3;
-typedef std::vector<Point3, Eigen::aligned_allocator<Point3> > Point3Vector;
+using Point3 = Vector3;
+using Point3Vector = std::vector<Point3, Eigen::aligned_allocator<Point3>>;
 
 // Convenience typedef
 using Point3Pair = std::pair<Point3, Point3>;

--- a/gtsam/geometry/StereoCamera.h
+++ b/gtsam/geometry/StereoCamera.h
@@ -52,8 +52,8 @@ public:
    *  Some classes template on either PinholeCamera or StereoCamera,
    *  and this typedef informs those classes what "project" returns.
    */
-  typedef StereoPoint2 Measurement;
-  typedef StereoPoint2Vector MeasurementVector;
+  using Measurement = StereoPoint2;
+  using MeasurementVector = StereoPoint2Vector;
 
 private:
   Pose3 leftCamPose_;

--- a/gtsam/geometry/doc/Cal3_S2.ipynb
+++ b/gtsam/geometry/doc/Cal3_S2.ipynb
@@ -12,6 +12,15 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "cal3s2-colab-badge"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/Cal3_S2.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "id": "cal3s2-intro"
       },
       "source": [
@@ -35,30 +44,34 @@
       ]
     },
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "cal3s2-colab-badge"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/Cal3_S2.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "cal3s2-pip-install"
+        "id": "cal3s2-pip-install",
+        "tags": [
+          "remove-cell"
+        ]
       },
       "outputs": [],
       "source": [
-        "%pip install --quiet gtsam-develop"
+        "try:\n",
+        "    import google.colab\n",
+        "    print(\"Running in Google Colab, installing necessary libraries...\")\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "    print(\"Done!\")\n",
+        "except ImportError:\n",
+        "    print(\"Not running in Google Colab. Please install necessary libraries as needed.\")\n",
+        "    pass"
       ]
     },
     {
       "cell_type": "code",
       "execution_count": 2,
       "metadata": {
-        "id": "cal3s2-imports"
+        "id": "cal3s2-imports",
+        "tags": [
+          "remove-cell"
+        ]
       },
       "outputs": [],
       "source": [
@@ -80,7 +93,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "A `Cal3_S2` can be initialized in several ways. Initializing with no arguments yields a calibration model with the identity matrix as the calibration matrix. You can also construct a particular model with either individual values for the focal lengths, skew, and principal point, or pass all parameters in a 5-vector."
+        "A `Cal3_S2` can be initialized in several ways:"
       ]
     },
     {
@@ -291,8 +304,7 @@
         "\n",
         "### `calibrate()`\n",
         "\n",
-        "`Cal3_S2` provides member functions to convert points between normalized image coordinates and pixel coordinates.\n",
-        "The `calibrate(p)` member function converts a 2D point `p` in image pixel coordinates $(u, v)$ to normalized image coordinates $(x, y)$. This member function effectively implements the formula\n",
+        "The `calibrate(p)` function converts a 2D point `p` in image pixel coordinates $(u, v)$ to normalized image coordinates $(x, y)$. This member function effectively implements the formula\n",
         "\n",
         "$$\n",
         "p_{\\text{norm}} = K^{-1} \\cdot p_{\\text{pixels}}\n",
@@ -547,7 +559,7 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": ".venv",
+      "display_name": "base",
       "language": "python",
       "name": "python3"
     },
@@ -561,7 +573,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.12.3"
+      "version": "3.12.10"
     }
   },
   "nbformat": 4,

--- a/gtsam/geometry/doc/Cal3_S2.ipynb
+++ b/gtsam/geometry/doc/Cal3_S2.ipynb
@@ -45,7 +45,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 1,
       "metadata": {
         "id": "cal3s2-pip-install",
         "tags": [
@@ -56,11 +56,8 @@
       "source": [
         "try:\n",
         "    import google.colab\n",
-        "    print(\"Running in Google Colab, installing necessary libraries...\")\n",
         "    %pip install --quiet gtsam-develop\n",
-        "    print(\"Done!\")\n",
         "except ImportError:\n",
-        "    print(\"Not running in Google Colab. Please install necessary libraries as needed.\")\n",
         "    pass"
       ]
     },

--- a/gtsam/geometry/doc/Cal3_S2Stereo.ipynb
+++ b/gtsam/geometry/doc/Cal3_S2Stereo.ipynb
@@ -11,15 +11,15 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "A `Cal3_S2Stereo` represents the calibration for a stereo camera rig. It assumes that both cameras in the rig share the same intrinsic calibration parameters but are separated by a horizontal baseline. \n",
+        "A `Cal3_S2Stereo` represents the calibration model for a stereo camera rig. It assumes that both cameras in the rig share the same intrinsic calibration parameters but are separated by a horizontal baseline. \n",
         "\n",
-        "This class inherits from the standard 5-parameter `Cal3_S2` model and adds a sixth parameter, the baseline `b`. The six parameters are, therefore: two focal lengths ($f_x, f_y$), skew ($s$), the principal point ($u_0, v_0$), and the baseline ($b$). The calibration matrix $K$ is identical to that of `Cal3_S2` and represents the intrinsics of the *left* camera:\n",
+        "This class inherits from the standard 5-parameter `Cal3_S2` model and adds a sixth parameter, the baseline `b`. The calibration matrix $K$ is identical to that of `Cal3_S2` and represents the intrinsics of a single camera from a stereo camera rig:\n",
         "\n",
         "$$\n",
         "K = \\begin{bmatrix} f_x & s & u_0 \\\\ 0 & f_y & v_0 \\\\ 0 & 0 & 1 \\end{bmatrix}\n",
         "$$\n",
         "\n",
-        "The `uncalibrate` and `calibrate` methods of this class behave identically to those in `Cal3_S2`, converting points for a single camera. The baseline parameter `b` is primarily used by other classes like `StereoCamera` to compute the disparity between the left and right images during 3D projection."
+        "The `uncalibrate` and `calibrate` methods of this class behave identically to those in `Cal3_S2`, converting between intrinsic camera coordinates and sensor coordinates for a single camera. Note that `Cal3_S2Stereo` itself does not perform the complete calibration of a stereo camera; it merely stores all the parameters necessary for the calibration. For instance, the baseline parameter `b` is primarily used by other classes like `StereoCamera` to compute the disparity between the left and right images during 3D projection."
       ]
     },
     {
@@ -48,7 +48,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": 2,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -68,7 +68,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": 3,
       "metadata": {},
       "outputs": [
         {
@@ -139,7 +139,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": 4,
       "metadata": {},
       "outputs": [
         {
@@ -186,47 +186,91 @@
       "source": [
         "## Basic Operations\n",
         "\n",
-        "The `calibrate` and `uncalibrate` methods work identically to their `Cal3_S2` counterparts, converting points for a single camera's perspective. The baseline does not affect these calculations directly but is used in higher-level classes like `StereoCamera`.\n",
-        "\n",
         "### `calibrate()`\n",
         "\n",
-        "The `calibrate(p)` method converts a 2D point `p` from image pixel coordinates $(u, v)$ to normalized image coordinates $(x, y)$."
+        "The `calibrate(p)` function converts a 2D point `p` from sensor coordinates $(u, v)$ to intrinsic coordinates $(x, y)$. Please review the user guide for [`Cal3_S2`](./Cal3_S2.ipynb) for a more detailed explanation of this function."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": 14,
       "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Pixel point: [420. 290.]\n",
-            "Calibrated (normalized) point: [0.1  0.05]\n",
+            "Model properties:\n",
+            "K: 1652.17       0    1024\n",
+            "      0 1652.17     768\n",
+            "      0       0       1\n",
+            "Baseline: 24\n",
             "\n",
-            "Jacobian Dcal_calibrate:\n",
-            "[[-1.e-04  0.e+00 -5.e-05 -1.e-03  0.e+00  0.e+00]\n",
-            " [ 0.e+00 -5.e-05  0.e+00  0.e+00 -1.e-03  0.e+00]]\n",
-            "\n",
-            "Jacobian Dp_calibrate:\n",
-            "[[ 0.001 -0.   ]\n",
-            " [ 0.     0.001]]\n"
+            "image[0, 0] -> (u, v)=(0.5px, 0.5px) -> (x, y)=(-0.619, -0.465)\n",
+            "image[768, 1024] -> (u, v)=(1024.5px, 768.5px) -> (x, y)=(0.0, 0.0)\n",
+            "image[1536, 2048] -> (u, v)=(2048.5px, 1536.5px) -> (x, y)=(0.62, 0.465)\n"
           ]
         }
       ],
       "source": [
-        "fx, fy, s, u0, v0, b = 1000.0, 1000.0, 0.0, 320.0, 240.0, 0.5\n",
-        "cal = Cal3_S2Stereo(fx, fy, s, u0, v0, b)\n",
+        "# Create a sample Cal3_S2Stereo model based on specs of Bumblebee X (BX-P5G-30C-XC3) with Full resolution\n",
+        "width = 2048    # px\n",
+        "height = 1536   # px\n",
+        "baseline = 24   # cm\n",
+        "px_sz = 3.45    # um\n",
+        "focal_len = 5.7 # mm\n",
+        "fx = focal_len / px_sz * 1000\n",
+        "fy = focal_len / px_sz * 1000\n",
+        "u0 = width / 2\n",
+        "v0 = height / 2\n",
+        "cal_xc3_BumblebeeX = Cal3_S2Stereo(fx=fx, fy=fy, s=0, u0=u0, v0=v0, b=baseline)\n",
         "\n",
-        "p_pixels = Point2(420, 290)\n",
-        "p_norm = cal.calibrate(p_pixels)\n",
-        "print(f\"Pixel point: {p_pixels}\")\n",
-        "print(f\"Calibrated (normalized) point: {p_norm}\")\n",
+        "print(f\"Model properties:\\n{cal_xc3_BumblebeeX}\")\n",
         "\n",
-        "# This method can optionally compute Jacobians.\n",
+        "def calibration_demo(cal: Cal3_S2Stereo, row: int, col: int):\n",
+        "  assert isinstance(row, int) and isinstance(col, int)\n",
+        "  u, v = col + 0.5, row + 0.5   # coordinates of pixel center\n",
+        "  x, y = cal.calibrate([u, v])\n",
+        "  print(f\"image[{row}, {col}] -> (u, v)=({round(u, 2)}px, {round(v, 2)}px) -> (x, y)=({round(x, 3)}, {round(y, 3)})\")\n",
+        "\n",
+        "calibration_demo(cal_xc3_BumblebeeX, 0, 0)\n",
+        "calibration_demo(cal_xc3_BumblebeeX, 768, 1024)\n",
+        "calibration_demo(cal_xc3_BumblebeeX, 1536, 2048)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "`calibrate(p)` can also optionally compute Jacobians."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "Jacobian Dcal_calibrate:\n",
+            "[[-1.99089333e-04  2.04166667e-08 -3.26666667e-04 -6.66666667e-04\n",
+            "   4.16666667e-08  0.00000000e+00]\n",
+            " [ 0.00000000e+00 -3.06250000e-04  0.00000000e+00  0.00000000e+00\n",
+            "  -6.25000000e-04  0.00000000e+00]]\n",
+            "\n",
+            "Jacobian Dp_calibrate:\n",
+            "[[ 6.66666667e-04 -4.16666667e-08]\n",
+            " [ 0.00000000e+00  6.25000000e-04]]\n"
+          ]
+        }
+      ],
+      "source": [
         "Dcal_calibrate = np.zeros((2, 6), order='F') # Note shape is 2x6\n",
         "Dp_calibrate = np.zeros((2, 2), order='F')\n",
+        "p_pixels = [768, 1024]\n",
         "_ = cal.calibrate(p_pixels, Dcal_calibrate, Dp_calibrate)\n",
         "print(f\"\\nJacobian Dcal_calibrate:\\n{Dcal_calibrate}\")\n",
         "print(f\"\\nJacobian Dp_calibrate:\\n{Dp_calibrate}\")"

--- a/gtsam/geometry/doc/Cal3_S2Stereo.ipynb
+++ b/gtsam/geometry/doc/Cal3_S2Stereo.ipynb
@@ -186,14 +186,12 @@
       "source": [
         "## Basic Operations\n",
         "\n",
-        "### `calibrate()`\n",
-        "\n",
-        "The `calibrate(p)` function converts a 2D point `p` from sensor coordinates $(u, v)$ to intrinsic coordinates $(x, y)$. Please review the user guide for [`Cal3_S2`](./Cal3_S2.ipynb) for a more detailed explanation of this function."
+        "All explanations and example code in this section will use the Bumblebee X (BX-P5G-30C-XC3) stereo camera as a representative model. This camera provides a practical reference for understanding `Cal3_S2Stereo`. Below is an example instantiation of a `Cal3_S2Stereo` calibration model using the parameters from the Bumblebee X."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": 7,
       "metadata": {},
       "outputs": [
         {
@@ -205,15 +203,12 @@
             "      0 1652.17     768\n",
             "      0       0       1\n",
             "Baseline: 24\n",
-            "\n",
-            "image[0, 0] -> (u, v)=(0.5px, 0.5px) -> (x, y)=(-0.619, -0.465)\n",
-            "image[768, 1024] -> (u, v)=(1024.5px, 768.5px) -> (x, y)=(0.0, 0.0)\n",
-            "image[1536, 2048] -> (u, v)=(2048.5px, 1536.5px) -> (x, y)=(0.62, 0.465)\n"
+            "\n"
           ]
         }
       ],
       "source": [
-        "# Create a sample Cal3_S2Stereo model based on specs of Bumblebee X (BX-P5G-30C-XC3) with Full resolution\n",
+        "# A sample Cal3_S2Stereo model based on specs of Bumblebee X (BX-P5G-30C-XC3) with Full resolution\n",
         "width = 2048    # px\n",
         "height = 1536   # px\n",
         "baseline = 24   # cm\n",
@@ -225,17 +220,43 @@
         "v0 = height / 2\n",
         "cal_xc3_BumblebeeX = Cal3_S2Stereo(fx=fx, fy=fy, s=0, u0=u0, v0=v0, b=baseline)\n",
         "\n",
-        "print(f\"Model properties:\\n{cal_xc3_BumblebeeX}\")\n",
+        "print(f\"Model properties:\\n{cal_xc3_BumblebeeX}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### `calibrate()`\n",
         "\n",
+        "The `calibrate(p)` function converts a 2D point `p` from sensor coordinates $(u, v)$ to intrinsic coordinates $(x, y)$. Please review the user guide for [`Cal3_S2`](./Cal3_S2.ipynb) for a more detailed explanation of this function."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 50,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "image[0, 0] -> (u, v)=(0.5px, 0.5px) -> (x, y)=(-0.61949, -0.46454)\n",
+            "image[768, 1024] -> (u, v)=(1024.5px, 768.5px) -> (x, y)=(0.0003, 0.0003)\n",
+            "image[1536, 2048] -> (u, v)=(2048.5px, 1536.5px) -> (x, y)=(0.62009, 0.46514)\n"
+          ]
+        }
+      ],
+      "source": [
         "def calibration_demo(cal: Cal3_S2Stereo, row: int, col: int):\n",
-        "  assert isinstance(row, int) and isinstance(col, int)\n",
         "  u, v = col + 0.5, row + 0.5   # coordinates of pixel center\n",
         "  x, y = cal.calibrate([u, v])\n",
-        "  print(f\"image[{row}, {col}] -> (u, v)=({round(u, 2)}px, {round(v, 2)}px) -> (x, y)=({round(x, 3)}, {round(y, 3)})\")\n",
+        "  print(f\"image[{row}, {col}] -> (u, v)=({round(u, 2)}px, {round(v, 2)}px) -> (x, y)=({round(x, 5)}, {round(y, 5)})\")\n",
+        "  return x, y\n",
         "\n",
-        "calibration_demo(cal_xc3_BumblebeeX, 0, 0)\n",
-        "calibration_demo(cal_xc3_BumblebeeX, 768, 1024)\n",
-        "calibration_demo(cal_xc3_BumblebeeX, 1536, 2048)"
+        "calibration_demo(cal_xc3_BumblebeeX, 0, 0);\n",
+        "calibration_demo(cal_xc3_BumblebeeX, 768, 1024);\n",
+        "calibration_demo(cal_xc3_BumblebeeX, 1536, 2048);"
       ]
     },
     {
@@ -247,7 +268,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": 51,
       "metadata": {},
       "outputs": [
         {
@@ -282,40 +303,70 @@
       "source": [
         "### `uncalibrate()`\n",
         "\n",
-        "The `uncalibrate(p)` method converts a 2D point `p` from normalized coordinates back to pixel coordinates."
+        "The `uncalibrate(p)` method converts a 2D point `p` from intrinsic coordinates $(x,y)$ back to sensor coordinates $(u, v)$. Please review the user guide for [`Cal3_S2`](./Cal3_S2.ipynb) for a more detailed explanation of this function."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": 52,
       "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Normalized point: [0.1  0.05]\n",
-            "Uncalibrated (pixel) point: [420. 290.]\n",
-            "\n",
-            "Jacobian Dcal_uncalibrate:\n",
-            "[[0.1  0.   0.05 1.   0.   0.  ]\n",
-            " [0.   0.05 0.   0.   1.   0.  ]]\n",
-            "\n",
-            "Jacobian Dp_uncalibrate:\n",
-            "[[1000.    0.]\n",
-            " [   0. 1000.]]\n"
+            "image[0, 0] -> (u, v)=(0.5px, 0.5px) -> (x, y)=(-0.61949, -0.46454)\n",
+            "(x, y)=(-0.61949, -0.46454) -> (u, v)=(0.5px, 0.5px) -> image[0.0, 0.0]\n",
+            "image[1024, 768] -> (u, v)=(768.5px, 1024.5px) -> (x, y)=(-0.15464, 0.15525)\n",
+            "(x, y)=(-0.15464, 0.15525) -> (u, v)=(768.5px, 1024.5px) -> image[768.0, 1024.0]\n"
           ]
         }
       ],
       "source": [
-        "p_pixels_recovered = cal.uncalibrate(p_norm)\n",
-        "print(f\"Normalized point: {p_norm}\")\n",
-        "print(f\"Uncalibrated (pixel) point: {p_pixels_recovered}\")\n",
+        "def uncalibration_demo(cal: Cal3_S2Stereo, x: float, y: float):\n",
+        "  u, v = cal.uncalibrate([x, y])\n",
+        "  print(f\"(x, y)=({round(x, 5)}, {round(y, 5)}) -> (u, v)=({round(u, 2)}px, {round(v, 2)}px) -> image[{np.floor(u)}, {np.floor(v)}]\")\n",
+        "  return u, v\n",
         "\n",
+        "x, y = calibration_demo(cal_xc3_BumblebeeX, 0, 0);\n",
+        "uncalibration_demo(cal_xc3_BumblebeeX, x, y);\n",
+        "x, y = calibration_demo(cal_xc3_BumblebeeX, 1024, 768);\n",
+        "uncalibration_demo(cal_xc3_BumblebeeX, x, y);"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Likewise, `uncalibrate(p)` can optionally compute Jacobians as well."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 53,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "Jacobian Dcal_uncalibrate:\n",
+            "[[0. 0. 0. 1. 0. 0.]\n",
+            " [0. 0. 0. 0. 1. 0.]]\n",
+            "\n",
+            "Jacobian Dp_uncalibrate:\n",
+            "[[1.5e+03 1.0e-01]\n",
+            " [0.0e+00 1.6e+03]]\n"
+          ]
+        }
+      ],
+      "source": [
         "# This method can also optionally compute Jacobians.\n",
         "Dcal_uncalibrate = np.zeros((2, 6), order='F')\n",
         "Dp_uncalibrate = np.zeros((2, 2), order='F')\n",
-        "_ = cal.uncalibrate(p_norm, Dcal_uncalibrate, Dp_uncalibrate)\n",
+        "p_intrinsic = [0, 0]\n",
+        "_ = cal.uncalibrate(p_intrinsic, Dcal_uncalibrate, Dp_uncalibrate)\n",
         "print(f\"\\nJacobian Dcal_uncalibrate:\\n{Dcal_uncalibrate}\")\n",
         "print(f\"\\nJacobian Dp_uncalibrate:\\n{Dp_uncalibrate}\")"
       ]
@@ -331,7 +382,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": 58,
       "metadata": {},
       "outputs": [
         {
@@ -339,8 +390,8 @@
           "output_type": "stream",
           "text": [
             "Original cal_model:\n",
-            "K: 1000    0  320\n",
-            "   0 1000  240\n",
+            "K: 1500  0.1  320\n",
+            "   0 1600  240\n",
             "   0    0    1\n",
             "Baseline: 0.5\n",
             "\n",
@@ -348,8 +399,8 @@
             "Delta vector: [ 1.e+01  2.e+01  5.e-02  1.e+00 -1.e+00  1.e-02]\n",
             "\n",
             "Retracted cal_retracted:\n",
-            "K: 1010 0.05  321\n",
-            "   0 1020  239\n",
+            "K: 1510 0.15  321\n",
+            "   0 1620  239\n",
             "   0    0    1\n",
             "Baseline: 0.51\n",
             "\n",
@@ -387,7 +438,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": 60,
       "metadata": {},
       "outputs": [
         {
@@ -444,6 +495,9 @@
         "## Additional Resources\n",
         "\n",
         "The following resources provide more detailed explanations of camera calibration and stereo vision.\n",
+        "\n",
+        "### Article(s)\n",
+        "- [\"5.3. Cameras for Robot Vision\"](https://www.roboticsbook.org/S53_diffdrive_sensing.html) by Dr. Frank Dellaert and Dr. Seth Hutchinson\n",
         "\n",
         "### Video(s)\n",
         "- [\"Simple Stereo | Camera Calibration\"](https://youtu.be/hUVyDabn1Mg?si=3zIrPPML-H7Zu5_i) by Dr. Shree Nayar from Columbia University\n",

--- a/gtsam/geometry/doc/Cal3_S2Stereo.ipynb
+++ b/gtsam/geometry/doc/Cal3_S2Stereo.ipynb
@@ -13,7 +13,7 @@
       "source": [
         "A `Cal3_S2Stereo` represents the calibration model for a stereo camera rig. It assumes that both cameras in the rig share the same intrinsic calibration parameters but are separated by a horizontal baseline. \n",
         "\n",
-        "This class inherits from the standard 5-parameter `Cal3_S2` model and adds a sixth parameter, the baseline `b`. The calibration matrix $K$ is identical to that of `Cal3_S2` and represents the intrinsics of a single camera from a stereo camera rig:\n",
+        "This class inherits from the standard 5-parameter `Cal3_S2` model and adds a sixth parameter, the baseline `b`, measured in meters. The calibration matrix $K$ is identical to that of `Cal3_S2` and represents the intrinsics of a single camera from a stereo camera rig:\n",
         "\n",
         "$$\n",
         "K = \\begin{bmatrix} f_x & s & u_0 \\\\ 0 & f_y & v_0 \\\\ 0 & 0 & 1 \\end{bmatrix}\n",
@@ -134,7 +134,7 @@
         "## Properties\n",
         "\n",
         "Since `Cal3_S2Stereo` inherits from `Cal3_S2`, it has access to all of its parent's property methods, in addition to its own specific methods, as follows:\n",
-        "- `baseline()`: Returns the horizontal baseline $b$."
+        "- `baseline()`: Returns the horizontal baseline $b$, in meters."
       ]
     },
     {
@@ -191,7 +191,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": null,
       "metadata": {},
       "outputs": [
         {
@@ -211,7 +211,7 @@
         "# A sample Cal3_S2Stereo model based on specs of Bumblebee X (BX-P5G-30C-XC3) with Full resolution\n",
         "width = 2048    # px\n",
         "height = 1536   # px\n",
-        "baseline = 24   # cm\n",
+        "baseline = 0.24 # m\n",
         "px_sz = 3.45    # um\n",
         "focal_len = 5.7 # mm\n",
         "fx = focal_len / px_sz * 1000\n",

--- a/gtsam/geometry/doc/Cal3_S2Stereo.ipynb
+++ b/gtsam/geometry/doc/Cal3_S2Stereo.ipynb
@@ -11,50 +11,68 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "A `Cal3_S2Stereo` represents the calibration model for a stereo camera rig. It assumes that both cameras in the rig share the same intrinsic calibration parameters but are separated by a horizontal baseline. \n",
-        "\n",
-        "This class inherits from the standard 5-parameter `Cal3_S2` model and adds a sixth parameter, the baseline `b`, measured in meters. The calibration matrix $K$ is identical to that of `Cal3_S2` and represents the intrinsics of a single camera from a stereo camera rig:\n",
-        "\n",
-        "$$\n",
-        "K = \\begin{bmatrix} f_x & s & u_0 \\\\ 0 & f_y & v_0 \\\\ 0 & 0 & 1 \\end{bmatrix}\n",
-        "$$\n",
-        "\n",
-        "The `uncalibrate` and `calibrate` methods of this class behave identically to those in `Cal3_S2`, converting between intrinsic camera coordinates and sensor coordinates for a single camera. Note that `Cal3_S2Stereo` itself does not perform the complete calibration of a stereo camera; it merely stores all the parameters necessary for the calibration. For instance, the baseline parameter `b` is primarily used by other classes like `StereoCamera` to compute the disparity between the left and right images during 3D projection."
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/Cal3_S2Stereo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/Cal3_S2Stereo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 12,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Note: you may need to restart the kernel to use updated packages.\n"
-          ]
-        }
-      ],
-      "source": [
-        "%pip install --quiet gtsam-develop"
+        "A `Cal3_S2Stereo` object describes the calibration model for a stereo camera rig, a setup for depth estimation where two cameras are mounted side by side at a fixed horizontal distance known as the baseline. This model assumes both cameras have the same intrinsic parameters.\n",
+        "\n",
+        "This class inherits from the standard 5-parameter [`Cal3_S2`](./Cal3_S2.ipynb) model and adds a sixth parameter, the baseline $b$. \n",
+        "\n",
+        "The calibration matrix $K$ is identical to that of [`Cal3_S2`](./Cal3_S2.ipynb) and represents the parameters of a single camera from the stereo camera rig:\n",
+        "\n",
+        "$$\n",
+        "K = \\begin{bmatrix} f_x & s & u_0 \\\\ 0 & f_y & v_0 \\\\ 0 & 0 & 1 \\end{bmatrix}\n",
+        "$$\n",
+        "\n",
+        "However, note that `Cal3_S2Stereo` itself does not perform the complete calibration of a stereo camera; it merely stores all the parameters necessary for the calibration. For instance, the baseline parameter $b$ is primarily used by other classes like [`StereoCamera`](./StereoCamera.ipynb) to compute the disparity between the left and right images during 3D projection.\n",
+        "\n",
+        "To see how `Cal3_S2Stereo` is used in practical applications, please refer to [StereoVOExample](../../../python/gtsam/examples/StereoVOExample.ipynb) and [StereoVOExample_large](../../../python/gtsam/examples/StereoVOExample_large.ipynb)."
       ]
     },
     {
       "cell_type": "code",
       "execution_count": 1,
-      "metadata": {},
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Not running in Google Colab. Please install necessary libraries as needed.\n"
+          ]
+        }
+      ],
+      "source": [
+        "try:\n",
+        "    import google.colab\n",
+        "    print(\"Running in Google Colab, installing necessary libraries...\")\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "    print(\"Done!\")\n",
+        "except ImportError:\n",
+        "    print(\"Not running in Google Colab. Please install necessary libraries as needed.\")\n",
+        "    pass"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      },
       "outputs": [],
       "source": [
         "import gtsam\n",
-        "import numpy as np\n",
-        "from gtsam import Cal3_S2Stereo, Point2, Point3, Pose3, StereoCamera"
+        "import numpy as np"
       ]
     },
     {
@@ -75,26 +93,29 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Default constructor:\n",
+            "Default constructor (fx=1, fy=1, s=0, u0=0, v0=0, b=1):\n",
             "K: 1 0 0\n",
             "0 1 0\n",
             "0 0 1\n",
             "Baseline: 1\n",
             "\n",
+            "fx: 1.0, fy: 1.0, s: 0.0, u0: 0.0, v0: 0.0, 1.0\n",
             "\n",
             "From parameters (fx, fy, s, u0, v0, b):\n",
-            "K: 1500  0.1  320\n",
+            "K: 1500    0  320\n",
             "   0 1600  240\n",
             "   0    0    1\n",
             "Baseline: 0.5\n",
             "\n",
+            "fx: 1500.0, fy: 1600.0, s: 0.0, u0: 320.0, v0: 240.0, 0.5\n",
             "\n",
             "From a 6-vector [fx, fy, s, u0, v0, b]:\n",
-            "K: 1500  0.1  320\n",
+            "K: 1500    0  320\n",
             "   0 1600  240\n",
             "   0    0    1\n",
             "Baseline: 0.5\n",
             "\n",
+            "fx: 1500.0, fy: 1600.0, s: 0.0, u0: 320.0, v0: 240.0, 0.5\n",
             "\n",
             "From fov, image dimensions, and baseline:\n",
             "K: 251.73      0    300\n",
@@ -102,29 +123,38 @@
             "     0      0      1\n",
             "Baseline: 0.5\n",
             "\n",
+            "fx: 1500.0, fy: 1600.0, s: 0.0, u0: 320.0, v0: 240.0, 0.5\n",
             "\n"
           ]
         }
       ],
       "source": [
         "# Default constructor\n",
-        "cal_default = Cal3_S2Stereo()\n",
-        "print(f\"Default constructor:\\n{cal_default}\\n\")\n",
+        "cal_default = gtsam.Cal3_S2Stereo()\n",
+        "print(\"Default constructor (fx=1, fy=1, s=0, u0=0, v0=0, b=1):\")\n",
+        "print(cal_default)\n",
+        "print(f\"fx: {cal_default.fx()}, fy: {cal_default.fy()}, s: {cal_default.skew()}, u0: {cal_default.px()}, v0: {cal_default.py()}, {cal_default.baseline()}\\n\")\n",
         "\n",
         "# From individual parameters: fx, fy, s, u0, v0, b\n",
-        "fx, fy, s, u0, v0, b = 1500.0, 1600.0, 0.1, 320.0, 240.0, 0.5\n",
-        "cal_params = Cal3_S2Stereo(fx, fy, s, u0, v0, b)\n",
-        "print(f\"From parameters (fx, fy, s, u0, v0, b):\\n{cal_params}\\n\")\n",
+        "fx, fy, s, u0, v0, b = 1500.0, 1600.0, 0, 320.0, 240.0, 0.5\n",
+        "cal_params = gtsam.Cal3_S2Stereo(fx, fy, s, u0, v0, b)\n",
+        "print(\"From parameters (fx, fy, s, u0, v0, b):\")\n",
+        "print(cal_params)\n",
+        "print(f\"fx: {cal_params.fx()}, fy: {cal_params.fy()}, s: {cal_params.skew()}, u0: {cal_params.px()}, v0: {cal_params.py()}, {cal_params.baseline()}\\n\")\n",
         "\n",
         "# From a 6-vector [fx, fy, s, u0, v0, b]\n",
-        "param_vector = np.array([1500.0, 1600.0, 0.1, 320.0, 240.0, 0.5])\n",
-        "cal_vector = Cal3_S2Stereo(param_vector)\n",
-        "print(f\"From a 6-vector [fx, fy, s, u0, v0, b]:\\n{cal_vector}\\n\")\n",
+        "param_vector = np.array([1500.0, 1600.0, 0, 320.0, 240.0, 0.5])\n",
+        "cal_vector = gtsam.Cal3_S2Stereo(param_vector)\n",
+        "print(\"From a 6-vector [fx, fy, s, u0, v0, b]:\")\n",
+        "print(cal_vector)\n",
+        "print(f\"fx: {cal_vector.fx()}, fy: {cal_vector.fy()}, s: {cal_vector.skew()}, u0: {cal_vector.px()}, v0: {cal_vector.py()}, {cal_vector.baseline()}\\n\")\n",
         "\n",
-        "# From fov in degrees, image dimensions, and stereo baseline\n",
+        "# From fov (in degrees), image dimensions, and stereo baseline\n",
         "fov, w, h, b = 100, 600, 500, 0.5\n",
-        "cal_fov = Cal3_S2Stereo(fov, w, h, b)\n",
-        "print(f\"From fov, image dimensions, and baseline:\\n{cal_fov}\\n\")"
+        "cal_fov = gtsam.Cal3_S2Stereo(fov, w, h, b)\n",
+        "print(\"From fov, image dimensions, and baseline:\")\n",
+        "print(cal_fov)\n",
+        "print(f\"fx: {cal_vector.fx()}, fy: {cal_vector.fy()}, s: {cal_vector.skew()}, u0: {cal_vector.px()}, v0: {cal_vector.py()}, {cal_vector.baseline()}\\n\")"
       ]
     },
     {
@@ -133,8 +163,8 @@
       "source": [
         "## Properties\n",
         "\n",
-        "Since `Cal3_S2Stereo` inherits from `Cal3_S2`, it has access to all of its parent's property methods, in addition to its own specific methods, as follows:\n",
-        "- `baseline()`: Returns the horizontal baseline $b$, in meters."
+        "Since `Cal3_S2Stereo` inherits from [`Cal3_S2`](./Cal3_S2.ipynb), it has access to all of its parent's property member functions, in addition to its own specific member functions, as follows:\n",
+        "- `baseline()`: Returns the horizontal baseline $b$."
       ]
     },
     {
@@ -149,23 +179,23 @@
             "Calibration object properties:\n",
             "fx: 1500.0\n",
             "fy: 1600.0\n",
-            "skew: 0.1\n",
+            "skew: 0.0\n",
             "u0: 320.0\n",
             "v0: 240.0\n",
             "Baseline: 0.5\n",
             "Principal Point: [320. 240.]\n",
-            "Vector [fx, fy, s, u0, v0, b]: [1.5e+03 1.6e+03 1.0e-01 3.2e+02 2.4e+02 5.0e-01]\n",
+            "Vector [fx, fy, s, u0, v0, b]: [1.5e+03 1.6e+03 0.0e+00 3.2e+02 2.4e+02 5.0e-01]\n",
             "Aspect ratio: 0.9375\n",
             "K matrix:\n",
-            "[[1.5e+03 1.0e-01 3.2e+02]\n",
+            "[[1.5e+03 0.0e+00 3.2e+02]\n",
             " [0.0e+00 1.6e+03 2.4e+02]\n",
             " [0.0e+00 0.0e+00 1.0e+00]]\n"
           ]
         }
       ],
       "source": [
-        "fx, fy, s, u0, v0, b = 1500.0, 1600.0, 0.1, 320.0, 240.0, 0.5\n",
-        "cal = Cal3_S2Stereo(fx, fy, s, u0, v0, b)\n",
+        "fx, fy, s, u0, v0, b = 1500.0, 1600.0, 0, 320.0, 240.0, 0.5\n",
+        "cal = gtsam.Cal3_S2Stereo(fx, fy, s, u0, v0, b)\n",
         "\n",
         "print(\"Calibration object properties:\")\n",
         "print(f\"fx: {cal.fx()}\")\n",
@@ -186,77 +216,39 @@
       "source": [
         "## Basic Operations\n",
         "\n",
-        "All explanations and example code in this section will use the Bumblebee X (BX-P5G-30C-XC3) stereo camera as a representative model. This camera provides a practical reference for understanding `Cal3_S2Stereo`. Below is an example instantiation of a `Cal3_S2Stereo` calibration model using the parameters from the Bumblebee X."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Model properties:\n",
-            "K: 1652.17       0    1024\n",
-            "      0 1652.17     768\n",
-            "      0       0       1\n",
-            "Baseline: 0.24\n",
-            "\n"
-          ]
-        }
-      ],
-      "source": [
-        "# A sample Cal3_S2Stereo model based on specs of Bumblebee X (BX-P5G-30C-XC3) with Full resolution\n",
-        "width = 2048    # px\n",
-        "height = 1536   # px\n",
-        "baseline = 0.24 # m\n",
-        "px_sz = 3.45    # um\n",
-        "focal_len = 5.7 # mm\n",
-        "fx = focal_len / px_sz * 1000\n",
-        "fy = focal_len / px_sz * 1000\n",
-        "u0 = width / 2\n",
-        "v0 = height / 2\n",
-        "cal_xc3_BumblebeeX = Cal3_S2Stereo(fx=fx, fy=fy, s=0, u0=u0, v0=v0, b=baseline)\n",
-        "\n",
-        "print(f\"Model properties:\\n{cal_xc3_BumblebeeX}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
         "### `calibrate()`\n",
         "\n",
-        "The `calibrate(p)` function converts a 2D point `p` from sensor coordinates $(u, v)$ to intrinsic coordinates $(x, y)$. Please review the user guide for [`Cal3_S2`](./Cal3_S2.ipynb) for a more detailed explanation of this function."
+        "The `calibrate(p)` function converts a 2D point `p` from pixel coordinates $(u, v)$ to intrinsic coordinates $(x, y)$. Please review the user guide for [`Cal3_S2`](./Cal3_S2.ipynb) for a more detailed explanation of this function."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": 6,
       "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "image[0, 0] -> (u, v)=(0.5px, 0.5px) -> (x, y)=(-0.61949, -0.46454)\n",
-            "image[768, 1024] -> (u, v)=(1024.5px, 768.5px) -> (x, y)=(0.0003, 0.0003)\n",
-            "image[1536, 2048] -> (u, v)=(2048.5px, 1536.5px) -> (x, y)=(0.62009, 0.46514)\n"
+            "image[0, 0] -> (u, v)=(0.5px, 0.5px) -> (x, y)=(-0.213, -0.14969)\n",
+            "image[768, 1024] -> (u, v)=(1024.5px, 768.5px) -> (x, y)=(0.46967, 0.33031)\n",
+            "image[1536, 2048] -> (u, v)=(2048.5px, 1536.5px) -> (x, y)=(1.15233, 0.81031)\n"
           ]
         }
       ],
       "source": [
-        "def calibration_demo(cal: Cal3_S2Stereo, row: int, col: int):\n",
+        "def calibration_demo(cal: gtsam.Cal3_S2Stereo, row: int, col: int):\n",
         "  u, v = col + 0.5, row + 0.5   # coordinates of pixel center\n",
         "  x, y = cal.calibrate([u, v])\n",
         "  print(f\"image[{row}, {col}] -> (u, v)=({round(u, 2)}px, {round(v, 2)}px) -> (x, y)=({round(x, 5)}, {round(y, 5)})\")\n",
         "  return x, y\n",
         "\n",
-        "calibration_demo(cal_xc3_BumblebeeX, 0, 0);\n",
-        "calibration_demo(cal_xc3_BumblebeeX, 768, 1024);\n",
-        "calibration_demo(cal_xc3_BumblebeeX, 1536, 2048);"
+        "fx, fy, s, u0, v0, b = 1500.0, 1600.0, 0, 320.0, 240.0, 0.5\n",
+        "cal = gtsam.Cal3_S2Stereo(fx, fy, s, u0, v0, b)\n",
+        "\n",
+        "calibration_demo(cal, 0, 0);\n",
+        "calibration_demo(cal, 768, 1024);\n",
+        "calibration_demo(cal, 1536, 2048);"
       ]
     },
     {
@@ -268,7 +260,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": 8,
       "metadata": {},
       "outputs": [
         {
@@ -277,14 +269,12 @@
           "text": [
             "\n",
             "Jacobian Dcal_calibrate:\n",
-            "[[-1.99089333e-04  2.04166667e-08 -3.26666667e-04 -6.66666667e-04\n",
-            "   4.16666667e-08  0.00000000e+00]\n",
-            " [ 0.00000000e+00 -3.06250000e-04  0.00000000e+00  0.00000000e+00\n",
-            "  -6.25000000e-04  0.00000000e+00]]\n",
+            "[[-0.00019911  0.         -0.00032667 -0.00066667  0.          0.        ]\n",
+            " [ 0.         -0.00030625  0.          0.         -0.000625    0.        ]]\n",
             "\n",
             "Jacobian Dp_calibrate:\n",
-            "[[ 6.66666667e-04 -4.16666667e-08]\n",
-            " [ 0.00000000e+00  6.25000000e-04]]\n"
+            "[[ 0.00066667 -0.        ]\n",
+            " [ 0.          0.000625  ]]\n"
           ]
         }
       ],
@@ -303,47 +293,47 @@
       "source": [
         "### `uncalibrate()`\n",
         "\n",
-        "The `uncalibrate(p)` method converts a 2D point `p` from intrinsic coordinates $(x,y)$ back to sensor coordinates $(u, v)$. Please review the user guide for [`Cal3_S2`](./Cal3_S2.ipynb) for a more detailed explanation of this function."
+        "The `uncalibrate(p)` method converts a 2D point `p` from intrinsic coordinates $(x,y)$ back to pixel coordinates $(u, v)$. Please review the user guide for [`Cal3_S2`](./Cal3_S2.ipynb) for a more detailed explanation of this function."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": 14,
       "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "image[0, 0] -> (u, v)=(0.5px, 0.5px) -> (x, y)=(-0.61949, -0.46454)\n",
-            "(x, y)=(-0.61949, -0.46454) -> (u, v)=(0.5px, 0.5px) -> image[0.0, 0.0]\n",
-            "image[1024, 768] -> (u, v)=(768.5px, 1024.5px) -> (x, y)=(-0.15464, 0.15525)\n",
-            "(x, y)=(-0.15464, 0.15525) -> (u, v)=(768.5px, 1024.5px) -> image[1024.0, 768.0]\n"
+            "image[0, 0] -> (u, v)=(0.5px, 0.5px) -> (x, y)=(-0.213, -0.14969)\n",
+            "(x, y)=(-0.213, -0.14969) -> (u, v)=(0.5px, 0.5px) -> image[0.0, 0.0]\n",
+            "image[1024, 768] -> (u, v)=(768.5px, 1024.5px) -> (x, y)=(0.299, 0.49031)\n",
+            "(x, y)=(0.299, 0.49031) -> (u, v)=(768.5px, 1024.5px) -> image[1024.0, 768.0]\n"
           ]
         }
       ],
       "source": [
-        "def uncalibration_demo(cal: Cal3_S2Stereo, x: float, y: float):\n",
+        "def uncalibration_demo(cal: gtsam.Cal3_S2Stereo, x: float, y: float):\n",
         "  u, v = cal.uncalibrate([x, y])\n",
         "  print(f\"(x, y)=({round(x, 5)}, {round(y, 5)}) -> (u, v)=({round(u, 2)}px, {round(v, 2)}px) -> image[{np.floor(v)}, {np.floor(u)}]\")\n",
         "  return u, v\n",
         "\n",
-        "x, y = calibration_demo(cal_xc3_BumblebeeX, 0, 0);\n",
-        "uncalibration_demo(cal_xc3_BumblebeeX, x, y);\n",
-        "x, y = calibration_demo(cal_xc3_BumblebeeX, 1024, 768);\n",
-        "uncalibration_demo(cal_xc3_BumblebeeX, x, y);"
+        "x, y = calibration_demo(cal, 0, 0)\n",
+        "_ = uncalibration_demo(cal, x, y)\n",
+        "x, y = calibration_demo(cal, 1024, 768)\n",
+        "_ = uncalibration_demo(cal, x, y)"
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Likewise, `uncalibrate(p)` can optionally compute Jacobians as well."
+        "`uncalibrate(p)` can optionally compute Jacobians as well."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": 13,
       "metadata": {},
       "outputs": [
         {
@@ -356,8 +346,8 @@
             " [0. 0. 0. 0. 1. 0.]]\n",
             "\n",
             "Jacobian Dp_uncalibrate:\n",
-            "[[1.5e+03 1.0e-01]\n",
-            " [0.0e+00 1.6e+03]]\n"
+            "[[1500.    0.]\n",
+            " [   0. 1600.]]\n"
           ]
         }
       ],
@@ -377,7 +367,7 @@
       "source": [
         "## Manifold Operations\n",
         "\n",
-        "Like other calibration classes in GTSAM, `Cal3_S2Stereo` is treated as a manifold type, even though it is simply a 6-dimensional vector in $\\mathbb{R}^6$. This abstraction allows it to integrate seamlessly into GTSAM's optimization framework.\n",
+        "Like other calibration classes in GTSAM, `Cal3_S2Stereo` is treated as a manifold type. This abstraction allows it to integrate seamlessly into GTSAM's optimization framework.\n",
         "\n",
         "- `retract(d)` maps a small update vector `d` in the tangent space to a new calibration object on the manifold.\n",
         "- `localCoordinates(T2)` computes the tangent-space vector that moves from the current calibration to another calibration `T2`."
@@ -393,7 +383,7 @@
           "output_type": "stream",
           "text": [
             "Original cal_model:\n",
-            "K: 1500  0.1  320\n",
+            "K: 1500    0  320\n",
             "   0 1600  240\n",
             "   0    0    1\n",
             "Baseline: 0.5\n",
@@ -402,7 +392,7 @@
             "Delta vector: [ 1.e+01  2.e+01  5.e-02  1.e+00 -1.e+00  1.e-02]\n",
             "\n",
             "Retracted cal_retracted:\n",
-            "K: 1510 0.15  321\n",
+            "K: 1510 0.05  321\n",
             "   0 1620  239\n",
             "   0    0    1\n",
             "Baseline: 0.51\n",
@@ -436,12 +426,12 @@
       "source": [
         "## Relationship with `StereoCamera`\n",
         "\n",
-        "The `Cal3_S2Stereo` object should be used with the `StereoCamera` class. A `StereoCamera` combines a `Pose3` (the pose of the left camera) and a `Cal3_S2Stereo` calibration to project 3D points into the stereo image plane, producing a `StereoPoint2` which contains the left and right image coordinates ($u_L, u_R, v$). Below is a basic example; please look at the user guide of [`StereoCamera`](./StereoCamera.ipynb) for a more thorough explanation."
+        "The `Cal3_S2Stereo` object should be used with the [`StereoCamera`](./StereoCamera.ipynb) class. A [`StereoCamera`](./StereoCamera.ipynb) combines a [`Pose3`](./Pose3.ipynb) (the pose of the left camera) and a `Cal3_S2Stereo` (holding the calibration parameters) to project 3D points into the stereo image plane, producing a [`StereoPoint2`](./StereoPoint2.ipynb) which contains the left and right image coordinates ($u_L, u_R, v$). Below is a basic example; please look at the user guide of [`StereoCamera`](./StereoCamera.ipynb) for a more thorough explanation."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
+      "execution_count": 19,
       "metadata": {},
       "outputs": [
         {
@@ -471,16 +461,16 @@
       ],
       "source": [
         "fx, fy, s, u0, v0, b = 1000, 1000, 0, 640, 360, 0.5\n",
-        "stereo_calibration = Cal3_S2Stereo(fx, fy, s, u0, v0, b)\n",
+        "stereo_calibration = gtsam.Cal3_S2Stereo(fx, fy, s, u0, v0, b)\n",
         "\n",
         "# Define the pose of the stereo camera rig in the world frame (left camera's pose)\n",
-        "camera_pose = Pose3(gtsam.Rot3.Ypr(-np.pi/2, 0, -np.pi/2), Point3(0, 0, 5.0))\n",
+        "camera_pose = gtsam.Pose3(gtsam.Rot3.Ypr(-np.pi/2, 0, -np.pi/2), [0, 0, 5.0])\n",
         "\n",
         "# Create a StereoCamera object\n",
-        "stereo_camera = StereoCamera(camera_pose, stereo_calibration)\n",
+        "stereo_camera = gtsam.StereoCamera(camera_pose, stereo_calibration)\n",
         "\n",
         "# Define a 3D point in the world frame\n",
-        "p_world = Point3(5, 3, 2)\n",
+        "p_world = gtsam.Point3(5, 3, 2)\n",
         "\n",
         "# Project the 3D point into the stereo camera\n",
         "p_stereo = stereo_camera.project(p_world)\n",

--- a/gtsam/geometry/doc/Cal3_S2Stereo.ipynb
+++ b/gtsam/geometry/doc/Cal3_S2Stereo.ipynb
@@ -31,16 +31,24 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 12,
       "metadata": {},
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Note: you may need to restart the kernel to use updated packages.\n"
+          ]
+        }
+      ],
       "source": [
         "%pip install --quiet gtsam-develop"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": 1,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -60,7 +68,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": 2,
       "metadata": {},
       "outputs": [
         {
@@ -87,18 +95,14 @@
             "   0    0    1\n",
             "Baseline: 0.5\n",
             "\n",
+            "\n",
+            "From fov, image dimensions, and baseline:\n",
+            "K: 251.73      0    300\n",
+            "     0 251.73    250\n",
+            "     0      0      1\n",
+            "Baseline: 0.5\n",
+            "\n",
             "\n"
-          ]
-        },
-        {
-          "ename": "TypeError",
-          "evalue": "__init__(): incompatible constructor arguments. The following argument types are supported:\n    1. gtsam.gtsam.Cal3_S2Stereo()\n    2. gtsam.gtsam.Cal3_S2Stereo(fx: float, fy: float, s: float, u0: float, v0: float, b: float)\n    3. gtsam.gtsam.Cal3_S2Stereo(v: numpy.ndarray[numpy.float64[m, 1]])\n\nInvoked with: 100, 600, 500, 0.5",
-          "output_type": "error",
-          "traceback": [
-            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-            "\u001b[31mTypeError\u001b[39m                                 Traceback (most recent call last)",
-            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[3]\u001b[39m\u001b[32m, line 17\u001b[39m\n\u001b[32m     15\u001b[39m \u001b[38;5;66;03m# From fov in degrees, image dimensions, and stereo baseline\u001b[39;00m\n\u001b[32m     16\u001b[39m fov, w, h, b = \u001b[32m100\u001b[39m, \u001b[32m600\u001b[39m, \u001b[32m500\u001b[39m, \u001b[32m0.5\u001b[39m\n\u001b[32m---> \u001b[39m\u001b[32m17\u001b[39m cal_fov = \u001b[43mCal3_S2Stereo\u001b[49m\u001b[43m(\u001b[49m\u001b[43mfov\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mw\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mh\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mb\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     18\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mFrom fov, image dimensions, and baseline:\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00mcal_fov\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33m\"\u001b[39m)\n",
-            "\u001b[31mTypeError\u001b[39m: __init__(): incompatible constructor arguments. The following argument types are supported:\n    1. gtsam.gtsam.Cal3_S2Stereo()\n    2. gtsam.gtsam.Cal3_S2Stereo(fx: float, fy: float, s: float, u0: float, v0: float, b: float)\n    3. gtsam.gtsam.Cal3_S2Stereo(v: numpy.ndarray[numpy.float64[m, 1]])\n\nInvoked with: 100, 600, 500, 0.5"
           ]
         }
       ],
@@ -135,7 +139,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
+      "execution_count": 3,
       "metadata": {},
       "outputs": [
         {
@@ -191,18 +195,23 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 18,
+      "execution_count": 4,
       "metadata": {},
       "outputs": [
         {
-          "ename": "AttributeError",
-          "evalue": "'gtsam.gtsam.Cal3_S2Stereo' object has no attribute 'calibrate'",
-          "output_type": "error",
-          "traceback": [
-            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-            "\u001b[31mAttributeError\u001b[39m                            Traceback (most recent call last)",
-            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[18]\u001b[39m\u001b[32m, line 5\u001b[39m\n\u001b[32m      2\u001b[39m cal = Cal3_S2Stereo(fx, fy, s, u0, v0, b)\n\u001b[32m      4\u001b[39m p_pixels = Point2(\u001b[32m420\u001b[39m, \u001b[32m290\u001b[39m)\n\u001b[32m----> \u001b[39m\u001b[32m5\u001b[39m p_norm = \u001b[43mcal\u001b[49m\u001b[43m.\u001b[49m\u001b[43mcalibrate\u001b[49m(p_pixels)\n\u001b[32m      6\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mPixel point: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mp_pixels\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n\u001b[32m      7\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mCalibrated (normalized) point: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mp_norm\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n",
-            "\u001b[31mAttributeError\u001b[39m: 'gtsam.gtsam.Cal3_S2Stereo' object has no attribute 'calibrate'"
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Pixel point: [420. 290.]\n",
+            "Calibrated (normalized) point: [0.1  0.05]\n",
+            "\n",
+            "Jacobian Dcal_calibrate:\n",
+            "[[-1.e-04  0.e+00 -5.e-05 -1.e-03  0.e+00  0.e+00]\n",
+            " [ 0.e+00 -5.e-05  0.e+00  0.e+00 -1.e-03  0.e+00]]\n",
+            "\n",
+            "Jacobian Dp_calibrate:\n",
+            "[[ 0.001 -0.   ]\n",
+            " [ 0.     0.001]]\n"
           ]
         }
       ],
@@ -234,18 +243,23 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 19,
+      "execution_count": 5,
       "metadata": {},
       "outputs": [
         {
-          "ename": "AttributeError",
-          "evalue": "'gtsam.gtsam.Cal3_S2Stereo' object has no attribute 'uncalibrate'",
-          "output_type": "error",
-          "traceback": [
-            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-            "\u001b[31mAttributeError\u001b[39m                            Traceback (most recent call last)",
-            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[19]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m p_pixels_recovered = \u001b[43mcal\u001b[49m\u001b[43m.\u001b[49m\u001b[43muncalibrate\u001b[49m(p_norm)\n\u001b[32m      2\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mNormalized point: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mp_norm\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n\u001b[32m      3\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mUncalibrated (pixel) point: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mp_pixels_recovered\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n",
-            "\u001b[31mAttributeError\u001b[39m: 'gtsam.gtsam.Cal3_S2Stereo' object has no attribute 'uncalibrate'"
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Normalized point: [0.1  0.05]\n",
+            "Uncalibrated (pixel) point: [420. 290.]\n",
+            "\n",
+            "Jacobian Dcal_uncalibrate:\n",
+            "[[0.1  0.   0.05 1.   0.   0.  ]\n",
+            " [0.   0.05 0.   0.   1.   0.  ]]\n",
+            "\n",
+            "Jacobian Dp_uncalibrate:\n",
+            "[[1000.    0.]\n",
+            " [   0. 1000.]]\n"
           ]
         }
       ],
@@ -273,7 +287,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 20,
+      "execution_count": 6,
       "metadata": {},
       "outputs": [
         {
@@ -329,7 +343,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 21,
+      "execution_count": 7,
       "metadata": {},
       "outputs": [
         {
@@ -401,7 +415,7 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": ".venv",
+      "display_name": "base",
       "language": "python",
       "name": "python3"
     },
@@ -415,7 +429,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.12.3"
+      "version": "3.12.10"
     }
   },
   "nbformat": 4,

--- a/gtsam/geometry/doc/Cal3_S2Stereo.ipynb
+++ b/gtsam/geometry/doc/Cal3_S2Stereo.ipynb
@@ -235,9 +235,9 @@
         "fx, fy, s, u0, v0, b = 1500.0, 1600.0, 0, 320.0, 240.0, 0.5\n",
         "cal = gtsam.Cal3_S2Stereo(fx, fy, s, u0, v0, b)\n",
         "\n",
-        "calibration_demo(cal, 0, 0);\n",
-        "calibration_demo(cal, 768, 1024);\n",
-        "calibration_demo(cal, 1536, 2048);"
+        "_ = calibration_demo(cal, 0, 0)\n",
+        "_ = calibration_demo(cal, 768, 1024)\n",
+        "_ = calibration_demo(cal, 1536, 2048)"
       ]
     },
     {

--- a/gtsam/geometry/doc/Cal3_S2Stereo.ipynb
+++ b/gtsam/geometry/doc/Cal3_S2Stereo.ipynb
@@ -1,0 +1,423 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Cal3_S2Stereo"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "A `Cal3_S2Stereo` represents the calibration for a stereo camera rig. It assumes that both cameras in the rig share the same intrinsic calibration parameters but are separated by a horizontal baseline. \n",
+        "\n",
+        "This class inherits from the standard 5-parameter `Cal3_S2` model and adds a sixth parameter, the baseline `b`. The six parameters are, therefore: two focal lengths ($f_x, f_y$), skew ($s$), the principal point ($u_0, v_0$), and the baseline ($b$). The calibration matrix $K$ is identical to that of `Cal3_S2` and represents the intrinsics of the *left* camera:\n",
+        "\n",
+        "$$\n",
+        "K = \\begin{bmatrix} f_x & s & u_0 \\\\ 0 & f_y & v_0 \\\\ 0 & 0 & 1 \\end{bmatrix}\n",
+        "$$\n",
+        "\n",
+        "The `uncalibrate` and `calibrate` methods of this class behave identically to those in `Cal3_S2`, converting points for a single camera. The baseline parameter `b` is primarily used by other classes like `StereoCamera` to compute the disparity between the left and right images during 3D projection."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/Cal3_S2Stereo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "%pip install --quiet gtsam-develop"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "from gtsam import Cal3_S2Stereo, Point2, Point3, Pose3, StereoCamera"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Initialization\n",
+        "\n",
+        "A `Cal3_S2Stereo` object can be initialized in several ways:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Default constructor:\n",
+            "K: 1 0 0\n",
+            "0 1 0\n",
+            "0 0 1\n",
+            "Baseline: 1\n",
+            "\n",
+            "\n",
+            "From parameters (fx, fy, s, u0, v0, b):\n",
+            "K: 1500  0.1  320\n",
+            "   0 1600  240\n",
+            "   0    0    1\n",
+            "Baseline: 0.5\n",
+            "\n",
+            "\n",
+            "From a 6-vector [fx, fy, s, u0, v0, b]:\n",
+            "K: 1500  0.1  320\n",
+            "   0 1600  240\n",
+            "   0    0    1\n",
+            "Baseline: 0.5\n",
+            "\n",
+            "\n"
+          ]
+        },
+        {
+          "ename": "TypeError",
+          "evalue": "__init__(): incompatible constructor arguments. The following argument types are supported:\n    1. gtsam.gtsam.Cal3_S2Stereo()\n    2. gtsam.gtsam.Cal3_S2Stereo(fx: float, fy: float, s: float, u0: float, v0: float, b: float)\n    3. gtsam.gtsam.Cal3_S2Stereo(v: numpy.ndarray[numpy.float64[m, 1]])\n\nInvoked with: 100, 600, 500, 0.5",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+            "\u001b[31mTypeError\u001b[39m                                 Traceback (most recent call last)",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[3]\u001b[39m\u001b[32m, line 17\u001b[39m\n\u001b[32m     15\u001b[39m \u001b[38;5;66;03m# From fov in degrees, image dimensions, and stereo baseline\u001b[39;00m\n\u001b[32m     16\u001b[39m fov, w, h, b = \u001b[32m100\u001b[39m, \u001b[32m600\u001b[39m, \u001b[32m500\u001b[39m, \u001b[32m0.5\u001b[39m\n\u001b[32m---> \u001b[39m\u001b[32m17\u001b[39m cal_fov = \u001b[43mCal3_S2Stereo\u001b[49m\u001b[43m(\u001b[49m\u001b[43mfov\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mw\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mh\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mb\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     18\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mFrom fov, image dimensions, and baseline:\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00mcal_fov\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33m\"\u001b[39m)\n",
+            "\u001b[31mTypeError\u001b[39m: __init__(): incompatible constructor arguments. The following argument types are supported:\n    1. gtsam.gtsam.Cal3_S2Stereo()\n    2. gtsam.gtsam.Cal3_S2Stereo(fx: float, fy: float, s: float, u0: float, v0: float, b: float)\n    3. gtsam.gtsam.Cal3_S2Stereo(v: numpy.ndarray[numpy.float64[m, 1]])\n\nInvoked with: 100, 600, 500, 0.5"
+          ]
+        }
+      ],
+      "source": [
+        "# Default constructor\n",
+        "cal_default = Cal3_S2Stereo()\n",
+        "print(f\"Default constructor:\\n{cal_default}\\n\")\n",
+        "\n",
+        "# From individual parameters: fx, fy, s, u0, v0, b\n",
+        "fx, fy, s, u0, v0, b = 1500.0, 1600.0, 0.1, 320.0, 240.0, 0.5\n",
+        "cal_params = Cal3_S2Stereo(fx, fy, s, u0, v0, b)\n",
+        "print(f\"From parameters (fx, fy, s, u0, v0, b):\\n{cal_params}\\n\")\n",
+        "\n",
+        "# From a 6-vector [fx, fy, s, u0, v0, b]\n",
+        "param_vector = np.array([1500.0, 1600.0, 0.1, 320.0, 240.0, 0.5])\n",
+        "cal_vector = Cal3_S2Stereo(param_vector)\n",
+        "print(f\"From a 6-vector [fx, fy, s, u0, v0, b]:\\n{cal_vector}\\n\")\n",
+        "\n",
+        "# From fov in degrees, image dimensions, and stereo baseline\n",
+        "fov, w, h, b = 100, 600, 500, 0.5\n",
+        "cal_fov = Cal3_S2Stereo(fov, w, h, b)\n",
+        "print(f\"From fov, image dimensions, and baseline:\\n{cal_fov}\\n\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Properties\n",
+        "\n",
+        "Since `Cal3_S2Stereo` inherits from `Cal3_S2`, it has access to all of its parent's property methods, in addition to its own specific methods, as follows:\n",
+        "- `baseline()`: Returns the horizontal baseline $b$."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 16,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Calibration object properties:\n",
+            "fx: 1500.0\n",
+            "fy: 1600.0\n",
+            "skew: 0.1\n",
+            "u0: 320.0\n",
+            "v0: 240.0\n",
+            "Baseline: 0.5\n",
+            "Principal Point: [320. 240.]\n",
+            "Vector [fx, fy, s, u0, v0, b]: [1.5e+03 1.6e+03 1.0e-01 3.2e+02 2.4e+02 5.0e-01]\n",
+            "Aspect ratio: 0.9375\n",
+            "K matrix:\n",
+            "[[1.5e+03 1.0e-01 3.2e+02]\n",
+            " [0.0e+00 1.6e+03 2.4e+02]\n",
+            " [0.0e+00 0.0e+00 1.0e+00]]\n"
+          ]
+        }
+      ],
+      "source": [
+        "fx, fy, s, u0, v0, b = 1500.0, 1600.0, 0.1, 320.0, 240.0, 0.5\n",
+        "cal = Cal3_S2Stereo(fx, fy, s, u0, v0, b)\n",
+        "\n",
+        "print(\"Calibration object properties:\")\n",
+        "print(f\"fx: {cal.fx()}\")\n",
+        "print(f\"fy: {cal.fy()}\")\n",
+        "print(f\"skew: {cal.skew()}\")\n",
+        "print(f\"u0: {cal.px()}\")\n",
+        "print(f\"v0: {cal.py()}\")\n",
+        "print(f\"Baseline: {cal.baseline()}\")\n",
+        "print(f\"Principal Point: {cal.principalPoint()}\")\n",
+        "print(f\"Vector [fx, fy, s, u0, v0, b]: {cal.vector()}\")\n",
+        "print(f\"Aspect ratio: {cal.aspectRatio()}\")\n",
+        "print(f\"K matrix:\\n{cal.K()}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Basic Operations\n",
+        "\n",
+        "The `calibrate` and `uncalibrate` methods work identically to their `Cal3_S2` counterparts, converting points for a single camera's perspective. The baseline does not affect these calculations directly but is used in higher-level classes like `StereoCamera`.\n",
+        "\n",
+        "### `calibrate()`\n",
+        "\n",
+        "The `calibrate(p)` method converts a 2D point `p` from image pixel coordinates $(u, v)$ to normalized image coordinates $(x, y)$."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 18,
+      "metadata": {},
+      "outputs": [
+        {
+          "ename": "AttributeError",
+          "evalue": "'gtsam.gtsam.Cal3_S2Stereo' object has no attribute 'calibrate'",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+            "\u001b[31mAttributeError\u001b[39m                            Traceback (most recent call last)",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[18]\u001b[39m\u001b[32m, line 5\u001b[39m\n\u001b[32m      2\u001b[39m cal = Cal3_S2Stereo(fx, fy, s, u0, v0, b)\n\u001b[32m      4\u001b[39m p_pixels = Point2(\u001b[32m420\u001b[39m, \u001b[32m290\u001b[39m)\n\u001b[32m----> \u001b[39m\u001b[32m5\u001b[39m p_norm = \u001b[43mcal\u001b[49m\u001b[43m.\u001b[49m\u001b[43mcalibrate\u001b[49m(p_pixels)\n\u001b[32m      6\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mPixel point: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mp_pixels\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n\u001b[32m      7\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mCalibrated (normalized) point: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mp_norm\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n",
+            "\u001b[31mAttributeError\u001b[39m: 'gtsam.gtsam.Cal3_S2Stereo' object has no attribute 'calibrate'"
+          ]
+        }
+      ],
+      "source": [
+        "fx, fy, s, u0, v0, b = 1000.0, 1000.0, 0.0, 320.0, 240.0, 0.5\n",
+        "cal = Cal3_S2Stereo(fx, fy, s, u0, v0, b)\n",
+        "\n",
+        "p_pixels = Point2(420, 290)\n",
+        "p_norm = cal.calibrate(p_pixels)\n",
+        "print(f\"Pixel point: {p_pixels}\")\n",
+        "print(f\"Calibrated (normalized) point: {p_norm}\")\n",
+        "\n",
+        "# This method can optionally compute Jacobians.\n",
+        "Dcal_calibrate = np.zeros((2, 6), order='F') # Note shape is 2x6\n",
+        "Dp_calibrate = np.zeros((2, 2), order='F')\n",
+        "_ = cal.calibrate(p_pixels, Dcal_calibrate, Dp_calibrate)\n",
+        "print(f\"\\nJacobian Dcal_calibrate:\\n{Dcal_calibrate}\")\n",
+        "print(f\"\\nJacobian Dp_calibrate:\\n{Dp_calibrate}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### `uncalibrate()`\n",
+        "\n",
+        "The `uncalibrate(p)` method converts a 2D point `p` from normalized coordinates back to pixel coordinates."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 19,
+      "metadata": {},
+      "outputs": [
+        {
+          "ename": "AttributeError",
+          "evalue": "'gtsam.gtsam.Cal3_S2Stereo' object has no attribute 'uncalibrate'",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+            "\u001b[31mAttributeError\u001b[39m                            Traceback (most recent call last)",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[19]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m p_pixels_recovered = \u001b[43mcal\u001b[49m\u001b[43m.\u001b[49m\u001b[43muncalibrate\u001b[49m(p_norm)\n\u001b[32m      2\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mNormalized point: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mp_norm\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n\u001b[32m      3\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mUncalibrated (pixel) point: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mp_pixels_recovered\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n",
+            "\u001b[31mAttributeError\u001b[39m: 'gtsam.gtsam.Cal3_S2Stereo' object has no attribute 'uncalibrate'"
+          ]
+        }
+      ],
+      "source": [
+        "p_pixels_recovered = cal.uncalibrate(p_norm)\n",
+        "print(f\"Normalized point: {p_norm}\")\n",
+        "print(f\"Uncalibrated (pixel) point: {p_pixels_recovered}\")\n",
+        "\n",
+        "# This method can also optionally compute Jacobians.\n",
+        "Dcal_uncalibrate = np.zeros((2, 6), order='F')\n",
+        "Dp_uncalibrate = np.zeros((2, 2), order='F')\n",
+        "_ = cal.uncalibrate(p_norm, Dcal_uncalibrate, Dp_uncalibrate)\n",
+        "print(f\"\\nJacobian Dcal_uncalibrate:\\n{Dcal_uncalibrate}\")\n",
+        "print(f\"\\nJacobian Dp_uncalibrate:\\n{Dp_uncalibrate}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Manifold Operations\n",
+        "\n",
+        "`Cal3_S2Stereo` is a 6-dimensional manifold and supports `retract` and `localCoordinates` to enable optimization. These operations apply updates in the 6-dimensional tangent space."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 20,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Original cal_model:\n",
+            "K: 1000    0  320\n",
+            "   0 1000  240\n",
+            "   0    0    1\n",
+            "Baseline: 0.5\n",
+            "\n",
+            "\n",
+            "Delta vector: [ 1.e+01  2.e+01  5.e-02  1.e+00 -1.e+00  1.e-02]\n",
+            "\n",
+            "Retracted cal_retracted:\n",
+            "K: 1010 0.05  321\n",
+            "   0 1020  239\n",
+            "   0    0    1\n",
+            "Baseline: 0.51\n",
+            "\n",
+            "\n",
+            "Local coordinates from cal_model to cal_retracted:\n",
+            "[ 1.e+01  2.e+01  5.e-02  1.e+00 -1.e+00  1.e-02]\n"
+          ]
+        }
+      ],
+      "source": [
+        "print(\"Original cal_model:\")\n",
+        "print(cal)\n",
+        "\n",
+        "# Retract: Apply a delta to the calibration parameters\n",
+        "delta_vec = np.array([10.0, 20.0, 0.05, 1.0, -1.0, 0.01])\n",
+        "cal_retracted = cal.retract(delta_vec)\n",
+        "print(f\"\\nDelta vector: {delta_vec}\")\n",
+        "print(\"\\nRetracted cal_retracted:\")\n",
+        "print(cal_retracted)\n",
+        "\n",
+        "# Local coordinates: Find the delta between two calibrations\n",
+        "local_coords = cal.localCoordinates(cal_retracted)\n",
+        "print(\"\\nLocal coordinates from cal_model to cal_retracted:\")\n",
+        "print(local_coords)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Relationship with `StereoCamera`\n",
+        "\n",
+        "The `Cal3_S2Stereo` object is most powerful when used with the `StereoCamera` class. A `StereoCamera` combines a `Pose3` (the pose of the left camera) and a `Cal3_S2Stereo` calibration to project 3D points into the stereo image plane, producing a `StereoPoint2` which contains the left and right image coordinates ($u_L, u_R, v$)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 21,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "3D Point in world frame: [5. 3. 2.]\n",
+            "StereoCamera pose:\n",
+            "R: [\n",
+            "\t6.12323e-17, 6.12323e-17, 1;\n",
+            "\t-1, 3.7494e-33, 6.12323e-17;\n",
+            "\t-0, -1, 6.12323e-17\n",
+            "]\n",
+            "t: 0 0 5\n",
+            "\n",
+            "Stereo calibration:\n",
+            "K: 1000    0  640\n",
+            "   0 1000  360\n",
+            "   0    0    1\n",
+            "Baseline: 0.5\n",
+            "\n",
+            "\n",
+            "Projected StereoPoint2 (u_L, u_R, v): (40, -60, 960)\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "fx, fy, s, u0, v0, b = 1000, 1000, 0, 640, 360, 0.5\n",
+        "stereo_calibration = Cal3_S2Stereo(fx, fy, s, u0, v0, b)\n",
+        "\n",
+        "# Define the pose of the stereo camera rig in the world frame (left camera's pose)\n",
+        "camera_pose = Pose3(gtsam.Rot3.Ypr(-np.pi/2, 0, -np.pi/2), Point3(0, 0, 5.0))\n",
+        "\n",
+        "# Create a StereoCamera object\n",
+        "stereo_camera = StereoCamera(camera_pose, stereo_calibration)\n",
+        "\n",
+        "# Define a 3D point in the world frame\n",
+        "p_world = Point3(5, 3, 2)\n",
+        "\n",
+        "# Project the 3D point into the stereo camera\n",
+        "p_stereo = stereo_camera.project(p_world)\n",
+        "\n",
+        "print(f\"3D Point in world frame: {p_world}\")\n",
+        "print(f\"StereoCamera pose:\\n{stereo_camera.pose()}\")\n",
+        "print(f\"Stereo calibration:\\n{stereo_camera.calibration()}\")\n",
+        "print(f\"\\nProjected StereoPoint2 (u_L, u_R, v): {p_stereo}\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Additional Resources\n",
+        "\n",
+        "The following resources provide more detailed explanations of camera calibration and stereo vision.\n",
+        "\n",
+        "### Video(s)\n",
+        "- [\"Simple Stereo | Camera Calibration\"](https://youtu.be/hUVyDabn1Mg?si=3zIrPPML-H7Zu5_i) by Dr. Shree Nayar from Columbia University\n",
+        "\n",
+        "## Source\n",
+        "- [Cal3_S2Stereo.h](https://github.com/borglab/gtsam/blob/develop/gtsam/geometry/Cal3_S2Stereo.h)\n",
+        "- [Cal3_S2Stereo.cpp](https://github.com/borglab/gtsam/blob/develop/gtsam/geometry/Cal3_S2Stereo.cpp)"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/gtsam/geometry/doc/Cal3_S2Stereo.ipynb
+++ b/gtsam/geometry/doc/Cal3_S2Stereo.ipynb
@@ -41,29 +41,18 @@
           "remove-cell"
         ]
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Not running in Google Colab. Please install necessary libraries as needed.\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "try:\n",
         "    import google.colab\n",
-        "    print(\"Running in Google Colab, installing necessary libraries...\")\n",
         "    %pip install --quiet gtsam-develop\n",
-        "    print(\"Done!\")\n",
         "except ImportError:\n",
-        "    print(\"Not running in Google Colab. Please install necessary libraries as needed.\")\n",
         "    pass"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": 2,
       "metadata": {
         "tags": [
           "remove-cell"
@@ -223,7 +212,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": 5,
       "metadata": {},
       "outputs": [
         {
@@ -260,7 +249,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": 6,
       "metadata": {},
       "outputs": [
         {
@@ -298,7 +287,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": 7,
       "metadata": {},
       "outputs": [
         {
@@ -333,7 +322,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": 8,
       "metadata": {},
       "outputs": [
         {
@@ -375,7 +364,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
+      "execution_count": 9,
       "metadata": {},
       "outputs": [
         {
@@ -431,7 +420,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 19,
+      "execution_count": 10,
       "metadata": {},
       "outputs": [
         {

--- a/gtsam/geometry/doc/Cal3_S2Stereo.ipynb
+++ b/gtsam/geometry/doc/Cal3_S2Stereo.ipynb
@@ -48,7 +48,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": 1,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -191,7 +191,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 5,
       "metadata": {},
       "outputs": [
         {
@@ -202,7 +202,7 @@
             "K: 1652.17       0    1024\n",
             "      0 1652.17     768\n",
             "      0       0       1\n",
-            "Baseline: 24\n",
+            "Baseline: 0.24\n",
             "\n"
           ]
         }
@@ -234,7 +234,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 50,
+      "execution_count": 10,
       "metadata": {},
       "outputs": [
         {
@@ -268,7 +268,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 51,
+      "execution_count": 7,
       "metadata": {},
       "outputs": [
         {
@@ -308,7 +308,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 52,
+      "execution_count": 11,
       "metadata": {},
       "outputs": [
         {
@@ -318,14 +318,14 @@
             "image[0, 0] -> (u, v)=(0.5px, 0.5px) -> (x, y)=(-0.61949, -0.46454)\n",
             "(x, y)=(-0.61949, -0.46454) -> (u, v)=(0.5px, 0.5px) -> image[0.0, 0.0]\n",
             "image[1024, 768] -> (u, v)=(768.5px, 1024.5px) -> (x, y)=(-0.15464, 0.15525)\n",
-            "(x, y)=(-0.15464, 0.15525) -> (u, v)=(768.5px, 1024.5px) -> image[768.0, 1024.0]\n"
+            "(x, y)=(-0.15464, 0.15525) -> (u, v)=(768.5px, 1024.5px) -> image[1024.0, 768.0]\n"
           ]
         }
       ],
       "source": [
         "def uncalibration_demo(cal: Cal3_S2Stereo, x: float, y: float):\n",
         "  u, v = cal.uncalibrate([x, y])\n",
-        "  print(f\"(x, y)=({round(x, 5)}, {round(y, 5)}) -> (u, v)=({round(u, 2)}px, {round(v, 2)}px) -> image[{np.floor(u)}, {np.floor(v)}]\")\n",
+        "  print(f\"(x, y)=({round(x, 5)}, {round(y, 5)}) -> (u, v)=({round(u, 2)}px, {round(v, 2)}px) -> image[{np.floor(v)}, {np.floor(u)}]\")\n",
         "  return u, v\n",
         "\n",
         "x, y = calibration_demo(cal_xc3_BumblebeeX, 0, 0);\n",
@@ -343,7 +343,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 53,
+      "execution_count": 12,
       "metadata": {},
       "outputs": [
         {
@@ -377,12 +377,15 @@
       "source": [
         "## Manifold Operations\n",
         "\n",
-        "`Cal3_S2Stereo` is a 6-dimensional manifold and supports `retract` and `localCoordinates` to enable optimization. These operations apply updates in the 6-dimensional tangent space."
+        "Like other calibration classes in GTSAM, `Cal3_S2Stereo` is treated as a manifold type, even though it is simply a 6-dimensional vector in $\\mathbb{R}^6$. This abstraction allows it to integrate seamlessly into GTSAM's optimization framework.\n",
+        "\n",
+        "- `retract(d)` maps a small update vector `d` in the tangent space to a new calibration object on the manifold.\n",
+        "- `localCoordinates(T2)` computes the tangent-space vector that moves from the current calibration to another calibration `T2`."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 58,
+      "execution_count": 16,
       "metadata": {},
       "outputs": [
         {
@@ -433,12 +436,12 @@
       "source": [
         "## Relationship with `StereoCamera`\n",
         "\n",
-        "The `Cal3_S2Stereo` object is most powerful when used with the `StereoCamera` class. A `StereoCamera` combines a `Pose3` (the pose of the left camera) and a `Cal3_S2Stereo` calibration to project 3D points into the stereo image plane, producing a `StereoPoint2` which contains the left and right image coordinates ($u_L, u_R, v$)."
+        "The `Cal3_S2Stereo` object should be used with the `StereoCamera` class. A `StereoCamera` combines a `Pose3` (the pose of the left camera) and a `Cal3_S2Stereo` calibration to project 3D points into the stereo image plane, producing a `StereoPoint2` which contains the left and right image coordinates ($u_L, u_R, v$). Below is a basic example; please look at the user guide of [`StereoCamera`](./StereoCamera.ipynb) for a more thorough explanation."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 60,
+      "execution_count": 17,
       "metadata": {},
       "outputs": [
         {

--- a/gtsam/geometry/doc/StereoCamera.ipynb
+++ b/gtsam/geometry/doc/StereoCamera.ipynb
@@ -12,15 +12,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "stereocamera-intro"
-      },
-      "source": [
-        "A `StereoCamera` in GTSAM is composed of a `Pose3` for the left camera and a `Cal3_S2Stereo` calibration object. Its main function is to project a 3D point into the stereo image plane, which results in a `StereoPoint2` measurement, or to backproject a `StereoPoint2` into a 3D point. This class is essential for stereo vision applications where you need to relate 3D world points to 2D image measurements from a stereo rig."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "stereocamera-colab-badge"
       },
       "source": [
@@ -28,27 +19,66 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": null,
+      "cell_type": "markdown",
       "metadata": {
-        "id": "stereocamera-pip-install"
+        "id": "stereocamera-intro"
       },
-      "outputs": [],
       "source": [
-        "%pip install --quiet gtsam-develop"
+        "A `StereoCamera` in GTSAM models a calibrated stereo camera rig composed of a [`Pose3`](./Pose3.ipynb) representing the left camera's pose in the world frame and a [`Cal3_S2Stereo`](./Cal3_S2Stereo.ipynb) object that contains the intrinsic parameters of both cameras and the baseline between them.\n",
+        "\n",
+        "It has two main functionalities:\n",
+        "- Project a 3D point from the world frame into stereo image coordinates $(u_L, u_R, v)$, represented by a [`StereoPoint2`](./StereoPoint2.ipynb)\n",
+        "- Backproject a stereo measurement $(u_L, u_R, v)$ into a 3D point in the world frame, using the known pose and calibration of the camera.\n",
+        "\n",
+        "In simulation, `StereoCamera.project()` allows you to generate synthetic measurements from known 3D points, which is useful for testing and verifying SLAM or structure-from-motion algorithms.\n",
+        "\n",
+        "In real-world applications, stereo image pairs are used to extract matching pixel coordinates $(u_L, u_R, v)$, which can then be passed to `StereoCamera.backproject()` to recover 3D points based on the pose of the camera.\n",
+        "\n",
+        "To see how `StereoCamera` is used in practical applications, please refer to [StereoVOExample](../../../python/gtsam/examples/StereoVOExample.ipynb) and [StereoVOExample_large](../../../python/gtsam/examples/StereoVOExample_large.ipynb)."
       ]
     },
     {
       "cell_type": "code",
       "execution_count": 1,
       "metadata": {
-        "id": "stereocamera-imports"
+        "id": "stereocamera-pip-install",
+        "tags": [
+          "remove-cell"
+        ]
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Not running in Google Colab. Please install necessary libraries as needed.\n"
+          ]
+        }
+      ],
+      "source": [
+        "try:\n",
+        "    import google.colab\n",
+        "    print(\"Running in Google Colab, installing necessary libraries...\")\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "    print(\"Done!\")\n",
+        "except ImportError:\n",
+        "    print(\"Not running in Google Colab. Please install necessary libraries as needed.\")\n",
+        "    pass"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "id": "stereocamera-imports",
+        "tags": [
+          "remove-cell"
+        ]
       },
       "outputs": [],
       "source": [
         "import gtsam\n",
-        "import numpy as np\n",
-        "from gtsam import Cal3_S2Stereo, Point3, Pose3, Rot3, StereoCamera, StereoPoint2"
+        "import numpy as np"
       ]
     },
     {
@@ -57,19 +87,14 @@
         "id": "stereocamera-initialization-header"
       },
       "source": [
-        "## Initialization"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "A `StereoCamera` is initialized by providing the camera's pose in the world frame and its stereo calibration parameters. The pose, represented by a `Pose3` object, defines the position and orientation of the left camera. The calibration, represented by a `Cal3_S2Stereo` object, contains the intrinsic parameters of the cameras and the baseline between them."
+        "## Initialization\n",
+        "\n",
+        "A `StereoCamera` can be initialized in two ways:"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": 5,
       "metadata": {
         "id": "stereocamera-initialization-code"
       },
@@ -78,31 +103,46 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "MyStereoCamera.camera. R: [\n",
+            "Default constructor:\n",
+            ".camera. R: [\n",
+            "\t1, 0, 0;\n",
+            "\t0, 1, 0;\n",
+            "\t0, 0, 1\n",
+            "]\n",
+            "t: 0 0 0\n",
+            ".calibration. K: 1 0 0\n",
+            "0 1 0\n",
+            "0 0 1\n",
+            "Baseline: 1\n",
+            "\n",
+            "From left-camera pose and shared calibration K:\n",
+            ".camera. R: [\n",
             "\t6.12323e-17, 6.12323e-17, 1;\n",
             "\t-1, 3.7494e-33, 6.12323e-17;\n",
             "\t-0, -1, 6.12323e-17\n",
             "]\n",
             "t: 0 0 5\n",
-            "MyStereoCamera.calibration. K: 1000    0  640\n",
+            ".calibration. K: 1000    0  640\n",
             "   0 1000  360\n",
             "   0    0    1\n",
-            "Baseline: 0.5\n"
+            "Baseline: 0.5\n",
+            "\n"
           ]
         }
       ],
       "source": [
-        "# Define the pose of the stereo camera rig in the world frame (left camera's pose).\n",
-        "left_camera_pose = Pose3(Rot3.Ypr(-np.pi/2, 0, -np.pi/2), Point3(0, 0, 5.0))\n",
+        "# Default constructor\n",
+        "stereo_camera_default = gtsam.StereoCamera()\n",
+        "print(\"Default constructor:\")\n",
+        "print(stereo_camera_default)\n",
         "\n",
-        "# Define the stereo calibration.\n",
+        "# With left-camera pose and shared calibration\n",
+        "left_camera_pose = gtsam.Pose3(gtsam.Rot3.Ypr(-np.pi/2, 0, -np.pi/2), gtsam.Point3(0, 0, 5.0))\n",
         "fx, fy, s, u0, v0, b = 1000, 1000, 0, 640, 360, 0.5\n",
-        "K = Cal3_S2Stereo(fx, fy, s, u0, v0, b)\n",
-        "\n",
-        "# Create a StereoCamera object.\n",
-        "stereo_camera = StereoCamera(left_camera_pose, K)\n",
-        "\n",
-        "stereo_camera.print(\"MyStereoCamera\")"
+        "K = gtsam.Cal3_S2Stereo(fx, fy, s, u0, v0, b)\n",
+        "stereo_camera = gtsam.StereoCamera(left_camera_pose, K)\n",
+        "print(\"From left-camera pose and shared calibration K:\")\n",
+        "print(stereo_camera)"
       ]
     },
     {
@@ -116,12 +156,15 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "You can access the camera's pose, calibration, and baseline using the following methods:"
+        "`StereoCamera` properties can be accessed by the following member functions:\n",
+        "- `pose()`: Returns a [`Pose3`](./Pose3.ipynb) object representing the pose of the left camera in the world frame.\n",
+        "- `calibration()`: Returns a [`Cal3_S2Stereo`](./Cal3_S2Stereo.ipynb) object, which includes the instrinsic parameters shared by both cameras.\n",
+        "- `baseline()`: Returns the baseline, the distance between left and right cameras."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": 7,
       "metadata": {
         "id": "stereocamera-properties-code"
       },
@@ -130,21 +173,18 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Camera Pose:\n",
-            "R: [\n",
+            "Stereo camera properties:\n",
+            "Camera pose: R: [\n",
             "\t6.12323e-17, 6.12323e-17, 1;\n",
             "\t-1, 3.7494e-33, 6.12323e-17;\n",
             "\t-0, -1, 6.12323e-17\n",
             "]\n",
             "t: 0 0 5\n",
             "\n",
-            "\n",
-            "Calibration:\n",
-            " K: 1000    0  640\n",
+            "Calibration: K: 1000    0  640\n",
             "   0 1000  360\n",
             "   0    0    1\n",
             "Baseline: 0.5\n",
-            "\n",
             "\n",
             "Baseline: 0.5\n"
           ]
@@ -155,33 +195,30 @@
         "calibration = stereo_camera.calibration()\n",
         "baseline = stereo_camera.baseline()\n",
         "\n",
-        "print(\"Camera Pose:\")\n",
-        "print(camera_pose)\n",
-        "print(\"\\nCalibration:\\n\", calibration)\n",
-        "print(f\"\\nBaseline: {baseline}\")"
+        "print(\"Stereo camera properties:\")\n",
+        "print(f\"Camera pose: {stereo_camera.pose()}\")\n",
+        "print(f\"Calibration: {stereo_camera.calibration()}\")\n",
+        "print(f\"Baseline: {stereo_camera.baseline()}\")"
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## Basic Operations"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### `project`\n",
+        "## Basic Operations\n",
         "\n",
-        "The primary function of the `StereoCamera` is to project 3D world points into 2D stereo image coordinates. The `project` method takes a `Point3` and returns a `StereoPoint2`, which contains the pixel coordinates $(u_L, u_R, v)$ for the left and right images.\n",
+        "### `project()`\n",
         "\n",
-        "If a point is behind the camera, a `StereoCheiralityException` is thrown."
+        "The `project()` member function maps a 3D point in the world frame to 2D stereo image coordinates. It takes a `Point3` and returns a [`StereoPoint2`](./StereoPoint2.ipynb) containing the pixel coordinates $(u_L, u_R, v)$ observed by the left and right cameras.\n",
+        "\n",
+        "This function is especially useful in simulation, where the 3D location of a point is known in advance. It enables the projection of ground-truth landmarks into pixel measurements based on the camera's pose and calibration.\n",
+        "\n",
+        "If the point lies behind the camera or is not visible in the stereo field of view, a `StereoCheiralityException` is thrown."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": 15,
       "metadata": {
         "id": "stereocamera-project-code"
       },
@@ -197,10 +234,7 @@
         }
       ],
       "source": [
-        "# Define a 3D point in the world frame.\n",
-        "p_world = Point3(5, 3, 2)\n",
-        "\n",
-        "# Project the 3D point into the stereo camera.\n",
+        "p_world = gtsam.Point3(5, 3, 2)\n",
         "p_stereo = stereo_camera.project(p_world)\n",
         "\n",
         "print(f\"3D Point in world frame: {p_world}\")\n",
@@ -211,36 +245,47 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "The `project` method can also calculate the Jacobians of the projection with respect to the camera pose (`H1`) and the 3D point (`H2`)."
+        "### `project2()`\n",
+        "\n",
+        "The `project2()` member function is the same as `project()`, except that it can also calculate the Jacobians of the projection with respect to the camera pose (`H1`) and the 3D point (`H2`)."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": 33,
       "metadata": {
         "id": "stereocamera-project-jacobian-code"
       },
       "outputs": [
         {
-          "ename": "TypeError",
-          "evalue": "project(): incompatible function arguments. The following argument types are supported:\n    1. (self: gtsam.gtsam.StereoCamera, point: numpy.ndarray[numpy.float64[3, 1]]) -> gtsam.gtsam.StereoPoint2\n\nInvoked with: .camera. R: [\n\t6.12323e-17, 6.12323e-17, 1;\n\t-1, 3.7494e-33, 6.12323e-17;\n\t-0, -1, 6.12323e-17\n]\nt: 0 0 5\n.calibration. K: 1000    0  640\n   0 1000  360\n   0    0    1\nBaseline: 0.5\n, [array([5., 3., 2.]), array([[0., 0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0., 0.]]), array([[0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.]])]",
-          "output_type": "error",
-          "traceback": [
-            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-            "\u001b[31mTypeError\u001b[39m                                 Traceback (most recent call last)",
-            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[6]\u001b[39m\u001b[32m, line 4\u001b[39m\n\u001b[32m      1\u001b[39m H1 = np.zeros((\u001b[32m3\u001b[39m, \u001b[32m6\u001b[39m), order=\u001b[33m'\u001b[39m\u001b[33mF\u001b[39m\u001b[33m'\u001b[39m) \u001b[38;5;66;03m# Jacobian wrt camera pose\u001b[39;00m\n\u001b[32m      2\u001b[39m H2 = np.zeros((\u001b[32m3\u001b[39m, \u001b[32m3\u001b[39m), order=\u001b[33m'\u001b[39m\u001b[33mF\u001b[39m\u001b[33m'\u001b[39m) \u001b[38;5;66;03m# Jacobian wrt point\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m4\u001b[39m p_stereo = \u001b[43mstereo_camera\u001b[49m\u001b[43m.\u001b[49m\u001b[43mproject\u001b[49m\u001b[43m(\u001b[49m\u001b[43m[\u001b[49m\u001b[43mp_world\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mH1\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mH2\u001b[49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m      6\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33m\"\u001b[39m\u001b[33mJacobian wrt Pose (H1):\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33m\"\u001b[39m, H1)\n\u001b[32m      7\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33m\"\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33mJacobian wrt Point (H2):\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33m\"\u001b[39m, H2)\n",
-            "\u001b[31mTypeError\u001b[39m: project(): incompatible function arguments. The following argument types are supported:\n    1. (self: gtsam.gtsam.StereoCamera, point: numpy.ndarray[numpy.float64[3, 1]]) -> gtsam.gtsam.StereoPoint2\n\nInvoked with: .camera. R: [\n\t6.12323e-17, 6.12323e-17, 1;\n\t-1, 3.7494e-33, 6.12323e-17;\n\t-0, -1, 6.12323e-17\n]\nt: 0 0 5\n.calibration. K: 1000    0  640\n   0 1000  360\n   0    0    1\nBaseline: 0.5\n, [array([5., 3., 2.]), array([[0., 0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0., 0.]]), array([[0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.]])]"
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "3D Point in world frame: [5. 3. 2.]\n",
+            "Projected StereoPoint2 (uL, uR, v): (40, -60, 960)\n",
+            "\n",
+            "Jacobian w.r.t. Pose (H1):\n",
+            " [[ -360. -1360.   600.  -200.     0.  -120.]\n",
+            " [ -420. -1420.   600.  -200.     0.  -140.]\n",
+            " [ 1360.   360.   600.     0.  -200.   120.]]\n",
+            "\n",
+            "Jacobian w.r.t. Point (H2):\n",
+            " [[ 1.20000000e+02 -2.00000000e+02  7.34788079e-15]\n",
+            " [ 1.40000000e+02 -2.00000000e+02  8.57252759e-15]\n",
+            " [-1.20000000e+02 -7.34788079e-15 -2.00000000e+02]]\n"
           ]
         }
       ],
       "source": [
-        "H1 = np.zeros((3, 6), order='F') # Jacobian wrt camera pose\n",
-        "H2 = np.zeros((3, 3), order='F') # Jacobian wrt point\n",
+        "H1 = np.zeros((3, 6), order='F') # Jacobian w.r.t. camera pose\n",
+        "H2 = np.zeros((3, 3), order='F') # Jacobian w.r.t. point\n",
         "\n",
-        "p_stereo = stereo_camera.project([p_world, H1, H2])\n",
+        "p_stereo = stereo_camera.project2(p_world, H1, H2)\n",
         "\n",
-        "print(\"Jacobian wrt Pose (H1):\\n\", H1)\n",
-        "print(\"\\nJacobian wrt Point (H2):\\n\", H2)"
+        "print(f\"3D Point in world frame: {p_world}\")\n",
+        "print(f\"Projected StereoPoint2 (uL, uR, v): {p_stereo}\")\n",
+        "print(\"Jacobian w.r.t. Pose (H1):\\n\", H1)\n",
+        "print(\"\\nJacobian w.r.t. Point (H2):\\n\", H2)"
       ]
     },
     {
@@ -249,21 +294,80 @@
       "source": [
         "### `backproject`\n",
         "\n",
-        "The `backproject` method performs the inverse operation, reconstructing a 3D `Point3` from a `StereoPoint2`."
+        "The `backproject()` member function performs the inverse operation of `project()`. Given a [`StereoPoint2`](./StereoPoint2) measurement $(u_L, u_R, v)$, it reconstructs and returns the corresponding 3D point in the world frame as a `Point3`.\n",
+        "\n",
+        "This function is especially useful in real-world applications, where stereo image pairs are used to extract pixel correspondences. When the stereo rig's pose and calibration are known (which should be true if you are using a `StereoCamera` in the first place), `backproject()` allows recovering the estimated position of a point in space from its stereo measurement."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 34,
       "metadata": {
         "id": "stereocamera-backproject-code"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Original Point: [5. 3. 2.]\n",
+            "Reprojected Point: [5. 3. 2.]\n"
+          ]
+        }
+      ],
       "source": [
         "reprojected_point = stereo_camera.backproject(p_stereo)\n",
         "\n",
         "print(f\"Original Point: {p_world}\")\n",
         "print(f\"Reprojected Point: {reprojected_point}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### `backproject2()`\n",
+        "\n",
+        "The `backproject2()` member function is the same as `backproject()`, except that it can also calculater the Jacobians of the backprojection with respect to the stereo measurement (`H1`) and the camera pose (`H2`)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 35,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Original Point: [5. 3. 2.]\n",
+            "Reprojected Point: [5. 3. 2.]\n",
+            "\n",
+            "Jacobian w.r.t. Pose (H1):\n",
+            " [[ 3.00000000e+00  3.00000000e+00 -3.67394040e-16  6.12323400e-17\n",
+            "   6.12323400e-17  1.00000000e+00]\n",
+            " [ 1.83697020e-16 -5.00000000e+00  3.00000000e+00 -1.00000000e+00\n",
+            "   3.74939946e-33  6.12323400e-17]\n",
+            " [ 5.00000000e+00  1.83697020e-16  3.00000000e+00 -0.00000000e+00\n",
+            "  -1.00000000e+00  6.12323400e-17]]\n",
+            "\n",
+            "Jacobian w.r.t. Point (H2):\n",
+            " [[-5.00000000e-02  5.00000000e-02  3.06161700e-19]\n",
+            " [-3.50000000e-02  3.00000000e-02  1.87469973e-35]\n",
+            " [ 3.00000000e-02 -3.00000000e-02 -5.00000000e-03]]\n"
+          ]
+        }
+      ],
+      "source": [
+        "H1 = np.zeros((3, 6), order='F') # Jacobian w.r.t. camera pose\n",
+        "H2 = np.zeros((3, 3), order='F') # Jacobian w.r.t. point\n",
+        "\n",
+        "reprojected_point = stereo_camera.backproject2(p_stereo, H1, H2)\n",
+        "\n",
+        "print(f\"Original Point: {p_world}\")\n",
+        "print(f\"Reprojected Point: {reprojected_point}\")\n",
+        "print(\"\\nJacobian w.r.t. Pose (H1):\\n\", H1)\n",
+        "print(\"\\nJacobian w.r.t. Point (H2):\\n\", H2)"
       ]
     },
     {
@@ -274,16 +378,50 @@
       "source": [
         "## Manifold Operations\n",
         "\n",
-        "`StereoCamera` is also a manifold, which allows it to be used in optimization problems. The manifold operations `retract` and `localCoordinates` are applied to the `Pose3` component of the camera, while the calibration is held constant."
+        "`StereoCamera` is a manifold, meaning it supports operations such as `retract()` and `localCoordinates()` that defines a continuous space of camera poses. These operations apply to the `Pose3` component (the left camera's pose), while the stereo calibration remains fixed.\n",
+        "\n",
+        "This structure allows `StereoCamera` to be integrated into optimization routines where small updates to the camera pose are computed on the manifold."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 36,
       "metadata": {
         "id": "stereocamera-manifold-code"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Original StereoCamera:\n",
+            ".camera. R: [\n",
+            "\t6.12323e-17, 6.12323e-17, 1;\n",
+            "\t-1, 3.7494e-33, 6.12323e-17;\n",
+            "\t-0, -1, 6.12323e-17\n",
+            "]\n",
+            "t: 0 0 5\n",
+            ".calibration. K: 1000    0  640\n",
+            "   0 1000  360\n",
+            "   0    0    1\n",
+            "Baseline: 0.5\n",
+            "\n",
+            "Retracted StereoCamera:\n",
+            ".camera. R: [\n",
+            "\t-0.18054, 0.127335, 0.97529;\n",
+            "\t-0.935755, 0.283165, -0.210192;\n",
+            "\t-0.302933, -0.950581, 0.0680313\n",
+            "]\n",
+            "t:   0.58716 -0.381202   4.47134\n",
+            ".calibration. K: 1000    0  640\n",
+            "   0 1000  360\n",
+            "   0    0    1\n",
+            "Baseline: 0.5\n",
+            "\n",
+            "Local Coordinates: [0.1 0.2 0.3 0.4 0.5 0.6]\n"
+          ]
+        }
+      ],
       "source": [
         "print(\"Original StereoCamera:\")\n",
         "stereo_camera.print()\n",
@@ -313,7 +451,7 @@
         "- [\"5.3. Cameras for Robot Vision\"](https://www.roboticsbook.org/S53_diffdrive_sensing.html) by Dr. Frank Dellaert and Dr. Seth Hutchinson\n",
         "\n",
         "### Video(s)\n",
-        "- [\"Simple Stereo | Camera Calibration\"](https://www.youtube.com/watch?v=hUVyD4z2-eY) by Dr. Shree Nayar from Columbia University\n",
+        "- [\"Simple Stereo | Camera Calibration\"](https://youtu.be/hUVyDabn1Mg?si=3zIrPPML-H7Zu5_i) by Dr. Shree Nayar from Columbia University\n",
         "\n",
         "## Source\n",
         "- [StereoCamera.h](https://github.com/borglab/gtsam/blob/develop/gtsam/geometry/StereoCamera.h)\n",

--- a/gtsam/geometry/doc/StereoCamera.ipynb
+++ b/gtsam/geometry/doc/StereoCamera.ipynb
@@ -40,7 +40,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 1,
       "metadata": {
         "id": "stereocamera-imports"
       },
@@ -69,11 +69,28 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 2,
       "metadata": {
         "id": "stereocamera-initialization-code"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "My Stereo Camera.camera. R: [\n",
+            "\t6.12323e-17, 6.12323e-17, 1;\n",
+            "\t-1, 3.7494e-33, 6.12323e-17;\n",
+            "\t-0, -1, 6.12323e-17\n",
+            "]\n",
+            "t: 0 0 5\n",
+            "My Stereo Camera.calibration. K: 1000    0  640\n",
+            "   0 1000  360\n",
+            "   0    0    1\n",
+            "Baseline: 0.5\n"
+          ]
+        }
+      ],
       "source": [
         "# Define the pose of the stereo camera rig in the world frame (left camera's pose).\n",
         "pose = Pose3(Rot3.Ypr(-np.pi/2, 0, -np.pi/2), Point3(0, 0, 5.0))\n",
@@ -104,11 +121,35 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 3,
       "metadata": {
         "id": "stereocamera-properties-code"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Camera Pose:\n",
+            "R: [\n",
+            "\t6.12323e-17, 6.12323e-17, 1;\n",
+            "\t-1, 3.7494e-33, 6.12323e-17;\n",
+            "\t-0, -1, 6.12323e-17\n",
+            "]\n",
+            "t: 0 0 5\n",
+            "\n",
+            "\n",
+            "Calibration:\n",
+            " K: 1000    0  640\n",
+            "   0 1000  360\n",
+            "   0    0    1\n",
+            "Baseline: 0.5\n",
+            "\n",
+            "\n",
+            "Baseline: 0.5\n"
+          ]
+        }
+      ],
       "source": [
         "camera_pose = stereo_camera.pose()\n",
         "calibration = stereo_camera.calibration()\n",
@@ -140,11 +181,21 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 4,
       "metadata": {
         "id": "stereocamera-project-code"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "3D Point in world frame: [5. 3. 2.]\n",
+            "Projected StereoPoint2 (uL, uR, v): (40, -60, 960)\n",
+            "\n"
+          ]
+        }
+      ],
       "source": [
         "# Define a 3D point in the world frame.\n",
         "p_world = Point3(5, 3, 2)\n",
@@ -165,16 +216,28 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 6,
       "metadata": {
         "id": "stereocamera-project-jacobian-code"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "ename": "TypeError",
+          "evalue": "project(): incompatible function arguments. The following argument types are supported:\n    1. (self: gtsam.gtsam.StereoCamera, point: numpy.ndarray[numpy.float64[3, 1]]) -> gtsam.gtsam.StereoPoint2\n\nInvoked with: .camera. R: [\n\t6.12323e-17, 6.12323e-17, 1;\n\t-1, 3.7494e-33, 6.12323e-17;\n\t-0, -1, 6.12323e-17\n]\nt: 0 0 5\n.calibration. K: 1000    0  640\n   0 1000  360\n   0    0    1\nBaseline: 0.5\n, [array([5., 3., 2.]), array([[0., 0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0., 0.]]), array([[0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.]])]",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+            "\u001b[31mTypeError\u001b[39m                                 Traceback (most recent call last)",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[6]\u001b[39m\u001b[32m, line 4\u001b[39m\n\u001b[32m      1\u001b[39m H1 = np.zeros((\u001b[32m3\u001b[39m, \u001b[32m6\u001b[39m), order=\u001b[33m'\u001b[39m\u001b[33mF\u001b[39m\u001b[33m'\u001b[39m) \u001b[38;5;66;03m# Jacobian wrt camera pose\u001b[39;00m\n\u001b[32m      2\u001b[39m H2 = np.zeros((\u001b[32m3\u001b[39m, \u001b[32m3\u001b[39m), order=\u001b[33m'\u001b[39m\u001b[33mF\u001b[39m\u001b[33m'\u001b[39m) \u001b[38;5;66;03m# Jacobian wrt point\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m4\u001b[39m p_stereo = \u001b[43mstereo_camera\u001b[49m\u001b[43m.\u001b[49m\u001b[43mproject\u001b[49m\u001b[43m(\u001b[49m\u001b[43m[\u001b[49m\u001b[43mp_world\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mH1\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mH2\u001b[49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m      6\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33m\"\u001b[39m\u001b[33mJacobian wrt Pose (H1):\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33m\"\u001b[39m, H1)\n\u001b[32m      7\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33m\"\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33mJacobian wrt Point (H2):\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33m\"\u001b[39m, H2)\n",
+            "\u001b[31mTypeError\u001b[39m: project(): incompatible function arguments. The following argument types are supported:\n    1. (self: gtsam.gtsam.StereoCamera, point: numpy.ndarray[numpy.float64[3, 1]]) -> gtsam.gtsam.StereoPoint2\n\nInvoked with: .camera. R: [\n\t6.12323e-17, 6.12323e-17, 1;\n\t-1, 3.7494e-33, 6.12323e-17;\n\t-0, -1, 6.12323e-17\n]\nt: 0 0 5\n.calibration. K: 1000    0  640\n   0 1000  360\n   0    0    1\nBaseline: 0.5\n, [array([5., 3., 2.]), array([[0., 0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0., 0.]]), array([[0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.]])]"
+          ]
+        }
+      ],
       "source": [
         "H1 = np.zeros((3, 6), order='F') # Jacobian wrt camera pose\n",
         "H2 = np.zeros((3, 3), order='F') # Jacobian wrt point\n",
         "\n",
-        "p_stereo = stereo_camera.project(p_world, H1, H2)\n",
+        "p_stereo = stereo_camera.project([p_world, H1, H2])\n",
         "\n",
         "print(\"Jacobian wrt Pose (H1):\\n\", H1)\n",
         "print(\"\\nJacobian wrt Point (H2):\\n\", H2)"
@@ -263,7 +326,7 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": ".venv",
+      "display_name": "base",
       "language": "python",
       "name": "python3"
     },
@@ -277,7 +340,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.12.3"
+      "version": "3.12.10"
     }
   },
   "nbformat": 4,

--- a/gtsam/geometry/doc/StereoCamera.ipynb
+++ b/gtsam/geometry/doc/StereoCamera.ipynb
@@ -1,0 +1,285 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "stereocamera-title"
+      },
+      "source": [
+        "# StereoCamera"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "stereocamera-intro"
+      },
+      "source": [
+        "A `StereoCamera` in GTSAM is composed of a `Pose3` for the left camera and a `Cal3_S2Stereo` calibration object. Its main function is to project a 3D point into the stereo image plane, which results in a `StereoPoint2` measurement, or to backproject a `StereoPoint2` into a 3D point. This class is essential for stereo vision applications where you need to relate 3D world points to 2D image measurements from a stereo rig."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "stereocamera-colab-badge"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/StereoCamera.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "stereocamera-pip-install"
+      },
+      "outputs": [],
+      "source": [
+        "%pip install --quiet gtsam-develop"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "stereocamera-imports"
+      },
+      "outputs": [],
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "from gtsam import Cal3_S2Stereo, Point3, Pose3, Rot3, StereoCamera, StereoPoint2"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "stereocamera-initialization-header"
+      },
+      "source": [
+        "## Initialization"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "A `StereoCamera` is initialized by providing the camera's pose in the world frame and its stereo calibration parameters. The pose, represented by a `Pose3` object, defines the position and orientation of the left camera. The calibration, represented by a `Cal3_S2Stereo` object, contains the intrinsic parameters of the cameras and the baseline between them."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "stereocamera-initialization-code"
+      },
+      "outputs": [],
+      "source": [
+        "# Define the pose of the stereo camera rig in the world frame (left camera's pose).\n",
+        "pose = Pose3(Rot3.Ypr(-np.pi/2, 0, -np.pi/2), Point3(0, 0, 5.0))\n",
+        "\n",
+        "# Define the stereo calibration.\n",
+        "fx, fy, s, u0, v0, b = 1000, 1000, 0, 640, 360, 0.5\n",
+        "K = Cal3_S2Stereo(fx, fy, s, u0, v0, b)\n",
+        "\n",
+        "# Create a StereoCamera object.\n",
+        "stereo_camera = StereoCamera(pose, K)\n",
+        "\n",
+        "stereo_camera.print(\"My Stereo Camera\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Properties"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "You can access the camera's pose, calibration, and baseline using the following methods:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "stereocamera-properties-code"
+      },
+      "outputs": [],
+      "source": [
+        "camera_pose = stereo_camera.pose()\n",
+        "calibration = stereo_camera.calibration()\n",
+        "baseline = stereo_camera.baseline()\n",
+        "\n",
+        "print(\"Camera Pose:\")\n",
+        "print(camera_pose)\n",
+        "print(\"\\nCalibration:\\n\", calibration)\n",
+        "print(f\"\\nBaseline: {baseline}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Basic Operations"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### `project`\n",
+        "\n",
+        "The primary function of the `StereoCamera` is to project 3D world points into 2D stereo image coordinates. The `project` method takes a `Point3` and returns a `StereoPoint2`, which contains the pixel coordinates $(u_L, u_R, v)$ for the left and right images.\n",
+        "\n",
+        "If a point is behind the camera, a `StereoCheiralityException` is thrown."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "stereocamera-project-code"
+      },
+      "outputs": [],
+      "source": [
+        "# Define a 3D point in the world frame.\n",
+        "p_world = Point3(5, 3, 2)\n",
+        "\n",
+        "# Project the 3D point into the stereo camera.\n",
+        "p_stereo = stereo_camera.project(p_world)\n",
+        "\n",
+        "print(f\"3D Point in world frame: {p_world}\")\n",
+        "print(f\"Projected StereoPoint2 (uL, uR, v): {p_stereo}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "The `project` method can also calculate the Jacobians of the projection with respect to the camera pose (`H1`) and the 3D point (`H2`)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "stereocamera-project-jacobian-code"
+      },
+      "outputs": [],
+      "source": [
+        "H1 = np.zeros((3, 6), order='F') # Jacobian wrt camera pose\n",
+        "H2 = np.zeros((3, 3), order='F') # Jacobian wrt point\n",
+        "\n",
+        "p_stereo = stereo_camera.project(p_world, H1, H2)\n",
+        "\n",
+        "print(\"Jacobian wrt Pose (H1):\\n\", H1)\n",
+        "print(\"\\nJacobian wrt Point (H2):\\n\", H2)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### `backproject`\n",
+        "\n",
+        "The `backproject` method performs the inverse operation, reconstructing a 3D `Point3` from a `StereoPoint2`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "stereocamera-backproject-code"
+      },
+      "outputs": [],
+      "source": [
+        "reprojected_point = stereo_camera.backproject(p_stereo)\n",
+        "\n",
+        "print(f\"Original Point: {p_world}\")\n",
+        "print(f\"Reprojected Point: {reprojected_point}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "stereocamera-manifold-header"
+      },
+      "source": [
+        "## Manifold Operations\n",
+        "\n",
+        "`StereoCamera` is also a manifold, which allows it to be used in optimization problems. The manifold operations `retract` and `localCoordinates` are applied to the `Pose3` component of the camera, while the calibration is held constant."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "stereocamera-manifold-code"
+      },
+      "outputs": [],
+      "source": [
+        "print(\"Original StereoCamera:\")\n",
+        "stereo_camera.print()\n",
+        "\n",
+        "# Define a delta vector in the tangent space.\n",
+        "delta = np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])\n",
+        "\n",
+        "# Retract the camera pose.\n",
+        "retracted_camera = stereo_camera.retract(delta)\n",
+        "print(\"\\nRetracted StereoCamera:\")\n",
+        "retracted_camera.print()\n",
+        "\n",
+        "# Calculate the local coordinates between the original and retracted cameras.\n",
+        "local_coords = stereo_camera.localCoordinates(retracted_camera)\n",
+        "print(\"\\nLocal Coordinates:\", local_coords)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Additional Resources\n",
+        "\n",
+        "The following resources provide more detailed explanations of camera calibration and stereo vision.\n",
+        "\n",
+        "### Article(s)\n",
+        "- [\"5.3. Cameras for Robot Vision\"](https://www.roboticsbook.org/S53_diffdrive_sensing.html) by Dr. Frank Dellaert and Dr. Seth Hutchinson\n",
+        "\n",
+        "### Video(s)\n",
+        "- [\"Simple Stereo | Camera Calibration\"](https://www.youtube.com/watch?v=hUVyD4z2-eY) by Dr. Shree Nayar from Columbia University\n",
+        "\n",
+        "## Source\n",
+        "- [StereoCamera.h](https://github.com/borglab/gtsam/blob/develop/gtsam/geometry/StereoCamera.h)\n",
+        "- [StereoCamera.cpp](https://github.com/borglab/gtsam/blob/develop/gtsam/geometry/StereoCamera.cpp)"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/gtsam/geometry/doc/StereoCamera.ipynb
+++ b/gtsam/geometry/doc/StereoCamera.ipynb
@@ -46,29 +46,18 @@
           "remove-cell"
         ]
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Not running in Google Colab. Please install necessary libraries as needed.\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "try:\n",
         "    import google.colab\n",
-        "    print(\"Running in Google Colab, installing necessary libraries...\")\n",
         "    %pip install --quiet gtsam-develop\n",
-        "    print(\"Done!\")\n",
         "except ImportError:\n",
-        "    print(\"Not running in Google Colab. Please install necessary libraries as needed.\")\n",
         "    pass"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": 2,
       "metadata": {
         "id": "stereocamera-imports",
         "tags": [
@@ -94,7 +83,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": 3,
       "metadata": {
         "id": "stereocamera-initialization-code"
       },
@@ -164,7 +153,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": 4,
       "metadata": {
         "id": "stereocamera-properties-code"
       },
@@ -218,7 +207,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
+      "execution_count": 5,
       "metadata": {
         "id": "stereocamera-project-code"
       },
@@ -252,7 +241,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 33,
+      "execution_count": 6,
       "metadata": {
         "id": "stereocamera-project-jacobian-code"
       },
@@ -301,7 +290,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 34,
+      "execution_count": 7,
       "metadata": {
         "id": "stereocamera-backproject-code"
       },
@@ -333,7 +322,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 35,
+      "execution_count": 8,
       "metadata": {},
       "outputs": [
         {
@@ -385,7 +374,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 36,
+      "execution_count": 9,
       "metadata": {
         "id": "stereocamera-manifold-code"
       },

--- a/gtsam/geometry/doc/StereoCamera.ipynb
+++ b/gtsam/geometry/doc/StereoCamera.ipynb
@@ -69,7 +69,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": 8,
       "metadata": {
         "id": "stereocamera-initialization-code"
       },
@@ -78,13 +78,13 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "My Stereo Camera.camera. R: [\n",
+            "MyStereoCamera.camera. R: [\n",
             "\t6.12323e-17, 6.12323e-17, 1;\n",
             "\t-1, 3.7494e-33, 6.12323e-17;\n",
             "\t-0, -1, 6.12323e-17\n",
             "]\n",
             "t: 0 0 5\n",
-            "My Stereo Camera.calibration. K: 1000    0  640\n",
+            "MyStereoCamera.calibration. K: 1000    0  640\n",
             "   0 1000  360\n",
             "   0    0    1\n",
             "Baseline: 0.5\n"
@@ -93,16 +93,16 @@
       ],
       "source": [
         "# Define the pose of the stereo camera rig in the world frame (left camera's pose).\n",
-        "pose = Pose3(Rot3.Ypr(-np.pi/2, 0, -np.pi/2), Point3(0, 0, 5.0))\n",
+        "left_camera_pose = Pose3(Rot3.Ypr(-np.pi/2, 0, -np.pi/2), Point3(0, 0, 5.0))\n",
         "\n",
         "# Define the stereo calibration.\n",
         "fx, fy, s, u0, v0, b = 1000, 1000, 0, 640, 360, 0.5\n",
         "K = Cal3_S2Stereo(fx, fy, s, u0, v0, b)\n",
         "\n",
         "# Create a StereoCamera object.\n",
-        "stereo_camera = StereoCamera(pose, K)\n",
+        "stereo_camera = StereoCamera(left_camera_pose, K)\n",
         "\n",
-        "stereo_camera.print(\"My Stereo Camera\")"
+        "stereo_camera.print(\"MyStereoCamera\")"
       ]
     },
     {

--- a/gtsam/geometry/geometry.i
+++ b/gtsam/geometry/geometry.i
@@ -818,6 +818,9 @@ virtual class Cal3_S2 : gtsam::Cal3 {
                             Eigen::Ref<Eigen::MatrixXd> Dcal,
                             Eigen::Ref<Eigen::MatrixXd> Dp) const;
 
+  // Action on Homogeneous Coordinates
+  gtsam::Vector3 calibrate(const gtsam::Vector3& p) const;
+
   // enabling serialization functionality
   void serialize() const;
 };
@@ -948,11 +951,12 @@ virtual class Cal3Fisheye : gtsam::Cal3 {
 };
 
 #include <gtsam/geometry/Cal3_S2Stereo.h>
-virtual class Cal3_S2Stereo   : gtsam::Cal3{
+virtual class Cal3_S2Stereo : gtsam::Cal3_S2{
   // Standard Constructors
   Cal3_S2Stereo();
   Cal3_S2Stereo(double fx, double fy, double s, double u0, double v0, double b);
   Cal3_S2Stereo(gtsam::Vector v);
+  Cal3_S2Stereo(double fov, int w, int h, double b);
 
   // Manifold
   gtsam::Cal3_S2Stereo retract(gtsam::Vector d) const;
@@ -965,6 +969,16 @@ virtual class Cal3_S2Stereo   : gtsam::Cal3{
   // Standard Interface
   double baseline() const;
   gtsam::Vector6 vector() const;
+
+  // Action on Point2
+  gtsam::Point2 calibrate(const gtsam::Point2& p) const;
+  gtsam::Point2 calibrate(const gtsam::Point2& p,
+                          Eigen::Ref<Eigen::MatrixXd> Dcal,
+                          Eigen::Ref<Eigen::MatrixXd> Dp) const;
+  gtsam::Point2 uncalibrate(const gtsam::Point2& p) const;
+  gtsam::Point2 uncalibrate(const gtsam::Point2& p,
+                            Eigen::Ref<Eigen::MatrixXd> Dcal,
+                            Eigen::Ref<Eigen::MatrixXd> Dp) const;
 };
 
 #include <gtsam/geometry/Cal3Bundler.h>

--- a/python/gtsam/examples/StereoVOExample.ipynb
+++ b/python/gtsam/examples/StereoVOExample.ipynb
@@ -288,7 +288,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 26,
+      "execution_count": null,
       "id": "093fe3dc",
       "metadata": {},
       "outputs": [
@@ -330,7 +330,6 @@
         }
       ],
       "source": [
-        "# print(result)\n",
         "print(f\"Initial Error: {graph.error(initial_estimate):.4f}\")\n",
         "print(f\"Final Error  : {graph.error(result):.4f}\")\n",
         "\n",

--- a/python/gtsam/examples/StereoVOExample.ipynb
+++ b/python/gtsam/examples/StereoVOExample.ipynb
@@ -1,0 +1,386 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "cc72e99e",
+      "metadata": {},
+      "source": [
+        "# Stereo Visual Odometry with GTSAM\n",
+        "\n",
+        "This notebook demonstrates a simple 3D stereo visual odometry problem using the GTSAM Python wrapper. The scenario is as follows:\n",
+        "\n",
+        "1.  A robot starts at the origin (Pose 1: `X(1)`).\n",
+        "2.  The robot moves approximately 1 meter forward (Pose 2: `X(2)`).\n",
+        "3.  From both poses, the robot observes three landmarks (`L(1)`, `L(2)`, `L(3)`) with a stereo camera.\n",
+        "\n",
+        "We will:\n",
+        "*   Define camera calibration and noise models.\n",
+        "*   Create a factor graph representing the problem.\n",
+        "*   Provide initial estimates for poses and landmark positions.\n",
+        "*   Optimize the graph using Levenberg-Marquardt to find the most probable configuration.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "e33e553a",
+      "metadata": {},
+      "source": [
+        "GTSAM Copyright 2010-2025, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "6af0f339",
+      "metadata": {},
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/gtsam-project/gtsam-examples/blob/main/python/StereoVOExample_py.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "id": "ac25f0ee",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "\n",
+        "# For shorthand for common GTSAM types (like X for poses, L for landmarks)\n",
+        "from gtsam.symbol_shorthand import X, L\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "8d3c4fd5",
+      "metadata": {},
+      "source": [
+        "## 1. Setup Factor Graph and Priors\n",
+        "\n",
+        "We start by creating an empty `NonlinearFactorGraph`.\n",
+        "\n",
+        "The first pose `X(1)` is assumed to be at the origin. We'll add a hard constraint (prior) for this using `NonlinearEqualityPose3`. In GTSAM, factor keys are typically integers. We use `X(1)` as a symbolic key for the first pose.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "id": "342a585f",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Graph size after adding prior: 1\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Create an empty nonlinear factor graph\n",
+        "graph = gtsam.NonlinearFactorGraph()\n",
+        "\n",
+        "# Define the first pose at the origin\n",
+        "first_pose = gtsam.Pose3() # Default constructor is identity\n",
+        "\n",
+        "# Add a prior on the first pose (X1). This constraint implies X1 is fixed at the origin.\n",
+        "# NonlinearEqualityPose3 is a factor that enforces X(1) == first_pose.\n",
+        "# It effectively acts as a prior with infinite precision (zero noise).\n",
+        "graph.add(gtsam.NonlinearEqualityPose3(X(1), first_pose))\n",
+        "\n",
+        "print(\"Graph size after adding prior:\", graph.size())\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "4cbc48f7",
+      "metadata": {},
+      "source": [
+        "## 2. Define Camera Calibration and Measurement Noise\n",
+        "\n",
+        "- **Noise Model:** We define an isotropic noise model for the stereo measurements. `Isotropic.Sigma(3, 1.0)` means a 3-dimensional noise (for $u_L, u_R, v$) with a standard deviation of 1 pixel for each dimension.\n",
+        "- **Camera Calibration ([`Cal3_S2Stereo`](/gtsam/geometry/doc/Cal3_S2Stereo.ipynb)):** We define a stereo calibration model based on a theoretical yet physically realistic stereo camera with the following parameters\n",
+        "  - Resolution: $640\\times 480$\n",
+        "  - Pixel Size: $4.8\\,\\mu m \\times 4.8\\,\\mu m$\n",
+        "  - Focal Length: $3.6\\,mm$\n",
+        "  - Skew: None\n",
+        "  - Baseline: $0.2\\,m$"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 20,
+      "id": "e04b26c7",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Define the stereo measurement noise model (isotropic, 1 pixel standard deviation)\n",
+        "# The C++ example uses Isotropic::Sigma(3,1) for (uL, uR, v)\n",
+        "# In Python, StereoPoint2 is (uL, uR, v), so it's a 3-vector.\n",
+        "measurement_noise = gtsam.noiseModel.Isotropic.Sigma(3, 1.0)\n",
+        "\n",
+        "# Create stereo camera calibration object\n",
+        "# Cal3_S2Stereo(fx, fy, s, u0, v0, b)\n",
+        "w = 640                 # px\n",
+        "h = 480                 # px\n",
+        "px_sz = 4.8             # um / px\n",
+        "f = 3.6                 # mm\n",
+        "b = 0.2                 # m\n",
+        "fx = f / px_sz * 1000   # mm / (um / px) * 1000 = px\n",
+        "fy = f / px_sz * 1000   # mm / (um / px) * 1000 = px\n",
+        "s = 0                   # UNITLESS\n",
+        "u0 = w / 2              # px\n",
+        "v0 = h / 2              # px\n",
+        "K = gtsam.Cal3_S2Stereo(fx=fx, fy=fy, s=s, u0=u0, v0=v0, b=b)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "a2f867ed",
+      "metadata": {},
+      "source": [
+        "## 3. Add Stereo Factors\n",
+        "\n",
+        "We now add stereo factors to the graph. Each factor connects a camera pose to a landmark.\n",
+        "The `GenericStereoFactor3D` takes:\n",
+        "*   `measured`: The `StereoPoint2` measurement $(u_L, u_R, v)$.\n",
+        "*   `model`: The noise model for the measurement.\n",
+        "*   `poseKey`: Key for the camera pose.\n",
+        "*   `landmarkKey`: Key for the landmark.\n",
+        "*   `K`: The stereo camera calibration.\n",
+        "\n",
+        "Landmark keys in the C++ example are 3, 4, 5. We'll use `L(1)`, `L(2)`, `L(3)` to map to these, but we could also use integer keys 3, 4, 5 directly. For clarity, let's use `L(1)` (maps to C++ key 3), `L(2)` (maps to C++ key 4), `L(3)` (maps to C++ key 5).\n",
+        "\n",
+        "**Measurements from Pose 1 (`X(1)`)**\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 21,
+      "id": "e9778bec",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Graph size after adding X(1) factors: 4\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Landmark keys used in C++ were 3, 4, 5. We map them to L(1), L(2), L(3)\n",
+        "# Or, more directly, we can use 3, 4, 5 as keys in Python too.\n",
+        "# Let's use 3, 4, 5 directly to match the C++ example keys.\n",
+        "landmark_key1 = 3 # Corresponds to L(1) conceptually, or just integer key 3\n",
+        "landmark_key2 = 4 # Corresponds to L(2) conceptually, or just integer key 4\n",
+        "landmark_key3 = 5 # Corresponds to L(3) conceptually, or just integer key 5\n",
+        "\n",
+        "\n",
+        "# Factors from X(1) to landmarks\n",
+        "# StereoPoint2(uL, uR, v)\n",
+        "graph.add(gtsam.GenericStereoFactor3D(\n",
+        "    gtsam.StereoPoint2(520, 480, 440), measurement_noise, X(1), L(1), K))\n",
+        "graph.add(gtsam.GenericStereoFactor3D(\n",
+        "    gtsam.StereoPoint2(120, 80, 440), measurement_noise, X(1), L(2), K))\n",
+        "graph.add(gtsam.GenericStereoFactor3D(\n",
+        "    gtsam.StereoPoint2(320, 280, 140), measurement_noise, X(1), L(3), K))\n",
+        "\n",
+        "print(\"Graph size after adding X(1) factors:\", graph.size())\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "d0160cf1",
+      "metadata": {},
+      "source": [
+        "**Measurements from Pose 2 (`X(2)`)**\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 27,
+      "id": "495fc44f",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Graph size after adding all factors: 22\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Factors from X(2) to landmarks\n",
+        "graph.add(gtsam.GenericStereoFactor3D(\n",
+        "    gtsam.StereoPoint2(570, 520, 490), measurement_noise, X(2), L(1), K))\n",
+        "graph.add(gtsam.GenericStereoFactor3D(\n",
+        "    gtsam.StereoPoint2(70, 20, 490), measurement_noise, X(2), L(2), K))\n",
+        "graph.add(gtsam.GenericStereoFactor3D(\n",
+        "    gtsam.StereoPoint2(320, 270, 115), measurement_noise, X(2), L(3), K))\n",
+        "\n",
+        "print(\"Graph size after adding all factors:\", graph.size())"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "b6dd7e48",
+      "metadata": {},
+      "source": [
+        "## 4. Create Initial Estimates\n",
+        "\n",
+        "Nonlinear optimization requires initial estimates for all variables (poses and landmarks).\n",
+        "We create a `Values` object to store these.\n",
+        "\n",
+        "*   `X(1)`: At origin (matches the prior).\n",
+        "*   `X(2)`: Robot moves forward, slightly off-axis: `Pose3(Rot3(), Point3(0.1, -0.1, 1.1))`.\n",
+        "*   Landmarks (`L(1)`, `L(2)`, `L(3)` or `3,4,5`): Placed at estimated 3D positions.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 32,
+      "id": "b4be6ab2",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "initial_estimate = gtsam.Values()\n",
+        "\n",
+        "# Initial estimate for X(1)\n",
+        "initial_estimate.insert(X(1), first_pose)\n",
+        "\n",
+        "# Initial estimate for X(2) - robot moved forward ~1m, with some small error\n",
+        "# Pose3(rotation, translation)\n",
+        "# gtsam.Rot3() is identity rotation\n",
+        "initial_pose2 = gtsam.Pose3(gtsam.Rot3(), gtsam.Point3(0.1, -0.1, 1.1))\n",
+        "initial_estimate.insert(X(2), initial_pose2)\n",
+        "\n",
+        "# Initial estimates for landmark positions (Point3)\n",
+        "initial_estimate.insert(L(1), gtsam.Point3(1.0, 1.0, 5.0))\n",
+        "initial_estimate.insert(L(2), gtsam.Point3(-1.0, 1.0, 5.0))\n",
+        "initial_estimate.insert(L(3), gtsam.Point3(0.0, -0.5, 5.0))\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "1c1a5a73",
+      "metadata": {},
+      "source": [
+        "## 5. Optimize the Factor Graph\n",
+        "\n",
+        "We use the Levenberg-Marquardt optimizer to find the solution that minimizes the sum of squared errors defined by the factors in the graph, starting from the `initial_estimate`.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 34,
+      "id": "d0c3a87b",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Create a Levenberg-Marquardt optimizer\n",
+        "optimizer = gtsam.LevenbergMarquardtOptimizer(graph, initial_estimate)\n",
+        "\n",
+        "# Optimize the graph\n",
+        "result = optimizer.optimize()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "3b3685e1",
+      "metadata": {},
+      "source": [
+        "## 6. Analyze Results (Optional)\n",
+        "\n",
+        "We can extract the optimized poses and landmark positions from the `result` Values object.\n",
+        "\n",
+        "For example, the true second pose (if the robot moved exactly 1m forward along Z from origin) would be `Pose3(Rot3(), Point3(0, 0, 1.0))`.\n",
+        "The true landmark positions can be triangulated from the perfect measurements and true poses.\n",
+        "The example's measurements and initial estimates are designed to be somewhat noisy/imperfect, so the optimizer refines them.\n",
+        "\n",
+        "Let's check the error before and after optimization.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 37,
+      "id": "093fe3dc",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Initial Error: 67574.1864\n",
+            "Final Error  : 0.0000\n",
+            "\\nOptimized Pose X(1):\\n R: [\n",
+            "\t1, 0, 0;\n",
+            "\t0, 1, 0;\n",
+            "\t0, 0, 1\n",
+            "]\n",
+            "t: 0 0 0\n",
+            "\n",
+            "\\nOptimized Pose X(2):\\n R: [\n",
+            "\t1, -1.94971e-17, 6.53254e-16;\n",
+            "\t1.94971e-17, 1, 4.11744e-16;\n",
+            "\t-6.53254e-16, -4.11744e-16, 1\n",
+            "]\n",
+            "t: -1.93365e-15 -1.10098e-15         0.75\n",
+            "\n",
+            "Translation component of X(2): [-1.93364764e-15 -1.10097834e-15  7.50000000e-01]\n",
+            "\\nOptimized Landmark {landmark_key1} (L(1)):\\n [1.   1.   3.75]\n",
+            "\\nOptimized Landmark {landmark_key2} (L(2)):\\n [-1.    1.    3.75]\n",
+            "\\nOptimized Landmark {landmark_key3} (L(3)):\\n [-6.14260025e-17 -5.00000000e-01  3.75000000e+00]\n"
+          ]
+        }
+      ],
+      "source": [
+        "print(f\"Initial Error: {graph.error(initial_estimate):.4f}\")\n",
+        "print(f\"Final Error  : {graph.error(result):.4f}\")\n",
+        "\n",
+        "# Extract and print optimized values for clarity\n",
+        "optimized_pose1 = result.atPose3(X(1))\n",
+        "optimized_pose2 = result.atPose3(X(2))\n",
+        "optimized_lm1 = result.atPoint3(L(1))\n",
+        "optimized_lm2 = result.atPoint3(L(2))\n",
+        "optimized_lm3 = result.atPoint3(L(3))\n",
+        "\n",
+        "print(\"\\\\nOptimized Pose X(1):\\\\n\", optimized_pose1)\n",
+        "print(\"\\\\nOptimized Pose X(2):\\\\n\", optimized_pose2)\n",
+        "print(f\"Translation component of X(2): {optimized_pose2.translation()}\")\n",
+        "\n",
+        "print(\"\\\\nOptimized Landmark {landmark_key1} (L(1)):\\\\n\", optimized_lm1)\n",
+        "print(\"\\\\nOptimized Landmark {landmark_key2} (L(2)):\\\\n\", optimized_lm2)\n",
+        "print(\"\\\\nOptimized Landmark {landmark_key3} (L(3)):\\\\n\", optimized_lm3)\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "base",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.10"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/python/gtsam/examples/StereoVOExample.ipynb
+++ b/python/gtsam/examples/StereoVOExample.ipynb
@@ -44,7 +44,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": 1,
       "id": "ac25f0ee",
       "metadata": {},
       "outputs": [],
@@ -70,7 +70,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": 2,
       "id": "342a585f",
       "metadata": {},
       "outputs": [
@@ -105,39 +105,25 @@
         "## 2. Define Camera Calibration and Measurement Noise\n",
         "\n",
         "- **Noise Model:** We define an isotropic noise model for the stereo measurements. `Isotropic.Sigma(3, 1.0)` means a 3-dimensional noise (for $u_L, u_R, v$) with a standard deviation of 1 pixel for each dimension.\n",
-        "- **Camera Calibration ([`Cal3_S2Stereo`](/gtsam/geometry/doc/Cal3_S2Stereo.ipynb)):** We define a stereo calibration model based on a theoretical yet physically realistic stereo camera with the following parameters\n",
-        "  - Resolution: $640\\times 480$\n",
-        "  - Pixel Size: $4.8\\,\\mu m \\times 4.8\\,\\mu m$\n",
-        "  - Focal Length: $3.6\\,mm$\n",
-        "  - Skew: None\n",
-        "  - Baseline: $0.2\\,m$"
+        "- **Camera Calibration ([`Cal3_S2Stereo`](/gtsam/geometry/doc/Cal3_S2Stereo.ipynb)):** We define a stereo calibration model with the following properties:\n",
+        "  - $f_x=f_y=1000$\n",
+        "  - $s=0$\n",
+        "  - $(u,v)=(320,\\,240)$\n",
+        "  - $b=0.2$"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 20,
+      "execution_count": 3,
       "id": "e04b26c7",
       "metadata": {},
       "outputs": [],
       "source": [
         "# Define the stereo measurement noise model (isotropic, 1 pixel standard deviation)\n",
-        "# The C++ example uses Isotropic::Sigma(3,1) for (uL, uR, v)\n",
-        "# In Python, StereoPoint2 is (uL, uR, v), so it's a 3-vector.\n",
         "measurement_noise = gtsam.noiseModel.Isotropic.Sigma(3, 1.0)\n",
         "\n",
         "# Create stereo camera calibration object\n",
-        "# Cal3_S2Stereo(fx, fy, s, u0, v0, b)\n",
-        "w = 640                 # px\n",
-        "h = 480                 # px\n",
-        "px_sz = 4.8             # um / px\n",
-        "f = 3.6                 # mm\n",
-        "b = 0.2                 # m\n",
-        "fx = f / px_sz * 1000   # mm / (um / px) * 1000 = px\n",
-        "fy = f / px_sz * 1000   # mm / (um / px) * 1000 = px\n",
-        "s = 0                   # UNITLESS\n",
-        "u0 = w / 2              # px\n",
-        "v0 = h / 2              # px\n",
-        "K = gtsam.Cal3_S2Stereo(fx=fx, fy=fy, s=s, u0=u0, v0=v0, b=b)"
+        "K = gtsam.Cal3_S2Stereo(1000, 1000, 0, 320, 240, 0.2)"
       ]
     },
     {
@@ -155,14 +141,14 @@
         "*   `landmarkKey`: Key for the landmark.\n",
         "*   `K`: The stereo camera calibration.\n",
         "\n",
-        "Landmark keys in the C++ example are 3, 4, 5. We'll use `L(1)`, `L(2)`, `L(3)` to map to these, but we could also use integer keys 3, 4, 5 directly. For clarity, let's use `L(1)` (maps to C++ key 3), `L(2)` (maps to C++ key 4), `L(3)` (maps to C++ key 5).\n",
+        "Landmark keys in the C++ example are 3, 4, 5. We'll use `L(1)`, `L(2)`, `L(3)` to map to these.\n",
         "\n",
         "**Measurements from Pose 1 (`X(1)`)**\n"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 21,
+      "execution_count": 4,
       "id": "e9778bec",
       "metadata": {},
       "outputs": [
@@ -175,14 +161,6 @@
         }
       ],
       "source": [
-        "# Landmark keys used in C++ were 3, 4, 5. We map them to L(1), L(2), L(3)\n",
-        "# Or, more directly, we can use 3, 4, 5 as keys in Python too.\n",
-        "# Let's use 3, 4, 5 directly to match the C++ example keys.\n",
-        "landmark_key1 = 3 # Corresponds to L(1) conceptually, or just integer key 3\n",
-        "landmark_key2 = 4 # Corresponds to L(2) conceptually, or just integer key 4\n",
-        "landmark_key3 = 5 # Corresponds to L(3) conceptually, or just integer key 5\n",
-        "\n",
-        "\n",
         "# Factors from X(1) to landmarks\n",
         "# StereoPoint2(uL, uR, v)\n",
         "graph.add(gtsam.GenericStereoFactor3D(\n",
@@ -205,7 +183,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 27,
+      "execution_count": 5,
       "id": "495fc44f",
       "metadata": {},
       "outputs": [
@@ -213,7 +191,7 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Graph size after adding all factors: 22\n"
+            "Graph size after adding all factors: 7\n"
           ]
         }
       ],
@@ -246,7 +224,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 32,
+      "execution_count": 6,
       "id": "b4be6ab2",
       "metadata": {},
       "outputs": [],
@@ -280,7 +258,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 34,
+      "execution_count": 7,
       "id": "d0c3a87b",
       "metadata": {},
       "outputs": [],
@@ -297,7 +275,7 @@
       "id": "3b3685e1",
       "metadata": {},
       "source": [
-        "## 6. Analyze Results (Optional)\n",
+        "## 6. Analyze Results\n",
         "\n",
         "We can extract the optimized poses and landmark positions from the `result` Values object.\n",
         "\n",
@@ -310,7 +288,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 37,
+      "execution_count": 18,
       "id": "093fe3dc",
       "metadata": {},
       "outputs": [
@@ -318,30 +296,41 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Initial Error: 67574.1864\n",
+            "Initial Error: 3434.6236\n",
             "Final Error  : 0.0000\n",
-            "\\nOptimized Pose X(1):\\n R: [\n",
+            "\n",
+            "Optimized Pose X(1):\n",
+            " R: [\n",
             "\t1, 0, 0;\n",
             "\t0, 1, 0;\n",
             "\t0, 0, 1\n",
             "]\n",
             "t: 0 0 0\n",
             "\n",
-            "\\nOptimized Pose X(2):\\n R: [\n",
-            "\t1, -1.94971e-17, 6.53254e-16;\n",
-            "\t1.94971e-17, 1, 4.11744e-16;\n",
-            "\t-6.53254e-16, -4.11744e-16, 1\n",
-            "]\n",
-            "t: -1.93365e-15 -1.10098e-15         0.75\n",
             "\n",
-            "Translation component of X(2): [-1.93364764e-15 -1.10097834e-15  7.50000000e-01]\n",
-            "\\nOptimized Landmark {landmark_key1} (L(1)):\\n [1.   1.   3.75]\n",
-            "\\nOptimized Landmark {landmark_key2} (L(2)):\\n [-1.    1.    3.75]\n",
-            "\\nOptimized Landmark {landmark_key3} (L(3)):\\n [-6.14260025e-17 -5.00000000e-01  3.75000000e+00]\n"
+            "Optimized Pose X(2):\n",
+            " R: [\n",
+            "\t1, -3.03422e-17, -2.0943e-16;\n",
+            "\t3.03422e-17, 1, 1.30264e-15;\n",
+            "\t2.0943e-16, -1.30264e-15, 1\n",
+            "]\n",
+            "t:  6.11092e-13 -6.15462e-13            1\n",
+            "\n",
+            "Translation component of X(2): [ 6.11092279e-13 -6.15461900e-13  1.00000000e+00]\n",
+            "\n",
+            "Optimized Landmark (L(1)):\n",
+            " [1. 1. 5.]\n",
+            "\n",
+            "Optimized Landmark (L(2)):\n",
+            " [-1.  1.  5.]\n",
+            "\n",
+            "Optimized Landmark (L(3)):\n",
+            " [-1.21564099e-16 -5.00000000e-01  5.00000000e+00]\n"
           ]
         }
       ],
       "source": [
+        "# print(result)\n",
         "print(f\"Initial Error: {graph.error(initial_estimate):.4f}\")\n",
         "print(f\"Final Error  : {graph.error(result):.4f}\")\n",
         "\n",
@@ -352,13 +341,13 @@
         "optimized_lm2 = result.atPoint3(L(2))\n",
         "optimized_lm3 = result.atPoint3(L(3))\n",
         "\n",
-        "print(\"\\\\nOptimized Pose X(1):\\\\n\", optimized_pose1)\n",
-        "print(\"\\\\nOptimized Pose X(2):\\\\n\", optimized_pose2)\n",
+        "print(\"\\nOptimized Pose X(1):\\n\", optimized_pose1)\n",
+        "print(\"\\nOptimized Pose X(2):\\n\", optimized_pose2)\n",
         "print(f\"Translation component of X(2): {optimized_pose2.translation()}\")\n",
         "\n",
-        "print(\"\\\\nOptimized Landmark {landmark_key1} (L(1)):\\\\n\", optimized_lm1)\n",
-        "print(\"\\\\nOptimized Landmark {landmark_key2} (L(2)):\\\\n\", optimized_lm2)\n",
-        "print(\"\\\\nOptimized Landmark {landmark_key3} (L(3)):\\\\n\", optimized_lm3)\n"
+        "print(\"\\nOptimized Landmark (L(1)):\\n\", optimized_lm1)\n",
+        "print(\"\\nOptimized Landmark (L(2)):\\n\", optimized_lm2)\n",
+        "print(\"\\nOptimized Landmark (L(3)):\\n\", optimized_lm3)"
       ]
     }
   ],


### PR DESCRIPTION
This PR adds user guides for `Cal3_S2Stereo` and `StereoCamera` along with some minor related changes. Details listed below.

Update(s):
- Added user guides for `Cal3_S2Stereo` and `StereoCamera`
- Minor correction in StereoVOExample notebook and `Cal3_S2` user guide
- Fixed Python wrapper for `Cal3_S2Stereo`
- Added `calibrate(Vector3 p)` to wrapper for `Cal3_S2` (wrapper for this function was missing prior to this)
- Removed unnecessary `inline` keyword for static function in `CalibratedCamera.h` 
- Replaced the old `typedef` with its modern replacement `using` in `CalibratedCamera.h`, `Point3.h`, `StereoCamera.h`