### PR TITLE
Fix all compile warnings on ubuntu_latest

### DIFF
--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -16,15 +16,15 @@ jobs:
       fail-fast: false
       matrix:
         include:      
-          #          - os: windows-latest
-#            triplet: x64-windows-release
-#            build_type: Release
-#            test_target: RUN_TESTS
-#            binary_cache: C:\Users\runneradmin\AppData\Local\vcpkg\archives
-#            python: python
-#            # check_constraint_program fail on windows. should fix it for windows.
-#            # Remove this excluded test when you fix it for windows.
-#            ctest_extra_flags: -E check_constraint_program
+          - os: windows-latest
+            triplet: x64-windows-release
+            build_type: Release
+            test_target: RUN_TESTS
+            binary_cache: C:\Users\runneradmin\AppData\Local\vcpkg\archives
+            python: python
+            # check_constraint_program fail on windows. should fix it for windows.
+            # Remove this excluded test when you fix it for windows.
+            ctest_extra_flags: -E check_constraint_program
           - os: ubuntu-latest
             triplet: x64-linux-release
             build_type: Release

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -16,15 +16,15 @@ jobs:
       fail-fast: false
       matrix:
         include:      
-          - os: windows-latest
-            triplet: x64-windows-release
-            build_type: Release
-            test_target: RUN_TESTS
-            binary_cache: C:\Users\runneradmin\AppData\Local\vcpkg\archives
-            python: python
-            # check_constraint_program fail on windows. should fix it for windows.
-            # Remove this excluded test when you fix it for windows.
-            ctest_extra_flags: -E check_constraint_program
+          # - os: windows-latest
+          #   triplet: x64-windows-release
+          #   build_type: Release
+          #   test_target: RUN_TESTS
+          #   binary_cache: C:\Users\runneradmin\AppData\Local\vcpkg\archives
+          #   python: python
+          #   # check_constraint_program fail on windows. should fix it for windows.
+          #   # Remove this excluded test when you fix it for windows.
+          #   ctest_extra_flags: -E check_constraint_program
           - os: ubuntu-latest
             triplet: x64-linux-release
             build_type: Release

--- a/gtsam/basis/tests/testFourier.cpp
+++ b/gtsam/basis/tests/testFourier.cpp
@@ -169,7 +169,7 @@ TEST(Basis, Derivative7) {
 
   // Calculate expected values by numerical derivative of proxy.
   const double x = 0.2;
-  Matrix numeric_dTdx = numericalDerivative11<double, double>(proxy, x);
+  Matrix1 numeric_dTdx = numericalDerivative11<double, double>(proxy, x);
 
   // Calculate derivatives at Chebyshev points using D7, interpolate
   Matrix D7 = FourierBasis::DifferentiationMatrix(7);

--- a/gtsam/geometry/tests/testUnit3.cpp
+++ b/gtsam/geometry/tests/testUnit3.cpp
@@ -64,7 +64,7 @@ static Unit3 rotate_(const Rot3& R, const Unit3& p) {
   return R * p;
 }
 
-TEST(Unit3, rotate) {
+TEST(Unit3, Rotate) {
   Rot3 R = Rot3::Yaw(0.5);
   Unit3 p(1, 0, 0);
   Unit3 expected = Unit3(R.matrix().col(0));
@@ -89,7 +89,7 @@ static Unit3 unrotate_(const Rot3& R, const Unit3& p) {
   return R.unrotate(p);
 }
 
-TEST(Unit3, unrotate) {
+TEST(Unit3, Unrotate) {
   Rot3 R = Rot3::Yaw(-M_PI / 4.0);
   Unit3 p(1, 0, 0);
   Unit3 expected = Unit3(1, 1, 0);
@@ -110,7 +110,7 @@ TEST(Unit3, unrotate) {
   }
 }
 
-TEST(Unit3, dot) {
+TEST(Unit3, Dot) {
   Unit3 p(1, 0.2, 0.3);
   Unit3 q = p.retract(Vector2(0.5, 0));
   Unit3 r = p.retract(Vector2(0.8, 0));
@@ -143,31 +143,31 @@ TEST(Unit3, dot) {
 }
 
 //*******************************************************************************
-TEST(Unit3, error) {
+TEST(Unit3, ErrorVector) {
   Unit3 p(1, 0, 0), q = p.retract(Vector2(0.5, 0)), //
   r = p.retract(Vector2(0.8, 0));
-  EXPECT(assert_equal((Vector)(Vector2(0, 0)), p.error(p), 1e-5));
-  EXPECT(assert_equal((Vector)(Vector2(0.479426, 0)), p.error(q), 1e-5));
-  EXPECT(assert_equal((Vector)(Vector2(0.717356, 0)), p.error(r), 1e-5));
+  EXPECT(assert_equal((Vector)(Vector2(0, 0)), p.errorVector(p), 1e-5));
+  EXPECT(assert_equal((Vector)(Vector2(0.479426, 0)), p.errorVector(q), 1e-5));
+  EXPECT(assert_equal((Vector)(Vector2(0.717356, 0)), p.errorVector(r), 1e-5));
 
   Matrix actual, expected;
   // Use numerical derivatives to calculate the expected Jacobian
   {
     expected = numericalDerivative11<Vector2,Unit3>(
-        std::bind(&Unit3::error, &p, std::placeholders::_1, nullptr), q);
-    p.error(q, actual);
+        std::bind(&Unit3::errorVector, &p, std::placeholders::_1, nullptr, nullptr), q);
+    p.errorVector(q, {}, actual);
     EXPECT(assert_equal(expected.transpose(), actual, 1e-5));
   }
   {
     expected = numericalDerivative11<Vector2,Unit3>(
-        std::bind(&Unit3::error, &p, std::placeholders::_1, nullptr), r);
-    p.error(r, actual);
+        std::bind(&Unit3::errorVector, &p, std::placeholders::_1, nullptr, nullptr), r);
+    p.errorVector(r, {}, actual);
     EXPECT(assert_equal(expected.transpose(), actual, 1e-5));
   }
 }
 
 //*******************************************************************************
-TEST(Unit3, error2) {
+TEST(Unit3, ErrorVector2) {
   Unit3 p(0.1, -0.2, 0.8);
   Unit3 q = p.retract(Vector2(0.2, -0.1));
   Unit3 r = p.retract(Vector2(0.8, 0));
@@ -214,7 +214,7 @@ TEST(Unit3, error2) {
 }
 
 //*******************************************************************************
-TEST(Unit3, distance) {
+TEST(Unit3, Distance) {
   Unit3 p(1, 0, 0), q = p.retract(Vector2(0.5, 0)), //
   r = p.retract(Vector2(0.8, 0));
   EXPECT_DOUBLES_EQUAL(0, p.distance(p), 1e-5);
@@ -238,7 +238,7 @@ TEST(Unit3, distance) {
 }
 
 //*******************************************************************************
-TEST(Unit3, localCoordinates0) {
+TEST(Unit3, LocalCoordinates0) {
   Unit3 p;
   Vector actual = p.localCoordinates(p);
   EXPECT(assert_equal(Z_2x1, actual, 1e-5));
@@ -342,7 +342,7 @@ TEST(Unit3, basis) {
 
 //*******************************************************************************
 /// Check the basis derivatives of a bunch of random Unit3s.
-TEST(Unit3, basis_derivatives) {
+TEST(Unit3, BasisDerivatives) {
   int num_tests = 100;
   std::mt19937 rng(42);
   for (int i = 0; i < num_tests; i++) {
@@ -358,7 +358,7 @@ TEST(Unit3, basis_derivatives) {
 }
 
 //*******************************************************************************
-TEST(Unit3, retract) {
+TEST(Unit3, Retract) {
   {
     Unit3 p;
     Vector2 v(0.5, 0);
@@ -377,7 +377,7 @@ TEST(Unit3, retract) {
 }
 
 //*******************************************************************************
-TEST (Unit3, jacobian_retract) {
+TEST (Unit3, JacobianRetract) {
   Matrix22 H;
   Unit3 p;
   std::function<Unit3(const Vector2&)> f =
@@ -397,7 +397,7 @@ TEST (Unit3, jacobian_retract) {
 }
 
 //*******************************************************************************
-TEST(Unit3, retract_expmap) {
+TEST(Unit3, RetractExpmap) {
   Unit3 p;
   Vector2 v((M_PI / 2.0), 0);
   Unit3 expected(Point3(0, 0, 1));
@@ -419,7 +419,7 @@ TEST(Unit3, Random) {
 
 //*******************************************************************************
 // New test that uses Unit3::Random
-TEST(Unit3, localCoordinates_retract) {
+TEST(Unit3, LocalCoordinatesRetract) {
   std::mt19937 rng(42);
   size_t numIterations = 10000;
 
@@ -492,10 +492,10 @@ TEST(Unit3, ErrorBetweenFactor) {
 TEST(Unit3, CopyAssign) {
   Unit3 p{1, 0.2, 0.3};
 
-  EXPECT(p.error(p).isZero());
+  EXPECT(p.errorVector(p).isZero());
 
   p = Unit3{-1, 2, 8};
-  EXPECT(p.error(p).isZero());
+  EXPECT(p.errorVector(p).isZero());
 }
 
 /* ************************************************************************* */

--- a/gtsam/inference/Conditional.h
+++ b/gtsam/inference/Conditional.h
@@ -86,8 +86,10 @@ namespace gtsam {
       size_t size() const { return std::distance(range_.first, range_.second); }
       const auto& front() const { return *begin(); }
       // == operator overload for comparison with another iterator
-      template<class OTHER>
+      template <class OTHER>
       bool operator==(const OTHER& rhs) const {
+        if (this->size() != rhs.size()) return false;
+        if (this->size() == 0) return true;
         return std::equal(begin(), end(), rhs.begin());
       }
     };

--- a/gtsam/inference/Conditional.h
+++ b/gtsam/inference/Conditional.h
@@ -90,7 +90,7 @@ namespace gtsam {
       bool operator==(const OTHER& rhs) const {
         if (this->size() != rhs.size()) return false;
         if (this->size() == 0) return true;
-        return std::equal(begin(), end(), rhs.begin());
+        return std::equal(begin(), end(), rhs.begin(), rhs.end());
       }
     };
 

--- a/gtsam/navigation/AttitudeFactor.cpp
+++ b/gtsam/navigation/AttitudeFactor.cpp
@@ -29,13 +29,13 @@ Vector AttitudeFactor::attitudeError(const Rot3& nRb,
     Matrix23 D_nRotated_R;
     Matrix22 D_e_nRotated;
     Unit3 nRotated = nRb.rotate(bMeasured_, D_nRotated_R);
-    Vector e = nRef_.error(nRotated, D_e_nRotated);
+    Vector e = nRef_.errorVector(nRotated, {}, D_e_nRotated);
 
     (*H) = D_e_nRotated * D_nRotated_R;
     return e;
   } else {
     Unit3 nRotated = nRb * bMeasured_;
-    return nRef_.error(nRotated);
+    return nRef_.errorVector(nRotated);
   }
 }
 

--- a/gtsam/slam/EssentialMatrixFactor.h
+++ b/gtsam/slam/EssentialMatrixFactor.h
@@ -404,8 +404,9 @@ class EssentialMatrixFactor4
       // H2 = df/dK = vB.T * E.T * dvA/dK + vA.T * E * dvB/dK
       // where dvA/dK = dvA/dcA * dcA/dK, dVB/dK = dvB/dcB * dcB/dK
       // and dvA/dcA = dvB/dcB = [[1, 0], [0, 1], [0, 0]]
-      *HK = vB.transpose() * E.matrix().transpose().leftCols<2>() * cA_H_K +
-            vA.transpose() * E.matrix().leftCols<2>() * cB_H_K;
+      Matrix DynamicH_K = vB.transpose() * E.matrix().transpose().leftCols<2>() * cA_H_K +
+          vA.transpose() * E.matrix().leftCols<2>() * cB_H_K;  // (1*2) * (2*DimK)
+      *HK = DynamicH_K;
     }
 
     Vector error(1);
@@ -504,12 +505,14 @@ class EssentialMatrixFactor5
 
     if (HKa) {
       // Compute the jacobian of error w.r.t Ka.
-      *HKa = vB.transpose() * E.matrix().transpose().leftCols<2>() * cA_H_Ka;
+      Matrix DynamicHka = vB.transpose() * E.matrix().transpose().leftCols<2>() * cA_H_Ka;
+      *HKa = DynamicHka;
     }
 
     if (HKb) {
       // Compute the jacobian of error w.r.t Kb.
-      *HKb = vA.transpose() * E.matrix().leftCols<2>() * cB_H_Kb;
+      Matrix DynamicHkb = vA.transpose() * E.matrix().leftCols<2>() * cB_H_Kb;
+      *HKb = DynamicHkb;
     }
 
     Vector error(1);

--- a/gtsam/slam/EssentialMatrixFactor.h
+++ b/gtsam/slam/EssentialMatrixFactor.h
@@ -97,7 +97,7 @@ class EssentialMatrixFactor : public NoiseModelFactorN<EssentialMatrix> {
   Vector evaluateError(const EssentialMatrix& E,
                        OptionalMatrixType H) const override {
     Vector error(1);
-    error << E.error(vA_, vB_, H);
+    error(0) = E.error(vA_, vB_, H);
     return error;
   }
 
@@ -409,7 +409,7 @@ class EssentialMatrixFactor4
     }
 
     Vector error(1);
-    error << E.error(vA, vB, HE);
+    error(0) = E.error(vA, vB, HE);
 
     return error;
   }
@@ -513,7 +513,7 @@ class EssentialMatrixFactor5
     }
 
     Vector error(1);
-    error << E.error(vA, vB, HE);
+    error(0) = E.error(vA, vB, HE);
 
     return error;
   }

--- a/gtsam/slam/OrientedPlane3Factor.cpp
+++ b/gtsam/slam/OrientedPlane3Factor.cpp
@@ -68,7 +68,7 @@ Vector OrientedPlane3DirectionPrior::evaluateError(
   Unit3 n_hat_p = measured_p_.normal();
   Unit3 n_hat_q = plane.normal();
   Matrix2 H_p;
-  Vector e = n_hat_p.error(n_hat_q, H ? &H_p : nullptr);
+  Vector e = n_hat_p.errorVector(n_hat_q, {}, H ? &H_p : nullptr);
   if (H) {
     H->resize(2, 3);
     *H << H_p, Z_2x1;

--- a/gtsam/slam/RotateFactor.h
+++ b/gtsam/slam/RotateFactor.h
@@ -109,7 +109,7 @@ public:
   /// vector of errors returns 2D vector
   Vector evaluateError(const Rot3& iRc, OptionalMatrixType H) const override {
     Unit3 i_q = iRc * c_z_;
-    Vector error = i_p_.error(i_q, H);
+    Vector error = i_p_.errorVector(i_q, {}, H);
     if (H) {
       Matrix DR;
       iRc.rotate(c_z_, DR);


### PR DESCRIPTION
I noticed possibly memory warnings on CI for ubuntu_latest, and maybe that is the cause of some CI troubles. 
Also fixed copy constructor in Unit3, and *really* deprecated `error()`