### PR TITLE
exclude windows tests

### DIFF
--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -16,15 +16,15 @@ jobs:
       fail-fast: false
       matrix:
         include:      
-          # - os: windows-latest
-          #   triplet: x64-windows-release
-          #   build_type: Release
-          #   test_target: RUN_TESTS
-          #   binary_cache: C:\Users\runneradmin\AppData\Local\vcpkg\archives
-          #   python: python
-          #   # check_constraint_program fail on windows. should fix it for windows.
-          #   # Remove this excluded test when you fix it for windows.
-          #   ctest_extra_flags: -E check_constraint_program
+          - os: windows-latest
+            triplet: x64-windows-release
+            build_type: Release
+            test_target: RUN_TESTS
+            binary_cache: C:\Users\runneradmin\AppData\Local\vcpkg\archives
+            python: python
+            # check_constraint_program fail on windows. should fix it for windows.
+            # Remove this excluded test when you fix it for windows.
+            ctest_extra_flags: -E check_constraint_program
           - os: ubuntu-latest
             triplet: x64-linux-release
             build_type: Release


### PR DESCRIPTION
On my local I get a linkage error when I compile vcpkg on windows as it compile on the ci.
I want to run it here, see the failing tests, and exclude them, that vcpkg windows can still run, and later when you have time, fix the tests for windows.
