### PR TITLE
Add vcpkg on push, it will save the vcpkg cache for all repo

### DIFF
--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -1,6 +1,9 @@
 name: vcpkg
 on:
   pull_request:
+  push:
+    # Runs on pushes targeting the develop branch
+    branches: [develop]
 
 # Every time you make a push to your PR, it cancel immediately the previous checks,
 # and start a new one. The other runner will be available more quickly to your PR.


### PR DESCRIPTION
Add vcpkg on push, it will save the vcpkg cache for all repo.

This is also mean that every merge a PR (a push) it will trigger the vcpkg ci. (3 vcpkg jobs).