### PR TITLE
Add gtsam unstable tests in vcpkg

### DIFF
--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -37,12 +37,18 @@ jobs:
             test_target: test
             binary_cache: /home/runner/.cache/vcpkg/archives
             python: python3
+            # vcpkg compile external metis, while test are configured to use vendored metis.
+            # Need to debug and fix it.
+            ctest_extra_flags: -E "testFindSeparator"
           - os: macos-latest
             triplet: arm64-osx-release
             build_type: Release
             test_target: test
             binary_cache: /Users/runner/.cache/vcpkg/archives
             python: python3
+            # vcpkg compile external metis, while test are configured to use vendored metis.
+            # Need to debug and fix it.
+            ctest_extra_flags: -E "testFindSeparator"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -137,13 +143,13 @@ jobs:
               -DVCPKG_INSTALLED_DIR=$VCPKG_INSTALLATION_ROOT/installed \
               -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }} \
               -DVCPKG_HOST_TRIPLET=${{ matrix.triplet }} \
-              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
               -DGTSAM_BUILD_EXAMPLES_ALWAYS=ON \
               -DGTSAM_ROT3_EXPMAP=ON \
               -DGTSAM_POSE3_EXPMAP=ON \
               -DGTSAM_BUILD_PYTHON=ON \
               -DGTSAM_BUILD_TESTS=ON \
-              -DGTSAM_BUILD_UNSTABLE=OFF \
+              -DGTSAM_BUILD_UNSTABLE=ON \
               -DGTSAM_ALLOW_DEPRECATED_SINCE_V43=OFF \
               -DGTSAM_USE_SYSTEM_EIGEN=ON \
               -DGTSAM_USE_SYSTEM_METIS=ON \
@@ -155,15 +161,17 @@ jobs:
       - name: cmake build
         shell: bash
         run: |
-          cmake --build build --config Release
+          cmake --build build --config ${{ matrix.build_type }}
 
       - name: Run Python tests
         shell: bash
         run: |
+          export PATH="$PATH:$VCPKG_INSTALLATION_ROOT/installed/${{ matrix.triplet }}/bin"
           cmake --build build --target python-install
           cmake --build build --target python-test
+          cmake --build build --target python-test-unstable
 
       - name: Run tests
         shell: bash
         run: |
-          cmake --build build --target check
+          cmake --build build --config ${{ matrix.build_type }} --target check

--- a/gtsam_unstable/discrete/tests/testScheduler.cpp
+++ b/gtsam_unstable/discrete/tests/testScheduler.cpp
@@ -69,7 +69,7 @@ DiscreteFactorGraph createExpected() {
   // Mutual exclusion for students
   expected.addAllDiff(A, J);
 
-  return std::move(expected);
+  return expected;
 }
 
 /* ************************************************************************* */


### PR DESCRIPTION
Add gtsam unstable tests in vcpkg.  
Add configure to tests.
Fix warning as error accure in linux in gtsam unstable of redundant move in return statement.