### PR TITLE
FrobeniusBetweenFactorNL, and better noise API

### DIFF
--- a/gtsam/sfm/tests/testShonanFactor.cpp
+++ b/gtsam/sfm/tests/testShonanFactor.cpp
@@ -81,7 +81,7 @@ TEST(ShonanFactor3, evaluateError) {
 TEST(ShonanFactor3, equivalenceToSO3) {
   using namespace ::submanifold;
   auto R12 = ::so3::R12.retract(Vector3(0.1, 0.2, -0.1));
-  auto model = noiseModel::Isotropic::Sigma(6, 1.2); // wrong dimension
+  auto model = noiseModel::Isotropic::Sigma(3, 1.2);
   auto factor3 = FrobeniusBetweenFactor<SO3>(1, 2, R12, model);
   auto factor4 = ShonanFactor3(1, 2, Rot3(R12.matrix()), 4, model);
   const Matrix3 E3(factor3.evaluateError(R1, R2).data());

--- a/gtsam/sfm/tests/testShonanFactor.cpp
+++ b/gtsam/sfm/tests/testShonanFactor.cpp
@@ -82,7 +82,7 @@ TEST(ShonanFactor3, equivalenceToSO3) {
   using namespace ::submanifold;
   auto R12 = ::so3::R12.retract(Vector3(0.1, 0.2, -0.1));
   auto model = noiseModel::Isotropic::Sigma(6, 1.2); // wrong dimension
-  auto factor3 = OldFrobeniusBetweenFactor<SO3>(1, 2, R12, model);
+  auto factor3 = FrobeniusBetweenFactor<SO3>(1, 2, R12, model);
   auto factor4 = ShonanFactor3(1, 2, Rot3(R12.matrix()), 4, model);
   const Matrix3 E3(factor3.evaluateError(R1, R2).data());
   const Matrix43 E4(

--- a/gtsam/sfm/tests/testShonanFactor.cpp
+++ b/gtsam/sfm/tests/testShonanFactor.cpp
@@ -82,7 +82,7 @@ TEST(ShonanFactor3, equivalenceToSO3) {
   using namespace ::submanifold;
   auto R12 = ::so3::R12.retract(Vector3(0.1, 0.2, -0.1));
   auto model = noiseModel::Isotropic::Sigma(6, 1.2); // wrong dimension
-  auto factor3 = FrobeniusBetweenFactor<SO3>(1, 2, R12, model);
+  auto factor3 = OldFrobeniusBetweenFactor<SO3>(1, 2, R12, model);
   auto factor4 = ShonanFactor3(1, 2, Rot3(R12.matrix()), 4, model);
   const Matrix3 E3(factor3.evaluateError(R1, R2).data());
   const Matrix43 E4(

--- a/gtsam/slam/FrobeniusFactor.h
+++ b/gtsam/slam/FrobeniusFactor.h
@@ -103,13 +103,17 @@ class FrobeniusFactor : public NoiseModelFactorN<T, T> {
 };
 
 /**
- * FrobeniusBetweenFactor is a BetweenFactor that evaluates the Frobenius norm
+ * FrobeniusBetweenFactorNL is a BetweenFactor that evaluates the Frobenius norm
  * of the rotation error between measured and predicted (rather than the
  * Logmap of the error). This factor is only defined for fixed-dimension types,
  * that are matrix Lie groups.
+ *
+ * This version is called NL, because it minimizes |inv(T2)*T1*T12_ - I|_F
+ * as opposed to the (historically older) FrobeniusBetweenFactor, that minimizes
+ * ||T2 - T1*T12_||_F. This only holds for certain groups, e.g., not Sim(3).
  */
 template <class T>
-class FrobeniusBetweenFactor : public NoiseModelFactorN<T, T> {
+class FrobeniusBetweenFactorNL : public NoiseModelFactorN<T, T> {
   GTSAM_CONCEPT_ASSERT(IsMatrixLieGroup<T>);
   inline constexpr static auto N = T::LieAlgebra::RowsAtCompileTime;
   inline constexpr static auto Dim = N * N;
@@ -131,8 +135,8 @@ class FrobeniusBetweenFactor : public NoiseModelFactorN<T, T> {
   /// @{
 
   /// Construct from two keys and measured rotation
-  FrobeniusBetweenFactor(Key j1, Key j2, const T& T12,
-                         const SharedNoiseModel& model = nullptr)
+  FrobeniusBetweenFactorNL(Key j1, Key j2, const T& T12,
+                           const SharedNoiseModel& model = nullptr)
       : NoiseModelFactorN<T, T>(ConvertNoiseModel(model, Dim), j1, j2),
         T12_(T12) {}
 
@@ -143,7 +147,7 @@ class FrobeniusBetweenFactor : public NoiseModelFactorN<T, T> {
   /// print with optional string
   void print(const std::string& s, const KeyFormatter& keyFormatter =
                                        DefaultKeyFormatter) const override {
-    std::cout << s << "FrobeniusBetweenFactor<" << demangle(typeid(T).name())
+    std::cout << s << "FrobeniusBetweenFactorNL<" << demangle(typeid(T).name())
               << ">(" << keyFormatter(this->key1()) << ","
               << keyFormatter(this->key2()) << ")\n";
     traits<T>::Print(T12_, "  T12: ");
@@ -153,7 +157,7 @@ class FrobeniusBetweenFactor : public NoiseModelFactorN<T, T> {
   /// assert equality up to a tolerance
   bool equals(const NonlinearFactor& expected,
               double tol = 1e-9) const override {
-    auto e = dynamic_cast<const FrobeniusBetweenFactor*>(&expected);
+    auto e = dynamic_cast<const FrobeniusBetweenFactorNL*>(&expected);
     return e != nullptr && NoiseModelFactorN<T, T>::equals(*e, tol) &&
            traits<T>::Equals(this->T12_, e->T12_, tol);
   }
@@ -179,10 +183,10 @@ class FrobeniusBetweenFactor : public NoiseModelFactorN<T, T> {
 
     // Calculate error
     Eigen::Matrix<double, Dim, T::dimension> H_vec_pred;
-    Vector error = vecI - traits<T>::Vec(pred, H1 ? &H_vec_pred : nullptr);
+    Vector error = traits<T>::Vec(pred, H1 ? &H_vec_pred : nullptr) - vecI;
 
     // Do chain rule
-    const auto H_error_hat21 = - H_vec_pred * H_pred_hat;
+    const auto H_error_hat21 = H_vec_pred * H_pred_hat;
     if (H1) *H1 = H_error_hat21;  // H_pred_T1 is identity
     if (H2) *H2 = H_error_hat21 * H_T21_T2;
     return error;
@@ -191,11 +195,11 @@ class FrobeniusBetweenFactor : public NoiseModelFactorN<T, T> {
 };
 
 /**
- * OldFrobeniusBetweenFactor uses ||T2 - T1*T12_||_F, which only works if the
+ * FrobeniusBetweenFactor uses ||T2 - T1*T12_||_F, which only works if the
  * Frobenius error is invariant to multiplying with an arbitrary element T.
  */
 template <class T>
-class OldFrobeniusBetweenFactor : public FrobeniusBetweenFactor<T> {
+class FrobeniusBetweenFactor : public FrobeniusBetweenFactorNL<T> {
   inline constexpr static auto N = T::LieAlgebra::RowsAtCompileTime;
   inline constexpr static auto Dim = N * N;
 
@@ -208,9 +212,9 @@ class OldFrobeniusBetweenFactor : public FrobeniusBetweenFactor<T> {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /// Construct from two keys and measured rotation
-  OldFrobeniusBetweenFactor(Key j1, Key j2, const T& T12,
-                            const SharedNoiseModel& model = nullptr)
-      : FrobeniusBetweenFactor<T>(j1, j2, T12, model),
+  FrobeniusBetweenFactor(Key j1, Key j2, const T& T12,
+                         const SharedNoiseModel& model = nullptr)
+      : FrobeniusBetweenFactorNL<T>(j1, j2, T12, model),
         T2hat_H_T1_(traits<T>::AdjointMap(traits<T>::Inverse(T12))) {}
 
   /// Error is Frobenius norm between T1*T12 and T2.

--- a/gtsam/slam/FrobeniusFactor.h
+++ b/gtsam/slam/FrobeniusFactor.h
@@ -26,21 +26,26 @@
 namespace gtsam {
 
 /**
- * When creating (any) FrobeniusFactor we can convert a Rot/Pose BetweenFactor
- * noise model into a n-dimensional isotropic noise
- * model used to weight the Frobenius norm.
- * If the noise model passed is null we return a n-dimensional isotropic noise
- * model with sigma=1.0.
- * If not, we we check if the d-dimensional noise model on rotations is
- * isotropic. If it is, we extend to 'n' dimensions, otherwise we throw an
- * error. If the noise model is a robust error model, we use the sigmas of the
- * underlying noise model.
+ * @brief Convert a possibly robust noise model to an isotropic model for
+ * Frobenius factors.
  *
- * If defaultToUnit == false throws an exception on unexpected input.
+ * This function is used to convert a noise model, which may be robust, into an
+ * isotropic noise model suitable for Frobenius factors. If the input noise
+ * model is null, it returns an n-dimensional isotropic noise model with
+ * sigma=1.0. If the input noise model is isotropic, it extends it to the
+ * desired dimension. If the noise model is robust, the sigmas of the underlying
+ * noise model are used. If the noise model is not isotropic and `defaultToUnit`
+ * is false, an exception is thrown.
+ *
+ * @param model The input noise model (possibly robust).
+ * @param dimension The desired dimension for the isotropic model.
+ * @param defaultToUnit If true, fallback to unit if conversion is not possible.
+ * @throws std::runtime_error if model not isotropic and defaultToUnit =false.
+ * @return An isotropic (possibly robust) noise model.
  */
-GTSAM_EXPORT SharedNoiseModel
-ConvertNoiseModel(const SharedNoiseModel &model, size_t n,
-                  bool defaultToUnit = true);
+GTSAM_EXPORT SharedNoiseModel ConvertNoiseModel(const SharedNoiseModel& model,
+                                                size_t n,
+                                                bool defaultToUnit = true);
 
 /**
  * FrobeniusPrior calculates the Frobenius norm between a given matrix and an
@@ -55,7 +60,6 @@ class FrobeniusPrior : public NoiseModelFactorN<T> {
   Eigen::Matrix<double, Dim, 1> vecM_;  ///< vectorized matrix to approximate
 
  public:
-
   // Provide access to the Matrix& version of evaluateError:
   using NoiseModelFactor1<T>::evaluateError;
 
@@ -70,7 +74,8 @@ class FrobeniusPrior : public NoiseModelFactorN<T> {
 
   /// Error is just Frobenius norm between T element and vectorized matrix M.
   Vector evaluateError(const T& g, OptionalMatrixType H) const override {
-    return traits<T>::Vec(g, H) - vecM_;  // Jacobian is computed only when needed.
+    return traits<T>::Vec(g, H) -
+           vecM_;  // Jacobian is computed only when needed.
   }
 };
 
@@ -85,7 +90,6 @@ class FrobeniusFactor : public NoiseModelFactorN<T, T> {
   inline constexpr static auto Dim = N * N;
 
  public:
-
   // Provide access to the Matrix& version of evaluateError:
   using NoiseModelFactor2<T, T>::evaluateError;
 
@@ -94,8 +98,8 @@ class FrobeniusFactor : public NoiseModelFactorN<T, T> {
       : NoiseModelFactorN<T, T>(ConvertNoiseModel(model, Dim), j1, j2) {}
 
   /// Error is just Frobenius norm between rotation matrices.
-  Vector evaluateError(const T& T1, const T& T2,
-                       OptionalMatrixType H1, OptionalMatrixType H2) const override {
+  Vector evaluateError(const T& T1, const T& T2, OptionalMatrixType H1,
+                       OptionalMatrixType H2) const override {
     Vector error = traits<T>::Vec(T2, H2) - traits<T>::Vec(T1, H1);
     if (H1) *H1 = -*H1;
     return error;

--- a/gtsam/slam/FrobeniusFactor.h
+++ b/gtsam/slam/FrobeniusFactor.h
@@ -48,6 +48,31 @@ GTSAM_EXPORT SharedNoiseModel ConvertNoiseModel(const SharedNoiseModel& model,
                                                 bool defaultToUnit = true);
 
 /**
+ * @brief Ensure a noise model has the correct dimension for a given type.
+ *
+ * If the model is already of dimension Dim, it is returned as-is.
+ * Otherwise, ConvertNoiseModel is called to convert it.
+ * Asserts that the model's dimension matches T's expected dimension before
+ * conversion.
+ *
+ * @tparam T The type whose dimension is checked.
+ * @tparam Dim The required dimension.
+ * @param model The input noise model.
+ * @return A noise model of dimension Dim.
+ */
+template <class T, size_t Dim>
+inline SharedNoiseModel ConvertModel(const SharedNoiseModel& model) {
+  if (!model || model->dim() == Dim) {
+    return model;
+  }
+  if (model->dim() != T::dimension) {
+    throw std::runtime_error(
+        "Noise model dimension does not match expected dimension for T.");
+  }
+  return ConvertNoiseModel(model, Dim);
+}
+
+/**
  * FrobeniusPrior calculates the Frobenius norm between a given matrix and an
  * element of SO(3) or SO(4).
  */
@@ -68,7 +93,7 @@ class FrobeniusPrior : public NoiseModelFactorN<T> {
   /// Constructor
   FrobeniusPrior(Key j, const MatrixNN& M,
                  const SharedNoiseModel& model = nullptr)
-      : NoiseModelFactorN<T>(ConvertNoiseModel(model, Dim), j) {
+      : NoiseModelFactorN<T>(ConvertModel<T, Dim>(model), j) {
     vecM_ << Eigen::Map<const Matrix>(M.data(), Dim, 1);
   }
 
@@ -95,7 +120,7 @@ class FrobeniusFactor : public NoiseModelFactorN<T, T> {
 
   /// Constructor
   FrobeniusFactor(Key j1, Key j2, const SharedNoiseModel& model = nullptr)
-      : NoiseModelFactorN<T, T>(ConvertNoiseModel(model, Dim), j1, j2) {}
+      : NoiseModelFactorN<T, T>(ConvertModel<T, Dim>(model), j1, j2) {}
 
   /// Error is just Frobenius norm between rotation matrices.
   Vector evaluateError(const T& T1, const T& T2, OptionalMatrixType H1,
@@ -107,13 +132,14 @@ class FrobeniusFactor : public NoiseModelFactorN<T, T> {
 };
 
 /**
- * FrobeniusBetweenFactorNL is a BetweenFactor that evaluates the Frobenius norm
- * of the rotation error between measured and predicted (rather than the
- * Logmap of the error). This factor is only defined for fixed-dimension types,
- * that are matrix Lie groups.
+ * FrobeniusBetweenFactorNL is a BetweenFactor that evaluates the Frobenius
+ * norm of the rotation error between measured and predicted (rather than the
+ * Logmap of the error). This factor is only defined for fixed-dimension
+ * types, that are matrix Lie groups.
  *
  * This version is called NL, because it minimizes |inv(T2)*T1*T12_ - I|_F
- * as opposed to the (historically older) FrobeniusBetweenFactor, that minimizes
+ * as opposed to the (historically older) FrobeniusBetweenFactor, that
+ * minimizes
  * ||T2 - T1*T12_||_F. This only holds for certain groups, e.g., not Sim(3).
  */
 template <class T>
@@ -141,7 +167,7 @@ class FrobeniusBetweenFactorNL : public NoiseModelFactorN<T, T> {
   /// Construct from two keys and measured rotation
   FrobeniusBetweenFactorNL(Key j1, Key j2, const T& T12,
                            const SharedNoiseModel& model = nullptr)
-      : NoiseModelFactorN<T, T>(ConvertNoiseModel(model, Dim), j1, j2),
+      : NoiseModelFactorN<T, T>(ConvertModel<T, Dim>(model), j1, j2),
         T12_(T12) {}
 
   /// @}

--- a/gtsam/slam/FrobeniusFactor.h
+++ b/gtsam/slam/FrobeniusFactor.h
@@ -106,19 +106,22 @@ class FrobeniusFactor : public NoiseModelFactorN<T, T> {
  * FrobeniusBetweenFactor is a BetweenFactor that evaluates the Frobenius norm
  * of the rotation error between measured and predicted (rather than the
  * Logmap of the error). This factor is only defined for fixed-dimension types,
- * and in fact only SO3 and SO4 really work, as we need SO<N>::AdjointMap.
+ * that are matrix Lie groups.
  */
 template <class T>
 class FrobeniusBetweenFactor : public NoiseModelFactorN<T, T> {
   GTSAM_CONCEPT_ASSERT(IsMatrixLieGroup<T>);
-  T T12_;  ///< measured rotation between T1 and T2
-  Eigen::Matrix<double, T::dimension, T::dimension>
-      T2hat_H_T1_;  ///< fixed derivative of T2hat wrpt T1
   inline constexpr static auto N = T::LieAlgebra::RowsAtCompileTime;
   inline constexpr static auto Dim = N * N;
-    
- public:
+  static_assert(N > 0, "The Lie algebra dimension N must be greater than 0.");
 
+ protected:
+  T T12_;  ///< measured rotation between T1 and T2
+
+  using MatrixN = Eigen::Matrix<double, N, N>;
+  using VectorD = Eigen::Matrix<double, Dim, 1>;
+
+ public:
   // Provide access to the Matrix& version of evaluateError:
   using NoiseModelFactor2<T, T>::evaluateError;
 
@@ -131,17 +134,15 @@ class FrobeniusBetweenFactor : public NoiseModelFactorN<T, T> {
   FrobeniusBetweenFactor(Key j1, Key j2, const T& T12,
                          const SharedNoiseModel& model = nullptr)
       : NoiseModelFactorN<T, T>(ConvertNoiseModel(model, Dim), j1, j2),
-        T12_(T12),
-        T2hat_H_T1_(traits<T>::AdjointMap(traits<T>::Inverse(T12_))) {}
+        T12_(T12) {}
 
   /// @}
   /// @name Testable
   /// @{
 
   /// print with optional string
-  void
-  print(const std::string &s,
-        const KeyFormatter &keyFormatter = DefaultKeyFormatter) const override {
+  void print(const std::string& s, const KeyFormatter& keyFormatter =
+                                       DefaultKeyFormatter) const override {
     std::cout << s << "FrobeniusBetweenFactor<" << demangle(typeid(T).name())
               << ">(" << keyFormatter(this->key1()) << ","
               << keyFormatter(this->key2()) << ")\n";
@@ -150,27 +151,78 @@ class FrobeniusBetweenFactor : public NoiseModelFactorN<T, T> {
   }
 
   /// assert equality up to a tolerance
-  bool equals(const NonlinearFactor &expected,
+  bool equals(const NonlinearFactor& expected,
               double tol = 1e-9) const override {
-    auto e = dynamic_cast<const FrobeniusBetweenFactor *>(&expected);
+    auto e = dynamic_cast<const FrobeniusBetweenFactor*>(&expected);
     return e != nullptr && NoiseModelFactorN<T, T>::equals(*e, tol) &&
            traits<T>::Equals(this->T12_, e->T12_, tol);
   }
 
   /// @}
-  /// @name NoiseModelFactorN methods 
+  /// @name NoiseModelFactorN methods
   /// @{
 
-  /// Error is Frobenius norm between T1*T12 and T2.
-  Vector evaluateError(const T& T1, const T& T2,
-                       OptionalMatrixType H1, OptionalMatrixType H2) const override {
-    const T T2hat = traits<T>::Compose(T1, T12_);
-    Eigen::Matrix<double, Dim, T::dimension> vec_H_T2hat;
-    Vector error = traits<T>::Vec(T2, H2) - traits<T>::Vec(T2hat, H1 ? &vec_H_T2hat : nullptr);
-    if (H1) *H1 = -vec_H_T2hat * T2hat_H_T1_;
+  /// Error is |inv(T2)*T1*T12_ - I|_F.
+  Vector evaluateError(const T& T1, const T& T2, OptionalMatrixType H1,
+                       OptionalMatrixType H2) const override {
+    // predict T2*T1
+    typename T::Jacobian H_T21_T2;
+    const T hatT21 = traits<T>::Between(T2, T1, H1 ? &H_T21_T2 : nullptr);
+
+    // Calculate \hat T21 * T12_, which is predicted to be I_NxN
+    typename T::Jacobian H_pred_hat;
+    const T pred = traits<T>::Compose(hatT21, T12_, H1 ? &H_pred_hat : nullptr);
+
+    // Move to constructor
+    const MatrixN I = MatrixN::Identity();
+    const VectorD vecI = Eigen::Map<const VectorD>(I.data());
+
+    // Calculate error
+    Eigen::Matrix<double, Dim, T::dimension> H_vec_pred;
+    Vector error = vecI - traits<T>::Vec(pred, H1 ? &H_vec_pred : nullptr);
+
+    // Do chain rule
+    const auto H_error_hat21 = - H_vec_pred * H_pred_hat;
+    if (H1) *H1 = H_error_hat21;  // H_pred_T1 is identity
+    if (H2) *H2 = H_error_hat21 * H_T21_T2;
     return error;
   }
   /// @}
+};
+
+/**
+ * OldFrobeniusBetweenFactor uses ||T2 - T1*T12_||_F, which only works if the
+ * Frobenius error is invariant to multiplying with an arbitrary element T.
+ */
+template <class T>
+class OldFrobeniusBetweenFactor : public FrobeniusBetweenFactor<T> {
+  inline constexpr static auto N = T::LieAlgebra::RowsAtCompileTime;
+  inline constexpr static auto Dim = N * N;
+
+  typename T::Jacobian T2hat_H_T1_;  ///< fixed derivative of T2hat wrpt T1
+
+ public:
+  // Provide access to the Matrix& version of evaluateError:
+  using NoiseModelFactor2<T, T>::evaluateError;
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  /// Construct from two keys and measured rotation
+  OldFrobeniusBetweenFactor(Key j1, Key j2, const T& T12,
+                            const SharedNoiseModel& model = nullptr)
+      : FrobeniusBetweenFactor<T>(j1, j2, T12, model),
+        T2hat_H_T1_(traits<T>::AdjointMap(traits<T>::Inverse(T12))) {}
+
+  /// Error is Frobenius norm between T1*T12 and T2.
+  Vector evaluateError(const T& T1, const T& T2, OptionalMatrixType H1,
+                       OptionalMatrixType H2) const override {
+    const T T2hat = traits<T>::Compose(T1, this->T12_);
+    Eigen::Matrix<double, Dim, T::dimension> vec_H_T2hat;
+    Vector error = traits<T>::Vec(T2, H2) -
+                   traits<T>::Vec(T2hat, H1 ? &vec_H_T2hat : nullptr);
+    if (H1) *H1 = -vec_H_T2hat * T2hat_H_T1_;
+    return error;
+  }
 };
 
 }  // namespace gtsam

--- a/gtsam/slam/doc/FrobeniusFactor.ipynb
+++ b/gtsam/slam/doc/FrobeniusFactor.ipynb
@@ -19,10 +19,15 @@
         "\n",
         "These factors can sometimes be useful in specific optimization contexts, particularly in rotation averaging problems or as alternatives to standard `BetweenFactor` or `PriorFactor` on rotations.\n",
         "\n",
-        "*   `FrobeniusPrior<T>`: Penalizes the Frobenius norm difference between a variable rotation `T` and a fixed target matrix `M`. Error is $||T - M||_F^2$.\n",
-        "*   `FrobeniusFactor<T>`: Penalizes the Frobenius norm difference between two variable rotations `T1` and `T2`. Error is $||T1 - T2||_F^2$.\n",
-        "*   `FrobeniusBetweenFactor<T>`: Penalizes the Frobenius norm difference between the predicted rotation `T2` and the expected rotation `T1 * T12_measured`. Error is $||T1 \\cdot T_{12} - T2||_F^2$.\n",
-        "**Note:** The noise models for these factors operate on the vectorized rotation matrix (e.g., 9 elements for `Rot3`). The helper function `ConvertNoiseModel` attempts to convert standard rotation noise models (like those for `BetweenFactor<Rot3>`) into an appropriate isotropic noise model for the Frobenius factor. It expects the input noise model to be isotropic."
+        "* `FrobeniusPrior<T>`: Penalizes the Frobenius norm difference between a variable rotation `T` and a fixed target matrix `M`. Error is $||T - M||_F^2$.\n",
+        "* `FrobeniusFactor<T>`: Penalizes the Frobenius norm difference between two variable rotations `T1` and `T2`. Error is $||T_1 - T_2||_F^2$.\n",
+        "* `FrobeniusBetweenFactorNL<T>`: Penalizes the Frobenius norm difference between the predicted measurement `T2^{-1} * T1` and the actual measurement `T12_measured`. Error is $||I - T_2^{-1} T_1 \\cdot \\tilde T_{12}||_F^2$. Use this with *any* Matrix Lie group.\n",
+        "* `FrobeniusBetweenFactor<T>`: Penalizes the Frobenius norm difference between the predicted rotation `T2` and the expected rotation `T1 * T12_measured`. Error is $||T_1 \\cdot \\tilde T_{12} - T_2||_F^2$. Uses this - easier to optimize factor - if the norm is invariant to multiplying with T2, as is the case for `Rot3`, `Pose3`, etc, but not, say, `Similarity3`. \n",
+        "\n",
+        "The helper function function `ConvertModel` ensures the noise model used by the various Frobenius factors has the correct dimension. You can either provide:\n",
+        "  - an isotropic noise model of the manifold dimension of the type T (e.g., 3 for Rot3)\n",
+        "  - any noise model of the full vectorized matrix dimension (N*N, where N is the matrix size, e.g., 9 for Rot3).\n",
+        "  -  If you provide an isotropic model of the manifold dimension, ConvertModel will automatically convert it to the correct dimension for the Frobenius factor."
       ]
     },
     {
@@ -36,31 +41,38 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 1,
       "metadata": {
         "id": "pip_code",
         "tags": [
           "remove-cell"
         ]
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Note: you may need to restart the kernel to use updated packages.\n"
+          ]
+        }
+      ],
       "source": [
         "%pip install --quiet gtsam-develop"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": 7,
       "metadata": {
         "id": "imports_code"
       },
       "outputs": [],
       "source": [
         "import gtsam\n",
-        "import numpy as np\n",
-        "from gtsam import Rot3, Pose3, Values\n",
-        "from gtsam import FrobeniusPriorRot3, FrobeniusFactorRot3, FrobeniusBetweenFactorRot3\n",
-        "from gtsam import symbol_shorthand\n",
+        "from gtsam import (SL4, FrobeniusBetweenFactorNLSL4,\n",
+        "                   FrobeniusBetweenFactorRot3, FrobeniusFactorRot3,\n",
+        "                   FrobeniusPriorRot3, Rot3, Values, symbol_shorthand)\n",
         "\n",
         "X = symbol_shorthand.X\n",
         "R = symbol_shorthand.R # Using 'R' for Rot3 keys"
@@ -86,7 +98,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": 3,
       "metadata": {
         "id": "fprior_example_code"
       },
@@ -96,9 +108,11 @@
           "output_type": "stream",
           "text": [
             "FrobeniusPriorRot3:   keys = { r0 }\n",
-            "  noise model: unit (9) \n",
+            "isotropic dim=9 sigma=0.01\n",
+            "FrobeniusPriorRot3 (full 9D noise):   keys = { r0 }\n",
+            "isotropic dim=9 sigma=0.01\n",
             "\n",
-            "FrobeniusPrior error (vectorized matrix diff): 9.999916666944462e-05\n"
+            "FrobeniusPrior error (vectorized matrix diff): 0.9999916666944463\n"
           ]
         }
       ],
@@ -106,18 +120,21 @@
         "target_matrix = Rot3.Yaw(0.1).matrix() # Target matrix (must be 3x3)\n",
         "key = R(0)\n",
         "\n",
-        "# Create a standard isotropic noise model for rotation (3 dimensional)\n",
+        "# Option 1: Provide an isotropic noise model of the manifold dimension (3 for Rot3)\n",
         "rot_noise_model = gtsam.noiseModel.Isotropic.Sigma(3, 0.01)\n",
+        "# ConvertModel will expand this to 9D for Frobenius factors\n",
         "\n",
-        "# Convert it for the Frobenius factor (9 dimensional)\n",
-        "frobenius_noise_model_prior = gtsam.noiseModel.Isotropic.Sigma(9, 0.01) # Or use ConvertNoiseModel\n",
-        "\n",
-        "prior_fro = FrobeniusPriorRot3(key, target_matrix, frobenius_noise_model_prior)\n",
+        "prior_fro = FrobeniusPriorRot3(key, target_matrix, rot_noise_model)\n",
         "prior_fro.print(\"FrobeniusPriorRot3: \")\n",
+        "\n",
+        "# Option 2: Provide any noise model of the full vectorized dimension (9 for Rot3)\n",
+        "frobenius_noise_model = gtsam.noiseModel.Isotropic.Sigma(9, 0.01)\n",
+        "prior_fro_full = FrobeniusPriorRot3(key, target_matrix, frobenius_noise_model)\n",
+        "prior_fro_full.print(\"FrobeniusPriorRot3 (full 9D noise): \")\n",
         "\n",
         "# Evaluate error\n",
         "values = Values()\n",
-        "values.insert(key, Rot3.Yaw(0.11)) # Slightly different rotation\n",
+        "values.insert(key, Rot3.Yaw(0.11))\n",
         "error_prior = prior_fro.error(values)\n",
         "print(f\"\\nFrobeniusPrior error (vectorized matrix diff): {error_prior}\")"
       ]
@@ -142,7 +159,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": 4,
       "metadata": {
         "id": "ffactor_example_code"
       },
@@ -153,9 +170,9 @@
           "text": [
             "\n",
             "FrobeniusFactorRot3:   keys = { r0 r1 }\n",
-            "  noise model: unit (9) \n",
+            "isotropic dim=9 sigma=0.02\n",
             "\n",
-            "FrobeniusFactor error (vectorized matrix diff): 2.499994791671017e-05\n"
+            "FrobeniusFactor error (vectorized matrix diff): 0.062499869791775416\n"
           ]
         }
       ],
@@ -164,9 +181,7 @@
         "\n",
         "key1 = R(0)\n",
         "key2 = R(1)\n",
-        "# Use same noise model dimension (9)\n",
         "frobenius_noise_model_between = gtsam.noiseModel.Isotropic.Sigma(9, 0.02)\n",
-        "\n",
         "factor_fro = FrobeniusFactorRot3(key1, key2, frobenius_noise_model_between)\n",
         "factor_fro.print(\"\\nFrobeniusFactorRot3: \")\n",
         "\n",
@@ -183,21 +198,14 @@
         "id": "fbetween_header_md"
       },
       "source": [
-        "## 3. `FrobeniusBetweenFactor<Rot3>`"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "fbetween_desc_md"
-      },
-      "source": [
+        "## 3. `FrobeniusBetweenFactor<Rot3>`\n",
+        "\n",
         "Acts like `BetweenFactor<Rot3>` but minimizes $||R_1 \\cdot R_{12} - R_2||_F^2$ instead of using the Log map error."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": 5,
       "metadata": {
         "id": "fbetween_example_code"
       },
@@ -207,15 +215,15 @@
           "output_type": "stream",
           "text": [
             "\n",
-            "FrobeniusBetweenFactorRot3: FrobeniusBetweenFactor<class gtsam::Rot3>(r0,r1)\n",
+            "FrobeniusBetweenFactorRot3: FrobeniusBetweenFactorNL<gtsam::Rot3>(r0,r1)\n",
             "  T12:  [\n",
             "\t0.999988, -0.00499998, 0;\n",
             "\t0.00499998, 0.999988, 0;\n",
             "\t0, 0, 1\n",
             "]\n",
-            "  noise model: unit (9) \n",
+            "isotropic dim=9 sigma=0.005\n",
             "\n",
-            "FrobeniusBetweenFactor error: 1.925929944387236e-34\n"
+            "FrobeniusBetweenFactor error: 7.703719777548943e-30\n"
           ]
         }
       ],
@@ -231,11 +239,68 @@
         "error_between = between_fro.error(values)\n",
         "print(f\"\\nFrobeniusBetweenFactor error: {error_between}\")"
       ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 4. `FrobeniusBetweenFactorNL<SL4>`\n",
+        "\n",
+        "Acts like `BetweenFactor<SL4>` but minimizes $||T_2^{-1} T_1 \\cdot T_{12} - I||_F^2$, for use with groups that do not satisfy the invariance property needed to use `FrobeniusBetweenFactor`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "FrobeniusBetweenFactorNL<SL4>: FrobeniusBetweenFactorNL<gtsam::SL4>(x0,x1)\n",
+            "  T12:    1.00505 0.00503769 0.00503769 0.00502517\n",
+            "0.00503769    1.00004 0.00502515 0.00501265\n",
+            "0.00503769 0.00502515    1.00004 0.00501265\n",
+            "0.00502517 0.00501265 0.00501265    0.99505\n",
+            "isotropic dim=16 sigma=0.01\n",
+            "\n",
+            "FrobeniusBetweenFactorNL<SL4> error: 0.003941370929502147\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Create two SL4 elements (4x4 special linear group matrices)\n",
+        "sl4_1 = SL4.Expmap([0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.11, 0.12, 0.13, 0.14, 0.15])\n",
+        "sl4_2 = SL4.Expmap([0.015, 0.025, 0.035, 0.045, 0.055, 0.065, 0.075, 0.085, 0.095, 0.105, 0.115, 0.125, 0.135, 0.145, 0.155])\n",
+        "measured_sl4 = SL4.Expmap([0.005, 0.005, 0.005, 0.005, 0.005, 0.005, 0.005, 0.005, 0.005, 0.005, 0.005, 0.005, 0.005, 0.005, 0.005])\n",
+        "\n",
+        "# Create keys for the variables\n",
+        "key_sl4_1 = X(0)\n",
+        "key_sl4_2 = X(1)\n",
+        "\n",
+        "# Noise model for 16D (4x4 matrix)\n",
+        "sl4_noise_model = gtsam.noiseModel.Isotropic.Sigma(16, 0.01)\n",
+        "\n",
+        "# Construct the FrobeniusBetweenFactorNL for SL4\n",
+        "fbf_sl4 = FrobeniusBetweenFactorNLSL4(key_sl4_1, key_sl4_2, measured_sl4, sl4_noise_model)\n",
+        "\n",
+        "# Insert values into Values container\n",
+        "values_sl4 = Values()\n",
+        "values_sl4.insert(key_sl4_1, sl4_1)\n",
+        "values_sl4.insert(key_sl4_2, sl4_2)\n",
+        "\n",
+        "# Print factor and evaluate error\n",
+        "fbf_sl4.print(\"\\nFrobeniusBetweenFactorNL<SL4>: \")\n",
+        "error_sl4 = fbf_sl4.error(values_sl4)\n",
+        "print(f\"\\nFrobeniusBetweenFactorNL<SL4> error: {error_sl4}\")"
+      ]
     }
   ],
   "metadata": {
     "kernelspec": {
-      "display_name": "gtsam",
+      "display_name": "py312",
       "language": "python",
       "name": "python3"
     },
@@ -249,7 +314,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.13.1"
+      "version": "3.12.6"
     }
   },
   "nbformat": 4,

--- a/gtsam/slam/slam.i
+++ b/gtsam/slam/slam.i
@@ -583,7 +583,7 @@ class InitializePose3 {
 
 #include <gtsam/slam/KarcherMeanFactor-inl.h>
 template <T = {gtsam::Point2, gtsam::Rot2, gtsam::Pose2, gtsam::Point3,
-               gtsam::SO3, gtsam::SO4, gtsam::Rot3, gtsam::Pose3}>
+               gtsam::SO3, gtsam::SO4, gtsam::Rot3, gtsam::Pose3, gtsam::Similarity2, gtsam::Similarity3, gtsam::Gal3, gtsam::SL4}>
 virtual class KarcherMeanFactor : gtsam::NonlinearFactor {
   KarcherMeanFactor(const gtsam::KeyVector& keys);
   KarcherMeanFactor(const gtsam::KeyVector& keys, int d, double beta);
@@ -597,7 +597,7 @@ T FindKarcherMean(const std::vector<T>& elements);
 gtsam::noiseModel::Isotropic* ConvertNoiseModel(gtsam::noiseModel::Base* model,
                                                 size_t d);
 
-template <T = {gtsam::Rot2, gtsam::Rot3, gtsam::SO3, gtsam::SO4, gtsam::Pose2, gtsam::Pose3, gtsam::Similarity2, gtsam::Similarity3, gtsam::Gal3}>
+template <T = {gtsam::Rot2, gtsam::Rot3, gtsam::SO3, gtsam::SO4, gtsam::Pose2, gtsam::Pose3, gtsam::Similarity2, gtsam::Similarity3, gtsam::Gal3, gtsam::SL4}>
 class FrobeniusPrior : gtsam::NoiseModelFactor {
   FrobeniusPrior(gtsam::Key j, const gtsam::Matrix& M,
     const gtsam::noiseModel::Base* model);
@@ -605,7 +605,7 @@ class FrobeniusPrior : gtsam::NoiseModelFactor {
     gtsam::Vector evaluateError(const T& g) const;
 };
 
-template <T = {gtsam::Rot2, gtsam::Rot3, gtsam::SO3, gtsam::SO4, gtsam::Pose2, gtsam::Pose3, gtsam::Similarity2, gtsam::Similarity3, gtsam::Gal3}>
+template <T = {gtsam::Rot2, gtsam::Rot3, gtsam::SO3, gtsam::SO4, gtsam::Pose2, gtsam::Pose3, gtsam::Similarity2, gtsam::Similarity3, gtsam::Gal3, gtsam::SL4}>
 virtual class FrobeniusFactor : gtsam::NoiseModelFactor {
   FrobeniusFactor(gtsam::Key key1, gtsam::Key key2);
   FrobeniusFactor(gtsam::Key j1, gtsam::Key j2, gtsam::noiseModel::Base* model);
@@ -613,7 +613,18 @@ virtual class FrobeniusFactor : gtsam::NoiseModelFactor {
   gtsam::Vector evaluateError(const T& T1, const T& T2);
 };
 
-template <T = {gtsam::Rot2, gtsam::Rot3, gtsam::SO3, gtsam::SO4, gtsam::Pose2, gtsam::Pose3, gtsam::Similarity2, gtsam::Similarity3, gtsam::Gal3}>
+// Available for all Matrix Lie groups
+template <T = {gtsam::Rot2, gtsam::Rot3, gtsam::SO3, gtsam::SO4, gtsam::Pose2, gtsam::Pose3, gtsam::Similarity2, gtsam::Similarity3, gtsam::Gal3, gtsam::SL4}>
+virtual class FrobeniusBetweenFactorNL : gtsam::NoiseModelFactor {
+  FrobeniusBetweenFactorNL(gtsam::Key j1, gtsam::Key j2, const T& T12);
+  FrobeniusBetweenFactorNL(gtsam::Key key1, gtsam::Key key2, const T& T12,
+                         gtsam::noiseModel::Base* model);
+
+  gtsam::Vector evaluateError(const T& T1, const T& T2);
+};
+
+// FrobeniusBetweenFactor is only available for a subset of matrix Lie Groups
+template <T = {gtsam::Rot2, gtsam::Rot3, gtsam::SO3, gtsam::SO4, gtsam::Pose2, gtsam::Pose3, gtsam::Gal3}>
 virtual class FrobeniusBetweenFactor : gtsam::NoiseModelFactor {
   FrobeniusBetweenFactor(gtsam::Key j1, gtsam::Key j2, const T& T12);
   FrobeniusBetweenFactor(gtsam::Key key1, gtsam::Key key2, const T& T12,

--- a/gtsam/slam/tests/testFrobeniusFactor.cpp
+++ b/gtsam/slam/tests/testFrobeniusFactor.cpp
@@ -28,6 +28,7 @@
 #include <gtsam/geometry/SO3.h>
 #include <gtsam/geometry/SO4.h>
 #include <gtsam/geometry/Gal3.h>
+#include <gtsam/geometry/SL4.h>
 #include <gtsam/nonlinear/factorTesting.h>
 #include <gtsam/nonlinear/GaussNewtonOptimizer.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
@@ -48,7 +49,7 @@ namespace so3 {
 }  // namespace so3
 
 /* ************************************************************************* */
-TEST(FrobeniusPriorSO3, evaluateError) {
+TEST(FrobeniusPriorSO3, EvaluateError) {
   using namespace ::so3;
   auto factor = FrobeniusPrior<SO3>(1, R2.matrix());
   Vector actual = factor.evaluateError(R1);
@@ -108,7 +109,7 @@ TEST(FrobeniusPriorSO3, ChordalL2mean) {
 }
 
 /* ************************************************************************* */
-TEST(FrobeniusFactorSO3, evaluateError) {
+TEST(FrobeniusFactorSO3, EvaluateError) {
   using namespace ::so3;
   auto factor = FrobeniusFactor<SO3>(1, 2);
   Vector actual = factor.evaluateError(R1, R2);
@@ -123,7 +124,7 @@ TEST(FrobeniusFactorSO3, evaluateError) {
 
 /* ************************************************************************* */
 // Commented out as SO(n) not yet supported (and might never be)
-// TEST(FrobeniusBetweenFactorSOn, evaluateError) {
+// TEST(FrobeniusBetweenFactorSOn, EvaluateError) {
 //   using namespace ::so3;
 //   auto factor =
 //       FrobeniusBetweenFactor<SOn>(1, 2, SOn::FromMatrix(R12.matrix()));
@@ -139,7 +140,7 @@ TEST(FrobeniusFactorSO3, evaluateError) {
 // }
 
 /* ************************************************************************* */
-TEST(FrobeniusBetweenFactorSO3, evaluateError) {
+TEST(FrobeniusBetweenFactorSO3, EvaluateError) {
   using namespace ::so3;
   auto factor = FrobeniusBetweenFactor<SO3>(1, 2, R12);
   Vector actual = factor.evaluateError(R1, R2);
@@ -162,7 +163,7 @@ namespace so4 {
 }  // namespace so4
 
 /* ************************************************************************* */
-TEST(FrobeniusFactorSO4, evaluateError) {
+TEST(FrobeniusFactorSO4, EvaluateError) {
   using namespace ::so4;
   auto factor = FrobeniusFactor<SO4>(1, 2, noiseModel::Unit::Create(6));
   Vector actual = factor.evaluateError(Q1, Q2);
@@ -176,7 +177,7 @@ TEST(FrobeniusFactorSO4, evaluateError) {
 }
 
 /* ************************************************************************* */
-TEST(FrobeniusBetweenFactorSO4, evaluateError) {
+TEST(FrobeniusBetweenFactorSO4, EvaluateError) {
   using namespace ::so4;
   Matrix4 M{ I_4x4 };
   M.topLeftCorner<3, 3>() = ::so3::R12.matrix();
@@ -200,7 +201,7 @@ namespace pose2 {
 }  // namespace pose2
 
 /* ************************************************************************* */
-TEST(FrobeniusFactorPose2, evaluateError) {
+TEST(FrobeniusFactorPose2, EvaluateError) {
   using namespace ::pose2;
   auto factor = FrobeniusFactor<Pose2>(1, 2, noiseModel::Unit::Create(3));
   Vector actual = factor.evaluateError(P1, P2);
@@ -214,7 +215,7 @@ TEST(FrobeniusFactorPose2, evaluateError) {
 }
 
 /* ************************************************************************* */
-TEST(FrobeniusBetweenFactorPose2, evaluateError) {
+TEST(FrobeniusBetweenFactorPose2, EvaluateError) {
   using namespace ::pose2;
   auto factor = FrobeniusBetweenFactor<Pose2>(1, 2, P1.between(P2));
   Matrix H1, H2;
@@ -236,7 +237,7 @@ namespace pose3 {
 }  // namespace pose3
 
 /* ************************************************************************* */
-TEST(FrobeniusFactorPose3, evaluateError) {
+TEST(FrobeniusFactorPose3, EvaluateError) {
   using namespace ::pose3;
   auto factor = FrobeniusFactor<Pose3>(1, 2, noiseModel::Unit::Create(12));
   Vector actual = factor.evaluateError(P1, P2);
@@ -250,7 +251,7 @@ TEST(FrobeniusFactorPose3, evaluateError) {
 }
 
 /* ************************************************************************* */
-TEST(FrobeniusBetweenFactorPose3, evaluateError) {
+TEST(FrobeniusBetweenFactorPose3, EvaluateError) {
   using namespace ::pose3;
   auto factor = FrobeniusBetweenFactor<Pose3>(1, 2, P1.between(P2));
   Matrix H1, H2;
@@ -273,7 +274,7 @@ namespace sim2 {
 }  // namespace sim2
 
 /* ************************************************************************* */
-TEST(FrobeniusFactorSimilarity2, evaluateError) {
+TEST(FrobeniusFactorSimilarity2, EvaluateError) {
   using namespace ::sim2;
   auto factor = FrobeniusFactor<Similarity2>(1, 2, noiseModel::Unit::Create(9));
   Vector actual = factor.evaluateError(P1, P2);
@@ -287,9 +288,9 @@ TEST(FrobeniusFactorSimilarity2, evaluateError) {
 }
 
 /* ************************************************************************* */
-TEST(FrobeniusBetweenFactorSimilarity2, evaluateError) {
+TEST(FrobeniusBetweenFactorNLSimilarity2, EvaluateError) {
   using namespace ::sim2;
-  auto factor = FrobeniusBetweenFactor<Similarity2>(1, 2, P1.between(P2));
+  auto factor = FrobeniusBetweenFactorNL<Similarity2>(1, 2, P1.between(P2));
   Matrix H1, H2;
   Vector actual = factor.evaluateError(P1, P2, H1, H2);
   Vector expected(9);
@@ -310,7 +311,7 @@ namespace sim3 {
 }  // namespace sim3
 
 /* ************************************************************************* */
-TEST(FrobeniusFactorSimilarity3, evaluateError) {
+TEST(FrobeniusFactorSimilarity3, EvaluateError) {
   using namespace ::sim3;
   auto factor = FrobeniusFactor<Similarity3>(1, 2, noiseModel::Unit::Create(16));
   Vector actual = factor.evaluateError(P1, P2);
@@ -324,9 +325,9 @@ TEST(FrobeniusFactorSimilarity3, evaluateError) {
 }
 
 /* ************************************************************************* */
-TEST(FrobeniusBetweenFactorSimilarity3, evaluateError) {
+TEST(FrobeniusBetweenFactorNLSimilarity3, EvaluateError) {
   using namespace ::sim3;
-  auto factor = FrobeniusBetweenFactor<Similarity3>(1, 2, P1.between(P2));
+  auto factor = FrobeniusBetweenFactorNL<Similarity3>(1, 2, P1.between(P2));
   Matrix H1, H2;
   Vector actual = factor.evaluateError(P1, P2, H1, H2);
   Vector expected(16);
@@ -347,7 +348,7 @@ namespace gal3 {
 }  // namespace gal3
 
 /* ************************************************************************* */
-TEST(FrobeniusFactorGal3, evaluateError) {
+TEST(FrobeniusFactorGal3, EvaluateError) {
   using namespace ::gal3;
   auto factor = FrobeniusFactor<Gal3>(1, 2, noiseModel::Unit::Create(25));
   Vector actual = factor.evaluateError(G1, G2);
@@ -361,7 +362,7 @@ TEST(FrobeniusFactorGal3, evaluateError) {
 }
 
 /* ************************************************************************* */
-TEST(FrobeniusBetweenFactorGal3, evaluateError) {
+TEST(FrobeniusBetweenFactorGal3, EvaluateError) {
   using namespace ::gal3;
   auto factor = FrobeniusBetweenFactor<Gal3>(1, 2, G1.between(G2));
   Matrix H1, H2;
@@ -373,6 +374,47 @@ TEST(FrobeniusBetweenFactorGal3, evaluateError) {
   Values values;
   values.insert(1, G1);
   values.insert(2, G2);
+  EXPECT_CORRECT_FACTOR_JACOBIANS(factor, values, 1e-7, 1e-5);
+}
+
+/* ************************************************************************* */
+namespace sl4 {
+SL4 id;
+const Matrix4 T_matrix =
+    (Matrix4() << 1, 0, 0, 1, 0, 1, 0, 2, 0, 0, 1, 3, 0, 0, 0, 1).finished();
+const SL4 T1(T_matrix);
+const Matrix4 T_matrix2 =
+    (Matrix4() << 1, 0, 0, 4, 0, 1, 0, 5, 0, 0, 1, 6, 0, 0, 0, 1).finished();
+const SL4 T2(T_matrix2);
+}  // namespace sl4
+
+/* ************************************************************************* */
+TEST(FrobeniusFactorSL4, EvaluateError) {
+  using namespace ::sl4;
+  auto factor = FrobeniusFactor<SL4>(1, 2, noiseModel::Unit::Create(25));
+  Vector actual = factor.evaluateError(T1, T2);
+  Vector expected = T2.vec() - T1.vec();
+  EXPECT(assert_equal(expected, actual, 1e-9));
+
+  Values values;
+  values.insert(1, T1);
+  values.insert(2, T2);
+  EXPECT_CORRECT_FACTOR_JACOBIANS(factor, values, 1e-7, 1e-5);
+}
+
+/* ************************************************************************* */
+TEST(FrobeniusBetweenFactorSL4, EvaluateError) {
+  using namespace ::sl4;
+  auto factor = FrobeniusBetweenFactor<SL4>(1, 2, T1.between(T2));
+  Matrix H1, H2;
+  Vector actual = factor.evaluateError(T1, T2, H1, H2);
+  Vector expected(16);
+  expected.setZero();
+  EXPECT(assert_equal(expected, actual, 1e-9));
+
+  Values values;
+  values.insert(1, T1);
+  values.insert(2, T2);
   EXPECT_CORRECT_FACTOR_JACOBIANS(factor, values, 1e-7, 1e-5);
 }
 

--- a/gtsam/slam/tests/testFrobeniusFactor.cpp
+++ b/gtsam/slam/tests/testFrobeniusFactor.cpp
@@ -239,7 +239,7 @@ namespace pose3 {
 /* ************************************************************************* */
 TEST(FrobeniusFactorPose3, EvaluateError) {
   using namespace ::pose3;
-  auto factor = FrobeniusFactor<Pose3>(1, 2, noiseModel::Unit::Create(12));
+  auto factor = FrobeniusFactor<Pose3>(1, 2, noiseModel::Unit::Create(6));
   Vector actual = factor.evaluateError(P1, P2);
   Vector expected = P2.vec() - P1.vec();
   EXPECT(assert_equal(expected, actual, 1e-9));
@@ -391,7 +391,7 @@ const SL4 T2(T_matrix2);
 /* ************************************************************************* */
 TEST(FrobeniusFactorSL4, EvaluateError) {
   using namespace ::sl4;
-  auto factor = FrobeniusFactor<SL4>(1, 2, noiseModel::Unit::Create(25));
+  auto factor = FrobeniusFactor<SL4>(1, 2, noiseModel::Unit::Create(16));
   Vector actual = factor.evaluateError(T1, T2);
   Vector expected = T2.vec() - T1.vec();
   EXPECT(assert_equal(expected, actual, 1e-9));

--- a/python/gtsam/tests/test_FrobeniusFactor.py
+++ b/python/gtsam/tests/test_FrobeniusFactor.py
@@ -8,27 +8,32 @@ See LICENSE for the license information
 FrobeniusFactor unit tests.
 Author: Frank Dellaert
 """
+
 # pylint: disable=no-name-in-module, import-error, invalid-name
 import unittest
 
 import numpy as np
+
 from gtsam import (
-    Rot3,
+    SL4,
     SO3,
     SO4,
+    FrobeniusBetweenFactorGal3,
+    FrobeniusBetweenFactorNLSimilarity2,
+    FrobeniusBetweenFactorNLSimilarity3,
+    FrobeniusBetweenFactorNLSL4,
     FrobeniusBetweenFactorSO4,
+    FrobeniusFactorGal3,
+    FrobeniusFactorSL4,
+    FrobeniusFactorSimilarity2,
+    FrobeniusFactorSimilarity3,
     FrobeniusFactorSO4,
+    Gal3,
+    Rot3,
     ShonanFactor3,
-    SOn,
     Similarity2,
     Similarity3,
-    FrobeniusFactorSimilarity2,
-    FrobeniusBetweenFactorSimilarity2,
-    FrobeniusFactorSimilarity3,
-    FrobeniusBetweenFactorSimilarity3,
-    Gal3,
-    FrobeniusFactorGal3,
-    FrobeniusBetweenFactorGal3,
+    SOn,
 )
 
 id = SO4()
@@ -45,6 +50,15 @@ P2_sim3 = Similarity3.Expmap(np.array([0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]))
 
 G1_gal3 = Gal3(Rot3.Rz(0.1), np.array([0.2, 0.3, 0.4]), np.array([0.5, 0.6, 0.7]), 0.8)
 G2_gal3 = Gal3(Rot3.Rz(0.2), np.array([0.3, 0.4, 0.5]), np.array([0.6, 0.7, 0.8]), 0.9)
+
+# Define SL4 transformations
+
+id_sl4 = SL4()
+T_matrix1 = np.array([[1, 0, 0, 1], [0, 1, 0, 2], [0, 0, 1, 3], [0, 0, 0, 1]])
+G1_sl4 = SL4(T_matrix1)
+
+T_matrix2 = np.array([[1, 0, 0, 4], [0, 1, 0, 5], [0, 0, 1, 6], [0, 0, 0, 1]])
+G2_sl4 = SL4(T_matrix2)
 
 
 class TestFrobeniusFactorSO4(unittest.TestCase):
@@ -85,7 +99,7 @@ class TestFrobeniusFactorSimilarity2(unittest.TestCase):
         np.testing.assert_allclose(actual, expected, atol=1e-9)
 
     def test_frobenius_between_factor(self):
-        factor = FrobeniusBetweenFactorSimilarity2(1, 2, P1_sim2.between(P2_sim2))
+        factor = FrobeniusBetweenFactorNLSimilarity2(1, 2, P1_sim2.between(P2_sim2))
         actual = factor.evaluateError(P1_sim2, P2_sim2)
         expected = np.zeros((9,))
         np.testing.assert_allclose(actual, expected, atol=1e-9)
@@ -99,7 +113,7 @@ class TestFrobeniusFactorSimilarity3(unittest.TestCase):
         np.testing.assert_allclose(actual, expected, atol=1e-9)
 
     def test_frobenius_between_factor(self):
-        factor = FrobeniusBetweenFactorSimilarity3(1, 2, P1_sim3.between(P2_sim3))
+        factor = FrobeniusBetweenFactorNLSimilarity3(1, 2, P1_sim3.between(P2_sim3))
         actual = factor.evaluateError(P1_sim3, P2_sim3)
         expected = np.zeros((16,))
         np.testing.assert_allclose(actual, expected, atol=1e-9)
@@ -116,6 +130,24 @@ class TestFrobeniusFactorGal3(unittest.TestCase):
         factor = FrobeniusBetweenFactorGal3(1, 2, G1_gal3.between(G2_gal3))
         actual = factor.evaluateError(G1_gal3, G2_gal3)
         expected = np.zeros((25,))
+        np.testing.assert_allclose(actual, expected, atol=1e-9)
+
+
+class TestFrobeniusFactorSL4(unittest.TestCase):
+    def test_frobenius_factor(self):
+        """Test Frobenius factor for SL4."""
+        factor = FrobeniusFactorSL4(1, 2)  # Replace with appropriate SL4 factor class
+        actual = factor.evaluateError(G1_sl4, G2_sl4)
+        expected = (G2_sl4.matrix() - G1_sl4.matrix()).transpose().reshape((16,))
+        np.testing.assert_allclose(actual, expected, atol=1e-9)
+
+    def test_frobenius_between_factor(self):
+        """Test Frobenius BetweenFactor for SL4."""
+        factor = FrobeniusBetweenFactorNLSL4(
+            1, 2, G1_sl4.between(G2_sl4)
+        )  # Replace with appropriate SL4 factor class
+        actual = factor.evaluateError(G1_sl4, G2_sl4)
+        expected = np.zeros((16,))
         np.testing.assert_allclose(actual, expected, atol=1e-9)
 
 


### PR DESCRIPTION
Sometimes the use of FrobeniusBetweenFactor is not mathematically sound. So now we have:

* `FrobeniusBetweenFactorNL<T>`: Penalizes the Frobenius norm difference between the predicted measurement `T2^{-1} * T1` and the actual measurement `T12_measured`. Error is $||I - T_2^{-1} T_1 \cdot \tilde T_{12}||_F^2$. Use this with *any* Matrix Lie group.
* `FrobeniusBetweenFactor<T>`: Penalizes the Frobenius norm difference between the predicted rotation `T2` and the expected rotation `T1 * T12_measured`. Error is $||T_1 \cdot \tilde T_{12} - T_2||_F^2$. Use this - easier to optimize factor - if the norm is invariant to multiplying with T2, as is the case for `Rot3`, `Pose3`, etc, but not, say, `Similarity3`. 

In addition, the new helper function function `ConvertModel` ensures the noise model used by the various Frobenius factors has the correct dimension. You can either provide (straight to the factors):
  - an isotropic noise model of the manifold dimension of the type T (e.g., 3 for Rot3)
  - any noise model of the full vectorized matrix dimension (N*N, where N is the matrix size, e.g., 9 for Rot3).
  -  If you provide an isotropic model of the manifold dimension, ConvertModel will automatically convert it to the correct dimension for the Frobenius factor.