### PR TITLE
IEKF Navstate motion propagation fix

### DIFF
--- a/examples/IEKF_NavstateExample.cpp
+++ b/examples/IEKF_NavstateExample.cpp
@@ -16,6 +16,8 @@
  * @authors Scott Baker, Matt Kielo, Frank Dellaert
  */
 
+#define GRAVITY_VECTOR gtsam::Vector3(0, 0, 0)
+
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/VectorSpace.h>
 #include <gtsam/base/OptionalJacobian.h>
@@ -77,7 +79,7 @@ int main() {
     << "\n\n";
 
   // --- first predict/update ---
-  ekf.predict(dynamics(imu1), dt, Q);
+  ekf.predict(dynamics(imu1), dt, Q, GRAVITY_VECTOR);
   cout << "--- After predict 1 ---\nX: " << ekf.state()
     << "\nP: " << ekf.covariance() << "\n\n";
   ekf.update(h_gps, z1, R);
@@ -85,7 +87,7 @@ int main() {
     << "\nP: " << ekf.covariance() << "\n\n";
 
   // --- second predict/update ---
-  ekf.predict(dynamics(imu2), dt, Q);
+  ekf.predict(dynamics(imu2), dt, Q, GRAVITY_VECTOR);
   cout << "--- After predict 2 ---\nX: " << ekf.state()
     << "\nP: " << ekf.covariance() << "\n\n";
   ekf.update(h_gps, z2, R);

--- a/gtsam/navigation/InvariantEKF.h
+++ b/gtsam/navigation/InvariantEKF.h
@@ -108,6 +108,80 @@ namespace gtsam {
       predict(U, Q); // Call the group composition predict
     }
 
+        /**
+     * Predict step via tangent control vector and manual imu integration on NavState (SE_2(3)) group.
+     * Gravity vector added to allow overloaded function and account for example code 
+     * IEKF_NavstateExample.cpp that does not have gravity offset
+     *
+     * Motion propagation equations follow the formulation from:
+     * Potokar et al., "Invariant Extended Kalman Filtering for Underwater Navigation"
+     * Link to paper: https://ieeexplore.ieee.org/document/9444664
+     * Source code can be found here: https://bitbucket.org/frostlab/underwateriekf/src/main/src/system.py
+     * 
+     *   Motion Propagation:
+     *   R_new = R * Expmap(omega*dt)
+     *   v_new = v + (R * accel + g) * dt   
+     *   p_new = p + v * dt + ((R * accel + g) * dt^2) / 2
+     *   X_ = NavState(Pose3(R_new, p_new), v_new);
+     * 
+     *   Covariance Update:
+     *   A = motion linearization which is dependent on control u input
+     *   P_ = exp(A) * P_ * exp(A).transpose() + exp(A) * Q * exp(A).transpose() * dt
+     *   
+     * @param u Tangent space control vector.
+     * @param dt Time interval.
+     * @param Q Process noise covariance matrix.
+     * @param g Gravity vector
+     * 
+     * @authors Derek Benham
+     */
+    
+    void predict(const TangentVector&u, double dt, const Covariance& Q, const Vector3 g) {
+      const Rot3 R = this->X_.pose().rotation();
+      const Vector3 v = this->X_.velocity();
+      const Vector3 p = this->X_.pose().translation();
+      
+      Vector3 omega = u.template segment<3>(0);
+      Vector3 accel = u.template segment<3>(6);
+      
+      // Motion propagation
+      Rot3 dR = traits<Rot3>::Expmap(omega * dt);
+      Rot3 R_new = R * dR; // R_new = R * \delta R
+      Vector3 v_new = v + (R * accel + g) * dt;
+      Vector3 p_new = p + v * dt + ((R * accel + g) * dt * dt) / 2;
+      this->X_ = gtsam::NavState(Pose3(R_new, p_new), v_new);
+      
+      // Updating Covariance
+      const Matrix3 zero = Matrix3::Zero();
+      const Matrix3 I = Matrix3::Identity();
+
+      Matrix3 w_cross;
+      w_cross <<     0, -omega(2),  omega(1),
+              omega(2),         0, -omega(0),
+             -omega(1),  omega(0),         0;
+
+      Matrix3 a_cross;
+      a_cross <<     0, -accel(2),  accel(1),
+              accel(2),         0, -accel(0),
+             -accel(1),  accel(0),         0;
+
+      // Left error A matrix
+      Matrix A(9, 9);
+      A << -w_cross,     zero,  zero,
+           -a_cross, -w_cross,  zero,
+               zero,        I,  -w_cross;
+
+      // Compute expA = exp(A * dt), where A is the system's linearized dynamics matrix
+      Matrix expA = (A * dt).exp();
+
+      // Update the covariance with process noise
+      // Pₖ₊₁ = expA * Pₖ * expAᵀ + expA * Q * expAᵀ * dt
+      Matrix P_predict = expA * this->P_ * expA.transpose();
+      Matrix Q_predict = expA * Q * expA.transpose() * dt;
+      this->P_ = P_predict + Q_predict;
+    }
+
+
   }; // InvariantEKF
 
 } // namespace gtsam


### PR DESCRIPTION
The current IEKF predict functions account for motion propagation in $SE(2)$ only. The current group composition equations and linearizations used do not apply to the NavState $SE_2(3)$ group.
The equations used for NavState motion propagation within the left-invariant EKF are defined in my function header and are explained in this tutorial:
```
E. R. Potokar, R. W. Beard and J. G. Mangelson, "An Introduction to the Invariant Extended Kalman Filter [Lecture Notes]," in IEEE Control Systems, vol. 44, no. 6, pp. 50-71, Dec. 2024, doi: 10.1109/MCS.2024.3466488. keywords: {Kalman filters;Mean square error methods;Stochastic processes;Jacobian matrices;Nonlinear systems;Tutorials;Error analysis;Open source software;C++ languages;Lie groups;Manifolds},
```
I also updated the IEKF_NavstateExample.cpp to use my new overloaded function. In the previous example the orientation and velocity of the vehicle would update after the predict step, but not the position.

## Evaluation:
I evaluated my fix against my own IEKF implementation that was used in this paper: [https://arxiv.org/abs/2506.10850](url)
```
D. Benham, E. R. Potokar, and J.G. Mangelson, (2025). Invariant Extended Kalman Filter for Autonomous Surface Vessels with Partial Orientation Measurements. arXiv. https://arxiv.org/abs/2506.10850
```
These graphs show the motion propagation only with no sensor updates.

This is using the original implementation. You can see that position remains constant, and the Z velocity does not account for gravity.
<img width="1687" height="1325" alt="GTSAM InEKF Predict Only" src="https://github.com/user-attachments/assets/e2aeb584-46a1-419a-a169-bfbf909caacb" />

This is what my IEKF outputs:
<img width="1687" height="1333" alt="Python InEKF Predict Only" src="https://github.com/user-attachments/assets/dcf461e4-7928-4944-8e05-f585269550a3" />

And now the GTSAM IEKF matches with the same results:
<img width="1687" height="1325" alt="GTSAM InEKF Predict Only_Fix" src="https://github.com/user-attachments/assets/9685c855-5c73-4fe5-867d-6df5420cfd9f" />

\# _A note on the velocity estimates_
I've noticed that the velocity estimates do not match ground truth. In this instance ground truth is established via a Gazebo simulation and I assume they use a different underlying motion model which contributes to the drift as these simulations were run with no noise.

