### PR TITLE
Fix tests and simplify Windows CI

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -70,25 +70,6 @@ jobs:
           scoop install cmake --global  # So we don't get issues with CMP0074 policy
           scoop install ninja --global
 
-          if ("${{ matrix.compiler }}".StartsWith("clang")) {
-            scoop install llvm --global
-          }
-
-          if ("${{ matrix.compiler }}" -eq "gcc") {
-            scoop install gcc --global
-            echo "CC=gcc" >> $GITHUB_ENV
-            echo "CXX=g++" >> $GITHUB_ENV
-
-          } elseif ("${{ matrix.compiler }}" -eq "clang") {
-            echo "CC=clang" >> $GITHUB_ENV
-            echo "CXX=clang++" >> $GITHUB_ENV
-
-          } else {
-            echo "CC=${{ matrix.compiler }}" >> $env:GITHUB_ENV
-            echo "CXX=${{ matrix.compiler }}" >> $env:GITHUB_ENV
-
-          }
-
           # Scoop modifies the PATH so we make the modified PATH global.
           echo "$env:PATH" >> $env:GITHUB_PATH
 
@@ -121,7 +102,6 @@ jobs:
           cmake -E remove_directory build
           if [ "${{ matrix.build_type }}" = "Release" ]; then
             cmake -B build \
-                  -S . \
                   -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF \
                   -DGTSAM_ALLOW_DEPRECATED_SINCE_V43=OFF \
                   -DGTSAM_USE_BOOST_FEATURES=ON \
@@ -131,7 +111,6 @@ jobs:
                   -DBOOST_LIBRARYDIR="${BOOST_ROOT_UNIX}/lib"
           else
             cmake -B build \
-                  -S . \
                   -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF \
                   -DGTSAM_ALLOW_DEPRECATED_SINCE_V43=OFF \
                   -DGTSAM_USE_BOOST_FEATURES=OFF \
@@ -140,47 +119,8 @@ jobs:
 
       - name: Build
         shell: bash
-        run: |
-          # Since Visual Studio is a multi-generator, we need to use --config
-          # https://stackoverflow.com/a/24470998/1236990
-          cmake --build build -j4 --config ${{ matrix.build_type }} --target gtsam
-          cmake --build build -j4 --config ${{ matrix.build_type }} --target gtsam_unstable
-          cmake --build build -j4 --config ${{ matrix.build_type }} --target all.tests
+        run: cmake --build build -j4 --target all.tests
 
       - name: Test
         shell: bash
-        run: |
-          # Run GTSAM tests
-          cmake --build build -j4 --config ${{ matrix.build_type }} --target check.base
-          cmake --build build -j4 --config ${{ matrix.build_type }} --target check.basis
-          cmake --build build -j4 --config ${{ matrix.build_type }} --target check.discrete
-          cmake --build build -j4 --config ${{ matrix.build_type }} --target check.geometry
-          cmake --build build -j4 --config ${{ matrix.build_type }} --target check.inference
-          cmake --build build -j4 --config ${{ matrix.build_type }} --target check.linear
-          cmake --build build -j4 --config ${{ matrix.build_type }} --target check.navigation
-          cmake --build build -j4 --config ${{ matrix.build_type }} --target check.sam
-          cmake --build build -j4 --config ${{ matrix.build_type }} --target check.sfm
-          cmake --build build -j4 --config ${{ matrix.build_type }} --target check.symbolic
-          cmake --build build -j4 --config ${{ matrix.build_type }} --target check.hybrid
-          cmake --build build -j4 --config ${{ matrix.build_type }} --target check.nonlinear
-          cmake --build build -j4 --config ${{ matrix.build_type }} --target check.slam
-
-          # Run GTSAM_UNSTABLE tests
-          cmake --build build -j4 --config ${{ matrix.build_type }} --target check.base_unstable
-          # Compile. Fail with exception
-          # cmake --build build -j4 --config ${{ matrix.build_type }} --target check.geometry_unstable
-          # Compile. Fail with exception
-          # cmake --build build -j4 --config ${{ matrix.build_type }} --target check.linear_unstable
-          # Compile. Fail with exception
-          # cmake --build build -j4 --config ${{ matrix.build_type }} --target check.discrete_unstable
-          # Compile. Fail with exception
-          # cmake --build build -j4 --config ${{ matrix.build_type }} --target check.dynamics_unstable
-          # Compile. Fail with exception
-          # cmake --build build -j4 --config ${{ matrix.build_type }} --target check.nonlinear_unstable
-          # Compile. Fail with exception
-          # cmake --build build -j4 --config ${{ matrix.build_type }} --target check.slam_unstable
-          # Compile. Fail with exception
-          # cmake --build build -j4 --config ${{ matrix.build_type }} --target check.partition
-
-          # Run all tests
-          # cmake --build build -j1 --config ${{ matrix.build_type }} --target check
+        run: cmake --build build -j1 --target check

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -25,9 +25,6 @@ jobs:
             test_target: RUN_TESTS
             binary_cache: C:\Users\runneradmin\AppData\Local\vcpkg\archives
             python: python
-            # check_constrained_program fail on windows. should fix it for windows.
-            # Remove this excluded test when you fix it for windows.
-            ctest_extra_flags: -E "check_constrained_program|check_inference_program|check_symbolic_program|check_discrete_program"
             # Exclude test_sumProduct and test_sumProduct_chain from pytest on windows.
             # These tests should be fixed for windows.
             pytest_extra_flags: -k "not test_sumProduct"

--- a/gtsam_unstable/nonlinear/NonlinearClusterTree.h
+++ b/gtsam_unstable/nonlinear/NonlinearClusterTree.h
@@ -37,10 +37,17 @@ class NonlinearClusterTree : public ClusterTree<NonlinearFactorGraph> {
     }
 
     static NonlinearCluster* DownCast(const std::shared_ptr<Cluster>& cluster) {
-      auto nonlinearCluster = std::dynamic_pointer_cast<NonlinearCluster>(cluster);
+#if defined(_MSC_VER) && !NDEBUG
+      // This is really gross, but dynamic_pointer_cast/dynamic_cast will not
+      // work on MSVC in Debug mode
+      return static_cast<NonlinearCluster*>(cluster.get());
+#else
+      auto nonlinearCluster =
+          std::dynamic_pointer_cast<NonlinearCluster>(cluster);
       if (!nonlinearCluster)
         throw std::runtime_error("Expected NonlinearCluster");
       return nonlinearCluster.get();
+#endif
     }
 
     // linearize local custer factors straight into hessianFactor, which is returned

--- a/tests/testDoglegOptimizer.cpp
+++ b/tests/testDoglegOptimizer.cpp
@@ -319,8 +319,9 @@ TEST(DogLegOptimizer, VariableUpdate) {
   // this should break the system
   isam2.update(graph, initialEstimate);
   result = isam2.calculateEstimate();
-  EXPECT(std::find(result.keys().begin(), result.keys().end(), pose_idx) !=
-         result.keys().end());
+  auto resultKeys = result.keys();
+  EXPECT(std::find(resultKeys.begin(), resultKeys.end(), pose_idx) !=
+         resultKeys.end());
 }
 
 /* ************************************************************************* */


### PR DESCRIPTION
MSBuild isn't used anymore, and Ninja isn't being used as a multi-config generator, so `--config` does nothing. `CMAKE_BUILD_TYPE` was being set as an environment variable, so that's why it's always built in the correct mode. The logic for detecting GCC/clang was removed because the Windows builds only use cl. All the tests pass on my local machine, but we'll see how it works on CI...

testDoglegOptimizer failed because `keys()` was being called multiple times, which means the iterators come from different vector objects, which trips an assertion in MSVC. The other failing test was nonlinear_unstable. For reasons I do not understand, dynamic_pointer_cast/dynamic_cast fails when building in Debug mode, but not Release mode. I added a preprocessor check to just use static_cast when the compiler is MSVC and Debug mode is being used. That way, all other builds keep the pointer check and will fail accordingly.