### PR TITLE
Fix CI and run non-boost QP tests

### DIFF
--- a/.github/scripts/python_wheels/cleanup_gtsam_develop.sh
+++ b/.github/scripts/python_wheels/cleanup_gtsam_develop.sh
@@ -33,7 +33,7 @@ echo "         of 'gtsam-develop' on PyPI for user '$PYPI_USER'."
 echo "         This cannot be undone."
 echo "-----------------------------------------------------------------------"
 read -rp "Proceed? [y/N]: " REPLY
-REPLY=${REPLY,,}   # to lowercase
+REPLY=$(echo "$REPLY" | tr '[:upper:]' '[:lower:]')   # to lowercase
 [[ "$REPLY" != "y" && "$REPLY" != "yes" ]] && { echo "Aborted."; exit 0; }
 
 echo "Running pypi_cleanup for user '$PYPI_USER'..."

--- a/gtsam_unstable/CMakeLists.txt
+++ b/gtsam_unstable/CMakeLists.txt
@@ -33,15 +33,14 @@ set (excluded_headers # "")
 if(NOT GTSAM_USE_BOOST_FEATURES)
     list (APPEND excluded_sources
         "${CMAKE_CURRENT_SOURCE_DIR}/linear/QPSParser.cpp"
-        "${CMAKE_CURRENT_SOURCE_DIR}/linear/QPSSolver.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/discrete/Scheduler.cpp"
     )
     list (APPEND excluded_headers
         "${CMAKE_CURRENT_SOURCE_DIR}/linear/QPSParser.h"
-        "${CMAKE_CURRENT_SOURCE_DIR}/linear/QPSSolver.h"
+        "${CMAKE_CURRENT_SOURCE_DIR}/linear/QPSParserException.h"
         "${CMAKE_CURRENT_SOURCE_DIR}/discrete/Scheduler.h"
-        "${CMAKE_CURRENT_SOURCE_DIR}/parition/FindSeparator.h"
-        "${CMAKE_CURRENT_SOURCE_DIR}/parition/FindSeparator-inl.h"
+        "${CMAKE_CURRENT_SOURCE_DIR}/partition/FindSeparator.h"
+        "${CMAKE_CURRENT_SOURCE_DIR}/partition/FindSeparator-inl.h"
     )
 endif()
 

--- a/gtsam_unstable/linear/QPSParser.cpp
+++ b/gtsam_unstable/linear/QPSParser.cpp
@@ -17,6 +17,12 @@
 
 #define BOOST_SPIRIT_USE_PHOENIX_V3 1
 
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ == 13)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overread"
+#endif
+
+#include <Eigen/Dense>
 #include <gtsam/base/Matrix.h>
 #include <gtsam/inference/Key.h>
 #include <gtsam/inference/Symbol.h>
@@ -30,6 +36,11 @@
 #include <boost/phoenix/bind.hpp>
 #include <boost/spirit/include/classic.hpp>
 #include <boost/spirit/include/qi.hpp>
+
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ == 13)
+#pragma GCC diagnostic pop
+#endif
+
 
 #include <algorithm>
 #include <iostream>

--- a/gtsam_unstable/linear/tests/CMakeLists.txt
+++ b/gtsam_unstable/linear/tests/CMakeLists.txt
@@ -1,10 +1,1 @@
-# if GTSAM_USE_BOOST_FEATURES is OFF then exclude some tests
-if (NOT GTSAM_USE_BOOST_FEATURES)
-	# create a semicolon seperated list of files to exclude
-	set(EXCLUDE_TESTS "testQPSolver.cpp")
-	message(STATUS "Excluding ${EXCLUDE_TESTS}")
-else()
-	set(EXCLUDE_TESTS "${EXCLUDE_TESTS}")
-endif()
-
 gtsamAddTestsGlob(linear_unstable "test*.cpp" "${EXCLUDE_TESTS}" "gtsam_unstable")


### PR DESCRIPTION
Small PR with:
- Fix some fallout resulting from #2254 (I think)
- Fix cmake Boost exclude lists in unstable
- Run non-boost QP tests (that do not need a parser).