### PR TITLE
temporary remove eigen3 from vcpkg

### DIFF
--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -98,7 +98,6 @@ jobs:
           boost-system
           boost-thread
           boost-timer
-          eigen3
           tbb
           pybind11
 
@@ -153,7 +152,7 @@ jobs:
               -DGTSAM_BUILD_TESTS=ON \
               -DGTSAM_BUILD_UNSTABLE=ON \
               -DGTSAM_ALLOW_DEPRECATED_SINCE_V43=OFF \
-              -DGTSAM_USE_SYSTEM_EIGEN=ON \
+              -DGTSAM_USE_SYSTEM_EIGEN=OFF \
               -DGTSAM_USE_SYSTEM_METIS=OFF \
               -DGTSAM_USE_SYSTEM_PYBIND=ON \
               -DGTSAM_SUPPORT_NESTED_DISSECTION=ON \


### PR DESCRIPTION
temporary remove eigen3 from vcpkg.

There is a bug in vcpkg that someone update the eigen3 port incorrectly. This will effect all os in vcpkg.
The solution already in the latest master, but I am not advising to go there. 
For now I remove eigen3 port from installation, and when vcpkg will update in github action vm's we can bring it back.
should be around 2 weeks.

FYI @dellaert 