### PR TITLE
[Do not merge] Add static build in the ci with workarounds

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build:
-    name: ${{ matrix.name }} ${{ matrix.build_type }}
+    name: ${{ matrix.name }} ${{ matrix.build_type }} ${{ (matrix.is_shared == 'ON') && 'Shared' || 'Static' }}
     runs-on: ${{ matrix.os }}
 
     env:
@@ -27,7 +27,7 @@ jobs:
       BOOST_EXE: boost_1_72_0-msvc-14.2
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         # Github Actions requires a single row to be added to the build matrix.
         # See https://help.github.com/en/articles/workflow-syntax-for-github-actions.
@@ -39,6 +39,11 @@ jobs:
             Debug,
             Release
           ]
+
+        is_shared: [
+          ON,
+          OFF
+        ]
 
         build_unstable: [ON]
         include:
@@ -102,6 +107,7 @@ jobs:
           cmake -E remove_directory build
           if [ "${{ matrix.build_type }}" = "Release" ]; then
             cmake -B build \
+                  -DBUILD_SHARED_LIBS=${{ matrix.is_shared }} \
                   -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF \
                   -DGTSAM_ALLOW_DEPRECATED_SINCE_V43=OFF \
                   -DGTSAM_USE_BOOST_FEATURES=ON \
@@ -111,6 +117,7 @@ jobs:
                   -DBOOST_LIBRARYDIR="${BOOST_ROOT_UNIX}/lib"
           else
             cmake -B build \
+                  -DBUILD_SHARED_LIBS=${{ matrix.is_shared }} \
                   -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF \
                   -DGTSAM_ALLOW_DEPRECATED_SINCE_V43=OFF \
                   -DGTSAM_USE_BOOST_FEATURES=OFF \

--- a/gtsam/3rdparty/cephes/CMakeLists.txt
+++ b/gtsam/3rdparty/cephes/CMakeLists.txt
@@ -6,6 +6,8 @@ project(
   VERSION 1.0.0
   LANGUAGES C)
 
+configure_file("dllexport.h.in" "dllexport.h")
+
 set(CEPHES_HEADER_FILES
     cephes.h
     cephes/dd_idefs.h
@@ -17,7 +19,8 @@ set(CEPHES_HEADER_FILES
     cephes/mconf.h
     cephes/polevl.h
     cephes/sf_error.h
-    dllexport.h)
+    ${CMAKE_CURRENT_BINARY_DIR}/dllexport.h
+ )
 
 # Add header files
 install(FILES ${CEPHES_HEADER_FILES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gtsam/3rdparty/cephes)
@@ -94,7 +97,9 @@ add_library(cephes-gtsam ${GTSAM_LIBRARY_TYPE} ${CEPHES_SOURCES})
 # Add include directory (aka headers)
 target_include_directories(
   cephes-gtsam BEFORE PUBLIC $<INSTALL_INTERFACE:include/gtsam/3rdparty/cephes/>
-                             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+                             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+                             $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+)
 
 set_target_properties(
   cephes-gtsam

--- a/gtsam/3rdparty/cephes/cephes.h
+++ b/gtsam/3rdparty/cephes/cephes.h
@@ -21,7 +21,7 @@ CEPHES_EXTERN_EXPORT double lbeta(double a, double b);
 
 CEPHES_EXTERN_EXPORT double btdtr(double a, double b, double x);
 
-CEPHES_EXTERN_EXPORT double cbrt(double x);
+// CEPHES_EXTERN_EXPORT double cbrt(double x);
 CEPHES_EXTERN_EXPORT double chbevl(double x, double array[], int n);
 CEPHES_EXTERN_EXPORT double chdtrc(double df, double x);
 CEPHES_EXTERN_EXPORT double chdtr(double df, double x);
@@ -36,7 +36,7 @@ CEPHES_EXTERN_EXPORT int ellpj(double u, double m, double *sn, double *cn,
                                double *dn, double *ph);
 CEPHES_EXTERN_EXPORT double ellpk(double x);
 CEPHES_EXTERN_EXPORT double exp10(double x);
-CEPHES_EXTERN_EXPORT double exp2(double x);
+// CEPHES_EXTERN_EXPORT double exp2(double x);
 
 CEPHES_EXTERN_EXPORT double expn(int n, double x);
 
@@ -73,12 +73,12 @@ CEPHES_EXTERN_EXPORT double incbet(double aa, double bb, double xx);
 CEPHES_EXTERN_EXPORT double incbi(double aa, double bb, double yy0);
 
 CEPHES_EXTERN_EXPORT double iv(double v, double x);
-CEPHES_EXTERN_EXPORT double j0(double x);
-CEPHES_EXTERN_EXPORT double y0(double x);
-CEPHES_EXTERN_EXPORT double j1(double x);
-CEPHES_EXTERN_EXPORT double y1(double x);
+// CEPHES_EXTERN_EXPORT double j0(double x);
+// CEPHES_EXTERN_EXPORT double y0(double x);
+// CEPHES_EXTERN_EXPORT double j1(double x);
+// CEPHES_EXTERN_EXPORT double y1(double x);
 
-CEPHES_EXTERN_EXPORT double jn(int n, double x);
+// CEPHES_EXTERN_EXPORT double jn(int n, double x);
 CEPHES_EXTERN_EXPORT double jv(double n, double x);
 CEPHES_EXTERN_EXPORT double k0(double x);
 CEPHES_EXTERN_EXPORT double k0e(double x);
@@ -92,8 +92,8 @@ CEPHES_EXTERN_EXPORT double nbdtri(int k, int n, double p);
 
 CEPHES_EXTERN_EXPORT double ndtr(double a);
 CEPHES_EXTERN_EXPORT double log_ndtr(double a);
-CEPHES_EXTERN_EXPORT double erfc(double a);
-CEPHES_EXTERN_EXPORT double erf(double x);
+// CEPHES_EXTERN_EXPORT double erfc(double a);
+// CEPHES_EXTERN_EXPORT double erf(double x);
 CEPHES_EXTERN_EXPORT double erfinv(double y);
 CEPHES_EXTERN_EXPORT double erfcinv(double y);
 CEPHES_EXTERN_EXPORT double ndtri(double y0);
@@ -107,7 +107,7 @@ CEPHES_EXTERN_EXPORT double poch(double x, double m);
 CEPHES_EXTERN_EXPORT double psi(double x);
 
 CEPHES_EXTERN_EXPORT double rgamma(double x);
-CEPHES_EXTERN_EXPORT double round(double x);
+// CEPHES_EXTERN_EXPORT double round(double x);
 
 CEPHES_EXTERN_EXPORT int shichi(double x, double *si, double *ci);
 CEPHES_EXTERN_EXPORT int sici(double x, double *si, double *ci);
@@ -137,13 +137,13 @@ CEPHES_EXTERN_EXPORT double yv(double v, double x);
 CEPHES_EXTERN_EXPORT double tandg(double x);
 CEPHES_EXTERN_EXPORT double cotdg(double x);
 
-CEPHES_EXTERN_EXPORT double log1p(double x);
+// CEPHES_EXTERN_EXPORT double log1p(double x);
 CEPHES_EXTERN_EXPORT double log1pmx(double x);
-CEPHES_EXTERN_EXPORT double expm1(double x);
+// CEPHES_EXTERN_EXPORT double expm1(double x);
 CEPHES_EXTERN_EXPORT double cosm1(double x);
 CEPHES_EXTERN_EXPORT double lgam1p(double x);
 
-CEPHES_EXTERN_EXPORT double yn(int n, double x);
+// CEPHES_EXTERN_EXPORT double yn(int n, double x);
 CEPHES_EXTERN_EXPORT double zeta(double x, double q);
 CEPHES_EXTERN_EXPORT double zetac(double x);
 

--- a/gtsam/3rdparty/cephes/dllexport.h.in
+++ b/gtsam/3rdparty/cephes/dllexport.h.in
@@ -11,9 +11,16 @@
 
 #pragma once
 
+#cmakedefine01 GTSAM_SHARED_LIB
+
 #ifdef _WIN32
-#      define CEPHES_EXPORT __declspec(dllimport)
-#      define CEPHES_EXTERN_EXPORT __declspec(dllimport)
+#  if !GTSAM_SHARED_LIB
+#    define CEPHES_EXPORT
+#    define CEPHES_EXTERN_EXPORT extern
+#  else
+#    define CEPHES_EXPORT __declspec(dllimport)
+#    define CEPHES_EXTERN_EXPORT __declspec(dllimport)
+#  endif
 #else
 #ifdef __APPLE__
 #  define CEPHES_EXPORT __attribute__((visibility("default")))
@@ -23,3 +30,5 @@
 #  define CEPHES_EXTERN_EXPORT extern
 #endif
 #endif
+
+#undef GTSAM_SHARED_LIB

--- a/gtsam/geometry/SO3.cpp
+++ b/gtsam/geometry/SO3.cpp
@@ -386,21 +386,6 @@ Vector3 SO3::ChartAtOrigin::Local(const SO3& R, ChartJacobian H) {
 }
 
 //******************************************************************************
-template <>
-GTSAM_EXPORT
-Vector9 SO3::vec(OptionalJacobian<9, 3> H) const {
-  const Matrix3& R = matrix_;
-  if (H) {
-    H->setZero();
-    H->block<3, 1>(0, 1) = -R.col(2);
-    H->block<3, 1>(0, 2) = R.col(1);
-    H->block<3, 1>(3, 0) = R.col(2);
-    H->block<3, 1>(3, 2) = -R.col(0);
-    H->block<3, 1>(6, 0) = -R.col(1);
-    H->block<3, 1>(6, 1) = R.col(0);
-  }
-  return Eigen::Map<const Vector9>(R.data());
-}
 //******************************************************************************
 
 }  // end namespace gtsam

--- a/gtsam/geometry/SO3.h
+++ b/gtsam/geometry/SO3.h
@@ -99,6 +99,22 @@ template <>
 GTSAM_EXPORT
 Vector9 SO3::vec(OptionalJacobian<9, 3> H) const;
 
+template <>
+GTSAM_EXPORT
+inline Vector9 SO3::vec(OptionalJacobian<9, 3> H) const {
+  const Matrix3& R = matrix_;
+  if (H) {
+    H->setZero();
+    H->block<3, 1>(0, 1) = -R.col(2);
+    H->block<3, 1>(0, 2) = R.col(1);
+    H->block<3, 1>(3, 0) = R.col(2);
+    H->block<3, 1>(3, 2) = -R.col(0);
+    H->block<3, 1>(6, 0) = -R.col(1);
+    H->block<3, 1>(6, 1) = R.col(0);
+  }
+  return Eigen::Map<const Vector9>(R.data());
+}
+
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
 template <class Archive>
 /** Serialization function */

--- a/gtsam/geometry/SO4.cpp
+++ b/gtsam/geometry/SO4.cpp
@@ -135,27 +135,6 @@ SO4 SO4::Expmap(const Vector6& xi, ChartJacobian H) {
 }
 
 //******************************************************************************
-template <>
-GTSAM_EXPORT
-SO4::VectorN2 SO4::vec(OptionalJacobian<16, 6> H) const {
-  const Matrix& Q = matrix_;
-  if (H) {
-    H->setZero();
-    H->block<4, 1>(0, 2) = -Q.col(3);
-    H->block<4, 1>(0, 4) = -Q.col(2);
-    H->block<4, 1>(0, 5) = Q.col(1);
-    H->block<4, 1>(4, 1) = Q.col(3);
-    H->block<4, 1>(4, 3) = Q.col(2);
-    H->block<4, 1>(4, 5) = -Q.col(0);
-    H->block<4, 1>(8, 0) = -Q.col(3);
-    H->block<4, 1>(8, 3) = -Q.col(1);
-    H->block<4, 1>(8, 4) = Q.col(0);
-    H->block<4, 1>(12, 0) = Q.col(2);
-    H->block<4, 1>(12, 1) = -Q.col(1);
-    H->block<4, 1>(12, 2) = Q.col(0);
-  }
-  return Eigen::Map<const SO4::VectorN2>(Q.data());
-}
 
 ///******************************************************************************
 template <>

--- a/gtsam/geometry/SO4.h
+++ b/gtsam/geometry/SO4.h
@@ -76,7 +76,7 @@ GTSAM_EXPORT Matrix43 stiefel(const SO4 &Q, OptionalJacobian<12, 6> H = {});
 
 template <>
 GTSAM_EXPORT
-SO4::VectorN2 SO4::vec(OptionalJacobian<16, 6> H) const {
+inline SO4::VectorN2 SO4::vec(OptionalJacobian<16, 6> H) const {
   const Matrix& Q = matrix_;
   if (H) {
     H->setZero();

--- a/gtsam/geometry/SO4.h
+++ b/gtsam/geometry/SO4.h
@@ -74,6 +74,28 @@ GTSAM_EXPORT Matrix3 topLeft(const SO4 &Q, OptionalJacobian<9, 6> H = {});
  */
 GTSAM_EXPORT Matrix43 stiefel(const SO4 &Q, OptionalJacobian<12, 6> H = {});
 
+template <>
+GTSAM_EXPORT
+SO4::VectorN2 SO4::vec(OptionalJacobian<16, 6> H) const {
+  const Matrix& Q = matrix_;
+  if (H) {
+    H->setZero();
+    H->block<4, 1>(0, 2) = -Q.col(3);
+    H->block<4, 1>(0, 4) = -Q.col(2);
+    H->block<4, 1>(0, 5) = Q.col(1);
+    H->block<4, 1>(4, 1) = Q.col(3);
+    H->block<4, 1>(4, 3) = Q.col(2);
+    H->block<4, 1>(4, 5) = -Q.col(0);
+    H->block<4, 1>(8, 0) = -Q.col(3);
+    H->block<4, 1>(8, 3) = -Q.col(1);
+    H->block<4, 1>(8, 4) = Q.col(0);
+    H->block<4, 1>(12, 0) = Q.col(2);
+    H->block<4, 1>(12, 1) = -Q.col(1);
+    H->block<4, 1>(12, 2) = Q.col(0);
+  }
+  return Eigen::Map<const SO4::VectorN2>(Q.data());
+}
+
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
 template <class Archive>
 /** Serialization function */

--- a/gtsam/linear/NoiseModel.h
+++ b/gtsam/linear/NoiseModel.h
@@ -575,9 +575,6 @@ namespace gtsam {
        * An isotropic noise model created by specifying a precision
        */
       static shared_ptr Precision(size_t dim, double precision, bool smart = true)  {
-        if (0 == precision) {
-          return nullptr;
-        }
         return Variance(dim, 1.0/precision, smart);
       }
 

--- a/gtsam/linear/NoiseModel.h
+++ b/gtsam/linear/NoiseModel.h
@@ -575,6 +575,9 @@ namespace gtsam {
        * An isotropic noise model created by specifying a precision
        */
       static shared_ptr Precision(size_t dim, double precision, bool smart = true)  {
+        if (0 == precision) {
+          return nullptr;
+        }
         return Variance(dim, 1.0/precision, smart);
       }
 


### PR DESCRIPTION
Add static build in the ci with workarounds.
I take the workarounds of @Gold856 in this commit: https://github.com/Gold856/gtsam/commit/6c530ef558ec33dcbb3b65855612f156d60ddd56
and combine them with mine and create this PR.

I manage to compile static build without permissive flag that suggested in this PR: https://github.com/borglab/gtsam/pull/2268
On static release build, the build fail on divided by zero that detected in the compilation time.
I can change the code, but it change the behavior of the function. In the new behavior tests are failing. 
I can add a seperate PR for it, and we can discuss it there. 

This PR is not meant to merge, because it solve the compilation problem with workarounds. The PR highlight the problems and people can take this PR and solve them in the correct way.
Some of the changes are good in my perspective, and I can make a PR for those changes. For example: Add the ability to compile cephes in static build.