### PR TITLE
Use sccache to cache Windows release builds

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -6,6 +6,9 @@ on:
       - '**.md'
       - '**.ipynb' 
       - 'myst.yml'
+  push:
+    # Runs on pushes targeting the develop branch 
+    branches: [develop]
 
 # Cancels any in-progress workflow runs for the same PR when a new push is made,
 # allowing the runner to become available more quickly for the latest changes.
@@ -25,6 +28,7 @@ jobs:
       GTSAM_BUILD_UNSTABLE: ${{ matrix.build_unstable }}
       BOOST_VERSION: 1.72.0
       BOOST_EXE: boost_1_72_0-msvc-14.2
+      SCCACHE_GHA_ENABLED: ON
 
     strategy:
       fail-fast: true
@@ -93,6 +97,10 @@ jobs:
           # Set the BOOST_ROOT variable
           echo "BOOST_ROOT=$BOOST_PATH" >> $env:GITHUB_ENV
 
+      - name: Install sccache
+        if: matrix.build_type == 'Release'
+        uses: mozilla-actions/sccache-action@v0.0.9
+
       - name: Configuration
         shell: bash
         run: |
@@ -106,9 +114,12 @@ jobs:
                   -DGTSAM_ALLOW_DEPRECATED_SINCE_V43=OFF \
                   -DGTSAM_USE_BOOST_FEATURES=ON \
                   -DGTSAM_ENABLE_BOOST_SERIALIZATION=ON \
+                  -DGTSAM_BUILD_WITH_PRECOMPILED_HEADERS=OFF \
                   -DBOOST_ROOT="${BOOST_ROOT_UNIX}" \
                   -DBOOST_INCLUDEDIR="${BOOST_ROOT_UNIX}/include" \
-                  -DBOOST_LIBRARYDIR="${BOOST_ROOT_UNIX}/lib"
+                  -DBOOST_LIBRARYDIR="${BOOST_ROOT_UNIX}/lib" \
+                  -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+                  -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
           else
             cmake -B build \
                   -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF \

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,33 @@
+# Modified from https://github.com/actions/cache/blob/main/tips-and-workarounds.md#force-deletion-of-caches-overriding-default-cache-eviction-policy
+name: Clean up PR caches
+on:
+  pull_request_target:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      # `actions:write` permission is required to delete caches
+      #   See also: https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#delete-a-github-actions-cache-for-a-repository-using-a-cache-id
+      actions: write
+      contents: read
+    steps:
+      - name: Clean up caches
+        run: |
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          for i in {1..10}
+          do
+              cacheIdsForPR=$(gh cache list -R $REPO -r $BRANCH -L 500 --sort size_in_bytes | cut -f 1 )
+              for cacheId in $cacheIdsForPR
+              do
+                  gh cache delete $cacheId -R $REPO
+                  sleep 0.1
+              done
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -59,6 +59,18 @@ jobs:
           arch: x64
           toolset: 14.40
 
+      - name: Install sccache
+        if: runner.os == 'Windows'
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Use sccache
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=ON" >> "$GITHUB_ENV"
+          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> "$GITHUB_ENV"
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> "$GITHUB_ENV"
+
       - name: cl version
         if: runner.os == 'Windows'
         shell: cmd
@@ -149,6 +161,7 @@ jobs:
               -DVCPKG_HOST_TRIPLET=${{ matrix.triplet }} \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
               -DGTSAM_BUILD_EXAMPLES_ALWAYS=ON \
+              -DGTSAM_BUILD_WITH_PRECOMPILED_HEADERS=OFF \
               -DGTSAM_ROT3_EXPMAP=ON \
               -DGTSAM_POSE3_EXPMAP=ON \
               -DGTSAM_BUILD_PYTHON=ON \

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -45,6 +45,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Restore cache dependencies
+        id: cache-restore
         uses: actions/cache/restore@v3
         with:
           path: ${{ matrix.binary_cache }}
@@ -122,6 +123,8 @@ jobs:
           done
 
       - name: Save cache dependencies
+        # Don't save if it's the exact same
+        if: steps.cache-restore.outputs.cache-matched-key != format('{0}-{1}', matrix.os, hashFiles('vcpkg-info/*'))
         uses: actions/cache/save@v4
         with:
           path: ${{ matrix.binary_cache }}

--- a/cmake/GtsamAddPch.cmake
+++ b/cmake/GtsamAddPch.cmake
@@ -14,7 +14,7 @@
 macro(gtsamAddPch precompiledHeader precompiledSource sources)
     get_filename_component(pchBasename ${precompiledHeader} NAME_WE)
     SET(precompiledBinary "${CMAKE_CURRENT_BINARY_DIR}/${pchBasename}.pch")
-	IF(MSVC)
+	if(MSVC AND GTSAM_BUILD_WITH_PRECOMPILED_HEADERS)
 		message(STATUS "Adding precompiled header for MSVC")
 		set_source_files_properties(${precompiledSource}
 									PROPERTIES COMPILE_FLAGS "/Yc\"${precompiledHeader}\" /Fp\"${precompiledBinary}\""
@@ -22,6 +22,6 @@ macro(gtsamAddPch precompiledHeader precompiledSource sources)
 		set_source_files_properties(${sources}
 									PROPERTIES COMPILE_FLAGS "/Yu\"${precompiledHeader}\" /FI\"${precompiledHeader}\" /Fp\"${precompiledBinary}\""
 											   OBJECT_DEPENDS "${precompiledBinary}")  
-	ENDIF(MSVC)
+	endif()
 endmacro(gtsamAddPch)
 

--- a/cmake/HandleGeneralOptions.cmake
+++ b/cmake/HandleGeneralOptions.cmake
@@ -20,6 +20,10 @@ if (NOT MSVC)
     option(GTSAM_BUILD_WITH_MARCH_NATIVE  "Enable/Disable building with all instructions supported by native architecture (binary may not be portable!)" OFF)
 endif()
 
+if(MSVC)
+    option(GTSAM_BUILD_WITH_PRECOMPILED_HEADERS "Enable/Disable building with precompiled headers" ON)
+endif()
+
 # Configurable Options
 option(BUILD_SHARED_LIBS                     "Build shared libraries" ON)
 if(GTSAM_UNSTABLE_AVAILABLE)

--- a/cmake/HandlePrintConfiguration.cmake
+++ b/cmake/HandlePrintConfiguration.cmake
@@ -22,6 +22,10 @@ if(GTSAM_UNSTABLE_AVAILABLE)
     print_enabled_config(${GTSAM_UNSTABLE_INSTALL_MATLAB_TOOLBOX} "Build MATLAB Toolbox for unstable")
 endif()
 
+if(MSVC)
+    print_enabled_config(${GTSAM_BUILD_WITH_PRECOMPILED_HEADERS} "Build with precompiled headers")
+endif()
+
 if(NOT MSVC AND NOT XCODE_VERSION AND NOT QNX)
     print_enabled_config(${GTSAM_BUILD_WITH_MARCH_NATIVE}     "Build for native architecture  ")
     print_config("Build type" "${CMAKE_BUILD_TYPE}")


### PR DESCRIPTION
I heard you didn't have any DevOps people :) Ready to have your mind blown?

Windows CI:
https://github.com/borglab/gtsam/actions/runs/18232137161/job/51989459877
Uncached run takes ~1 hour, build takes ~50 minutes.

https://github.com/Gold856/gtsam/actions/runs/18301774268/job/52111040305
Completely cached run takes _10 minutes_, build takes _~3 minutes_. More time is spent installing dependencies than building code :)

Less fantastical is vcpkg:
https://github.com/borglab/gtsam/actions/runs/18228729434/job/51906606067
~1.5 hours to complete a Windows run, build takes 49 + 39 minutes.

https://github.com/Gold856/gtsam/actions/runs/18301774262/job/52111040326
Run takes ~22 minutes, build takes ~17 + ~2 minutes. Spent 14 minutes on building the Python modules (I believe these use LTO? I assume that's why it spends so long linking.)

And obviously, these are optimal runs, with 100% cache hit rates. Real usage will be much worse. For this project, I would expect build times should take 50% less time 99% of the time compared to before, given what's modified frequently. As long as you don't touch your base headers in base or geometry, I'd expect builds to take around 10-20 minutes, assuming a header in nonlinear, sfm, or slam was modified.

sccache uploaded ~680.8 MB in the GitHub Actions Cache. You should be able to comfortably have a dozen open PRs with no object files shared between them before you overflow your cache. If you want, we can probably cache one or two more builds and still have space left over for PRs (assuming complete cache misses.)

I also took the liberty to fix your vcpkg cache so a new one isn't saved if it's a 100% match. You're already using 9 GB and you not even using 95% of it! And I implemented a cache cleaner to clean up caches after PRs are closed to free up space for other PRs.
Resolves #2255.