### PR TITLE
Cast Eigen::Matrix dimension type to int

### DIFF
--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -2,7 +2,7 @@ name: vcpkg
 on:
   pull_request:
   push:
-    # Runs on pushes targeting the develop branch 
+    # Runs on pushes targeting the develop branch
     branches: [develop]
 
 # Cancels any in-progress workflow runs for the same PR when a new push is made,
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:      
+        include:
           - os: windows-latest
             triplet: x64-windows-release
             build_type: Release
@@ -145,6 +145,12 @@ jobs:
         run: |
           $VCPKG_INSTALLATION_ROOT/installed/${{ matrix.triplet }}/tools/python3/${{ matrix.python }} -m ensurepip --upgrade
           $VCPKG_INSTALLATION_ROOT/installed/${{ matrix.triplet }}/tools/python3/${{ matrix.python }} -m pip install -r python/dev_requirements.txt
+
+      - name: Set Swap Space (Linux)
+        if: runner.os == 'Linux'
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 6
 
       - name: cmake config
         if: success()

--- a/gtsam/base/ProductLieGroup.h
+++ b/gtsam/base/ProductLieGroup.h
@@ -67,12 +67,12 @@ public:
 
   /// @name Manifold
   /// @{
-  inline constexpr static auto dimension = dimension1 + dimension2;
+  inline constexpr static size_t dimension = dimension1 + dimension2;
   inline static size_t Dim() { return dimension; }
   inline size_t dim() const { return dimension; }
 
-  typedef Eigen::Matrix<double, dimension, 1> TangentVector;
-  typedef OptionalJacobian<dimension, dimension> ChartJacobian;
+  using TangentVector = Eigen::Matrix<double, static_cast<int>(dimension), 1>;
+  using ChartJacobian = OptionalJacobian<dimension, dimension>;
 
   ProductLieGroup retract(const TangentVector& v, //
       ChartJacobian H1 = {}, ChartJacobian H2 = {}) const {
@@ -95,9 +95,9 @@ public:
   /// @name Lie Group
   /// @{
 protected:
-  typedef Eigen::Matrix<double, dimension, dimension> Jacobian;
-  typedef Eigen::Matrix<double, dimension1, dimension1> Jacobian1;
-  typedef Eigen::Matrix<double, dimension2, dimension2> Jacobian2;
+  using Jacobian = Eigen::Matrix<double, static_cast<int>(dimension), static_cast<int>(dimension)>;
+  using Jacobian1 = Eigen::Matrix<double, static_cast<int>(dimension1), static_cast<int>(dimension1)>;
+  using Jacobian2 = Eigen::Matrix<double, static_cast<int>(dimension2), static_cast<int>(dimension2)>;
 
 public:
   ProductLieGroup compose(const ProductLieGroup& other, ChartJacobian H1,


### PR DESCRIPTION
When compiling GTSAM with clang (particularly for GPMP2) and `-Wc++11-narrowing` enabled (which clang is more strict about), I am getting the error
```
/opt/homebrew/lib/cmake/GTSAM/../../../include/gtsam/base/ProductLieGroup.h:100:33: error: non-type template argument evaluates to 18446744073709551615, which cannot be narrowed to type 'int' [-Wc++11-narrowing]
  typedef Eigen::Matrix<double, dimension2, dimension2> Jacobian2;
                                ^
```
since `dimension2` is of type `size_t` and the template type for `Eigen::Matrix` is `int`.

ChatGPT confirmed this is a signed vs unsigned int issue and I applied a `static_cast` as it recommended.

Also replaced `typedef` with `using` for Jacobian type aliases.