### PR TITLE
Add back eigen3 to vcpkg

### DIFF
--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -108,6 +108,7 @@ jobs:
           boost-system
           boost-thread
           boost-timer
+          eigen3
           tbb
           pybind11
           geographiclib
@@ -172,7 +173,7 @@ jobs:
               -DGTSAM_BUILD_TESTS=ON \
               -DGTSAM_BUILD_UNSTABLE=ON \
               -DGTSAM_ALLOW_DEPRECATED_SINCE_V43=OFF \
-              -DGTSAM_USE_SYSTEM_EIGEN=OFF \
+              -DGTSAM_USE_SYSTEM_EIGEN=ON \
               -DGTSAM_USE_SYSTEM_METIS=OFF \
               -DGTSAM_USE_SYSTEM_PYBIND=ON \
               -DGTSAM_ENABLE_GEOGRAPHICLIB=ON \


### PR DESCRIPTION
There was a bug in vcpkg when installing eigen3.
We remove it temporary and now:
Add back eigen3 to vcpkg
Revert "remove eigen3"
This reverts commit 0c00fc030b6a8a55246e845d73808d2983d6dbdc.

Revert this PR:
https://github.com/borglab/gtsam/pull/2267