### PR TITLE
Remove temporary eigen3

### DIFF
--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -108,7 +108,6 @@ jobs:
           boost-system
           boost-thread
           boost-timer
-          eigen3
           tbb
           pybind11
           geographiclib
@@ -173,7 +172,7 @@ jobs:
               -DGTSAM_BUILD_TESTS=ON \
               -DGTSAM_BUILD_UNSTABLE=ON \
               -DGTSAM_ALLOW_DEPRECATED_SINCE_V43=OFF \
-              -DGTSAM_USE_SYSTEM_EIGEN=ON \
+              -DGTSAM_USE_SYSTEM_EIGEN=OFF \
               -DGTSAM_USE_SYSTEM_METIS=OFF \
               -DGTSAM_USE_SYSTEM_PYBIND=ON \
               -DGTSAM_ENABLE_GEOGRAPHICLIB=ON \


### PR DESCRIPTION
Remove temporary eigen3

The version of vcpkg on vm in github action get revert to older version with the bug of eigen3. Remove it temporarily until they updated again. 

Note, they revert the version of vcpkg only on linux vm. Not sure why.