### PR TITLE
Remove-macos-13-ci

### DIFF
--- a/.github/workflows/build-cibw.yml
+++ b/.github/workflows/build-cibw.yml
@@ -76,37 +76,37 @@ jobs:
             manylinux_image: manylinux2014
 
           # MacOS x86_64
-          - os: macos-13
+          - os: macos-15-intel
             python_version: "3.10"
             cibw_python_version: 310
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-15-intel
             python_version: "3.11"
             cibw_python_version: 311
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-15-intel
             python_version: "3.12"
             cibw_python_version: 312
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-15-intel
             python_version: "3.13"
             cibw_python_version: 313
             platform_id: macosx_x86_64
 
           # MacOS arm64
-          - os: macos-14
+          - os: macos-latest
             python_version: "3.10"
             cibw_python_version: 310
             platform_id: macosx_arm64
-          - os: macos-14
+          - os: macos-latest
             python_version: "3.11"
             cibw_python_version: 311
             platform_id: macosx_arm64
-          - os: macos-14
+          - os: macos-latest
             python_version: "3.12"
             cibw_python_version: 312
             platform_id: macosx_arm64
-          - os: macos-14
+          - os: macos-latest
             python_version: "3.13"
             cibw_python_version: 313
             platform_id: macosx_arm64

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -31,6 +31,7 @@ jobs:
         # See https://help.github.com/en/articles/workflow-syntax-for-github-actions.
         name: [
           macos-14-xcode-15.4,
+          macos-15-xcode-16,
           macos-14-xcode-15.4-boost,
           macos-14-xcode-15.4-geographiclib,
         ]
@@ -42,6 +43,11 @@ jobs:
             os: macos-14
             compiler: xcode
             version: "15.4"
+
+          - name: macos-15-xcode-16
+            os: macos-15
+            compiler: xcode
+            version: "16"
 
           - name: macos-14-xcode-15.4-boost
             os: macos-14

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -30,7 +30,6 @@ jobs:
         # Github Actions requires a single row to be added to the build matrix.
         # See https://help.github.com/en/articles/workflow-syntax-for-github-actions.
         name: [
-          macos-13-xcode-14.2,
           macos-14-xcode-15.4,
           macos-14-xcode-15.4-boost,
           macos-14-xcode-15.4-geographiclib,
@@ -39,11 +38,6 @@ jobs:
         build_type: [Debug, Release]
         build_unstable: [ON]
         include:
-          - name: macos-13-xcode-14.2
-            os: macos-13
-            compiler: xcode
-            version: "14.2"
-
           - name: macos-14-xcode-15.4
             os: macos-14
             compiler: xcode

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -69,7 +69,6 @@ jobs:
           [
             ubuntu-22.04-gcc-9,
             ubuntu-22.04-clang-11,
-            macos-13-xcode-14.2,
             macos-14-xcode-15.4,
             windows-2022-msbuild,
           ]
@@ -86,11 +85,6 @@ jobs:
             os: ubuntu-22.04
             compiler: clang
             version: "11"
-
-          - name: macos-13-xcode-14.2
-            os: macos-13
-            compiler: xcode
-            version: "14.2"
 
           - name: macos-14-xcode-15.4
             os: macos-14

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -70,6 +70,7 @@ jobs:
             ubuntu-22.04-gcc-9,
             ubuntu-22.04-clang-11,
             macos-14-xcode-15.4,
+            macos-15-xcode-16,
             windows-2022-msbuild,
           ]
 
@@ -90,6 +91,11 @@ jobs:
             os: macos-14
             compiler: xcode
             version: "15.4"
+
+          - name: macos-15-xcode-16
+            os: macos-15
+            compiler: xcode
+            version: "16"
 
           - name: windows-2022-msbuild
             os: windows-2022

--- a/.github/workflows/prod-cibw.yml
+++ b/.github/workflows/prod-cibw.yml
@@ -61,37 +61,37 @@ jobs:
             manylinux_image: manylinux2014
 
           # MacOS x86_64
-          - os: macos-13
+          - os: macos-15-intel
             python_version: "3.10"
             cibw_python_version: 310
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-15-intel
             python_version: "3.11"
             cibw_python_version: 311
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-15-intel
             python_version: "3.12"
             cibw_python_version: 312
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-15-intel
             python_version: "3.13"
             cibw_python_version: 313
             platform_id: macosx_x86_64
 
           # MacOS arm64
-          - os: macos-14
+          - os: macos-latest
             python_version: "3.10"
             cibw_python_version: 310
             platform_id: macosx_arm64
-          - os: macos-14
+          - os: macos-latest
             python_version: "3.11"
             cibw_python_version: 311
             platform_id: macosx_arm64
-          - os: macos-14
+          - os: macos-latest
             python_version: "3.12"
             cibw_python_version: 312
             platform_id: macosx_arm64
-          - os: macos-14
+          - os: macos-latest
             python_version: "3.13"
             cibw_python_version: 313
             platform_id: macosx_arm64


### PR DESCRIPTION
Remove macOS 13 from CI workflows and update macOS runners
- Add macos-15-xcode-16 to build-python.yml matrix
- Add macos-15-xcode-16 to build-macos.yml matrix

Update cibuildwheel workflows:
  - Use macos-15-intel for x86_64 builds (replacing macos-13)
  - Use macos-latest for ARM64 builds (replacing macos-14)
