### PR TITLE
Various filter changes

### DIFF
--- a/examples/GEKF_Rot3Example.cpp
+++ b/examples/GEKF_Rot3Example.cpp
@@ -57,7 +57,8 @@ int main() {
 
   // Timestep, process noise, measurement noise
   double dt = 0.1;
-  Matrix3 Q = Matrix3::Identity() * 0.01;
+  // Continuous-time process noise (scaled by dt inside predict).
+  Matrix3 Qc = Matrix3::Identity() * 0.1;
   Matrix3 Rm = Matrix3::Identity() * 0.05;
 
   cout << "=== Init ===\nR:\n"
@@ -65,7 +66,7 @@ int main() {
        << ekf.covariance() << "\n\n";
 
   // Predict using state‐dependent f
-  ekf.predict(dynamicsSO3, dt, Q);
+  ekf.predict(dynamicsSO3, dt, Qc);
   cout << "--- After predict ---\nR:\n" << ekf.state().matrix() << "\n\n";
 
   // Magnetometer measurement = body‐frame reading of m_world

--- a/examples/IEKF_NavstateExample.cpp
+++ b/examples/IEKF_NavstateExample.cpp
@@ -58,7 +58,8 @@ int main() {
 
   // Noise & timestep
   double dt = 1.0;
-  Matrix9 Q = Matrix9::Identity() * 0.01;
+  // Continuous-time process noise (scaled by dt inside predict)
+  Matrix9 Qc = Matrix9::Identity() * 0.01;
   Matrix3 R = Matrix3::Identity() * 0.5;
 
   // Two IMU samples [a; ω]
@@ -77,7 +78,7 @@ int main() {
     << "\n\n";
 
   // --- first predict/update ---
-  ekf.predict(dynamics(imu1), dt, Q);
+  ekf.predict(dynamics(imu1), dt, Qc);
   cout << "--- After predict 1 ---\nX: " << ekf.state()
     << "\nP: " << ekf.covariance() << "\n\n";
   ekf.update(h_gps, z1, R);
@@ -85,7 +86,7 @@ int main() {
     << "\nP: " << ekf.covariance() << "\n\n";
 
   // --- second predict/update ---
-  ekf.predict(dynamics(imu2), dt, Q);
+  ekf.predict(dynamics(imu2), dt, Qc);
   cout << "--- After predict 2 ---\nX: " << ekf.state()
     << "\nP: " << ekf.covariance() << "\n\n";
   ekf.update(h_gps, z2, R);

--- a/gtsam/geometry/Rot2.cpp
+++ b/gtsam/geometry/Rot2.cpp
@@ -81,6 +81,23 @@ Vector1 Rot2::Logmap(const Rot2& r, OptionalJacobian<1, 1> H) {
   v << r.theta();
   return v;
 }
+
+/* ************************************************************************* */
+Matrix1 Rot2::adjointMap(const Vector1&) {
+  Matrix1 ad;
+  ad << 0.0;
+  return ad;
+}
+
+/* ************************************************************************* */
+Vector1 Rot2::adjoint(const Vector1&, const Vector1&,
+                      OptionalJacobian<1, 1> Hxi,
+                      OptionalJacobian<1, 1> Hy) {
+  if (Hxi) *Hxi = Matrix1::Zero();
+  if (Hy) *Hy = Matrix1::Zero();
+  return Vector1::Zero();
+}
+
 /* ************************************************************************* */
 Matrix2 Rot2::Hat(const Vector1& xi) {
   Matrix2 X;

--- a/gtsam/geometry/Rot2.h
+++ b/gtsam/geometry/Rot2.h
@@ -135,6 +135,14 @@ namespace gtsam {
     /** Calculate Adjoint map */
     Matrix1 AdjointMap() const { return I_1x1; }
 
+    /// Lie-algebra adjoint (zero for abelian SO(2)).
+    static Matrix1 adjointMap(const Vector1&);
+
+    /// Apply Lie-algebra adjoint (always zero).
+    static Vector1 adjoint(const Vector1&, const Vector1&,
+                           OptionalJacobian<1, 1> Hxi = {},
+                           OptionalJacobian<1, 1> Hy = {});
+
     /// Left-trivialized derivative of the exponential map
     static Matrix ExpmapDerivative(const Vector& /*v*/) {
       return I_1x1;

--- a/gtsam/geometry/Rot3.cpp
+++ b/gtsam/geometry/Rot3.cpp
@@ -246,6 +246,19 @@ Matrix3 Rot3::LogmapDerivative(const Vector3& x)    {
 }
 
 /* ************************************************************************* */
+Matrix3 Rot3::adjointMap(const Vector3& xi) { return Hat(xi); }
+
+/* ************************************************************************* */
+Vector3 Rot3::adjoint(const Vector3& xi, const Vector3& y,
+                      OptionalJacobian<3, 3> Hxi,
+                      OptionalJacobian<3, 3> Hy) {
+  const Matrix3 ad_xi = adjointMap(xi);
+  if (Hxi) *Hxi = -Hat(y);
+  if (Hy) *Hy = ad_xi;
+  return ad_xi * y;
+}
+
+/* ************************************************************************* */
 pair<Matrix3, Vector3> RQ(const Matrix3& A, OptionalJacobian<3, 9> H) {
   const double x = -atan2(-A(2, 1), A(2, 2));
   const auto Qx = Rot3::Rx(-x).matrix();
@@ -319,4 +332,3 @@ Rot3 Rot3::slerp(double t, const Rot3& other) const {
 /* ************************************************************************* */
 
 } // namespace gtsam
-

--- a/gtsam/geometry/Rot3.h
+++ b/gtsam/geometry/Rot3.h
@@ -396,6 +396,14 @@ class GTSAM_EXPORT Rot3 : public LieGroup<Rot3, 3> {
     /** Calculate Adjoint map */
     Matrix3 AdjointMap() const { return matrix(); }
 
+    /// Matrix representation of the Lie-algebra adjoint operator ad_xi on so(3).
+    static Matrix3 adjointMap(const Vector3& xi);
+
+    /// Apply the Lie-algebra adjoint map to y with optional derivatives.
+    static Vector3 adjoint(const Vector3& xi, const Vector3& y,
+                           OptionalJacobian<3, 3> Hxi = {},
+                           OptionalJacobian<3, 3> Hy = {});
+
     // Chart at origin, depends on compile-time flag ROT3_DEFAULT_COORDINATES_MODE
     struct GTSAM_EXPORT ChartAtOrigin {
       static Rot3 Retract(const Vector3& v, ChartJacobian H = {});
@@ -599,4 +607,3 @@ template <>
 struct traits<const Rot3> : public internal::MatrixLieGroup<Rot3, 3> {};
   
 }  // namespace gtsam
-

--- a/gtsam/navigation/InvariantEKF.h
+++ b/gtsam/navigation/InvariantEKF.h
@@ -43,6 +43,11 @@ namespace gtsam {
  * 2. Prediction via tangent control vector: `predict(const TangentVector& u,
  * double dt, const Covariance& Q)`
  *
+ *
+ * Noise convention mirrors LieGroupEKF:
+ * - `predict(U, Q)` expects `Q` to be a discrete covariance.
+ * - `predict(u, dt, Q)` interprets `Q` as continuous-time and scales by `dt`.
+ *
  * The state-dependent prediction methods from LeftLinearEKF are hidden.
  * The update step remains the same as in ManifoldEKF/LeftLinearEKF.
  * For details on how static and dynamic dimensions are handled, please refer to
@@ -107,7 +112,7 @@ class InvariantEKF : public LeftLinearEKF<G> {
    *
    * @param u Tangent space control vector.
    * @param dt Time interval.
-   * @param Q Process noise covariance matrix.
+   * @param Q Continuous-time process noise covariance matrix (scaled by dt).
    */
   void predict(const TangentVector& u, double dt, const Covariance& Q) {
     G U;
@@ -119,7 +124,7 @@ class InvariantEKF : public LeftLinearEKF<G> {
     } else {
       U = traits<G>::Expmap(u * dt);
     }
-    predict(U, Q);  // Call the group composition predict
+    predict(U, Q * dt);  // Q interpreted as continuous-time; discretize with dt
   }
 
   /**

--- a/gtsam/navigation/LieGroupEKF.h
+++ b/gtsam/navigation/LieGroupEKF.h
@@ -63,7 +63,6 @@ class LieGroupEKF : public ManifoldEKF<G> {
   using Jacobian = typename Base::Jacobian;            ///< Dim x Dim
   using Covariance = typename Base::Covariance;        ///< Dim x Dim
   using TangentVector = typename Base::TangentVector;  ///< Tangent vector type.
-  using OptionalJacobian = OptionalJacobian<Dim, Dim>;  ///< Optional Jacobian.
 
  private:
   /**
@@ -74,15 +73,16 @@ class LieGroupEKF : public ManifoldEKF<G> {
   using enable_if_dynamics =
       std::enable_if_t<!std::is_convertible_v<Dynamics, TangentVector> &&
                        std::is_invocable_r_v<TangentVector, Dynamics, const G&,
-                                             OptionalJacobian&>>;
+                                             OptionalJacobian<Dim, Dim>&>>;
 
   /**
    * SFINAE check for state- and control-dependent dynamics function.
    * TangentVector f(const G& X, const Control& u, OptionalJacobian Df)
    */
   template <typename Control, typename Dynamics>
-  using enable_if_full_dynamics = std::enable_if_t<std::is_invocable_r_v<
-      TangentVector, Dynamics, const G&, const Control&, OptionalJacobian&>>;
+  using enable_if_full_dynamics = std::enable_if_t<
+      std::is_invocable_r_v<TangentVector, Dynamics, const G&, const Control&,
+                            OptionalJacobian<Dim, Dim>&>>;
 
   template <typename T, typename = void>
   struct has_adjoint_map : std::false_type {};
@@ -181,7 +181,8 @@ class LieGroupEKF : public ManifoldEKF<G> {
    */
   template <size_t K = 1, typename Dynamics,
             typename = enable_if_dynamics<Dynamics>>
-  G predictMean(Dynamics&& f, double dt, OptionalJacobian Phi = {}) const {
+  G predictMean(Dynamics&& f, double dt,
+                OptionalJacobian<Dim, Dim> Phi = {}) const {
     Jacobian Df, Dexp;
 
     if constexpr (std::is_same_v<G, Matrix>) {
@@ -240,9 +241,10 @@ class LieGroupEKF : public ManifoldEKF<G> {
   template <size_t K = 1, typename Control, typename Dynamics,
             typename = enable_if_full_dynamics<Control, Dynamics>>
   G predictMean(Dynamics&& f, const Control& u, double dt,
-                OptionalJacobian Phi = {}) const {
+                OptionalJacobian<Dim, Dim> Phi = {}) const {
     return predictMean<K>(
-        [&](const G& X, OptionalJacobian Df) { return f(X, u, Df); }, dt, Phi);
+        [&](const G& X, OptionalJacobian<Dim, Dim> Df) { return f(X, u, Df); },
+        dt, Phi);
   }
 
   /**
@@ -264,7 +266,8 @@ class LieGroupEKF : public ManifoldEKF<G> {
             typename = enable_if_full_dynamics<Control, Dynamics>>
   void predict(Dynamics&& f, const Control& u, double dt, const Covariance& Q) {
     return predict<K>(
-        [&](const G& X, OptionalJacobian Df) { return f(X, u, Df); }, dt, Q);
+        [&](const G& X, OptionalJacobian<Dim, Dim> Df) { return f(X, u, Df); },
+        dt, Q);
   }
 
   /**

--- a/gtsam/navigation/LieGroupEKF.h
+++ b/gtsam/navigation/LieGroupEKF.h
@@ -125,7 +125,29 @@ class LieGroupEKF : public ManifoldEKF<G> {
         // First-order Lie group transition matrix
         return traits<G>::Inverse(U).AdjointMap() + Dexp * Df * dt;
       } else {
-        // Higher-order Lie group transition matrix via matrix exponential
+        // Higher-order Lie group transition matrix via matrix exponential.
+        //
+        // GTSAM's LieGroupEKF uses a left-invariant error, i.e. we write the
+        // true state as
+        //
+        //     X_true ≈ X_hat * Exp(η),
+        //
+        // and η lives in the tangent space at the identity. Even if the
+        // *global* perturbation is constant, composing the nominal motion X_hat
+        // with Exp(ξ dt) on the right will "drag" η along the group because G
+        // is non-commutative. The Baker–Campbell–Hausdorff expansion shows that
+        // the linearized error dynamics contain an extra term -ad_ξ η coming
+        // from this non-commutativity, where ad_ξ(·) = [ξ, ·] is the Lie
+        // bracket. With this convention, and a dynamics linearization Df =
+        // ∂ξ/∂(local X), the continuous-time error satisfies approximately
+        //
+        //     dη/dt ≈ (Df - ad_ξ) η,
+        //
+        // and the corresponding discrete-time transition matrix is
+        //
+        //     Φ ≈ expm((Df - ad_ξ) dt).
+        //
+        // This is exactly what we implement below.
         static_assert(
             has_adjoint_map<G>::value,
             "transitionMatrix<K> requires G::adjointMap(xi) when K > 1.");

--- a/gtsam/navigation/LieGroupEKF.h
+++ b/gtsam/navigation/LieGroupEKF.h
@@ -46,6 +46,12 @@ namespace gtsam {
  * Use the InvariantEKF class for prediction via group composition.
  * For details on how static and dynamic dimensions are handled, please refer to
  * the `ManifoldEKF` class documentation.
+ *
+ * Noise convention:
+ * - Overloads **without** `dt` (e.g., `predict(X_next, F, Q)` inherited from
+ *   ManifoldEKF) expect `Q` to be a *discrete* covariance already scaled for
+ *   the step being applied.
+ * - Overloads **with** `dt` interpret `Q` as a *continuous-time* covariance.
  */
 template <typename G>
 class LieGroupEKF : public ManifoldEKF<G> {
@@ -201,7 +207,7 @@ class LieGroupEKF : public ManifoldEKF<G> {
    * OptionalJacobian<Dim,Dim>&)
    * @param f Dynamics functor.
    * @param dt Time step.
-   * @param Q Process noise covariance.
+   * @param Q Continuous-time process noise covariance (will be scaled by dt).
    */
   template <size_t K = 1, typename Dynamics,
             typename = enable_if_dynamics<Dynamics>>
@@ -211,7 +217,8 @@ class LieGroupEKF : public ManifoldEKF<G> {
       Phi.resize(this->n_, this->n_);
     }
     G X_next = predictMean<K>(std::forward<Dynamics>(f), dt, Phi);
-    predict(X_next, Phi, Q);
+    predict(X_next, Phi,
+            Q * dt);  // Q interpreted as continuous-time; discretize with dt
   }
 
   /**
@@ -251,7 +258,7 @@ class LieGroupEKF : public ManifoldEKF<G> {
    * @param f Dynamics functor.
    * @param u Control input.
    * @param dt Time step.
-   * @param Q Process noise covariance.
+   * @param Q Continuous-time process noise covariance (will be scaled by dt).
    */
   template <size_t K = 1, typename Control, typename Dynamics,
             typename = enable_if_full_dynamics<Control, Dynamics>>

--- a/gtsam/navigation/LieGroupEKF.h
+++ b/gtsam/navigation/LieGroupEKF.h
@@ -103,7 +103,7 @@ class LieGroupEKF : public ManifoldEKF<G> {
   using Base::predict;
 
   /**
-   * Compute the discrete-time transition Jacobian Φ corresponding to a
+   * Compute the discrete-time transition matrix Φ corresponding to a
    * continuous-time linearization (Df) over time dt.
    *
    * @param xi Tangent increment (used only for Lie groups).
@@ -118,22 +118,20 @@ class LieGroupEKF : public ManifoldEKF<G> {
     if constexpr (std::is_same_v<G, Matrix>) {
       (void)xi;
       (void)U;
-      const Matrix I_n = Matrix::Identity(this->n_, this->n_);
-      if constexpr (K == 1) {
-        return I_n + Dexp * Df * dt;
-      } else {
-        return expm(Df * dt, K);
-      }
+      (void)Dexp;
+      return expm(Df * dt, K);
     } else {
       if constexpr (K == 1) {
+        // First-order Lie group transition matrix
         return traits<G>::Inverse(U).AdjointMap() + Dexp * Df * dt;
       } else {
+        // Higher-order Lie group transition matrix via matrix exponential
         static_assert(
             has_adjoint_map<G>::value,
             "transitionMatrix<K> requires G::adjointMap(xi) when K > 1.");
         Jacobian ad_xi = G::adjointMap(xi);
-        const Matrix generator = (Df - ad_xi) * dt;
-        return expm(generator, K);
+        const Matrix A = Df - ad_xi;
+        return expm(A * dt, K);
       }
     }
   }
@@ -160,10 +158,8 @@ class LieGroupEKF : public ManifoldEKF<G> {
 
     if constexpr (std::is_same_v<G, Matrix>) {
       TangentVector xi = f(this->X_, Phi ? &Df : nullptr);
-      const Matrix nextX =
-          traits<Matrix>::Retract(this->X_, xi * dt, Phi ? &Dexp : nullptr);
-      if (Phi) *Phi = transitionMatrix<K>(xi, Df, dt, nextX, Dexp);
-      return nextX;
+      if (Phi) *Phi = expm(Df * dt, K);
+      return traits<G>::Retract(this->X_, xi * dt);
     } else {
       TangentVector xi = f(this->X_, Phi ? &Df : nullptr);
       G U = traits<G>::Expmap(xi * dt, Phi ? &Dexp : nullptr);

--- a/gtsam/navigation/LieGroupEKF.h
+++ b/gtsam/navigation/LieGroupEKF.h
@@ -119,7 +119,7 @@ class LieGroupEKF : public ManifoldEKF<G> {
         // State transition Jacobian for left-invariant EKF:
         *A = traits<G>::Inverse(U).AdjointMap() + Dexp * Df * dt;
       }
-      return this->X_.compose(U);
+      return traits<G>::Compose(this->X_, U);
     }
   }
 

--- a/gtsam/navigation/LieGroupEKF.h
+++ b/gtsam/navigation/LieGroupEKF.h
@@ -26,12 +26,12 @@
 #pragma once
 
 #include <gtsam/base/Lie.h>  // Include for Lie group traits and operations
-#include <gtsam/base/VectorSpace.h>        // Matrix traits
 #include <gtsam/navigation/ManifoldEKF.h>  // Include the base class
 
 #include <Eigen/Dense>
 #include <functional>  // For std::function
 #include <type_traits>
+#include <utility>
 
 namespace gtsam {
 
@@ -50,15 +50,44 @@ namespace gtsam {
 template <typename G>
 class LieGroupEKF : public ManifoldEKF<G> {
  public:
+  using This = LieGroupEKF<G>;
   using Base = ManifoldEKF<G>;           ///< Base class type
   static constexpr int Dim = Base::Dim;  ///< Compile-time dimension of G.
-  using TangentVector =
-      typename Base::TangentVector;  ///< Tangent vector type for G.
-  /// Jacobian for group operations (Adjoint, Expmap derivatives, F).
-  using Jacobian = typename Base::Jacobian;  // Eigen::Matrix<double, Dim, Dim>
-  using Covariance =
-      typename Base::Covariance;  // Eigen::Matrix<double, Dim, Dim>
 
+  using Jacobian = typename Base::Jacobian;            ///< Dim x Dim
+  using Covariance = typename Base::Covariance;        ///< Dim x Dim
+  using TangentVector = typename Base::TangentVector;  ///< Tangent vector type.
+  using OptionalJacobian = OptionalJacobian<Dim, Dim>;  ///< Optional Jacobian.
+
+ private:
+  /**
+   * SFINAE check for correctly typed state-dependent dynamics function.
+   * TangentVector f(const G& X, OptionalJacobian Df)
+   */
+  template <typename Dynamics>
+  using enable_if_dynamics =
+      std::enable_if_t<!std::is_convertible_v<Dynamics, TangentVector> &&
+                       std::is_invocable_r_v<TangentVector, Dynamics, const G&,
+                                             OptionalJacobian&>>;
+
+  /**
+   * SFINAE check for state- and control-dependent dynamics function.
+   * TangentVector f(const G& X, const Control& u, OptionalJacobian Df)
+   */
+  template <typename Control, typename Dynamics>
+  using enable_if_full_dynamics = std::enable_if_t<std::is_invocable_r_v<
+      TangentVector, Dynamics, const G&, const Control&, OptionalJacobian&>>;
+
+  template <typename T, typename = void>
+  struct has_adjoint_map : std::false_type {};
+
+  template <typename T>
+  struct has_adjoint_map<
+      T, std::void_t<decltype(T::adjointMap(
+             std::declval<typename traits<T>::TangentVector>()))>>
+      : std::true_type {};
+
+ public:
   /**
    * Constructor: initialize with state and covariance.
    * @param X0 Initial state on Lie group G.
@@ -69,101 +98,110 @@ class LieGroupEKF : public ManifoldEKF<G> {
                   "Template parameter G must be a GTSAM Lie Group");
   }
 
-    /// Expose base class predict method,
-    /// predict(const M& X_next, const Jacobian& F, const Covariance& Q)
-    using Base::predict;
+  /// Expose base class predict method,
+  /// predict(const M& X_next, const Jacobian& F, const Covariance& Q)
+  using Base::predict;
 
   /**
-   * SFINAE check for correctly typed state-dependent dynamics function.
-   * Signature: TangentVector f(const G& X, OptionalJacobian<Dim, Dim> Df)
-   * Df = d(xi)/d(local(X))
-   */
-  template <typename Dynamics>
-  using enable_if_dynamics =
-      std::enable_if_t<!std::is_convertible_v<Dynamics, TangentVector> &&
-                       std::is_invocable_r_v<TangentVector, Dynamics, const G&,
-                                             OptionalJacobian<Dim, Dim>&>>;
-
-  /**
-   * Predict mean and Jacobian A with state-dependent dynamics:
-   *   xi = f(X_k, Df)           (Compute tangent vector dynamics and Jacobian
-   * Df) U = Expmap(xi * dt, Dexp) (Compute motion increment U and Expmap
-   * Jacobian Dexp) X_{k+1} = X_k * U         (Predict next state) A =
-   * Ad_{U^{-1}} + Dexp * Df * dt (Compute full state transition Jacobian)
+   * Compute the discrete-time transition Jacobian Φ corresponding to a
+   * continuous-time linearization (Df) over time dt.
    *
-   * @tparam Dynamics Functor signature: TangentVector f(const G&,
-   * OptionalJacobian<Dim,Dim>&)
-   * @param f Dynamics functor returning tangent vector xi and its Jacobian Df
-   * w.r.t. local(X).
+   * @param xi Tangent increment (used only for Lie groups).
+   * @param Df Jacobian of dynamics w.r.t. local coordinates.
    * @param dt Time step.
-   * @param A OptionalJacobian to store the computed state transition Jacobian
-   * A.
+   * @param U Increment Expmap(xi * dt) (ignored for Matrix case).
+   * @param Dexp Jacobian returned by Expmap (ignored for Matrix case).
+   */
+  template <size_t K = 1>
+  Jacobian transitionMatrix(const TangentVector& xi, const Jacobian& Df,
+                            double dt, const G& U, const Jacobian& Dexp) const {
+    if constexpr (std::is_same_v<G, Matrix>) {
+      (void)xi;
+      (void)U;
+      const Matrix I_n = Matrix::Identity(this->n_, this->n_);
+      if constexpr (K == 1) {
+        return I_n + Dexp * Df * dt;
+      } else {
+        return expm(Df * dt, K);
+      }
+    } else {
+      if constexpr (K == 1) {
+        return traits<G>::Inverse(U).AdjointMap() + Dexp * Df * dt;
+      } else {
+        static_assert(
+            has_adjoint_map<G>::value,
+            "transitionMatrix<K> requires G::adjointMap(xi) when K > 1.");
+        Jacobian ad_xi = G::adjointMap(xi);
+        const Matrix generator = (Df - ad_xi) * dt;
+        return expm(generator, K);
+      }
+    }
+  }
+
+  /**
+   * Predict mean and Jacobian Phi with state-dependent dynamics:
+   *   xi = f(X_k, Df)           (tangent vector dynamics and Jacobian Df)
+   *   U = Expmap(xi * dt, Dexp) (motion increment U and Expmap Jacobian Dexp)
+   *   X_{k+1} = X_k * U         (Predict next state via compose)
+   *   Phi = Ad_{U^{-1}} + Dexp * Df * dt (K=1 first-order Jacobian)
+   *       expm((Df - ad(xi))dt) (K>1 matrix exponential discretization)
+   *
+   * @tparam K Truncation order for expm (K=1 for first-order).
+   * @tparam Dynamics: TangentVector f(const G&, OptionalJacobian<Dim,Dim>&)
+   * @param f Dynamics function computing tangent vector xi and its Jacobian Df.
+   * @param dt Time step.
+   * @param Phi OptionalJacobian to store the computed transition matrix Phi.
    * @return Predicted state X_{k+1}.
    */
-  template <typename Dynamics, typename = enable_if_dynamics<Dynamics>>
-  G predictMean(Dynamics&& f, double dt,
-                OptionalJacobian<Dim, Dim> A = {}) const {
-    Jacobian Df, Dexp;  // Eigen::Matrix<double, Dim, Dim>
+  template <size_t K = 1, typename Dynamics,
+            typename = enable_if_dynamics<Dynamics>>
+  G predictMean(Dynamics&& f, double dt, OptionalJacobian Phi = {}) const {
+    Jacobian Df, Dexp;
 
     if constexpr (std::is_same_v<G, Matrix>) {
-      // Specialize to Matrix case as its Expmap is not defined.
-      TangentVector xi = f(this->X_, A ? &Df : nullptr);
-      const Matrix nextX = traits<Matrix>::Retract(
-          this->X_, xi * dt, A ? &Dexp : nullptr);  // just addition
-      if (A) {
-        const Matrix I_n = Matrix::Identity(this->n_, this->n_);
-        *A = I_n + Dexp * Df * dt;  // AdjointMap is always identity for Matrix
-      }
+      TangentVector xi = f(this->X_, Phi ? &Df : nullptr);
+      const Matrix nextX =
+          traits<Matrix>::Retract(this->X_, xi * dt, Phi ? &Dexp : nullptr);
+      if (Phi) *Phi = transitionMatrix<K>(xi, Df, dt, nextX, Dexp);
       return nextX;
     } else {
-      TangentVector xi =
-          f(this->X_, A ? &Df : nullptr);  // xi and Df = d(xi)/d(localX)
-      G U = traits<G>::Expmap(xi * dt, A ? &Dexp : nullptr);
-      if (A) {
-        // State transition Jacobian for left-invariant EKF:
-        *A = traits<G>::Inverse(U).AdjointMap() + Dexp * Df * dt;
-      }
+      TangentVector xi = f(this->X_, Phi ? &Df : nullptr);
+      G U = traits<G>::Expmap(xi * dt, Phi ? &Dexp : nullptr);
+      if (Phi) *Phi = transitionMatrix<K>(xi, Df, dt, U, Dexp);
       return traits<G>::Compose(this->X_, U);
     }
   }
 
   /**
    * Predict step with state-dependent dynamics:
-   * Uses predictMean to compute X_{k+1} and A, then updates covariance.
-   *   X_{k+1}, A = predictMean(f, dt)
-   *   P_{k+1} = A P_k A^T + Q
+   * Uses predictMean to compute X_{k+1} and Phi, then updates covariance.
+   *   X_{k+1}, Phi = predictMean(f, dt)
+   *   P_{k+1} = Phi P_k Phi^T + Q
    *
+   * @tparam K Truncation order for expm (K=1 for first-order).
    * @tparam Dynamics Functor signature: TangentVector f(const G&,
    * OptionalJacobian<Dim,Dim>&)
    * @param f Dynamics functor.
    * @param dt Time step.
    * @param Q Process noise covariance.
    */
-  template <typename Dynamics, typename = enable_if_dynamics<Dynamics>>
+  template <size_t K = 1, typename Dynamics,
+            typename = enable_if_dynamics<Dynamics>>
   void predict(Dynamics&& f, double dt, const Covariance& Q) {
-    Jacobian A;
+    Jacobian Phi;
     if constexpr (Dim == Eigen::Dynamic) {
-      A.resize(this->n_, this->n_);
+      Phi.resize(this->n_, this->n_);
     }
-    G X_next = predictMean(std::forward<Dynamics>(f), dt, A);
-    predict(X_next, A, Q);
+    G X_next = predictMean<K>(std::forward<Dynamics>(f), dt, Phi);
+    predict(X_next, Phi, Q);
   }
-
-  /**
-   * SFINAE check for state- and control-dependent dynamics function.
-   * Signature: TangentVector f(const G& X, const Control& u,
-   * OptionalJacobian<Dim, Dim> Df)
-   */
-  template <typename Control, typename Dynamics>
-  using enable_if_full_dynamics = std::enable_if_t<
-      std::is_invocable_r_v<TangentVector, Dynamics, const G&, const Control&,
-                            OptionalJacobian<Dim, Dim>&>>;
 
   /**
    * Predict mean and Jacobian A with state and control input dynamics:
    * Wraps the dynamics function and calls the state-only predictMean.
    *   xi = f(X_k, u, Df)
    *
+   * @tparam K Truncation order for expm (K=1 for first-order).
    * @tparam Control Control input type.
    * @tparam Dynamics Functor signature: TangentVector f(const G&, const
    * Control&, OptionalJacobian<Dim,Dim>&)
@@ -174,13 +212,12 @@ class LieGroupEKF : public ManifoldEKF<G> {
    * A.
    * @return Predicted state X_{k+1}.
    */
-  template <typename Control, typename Dynamics,
+  template <size_t K = 1, typename Control, typename Dynamics,
             typename = enable_if_full_dynamics<Control, Dynamics>>
   G predictMean(Dynamics&& f, const Control& u, double dt,
-                OptionalJacobian<Dim, Dim> A = {}) const {
-    return predictMean(
-        [&](const G& X, OptionalJacobian<Dim, Dim> Df) { return f(X, u, Df); },
-        dt, A);
+                OptionalJacobian Phi = {}) const {
+    return predictMean<K>(
+        [&](const G& X, OptionalJacobian Df) { return f(X, u, Df); }, dt, Phi);
   }
 
   /**
@@ -188,6 +225,8 @@ class LieGroupEKF : public ManifoldEKF<G> {
    * Wraps the dynamics function and calls the state-only predict.
    *   xi = f(X_k, u, Df)
    *
+   * @tparam K Truncation order for the matrix exponential (K=1 recovers
+   * first-order).
    * @tparam Control Control input type.
    * @tparam Dynamics Functor signature: TangentVector f(const G&, const
    * Control&, OptionalJacobian<Dim,Dim>&)
@@ -196,12 +235,11 @@ class LieGroupEKF : public ManifoldEKF<G> {
    * @param dt Time step.
    * @param Q Process noise covariance.
    */
-  template <typename Control, typename Dynamics,
+  template <size_t K = 1, typename Control, typename Dynamics,
             typename = enable_if_full_dynamics<Control, Dynamics>>
   void predict(Dynamics&& f, const Control& u, double dt, const Covariance& Q) {
-    return predict(
-        [&](const G& X, OptionalJacobian<Dim, Dim> Df) { return f(X, u, Df); },
-        dt, Q);
+    return predict<K>(
+        [&](const G& X, OptionalJacobian Df) { return f(X, u, Df); }, dt, Q);
   }
 
   /**

--- a/gtsam/navigation/LieGroupEKF.h
+++ b/gtsam/navigation/LieGroupEKF.h
@@ -69,6 +69,10 @@ class LieGroupEKF : public ManifoldEKF<G> {
                   "Template parameter G must be a GTSAM Lie Group");
   }
 
+    /// Expose base class predict method,
+    /// predict(const M& X_next, const Jacobian& F, const Covariance& Q)
+    using Base::predict;
+
   /**
    * SFINAE check for correctly typed state-dependent dynamics function.
    * Signature: TangentVector f(const G& X, OptionalJacobian<Dim, Dim> Df)
@@ -141,8 +145,8 @@ class LieGroupEKF : public ManifoldEKF<G> {
     if constexpr (Dim == Eigen::Dynamic) {
       A.resize(this->n_, this->n_);
     }
-    this->X_ = predictMean(std::forward<Dynamics>(f), dt, A);
-    this->P_ = A * this->P_ * A.transpose() + Q;
+    G X_next = predictMean(std::forward<Dynamics>(f), dt, A);
+    predict(X_next, A, Q);
   }
 
   /**

--- a/gtsam/navigation/ManifoldEKF.h
+++ b/gtsam/navigation/ManifoldEKF.h
@@ -116,6 +116,8 @@ class ManifoldEKF {
   /**
    * Basic predict step: Updates state and covariance given the predicted
    * next state and the state transition Jacobian F.
+   * This overload expects a **discrete-time** process covariance Q already
+   * scaled for the step being applied.
    *   X_{k+1} = X_next
    *   P_{k+1} = F P_k F^T + Q
    * where F = d(local(X_{k+1})) / d(local(X_k)) is the Jacobian of the

--- a/gtsam/navigation/doc/EKF-variants.md
+++ b/gtsam/navigation/doc/EKF-variants.md
@@ -112,6 +112,8 @@ The **[LieGroupEKF](https://github.com/borglab/gtsam/blob/develop/gtsam/navigati
 
 This class implements two overloaded functions ```predictMean()``` and ```predict()```. The ```predictMean()``` computes the next state estimate and state transition Jacobian $A$, whereas ```predict()``` takes in that state estimate and computes the covariance estimate. 
 
+**Process noise convention.** When a predict overload does **not** take a `dt` argument (e.g., `predict(U, Q)`), the filter expects `Q` to be a *discrete* covariance already scaled for the step being applied. When the overload **does** take `dt` (e.g., `predict(f, dt, Q)` or `predict(u, dt, Q)`), `Q` is interpreted as a *continuous-time* covariance `Q_c`; the implementation multiplies by `dt` internally to obtain the discrete covariance `Q_c dt`.
+
 In ```predictMean()``` the motion model $f$ is passed into the function; then, the tangent space increment is given by
 
 ```math
@@ -276,7 +278,8 @@ and the IEKF is created using
 
 For this example, assume constant process and observation covariances. Then,
 ```cpp
-  Matrix9 Q = Matrix9::Identity() * 0.01;
+  // Continuous-time process noise (scaled by dt inside predict)
+  Matrix9 Qc = Matrix9::Identity() * 0.01;
   Matrix3 R = Matrix3::Identity() * 0.5;
 ```
 
@@ -303,7 +306,7 @@ Since control vector inputs $u$ are used, a time interval $\Delta t$ is also nee
 #### Running the EKF
 The prediction stage is called using
 ```cpp
- ekf.predict(dynamics(imu1), dt, Q);
+ ekf.predict(dynamics(imu1), dt, Qc);
 ```
 
 and the update stage is called using
@@ -378,13 +381,14 @@ and the LieGroup EKF is created using
 For this example,assume constant process and observation covariances. A time interval $\Delta t$ is needed for the tangent space increment; then
 ```cpp
   double dt = 0.1;
-  Matrix3 Q = Matrix3::Identity() * 0.01;
+  // Continuous-time process noise (scaled by dt inside predict).
+  Matrix3 Qc = Matrix3::Identity() * 0.1;
   Matrix3 Rm = Matrix3::Identity() * 0.05;
 ```
 #### Running the EKF
 The prediction stage is called using
 ```cpp
-  ekf.predict(dynamicsSO3, dt, Q);
+  ekf.predict(dynamicsSO3, dt, Qc);
 ```
 The magnetometer measurement $z$ is found by taking a body frame measurement of the world vector; then, 
 ```cpp
@@ -448,10 +452,6 @@ classDiagram
   LeftLinearEKF~G~ <|-- InvariantEKF~G~
   LeftLinearEKF~G~ <|-- NavStateImuEKF
 ```
-
-
-
-
 
 
 

--- a/gtsam/navigation/doc/InvariantEKF.ipynb
+++ b/gtsam/navigation/doc/InvariantEKF.ipynb
@@ -1,0 +1,139 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "83ec2b32",
+      "metadata": {},
+      "source": [
+        "# InvariantEKF User Guide\n",
+        "\n",
+        "This short guide summarizes the `InvariantEKF` API (and the related `LieGroupEKF`) and points to concrete examples in the repository.\n",
+        "\n",
+        "## What is the InvariantEKF?\n",
+        "- A left-invariant EKF on a Lie group `G`.\n",
+        "- State transition can be given by right multiplication (`predict(U, Q)`) or by a left–right pair (`predict(W, U, Q)`) that executes `X_{k+1} = W · X_k · U`."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "5381b579",
+      "metadata": {},
+      "source": [
+        "## Python usage sketch"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "id": "76d8bece",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import numpy as np\n",
+        "import gtsam\n",
+        "\n",
+        "# State type\n",
+        "G = gtsam.Pose2\n",
+        "\n",
+        "# Initialize filter\n",
+        "X0 = G.Identity()\n",
+        "P0 = np.eye(3) * 0.1\n",
+        "ekf = gtsam.InvariantEKFPose2(X0, P0)\n",
+        "\n",
+        "# Right-increment predict with discrete Q\n",
+        "U = G(1.0, 0.0, 0.1)\n",
+        "Qd = np.eye(3) * 0.01\n",
+        "ekf.predict(U, Qd)\n",
+        "\n",
+        "# Left–right predict: X <- W * X * U\n",
+        "W = G(0.1, 0.0, 0.0)\n",
+        "ekf.predict(W, U, Qd)\n",
+        "\n",
+        "# In python, update using ManifoldEKF updateWithVector\n",
+        "X = ekf.state()\n",
+        "prediction = np.array([X.x(), X.y()])\n",
+        "H = np.array([[1, 0, 0], [0, 1, 0]])\n",
+        "z = np.array([1.0, 0.0])\n",
+        "R = np.eye(2) * 0.01\n",
+        "ekf.updateWithVector(prediction, H, z, R)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "796ed3be",
+      "metadata": {},
+      "source": [
+        "## Usage sketch (C++)\n",
+        "```cpp\n",
+        "using namespace gtsam;\n",
+        "using G = Pose2;\n",
+        "Matrix3 P0 = I_3x3 * 0.1;\n",
+        "InvariantEKF<G> ekf(G(), P0);\n",
+        "\n",
+        "G U(1.0, 0.0, 0.1);\n",
+        "Matrix3 Qd = I_3x3 * 0.01;\n",
+        "ekf.predict(U, Qd);            // right increment\n",
+        "G W(0.1, 0.0, 0.0);\n",
+        "ekf.predict(W, U, Qd);         // left–right increment\n",
+        "\n",
+        "auto h = [](const G& X, OptionalJacobian<2,3> H) {\n",
+        "    if (H) *H << 1, 0, 0, 0, 1, 0;\n",
+        "    return Vector2(X.x(), X.y());\n",
+        "};\n",
+        "Vector2 z; z << 1.0, 0.0;\n",
+        "Matrix2 R = Matrix2::Identity() * 0.01;\n",
+        "ekf.update(h, z, R);\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "55098c65",
+      "metadata": {},
+      "source": [
+        "## Notes\n",
+        "- `predict(W, U, Q)` treats `Q` as **discrete** (no `dt`).\n",
+        "- `predict(u, dt, Q)` uses continuous-time `Q` and scales by `dt` internally.\n",
+        "- IMU-specific EKFs (`NavStateImuEKF`, `Gal3ImuEKF`) reuse these interfaces; see the notebooks above for end-to-end flows."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "7a292821",
+      "metadata": {},
+      "source": [
+        "## Where it is used today\n",
+        "- C++ tests: [gtsam/navigation/tests/testInvariantEKF.cpp](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/tests/testInvariantEKF.cpp) exercises `predict(U, Q)` and the `dt` overload.\n",
+        "- C++ examples: [examples/IEKF_NavstateExample.cpp](https://github.com/borglab/gtsam/blob/develop/examples/IEKF_NavstateExample.cpp) (NavState), [examples/GEKF_Rot3Example.cpp](https://github.com/borglab/gtsam/blob/develop/examples/GEKF_Rot3Example.cpp) (LieGroupEKF on SO(3)).\n",
+        "- Docs: [gtsam/navigation/doc/InvariantEKF.md](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/doc/InvariantEKF.md) (math/background).\n",
+        "- Python notebooks with IMU-specialized EKFs built on the same interface:\n",
+        "  - [python/gtsam/examples/NavStateImuASVExample.ipynb](https://github.com/borglab/gtsam/blob/develop/python/gtsam/examples/NavStateImuASVExample.ipynb)\n",
+        "  - [python/gtsam/examples/Gal3ImuExample.ipynb](https://github.com/borglab/gtsam/blob/develop/python/gtsam/examples/Gal3ImuExample.ipynb)\n",
+        "  - [python/gtsam/examples/Gal3ImuASVExample.ipynb](https://github.com/borglab/gtsam/blob/develop/python/gtsam/examples/Gal3ImuASVExample.ipynb)\n",
+        "\n",
+        "If you add new examples that use `predict(W, U, Q)`, please link them here for discoverability."
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "py312",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.6"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/gtsam/navigation/navigation.i
+++ b/gtsam/navigation/navigation.i
@@ -639,6 +639,7 @@ virtual class InvariantEKF : gtsam::LeftLinearEKF<G> {
 
   // Left-invariant predict APIs
   void predict(const G& U, gtsam::Matrix Q);
+  void predict(const G& W, const G& U, const gtsam::Matrix& Q);
   void predict(const gtsam::Vector& u, double dt, gtsam::Matrix Q);
 };
 

--- a/gtsam/navigation/navigation.md
+++ b/gtsam/navigation/navigation.md
@@ -12,7 +12,7 @@ The `navigation` module in GTSAM provides specialized tools for inertial navigat
 
 - **[ManifoldEKF](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/ManifoldEKF.h)**: Implements an EKF for states that operate on a differentiable manifold.
 - **[LieGroupEKF](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/LieGroupEKF.h)**: Implements an EKF for states that operate on a Lie group with state dependent dynamics.
-- **[InvariantEKF](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/InvariantEKF.h)**: Implements an EKF for states that operate on a Lie group with group composition (state independent) dynamics.
+- **[InvariantEKF](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/InvariantEKF.h)**: Implements an EKF for states that operate on a Lie group with group composition (state independent) dynamics. See the [InvariantEKF user guide](doc/InvariantEKF.ipynb).
 
 ### Attitude Estimation
 

--- a/gtsam/navigation/tests/testInvariantEKF.cpp
+++ b/gtsam/navigation/tests/testInvariantEKF.cpp
@@ -138,7 +138,8 @@ TEST(InvariantEKF_DynamicMatrix, PredictAndUpdate) {
   Matrix p0Covariance = I_4x4 * 0.01;
   Vector velocityTangent = (Vector(4) << 0.5, 0.1, -0.1, -0.5).finished();
   double dt = 0.1;
-  Matrix Q = I_4x4 * 0.001;
+  // Continuous-time;
+  Matrix Qc = I_4x4 * 0.01;
   Matrix R = Matrix::Identity(1, 1) * 0.005;
 
   InvariantEKF<Matrix> ekf(p0Matrix, p0Covariance);
@@ -146,11 +147,11 @@ TEST(InvariantEKF_DynamicMatrix, PredictAndUpdate) {
   EXPECT_LONGS_EQUAL(4, ekf.dimension());
 
   // --- Predict ---
-  ekf.predict(velocityTangent, dt, Q);
+  ekf.predict(velocityTangent, dt, Qc);
 
   // Verification for Predict
   Matrix pPredictedExpected = invariant_ekf_example::f(p0Matrix, velocityTangent, dt);
-  Matrix pCovariancePredictedExpected = p0Covariance + Q;
+  Matrix pCovariancePredictedExpected = p0Covariance + Qc * dt; // Q is continuous-time here
   EXPECT(assert_equal(pPredictedExpected, ekf.state(), 1e-9));
   EXPECT(assert_equal(pCovariancePredictedExpected, ekf.covariance(), 1e-9));
 

--- a/gtsam/navigation/tests/testInvariantEKF.cpp
+++ b/gtsam/navigation/tests/testInvariantEKF.cpp
@@ -7,12 +7,12 @@
  * See LICENSE for the license information
  * -------------------------------------------------------------------------- */
 
- /**
-  * @file testInvariantEKF.cpp
-  * @brief Unit tests for the InvariantEKF
-  * @date April 26, 2025
-  * @authors Frank Dellaert (adapted from example by Scott Baker, Matt Kielo)
-  */
+/**
+ * @file testInvariantEKF.cpp
+ * @brief Unit tests for the InvariantEKF
+ * @date April 26, 2025
+ * @authors Frank Dellaert (adapted from example by Scott Baker, Matt Kielo)
+ */
 
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/Testable.h>
@@ -26,12 +26,11 @@ using namespace std;
 using namespace gtsam;
 
 // Create a 2D GPS measurement function that returns the predicted measurement h
-// and Jacobian H. The predicted measurement h is the translation of the state X.
-// (Copied from IEKF_SE2Example.cpp)
+// and Jacobian H. The predicted measurement h is the translation of the state
+// X. (Copied from IEKF_SE2Example.cpp)
 Vector2 h_gps(const Pose2& X, OptionalJacobian<2, 3> H = {}) {
   return X.translation(H);
 }
-
 
 TEST(IEKF_Pose2, PredictUpdateSequence) {
   // GIVEN: Initial state, covariance, noises, motions, measurements
@@ -65,25 +64,24 @@ TEST(IEKF_Pose2, PredictUpdateSequence) {
   EXPECT(assert_equal(X1_expected, ekf.state(), 1e-9));
   EXPECT(assert_equal(P1_expected, ekf.covariance(), 1e-9));
 
-
   // --- First Update ---
   ekf.update(h_gps, z1, R);
 
   // Calculate expected state and covariance (manual Kalman steps)
-  Matrix H1; // H = dh/dlocal(X) -> 2x3
+  Matrix H1;  // H = dh/dlocal(X) -> 2x3
   Vector2 z_pred1 = h_gps(X1_expected, H1);
-  Vector2 y1 = z_pred1 - z1; // Innovation
+  Vector2 y1 = z_pred1 - z1;  // Innovation
   Matrix S1 = H1 * P1_expected * H1.transpose() + R;
-  Matrix K1 = P1_expected * H1.transpose() * S1.inverse(); // Gain (3x2)
-  Vector3 delta_xi1 = -K1 * y1; // Correction (tangent space)
+  Matrix K1 = P1_expected * H1.transpose() * S1.inverse();  // Gain (3x2)
+  Vector3 delta_xi1 = -K1 * y1;  // Correction (tangent space)
   Pose2 X1_updated_expected = X1_expected.retract(delta_xi1);
   Matrix3 I_KH1 = Matrix3::Identity() - K1 * H1;
-  Matrix3 P1_updated_expected = I_KH1 * P1_expected; // Standard form P = (I-KH)P
+  Matrix3 P1_updated_expected =
+      I_KH1 * P1_expected;  // Standard form P = (I-KH)P
 
   // Verify
   EXPECT(assert_equal(X1_updated_expected, ekf.state(), 1e-9));
   EXPECT(assert_equal(P1_updated_expected, ekf.covariance(), 1e-9));
-
 
   // --- Second Prediction ---
   ekf.predict(U2, Q);
@@ -91,46 +89,45 @@ TEST(IEKF_Pose2, PredictUpdateSequence) {
   // Calculate expected state and covariance
   Pose2 X2_expected = X1_updated_expected.compose(U2);
   Matrix3 Ad_U2_inv = U2.inverse().AdjointMap();
-  Matrix3 P2_expected = Ad_U2_inv * P1_updated_expected * Ad_U2_inv.transpose() + Q;
+  Matrix3 P2_expected =
+      Ad_U2_inv * P1_updated_expected * Ad_U2_inv.transpose() + Q;
 
   // Verify
   EXPECT(assert_equal(X2_expected, ekf.state(), 1e-9));
   EXPECT(assert_equal(P2_expected, ekf.covariance(), 1e-9));
 
-
   // --- Second Update ---
   ekf.update(h_gps, z2, R);
 
   // Calculate expected state and covariance (manual Kalman steps)
-  Matrix H2; // 2x3
+  Matrix H2;  // 2x3
   Vector2 z_pred2 = h_gps(X2_expected, H2);
-  Vector2 y2 = z_pred2 - z2; // Innovation
+  Vector2 y2 = z_pred2 - z2;  // Innovation
   Matrix S2 = H2 * P2_expected * H2.transpose() + R;
-  Matrix K2 = P2_expected * H2.transpose() * S2.inverse(); // Gain (3x2)
-  Vector3 delta_xi2 = -K2 * y2; // Correction (tangent space)
+  Matrix K2 = P2_expected * H2.transpose() * S2.inverse();  // Gain (3x2)
+  Vector3 delta_xi2 = -K2 * y2;  // Correction (tangent space)
   Pose2 X2_updated_expected = X2_expected.retract(delta_xi2);
   Matrix3 I_KH2 = Matrix3::Identity() - K2 * H2;
-  Matrix3 P2_updated_expected = I_KH2 * P2_expected; // Standard form
+  Matrix3 P2_updated_expected = I_KH2 * P2_expected;  // Standard form
 
   // Verify
   EXPECT(assert_equal(X2_updated_expected, ekf.state(), 1e-9));
   EXPECT(assert_equal(P2_updated_expected, ekf.covariance(), 1e-9));
-
 }
 
 // Define simple dynamics and measurement for a 2x2 Matrix state
 namespace invariant_ekf_example {
-  Matrix f(const Matrix& p, const Vector& vTangent, double dt) {
-    return traits<Matrix>::Retract(p, vTangent * dt);
+Matrix f(const Matrix& p, const Vector& vTangent, double dt) {
+  return traits<Matrix>::Retract(p, vTangent * dt);
+}
+double h(const Matrix& p, OptionalJacobian<-1, -1> H = {}) {
+  if (H) {
+    H->resize(1, p.size());
+    (*H) << 1.0, 0.0, 0.0, 1.0;  // Assuming 2x2
   }
-  double h(const Matrix& p, OptionalJacobian<-1, -1> H = {}) {
-    if (H) {
-      H->resize(1, p.size());
-      (*H) << 1.0, 0.0, 0.0, 1.0; // Assuming 2x2
-    }
-    return p(0, 0) + p(1, 1); // trace !
-  }
-} // namespace invariant_ekf_example
+  return p(0, 0) + p(1, 1);  // trace !
+}
+}  // namespace invariant_ekf_example
 
 TEST(InvariantEKF_DynamicMatrix, PredictAndUpdate) {
   // --- Setup ---
@@ -138,7 +135,7 @@ TEST(InvariantEKF_DynamicMatrix, PredictAndUpdate) {
   Matrix p0Covariance = I_4x4 * 0.01;
   Vector velocityTangent = (Vector(4) << 0.5, 0.1, -0.1, -0.5).finished();
   double dt = 0.1;
-  // Continuous-time;
+  // Continuous-time
   Matrix Qc = I_4x4 * 0.01;
   Matrix R = Matrix::Identity(1, 1) * 0.005;
 
@@ -150,8 +147,10 @@ TEST(InvariantEKF_DynamicMatrix, PredictAndUpdate) {
   ekf.predict(velocityTangent, dt, Qc);
 
   // Verification for Predict
-  Matrix pPredictedExpected = invariant_ekf_example::f(p0Matrix, velocityTangent, dt);
-  Matrix pCovariancePredictedExpected = p0Covariance + Qc * dt; // Q is continuous-time here
+  Matrix pPredictedExpected =
+      invariant_ekf_example::f(p0Matrix, velocityTangent, dt);
+  Matrix pCovariancePredictedExpected =
+      p0Covariance + Qc * dt;  // Q is continuous-time here
   EXPECT(assert_equal(pPredictedExpected, ekf.state(), 1e-9));
   EXPECT(assert_equal(pCovariancePredictedExpected, ekf.covariance(), 1e-9));
 
@@ -161,7 +160,7 @@ TEST(InvariantEKF_DynamicMatrix, PredictAndUpdate) {
   Matrix pCovarianceBeforeUpdate = ekf.covariance();
 
   double zTrue = invariant_ekf_example::h(pStateBeforeUpdate);
-  double zObserved = zTrue - 0.03; // Simulated measurement with some error
+  double zObserved = zTrue - 0.03;  // Simulated measurement with some error
 
   ekf.update(invariant_ekf_example::h, zObserved, R);
 
@@ -172,14 +171,16 @@ TEST(InvariantEKF_DynamicMatrix, PredictAndUpdate) {
   Matrix S = H * pCovarianceBeforeUpdate * H.transpose() + R;
   Matrix kalmanGainK = pCovarianceBeforeUpdate * H.transpose() * S.inverse();
   Vector deltaXiTangent = kalmanGainK * innovationY_tangent;
-  Matrix pUpdatedExpected = traits<Matrix>::Retract(pStateBeforeUpdate, deltaXiTangent);
+  Matrix pUpdatedExpected =
+      traits<Matrix>::Retract(pStateBeforeUpdate, deltaXiTangent);
   Matrix I_KH = I_4x4 - kalmanGainK * H;
-  Matrix pUpdatedCovarianceExpected = I_KH * pCovarianceBeforeUpdate * I_KH.transpose() + kalmanGainK * R * kalmanGainK.transpose();
+  Matrix pUpdatedCovarianceExpected =
+      I_KH * pCovarianceBeforeUpdate * I_KH.transpose() +
+      kalmanGainK * R * kalmanGainK.transpose();
 
   EXPECT(assert_equal(pUpdatedExpected, ekf.state(), 1e-9));
   EXPECT(assert_equal(pUpdatedCovarianceExpected, ekf.covariance(), 1e-9));
 }
-
 
 int main() {
   TestResult tr;

--- a/gtsam/navigation/tests/testLieGroupEKF.cpp
+++ b/gtsam/navigation/tests/testLieGroupEKF.cpp
@@ -80,6 +80,35 @@ TEST(GroupeEKF, PredictNumericState) {
   EXPECT(assert_equal(expectedH, actualH));
 }
 
+TEST(GroupeEKF, Rot3HigherOrderTransition) {
+  Rot3 R0 = Rot3::RzRyRx(0.2, -0.1, 0.3);
+  Matrix3 P0 = Matrix3::Identity() * 0.2;
+  double dt = 0.1;
+
+  Matrix3 PhiK1, PhiK2, PhiHighOrder;
+
+  {
+    LieGroupEKF<Rot3> ekf(R0, P0);
+    ekf.predictMean<1>(exampleSO3::dynamics, dt, PhiK1);
+  }
+
+  {
+    LieGroupEKF<Rot3> ekf(R0, P0);
+    ekf.predictMean<2>(exampleSO3::dynamics, dt, PhiK2);
+  }
+
+  {
+    LieGroupEKF<Rot3> ekf(R0, P0);
+    ekf.predictMean<6>(exampleSO3::dynamics, dt, PhiHighOrder);
+  }
+
+  double diffK1 = (PhiK1 - PhiHighOrder).norm();
+  double diffK2 = (PhiK2 - PhiHighOrder).norm();
+
+  EXPECT(diffK2 < diffK1);
+  EXPECT((PhiK1 - PhiK2).norm() > 1e-6);
+}
+
 TEST(GroupeEKF, StateAndControl) {
   auto f = [](const Rot3& X, const Vector2& dummy_u,
     OptionalJacobian<3, 3> H = {}) {

--- a/gtsam/navigation/tests/testLieGroupEKF.cpp
+++ b/gtsam/navigation/tests/testLieGroupEKF.cpp
@@ -176,7 +176,8 @@ TEST(LieGroupEKF_DynamicMatrix, PredictAndUpdate) {
   Matrix p0Matrix = (Matrix(2, 2) << 1.0, 2.0, 3.0, 4.0).finished();
   Matrix p0Covariance = I_4x4 * 0.01;
   double dt = 0.1;
-  Matrix process_noise_Q = I_4x4 * 0.001;
+  // Continuous-time;
+  Matrix process_noise_Qc = I_4x4 * 0.01;
   Matrix measurement_noise_R = Matrix::Identity(1, 1) * 0.005;
 
   LieGroupEKF<Matrix> ekf(p0Matrix, p0Covariance);
@@ -185,16 +186,16 @@ TEST(LieGroupEKF_DynamicMatrix, PredictAndUpdate) {
 
   // --- Predict ---
   // ekf.predict takes f(X, H_X), dt, process_noise_Q
-  ekf.predict(exampleLieGroupDynamicMatrix::f, dt, process_noise_Q);
+  ekf.predict(exampleLieGroupDynamicMatrix::f, dt, process_noise_Qc);
 
   // Verification for Predict
   // For f, Df_DXk = 0 (Jacobian of xi w.r.t X_local is Zero).
   // State transition Jacobian A = Ad_Uinv + Dexp * Df_DXk * dt.
   // For Matrix (VectorSpace): Ad_Uinv = I, Dexp = I.
   // So, A = I + I * 0 * dt = I.
-  // Covariance update: P_next = A * P_current * A.transpose() + Q = I * P_current * I + Q = P_current + Q.
+  // Covariance update: P_next = A * P_current * A.transpose() + Q*dt = I * P_current * I + Q*dt = P_current + Q*dt.
   Matrix pPredictedExpected = traits<Matrix>::Retract(p0Matrix, exampleLieGroupDynamicMatrix::kFixedVelocityTangent * dt);
-  Matrix pCovariancePredictedExpected = p0Covariance + process_noise_Q;
+  Matrix pCovariancePredictedExpected = p0Covariance + process_noise_Qc * dt;
 
   EXPECT(assert_equal(pPredictedExpected, ekf.state(), 1e-9));
   EXPECT(assert_equal(pCovariancePredictedExpected, ekf.covariance(), 1e-9));

--- a/gtsam/navigation/tests/testLieGroupEKF.cpp
+++ b/gtsam/navigation/tests/testLieGroupEKF.cpp
@@ -7,12 +7,12 @@
  * See LICENSE for the license information
  * -------------------------------------------------------------------------- */
 
- /**
-  * @file testGroupEKF.cpp
-  * @brief Unit test for LieGroupEKF, as well as dynamics used in Rot3 example.
-  * @date April 26, 2025
-  * @authors Scott Baker, Matt Kielo, Frank Dellaert
-  */
+/**
+ * @file testGroupEKF.cpp
+ * @brief Unit test for LieGroupEKF, as well as dynamics used in Rot3 example.
+ * @date April 26, 2025
+ * @authors Scott Baker, Matt Kielo, Frank Dellaert
+ */
 
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/Matrix.h>
@@ -27,21 +27,21 @@ using namespace gtsam;
 
 // Duplicate the dynamics function in GEKF_Rot3Example
 namespace exampleSO3 {
-  static constexpr double k = 0.5;
-  Vector3 dynamics(const Rot3& X, OptionalJacobian<3, 3> H = {}) {
-    // φ = Logmap(R), Dφ = ∂φ/∂δR
-    Matrix3 D_phi;
-    Vector3 phi = Rot3::Logmap(X, D_phi);
-    // zero out yaw
-    phi[2] = 0.0;
-    D_phi.row(2).setZero();
+static constexpr double k = 0.5;
+Vector3 dynamics(const Rot3& X, OptionalJacobian<3, 3> H = {}) {
+  // φ = Logmap(R), Dφ = ∂φ/∂δR
+  Matrix3 D_phi;
+  Vector3 phi = Rot3::Logmap(X, D_phi);
+  // zero out yaw
+  phi[2] = 0.0;
+  D_phi.row(2).setZero();
 
-    if (H) *H = -k * D_phi;  // ∂(–kφ)/∂δR
-    return -k * phi;         // xi ∈ 𝔰𝔬(3)
-  }
+  if (H) *H = -k * D_phi;  // ∂(–kφ)/∂δR
+  return -k * phi;         // xi ∈ 𝔰𝔬(3)
+}
 }  // namespace exampleSO3
 
-TEST(GroupeEKF, DynamicsJacobian) {
+TEST(LieGroupEKF, DynamicsJacobian) {
   // Construct a nontrivial state and IMU input
   Rot3 R = Rot3::RzRyRx(0.1, -0.2, 0.3);
 
@@ -57,7 +57,7 @@ TEST(GroupeEKF, DynamicsJacobian) {
   EXPECT(assert_equal(expectedH, actualH));
 }
 
-TEST(GroupeEKF, PredictNumericState) {
+TEST(LieGroupEKF, PredictNumericState) {
   // GIVEN
   Rot3 R0 = Rot3::RzRyRx(0.2, -0.1, 0.3);
   Matrix3 P0 = Matrix3::Identity() * 0.2;
@@ -72,7 +72,7 @@ TEST(GroupeEKF, PredictNumericState) {
   auto g = [&](const Rot3& R) -> Rot3 {
     LieGroupEKF<Rot3> ekf(R, P0);
     return ekf.predictMean(exampleSO3::dynamics, dt);
-    };
+  };
 
   // numeric Jacobian of g at R0
   Matrix3 expectedH = numericalDerivative11<Rot3, Rot3>(g, R0);
@@ -80,7 +80,7 @@ TEST(GroupeEKF, PredictNumericState) {
   EXPECT(assert_equal(expectedH, actualH));
 }
 
-TEST(GroupeEKF, Rot3HigherOrderTransition) {
+TEST(LieGroupEKF, Rot3HigherOrderTransition) {
   Rot3 R0 = Rot3::RzRyRx(0.2, -0.1, 0.3);
   Matrix3 P0 = Matrix3::Identity() * 0.2;
   double dt = 0.1;
@@ -109,11 +109,11 @@ TEST(GroupeEKF, Rot3HigherOrderTransition) {
   EXPECT((PhiK1 - PhiK2).norm() > 1e-6);
 }
 
-TEST(GroupeEKF, StateAndControl) {
+TEST(LieGroupEKF, StateAndControl) {
   auto f = [](const Rot3& X, const Vector2& dummy_u,
-    OptionalJacobian<3, 3> H = {}) {
-      return exampleSO3::dynamics(X, H);
-    };
+              OptionalJacobian<3, 3> H = {}) {
+    return exampleSO3::dynamics(X, H);
+  };
 
   // GIVEN
   Rot3 R0 = Rot3::RzRyRx(0.2, -0.1, 0.3);
@@ -131,7 +131,7 @@ TEST(GroupeEKF, StateAndControl) {
   auto g = [&](const Rot3& R) -> Rot3 {
     LieGroupEKF<Rot3> ekf(R, P0);
     return ekf.predictMean(f, dummy_u, dt, Q);
-    };
+  };
 
   // numeric Jacobian of g at R0
   Matrix3 expectedH = numericalDerivative11<Rot3, Rot3>(g, R0);
@@ -141,42 +141,47 @@ TEST(GroupeEKF, StateAndControl) {
 
 // Namespace for dynamic Matrix LieGroupEKF test
 namespace exampleLieGroupDynamicMatrix {
-  // Constant tangent vector for dynamics (same as "velocityTangent" in IEKF test)
-  const Vector kFixedVelocityTangent = (Vector(4) << 0.5, 0.1, -0.1, -0.5).finished();
+// Constant tangent vector for dynamics (same as "velocityTangent" in IEKF test)
+const Vector kFixedVelocityTangent =
+    (Vector(4) << 0.5, 0.1, -0.1, -0.5).finished();
 
-  // Dynamics function: xi = f(X, H_X)
-  // Returns a constant tangent vector, so Df_DX = 0.
-  // H_X is D(xi)/D(X_local), where X_local is the tangent space perturbation of X.
-  Vector f(const Matrix& X, OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H_X = {}) {
-    if (H_X) {
-      size_t state_dim = X.size();
-      size_t tangent_dim = kFixedVelocityTangent.size();
-      // Ensure Jacobian dimensions are consistent even if state or tangent is 0-dim
-      H_X->setZero(tangent_dim, state_dim);
-    }
-    return kFixedVelocityTangent;
+// Dynamics function: xi = f(X, H_X)
+// Returns a constant tangent vector, so Df_DX = 0.
+// H_X is D(xi)/D(X_local), where X_local is the tangent space perturbation of
+// X.
+Vector f(const Matrix& X,
+         OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H_X = {}) {
+  if (H_X) {
+    size_t state_dim = X.size();
+    size_t tangent_dim = kFixedVelocityTangent.size();
+    // Ensure Jacobian dimensions are consistent even if state or tangent is
+    // 0-dim
+    H_X->setZero(tangent_dim, state_dim);
   }
+  return kFixedVelocityTangent;
+}
 
-  // Measurement function h(X, H)
-  double h(const Matrix& p, OptionalJacobian<-1, -1> H = {}) {
-    // Specialized for a 2x2 matrix!
-    if (p.rows() != 2 || p.cols() != 2) {
-      throw std::invalid_argument("Matrix must be 2x2.");
-    }
-    if (H) {
-      H->resize(1, p.size());
-      *H << 1.0, 0.0, 0.0, 1.0; // d(trace)/dp00, d(trace)/dp01, d(trace)/dp10, d(trace)/dp11
-    }
-    return p(0, 0) + p(1, 1); // Trace of the matrix
+// Measurement function h(X, H)
+double h(const Matrix& p, OptionalJacobian<-1, -1> H = {}) {
+  // Specialized for a 2x2 matrix!
+  if (p.rows() != 2 || p.cols() != 2) {
+    throw std::invalid_argument("Matrix must be 2x2.");
   }
-} // namespace exampleLieGroupDynamicMatrix
+  if (H) {
+    H->resize(1, p.size());
+    *H << 1.0, 0.0, 0.0,
+        1.0;  // d(trace)/dp00, d(trace)/dp01, d(trace)/dp10, d(trace)/dp11
+  }
+  return p(0, 0) + p(1, 1);  // Trace of the matrix
+}
+}  // namespace exampleLieGroupDynamicMatrix
 
 TEST(LieGroupEKF_DynamicMatrix, PredictAndUpdate) {
   // --- Setup ---
   Matrix p0Matrix = (Matrix(2, 2) << 1.0, 2.0, 3.0, 4.0).finished();
   Matrix p0Covariance = I_4x4 * 0.01;
   double dt = 0.1;
-  // Continuous-time;
+  // Continuous-time.
   Matrix process_noise_Qc = I_4x4 * 0.01;
   Matrix measurement_noise_R = Matrix::Identity(1, 1) * 0.005;
 
@@ -193,8 +198,10 @@ TEST(LieGroupEKF_DynamicMatrix, PredictAndUpdate) {
   // State transition Jacobian A = Ad_Uinv + Dexp * Df_DXk * dt.
   // For Matrix (VectorSpace): Ad_Uinv = I, Dexp = I.
   // So, A = I + I * 0 * dt = I.
-  // Covariance update: P_next = A * P_current * A.transpose() + Q*dt = I * P_current * I + Q*dt = P_current + Q*dt.
-  Matrix pPredictedExpected = traits<Matrix>::Retract(p0Matrix, exampleLieGroupDynamicMatrix::kFixedVelocityTangent * dt);
+  // Covariance update: P_next = A * P_current * A.transpose() + Q*dt = I *
+  // P_current * I + Q*dt = P_current + Q*dt.
+  Matrix pPredictedExpected = traits<Matrix>::Retract(
+      p0Matrix, exampleLieGroupDynamicMatrix::kFixedVelocityTangent * dt);
   Matrix pCovariancePredictedExpected = p0Covariance + process_noise_Qc * dt;
 
   EXPECT(assert_equal(pPredictedExpected, ekf.state(), 1e-9));
@@ -205,22 +212,33 @@ TEST(LieGroupEKF_DynamicMatrix, PredictAndUpdate) {
   Matrix pCovarianceBeforeUpdate = ekf.covariance();
 
   double zTrue = exampleLieGroupDynamicMatrix::h(pStateBeforeUpdate);
-  double zObserved = zTrue - 0.03; // Simulated measurement with some error
+  double zObserved = zTrue - 0.03;  // Simulated measurement with some error
 
   ekf.update(exampleLieGroupDynamicMatrix::h, zObserved, measurement_noise_R);
 
   // Verification for Update (Manual Kalman Steps)
-  Matrix H_update(1, 4); // Measurement Jacobian: 1x4 for 2x2 matrix, trace measurement
-  double zPredictionManual = exampleLieGroupDynamicMatrix::h(pStateBeforeUpdate, H_update);
+  Matrix H_update(
+      1, 4);  // Measurement Jacobian: 1x4 for 2x2 matrix, trace measurement
+  double zPredictionManual =
+      exampleLieGroupDynamicMatrix::h(pStateBeforeUpdate, H_update);
   // Innovation: y_tangent = traits<Measurement>::Local(prediction, observation)
   // For double (scalar), Local(A,B) is B-A.
   double innovationY_tangent = zObserved - zPredictionManual;
-  Matrix S_innovation_cov = H_update * pCovarianceBeforeUpdate * H_update.transpose() + measurement_noise_R;
-  Matrix K_gain = pCovarianceBeforeUpdate * H_update.transpose() * S_innovation_cov.inverse();
-  Vector deltaXiTangent = K_gain * innovationY_tangent; // Tangent space correction for Matrix state
-  Matrix pUpdatedExpected = traits<Matrix>::Retract(pStateBeforeUpdate, deltaXiTangent);
-  Matrix I_KH = I_4x4 - K_gain * H_update; // I_4x4 because state dimension is 4
-  Matrix pUpdatedCovarianceExpected = I_KH * pCovarianceBeforeUpdate * I_KH.transpose() + K_gain * measurement_noise_R * K_gain.transpose();
+  Matrix S_innovation_cov =
+      H_update * pCovarianceBeforeUpdate * H_update.transpose() +
+      measurement_noise_R;
+  Matrix K_gain = pCovarianceBeforeUpdate * H_update.transpose() *
+                  S_innovation_cov.inverse();
+  Vector deltaXiTangent =
+      K_gain *
+      innovationY_tangent;  // Tangent space correction for Matrix state
+  Matrix pUpdatedExpected =
+      traits<Matrix>::Retract(pStateBeforeUpdate, deltaXiTangent);
+  Matrix I_KH =
+      I_4x4 - K_gain * H_update;  // I_4x4 because state dimension is 4
+  Matrix pUpdatedCovarianceExpected =
+      I_KH * pCovarianceBeforeUpdate * I_KH.transpose() +
+      K_gain * measurement_noise_R * K_gain.transpose();
 
   EXPECT(assert_equal(pUpdatedExpected, ekf.state(), 1e-9));
   EXPECT(assert_equal(pUpdatedCovarianceExpected, ekf.covariance(), 1e-9));

--- a/gtsam/navigation/tests/testLieGroupEKF.cpp
+++ b/gtsam/navigation/tests/testLieGroupEKF.cpp
@@ -15,6 +15,8 @@
   */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/Matrix.h>
+#include <gtsam/base/OptionalJacobian.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/geometry/Rot3.h>
@@ -192,6 +194,43 @@ TEST(LieGroupEKF_DynamicMatrix, PredictAndUpdate) {
 
   EXPECT(assert_equal(pUpdatedExpected, ekf.state(), 1e-9));
   EXPECT(assert_equal(pUpdatedCovarianceExpected, ekf.covariance(), 1e-9));
+}
+
+namespace matrixK1Consistency {
+struct LinearDynamics {
+  Matrix A;
+  Vector xi;
+  LinearDynamics() {
+    A = (Matrix(4, 4) << 0.1, -0.2, 0.0, 0.3,  //
+         0.05, 0.1, -0.15, 0.2,                //
+         -0.25, 0.0, 0.05, -0.1,               //
+         0.0, 0.2, -0.05, 0.15)
+            .finished();
+    xi = (Vector(4) << 0.4, -0.3, 0.2, 0.1).finished();
+  }
+
+  Vector operator()(
+      const Matrix&,
+      OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H = {}) const {
+    if (H) *H = A;
+    return xi;
+  }
+};
+}  // namespace matrixK1Consistency
+
+TEST(LieGroupEKF_DynamicMatrix, FirstOrderMatchesExpmK1) {
+  Matrix X0 = Matrix::Zero(2, 2);
+  Matrix P0 = I_4x4 * 0.1;
+  double dt = 0.05;
+  LieGroupEKF<Matrix> ekf(X0, P0);
+
+  matrixK1Consistency::LinearDynamics dynamics;
+  Matrix actualA_storage = Matrix::Zero(4, 4);
+  OptionalJacobian<-1, -1> actualA(actualA_storage);
+  ekf.predictMean<1>(dynamics, dt, actualA);
+
+  Matrix expectedA = expm(dynamics.A * dt, 1);
+  EXPECT(assert_equal(expectedA, actualA_storage));
 }
 
 int main() {


### PR DESCRIPTION
Enhancements to EKF implementations, focusing on clarifying the process noise convention and adding support for higher-order numerical integration in the LieGroupEKF. Also standardizes how continuous-time vs. discrete-time process noise covariances are handled across the filter classes.

**Key Changes:**
- Clarified and documented process noise convention: overloads with `dt` interpret `Q` as continuous-time covariance (scaled internally by `dt`), while overloads without `dt` expect discrete covariance
- Added support for higher-order transition matrix computation via matrix exponential with configurable truncation order `K`
- Implemented Lie-algebra adjoint operations (`adjointMap` and `adjoint`) for Rot2 and Rot3 to support these higher-order methods
