### PR TITLE
Added BayesTree cache clearing for Marginals

### DIFF
--- a/gtsam/nonlinear/Marginals.cpp
+++ b/gtsam/nonlinear/Marginals.cpp
@@ -103,6 +103,12 @@ void Marginals::computeBayesTree(const Ordering& ordering) {
 /* ************************************************************************* */
 void Marginals::print(const std::string& str, const KeyFormatter& keyFormatter) const
 {
+  if (factorization_ == CHOLESKY)
+    cout << str << "Marginals using CHOLESKY factorization" << endl;
+  else if (factorization_ == QR)
+    cout << str << "Marginals using QR factorization" << endl;
+  else
+    cout << str << "Marginals using UNKNOWN factorization" << endl;
   graph_.print(str+"Graph: ");
   values_.print(str+"Solution: ", keyFormatter);
   bayesTree_.print(str+"Bayes Tree: ");
@@ -191,6 +197,11 @@ JointMarginal Marginals::jointMarginalInformation(const KeyVector& variables) co
 /* ************************************************************************* */
 VectorValues Marginals::optimize() const {
   return bayesTree_.optimize();
+}
+
+/* ************************************************************************* */
+void Marginals::deleteCachedShortcuts() {
+  bayesTree_.deleteCachedShortcuts();
 }
 
 /* ************************************************************************* */

--- a/gtsam/nonlinear/Marginals.cpp
+++ b/gtsam/nonlinear/Marginals.cpp
@@ -103,12 +103,6 @@ void Marginals::computeBayesTree(const Ordering& ordering) {
 /* ************************************************************************* */
 void Marginals::print(const std::string& str, const KeyFormatter& keyFormatter) const
 {
-  if (factorization_ == CHOLESKY)
-    cout << str << "Marginals using CHOLESKY factorization" << endl;
-  else if (factorization_ == QR)
-    cout << str << "Marginals using QR factorization" << endl;
-  else
-    cout << str << "Marginals using UNKNOWN factorization" << endl;
   graph_.print(str+"Graph: ");
   values_.print(str+"Solution: ", keyFormatter);
   bayesTree_.print(str+"Bayes Tree: ");

--- a/gtsam/nonlinear/Marginals.h
+++ b/gtsam/nonlinear/Marginals.h
@@ -72,7 +72,7 @@ public:
    * @param solution The solution point to compute Gaussian marginals.
    * @param factorization The linear decomposition mode - either Marginals::CHOLESKY (faster and suitable for most problems) or Marginals::QR (slower but more numerically stable for poorly-conditioned problems).
    */          
-  Marginals(const GaussianFactorGraph& graph, const Values& solution, Factorization factorization = CHOLESKY);
+  Marginals(const GaussianFactorGraph& graph, const Values& solution, Factorization factorization = QR);
 
   /** Construct a marginals class from a linear factor graph.
    * @param graph The factor graph defining the full joint density on all variables.
@@ -118,6 +118,9 @@ public:
 
   /** Compute the joint marginal information of several variables */
   JointMarginal jointMarginalInformation(const KeyVector& variables) const;
+
+  /** Delete cached Bayes tree shortcuts created while computing marginals */
+  void deleteCachedShortcuts();
 
   /** Optimize the bayes tree */
   VectorValues optimize() const;

--- a/gtsam/nonlinear/Marginals.h
+++ b/gtsam/nonlinear/Marginals.h
@@ -72,7 +72,7 @@ public:
    * @param solution The solution point to compute Gaussian marginals.
    * @param factorization The linear decomposition mode - either Marginals::CHOLESKY (faster and suitable for most problems) or Marginals::QR (slower but more numerically stable for poorly-conditioned problems).
    */          
-  Marginals(const GaussianFactorGraph& graph, const Values& solution, Factorization factorization = QR);
+  Marginals(const GaussianFactorGraph& graph, const Values& solution, Factorization factorization = CHOLESKY);
 
   /** Construct a marginals class from a linear factor graph.
    * @param graph The factor graph defining the full joint density on all variables.

--- a/gtsam/nonlinear/nonlinear.i
+++ b/gtsam/nonlinear/nonlinear.i
@@ -169,6 +169,7 @@ class Marginals {
       const gtsam::KeyVector& variables) const;
   gtsam::JointMarginal jointMarginalInformation(
       const gtsam::KeyVector& variables) const;
+  void deleteCachedShortcuts();
 };
 
 class JointMarginal {


### PR DESCRIPTION
The cache of the underlying BayesTree of the Marginals class can get very large and lead to memory issues when computing the marginal covariance for a large number of variables in a large graph, so I added a method to allow clearing the cache as a method in the Marginals class.