### PR TITLE
MultifrontalSolver

### DIFF
--- a/gtsam/base/SymmetricBlockMatrix.h
+++ b/gtsam/base/SymmetricBlockMatrix.h
@@ -133,6 +133,11 @@ namespace gtsam {
     /// This method makes a copy - use the methods below if performance is critical.
     Matrix block(DenseIndex I, DenseIndex J) const;
 
+    /// Get a block view (anywhere in the matrix) without allocating a copy.
+    constBlock blockView(DenseIndex I, DenseIndex J) const {
+      return block_(I, J);
+    }
+
     /// Return the J'th diagonal block as a self adjoint view.
     Eigen::SelfAdjointView<Block, Eigen::Upper> diagonalBlock(DenseIndex J) {
       return block_(J, J).selfadjointView<Eigen::Upper>();

--- a/gtsam/base/SymmetricBlockMatrix.h
+++ b/gtsam/base/SymmetricBlockMatrix.h
@@ -134,6 +134,10 @@ namespace gtsam {
     Matrix block(DenseIndex I, DenseIndex J) const;
 
     /// Get a block view (anywhere in the matrix) without allocating a copy.
+    /// This method returns a const reference to the block for efficient read access.
+    /// @param I The row block index.
+    /// @param J The column block index.
+    /// @return A const block view into the matrix.
     constBlock blockView(DenseIndex I, DenseIndex J) const {
       return block_(I, J);
     }

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -29,21 +29,19 @@ namespace gtsam {
 namespace {
 
 // Build a stacked separator vector x_sep in the provided scratch buffer.
-Vector& buildSeparatorVector(const KeyVector& separatorKeys,
-                             const std::map<Key, size_t>& dims,
-                             const VectorValues& x, Vector* scratch) {
+Vector& buildSeparatorVector(const std::vector<const Vector*>& separatorPtrs,
+                             Vector* scratch) {
   size_t separatorDim = 0;
-  for (Key key : separatorKeys) {
-    separatorDim += dims.at(key);
+  for (const Vector* values : separatorPtrs) {
+    separatorDim += values->size();
   }
   if (static_cast<size_t>(scratch->size()) != separatorDim) {
     scratch->resize(separatorDim);
   }
   size_t offset = 0;
-  for (Key key : separatorKeys) {
-    const Vector& values = x.at(key);
-    scratch->segment(offset, values.size()) = values;
-    offset += values.size();
+  for (const Vector* values : separatorPtrs) {
+    scratch->segment(offset, values->size()) = *values;
+    offset += values->size();
   }
   return *scratch;
 }
@@ -116,6 +114,19 @@ void MultifrontalClique::calculateSeparatorKeys() {
   separatorKeys_.assign(allKeys.begin(), allKeys.end());
 }
 
+void MultifrontalClique::cacheValuePointers(VectorValues* values) {
+  frontalPtrs_.clear();
+  separatorPtrs_.clear();
+  frontalPtrs_.reserve(frontals().size());
+  separatorPtrs_.reserve(separatorKeys_.size());
+  for (Key key : frontals()) {
+    frontalPtrs_.push_back(&values->at(key));
+  }
+  for (Key key : separatorKeys_) {
+    separatorPtrs_.push_back(&values->at(key));
+  }
+}
+
 const KeyVector& MultifrontalClique::separatorKeys() const {
   return separatorKeys_;
 }
@@ -183,7 +194,8 @@ void MultifrontalClique::fillAb(const GaussianFactorGraph& graph) {
     auto indexed =
         std::dynamic_pointer_cast<internal::IndexedSymbolicFactor>(factor);
     if (!indexed) continue;
-    auto jacobianFactor = std::dynamic_pointer_cast<JacobianFactor>(graph[indexed->index_]);
+    auto jacobianFactor =
+        std::dynamic_pointer_cast<JacobianFactor>(graph[indexed->index_]);
     if (!jacobianFactor) continue;
 
     for (auto it = jacobianFactor->begin(); it != jacobianFactor->end(); ++it) {
@@ -200,10 +212,12 @@ void MultifrontalClique::fillAb(const GaussianFactorGraph& graph) {
         } else
           continue;
       }
-      Ab_(blockIdx).middleRows(rowOffset, jacobianFactor->rows()) = jacobianFactor->getA(it);
+      Ab_(blockIdx).middleRows(rowOffset, jacobianFactor->rows()) =
+          jacobianFactor->getA(it);
     }
     size_t rhsBlockIdx = Ab_.nBlocks() - 1;  // RHS block is appended by VBM.
-    Ab_(rhsBlockIdx).middleRows(rowOffset, jacobianFactor->rows()) = jacobianFactor->getb();
+    Ab_(rhsBlockIdx).middleRows(rowOffset, jacobianFactor->rows()) =
+        jacobianFactor->getb();
     rowOffset += jacobianFactor->rows();
   }
 }
@@ -227,20 +241,19 @@ void MultifrontalClique::eliminateClique() {
   }
 }
 
-void MultifrontalClique::solveClique(const std::map<Key, size_t>& dims,
-                                     VectorValues* x) const {
+void MultifrontalClique::solveClique() const {
   // Solve with block back-substitution on the Cholesky-stored SBM, avoiding
   // materializing an explicit R matrix or split representation.
   const auto oldStart = sbm_.blockStart();
   sbm_.blockStart() = 0;
-  const size_t nFrontals = frontals().size();
-  const size_t nSeparators = separatorKeys_.size();
+  const size_t nFrontals = frontalPtrs_.size();
+  const size_t nSeparators = separatorPtrs_.size();
 
   const size_t rhsBlock = nFrontals + nSeparators;
 
   size_t frontalDim = 0;
-  for (Key key : frontals()) {
-    frontalDim += dims.at(key);
+  for (const Vector* values : frontalPtrs_) {
+    frontalDim += values->size();
   }
   if (static_cast<size_t>(rhsScratch_.size()) != frontalDim) {
     rhsScratch_.resize(frontalDim);
@@ -251,18 +264,22 @@ void MultifrontalClique::solveClique(const std::map<Key, size_t>& dims,
   // Eliminate separator contributions: b -= S * x_sep.
   if (nSeparators > 0) {
     const Vector& xSep =
-        buildSeparatorVector(separatorKeys_, dims, *x, &separatorScratch_);
-    rhsScratch_.noalias() -=
-        sbm_.aboveDiagonalRange(0, nFrontals, nFrontals,
-                                nFrontals + nSeparators) *
-        xSep;
+        buildSeparatorVector(separatorPtrs_, &separatorScratch_);
+    rhsScratch_.noalias() -= sbm_.aboveDiagonalRange(0, nFrontals, nFrontals,
+                                                     nFrontals + nSeparators) *
+                             xSep;
   }
 
   // Solve the contiguous frontal system in one triangular solve.
   sbm_.triangularView(0, nFrontals).solveInPlace(rhsScratch_);
 
   // Write solved frontal blocks back into the global solution.
-  x->insert(rhsScratch_, frontals(), dims);
+  size_t offset = 0;
+  for (Vector* values : frontalPtrs_) {
+    const size_t dim = values->size();
+    values->noalias() = rhsScratch_.segment(offset, dim);
+    offset += dim;
+  }
   sbm_.blockStart() = oldStart;
 }
 

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -242,27 +242,27 @@ void MultifrontalClique::solveClique(const std::map<Key, size_t>& dims,
   for (Key key : frontals()) {
     frontalDim += dims.at(key);
   }
-  if (static_cast<size_t>(rightHandSideScratch_.size()) != frontalDim) {
-    rightHandSideScratch_.resize(frontalDim);
+  if (static_cast<size_t>(rhsScratch_.size()) != frontalDim) {
+    rhsScratch_.resize(frontalDim);
   }
-  rightHandSideScratch_.noalias() =
+  rhsScratch_.noalias() =
       sbm_.aboveDiagonalRange(0, nFrontals, rhsBlock, rhsBlock + 1);
 
   // Eliminate separator contributions: b -= S * x_sep.
   if (nSeparators > 0) {
     const Vector& xSep =
-        buildSeparatorVector(separatorKeys_, dims, *x, &separatorSolutionScratch_);
-    rightHandSideScratch_.noalias() -=
+        buildSeparatorVector(separatorKeys_, dims, *x, &separatorScratch_);
+    rhsScratch_.noalias() -=
         sbm_.aboveDiagonalRange(0, nFrontals, nFrontals,
                                 nFrontals + nSeparators) *
         xSep;
   }
 
   // Solve the contiguous frontal system in one triangular solve.
-  sbm_.triangularView(0, nFrontals).solveInPlace(rightHandSideScratch_);
+  sbm_.triangularView(0, nFrontals).solveInPlace(rhsScratch_);
 
   // Write solved frontal blocks back into the global solution.
-  x->insert(rightHandSideScratch_, frontals(), dims);
+  x->insert(rhsScratch_, frontals(), dims);
   sbm_.blockStart() = oldStart;
 }
 

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -26,6 +26,30 @@
 
 namespace gtsam {
 
+namespace {
+
+// Build a stacked separator vector x_sep in the provided scratch buffer.
+Vector& buildSeparatorVector(const KeyVector& separatorKeys,
+                             const std::map<Key, size_t>& dims,
+                             const VectorValues& x, Vector* scratch) {
+  size_t separatorDim = 0;
+  for (Key key : separatorKeys) {
+    separatorDim += dims.at(key);
+  }
+  if (static_cast<size_t>(scratch->size()) != separatorDim) {
+    scratch->resize(separatorDim);
+  }
+  size_t offset = 0;
+  for (Key key : separatorKeys) {
+    const Vector& values = x.at(key);
+    scratch->segment(offset, values.size()) = values;
+    offset += values.size();
+  }
+  return *scratch;
+}
+
+}  // namespace
+
 MultifrontalClique::MultifrontalClique(
     const SymbolicJunctionTree::sharedNode& cluster) {
   if (!cluster) {
@@ -187,48 +211,59 @@ void MultifrontalClique::fillAb(const GaussianFactorGraph& graph) {
 void MultifrontalClique::eliminateClique() {
   sbm_.selfadjointView().rankUpdate(Ab_.matrix().transpose());
   sbm_.choleskyPartial(frontals().size());
-  R_Sd_ = sbm_.split(frontals().size());
 
   auto parent = parent_.lock();
   if (!parent) return;
+  const size_t nFrontals = frontals().size();
   const size_t nSeparatorBlocks = separatorKeys_.size();
   for (size_t i = 0; i <= nSeparatorBlocks; ++i) {
     size_t p_i = parentIndices_[i];
-    parent->sbm_.updateDiagonalBlock(p_i, sbm_.diagonalBlock(i));
+    parent->sbm_.updateDiagonalBlock(p_i, sbm_.diagonalBlock(nFrontals + i));
     for (size_t j = i + 1; j <= nSeparatorBlocks; ++j) {
       size_t p_j = parentIndices_[j];
-      parent->sbm_.updateOffDiagonalBlock(p_i, p_j,
-                                          sbm_.aboveDiagonalBlock(i, j));
+      parent->sbm_.updateOffDiagonalBlock(
+          p_i, p_j, sbm_.aboveDiagonalBlock(nFrontals + i, nFrontals + j));
     }
   }
 }
 
 void MultifrontalClique::solveClique(const std::map<Key, size_t>& dims,
                                      VectorValues* x) const {
+  // Solve with block back-substitution on the Cholesky-stored SBM, avoiding
+  // materializing an explicit R matrix or split representation.
+  const auto oldStart = sbm_.blockStart();
+  sbm_.blockStart() = 0;
   const size_t nFrontals = frontals().size();
   const size_t nSeparators = separatorKeys_.size();
 
-  size_t nFrontalDim = 0;
-  for (Key k : frontals()) nFrontalDim += dims.at(k);
+  const size_t rhsBlock = nFrontals + nSeparators;
 
-  const Matrix& RSd = R_Sd_.full();
-  Vector rhs = RSd.col(RSd.cols() - 1);
+  size_t frontalDim = 0;
+  for (Key key : frontals()) {
+    frontalDim += dims.at(key);
+  }
+  if (static_cast<size_t>(rhsScratch_.size()) != frontalDim) {
+    rhsScratch_.resize(frontalDim);
+  }
+  rhsScratch_.noalias() =
+      sbm_.aboveDiagonalRange(0, nFrontals, rhsBlock, rhsBlock + 1);
 
-  for (size_t i = 0; i < nSeparators; ++i) {
-    Key k = separatorKeys_[i];
-    rhs.noalias() -= R_Sd_(nFrontals + i) * x->at(k);
+  // Eliminate separator contributions: b -= S * x_sep.
+  if (nSeparators > 0) {
+    const Vector& xSep =
+        buildSeparatorVector(separatorKeys_, dims, *x, &xSepScratch_);
+    rhsScratch_.noalias() -=
+        sbm_.aboveDiagonalRange(0, nFrontals, nFrontals,
+                                nFrontals + nSeparators) *
+        xSep;
   }
 
-  Vector xF = RSd.leftCols(nFrontalDim)
-                  .template triangularView<Eigen::Upper>()
-                  .solve(rhs);
+  // Solve the contiguous frontal system in one triangular solve.
+  sbm_.triangularView(0, nFrontals).solveInPlace(rhsScratch_);
 
-  size_t offset = 0;
-  for (Key k : frontals()) {
-    size_t d = dims.at(k);
-    x->insert(k, xF.segment(offset, d));
-    offset += d;
-  }
+  // Write solved frontal blocks back into the global solution.
+  x->insert(rhsScratch_, frontals(), dims);
+  sbm_.blockStart() = oldStart;
 }
 
 void MultifrontalClique::print(const std::string& s,
@@ -267,7 +302,6 @@ void MultifrontalClique::print(const std::string& s,
 
   std::cout << "  Ab:\n" << Ab_.matrix() << "\n";
   std::cout << "  SBM:\n" << assembleSbm(sbm_) << "\n";
-  std::cout << "  R_Sd:\n" << R_Sd_.matrix() << "\n";
 }
 
 std::ostream& operator<<(std::ostream& os, const MultifrontalClique& clique) {

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -11,7 +11,7 @@
 
 /**
  * @file MultifrontalClique.cpp
- * @brief  Imperative multifrontal clique data structure
+ * @brief Implementation of imperative multifrontal clique data structure.
  * @author Frank Dellaert
  * @date   December 2025
  */
@@ -134,9 +134,9 @@ size_t MultifrontalClique::countRows(const GaussianFactorGraph& graph) const {
     auto indexed =
         std::dynamic_pointer_cast<internal::IndexedSymbolicFactor>(factor);
     if (!indexed) continue;
-    if (auto jf =
+    if (auto jacobianFactor =
             std::dynamic_pointer_cast<JacobianFactor>(graph[indexed->index_])) {
-      vbmRows += jf->rows();
+      vbmRows += jacobianFactor->rows();
     }
   }
   return vbmRows;
@@ -166,9 +166,9 @@ std::vector<size_t> MultifrontalClique::parentIndicesFor(
 }
 
 void MultifrontalClique::initializeMatrices(
-    const std::vector<size_t>& blockDims, size_t vbmRows) {
+    const std::vector<size_t>& blockDims, size_t verticalBlockMatrixRows) {
   sbm_ = SymmetricBlockMatrix(blockDims, true);
-  Ab_ = VerticalBlockMatrix(blockDims, vbmRows, true);
+  Ab_ = VerticalBlockMatrix(blockDims, verticalBlockMatrixRows, true);
   Ab_.matrix().setZero();
 }
 
@@ -183,10 +183,10 @@ void MultifrontalClique::fillAb(const GaussianFactorGraph& graph) {
     auto indexed =
         std::dynamic_pointer_cast<internal::IndexedSymbolicFactor>(factor);
     if (!indexed) continue;
-    auto jf = std::dynamic_pointer_cast<JacobianFactor>(graph[indexed->index_]);
-    if (!jf) continue;
+    auto jacobianFactor = std::dynamic_pointer_cast<JacobianFactor>(graph[indexed->index_]);
+    if (!jacobianFactor) continue;
 
-    for (auto it = jf->begin(); it != jf->end(); ++it) {
+    for (auto it = jacobianFactor->begin(); it != jacobianFactor->end(); ++it) {
       Key k = *it;
       auto fIt = std::find(frontals().begin(), frontals().end(), k);
       size_t blockIdx = 0;
@@ -200,11 +200,11 @@ void MultifrontalClique::fillAb(const GaussianFactorGraph& graph) {
         } else
           continue;
       }
-      Ab_(blockIdx).middleRows(rowOffset, jf->rows()) = jf->getA(it);
+      Ab_(blockIdx).middleRows(rowOffset, jacobianFactor->rows()) = jacobianFactor->getA(it);
     }
     size_t rhsBlockIdx = Ab_.nBlocks() - 1;  // RHS block is appended by VBM.
-    Ab_(rhsBlockIdx).middleRows(rowOffset, jf->rows()) = jf->getb();
-    rowOffset += jf->rows();
+    Ab_(rhsBlockIdx).middleRows(rowOffset, jacobianFactor->rows()) = jacobianFactor->getb();
+    rowOffset += jacobianFactor->rows();
   }
 }
 
@@ -242,27 +242,27 @@ void MultifrontalClique::solveClique(const std::map<Key, size_t>& dims,
   for (Key key : frontals()) {
     frontalDim += dims.at(key);
   }
-  if (static_cast<size_t>(rhsScratch_.size()) != frontalDim) {
-    rhsScratch_.resize(frontalDim);
+  if (static_cast<size_t>(rightHandSideScratch_.size()) != frontalDim) {
+    rightHandSideScratch_.resize(frontalDim);
   }
-  rhsScratch_.noalias() =
+  rightHandSideScratch_.noalias() =
       sbm_.aboveDiagonalRange(0, nFrontals, rhsBlock, rhsBlock + 1);
 
   // Eliminate separator contributions: b -= S * x_sep.
   if (nSeparators > 0) {
     const Vector& xSep =
-        buildSeparatorVector(separatorKeys_, dims, *x, &xSepScratch_);
-    rhsScratch_.noalias() -=
+        buildSeparatorVector(separatorKeys_, dims, *x, &separatorSolutionScratch_);
+    rightHandSideScratch_.noalias() -=
         sbm_.aboveDiagonalRange(0, nFrontals, nFrontals,
                                 nFrontals + nSeparators) *
         xSep;
   }
 
   // Solve the contiguous frontal system in one triangular solve.
-  sbm_.triangularView(0, nFrontals).solveInPlace(rhsScratch_);
+  sbm_.triangularView(0, nFrontals).solveInPlace(rightHandSideScratch_);
 
   // Write solved frontal blocks back into the global solution.
-  x->insert(rhsScratch_, frontals(), dims);
+  x->insert(rightHandSideScratch_, frontals(), dims);
   sbm_.blockStart() = oldStart;
 }
 

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -1,0 +1,295 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file MultifrontalClique.cpp
+ * @brief  Imperative multifrontal clique data structure
+ * @author Frank Dellaert
+ * @date   December 2025
+ */
+
+#include <gtsam/linear/JacobianFactor.h>
+#include <gtsam/linear/MultifrontalClique.h>
+
+#include <algorithm>
+#include <iostream>
+#include <set>
+#include <stdexcept>
+
+namespace gtsam {
+
+MultifrontalClique::MultifrontalClique(
+    const SymbolicJunctionTree::sharedNode& cluster) {
+  if (!cluster) {
+    throw std::runtime_error("MultifrontalSolver: null cluster.");
+  }
+  cluster_ = cluster;
+  const auto& frontals = cluster_->orderedFrontalKeys;
+  if (frontals.empty()) {
+    throw std::runtime_error(
+        "MultifrontalSolver: cluster has no frontal keys.");
+  }
+  key_ = frontals.front();
+}
+
+void MultifrontalClique::setParent(
+    const std::weak_ptr<MultifrontalClique>& parent) {
+  parent_ = parent;
+}
+
+void MultifrontalClique::addChild(const shared_ptr& child) {
+  children_.push_back(child);
+}
+
+const KeyVector& MultifrontalClique::frontals() const {
+  return cluster_->orderedFrontalKeys;
+}
+
+const std::vector<MultifrontalClique::shared_ptr>&
+MultifrontalClique::children() const {
+  return children_;
+}
+
+const std::weak_ptr<MultifrontalClique>& MultifrontalClique::parent() const {
+  return parent_;
+}
+
+void MultifrontalClique::assignParentIndicesForChildren() {
+  for (const auto& child : children_) {
+    if (!child) continue;
+    child->setParentIndices(child->parentIndicesFor(*this));
+  }
+}
+
+Key MultifrontalClique::key() const { return key_; }
+
+size_t MultifrontalClique::factorCount() const {
+  return cluster_->factors.size();
+}
+
+void MultifrontalClique::calculateSeparatorKeys() {
+  // Separator keys are computed from local factor keys and child separators.
+  KeySet allKeys;
+  for (const auto& factor : cluster_->factors) {
+    if (!factor) continue;
+    allKeys.insert(factor->begin(), factor->end());
+  }
+  for (const auto& child : children_) {
+    if (!child) continue;
+    allKeys.insert(child->separatorKeys_.begin(), child->separatorKeys_.end());
+  }
+  for (Key k : frontals()) {
+    allKeys.erase(k);
+  }
+  separatorKeys_.assign(allKeys.begin(), allKeys.end());
+}
+
+const KeyVector& MultifrontalClique::separatorKeys() const {
+  return separatorKeys_;
+}
+
+std::vector<size_t> MultifrontalClique::blockDims(
+    const std::map<Key, size_t>& dims) const {
+  std::vector<size_t> blockDims;
+  for (Key k : frontals()) blockDims.push_back(dims.at(k));
+  for (Key k : separatorKeys_) blockDims.push_back(dims.at(k));
+  return blockDims;
+}
+
+size_t MultifrontalClique::countRows(const GaussianFactorGraph& graph) const {
+  size_t vbmRows = 0;
+  for (const auto& factor : cluster_->factors) {
+    auto indexed =
+        std::dynamic_pointer_cast<internal::IndexedSymbolicFactor>(factor);
+    if (!indexed) continue;
+    if (auto jf =
+            std::dynamic_pointer_cast<JacobianFactor>(graph[indexed->index_])) {
+      vbmRows += jf->rows();
+    }
+  }
+  return vbmRows;
+}
+
+std::vector<size_t> MultifrontalClique::parentIndicesFor(
+    const MultifrontalClique& parent) const {
+  std::vector<size_t> indices;
+  for (Key k : separatorKeys_) {
+    auto fIt = std::find(parent.frontals().begin(), parent.frontals().end(), k);
+    if (fIt != parent.frontals().end()) {
+      indices.push_back(std::distance(parent.frontals().begin(), fIt));
+      continue;
+    }
+    auto sIt = std::find(parent.separatorKeys_.begin(),
+                         parent.separatorKeys_.end(), k);
+    if (sIt != parent.separatorKeys_.end()) {
+      indices.push_back(parent.frontals().size() +
+                        std::distance(parent.separatorKeys_.begin(), sIt));
+      continue;
+    }
+    throw std::runtime_error(
+        "MultifrontalSolver: separator key not found in parent clique");
+  }
+  indices.push_back(parent.frontals().size() + parent.separatorKeys_.size());
+  return indices;
+}
+
+void MultifrontalClique::initializeMatrices(
+    const std::vector<size_t>& blockDims, size_t vbmRows) {
+  sbm_ = SymmetricBlockMatrix(blockDims, true);
+  Ab_ = VerticalBlockMatrix(blockDims, vbmRows, true);
+  Ab_.matrix().setZero();
+}
+
+void MultifrontalClique::fillAb(const GaussianFactorGraph& graph) {
+  sbm_.blockStart() = 0;
+  sbm_.setZero();
+
+  // We only overwrite the fixed sparsity pattern, so Ab must be zeroed once in
+  // initializeMatrices and then kept consistent across loads.
+  size_t rowOffset = 0;
+  for (const auto& factor : cluster_->factors) {
+    auto indexed =
+        std::dynamic_pointer_cast<internal::IndexedSymbolicFactor>(factor);
+    if (!indexed) continue;
+    auto jf = std::dynamic_pointer_cast<JacobianFactor>(graph[indexed->index_]);
+    if (!jf) continue;
+
+    for (auto it = jf->begin(); it != jf->end(); ++it) {
+      Key k = *it;
+      auto fIt = std::find(frontals().begin(), frontals().end(), k);
+      size_t blockIdx = 0;
+      if (fIt != frontals().end()) {
+        blockIdx = std::distance(frontals().begin(), fIt);
+      } else {
+        auto sIt = std::find(separatorKeys_.begin(), separatorKeys_.end(), k);
+        if (sIt != separatorKeys_.end()) {
+          blockIdx =
+              frontals().size() + std::distance(separatorKeys_.begin(), sIt);
+        } else
+          continue;
+      }
+      Ab_(blockIdx).middleRows(rowOffset, jf->rows()) = jf->getA(it);
+    }
+    size_t rhsBlockIdx = Ab_.nBlocks() - 1;  // RHS block is appended by VBM.
+    Ab_(rhsBlockIdx).middleRows(rowOffset, jf->rows()) = jf->getb();
+    rowOffset += jf->rows();
+  }
+}
+
+void MultifrontalClique::eliminateClique() {
+  sbm_.selfadjointView().rankUpdate(Ab_.matrix().transpose());
+  sbm_.choleskyPartial(frontals().size());
+  R_Sd_ = sbm_.split(frontals().size());
+
+  auto parent = parent_.lock();
+  if (!parent) return;
+  const size_t nSeparatorBlocks = separatorKeys_.size();
+  for (size_t i = 0; i <= nSeparatorBlocks; ++i) {
+    size_t p_i = parentIndices_[i];
+    parent->sbm_.updateDiagonalBlock(p_i, sbm_.diagonalBlock(i));
+    for (size_t j = i + 1; j <= nSeparatorBlocks; ++j) {
+      size_t p_j = parentIndices_[j];
+      parent->sbm_.updateOffDiagonalBlock(p_i, p_j,
+                                          sbm_.aboveDiagonalBlock(i, j));
+    }
+  }
+}
+
+void MultifrontalClique::solveClique(const std::map<Key, size_t>& dims,
+                                     VectorValues* x) const {
+  const size_t nFrontals = frontals().size();
+  const size_t nSeparators = separatorKeys_.size();
+
+  size_t nFrontalDim = 0;
+  for (Key k : frontals()) nFrontalDim += dims.at(k);
+
+  const Matrix& RSd = R_Sd_.full();
+  Vector rhs = RSd.col(RSd.cols() - 1);
+
+  for (size_t i = 0; i < nSeparators; ++i) {
+    Key k = separatorKeys_[i];
+    rhs.noalias() -= R_Sd_(nFrontals + i) * x->at(k);
+  }
+
+  Vector xF = RSd.leftCols(nFrontalDim)
+                  .template triangularView<Eigen::Upper>()
+                  .solve(rhs);
+
+  size_t offset = 0;
+  for (Key k : frontals()) {
+    size_t d = dims.at(k);
+    x->insert(k, xF.segment(offset, d));
+    offset += d;
+  }
+}
+
+void MultifrontalClique::print(const std::string& s,
+                               const KeyFormatter& keyFormatter) const {
+  if (!s.empty()) std::cout << s;
+  std::cout << "Clique(key=" << keyFormatter(key_) << ", frontals=[";
+  for (size_t i = 0; i < frontals().size(); ++i) {
+    std::cout << keyFormatter(frontals()[i]);
+    if (i + 1 < frontals().size()) std::cout << ", ";
+  }
+  std::cout << "], separators=[";
+  for (size_t i = 0; i < separatorKeys_.size(); ++i) {
+    std::cout << keyFormatter(separatorKeys_[i]);
+    if (i + 1 < separatorKeys_.size()) std::cout << ", ";
+  }
+  std::cout << "], factors=" << cluster_->factors.size()
+            << ", children=" << children_.size()
+            << ", sbmBlocks=" << sbm_.nBlocks()
+            << ", AbRows=" << Ab_.matrix().rows() << ")\n";
+
+  auto assembleSbm = [](const SymmetricBlockMatrix& sbm) {
+    const size_t nBlocks = sbm.nBlocks();
+    std::vector<size_t> offsets(nBlocks + 1, 0);
+    for (size_t i = 0; i < nBlocks; ++i) {
+      offsets[i + 1] = offsets[i] + sbm.getDim(i);
+    }
+    Matrix full = Matrix::Zero(offsets.back(), offsets.back());
+    for (size_t i = 0; i < nBlocks; ++i) {
+      for (size_t j = 0; j < nBlocks; ++j) {
+        Matrix block = sbm.block(i, j);
+        full.block(offsets[i], offsets[j], block.rows(), block.cols()) = block;
+      }
+    }
+    return full;
+  };
+
+  std::cout << "  Ab:\n" << Ab_.matrix() << "\n";
+  std::cout << "  SBM:\n" << assembleSbm(sbm_) << "\n";
+  std::cout << "  R_Sd:\n" << R_Sd_.matrix() << "\n";
+}
+
+std::ostream& operator<<(std::ostream& os, const MultifrontalClique& clique) {
+  const KeyFormatter formatter = DefaultKeyFormatter;
+  auto printKeys = [&](const KeyVector& keys) {
+    os << "[";
+    for (size_t i = 0; i < keys.size(); ++i) {
+      os << formatter(keys[i]);
+      if (i + 1 < keys.size()) os << ", ";
+    }
+    os << "]";
+  };
+
+  os << "Clique(key=" << formatter(clique.key()) << ", frontals=";
+  printKeys(clique.frontals());
+  os << ", separators=";
+  printKeys(clique.separatorKeys());
+  os << ", factors=" << clique.factorCount();
+  os << ", children=" << clique.children().size();
+  os << ", sbmBlocks=" << clique.sbm().nBlocks();
+  os << ", AbRows=" << clique.Ab().matrix().rows() << ")";
+  return os;
+}
+
+}  // namespace gtsam

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -20,6 +20,7 @@
 #include <gtsam/linear/MultifrontalClique.h>
 
 #include <algorithm>
+#include <cassert>
 #include <iostream>
 #include <set>
 #include <stdexcept>
@@ -172,7 +173,6 @@ std::vector<size_t> MultifrontalClique::parentIndicesFor(
     throw std::runtime_error(
         "MultifrontalSolver: separator key not found in parent clique");
   }
-  indices.push_back(parent.frontals().size() + parent.separatorKeys_.size());
   return indices;
 }
 
@@ -184,7 +184,6 @@ void MultifrontalClique::initializeMatrices(
 }
 
 void MultifrontalClique::fillAb(const GaussianFactorGraph& graph) {
-  sbm_.blockStart() = 0;
   sbm_.setZero();
 
   // We only overwrite the fixed sparsity pattern, so Ab must be zeroed once in
@@ -222,30 +221,40 @@ void MultifrontalClique::fillAb(const GaussianFactorGraph& graph) {
   }
 }
 
-void MultifrontalClique::eliminateClique() {
+void MultifrontalClique::eliminate() {
+  // Update SBM with the local factors, Ab^T * Ab
   sbm_.selfadjointView().rankUpdate(Ab_.matrix().transpose());
+  
+  // Form normal equations and factor the frontal block (Schur complement step).
   sbm_.choleskyPartial(frontals().size());
 
   auto parent = parent_.lock();
   if (!parent) return;
-  const size_t nFrontals = frontals().size();
-  const size_t nSeparatorBlocks = separatorKeys_.size();
-  for (size_t i = 0; i <= nSeparatorBlocks; ++i) {
-    size_t p_i = parentIndices_[i];
-    parent->sbm_.updateDiagonalBlock(p_i, sbm_.diagonalBlock(nFrontals + i));
-    for (size_t j = i + 1; j <= nSeparatorBlocks; ++j) {
-      size_t p_j = parentIndices_[j];
-      parent->sbm_.updateOffDiagonalBlock(
-          p_i, p_j, sbm_.aboveDiagonalBlock(nFrontals + i, nFrontals + j));
+  // Expose only the separator+RHS view when contributing to the parent.
+  sbm_.blockStart() = frontals().size();
+  parent->updateWith(sbm_, parentIndices_);
+  sbm_.blockStart() = 0;
+}
+
+void MultifrontalClique::updateWith(const SymmetricBlockMatrix& separator,
+                                    const std::vector<size_t>& indices) {
+  const size_t numBlocks = indices.size();
+  assert(separator.nBlocks() == numBlocks + 1);
+  const size_t rhsBlock = sbm_.nBlocks() - 1;
+
+  for (size_t i = 0; i <= numBlocks; ++i) {
+    const size_t p_i = (i < numBlocks) ? indices[i] : rhsBlock;
+    sbm_.updateDiagonalBlock(p_i, separator.diagonalBlock(i));
+    for (size_t j = i + 1; j <= numBlocks; ++j) {
+      const size_t p_j = (j < numBlocks) ? indices[j] : rhsBlock;
+      sbm_.updateOffDiagonalBlock(p_i, p_j, separator.aboveDiagonalBlock(i, j));
     }
   }
 }
 
-void MultifrontalClique::solveClique() const {
+void MultifrontalClique::solve() const {
   // Solve with block back-substitution on the Cholesky-stored SBM, avoiding
   // materializing an explicit R matrix or split representation.
-  const auto oldStart = sbm_.blockStart();
-  sbm_.blockStart() = 0;
   const size_t nFrontals = frontalPtrs_.size();
   const size_t nSeparators = separatorPtrs_.size();
 
@@ -280,7 +289,6 @@ void MultifrontalClique::solveClique() const {
     values->noalias() = rhsScratch_.segment(offset, dim);
     offset += dim;
   }
-  sbm_.blockStart() = oldStart;
 }
 
 void MultifrontalClique::print(const std::string& s,

--- a/gtsam/linear/MultifrontalClique.h
+++ b/gtsam/linear/MultifrontalClique.h
@@ -61,26 +61,30 @@ class GTSAM_EXPORT MultifrontalClique {
 
   /// @name Setup (non-const)
   /// @{
-  
+
   /// Set the parent clique.
   /// @param parent Weak pointer to the parent clique.
   void setParent(const std::weak_ptr<MultifrontalClique>& parent);
-  
+
   /// Add a child clique.
   /// @param child Shared pointer to the child clique.
   void addChild(const shared_ptr& child);
-  
+
   /// Compute parent indices for all children after separators are finalized.
   void assignParentIndicesForChildren();
-  
+  /// Cache pointers to frontal and separator update vectors.
+  void cacheValuePointers(VectorValues* delta);
+
   /// Calculate separator keys from children's frontals.
   void calculateSeparatorKeys();
-  
+
   /// Pre-allocate matrices for this clique.
   /// @param blockDims Block dimensions (excluding RHS).
-  /// @param verticalBlockMatrixRows Number of rows for the vertical block matrix.
-  void initializeMatrices(const std::vector<size_t>& blockDims, size_t verticalBlockMatrixRows);
-  
+  /// @param verticalBlockMatrixRows Number of rows for the vertical block
+  /// matrix.
+  void initializeMatrices(const std::vector<size_t>& blockDims,
+                          size_t verticalBlockMatrixRows);
+
   /// Load factor values into the pre-allocated Ab matrix.
   /// @param graph The factor graph with updated values.
   void fillAb(const GaussianFactorGraph& graph);
@@ -88,48 +92,46 @@ class GTSAM_EXPORT MultifrontalClique {
 
   /// @name Read-only accessors
   /// @{
-  
+
   /// Get the frontal keys for this clique.
   const KeyVector& frontals() const;
-  
+
   /// Get the separator keys for this clique.
   const KeyVector& separatorKeys() const;
-  
+
   /// Get the children of this clique.
   const std::vector<shared_ptr>& children() const;
-  
+
   /// Get the parent of this clique.
   const std::weak_ptr<MultifrontalClique>& parent() const;
-  
+
   /// Get the primary key of this clique (first frontal).
   Key key() const;
-  
+
   /// Get the number of factors in this clique.
   size_t factorCount() const;
-  
+
   /// Get the vertical block matrix Ab.
   const VerticalBlockMatrix& Ab() const { return Ab_; }
-  
+
   /// Get the symmetric block matrix (mutable).
   SymmetricBlockMatrix& sbm() { return sbm_; }
-  
+
   /// Get the symmetric block matrix (const).
   const SymmetricBlockMatrix& sbm() const { return sbm_; }
-  
+
   /// Get the parent indices for scatter operations.
   const std::vector<size_t>& parentIndices() const { return parentIndices_; }
   /// @}
 
   /// @name Solve (non-const)
   /// @{
-  
+
   /// Eliminate this clique and propagate to its parent.
   void eliminateClique();
 
   /// Solve for the variables in this clique and update the solution vector.
-  /// @param dims Variable dimensions.
-  /// @param x Solution vector to update.
-  void solveClique(const std::map<Key, size_t>& dims, VectorValues* x) const;
+  void solveClique() const;
   /// @}
 
   /// Compute block dimensions from variable dimensions (excluding RHS).
@@ -141,12 +143,12 @@ class GTSAM_EXPORT MultifrontalClique {
   /// @param graph The factor graph.
   /// @return Total number of rows.
   size_t countRows(const GaussianFactorGraph& graph) const;
-  
+
   /// Compute parent scatter indices for this clique.
   /// @param parent The parent clique.
   /// @return Parent indices for scatter operations.
   std::vector<size_t> parentIndicesFor(const MultifrontalClique& parent) const;
-  
+
   /// Print this clique.
   /// @param s Optional string prefix.
   /// @param keyFormatter Key formatter for printing.
@@ -169,6 +171,8 @@ class GTSAM_EXPORT MultifrontalClique {
   SymbolicJunctionTree::sharedNode cluster_;
   KeyVector separatorKeys_;
   std::vector<size_t> parentIndices_;
+  std::vector<Vector*> frontalPtrs_;
+  std::vector<const Vector*> separatorPtrs_;
 };
 
 std::ostream& operator<<(std::ostream& os, const MultifrontalClique& clique);

--- a/gtsam/linear/MultifrontalClique.h
+++ b/gtsam/linear/MultifrontalClique.h
@@ -78,7 +78,6 @@ class GTSAM_EXPORT MultifrontalClique {
   const VerticalBlockMatrix& Ab() const { return Ab_; }
   SymmetricBlockMatrix& sbm() { return sbm_; }
   const SymmetricBlockMatrix& sbm() const { return sbm_; }
-  const VerticalBlockMatrix& R_Sd() const { return R_Sd_; }
   const std::vector<size_t>& parentIndices() const { return parentIndices_; }
   /// @}
 
@@ -108,8 +107,9 @@ class GTSAM_EXPORT MultifrontalClique {
   std::vector<shared_ptr> children_;
 
   VerticalBlockMatrix Ab_;
-  SymmetricBlockMatrix sbm_;
-  VerticalBlockMatrix R_Sd_;
+  mutable SymmetricBlockMatrix sbm_;
+  mutable Vector rhsScratch_;
+  mutable Vector xSepScratch_;
 
   SymbolicJunctionTree::sharedNode cluster_;
   KeyVector separatorKeys_;

--- a/gtsam/linear/MultifrontalClique.h
+++ b/gtsam/linear/MultifrontalClique.h
@@ -163,8 +163,8 @@ class GTSAM_EXPORT MultifrontalClique {
 
   VerticalBlockMatrix Ab_;
   mutable SymmetricBlockMatrix sbm_;
-  mutable Vector rightHandSideScratch_;
-  mutable Vector separatorSolutionScratch_;
+  mutable Vector rhsScratch_;
+  mutable Vector separatorScratch_;
 
   SymbolicJunctionTree::sharedNode cluster_;
   KeyVector separatorKeys_;

--- a/gtsam/linear/MultifrontalClique.h
+++ b/gtsam/linear/MultifrontalClique.h
@@ -11,7 +11,7 @@
 
 /**
  * @file MultifrontalClique.h
- * @brief  Imperative multifrontal clique data structure
+ * @brief Imperative multifrontal clique data structure.
  * @author Frank Dellaert
  * @date   December 2025
  */
@@ -38,7 +38,7 @@ namespace gtsam {
 
 namespace internal {
 
-// Helper class to track original factor indices.
+/// Helper class to track original factor indices.
 class IndexedSymbolicFactor : public SymbolicFactor {
  public:
   size_t index_;
@@ -55,46 +55,101 @@ class GTSAM_EXPORT MultifrontalClique {
  public:
   using shared_ptr = std::shared_ptr<MultifrontalClique>;
 
+  /// Construct a clique from a symbolic junction tree node.
+  /// @param cluster The symbolic junction tree node.
   explicit MultifrontalClique(const SymbolicJunctionTree::sharedNode& cluster);
 
   /// @name Setup (non-const)
   /// @{
+  
+  /// Set the parent clique.
+  /// @param parent Weak pointer to the parent clique.
   void setParent(const std::weak_ptr<MultifrontalClique>& parent);
+  
+  /// Add a child clique.
+  /// @param child Shared pointer to the child clique.
   void addChild(const shared_ptr& child);
+  
+  /// Compute parent indices for all children after separators are finalized.
   void assignParentIndicesForChildren();
+  
+  /// Calculate separator keys from children's frontals.
   void calculateSeparatorKeys();
-  void initializeMatrices(const std::vector<size_t>& blockDims, size_t vbmRows);
+  
+  /// Pre-allocate matrices for this clique.
+  /// @param blockDims Block dimensions (excluding RHS).
+  /// @param verticalBlockMatrixRows Number of rows for the vertical block matrix.
+  void initializeMatrices(const std::vector<size_t>& blockDims, size_t verticalBlockMatrixRows);
+  
+  /// Load factor values into the pre-allocated Ab matrix.
+  /// @param graph The factor graph with updated values.
   void fillAb(const GaussianFactorGraph& graph);
   /// @}
 
   /// @name Read-only accessors
   /// @{
+  
+  /// Get the frontal keys for this clique.
   const KeyVector& frontals() const;
+  
+  /// Get the separator keys for this clique.
   const KeyVector& separatorKeys() const;
+  
+  /// Get the children of this clique.
   const std::vector<shared_ptr>& children() const;
+  
+  /// Get the parent of this clique.
   const std::weak_ptr<MultifrontalClique>& parent() const;
+  
+  /// Get the primary key of this clique (first frontal).
   Key key() const;
+  
+  /// Get the number of factors in this clique.
   size_t factorCount() const;
+  
+  /// Get the vertical block matrix Ab.
   const VerticalBlockMatrix& Ab() const { return Ab_; }
+  
+  /// Get the symmetric block matrix (mutable).
   SymmetricBlockMatrix& sbm() { return sbm_; }
+  
+  /// Get the symmetric block matrix (const).
   const SymmetricBlockMatrix& sbm() const { return sbm_; }
+  
+  /// Get the parent indices for scatter operations.
   const std::vector<size_t>& parentIndices() const { return parentIndices_; }
   /// @}
 
   /// @name Solve (non-const)
   /// @{
+  
   /// Eliminate this clique and propagate to its parent.
   void eliminateClique();
 
   /// Solve for the variables in this clique and update the solution vector.
+  /// @param dims Variable dimensions.
+  /// @param x Solution vector to update.
   void solveClique(const std::map<Key, size_t>& dims, VectorValues* x) const;
   /// @}
 
-  // Block dimensions exclude RHS; matrices append it via appendOneDimension.
+  /// Compute block dimensions from variable dimensions (excluding RHS).
+  /// @param dims Variable dimensions.
+  /// @return Block dimensions for this clique.
   std::vector<size_t> blockDims(const std::map<Key, size_t>& dims) const;
 
+  /// Count rows needed for the vertical block matrix.
+  /// @param graph The factor graph.
+  /// @return Total number of rows.
   size_t countRows(const GaussianFactorGraph& graph) const;
+  
+  /// Compute parent scatter indices for this clique.
+  /// @param parent The parent clique.
+  /// @return Parent indices for scatter operations.
   std::vector<size_t> parentIndicesFor(const MultifrontalClique& parent) const;
+  
+  /// Print this clique.
+  /// @param s Optional string prefix.
+  /// @param keyFormatter Key formatter for printing.
   void print(const std::string& s = "",
              const KeyFormatter& keyFormatter = DefaultKeyFormatter) const;
 
@@ -108,8 +163,8 @@ class GTSAM_EXPORT MultifrontalClique {
 
   VerticalBlockMatrix Ab_;
   mutable SymmetricBlockMatrix sbm_;
-  mutable Vector rhsScratch_;
-  mutable Vector xSepScratch_;
+  mutable Vector rightHandSideScratch_;
+  mutable Vector separatorSolutionScratch_;
 
   SymbolicJunctionTree::sharedNode cluster_;
   KeyVector separatorKeys_;

--- a/gtsam/linear/MultifrontalClique.h
+++ b/gtsam/linear/MultifrontalClique.h
@@ -1,0 +1,121 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file MultifrontalClique.h
+ * @brief  Imperative multifrontal clique data structure
+ * @author Frank Dellaert
+ * @date   December 2025
+ */
+
+#pragma once
+
+#include <gtsam/base/SymmetricBlockMatrix.h>
+#include <gtsam/base/VerticalBlockMatrix.h>
+#include <gtsam/dllexport.h>
+#include <gtsam/inference/Key.h>
+#include <gtsam/linear/GaussianFactor.h>
+#include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/linear/VectorValues.h>
+#include <gtsam/symbolic/SymbolicFactor.h>
+#include <gtsam/symbolic/SymbolicJunctionTree.h>
+
+#include <iosfwd>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace gtsam {
+
+namespace internal {
+
+// Helper class to track original factor indices.
+class IndexedSymbolicFactor : public SymbolicFactor {
+ public:
+  size_t index_;
+  IndexedSymbolicFactor(const GaussianFactor& factor, size_t index)
+      : SymbolicFactor(factor), index_(index) {}
+};
+
+}  // namespace internal
+
+/**
+ * Imperative multifrontal clique structure used by MultifrontalSolver.
+ */
+class GTSAM_EXPORT MultifrontalClique {
+ public:
+  using shared_ptr = std::shared_ptr<MultifrontalClique>;
+
+  explicit MultifrontalClique(const SymbolicJunctionTree::sharedNode& cluster);
+
+  /// @name Setup (non-const)
+  /// @{
+  void setParent(const std::weak_ptr<MultifrontalClique>& parent);
+  void addChild(const shared_ptr& child);
+  void assignParentIndicesForChildren();
+  void calculateSeparatorKeys();
+  void initializeMatrices(const std::vector<size_t>& blockDims, size_t vbmRows);
+  void fillAb(const GaussianFactorGraph& graph);
+  /// @}
+
+  /// @name Read-only accessors
+  /// @{
+  const KeyVector& frontals() const;
+  const KeyVector& separatorKeys() const;
+  const std::vector<shared_ptr>& children() const;
+  const std::weak_ptr<MultifrontalClique>& parent() const;
+  Key key() const;
+  size_t factorCount() const;
+  const VerticalBlockMatrix& Ab() const { return Ab_; }
+  SymmetricBlockMatrix& sbm() { return sbm_; }
+  const SymmetricBlockMatrix& sbm() const { return sbm_; }
+  const VerticalBlockMatrix& R_Sd() const { return R_Sd_; }
+  const std::vector<size_t>& parentIndices() const { return parentIndices_; }
+  /// @}
+
+  /// @name Solve (non-const)
+  /// @{
+  /// Eliminate this clique and propagate to its parent.
+  void eliminateClique();
+
+  /// Solve for the variables in this clique and update the solution vector.
+  void solveClique(const std::map<Key, size_t>& dims, VectorValues* x) const;
+  /// @}
+
+  // Block dimensions exclude RHS; matrices append it via appendOneDimension.
+  std::vector<size_t> blockDims(const std::map<Key, size_t>& dims) const;
+
+  size_t countRows(const GaussianFactorGraph& graph) const;
+  std::vector<size_t> parentIndicesFor(const MultifrontalClique& parent) const;
+  void print(const std::string& s = "",
+             const KeyFormatter& keyFormatter = DefaultKeyFormatter) const;
+
+ private:
+  void setParentIndices(const std::vector<size_t>& indices) {
+    parentIndices_ = indices;
+  }
+  Key key_;
+  std::weak_ptr<MultifrontalClique> parent_;
+  std::vector<shared_ptr> children_;
+
+  VerticalBlockMatrix Ab_;
+  SymmetricBlockMatrix sbm_;
+  VerticalBlockMatrix R_Sd_;
+
+  SymbolicJunctionTree::sharedNode cluster_;
+  KeyVector separatorKeys_;
+  std::vector<size_t> parentIndices_;
+};
+
+std::ostream& operator<<(std::ostream& os, const MultifrontalClique& clique);
+
+}  // namespace gtsam

--- a/gtsam/linear/MultifrontalClique.h
+++ b/gtsam/linear/MultifrontalClique.h
@@ -72,6 +72,7 @@ class GTSAM_EXPORT MultifrontalClique {
 
   /// Compute parent indices for all children after separators are finalized.
   void assignParentIndicesForChildren();
+
   /// Cache pointers to frontal and separator update vectors.
   void cacheValuePointers(VectorValues* delta);
 
@@ -90,7 +91,7 @@ class GTSAM_EXPORT MultifrontalClique {
   void fillAb(const GaussianFactorGraph& graph);
   /// @}
 
-  /// @name Read-only accessors
+  /// @name Read-only methods
   /// @{
 
   /// Get the frontal keys for this clique.
@@ -120,40 +121,70 @@ class GTSAM_EXPORT MultifrontalClique {
   /// Get the symmetric block matrix (const).
   const SymmetricBlockMatrix& sbm() const { return sbm_; }
 
-  /// Get the parent indices for scatter operations.
-  const std::vector<size_t>& parentIndices() const { return parentIndices_; }
+
+  /**
+   * Compute block dimensions from variable dimensions (excluding RHS).
+   * @param dims Variable dimensions.
+   * @return Block dimensions for this clique.
+   */
+  std::vector<size_t> blockDims(const std::map<Key, size_t>& dims) const;
+
+  /**
+   * Count rows needed for the vertical block matrix.
+   * @param graph The factor graph.
+   * @return Total number of rows.
+   */
+  size_t countRows(const GaussianFactorGraph& graph) const;
+
+  /**
+   * Compute parent scatter indices for this clique.
+   * @param parent The parent clique.
+   * @return Parent indices for separator blocks (excluding RHS).
+   */
+  std::vector<size_t> parentIndicesFor(const MultifrontalClique& parent) const;
+
+  /**
+   * Print this clique.
+   * @param s Optional string prefix.
+   * @param keyFormatter Key formatter for printing.
+   */
+  void print(const std::string& s = "",
+             const KeyFormatter& keyFormatter = DefaultKeyFormatter) const;
+
   /// @}
 
   /// @name Solve (non-const)
   /// @{
 
-  /// Eliminate this clique and propagate to its parent.
-  void eliminateClique();
+  /**
+   * Eliminate this clique and propagate its separator contribution upward.
+   *
+   * Computes the local normal equations (SBM) from the stacked Jacobian (Ab),
+   * performs partial Cholesky on the frontal blocks, and then updates the
+   * parent's SBM using only the separator view (plus RHS) of this clique.
+   * Requires parent indices to be precomputed.
+   */
+  void eliminate();
 
-  /// Solve for the variables in this clique and update the solution vector.
-  void solveClique() const;
+  /**
+   * Update this clique using a child's contribution.
+   * @param separator Child clique's SBM restricted to its separator blocks,
+   * with the RHS block appended as the last block.
+   * @param indices Mapping from the child's separator blocks into this
+   * parent's SBM block indices (RHS is implicit).
+   */
+  void updateWith(const SymmetricBlockMatrix& separator,
+                  const std::vector<size_t>& indices);
+
+  /**
+   * Solve for this clique's frontal variables and write them back to the
+   * cached solution vectors.
+   *
+   * Uses block back-substitution using the upper triangular-part of the
+   * Cholesky-stored SBM, solving the triangular system for the frontal blocks.
+   */
+  void solve() const;
   /// @}
-
-  /// Compute block dimensions from variable dimensions (excluding RHS).
-  /// @param dims Variable dimensions.
-  /// @return Block dimensions for this clique.
-  std::vector<size_t> blockDims(const std::map<Key, size_t>& dims) const;
-
-  /// Count rows needed for the vertical block matrix.
-  /// @param graph The factor graph.
-  /// @return Total number of rows.
-  size_t countRows(const GaussianFactorGraph& graph) const;
-
-  /// Compute parent scatter indices for this clique.
-  /// @param parent The parent clique.
-  /// @return Parent indices for scatter operations.
-  std::vector<size_t> parentIndicesFor(const MultifrontalClique& parent) const;
-
-  /// Print this clique.
-  /// @param s Optional string prefix.
-  /// @param keyFormatter Key formatter for printing.
-  void print(const std::string& s = "",
-             const KeyFormatter& keyFormatter = DefaultKeyFormatter) const;
 
  private:
   void setParentIndices(const std::vector<size_t>& indices) {

--- a/gtsam/linear/MultifrontalSolver.cpp
+++ b/gtsam/linear/MultifrontalSolver.cpp
@@ -16,29 +16,54 @@
  * @date   December 2025
  */
 
+#include <gtsam/inference/Key.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/linear/GaussianFactor.h>
 #include <gtsam/linear/JacobianFactor.h>
+#include <gtsam/linear/MultifrontalClique.h>
 #include <gtsam/linear/MultifrontalSolver.h>
 #include <gtsam/symbolic/SymbolicEliminationTree.h>
 #include <gtsam/symbolic/SymbolicFactorGraph.h>
 
 #include <algorithm>
 #include <functional>
+#include <iostream>
+#include <ostream>
 #include <set>
 #include <stdexcept>
+#include <utility>
 
 namespace gtsam {
 
 namespace {
 
-// Helper class to track original factor indices
-class IndexedSymbolicFactor : public SymbolicFactor {
- public:
-  size_t index_;
-  IndexedSymbolicFactor(const GaussianFactor& factor, size_t index)
-      : SymbolicFactor(factor), index_(index) {}
-};
+// Compute variable dimensions from the GaussianFactorGraph
+std::map<Key, size_t> ComputeDims(const GaussianFactorGraph& graph) {
+  std::map<Key, size_t> dims;
+  for (const auto& factor : graph) {
+    if (!factor) continue;
+    if (auto jf = std::dynamic_pointer_cast<JacobianFactor>(factor)) {
+      for (auto it = jf->begin(); it != jf->end(); ++it) {
+        dims[*it] = jf->getDim(it);
+      }
+    } else if (auto hf = std::dynamic_pointer_cast<HessianFactor>(factor)) {
+      throw std::runtime_error(
+          "MultifrontalSolver: HessianFactors not supported.");
+    }
+  }
+  return dims;
+}
+
+// Build SymbolicFactorGraph from GaussianFactorGraph
+SymbolicFactorGraph BuildSymbolicGraph(const GaussianFactorGraph& graph) {
+  SymbolicFactorGraph symbolicGraph;
+  symbolicGraph.reserve(graph.size());
+  for (size_t i = 0; i < graph.size(); ++i) {
+    if (!graph[i]) continue;
+    symbolicGraph.emplace_shared<internal::IndexedSymbolicFactor>(*graph[i], i);
+  }
+  return symbolicGraph;
+}
 
 }  // namespace
 
@@ -46,162 +71,57 @@ class IndexedSymbolicFactor : public SymbolicFactor {
 MultifrontalSolver::MultifrontalSolver(const GaussianFactorGraph& graph,
                                        const Ordering& ordering) {
   // 0. Pre-compute variable dimensions
-  for (const auto& factor : graph) {
-    if (!factor) continue;
-    if (auto jf = std::dynamic_pointer_cast<JacobianFactor>(factor)) {
-      for (auto it = jf->begin(); it != jf->end(); ++it) {
-        dims_[*it] = jf->getDim(it);
-      }
-    } else if (auto hf = std::dynamic_pointer_cast<HessianFactor>(factor)) {
-      for (auto it = hf->begin(); it != hf->end(); ++it) {
-        dims_[*it] = hf->getDim(it);
-      }
-    }
-  }
+  dims_ = ComputeDims(graph);
 
   // 1. Convert to SymbolicFactorGraph to build the elimination tree
-  SymbolicFactorGraph symbolicGraph;
-  symbolicGraph.reserve(graph.size());
-  for (size_t i = 0; i < graph.size(); ++i) {
-    if (graph[i]) {
-      symbolicGraph.push_back(
-          std::make_shared<IndexedSymbolicFactor>(*graph[i], i));
-    } else {
-      symbolicGraph.push_back(SymbolicFactor::shared_ptr());
-    }
-  }
+  SymbolicFactorGraph symbolicGraph = BuildSymbolicGraph(graph);
 
   // 2. Build SymbolicEliminationTree and then SymbolicJunctionTree
-  SymbolicEliminationTree etree(symbolicGraph, ordering);
-  SymbolicJunctionTree jtree(etree);
+  SymbolicEliminationTree eliminationTree(symbolicGraph, ordering);
+  SymbolicJunctionTree junctionTree(eliminationTree);
 
   // 3. Recursive function to build Clique hierarchy
   std::function<CliquePtr(const SymbolicJunctionTree::sharedNode&,
-                          std::weak_ptr<Clique>)>
-      buildRecursive = [&](const SymbolicJunctionTree::sharedNode& cluster,
-                           std::weak_ptr<Clique> parent) -> CliquePtr {
+                          std::weak_ptr<MultifrontalClique>)>
+      buildRecursive =
+          [&](const SymbolicJunctionTree::sharedNode& cluster,
+              std::weak_ptr<MultifrontalClique> parent) -> CliquePtr {
     if (!cluster) return nullptr;
 
     // Create Clique
-    Key representativeKey = cluster->orderedFrontalKeys.empty()
-                                ? 0
-                                : cluster->orderedFrontalKeys.front();
-    auto clique = std::make_shared<Clique>(representativeKey);
-    clique->parent = parent;
-    clique->frontalKeys = cluster->orderedFrontalKeys;
+    auto clique = std::make_shared<MultifrontalClique>(cluster);
+    auto& c = *clique;
+    c.setParent(parent);
     cliques_.push_back(clique);
-
-    // Identify factor indices
-    for (const auto& factor : cluster->factors) {
-      if (auto indexed =
-              std::dynamic_pointer_cast<IndexedSymbolicFactor>(factor)) {
-        clique->factorIndices.push_back(indexed->index_);
-      }
-    }
 
     // Process children
     for (const auto& childCluster : cluster->children) {
       auto childClique = buildRecursive(childCluster, clique);
-      clique->children.push_back(childClique);
+      c.addChild(childClique);
     }
 
-    // Determine separator keys for THIS clique from local factors only.
-    std::set<Key> allKeys;
-    for (const auto& factor : cluster->factors) {
-      for (Key k : factor->keys()) {
-        allKeys.insert(k);
-      }
-    }
-
-    // Remove frontal keys
-    for (Key k : clique->frontalKeys) {
-      allKeys.erase(k);
-    }
-
-    // Store separator keys
-    clique->separatorKeys.assign(allKeys.begin(), allKeys.end());
-
-    // Calculate block dimensions
-    std::vector<size_t> blockDims;
-    for (Key k : clique->frontalKeys) blockDims.push_back(dims_.at(k));
-    for (Key k : clique->separatorKeys) blockDims.push_back(dims_.at(k));
-    blockDims.push_back(1);  // RHS
+    c.calculateSeparatorKeys();
 
     // Initialize matrices
-    clique->sbm = SymmetricBlockMatrix(blockDims);
-    clique->sbm.setZero();
-
-    size_t vbmRows = 0;
-    for (size_t idx : clique->factorIndices) {
-      if (auto jf = std::dynamic_pointer_cast<JacobianFactor>(graph[idx])) {
-        vbmRows += jf->rows();
-      }
-    }
-    clique->Ab = VerticalBlockMatrix(blockDims, vbmRows);
-    clique->Ab.matrix().setZero();
+    std::vector<size_t> blockDims = c.blockDims(dims_);
+    size_t vbmRows = c.countRows(graph);
+    c.initializeMatrices(blockDims, vbmRows);
 
     // Initial load
-    size_t rowOffset = 0;
-    for (size_t idx : clique->factorIndices) {
-      auto jf = std::dynamic_pointer_cast<JacobianFactor>(graph[idx]);
-      if (!jf) continue;
+    c.fillAb(graph);
 
-      for (auto it = jf->begin(); it != jf->end(); ++it) {
-        Key k = *it;
-        auto fIt = std::find(clique->frontalKeys.begin(),
-                             clique->frontalKeys.end(), k);
-        size_t blockIdx = 0;
-        if (fIt != clique->frontalKeys.end()) {
-          blockIdx = std::distance(clique->frontalKeys.begin(), fIt);
-        } else {
-          auto sIt = std::find(clique->separatorKeys.begin(),
-                               clique->separatorKeys.end(), k);
-          if (sIt != clique->separatorKeys.end()) {
-            blockIdx = clique->frontalKeys.size() +
-                       std::distance(clique->separatorKeys.begin(), sIt);
-          } else
-            continue;
-        }
-        clique->Ab(blockIdx).middleRows(rowOffset, jf->rows()) = jf->getA(it);
-      }
-      size_t rhsBlockIdx = blockDims.size() - 1;
-      clique->Ab(rhsBlockIdx).middleRows(rowOffset, jf->rows()) = jf->getb();
-      rowOffset += jf->rows();
-    }
-
-    // Pre-compute parent mapping
-    if (auto p = parent.lock()) {
-      for (Key k : clique->separatorKeys) {
-        auto fIt = std::find(p->frontalKeys.begin(), p->frontalKeys.end(), k);
-        if (fIt != p->frontalKeys.end()) {
-          clique->parentIndices.push_back(
-              std::distance(p->frontalKeys.begin(), fIt));
-          continue;
-        }
-        auto sIt =
-            std::find(p->separatorKeys.begin(), p->separatorKeys.end(), k);
-        if (sIt != p->separatorKeys.end()) {
-          clique->parentIndices.push_back(
-              p->frontalKeys.size() +
-              std::distance(p->separatorKeys.begin(), sIt));
-          continue;
-        }
-        throw std::runtime_error(
-            "MultifrontalSolver: separator key not found in parent clique");
-      }
-      // Last block is RHS
-      clique->parentIndices.push_back(p->frontalKeys.size() +
-                                      p->separatorKeys.size());
-    }
+    // Pre-compute parent mapping after separators are finalized.
+    c.assignParentIndicesForChildren();
 
     postOrderCliques_.push_back(clique);
     return clique;
   };
 
   // 4. Start traversal from roots
-  for (const auto& rootCluster : jtree.roots()) {
+  for (const auto& rootCluster : junctionTree.roots()) {
     if (rootCluster) {
-      roots_.push_back(buildRecursive(rootCluster, std::weak_ptr<Clique>()));
+      roots_.push_back(
+          buildRecursive(rootCluster, std::weak_ptr<MultifrontalClique>()));
     }
   }
 }
@@ -209,69 +129,14 @@ MultifrontalSolver::MultifrontalSolver(const GaussianFactorGraph& graph,
 /* ************************************************************************* */
 void MultifrontalSolver::load(const GaussianFactorGraph& graph) {
   for (auto& clique : cliques_) {
-    // 1. Reset SymmetricBlockMatrix
-    clique->sbm.blockStart() = 0;
-    clique->sbm.setZero();
-
-    // 2. Reset VerticalBlockMatrix
-    clique->Ab.matrix().setZero();
-
-    // 3. Fill VerticalBlockMatrix from graph
-    size_t rowOffset = 0;
-    for (size_t idx : clique->factorIndices) {
-      auto jf = std::dynamic_pointer_cast<JacobianFactor>(graph[idx]);
-      if (!jf) continue;
-
-      for (auto it = jf->begin(); it != jf->end(); ++it) {
-        Key k = *it;
-        auto fIt = std::find(clique->frontalKeys.begin(),
-                             clique->frontalKeys.end(), k);
-        size_t blockIdx = 0;
-        if (fIt != clique->frontalKeys.end()) {
-          blockIdx = std::distance(clique->frontalKeys.begin(), fIt);
-        } else {
-          auto sIt = std::find(clique->separatorKeys.begin(),
-                               clique->separatorKeys.end(), k);
-          if (sIt != clique->separatorKeys.end()) {
-            blockIdx = clique->frontalKeys.size() +
-                       std::distance(clique->separatorKeys.begin(), sIt);
-          } else
-            continue;
-        }
-        clique->Ab(blockIdx).middleRows(rowOffset, jf->rows()) = jf->getA(it);
-      }
-      size_t rhsBlockIdx = clique->Ab.nBlocks() - 1;
-      clique->Ab(rhsBlockIdx).middleRows(rowOffset, jf->rows()) = jf->getb();
-      rowOffset += jf->rows();
-    }
+    clique->fillAb(graph);
   }
 }
 
 /* ************************************************************************* */
 void MultifrontalSolver::eliminate() {
   for (auto& clique : postOrderCliques_) {
-    // 1. Add local Hessian: SBM += Ab' * Ab
-    clique->sbm.selfadjointView().rankUpdate(clique->Ab.matrix().transpose());
-
-    // 2. Eliminate frontal variables
-    clique->sbm.choleskyPartial(clique->frontalKeys.size());
-
-    // 3. Always split to store R_Sd for back-substitution
-    clique->R_Sd = clique->sbm.split(clique->frontalKeys.size());
-
-    // 4. Propagate separator to parent
-    if (auto parent = clique->parent.lock()) {
-      size_t nSeparatorBlocks = clique->separatorKeys.size();
-      for (size_t i = 0; i <= nSeparatorBlocks; ++i) {
-        size_t p_i = clique->parentIndices[i];
-        parent->sbm.updateDiagonalBlock(p_i, clique->sbm.diagonalBlock(i));
-        for (size_t j = i + 1; j <= nSeparatorBlocks; ++j) {
-          size_t p_j = clique->parentIndices[j];
-          parent->sbm.updateOffDiagonalBlock(
-              p_i, p_j, clique->sbm.aboveDiagonalBlock(i, j));
-        }
-      }
-    }
+    clique->eliminateClique();
   }
 }
 
@@ -279,32 +144,43 @@ void MultifrontalSolver::eliminate() {
 VectorValues MultifrontalSolver::solve() const {
   VectorValues x;
   for (const auto& clique : cliques_) {
-    size_t nFrontals = clique->frontalKeys.size();
-    size_t nSeparators = clique->separatorKeys.size();
-
-    size_t nFrontalDim = 0;
-    for (Key k : clique->frontalKeys) nFrontalDim += dims_.at(k);
-
-    const Matrix& RSd = clique->R_Sd.full();
-    Vector rhs = RSd.col(RSd.cols() - 1);
-
-    for (size_t i = 0; i < nSeparators; ++i) {
-      Key k = clique->separatorKeys[i];
-      rhs.noalias() -= clique->R_Sd(nFrontals + i) * x.at(k);
-    }
-
-    Vector xF = RSd.leftCols(nFrontalDim)
-                    .template triangularView<Eigen::Upper>()
-                    .solve(rhs);
-
-    size_t offset = 0;
-    for (Key k : clique->frontalKeys) {
-      size_t d = dims_.at(k);
-      x.insert(k, xF.segment(offset, d));
-      offset += d;
-    }
+    clique->solveClique(dims_, &x);
   }
   return x;
+}
+
+/* ************************************************************************* */
+std::ostream& operator<<(std::ostream& os, const MultifrontalSolver& solver) {
+  os << "MultifrontalSolver(roots=" << solver.roots_.size()
+     << ", cliques=" << solver.cliques_.size()
+     << ", postOrder=" << solver.postOrderCliques_.size()
+     << ", dims=" << solver.dims_.size() << ")\n";
+
+  std::function<void(const MultifrontalSolver::CliquePtr&, int)> dump =
+      [&](const MultifrontalSolver::CliquePtr& clique, int depth) {
+        if (!clique) return;
+        os << std::string(depth * 2, ' ') << *clique << "\n";
+        for (const auto& child : clique->children()) {
+          dump(child, depth + 1);
+        }
+      };
+
+  for (const auto& root : solver.roots_) {
+    dump(root, 0);
+  }
+  return os;
+}
+
+/* ************************************************************************* */
+void MultifrontalSolver::print(const std::string& s,
+                               const KeyFormatter& keyFormatter) const {
+  if (!s.empty()) std::cout << s;
+  std::cout << "MultifrontalSolver matrices (cliques=" << cliques_.size()
+            << ")\n";
+  for (const auto& clique : cliques_) {
+    if (!clique) continue;
+    clique->print("", keyFormatter);
+  }
 }
 
 }  // namespace gtsam

--- a/gtsam/linear/MultifrontalSolver.cpp
+++ b/gtsam/linear/MultifrontalSolver.cpp
@@ -11,7 +11,7 @@
 
 /**
  * @file MultifrontalSolver.cpp
- * @brief
+ * @brief Implementation of imperative-style multifrontal solver.
  * @author Frank Dellaert
  * @date   December 2025
  */
@@ -38,15 +38,15 @@ namespace gtsam {
 namespace {
 
 // Compute variable dimensions from the GaussianFactorGraph
-std::map<Key, size_t> ComputeDims(const GaussianFactorGraph& graph) {
+std::map<Key, size_t> computeDims(const GaussianFactorGraph& graph) {
   std::map<Key, size_t> dims;
   for (const auto& factor : graph) {
     if (!factor) continue;
-    if (auto jf = std::dynamic_pointer_cast<JacobianFactor>(factor)) {
-      for (auto it = jf->begin(); it != jf->end(); ++it) {
-        dims[*it] = jf->getDim(it);
+    if (auto jacobianFactor = std::dynamic_pointer_cast<JacobianFactor>(factor)) {
+      for (auto it = jacobianFactor->begin(); it != jacobianFactor->end(); ++it) {
+        dims[*it] = jacobianFactor->getDim(it);
       }
-    } else if (auto hf = std::dynamic_pointer_cast<HessianFactor>(factor)) {
+    } else if (auto hessianFactor = std::dynamic_pointer_cast<HessianFactor>(factor)) {
       throw std::runtime_error(
           "MultifrontalSolver: HessianFactors not supported.");
     }
@@ -55,7 +55,7 @@ std::map<Key, size_t> ComputeDims(const GaussianFactorGraph& graph) {
 }
 
 // Build SymbolicFactorGraph from GaussianFactorGraph
-SymbolicFactorGraph BuildSymbolicGraph(const GaussianFactorGraph& graph) {
+SymbolicFactorGraph buildSymbolicGraph(const GaussianFactorGraph& graph) {
   SymbolicFactorGraph symbolicGraph;
   symbolicGraph.reserve(graph.size());
   for (size_t i = 0; i < graph.size(); ++i) {
@@ -71,10 +71,10 @@ SymbolicFactorGraph BuildSymbolicGraph(const GaussianFactorGraph& graph) {
 MultifrontalSolver::MultifrontalSolver(const GaussianFactorGraph& graph,
                                        const Ordering& ordering) {
   // 0. Pre-compute variable dimensions
-  dims_ = ComputeDims(graph);
+  dims_ = computeDims(graph);
 
   // 1. Convert to SymbolicFactorGraph to build the elimination tree
-  SymbolicFactorGraph symbolicGraph = BuildSymbolicGraph(graph);
+  SymbolicFactorGraph symbolicGraph = buildSymbolicGraph(graph);
 
   // 2. Build SymbolicEliminationTree and then SymbolicJunctionTree
   SymbolicEliminationTree eliminationTree(symbolicGraph, ordering);
@@ -90,28 +90,28 @@ MultifrontalSolver::MultifrontalSolver(const GaussianFactorGraph& graph,
 
     // Create Clique
     auto clique = std::make_shared<MultifrontalClique>(cluster);
-    auto& c = *clique;
-    c.setParent(parent);
+    auto& currentClique = *clique;
+    currentClique.setParent(parent);
     cliques_.push_back(clique);
 
     // Process children
     for (const auto& childCluster : cluster->children) {
       auto childClique = buildRecursive(childCluster, clique);
-      c.addChild(childClique);
+      currentClique.addChild(childClique);
     }
 
-    c.calculateSeparatorKeys();
+    currentClique.calculateSeparatorKeys();
 
     // Initialize matrices
-    std::vector<size_t> blockDims = c.blockDims(dims_);
-    size_t vbmRows = c.countRows(graph);
-    c.initializeMatrices(blockDims, vbmRows);
+    std::vector<size_t> blockDims = currentClique.blockDims(dims_);
+    size_t vbmRows = currentClique.countRows(graph);
+    currentClique.initializeMatrices(blockDims, vbmRows);
 
     // Initial load
-    c.fillAb(graph);
+    currentClique.fillAb(graph);
 
     // Pre-compute parent mapping after separators are finalized.
-    c.assignParentIndicesForChildren();
+    currentClique.assignParentIndicesForChildren();
 
     postOrderCliques_.push_back(clique);
     return clique;

--- a/gtsam/linear/MultifrontalSolver.cpp
+++ b/gtsam/linear/MultifrontalSolver.cpp
@@ -42,11 +42,14 @@ std::map<Key, size_t> computeDims(const GaussianFactorGraph& graph) {
   std::map<Key, size_t> dims;
   for (const auto& factor : graph) {
     if (!factor) continue;
-    if (auto jacobianFactor = std::dynamic_pointer_cast<JacobianFactor>(factor)) {
-      for (auto it = jacobianFactor->begin(); it != jacobianFactor->end(); ++it) {
+    if (auto jacobianFactor =
+            std::dynamic_pointer_cast<JacobianFactor>(factor)) {
+      for (auto it = jacobianFactor->begin(); it != jacobianFactor->end();
+           ++it) {
         dims[*it] = jacobianFactor->getDim(it);
       }
-    } else if (auto hessianFactor = std::dynamic_pointer_cast<HessianFactor>(factor)) {
+    } else if (auto hessianFactor =
+                   std::dynamic_pointer_cast<HessianFactor>(factor)) {
       throw std::runtime_error(
           "MultifrontalSolver: HessianFactors not supported.");
     }
@@ -72,6 +75,9 @@ MultifrontalSolver::MultifrontalSolver(const GaussianFactorGraph& graph,
                                        const Ordering& ordering) {
   // 0. Pre-compute variable dimensions
   dims_ = computeDims(graph);
+  for (Key key : ordering) {
+    solution_.insert(key, Vector::Zero(dims_.at(key)));
+  }
 
   // 1. Convert to SymbolicFactorGraph to build the elimination tree
   SymbolicFactorGraph symbolicGraph = buildSymbolicGraph(graph);
@@ -100,6 +106,7 @@ MultifrontalSolver::MultifrontalSolver(const GaussianFactorGraph& graph,
     }
 
     clique->calculateSeparatorKeys();
+    clique->cacheValuePointers(&solution_);
 
     // Initialize matrices
     std::vector<size_t> blockDims = clique->blockDims(dims_);
@@ -140,12 +147,11 @@ void MultifrontalSolver::eliminate() {
 }
 
 /* ************************************************************************* */
-VectorValues MultifrontalSolver::solve() const {
-  VectorValues x;
+const VectorValues& MultifrontalSolver::solve() const {
   for (const auto& clique : cliques_) {
-    clique->solveClique(dims_, &x);
+    clique->solveClique();
   }
-  return x;
+  return solution_;
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/MultifrontalSolver.cpp
+++ b/gtsam/linear/MultifrontalSolver.cpp
@@ -90,28 +90,27 @@ MultifrontalSolver::MultifrontalSolver(const GaussianFactorGraph& graph,
 
     // Create Clique
     auto clique = std::make_shared<MultifrontalClique>(cluster);
-    auto& currentClique = *clique;
-    currentClique.setParent(parent);
+    clique->setParent(parent);
     cliques_.push_back(clique);
 
     // Process children
     for (const auto& childCluster : cluster->children) {
       auto childClique = buildRecursive(childCluster, clique);
-      currentClique.addChild(childClique);
+      clique->addChild(childClique);
     }
 
-    currentClique.calculateSeparatorKeys();
+    clique->calculateSeparatorKeys();
 
     // Initialize matrices
-    std::vector<size_t> blockDims = currentClique.blockDims(dims_);
-    size_t vbmRows = currentClique.countRows(graph);
-    currentClique.initializeMatrices(blockDims, vbmRows);
+    std::vector<size_t> blockDims = clique->blockDims(dims_);
+    size_t vbmRows = clique->countRows(graph);
+    clique->initializeMatrices(blockDims, vbmRows);
 
     // Initial load
-    currentClique.fillAb(graph);
+    clique->fillAb(graph);
 
     // Pre-compute parent mapping after separators are finalized.
-    currentClique.assignParentIndicesForChildren();
+    clique->assignParentIndicesForChildren();
 
     postOrderCliques_.push_back(clique);
     return clique;

--- a/gtsam/linear/MultifrontalSolver.cpp
+++ b/gtsam/linear/MultifrontalSolver.cpp
@@ -142,14 +142,14 @@ void MultifrontalSolver::load(const GaussianFactorGraph& graph) {
 /* ************************************************************************* */
 void MultifrontalSolver::eliminate() {
   for (auto& clique : postOrderCliques_) {
-    clique->eliminateClique();
+    clique->eliminate();
   }
 }
 
 /* ************************************************************************* */
 const VectorValues& MultifrontalSolver::solve() const {
   for (const auto& clique : cliques_) {
-    clique->solveClique();
+    clique->solve();
   }
   return solution_;
 }

--- a/gtsam/linear/MultifrontalSolver.cpp
+++ b/gtsam/linear/MultifrontalSolver.cpp
@@ -1,0 +1,310 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file MultifrontalSolver.cpp
+ * @brief
+ * @author Frank Dellaert
+ * @date   December 2025
+ */
+
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/linear/GaussianFactor.h>
+#include <gtsam/linear/JacobianFactor.h>
+#include <gtsam/linear/MultifrontalSolver.h>
+#include <gtsam/symbolic/SymbolicEliminationTree.h>
+#include <gtsam/symbolic/SymbolicFactorGraph.h>
+
+#include <algorithm>
+#include <functional>
+#include <set>
+#include <stdexcept>
+
+namespace gtsam {
+
+namespace {
+
+// Helper class to track original factor indices
+class IndexedSymbolicFactor : public SymbolicFactor {
+ public:
+  size_t index_;
+  IndexedSymbolicFactor(const GaussianFactor& factor, size_t index)
+      : SymbolicFactor(factor), index_(index) {}
+};
+
+}  // namespace
+
+/* ************************************************************************* */
+MultifrontalSolver::MultifrontalSolver(const GaussianFactorGraph& graph,
+                                       const Ordering& ordering) {
+  // 0. Pre-compute variable dimensions
+  for (const auto& factor : graph) {
+    if (!factor) continue;
+    if (auto jf = std::dynamic_pointer_cast<JacobianFactor>(factor)) {
+      for (auto it = jf->begin(); it != jf->end(); ++it) {
+        dims_[*it] = jf->getDim(it);
+      }
+    } else if (auto hf = std::dynamic_pointer_cast<HessianFactor>(factor)) {
+      for (auto it = hf->begin(); it != hf->end(); ++it) {
+        dims_[*it] = hf->getDim(it);
+      }
+    }
+  }
+
+  // 1. Convert to SymbolicFactorGraph to build the elimination tree
+  SymbolicFactorGraph symbolicGraph;
+  symbolicGraph.reserve(graph.size());
+  for (size_t i = 0; i < graph.size(); ++i) {
+    if (graph[i]) {
+      symbolicGraph.push_back(
+          std::make_shared<IndexedSymbolicFactor>(*graph[i], i));
+    } else {
+      symbolicGraph.push_back(SymbolicFactor::shared_ptr());
+    }
+  }
+
+  // 2. Build SymbolicEliminationTree and then SymbolicJunctionTree
+  SymbolicEliminationTree etree(symbolicGraph, ordering);
+  SymbolicJunctionTree jtree(etree);
+
+  // 3. Recursive function to build Clique hierarchy
+  std::function<CliquePtr(const SymbolicJunctionTree::sharedNode&,
+                          std::weak_ptr<Clique>)>
+      buildRecursive = [&](const SymbolicJunctionTree::sharedNode& cluster,
+                           std::weak_ptr<Clique> parent) -> CliquePtr {
+    if (!cluster) return nullptr;
+
+    // Create Clique
+    Key representativeKey = cluster->orderedFrontalKeys.empty()
+                                ? 0
+                                : cluster->orderedFrontalKeys.front();
+    auto clique = std::make_shared<Clique>(representativeKey);
+    clique->parent = parent;
+    clique->frontalKeys = cluster->orderedFrontalKeys;
+    cliques_.push_back(clique);
+
+    // Identify factor indices
+    for (const auto& factor : cluster->factors) {
+      if (auto indexed =
+              std::dynamic_pointer_cast<IndexedSymbolicFactor>(factor)) {
+        clique->factorIndices.push_back(indexed->index_);
+      }
+    }
+
+    // Process children
+    for (const auto& childCluster : cluster->children) {
+      auto childClique = buildRecursive(childCluster, clique);
+      clique->children.push_back(childClique);
+    }
+
+    // Determine separator keys for THIS clique from local factors only.
+    std::set<Key> allKeys;
+    for (const auto& factor : cluster->factors) {
+      for (Key k : factor->keys()) {
+        allKeys.insert(k);
+      }
+    }
+
+    // Remove frontal keys
+    for (Key k : clique->frontalKeys) {
+      allKeys.erase(k);
+    }
+
+    // Store separator keys
+    clique->separatorKeys.assign(allKeys.begin(), allKeys.end());
+
+    // Calculate block dimensions
+    std::vector<size_t> blockDims;
+    for (Key k : clique->frontalKeys) blockDims.push_back(dims_.at(k));
+    for (Key k : clique->separatorKeys) blockDims.push_back(dims_.at(k));
+    blockDims.push_back(1);  // RHS
+
+    // Initialize matrices
+    clique->sbm = SymmetricBlockMatrix(blockDims);
+    clique->sbm.setZero();
+
+    size_t vbmRows = 0;
+    for (size_t idx : clique->factorIndices) {
+      if (auto jf = std::dynamic_pointer_cast<JacobianFactor>(graph[idx])) {
+        vbmRows += jf->rows();
+      }
+    }
+    clique->Ab = VerticalBlockMatrix(blockDims, vbmRows);
+    clique->Ab.matrix().setZero();
+
+    // Initial load
+    size_t rowOffset = 0;
+    for (size_t idx : clique->factorIndices) {
+      auto jf = std::dynamic_pointer_cast<JacobianFactor>(graph[idx]);
+      if (!jf) continue;
+
+      for (auto it = jf->begin(); it != jf->end(); ++it) {
+        Key k = *it;
+        auto fIt = std::find(clique->frontalKeys.begin(),
+                             clique->frontalKeys.end(), k);
+        size_t blockIdx = 0;
+        if (fIt != clique->frontalKeys.end()) {
+          blockIdx = std::distance(clique->frontalKeys.begin(), fIt);
+        } else {
+          auto sIt = std::find(clique->separatorKeys.begin(),
+                               clique->separatorKeys.end(), k);
+          if (sIt != clique->separatorKeys.end()) {
+            blockIdx = clique->frontalKeys.size() +
+                       std::distance(clique->separatorKeys.begin(), sIt);
+          } else
+            continue;
+        }
+        clique->Ab(blockIdx).middleRows(rowOffset, jf->rows()) = jf->getA(it);
+      }
+      size_t rhsBlockIdx = blockDims.size() - 1;
+      clique->Ab(rhsBlockIdx).middleRows(rowOffset, jf->rows()) = jf->getb();
+      rowOffset += jf->rows();
+    }
+
+    // Pre-compute parent mapping
+    if (auto p = parent.lock()) {
+      for (Key k : clique->separatorKeys) {
+        auto fIt = std::find(p->frontalKeys.begin(), p->frontalKeys.end(), k);
+        if (fIt != p->frontalKeys.end()) {
+          clique->parentIndices.push_back(
+              std::distance(p->frontalKeys.begin(), fIt));
+          continue;
+        }
+        auto sIt =
+            std::find(p->separatorKeys.begin(), p->separatorKeys.end(), k);
+        if (sIt != p->separatorKeys.end()) {
+          clique->parentIndices.push_back(
+              p->frontalKeys.size() +
+              std::distance(p->separatorKeys.begin(), sIt));
+          continue;
+        }
+        throw std::runtime_error(
+            "MultifrontalSolver: separator key not found in parent clique");
+      }
+      // Last block is RHS
+      clique->parentIndices.push_back(p->frontalKeys.size() +
+                                      p->separatorKeys.size());
+    }
+
+    postOrderCliques_.push_back(clique);
+    return clique;
+  };
+
+  // 4. Start traversal from roots
+  for (const auto& rootCluster : jtree.roots()) {
+    if (rootCluster) {
+      roots_.push_back(buildRecursive(rootCluster, std::weak_ptr<Clique>()));
+    }
+  }
+}
+
+/* ************************************************************************* */
+void MultifrontalSolver::load(const GaussianFactorGraph& graph) {
+  for (auto& clique : cliques_) {
+    // 1. Reset SymmetricBlockMatrix
+    clique->sbm.blockStart() = 0;
+    clique->sbm.setZero();
+
+    // 2. Reset VerticalBlockMatrix
+    clique->Ab.matrix().setZero();
+
+    // 3. Fill VerticalBlockMatrix from graph
+    size_t rowOffset = 0;
+    for (size_t idx : clique->factorIndices) {
+      auto jf = std::dynamic_pointer_cast<JacobianFactor>(graph[idx]);
+      if (!jf) continue;
+
+      for (auto it = jf->begin(); it != jf->end(); ++it) {
+        Key k = *it;
+        auto fIt = std::find(clique->frontalKeys.begin(),
+                             clique->frontalKeys.end(), k);
+        size_t blockIdx = 0;
+        if (fIt != clique->frontalKeys.end()) {
+          blockIdx = std::distance(clique->frontalKeys.begin(), fIt);
+        } else {
+          auto sIt = std::find(clique->separatorKeys.begin(),
+                               clique->separatorKeys.end(), k);
+          if (sIt != clique->separatorKeys.end()) {
+            blockIdx = clique->frontalKeys.size() +
+                       std::distance(clique->separatorKeys.begin(), sIt);
+          } else
+            continue;
+        }
+        clique->Ab(blockIdx).middleRows(rowOffset, jf->rows()) = jf->getA(it);
+      }
+      size_t rhsBlockIdx = clique->Ab.nBlocks() - 1;
+      clique->Ab(rhsBlockIdx).middleRows(rowOffset, jf->rows()) = jf->getb();
+      rowOffset += jf->rows();
+    }
+  }
+}
+
+/* ************************************************************************* */
+void MultifrontalSolver::eliminate() {
+  for (auto& clique : postOrderCliques_) {
+    // 1. Add local Hessian: SBM += Ab' * Ab
+    clique->sbm.selfadjointView().rankUpdate(clique->Ab.matrix().transpose());
+
+    // 2. Eliminate frontal variables
+    clique->sbm.choleskyPartial(clique->frontalKeys.size());
+
+    // 3. Always split to store R_Sd for back-substitution
+    clique->R_Sd = clique->sbm.split(clique->frontalKeys.size());
+
+    // 4. Propagate separator to parent
+    if (auto parent = clique->parent.lock()) {
+      size_t nSeparatorBlocks = clique->separatorKeys.size();
+      for (size_t i = 0; i <= nSeparatorBlocks; ++i) {
+        size_t p_i = clique->parentIndices[i];
+        parent->sbm.updateDiagonalBlock(p_i, clique->sbm.diagonalBlock(i));
+        for (size_t j = i + 1; j <= nSeparatorBlocks; ++j) {
+          size_t p_j = clique->parentIndices[j];
+          parent->sbm.updateOffDiagonalBlock(
+              p_i, p_j, clique->sbm.aboveDiagonalBlock(i, j));
+        }
+      }
+    }
+  }
+}
+
+/* ************************************************************************* */
+VectorValues MultifrontalSolver::solve() const {
+  VectorValues x;
+  for (const auto& clique : cliques_) {
+    size_t nFrontals = clique->frontalKeys.size();
+    size_t nSeparators = clique->separatorKeys.size();
+
+    size_t nFrontalDim = 0;
+    for (Key k : clique->frontalKeys) nFrontalDim += dims_.at(k);
+
+    const Matrix& RSd = clique->R_Sd.full();
+    Vector rhs = RSd.col(RSd.cols() - 1);
+
+    for (size_t i = 0; i < nSeparators; ++i) {
+      Key k = clique->separatorKeys[i];
+      rhs.noalias() -= clique->R_Sd(nFrontals + i) * x.at(k);
+    }
+
+    Vector xF = RSd.leftCols(nFrontalDim)
+                    .template triangularView<Eigen::Upper>()
+                    .solve(rhs);
+
+    size_t offset = 0;
+    for (Key k : clique->frontalKeys) {
+      size_t d = dims_.at(k);
+      x.insert(k, xF.segment(offset, d));
+      offset += d;
+    }
+  }
+  return x;
+}
+
+}  // namespace gtsam

--- a/gtsam/linear/MultifrontalSolver.h
+++ b/gtsam/linear/MultifrontalSolver.h
@@ -85,12 +85,9 @@ class GTSAM_EXPORT MultifrontalSolver {
              const KeyFormatter& keyFormatter = DefaultKeyFormatter) const;
 
   friend std::ostream& operator<<(std::ostream& os,
-                                  const MultifrontalClique& clique);
-  friend std::ostream& operator<<(std::ostream& os,
                                   const MultifrontalSolver& solver);
 };
 
-std::ostream& operator<<(std::ostream& os, const MultifrontalClique& clique);
 std::ostream& operator<<(std::ostream& os, const MultifrontalSolver& solver);
 
 }  // namespace gtsam

--- a/gtsam/linear/MultifrontalSolver.h
+++ b/gtsam/linear/MultifrontalSolver.h
@@ -11,7 +11,7 @@
 
 /**
  * @file MultifrontalSolver.h
- * @brief
+ * @brief Imperative-style multifrontal solver for Gaussian factor graphs.
  * @author Frank Dellaert
  * @date   December 2025
  */
@@ -53,6 +53,8 @@ class GTSAM_EXPORT MultifrontalSolver {
   /**
    * Construct the solver from a factor graph and an ordering.
    * This builds the symbolic junction tree and pre-allocates all matrices.
+   * @param graph The factor graph to solve.
+   * @param ordering The variable ordering to use for elimination.
    */
   MultifrontalSolver(const GaussianFactorGraph& graph,
                      const Ordering& ordering);

--- a/gtsam/linear/MultifrontalSolver.h
+++ b/gtsam/linear/MultifrontalSolver.h
@@ -18,20 +18,22 @@
 
 #pragma once
 
-#include <gtsam/base/SymmetricBlockMatrix.h>
-#include <gtsam/base/VerticalBlockMatrix.h>
+#include <gtsam/inference/Key.h>
 #include <gtsam/inference/Ordering.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
 #include <gtsam/linear/VectorValues.h>
-#include <gtsam/symbolic/SymbolicJunctionTree.h>
 
+#include <iosfwd>
 #include <map>
+#include <memory>
 #include <vector>
 
 namespace gtsam {
 
+class MultifrontalClique;
+
 /**
- * Imperative, imperative-style multifrontal solver for Gaussian factor graphs.
+ * Imperative-style multifrontal solver for Gaussian factor graphs.
  *
  * This class pre-allocates all necessary memory for the elimination tree and
  * provides efficient methods for loading new factors, eliminating the graph,
@@ -39,37 +41,7 @@ namespace gtsam {
  */
 class GTSAM_EXPORT MultifrontalSolver {
  public:
-  struct Clique {
-    using shared_ptr = std::shared_ptr<Clique>;
-
-    Key key;                       ///< The clique's key in the junction tree
-    std::weak_ptr<Clique> parent;  ///< Parent clique
-    std::vector<shared_ptr> children;  ///< Child cliques
-
-    // Local factors (A, b) stored in a VerticalBlockMatrix
-    VerticalBlockMatrix Ab;
-
-    // Elimination result (R, S, d) stored in a SymmetricBlockMatrix
-    // SBM structure: [R S d; 0 L 0; 0 0 0] where L is the separator Hessian
-    SymmetricBlockMatrix sbm;
-
-    // Split-off conditional matrix [R S d]
-    VerticalBlockMatrix R_Sd;
-
-    // Indices of factors in the original graph that belong to this clique
-    std::vector<size_t> factorIndices;
-
-    KeyVector frontalKeys;    ///< Frontal keys for this clique
-    KeyVector separatorKeys;  ///< Separator keys for this clique
-
-    // Mapping from this clique's blocks (after elimination) to parent's blocks
-    // Index 0 is the first separator block, last index is the RHS block.
-    std::vector<size_t> parentIndices;
-
-    Clique(Key k) : key(k) {}
-  };
-
-  using CliquePtr = Clique::shared_ptr;
+  using CliquePtr = std::shared_ptr<MultifrontalClique>;
 
  private:
   std::vector<CliquePtr> roots_;
@@ -108,6 +80,17 @@ class GTSAM_EXPORT MultifrontalSolver {
 
   // Accessors for testing
   const std::vector<CliquePtr>& roots() const { return roots_; }
+
+  void print(const std::string& s = "",
+             const KeyFormatter& keyFormatter = DefaultKeyFormatter) const;
+
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const MultifrontalClique& clique);
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const MultifrontalSolver& solver);
 };
+
+std::ostream& operator<<(std::ostream& os, const MultifrontalClique& clique);
+std::ostream& operator<<(std::ostream& os, const MultifrontalSolver& solver);
 
 }  // namespace gtsam

--- a/gtsam/linear/MultifrontalSolver.h
+++ b/gtsam/linear/MultifrontalSolver.h
@@ -48,6 +48,7 @@ class GTSAM_EXPORT MultifrontalSolver {
   std::vector<CliquePtr> cliques_;           // All cliques
   std::vector<CliquePtr> postOrderCliques_;  // For elimination
   std::map<Key, size_t> dims_;               // Variable dimensions
+  mutable VectorValues solution_;
 
  public:
   /**
@@ -76,9 +77,9 @@ class GTSAM_EXPORT MultifrontalSolver {
   /**
    * Solve for the update vector.
    *
-   * @return The solution vector delta.
+   * @return Reference to the internally cached solution vector.
    */
-  VectorValues solve() const;
+  const VectorValues& solve() const;
 
   // Accessors for testing
   const std::vector<CliquePtr>& roots() const { return roots_; }

--- a/gtsam/linear/MultifrontalSolver.h
+++ b/gtsam/linear/MultifrontalSolver.h
@@ -1,0 +1,113 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file MultifrontalSolver.h
+ * @brief
+ * @author Frank Dellaert
+ * @date   December 2025
+ */
+
+#pragma once
+
+#include <gtsam/base/SymmetricBlockMatrix.h>
+#include <gtsam/base/VerticalBlockMatrix.h>
+#include <gtsam/inference/Ordering.h>
+#include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/linear/VectorValues.h>
+#include <gtsam/symbolic/SymbolicJunctionTree.h>
+
+#include <map>
+#include <vector>
+
+namespace gtsam {
+
+/**
+ * Imperative, imperative-style multifrontal solver for Gaussian factor graphs.
+ *
+ * This class pre-allocates all necessary memory for the elimination tree and
+ * provides efficient methods for loading new factors, eliminating the graph,
+ * and solving for the update vector.
+ */
+class GTSAM_EXPORT MultifrontalSolver {
+ public:
+  struct Clique {
+    using shared_ptr = std::shared_ptr<Clique>;
+
+    Key key;                       ///< The clique's key in the junction tree
+    std::weak_ptr<Clique> parent;  ///< Parent clique
+    std::vector<shared_ptr> children;  ///< Child cliques
+
+    // Local factors (A, b) stored in a VerticalBlockMatrix
+    VerticalBlockMatrix Ab;
+
+    // Elimination result (R, S, d) stored in a SymmetricBlockMatrix
+    // SBM structure: [R S d; 0 L 0; 0 0 0] where L is the separator Hessian
+    SymmetricBlockMatrix sbm;
+
+    // Split-off conditional matrix [R S d]
+    VerticalBlockMatrix R_Sd;
+
+    // Indices of factors in the original graph that belong to this clique
+    std::vector<size_t> factorIndices;
+
+    KeyVector frontalKeys;    ///< Frontal keys for this clique
+    KeyVector separatorKeys;  ///< Separator keys for this clique
+
+    // Mapping from this clique's blocks (after elimination) to parent's blocks
+    // Index 0 is the first separator block, last index is the RHS block.
+    std::vector<size_t> parentIndices;
+
+    Clique(Key k) : key(k) {}
+  };
+
+  using CliquePtr = Clique::shared_ptr;
+
+ private:
+  std::vector<CliquePtr> roots_;
+  std::vector<CliquePtr> cliques_;           // All cliques
+  std::vector<CliquePtr> postOrderCliques_;  // For elimination
+  std::map<Key, size_t> dims_;               // Variable dimensions
+
+ public:
+  /**
+   * Construct the solver from a factor graph and an ordering.
+   * This builds the symbolic junction tree and pre-allocates all matrices.
+   */
+  MultifrontalSolver(const GaussianFactorGraph& graph,
+                     const Ordering& ordering);
+
+  /**
+   * Load new numerical values from the factor graph.
+   * This overwrites the values in the pre-allocated matrices.
+   *
+   * @param graph The factor graph with updated values (structure must match).
+   */
+  void load(const GaussianFactorGraph& graph);
+
+  /**
+   * Eliminate the graph using Cholesky factorization.
+   * This operates in-place on the pre-allocated matrices.
+   */
+  void eliminate();
+
+  /**
+   * Solve for the update vector.
+   *
+   * @return The solution vector delta.
+   */
+  VectorValues solve() const;
+
+  // Accessors for testing
+  const std::vector<CliquePtr>& roots() const { return roots_; }
+};
+
+}  // namespace gtsam

--- a/gtsam/linear/VectorValues.cpp
+++ b/gtsam/linear/VectorValues.cpp
@@ -128,6 +128,18 @@ namespace gtsam {
   }
 
   /* ************************************************************************ */
+  VectorValues& VectorValues::insert(const Vector& values,
+                                     const KeyVector& keys, const Dims& dims) {
+    DenseIndex offset = 0;
+    for (Key key : keys) {
+      const size_t dim = dims.at(key);
+      insert(key, values.segment(offset, dim));
+      offset += dim;
+    }
+    return *this;
+  }
+
+  /* ************************************************************************ */
   void VectorValues::setZero()
   {
     for(auto& [key, value] : *this) {

--- a/gtsam/linear/VectorValues.h
+++ b/gtsam/linear/VectorValues.h
@@ -208,6 +208,10 @@ namespace gtsam {
      *  inserted are already used. */
     VectorValues& insert(const VectorValues& values);
 
+    /** Insert values from a concatenated vector using an explicit key order and dims. */
+    VectorValues& insert(const Vector& values, const KeyVector& keys,
+                         const Dims& dims);
+
     /** insert that mimics the STL map insert - if the value already exists, the map is not modified
      *  and an iterator to the existing value is returned, along with 'false'.  If the value did not
      *  exist, it is inserted and an iterator pointing to the new element, along with 'true', is

--- a/gtsam/linear/VectorValues.h
+++ b/gtsam/linear/VectorValues.h
@@ -208,7 +208,14 @@ namespace gtsam {
      *  inserted are already used. */
     VectorValues& insert(const VectorValues& values);
 
-    /** Insert values from a concatenated vector using an explicit key order and dims. */
+    /** Insert values from a concatenated vector using an explicit key order and dims.
+     * This method splits the concatenated vector according to the dimensions
+     * specified in dims and inserts each segment with the corresponding key from keys.
+     * @param values The concatenated vector to insert.
+     * @param keys The keys in order corresponding to segments in values.
+     * @param dims The dimensions map specifying the size of each key's vector.
+     * @return Reference to this VectorValues for chaining.
+     * @throws invalid_argument if any key already exists or if dimensions don't match. */
     VectorValues& insert(const Vector& values, const KeyVector& keys,
                          const Dims& dims);
 

--- a/gtsam/linear/VectorValues.h
+++ b/gtsam/linear/VectorValues.h
@@ -289,11 +289,11 @@ namespace gtsam {
     Vector vector(const CONTAINER& keys) const {
       DenseIndex totalDim = 0;
       FastVector<const Vector*> items;
-      items.reserve(keys.end() - keys.begin());
+      items.reserve(keys.size());
       for (Key key : keys) {
         const Vector* v = &at(key);
         totalDim += v->size();
-        items.push_back(v);
+        items.emplace_back(v);
       }
 
       Vector result(totalDim);

--- a/gtsam/linear/tests/testMultifrontalSolver.cpp
+++ b/gtsam/linear/tests/testMultifrontalSolver.cpp
@@ -11,7 +11,7 @@
 
 /**
  * @file testMultifrontalSolver.cpp
- * @brief
+ * @brief Unit tests for MultifrontalSolver.
  * @author Frank Dellaert
  * @date   December 2025
  */
@@ -59,20 +59,20 @@ TEST(MultifrontalSolver, Constructor) {
 
   // Root should have 1 child {x2, x1}
   EXPECT_LONGS_EQUAL(1, root->children().size());
-  auto c1 = root->children()[0];
+  auto childClique = root->children()[0];
 
-  // Verify matrices in leaf (c1)
-  EXPECT_LONGS_EQUAL(4, c1->sbm().nBlocks());
-  EXPECT_LONGS_EQUAL(2, c1->Ab().rows());
-  EXPECT_LONGS_EQUAL(4, c1->Ab().nBlocks());
+  // Verify matrices in leaf (childClique)
+  EXPECT_LONGS_EQUAL(4, childClique->sbm().nBlocks());
+  EXPECT_LONGS_EQUAL(2, childClique->Ab().rows());
+  EXPECT_LONGS_EQUAL(4, childClique->Ab().nBlocks());
 
-  // Verify initial load for c1
+  // Verify initial load for childClique
   // Block 0 (x2):
-  Matrix A0 = c1->Ab()(0);  // 2x1
+  Matrix A0 = childClique->Ab()(0);  // 2x1
   EXPECT(assert_equal((Matrix(2, 1) << 1., 1.).finished(), A0));
 
   // Block 3 (RHS):
-  Matrix Ab = c1->Ab()(3);  // 2x1
+  Matrix Ab = childClique->Ab()(3);  // 2x1
   EXPECT(assert_equal((Matrix(2, 1) << 1., 1.).finished(), Ab));
 }
 
@@ -83,23 +83,23 @@ TEST(MultifrontalSolver, Load) {
   // Create a new graph with doubled values
   GaussianFactorGraph chain2;
   for (const auto& factor : chain) {
-    auto jf = std::dynamic_pointer_cast<JacobianFactor>(factor);
+    auto jacobianFactor = std::dynamic_pointer_cast<JacobianFactor>(factor);
     std::map<Key, Matrix> terms;
-    for (auto it = jf->begin(); it != jf->end(); ++it) {
-      terms[*it] = jf->getA(it) * 2.0;
+    for (auto it = jacobianFactor->begin(); it != jacobianFactor->end(); ++it) {
+      terms[*it] = jacobianFactor->getA(it) * 2.0;
     }
-    chain2.push_back(std::make_shared<JacobianFactor>(terms, jf->getb() * 2.0,
-                                                      jf->get_model()));
+    chain2.push_back(std::make_shared<JacobianFactor>(terms, jacobianFactor->getb() * 2.0,
+                                                      jacobianFactor->get_model()));
   }
 
   solver.load(chain2);
 
-  // Verify values in c1
+  // Verify values in childClique
   auto root = solver.roots()[0];
-  auto c1 = root->children()[0];
+  auto childClique = root->children()[0];
 
   // Block 0 (x2) should now be 2.0
-  Matrix A0 = c1->Ab()(0);
+  Matrix A0 = childClique->Ab()(0);
   EXPECT(assert_equal((Matrix(2, 1) << 2., 2.).finished(), A0));
 }
 

--- a/gtsam/linear/tests/testMultifrontalSolver.cpp
+++ b/gtsam/linear/tests/testMultifrontalSolver.cpp
@@ -88,8 +88,8 @@ TEST(MultifrontalSolver, Load) {
     for (auto it = jacobianFactor->begin(); it != jacobianFactor->end(); ++it) {
       terms[*it] = jacobianFactor->getA(it) * 2.0;
     }
-    chain2.push_back(std::make_shared<JacobianFactor>(terms, jacobianFactor->getb() * 2.0,
-                                                      jacobianFactor->get_model()));
+    chain2.push_back(std::make_shared<JacobianFactor>(
+        terms, jacobianFactor->getb() * 2.0, jacobianFactor->get_model()));
   }
 
   solver.load(chain2);
@@ -109,7 +109,7 @@ TEST(MultifrontalSolver, Eliminate) {
   solver.eliminate();
 
   // Solve
-  VectorValues actual = solver.solve();
+  const VectorValues& actual = solver.solve();
 
   // Reference elimination and solve
   GaussianBayesTree expectedBT = *chain.eliminateMultifrontal(chainOrdering);
@@ -152,7 +152,7 @@ TEST(MultifrontalSolver, BalancedSmoother) {
 
   // Eliminate and solve
   solver.eliminate();
-  VectorValues actual = solver.solve();
+  const VectorValues& actual = solver.solve();
 
   GaussianBayesTree expectedBT = *smoother.eliminateMultifrontal(ordering);
   VectorValues expected = expectedBT.optimize();
@@ -161,7 +161,7 @@ TEST(MultifrontalSolver, BalancedSmoother) {
   // Eliminate and solve after loading new values
   solver.load(smoother);
   solver.eliminate();
-  VectorValues actual2 = solver.solve();
+  const VectorValues& actual2 = solver.solve();
   EXPECT(assert_equal(expected, actual2, 1e-9));
 }
 

--- a/gtsam/linear/tests/testMultifrontalSolver.cpp
+++ b/gtsam/linear/tests/testMultifrontalSolver.cpp
@@ -24,7 +24,6 @@
 #include <gtsam/linear/MultifrontalSolver.h>
 #include <tests/smallExample.h>
 
-#include <chrono>
 #include <functional>
 
 using namespace std;
@@ -35,12 +34,9 @@ namespace {
 const Key x1 = 1, x2 = 2, x3 = 3, x4 = 4;
 const SharedDiagonal chainNoise = noiseModel::Isotropic::Sigma(1, 0.5);
 const GaussianFactorGraph chain = {
-    std::make_shared<JacobianFactor>(x2, I_1x1, x1, I_1x1,
-                                     (Vector(1) << 1.).finished(), chainNoise),
-    std::make_shared<JacobianFactor>(x2, I_1x1, x3, I_1x1,
-                                     (Vector(1) << 1.).finished(), chainNoise),
-    std::make_shared<JacobianFactor>(x3, I_1x1, x4, I_1x1,
-                                     (Vector(1) << 1.).finished(), chainNoise),
+    std::make_shared<JacobianFactor>(x2, I_1x1, x1, I_1x1, I_1x1, chainNoise),
+    std::make_shared<JacobianFactor>(x2, I_1x1, x3, I_1x1, I_1x1, chainNoise),
+    std::make_shared<JacobianFactor>(x3, I_1x1, x4, I_1x1, I_1x1, chainNoise),
     std::make_shared<JacobianFactor>(x4, I_1x1, (Vector(1) << 1.).finished(),
                                      chainNoise)};
 const Ordering chainOrdering{x2, x1, x3, x4};
@@ -126,7 +122,6 @@ TEST(MultifrontalSolver, Eliminate) {
 TEST(MultifrontalSolver, BalancedSmoother) {
   // Create smoother with 7 nodes
   auto [nlfg, poses] = example::createNonlinearSmoother(7);
-  poses.print("Poses:");
   poses.update(X(1), Point2(1.1, 0.2));
   GaussianFactorGraph smoother = *nlfg.linearize(poses);
 
@@ -134,8 +129,6 @@ TEST(MultifrontalSolver, BalancedSmoother) {
   const Ordering ordering{X(1), X(3), X(5), X(7), X(2), X(6), X(4)};
 
   MultifrontalSolver solver(smoother, ordering);
-  std::cout << solver << std::endl;
-  solver.print();
 
   // Verify roots
   EXPECT(solver.roots().size() == 1);
@@ -150,7 +143,7 @@ TEST(MultifrontalSolver, BalancedSmoother) {
       [&](MultifrontalSolver::CliquePtr c) {
         for (Key k : c->frontals())
           if (k == X(1)) cX1 = c;
-      for (auto child : c->children()) findX1(child);
+        for (auto child : c->children()) findX1(child);
       };
   findX1(root);
 
@@ -159,9 +152,7 @@ TEST(MultifrontalSolver, BalancedSmoother) {
 
   // Eliminate and solve
   solver.eliminate();
-  solver.print();
   VectorValues actual = solver.solve();
-  GTSAM_PRINT(actual);
 
   GaussianBayesTree expectedBT = *smoother.eliminateMultifrontal(ordering);
   VectorValues expected = expectedBT.optimize();
@@ -169,47 +160,9 @@ TEST(MultifrontalSolver, BalancedSmoother) {
 
   // Eliminate and solve after loading new values
   solver.load(smoother);
-  solver.print();
   solver.eliminate();
   VectorValues actual2 = solver.solve();
   EXPECT(assert_equal(expected, actual2, 1e-9));
-}
-
-/* *************************************************************************
- */
-TEST(MultifrontalSolver, Benchmark) {
-  const size_t T = 500;
-  GaussianFactorGraph smoother = example::createSmoother(T);
-  const Ordering ordering = Ordering::Metis(smoother);
-
-  const size_t iterations = 100;
-
-  // Standard GTSAM
-  auto start = std::chrono::high_resolution_clock::now();
-  for (size_t i = 0; i < iterations; ++i) {
-    GaussianBayesTree bt = *smoother.eliminateMultifrontal(ordering);
-    VectorValues x = bt.optimize();
-  }
-  auto end = std::chrono::high_resolution_clock::now();
-  std::chrono::duration<double> t_standard = end - start;
-
-  // MultifrontalSolver
-  MultifrontalSolver solver(smoother, ordering);
-  start = std::chrono::high_resolution_clock::now();
-  for (size_t i = 0; i < iterations; ++i) {
-    solver.load(smoother);
-    solver.eliminate();
-    VectorValues x = solver.solve();
-  }
-  end = std::chrono::high_resolution_clock::now();
-  std::chrono::duration<double> t_imperative = end - start;
-
-  std::cout << "\nBenchmark (T=" << T << ", iterations=" << iterations
-            << "):\n";
-  std::cout << "  Standard GTSAM:     " << t_standard.count() << " s\n";
-  std::cout << "  MultifrontalSolver: " << t_imperative.count() << " s\n";
-  std::cout << "  Speedup:            "
-            << t_standard.count() / t_imperative.count() << "x\n";
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/tests/testMultifrontalSolver.cpp
+++ b/gtsam/linear/tests/testMultifrontalSolver.cpp
@@ -20,6 +20,7 @@
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/linear/GaussianBayesTree.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/linear/MultifrontalClique.h>
 #include <gtsam/linear/MultifrontalSolver.h>
 #include <tests/smallExample.h>
 
@@ -56,26 +57,26 @@ TEST(MultifrontalSolver, Constructor) {
 
   // Root should be {x3, x4} (merged)
   // Frontals: x3, x4
-  EXPECT_LONGS_EQUAL(2, root->frontalKeys.size());
-  EXPECT_LONGS_EQUAL(x3, root->frontalKeys[0]);
-  EXPECT_LONGS_EQUAL(x4, root->frontalKeys[1]);
+  EXPECT_LONGS_EQUAL(2, root->frontals().size());
+  EXPECT_LONGS_EQUAL(x3, root->frontals()[0]);
+  EXPECT_LONGS_EQUAL(x4, root->frontals()[1]);
 
   // Root should have 1 child {x2, x1}
-  EXPECT_LONGS_EQUAL(1, root->children.size());
-  auto c1 = root->children[0];
+  EXPECT_LONGS_EQUAL(1, root->children().size());
+  auto c1 = root->children()[0];
 
   // Verify matrices in leaf (c1)
-  EXPECT_LONGS_EQUAL(4, c1->sbm.nBlocks());
-  EXPECT_LONGS_EQUAL(2, c1->Ab.rows());
-  EXPECT_LONGS_EQUAL(4, c1->Ab.nBlocks());
+  EXPECT_LONGS_EQUAL(4, c1->sbm().nBlocks());
+  EXPECT_LONGS_EQUAL(2, c1->Ab().rows());
+  EXPECT_LONGS_EQUAL(4, c1->Ab().nBlocks());
 
   // Verify initial load for c1
   // Block 0 (x2):
-  Matrix A0 = c1->Ab(0);  // 2x1
+  Matrix A0 = c1->Ab()(0);  // 2x1
   EXPECT(assert_equal((Matrix(2, 1) << 1., 1.).finished(), A0));
 
   // Block 3 (RHS):
-  Matrix Ab = c1->Ab(3);  // 2x1
+  Matrix Ab = c1->Ab()(3);  // 2x1
   EXPECT(assert_equal((Matrix(2, 1) << 1., 1.).finished(), Ab));
 }
 
@@ -99,10 +100,10 @@ TEST(MultifrontalSolver, Load) {
 
   // Verify values in c1
   auto root = solver.roots()[0];
-  auto c1 = root->children[0];
+  auto c1 = root->children()[0];
 
   // Block 0 (x2) should now be 2.0
-  Matrix A0 = c1->Ab(0);
+  Matrix A0 = c1->Ab()(0);
   EXPECT(assert_equal((Matrix(2, 1) << 2., 2.).finished(), A0));
 }
 
@@ -124,59 +125,62 @@ TEST(MultifrontalSolver, Eliminate) {
 /* ************************************************************************* */
 TEST(MultifrontalSolver, BalancedSmoother) {
   // Create smoother with 7 nodes
-  GaussianFactorGraph smoother = example::createSmoother(7);
+  auto [nlfg, poses] = example::createNonlinearSmoother(7);
+  poses.print("Poses:");
+  poses.update(X(1), Point2(1.1, 0.2));
+  GaussianFactorGraph smoother = *nlfg.linearize(poses);
 
   // Create the Bayes tree ordering
   const Ordering ordering{X(1), X(3), X(5), X(7), X(2), X(6), X(4)};
 
   MultifrontalSolver solver(smoother, ordering);
+  std::cout << solver << std::endl;
+  solver.print();
 
   // Verify roots
   EXPECT(solver.roots().size() == 1);
   auto root = solver.roots()[0];
 
-  EXPECT_LONGS_EQUAL(root->frontalKeys.size() + root->separatorKeys.size() + 1,
-                     root->sbm.nBlocks());
+  EXPECT_LONGS_EQUAL(root->frontals().size() + root->separatorKeys().size() + 1,
+                     root->sbm().nBlocks());
 
   // Check a leaf clique (for X(1))
   MultifrontalSolver::CliquePtr cX1 = nullptr;
   std::function<void(MultifrontalSolver::CliquePtr)> findX1 =
       [&](MultifrontalSolver::CliquePtr c) {
-        for (Key k : c->frontalKeys)
+        for (Key k : c->frontals())
           if (k == X(1)) cX1 = c;
-        for (auto child : c->children) findX1(child);
+      for (auto child : c->children()) findX1(child);
       };
   findX1(root);
 
   EXPECT(cX1 != nullptr);
-  EXPECT_LONGS_EQUAL(3, cX1->sbm.nBlocks());
+  EXPECT_LONGS_EQUAL(3, cX1->sbm().nBlocks());
+
+  // Eliminate and solve
+  solver.eliminate();
+  solver.print();
+  VectorValues actual = solver.solve();
+  GTSAM_PRINT(actual);
+
+  GaussianBayesTree expectedBT = *smoother.eliminateMultifrontal(ordering);
+  VectorValues expected = expectedBT.optimize();
+  EXPECT(assert_equal(expected, actual, 1e-9));
+
+  // Eliminate and solve after loading new values
+  solver.load(smoother);
+  solver.print();
+  solver.eliminate();
+  VectorValues actual2 = solver.solve();
+  EXPECT(assert_equal(expected, actual2, 1e-9));
 }
 
-/* ************************************************************************* */
-TEST(MultifrontalSolver, IterativeSolve) {
-  GaussianFactorGraph smoother = example::createSmoother(100);
-  const Ordering ordering = Ordering::Colamd(smoother);
-
-  MultifrontalSolver solver(smoother, ordering);
-
-  for (size_t i = 0; i < 5; ++i) {
-    solver.load(smoother);
-    solver.eliminate();
-    VectorValues actual = solver.solve();
-
-    if (i == 0) {
-      GaussianBayesTree expectedBT = *smoother.eliminateMultifrontal(ordering);
-      VectorValues expected = expectedBT.optimize();
-      EXPECT(assert_equal(expected, actual, 1e-9));
-    }
-  }
-}
-
-/* ************************************************************************* */
+/* *************************************************************************
+ */
 TEST(MultifrontalSolver, Benchmark) {
   const size_t T = 500;
   GaussianFactorGraph smoother = example::createSmoother(T);
-  const Ordering ordering = Ordering::Colamd(smoother);
+  const Ordering ordering = Ordering::Metis(smoother);
 
   const size_t iterations = 100;
 

--- a/gtsam/linear/tests/testMultifrontalSolver.cpp
+++ b/gtsam/linear/tests/testMultifrontalSolver.cpp
@@ -1,0 +1,215 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file testMultifrontalSolver.cpp
+ * @brief
+ * @author Frank Dellaert
+ * @date   December 2025
+ */
+
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/linear/GaussianBayesTree.h>
+#include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/linear/MultifrontalSolver.h>
+#include <tests/smallExample.h>
+
+#include <chrono>
+#include <functional>
+
+using namespace std;
+using namespace gtsam;
+using symbol_shorthand::X;
+
+namespace {
+const Key x1 = 1, x2 = 2, x3 = 3, x4 = 4;
+const SharedDiagonal chainNoise = noiseModel::Isotropic::Sigma(1, 0.5);
+const GaussianFactorGraph chain = {
+    std::make_shared<JacobianFactor>(x2, I_1x1, x1, I_1x1,
+                                     (Vector(1) << 1.).finished(), chainNoise),
+    std::make_shared<JacobianFactor>(x2, I_1x1, x3, I_1x1,
+                                     (Vector(1) << 1.).finished(), chainNoise),
+    std::make_shared<JacobianFactor>(x3, I_1x1, x4, I_1x1,
+                                     (Vector(1) << 1.).finished(), chainNoise),
+    std::make_shared<JacobianFactor>(x4, I_1x1, (Vector(1) << 1.).finished(),
+                                     chainNoise)};
+const Ordering chainOrdering{x2, x1, x3, x4};
+}  // namespace
+
+/* ************************************************************************* */
+TEST(MultifrontalSolver, Constructor) {
+  MultifrontalSolver solver(chain, chainOrdering);
+
+  // Verify roots
+  EXPECT(solver.roots().size() == 1);
+  auto root = solver.roots()[0];
+  EXPECT(root != nullptr);
+
+  // Root should be {x3, x4} (merged)
+  // Frontals: x3, x4
+  EXPECT_LONGS_EQUAL(2, root->frontalKeys.size());
+  EXPECT_LONGS_EQUAL(x3, root->frontalKeys[0]);
+  EXPECT_LONGS_EQUAL(x4, root->frontalKeys[1]);
+
+  // Root should have 1 child {x2, x1}
+  EXPECT_LONGS_EQUAL(1, root->children.size());
+  auto c1 = root->children[0];
+
+  // Verify matrices in leaf (c1)
+  EXPECT_LONGS_EQUAL(4, c1->sbm.nBlocks());
+  EXPECT_LONGS_EQUAL(2, c1->Ab.rows());
+  EXPECT_LONGS_EQUAL(4, c1->Ab.nBlocks());
+
+  // Verify initial load for c1
+  // Block 0 (x2):
+  Matrix A0 = c1->Ab(0);  // 2x1
+  EXPECT(assert_equal((Matrix(2, 1) << 1., 1.).finished(), A0));
+
+  // Block 3 (RHS):
+  Matrix Ab = c1->Ab(3);  // 2x1
+  EXPECT(assert_equal((Matrix(2, 1) << 1., 1.).finished(), Ab));
+}
+
+/* ************************************************************************* */
+TEST(MultifrontalSolver, Load) {
+  MultifrontalSolver solver(chain, chainOrdering);
+
+  // Create a new graph with doubled values
+  GaussianFactorGraph chain2;
+  for (const auto& factor : chain) {
+    auto jf = std::dynamic_pointer_cast<JacobianFactor>(factor);
+    std::map<Key, Matrix> terms;
+    for (auto it = jf->begin(); it != jf->end(); ++it) {
+      terms[*it] = jf->getA(it) * 2.0;
+    }
+    chain2.push_back(std::make_shared<JacobianFactor>(terms, jf->getb() * 2.0,
+                                                      jf->get_model()));
+  }
+
+  solver.load(chain2);
+
+  // Verify values in c1
+  auto root = solver.roots()[0];
+  auto c1 = root->children[0];
+
+  // Block 0 (x2) should now be 2.0
+  Matrix A0 = c1->Ab(0);
+  EXPECT(assert_equal((Matrix(2, 1) << 2., 2.).finished(), A0));
+}
+
+/* ************************************************************************* */
+TEST(MultifrontalSolver, Eliminate) {
+  MultifrontalSolver solver(chain, chainOrdering);
+  solver.eliminate();
+
+  // Solve
+  VectorValues actual = solver.solve();
+
+  // Reference elimination and solve
+  GaussianBayesTree expectedBT = *chain.eliminateMultifrontal(chainOrdering);
+  VectorValues expected = expectedBT.optimize();
+
+  EXPECT(assert_equal(expected, actual, 1e-9));
+}
+
+/* ************************************************************************* */
+TEST(MultifrontalSolver, BalancedSmoother) {
+  // Create smoother with 7 nodes
+  GaussianFactorGraph smoother = example::createSmoother(7);
+
+  // Create the Bayes tree ordering
+  const Ordering ordering{X(1), X(3), X(5), X(7), X(2), X(6), X(4)};
+
+  MultifrontalSolver solver(smoother, ordering);
+
+  // Verify roots
+  EXPECT(solver.roots().size() == 1);
+  auto root = solver.roots()[0];
+
+  EXPECT_LONGS_EQUAL(root->frontalKeys.size() + root->separatorKeys.size() + 1,
+                     root->sbm.nBlocks());
+
+  // Check a leaf clique (for X(1))
+  MultifrontalSolver::CliquePtr cX1 = nullptr;
+  std::function<void(MultifrontalSolver::CliquePtr)> findX1 =
+      [&](MultifrontalSolver::CliquePtr c) {
+        for (Key k : c->frontalKeys)
+          if (k == X(1)) cX1 = c;
+        for (auto child : c->children) findX1(child);
+      };
+  findX1(root);
+
+  EXPECT(cX1 != nullptr);
+  EXPECT_LONGS_EQUAL(3, cX1->sbm.nBlocks());
+}
+
+/* ************************************************************************* */
+TEST(MultifrontalSolver, IterativeSolve) {
+  GaussianFactorGraph smoother = example::createSmoother(100);
+  const Ordering ordering = Ordering::Colamd(smoother);
+
+  MultifrontalSolver solver(smoother, ordering);
+
+  for (size_t i = 0; i < 5; ++i) {
+    solver.load(smoother);
+    solver.eliminate();
+    VectorValues actual = solver.solve();
+
+    if (i == 0) {
+      GaussianBayesTree expectedBT = *smoother.eliminateMultifrontal(ordering);
+      VectorValues expected = expectedBT.optimize();
+      EXPECT(assert_equal(expected, actual, 1e-9));
+    }
+  }
+}
+
+/* ************************************************************************* */
+TEST(MultifrontalSolver, Benchmark) {
+  const size_t T = 500;
+  GaussianFactorGraph smoother = example::createSmoother(T);
+  const Ordering ordering = Ordering::Colamd(smoother);
+
+  const size_t iterations = 100;
+
+  // Standard GTSAM
+  auto start = std::chrono::high_resolution_clock::now();
+  for (size_t i = 0; i < iterations; ++i) {
+    GaussianBayesTree bt = *smoother.eliminateMultifrontal(ordering);
+    VectorValues x = bt.optimize();
+  }
+  auto end = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> t_standard = end - start;
+
+  // MultifrontalSolver
+  MultifrontalSolver solver(smoother, ordering);
+  start = std::chrono::high_resolution_clock::now();
+  for (size_t i = 0; i < iterations; ++i) {
+    solver.load(smoother);
+    solver.eliminate();
+    VectorValues x = solver.solve();
+  }
+  end = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> t_imperative = end - start;
+
+  std::cout << "\nBenchmark (T=" << T << ", iterations=" << iterations
+            << "):\n";
+  std::cout << "  Standard GTSAM:     " << t_standard.count() << " s\n";
+  std::cout << "  MultifrontalSolver: " << t_imperative.count() << " s\n";
+  std::cout << "  Speedup:            "
+            << t_standard.count() / t_imperative.count() << "x\n";
+}
+
+/* ************************************************************************* */
+int main() {
+  TestResult tr;
+  return TestRegistry::runAllTests(tr);
+}

--- a/timing/timeMultifrontalSolver.cpp
+++ b/timing/timeMultifrontalSolver.cpp
@@ -1,0 +1,63 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file    timeMultifrontalSolver.cpp
+ * @brief   Compare MultifrontalSolver against standard elimination
+ * @author  Frank Dellaert
+ * @date    December 2025
+ */
+
+#include <gtsam/linear/GaussianBayesTree.h>
+#include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/linear/MultifrontalSolver.h>
+#include <tests/smallExample.h>
+
+#include <chrono>
+#include <iostream>
+
+using namespace std;
+using namespace gtsam;
+using namespace example;
+
+int main() {
+  const size_t T = 500;
+  GaussianFactorGraph smoother = createSmoother(T);
+  const Ordering ordering = Ordering::Metis(smoother);
+
+  const size_t iterations = 1000;
+
+  auto start = std::chrono::high_resolution_clock::now();
+  for (size_t i = 0; i < iterations; ++i) {
+    GaussianBayesTree bt = *smoother.eliminateMultifrontal(ordering);
+    VectorValues x = bt.optimize();
+  }
+  auto end = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> t_standard = end - start;
+
+  MultifrontalSolver solver(smoother, ordering);
+  start = std::chrono::high_resolution_clock::now();
+  for (size_t i = 0; i < iterations; ++i) {
+    solver.load(smoother);
+    solver.eliminate();
+    VectorValues x = solver.solve();
+  }
+  end = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> t_imperative = end - start;
+
+  cout << "\nBenchmark (T=" << T << ", iterations=" << iterations << "):\n";
+  cout << "  Standard GTSAM:     " << t_standard.count() << " s\n";
+  cout << "  MultifrontalSolver: " << t_imperative.count() << " s\n";
+  cout << "  Speedup:            " << t_standard.count() / t_imperative.count()
+       << "x\n";
+
+  return 0;
+}

--- a/timing/timeMultifrontalSolver.cpp
+++ b/timing/timeMultifrontalSolver.cpp
@@ -28,28 +28,40 @@ using namespace std;
 using namespace gtsam;
 using namespace example;
 
+/// Run standard GTSAM multifrontal elimination and optimization.
+static void runStandardSolver(const GaussianFactorGraph& smoother,
+                              const Ordering& ordering, size_t iterations) {
+  for (size_t i = 0; i < iterations; ++i) {
+    GaussianBayesTree bayesTree = *smoother.eliminateMultifrontal(ordering);
+    VectorValues solution = bayesTree.optimize();
+  }
+}
+
+/// Run new MultifrontalSolver elimination and optimization.
+static void runMultifrontalSolver(const GaussianFactorGraph& smoother,
+                                  const Ordering& ordering, size_t iterations) {
+  MultifrontalSolver solver(smoother, ordering);
+  for (size_t i = 0; i < iterations; ++i) {
+    solver.load(smoother);
+    solver.eliminate();
+    const VectorValues& solution = solver.solve();
+    (void)solution;
+  }
+}
+
 int main() {
   const size_t T = 500;
   GaussianFactorGraph smoother = createSmoother(T);
   const Ordering ordering = Ordering::Metis(smoother);
-
   const size_t iterations = 1000;
 
   auto start = std::chrono::high_resolution_clock::now();
-  for (size_t i = 0; i < iterations; ++i) {
-    GaussianBayesTree bt = *smoother.eliminateMultifrontal(ordering);
-    VectorValues x = bt.optimize();
-  }
+  runStandardSolver(smoother, ordering, iterations);
   auto end = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> t_standard = end - start;
 
-  MultifrontalSolver solver(smoother, ordering);
   start = std::chrono::high_resolution_clock::now();
-  for (size_t i = 0; i < iterations; ++i) {
-    solver.load(smoother);
-    solver.eliminate();
-    VectorValues x = solver.solve();
-  }
+  runMultifrontalSolver(smoother, ordering, iterations);
   end = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> t_imperative = end - start;
 

--- a/timing/timeMultifrontalSolver.cpp
+++ b/timing/timeMultifrontalSolver.cpp
@@ -50,26 +50,28 @@ static void runMultifrontalSolver(const GaussianFactorGraph& smoother,
 }
 
 int main() {
-  const size_t T = 500;
-  GaussianFactorGraph smoother = createSmoother(T);
-  const Ordering ordering = Ordering::Metis(smoother);
+  const std::vector<size_t> T_values = {10, 50, 100, 500, 1000, 5000};
   const size_t iterations = 1000;
 
-  auto start = std::chrono::high_resolution_clock::now();
-  runStandardSolver(smoother, ordering, iterations);
-  auto end = std::chrono::high_resolution_clock::now();
-  std::chrono::duration<double> t_standard = end - start;
+  for (size_t T : T_values) {
+    GaussianFactorGraph smoother = createSmoother(T);
+    const Ordering ordering = Ordering::Metis(smoother);
 
-  start = std::chrono::high_resolution_clock::now();
-  runMultifrontalSolver(smoother, ordering, iterations);
-  end = std::chrono::high_resolution_clock::now();
-  std::chrono::duration<double> t_imperative = end - start;
+    auto start = std::chrono::high_resolution_clock::now();
+    runStandardSolver(smoother, ordering, iterations);
+    auto end = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> t_standard = end - start;
 
-  cout << "\nBenchmark (T=" << T << ", iterations=" << iterations << "):\n";
-  cout << "  Standard GTSAM:     " << t_standard.count() << " s\n";
-  cout << "  MultifrontalSolver: " << t_imperative.count() << " s\n";
-  cout << "  Speedup:            " << t_standard.count() / t_imperative.count()
-       << "x\n";
+    start = std::chrono::high_resolution_clock::now();
+    runMultifrontalSolver(smoother, ordering, iterations);
+    end = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> t_imperative = end - start;
 
+    cout << "\nBenchmark (T=" << T << ", iterations=" << iterations << "):\n";
+    cout << "  Standard GTSAM:     " << t_standard.count() << " s\n";
+    cout << "  MultifrontalSolver: " << t_imperative.count() << " s\n";
+    cout << "  Speedup:            "
+         << t_standard.count() / t_imperative.count() << "x\n";
+  }
   return 0;
 }


### PR DESCRIPTION
In order to speed up optimization, I created a fully imperative multifrontal solver that nevertheless is in the style of GTSAM. However, it creates the structure and allocates memory only once, and then can be re-used in subsequent iterations. For a simple chain with 500 nodes, with metis ordering (tree of $\log_2(500)$ deep) it is between 3.5 and 4 times as fast:

```bash
make timeMultifrontalSolver.run

Benchmark (T=500, iterations=1000):
  Standard GTSAM:     2.12248 s
  MultifrontalSolver: 0.548226 s
  Speedup:            3.87155x
```

## Update

After storing pointers into the vectorValues data structure, we are now 5-6 times as fast (on Mac):

```bash
Benchmark (T=500, iterations=1000):
  Standard GTSAM:     1.8607 s
  MultifrontalSolver: 0.314121 s
  Speedup:            5.92352x
```
Also, I realized GTSAM is using TBB, whereas new solver is single-threaded for now.

<img width="840" height="490" alt="image" src="https://github.com/user-attachments/assets/4ebc36bc-f1e2-462a-8373-69afaaa4b3e3" />
