### PR TITLE
JacobianFactor now compute the error more efficiently by first assembling the X vector

### DIFF
--- a/gtsam/base/ConcurrentMap.h
+++ b/gtsam/base/ConcurrentMap.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <gtsam/global_includes.h>
+#include "gtsam/base/FastMap.h"
 
 // Change class depending on whether we are using TBB
 #ifdef GTSAM_USE_TBB
@@ -41,8 +42,7 @@ using ConcurrentMapBase = tbb::concurrent_unordered_map<
 
 #else
 
-// If we're not using TBB, use a FastMap for ConcurrentMap
-#include <gtsam/base/FastMap.h>
+// If we're not using TBB, use a std::map
 template <typename KEY, typename VALUE>
 using ConcurrentMapBase = gtsam::FastMap<KEY, VALUE>;
 

--- a/gtsam/base/ConcurrentMap.h
+++ b/gtsam/base/ConcurrentMap.h
@@ -19,7 +19,7 @@
 #pragma once
 
 #include <gtsam/global_includes.h>
-#include "gtsam/base/FastMap.h"
+#include <gtsam/base/FastMap.h>
 
 // Change class depending on whether we are using TBB
 #ifdef GTSAM_USE_TBB

--- a/gtsam/inference/BayesTree-inst.h
+++ b/gtsam/inference/BayesTree-inst.h
@@ -269,8 +269,35 @@ namespace gtsam {
   /* ************************************************************************* */
   template<class CLIQUE>
   bool BayesTree<CLIQUE>::equals(const BayesTree<CLIQUE>& other, double tol) const {
-    return size()==other.size() &&
-      std::equal(nodes_.begin(), nodes_.end(), other.nodes_.begin(), &check_sharedCliques<CLIQUE>);
+    // Compare number of cliques first.
+    if (size() != other.size())
+      return false;
+
+    // Compare number of variables (nodes index size).
+    if (nodes_.size() != other.nodes_.size())
+      return false;
+
+    // Compare cliques by key so equality does not depend on the
+    // iteration order of the underlying ConcurrentMap.
+    for (const auto& kv : nodes_) {
+      const Key key = kv.first;
+      const sharedClique& clique = kv.second;
+
+      auto it = other.nodes_.find(key);
+      if (it == other.nodes_.end())
+        return false;
+
+      const sharedClique& otherClique = it->second;
+
+      if (!clique && !otherClique)
+        continue;
+      if (!clique || !otherClique)
+        return false;
+      if (!clique->equals(*otherClique, tol))
+        return false;
+    }
+
+    return true;
   }
 
   /* ************************************************************************* */

--- a/gtsam/linear/Errors.cpp
+++ b/gtsam/linear/Errors.cpp
@@ -27,9 +27,9 @@ namespace gtsam {
 /* ************************************************************************* */
 Errors createErrors(const VectorValues& V) {
   Errors result;
-  for (const auto& [key, e] : V) {
-    result.push_back(e);
-  }
+  // Use a key-sorted view of VectorValues so the resulting Errors
+  // order is deterministic and independent of the underlying map.
+  for (const auto& [key, e] : V.sorted()) result.push_back(e);
   return result;
 }
 

--- a/gtsam/linear/GaussianConditional.cpp
+++ b/gtsam/linear/GaussianConditional.cpp
@@ -305,23 +305,36 @@ namespace gtsam {
     const Vector x =
         frontalValues.vector(KeyVector(beginFrontals(), endFrontals()));
 
-    // Copy the augmented Jacobian matrix:
-    auto newAb = Ab_;
-
-    // Restrict view to parent blocks
-    newAb.firstBlock() += nrFrontals_;
-
-    // Update right-hand-side (last column)
-    auto last = newAb.matrix().cols() - 1;
+    // Compute updated right-hand side: d - R * x
     const auto RR = R().triangularView<Eigen::Upper>();
-    newAb.matrix().col(last) -= RR * x;
+    const Vector rhs = d() - RR * x;
+
+    // Collect parent dimensions
+    FastVector<DenseIndex> parentDims;
+    parentDims.reserve(nrParents());
+    for (auto it = beginParents(); it != endParents(); ++it) {
+      parentDims.push_back(getDim(it));
+    }
+
+    // Build a VerticalBlockMatrix containing only parent blocks and RHS.
+    const DenseIndex m = rows();
+    VerticalBlockMatrix newAb(parentDims, m, true);
+
+    // Copy parent blocks (S matrices).
+    DenseIndex blockIndex = 0;
+    for (auto it = beginParents(); it != endParents(); ++it, ++blockIndex) {
+      newAb(blockIndex) = S(it);
+    }
+
+    // Set the RHS block.
+    const DenseIndex lastBlock = newAb.nBlocks() - 1;
+    newAb(lastBlock).col(0) = rhs;
 
     // The keys now do not include the frontal keys:
     KeyVector newKeys;
     newKeys.reserve(nrParents());
     for (auto&& key : parents()) newKeys.push_back(key);
 
-    // Hopefully second newAb copy below is optimized out...
     return std::make_shared<JacobianFactor>(newKeys, newAb, model_);
   }
 

--- a/gtsam/linear/JacobianFactor.cpp
+++ b/gtsam/linear/JacobianFactor.cpp
@@ -491,10 +491,17 @@ bool JacobianFactor::equals(const GaussianFactor& f_, double tol) const {
 
 /* ************************************************************************* */
 Vector JacobianFactor::unweighted_error(const VectorValues& c) const {
-  Vector e = -getb();
-  for (size_t pos = 0; pos < size(); ++pos)
-    e += Ab_(pos) * c[keys_[pos]];
-  return e;
+  const Vector v = c.vector(keys_);
+  Vector w(v.size() + 1);
+  w.segment(0, v.size()) = v;
+  w(v.size()) = -1.0;
+  // Fast path when the active view is the full matrix (no row/column offsets).
+  if (Ab_.firstBlock() == 0 && Ab_.rowStart() == 0 &&
+      Ab_.rowEnd() == Ab_.matrix().rows()) {
+    return Ab_.matrix() * w;
+  }
+  // Fallback that respects firstBlock/rowStart/rowEnd for subviews.
+  return Ab_.full() * w;
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/JacobianFactor.cpp
+++ b/gtsam/linear/JacobianFactor.cpp
@@ -491,10 +491,10 @@ bool JacobianFactor::equals(const GaussianFactor& f_, double tol) const {
 
 /* ************************************************************************* */
 Vector JacobianFactor::unweighted_error(const VectorValues& c) const {
-  const Vector v = c.vector(keys_);
-  Vector w(v.size() + 1);
-  w.segment(0, v.size()) = v;
-  w(v.size()) = -1.0;
+  const DenseIndex totalDim = c.totalDim(keys_);
+  Vector w(totalDim + 1);
+  c.fillVector(keys_, w);
+  w(totalDim) = -1.0;
   // Fast path when the active view is the full matrix (no row/column offsets).
   if (Ab_.firstBlock() == 0 && Ab_.rowStart() == 0 &&
       Ab_.rowEnd() == Ab_.matrix().rows()) {

--- a/gtsam/linear/SubgraphPreconditioner.cpp
+++ b/gtsam/linear/SubgraphPreconditioner.cpp
@@ -139,8 +139,9 @@ Errors SubgraphPreconditioner::operator*(const VectorValues &y) const {
 void SubgraphPreconditioner::multiplyInPlace(const VectorValues& y, Errors& e) const {
 
   Errors::iterator ei = e.begin();
-  for(const auto& key_value: y) {
-    *ei = key_value.second;
+  // Fill the identity-part errors in key-sorted order, to match createErrors.
+  for (const auto& [key, value] : y.sorted()) {
+    *ei = value;
     ++ei;
   }
 
@@ -155,8 +156,9 @@ VectorValues SubgraphPreconditioner::operator^(const Errors& e) const {
 
   Errors::const_iterator it = e.begin();
   VectorValues y = zero();
-  for(auto& key_value: y) {
-    key_value.second = *it;
+  // Map the identity-part errors back into y using key-sorted order.
+  for (const auto& [key, value] : y.sorted()) {
+    y.at(key) = *it;
     ++it;
   }
   transposeMultiplyAdd2(1.0, it, e.end(), y);
@@ -169,9 +171,11 @@ void SubgraphPreconditioner::transposeMultiplyAdd
 (double alpha, const Errors& e, VectorValues& y) const {
 
   Errors::const_iterator it = e.begin();
-  for(auto& key_value: y) {
+  // Add the identity-part contribution in key-sorted order so it
+  // matches the layout produced by createErrors().
+  for (const auto& [key, value] : y.sorted()) {
     const Vector& ei = *it;
-    key_value.second += alpha * ei;
+    y.at(key) += alpha * ei;
     ++it;
   }
   transposeMultiplyAdd2(alpha, it, e.end(), y);

--- a/gtsam/linear/VectorValues.cpp
+++ b/gtsam/linear/VectorValues.cpp
@@ -67,8 +67,8 @@ namespace gtsam {
   }
 
   /* ************************************************************************ */
-  std::map<Key, Vector> VectorValues::sorted() const {
-    std::map<Key, Vector> ordered;
+  std::map<Key, const Vector&> VectorValues::sorted() const {
+    std::map<Key, const Vector&> ordered;
     for (const auto& kv : *this) ordered.emplace(kv);
     return ordered;
   }
@@ -149,13 +149,8 @@ namespace gtsam {
 
   /* ************************************************************************ */
   GTSAM_EXPORT std::ostream& operator<<(std::ostream& os, const VectorValues& v) {
-    // Change print depending on whether we are using TBB
-#ifdef GTSAM_USE_TBB
-    for (const auto& [key, value] : v.sorted())
-#else
-    for (const auto& [key,value] : v)
-#endif
-    {
+    // Always print in key-sorted order for deterministic output.
+    for (const auto& [key, value] : v.sorted()) {
       os << "  " << StreamedKey(key) << ": " << value.transpose() << "\n";
     }
     return os;
@@ -171,13 +166,18 @@ namespace gtsam {
 
   /* ************************************************************************ */
   bool VectorValues::equals(const VectorValues& x, double tol) const {
-    if(this->size() != x.size())
-      return false;
-    auto this_it = this->begin();
-    auto x_it = x.begin();
-    for(; this_it != this->end(); ++this_it, ++x_it) {
-      if(this_it->first != x_it->first || 
-          !equal_with_abs_tol(this_it->second, x_it->second, tol))
+    if (this->size() != x.size()) return false;
+
+    // Compare in key-sorted order so equality is independent of
+    // the underlying (possibly unordered) container iteration order.
+    const auto thisOrdered = this->sorted();
+    const auto xOrdered = x.sorted();
+
+    auto it1 = thisOrdered.begin();
+    auto it2 = xOrdered.begin();
+    for (; it1 != thisOrdered.end(); ++it1, ++it2) {
+      if (it1->first != it2->first ||
+          !equal_with_abs_tol(it1->second, it2->second, tol))
         return false;
     }
     return true;
@@ -193,12 +193,9 @@ namespace gtsam {
     // Copy vectors
     Vector result(totalDim);
     DenseIndex pos = 0;
-#ifdef GTSAM_USE_TBB
-    // TBB uses un-ordered map, so inefficiently order them:
+    // Always order by key so the concatenated vector is deterministic
+    // even if the underlying container is unordered.
     for (const auto& [key, value] : sorted()) {
-#else
-    for (const auto& [key, value] : *this) {
-#endif
       result.segment(pos, value.size()) = value;
       pos += value.size();
     }
@@ -239,26 +236,40 @@ namespace gtsam {
   /* ************************************************************************ */
   bool VectorValues::hasSameStructure(const VectorValues other) const
   {
-    // compare the "other" container with this one, using the structureCompareOp
-    // and then return true if all elements are compared as equal
-    return std::equal(this->begin(), this->end(), other.begin(), other.end(),
-      internal::structureCompareOp);
+    if (this->size() != other.size()) return false;
+
+    // Compare in key-sorted order so structure comparison is
+    // independent of the underlying container iteration order.
+    const auto thisOrdered = this->sorted();
+    const auto otherOrdered = other.sorted();
+
+    auto it1 = thisOrdered.begin();
+    auto it2 = otherOrdered.begin();
+    for (; it1 != thisOrdered.end(); ++it1, ++it2) {
+      if (!internal::structureCompareOp(*it1, *it2)) return false;
+    }
+    return true;
   }
 
   /* ************************************************************************ */
   double VectorValues::dot(const VectorValues& v) const
   {
-    if(this->size() != v.size())
-      throw std::invalid_argument("VectorValues::dot called with a VectorValues of different structure");
+    if (this->size() != v.size())
+      throw std::invalid_argument(
+          "VectorValues::dot called with a VectorValues of different "
+          "structure");
+
     double result = 0.0;
-    auto this_it = this->begin();
-    auto v_it = v.begin();
-    for(; this_it != this->end(); ++this_it, ++v_it) {
-      assert_throw(this_it->first == v_it->first, 
-          std::invalid_argument("VectorValues::dot called with a VectorValues of different structure"));
-      assert_throw(this_it->second.size() == v_it->second.size(), 
-          std::invalid_argument("VectorValues::dot called with a VectorValues of different structure"));
-      result += this_it->second.dot(v_it->second);
+    for (const auto& [key, value] : *this) {
+      const auto it = v.find(key);
+      assert_throw(it != v.end(), std::invalid_argument(
+                                      "VectorValues::dot called with a "
+                                      "VectorValues of different structure"));
+      assert_throw(
+          value.size() == it->second.size(),
+          std::invalid_argument("VectorValues::dot called with a VectorValues "
+                                "of different structure"));
+      result += value.dot(it->second);
     }
     return result;
   }
@@ -280,19 +291,27 @@ namespace gtsam {
   /* ************************************************************************ */
   VectorValues VectorValues::operator+(const VectorValues& c) const
   {
-    if(this->size() != c.size())
-      throw std::invalid_argument("VectorValues::operator+ called with different vector sizes");
-    assert_throw(hasSameStructure(c),
-      std::invalid_argument("VectorValues::operator+ called with different vector sizes"));
+    if (this->size() != c.size())
+      throw std::invalid_argument(
+          "VectorValues::operator+ called with different vector sizes");
 
     VectorValues result;
-    // The result.end() hint here should result in constant-time inserts
-    for(const_iterator j1 = begin(), j2 = c.begin(); j1 != end(); ++j1, ++j2)
+    for (const auto& [key, value] : *this) {
+      const auto it = c.find(key);
+      assert_throw(
+          it != c.end(),
+          std::invalid_argument(
+              "VectorValues::operator+ called with different vector sizes"));
+      assert_throw(
+          value.size() == it->second.size(),
+          std::invalid_argument(
+              "VectorValues::operator+ called with different vector sizes"));
 #ifdef TBB_GREATER_EQUAL_2020
-      result.values_.emplace(j1->first, j1->second + j2->second);
+      result.values_.emplace(key, value + it->second);
 #else
-      result.values_.insert({j1->first, j1->second + j2->second});
+      result.values_.insert({key, value + it->second});
 #endif
+    }
 
     return result;
   }
@@ -306,16 +325,22 @@ namespace gtsam {
   /* ************************************************************************ */
   VectorValues& VectorValues::operator+=(const VectorValues& c)
   {
-    if(this->size() != c.size())
-      throw std::invalid_argument("VectorValues::operator+= called with different vector sizes");
-    assert_throw(hasSameStructure(c),
-      std::invalid_argument("VectorValues::operator+= called with different vector sizes"));
+    if (this->size() != c.size())
+      throw std::invalid_argument(
+          "VectorValues::operator+= called with different vector sizes");
 
-    iterator j1 = begin();
-    const_iterator j2 = c.begin();
-    // The result.end() hint here should result in constant-time inserts
-    for(; j1 != end(); ++j1, ++j2)
-      j1->second += j2->second;
+    for (auto& [key, value] : *this) {
+      const auto it = c.find(key);
+      assert_throw(
+          it != c.end(),
+          std::invalid_argument(
+              "VectorValues::operator+= called with different vector sizes"));
+      assert_throw(
+          value.size() == it->second.size(),
+          std::invalid_argument(
+              "VectorValues::operator+= called with different vector sizes"));
+      value += it->second;
+    }
 
     return *this;
   }
@@ -342,19 +367,27 @@ namespace gtsam {
   /* ************************************************************************ */
   VectorValues VectorValues::operator-(const VectorValues& c) const
   {
-    if(this->size() != c.size())
-      throw std::invalid_argument("VectorValues::operator- called with different vector sizes");
-    assert_throw(hasSameStructure(c),
-      std::invalid_argument("VectorValues::operator- called with different vector sizes"));
+    if (this->size() != c.size())
+      throw std::invalid_argument(
+          "VectorValues::operator- called with different vector sizes");
 
     VectorValues result;
-    // The result.end() hint here should result in constant-time inserts
-    for(const_iterator j1 = begin(), j2 = c.begin(); j1 != end(); ++j1, ++j2)
+    for (const auto& [key, value] : *this) {
+      const auto it = c.find(key);
+      assert_throw(
+          it != c.end(),
+          std::invalid_argument(
+              "VectorValues::operator- called with different vector sizes"));
+      assert_throw(
+          value.size() == it->second.size(),
+          std::invalid_argument(
+              "VectorValues::operator- called with different vector sizes"));
 #ifdef TBB_GREATER_EQUAL_2020
-      result.values_.emplace(j1->first, j1->second - j2->second);
+      result.values_.emplace(key, value - it->second);
 #else
-      result.values_.insert({j1->first, j1->second - j2->second});
+      result.values_.insert({key, value - it->second});
 #endif
+    }
 
     return result;
   }
@@ -412,12 +445,7 @@ namespace gtsam {
     ss << "  </thead>\n  <tbody>\n";
 
     // Print out all rows.
-#ifdef GTSAM_USE_TBB
-    // TBB uses un-ordered map, so inefficiently order them:
     for (const auto& kv : sorted()) {
-#else
-    for (const auto& kv : *this) {
-#endif
       ss << "    <tr>";
       ss << "<th>" << keyFormatter(kv.first) << "</th><td>"
          << kv.second.transpose() << "</td>";

--- a/gtsam/linear/VectorValues.h
+++ b/gtsam/linear/VectorValues.h
@@ -76,9 +76,6 @@ namespace gtsam {
     typedef ConcurrentMap<Key, Vector> Values;  ///< Collection of Vectors making up a VectorValues
     Values values_;                             ///< Vectors making up this VectorValues
 
-    /** Sort by key (primarily for use with TBB, which uses an unordered map)*/
-    std::map<Key, Vector> sorted() const;
-
    public:
     typedef Values::iterator iterator;              ///< Iterator over vector values
     typedef Values::const_iterator const_iterator;  ///< Const iterator over vector values
@@ -367,6 +364,9 @@ namespace gtsam {
 
     /** Element-wise scaling by a constant in-place. */
     VectorValues& scaleInPlace(double alpha);
+
+    /** Sort by key (primarily for use with TBB, which uses an unordered map)*/
+    std::map<Key, const Vector&> sorted() const;
 
     /// @}
 

--- a/gtsam/linear/VectorValues.h
+++ b/gtsam/linear/VectorValues.h
@@ -280,6 +280,29 @@ namespace gtsam {
     /** Retrieve the entire solution as a single vector */
     Vector vector() const;
 
+    /** Compute the total dimension of a subset of relevant keys. */
+    template <typename CONTAINER>
+    DenseIndex totalDim(const CONTAINER& keys) const {
+      DenseIndex totalDim = 0;
+      for (Key key : keys) {
+        totalDim += static_cast<DenseIndex>(at(key).size());
+      }
+      return totalDim;
+    }
+
+    /** Fill a preallocated Eigen vector expression with a subset of relevant keys. */
+    template <typename CONTAINER, typename Derived>
+    void fillVector(const CONTAINER& keys,
+                    const Eigen::MatrixBase<Derived>& result) const {
+      auto& writable = const_cast<Eigen::MatrixBase<Derived>&>(result);
+      DenseIndex pos = 0;
+      for (Key key : keys) {
+        const Vector& v = at(key);
+        writable.segment(pos, v.size()) = v;
+        pos += v.size();
+      }
+    }
+
     /** Access a vector that is a subset of relevant keys. */
     template <typename CONTAINER>
     Vector vector(const CONTAINER& keys) const {

--- a/gtsam/navigation/tests/testCombinedImuFactor.cpp
+++ b/gtsam/navigation/tests/testCombinedImuFactor.cpp
@@ -198,7 +198,7 @@ TEST_PIM(CombinedImuFactor, PredictRotation) {
 
   // Predict
   const Pose3 x(Rot3::Ypr(0, 0, 0), Point3(0, 0, 0)), x2;
-  const Vector3 v(0, 0, 0), v2(0, 0, 0);
+  const Vector3 v(0, 0, 0);
   const NavState actual = pim.predict(NavState(x, v), bias);
   const Pose3 expectedPose(Rot3::Ypr(M_PI / 10, 0, 0), Point3(0, 0, 0));
   EXPECT(assert_equal(expectedPose, actual.pose(), tol));

--- a/gtsam/nonlinear/Values.cpp
+++ b/gtsam/nonlinear/Values.cpp
@@ -107,14 +107,8 @@ namespace gtsam {
     assert(this->size() == delta.size());
     auto key_value = values_.begin();
     VectorValues::const_iterator key_delta;
-#ifdef GTSAM_USE_TBB
     for (; key_value != values_.end(); ++key_value) {
       key_delta = delta.find(key_value->first);
-#else
-    for (key_delta = delta.begin(); key_value != values_.end();
-         ++key_value, ++key_delta) {
-      assert(key_value->first == key_delta->first);
-#endif
       Key var = key_value->first;
       assert(static_cast<size_t>(delta[var].size()) == key_value->second->dim());
       assert(delta[var].allFinite());

--- a/tests/testSubgraphPreconditioner.cpp
+++ b/tests/testSubgraphPreconditioner.cpp
@@ -15,8 +15,7 @@
  *  @author Frank Dellaert
  **/
 
-#include <tests/smallExample.h>
-
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/linear/GaussianEliminationTree.h>
@@ -25,8 +24,7 @@
 #include <gtsam/linear/iterative.h>
 #include <gtsam/slam/dataset.h>
 #include <gtsam/symbolic/SymbolicFactorGraph.h>
-
-#include <CppUnitLite/TestHarness.h>
+#include <tests/smallExample.h>
 
 #include <fstream>
 
@@ -98,7 +96,7 @@ TEST(SubgraphPreconditioner, system) {
   // Eliminate the spanning tree to build a prior
   const Ordering ord = planarOrdering(N);
   auto Rc1 = *Ab1.eliminateSequential(ord);  // R1*x-c1
-  VectorValues xbar = Rc1.optimize();       // xbar = inv(R1)*c1
+  VectorValues xbar = Rc1.optimize();        // xbar = inv(R1)*c1
 
   // Create Subgraph-preconditioned system
   const SubgraphPreconditioner system(Ab2, Rc1, xbar);
@@ -188,7 +186,7 @@ TEST(SubgraphPreconditioner, conjugateGradients) {
 
   // Eliminate the spanning tree to build a prior
   GaussianBayesNet Rc1 = *Ab1.eliminateSequential();  // R1*x-c1
-  VectorValues xbar = Rc1.optimize();  // xbar = inv(R1)*c1
+  VectorValues xbar = Rc1.optimize();                 // xbar = inv(R1)*c1
 
   // Create Subgraph-preconditioned system
   SubgraphPreconditioner system(Ab2, Rc1, xbar);
@@ -202,9 +200,11 @@ TEST(SubgraphPreconditioner, conjugateGradients) {
 
   // Solve for the remaining constraints using PCG
   ConjugateGradientParameters parameters;
-  VectorValues actual = conjugateGradients<SubgraphPreconditioner,
-      VectorValues, Errors>(system, y1, parameters);
-  EXPECT(assert_equal(y0,actual));
+  parameters.setVerbosity("ERROR");
+  VectorValues actual =
+      conjugateGradients<SubgraphPreconditioner, VectorValues, Errors>(
+          system, y1, parameters);
+  EXPECT(assert_equal(y0, actual));
 
   // Compare with non preconditioned version:
   VectorValues actual2 = conjugateGradientDescent(Ab, x1, parameters);


### PR DESCRIPTION
We also now directly assemble the new `GaussianConditional` instead of using the `copy-then-offset` strategy.

During the implementation I also discovered some latent bugs related to the iteration order of the `VectorValues`.

- ~~Replace `FastMap`-based `ConcurrentMap` fallback with `std::unordered_map` when TBB is disabled.~~
- Tighten `BayesTree::equals` logic and related `Values` handling.
- Silence `Point2`/`Point3` constructor unused variable warnings.