### PR TITLE
Handle noise and NonlinearEquality constraints

### DIFF
--- a/gtsam/base/SymmetricBlockMatrix.cpp
+++ b/gtsam/base/SymmetricBlockMatrix.cpp
@@ -107,6 +107,26 @@ VerticalBlockMatrix SymmetricBlockMatrix::split(DenseIndex nFrontals) {
 }
 
 /* ************************************************************************* */
+void SymmetricBlockMatrix::updateFromMappedBlocks(
+    const SymmetricBlockMatrix& other,
+    const std::vector<DenseIndex>& blockIndices) {
+  assert(static_cast<DenseIndex>(blockIndices.size()) == other.nBlocks());
+  const DenseIndex nBlocks = other.nBlocks();
+  for (DenseIndex i = 0; i < nBlocks; ++i) {
+    const DenseIndex I = blockIndices[i];
+    if (I < 0) continue;
+    assert(I < nBlocks());
+    updateDiagonalBlock(I, other.diagonalBlock(i));
+    for (DenseIndex j = i + 1; j < nBlocks; ++j) {
+      const DenseIndex J = blockIndices[j];
+      if (J < 0) continue;
+      assert(J < nBlocks());
+      updateOffDiagonalBlock(I, J, other.aboveDiagonalBlock(i, j));
+    }
+  }
+}
+
+/* ************************************************************************* */
 
 } //\ namespace gtsam
 

--- a/gtsam/base/SymmetricBlockMatrix.cpp
+++ b/gtsam/base/SymmetricBlockMatrix.cpp
@@ -111,13 +111,13 @@ void SymmetricBlockMatrix::updateFromMappedBlocks(
     const SymmetricBlockMatrix& other,
     const std::vector<DenseIndex>& blockIndices) {
   assert(static_cast<DenseIndex>(blockIndices.size()) == other.nBlocks());
-  const DenseIndex nBlocks = other.nBlocks();
-  for (DenseIndex i = 0; i < nBlocks; ++i) {
+  const DenseIndex otherBlocks = other.nBlocks();
+  for (DenseIndex i = 0; i < otherBlocks; ++i) {
     const DenseIndex I = blockIndices[i];
     if (I < 0) continue;
     assert(I < nBlocks());
     updateDiagonalBlock(I, other.diagonalBlock(i));
-    for (DenseIndex j = i + 1; j < nBlocks; ++j) {
+    for (DenseIndex j = i + 1; j < otherBlocks; ++j) {
       const DenseIndex J = blockIndices[j];
       if (J < 0) continue;
       assert(J < nBlocks());
@@ -129,4 +129,3 @@ void SymmetricBlockMatrix::updateFromMappedBlocks(
 /* ************************************************************************* */
 
 } //\ namespace gtsam
-

--- a/gtsam/base/SymmetricBlockMatrix.h
+++ b/gtsam/base/SymmetricBlockMatrix.h
@@ -247,20 +247,9 @@ namespace gtsam {
     }
 
     /// Update this matrix with blocks from another block matrix using a mapping.
-    template <typename INDEX_CONTAINER>
+    /// Entries with index -1 are skipped.
     void updateFromMappedBlocks(const SymmetricBlockMatrix& other,
-                                const INDEX_CONTAINER& blockIndices) {
-      assert(static_cast<DenseIndex>(blockIndices.size()) == other.nBlocks());
-      const DenseIndex nBlocks = other.nBlocks();
-      for (DenseIndex i = 0; i < nBlocks; ++i) {
-        const DenseIndex I = static_cast<DenseIndex>(blockIndices[i]);
-        updateDiagonalBlock(I, other.diagonalBlock(i));
-        for (DenseIndex j = i + 1; j < nBlocks; ++j) {
-          const DenseIndex J = static_cast<DenseIndex>(blockIndices[j]);
-          updateOffDiagonalBlock(I, J, other.aboveDiagonalBlock(i, j));
-        }
-      }
-    }
+                                const std::vector<DenseIndex>& blockIndices);
 
     /// @}
     /// @name Accessing the full matrix.

--- a/gtsam/base/SymmetricBlockMatrix.h
+++ b/gtsam/base/SymmetricBlockMatrix.h
@@ -27,6 +27,7 @@
 #include <cassert>
 #include <stdexcept>
 #include <array>
+#include <vector>
 
 namespace boost {
 namespace serialization {
@@ -242,6 +243,22 @@ namespace gtsam {
         block_(I, J).noalias() += xpr;
       } else {
         block_(J, I).noalias() += xpr.transpose();
+      }
+    }
+
+    /// Update this matrix with blocks from another block matrix using a mapping.
+    template <typename INDEX_CONTAINER>
+    void updateFromMappedBlocks(const SymmetricBlockMatrix& other,
+                                const INDEX_CONTAINER& blockIndices) {
+      assert(static_cast<DenseIndex>(blockIndices.size()) == other.nBlocks());
+      const DenseIndex nBlocks = other.nBlocks();
+      for (DenseIndex i = 0; i < nBlocks; ++i) {
+        const DenseIndex I = static_cast<DenseIndex>(blockIndices[i]);
+        updateDiagonalBlock(I, other.diagonalBlock(i));
+        for (DenseIndex j = i + 1; j < nBlocks; ++j) {
+          const DenseIndex J = static_cast<DenseIndex>(blockIndices[j]);
+          updateOffDiagonalBlock(I, J, other.aboveDiagonalBlock(i, j));
+        }
       }
     }
 

--- a/gtsam/base/tests/testSymmetricBlockMatrix.cpp
+++ b/gtsam/base/tests/testSymmetricBlockMatrix.cpp
@@ -159,7 +159,7 @@ TEST(SymmetricBlockMatrix, expressions)
 TEST(SymmetricBlockMatrix, UpdateFromMappedBlocks)
 {
   const std::vector<size_t> destDims{1, 3, 2};
-  const std::vector<size_t> mapping{1, 2, 0};
+  const std::vector<DenseIndex> mapping{1, 2, 0};
 
   SymmetricBlockMatrix actual(destDims);
   actual.setZero();

--- a/gtsam/base/tests/testSymmetricBlockMatrix.cpp
+++ b/gtsam/base/tests/testSymmetricBlockMatrix.cpp
@@ -32,6 +32,7 @@ static SymmetricBlockMatrix testBlockMatrix(
   6, 12, 18, 24, 30, 36).finished());
 
 /* ************************************************************************* */
+// Read block accessors.
 TEST(SymmetricBlockMatrix, ReadBlocks)
 {
   // On the diagonal
@@ -51,6 +52,7 @@ TEST(SymmetricBlockMatrix, ReadBlocks)
 }
 
 /* ************************************************************************* */
+// Write block setters.
 TEST(SymmetricBlockMatrix, WriteBlocks)
 {
   // On the diagonal
@@ -77,6 +79,7 @@ TEST(SymmetricBlockMatrix, WriteBlocks)
 }
 
 /* ************************************************************************* */
+// Verify block range access.
 TEST(SymmetricBlockMatrix, Ranges)
 {
   // On the diagonal
@@ -97,6 +100,7 @@ TEST(SymmetricBlockMatrix, Ranges)
 }
 
 /* ************************************************************************* */
+// Exercise block expression helpers.
 TEST(SymmetricBlockMatrix, expressions)
 {
   const std::vector<size_t> dimensions{2, 3, 1};
@@ -151,6 +155,40 @@ TEST(SymmetricBlockMatrix, expressions)
 }
 
 /* ************************************************************************* */
+// Update via block mapping.
+TEST(SymmetricBlockMatrix, UpdateFromMappedBlocks)
+{
+  const std::vector<size_t> destDims{1, 3, 2};
+  const std::vector<size_t> mapping{1, 2, 0};
+
+  SymmetricBlockMatrix actual(destDims);
+  actual.setZero();
+  actual.updateFromMappedBlocks(testBlockMatrix, mapping);
+
+  SymmetricBlockMatrix expected(destDims);
+  expected.setZero();
+  for (DenseIndex i = 0; i < testBlockMatrix.nBlocks(); ++i) {
+    const DenseIndex I = static_cast<DenseIndex>(mapping[i]);
+    expected.updateDiagonalBlock(I, testBlockMatrix.diagonalBlock(i));
+    for (DenseIndex j = i + 1; j < testBlockMatrix.nBlocks(); ++j) {
+      const DenseIndex J = static_cast<DenseIndex>(mapping[j]);
+      expected.setOffDiagonalBlock(I, J,
+                                   testBlockMatrix.aboveDiagonalBlock(i, j));
+    }
+  }
+  EXPECT(assert_equal(Matrix(expected.selfadjointView()),
+                      actual.selfadjointView()));
+
+  SymmetricBlockMatrix doubled(destDims);
+  doubled.setZero();
+  doubled.updateFromMappedBlocks(testBlockMatrix, mapping);
+  doubled.updateFromMappedBlocks(testBlockMatrix, mapping);
+  EXPECT(assert_equal(2.0 * Matrix(expected.selfadjointView()),
+                      Matrix(doubled.selfadjointView())));
+}
+
+/* ************************************************************************* */
+// In-place inversion path.
 TEST(SymmetricBlockMatrix, inverseInPlace) {
   // generate an invertible matrix
   const Vector3 a(1.0, 0.2, 2.0), b(0.3, 0.8, -1.0), c(0.1, 0.2, 0.7);
@@ -171,4 +209,3 @@ TEST(SymmetricBlockMatrix, inverseInPlace) {
 /* ************************************************************************* */
 int main() { TestResult tr; return TestRegistry::runAllTests(tr); }
 /* ************************************************************************* */
-

--- a/gtsam/inference/ClusterTree-inst.h
+++ b/gtsam/inference/ClusterTree-inst.h
@@ -42,6 +42,34 @@ std::vector<size_t> ClusterTree<GRAPH>::Cluster::nrFrontalsOfChildren() const {
 
 /* ************************************************************************* */
 template <class GRAPH>
+KeySet ClusterTree<GRAPH>::Cluster::separatorKeys(KeySetMap* cache) const {
+  if (cache) {
+    auto it = cache->find(this);
+    if (it != cache->end()) return it->second;
+  }
+
+  KeySet keys;
+  for (const auto& factor : factors) {
+    if (!factor) continue;
+    keys.insert(factor->begin(), factor->end());
+  }
+  for (const auto& child : children) {
+    KeySet childSeparators = child->separatorKeys(cache);
+    keys.insert(childSeparators.begin(), childSeparators.end());
+  }
+  for (Key key : orderedFrontalKeys) {
+    keys.erase(key);
+  }
+
+  if (cache) {
+    auto result = cache->emplace(this, std::move(keys));
+    return result.first->second;
+  }
+  return keys;
+}
+
+/* ************************************************************************* */
+template <class GRAPH>
 void ClusterTree<GRAPH>::Cluster::merge(const std::shared_ptr<Cluster>& cluster) {
   // Merge keys. For efficiency, we add keys in reverse order at end, calling reverse after..
   orderedFrontalKeys.insert(orderedFrontalKeys.end(), cluster->orderedFrontalKeys.rbegin(),

--- a/gtsam/inference/ClusterTree.h
+++ b/gtsam/inference/ClusterTree.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <gtsam/base/Testable.h>
+#include <gtsam/base/FastMap.h>
 #include <gtsam/base/FastVector.h>
 #include <gtsam/inference/Ordering.h>
 
@@ -95,6 +96,11 @@ class ClusterTree {
 
     /// Return a vector with nrFrontal keys for each child
     std::vector<size_t> nrFrontalsOfChildren() const;
+
+    using KeySetMap = FastMap<const Cluster*, KeySet>;
+
+    /// Return the separator keys (subtree keys minus frontals), optionally cached.
+    KeySet separatorKeys(KeySetMap* cache = nullptr) const;
 
     /// Merge in given cluster
     void merge(const std::shared_ptr<Cluster>& cluster);

--- a/gtsam/linear/HessianFactor.cpp
+++ b/gtsam/linear/HessianFactor.cpp
@@ -357,19 +357,7 @@ void HessianFactor::updateHessian(const KeyVector& infoKeys,
     slots[j] = Slot(infoKeys, keys_[j]);
   slots[nrVariablesInThisFactor] = info->nBlocks() - 1;
 
-  // Apply updates to the upper triangle
-  // Loop over this factor's blocks with indices (i,j)
-  // For every block (i,j), we determine the block (I,J) in info.
-  for (DenseIndex j = 0; j <= nrVariablesInThisFactor; ++j) {
-    const DenseIndex J = slots[j];
-    info->updateDiagonalBlock(J, info_.diagonalBlock(j));
-    for (DenseIndex i = 0; i < j; ++i) {
-      const DenseIndex I = slots[i];
-      assert(i < j);
-      assert(I != J);
-      info->updateOffDiagonalBlock(I, J, info_.aboveDiagonalBlock(i, j));
-    }
-  }
+  info->updateFromMappedBlocks(info_, slots);
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -79,6 +79,18 @@ void MultifrontalClique::finalize(const std::map<Key, size_t>& dims,
                                   VectorValues* solution) {
   calculateSeparatorKeys();
 
+  // Cache the mapping from key to Ab block index for fast fills.
+  blockIndex_.clear();
+  size_t blockIdx = 0;
+  for (Key key : frontals()) {
+    blockIndex_[key] = blockIdx;
+    ++blockIdx;
+  }
+  for (Key key : separatorKeys_) {
+    blockIndex_[key] = blockIdx;
+    ++blockIdx;
+  }
+
   size_t dim = 0;
   for (Key key : frontals()) {
     auto it = dims.find(key);
@@ -93,9 +105,10 @@ void MultifrontalClique::finalize(const std::map<Key, size_t>& dims,
   }
   separatorDim = dim;
 
+  // Cache pointers into the solution for fast back-substitution.
   cacheSolutionPointers(solution);
 
-  /// Compute parent indices for all children
+  // Compute parent indices for all children.
   for (const auto& child : children) {
     if (!child) continue;
     child->setParentIndices(child->parentIndicesFor(*this));
@@ -193,6 +206,7 @@ void MultifrontalClique::fillAb(const GaussianFactorGraph& graph) {
   // We only overwrite the fixed sparsity pattern, so Ab must be zeroed once in
   // initializeMatrices and then kept consistent across loads.
   size_t rowOffset = 0;
+  const size_t rhsBlockIdx = Ab_.nBlocks() - 1;
   for (const auto& factor : cluster_->factors) {
     assert(factor);
     auto indexed =
@@ -201,27 +215,22 @@ void MultifrontalClique::fillAb(const GaussianFactorGraph& graph) {
         std::dynamic_pointer_cast<JacobianFactor>(graph[indexed->index_]);
     if (!jacobianFactor) continue;
 
+    const size_t rows = jacobianFactor->rows();
     for (auto it = jacobianFactor->begin(); it != jacobianFactor->end(); ++it) {
       Key k = *it;
-      auto fIt = std::find(frontals().begin(), frontals().end(), k);
-      size_t blockIdx = 0;
-      if (fIt != frontals().end()) {
-        blockIdx = std::distance(frontals().begin(), fIt);
-      } else {
-        auto sIt = std::find(separatorKeys_.begin(), separatorKeys_.end(), k);
-        if (sIt != separatorKeys_.end()) {
-          blockIdx =
-              frontals().size() + std::distance(separatorKeys_.begin(), sIt);
-        } else
-          continue;
-      }
+      auto blockIt = blockIndex_.find(k);
+      if (blockIt == blockIndex_.end()) continue;
+      const size_t blockIdx = blockIt->second;
       Ab_(blockIdx).middleRows(rowOffset, jacobianFactor->rows()) =
           jacobianFactor->getA(it);
     }
-    size_t rhsBlockIdx = Ab_.nBlocks() - 1;  // RHS block is appended by VBM.
-    Ab_(rhsBlockIdx).middleRows(rowOffset, jacobianFactor->rows()) =
-        jacobianFactor->getb();
-    rowOffset += jacobianFactor->rows();
+    Ab_(rhsBlockIdx).middleRows(rowOffset, rows) = jacobianFactor->getb();
+
+    if (auto model = jacobianFactor->get_model()) {
+      model->WhitenInPlace(Ab_.matrix().middleRows(rowOffset, rows));
+    }
+
+    rowOffset += rows;
   }
 }
 

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -229,8 +229,8 @@ void MultifrontalClique::initializeMatrices(
   Ab_.matrix().setZero();
 }
 
-void MultifrontalClique::addJacobianFactor(const JacobianFactor& jacobianFactor,
-                                           size_t rowOffset) {
+size_t MultifrontalClique::addJacobianFactor(
+    const JacobianFactor& jacobianFactor, size_t rowOffset) {
   // We only overwrite the fixed sparsity pattern, so Ab must be zeroed once in
   // initializeMatrices and then kept consistent across loads.
   const size_t rows = jacobianFactor.rows();
@@ -247,6 +247,7 @@ void MultifrontalClique::addJacobianFactor(const JacobianFactor& jacobianFactor,
       model->WhitenInPlace(Ab_.matrix().middleRows(rowOffset, rows));
     }
   }
+  return rows;
 }
 
 void MultifrontalClique::addHessianFactor(const HessianFactor& hessianFactor) {
@@ -264,7 +265,7 @@ void MultifrontalClique::addHessianFactor(const HessianFactor& hessianFactor) {
 }
 
 void MultifrontalClique::fillAb(const GaussianFactorGraph& graph) {
-  sbm_.setZero();
+  sbm_.setZero();  // Easily half of the cost !
 
   size_t rowOffset = 0;
   for (size_t index : factorIndices_) {
@@ -272,8 +273,7 @@ void MultifrontalClique::fillAb(const GaussianFactorGraph& graph) {
     const GaussianFactor::shared_ptr& gf = graph[index];
     if (!gf) continue;
     if (auto jacobianFactor = std::dynamic_pointer_cast<JacobianFactor>(gf)) {
-      addJacobianFactor(*jacobianFactor, rowOffset);
-      rowOffset += jacobianFactor->rows();
+      rowOffset += addJacobianFactor(*jacobianFactor, rowOffset);
     } else if (auto hessianFactor =
                    std::dynamic_pointer_cast<HessianFactor>(gf)) {
       addHessianFactor(*hessianFactor);

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -20,7 +20,6 @@
 #include <gtsam/linear/HessianFactor.h>
 #include <gtsam/linear/JacobianFactor.h>
 #include <gtsam/linear/MultifrontalClique.h>
-#include <gtsam/linear/NoiseModel.h>
 
 #include <algorithm>
 #include <cassert>
@@ -30,9 +29,6 @@
 namespace gtsam {
 
 namespace {
-
-constexpr double kConstraintSigmaTol = 1e-12;
-constexpr double kConstraintFeasibleTol = 1e-9;
 
 KeyVector orderedKeysFromBlockIndex(const std::map<Key, size_t>& blockIndex) {
   const size_t totalKeys = blockIndex.size();
@@ -55,29 +51,6 @@ void printKeyRange(std::ostream& os, const KeyVector& keys, size_t start,
   os << "]";
 }
 
-// Mark frontal variables that are fixed by the given constrained factor.
-void markFixedFrontals(const JacobianFactor& factor,
-                       const std::map<Key, size_t>& blockIndex,
-                       std::unordered_set<size_t>* fixedFrontals) {
-  if (factor.size() != 1) {
-    throw std::runtime_error(
-        "MultifrontalSolver: only unary constrained factors are supported.");
-  }
-  const auto model = factor.get_model();
-  const Vector sigmas = model->sigmas();
-  if (!(sigmas.array().abs() <= kConstraintSigmaTol).all()) {
-    throw std::runtime_error(
-        "MultifrontalSolver: only fully constrained factors are supported.");
-  }
-  if (factor.getb().array().abs().maxCoeff() > kConstraintFeasibleTol) {
-    throw std::runtime_error(
-        "MultifrontalSolver: constrained factor is not feasible.");
-  }
-  const Key key = *factor.begin();
-  const size_t blockIndexValue = blockIndex.at(key);
-  fixedFrontals->insert(blockIndexValue);
-}
-
 // Build a stacked separator vector x_sep in the provided scratch buffer.
 Vector& buildSeparatorVector(const std::vector<const Vector*>& separatorPtrs,
                              Vector* scratch) {
@@ -89,15 +62,36 @@ Vector& buildSeparatorVector(const std::vector<const Vector*>& separatorPtrs,
   return *scratch;
 }
 
+#ifndef NDEBUG
+bool validateFactorKeys(const GaussianFactorGraph& graph,
+                        const std::vector<size_t>& factorIndices,
+                        const std::map<Key, size_t>& blockIndex,
+                        const std::unordered_set<Key>* fixedKeys) {
+  for (size_t index : factorIndices) {
+    assert(index < graph.size());
+    const GaussianFactor::shared_ptr& gf = graph[index];
+    if (!gf) continue;
+    for (Key key : gf->keys()) {
+      if (blockIndex.find(key) != blockIndex.end()) continue;
+      if (fixedKeys && fixedKeys->count(key)) continue;
+      return false;
+    }
+  }
+  return true;
+}
+#endif
+
 }  // namespace
 
 MultifrontalClique::MultifrontalClique(
     std::vector<size_t> factorIndices,
     const std::weak_ptr<MultifrontalClique>& parent, const KeyVector& frontals,
     const KeyVector& separatorKeys, const std::map<Key, size_t>& dims,
-    const GaussianFactorGraph& graph, VectorValues* solution) {
+    const GaussianFactorGraph& graph, VectorValues* solution,
+    const std::unordered_set<Key>* fixedKeys) {
   factorIndices_ = std::move(factorIndices);
   this->parent = parent;
+  fixedKeys_ = fixedKeys;
 
   if (frontals.empty()) {
     throw std::runtime_error(
@@ -136,12 +130,11 @@ MultifrontalClique::MultifrontalClique(
   // Cache pointers into the solution for fast back-substitution.
   cacheSolutionPointers(solution, frontals, separatorKeys);
 
-  // Pre-allocate matrices and cache constraints once per structure.
+  // Pre-allocate matrices once per structure.
   std::vector<size_t> blockDims =
       this->blockDims(dims, frontals, separatorKeys);
   size_t vbmRows = countRows(graph);
   initializeMatrices(blockDims, vbmRows);
-  cacheConstraintInfo(graph);
 }
 
 void MultifrontalClique::finalize(std::vector<ChildInfo> children) {
@@ -154,7 +147,7 @@ void MultifrontalClique::finalize(std::vector<ChildInfo> children) {
   // Compute parent indices for all children.
   for (const auto& child : children) {
     if (!child.clique) continue;
-    std::vector<size_t> indices;
+    std::vector<DenseIndex> indices;
     indices.reserve(child.separatorKeys.size() + 1);
     for (Key key : child.separatorKeys) {
       auto it = blockIndex_.find(key);
@@ -162,27 +155,10 @@ void MultifrontalClique::finalize(std::vector<ChildInfo> children) {
         throw std::runtime_error(
             "MultifrontalSolver: separator key not found in parent clique");
       }
-      indices.push_back(it->second);
+      indices.push_back(static_cast<DenseIndex>(it->second));
     }
-    indices.push_back(blockIndex_.size());
+    indices.push_back(static_cast<DenseIndex>(blockIndex_.size()));
     child.clique->setParentIndices(indices);
-  }
-}
-
-void MultifrontalClique::cacheConstraintInfo(const GaussianFactorGraph& graph) {
-  fixedFrontals_.clear();
-
-  for (size_t index : factorIndices_) {
-    assert(index < graph.size());
-    const GaussianFactor::shared_ptr& gf = graph[index];
-    if (!gf) continue;
-    if (auto jacobianFactor = std::dynamic_pointer_cast<JacobianFactor>(gf)) {
-      if (auto model = jacobianFactor->get_model()) {
-        if (model->isConstrained()) {
-          markFixedFrontals(*jacobianFactor, blockIndex_, &fixedFrontals_);
-        }
-      }
-    }
   }
 }
 
@@ -237,6 +213,7 @@ size_t MultifrontalClique::addJacobianFactor(
   const size_t rhsBlockIdx = Ab_.nBlocks() - 1;
   for (auto it = jacobianFactor.begin(); it != jacobianFactor.end(); ++it) {
     Key k = *it;
+    if (fixedKeys_ && fixedKeys_->count(k)) continue;
     const size_t blockIdx = blockIndex_.at(k);
     Ab_(blockIdx).middleRows(rowOffset, rows) = jacobianFactor.getA(it);
   }
@@ -252,19 +229,24 @@ size_t MultifrontalClique::addJacobianFactor(
 
 void MultifrontalClique::addHessianFactor(const HessianFactor& hessianFactor) {
   const SymmetricBlockMatrix& info = hessianFactor.info();
-  const size_t factorBlocks = hessianFactor.size();
+  const DenseIndex factorBlocks = static_cast<DenseIndex>(hessianFactor.size());
+  const DenseIndex rhsBlock = static_cast<DenseIndex>(sbm_.nBlocks() - 1);
 
-  std::vector<DenseIndex> blockIndices(factorBlocks + 1);
-  size_t slot = 0;
+  std::vector<DenseIndex> blockIndices(factorBlocks + 1, -1);
+  DenseIndex slot = 0;
   for (auto it = hessianFactor.begin(); it != hessianFactor.end();
        ++it, ++slot) {
-    blockIndices[slot] = static_cast<DenseIndex>(blockIndex_.at(*it));
+    const Key key = *it;
+    if (fixedKeys_ && fixedKeys_->count(key)) continue;
+    blockIndices[slot] = static_cast<DenseIndex>(blockIndex_.at(key));
   }
-  blockIndices[factorBlocks] = static_cast<DenseIndex>(sbm_.nBlocks() - 1);
+  blockIndices[factorBlocks] = rhsBlock;
+
   sbm_.updateFromMappedBlocks(info, blockIndices);
 }
 
 void MultifrontalClique::fillAb(const GaussianFactorGraph& graph) {
+  assert(validateFactorKeys(graph, factorIndices_, blockIndex_, fixedKeys_));
   sbm_.setZero();  // Easily half of the cost !
 
   size_t rowOffset = 0;
@@ -290,22 +272,6 @@ void MultifrontalClique::eliminateInPlace() {
     child->updateParent(*this);
   }
 
-  if (!fixedFrontals_.empty()) {
-    const DenseIndex nBlocks = sbm_.nBlocks();
-    for (size_t fixedBlock : fixedFrontals_) {
-      const DenseIndex i = static_cast<DenseIndex>(fixedBlock);
-      const DenseIndex dimI = sbm_.getDim(i);
-      // Enforce hard constraints by clamping the frontal block to identity
-      // and zeroing cross-terms, so the variable is fixed at zero in the solve.
-      sbm_.setDiagonalBlock(i, Matrix::Identity(dimI, dimI));
-      for (DenseIndex j = 0; j < nBlocks; ++j) {
-        if (j == i) continue;
-        const DenseIndex dimJ = sbm_.getDim(j);
-        sbm_.setOffDiagonalBlock(i, j, Matrix::Zero(dimI, dimJ));
-      }
-    }
-  }
-
   // Form normal equations and factor the frontal block (Schur complement step).
   sbm_.choleskyPartial(numFrontals());
 }
@@ -323,19 +289,8 @@ std::shared_ptr<GaussianConditional> MultifrontalClique::conditional() const {
   SymmetricBlockMatrix& sbm = sbm_;
   VerticalBlockMatrix Ab = sbm.split(numFrontals());
   sbm.blockStart() = 0;  // Split sets it to numFrontals(), reset to 0.
-  SharedDiagonal model;  // defaults to empty
-  if (!fixedFrontals_.empty()) {
-    // Create a mixed sigmas model to represent constrained variables.
-    Vector sigmas = Vector::Ones(frontalDim);
-    for (size_t block : fixedFrontals_) {
-      const DenseIndex start = Ab.offset(static_cast<DenseIndex>(block));
-      const DenseIndex end = Ab.offset(static_cast<DenseIndex>(block + 1));
-      sigmas.segment(start, end - start).setZero();
-    }
-    model = noiseModel::Constrained::MixedSigmas(sigmas);
-  }
   return std::make_shared<GaussianConditional>(keys, numFrontals(),
-                                               std::move(Ab), model);
+                                               std::move(Ab));
 }
 
 // Solve with block back-substitution on the Cholesky-stored SBM.

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -80,13 +80,6 @@ void markFixedFrontals(const JacobianFactor& factor,
 // Build a stacked separator vector x_sep in the provided scratch buffer.
 Vector& buildSeparatorVector(const std::vector<const Vector*>& separatorPtrs,
                              Vector* scratch) {
-  size_t separatorDim = 0;
-  for (const Vector* values : separatorPtrs) {
-    separatorDim += values->size();
-  }
-  if (static_cast<size_t>(scratch->size()) != separatorDim) {
-    scratch->resize(separatorDim);
-  }
   size_t offset = 0;
   for (const Vector* values : separatorPtrs) {
     scratch->segment(offset, values->size()) = *values;
@@ -158,6 +151,9 @@ void MultifrontalClique::finalize(const KeyVector& frontals,
     if (it != dims.end()) dim += it->second;
   }
   separatorDim = dim;
+
+  rhsScratch_.resize(frontalDim);
+  separatorScratch_.resize(separatorDim);
 
   // Cache pointers into the solution for fast back-substitution.
   cacheSolutionPointers(solution, frontals, separatorKeys);
@@ -313,6 +309,8 @@ void MultifrontalClique::eliminateInPlace() {
     for (size_t fixedBlock : fixedFrontals_) {
       const DenseIndex i = static_cast<DenseIndex>(fixedBlock);
       const DenseIndex dimI = sbm_.getDim(i);
+      // Enforce hard constraints by clamping the frontal block to identity
+      // and zeroing cross-terms, so the variable is fixed at zero in the solve.
       sbm_.setDiagonalBlock(i, Matrix::Identity(dimI, dimI));
       for (DenseIndex j = 0; j < nBlocks; ++j) {
         if (j == i) continue;
@@ -334,41 +332,36 @@ void MultifrontalClique::updateParent(MultifrontalClique& parent) const {
   sbm_.blockStart() = 0;
 }
 
+// Solve with block back-substitution on the Cholesky-stored SBM.
 void MultifrontalClique::updateSolution() const {
-  // Solve with block back-substitution on the Cholesky-stored SBM, avoiding
-  // materializing an explicit R matrix or split representation.
   const size_t nFrontals = frontalPtrs_.size();
-  const size_t nSeparators = separatorPtrs_.size();
+  const size_t rhsBlock = sbm_.nBlocks() - 1;  // # frontals + # separators
 
-  const size_t rhsBlock = nFrontals + nSeparators;
+  // The in-place factorization yields an upper-triangular system [R S d]:
+  //   R * x_f + S * x_s = d,
+  // with x_f the frontals and x_s the separators.
+  const auto R = sbm_.triangularView(0, nFrontals);
+  const auto S = sbm_.aboveDiagonalRange(0, nFrontals, nFrontals, rhsBlock);
+  const auto d = sbm_.aboveDiagonalRange(0, nFrontals, rhsBlock, rhsBlock + 1);
 
-  size_t frontalDim = 0;
-  for (const Vector* values : frontalPtrs_) {
-    frontalDim += values->size();
-  }
-  if (static_cast<size_t>(rhsScratch_.size()) != frontalDim) {
-    rhsScratch_.resize(frontalDim);
-  }
-  rhsScratch_.noalias() =
-      sbm_.aboveDiagonalRange(0, nFrontals, rhsBlock, rhsBlock + 1);
-
-  // Eliminate separator contributions: b -= S * x_sep.
-  if (nSeparators > 0) {
-    const Vector& xSep =
+  // We first solve rhs = d - S * x_s
+  rhsScratch_.noalias() = d;
+  if (rhsBlock > nFrontals) {
+    const Vector& x_s =
         buildSeparatorVector(separatorPtrs_, &separatorScratch_);
-    rhsScratch_.noalias() -= sbm_.aboveDiagonalRange(0, nFrontals, nFrontals,
-                                                     nFrontals + nSeparators) *
-                             xSep;
+    rhsScratch_.noalias() -= S * x_s;
   }
 
-  // Solve the contiguous frontal system in one triangular solve.
-  sbm_.triangularView(0, nFrontals).solveInPlace(rhsScratch_);
+  // Then solve for x_f, our solution, via R * x_f = rhs
+  // We solve the contiguous frontal system in one triangular solve.
+  R.solveInPlace(rhsScratch_);
+  auto& x_f = rhsScratch_;
 
   // Write solved frontal blocks back into the global solution.
   size_t offset = 0;
   for (Vector* values : frontalPtrs_) {
     const size_t dim = values->size();
-    values->noalias() = rhsScratch_.segment(offset, dim);
+    values->noalias() = x_f.segment(offset, dim);
     offset += dim;
   }
 }

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -16,6 +16,7 @@
  * @date   December 2025
  */
 
+#include <gtsam/linear/HessianFactor.h>
 #include <gtsam/linear/JacobianFactor.h>
 #include <gtsam/linear/MultifrontalClique.h>
 
@@ -201,6 +202,7 @@ size_t MultifrontalClique::countRows(const GaussianFactorGraph& graph) const {
 std::vector<size_t> MultifrontalClique::parentIndicesFor(
     const MultifrontalClique& parent) const {
   std::vector<size_t> indices;
+  indices.reserve(separatorKeys_.size() + 1);
   for (Key k : separatorKeys_) {
     auto fIt = std::find(parent.frontals().begin(), parent.frontals().end(), k);
     if (fIt != parent.frontals().end()) {
@@ -217,6 +219,7 @@ std::vector<size_t> MultifrontalClique::parentIndicesFor(
     throw std::runtime_error(
         "MultifrontalSolver: separator key not found in parent clique");
   }
+  indices.push_back(parent.frontals().size() + parent.separatorKeys_.size());
   return indices;
 }
 
@@ -227,42 +230,60 @@ void MultifrontalClique::initializeMatrices(
   Ab_.matrix().setZero();
 }
 
+void MultifrontalClique::addJacobianFactor(const JacobianFactor& jacobianFactor,
+                                           size_t rowOffset) {
+  // We only overwrite the fixed sparsity pattern, so Ab must be zeroed once in
+  // initializeMatrices and then kept consistent across loads.
+  const size_t rows = jacobianFactor.rows();
+  const size_t rhsBlockIdx = Ab_.nBlocks() - 1;
+  for (auto it = jacobianFactor.begin(); it != jacobianFactor.end(); ++it) {
+    Key k = *it;
+    const size_t blockIdx = blockIndex_.at(k);
+    Ab_(blockIdx).middleRows(rowOffset, rows) = jacobianFactor.getA(it);
+  }
+  Ab_(rhsBlockIdx).middleRows(rowOffset, rows) = jacobianFactor.getb();
+
+  if (auto model = jacobianFactor.get_model()) {
+    if (model->isConstrained()) {
+      markFixedFrontals(jacobianFactor, blockIndex_, &fixedFrontals_);
+    } else {
+      model->WhitenInPlace(Ab_.matrix().middleRows(rowOffset, rows));
+    }
+  }
+}
+
+void MultifrontalClique::addHessianFactor(const HessianFactor& hessianFactor) {
+  const SymmetricBlockMatrix& info = hessianFactor.info();
+  const size_t factorBlocks = hessianFactor.size();
+
+  std::vector<DenseIndex> blockIndices(factorBlocks + 1);
+  size_t slot = 0;
+  for (auto it = hessianFactor.begin(); it != hessianFactor.end();
+       ++it, ++slot) {
+    blockIndices[slot] = static_cast<DenseIndex>(blockIndex_.at(*it));
+  }
+  blockIndices[factorBlocks] = static_cast<DenseIndex>(sbm_.nBlocks() - 1);
+  sbm_.updateFromMappedBlocks(info, blockIndices);
+}
+
 void MultifrontalClique::fillAb(const GaussianFactorGraph& graph) {
   sbm_.setZero();
   fixedFrontals_.clear();
 
-  // We only overwrite the fixed sparsity pattern, so Ab must be zeroed once in
-  // initializeMatrices and then kept consistent across loads.
   size_t rowOffset = 0;
-  const size_t rhsBlockIdx = Ab_.nBlocks() - 1;
   for (const auto& factor : cluster_->factors) {
     assert(factor);
     auto indexed =
         std::static_pointer_cast<internal::IndexedSymbolicFactor>(factor);
-    auto jacobianFactor =
-        std::dynamic_pointer_cast<JacobianFactor>(graph[indexed->index_]);
-    if (!jacobianFactor) continue;
-
-    const size_t rows = jacobianFactor->rows();
-    for (auto it = jacobianFactor->begin(); it != jacobianFactor->end(); ++it) {
-      Key k = *it;
-      auto blockIt = blockIndex_.find(k);
-      if (blockIt == blockIndex_.end()) continue;
-      const size_t blockIdx = blockIt->second;
-      Ab_(blockIdx).middleRows(rowOffset, jacobianFactor->rows()) =
-          jacobianFactor->getA(it);
+    const GaussianFactor::shared_ptr& gf = graph[indexed->index_];
+    if (auto jacobianFactor = std::dynamic_pointer_cast<JacobianFactor>(gf)) {
+      addJacobianFactor(*jacobianFactor, rowOffset);
+      rowOffset += jacobianFactor->rows();
+      continue;
+    } else if (auto hessianFactor =
+                   std::dynamic_pointer_cast<HessianFactor>(gf)) {
+      addHessianFactor(*hessianFactor);
     }
-    Ab_(rhsBlockIdx).middleRows(rowOffset, rows) = jacobianFactor->getb();
-
-    if (auto model = jacobianFactor->get_model()) {
-      if (model->isConstrained()) {
-        markFixedFrontals(*jacobianFactor, blockIndex_, &fixedFrontals_);
-      } else {
-        model->WhitenInPlace(Ab_.matrix().middleRows(rowOffset, rows));
-      }
-    }
-
-    rowOffset += rows;
   }
 }
 
@@ -296,19 +317,8 @@ void MultifrontalClique::eliminateInPlace() {
 void MultifrontalClique::updateParent(MultifrontalClique& parent) const {
   // Expose only the separator+RHS view when contributing to the parent.
   sbm_.blockStart() = frontals().size();
-  const size_t numBlocks = parentIndices_.size();
-  assert(sbm_.nBlocks() == numBlocks + 1);
-  const size_t rhsBlock = parent.sbm_.nBlocks() - 1;
-
-  for (size_t i = 0; i <= numBlocks; ++i) {
-    const size_t p_i = (i < numBlocks) ? parentIndices_[i] : rhsBlock;
-    parent.sbm_.updateDiagonalBlock(p_i, sbm_.diagonalBlock(i));
-    for (size_t j = i + 1; j <= numBlocks; ++j) {
-      const size_t p_j = (j < numBlocks) ? parentIndices_[j] : rhsBlock;
-      parent.sbm_.updateOffDiagonalBlock(p_i, p_j,
-                                         sbm_.aboveDiagonalBlock(i, j));
-    }
-  }
+  assert(sbm_.nBlocks() == parentIndices_.size());
+  parent.sbm_.updateFromMappedBlocks(sbm_, parentIndices_);
   sbm_.blockStart() = 0;
 }
 

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -16,6 +16,7 @@
  * @date   December 2025
  */
 
+#include <gtsam/linear/GaussianConditional.h>
 #include <gtsam/linear/HessianFactor.h>
 #include <gtsam/linear/JacobianFactor.h>
 #include <gtsam/linear/MultifrontalClique.h>
@@ -105,6 +106,16 @@ MultifrontalClique::MultifrontalClique(
 
 size_t MultifrontalClique::factorCount() const { return factorIndices_.size(); }
 
+std::shared_ptr<GaussianConditional> MultifrontalClique::conditional() const {
+  const KeyVector keys = orderedKeysFromBlockIndex(blockIndex_);
+  SymmetricBlockMatrix& sbm = sbm_;
+  const DenseIndex oldBlockStart = sbm.blockStart();
+  VerticalBlockMatrix Ab = sbm.split(numFrontals_);
+  sbm.blockStart() = oldBlockStart;
+  return std::make_shared<GaussianConditional>(keys, numFrontals_,
+                                               std::move(Ab));
+}
+
 void MultifrontalClique::finalize(const KeyVector& frontals,
                                   const KeyVector& separatorKeys,
                                   const std::map<Key, size_t>& dims,
@@ -169,7 +180,8 @@ void MultifrontalClique::finalize(const KeyVector& frontals,
   }
 
   // Pre-allocate matrices and cache constraints once per structure.
-  std::vector<size_t> blockDims = this->blockDims(dims, frontals, separatorKeys);
+  std::vector<size_t> blockDims =
+      this->blockDims(dims, frontals, separatorKeys);
   size_t vbmRows = countRows(graph);
   initializeMatrices(blockDims, vbmRows);
   cacheConstraintInfo(graph);
@@ -192,9 +204,9 @@ void MultifrontalClique::cacheConstraintInfo(const GaussianFactorGraph& graph) {
   }
 }
 
-void MultifrontalClique::cacheSolutionPointers(
-    VectorValues* solution, const KeyVector& frontals,
-    const KeyVector& separatorKeys) {
+void MultifrontalClique::cacheSolutionPointers(VectorValues* solution,
+                                               const KeyVector& frontals,
+                                               const KeyVector& separatorKeys) {
   frontalPtrs_.clear();
   separatorPtrs_.clear();
   frontalPtrs_.reserve(frontals.size());
@@ -370,8 +382,8 @@ void MultifrontalClique::print(const std::string& s,
                 std::min(numFrontals_, orderedKeys.size()), keyFormatter);
   std::cout << "], separators=[";
   printKeyRange(std::cout, orderedKeys,
-                std::min(numFrontals_, orderedKeys.size()),
-                orderedKeys.size(), keyFormatter);
+                std::min(numFrontals_, orderedKeys.size()), orderedKeys.size(),
+                keyFormatter);
   std::cout << "], factors=" << factorIndices_.size()
             << ", children=" << children.size()
             << ", sbmBlocks=" << sbm_.nBlocks()

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -92,36 +92,15 @@ Vector& buildSeparatorVector(const std::vector<const Vector*>& separatorPtrs,
 
 MultifrontalClique::MultifrontalClique(
     std::vector<size_t> factorIndices,
-    const std::weak_ptr<MultifrontalClique>& parent) {
+    const std::weak_ptr<MultifrontalClique>& parent, const KeyVector& frontals,
+    const KeyVector& separatorKeys, const std::map<Key, size_t>& dims,
+    const GaussianFactorGraph& graph, VectorValues* solution) {
   factorIndices_ = std::move(factorIndices);
   this->parent = parent;
-}
 
-size_t MultifrontalClique::factorCount() const { return factorIndices_.size(); }
-
-std::shared_ptr<GaussianConditional> MultifrontalClique::conditional() const {
-  const KeyVector keys = orderedKeysFromBlockIndex(blockIndex_);
-  SymmetricBlockMatrix& sbm = sbm_;
-  VerticalBlockMatrix Ab = sbm.split(numFrontals());
-  sbm.blockStart() = 0;  // Split sets it to numFrontals(), reset to 0.
-  return std::make_shared<GaussianConditional>(keys, numFrontals(),
-                                               std::move(Ab));
-}
-
-void MultifrontalClique::finalize(const KeyVector& frontals,
-                                  const KeyVector& separatorKeys,
-                                  const std::map<Key, size_t>& dims,
-                                  const GaussianFactorGraph& graph,
-                                  VectorValues* solution,
-                                  std::vector<ChildInfo> children) {
   if (frontals.empty()) {
     throw std::runtime_error(
         "MultifrontalSolver: cluster has no frontal keys.");
-  }
-  this->children.clear();
-  this->children.reserve(children.size());
-  for (const auto& child : children) {
-    this->children.push_back(child.clique);
   }
 
   // Cache the mapping from key to Ab block index for fast fills.
@@ -156,6 +135,21 @@ void MultifrontalClique::finalize(const KeyVector& frontals,
   // Cache pointers into the solution for fast back-substitution.
   cacheSolutionPointers(solution, frontals, separatorKeys);
 
+  // Pre-allocate matrices and cache constraints once per structure.
+  std::vector<size_t> blockDims =
+      this->blockDims(dims, frontals, separatorKeys);
+  size_t vbmRows = countRows(graph);
+  initializeMatrices(blockDims, vbmRows);
+  cacheConstraintInfo(graph);
+}
+
+void MultifrontalClique::finalize(std::vector<ChildInfo> children) {
+  this->children.clear();
+  this->children.reserve(children.size());
+  for (const auto& child : children) {
+    this->children.push_back(child.clique);
+  }
+
   // Compute parent indices for all children.
   for (const auto& child : children) {
     if (!child.clique) continue;
@@ -172,13 +166,6 @@ void MultifrontalClique::finalize(const KeyVector& frontals,
     indices.push_back(blockIndex_.size());
     child.clique->setParentIndices(indices);
   }
-
-  // Pre-allocate matrices and cache constraints once per structure.
-  std::vector<size_t> blockDims =
-      this->blockDims(dims, frontals, separatorKeys);
-  size_t vbmRows = countRows(graph);
-  initializeMatrices(blockDims, vbmRows);
-  cacheConstraintInfo(graph);
 }
 
 void MultifrontalClique::cacheConstraintInfo(const GaussianFactorGraph& graph) {
@@ -330,6 +317,15 @@ void MultifrontalClique::updateParent(MultifrontalClique& parent) const {
   sbm_.blockStart() = 0;
 }
 
+std::shared_ptr<GaussianConditional> MultifrontalClique::conditional() const {
+  const KeyVector keys = orderedKeysFromBlockIndex(blockIndex_);
+  SymmetricBlockMatrix& sbm = sbm_;
+  VerticalBlockMatrix Ab = sbm.split(numFrontals());
+  sbm.blockStart() = 0;  // Split sets it to numFrontals(), reset to 0.
+  return std::make_shared<GaussianConditional>(keys, numFrontals(),
+                                               std::move(Ab));
+}
+
 // Solve with block back-substitution on the Cholesky-stored SBM.
 void MultifrontalClique::updateSolution() const {
   const size_t nf = numFrontals();
@@ -410,7 +406,7 @@ std::ostream& operator<<(std::ostream& os, const MultifrontalClique& clique) {
   printKeyRange(os, orderedKeys,
                 std::min(clique.numFrontals(), orderedKeys.size()),
                 orderedKeys.size(), formatter);
-  os << ", factors=" << clique.factorCount();
+  os << ", factors=" << clique.factorIndices_.size();
   os << ", children=" << clique.children.size();
   os << ", sbmBlocks=" << clique.sbm().nBlocks();
   os << ", AbRows=" << clique.Ab().matrix().rows() << ")";

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -32,6 +32,27 @@ namespace {
 constexpr double kConstraintSigmaTol = 1e-12;
 constexpr double kConstraintFeasibleTol = 1e-9;
 
+KeyVector orderedKeysFromBlockIndex(const std::map<Key, size_t>& blockIndex) {
+  const size_t totalKeys = blockIndex.size();
+  KeyVector orderedKeys(totalKeys);
+  for (const auto& entry : blockIndex) {
+    if (entry.second < totalKeys) {
+      orderedKeys[entry.second] = entry.first;
+    }
+  }
+  return orderedKeys;
+}
+
+void printKeyRange(std::ostream& os, const KeyVector& keys, size_t start,
+                   size_t end, const KeyFormatter& formatter) {
+  os << "[";
+  for (size_t i = start; i < end; ++i) {
+    os << formatter(keys[i]);
+    if (i + 1 < end) os << ", ";
+  }
+  os << "]";
+}
+
 // Mark frontal variables that are fixed by the given constrained factor.
 void markFixedFrontals(const JacobianFactor& factor,
                        const std::map<Key, size_t>& blockIndex,
@@ -76,74 +97,79 @@ Vector& buildSeparatorVector(const std::vector<const Vector*>& separatorPtrs,
 }  // namespace
 
 MultifrontalClique::MultifrontalClique(
-    const SymbolicJunctionTree::sharedNode& cluster,
+    std::vector<size_t> factorIndices,
     const std::weak_ptr<MultifrontalClique>& parent) {
-  if (!cluster) {
-    throw std::runtime_error("MultifrontalSolver: null cluster.");
-  }
-  cluster_ = cluster;
+  factorIndices_ = std::move(factorIndices);
   this->parent = parent;
-  const auto& frontals = cluster_->orderedFrontalKeys;
+}
+
+size_t MultifrontalClique::factorCount() const { return factorIndices_.size(); }
+
+void MultifrontalClique::finalize(const KeyVector& frontals,
+                                  const KeyVector& separatorKeys,
+                                  const std::map<Key, size_t>& dims,
+                                  const GaussianFactorGraph& graph,
+                                  VectorValues* solution,
+                                  std::vector<ChildInfo> children) {
   if (frontals.empty()) {
     throw std::runtime_error(
         "MultifrontalSolver: cluster has no frontal keys.");
   }
-}
-
-void MultifrontalClique::addChild(const shared_ptr& child) {
-  children.push_back(child);
-}
-
-const KeyVector& MultifrontalClique::frontals() const {
-  return cluster_->orderedFrontalKeys;
-}
-
-size_t MultifrontalClique::factorCount() const {
-  return cluster_->factors.size();
-}
-
-void MultifrontalClique::finalize(const std::map<Key, size_t>& dims,
-                                  const GaussianFactorGraph& graph,
-                                  VectorValues* solution) {
-  calculateSeparatorKeys();
+  numFrontals_ = frontals.size();
+  this->children.clear();
+  this->children.reserve(children.size());
+  for (const auto& child : children) {
+    this->children.push_back(child.clique);
+  }
 
   // Cache the mapping from key to Ab block index for fast fills.
   blockIndex_.clear();
   size_t blockIdx = 0;
-  for (Key key : frontals()) {
+  for (Key key : frontals) {
     blockIndex_[key] = blockIdx;
     ++blockIdx;
   }
-  for (Key key : separatorKeys_) {
+  for (Key key : separatorKeys) {
     blockIndex_[key] = blockIdx;
     ++blockIdx;
   }
 
   size_t dim = 0;
-  for (Key key : frontals()) {
+  for (Key key : frontals) {
     auto it = dims.find(key);
     if (it != dims.end()) dim += it->second;
   }
   frontalDim = dim;
 
   dim = 0;
-  for (Key key : separatorKeys_) {
+  for (Key key : separatorKeys) {
     auto it = dims.find(key);
     if (it != dims.end()) dim += it->second;
   }
   separatorDim = dim;
 
   // Cache pointers into the solution for fast back-substitution.
-  cacheSolutionPointers(solution);
+  cacheSolutionPointers(solution, frontals, separatorKeys);
 
   // Compute parent indices for all children.
   for (const auto& child : children) {
-    if (!child) continue;
-    child->setParentIndices(child->parentIndicesFor(*this));
+    if (!child.clique) continue;
+    std::vector<size_t> indices;
+    indices.reserve(child.separatorKeys.size() + 1);
+    for (Key key : child.separatorKeys) {
+      auto it = blockIndex_.find(key);
+      if (it == blockIndex_.end()) {
+        throw std::runtime_error(
+            "MultifrontalSolver: separator key not found in parent clique");
+      }
+      indices.push_back(it->second);
+    }
+    indices.push_back(blockIndex_.size());
+    child.clique->setParentIndices(indices);
   }
 
   // Pre-allocate matrices and cache constraints once per structure.
-  std::vector<size_t> blockDims = this->blockDims(dims);
+  std::vector<size_t> blockDims = this->blockDims(dims, frontals, separatorKeys);
   size_t vbmRows = countRows(graph);
   initializeMatrices(blockDims, vbmRows);
   cacheConstraintInfo(graph);
@@ -152,11 +178,10 @@ void MultifrontalClique::finalize(const std::map<Key, size_t>& dims,
 void MultifrontalClique::cacheConstraintInfo(const GaussianFactorGraph& graph) {
   fixedFrontals_.clear();
 
-  for (const auto& factor : cluster_->factors) {
-    assert(factor);
-    auto indexed =
-        std::static_pointer_cast<internal::IndexedSymbolicFactor>(factor);
-    const GaussianFactor::shared_ptr& gf = graph[indexed->index_];
+  for (size_t index : factorIndices_) {
+    assert(index < graph.size());
+    const GaussianFactor::shared_ptr& gf = graph[index];
+    if (!gf) continue;
     if (auto jacobianFactor = std::dynamic_pointer_cast<JacobianFactor>(gf)) {
       if (auto model = jacobianFactor->get_model()) {
         if (model->isConstrained()) {
@@ -167,84 +192,40 @@ void MultifrontalClique::cacheConstraintInfo(const GaussianFactorGraph& graph) {
   }
 }
 
-void MultifrontalClique::calculateSeparatorKeys() {
-  // Separator keys are computed from local factor keys and child separators.
-  KeySet allKeys;
-  for (const auto& factor : cluster_->factors) {
-    assert(factor);
-    allKeys.insert(factor->begin(), factor->end());
-  }
-  for (const auto& child : children) {
-    if (!child) continue;
-    allKeys.insert(child->separatorKeys_.begin(), child->separatorKeys_.end());
-  }
-  for (Key k : frontals()) {
-    allKeys.erase(k);
-  }
-  separatorKeys_.assign(allKeys.begin(), allKeys.end());
-}
-
-void MultifrontalClique::cacheSolutionPointers(VectorValues* solution) {
+void MultifrontalClique::cacheSolutionPointers(
+    VectorValues* solution, const KeyVector& frontals,
+    const KeyVector& separatorKeys) {
   frontalPtrs_.clear();
   separatorPtrs_.clear();
-  frontalPtrs_.reserve(frontals().size());
-  separatorPtrs_.reserve(separatorKeys_.size());
-  for (Key key : frontals()) {
+  frontalPtrs_.reserve(frontals.size());
+  separatorPtrs_.reserve(separatorKeys.size());
+  for (Key key : frontals) {
     frontalPtrs_.push_back(&solution->at(key));
   }
-  for (Key key : separatorKeys_) {
+  for (Key key : separatorKeys) {
     separatorPtrs_.push_back(&solution->at(key));
   }
 }
 
-const KeyVector& MultifrontalClique::separatorKeys() const {
-  return separatorKeys_;
-}
-
 std::vector<size_t> MultifrontalClique::blockDims(
-    const std::map<Key, size_t>& dims) const {
+    const std::map<Key, size_t>& dims, const KeyVector& frontals,
+    const KeyVector& separatorKeys) const {
   std::vector<size_t> blockDims;
-  for (Key k : frontals()) blockDims.push_back(dims.at(k));
-  for (Key k : separatorKeys_) blockDims.push_back(dims.at(k));
+  for (Key k : frontals) blockDims.push_back(dims.at(k));
+  for (Key k : separatorKeys) blockDims.push_back(dims.at(k));
   return blockDims;
 }
 
 size_t MultifrontalClique::countRows(const GaussianFactorGraph& graph) const {
   size_t vbmRows = 0;
-  for (const auto& factor : cluster_->factors) {
-    assert(factor);
-    auto indexed =
-        std::static_pointer_cast<internal::IndexedSymbolicFactor>(factor);
+  for (size_t index : factorIndices_) {
+    assert(index < graph.size());
     if (auto jacobianFactor =
-            std::dynamic_pointer_cast<JacobianFactor>(graph[indexed->index_])) {
+            std::dynamic_pointer_cast<JacobianFactor>(graph[index])) {
       vbmRows += jacobianFactor->rows();
     }
   }
   return vbmRows;
-}
-
-std::vector<size_t> MultifrontalClique::parentIndicesFor(
-    const MultifrontalClique& parent) const {
-  std::vector<size_t> indices;
-  indices.reserve(separatorKeys_.size() + 1);
-  for (Key k : separatorKeys_) {
-    auto fIt = std::find(parent.frontals().begin(), parent.frontals().end(), k);
-    if (fIt != parent.frontals().end()) {
-      indices.push_back(std::distance(parent.frontals().begin(), fIt));
-      continue;
-    }
-    auto sIt = std::find(parent.separatorKeys_.begin(),
-                         parent.separatorKeys_.end(), k);
-    if (sIt != parent.separatorKeys_.end()) {
-      indices.push_back(parent.frontals().size() +
-                        std::distance(parent.separatorKeys_.begin(), sIt));
-      continue;
-    }
-    throw std::runtime_error(
-        "MultifrontalSolver: separator key not found in parent clique");
-  }
-  indices.push_back(parent.frontals().size() + parent.separatorKeys_.size());
-  return indices;
 }
 
 void MultifrontalClique::initializeMatrices(
@@ -292,11 +273,10 @@ void MultifrontalClique::fillAb(const GaussianFactorGraph& graph) {
   sbm_.setZero();
 
   size_t rowOffset = 0;
-  for (const auto& factor : cluster_->factors) {
-    assert(factor);
-    auto indexed =
-        std::static_pointer_cast<internal::IndexedSymbolicFactor>(factor);
-    const GaussianFactor::shared_ptr& gf = graph[indexed->index_];
+  for (size_t index : factorIndices_) {
+    assert(index < graph.size());
+    const GaussianFactor::shared_ptr& gf = graph[index];
+    if (!gf) continue;
     if (auto jacobianFactor = std::dynamic_pointer_cast<JacobianFactor>(gf)) {
       addJacobianFactor(*jacobianFactor, rowOffset);
       rowOffset += jacobianFactor->rows();
@@ -331,12 +311,12 @@ void MultifrontalClique::eliminateInPlace() {
   }
 
   // Form normal equations and factor the frontal block (Schur complement step).
-  sbm_.choleskyPartial(frontals().size());
+  sbm_.choleskyPartial(numFrontals_);
 }
 
 void MultifrontalClique::updateParent(MultifrontalClique& parent) const {
   // Expose only the separator+RHS view when contributing to the parent.
-  sbm_.blockStart() = frontals().size();
+  sbm_.blockStart() = numFrontals_;
   assert(sbm_.nBlocks() == parentIndices_.size());
   parent.sbm_.updateFromMappedBlocks(sbm_, parentIndices_);
   sbm_.blockStart() = 0;
@@ -384,17 +364,15 @@ void MultifrontalClique::updateSolution() const {
 void MultifrontalClique::print(const std::string& s,
                                const KeyFormatter& keyFormatter) const {
   if (!s.empty()) std::cout << s;
+  const KeyVector orderedKeys = orderedKeysFromBlockIndex(blockIndex_);
   std::cout << "Clique(frontals=[";
-  for (size_t i = 0; i < frontals().size(); ++i) {
-    std::cout << keyFormatter(frontals()[i]);
-    if (i + 1 < frontals().size()) std::cout << ", ";
-  }
+  printKeyRange(std::cout, orderedKeys, 0,
+                std::min(numFrontals_, orderedKeys.size()), keyFormatter);
   std::cout << "], separators=[";
-  for (size_t i = 0; i < separatorKeys_.size(); ++i) {
-    std::cout << keyFormatter(separatorKeys_[i]);
-    if (i + 1 < separatorKeys_.size()) std::cout << ", ";
-  }
-  std::cout << "], factors=" << cluster_->factors.size()
+  printKeyRange(std::cout, orderedKeys,
+                std::min(numFrontals_, orderedKeys.size()),
+                orderedKeys.size(), keyFormatter);
+  std::cout << "], factors=" << factorIndices_.size()
             << ", children=" << children.size()
             << ", sbmBlocks=" << sbm_.nBlocks()
             << ", AbRows=" << Ab_.matrix().rows() << ")\n";
@@ -420,20 +398,15 @@ void MultifrontalClique::print(const std::string& s,
 }
 
 std::ostream& operator<<(std::ostream& os, const MultifrontalClique& clique) {
+  const KeyVector orderedKeys = orderedKeysFromBlockIndex(clique.blockIndex_);
   const KeyFormatter formatter = DefaultKeyFormatter;
-  auto printKeys = [&](const KeyVector& keys) {
-    os << "[";
-    for (size_t i = 0; i < keys.size(); ++i) {
-      os << formatter(keys[i]);
-      if (i + 1 < keys.size()) os << ", ";
-    }
-    os << "]";
-  };
-
   os << "Clique(frontals=";
-  printKeys(clique.frontals());
+  printKeyRange(os, orderedKeys, 0,
+                std::min(clique.numFrontals_, orderedKeys.size()), formatter);
   os << ", separators=";
-  printKeys(clique.separatorKeys());
+  printKeyRange(os, orderedKeys,
+                std::min(clique.numFrontals_, orderedKeys.size()),
+                orderedKeys.size(), formatter);
   os << ", factors=" << clique.factorCount();
   os << ", children=" << clique.children.size();
   os << ", sbmBlocks=" << clique.sbm().nBlocks();

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -103,6 +103,7 @@ size_t MultifrontalClique::factorCount() const {
 }
 
 void MultifrontalClique::finalize(const std::map<Key, size_t>& dims,
+                                  const GaussianFactorGraph& graph,
                                   VectorValues* solution) {
   calculateSeparatorKeys();
 
@@ -134,12 +135,35 @@ void MultifrontalClique::finalize(const std::map<Key, size_t>& dims,
 
   // Cache pointers into the solution for fast back-substitution.
   cacheSolutionPointers(solution);
-  fixedFrontals_.clear();
 
   // Compute parent indices for all children.
   for (const auto& child : children) {
     if (!child) continue;
     child->setParentIndices(child->parentIndicesFor(*this));
+  }
+
+  // Pre-allocate matrices and cache constraints once per structure.
+  std::vector<size_t> blockDims = this->blockDims(dims);
+  size_t vbmRows = countRows(graph);
+  initializeMatrices(blockDims, vbmRows);
+  cacheConstraintInfo(graph);
+}
+
+void MultifrontalClique::cacheConstraintInfo(const GaussianFactorGraph& graph) {
+  fixedFrontals_.clear();
+
+  for (const auto& factor : cluster_->factors) {
+    assert(factor);
+    auto indexed =
+        std::static_pointer_cast<internal::IndexedSymbolicFactor>(factor);
+    const GaussianFactor::shared_ptr& gf = graph[indexed->index_];
+    if (auto jacobianFactor = std::dynamic_pointer_cast<JacobianFactor>(gf)) {
+      if (auto model = jacobianFactor->get_model()) {
+        if (model->isConstrained()) {
+          markFixedFrontals(*jacobianFactor, blockIndex_, &fixedFrontals_);
+        }
+      }
+    }
   }
 }
 
@@ -244,9 +268,7 @@ void MultifrontalClique::addJacobianFactor(const JacobianFactor& jacobianFactor,
   Ab_(rhsBlockIdx).middleRows(rowOffset, rows) = jacobianFactor.getb();
 
   if (auto model = jacobianFactor.get_model()) {
-    if (model->isConstrained()) {
-      markFixedFrontals(jacobianFactor, blockIndex_, &fixedFrontals_);
-    } else {
+    if (!model->isConstrained()) {
       model->WhitenInPlace(Ab_.matrix().middleRows(rowOffset, rows));
     }
   }
@@ -268,7 +290,6 @@ void MultifrontalClique::addHessianFactor(const HessianFactor& hessianFactor) {
 
 void MultifrontalClique::fillAb(const GaussianFactorGraph& graph) {
   sbm_.setZero();
-  fixedFrontals_.clear();
 
   size_t rowOffset = 0;
   for (const auto& factor : cluster_->factors) {
@@ -279,7 +300,6 @@ void MultifrontalClique::fillAb(const GaussianFactorGraph& graph) {
     if (auto jacobianFactor = std::dynamic_pointer_cast<JacobianFactor>(gf)) {
       addJacobianFactor(*jacobianFactor, rowOffset);
       rowOffset += jacobianFactor->rows();
-      continue;
     } else if (auto hessianFactor =
                    std::dynamic_pointer_cast<HessianFactor>(gf)) {
       addHessianFactor(*hessianFactor);

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -102,10 +102,9 @@ size_t MultifrontalClique::factorCount() const { return factorIndices_.size(); }
 std::shared_ptr<GaussianConditional> MultifrontalClique::conditional() const {
   const KeyVector keys = orderedKeysFromBlockIndex(blockIndex_);
   SymmetricBlockMatrix& sbm = sbm_;
-  const DenseIndex oldBlockStart = sbm.blockStart();
-  VerticalBlockMatrix Ab = sbm.split(numFrontals_);
-  sbm.blockStart() = oldBlockStart;
-  return std::make_shared<GaussianConditional>(keys, numFrontals_,
+  VerticalBlockMatrix Ab = sbm.split(numFrontals());
+  sbm.blockStart() = 0;  // Split sets it to numFrontals(), reset to 0.
+  return std::make_shared<GaussianConditional>(keys, numFrontals(),
                                                std::move(Ab));
 }
 
@@ -119,7 +118,6 @@ void MultifrontalClique::finalize(const KeyVector& frontals,
     throw std::runtime_error(
         "MultifrontalSolver: cluster has no frontal keys.");
   }
-  numFrontals_ = frontals.size();
   this->children.clear();
   this->children.reserve(children.size());
   for (const auto& child : children) {
@@ -321,12 +319,12 @@ void MultifrontalClique::eliminateInPlace() {
   }
 
   // Form normal equations and factor the frontal block (Schur complement step).
-  sbm_.choleskyPartial(numFrontals_);
+  sbm_.choleskyPartial(numFrontals());
 }
 
 void MultifrontalClique::updateParent(MultifrontalClique& parent) const {
   // Expose only the separator+RHS view when contributing to the parent.
-  sbm_.blockStart() = numFrontals_;
+  sbm_.blockStart() = numFrontals();
   assert(sbm_.nBlocks() == parentIndices_.size());
   parent.sbm_.updateFromMappedBlocks(sbm_, parentIndices_);
   sbm_.blockStart() = 0;
@@ -334,19 +332,19 @@ void MultifrontalClique::updateParent(MultifrontalClique& parent) const {
 
 // Solve with block back-substitution on the Cholesky-stored SBM.
 void MultifrontalClique::updateSolution() const {
-  const size_t nFrontals = frontalPtrs_.size();
-  const size_t rhsBlock = sbm_.nBlocks() - 1;  // # frontals + # separators
+  const size_t nf = numFrontals();
+  const size_t n = sbm_.nBlocks() - 1;  // # frontals + # separators
 
   // The in-place factorization yields an upper-triangular system [R S d]:
   //   R * x_f + S * x_s = d,
   // with x_f the frontals and x_s the separators.
-  const auto R = sbm_.triangularView(0, nFrontals);
-  const auto S = sbm_.aboveDiagonalRange(0, nFrontals, nFrontals, rhsBlock);
-  const auto d = sbm_.aboveDiagonalRange(0, nFrontals, rhsBlock, rhsBlock + 1);
+  const auto R = sbm_.triangularView(0, nf);
+  const auto S = sbm_.aboveDiagonalRange(0, nf, nf, n);
+  const auto d = sbm_.aboveDiagonalRange(0, nf, n, n + 1);
 
   // We first solve rhs = d - S * x_s
   rhsScratch_.noalias() = d;
-  if (rhsBlock > nFrontals) {
+  if (n > nf) {
     const Vector& x_s =
         buildSeparatorVector(separatorPtrs_, &separatorScratch_);
     rhsScratch_.noalias() -= S * x_s;
@@ -372,10 +370,10 @@ void MultifrontalClique::print(const std::string& s,
   const KeyVector orderedKeys = orderedKeysFromBlockIndex(blockIndex_);
   std::cout << "Clique(frontals=[";
   printKeyRange(std::cout, orderedKeys, 0,
-                std::min(numFrontals_, orderedKeys.size()), keyFormatter);
+                std::min(numFrontals(), orderedKeys.size()), keyFormatter);
   std::cout << "], separators=[";
   printKeyRange(std::cout, orderedKeys,
-                std::min(numFrontals_, orderedKeys.size()), orderedKeys.size(),
+                std::min(numFrontals(), orderedKeys.size()), orderedKeys.size(),
                 keyFormatter);
   std::cout << "], factors=" << factorIndices_.size()
             << ", children=" << children.size()
@@ -407,10 +405,10 @@ std::ostream& operator<<(std::ostream& os, const MultifrontalClique& clique) {
   const KeyFormatter formatter = DefaultKeyFormatter;
   os << "Clique(frontals=";
   printKeyRange(os, orderedKeys, 0,
-                std::min(clique.numFrontals_, orderedKeys.size()), formatter);
+                std::min(clique.numFrontals(), orderedKeys.size()), formatter);
   os << ", separators=";
   printKeyRange(os, orderedKeys,
-                std::min(clique.numFrontals_, orderedKeys.size()),
+                std::min(clique.numFrontals(), orderedKeys.size()),
                 orderedKeys.size(), formatter);
   os << ", factors=" << clique.factorCount();
   os << ", children=" << clique.children.size();

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -28,6 +28,32 @@ namespace gtsam {
 
 namespace {
 
+constexpr double kConstraintSigmaTol = 1e-12;
+constexpr double kConstraintFeasibleTol = 1e-9;
+
+// Mark frontal variables that are fixed by the given constrained factor.
+void markFixedFrontals(const JacobianFactor& factor,
+                       const std::map<Key, size_t>& blockIndex,
+                       std::unordered_set<size_t>* fixedFrontals) {
+  if (factor.size() != 1) {
+    throw std::runtime_error(
+        "MultifrontalSolver: only unary constrained factors are supported.");
+  }
+  const auto model = factor.get_model();
+  const Vector sigmas = model->sigmas();
+  if (!(sigmas.array().abs() <= kConstraintSigmaTol).all()) {
+    throw std::runtime_error(
+        "MultifrontalSolver: only fully constrained factors are supported.");
+  }
+  if (factor.getb().array().abs().maxCoeff() > kConstraintFeasibleTol) {
+    throw std::runtime_error(
+        "MultifrontalSolver: constrained factor is not feasible.");
+  }
+  const Key key = *factor.begin();
+  const size_t blockIndexValue = blockIndex.at(key);
+  fixedFrontals->insert(blockIndexValue);
+}
+
 // Build a stacked separator vector x_sep in the provided scratch buffer.
 Vector& buildSeparatorVector(const std::vector<const Vector*>& separatorPtrs,
                              Vector* scratch) {
@@ -107,6 +133,7 @@ void MultifrontalClique::finalize(const std::map<Key, size_t>& dims,
 
   // Cache pointers into the solution for fast back-substitution.
   cacheSolutionPointers(solution);
+  fixedFrontals_.clear();
 
   // Compute parent indices for all children.
   for (const auto& child : children) {
@@ -202,6 +229,7 @@ void MultifrontalClique::initializeMatrices(
 
 void MultifrontalClique::fillAb(const GaussianFactorGraph& graph) {
   sbm_.setZero();
+  fixedFrontals_.clear();
 
   // We only overwrite the fixed sparsity pattern, so Ab must be zeroed once in
   // initializeMatrices and then kept consistent across loads.
@@ -227,7 +255,11 @@ void MultifrontalClique::fillAb(const GaussianFactorGraph& graph) {
     Ab_(rhsBlockIdx).middleRows(rowOffset, rows) = jacobianFactor->getb();
 
     if (auto model = jacobianFactor->get_model()) {
-      model->WhitenInPlace(Ab_.matrix().middleRows(rowOffset, rows));
+      if (model->isConstrained()) {
+        markFixedFrontals(*jacobianFactor, blockIndex_, &fixedFrontals_);
+      } else {
+        model->WhitenInPlace(Ab_.matrix().middleRows(rowOffset, rows));
+      }
     }
 
     rowOffset += rows;
@@ -241,6 +273,20 @@ void MultifrontalClique::eliminateInPlace() {
   for (const auto& child : children) {
     if (!child) continue;
     child->updateParent(*this);
+  }
+
+  if (!fixedFrontals_.empty()) {
+    const DenseIndex nBlocks = sbm_.nBlocks();
+    for (size_t fixedBlock : fixedFrontals_) {
+      const DenseIndex i = static_cast<DenseIndex>(fixedBlock);
+      const DenseIndex dimI = sbm_.getDim(i);
+      sbm_.setDiagonalBlock(i, Matrix::Identity(dimI, dimI));
+      for (DenseIndex j = 0; j < nBlocks; ++j) {
+        if (j == i) continue;
+        const DenseIndex dimJ = sbm_.getDim(j);
+        sbm_.setOffDiagonalBlock(i, j, Matrix::Zero(dimI, dimJ));
+      }
+    }
   }
 
   // Form normal equations and factor the frontal block (Schur complement step).

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -20,6 +20,7 @@
 #include <gtsam/linear/HessianFactor.h>
 #include <gtsam/linear/JacobianFactor.h>
 #include <gtsam/linear/MultifrontalClique.h>
+#include <gtsam/linear/NoiseModel.h>
 
 #include <algorithm>
 #include <cassert>
@@ -322,8 +323,19 @@ std::shared_ptr<GaussianConditional> MultifrontalClique::conditional() const {
   SymmetricBlockMatrix& sbm = sbm_;
   VerticalBlockMatrix Ab = sbm.split(numFrontals());
   sbm.blockStart() = 0;  // Split sets it to numFrontals(), reset to 0.
+  SharedDiagonal model;  // defaults to empty
+  if (!fixedFrontals_.empty()) {
+    // Create a mixed sigmas model to represent constrained variables.
+    Vector sigmas = Vector::Ones(frontalDim);
+    for (size_t block : fixedFrontals_) {
+      const DenseIndex start = Ab.offset(static_cast<DenseIndex>(block));
+      const DenseIndex end = Ab.offset(static_cast<DenseIndex>(block + 1));
+      sigmas.segment(start, end - start).setZero();
+    }
+    model = noiseModel::Constrained::MixedSigmas(sigmas);
+  }
   return std::make_shared<GaussianConditional>(keys, numFrontals(),
-                                               std::move(Ab));
+                                               std::move(Ab), model);
 }
 
 // Solve with block back-substitution on the Cholesky-stored SBM.

--- a/gtsam/linear/MultifrontalClique.h
+++ b/gtsam/linear/MultifrontalClique.h
@@ -36,6 +36,8 @@
 
 namespace gtsam {
 
+class GaussianConditional;
+
 namespace internal {
 
 /// Helper class to track original factor indices.
@@ -97,6 +99,12 @@ class GTSAM_EXPORT MultifrontalClique {
 
   /// Get the number of factors in this clique.
   size_t factorCount() const;
+
+  /// Return the number of frontal keys in this clique.
+  size_t numFrontals() const { return numFrontals_; }
+
+  /// Build a GaussianConditional from the in-place factorization.
+  std::shared_ptr<GaussianConditional> conditional() const;
 
   /// Get the vertical block matrix Ab.
   const VerticalBlockMatrix& Ab() const { return Ab_; }

--- a/gtsam/linear/MultifrontalClique.h
+++ b/gtsam/linear/MultifrontalClique.h
@@ -179,15 +179,19 @@ class GTSAM_EXPORT MultifrontalClique {
                                 const KeyVector& frontals,
                                 const KeyVector& separatorKeys) const;
 
-  /// Pre-allocate matrices for this clique.
-  /// @param blockDims Block dimensions (excluding RHS).
-  /// @param verticalBlockMatrixRows Number of rows for the vertical block
-  /// matrix.
+  /**
+   * Pre-allocate matrices for this clique.
+   * @param blockDims Block dimensions (excluding RHS).
+   * @param totalNumRows Number of rows for the vertical block matrix.
+   */
   void initializeMatrices(const std::vector<size_t>& blockDims,
-                          size_t verticalBlockMatrixRows);
+                          size_t totalNumRows);
 
-  /// Add a Jacobian factor's contributions into the Ab matrix.
-  void addJacobianFactor(const JacobianFactor& factor, size_t rowOffset);
+  /**
+   * Add a Jacobian factor's contributions into the Ab matrix.
+   * @return Number of rows added.
+   */
+  size_t addJacobianFactor(const JacobianFactor& factor, size_t rowOffset);
 
   /// Add a Hessian factor's contributions into the sbm_ matrix.
   void addHessianFactor(const HessianFactor& factor);

--- a/gtsam/linear/MultifrontalClique.h
+++ b/gtsam/linear/MultifrontalClique.h
@@ -85,7 +85,8 @@ class GTSAM_EXPORT MultifrontalClique {
   void initializeMatrices(const std::vector<size_t>& blockDims,
                           size_t verticalBlockMatrixRows);
 
-  /// Load factor values into the pre-allocated Ab matrix.
+  /// Load factor values into the pre-allocated Ab matrix and Hessians into
+  /// sbm_.
   /// @param graph The factor graph with updated values.
   void fillAb(const GaussianFactorGraph& graph);
   /// @}
@@ -133,7 +134,7 @@ class GTSAM_EXPORT MultifrontalClique {
   /**
    * Compute parent scatter indices for this clique.
    * @param parent The parent clique.
-   * @return Parent indices for separator blocks (excluding RHS).
+   * @return Parent indices for separator blocks and RHS.
    */
   std::vector<size_t> parentIndicesFor(const MultifrontalClique& parent) const;
 
@@ -182,6 +183,12 @@ class GTSAM_EXPORT MultifrontalClique {
   /// Cache pointers to frontal and separator update vectors.
   void cacheSolutionPointers(VectorValues* delta);
 
+  /// Add a Jacobian factor's contributions into the Ab matrix.
+  void addJacobianFactor(const JacobianFactor& factor, size_t rowOffset);
+
+  /// Add a Hessian factor's contributions into the sbm_ matrix.
+  void addHessianFactor(const HessianFactor& factor);
+
   void setParentIndices(const std::vector<size_t>& indices) {
     parentIndices_ = indices;
   }
@@ -193,9 +200,10 @@ class GTSAM_EXPORT MultifrontalClique {
 
   SymbolicJunctionTree::sharedNode cluster_;
   KeyVector separatorKeys_;
-  std::map<Key, size_t> blockIndex_;   ///< Key->block index for fast Ab fills.
-  std::unordered_set<size_t> fixedFrontals_;  ///< Frontal block indices fixed by constraints.
-  std::vector<size_t> parentIndices_;  ///< Parent block indices for separators.
+  std::map<Key, size_t> blockIndex_;  ///< Key->block index for fast Ab fills.
+  std::unordered_set<size_t>
+      fixedFrontals_;  ///< Frontal block indices fixed by constraints.
+  std::vector<size_t> parentIndices_;  ///< Parent block indices for separators and RHS.
   std::vector<Vector*> frontalPtrs_;   ///< Pointers into solution frontals.
   std::vector<const Vector*>
       separatorPtrs_;  ///< Pointers into solution separator.

--- a/gtsam/linear/MultifrontalClique.h
+++ b/gtsam/linear/MultifrontalClique.h
@@ -186,14 +186,17 @@ class GTSAM_EXPORT MultifrontalClique {
   }
   VerticalBlockMatrix Ab_;
   mutable SymmetricBlockMatrix sbm_;
-  mutable Vector rhsScratch_;
-  mutable Vector separatorScratch_;
+  mutable Vector rhsScratch_;  ///< Cached RHS workspace for back-substitution.
+  mutable Vector
+      separatorScratch_;  ///< Cached separator stack for back-substitution.
 
   SymbolicJunctionTree::sharedNode cluster_;
   KeyVector separatorKeys_;
-  std::vector<size_t> parentIndices_;
-  std::vector<Vector*> frontalPtrs_;
-  std::vector<const Vector*> separatorPtrs_;
+  std::map<Key, size_t> blockIndex_;   ///< Key->block index for fast Ab fills.
+  std::vector<size_t> parentIndices_;  ///< Parent block indices for separators.
+  std::vector<Vector*> frontalPtrs_;   ///< Pointers into solution frontals.
+  std::vector<const Vector*>
+      separatorPtrs_;  ///< Pointers into solution separator.
 };
 
 std::ostream& operator<<(std::ostream& os, const MultifrontalClique& clique);

--- a/gtsam/linear/MultifrontalClique.h
+++ b/gtsam/linear/MultifrontalClique.h
@@ -67,21 +67,27 @@ class GTSAM_EXPORT MultifrontalClique {
   size_t frontalDim = 0;    ///< Frontal dimension.
   size_t separatorDim = 0;  ///< Separator dimension.
 
-  /// Construct a clique from factor indices.
+  /// Construct a clique from factor indices and cache static structure.
   /// @param factorIndices Indices of factors associated with this clique.
   /// @param parent Weak pointer to the parent clique.
+  /// @param frontals Frontal keys for this clique.
+  /// @param separatorKeys Separator keys for this clique.
+  /// @param dims Key->dimension map.
+  /// @param graph Factor graph for sizing and constraints.
+  /// @param solution Solution storage for cached pointers.
   explicit MultifrontalClique(std::vector<size_t> factorIndices,
-                              const std::weak_ptr<MultifrontalClique>& parent);
+                              const std::weak_ptr<MultifrontalClique>& parent,
+                              const KeyVector& frontals,
+                              const KeyVector& separatorKeys,
+                              const std::map<Key, size_t>& dims,
+                              const GaussianFactorGraph& graph,
+                              VectorValues* solution);
 
   /// @name Setup (non-const)
   /// @{
 
-  /// Cache dimensions, cache value pointers, pre-allocate matrices,
-  /// and cache constraint metadata.
-  void finalize(const KeyVector& frontals, const KeyVector& separatorKeys,
-                const std::map<Key, size_t>& dims,
-                const GaussianFactorGraph& graph, VectorValues* solution,
-                std::vector<ChildInfo> children);
+  /// Cache the children list and compute parent indices.
+  void finalize(std::vector<ChildInfo> children);
 
   /// Load factor values into the pre-allocated Ab matrix and Hessians into
   /// sbm_.
@@ -96,9 +102,6 @@ class GTSAM_EXPORT MultifrontalClique {
   int problemSize() const {
     return static_cast<int>(frontalDim + separatorDim);
   }
-
-  /// Get the number of factors in this clique.
-  size_t factorCount() const;
 
   /// Return the number of frontal keys in this clique.
   size_t numFrontals() const { return frontalPtrs_.size(); }

--- a/gtsam/linear/MultifrontalClique.h
+++ b/gtsam/linear/MultifrontalClique.h
@@ -44,6 +44,10 @@ namespace internal {
 class IndexedSymbolicFactor : public SymbolicFactor {
  public:
   size_t index_;
+  IndexedSymbolicFactor(const KeyVector& keys, size_t index)
+      : SymbolicFactor(), index_(index) {
+    keys_ = keys;
+  }
   IndexedSymbolicFactor(const GaussianFactor& factor, size_t index)
       : SymbolicFactor(factor), index_(index) {}
 };
@@ -75,13 +79,15 @@ class GTSAM_EXPORT MultifrontalClique {
   /// @param dims Key->dimension map.
   /// @param graph Factor graph for sizing and constraints.
   /// @param solution Solution storage for cached pointers.
+  /// @param fixedKeys Keys fixed to zero by constraints (may be null).
   explicit MultifrontalClique(std::vector<size_t> factorIndices,
                               const std::weak_ptr<MultifrontalClique>& parent,
                               const KeyVector& frontals,
                               const KeyVector& separatorKeys,
                               const std::map<Key, size_t>& dims,
                               const GaussianFactorGraph& graph,
-                              VectorValues* solution);
+                              VectorValues* solution,
+                              const std::unordered_set<Key>* fixedKeys);
 
   /// @name Setup (non-const)
   /// @{
@@ -171,9 +177,6 @@ class GTSAM_EXPORT MultifrontalClique {
   void cacheSolutionPointers(VectorValues* delta, const KeyVector& frontals,
                              const KeyVector& separatorKeys);
 
-  /// Cache constraint metadata (fixed frontals, constrained factors).
-  void cacheConstraintInfo(const GaussianFactorGraph& graph);
-
   /// Compute block dimensions from variable dimensions (excluding RHS).
   std::vector<size_t> blockDims(const std::map<Key, size_t>& dims,
                                 const KeyVector& frontals,
@@ -196,7 +199,7 @@ class GTSAM_EXPORT MultifrontalClique {
   /// Add a Hessian factor's contributions into the sbm_ matrix.
   void addHessianFactor(const HessianFactor& factor);
 
-  void setParentIndices(const std::vector<size_t>& indices) {
+  void setParentIndices(const std::vector<DenseIndex>& indices) {
     parentIndices_ = indices;
   }
   VerticalBlockMatrix Ab_;
@@ -207,9 +210,8 @@ class GTSAM_EXPORT MultifrontalClique {
 
   std::vector<size_t> factorIndices_;
   std::map<Key, size_t> blockIndex_;  ///< Key->block index for fast Ab fills.
-  std::unordered_set<size_t>
-      fixedFrontals_;  ///< Frontal block indices fixed by constraints.
-  std::vector<size_t>
+  const std::unordered_set<Key>* fixedKeys_ = nullptr;
+  std::vector<DenseIndex>
       parentIndices_;  ///< Parent block indices for separators and RHS.
   std::vector<Vector*> frontalPtrs_;  ///< Pointers into solution frontals.
   std::vector<const Vector*>

--- a/gtsam/linear/MultifrontalClique.h
+++ b/gtsam/linear/MultifrontalClique.h
@@ -26,7 +26,6 @@
 #include <gtsam/linear/GaussianFactorGraph.h>
 #include <gtsam/linear/VectorValues.h>
 #include <gtsam/symbolic/SymbolicFactor.h>
-#include <gtsam/symbolic/SymbolicJunctionTree.h>
 
 #include <iosfwd>
 #include <map>
@@ -56,29 +55,31 @@ class GTSAM_EXPORT MultifrontalClique {
  public:
   using shared_ptr = std::shared_ptr<MultifrontalClique>;
   using Children = std::vector<shared_ptr>;
+  struct ChildInfo {
+    shared_ptr clique;
+    KeyVector separatorKeys;
+  };
 
   std::weak_ptr<MultifrontalClique> parent;  ///< Parent clique.
   Children children;        ///< Child cliques used for traversal.
   size_t frontalDim = 0;    ///< Frontal dimension.
   size_t separatorDim = 0;  ///< Separator dimension.
 
-  /// Construct a clique from a symbolic junction tree node.
-  /// @param cluster The symbolic junction tree node.
+  /// Construct a clique from factor indices.
+  /// @param factorIndices Indices of factors associated with this clique.
   /// @param parent Weak pointer to the parent clique.
-  explicit MultifrontalClique(const SymbolicJunctionTree::sharedNode& cluster,
+  explicit MultifrontalClique(std::vector<size_t> factorIndices,
                               const std::weak_ptr<MultifrontalClique>& parent);
 
   /// @name Setup (non-const)
   /// @{
 
-  /// Add a child clique.
-  /// @param child Shared pointer to the child clique.
-  void addChild(const shared_ptr& child);
-
-  /// Compute separator keys, cache dimensions, cache value pointers,
-  /// pre-allocate matrices, and cache constraint metadata.
-  void finalize(const std::map<Key, size_t>& dims,
-                const GaussianFactorGraph& graph, VectorValues* solution);
+  /// Cache dimensions, cache value pointers, pre-allocate matrices,
+  /// and cache constraint metadata.
+  void finalize(const KeyVector& frontals, const KeyVector& separatorKeys,
+                const std::map<Key, size_t>& dims,
+                const GaussianFactorGraph& graph, VectorValues* solution,
+                std::vector<ChildInfo> children);
 
   /// Load factor values into the pre-allocated Ab matrix and Hessians into
   /// sbm_.
@@ -88,12 +89,6 @@ class GTSAM_EXPORT MultifrontalClique {
 
   /// @name Read-only methods
   /// @{
-
-  /// Get the frontal keys for this clique.
-  const KeyVector& frontals() const;
-
-  /// Get the separator keys for this clique.
-  const KeyVector& separatorKeys() const;
 
   /// Get the cached problem size for traversal scheduling.
   int problemSize() const {
@@ -113,13 +108,6 @@ class GTSAM_EXPORT MultifrontalClique {
   const SymmetricBlockMatrix& sbm() const { return sbm_; }
 
   /**
-   * Compute block dimensions from variable dimensions (excluding RHS).
-   * @param dims Variable dimensions.
-   * @return Block dimensions for this clique.
-   */
-  std::vector<size_t> blockDims(const std::map<Key, size_t>& dims) const;
-
-  /**
    * Count rows needed for the vertical block matrix.
    * @param graph The factor graph.
    * @return Total number of rows.
@@ -127,16 +115,9 @@ class GTSAM_EXPORT MultifrontalClique {
   size_t countRows(const GaussianFactorGraph& graph) const;
 
   /**
-   * Compute parent scatter indices for this clique.
-   * @param parent The parent clique.
-   * @return Parent indices for separator blocks and RHS.
-   */
-  std::vector<size_t> parentIndicesFor(const MultifrontalClique& parent) const;
-
-  /**
    * Print this clique.
    * @param s Optional string prefix.
-   * @param keyFormatter Key formatter for printing.
+   * @param keyFormatter Ignored; retained for API compatibility.
    */
   void print(const std::string& s = "",
              const KeyFormatter& keyFormatter = DefaultKeyFormatter) const;
@@ -172,14 +153,17 @@ class GTSAM_EXPORT MultifrontalClique {
   /// @}
 
  private:
-  /// Calculate separator keys from children's frontals.
-  void calculateSeparatorKeys();
-
   /// Cache pointers to frontal and separator update vectors.
-  void cacheSolutionPointers(VectorValues* delta);
+  void cacheSolutionPointers(VectorValues* delta, const KeyVector& frontals,
+                             const KeyVector& separatorKeys);
 
   /// Cache constraint metadata (fixed frontals, constrained factors).
   void cacheConstraintInfo(const GaussianFactorGraph& graph);
+
+  /// Compute block dimensions from variable dimensions (excluding RHS).
+  std::vector<size_t> blockDims(const std::map<Key, size_t>& dims,
+                                const KeyVector& frontals,
+                                const KeyVector& separatorKeys) const;
 
   /// Pre-allocate matrices for this clique.
   /// @param blockDims Block dimensions (excluding RHS).
@@ -203,9 +187,9 @@ class GTSAM_EXPORT MultifrontalClique {
   mutable Vector
       separatorScratch_;  ///< Cached separator stack for back-substitution.
 
-  SymbolicJunctionTree::sharedNode cluster_;
-  KeyVector separatorKeys_;
+  std::vector<size_t> factorIndices_;
   std::map<Key, size_t> blockIndex_;  ///< Key->block index for fast Ab fills.
+  size_t numFrontals_ = 0;
   std::unordered_set<size_t>
       fixedFrontals_;  ///< Frontal block indices fixed by constraints.
   std::vector<size_t> parentIndices_;  ///< Parent block indices for separators and RHS.

--- a/gtsam/linear/MultifrontalClique.h
+++ b/gtsam/linear/MultifrontalClique.h
@@ -75,15 +75,10 @@ class GTSAM_EXPORT MultifrontalClique {
   /// @param child Shared pointer to the child clique.
   void addChild(const shared_ptr& child);
 
-  /// Compute separator keys, cache dimensions, and cache value pointers.
-  void finalize(const std::map<Key, size_t>& dims, VectorValues* solution);
-
-  /// Pre-allocate matrices for this clique.
-  /// @param blockDims Block dimensions (excluding RHS).
-  /// @param verticalBlockMatrixRows Number of rows for the vertical block
-  /// matrix.
-  void initializeMatrices(const std::vector<size_t>& blockDims,
-                          size_t verticalBlockMatrixRows);
+  /// Compute separator keys, cache dimensions, cache value pointers,
+  /// pre-allocate matrices, and cache constraint metadata.
+  void finalize(const std::map<Key, size_t>& dims,
+                const GaussianFactorGraph& graph, VectorValues* solution);
 
   /// Load factor values into the pre-allocated Ab matrix and Hessians into
   /// sbm_.
@@ -182,6 +177,16 @@ class GTSAM_EXPORT MultifrontalClique {
 
   /// Cache pointers to frontal and separator update vectors.
   void cacheSolutionPointers(VectorValues* delta);
+
+  /// Cache constraint metadata (fixed frontals, constrained factors).
+  void cacheConstraintInfo(const GaussianFactorGraph& graph);
+
+  /// Pre-allocate matrices for this clique.
+  /// @param blockDims Block dimensions (excluding RHS).
+  /// @param verticalBlockMatrixRows Number of rows for the vertical block
+  /// matrix.
+  void initializeMatrices(const std::vector<size_t>& blockDims,
+                          size_t verticalBlockMatrixRows);
 
   /// Add a Jacobian factor's contributions into the Ab matrix.
   void addJacobianFactor(const JacobianFactor& factor, size_t rowOffset);

--- a/gtsam/linear/MultifrontalClique.h
+++ b/gtsam/linear/MultifrontalClique.h
@@ -32,6 +32,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 namespace gtsam {
@@ -193,6 +194,7 @@ class GTSAM_EXPORT MultifrontalClique {
   SymbolicJunctionTree::sharedNode cluster_;
   KeyVector separatorKeys_;
   std::map<Key, size_t> blockIndex_;   ///< Key->block index for fast Ab fills.
+  std::unordered_set<size_t> fixedFrontals_;  ///< Frontal block indices fixed by constraints.
   std::vector<size_t> parentIndices_;  ///< Parent block indices for separators.
   std::vector<Vector*> frontalPtrs_;   ///< Pointers into solution frontals.
   std::vector<const Vector*>

--- a/gtsam/linear/MultifrontalClique.h
+++ b/gtsam/linear/MultifrontalClique.h
@@ -152,6 +152,9 @@ class GTSAM_EXPORT MultifrontalClique {
   void updateSolution() const;
   /// @}
 
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const MultifrontalClique& clique);
+
  private:
   /// Cache pointers to frontal and separator update vectors.
   void cacheSolutionPointers(VectorValues* delta, const KeyVector& frontals,

--- a/gtsam/linear/MultifrontalClique.h
+++ b/gtsam/linear/MultifrontalClique.h
@@ -101,7 +101,7 @@ class GTSAM_EXPORT MultifrontalClique {
   size_t factorCount() const;
 
   /// Return the number of frontal keys in this clique.
-  size_t numFrontals() const { return numFrontals_; }
+  size_t numFrontals() const { return frontalPtrs_.size(); }
 
   /// Build a GaussianConditional from the in-place factorization.
   std::shared_ptr<GaussianConditional> conditional() const;
@@ -200,11 +200,11 @@ class GTSAM_EXPORT MultifrontalClique {
 
   std::vector<size_t> factorIndices_;
   std::map<Key, size_t> blockIndex_;  ///< Key->block index for fast Ab fills.
-  size_t numFrontals_ = 0;
   std::unordered_set<size_t>
       fixedFrontals_;  ///< Frontal block indices fixed by constraints.
-  std::vector<size_t> parentIndices_;  ///< Parent block indices for separators and RHS.
-  std::vector<Vector*> frontalPtrs_;   ///< Pointers into solution frontals.
+  std::vector<size_t>
+      parentIndices_;  ///< Parent block indices for separators and RHS.
+  std::vector<Vector*> frontalPtrs_;  ///< Pointers into solution frontals.
   std::vector<const Vector*>
       separatorPtrs_;  ///< Pointers into solution separator.
 };

--- a/gtsam/linear/MultifrontalSolver.cpp
+++ b/gtsam/linear/MultifrontalSolver.cpp
@@ -19,6 +19,7 @@
 #include <gtsam/base/treeTraversal-inst.h>
 #include <gtsam/base/types.h>
 #include <gtsam/inference/Key.h>
+#include <gtsam/linear/GaussianBayesTree.h>
 #include <gtsam/linear/GaussianFactor.h>
 #include <gtsam/linear/HessianFactor.h>
 #include <gtsam/linear/JacobianFactor.h>
@@ -364,6 +365,29 @@ void MultifrontalSolver::eliminateInPlace() {
   EliminatePostVisitor visitorPost;
   TbbOpenMPMixedScope threadLimiter;
   treeTraversal::PostOrderForestParallel(*this, visitorPost, 10);
+}
+
+/* ************************************************************************* */
+GaussianBayesTree MultifrontalSolver::computeBayesTree() const {
+  GaussianBayesTree bayesTree;
+  using Clique = GaussianBayesTreeClique;
+  using BayesCliquePtr = GaussianBayesTree::sharedClique;
+
+  std::function<void(const CliquePtr&, const BayesCliquePtr&)> buildClique =
+      [&](const CliquePtr& clique, const BayesCliquePtr& parent) {
+        if (!clique) return;
+        auto conditional = clique->conditional();
+        auto bayesClique = std::make_shared<Clique>(conditional);
+        bayesTree.addClique(bayesClique, parent);
+        for (const auto& child : clique->children) {
+          buildClique(child, bayesClique);
+        }
+      };
+
+  for (const auto& root : roots_) {
+    buildClique(root, BayesCliquePtr());
+  }
+  return bayesTree;
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/MultifrontalSolver.cpp
+++ b/gtsam/linear/MultifrontalSolver.cpp
@@ -20,11 +20,13 @@
 #include <gtsam/base/types.h>
 #include <gtsam/inference/Key.h>
 #include <gtsam/linear/GaussianBayesTree.h>
+#include <gtsam/linear/GaussianConditional.h>
 #include <gtsam/linear/GaussianFactor.h>
 #include <gtsam/linear/HessianFactor.h>
 #include <gtsam/linear/JacobianFactor.h>
 #include <gtsam/linear/MultifrontalClique.h>
 #include <gtsam/linear/MultifrontalSolver.h>
+#include <gtsam/linear/NoiseModel.h>
 #include <gtsam/symbolic/SymbolicEliminationTree.h>
 #include <gtsam/symbolic/SymbolicFactorGraph.h>
 #include <gtsam/symbolic/SymbolicJunctionTree.h>
@@ -83,6 +85,36 @@ struct StructureStats {
   }
 };
 
+constexpr double kConstraintSigmaTol = 1e-12;
+constexpr double kConstraintFeasibleTol = 1e-9;
+
+std::unordered_set<Key> collectFixedKeys(const GaussianFactorGraph& graph) {
+  std::unordered_set<Key> fixedKeys;
+  for (const auto& factor : graph) {
+    if (!factor) continue;
+    auto jacobianFactor = std::dynamic_pointer_cast<JacobianFactor>(factor);
+    if (!jacobianFactor) continue;
+    auto model = jacobianFactor->get_model();
+    if (!model || !model->isConstrained()) continue;
+    if (jacobianFactor->size() != 1) {
+      throw std::runtime_error(
+          "MultifrontalSolver: only unary constrained factors are supported.");
+    }
+    const Vector sigmas = model->sigmas();
+    if (!(sigmas.array().abs() <= kConstraintSigmaTol).all()) {
+      throw std::runtime_error(
+          "MultifrontalSolver: only fully constrained factors are supported.");
+    }
+    if (jacobianFactor->getb().array().abs().maxCoeff() >
+        kConstraintFeasibleTol) {
+      throw std::runtime_error(
+          "MultifrontalSolver: constrained factor is not feasible.");
+    }
+    fixedKeys.insert(*jacobianFactor->begin());
+  }
+  return fixedKeys;
+}
+
 // Compute variable dimensions from the GaussianFactorGraph
 std::map<Key, size_t> computeDims(const GaussianFactorGraph& graph) {
   std::map<Key, size_t> dims;
@@ -105,12 +137,22 @@ std::map<Key, size_t> computeDims(const GaussianFactorGraph& graph) {
 }
 
 // Build SymbolicFactorGraph from GaussianFactorGraph
-SymbolicFactorGraph buildSymbolicGraph(const GaussianFactorGraph& graph) {
+SymbolicFactorGraph buildSymbolicGraph(
+    const GaussianFactorGraph& graph,
+    const std::unordered_set<Key>& fixedKeys) {
   SymbolicFactorGraph symbolicGraph;
   symbolicGraph.reserve(graph.size());
   for (size_t i = 0; i < graph.size(); ++i) {
     if (!graph[i]) continue;
-    symbolicGraph.emplace_shared<internal::IndexedSymbolicFactor>(*graph[i], i);
+    KeyVector keys;
+    keys.reserve(graph[i]->size());
+    for (Key key : graph[i]->keys()) {
+      if (!fixedKeys.count(key)) {
+        keys.push_back(key);
+      }
+    }
+    if (keys.empty()) continue;
+    symbolicGraph.emplace_shared<internal::IndexedSymbolicFactor>(keys, i);
   }
   return symbolicGraph;
 }
@@ -149,11 +191,10 @@ size_t totalDimForSymbolicCluster(
          separatorDimForSymbolicCluster(cluster, dims, cache);
 }
 
-void accumulateSymbolicStats(
-    const SymbolicJunctionTree::sharedNode& cluster,
-    const std::map<Key, size_t>& dims,
-    SymbolicJunctionTree::Cluster::KeySetMap* cache,
-    StructureStats* stats) {
+void accumulateSymbolicStats(const SymbolicJunctionTree::sharedNode& cluster,
+                             const std::map<Key, size_t>& dims,
+                             SymbolicJunctionTree::Cluster::KeySetMap* cache,
+                             StructureStats* stats) {
   if (!cluster) return;
   const size_t frontalDim = frontalDimForSymbolicCluster(cluster, dims);
   const size_t separatorDim =
@@ -237,6 +278,7 @@ struct CliqueBuilder {
   VectorValues* solution;
   std::vector<MultifrontalSolver::CliquePtr>* cliques;
   SymbolicJunctionTree::Cluster::KeySetMap separatorCache;
+  const std::unordered_set<Key>* fixedKeys;
 
   BuiltClique build(const SymbolicJunctionTree::sharedNode& cluster,
                     std::weak_ptr<MultifrontalClique> parent) {
@@ -244,13 +286,13 @@ struct CliqueBuilder {
 
     // Gather symbolic metadata for this clique.
     const KeyVector& frontals = cluster->orderedFrontalKeys;
-    KeyVector separatorKeys = keyVectorFromKeySet(
-        cluster->separatorKeys(&separatorCache));
+    KeyVector separatorKeys =
+        keyVectorFromKeySet(cluster->separatorKeys(&separatorCache));
 
     // Create the clique node and cache static structure.
     auto clique = std::make_shared<MultifrontalClique>(
         factorIndicesForSymbolicCluster(cluster), parent, frontals,
-        separatorKeys, dims, graph, solution);
+        separatorKeys, dims, graph, solution, fixedKeys);
 
     // Build children and collect separator keys.
     std::vector<MultifrontalClique::ChildInfo> childInfos;
@@ -279,15 +321,26 @@ MultifrontalSolver::MultifrontalSolver(const GaussianFactorGraph& graph,
                                        std::ostream* reportStream) {
   // Pre-compute variable dimensions
   dims_ = computeDims(graph);
+  fixedKeys_ = collectFixedKeys(graph);
+  Ordering reducedOrdering;
+  reducedOrdering.reserve(ordering.size());
   for (Key key : ordering) {
     solution_.insert(key, Vector::Zero(dims_.at(key)));
+    if (!fixedKeys_.count(key)) {
+      reducedOrdering.push_back(key);
+    }
+  }
+  for (Key key : fixedKeys_) {
+    if (!solution_.exists(key)) {
+      solution_.insert(key, Vector::Zero(dims_.at(key)));
+    }
   }
 
   // Convert to SymbolicFactorGraph to build the elimination tree
-  SymbolicFactorGraph symbolicGraph = buildSymbolicGraph(graph);
+  SymbolicFactorGraph symbolicGraph = buildSymbolicGraph(graph, fixedKeys_);
 
   // Build SymbolicEliminationTree and then SymbolicJunctionTree
-  SymbolicEliminationTree eliminationTree(symbolicGraph, ordering);
+  SymbolicEliminationTree eliminationTree(symbolicGraph, reducedOrdering);
   SymbolicJunctionTree junctionTree(eliminationTree);
 
   // Report the symbolic structure before any merge.
@@ -304,7 +357,7 @@ MultifrontalSolver::MultifrontalSolver(const GaussianFactorGraph& graph,
   }
 
   // Build the actual MultifrontalClique structure.
-  CliqueBuilder builder{dims_, graph, &solution_, &cliques_, {}};
+  CliqueBuilder builder{dims_, graph, &solution_, &cliques_, {}, &fixedKeys_};
   for (const auto& rootCluster : junctionTree.roots()) {
     if (rootCluster) {
       roots_.push_back(
@@ -358,6 +411,24 @@ GaussianBayesTree MultifrontalSolver::computeBayesTree() const {
   for (const auto& root : roots_) {
     buildClique(root, BayesCliquePtr());
   }
+
+  if (!fixedKeys_.empty()) {
+    for (Key key : fixedKeys_) {
+      auto dimIt = dims_.find(key);
+      if (dimIt == dims_.end()) {
+        throw std::runtime_error(
+            "MultifrontalSolver: fixed key has unknown dimension.");
+      }
+      const size_t dim = dimIt->second;
+      Vector d = Vector::Zero(dim);
+      Matrix R = Matrix::Identity(dim, dim);
+      auto model = noiseModel::Constrained::All(dim);
+      auto conditional =
+          std::make_shared<GaussianConditional>(key, d, R, model);
+      auto bayesClique = std::make_shared<Clique>(conditional);
+      bayesTree.addClique(bayesClique, BayesCliquePtr());
+    }
+  }
   return bayesTree;
 }
 
@@ -365,6 +436,9 @@ GaussianBayesTree MultifrontalSolver::computeBayesTree() const {
 const VectorValues& MultifrontalSolver::updateSolution() const {
   for (const auto& clique : cliques_) {
     clique->updateSolution();
+  }
+  for (Key key : fixedKeys_) {
+    solution_.at(key).setZero();
   }
   return solution_;
 }

--- a/gtsam/linear/MultifrontalSolver.cpp
+++ b/gtsam/linear/MultifrontalSolver.cpp
@@ -20,6 +20,7 @@
 #include <gtsam/base/types.h>
 #include <gtsam/inference/Key.h>
 #include <gtsam/linear/GaussianFactor.h>
+#include <gtsam/linear/HessianFactor.h>
 #include <gtsam/linear/JacobianFactor.h>
 #include <gtsam/linear/MultifrontalClique.h>
 #include <gtsam/linear/MultifrontalSolver.h>
@@ -93,8 +94,9 @@ std::map<Key, size_t> computeDims(const GaussianFactorGraph& graph) {
       }
     } else if (auto hessianFactor =
                    std::dynamic_pointer_cast<HessianFactor>(factor)) {
-      throw std::runtime_error(
-          "MultifrontalSolver: HessianFactors not supported.");
+      for (auto it = hessianFactor->begin(); it != hessianFactor->end(); ++it) {
+        dims[*it] = hessianFactor->getDim(it);
+      }
     }
   }
   return dims;

--- a/gtsam/linear/MultifrontalSolver.cpp
+++ b/gtsam/linear/MultifrontalSolver.cpp
@@ -276,9 +276,10 @@ struct CliqueBuilder {
     KeyVector separatorKeys = keyVectorFromKeySet(
         separatorKeysForSymbolicCluster(cluster, &separatorCache));
 
-    // Create the clique node.
+    // Create the clique node and cache static structure.
     auto clique = std::make_shared<MultifrontalClique>(
-        factorIndicesForSymbolicCluster(cluster), parent);
+        factorIndicesForSymbolicCluster(cluster), parent, frontals,
+        separatorKeys, dims, graph, solution);
 
     // Build children and collect separator keys.
     std::vector<MultifrontalClique::ChildInfo> childInfos;
@@ -291,9 +292,8 @@ struct CliqueBuilder {
       }
     }
 
-    // Finalize cached structure and register clique.
-    clique->finalize(frontals, separatorKeys, dims, graph, solution,
-                     std::move(childInfos));
+    // Finalize children metadata and register clique.
+    clique->finalize(std::move(childInfos));
     cliques->push_back(clique);
     return {clique, std::move(separatorKeys)};
   }

--- a/gtsam/linear/MultifrontalSolver.cpp
+++ b/gtsam/linear/MultifrontalSolver.cpp
@@ -26,6 +26,7 @@
 #include <gtsam/linear/MultifrontalSolver.h>
 #include <gtsam/symbolic/SymbolicEliminationTree.h>
 #include <gtsam/symbolic/SymbolicFactorGraph.h>
+#include <gtsam/symbolic/SymbolicJunctionTree.h>
 
 #include <algorithm>
 #include <cassert>
@@ -258,37 +259,70 @@ MultifrontalSolver::MultifrontalSolver(const GaussianFactorGraph& graph,
     reportStructure("Clique structure after merge");
   }
 
+  std::map<const SymbolicJunctionTree::Node*, KeySet> separatorCache;
+
+  struct BuiltClique {
+    CliquePtr clique;
+    KeyVector separatorKeys;
+  };
+
   // 3. Recursive function to build Clique hierarchy (independent of traversal).
-  std::function<CliquePtr(const SymbolicJunctionTree::sharedNode&,
-                          std::weak_ptr<MultifrontalClique>)>
+  std::function<BuiltClique(const SymbolicJunctionTree::sharedNode&,
+                            std::weak_ptr<MultifrontalClique>)>
       buildRecursive =
           [&](const SymbolicJunctionTree::sharedNode& cluster,
-              std::weak_ptr<MultifrontalClique> parent) -> CliquePtr {
-    if (!cluster) return nullptr;
+              std::weak_ptr<MultifrontalClique> parent) -> BuiltClique {
+    if (!cluster) return {nullptr, KeyVector()};
 
-    // Create Clique
-    auto clique = std::make_shared<MultifrontalClique>(cluster, parent);
-
-    // Process children
-    for (const auto& childCluster : cluster->children) {
-      auto childClique = buildRecursive(childCluster, clique);
-      clique->addChild(childClique);
+    const KeyVector frontals = cluster->orderedFrontalKeys;
+    std::vector<size_t> factorIndices;
+    factorIndices.reserve(cluster->factors.size());
+    for (const auto& factor : cluster->factors) {
+      assert(factor);
+      auto indexed =
+          std::static_pointer_cast<internal::IndexedSymbolicFactor>(factor);
+      factorIndices.push_back(indexed->index_);
     }
 
-    clique->finalize(dims_, graph, &solution_);
+    KeyVector separatorKeys;
+    {
+      const KeySet separators =
+          separatorKeysForSymbolicCluster(cluster, &separatorCache);
+      separatorKeys.assign(separators.begin(), separators.end());
+    }
+
+    // Create Clique
+    auto clique = std::make_shared<MultifrontalClique>(std::move(factorIndices),
+                                                       parent);
+
+    // Process children
+    std::vector<MultifrontalClique::ChildInfo> childInfos;
+    childInfos.reserve(cluster->children.size());
+    for (const auto& childCluster : cluster->children) {
+      BuiltClique child = buildRecursive(childCluster, clique);
+      if (child.clique) {
+        childInfos.push_back(
+            MultifrontalClique::ChildInfo{child.clique,
+                                          std::move(child.separatorKeys)});
+      }
+    }
+
+    clique->finalize(frontals, separatorKeys, dims_, graph, &solution_,
+                     std::move(childInfos));
     cliques_.push_back(clique);
 
     // Initial load
     clique->fillAb(graph);
 
-    return clique;
+    return {clique, std::move(separatorKeys)};
   };
 
   // 4. Start traversal from roots
   for (const auto& rootCluster : junctionTree.roots()) {
     if (rootCluster) {
-      roots_.push_back(
-          buildRecursive(rootCluster, std::weak_ptr<MultifrontalClique>()));
+      roots_.push_back(buildRecursive(rootCluster,
+                                      std::weak_ptr<MultifrontalClique>())
+                           .clique);
     }
   }
 }

--- a/gtsam/linear/MultifrontalSolver.cpp
+++ b/gtsam/linear/MultifrontalSolver.cpp
@@ -220,6 +220,84 @@ void mergeSmallClusters(const SymbolicJunctionTree::sharedNode& cluster,
   }
 }
 
+void reportStructure(const SymbolicJunctionTree& junctionTree,
+                     const std::map<Key, size_t>& dims, const std::string& name,
+                     std::ostream* reportStream) {
+  if (!reportStream) return;
+  // Accumulate stats using cached separator keys.
+  StructureStats stats;
+  std::map<const SymbolicJunctionTree::Node*, KeySet> separatorCache;
+  for (const auto& rootCluster : junctionTree.roots()) {
+    accumulateSymbolicStats(rootCluster, dims, &separatorCache, &stats);
+  }
+  stats.report(name, reportStream);
+}
+
+KeyVector keyVectorFromKeySet(const KeySet& keys) {
+  KeyVector result;
+  result.reserve(keys.size());
+  for (Key key : keys) result.push_back(key);
+  return result;
+}
+
+std::vector<size_t> factorIndicesForSymbolicCluster(
+    const SymbolicJunctionTree::sharedNode& cluster) {
+  std::vector<size_t> indices;
+  indices.reserve(cluster->factors.size());
+  for (const auto& factor : cluster->factors) {
+    assert(factor);
+    auto indexed =
+        std::static_pointer_cast<internal::IndexedSymbolicFactor>(factor);
+    indices.push_back(indexed->index_);
+  }
+  return indices;
+}
+
+struct BuiltClique {
+  MultifrontalSolver::CliquePtr clique;
+  KeyVector separatorKeys;
+};
+
+// Build cliques from a symbolic junction tree and wire parent/child metadata.
+struct CliqueBuilder {
+  const std::map<Key, size_t>& dims;
+  const GaussianFactorGraph& graph;
+  VectorValues* solution;
+  std::vector<MultifrontalSolver::CliquePtr>* cliques;
+  std::map<const SymbolicJunctionTree::Node*, KeySet> separatorCache;
+
+  BuiltClique build(const SymbolicJunctionTree::sharedNode& cluster,
+                    std::weak_ptr<MultifrontalClique> parent) {
+    if (!cluster) return {nullptr, KeyVector()};
+
+    // Gather symbolic metadata for this clique.
+    const KeyVector& frontals = cluster->orderedFrontalKeys;
+    KeyVector separatorKeys = keyVectorFromKeySet(
+        separatorKeysForSymbolicCluster(cluster, &separatorCache));
+
+    // Create the clique node.
+    auto clique = std::make_shared<MultifrontalClique>(
+        factorIndicesForSymbolicCluster(cluster), parent);
+
+    // Build children and collect separator keys.
+    std::vector<MultifrontalClique::ChildInfo> childInfos;
+    childInfos.reserve(cluster->children.size());
+    for (const auto& childCluster : cluster->children) {
+      BuiltClique child = build(childCluster, clique);
+      if (child.clique) {
+        childInfos.push_back(MultifrontalClique::ChildInfo{
+            child.clique, std::move(child.separatorKeys)});
+      }
+    }
+
+    // Finalize cached structure and register clique.
+    clique->finalize(frontals, separatorKeys, dims, graph, solution,
+                     std::move(childInfos));
+    cliques->push_back(clique);
+    return {clique, std::move(separatorKeys)};
+  }
+};
+
 }  // namespace
 
 /* ************************************************************************* */
@@ -227,104 +305,44 @@ MultifrontalSolver::MultifrontalSolver(const GaussianFactorGraph& graph,
                                        const Ordering& ordering,
                                        size_t mergeDimCap,
                                        std::ostream* reportStream) {
-  // 0. Pre-compute variable dimensions
+  // Pre-compute variable dimensions
   dims_ = computeDims(graph);
   for (Key key : ordering) {
     solution_.insert(key, Vector::Zero(dims_.at(key)));
   }
 
-  // 1. Convert to SymbolicFactorGraph to build the elimination tree
+  // Convert to SymbolicFactorGraph to build the elimination tree
   SymbolicFactorGraph symbolicGraph = buildSymbolicGraph(graph);
 
-  // 2. Build SymbolicEliminationTree and then SymbolicJunctionTree
+  // Build SymbolicEliminationTree and then SymbolicJunctionTree
   SymbolicEliminationTree eliminationTree(symbolicGraph, ordering);
   SymbolicJunctionTree junctionTree(eliminationTree);
 
-  const auto reportStructure = [&](const std::string& name) {
-    if (!reportStream) return;
-    StructureStats stats;
-    std::map<const SymbolicJunctionTree::Node*, KeySet> separatorCache;
-    for (const auto& rootCluster : junctionTree.roots()) {
-      accumulateSymbolicStats(rootCluster, dims_, &separatorCache, &stats);
-    }
-    stats.report(name, reportStream);
-  };
+  // Report the symbolic structure before any merge.
+  reportStructure(junctionTree, dims_, "Symbolic cluster structure",
+                  reportStream);
 
-  reportStructure("Symbolic cluster structure");
-
+  // If applicable, merge small child cliques bottom-up.
   if (mergeDimCap > 0) {
     for (const auto& rootCluster : junctionTree.roots()) {
       mergeSmallClusters(rootCluster, dims_, mergeDimCap);
     }
-    reportStructure("Clique structure after merge");
+    reportStructure(junctionTree, dims_, "Clique structure after merge",
+                    reportStream);
   }
 
-  std::map<const SymbolicJunctionTree::Node*, KeySet> separatorCache;
-
-  struct BuiltClique {
-    CliquePtr clique;
-    KeyVector separatorKeys;
-  };
-
-  // 3. Recursive function to build Clique hierarchy (independent of traversal).
-  std::function<BuiltClique(const SymbolicJunctionTree::sharedNode&,
-                            std::weak_ptr<MultifrontalClique>)>
-      buildRecursive =
-          [&](const SymbolicJunctionTree::sharedNode& cluster,
-              std::weak_ptr<MultifrontalClique> parent) -> BuiltClique {
-    if (!cluster) return {nullptr, KeyVector()};
-
-    const KeyVector frontals = cluster->orderedFrontalKeys;
-    std::vector<size_t> factorIndices;
-    factorIndices.reserve(cluster->factors.size());
-    for (const auto& factor : cluster->factors) {
-      assert(factor);
-      auto indexed =
-          std::static_pointer_cast<internal::IndexedSymbolicFactor>(factor);
-      factorIndices.push_back(indexed->index_);
-    }
-
-    KeyVector separatorKeys;
-    {
-      const KeySet separators =
-          separatorKeysForSymbolicCluster(cluster, &separatorCache);
-      separatorKeys.assign(separators.begin(), separators.end());
-    }
-
-    // Create Clique
-    auto clique = std::make_shared<MultifrontalClique>(std::move(factorIndices),
-                                                       parent);
-
-    // Process children
-    std::vector<MultifrontalClique::ChildInfo> childInfos;
-    childInfos.reserve(cluster->children.size());
-    for (const auto& childCluster : cluster->children) {
-      BuiltClique child = buildRecursive(childCluster, clique);
-      if (child.clique) {
-        childInfos.push_back(
-            MultifrontalClique::ChildInfo{child.clique,
-                                          std::move(child.separatorKeys)});
-      }
-    }
-
-    clique->finalize(frontals, separatorKeys, dims_, graph, &solution_,
-                     std::move(childInfos));
-    cliques_.push_back(clique);
-
-    // Initial load
-    clique->fillAb(graph);
-
-    return {clique, std::move(separatorKeys)};
-  };
-
-  // 4. Start traversal from roots
+  // Build the actual MultifrontalClique structure.
+  CliqueBuilder builder{dims_, graph, &solution_, &cliques_, {}};
   for (const auto& rootCluster : junctionTree.roots()) {
     if (rootCluster) {
-      roots_.push_back(buildRecursive(rootCluster,
-                                      std::weak_ptr<MultifrontalClique>())
-                           .clique);
+      roots_.push_back(
+          builder.build(rootCluster, std::weak_ptr<MultifrontalClique>())
+              .clique);
     }
   }
+
+  // Load initial numerical values after the structure is built.
+  load(graph);
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/MultifrontalSolver.cpp
+++ b/gtsam/linear/MultifrontalSolver.cpp
@@ -275,13 +275,8 @@ MultifrontalSolver::MultifrontalSolver(const GaussianFactorGraph& graph,
       clique->addChild(childClique);
     }
 
-    clique->finalize(dims_, &solution_);
+    clique->finalize(dims_, graph, &solution_);
     cliques_.push_back(clique);
-
-    // Initialize matrices
-    std::vector<size_t> blockDims = clique->blockDims(dims_);
-    size_t vbmRows = clique->countRows(graph);
-    clique->initializeMatrices(blockDims, vbmRows);
 
     // Initial load
     clique->fillAb(graph);

--- a/gtsam/linear/MultifrontalSolver.cpp
+++ b/gtsam/linear/MultifrontalSolver.cpp
@@ -127,42 +127,13 @@ size_t frontalDimForSymbolicCluster(
   return dim;
 }
 
-KeySet separatorKeysForSymbolicCluster(
-    const SymbolicJunctionTree::sharedNode& cluster,
-    std::map<const SymbolicJunctionTree::Node*, KeySet>* cache) {
-  if (!cluster) return KeySet();
-  if (cache) {
-    auto* raw = cluster.get();
-    auto it = cache->find(raw);
-    if (it != cache->end()) return it->second;
-  }
-
-  KeySet keys;
-  for (const auto& factor : cluster->factors) {
-    assert(factor);
-    keys.insert(factor->begin(), factor->end());
-  }
-  for (const auto& child : cluster->children) {
-    KeySet childSeparators = separatorKeysForSymbolicCluster(child, cache);
-    keys.insert(childSeparators.begin(), childSeparators.end());
-  }
-  for (Key key : cluster->orderedFrontalKeys) {
-    keys.erase(key);
-  }
-
-  if (cache) {
-    auto result = cache->emplace(cluster.get(), std::move(keys));
-    return result.first->second;
-  }
-  return keys;
-}
-
 size_t separatorDimForSymbolicCluster(
     const SymbolicJunctionTree::sharedNode& cluster,
     const std::map<Key, size_t>& dims,
-    std::map<const SymbolicJunctionTree::Node*, KeySet>* cache) {
+    SymbolicJunctionTree::Cluster::KeySetMap* cache) {
+  if (!cluster) return 0;
   size_t dim = 0;
-  const KeySet separatorKeys = separatorKeysForSymbolicCluster(cluster, cache);
+  const KeySet separatorKeys = cluster->separatorKeys(cache);
   for (Key key : separatorKeys) {
     auto it = dims.find(key);
     if (it != dims.end()) dim += it->second;
@@ -173,7 +144,7 @@ size_t separatorDimForSymbolicCluster(
 size_t totalDimForSymbolicCluster(
     const SymbolicJunctionTree::sharedNode& cluster,
     const std::map<Key, size_t>& dims,
-    std::map<const SymbolicJunctionTree::Node*, KeySet>* cache) {
+    SymbolicJunctionTree::Cluster::KeySetMap* cache) {
   return frontalDimForSymbolicCluster(cluster, dims) +
          separatorDimForSymbolicCluster(cluster, dims, cache);
 }
@@ -181,7 +152,7 @@ size_t totalDimForSymbolicCluster(
 void accumulateSymbolicStats(
     const SymbolicJunctionTree::sharedNode& cluster,
     const std::map<Key, size_t>& dims,
-    std::map<const SymbolicJunctionTree::Node*, KeySet>* cache,
+    SymbolicJunctionTree::Cluster::KeySetMap* cache,
     StructureStats* stats) {
   if (!cluster) return;
   const size_t frontalDim = frontalDimForSymbolicCluster(cluster, dims);
@@ -227,7 +198,7 @@ void reportStructure(const SymbolicJunctionTree& junctionTree,
   if (!reportStream) return;
   // Accumulate stats using cached separator keys.
   StructureStats stats;
-  std::map<const SymbolicJunctionTree::Node*, KeySet> separatorCache;
+  SymbolicJunctionTree::Cluster::KeySetMap separatorCache;
   for (const auto& rootCluster : junctionTree.roots()) {
     accumulateSymbolicStats(rootCluster, dims, &separatorCache, &stats);
   }
@@ -265,7 +236,7 @@ struct CliqueBuilder {
   const GaussianFactorGraph& graph;
   VectorValues* solution;
   std::vector<MultifrontalSolver::CliquePtr>* cliques;
-  std::map<const SymbolicJunctionTree::Node*, KeySet> separatorCache;
+  SymbolicJunctionTree::Cluster::KeySetMap separatorCache;
 
   BuiltClique build(const SymbolicJunctionTree::sharedNode& cluster,
                     std::weak_ptr<MultifrontalClique> parent) {
@@ -274,7 +245,7 @@ struct CliqueBuilder {
     // Gather symbolic metadata for this clique.
     const KeyVector& frontals = cluster->orderedFrontalKeys;
     KeyVector separatorKeys = keyVectorFromKeySet(
-        separatorKeysForSymbolicCluster(cluster, &separatorCache));
+        cluster->separatorKeys(&separatorCache));
 
     // Create the clique node and cache static structure.
     auto clique = std::make_shared<MultifrontalClique>(

--- a/gtsam/linear/MultifrontalSolver.h
+++ b/gtsam/linear/MultifrontalSolver.h
@@ -30,6 +30,7 @@
 
 namespace gtsam {
 
+class GaussianBayesTree;
 class MultifrontalClique;
 
 /**
@@ -80,6 +81,12 @@ class GTSAM_EXPORT MultifrontalSolver {
    * This operates in-place on the pre-allocated matrices.
    */
   void eliminateInPlace();
+
+  /**
+   * Compute a Bayes tree from the in-place Cholesky factorization.
+   * Requires eliminateInPlace() to have been called.
+   */
+  GaussianBayesTree computeBayesTree() const;
 
   /**
    * Solve for the update vector.

--- a/gtsam/linear/MultifrontalSolver.h
+++ b/gtsam/linear/MultifrontalSolver.h
@@ -26,6 +26,7 @@
 #include <iosfwd>
 #include <map>
 #include <memory>
+#include <unordered_set>
 #include <vector>
 
 namespace gtsam {
@@ -48,10 +49,11 @@ class GTSAM_EXPORT MultifrontalSolver {
   using Node = MultifrontalClique;
 
  private:
-  std::vector<CliquePtr> roots_;    ///< Roots of the elimination tree.
-  std::vector<CliquePtr> cliques_;  ///< All cliques in the solver.
-  std::map<Key, size_t> dims_;      ///< Map from variable key to dimension.
-  mutable VectorValues solution_;   ///< Cached solution vector.
+  std::vector<CliquePtr> roots_;       ///< Roots of the elimination tree.
+  std::vector<CliquePtr> cliques_;     ///< All cliques in the solver.
+  std::map<Key, size_t> dims_;         ///< Map from variable key to dimension.
+  mutable VectorValues solution_;      ///< Cached solution vector.
+  std::unordered_set<Key> fixedKeys_;  ///< Keys fixed by constrained factors.
 
  public:
   /**

--- a/gtsam/linear/MultifrontalSolver.h
+++ b/gtsam/linear/MultifrontalSolver.h
@@ -51,7 +51,7 @@ class GTSAM_EXPORT MultifrontalSolver {
   std::vector<CliquePtr> roots_;    ///< Roots of the elimination tree.
   std::vector<CliquePtr> cliques_;  ///< All cliques in the solver.
   std::map<Key, size_t> dims_;      ///< Map from variable key to dimension.
-  mutable VectorValues solution_;  ///< Cached solution vector.
+  mutable VectorValues solution_;   ///< Cached solution vector.
 
  public:
   /**
@@ -84,7 +84,9 @@ class GTSAM_EXPORT MultifrontalSolver {
 
   /**
    * Compute a Bayes tree from the in-place Cholesky factorization.
-   * Requires eliminateInPlace() to have been called.
+   * Requires eliminateInPlace() to have been called beforehand.
+   * @return A GaussianBayesTree representing the eliminated factor graph
+   * encoded by the current multifrontal factorization.
    */
   GaussianBayesTree computeBayesTree() const;
 

--- a/gtsam/linear/tests/testMultifrontalSolver.cpp
+++ b/gtsam/linear/tests/testMultifrontalSolver.cpp
@@ -24,6 +24,7 @@
 #include <gtsam/linear/MultifrontalSolver.h>
 #include <tests/smallExample.h>
 
+#include <cmath>
 #include <functional>
 
 using namespace std;
@@ -32,13 +33,15 @@ using symbol_shorthand::X;
 
 namespace {
 const Key x1 = 1, x2 = 2, x3 = 3, x4 = 4;
-const SharedDiagonal chainNoise = noiseModel::Isotropic::Sigma(1, 0.5);
+const SharedDiagonal chainNoise1 = noiseModel::Isotropic::Sigma(1, 0.5);
+const SharedDiagonal chainNoise2 = noiseModel::Isotropic::Sigma(1, 1.0);
+const SharedDiagonal chainNoise3 = noiseModel::Isotropic::Sigma(1, 2.0);
+const SharedDiagonal chainNoise4 = noiseModel::Isotropic::Sigma(1, 0.25);
 const GaussianFactorGraph chain = {
-    std::make_shared<JacobianFactor>(x2, I_1x1, x1, I_1x1, I_1x1, chainNoise),
-    std::make_shared<JacobianFactor>(x2, I_1x1, x3, I_1x1, I_1x1, chainNoise),
-    std::make_shared<JacobianFactor>(x3, I_1x1, x4, I_1x1, I_1x1, chainNoise),
-    std::make_shared<JacobianFactor>(x4, I_1x1, (Vector(1) << 1.).finished(),
-                                     chainNoise)};
+    std::make_shared<JacobianFactor>(x2, I_1x1, x1, I_1x1, I_1x1, chainNoise1),
+    std::make_shared<JacobianFactor>(x2, I_1x1, x3, I_1x1, I_1x1, chainNoise2),
+    std::make_shared<JacobianFactor>(x3, I_1x1, x4, I_1x1, I_1x1, chainNoise3),
+    std::make_shared<JacobianFactor>(x4, I_1x1, I_1x1, chainNoise4)};
 const Ordering chainOrdering{x2, x1, x3, x4};
 
 }  // namespace
@@ -70,11 +73,11 @@ TEST(MultifrontalSolver, Constructor) {
   // Verify initial load for childClique
   // Block 0 (x2):
   Matrix A0 = childClique->Ab()(0);  // 2x1
-  EXPECT(assert_equal((Matrix(2, 1) << 1., 1.).finished(), A0));
+  EXPECT(assert_equal((Matrix(2, 1) << 2., 1.).finished(), A0));
 
   // Block 3 (RHS):
   Matrix Ab = childClique->Ab()(3);  // 2x1
-  EXPECT(assert_equal((Matrix(2, 1) << 1., 1.).finished(), Ab));
+  EXPECT(assert_equal((Matrix(2, 1) << 2., 1.).finished(), Ab));
 }
 
 /* ************************************************************************* */
@@ -99,9 +102,9 @@ TEST(MultifrontalSolver, Load) {
   auto root = solver.roots()[0];
   auto childClique = root->children[0];
 
-  // Block 0 (x2) should now be 2.0
+  // Block 0 (x2) should now be doubled, then whitened.
   Matrix A0 = childClique->Ab()(0);
-  EXPECT(assert_equal((Matrix(2, 1) << 2., 2.).finished(), A0));
+  EXPECT(assert_equal((Matrix(2, 1) << 4., 2.).finished(), A0));
 }
 
 /* ************************************************************************* */
@@ -117,6 +120,50 @@ TEST(MultifrontalSolver, Eliminate) {
   VectorValues expected = expectedBT.optimize();
 
   EXPECT(assert_equal(expected, actual, 1e-9));
+}
+
+/* ************************************************************************* */
+TEST(MultifrontalSolver, ConstrainedNoiseIgnored) {
+  const SharedDiagonal hardConstraint =
+      noiseModel::Constrained::MixedSigmas((Vector(1) << 0.0).finished());
+  const SharedDiagonal softNoise = noiseModel::Isotropic::Sigma(1, 10.0);
+  GaussianFactorGraph graph;
+  graph.emplace_shared<JacobianFactor>(x1, I_1x1, (Vector(1) << 1.0).finished(),
+                                       hardConstraint);
+  graph.emplace_shared<JacobianFactor>(
+      x1, I_1x1, (Vector(1) << 100.0).finished(), softNoise);
+  const Ordering ordering{x1};
+
+  MultifrontalSolver solver(graph, ordering);
+  solver.eliminateInPlace();
+  const VectorValues& actual = solver.updateSolution();
+
+  GaussianBayesTree expectedBT = *graph.eliminateMultifrontal(ordering);
+  VectorValues expected = expectedBT.optimize();
+
+  EXPECT(!assert_equal(expected, actual, 1e-9));
+}
+
+/* ************************************************************************* */
+TEST(MultifrontalSolver, WeightedScalarMeasurements) {
+  const double w1 = 0.2;
+  const double w2 = 0.8;
+  const double sigma1 = std::sqrt(1.0 / w1);
+  const double sigma2 = std::sqrt(1.0 / w2);
+
+  GaussianFactorGraph graph;
+  graph.emplace_shared<JacobianFactor>(x1, I_1x1, (Vector(1) << 0.0).finished(),
+                                       noiseModel::Isotropic::Sigma(1, sigma1));
+  graph.emplace_shared<JacobianFactor>(x1, I_1x1,
+                                       (Vector(1) << 10.0).finished(),
+                                       noiseModel::Isotropic::Sigma(1, sigma2));
+
+  const Ordering ordering{x1};
+  MultifrontalSolver solver(graph, ordering);
+  solver.eliminateInPlace();
+  const VectorValues& actual = solver.updateSolution();
+
+  EXPECT_DOUBLES_EQUAL(8.0, actual.at(x1)(0), 1e-9);
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/tests/testMultifrontalSolver.cpp
+++ b/gtsam/linear/tests/testMultifrontalSolver.cpp
@@ -20,6 +20,7 @@
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/linear/GaussianBayesTree.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/linear/HessianFactor.h>
 #include <gtsam/linear/MultifrontalClique.h>
 #include <gtsam/linear/MultifrontalSolver.h>
 #include <tests/smallExample.h>
@@ -216,6 +217,22 @@ TEST(MultifrontalSolver, WeightedScalarMeasurements) {
   const VectorValues& actual = solver.updateSolution();
 
   EXPECT_DOUBLES_EQUAL(8.0, actual.at(x1)(0), 1e-9);
+}
+
+/* ************************************************************************* */
+// Hessian factors contribute directly to the augmented normal equations.
+TEST(MultifrontalSolver, HessianFactors) {
+  GaussianFactorGraph graph;
+  graph.emplace_shared<HessianFactor>(
+      x1, (Matrix(1, 1) << 4.0).finished(),
+      (Vector(1) << 8.0).finished(), 0.0);
+
+  const Ordering ordering{x1};
+  MultifrontalSolver solver(graph, ordering);
+  solver.eliminateInPlace();
+  const VectorValues& actual = solver.updateSolution();
+
+  EXPECT_DOUBLES_EQUAL(2.0, actual.at(x1)(0), 1e-9);
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/tests/testMultifrontalSolver.cpp
+++ b/gtsam/linear/tests/testMultifrontalSolver.cpp
@@ -23,6 +23,7 @@
 #include <gtsam/linear/HessianFactor.h>
 #include <gtsam/linear/MultifrontalClique.h>
 #include <gtsam/linear/MultifrontalSolver.h>
+#include <gtsam/nonlinear/Marginals.h>
 #include <tests/smallExample.h>
 
 #include <cmath>
@@ -119,6 +120,58 @@ TEST(MultifrontalSolver, Eliminate) {
   VectorValues expected = expectedBT.optimize();
 
   EXPECT(assert_equal(expected, actual, 1e-9));
+}
+
+/* ************************************************************************* */
+// Compare marginals from in-place Bayes tree against standard elimination.
+TEST(MultifrontalSolver, ComputeBayesTreeMarginals) {
+  MultifrontalSolver solver(chain, chainOrdering);
+  solver.eliminateInPlace();
+
+  GaussianBayesTree actualBT = solver.computeBayesTree();
+  GaussianBayesTree expectedBT = *chain.eliminateMultifrontal(chainOrdering);
+
+  EXPECT(assert_equal(expectedBT.marginalCovariance(x2),
+                      actualBT.marginalCovariance(x2), 1e-9));
+  EXPECT(assert_equal(expectedBT.marginalCovariance(x3),
+                      actualBT.marginalCovariance(x3), 1e-9));
+
+  Marginals actualMarginals(std::move(actualBT), solver.updateSolution());
+  Marginals expectedMarginals(chain, solver.updateSolution());
+
+  EXPECT(assert_equal(expectedMarginals.marginalCovariance(x2),
+                      actualMarginals.marginalCovariance(x2), 1e-9));
+
+  const KeyVector jointKeys{x2, x3};
+  const JointMarginal expectedJoint =
+      expectedMarginals.jointMarginalCovariance(jointKeys);
+  const JointMarginal actualJoint =
+      actualMarginals.jointMarginalCovariance(jointKeys);
+  EXPECT(assert_equal(expectedJoint.fullMatrix(), actualJoint.fullMatrix(),
+                      1e-9));
+}
+
+/* ************************************************************************* */
+// Compare marginals on a constrained chain against legacy marginals.
+TEST(MultifrontalSolver, ComputeBayesTreeMarginalsConstrainedChain) {
+  const SharedDiagonal hardConstraint =
+      noiseModel::Constrained::MixedSigmas((Vector(1) << 0.0).finished());
+  GaussianFactorGraph constrainedChain = chain;
+  constrainedChain.emplace_shared<JacobianFactor>(
+      x2, I_1x1, (Vector(1) << 0.0).finished(), hardConstraint);
+
+  MultifrontalSolver solver(constrainedChain, chainOrdering);
+  solver.eliminateInPlace();
+
+  GaussianBayesTree actualBT = solver.computeBayesTree();
+  Marginals actualMarginals(std::move(actualBT), solver.updateSolution());
+  Marginals expectedMarginals(constrainedChain, solver.updateSolution());
+
+  const KeyVector keys{x1, x2, x3, x4};
+  for (Key key : keys) {
+    EXPECT(assert_equal(expectedMarginals.marginalCovariance(key),
+                        actualMarginals.marginalCovariance(key), 1e-9));
+  }
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/tests/testMultifrontalSolver.cpp
+++ b/gtsam/linear/tests/testMultifrontalSolver.cpp
@@ -147,8 +147,8 @@ TEST(MultifrontalSolver, ComputeBayesTreeMarginals) {
       expectedMarginals.jointMarginalCovariance(jointKeys);
   const JointMarginal actualJoint =
       actualMarginals.jointMarginalCovariance(jointKeys);
-  EXPECT(assert_equal(expectedJoint.fullMatrix(), actualJoint.fullMatrix(),
-                      1e-9));
+  EXPECT(
+      assert_equal(expectedJoint.fullMatrix(), actualJoint.fullMatrix(), 1e-9));
 }
 
 /* ************************************************************************* */
@@ -271,9 +271,8 @@ TEST(MultifrontalSolver, WeightedScalarMeasurements) {
 // Hessian factors contribute directly to the augmented normal equations.
 TEST(MultifrontalSolver, HessianFactors) {
   GaussianFactorGraph graph;
-  graph.emplace_shared<HessianFactor>(
-      x1, (Matrix(1, 1) << 4.0).finished(),
-      (Vector(1) << 8.0).finished(), 0.0);
+  graph.emplace_shared<HessianFactor>(x1, (Matrix(1, 1) << 4.0).finished(),
+                                      (Vector(1) << 8.0).finished(), 0.0);
 
   const Ordering ordering{x1};
   MultifrontalSolver solver(graph, ordering);

--- a/gtsam/linear/tests/testMultifrontalSolver.cpp
+++ b/gtsam/linear/tests/testMultifrontalSolver.cpp
@@ -27,6 +27,7 @@
 
 #include <cmath>
 #include <functional>
+#include <limits>
 
 using namespace std;
 using namespace gtsam;
@@ -56,12 +57,6 @@ TEST(MultifrontalSolver, Constructor) {
   EXPECT(solver.roots().size() == 1);
   auto root = solver.roots()[0];
   EXPECT(root != nullptr);
-
-  // Root should be {x3, x4} (merged)
-  // Frontals: x3, x4
-  EXPECT_LONGS_EQUAL(2, root->frontals().size());
-  EXPECT_LONGS_EQUAL(x3, root->frontals()[0]);
-  EXPECT_LONGS_EQUAL(x4, root->frontals()[1]);
 
   // Root should have 1 child {x2, x1}
   EXPECT_LONGS_EQUAL(1, root->children.size());
@@ -262,21 +257,27 @@ TEST(MultifrontalSolver, BalancedSmoother) {
   EXPECT(solver.roots().size() == 1);
   auto root = solver.roots()[0];
 
-  EXPECT_LONGS_EQUAL(root->frontals().size() + root->separatorKeys().size() + 1,
-                     root->sbm().nBlocks());
+  EXPECT_LONGS_EQUAL(root->Ab().nBlocks(), root->sbm().nBlocks());
 
-  // Check a leaf clique (for X(1))
-  MultifrontalSolver::CliquePtr cX1 = nullptr;
-  std::function<void(MultifrontalSolver::CliquePtr)> findX1 =
+  // Check a leaf clique block structure.
+  MultifrontalSolver::CliquePtr leaf = nullptr;
+  size_t minBlocks = std::numeric_limits<size_t>::max();
+  std::function<void(MultifrontalSolver::CliquePtr)> findLeaf =
       [&](MultifrontalSolver::CliquePtr c) {
-        for (Key k : c->frontals())
-          if (k == X(1)) cX1 = c;
-        for (auto child : c->children) findX1(child);
+        if (!c) return;
+        if (c->children.empty()) {
+          const size_t blocks = c->sbm().nBlocks();
+          if (blocks < minBlocks) {
+            minBlocks = blocks;
+            leaf = c;
+          }
+        }
+        for (auto child : c->children) findLeaf(child);
       };
-  findX1(root);
+  findLeaf(root);
 
-  EXPECT(cX1 != nullptr);
-  EXPECT_LONGS_EQUAL(3, cX1->sbm().nBlocks());
+  EXPECT(leaf != nullptr);
+  EXPECT_LONGS_EQUAL(3, minBlocks);
 
   // Eliminate and solve
   solver.eliminateInPlace();

--- a/gtsam/linear/tests/testMultifrontalSolver.cpp
+++ b/gtsam/linear/tests/testMultifrontalSolver.cpp
@@ -47,6 +47,7 @@ const Ordering chainOrdering{x2, x1, x3, x4};
 }  // namespace
 
 /* ************************************************************************* */
+// Build the solver and validate initial structure and load.
 TEST(MultifrontalSolver, Constructor) {
   MultifrontalSolver solver(chain, chainOrdering);
 
@@ -81,6 +82,7 @@ TEST(MultifrontalSolver, Constructor) {
 }
 
 /* ************************************************************************* */
+// Reload numerical values and ensure Ab updates match whitening.
 TEST(MultifrontalSolver, Load) {
   MultifrontalSolver solver(chain, chainOrdering);
 
@@ -108,6 +110,7 @@ TEST(MultifrontalSolver, Load) {
 }
 
 /* ************************************************************************* */
+// Compare solver output against multifrontal elimination baseline.
 TEST(MultifrontalSolver, Eliminate) {
   MultifrontalSolver solver(chain, chainOrdering);
   solver.eliminateInPlace();
@@ -123,7 +126,29 @@ TEST(MultifrontalSolver, Eliminate) {
 }
 
 /* ************************************************************************* */
-TEST(MultifrontalSolver, ConstrainedNoiseIgnored) {
+// Verify feasible unary constrained factor clamps the update to zero.
+TEST(MultifrontalSolver, ConstrainedNoiseFeasible) {
+  const SharedDiagonal hardConstraint =
+      noiseModel::Constrained::MixedSigmas((Vector(1) << 0.0).finished());
+  const SharedDiagonal softNoise = noiseModel::Isotropic::Sigma(1, 10.0);
+  GaussianFactorGraph graph;
+  // Same setup as ConstrainedNoiseUnsupported, but feasible (b == 0).
+  graph.emplace_shared<JacobianFactor>(x1, I_1x1, (Vector(1) << 0.0).finished(),
+                                       hardConstraint);
+  graph.emplace_shared<JacobianFactor>(
+      x1, I_1x1, (Vector(1) << 100.0).finished(), softNoise);
+  const Ordering ordering{x1};
+
+  MultifrontalSolver solver(graph, ordering);
+  solver.eliminateInPlace();
+  const VectorValues& actual = solver.updateSolution();
+
+  EXPECT_DOUBLES_EQUAL(0.0, actual.at(x1)(0), 1e-9);
+}
+
+/* ************************************************************************* */
+// Infeasible unary constrained factor is rejected.
+TEST(MultifrontalSolver, ConstrainedNoiseUnsupported) {
   const SharedDiagonal hardConstraint =
       noiseModel::Constrained::MixedSigmas((Vector(1) << 0.0).finished());
   const SharedDiagonal softNoise = noiseModel::Isotropic::Sigma(1, 10.0);
@@ -134,17 +159,44 @@ TEST(MultifrontalSolver, ConstrainedNoiseIgnored) {
       x1, I_1x1, (Vector(1) << 100.0).finished(), softNoise);
   const Ordering ordering{x1};
 
+  CHECK_EXCEPTION(
+      { MultifrontalSolver solver(graph, ordering); }, std::runtime_error);
+}
+
+/* ************************************************************************* */
+// Fully constrained unary factor with All() keeps delta fixed at zero.
+TEST(MultifrontalSolver, ConstrainedNoiseUnaryFeasible) {
+  const SharedDiagonal hardConstraint = noiseModel::Constrained::All(1);
+  const SharedDiagonal softNoise = noiseModel::Isotropic::Sigma(1, 1.0);
+  GaussianFactorGraph graph;
+  graph.emplace_shared<JacobianFactor>(x1, I_1x1, (Vector(1) << 0.0).finished(),
+                                       hardConstraint);
+  graph.emplace_shared<JacobianFactor>(x1, I_1x1, (Vector(1) << 5.0).finished(),
+                                       softNoise);
+  const Ordering ordering{x1};
+
   MultifrontalSolver solver(graph, ordering);
   solver.eliminateInPlace();
   const VectorValues& actual = solver.updateSolution();
 
-  GaussianBayesTree expectedBT = *graph.eliminateMultifrontal(ordering);
-  VectorValues expected = expectedBT.optimize();
-
-  EXPECT(!assert_equal(expected, actual, 1e-9));
+  EXPECT_DOUBLES_EQUAL(0.0, actual.at(x1)(0), 1e-9);
 }
 
 /* ************************************************************************* */
+// Mixed-key constrained factor is not supported.
+TEST(MultifrontalSolver, ConstrainedNoiseMixedKeysUnsupported) {
+  const SharedDiagonal hardConstraint = noiseModel::Constrained::All(1);
+  GaussianFactorGraph graph;
+  graph.emplace_shared<JacobianFactor>(
+      x1, I_1x1, x2, I_1x1, (Vector(1) << 0.0).finished(), hardConstraint);
+  const Ordering ordering{x1, x2};
+
+  CHECK_EXCEPTION(
+      { MultifrontalSolver solver(graph, ordering); }, std::runtime_error);
+}
+
+/* ************************************************************************* */
+// Weighted scalar measurements produce the expected weighted estimate.
 TEST(MultifrontalSolver, WeightedScalarMeasurements) {
   const double w1 = 0.2;
   const double w2 = 0.8;
@@ -167,6 +219,7 @@ TEST(MultifrontalSolver, WeightedScalarMeasurements) {
 }
 
 /* ************************************************************************* */
+// Merge threshold changes the clique count.
 TEST(MultifrontalSolver, MergeDimCap) {
   MultifrontalSolver solverNoMerge(chain, chainOrdering, 0);
   EXPECT_LONGS_EQUAL(2, solverNoMerge.cliqueCount());
@@ -176,6 +229,7 @@ TEST(MultifrontalSolver, MergeDimCap) {
 }
 
 /* ************************************************************************* */
+// End-to-end balanced smoother test with reload.
 TEST(MultifrontalSolver, BalancedSmoother) {
   // Create smoother with 7 nodes
   auto [nlfg, poses] = example::createNonlinearSmoother(7);

--- a/gtsam/nonlinear/Marginals.cpp
+++ b/gtsam/nonlinear/Marginals.cpp
@@ -79,6 +79,18 @@ Marginals::Marginals(const GaussianFactorGraph& graph, const VectorValues& solut
 }
 
 /* ************************************************************************* */
+Marginals::Marginals(GaussianBayesTree&& bayesTree,
+                     const VectorValues& solution,
+                     Factorization factorization)
+    : factorization_(factorization), bayesTree_(std::move(bayesTree)) {
+  gttic(MarginalsConstructor);
+  for (const auto& keyValue: solution) {
+    values_.insert(keyValue.first, keyValue.second);
+  }
+  bayesTree_.addFactorsToGraph(&graph_);
+}
+
+/* ************************************************************************* */
 void Marginals::computeBayesTree() {
   // The default ordering to use.
   const Ordering::OrderingType defaultOrderingType = Ordering::COLAMD;

--- a/gtsam/nonlinear/Marginals.h
+++ b/gtsam/nonlinear/Marginals.h
@@ -100,6 +100,10 @@ public:
   Marginals(const GaussianFactorGraph& graph, const VectorValues& solution, const Ordering& ordering,
               Factorization factorization = CHOLESKY);
 
+  /** Construct a marginals class from a precomputed Bayes tree. */
+  Marginals(GaussianBayesTree&& bayesTree, const VectorValues& solution,
+            Factorization factorization = CHOLESKY);
+
   /** print */
   void print(const std::string& str = "Marginals: ", const KeyFormatter& keyFormatter = DefaultKeyFormatter) const;
 

--- a/gtsam/nonlinear/Marginals.h
+++ b/gtsam/nonlinear/Marginals.h
@@ -31,22 +31,22 @@ class JointMarginal;
  */
 class GTSAM_EXPORT Marginals {
 
-public:
-
-  /** The linear factorization mode - either CHOLESKY (faster and suitable for most problems) or QR (slower but more numerically stable for poorly-conditioned problems). */
+ public:
+  /** The linear factorization mode - either CHOLESKY (faster and suitable for
+   * most problems) or QR (slower but more numerically stable for
+   * poorly-conditioned problems). */
   enum Factorization {
     CHOLESKY,
     QR
   };
 
-protected:
-
+ protected:
   GaussianFactorGraph graph_;
   Values values_;
   Factorization factorization_;
   GaussianBayesTree bayesTree_;
 
-public:
+ public:
 
   /// Default constructor only for wrappers
   Marginals(){}
@@ -54,14 +54,15 @@ public:
   /** Construct a marginals class from a nonlinear factor graph.
    * @param graph The factor graph defining the full joint density on all variables.
    * @param solution The linearization point about which to compute Gaussian marginals (usually the MLE as obtained from a NonlinearOptimizer).
-   * @param factorization The linear decomposition mode - either Marginals::CHOLESKY (faster and suitable for most problems) or Marginals::QR (slower but more numerically stable for poorly-conditioned problems).
+   * @param factorization The linear decomposition mode: CHOLESKY|QR
    */
-  Marginals(const NonlinearFactorGraph& graph, const Values& solution, Factorization factorization = CHOLESKY);
+  Marginals(const NonlinearFactorGraph& graph, const Values& solution,
+            Factorization factorization = CHOLESKY);
 
   /** Construct a marginals class from a nonlinear factor graph.
    * @param graph The factor graph defining the full joint density on all variables.
    * @param solution The linearization point about which to compute Gaussian marginals (usually the MLE as obtained from a NonlinearOptimizer).
-   * @param factorization The linear decomposition mode - either Marginals::CHOLESKY (faster and suitable for most problems) or Marginals::QR (slower but more numerically stable for poorly-conditioned problems).
+   * @param factorization The linear decomposition mode: CHOLESKY|QR
    * @param ordering The ordering for elimination.
    */
   Marginals(const NonlinearFactorGraph& graph, const Values& solution, const Ordering& ordering,
@@ -70,37 +71,43 @@ public:
   /** Construct a marginals class from a linear factor graph.
    * @param graph The factor graph defining the full joint density on all variables.
    * @param solution The solution point to compute Gaussian marginals.
-   * @param factorization The linear decomposition mode - either Marginals::CHOLESKY (faster and suitable for most problems) or Marginals::QR (slower but more numerically stable for poorly-conditioned problems).
-   */          
+   * @param factorization The linear decomposition mode: CHOLESKY|QR
+   */
   Marginals(const GaussianFactorGraph& graph, const Values& solution, Factorization factorization = CHOLESKY);
 
   /** Construct a marginals class from a linear factor graph.
    * @param graph The factor graph defining the full joint density on all variables.
    * @param solution The solution point to compute Gaussian marginals.
-   * @param factorization The linear decomposition mode - either Marginals::CHOLESKY (faster and suitable for most problems) or Marginals::QR (slower but more numerically stable for poorly-conditioned problems).
+   * @param factorization The linear decomposition mode: CHOLESKY|QR
    * @param ordering The ordering for elimination.
-   */          
+   */
   Marginals(const GaussianFactorGraph& graph, const Values& solution, const Ordering& ordering,
               Factorization factorization = CHOLESKY);
 
   /** Construct a marginals class from a linear factor graph.
    * @param graph The factor graph defining the full joint density on all variables.
    * @param solution The solution point to compute Gaussian marginals.
-   * @param factorization The linear decomposition mode - either Marginals::CHOLESKY (faster and suitable for most problems) or Marginals::QR (slower but more numerically stable for poorly-conditioned problems).
+   * @param factorization The linear decomposition mode: CHOLESKY|QR
    * @param ordering An optional variable ordering for elimination.
-   */          
+   */
   Marginals(const GaussianFactorGraph& graph, const VectorValues& solution, Factorization factorization = CHOLESKY);
 
   /** Construct a marginals class from a linear factor graph.
    * @param graph The factor graph defining the full joint density on all variables.
    * @param solution The solution point to compute Gaussian marginals.
-   * @param factorization The linear decomposition mode - either Marginals::CHOLESKY (faster and suitable for most problems) or Marginals::QR (slower but more numerically stable for poorly-conditioned problems).
+   * @param factorization The linear decomposition mode: CHOLESKY|QR
    * @param ordering An optional variable ordering for elimination.
-   */          
+   */
   Marginals(const GaussianFactorGraph& graph, const VectorValues& solution, const Ordering& ordering,
               Factorization factorization = CHOLESKY);
 
-  /** Construct a marginals class from a precomputed Bayes tree. */
+  /**
+   * Construct a marginals class from a precomputed Bayes tree.
+   * @param bayesTree The precomputed Gaussian Bayes tree representing the
+   * factorization of the linear system.
+   * @param solution The solution point at which to compute Gaussian marginals.
+   * @param factorization The linear decomposition mode: CHOLESKY|QR
+   */
   Marginals(GaussianBayesTree&& bayesTree, const VectorValues& solution,
             Factorization factorization = CHOLESKY);
 
@@ -129,7 +136,7 @@ public:
   /** Optimize the bayes tree */
   VectorValues optimize() const;
 
-protected:
+ protected:
   
   /** Compute the Bayes Tree as a helper function to the constructor */
   void computeBayesTree();
@@ -143,12 +150,12 @@ protected:
  */
 class GTSAM_EXPORT JointMarginal {
 
-protected:
+ protected:
   SymmetricBlockMatrix blockMatrix_;
   KeyVector keys_;
   FastMap<Key, size_t> indices_;
 
-public:
+ public:
   /// Default constructor only for wrappers
   JointMarginal() {}
 
@@ -184,7 +191,7 @@ public:
   /** Print */
   void print(const std::string& s = "", const KeyFormatter& formatter = DefaultKeyFormatter) const;
 
-protected:
+ protected:
   JointMarginal(const Matrix& fullMatrix, const std::vector<size_t>& dims, const KeyVector& keys) :
     blockMatrix_(dims, fullMatrix), keys_(keys), indices_(Ordering(keys).invert()) {}
 

--- a/gtsam/symbolic/tests/testSymbolicClusterTree.cpp
+++ b/gtsam/symbolic/tests/testSymbolicClusterTree.cpp
@@ -1,0 +1,54 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file    testSymbolicClusterTree.cpp
+ * @brief   Unit tests for Cluster Tree
+ * @author  Frank Dellaert
+ */
+
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/TestableAssertions.h>
+#include <gtsam/symbolic/SymbolicEliminationTree.h>
+#include <gtsam/symbolic/SymbolicJunctionTree.h>
+
+#include "symbolicExampleGraphs.h"
+
+using namespace gtsam;
+using namespace std;
+
+/* ************************************************************************* */
+TEST(ClusterTree, SeparatorKeys) {
+  const Ordering order{0, 1, 2, 3};
+
+  SymbolicJunctionTree tree(SymbolicEliminationTree(simpleChain, order));
+
+  auto root = tree.roots().front();
+  auto child = root->children.front();
+
+  const KeySet expectedRoot;
+  const KeySet expectedChild{2};
+
+  EXPECT(assert_container_equality(expectedRoot, root->separatorKeys()));
+  EXPECT(assert_container_equality(expectedChild, child->separatorKeys()));
+
+  SymbolicJunctionTree::Cluster::KeySetMap cache;
+  EXPECT(assert_container_equality(expectedRoot, root->separatorKeys(&cache)));
+  EXPECT(
+      assert_container_equality(expectedChild, child->separatorKeys(&cache)));
+}
+
+/* ************************************************************************* */
+int main() {
+  TestResult tr;
+  return TestRegistry::runAllTests(tr);
+}
+/* ************************************************************************* */

--- a/gtsam/symbolic/tests/testSymbolicJunctionTree.cpp
+++ b/gtsam/symbolic/tests/testSymbolicJunctionTree.cpp
@@ -10,7 +10,7 @@
  * -------------------------------------------------------------------------- */
 
 /**
- * @file    testJunctionTree.cpp
+ * @file    testSymbolicJunctionTree.cpp
  * @brief   Unit tests for Junction Tree
  * @author  Kai Ni
  * @author  Frank Dellaert
@@ -18,9 +18,8 @@
 
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/TestableAssertions.h>
-
-#include <gtsam/symbolic/SymbolicFactorGraph.h>
 #include <gtsam/symbolic/SymbolicEliminationTree.h>
+#include <gtsam/symbolic/SymbolicFactorGraph.h>
 #include <gtsam/symbolic/SymbolicJunctionTree.h>
 
 #include "symbolicExampleGraphs.h"
@@ -33,25 +32,25 @@ using namespace std;
  * 2 3
  *   0 1 : 2
  ****************************************************************************/
-TEST( JunctionTree, constructor )
-{
+TEST(JunctionTree, constructor) {
   const Ordering order{0, 1, 2, 3};
 
   SymbolicJunctionTree actual(SymbolicEliminationTree(simpleChain, order));
 
-  SymbolicJunctionTree::Node::Keys
-    frontal1 {2, 3},
-    frontal2 {0, 1},
-    sep1, sep2 {2};
-  EXPECT(assert_container_equality(frontal1, actual.roots().front()->orderedFrontalKeys));
-  //EXPECT(assert_equal(sep1,     actual.roots().front()->separator));
-  LONGS_EQUAL(1,                (long)actual.roots().front()->factors.size());
-  EXPECT(assert_container_equality(frontal2, actual.roots().front()->children.front()->orderedFrontalKeys));
-  //EXPECT(assert_equal(sep2,     actual.roots().front()->children.front()->separator));
-  LONGS_EQUAL(2,                (long)actual.roots().front()->children.front()->factors.size());
-  EXPECT(assert_equal(*simpleChain[2],   *actual.roots().front()->factors[0]));
-  EXPECT(assert_equal(*simpleChain[0],   *actual.roots().front()->children.front()->factors[0]));
-  EXPECT(assert_equal(*simpleChain[1],   *actual.roots().front()->children.front()->factors[1]));
+  SymbolicJunctionTree::Node::Keys frontal1{2, 3}, frontal2{0, 1}, sep1,
+      sep2{2};
+  EXPECT(assert_container_equality(frontal1,
+                                   actual.roots().front()->orderedFrontalKeys));
+  LONGS_EQUAL(1, (long)actual.roots().front()->factors.size());
+  EXPECT(assert_container_equality(
+      frontal2, actual.roots().front()->children.front()->orderedFrontalKeys));
+  LONGS_EQUAL(2,
+              (long)actual.roots().front()->children.front()->factors.size());
+  EXPECT(assert_equal(*simpleChain[2], *actual.roots().front()->factors[0]));
+  EXPECT(assert_equal(*simpleChain[0],
+                      *actual.roots().front()->children.front()->factors[0]));
+  EXPECT(assert_equal(*simpleChain[1],
+                      *actual.roots().front()->children.front()->factors[1]));
 }
 
 /* ************************************************************************* */

--- a/timing/timeMultifrontalSolver.cpp
+++ b/timing/timeMultifrontalSolver.cpp
@@ -63,7 +63,7 @@ int main() {
   cout << "Merging dim cap " << kMergeDimCap << std::endl;
 
   {
-    const size_t bal_iterations = 10;
+    const size_t bal_iterations = 5;
     const string bal16 = findExampleDataFile("dubrovnik-16-22106-pre");
     const string bal88 = findExampleDataFile("dubrovnik-88-64298-pre");
     for (const auto& filename : {bal16, bal88}) {
@@ -74,6 +74,7 @@ int main() {
       const GaussianFactorGraph linear = *graph.linearize(initial);
 
       const std::vector<std::pair<string, Ordering>> orderings = {
+          {"Burn", createSchurOrdering(db, false)},
           {"Metis", Ordering::Metis(linear)},
           {"Schur", createSchurOrdering(db, false)},
           {"Colamd", Ordering::Colamd(linear)},

--- a/timing/timeMultifrontalSolver.cpp
+++ b/timing/timeMultifrontalSolver.cpp
@@ -52,7 +52,7 @@ static void runMultifrontalSolver(MultifrontalSolver& solver,
                                   const GaussianFactorGraph& smoother,
                                   size_t iterations) {
   for (size_t i = 0; i < iterations; ++i) {
-    solver.load(smoother);
+    if (i > 0) solver.load(smoother);
     solver.eliminateInPlace();
     const VectorValues& solution = solver.updateSolution();
     (void)solution;
@@ -84,8 +84,8 @@ int main() {
         cout << "\nBAL Benchmark (" << label
              << ", iterations=" << bal_iterations << "):" << std::endl;
 
-        MultifrontalSolver solver(linear, ordering, kMergeDimCap, nullptr);
         auto start = std::chrono::high_resolution_clock::now();
+        MultifrontalSolver solver(linear, ordering, kMergeDimCap, nullptr);
         runMultifrontalSolver(solver, linear, bal_iterations);
         auto end = std::chrono::high_resolution_clock::now();
         std::chrono::duration<double> t_imperative = end - start;
@@ -114,8 +114,8 @@ int main() {
     GaussianFactorGraph smoother = createSmoother(T);
     const Ordering ordering = Ordering::Metis(smoother);
 
-    MultifrontalSolver solver(smoother, ordering, kMergeDimCap, &std::cout);
     auto start = std::chrono::high_resolution_clock::now();
+    MultifrontalSolver solver(smoother, ordering, kMergeDimCap, &std::cout);
     runMultifrontalSolver(solver, smoother, iterations);
     auto end = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> t_imperative = end - start;


### PR DESCRIPTION
- Whiten if a noise model is there
- Handle constraints derived from NonlinearEquality
- More general constraints are *not* handled: that is quite involved and would blow up complexity

Also added burn in timing script. Schur advantage is not so apparent now:
```
Processing BAL file: /Users/dellaert/git/github/examples/Data/dubrovnik-16-22106-pre.txt

BAL Benchmark (Burn, iterations=5):
  MultifrontalSolver: 0.641586 s
  Standard GTSAM:     1.35091 s
  Speedup:            2.10558x

BAL Benchmark (Metis, iterations=5):
  MultifrontalSolver: 0.57023 s
  Standard GTSAM:     1.3083 s
  Speedup:            2.29433x

BAL Benchmark (Schur, iterations=5):
  MultifrontalSolver: 0.566681 s
  Standard GTSAM:     1.16493 s
  Speedup:            2.05571x

BAL Benchmark (Colamd, iterations=5):
  MultifrontalSolver: 0.597309 s
  Standard GTSAM:     1.19801 s
  Speedup:            2.00568x

Processing BAL file: /Users/dellaert/git/github/examples/Data/dubrovnik-88-64298-pre.txt

BAL Benchmark (Burn, iterations=5):
  MultifrontalSolver: 35.3935 s
  Standard GTSAM:     15.9401 s
  Speedup:            0.450367x

BAL Benchmark (Metis, iterations=5):
  MultifrontalSolver: 11.8535 s
  Standard GTSAM:     15.1518 s
  Speedup:            1.27826x

BAL Benchmark (Schur, iterations=5):
  MultifrontalSolver: 10.8207 s
  Standard GTSAM:     15.2233 s
  Speedup:            1.40687x

BAL Benchmark (Colamd, iterations=5):
  MultifrontalSolver: 6.41992 s
  Standard GTSAM:     14.8429 s
  Speedup:            2.31201x
```

### Linux benchmarks

A bit disheartening for BAL :-( For chain (large balanced tree) still have speedups > 10, but for these BAL datasets GTSAM and new solver are essentially the same. Puzzling.

#### With TBB:
```
Processing BAL file: /home/dellaert/git/gtsam/examples/Data/dubrovnik-16-22106-pre.txt

BAL Benchmark (Burn, iterations=5):
  MultifrontalSolver: 0.52199 s
  Standard GTSAM:     0.591581 s
  Speedup:            1.13332x

BAL Benchmark (Metis, iterations=5):
  MultifrontalSolver: 0.427423 s
  Standard GTSAM:     0.607558 s
  Speedup:            1.42144x

BAL Benchmark (Schur, iterations=5):
  MultifrontalSolver: 0.405464 s
  Standard GTSAM:     0.576696 s
  Speedup:            1.42231x

BAL Benchmark (Colamd, iterations=5):
  MultifrontalSolver: 0.466439 s
  Standard GTSAM:     0.587623 s
  Speedup:            1.25981x

Processing BAL file: /home/dellaert/git/gtsam/examples/Data/dubrovnik-88-64298-pre.txt

BAL Benchmark (Burn, iterations=5):
  MultifrontalSolver: 3.68102 s
  Standard GTSAM:     3.19029 s
  Speedup:            0.866687x

BAL Benchmark (Metis, iterations=5):
  MultifrontalSolver: 3.03568 s
  Standard GTSAM:     3.21428 s
  Speedup:            1.05883x

BAL Benchmark (Schur, iterations=5):
  MultifrontalSolver: 3.02861 s
  Standard GTSAM:     3.04441 s
  Speedup:            1.00522x

BAL Benchmark (Colamd, iterations=5):
  MultifrontalSolver: 2.97899 s
  Standard GTSAM:     3.06014 s
  Speedup:            1.02724x

Benchmark (T=5000, iterations=1000):
Symbolic cluster structure
  cliques:    4978
  frontals:   max=6 avg=2.00884
  separators: max=4 avg=3.98955
  total dim:  max=6 avg=5.99839
  children:   max=4 avg=0.999799
Clique structure after merge
  cliques:    728
  frontals:   max=22 avg=13.7363
  separators: max=4 avg=3.96154
  total dim:  max=24 avg=17.6978
  children:   max=9 avg=0.998626

Timing results:
  MultifrontalSolver: 0.866464 s
  Standard GTSAM:     9.76246 s
  Speedup:            11.267x
```

#### Without TBB:
```
Processing BAL file: /home/dellaert/git/gtsam/examples/Data/dubrovnik-16-22106-pre.txt

BAL Benchmark (Burn, iterations=5):
  MultifrontalSolver: 0.771404 s
  Standard GTSAM:     0.924484 s
  Speedup:            1.19844x

BAL Benchmark (Metis, iterations=5):
  MultifrontalSolver: 0.705401 s
  Standard GTSAM:     0.890044 s
  Speedup:            1.26176x

BAL Benchmark (Schur, iterations=5):
  MultifrontalSolver: 0.689904 s
  Standard GTSAM:     0.869505 s
  Speedup:            1.26033x

BAL Benchmark (Colamd, iterations=5):
  MultifrontalSolver: 0.711992 s
  Standard GTSAM:     0.897607 s
  Speedup:            1.2607x

Processing BAL file: /home/dellaert/git/gtsam/examples/Data/dubrovnik-88-64298-pre.txt

BAL Benchmark (Burn, iterations=5):
  MultifrontalSolver: 8.06685 s
  Standard GTSAM:     5.58751 s
  Speedup:            0.69265x

BAL Benchmark (Metis, iterations=5):
  MultifrontalSolver: 7.36221 s
  Standard GTSAM:     5.24252 s
  Speedup:            0.712084x

BAL Benchmark (Schur, iterations=5):
  MultifrontalSolver: 7.20498 s
  Standard GTSAM:     5.02448 s
  Speedup:            0.697362x

BAL Benchmark (Colamd, iterations=5):
  MultifrontalSolver: 7.35469 s
  Standard GTSAM:     4.98342 s
  Speedup:            0.677584x

Benchmark (T=5000, iterations=1000):
Symbolic cluster structure
  cliques:    4978
  frontals:   max=6 avg=2.00884
  separators: max=4 avg=3.98955
  total dim:  max=6 avg=5.99839
  children:   max=4 avg=0.999799
Clique structure after merge
  cliques:    728
  frontals:   max=22 avg=13.7363
  separators: max=4 avg=3.96154
  total dim:  max=24 avg=17.6978
  children:   max=9 avg=0.998626

Timing results:
  MultifrontalSolver: 1.63542 s
  Standard GTSAM:     10.9214 s
  Speedup:            6.67801x
``` 