### PR TITLE
Scheduled MultifrontalSolver

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,3 +8,4 @@ For reviewing PRs:
 * Classes are Uppercase, methods and functions lowerMixedCase.
 * Public fields in structs keep plain names (no trailing underscore).
 * Apart from those naming conventions, we adopt Google C++ style.
+* After any code change, always run relevant tests via `make -j6 testXXX.run` in the build folder $WORKSPACE/build. If in VS code, ask for escalated permissions if needed.

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ doc/#*.lyx#
 /cmake-build-debug/
 .venv/
 conductor/
+.ccache/

--- a/gtsam/base/ForestTraversal.h
+++ b/gtsam/base/ForestTraversal.h
@@ -12,7 +12,7 @@
  *
  * @details
  * Provides top-down and bottom-up traversal helpers that either enqueue work
- * on an internal `PriorityScheduler` (for builds without TBB) or call the
+ * on an internal `TaskScheduler` (for builds without TBB) or call the
  * `treeTraversal` parallel helpers when `GTSAM_USE_TBB` is enabled.
  *
  * @note `Forest::roots()` or `Forest::roots` must return a range of
@@ -168,7 +168,7 @@ class ForestTraversal {
   }
 
  private:
-  PriorityScheduler<void> scheduler_;
+  TaskScheduler<void> scheduler_;
 
   /// Return forest roots via method or field.
   decltype(auto) getRoots() const {
@@ -251,7 +251,7 @@ class ForestTraversal {
   /// Per-node traversal frame to avoid threading many parameters.
   template <typename Fn>
   struct Frame {
-    PriorityScheduler<void>* scheduler;
+    TaskScheduler<void>* scheduler;
     Node& node;
     int depth;
     const Fn& fn;
@@ -293,11 +293,9 @@ class ForestTraversal {
         MaybeFinish finish{frame.state};
         frame.topDownTraverse();
       };
-      const int topDownPriority = depth;  // Shallower nodes = higher priority
       /// Schedule a task and increment the pending counter.
       state->incrementPending();
-      scheduler->schedule(topDownPriority,
-                          std::function<void()>(std::move(task)));
+      scheduler->schedule(std::function<void()>(std::move(task)));
     }
 
     /// Inline node work followed by traversal of children.
@@ -369,9 +367,7 @@ class ForestTraversal {
       state->incrementPending();
 
       // Schedule a continuation or run it inline if already on a worker thread.
-      const int bottomUpPriority = -depth;  // Deeper nodes = higher priority
-      scheduler->scheduleOrRunInline(bottomUpPriority,
-                                     std::function<void()>(std::move(task)));
+      scheduler->scheduleOrRunInline(std::function<void()>(std::move(task)));
     }
 
     /// Do bottom-up node work, then invoke the continuation.

--- a/gtsam/base/ForestTraversal.h
+++ b/gtsam/base/ForestTraversal.h
@@ -32,7 +32,7 @@
 #include <gtsam/base/types.h>
 #include <tbb/global_control.h>
 #else
-#include <gtsam/base/PriorityScheduler.h>
+#include <gtsam/base/TaskScheduler.h>
 #endif
 
 #include <atomic>

--- a/gtsam/base/ForestTraversal.h
+++ b/gtsam/base/ForestTraversal.h
@@ -295,7 +295,7 @@ class ForestTraversal {
       };
       /// Schedule a task and increment the pending counter.
       state->incrementPending();
-      scheduler->schedule(std::function<void()>(std::move(task)));
+      scheduler->enqueue(std::function<void()>(std::move(task)));
     }
 
     /// Inline node work followed by traversal of children.
@@ -367,7 +367,7 @@ class ForestTraversal {
       state->incrementPending();
 
       // Schedule a continuation or run it inline if already on a worker thread.
-      scheduler->scheduleOrRunInline(std::function<void()>(std::move(task)));
+      scheduler->enqueueOrRunInline(std::function<void()>(std::move(task)));
     }
 
     /// Do bottom-up node work, then invoke the continuation.

--- a/gtsam/base/PriorityScheduler.h
+++ b/gtsam/base/PriorityScheduler.h
@@ -31,6 +31,7 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <deque>
 #include <exception>
 #include <functional>
 #include <future>
@@ -44,6 +45,210 @@
 #include <vector>
 
 namespace gtsam {
+
+/**
+ * @brief Thread pool scheduler that executes tasks without priority ordering.
+ *
+ * @details
+ * - Tasks are executed in an efficient deque-based order (LIFO locally).
+ * - Per-thread queues reduce contention; workers steal from peers when idle.
+ * - External submissions are round-robin distributed across worker queues.
+ * - A condition variable parks workers when no work is available.
+ *
+ * @tparam Y Result type returned by tasks. Use `void` for no return value.
+ */
+template <typename Y>
+class TaskScheduler {
+  struct Task {
+    std::function<Y()> job;
+    std::promise<Y> promise;
+
+    Task(std::function<Y()> j, std::promise<Y> p_out)
+        : job(std::move(j)), promise(std::move(p_out)) {}
+  };
+
+  using TaskPtr = std::shared_ptr<Task>;
+
+  struct WorkerQueue {
+    std::mutex mutex;
+    std::deque<TaskPtr> queue;
+  };
+
+  std::vector<std::unique_ptr<WorkerQueue>> queues_;  // Per-worker queues.
+  std::atomic<size_t> queuedTasks_{0};  // Tracks queued work for wakeups.
+  std::vector<std::thread> workers_;
+  mutable std::mutex waitMutex_;  // Dedicated mutex for condition_variable.
+  std::condition_variable condition_;
+  std::atomic<bool> stop_{false};
+  std::atomic<int> activeTasks_{0};  // In-flight tasks (queued + running).
+  inline static thread_local TaskScheduler<Y>* currentScheduler_ = nullptr;
+  inline static thread_local int workerIndex_ = -1;
+  std::atomic<size_t> nextWorker_{0};  // Round-robin distributor.
+
+  /// Worker loop that executes tasks until shutdown.
+  void worker_thread(size_t index) {
+    currentScheduler_ = this;
+    workerIndex_ = static_cast<int>(index);
+    while (true) {
+      TaskPtr task;
+      if (!tryPopTask(index, task)) {
+        std::unique_lock<std::mutex> lock(waitMutex_);
+        condition_.wait(lock, [this] {
+          return stop_.load(std::memory_order_acquire) ||
+                 queuedTasks_.load(std::memory_order_acquire) > 0;
+        });
+        if (stop_.load(std::memory_order_acquire) &&
+            queuedTasks_.load(std::memory_order_acquire) == 0) {
+          currentScheduler_ = nullptr;
+          workerIndex_ = -1;
+          return;
+        }
+        continue;
+      }
+
+      try {
+        if constexpr (std::is_void_v<Y>) {
+          task->job();
+          task->promise.set_value();
+        } else {
+          task->promise.set_value(task->job());
+        }
+      } catch (...) {
+        try {
+          task->promise.set_exception(std::current_exception());
+        } catch (...) { /* ignore */
+        }
+      }
+
+      activeTasks_.fetch_sub(1, std::memory_order_release);
+      condition_.notify_all();
+    }
+  }
+
+  /// Attempt to get a task from local or stolen queues.
+  bool tryPopTask(size_t index, TaskPtr& task) {
+    if (tryPopLocal(index, task)) return true;
+    if (trySteal(index, task)) return true;
+    return false;
+  }
+
+  /// Try to pop a task from the current worker queue (LIFO for locality).
+  bool tryPopLocal(size_t index, TaskPtr& task) {
+    WorkerQueue& queue = *queues_[index];
+    std::lock_guard<std::mutex> lock(queue.mutex);
+    if (queue.queue.empty()) return false;
+    task = queue.queue.back();
+    queue.queue.pop_back();
+    queuedTasks_.fetch_sub(1, std::memory_order_release);
+    return true;
+  }
+
+  /// Try to steal a task from another worker queue (FIFO to reduce
+  /// interference).
+  bool trySteal(size_t index, TaskPtr& task) {
+    const size_t workerCount = queues_.size();
+    if (workerCount <= 1) return false;
+    for (size_t offset = 1; offset < workerCount; ++offset) {
+      size_t target = (index + offset) % workerCount;
+      WorkerQueue& queue = *queues_[target];
+      std::unique_lock<std::mutex> lock(queue.mutex, std::try_to_lock);
+      if (!lock.owns_lock() || queue.queue.empty()) continue;
+      task = queue.queue.front();
+      queue.queue.pop_front();
+      queuedTasks_.fetch_sub(1, std::memory_order_release);
+      return true;
+    }
+    return false;
+  }
+
+  /// Return true if called on a scheduler worker thread.
+  bool isWorkerThread() const { return currentScheduler_ == this; }
+
+ public:
+  /// Construct a scheduler with a fixed worker count.
+  explicit TaskScheduler(
+      size_t numThreads = std::thread::hardware_concurrency()) {
+    if (numThreads == 0) numThreads = 1;
+    queues_.reserve(numThreads);
+    for (size_t i = 0; i < numThreads; ++i) {
+      queues_.push_back(std::make_unique<WorkerQueue>());
+    }
+    for (size_t i = 0; i < numThreads; ++i) {
+      workers_.emplace_back(&TaskScheduler::worker_thread, this, i);
+    }
+  }
+
+  /// Wait for tasks and join worker threads on destruction.
+  ~TaskScheduler() {
+    waitForAllTasks();
+    stop_.store(true, std::memory_order_release);
+    condition_.notify_all();
+    for (std::thread& worker : workers_) {
+      if (worker.joinable()) worker.join();
+    }
+  }
+
+  /// Enqueue a task for execution and return its future.
+  std::future<Y> schedule(std::function<Y()> job) {
+    if (stop_.load(std::memory_order_acquire)) {
+      std::promise<Y> err_promise;
+      err_promise.set_exception(std::make_exception_ptr(
+          std::runtime_error("Scheduler is stopping or stopped.")));
+      return err_promise.get_future();
+    }
+
+    std::promise<Y> promise;
+    std::future<Y> future = promise.get_future();
+    auto task = std::make_shared<Task>(std::move(job), std::move(promise));
+
+    if (isWorkerThread()) {
+      WorkerQueue& queue = *queues_[static_cast<size_t>(workerIndex_)];
+      {
+        std::lock_guard<std::mutex> lock(queue.mutex);
+        queue.queue.push_back(task);
+      }
+    } else {
+      const size_t target =
+          nextWorker_.fetch_add(1, std::memory_order_relaxed) % queues_.size();
+      WorkerQueue& queue = *queues_[target];
+      std::lock_guard<std::mutex> lock(queue.mutex);
+      queue.queue.push_back(task);
+    }
+
+    queuedTasks_.fetch_add(1, std::memory_order_release);
+    activeTasks_.fetch_add(1, std::memory_order_release);
+    condition_.notify_one();
+    return future;
+  }
+
+  /// Run inline on workers, otherwise enqueue normally.
+  template <typename T = Y, typename = std::enable_if_t<std::is_void_v<T>>>
+  void scheduleOrRunInline(std::function<void()> job) {
+    if (stop_.load(std::memory_order_relaxed)) return;
+    if (!isWorkerThread()) {
+      schedule(std::move(job));
+      return;
+    }
+
+    activeTasks_.fetch_add(1, std::memory_order_release);
+    try {
+      job();
+    } catch (...) { /* ignore */
+    }
+    activeTasks_.fetch_sub(1, std::memory_order_release);
+    condition_.notify_all();
+  }
+
+  /// Block until all queued and active tasks complete.
+  void waitForAllTasks() {
+    std::unique_lock<std::mutex> lock(waitMutex_);
+    condition_.wait(lock, [this] {
+      return stop_.load(std::memory_order_acquire) ||
+             (activeTasks_.load(std::memory_order_acquire) == 0 &&
+              queuedTasks_.load(std::memory_order_acquire) == 0);
+    });
+  }
+};
 
 /**
  * @brief Thread pool scheduler that prioritizes tasks by numeric priority.

--- a/gtsam/base/PriorityScheduler.h
+++ b/gtsam/base/PriorityScheduler.h
@@ -45,7 +45,7 @@ struct PrioritySchedulerPolicy {
   template <typename TaskPtr>
   struct Compare {
     bool operator()(const TaskPtr& a, const TaskPtr& b) const {
-      return a->metadata > b->metadata;
+      return a.metadata > b.metadata;
     }
   };
 

--- a/gtsam/base/Scheduler.h
+++ b/gtsam/base/Scheduler.h
@@ -65,19 +65,12 @@ template <typename Y, typename Policy>
 class Scheduler {
   using Metadata = typename Policy::Metadata;
 
-  struct Task {
-    Metadata metadata;
-    std::function<Y()> job;
-    std::promise<Y> promise;
-
-    Task(Metadata m, std::function<Y()> j, std::promise<Y> p_out)
-        : metadata(std::move(m)),
-          job(std::move(j)),
-          promise(std::move(p_out)) {}
+  struct WorkItem {
+    Metadata metadata{};
+    std::function<void()> run;
   };
 
-  using TaskPtr = std::shared_ptr<Task>;
-  using Container = typename Policy::template Container<TaskPtr>;
+  using Container = typename Policy::template Container<WorkItem>;
 
   struct WorkerQueue {
     std::mutex mutex;
@@ -105,8 +98,8 @@ class Scheduler {
     currentScheduler_ = this;
     workerIndex_ = static_cast<int>(index);
     while (true) {
-      TaskPtr task;
-      if (!tryPopTask(index, task)) {
+      WorkItem item;
+      if (!tryPopTask(index, item)) {
         std::unique_lock<std::mutex> lock(waitMutex_);
         condition_.wait(lock, [this] {
           return stop_.load(std::memory_order_acquire) ||
@@ -122,19 +115,9 @@ class Scheduler {
       }
 
       try {
-        // Execute the task and set the promise value:
-        if constexpr (std::is_void_v<Y>) {
-          task->job();
-          task->promise.set_value();
-        } else {
-          task->promise.set_value(task->job());
-        }
+        item.run();
       } catch (...) {
-        // On exception, set the exception on the promise:
-        try {
-          task->promise.set_exception(std::current_exception());
-        } catch (...) { /* ignore */
-        }
+        /* ignore */
       }
 
       // Decrement active task count and notify waiters.
@@ -144,24 +127,24 @@ class Scheduler {
   }
 
   /// Attempt to get a task from local or stolen queues.
-  bool tryPopTask(size_t index, TaskPtr& task) {
+  bool tryPopTask(size_t index, WorkItem& item) {
     // Prefer local queue, then steal to keep workers busy.
-    if (tryPopLocal(index, task)) return true;
-    if (trySteal(index, task)) return true;
+    if (tryPopLocal(index, item)) return true;
+    if (trySteal(index, item)) return true;
     return false;
   }
 
   /// Try to pop a task from the current worker queue.
-  bool tryPopLocal(size_t index, TaskPtr& task) {
+  bool tryPopLocal(size_t index, WorkItem& item) {
     WorkerQueue& queue = *queues_[index];
     std::lock_guard<std::mutex> lock(queue.mutex);
-    if (!Policy::template popLocal<TaskPtr>(queue.queue, task)) return false;
+    if (!Policy::template popLocal<WorkItem>(queue.queue, item)) return false;
     queuedTasks_.fetch_sub(1, std::memory_order_release);
     return true;
   }
 
   /// Try to steal a task from another worker queue.
-  bool trySteal(size_t index, TaskPtr& task) {
+  bool trySteal(size_t index, WorkItem& item) {
     const size_t workerCount = queues_.size();
     if (workerCount <= 1) return false;
     // Steal from other workers if local queue is empty.
@@ -170,7 +153,7 @@ class Scheduler {
       WorkerQueue& queue = *queues_[target];
       std::unique_lock<std::mutex> lock(queue.mutex, std::try_to_lock);
       if (!lock.owns_lock()) continue;
-      if (!Policy::template popSteal<TaskPtr>(queue.queue, task)) continue;
+      if (!Policy::template popSteal<WorkItem>(queue.queue, item)) continue;
       queuedTasks_.fetch_sub(1, std::memory_order_release);
       return true;
     }
@@ -180,19 +163,8 @@ class Scheduler {
   /// Return true if called on a scheduler worker thread.
   bool isWorkerThread() const { return currentScheduler_ == this; }
 
-  std::future<Y> scheduleImpl(Metadata metadata, std::function<Y()> job) {
-    if (stop_.load(std::memory_order_acquire)) {
-      std::promise<Y> err_promise;
-      err_promise.set_exception(std::make_exception_ptr(
-          std::runtime_error("Scheduler is stopping or stopped.")));
-      return err_promise.get_future();
-    }
-
-    std::promise<Y> promise;
-    std::future<Y> future = promise.get_future();
-    auto task = std::make_shared<Task>(std::move(metadata), std::move(job),
-                                       std::move(promise));
-
+  bool enqueueImpl(Metadata metadata, std::function<void()> work) {
+    if (stop_.load(std::memory_order_acquire)) return false;
     WorkerQueue* targetQueue = nullptr;
     if (isWorkerThread()) {
       targetQueue = queues_[static_cast<size_t>(workerIndex_)].get();
@@ -204,20 +176,21 @@ class Scheduler {
 
     {
       std::lock_guard<std::mutex> lock(targetQueue->mutex);
-      Policy::template push<TaskPtr>(targetQueue->queue, std::move(task));
+      Policy::template push<WorkItem>(
+          targetQueue->queue, WorkItem{std::move(metadata), std::move(work)});
     }
 
     queuedTasks_.fetch_add(1, std::memory_order_release);
     activeTasks_.fetch_add(1, std::memory_order_release);
     condition_.notify_one();
-    return future;
+    return true;
   }
 
   template <typename T = Y, typename = std::enable_if_t<std::is_void_v<T>>>
   void scheduleOrRunInlineImpl(Metadata metadata, std::function<void()> job) {
     if (stop_.load(std::memory_order_relaxed)) return;
     if (!isWorkerThread()) {
-      scheduleImpl(std::move(metadata), std::move(job));
+      enqueueImpl(std::move(metadata), std::move(job));
       return;
     }
 
@@ -273,7 +246,40 @@ class Scheduler {
   template <typename P = Policy, typename = std::enable_if_t<std::is_same_v<
                                      typename P::Metadata, std::monostate>>>
   std::future<Y> schedule(std::function<Y()> job) {
-    return scheduleImpl(Metadata{}, std::move(job));
+    if (stop_.load(std::memory_order_acquire)) {
+      std::promise<Y> err_promise;
+      err_promise.set_exception(std::make_exception_ptr(
+          std::runtime_error("Scheduler is stopping or stopped.")));
+      return err_promise.get_future();
+    }
+
+    auto promise = std::make_shared<std::promise<Y>>();
+    std::future<Y> future = promise->get_future();
+
+    auto work = [promise, job = std::move(job)]() mutable {
+      try {
+        if constexpr (std::is_void_v<Y>) {
+          job();
+          promise->set_value();
+        } else {
+          promise->set_value(job());
+        }
+      } catch (...) {
+        try {
+          promise->set_exception(std::current_exception());
+        } catch (...) { /* ignore */
+        }
+      }
+    };
+
+    if (!enqueueImpl(Metadata{}, std::move(work))) {
+      try {
+        promise->set_exception(std::make_exception_ptr(
+            std::runtime_error("Scheduler is stopping or stopped.")));
+      } catch (...) { /* ignore */
+      }
+    }
+    return future;
   }
 
   /**
@@ -288,7 +294,40 @@ class Scheduler {
   template <typename P = Policy, typename = std::enable_if_t<!std::is_same_v<
                                      typename P::Metadata, std::monostate>>>
   std::future<Y> schedule(Metadata metadata, std::function<Y()> job) {
-    return scheduleImpl(std::move(metadata), std::move(job));
+    if (stop_.load(std::memory_order_acquire)) {
+      std::promise<Y> err_promise;
+      err_promise.set_exception(std::make_exception_ptr(
+          std::runtime_error("Scheduler is stopping or stopped.")));
+      return err_promise.get_future();
+    }
+
+    auto promise = std::make_shared<std::promise<Y>>();
+    std::future<Y> future = promise->get_future();
+
+    auto work = [promise, job = std::move(job)]() mutable {
+      try {
+        if constexpr (std::is_void_v<Y>) {
+          job();
+          promise->set_value();
+        } else {
+          promise->set_value(job());
+        }
+      } catch (...) {
+        try {
+          promise->set_exception(std::current_exception());
+        } catch (...) { /* ignore */
+        }
+      }
+    };
+
+    if (!enqueueImpl(std::move(metadata), std::move(work))) {
+      try {
+        promise->set_exception(std::make_exception_ptr(
+            std::runtime_error("Scheduler is stopping or stopped.")));
+      } catch (...) { /* ignore */
+      }
+    }
+    return future;
   }
 
   /**
@@ -313,6 +352,30 @@ class Scheduler {
                 std::is_void_v<T> && !std::is_same_v<Metadata, std::monostate>>>
   void scheduleOrRunInline(Metadata metadata, std::function<void()> job) {
     scheduleOrRunInlineImpl(std::move(metadata), std::move(job));
+  }
+
+  /**
+   * @brief Enqueue a fire-and-forget task for execution.
+   *
+   * Enabled only for `TaskScheduler<void>` (i.e., `Y = void` and no metadata).
+   */
+  template <typename T = Y,
+            typename = std::enable_if_t<
+                std::is_void_v<T> && std::is_same_v<Metadata, std::monostate>>>
+  void enqueue(std::function<void()> job) {
+    enqueueImpl(Metadata{}, std::move(job));
+  }
+
+  /**
+   * @brief Enqueue a fire-and-forget task or run it inline on worker threads.
+   *
+   * Enabled only for `TaskScheduler<void>` (i.e., `Y = void` and no metadata).
+   */
+  template <typename T = Y,
+            typename = std::enable_if_t<
+                std::is_void_v<T> && std::is_same_v<Metadata, std::monostate>>>
+  void enqueueOrRunInline(std::function<void()> job) {
+    scheduleOrRunInlineImpl(Metadata{}, std::move(job));
   }
 
   /**

--- a/gtsam/base/Scheduler.h
+++ b/gtsam/base/Scheduler.h
@@ -1,0 +1,333 @@
+/* ----------------------------------------------------------------------------
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+ * See LICENSE for the license information
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file Scheduler.h
+ * @brief Policy-based work-stealing scheduler.
+ *
+ * @details
+ * This header defines a small, thread-based scheduler core that executes tasks
+ * using per-worker queues with opportunistic work-stealing. The queue behavior
+ * (e.g., LIFO/FIFO, priority ordering) is defined by a Policy type.
+ *
+ * Public convenience wrappers are provided in `TaskScheduler.h` and
+ * `PriorityScheduler.h`.
+ *
+ * @author Frank Dellaert
+ * @date May, 2025
+ */
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <exception>
+#include <functional>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <stdexcept>
+#include <thread>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace gtsam {
+
+/**
+ * @brief Thread pool scheduler parameterized by a queue Policy.
+ *
+ * @details
+ * - Tasks are executed by worker threads created at construction.
+ * - Per-worker queues reduce contention; workers steal from peers when idle.
+ * - External submissions are round-robin distributed across worker queues.
+ * - A condition variable parks workers when no work is available.
+ *
+ * Policy requirements:
+ * - `using Metadata = ...;` carried with each task (e.g., `std::monostate`,
+ * `int`)
+ * - `template <typename TaskPtr> using Container = ...;`
+ * - `push(container, task)`, `popLocal(container, out)`, `popSteal(container,
+ * out)`
+ *
+ * @tparam Y Result type returned by tasks. Use `void` for no return value.
+ * @tparam Policy Queue behavior policy.
+ */
+template <typename Y, typename Policy>
+class Scheduler {
+  using Metadata = typename Policy::Metadata;
+
+  struct Task {
+    Metadata metadata;
+    std::function<Y()> job;
+    std::promise<Y> promise;
+
+    Task(Metadata m, std::function<Y()> j, std::promise<Y> p_out)
+        : metadata(std::move(m)),
+          job(std::move(j)),
+          promise(std::move(p_out)) {}
+  };
+
+  using TaskPtr = std::shared_ptr<Task>;
+  using Container = typename Policy::template Container<TaskPtr>;
+
+  struct WorkerQueue {
+    std::mutex mutex;
+    Container queue;
+  };
+
+  std::vector<std::unique_ptr<WorkerQueue>> queues_;  // Per-worker queues.
+  std::atomic<size_t> queuedTasks_{0};  // Tracks queued work for wakeups.
+  std::vector<std::thread> workers_;
+  mutable std::mutex waitMutex_;  // Dedicated mutex for condition_variable.
+  std::condition_variable condition_;
+  std::atomic<bool> stop_{false};
+  std::atomic<int> activeTasks_{0};  // In-flight tasks (queued + running).
+  inline static thread_local Scheduler* currentScheduler_ = nullptr;
+  inline static thread_local int workerIndex_ = -1;
+  std::atomic<size_t> nextWorker_{0};  // Round-robin distributor.
+
+  /**
+   * @brief Worker loop: wait for tasks, run them, and fulfill promises.
+   *
+   * Uses a condition variable to avoid spinning while the queue is empty.
+   * Stops once `stop_` is set and no queued work remains.
+   */
+  void worker_thread(size_t index) {
+    currentScheduler_ = this;
+    workerIndex_ = static_cast<int>(index);
+    while (true) {
+      TaskPtr task;
+      if (!tryPopTask(index, task)) {
+        std::unique_lock<std::mutex> lock(waitMutex_);
+        condition_.wait(lock, [this] {
+          return stop_.load(std::memory_order_acquire) ||
+                 queuedTasks_.load(std::memory_order_acquire) > 0;
+        });
+        if (stop_.load(std::memory_order_acquire) &&
+            queuedTasks_.load(std::memory_order_acquire) == 0) {
+          currentScheduler_ = nullptr;
+          workerIndex_ = -1;
+          return;
+        }
+        continue;
+      }
+
+      try {
+        // Execute the task and set the promise value:
+        if constexpr (std::is_void_v<Y>) {
+          task->job();
+          task->promise.set_value();
+        } else {
+          task->promise.set_value(task->job());
+        }
+      } catch (...) {
+        // On exception, set the exception on the promise:
+        try {
+          task->promise.set_exception(std::current_exception());
+        } catch (...) { /* ignore */
+        }
+      }
+
+      // Decrement active task count and notify waiters.
+      activeTasks_.fetch_sub(1, std::memory_order_release);
+      condition_.notify_all();
+    }
+  }
+
+  /// Attempt to get a task from local or stolen queues.
+  bool tryPopTask(size_t index, TaskPtr& task) {
+    // Prefer local queue, then steal to keep workers busy.
+    if (tryPopLocal(index, task)) return true;
+    if (trySteal(index, task)) return true;
+    return false;
+  }
+
+  /// Try to pop a task from the current worker queue.
+  bool tryPopLocal(size_t index, TaskPtr& task) {
+    WorkerQueue& queue = *queues_[index];
+    std::lock_guard<std::mutex> lock(queue.mutex);
+    if (!Policy::template popLocal<TaskPtr>(queue.queue, task)) return false;
+    queuedTasks_.fetch_sub(1, std::memory_order_release);
+    return true;
+  }
+
+  /// Try to steal a task from another worker queue.
+  bool trySteal(size_t index, TaskPtr& task) {
+    const size_t workerCount = queues_.size();
+    if (workerCount <= 1) return false;
+    // Steal from other workers if local queue is empty.
+    for (size_t offset = 1; offset < workerCount; ++offset) {
+      size_t target = (index + offset) % workerCount;
+      WorkerQueue& queue = *queues_[target];
+      std::unique_lock<std::mutex> lock(queue.mutex, std::try_to_lock);
+      if (!lock.owns_lock()) continue;
+      if (!Policy::template popSteal<TaskPtr>(queue.queue, task)) continue;
+      queuedTasks_.fetch_sub(1, std::memory_order_release);
+      return true;
+    }
+    return false;
+  }
+
+  /// Return true if called on a scheduler worker thread.
+  bool isWorkerThread() const { return currentScheduler_ == this; }
+
+  std::future<Y> scheduleImpl(Metadata metadata, std::function<Y()> job) {
+    if (stop_.load(std::memory_order_acquire)) {
+      std::promise<Y> err_promise;
+      err_promise.set_exception(std::make_exception_ptr(
+          std::runtime_error("Scheduler is stopping or stopped.")));
+      return err_promise.get_future();
+    }
+
+    std::promise<Y> promise;
+    std::future<Y> future = promise.get_future();
+    auto task = std::make_shared<Task>(std::move(metadata), std::move(job),
+                                       std::move(promise));
+
+    WorkerQueue* targetQueue = nullptr;
+    if (isWorkerThread()) {
+      targetQueue = queues_[static_cast<size_t>(workerIndex_)].get();
+    } else {
+      const size_t target =
+          nextWorker_.fetch_add(1, std::memory_order_relaxed) % queues_.size();
+      targetQueue = queues_[target].get();
+    }
+
+    {
+      std::lock_guard<std::mutex> lock(targetQueue->mutex);
+      Policy::template push<TaskPtr>(targetQueue->queue, std::move(task));
+    }
+
+    queuedTasks_.fetch_add(1, std::memory_order_release);
+    activeTasks_.fetch_add(1, std::memory_order_release);
+    condition_.notify_one();
+    return future;
+  }
+
+  template <typename T = Y, typename = std::enable_if_t<std::is_void_v<T>>>
+  void scheduleOrRunInlineImpl(Metadata metadata, std::function<void()> job) {
+    if (stop_.load(std::memory_order_relaxed)) return;
+    if (!isWorkerThread()) {
+      scheduleImpl(std::move(metadata), std::move(job));
+      return;
+    }
+
+    activeTasks_.fetch_add(1, std::memory_order_release);
+    try {
+      job();
+    } catch (...) { /* ignore */
+    }
+    activeTasks_.fetch_sub(1, std::memory_order_release);
+    condition_.notify_all();
+  }
+
+ public:
+  /**
+   * @brief Construct a scheduler with a fixed number of worker threads.
+   *
+   * @param numThreads Number of worker threads to create. If zero, a single
+   * thread is created.
+   */
+  explicit Scheduler(size_t numThreads = std::thread::hardware_concurrency()) {
+    if (numThreads == 0) numThreads = 1;
+    queues_.reserve(numThreads);
+    for (size_t i = 0; i < numThreads; ++i) {
+      queues_.push_back(std::make_unique<WorkerQueue>());
+    }
+    for (size_t i = 0; i < numThreads; ++i) {
+      workers_.emplace_back(&Scheduler::worker_thread, this, i);
+    }
+  }
+
+  /**
+   * @brief Wait for all tasks to finish, then stop worker threads.
+   *
+   * @note The destructor calls `waitForAllTasks` before stopping workers.
+   */
+  ~Scheduler() {
+    waitForAllTasks();
+    stop_.store(true, std::memory_order_release);
+    condition_.notify_all();
+    for (std::thread& worker : workers_) {
+      if (worker.joinable()) worker.join();
+    }
+  }
+
+  /**
+   * @brief Enqueue a task for execution (no metadata).
+   *
+   * Only enabled when `Policy::Metadata` is `std::monostate`.
+   *
+   * @param job Callable returning a `Y`.
+   * @return `std::future<Y>` associated with the task.
+   */
+  template <typename P = Policy, typename = std::enable_if_t<std::is_same_v<
+                                     typename P::Metadata, std::monostate>>>
+  std::future<Y> schedule(std::function<Y()> job) {
+    return scheduleImpl(Metadata{}, std::move(job));
+  }
+
+  /**
+   * @brief Enqueue a task for execution with metadata.
+   *
+   * Enabled when `Policy::Metadata` is not `std::monostate`.
+   *
+   * @param metadata Policy-defined metadata for ordering (e.g., priority).
+   * @param job Callable returning a `Y`.
+   * @return `std::future<Y>` associated with the task.
+   */
+  template <typename P = Policy, typename = std::enable_if_t<!std::is_same_v<
+                                     typename P::Metadata, std::monostate>>>
+  std::future<Y> schedule(Metadata metadata, std::function<Y()> job) {
+    return scheduleImpl(std::move(metadata), std::move(job));
+  }
+
+  /**
+   * @brief Schedule or run inline when called from a worker thread.
+   *
+   * Used to fuse continuations without re-entering the queues.
+   */
+  template <typename T = Y,
+            typename = std::enable_if_t<
+                std::is_void_v<T> && std::is_same_v<Metadata, std::monostate>>>
+  void scheduleOrRunInline(std::function<void()> job) {
+    scheduleOrRunInlineImpl(Metadata{}, std::move(job));
+  }
+
+  /**
+   * @brief Schedule or run inline when called from a worker thread.
+   *
+   * Used to fuse continuations without re-entering the queues.
+   */
+  template <typename T = Y,
+            typename = std::enable_if_t<
+                std::is_void_v<T> && !std::is_same_v<Metadata, std::monostate>>>
+  void scheduleOrRunInline(Metadata metadata, std::function<void()> job) {
+    scheduleOrRunInlineImpl(std::move(metadata), std::move(job));
+  }
+
+  /**
+   * @brief Block until all queued and active tasks complete.
+   *
+   * @note If the scheduler is stopping, this returns early.
+   */
+  void waitForAllTasks() {
+    std::unique_lock<std::mutex> lock(waitMutex_);
+    condition_.wait(lock, [this] {
+      return stop_.load(std::memory_order_acquire) ||
+             (activeTasks_.load(std::memory_order_acquire) == 0 &&
+              queuedTasks_.load(std::memory_order_acquire) == 0);
+    });
+  }
+};
+
+}  // namespace gtsam

--- a/gtsam/base/Scheduler.h
+++ b/gtsam/base/Scheduler.h
@@ -120,9 +120,10 @@ class Scheduler {
         /* ignore */
       }
 
-      // Decrement active task count and notify waiters.
-      activeTasks_.fetch_sub(1, std::memory_order_release);
-      condition_.notify_all();
+      // Notify waiters only when work transitions to "done".
+      if (activeTasks_.fetch_sub(1, std::memory_order_release) == 1) {
+        condition_.notify_all();
+      }
     }
   }
 
@@ -199,8 +200,9 @@ class Scheduler {
       job();
     } catch (...) { /* ignore */
     }
-    activeTasks_.fetch_sub(1, std::memory_order_release);
-    condition_.notify_all();
+    if (activeTasks_.fetch_sub(1, std::memory_order_release) == 1) {
+      condition_.notify_all();
+    }
   }
 
  public:

--- a/gtsam/base/TaskScheduler.h
+++ b/gtsam/base/TaskScheduler.h
@@ -7,21 +7,20 @@
  * -------------------------------------------------------------------------- */
 
 /**
- * @file PriorityScheduler.h
- * @brief Priority-based task scheduler.
+ * @file TaskScheduler.h
+ * @brief Cooperative task scheduler.
  *
  * @details
  * This header defines a small, thread-based scheduler that executes tasks in
- * priority order. A lower numeric priority is executed before a higher numeric
- * priority (min-heap behavior). Tasks return a value of type `Y`, and callers
- * can wait on results via `std::future<Y>`.
+ * a cooperative manner without priority ordering. Tasks return a value of type
+ * `Y`, and callers can wait on results via `std::future<Y>`.
  *
  * This is implemented as a policy specialization of `gtsam::Scheduler`.
  *
  * @par Example
  * @code
- * gtsam::PriorityScheduler<int> scheduler(4);
- * auto future = scheduler.schedule(0, [] { return 42; });
+ * gtsam::TaskScheduler<int> scheduler(4);
+ * auto future = scheduler.schedule([] { return 42; });
  * int value = future.get();
  * @endcode
  *
@@ -36,51 +35,41 @@
 namespace gtsam {
 
 namespace detail {
-
-/// Queue policy for PriorityScheduler: min-heap priority_queue by task
-/// priority.
-struct PrioritySchedulerPolicy {
-  using Metadata = int;
+/// Queue policy for TaskScheduler: deque with local LIFO and stolen FIFO.
+struct TaskSchedulerPolicy {
+  using Metadata = std::monostate;
 
   template <typename TaskPtr>
-  struct Compare {
-    bool operator()(const TaskPtr& a, const TaskPtr& b) const {
-      return a->metadata > b->metadata;
-    }
-  };
-
-  template <typename TaskPtr>
-  using Container =
-      std::priority_queue<TaskPtr, std::vector<TaskPtr>, Compare<TaskPtr>>;
+  using Container = std::deque<TaskPtr>;
 
   template <typename TaskPtr>
   static void push(Container<TaskPtr>& container, TaskPtr task) {
-    container.push(std::move(task));
+    container.push_back(std::move(task));
   }
 
   template <typename TaskPtr>
   static bool popLocal(Container<TaskPtr>& container, TaskPtr& out) {
     if (container.empty()) return false;
-    out = container.top();
-    container.pop();
+    out = container.back();
+    container.pop_back();
     return true;
   }
 
   template <typename TaskPtr>
   static bool popSteal(Container<TaskPtr>& container, TaskPtr& out) {
-    return popLocal(container, out);
+    if (container.empty()) return false;
+    out = container.front();
+    container.pop_front();
+    return true;
   }
 };
-
 }  // namespace detail
 
 /**
- * @brief Thread pool scheduler that prioritizes tasks by numeric priority.
+ * @brief Thread pool scheduler that executes tasks without priority ordering.
  *
  * @details
- * - Lower numeric values are executed first.
- * - Tasks are executed by worker threads created at construction.
- * - `schedule` returns a `std::future<Y>` for the task result.
+ * - Tasks are executed in an efficient deque-based order (LIFO locally).
  * - Per-thread queues reduce contention; workers steal from peers when idle.
  * - External submissions are round-robin distributed across worker queues.
  * - A condition variable parks workers when no work is available.
@@ -88,6 +77,6 @@ struct PrioritySchedulerPolicy {
  * @tparam Y Result type returned by tasks. Use `void` for no return value.
  */
 template <typename Y>
-using PriorityScheduler = Scheduler<Y, detail::PrioritySchedulerPolicy>;
+using TaskScheduler = Scheduler<Y, detail::TaskSchedulerPolicy>;
 
 }  // namespace gtsam

--- a/gtsam/base/TaskScheduler.h
+++ b/gtsam/base/TaskScheduler.h
@@ -50,7 +50,7 @@ struct TaskSchedulerPolicy {
   template <typename TaskPtr>
   static bool popLocal(Container<TaskPtr>& container, TaskPtr& out) {
     if (container.empty()) return false;
-    out = container.back();
+    out = std::move(container.back());
     container.pop_back();
     return true;
   }
@@ -58,7 +58,7 @@ struct TaskSchedulerPolicy {
   template <typename TaskPtr>
   static bool popSteal(Container<TaskPtr>& container, TaskPtr& out) {
     if (container.empty()) return false;
-    out = container.front();
+    out = std::move(container.front());
     container.pop_front();
     return true;
   }

--- a/gtsam/base/tests/testPriorityScheduler.cpp
+++ b/gtsam/base/tests/testPriorityScheduler.cpp
@@ -16,6 +16,9 @@
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/PriorityScheduler.h>
 
+#include <mutex>
+#include <vector>
+
 using namespace gtsam;
 
 /* ************************************************************************* */
@@ -34,6 +37,33 @@ TEST(PriorityScheduler, ReturnValueComposition) {
 
   const size_t expectedSum = 7;
   EXPECT_LONGS_EQUAL(expectedSum, parent.get());
+}
+
+/* ************************************************************************* */
+TEST(PriorityScheduler, VoidPriorityOrderingSingleWorker) {
+  PriorityScheduler<void> scheduler(1);
+
+  std::mutex mutex;
+  std::vector<int> executionOrder;
+
+  scheduler.schedule(5, [&] {
+    std::lock_guard<std::mutex> lock(mutex);
+    executionOrder.push_back(5);
+  });
+  scheduler.schedule(1, [&] {
+    std::lock_guard<std::mutex> lock(mutex);
+    executionOrder.push_back(1);
+  });
+  scheduler.schedule(3, [&] {
+    std::lock_guard<std::mutex> lock(mutex);
+    executionOrder.push_back(3);
+  });
+
+  scheduler.waitForAllTasks();
+  EXPECT_LONGS_EQUAL(3, executionOrder.size());
+  EXPECT_LONGS_EQUAL(1, executionOrder.at(0));
+  EXPECT_LONGS_EQUAL(3, executionOrder.at(1));
+  EXPECT_LONGS_EQUAL(5, executionOrder.at(2));
 }
 
 /* ************************************************************************* */

--- a/gtsam/base/tests/testTaskScheduler.cpp
+++ b/gtsam/base/tests/testTaskScheduler.cpp
@@ -1,0 +1,75 @@
+/* ----------------------------------------------------------------------------
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+ * See LICENSE for the license information
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file testTaskScheduler.cpp
+ * @brief Unit tests for TaskScheduler scheduling behavior.
+ * @author Frank Dellaert
+ * @date Jan, 2026
+ */
+
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/TaskScheduler.h>
+
+#include <atomic>
+#include <mutex>
+#include <vector>
+
+using namespace gtsam;
+
+/* ************************************************************************* */
+// Compose child return values inside a parent task
+TEST(TaskScheduler, ReturnValueComposition) {
+  // Use multiple workers so parent tasks can wait without stalling the pool.
+  TaskScheduler<size_t> scheduler(2);
+
+  auto left = scheduler.schedule([] { return size_t{3}; }).share();
+  auto right = scheduler.schedule([] { return size_t{4}; }).share();
+
+  auto parent = scheduler.schedule(
+      [left, right]() mutable { return left.get() + right.get(); });
+
+  const size_t expectedSum = 7;
+  EXPECT_LONGS_EQUAL(expectedSum, parent.get());
+}
+
+/* ************************************************************************* */
+TEST(TaskScheduler, EnqueueFireAndForget) {
+  TaskScheduler<void> scheduler(2);
+
+  std::atomic<size_t> counter{0};
+  const size_t taskCount = 256;
+
+  for (size_t i = 0; i < taskCount; ++i) {
+    scheduler.enqueue([&counter] { counter.fetch_add(1); });
+  }
+
+  scheduler.waitForAllTasks();
+  EXPECT_LONGS_EQUAL(taskCount, counter.load());
+}
+
+/* ************************************************************************* */
+TEST(TaskScheduler, EnqueueOrRunInlineOnWorker) {
+  TaskScheduler<void> scheduler(1);
+
+  std::atomic<size_t> inlineCounter{0};
+  auto future = scheduler.schedule([&] {
+    scheduler.enqueueOrRunInline([&] { inlineCounter.fetch_add(1); });
+  });
+
+  future.get();
+  scheduler.waitForAllTasks();
+  EXPECT_LONGS_EQUAL(1, inlineCounter.load());
+}
+
+/* ************************************************************************* */
+int main() {
+  TestResult tr;
+  return TestRegistry::runAllTests(tr);
+}
+/* ************************************************************************* */

--- a/gtsam/inference/ClusterTree-inst.h
+++ b/gtsam/inference/ClusterTree-inst.h
@@ -81,27 +81,40 @@ void ClusterTree<GRAPH>::Cluster::merge(const std::shared_ptr<Cluster>& cluster)
 }
 
 /* ************************************************************************* */
-template<class GRAPH>
+template <class GRAPH>
 void ClusterTree<GRAPH>::Cluster::mergeChildren(
     const std::vector<bool>& merge) {
+  mergeChildren(childrenFromMask(merge));
+}
+
+/* ************************************************************************* */
+template <class GRAPH>
+void ClusterTree<GRAPH>::Cluster::mergeChildren(
+    const Children& selected) {
   gttic(Cluster_mergeChildren);
-  assert(merge.size() == this->children.size());
+  // Merge selected children into this node while preserving unselected children.
+  if (selected.empty()) return;
+
+  FastSet<const Cluster*> selectedSet;
+  for (const auto& child : selected) {
+    if (child) {
+      selectedSet.insert(child.get());
+    }
+  }
+  if (selectedSet.empty()) return;
 
   // Count how many keys, factors and children we'll end up with
   size_t nrKeys = orderedFrontalKeys.size();
   size_t nrFactors = factors.size();
   size_t nrNewChildren = 0;
-  // Loop over children
-  size_t i = 0;
-  for(const sharedNode& child: this->children) {
-    if (merge[i]) {
+  for (const sharedNode& child : this->children) {
+    if (child && selectedSet.count(child.get()) != 0) {
       nrKeys += child->orderedFrontalKeys.size();
       nrFactors += child->factors.size();
       nrNewChildren += child->nrChildren();
     } else {
-      nrNewChildren += 1; // we keep the child
+      nrNewChildren += 1;  // we keep the child
     }
-    ++i;
   }
 
   // now reserve space, and really merge
@@ -110,16 +123,82 @@ void ClusterTree<GRAPH>::Cluster::mergeChildren(
   this->children.reserve(nrNewChildren);
   orderedFrontalKeys.reserve(nrKeys);
   factors.reserve(nrFactors);
-  i = 0;
   for (const sharedNode& child : oldChildren) {
-    if (merge[i]) {
+    if (child && selectedSet.count(child.get()) != 0) {
       this->merge(child);
     } else {
       this->addChild(child);  // we keep the child
     }
-    ++i;
   }
+  // merge() appends keys in reverse order to defer a final reverse.
   std::reverse(orderedFrontalKeys.begin(), orderedFrontalKeys.end());
+}
+
+/* ************************************************************************* */
+template <class GRAPH>
+void ClusterTree<GRAPH>::Cluster::mergeChildrenSiblings(
+    const std::vector<bool>& merge) {
+  mergeChildrenSiblings(childrenFromMask(merge));
+}
+
+/* ************************************************************************* */
+template <class GRAPH>
+void ClusterTree<GRAPH>::Cluster::mergeChildrenSiblings(
+    const Children& selected) {
+  gttic(Cluster_mergeChildrenSiblings);
+  // Merge selected siblings into a new child while keeping unselected children.
+  if (selected.empty()) return;
+
+  FastSet<const Cluster*> selectedSet;
+  for (const auto& child : selected) {
+    if (child) {
+      selectedSet.insert(child.get());
+    }
+  }
+  const size_t selectedCount = selectedSet.size();
+  // Nothing to merge (0 or 1 selected), so keep children unchanged.
+  if (selectedCount <= 1) return;
+
+  auto oldChildren = this->children;
+  Children newChildren;
+  newChildren.reserve(oldChildren.size() - selectedCount + 1);
+  auto merged = std::make_shared<Cluster>();
+  bool inserted = false;
+
+  for (const sharedNode& child : oldChildren) {
+    if (child && selectedSet.count(child.get()) != 0) {
+      // Merge selected siblings into a single new cluster.
+      merged->merge(child);
+      if (!inserted) {
+        // Insert merged cluster at the first selected child's position.
+        newChildren.push_back(merged);
+        inserted = true;
+      }
+    } else {
+      newChildren.push_back(child);
+    }
+  }
+
+  // merge() appends keys in reverse order to defer a final reverse.
+  std::reverse(merged->orderedFrontalKeys.begin(),
+               merged->orderedFrontalKeys.end());
+  this->children.swap(newChildren);
+}
+
+/* ************************************************************************* */
+template <class GRAPH>
+typename ClusterTree<GRAPH>::Cluster::Children
+ClusterTree<GRAPH>::Cluster::childrenFromMask(
+    const std::vector<bool>& merge) const {
+  assert(merge.size() == this->children.size());
+  // Translate a boolean mask into the corresponding child pointers.
+  Children selected;
+  for (size_t i = 0; i < children.size(); ++i) {
+    if (merge[i]) {
+      selected.push_back(children[i]);
+    }
+  }
+  return selected;
 }
 
 /* ************************************************************************* */

--- a/gtsam/inference/ClusterTree.h
+++ b/gtsam/inference/ClusterTree.h
@@ -11,6 +11,7 @@
 
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/FastMap.h>
+#include <gtsam/base/FastSet.h>
 #include <gtsam/base/FastVector.h>
 #include <gtsam/inference/Ordering.h>
 
@@ -107,6 +108,18 @@ class ClusterTree {
 
     /// Merge all children for which bit is set into this node
     void mergeChildren(const std::vector<bool>& merge);
+
+    /** Merge selected siblings into a new child cluster. */
+    void mergeChildrenSiblings(const std::vector<bool>& merge);
+
+    /** Merge selected children (provided as pointers) into this node. */
+    void mergeChildren(const Children& selected);
+
+    /** Merge selected siblings (provided as pointers) into a new child. */
+    void mergeChildrenSiblings(const Children& selected);
+
+    /** Convert a child-selection mask into the selected child pointers. */
+    Children childrenFromMask(const std::vector<bool>& merge) const;
   };
 
   typedef std::shared_ptr<Cluster> sharedCluster;  ///< Shared pointer to Cluster

--- a/gtsam/linear/GaussianFactor.h
+++ b/gtsam/linear/GaussianFactor.h
@@ -170,6 +170,9 @@ namespace gtsam {
     /// @name Advanced Interface
     /// @{
 
+    /// Fast check for JacobianFactor-based types.
+    virtual bool isJacobian() const { return false; }
+
     // Determine position of a given key
     template <typename CONTAINER>
     static DenseIndex Slot(const CONTAINER& keys, Key key) {

--- a/gtsam/linear/JacobianFactor.h
+++ b/gtsam/linear/JacobianFactor.h
@@ -198,6 +198,9 @@ namespace gtsam {
           std::make_shared<JacobianFactor>(*this));
     }
 
+    /// Identify JacobianFactor-based types.
+    bool isJacobian() const override { return true; }
+
     // Implementing Testable interface
     void print(const std::string& s = "",
       const KeyFormatter& formatter = DefaultKeyFormatter) const override;
@@ -483,5 +486,4 @@ BOOST_CLASS_VERSION(gtsam::JacobianFactor, 1)
 #endif
 
 #include <gtsam/linear/JacobianFactor-inl.h>
-
 

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -18,7 +18,6 @@
 
 #include <gtsam/base/Matrix.h>
 #include <gtsam/linear/GaussianConditional.h>
-#include <gtsam/linear/HessianFactor.h>
 #include <gtsam/linear/JacobianFactor.h>
 #include <gtsam/linear/MultifrontalClique.h>
 
@@ -207,45 +206,27 @@ size_t MultifrontalClique::addJacobianFactor(
   return rows;
 }
 
-void MultifrontalClique::addHessianFactor(const HessianFactor& hessianFactor) {
-  const SymmetricBlockMatrix& info = hessianFactor.info();
-  const DenseIndex factorBlocks = static_cast<DenseIndex>(hessianFactor.size());
-  const DenseIndex rhsBlock = static_cast<DenseIndex>(sbm_.nBlocks() - 1);
-
-  std::vector<DenseIndex> blockIndices(factorBlocks + 1, -1);
-  DenseIndex slot = 0;
-  for (auto it = hessianFactor.begin(); it != hessianFactor.end();
-       ++it, ++slot) {
-    const Key key = *it;
-    if (fixedKeys_ && fixedKeys_->count(key)) continue;
-    blockIndices[slot] = blockIndex(key);
-  }
-  blockIndices[factorBlocks] = rhsBlock;
-
-  sbm_.updateFromMappedBlocks(info, blockIndices);
-}
-
 void MultifrontalClique::fillAb(const GaussianFactorGraph& graph) {
   assert(validateFactorKeys(graph, factorIndices_, orderedKeys_, fixedKeys_));
 
-  hessianFactors_.clear();
   size_t rowOffset = 0;
   for (size_t index : factorIndices_) {
     assert(index < graph.size());
     const GaussianFactor::shared_ptr& gf = graph[index];
     if (!gf) continue;
-    if (auto jacobianFactor = std::dynamic_pointer_cast<JacobianFactor>(gf)) {
-      rowOffset += addJacobianFactor(*jacobianFactor, rowOffset);
-    } else if (auto hessianFactor =
-                   std::dynamic_pointer_cast<HessianFactor>(gf)) {
-      hessianFactors_.push_back(hessianFactor);
+    if (!gf->isJacobian()) {
+      throw std::runtime_error(
+          "MultifrontalClique::fillAb: only JacobianFactor inputs are "
+          "supported.");
     }
+    auto jacobianFactor = std::static_pointer_cast<JacobianFactor>(gf);
+    rowOffset += addJacobianFactor(*jacobianFactor, rowOffset);
   }
 
-  // Lock in QR only for leaf cliques with no Hessian factors.
+  // Lock in QR only for leaf cliques.
   const bool isLeaf = children.empty();
   const bool useQR =
-      isLeaf && hessianFactors_.empty() && (frontalDim > 0) &&
+      isLeaf && (frontalDim > 0) &&
       (frontalDim + separatorDim > kQrAspectRatio * frontalDim) &&
       (Ab_.matrix().rows() >= static_cast<DenseIndex>(frontalDim));
   solveMode_ = useQR ? SolveMode::QrLeaf : SolveMode::Cholesky;
@@ -261,10 +242,6 @@ void MultifrontalClique::prepareForElimination() {
   if (useQR()) return;
   assert(sbm_.nBlocks() > 0);
   sbm_.setZero();
-  for (const auto& hf : hessianFactors_) {
-    addHessianFactor(*hf);
-  }
-
   if (Ab_.matrix().rows() > 0) {
     sbm_.selfadjointView().rankUpdate(Ab_.matrix().transpose());
   }

--- a/gtsam/linear/MultifrontalClique.h
+++ b/gtsam/linear/MultifrontalClique.h
@@ -108,7 +108,9 @@ class GTSAM_EXPORT MultifrontalClique {
   void finalize(std::vector<ChildInfo> children);
 
   /// Load factor values into the pre-allocated Ab matrix.
-  /// @param graph The factor graph with updated values.
+  /// @param graph The factor graph with updated values (structure must match
+  ///              the graph used to build this clique, apart from updated
+  ///              numerical values). Only JacobianFactor inputs are supported.
   void fillAb(const GaussianFactorGraph& graph);
 
   /// Zero out sbm, re-add Hessians, accumulate Jacobians and children.
@@ -230,9 +232,6 @@ class GTSAM_EXPORT MultifrontalClique {
    */
   size_t addJacobianFactor(const JacobianFactor& factor, size_t rowOffset);
 
-  /// Add a Hessian factor's contributions into the sbm_ matrix.
-  void addHessianFactor(const HessianFactor& factor);
-
   void setParentIndices(const std::vector<DenseIndex>& indices) {
     parentIndices_ = indices;
   }
@@ -249,7 +248,6 @@ class GTSAM_EXPORT MultifrontalClique {
 
   // Load-time state.
   VerticalBlockMatrix Ab_;
-  std::vector<HessianFactor::shared_ptr> hessianFactors_;  ///< Hessian factors.
   SolveMode solveMode_ = SolveMode::Cholesky;
 
   // Elimination-time state.

--- a/gtsam/linear/MultifrontalSolver.cpp
+++ b/gtsam/linear/MultifrontalSolver.cpp
@@ -18,6 +18,7 @@
 
 #include <gtsam/base/treeTraversal-inst.h>
 #include <gtsam/base/types.h>
+#include <gtsam/config.h>
 #include <gtsam/inference/Key.h>
 #include <gtsam/linear/GaussianBayesTree.h>
 #include <gtsam/linear/GaussianConditional.h>
@@ -307,16 +308,20 @@ struct CliqueBuilder {
 /* ************************************************************************* */
 MultifrontalSolver::MultifrontalSolver(const GaussianFactorGraph& graph,
                                        const Ordering& ordering,
-                                       size_t mergeDimCap,
-                                       std::ostream* reportStream)
-    : MultifrontalSolver(Precompute(graph, ordering), ordering, mergeDimCap,
-                         reportStream) {}
+                                       const Parameters& params)
+    : MultifrontalSolver(Precompute(graph, ordering), ordering, params) {}
+
+/* ************************************************************************* */
+MultifrontalSolver::MultifrontalSolver(const GaussianFactorGraph& graph,
+                                       const Ordering& ordering)
+    : MultifrontalSolver(graph, ordering, Parameters{}) {}
+
 
 /* ************************************************************************* */
 MultifrontalSolver::MultifrontalSolver(PrecomputedData data,
                                        const Ordering& ordering,
-                                       size_t mergeDimCap,
-                                       std::ostream* reportStream) {
+                                       const Parameters& params)
+    : TaskMixin<MultifrontalSolver, MultifrontalClique>(), params_(params) {
   dims_ = std::move(data.dims);
   fixedKeys_ = std::move(data.fixedKeys);
 
@@ -332,15 +337,15 @@ MultifrontalSolver::MultifrontalSolver(PrecomputedData data,
 
   // Report the symbolic structure before any merge.
   reportStructure(data.junctionTree, dims_, "Symbolic cluster structure",
-                  reportStream);
+                  params_.reportStream);
 
   // If applicable, merge small child cliques bottom-up.
-  if (mergeDimCap > 0) {
+  if (params_.mergeDimCap > 0) {
     for (const auto& rootCluster : data.junctionTree.roots()) {
-      mergeSmallClusters(rootCluster, dims_, mergeDimCap);
+      mergeSmallClusters(rootCluster, dims_, params_.mergeDimCap);
     }
     reportStructure(data.junctionTree, dims_, "Clique structure after merge",
-                    reportStream);
+                    params_.reportStream);
   }
 
   // Build the actual MultifrontalClique structure.
@@ -355,6 +360,12 @@ MultifrontalSolver::MultifrontalSolver(PrecomputedData data,
 
   // Caller is responsible for loading numerical values via load().
 }
+
+/* ************************************************************************* */
+MultifrontalSolver::MultifrontalSolver(PrecomputedData data,
+                                       const Ordering& ordering)
+    : MultifrontalSolver(std::move(data), ordering, Parameters{}) {}
+
 
 /* ************************************************************************* */
 MultifrontalSolver::PrecomputedData MultifrontalSolver::Precompute(
@@ -395,26 +406,39 @@ void MultifrontalSolver::eliminateInPlace() {
         "eliminating.");
   }
   eliminated_ = false;
+#ifdef GTSAM_USE_TBB
   // Parallel elimination uses PostOrderForestParallel, which will be
   // multi-threaded if GTSAM was compiled with TBB.
   TbbOpenMPMixedScope threadLimiter;
   auto visitorPost = [](const CliquePtr& node) {
     if (node) node->eliminateInPlace();
   };
-  treeTraversal::PostOrderForestParallel(*this, visitorPost, 10);
+  treeTraversal::PostOrderForestParallel(
+      *this, visitorPost, params_.eliminationParallelThreshold);
+#else
+  runBottomUp([](MultifrontalClique& node) { node.eliminateInPlace(); });
+#endif
   eliminated_ = true;
 }
 
 /* ************************************************************************* */
 void MultifrontalSolver::eliminateInPlace(const GaussianFactorGraph& graph) {
   // Combine load + eliminate in one post-order traversal to improve locality.
+#ifdef GTSAM_USE_TBB
   TbbOpenMPMixedScope threadLimiter;
   auto visitorPost = [&graph](const CliquePtr& node) {
     if (!node) return;
     node->fillAb(graph);
     node->eliminateInPlace();
   };
-  treeTraversal::PostOrderForestParallel(*this, visitorPost, 10);
+  treeTraversal::PostOrderForestParallel(
+      *this, visitorPost, params_.eliminationParallelThreshold);
+#else
+  runBottomUp([&graph](MultifrontalClique& node) {
+    node.fillAb(graph);
+    node.eliminateInPlace();
+  });
+#endif
   loaded_ = true;
   eliminated_ = true;
 }
@@ -477,13 +501,11 @@ const VectorValues& MultifrontalSolver::updateSolution() const {
   // Threshold chosen to balance task overhead vs parallelism. Small cliques
   // (like points in SFM) are better handled sequentially within larger tasks
   // to minimize scheduling overhead and maximize cache locality.
-  constexpr int kSolutionParallelThreshold = 4096;
-
   // Cast to non-const because treeTraversal expects a non-const reference,
   // even though we are only calling const methods on the nodes.
   treeTraversal::DepthFirstForestParallel(
       const_cast<MultifrontalSolver&>(*this), rootData, visitorPre, visitorPost,
-      kSolutionParallelThreshold);
+      params_.solutionParallelThreshold);
 
   for (Key key : fixedKeys_) {
     solution_.at(key).setZero();

--- a/gtsam/linear/MultifrontalSolver.cpp
+++ b/gtsam/linear/MultifrontalSolver.cpp
@@ -18,6 +18,7 @@
 
 #include <gtsam/base/treeTraversal-inst.h>
 #include <gtsam/base/types.h>
+#include <gtsam/base/FastMap.h>
 #include <gtsam/config.h>
 #include <gtsam/inference/Key.h>
 #include <gtsam/linear/GaussianBayesTree.h>
@@ -194,6 +195,100 @@ size_t totalDimForSymbolicCluster(
          separatorDimForSymbolicCluster(cluster, dims, cache);
 }
 
+struct LeafInfo {
+  SymbolicJunctionTree::sharedNode child;
+  size_t totalDim = 0;
+  size_t index = 0;
+};
+
+struct LeafGroup {
+  std::vector<LeafInfo> leaves;
+  size_t firstIndex = 0;
+};
+
+struct LeafBatch {
+  SymbolicJunctionTree::Cluster::Children leaves;
+  size_t firstIndex = 0;
+};
+
+std::vector<LeafGroup> collectLeafGroups(
+    const SymbolicJunctionTree::sharedNode& cluster,
+    const std::map<Key, size_t>& dims,
+    SymbolicJunctionTree::Cluster::KeySetMap* separatorCache) {
+  // Group leaf children by identical separators, keeping first-seen order.
+  FastMap<KeySet, size_t> groupIndexBySeparator;
+  std::vector<LeafGroup> groups;
+
+  for (size_t i = 0; i < cluster->children.size(); ++i) {
+    const auto& child = cluster->children[i];
+    if (!child || !child->children.empty()) continue;
+
+    child->separatorKeys(separatorCache);
+    const KeySet& separatorKeys = separatorCache->at(child.get());
+    auto it = groupIndexBySeparator.find(separatorKeys);
+    size_t groupIndex = 0;
+    if (it == groupIndexBySeparator.end()) {
+      groupIndex = groups.size();
+      groupIndexBySeparator.emplace(separatorKeys, groupIndex);
+      groups.push_back(LeafGroup{{}, i});
+    } else {
+      groupIndex = it->second;
+    }
+
+    const size_t totalDim =
+        totalDimForSymbolicCluster(child, dims, separatorCache);
+    groups[groupIndex].leaves.push_back({child, totalDim, i});
+  }
+
+  return groups;
+}
+
+std::vector<LeafBatch> buildLeafBatches(const std::vector<LeafGroup>& groups,
+                                        size_t leafMergeDimCap) {
+  // Pack each group into batches capped by total dimension.
+  std::vector<LeafBatch> batches;
+  for (const auto& group : groups) {
+    size_t currentTotalDim = 0;
+    LeafBatch batch;
+    batch.firstIndex = group.firstIndex;
+    for (const auto& leaf : group.leaves) {
+      if (!batch.leaves.empty() &&
+          currentTotalDim + leaf.totalDim > leafMergeDimCap) {
+        batches.push_back(batch);
+        batch.leaves.clear();
+        currentTotalDim = 0;
+        batch.firstIndex = leaf.index;
+      }
+      if (batch.leaves.empty()) {
+        batch.firstIndex = leaf.index;
+      }
+      batch.leaves.push_back(leaf.child);
+      currentTotalDim += leaf.totalDim;
+    }
+    if (!batch.leaves.empty()) {
+      batches.push_back(batch);
+    }
+  }
+
+  std::sort(batches.begin(), batches.end(),
+            [](const LeafBatch& a, const LeafBatch& b) {
+              return a.firstIndex < b.firstIndex;
+            });
+  return batches;
+}
+
+bool mergeLeafBatches(const SymbolicJunctionTree::sharedNode& cluster,
+                      const std::vector<LeafBatch>& batches) {
+  // Merge each batch of siblings into a super-leaf in-place.
+  bool anyMerged = false;
+  for (const auto& batch : batches) {
+    if (batch.leaves.size() <= 1) continue;
+    cluster->mergeChildrenSiblings(batch.leaves);
+    anyMerged = true;
+  }
+  return anyMerged;
+}
+
 void accumulateSymbolicStats(const SymbolicJunctionTree::sharedNode& cluster,
                              const std::map<Key, size_t>& dims,
                              SymbolicJunctionTree::Cluster::KeySetMap* cache,
@@ -206,6 +301,49 @@ void accumulateSymbolicStats(const SymbolicJunctionTree::sharedNode& cluster,
   for (const auto& child : cluster->children) {
     accumulateSymbolicStats(child, dims, cache, stats);
   }
+}
+
+/**
+ * @brief Recursively groups leaf children into super-leaves capped by total
+ * dimension.
+ *
+ * This function traverses the symbolic junction tree rooted at the given
+ * cluster node. For each cluster, it gathers direct leaf children (i.e.,
+ * children with no further descendants) and groups those with identical
+ * separators into new super-leaves until the running total dimension reaches
+ * the specified leafMergeDimCap, then starts a new group.
+ *
+ * The merging process works as follows:
+ * - Recursively process all children clusters first.
+ * - Identify all direct leaf children of the current cluster and collect their
+ * total dimensions (separator + frontal) and separator keys.
+ * - Group leaf children by identical separator keys, preserving first-seen
+ * order for each separator.
+ * - Build super-leaves by accumulating leaf children until the total dimension
+ * hits the cap, then start a new super-leaf.
+ * - Replace leaf children with the new super-leaves (non-leaf children keep
+ * their relative order and grouped leaves appear at the first leaf location
+ * for that separator).
+ *
+ * @param cluster         The current symbolic junction tree node (cluster) to
+ * process.
+ * @param dims            A map from variable keys to their dimensions.
+ * @param leafMergeDimCap The maximum allowed dimension for a merged cluster.
+ */
+void mergeLeafChildren(const SymbolicJunctionTree::sharedNode& cluster,
+                       const std::map<Key, size_t>& dims,
+                       size_t leafMergeDimCap) {
+  if (!cluster || cluster->children.empty()) return;
+  for (const auto& child : cluster->children) {
+    mergeLeafChildren(child, dims, leafMergeDimCap);
+  }
+
+  SymbolicJunctionTree::Cluster::KeySetMap separatorCache;
+  const std::vector<LeafGroup> groups =
+      collectLeafGroups(cluster, dims, &separatorCache);
+  const std::vector<LeafBatch> batches =
+      buildLeafBatches(groups, leafMergeDimCap);
+  if (!mergeLeafBatches(cluster, batches)) return;
 }
 
 // Bottom-up merge of child clusters whose merged total dimension stays below
@@ -316,7 +454,6 @@ MultifrontalSolver::MultifrontalSolver(const GaussianFactorGraph& graph,
                                        const Ordering& ordering)
     : MultifrontalSolver(graph, ordering, Parameters{}) {}
 
-
 /* ************************************************************************* */
 MultifrontalSolver::MultifrontalSolver(PrecomputedData data,
                                        const Ordering& ordering,
@@ -338,6 +475,15 @@ MultifrontalSolver::MultifrontalSolver(PrecomputedData data,
   // Report the symbolic structure before any merge.
   reportStructure(data.junctionTree, dims_, "Symbolic cluster structure",
                   params_.reportStream);
+
+  // If applicable, merge leaf children by a separate cap first.
+  if (params_.leafMergeDimCap > 0) {
+    for (const auto& rootCluster : data.junctionTree.roots()) {
+      mergeLeafChildren(rootCluster, dims_, params_.leafMergeDimCap);
+    }
+    reportStructure(data.junctionTree, dims_,
+                    "Clique structure after leaf merge", params_.reportStream);
+  }
 
   // If applicable, merge small child cliques bottom-up.
   if (params_.mergeDimCap > 0) {
@@ -365,7 +511,6 @@ MultifrontalSolver::MultifrontalSolver(PrecomputedData data,
 MultifrontalSolver::MultifrontalSolver(PrecomputedData data,
                                        const Ordering& ordering)
     : MultifrontalSolver(std::move(data), ordering, Parameters{}) {}
-
 
 /* ************************************************************************* */
 MultifrontalSolver::PrecomputedData MultifrontalSolver::Precompute(
@@ -413,8 +558,8 @@ void MultifrontalSolver::eliminateInPlace() {
   auto visitorPost = [](const CliquePtr& node) {
     if (node) node->eliminateInPlace();
   };
-  treeTraversal::PostOrderForestParallel(
-      *this, visitorPost, params_.eliminationParallelThreshold);
+  treeTraversal::PostOrderForestParallel(*this, visitorPost,
+                                         params_.eliminationParallelThreshold);
 #else
   runBottomUp([](MultifrontalClique& node) { node.eliminateInPlace(); });
 #endif
@@ -431,8 +576,8 @@ void MultifrontalSolver::eliminateInPlace(const GaussianFactorGraph& graph) {
     node->fillAb(graph);
     node->eliminateInPlace();
   };
-  treeTraversal::PostOrderForestParallel(
-      *this, visitorPost, params_.eliminationParallelThreshold);
+  treeTraversal::PostOrderForestParallel(*this, visitorPost,
+                                         params_.eliminationParallelThreshold);
 #else
   runBottomUp([&graph](MultifrontalClique& node) {
     node.fillAb(graph);

--- a/gtsam/linear/MultifrontalSolver.cpp
+++ b/gtsam/linear/MultifrontalSolver.cpp
@@ -17,8 +17,6 @@
  */
 
 #include <gtsam/base/FastMap.h>
-#include <gtsam/base/treeTraversal-inst.h>
-#include <gtsam/base/types.h>
 #include <gtsam/config.h>
 #include <gtsam/inference/Key.h>
 #include <gtsam/linear/GaussianBayesTree.h>
@@ -40,10 +38,6 @@
 #include <stdexcept>
 #include <string>
 #include <thread>
-
-#ifdef GTSAM_USE_TBB
-#include <tbb/global_control.h>
-#endif
 
 namespace gtsam {
 
@@ -470,7 +464,7 @@ MultifrontalSolver::MultifrontalSolver(const GaussianFactorGraph& graph,
 MultifrontalSolver::MultifrontalSolver(PrecomputedData data,
                                        const Ordering& ordering,
                                        const Parameters& params)
-    : SolverTaskMixin<MultifrontalSolver, MultifrontalClique>(
+    : ForestTraversal<MultifrontalSolver, MultifrontalClique>(
           resolveThreadCount(params.numThreads)),
       params_(params),
       numThreads_(resolveThreadCount(params.numThreads)) {
@@ -566,43 +560,20 @@ void MultifrontalSolver::eliminateInPlace() {
         "eliminating.");
   }
   eliminated_ = false;
-#ifdef GTSAM_USE_TBB
-  tbb::global_control tbbControl(tbb::global_control::max_allowed_parallelism,
-                                 static_cast<int>(numThreads_));
-  // Parallel elimination uses PostOrderForestParallel, which will be
-  // multi-threaded if GTSAM was compiled with TBB.
-  TbbOpenMPMixedScope threadLimiter;
-  auto visitorPost = [](const CliquePtr& node) {
-    if (node) node->eliminateInPlace();
-  };
-  treeTraversal::PostOrderForestParallel(*this, visitorPost,
-                                         params_.eliminationParallelThreshold);
-#else
-  runBottomUp([](MultifrontalClique& node) { node.eliminateInPlace(); });
-#endif
+  runBottomUp([](MultifrontalClique& node) { node.eliminateInPlace(); },
+              params_.eliminationParallelThreshold);
   eliminated_ = true;
 }
 
 /* ************************************************************************* */
 void MultifrontalSolver::eliminateInPlace(const GaussianFactorGraph& graph) {
   // Combine load + eliminate in one post-order traversal to improve locality.
-#ifdef GTSAM_USE_TBB
-  tbb::global_control tbbControl(tbb::global_control::max_allowed_parallelism,
-                                 static_cast<int>(numThreads_));
-  TbbOpenMPMixedScope threadLimiter;
-  auto visitorPost = [&graph](const CliquePtr& node) {
-    if (!node) return;
-    node->fillAb(graph);
-    node->eliminateInPlace();
-  };
-  treeTraversal::PostOrderForestParallel(*this, visitorPost,
-                                         params_.eliminationParallelThreshold);
-#else
-  runBottomUp([&graph](MultifrontalClique& node) {
-    node.fillAb(graph);
-    node.eliminateInPlace();
-  });
-#endif
+  runBottomUp(
+      [&graph](MultifrontalClique& node) {
+        node.fillAb(graph);
+        node.eliminateInPlace();
+      },
+      params_.eliminationParallelThreshold);
   loaded_ = true;
   eliminated_ = true;
 }
@@ -650,30 +621,10 @@ GaussianBayesTree MultifrontalSolver::computeBayesTree() const {
 }
 
 /* ************************************************************************* */
-const VectorValues& MultifrontalSolver::updateSolution() const {
+const VectorValues& MultifrontalSolver::updateSolution() {
   assert(loaded_ && eliminated_);
-#ifdef GTSAM_USE_TBB
-  tbb::global_control tbbControl(tbb::global_control::max_allowed_parallelism,
-                                 static_cast<int>(numThreads_));
-  TbbOpenMPMixedScope threadLimiter;
-#endif
-  // Parallel solve uses treeTraversal::DepthFirstForestParallel (Pre-order /
-  // Top-Down).
-  int rootData = 0;
-  auto visitorPre = [](const CliquePtr& node, int&) {
-    if (node) node->updateSolution();
-    return 0;
-  };
-  auto visitorPost = [](const CliquePtr&, int) {};
-
-  // Threshold chosen to balance task overhead vs parallelism. Small cliques
-  // (like points in SFM) are better handled sequentially within larger tasks
-  // to minimize scheduling overhead and maximize cache locality.
-  // Cast to non-const because treeTraversal expects a non-const reference,
-  // even though we are only calling const methods on the nodes.
-  treeTraversal::DepthFirstForestParallel(
-      const_cast<MultifrontalSolver&>(*this), rootData, visitorPre, visitorPost,
-      params_.solutionParallelThreshold);
+  runTopDown([](MultifrontalClique& node) { node.updateSolution(); },
+             params_.solutionParallelThreshold);
 
   for (Key key : fixedKeys_) {
     solution_.at(key).setZero();

--- a/gtsam/linear/MultifrontalSolver.cpp
+++ b/gtsam/linear/MultifrontalSolver.cpp
@@ -16,15 +16,14 @@
  * @date   December 2025
  */
 
+#include <gtsam/base/FastMap.h>
 #include <gtsam/base/treeTraversal-inst.h>
 #include <gtsam/base/types.h>
-#include <gtsam/base/FastMap.h>
 #include <gtsam/config.h>
 #include <gtsam/inference/Key.h>
 #include <gtsam/linear/GaussianBayesTree.h>
 #include <gtsam/linear/GaussianConditional.h>
 #include <gtsam/linear/GaussianFactor.h>
-#include <gtsam/linear/HessianFactor.h>
 #include <gtsam/linear/JacobianFactor.h>
 #include <gtsam/linear/MultifrontalClique.h>
 #include <gtsam/linear/MultifrontalSolver.h>
@@ -40,6 +39,11 @@
 #include <ostream>
 #include <stdexcept>
 #include <string>
+#include <thread>
+
+#ifdef GTSAM_USE_TBB
+#include <tbb/global_control.h>
+#endif
 
 namespace gtsam {
 
@@ -94,8 +98,11 @@ std::unordered_set<Key> collectFixedKeys(const GaussianFactorGraph& graph) {
   std::unordered_set<Key> fixedKeys;
   for (const auto& factor : graph) {
     if (!factor) continue;
-    auto jacobianFactor = std::dynamic_pointer_cast<JacobianFactor>(factor);
-    if (!jacobianFactor) continue;
+    if (!factor->isJacobian()) {
+      throw std::runtime_error(
+          "MultifrontalSolver: only JacobianFactor inputs are supported.");
+    }
+    auto jacobianFactor = std::static_pointer_cast<JacobianFactor>(factor);
     auto model = jacobianFactor->get_model();
     if (!model || !model->isConstrained()) continue;
     // Only accept fully constrained unary factors with zero residuals.
@@ -123,17 +130,13 @@ std::map<Key, size_t> computeDims(const GaussianFactorGraph& graph) {
   std::map<Key, size_t> dims;
   for (const auto& factor : graph) {
     if (!factor) continue;
-    if (auto jacobianFactor =
-            std::dynamic_pointer_cast<JacobianFactor>(factor)) {
-      for (auto it = jacobianFactor->begin(); it != jacobianFactor->end();
-           ++it) {
-        dims[*it] = jacobianFactor->getDim(it);
-      }
-    } else if (auto hessianFactor =
-                   std::dynamic_pointer_cast<HessianFactor>(factor)) {
-      for (auto it = hessianFactor->begin(); it != hessianFactor->end(); ++it) {
-        dims[*it] = hessianFactor->getDim(it);
-      }
+    if (!factor->isJacobian()) {
+      throw std::runtime_error(
+          "MultifrontalSolver: only JacobianFactor inputs are supported.");
+    }
+    auto jacobianFactor = std::static_pointer_cast<JacobianFactor>(factor);
+    for (auto it = jacobianFactor->begin(); it != jacobianFactor->end(); ++it) {
+      dims[*it] = jacobianFactor->getDim(it);
     }
   }
   return dims;
@@ -141,11 +144,12 @@ std::map<Key, size_t> computeDims(const GaussianFactorGraph& graph) {
 
 size_t factorRowCount(const GaussianFactorGraph& graph, size_t index) {
   if (index >= graph.size() || !graph[index]) return 0;
-  if (auto jacobianFactor =
-          std::dynamic_pointer_cast<JacobianFactor>(graph[index])) {
-    return jacobianFactor->rows();
+  if (!graph[index]->isJacobian()) {
+    throw std::runtime_error(
+        "MultifrontalSolver: only JacobianFactor inputs are supported.");
   }
-  return 0;
+  auto jacobianFactor = std::static_pointer_cast<JacobianFactor>(graph[index]);
+  return jacobianFactor->rows();
 }
 
 // Build SymbolicFactorGraph from GaussianFactorGraph
@@ -441,6 +445,14 @@ struct CliqueBuilder {
   }
 };
 
+size_t resolveThreadCount(size_t requested) {
+  if (requested != 0) return requested;
+  unsigned int hardwareThreads = std::thread::hardware_concurrency();
+  if (hardwareThreads == 0) hardwareThreads = 1;
+  size_t threads = (hardwareThreads * 3) / 4;
+  return threads == 0 ? 1 : threads;
+}
+
 }  // namespace
 
 /* ************************************************************************* */
@@ -458,7 +470,10 @@ MultifrontalSolver::MultifrontalSolver(const GaussianFactorGraph& graph,
 MultifrontalSolver::MultifrontalSolver(PrecomputedData data,
                                        const Ordering& ordering,
                                        const Parameters& params)
-    : TaskMixin<MultifrontalSolver, MultifrontalClique>(), params_(params) {
+    : SolverTaskMixin<MultifrontalSolver, MultifrontalClique>(
+          resolveThreadCount(params.numThreads)),
+      params_(params),
+      numThreads_(resolveThreadCount(params.numThreads)) {
   dims_ = std::move(data.dims);
   fixedKeys_ = std::move(data.fixedKeys);
 
@@ -552,6 +567,8 @@ void MultifrontalSolver::eliminateInPlace() {
   }
   eliminated_ = false;
 #ifdef GTSAM_USE_TBB
+  tbb::global_control tbbControl(tbb::global_control::max_allowed_parallelism,
+                                 static_cast<int>(numThreads_));
   // Parallel elimination uses PostOrderForestParallel, which will be
   // multi-threaded if GTSAM was compiled with TBB.
   TbbOpenMPMixedScope threadLimiter;
@@ -570,6 +587,8 @@ void MultifrontalSolver::eliminateInPlace() {
 void MultifrontalSolver::eliminateInPlace(const GaussianFactorGraph& graph) {
   // Combine load + eliminate in one post-order traversal to improve locality.
 #ifdef GTSAM_USE_TBB
+  tbb::global_control tbbControl(tbb::global_control::max_allowed_parallelism,
+                                 static_cast<int>(numThreads_));
   TbbOpenMPMixedScope threadLimiter;
   auto visitorPost = [&graph](const CliquePtr& node) {
     if (!node) return;
@@ -633,9 +652,13 @@ GaussianBayesTree MultifrontalSolver::computeBayesTree() const {
 /* ************************************************************************* */
 const VectorValues& MultifrontalSolver::updateSolution() const {
   assert(loaded_ && eliminated_);
+#ifdef GTSAM_USE_TBB
+  tbb::global_control tbbControl(tbb::global_control::max_allowed_parallelism,
+                                 static_cast<int>(numThreads_));
+  TbbOpenMPMixedScope threadLimiter;
+#endif
   // Parallel solve uses treeTraversal::DepthFirstForestParallel (Pre-order /
   // Top-Down).
-  TbbOpenMPMixedScope threadLimiter;
   int rootData = 0;
   auto visitorPre = [](const CliquePtr& node, int&) {
     if (node) node->updateSolution();

--- a/gtsam/linear/MultifrontalSolver.h
+++ b/gtsam/linear/MultifrontalSolver.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <gtsam/base/PriorityScheduler.h>
 #include <gtsam/inference/Key.h>
 #include <gtsam/inference/Ordering.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
@@ -42,8 +43,17 @@ class MultifrontalClique;
  * provides efficient methods for loading new factors, eliminating the graph,
  * and solving for the update vector.
  */
-class GTSAM_EXPORT MultifrontalSolver {
+class GTSAM_EXPORT MultifrontalSolver
+    : public TaskMixin<MultifrontalSolver, MultifrontalClique> {
  public:
+  /// Tuning parameters for traversal and reporting.
+  struct Parameters {
+    size_t mergeDimCap = 16;                ///< Merge threshold (0 disables).
+    std::ostream* reportStream = nullptr;   ///< Optional structure reporting.
+    int eliminationParallelThreshold = 10;  ///< Post-order task threshold.
+    int solutionParallelThreshold = 4096;   ///< Pre-order task threshold.
+  };
+
   struct PrecomputedData {
     std::map<Key, size_t> dims;         ///< Map from variable key to dimension.
     std::unordered_set<Key> fixedKeys;  ///< Keys fixed by constrained factors.
@@ -63,6 +73,7 @@ class GTSAM_EXPORT MultifrontalSolver {
   std::unordered_set<Key> fixedKeys_;  ///< Keys fixed by constrained factors.
   bool loaded_ = false;                ///< Whether load() has been called.
   bool eliminated_ = false;            ///< Whether eliminateInPlace() ran.
+  Parameters params_;                  ///< Tunable solver parameters.
 
  public:
   /**
@@ -71,28 +82,27 @@ class GTSAM_EXPORT MultifrontalSolver {
    * Call load() before eliminating to populate numerical values.
    * @param graph The factor graph to solve.
    * @param ordering The variable ordering to use for elimination.
-   * @param mergeDimCap Merge a child if its frontal dimension plus the
-   * parent's total dimension is below this threshold (0 disables merging).
-   * @param reportStream Optional stream to report clique structure stats
-   * (frontals, separators, total dims, and children).
+   * @param params Tunable parameters for traversal and reporting.
    */
   MultifrontalSolver(const GaussianFactorGraph& graph, const Ordering& ordering,
-                     size_t mergeDimCap = 0,
-                     std::ostream* reportStream = nullptr);
+                     const Parameters& params);
+
+  /// Construct the solver with default parameters.
+  MultifrontalSolver(const GaussianFactorGraph& graph,
+                     const Ordering& ordering);
 
   /**
    * Construct the solver from precomputed symbolic data.
    * Call load() before eliminating to populate numerical values.
    * @param data Precomputed symbolic structure and sizing data.
    * @param ordering The variable ordering to use for seeding solution storage.
-   * @param mergeDimCap Merge a child if its frontal dimension plus the
-   * parent's total dimension is below this threshold (0 disables merging).
-   * @param reportStream Optional stream to report clique structure stats
-   * (frontals, separators, total dims, and children).
+   * @param params Tunable parameters for traversal and reporting.
    */
   MultifrontalSolver(PrecomputedData data, const Ordering& ordering,
-                     size_t mergeDimCap = 0,
-                     std::ostream* reportStream = nullptr);
+                     const Parameters& params);
+
+  /// Construct the solver with default parameters.
+  MultifrontalSolver(PrecomputedData data, const Ordering& ordering);
 
   /// Precompute symbolic structure and sizing data from a factor graph.
   static PrecomputedData Precompute(const GaussianFactorGraph& graph,

--- a/gtsam/linear/MultifrontalSolver.h
+++ b/gtsam/linear/MultifrontalSolver.h
@@ -42,12 +42,21 @@ class MultifrontalClique;
  * This class pre-allocates all necessary memory for the elimination tree and
  * provides efficient methods for loading new factors, eliminating the graph,
  * and solving for the update vector.
+ *
+ * @note Clique merging has two optional phases: an initial leaf-merge pass
+ * (leafMergeDimCap) that merges multiple leaf children into a common parent
+ * while the parent's total dimension plus merged frontal dimensions stays
+ * below the cap, followed by a bottom-up pass (mergeDimCap) that merges any
+ * remaining small child cliques into their parent. Both phases run before
+ * numeric elimination and can reduce tiny cliques and improve cache locality.
+ * Defaults are conservative and may need tuning per machine or dataset.
  */
 class GTSAM_EXPORT MultifrontalSolver
     : public TaskMixin<MultifrontalSolver, MultifrontalClique> {
  public:
   /// Tuning parameters for traversal and reporting.
   struct Parameters {
+    size_t leafMergeDimCap = 256;           ///< Leaf-merge cap (0 disables).
     size_t mergeDimCap = 16;                ///< Merge threshold (0 disables).
     std::ostream* reportStream = nullptr;   ///< Optional structure reporting.
     int eliminationParallelThreshold = 10;  ///< Post-order task threshold.

--- a/gtsam/linear/MultifrontalSolver.h
+++ b/gtsam/linear/MultifrontalSolver.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <gtsam/base/ForestTraversal.h>
 #include <gtsam/inference/Key.h>
 #include <gtsam/inference/Ordering.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
@@ -30,27 +31,10 @@
 #include <unordered_set>
 #include <vector>
 
-#ifndef GTSAM_USE_TBB
-#include <gtsam/base/PriorityScheduler.h>
-#endif
-
 namespace gtsam {
 
 class GaussianBayesTree;
 class MultifrontalClique;
-
-template <typename Forest, typename Node>
-struct EmptyTaskMixin {
-  explicit EmptyTaskMixin(size_t = 0) {}
-};
-
-#ifdef GTSAM_USE_TBB
-template <typename Forest, typename Node>
-using SolverTaskMixin = EmptyTaskMixin<Forest, Node>;
-#else
-template <typename Forest, typename Node>
-using SolverTaskMixin = TaskMixin<Forest, Node>;
-#endif
 
 /**
  * Imperative-style multifrontal solver for Gaussian factor graphs.
@@ -71,7 +55,7 @@ using SolverTaskMixin = TaskMixin<Forest, Node>;
  * Defaults are conservative and may need tuning per machine or dataset.
  */
 class GTSAM_EXPORT MultifrontalSolver
-    : public SolverTaskMixin<MultifrontalSolver, MultifrontalClique> {
+    : public ForestTraversal<MultifrontalSolver, MultifrontalClique> {
  public:
   /// Tuning parameters for traversal and reporting.
   struct Parameters {
@@ -175,7 +159,7 @@ class GTSAM_EXPORT MultifrontalSolver
    *
    * @return Reference to the internally cached solution vector.
    */
-  const VectorValues& updateSolution() const;
+  const VectorValues& updateSolution();
 
   /// Accessor for the roots of the elimination tree.
   const std::vector<CliquePtr>& roots() const { return roots_; }

--- a/gtsam/linear/MultifrontalSolver.h
+++ b/gtsam/linear/MultifrontalSolver.h
@@ -18,7 +18,6 @@
 
 #pragma once
 
-#include <gtsam/base/PriorityScheduler.h>
 #include <gtsam/inference/Key.h>
 #include <gtsam/inference/Ordering.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
@@ -31,10 +30,27 @@
 #include <unordered_set>
 #include <vector>
 
+#ifndef GTSAM_USE_TBB
+#include <gtsam/base/PriorityScheduler.h>
+#endif
+
 namespace gtsam {
 
 class GaussianBayesTree;
 class MultifrontalClique;
+
+template <typename Forest, typename Node>
+struct EmptyTaskMixin {
+  explicit EmptyTaskMixin(size_t = 0) {}
+};
+
+#ifdef GTSAM_USE_TBB
+template <typename Forest, typename Node>
+using SolverTaskMixin = EmptyTaskMixin<Forest, Node>;
+#else
+template <typename Forest, typename Node>
+using SolverTaskMixin = TaskMixin<Forest, Node>;
+#endif
 
 /**
  * Imperative-style multifrontal solver for Gaussian factor graphs.
@@ -42,6 +58,9 @@ class MultifrontalClique;
  * This class pre-allocates all necessary memory for the elimination tree and
  * provides efficient methods for loading new factors, eliminating the graph,
  * and solving for the update vector.
+ *
+ * @note Only JacobianFactor inputs are supported. Any non-Jacobian factors
+ * will throw during construction/precompute or load.
  *
  * @note Clique merging has two optional phases: an initial leaf-merge pass
  * (leafMergeDimCap) that merges multiple leaf children into a common parent
@@ -52,15 +71,16 @@ class MultifrontalClique;
  * Defaults are conservative and may need tuning per machine or dataset.
  */
 class GTSAM_EXPORT MultifrontalSolver
-    : public TaskMixin<MultifrontalSolver, MultifrontalClique> {
+    : public SolverTaskMixin<MultifrontalSolver, MultifrontalClique> {
  public:
   /// Tuning parameters for traversal and reporting.
   struct Parameters {
     size_t leafMergeDimCap = 256;           ///< Leaf-merge cap (0 disables).
-    size_t mergeDimCap = 16;                ///< Merge threshold (0 disables).
+    size_t mergeDimCap = 32;                ///< Merge threshold (0 disables).
     std::ostream* reportStream = nullptr;   ///< Optional structure reporting.
     int eliminationParallelThreshold = 10;  ///< Post-order task threshold.
     int solutionParallelThreshold = 4096;   ///< Pre-order task threshold.
+    size_t numThreads = 0;  ///< Worker count (0 uses 0.75 * hw threads).
   };
 
   struct PrecomputedData {
@@ -83,6 +103,7 @@ class GTSAM_EXPORT MultifrontalSolver
   bool loaded_ = false;                ///< Whether load() has been called.
   bool eliminated_ = false;            ///< Whether eliminateInPlace() ran.
   Parameters params_;                  ///< Tunable solver parameters.
+  size_t numThreads_ = 0;              ///< Resolved thread count for traversal.
 
  public:
   /**
@@ -90,6 +111,7 @@ class GTSAM_EXPORT MultifrontalSolver
    * This builds the symbolic junction tree and pre-allocates all matrices.
    * Call load() before eliminating to populate numerical values.
    * @param graph The factor graph to solve.
+   *              Must contain only JacobianFactor instances.
    * @param ordering The variable ordering to use for elimination.
    * @param params Tunable parameters for traversal and reporting.
    */
@@ -114,6 +136,7 @@ class GTSAM_EXPORT MultifrontalSolver
   MultifrontalSolver(PrecomputedData data, const Ordering& ordering);
 
   /// Precompute symbolic structure and sizing data from a factor graph.
+  /// Only JacobianFactor inputs are supported.
   static PrecomputedData Precompute(const GaussianFactorGraph& graph,
                                     const Ordering& ordering);
 
@@ -121,7 +144,9 @@ class GTSAM_EXPORT MultifrontalSolver
    * Load new numerical values from the factor graph.
    * This overwrites the values in the pre-allocated matrices.
    *
-   * @param graph The factor graph with updated values (structure must match).
+   * @param graph The factor graph with updated values (structure must match
+   *              the graph used to construct/precompute this solver, apart
+   *              from updated numerical values).
    */
   void load(const GaussianFactorGraph& graph);
 

--- a/gtsam/linear/tests/testMultifrontalSolver.cpp
+++ b/gtsam/linear/tests/testMultifrontalSolver.cpp
@@ -334,10 +334,13 @@ TEST(MultifrontalSolver, HessianFactors) {
 /* ************************************************************************* */
 // Merge threshold changes the clique count.
 TEST(MultifrontalSolver, MergeDimCap) {
-  MultifrontalSolver solverNoMerge(chain, chainOrdering, 0);
+  MultifrontalSolver::Parameters noMergeParams;
+  MultifrontalSolver solverNoMerge(chain, chainOrdering, noMergeParams);
   EXPECT_LONGS_EQUAL(2, solverNoMerge.cliqueCount());
 
-  MultifrontalSolver solverMerge(chain, chainOrdering, 1000);
+  MultifrontalSolver::Parameters mergeParams;
+  mergeParams.mergeDimCap = 1000;
+  MultifrontalSolver solverMerge(chain, chainOrdering, mergeParams);
   EXPECT_LONGS_EQUAL(1, solverMerge.cliqueCount());
 }
 

--- a/gtsam/linear/tests/testMultifrontalSolver.cpp
+++ b/gtsam/linear/tests/testMultifrontalSolver.cpp
@@ -325,19 +325,16 @@ TEST(MultifrontalSolver, WeightedScalarMeasurements) {
 }
 
 /* ************************************************************************* */
-// Hessian factors contribute directly to the augmented normal equations.
+// Hessian factors are rejected by the multifrontal solver.
 TEST(MultifrontalSolver, HessianFactors) {
   GaussianFactorGraph graph;
   graph.emplace_shared<HessianFactor>(x1, (Matrix(1, 1) << 4.0).finished(),
                                       (Vector(1) << 8.0).finished(), 0.0);
 
   const Ordering ordering{x1};
-  MultifrontalSolver solver(graph, ordering, noMergeParams());
-  solver.load(graph);
-  solver.eliminateInPlace();
-  const VectorValues& actual = solver.updateSolution();
-
-  EXPECT_DOUBLES_EQUAL(2.0, actual.at(x1)(0), 1e-9);
+  CHECK_EXCEPTION(
+      { MultifrontalSolver solver(graph, ordering, noMergeParams()); },
+      std::runtime_error);
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/tests/testMultifrontalSolver.cpp
+++ b/gtsam/linear/tests/testMultifrontalSolver.cpp
@@ -47,12 +47,19 @@ const GaussianFactorGraph chain = {
     std::make_shared<JacobianFactor>(x4, I_1x1, I_1x1, chainNoise4)};
 const Ordering chainOrdering{x2, x1, x3, x4};
 
+MultifrontalSolver::Parameters noMergeParams() {
+  MultifrontalSolver::Parameters params;
+  params.mergeDimCap = 0;
+  params.leafMergeDimCap = 0;
+  return params;
+}
+
 }  // namespace
 
 /* ************************************************************************* */
 // Build the solver and validate initial structure and explicit load.
 TEST(MultifrontalSolver, Constructor) {
-  MultifrontalSolver solver(chain, chainOrdering);
+  MultifrontalSolver solver(chain, chainOrdering, noMergeParams());
   solver.load(chain);
 
   // Verify roots
@@ -83,7 +90,7 @@ TEST(MultifrontalSolver, Constructor) {
 // Build the solver from precomputed data and validate structure and load.
 TEST(MultifrontalSolver, ConstructorPrecomputed) {
   auto data = MultifrontalSolver::Precompute(chain, chainOrdering);
-  MultifrontalSolver solver(std::move(data), chainOrdering);
+  MultifrontalSolver solver(std::move(data), chainOrdering, noMergeParams());
   solver.load(chain);
 
   // Verify roots
@@ -109,7 +116,7 @@ TEST(MultifrontalSolver, ConstructorPrecomputed) {
 /* ************************************************************************* */
 // Reload numerical values and ensure Ab updates match whitening.
 TEST(MultifrontalSolver, Load) {
-  MultifrontalSolver solver(chain, chainOrdering);
+  MultifrontalSolver solver(chain, chainOrdering, noMergeParams());
 
   // Create a new graph with doubled values
   GaussianFactorGraph chain2;
@@ -137,7 +144,7 @@ TEST(MultifrontalSolver, Load) {
 /* ************************************************************************* */
 // Compare solver output against multifrontal elimination baseline.
 TEST(MultifrontalSolver, Eliminate) {
-  MultifrontalSolver solver(chain, chainOrdering);
+  MultifrontalSolver solver(chain, chainOrdering, noMergeParams());
   solver.load(chain);
   solver.eliminateInPlace();
 
@@ -154,7 +161,7 @@ TEST(MultifrontalSolver, Eliminate) {
 /* ************************************************************************* */
 // Load + eliminate in one traversal matches standard elimination.
 TEST(MultifrontalSolver, EliminateWithLoad) {
-  MultifrontalSolver solver(chain, chainOrdering);
+  MultifrontalSolver solver(chain, chainOrdering, noMergeParams());
   solver.eliminateInPlace(chain);
 
   const VectorValues& actual = solver.updateSolution();
@@ -168,7 +175,7 @@ TEST(MultifrontalSolver, EliminateWithLoad) {
 /* ************************************************************************* */
 // Compare marginals from in-place Bayes tree against standard elimination.
 TEST(MultifrontalSolver, ComputeBayesTreeMarginals) {
-  MultifrontalSolver solver(chain, chainOrdering);
+  MultifrontalSolver solver(chain, chainOrdering, noMergeParams());
   solver.load(chain);
   solver.eliminateInPlace();
 
@@ -204,7 +211,7 @@ TEST(MultifrontalSolver, ComputeBayesTreeMarginalsConstrainedChain) {
   constrainedChain.emplace_shared<JacobianFactor>(
       x2, I_1x1, (Vector(1) << 0.0).finished(), hardConstraint);
 
-  MultifrontalSolver solver(constrainedChain, chainOrdering);
+  MultifrontalSolver solver(constrainedChain, chainOrdering, noMergeParams());
   solver.load(constrainedChain);
   solver.eliminateInPlace();
 
@@ -233,7 +240,7 @@ TEST(MultifrontalSolver, ConstrainedNoiseFeasible) {
       x1, I_1x1, (Vector(1) << 100.0).finished(), softNoise);
   const Ordering ordering{x1};
 
-  MultifrontalSolver solver(graph, ordering);
+  MultifrontalSolver solver(graph, ordering, noMergeParams());
   solver.load(graph);
   solver.eliminateInPlace();
   const VectorValues& actual = solver.updateSolution();
@@ -255,7 +262,8 @@ TEST(MultifrontalSolver, ConstrainedNoiseUnsupported) {
   const Ordering ordering{x1};
 
   CHECK_EXCEPTION(
-      { MultifrontalSolver solver(graph, ordering); }, std::runtime_error);
+      { MultifrontalSolver solver(graph, ordering, noMergeParams()); },
+      std::runtime_error);
 }
 
 /* ************************************************************************* */
@@ -270,7 +278,7 @@ TEST(MultifrontalSolver, ConstrainedNoiseUnaryFeasible) {
                                        softNoise);
   const Ordering ordering{x1};
 
-  MultifrontalSolver solver(graph, ordering);
+  MultifrontalSolver solver(graph, ordering, noMergeParams());
   solver.load(graph);
   solver.eliminateInPlace();
   const VectorValues& actual = solver.updateSolution();
@@ -288,7 +296,8 @@ TEST(MultifrontalSolver, ConstrainedNoiseMixedKeysUnsupported) {
   const Ordering ordering{x1, x2};
 
   CHECK_EXCEPTION(
-      { MultifrontalSolver solver(graph, ordering); }, std::runtime_error);
+      { MultifrontalSolver solver(graph, ordering, noMergeParams()); },
+      std::runtime_error);
 }
 
 /* ************************************************************************* */
@@ -307,7 +316,7 @@ TEST(MultifrontalSolver, WeightedScalarMeasurements) {
                                        noiseModel::Isotropic::Sigma(1, sigma2));
 
   const Ordering ordering{x1};
-  MultifrontalSolver solver(graph, ordering);
+  MultifrontalSolver solver(graph, ordering, noMergeParams());
   solver.load(graph);
   solver.eliminateInPlace();
   const VectorValues& actual = solver.updateSolution();
@@ -323,7 +332,7 @@ TEST(MultifrontalSolver, HessianFactors) {
                                       (Vector(1) << 8.0).finished(), 0.0);
 
   const Ordering ordering{x1};
-  MultifrontalSolver solver(graph, ordering);
+  MultifrontalSolver solver(graph, ordering, noMergeParams());
   solver.load(graph);
   solver.eliminateInPlace();
   const VectorValues& actual = solver.updateSolution();
@@ -334,13 +343,13 @@ TEST(MultifrontalSolver, HessianFactors) {
 /* ************************************************************************* */
 // Merge threshold changes the clique count.
 TEST(MultifrontalSolver, MergeDimCap) {
-  MultifrontalSolver::Parameters noMergeParams;
-  MultifrontalSolver solverNoMerge(chain, chainOrdering, noMergeParams);
+  MultifrontalSolver::Parameters noMerge = noMergeParams();
+  MultifrontalSolver solverNoMerge(chain, chainOrdering, noMerge);
   EXPECT_LONGS_EQUAL(2, solverNoMerge.cliqueCount());
 
-  MultifrontalSolver::Parameters mergeParams;
-  mergeParams.mergeDimCap = 1000;
-  MultifrontalSolver solverMerge(chain, chainOrdering, mergeParams);
+  MultifrontalSolver::Parameters merge = noMergeParams();
+  merge.mergeDimCap = 1000;
+  MultifrontalSolver solverMerge(chain, chainOrdering, merge);
   EXPECT_LONGS_EQUAL(1, solverMerge.cliqueCount());
 }
 
@@ -355,7 +364,7 @@ TEST(MultifrontalSolver, BalancedSmoother) {
   // Create the Bayes tree ordering
   const Ordering ordering{X(1), X(3), X(5), X(7), X(2), X(6), X(4)};
 
-  MultifrontalSolver solver(smoother, ordering);
+  MultifrontalSolver solver(smoother, ordering, noMergeParams());
   solver.load(smoother);
 
   // Verify roots

--- a/gtsam/symbolic/tests/testSymbolicClusterTree.cpp
+++ b/gtsam/symbolic/tests/testSymbolicClusterTree.cpp
@@ -47,6 +47,125 @@ TEST(ClusterTree, SeparatorKeys) {
 }
 
 /* ************************************************************************* */
+TEST(ClusterTree, MergeChildren) {
+  using Cluster = SymbolicJunctionTree::Cluster;
+  auto parent = std::make_shared<Cluster>();
+  auto child1 = std::make_shared<Cluster>();
+  auto child2 = std::make_shared<Cluster>();
+  auto child3 = std::make_shared<Cluster>();
+
+  child1->orderedFrontalKeys.push_back(1);
+  child2->orderedFrontalKeys.push_back(2);
+  child3->orderedFrontalKeys.push_back(3);
+
+  parent->addChild(child1);
+  parent->addChild(child2);
+  parent->addChild(child3);
+
+  parent->mergeChildren({true, false, true});
+
+  EXPECT_LONGS_EQUAL(1, parent->children.size());
+  EXPECT(parent->children.front() == child2);
+  const KeySet expected{1, 3};
+  const KeySet actual(parent->orderedFrontalKeys.begin(),
+                      parent->orderedFrontalKeys.end());
+  EXPECT(assert_container_equality(expected, actual));
+}
+
+/* ************************************************************************* */
+TEST(ClusterTree, MergeChildrenSiblings) {
+  using Cluster = SymbolicJunctionTree::Cluster;
+  auto parent = std::make_shared<Cluster>();
+  auto child1 = std::make_shared<Cluster>();
+  auto child2 = std::make_shared<Cluster>();
+  auto child3 = std::make_shared<Cluster>();
+
+  child1->orderedFrontalKeys.push_back(1);
+  child2->orderedFrontalKeys.push_back(2);
+  child3->orderedFrontalKeys.push_back(3);
+
+  parent->addChild(child1);
+  parent->addChild(child2);
+  parent->addChild(child3);
+
+  parent->mergeChildrenSiblings({true, false, true});
+
+  EXPECT_LONGS_EQUAL(2, parent->children.size());
+  EXPECT(parent->children[1] == child2);
+  const KeySet expected{1, 3};
+  const KeySet actual(parent->children[0]->orderedFrontalKeys.begin(),
+                      parent->children[0]->orderedFrontalKeys.end());
+  EXPECT(assert_container_equality(expected, actual));
+}
+
+/* ************************************************************************* */
+TEST(ClusterTree, MergeChildrenWithGrandchildren) {
+  using Cluster = SymbolicJunctionTree::Cluster;
+  auto parent = std::make_shared<Cluster>();
+  auto child1 = std::make_shared<Cluster>();
+  auto child2 = std::make_shared<Cluster>();
+  auto child3 = std::make_shared<Cluster>();
+  auto grandchild1 = std::make_shared<Cluster>();
+  auto grandchild2 = std::make_shared<Cluster>();
+
+  child1->orderedFrontalKeys.push_back(1);
+  child2->orderedFrontalKeys.push_back(2);
+  child3->orderedFrontalKeys.push_back(3);
+  grandchild1->orderedFrontalKeys.push_back(10);
+  grandchild2->orderedFrontalKeys.push_back(20);
+
+  child1->addChild(grandchild1);
+  child2->addChild(grandchild2);
+  parent->addChild(child1);
+  parent->addChild(child2);
+  parent->addChild(child3);
+
+  parent->mergeChildren({child1, child2});
+
+  EXPECT_LONGS_EQUAL(3, parent->children.size());
+  EXPECT(parent->children[2] == child3);
+  EXPECT(parent->children[0] == grandchild1);
+  EXPECT(parent->children[1] == grandchild2);
+  const KeySet expected{1, 2};
+  const KeySet actual(parent->orderedFrontalKeys.begin(),
+                      parent->orderedFrontalKeys.end());
+  EXPECT(assert_container_equality(expected, actual));
+}
+
+/* ************************************************************************* */
+TEST(ClusterTree, MergeChildrenSiblingsWithGrandchildren) {
+  using Cluster = SymbolicJunctionTree::Cluster;
+  auto parent = std::make_shared<Cluster>();
+  auto child1 = std::make_shared<Cluster>();
+  auto child2 = std::make_shared<Cluster>();
+  auto child3 = std::make_shared<Cluster>();
+  auto grandchild1 = std::make_shared<Cluster>();
+  auto grandchild2 = std::make_shared<Cluster>();
+
+  child1->orderedFrontalKeys.push_back(1);
+  child2->orderedFrontalKeys.push_back(2);
+  child3->orderedFrontalKeys.push_back(3);
+  grandchild1->orderedFrontalKeys.push_back(10);
+  grandchild2->orderedFrontalKeys.push_back(20);
+
+  child1->addChild(grandchild1);
+  child2->addChild(grandchild2);
+  parent->addChild(child1);
+  parent->addChild(child2);
+  parent->addChild(child3);
+
+  parent->mergeChildrenSiblings({child1, child2});
+
+  EXPECT_LONGS_EQUAL(2, parent->children.size());
+  EXPECT(parent->children[1] == child3);
+  EXPECT_LONGS_EQUAL(2, parent->children[0]->children.size());
+  const KeySet expected{1, 2};
+  const KeySet actual(parent->children[0]->orderedFrontalKeys.begin(),
+                      parent->children[0]->orderedFrontalKeys.end());
+  EXPECT(assert_container_equality(expected, actual));
+}
+
+/* ************************************************************************* */
 int main() {
   TestResult tr;
   return TestRegistry::runAllTests(tr);

--- a/timing/timeMultifrontalSolver.cpp
+++ b/timing/timeMultifrontalSolver.cpp
@@ -71,9 +71,11 @@ void runBAL135Benchmark() {
   const NonlinearFactorGraph graph = buildGeneralSfmGraph(db, 0.1);
   const Values initial = buildGeneralSfmInitial(db);
   const GaussianFactorGraph linear = *graph.linearize(initial);
-  const Ordering ordering = Ordering::Metis(linear);
+  const Ordering ordering = createSchurOrdering(db, false);
 
-  MultifrontalSolver solver(linear, ordering, kMergeDimCap, nullptr);
+  MultifrontalSolver::Parameters params;
+  params.mergeDimCap = kMergeDimCap;
+  MultifrontalSolver solver(linear, ordering, params);
   auto start = std::chrono::high_resolution_clock::now();
   runMultifrontalSolver(solver, linear, iterations);
   auto end = std::chrono::high_resolution_clock::now();
@@ -93,29 +95,29 @@ void runBALBenchmark() {
     const Values initial = buildGeneralSfmInitial(db);
     const GaussianFactorGraph linear = *graph.linearize(initial);
 
-    auto orderings = createOrderings(db, linear);
-    for (const auto& [label, ordering] : orderings) {
-      cout << "\nBAL Benchmark (" << label << ", iterations=" << bal_iterations
-           << "):" << std::endl;
+    const Ordering ordering = createSchurOrdering(db, false);
+    cout << "\nBAL Benchmark (" << filename << ", iterations=" << bal_iterations
+         << "):" << std::endl;
 
-      MultifrontalSolver solver(linear, ordering, kMergeDimCap, nullptr);
-      auto start = std::chrono::high_resolution_clock::now();
-      runMultifrontalSolver(solver, linear, bal_iterations);
-      auto end = std::chrono::high_resolution_clock::now();
-      std::chrono::duration<double> t_imperative = end - start;
-      cout << "  MultifrontalSolver: " << t_imperative.count() << " s"
-           << std::endl;
+    MultifrontalSolver::Parameters params;
+    params.mergeDimCap = kMergeDimCap;
+    MultifrontalSolver solver(linear, ordering, params);
+    solver.eliminateInPlace(linear);  // Warm up cache.
+    auto start = std::chrono::high_resolution_clock::now();
+    runMultifrontalSolver(solver, linear, bal_iterations);
+    auto end = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> t_imperative = end - start;
+    cout << "  MultifrontalSolver: " << t_imperative.count() << " s"
+         << std::endl;
 
-      start = std::chrono::high_resolution_clock::now();
-      runStandardSolver(linear, ordering, bal_iterations);
-      end = std::chrono::high_resolution_clock::now();
-      std::chrono::duration<double> t_standard = end - start;
-      cout << "  Standard GTSAM:     " << t_standard.count() << " s"
-           << std::endl;
+    start = std::chrono::high_resolution_clock::now();
+    runStandardSolver(linear, ordering, bal_iterations);
+    end = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> t_standard = end - start;
+    cout << "  Standard GTSAM:     " << t_standard.count() << " s" << std::endl;
 
-      cout << "  Speedup:            "
-           << t_standard.count() / t_imperative.count() << "x" << std::endl;
-    }
+    cout << "  Speedup:            "
+         << t_standard.count() / t_imperative.count() << "x" << std::endl;
   }
 }
 void runChainBenchmark() {
@@ -129,7 +131,10 @@ void runChainBenchmark() {
     const Ordering ordering = Ordering::Metis(smoother);
 
     auto start = std::chrono::high_resolution_clock::now();
-    MultifrontalSolver solver(smoother, ordering, kMergeDimCap, &std::cout);
+    MultifrontalSolver::Parameters params;
+    params.mergeDimCap = kMergeDimCap;
+    params.reportStream = &std::cout;
+    MultifrontalSolver solver(smoother, ordering, params);
     runMultifrontalSolver(solver, smoother, iterations);
     auto end = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> t_imperative = end - start;

--- a/timing/timeMultifrontalSolver.cpp
+++ b/timing/timeMultifrontalSolver.cpp
@@ -37,7 +37,7 @@ namespace {
 MultifrontalSolver::Parameters makeDefaultParams() {
   MultifrontalSolver::Parameters params;
   params.mergeDimCap = 32;
-  params.reportStream = &std::cout;
+  // params.reportStream = &std::cout;
   return params;
 }
 

--- a/timing/timeMultifrontalSolver.cpp
+++ b/timing/timeMultifrontalSolver.cpp
@@ -31,10 +31,16 @@ using namespace gtsam;
 using namespace example;
 
 namespace {
-// Threshold chosen empirically for these timing experiments: merging small
+// Thresholds chosen empirically for these timing experiments: merging small
 // frontal cliques tends to improve performance without materially affecting
 // numerical behavior for the tested problems.
-constexpr size_t kMergeDimCap = 16;
+MultifrontalSolver::Parameters makeDefaultParams() {
+  MultifrontalSolver::Parameters params;
+  params.mergeDimCap = 32;
+  params.reportStream = &std::cout;
+  return params;
+}
+
 }  // namespace
 
 /// Run standard GTSAM multifrontal elimination and optimization.
@@ -64,7 +70,7 @@ const string bal16 = findExampleDataFile("dubrovnik-16-22106-pre");
 const string bal88 = findExampleDataFile("dubrovnik-88-64298-pre");
 }  // namespace
 
-void runBAL135Benchmark() {
+void runBAL135Benchmark(MultifrontalSolver::Parameters params) {
   const size_t iterations = 1;
   cout << "\nSingle MFS test: " << bal135 << " (iterations=" << iterations
        << ")" << std::endl;
@@ -75,8 +81,6 @@ void runBAL135Benchmark() {
   const GaussianFactorGraph linear = *graph.linearize(initial);
   const Ordering ordering = createSchurOrdering(db, false);
 
-  MultifrontalSolver::Parameters params;
-  params.mergeDimCap = kMergeDimCap;
   MultifrontalSolver solver(linear, ordering, params);
   auto start = std::chrono::high_resolution_clock::now();
   runMultifrontalSolver(solver, linear, iterations);
@@ -86,7 +90,7 @@ void runBAL135Benchmark() {
   tictoc_print();
 }
 
-void runBALBenchmark() {
+void runBALBenchmark(MultifrontalSolver::Parameters params) {
   const size_t bal_iterations = 2;
   for (const auto& filename : {bal16, bal88, bal135}) {
     cout << "\nProcessing BAL file: " << filename << std::endl;
@@ -99,9 +103,6 @@ void runBALBenchmark() {
     cout << "\nBAL Benchmark (" << filename << ", iterations=" << bal_iterations
          << "):" << std::endl;
 
-    MultifrontalSolver::Parameters params;
-    params.mergeDimCap = kMergeDimCap;
-    params.reportStream = &std::cout;
     MultifrontalSolver solver(linear, ordering, params);
     solver.eliminateInPlace(linear);  // Warm up cache.
     auto start = std::chrono::high_resolution_clock::now();
@@ -122,7 +123,7 @@ void runBALBenchmark() {
   }
 }
 
-void runChainBenchmark() {
+void runChainBenchmark(MultifrontalSolver::Parameters params) {
   const std::vector<size_t> T_values = {10, 50, 100, 500, 1000, 5000};
   const size_t iterations = 500;
 
@@ -133,9 +134,6 @@ void runChainBenchmark() {
     const Ordering ordering = Ordering::Metis(smoother);
 
     auto start = std::chrono::high_resolution_clock::now();
-    MultifrontalSolver::Parameters params;
-    params.mergeDimCap = kMergeDimCap;
-    params.reportStream = &std::cout;
     MultifrontalSolver solver(smoother, ordering, params);
     runMultifrontalSolver(solver, smoother, iterations);
     auto end = std::chrono::high_resolution_clock::now();
@@ -155,15 +153,33 @@ void runChainBenchmark() {
   }
 }
 
-void tuneMergingBAL() {
+void runChain5000(MultifrontalSolver::Parameters params) {
+  const size_t iterations = 5000;
+
+  const size_t T = 5000;
+  cout << "\nBenchmark (T=" << T << ", iterations=" << iterations
+       << "):" << std::endl;
+  GaussianFactorGraph smoother = createSmoother(T);
+  const Ordering ordering = Ordering::Metis(smoother);
+
+  auto start = std::chrono::high_resolution_clock::now();
+  MultifrontalSolver solver(smoother, ordering, params);
+  runMultifrontalSolver(solver, smoother, iterations);
+  auto end = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> t_imperative = end - start;
+  cout << "\nTiming results:\n";
+  cout << "  MultifrontalSolver: " << t_imperative.count() << " s" << std::endl;
+}
+
+void tuneMergingBAL(MultifrontalSolver::Parameters params) {
   const size_t iterations = 2;
   const std::vector<std::string> balFiles = {bal16, bal88, bal135};
   cout << "\nTune leaf merging (BAL, iterations=" << iterations << ")"
        << std::endl;
 
-  const std::vector<size_t> caps = {0, 64, 128, 256, 512, 1024, 2048};
+  const std::vector<size_t> sweep = {0, 64, 128, 256, 512, 1024, 2048};
   std::vector<std::vector<double>> results(
-      caps.size(), std::vector<double>(balFiles.size(), 0.0));
+      sweep.size(), std::vector<double>(balFiles.size(), 0.0));
 
   for (size_t fileIndex = 0; fileIndex < balFiles.size(); ++fileIndex) {
     const std::string& filename = balFiles[fileIndex];
@@ -174,12 +190,9 @@ void tuneMergingBAL() {
     const GaussianFactorGraph linear = *graph.linearize(initial);
     const Ordering ordering = createSchurOrdering(db, false);
 
-    MultifrontalSolver::Parameters params;
-    params.mergeDimCap = 0;
-    params.reportStream = &std::cout;
-    for (size_t capIndex = 0; capIndex < caps.size(); ++capIndex) {
-      const size_t cap = caps[capIndex];
-      params.leafMergeDimCap = cap;
+    for (size_t i = 0; i < sweep.size(); ++i) {
+      const size_t parameter = sweep[i];
+      params.leafMergeDimCap = parameter;
 
       MultifrontalSolver solver(linear, ordering, params);
       solver.eliminateInPlace(linear);  // Warm up cache.
@@ -187,25 +200,25 @@ void tuneMergingBAL() {
       runMultifrontalSolver(solver, linear, iterations);
       auto end = std::chrono::high_resolution_clock::now();
       std::chrono::duration<double> t_imperative = end - start;
-      results[capIndex][fileIndex] = t_imperative.count();
-      cout << "  leafMergeDimCap=" << cap << " -> " << t_imperative.count()
-           << " s\n"
+      results[i][fileIndex] = t_imperative.count();
+      cout << "  leafMergeDimCap=" << parameter << " -> "
+           << t_imperative.count() << " s\n"
            << std::endl;
     }
   }
 
   cout << "\n| LeafMergeDimCap | BAL16 | BAL88 | BAL135 |\n";
   cout << "| --- | --- | --- | --- |\n";
-  for (size_t capIndex = 0; capIndex < caps.size(); ++capIndex) {
-    cout << "| " << caps[capIndex];
+  for (size_t i = 0; i < sweep.size(); ++i) {
+    cout << "| " << sweep[i];
     for (size_t fileIndex = 0; fileIndex < balFiles.size(); ++fileIndex) {
-      cout << " | " << results[capIndex][fileIndex];
+      cout << " | " << results[i][fileIndex];
     }
     cout << " |\n";
   }
 }
 
-void tuneMergeChain() {
+void tuneMergeChain(MultifrontalSolver::Parameters params) {
   const size_t iterations = 100;
   const size_t T = 5000;
   cout << "\nTune mergeDimCap (chain T=" << T << ", iterations=" << iterations
@@ -214,21 +227,19 @@ void tuneMergeChain() {
   GaussianFactorGraph smoother = createSmoother(T);
   const Ordering ordering = Ordering::Metis(smoother);
 
-  const std::vector<size_t> caps = {0, 16, 32, 64, 128, 256, 512};
+  const std::vector<size_t> sweep = {0, 16, 32, 64, 128, 256, 512};
   std::vector<std::pair<size_t, double>> results;
-  MultifrontalSolver::Parameters params;
-  params.leafMergeDimCap = 0;
-  params.reportStream = &std::cout;
-  for (size_t cap : caps) {
-    params.mergeDimCap = cap;
+  for (size_t parameter : sweep) {
+    params.mergeDimCap = parameter;
     MultifrontalSolver solver(smoother, ordering, params);
 
     auto start = std::chrono::high_resolution_clock::now();
     runMultifrontalSolver(solver, smoother, iterations);
     auto end = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> t_imperative = end - start;
-    results.emplace_back(cap, t_imperative.count());
-    cout << "  mergeDimCap=" << cap << " -> " << t_imperative.count() << " s\n"
+    results.emplace_back(parameter, t_imperative.count());
+    cout << "  mergeDimCap=" << parameter << " -> " << t_imperative.count()
+         << " s\n"
          << std::endl;
   }
 
@@ -241,12 +252,14 @@ void tuneMergeChain() {
 }
 
 int main() {
-  cout << "Merging dim cap " << kMergeDimCap << std::endl;
+  auto params = makeDefaultParams();
+  cout << "Merging dim parameter " << params.mergeDimCap << std::endl;
 
-  runBAL135Benchmark();
-  runBALBenchmark();
-  runChainBenchmark();
-  // tuneMergingBAL();
-  // tuneMergeChain();
+  // runBAL135Benchmark(params);
+  runBALBenchmark(params);
+  runChainBenchmark(params);
+  // runChain5000(params);
+  // tuneMergingBAL(params);
+  // tuneMergeChain(params);
   return 0;
 }

--- a/timing/timeMultifrontalSolver.cpp
+++ b/timing/timeMultifrontalSolver.cpp
@@ -60,7 +60,9 @@ static void runMultifrontalSolver(MultifrontalSolver& solver,
 
 namespace {
 const std::string bal135 = findExampleDataFile("dubrovnik-135-90642-pre.txt");
-}
+const string bal16 = findExampleDataFile("dubrovnik-16-22106-pre");
+const string bal88 = findExampleDataFile("dubrovnik-88-64298-pre");
+}  // namespace
 
 void runBAL135Benchmark() {
   const size_t iterations = 1;
@@ -86,8 +88,6 @@ void runBAL135Benchmark() {
 
 void runBALBenchmark() {
   const size_t bal_iterations = 2;
-  const string bal16 = findExampleDataFile("dubrovnik-16-22106-pre");
-  const string bal88 = findExampleDataFile("dubrovnik-88-64298-pre");
   for (const auto& filename : {bal16, bal88, bal135}) {
     cout << "\nProcessing BAL file: " << filename << std::endl;
     const SfmData db = SfmData::FromBalFile(filename);
@@ -101,6 +101,7 @@ void runBALBenchmark() {
 
     MultifrontalSolver::Parameters params;
     params.mergeDimCap = kMergeDimCap;
+    params.reportStream = &std::cout;
     MultifrontalSolver solver(linear, ordering, params);
     solver.eliminateInPlace(linear);  // Warm up cache.
     auto start = std::chrono::high_resolution_clock::now();
@@ -120,6 +121,7 @@ void runBALBenchmark() {
          << t_standard.count() / t_imperative.count() << "x" << std::endl;
   }
 }
+
 void runChainBenchmark() {
   const std::vector<size_t> T_values = {10, 50, 100, 500, 1000, 5000};
   const size_t iterations = 500;
@@ -152,11 +154,99 @@ void runChainBenchmark() {
          << t_standard.count() / t_imperative.count() << "x" << std::endl;
   }
 }
+
+void tuneMergingBAL() {
+  const size_t iterations = 2;
+  const std::vector<std::string> balFiles = {bal16, bal88, bal135};
+  cout << "\nTune leaf merging (BAL, iterations=" << iterations << ")"
+       << std::endl;
+
+  const std::vector<size_t> caps = {0, 64, 128, 256, 512, 1024, 2048};
+  std::vector<std::vector<double>> results(
+      caps.size(), std::vector<double>(balFiles.size(), 0.0));
+
+  for (size_t fileIndex = 0; fileIndex < balFiles.size(); ++fileIndex) {
+    const std::string& filename = balFiles[fileIndex];
+    cout << "\n  BAL file: " << filename << std::endl;
+    const SfmData db = SfmData::FromBalFile(filename);
+    const NonlinearFactorGraph graph = buildGeneralSfmGraph(db, 0.1);
+    const Values initial = buildGeneralSfmInitial(db);
+    const GaussianFactorGraph linear = *graph.linearize(initial);
+    const Ordering ordering = createSchurOrdering(db, false);
+
+    MultifrontalSolver::Parameters params;
+    params.mergeDimCap = 0;
+    params.reportStream = &std::cout;
+    for (size_t capIndex = 0; capIndex < caps.size(); ++capIndex) {
+      const size_t cap = caps[capIndex];
+      params.leafMergeDimCap = cap;
+
+      MultifrontalSolver solver(linear, ordering, params);
+      solver.eliminateInPlace(linear);  // Warm up cache.
+      auto start = std::chrono::high_resolution_clock::now();
+      runMultifrontalSolver(solver, linear, iterations);
+      auto end = std::chrono::high_resolution_clock::now();
+      std::chrono::duration<double> t_imperative = end - start;
+      results[capIndex][fileIndex] = t_imperative.count();
+      cout << "  leafMergeDimCap=" << cap << " -> " << t_imperative.count()
+           << " s\n"
+           << std::endl;
+    }
+  }
+
+  cout << "\n| LeafMergeDimCap | BAL16 | BAL88 | BAL135 |\n";
+  cout << "| --- | --- | --- | --- |\n";
+  for (size_t capIndex = 0; capIndex < caps.size(); ++capIndex) {
+    cout << "| " << caps[capIndex];
+    for (size_t fileIndex = 0; fileIndex < balFiles.size(); ++fileIndex) {
+      cout << " | " << results[capIndex][fileIndex];
+    }
+    cout << " |\n";
+  }
+}
+
+void tuneMergeChain() {
+  const size_t iterations = 100;
+  const size_t T = 5000;
+  cout << "\nTune mergeDimCap (chain T=" << T << ", iterations=" << iterations
+       << ")" << std::endl;
+
+  GaussianFactorGraph smoother = createSmoother(T);
+  const Ordering ordering = Ordering::Metis(smoother);
+
+  const std::vector<size_t> caps = {0, 16, 32, 64, 128, 256, 512};
+  std::vector<std::pair<size_t, double>> results;
+  MultifrontalSolver::Parameters params;
+  params.leafMergeDimCap = 0;
+  params.reportStream = &std::cout;
+  for (size_t cap : caps) {
+    params.mergeDimCap = cap;
+    MultifrontalSolver solver(smoother, ordering, params);
+
+    auto start = std::chrono::high_resolution_clock::now();
+    runMultifrontalSolver(solver, smoother, iterations);
+    auto end = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> t_imperative = end - start;
+    results.emplace_back(cap, t_imperative.count());
+    cout << "  mergeDimCap=" << cap << " -> " << t_imperative.count() << " s\n"
+         << std::endl;
+  }
+
+  cout << "\n| Phase | Cap | Seconds |\n";
+  cout << "| --- | --- | --- |\n";
+  for (const auto& result : results) {
+    cout << "| mergeDimCap | " << result.first << " | " << result.second
+         << " |\n";
+  }
+}
+
 int main() {
   cout << "Merging dim cap " << kMergeDimCap << std::endl;
 
   runBAL135Benchmark();
   runBALBenchmark();
   runChainBenchmark();
+  // tuneMergingBAL();
+  // tuneMergeChain();
   return 0;
 }


### PR DESCRIPTION
I based the solver on the new scheduler, so now we also have large speedups even when not using TBB. I also made some improvements to the solver itself:
- A new leaf merging scheme that helps a lot with BAL datasets. 
- A parameter struct that can be used to tune /experiment with different settings. 
- No longer supports Hessian factors: with leaf merging, it was too cumbersome to support Hessian factors, which we don't produce in non-linear solvers anyway. 

Below are timings on my M1 Mac laptop (16GB of RAM and 8 cores( and a Linux machine (with 20 cores, 32GB, and a much larger set of L1 and L2 caches). On Linux for a large linear chain, we are a whopping 23 times faster than the legacy GTSAM solver (with TBB-enabled). 

| OS    | Backend | Problem              | Multifrontal (s) | Classic GTSAM (s) | Speedup (×) |
|------ |---------|----------------------|------------------|-------------------|-------------|
| macOS | MixIn   | BAL dubrovnik-135    | 2.42188          | 8.62997           | 3.56334     |
| macOS | TBB     | BAL dubrovnik-135    | **2.25416**      | 8.34670           | 3.70280     |
| Linux | MixIn   | BAL dubrovnik-135    | 1.91138          | 4.05724           | 2.12267     |
| Linux | TBB     | BAL dubrovnik-135    | **1.85005**      | 2.24648           | 1.21428     |
| macOS | MixIn   | Chain T=5000         | 0.520024         | 8.46253           | 16.2733     |
| macOS | TBB     | Chain T=5000         | **0.430629**     | 6.59811           | 15.3220     |
| Linux | MixIn   | Chain T=5000         | 1.27064          | 6.11931           | 4.81592     |
| Linux | TBB     | Chain T=5000         | **0.202529**     | 4.74072           | 23.4077     |