### PR TITLE
Two Schedulers - One very fast Solver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ doc/#*.lyx#
 /cmake-build-debug/
 .venv/
 conductor/
+.ccache/

--- a/gtsam/base/ForestTraversal.h
+++ b/gtsam/base/ForestTraversal.h
@@ -12,7 +12,7 @@
  *
  * @details
  * Provides top-down and bottom-up traversal helpers that either enqueue work
- * on an internal `PriorityScheduler` (for builds without TBB) or call the
+ * on an internal `TaskScheduler` (for builds without TBB) or call the
  * `treeTraversal` parallel helpers when `GTSAM_USE_TBB` is enabled.
  *
  * @note `Forest::roots()` or `Forest::roots` must return a range of
@@ -168,7 +168,7 @@ class ForestTraversal {
   }
 
  private:
-  PriorityScheduler<void> scheduler_;
+  TaskScheduler<void> scheduler_;
 
   /// Return forest roots via method or field.
   decltype(auto) getRoots() const {
@@ -251,7 +251,7 @@ class ForestTraversal {
   /// Per-node traversal frame to avoid threading many parameters.
   template <typename Fn>
   struct Frame {
-    PriorityScheduler<void>* scheduler;
+    TaskScheduler<void>* scheduler;
     Node& node;
     int depth;
     const Fn& fn;
@@ -293,11 +293,9 @@ class ForestTraversal {
         MaybeFinish finish{frame.state};
         frame.topDownTraverse();
       };
-      const int topDownPriority = depth;  // Shallower nodes = higher priority
       /// Schedule a task and increment the pending counter.
       state->incrementPending();
-      scheduler->schedule(topDownPriority,
-                          std::function<void()>(std::move(task)));
+      scheduler->schedule(std::function<void()>(std::move(task)));
     }
 
     /// Inline node work followed by traversal of children.
@@ -369,9 +367,7 @@ class ForestTraversal {
       state->incrementPending();
 
       // Schedule a continuation or run it inline if already on a worker thread.
-      const int bottomUpPriority = -depth;  // Deeper nodes = higher priority
-      scheduler->scheduleOrRunInline(bottomUpPriority,
-                                     std::function<void()>(std::move(task)));
+      scheduler->scheduleOrRunInline(std::function<void()>(std::move(task)));
     }
 
     /// Do bottom-up node work, then invoke the continuation.

--- a/gtsam/base/ForestTraversal.h
+++ b/gtsam/base/ForestTraversal.h
@@ -32,7 +32,7 @@
 #include <gtsam/base/types.h>
 #include <tbb/global_control.h>
 #else
-#include <gtsam/base/PriorityScheduler.h>
+#include <gtsam/base/TaskScheduler.h>
 #endif
 
 #include <atomic>

--- a/gtsam/base/ForestTraversal.h
+++ b/gtsam/base/ForestTraversal.h
@@ -295,7 +295,7 @@ class ForestTraversal {
       };
       /// Schedule a task and increment the pending counter.
       state->incrementPending();
-      scheduler->schedule(std::function<void()>(std::move(task)));
+      scheduler->enqueue(std::function<void()>(std::move(task)));
     }
 
     /// Inline node work followed by traversal of children.
@@ -367,7 +367,7 @@ class ForestTraversal {
       state->incrementPending();
 
       // Schedule a continuation or run it inline if already on a worker thread.
-      scheduler->scheduleOrRunInline(std::function<void()>(std::move(task)));
+      scheduler->enqueueOrRunInline(std::function<void()>(std::move(task)));
     }
 
     /// Do bottom-up node work, then invoke the continuation.

--- a/gtsam/base/PriorityScheduler.h
+++ b/gtsam/base/PriorityScheduler.h
@@ -31,6 +31,7 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <deque>
 #include <exception>
 #include <functional>
 #include <future>
@@ -44,6 +45,210 @@
 #include <vector>
 
 namespace gtsam {
+
+/**
+ * @brief Thread pool scheduler that executes tasks without priority ordering.
+ *
+ * @details
+ * - Tasks are executed in an efficient deque-based order (LIFO locally).
+ * - Per-thread queues reduce contention; workers steal from peers when idle.
+ * - External submissions are round-robin distributed across worker queues.
+ * - A condition variable parks workers when no work is available.
+ *
+ * @tparam Y Result type returned by tasks. Use `void` for no return value.
+ */
+template <typename Y>
+class TaskScheduler {
+  struct Task {
+    std::function<Y()> job;
+    std::promise<Y> promise;
+
+    Task(std::function<Y()> j, std::promise<Y> p_out)
+        : job(std::move(j)), promise(std::move(p_out)) {}
+  };
+
+  using TaskPtr = std::shared_ptr<Task>;
+
+  struct WorkerQueue {
+    std::mutex mutex;
+    std::deque<TaskPtr> queue;
+  };
+
+  std::vector<std::unique_ptr<WorkerQueue>> queues_;  // Per-worker queues.
+  std::atomic<size_t> queuedTasks_{0};  // Tracks queued work for wakeups.
+  std::vector<std::thread> workers_;
+  mutable std::mutex waitMutex_;  // Dedicated mutex for condition_variable.
+  std::condition_variable condition_;
+  std::atomic<bool> stop_{false};
+  std::atomic<int> activeTasks_{0};  // In-flight tasks (queued + running).
+  inline static thread_local TaskScheduler<Y>* currentScheduler_ = nullptr;
+  inline static thread_local int workerIndex_ = -1;
+  std::atomic<size_t> nextWorker_{0};  // Round-robin distributor.
+
+  /// Worker loop that executes tasks until shutdown.
+  void worker_thread(size_t index) {
+    currentScheduler_ = this;
+    workerIndex_ = static_cast<int>(index);
+    while (true) {
+      TaskPtr task;
+      if (!tryPopTask(index, task)) {
+        std::unique_lock<std::mutex> lock(waitMutex_);
+        condition_.wait(lock, [this] {
+          return stop_.load(std::memory_order_acquire) ||
+                 queuedTasks_.load(std::memory_order_acquire) > 0;
+        });
+        if (stop_.load(std::memory_order_acquire) &&
+            queuedTasks_.load(std::memory_order_acquire) == 0) {
+          currentScheduler_ = nullptr;
+          workerIndex_ = -1;
+          return;
+        }
+        continue;
+      }
+
+      try {
+        if constexpr (std::is_void_v<Y>) {
+          task->job();
+          task->promise.set_value();
+        } else {
+          task->promise.set_value(task->job());
+        }
+      } catch (...) {
+        try {
+          task->promise.set_exception(std::current_exception());
+        } catch (...) { /* ignore */
+        }
+      }
+
+      activeTasks_.fetch_sub(1, std::memory_order_release);
+      condition_.notify_all();
+    }
+  }
+
+  /// Attempt to get a task from local or stolen queues.
+  bool tryPopTask(size_t index, TaskPtr& task) {
+    if (tryPopLocal(index, task)) return true;
+    if (trySteal(index, task)) return true;
+    return false;
+  }
+
+  /// Try to pop a task from the current worker queue (LIFO for locality).
+  bool tryPopLocal(size_t index, TaskPtr& task) {
+    WorkerQueue& queue = *queues_[index];
+    std::lock_guard<std::mutex> lock(queue.mutex);
+    if (queue.queue.empty()) return false;
+    task = queue.queue.back();
+    queue.queue.pop_back();
+    queuedTasks_.fetch_sub(1, std::memory_order_release);
+    return true;
+  }
+
+  /// Try to steal a task from another worker queue (FIFO to reduce
+  /// interference).
+  bool trySteal(size_t index, TaskPtr& task) {
+    const size_t workerCount = queues_.size();
+    if (workerCount <= 1) return false;
+    for (size_t offset = 1; offset < workerCount; ++offset) {
+      size_t target = (index + offset) % workerCount;
+      WorkerQueue& queue = *queues_[target];
+      std::unique_lock<std::mutex> lock(queue.mutex, std::try_to_lock);
+      if (!lock.owns_lock() || queue.queue.empty()) continue;
+      task = queue.queue.front();
+      queue.queue.pop_front();
+      queuedTasks_.fetch_sub(1, std::memory_order_release);
+      return true;
+    }
+    return false;
+  }
+
+  /// Return true if called on a scheduler worker thread.
+  bool isWorkerThread() const { return currentScheduler_ == this; }
+
+ public:
+  /// Construct a scheduler with a fixed worker count.
+  explicit TaskScheduler(
+      size_t numThreads = std::thread::hardware_concurrency()) {
+    if (numThreads == 0) numThreads = 1;
+    queues_.reserve(numThreads);
+    for (size_t i = 0; i < numThreads; ++i) {
+      queues_.push_back(std::make_unique<WorkerQueue>());
+    }
+    for (size_t i = 0; i < numThreads; ++i) {
+      workers_.emplace_back(&TaskScheduler::worker_thread, this, i);
+    }
+  }
+
+  /// Wait for tasks and join worker threads on destruction.
+  ~TaskScheduler() {
+    waitForAllTasks();
+    stop_.store(true, std::memory_order_release);
+    condition_.notify_all();
+    for (std::thread& worker : workers_) {
+      if (worker.joinable()) worker.join();
+    }
+  }
+
+  /// Enqueue a task for execution and return its future.
+  std::future<Y> schedule(std::function<Y()> job) {
+    if (stop_.load(std::memory_order_acquire)) {
+      std::promise<Y> err_promise;
+      err_promise.set_exception(std::make_exception_ptr(
+          std::runtime_error("Scheduler is stopping or stopped.")));
+      return err_promise.get_future();
+    }
+
+    std::promise<Y> promise;
+    std::future<Y> future = promise.get_future();
+    auto task = std::make_shared<Task>(std::move(job), std::move(promise));
+
+    if (isWorkerThread()) {
+      WorkerQueue& queue = *queues_[static_cast<size_t>(workerIndex_)];
+      {
+        std::lock_guard<std::mutex> lock(queue.mutex);
+        queue.queue.push_back(task);
+      }
+    } else {
+      const size_t target =
+          nextWorker_.fetch_add(1, std::memory_order_relaxed) % queues_.size();
+      WorkerQueue& queue = *queues_[target];
+      std::lock_guard<std::mutex> lock(queue.mutex);
+      queue.queue.push_back(task);
+    }
+
+    queuedTasks_.fetch_add(1, std::memory_order_release);
+    activeTasks_.fetch_add(1, std::memory_order_release);
+    condition_.notify_one();
+    return future;
+  }
+
+  /// Run inline on workers, otherwise enqueue normally.
+  template <typename T = Y, typename = std::enable_if_t<std::is_void_v<T>>>
+  void scheduleOrRunInline(std::function<void()> job) {
+    if (stop_.load(std::memory_order_relaxed)) return;
+    if (!isWorkerThread()) {
+      schedule(std::move(job));
+      return;
+    }
+
+    activeTasks_.fetch_add(1, std::memory_order_release);
+    try {
+      job();
+    } catch (...) { /* ignore */
+    }
+    activeTasks_.fetch_sub(1, std::memory_order_release);
+    condition_.notify_all();
+  }
+
+  /// Block until all queued and active tasks complete.
+  void waitForAllTasks() {
+    std::unique_lock<std::mutex> lock(waitMutex_);
+    condition_.wait(lock, [this] {
+      return stop_.load(std::memory_order_acquire) ||
+             (activeTasks_.load(std::memory_order_acquire) == 0 &&
+              queuedTasks_.load(std::memory_order_acquire) == 0);
+    });
+  }
+};
 
 /**
  * @brief Thread pool scheduler that prioritizes tasks by numeric priority.

--- a/gtsam/base/PriorityScheduler.h
+++ b/gtsam/base/PriorityScheduler.h
@@ -45,7 +45,7 @@ struct PrioritySchedulerPolicy {
   template <typename TaskPtr>
   struct Compare {
     bool operator()(const TaskPtr& a, const TaskPtr& b) const {
-      return a->metadata > b->metadata;
+      return a.metadata > b.metadata;
     }
   };
 

--- a/gtsam/base/Scheduler.h
+++ b/gtsam/base/Scheduler.h
@@ -65,19 +65,12 @@ template <typename Y, typename Policy>
 class Scheduler {
   using Metadata = typename Policy::Metadata;
 
-  struct Task {
-    Metadata metadata;
-    std::function<Y()> job;
-    std::promise<Y> promise;
-
-    Task(Metadata m, std::function<Y()> j, std::promise<Y> p_out)
-        : metadata(std::move(m)),
-          job(std::move(j)),
-          promise(std::move(p_out)) {}
+  struct WorkItem {
+    Metadata metadata{};
+    std::function<void()> run;
   };
 
-  using TaskPtr = std::shared_ptr<Task>;
-  using Container = typename Policy::template Container<TaskPtr>;
+  using Container = typename Policy::template Container<WorkItem>;
 
   struct WorkerQueue {
     std::mutex mutex;
@@ -105,8 +98,8 @@ class Scheduler {
     currentScheduler_ = this;
     workerIndex_ = static_cast<int>(index);
     while (true) {
-      TaskPtr task;
-      if (!tryPopTask(index, task)) {
+      WorkItem item;
+      if (!tryPopTask(index, item)) {
         std::unique_lock<std::mutex> lock(waitMutex_);
         condition_.wait(lock, [this] {
           return stop_.load(std::memory_order_acquire) ||
@@ -122,19 +115,9 @@ class Scheduler {
       }
 
       try {
-        // Execute the task and set the promise value:
-        if constexpr (std::is_void_v<Y>) {
-          task->job();
-          task->promise.set_value();
-        } else {
-          task->promise.set_value(task->job());
-        }
+        item.run();
       } catch (...) {
-        // On exception, set the exception on the promise:
-        try {
-          task->promise.set_exception(std::current_exception());
-        } catch (...) { /* ignore */
-        }
+        /* ignore */
       }
 
       // Decrement active task count and notify waiters.
@@ -144,24 +127,24 @@ class Scheduler {
   }
 
   /// Attempt to get a task from local or stolen queues.
-  bool tryPopTask(size_t index, TaskPtr& task) {
+  bool tryPopTask(size_t index, WorkItem& item) {
     // Prefer local queue, then steal to keep workers busy.
-    if (tryPopLocal(index, task)) return true;
-    if (trySteal(index, task)) return true;
+    if (tryPopLocal(index, item)) return true;
+    if (trySteal(index, item)) return true;
     return false;
   }
 
   /// Try to pop a task from the current worker queue.
-  bool tryPopLocal(size_t index, TaskPtr& task) {
+  bool tryPopLocal(size_t index, WorkItem& item) {
     WorkerQueue& queue = *queues_[index];
     std::lock_guard<std::mutex> lock(queue.mutex);
-    if (!Policy::template popLocal<TaskPtr>(queue.queue, task)) return false;
+    if (!Policy::template popLocal<WorkItem>(queue.queue, item)) return false;
     queuedTasks_.fetch_sub(1, std::memory_order_release);
     return true;
   }
 
   /// Try to steal a task from another worker queue.
-  bool trySteal(size_t index, TaskPtr& task) {
+  bool trySteal(size_t index, WorkItem& item) {
     const size_t workerCount = queues_.size();
     if (workerCount <= 1) return false;
     // Steal from other workers if local queue is empty.
@@ -170,7 +153,7 @@ class Scheduler {
       WorkerQueue& queue = *queues_[target];
       std::unique_lock<std::mutex> lock(queue.mutex, std::try_to_lock);
       if (!lock.owns_lock()) continue;
-      if (!Policy::template popSteal<TaskPtr>(queue.queue, task)) continue;
+      if (!Policy::template popSteal<WorkItem>(queue.queue, item)) continue;
       queuedTasks_.fetch_sub(1, std::memory_order_release);
       return true;
     }
@@ -180,19 +163,8 @@ class Scheduler {
   /// Return true if called on a scheduler worker thread.
   bool isWorkerThread() const { return currentScheduler_ == this; }
 
-  std::future<Y> scheduleImpl(Metadata metadata, std::function<Y()> job) {
-    if (stop_.load(std::memory_order_acquire)) {
-      std::promise<Y> err_promise;
-      err_promise.set_exception(std::make_exception_ptr(
-          std::runtime_error("Scheduler is stopping or stopped.")));
-      return err_promise.get_future();
-    }
-
-    std::promise<Y> promise;
-    std::future<Y> future = promise.get_future();
-    auto task = std::make_shared<Task>(std::move(metadata), std::move(job),
-                                       std::move(promise));
-
+  bool enqueueImpl(Metadata metadata, std::function<void()> work) {
+    if (stop_.load(std::memory_order_acquire)) return false;
     WorkerQueue* targetQueue = nullptr;
     if (isWorkerThread()) {
       targetQueue = queues_[static_cast<size_t>(workerIndex_)].get();
@@ -204,20 +176,21 @@ class Scheduler {
 
     {
       std::lock_guard<std::mutex> lock(targetQueue->mutex);
-      Policy::template push<TaskPtr>(targetQueue->queue, std::move(task));
+      Policy::template push<WorkItem>(
+          targetQueue->queue, WorkItem{std::move(metadata), std::move(work)});
     }
 
     queuedTasks_.fetch_add(1, std::memory_order_release);
     activeTasks_.fetch_add(1, std::memory_order_release);
     condition_.notify_one();
-    return future;
+    return true;
   }
 
   template <typename T = Y, typename = std::enable_if_t<std::is_void_v<T>>>
   void scheduleOrRunInlineImpl(Metadata metadata, std::function<void()> job) {
     if (stop_.load(std::memory_order_relaxed)) return;
     if (!isWorkerThread()) {
-      scheduleImpl(std::move(metadata), std::move(job));
+      enqueueImpl(std::move(metadata), std::move(job));
       return;
     }
 
@@ -273,7 +246,40 @@ class Scheduler {
   template <typename P = Policy, typename = std::enable_if_t<std::is_same_v<
                                      typename P::Metadata, std::monostate>>>
   std::future<Y> schedule(std::function<Y()> job) {
-    return scheduleImpl(Metadata{}, std::move(job));
+    if (stop_.load(std::memory_order_acquire)) {
+      std::promise<Y> err_promise;
+      err_promise.set_exception(std::make_exception_ptr(
+          std::runtime_error("Scheduler is stopping or stopped.")));
+      return err_promise.get_future();
+    }
+
+    auto promise = std::make_shared<std::promise<Y>>();
+    std::future<Y> future = promise->get_future();
+
+    auto work = [promise, job = std::move(job)]() mutable {
+      try {
+        if constexpr (std::is_void_v<Y>) {
+          job();
+          promise->set_value();
+        } else {
+          promise->set_value(job());
+        }
+      } catch (...) {
+        try {
+          promise->set_exception(std::current_exception());
+        } catch (...) { /* ignore */
+        }
+      }
+    };
+
+    if (!enqueueImpl(Metadata{}, std::move(work))) {
+      try {
+        promise->set_exception(std::make_exception_ptr(
+            std::runtime_error("Scheduler is stopping or stopped.")));
+      } catch (...) { /* ignore */
+      }
+    }
+    return future;
   }
 
   /**
@@ -288,7 +294,40 @@ class Scheduler {
   template <typename P = Policy, typename = std::enable_if_t<!std::is_same_v<
                                      typename P::Metadata, std::monostate>>>
   std::future<Y> schedule(Metadata metadata, std::function<Y()> job) {
-    return scheduleImpl(std::move(metadata), std::move(job));
+    if (stop_.load(std::memory_order_acquire)) {
+      std::promise<Y> err_promise;
+      err_promise.set_exception(std::make_exception_ptr(
+          std::runtime_error("Scheduler is stopping or stopped.")));
+      return err_promise.get_future();
+    }
+
+    auto promise = std::make_shared<std::promise<Y>>();
+    std::future<Y> future = promise->get_future();
+
+    auto work = [promise, job = std::move(job)]() mutable {
+      try {
+        if constexpr (std::is_void_v<Y>) {
+          job();
+          promise->set_value();
+        } else {
+          promise->set_value(job());
+        }
+      } catch (...) {
+        try {
+          promise->set_exception(std::current_exception());
+        } catch (...) { /* ignore */
+        }
+      }
+    };
+
+    if (!enqueueImpl(std::move(metadata), std::move(work))) {
+      try {
+        promise->set_exception(std::make_exception_ptr(
+            std::runtime_error("Scheduler is stopping or stopped.")));
+      } catch (...) { /* ignore */
+      }
+    }
+    return future;
   }
 
   /**
@@ -313,6 +352,30 @@ class Scheduler {
                 std::is_void_v<T> && !std::is_same_v<Metadata, std::monostate>>>
   void scheduleOrRunInline(Metadata metadata, std::function<void()> job) {
     scheduleOrRunInlineImpl(std::move(metadata), std::move(job));
+  }
+
+  /**
+   * @brief Enqueue a fire-and-forget task for execution.
+   *
+   * Enabled only for `TaskScheduler<void>` (i.e., `Y = void` and no metadata).
+   */
+  template <typename T = Y,
+            typename = std::enable_if_t<
+                std::is_void_v<T> && std::is_same_v<Metadata, std::monostate>>>
+  void enqueue(std::function<void()> job) {
+    enqueueImpl(Metadata{}, std::move(job));
+  }
+
+  /**
+   * @brief Enqueue a fire-and-forget task or run it inline on worker threads.
+   *
+   * Enabled only for `TaskScheduler<void>` (i.e., `Y = void` and no metadata).
+   */
+  template <typename T = Y,
+            typename = std::enable_if_t<
+                std::is_void_v<T> && std::is_same_v<Metadata, std::monostate>>>
+  void enqueueOrRunInline(std::function<void()> job) {
+    scheduleOrRunInlineImpl(Metadata{}, std::move(job));
   }
 
   /**

--- a/gtsam/base/Scheduler.h
+++ b/gtsam/base/Scheduler.h
@@ -1,0 +1,333 @@
+/* ----------------------------------------------------------------------------
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+ * See LICENSE for the license information
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file Scheduler.h
+ * @brief Policy-based work-stealing scheduler.
+ *
+ * @details
+ * This header defines a small, thread-based scheduler core that executes tasks
+ * using per-worker queues with opportunistic work-stealing. The queue behavior
+ * (e.g., LIFO/FIFO, priority ordering) is defined by a Policy type.
+ *
+ * Public convenience wrappers are provided in `TaskScheduler.h` and
+ * `PriorityScheduler.h`.
+ *
+ * @author Frank Dellaert
+ * @date May, 2025
+ */
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <exception>
+#include <functional>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <stdexcept>
+#include <thread>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace gtsam {
+
+/**
+ * @brief Thread pool scheduler parameterized by a queue Policy.
+ *
+ * @details
+ * - Tasks are executed by worker threads created at construction.
+ * - Per-worker queues reduce contention; workers steal from peers when idle.
+ * - External submissions are round-robin distributed across worker queues.
+ * - A condition variable parks workers when no work is available.
+ *
+ * Policy requirements:
+ * - `using Metadata = ...;` carried with each task (e.g., `std::monostate`,
+ * `int`)
+ * - `template <typename TaskPtr> using Container = ...;`
+ * - `push(container, task)`, `popLocal(container, out)`, `popSteal(container,
+ * out)`
+ *
+ * @tparam Y Result type returned by tasks. Use `void` for no return value.
+ * @tparam Policy Queue behavior policy.
+ */
+template <typename Y, typename Policy>
+class Scheduler {
+  using Metadata = typename Policy::Metadata;
+
+  struct Task {
+    Metadata metadata;
+    std::function<Y()> job;
+    std::promise<Y> promise;
+
+    Task(Metadata m, std::function<Y()> j, std::promise<Y> p_out)
+        : metadata(std::move(m)),
+          job(std::move(j)),
+          promise(std::move(p_out)) {}
+  };
+
+  using TaskPtr = std::shared_ptr<Task>;
+  using Container = typename Policy::template Container<TaskPtr>;
+
+  struct WorkerQueue {
+    std::mutex mutex;
+    Container queue;
+  };
+
+  std::vector<std::unique_ptr<WorkerQueue>> queues_;  // Per-worker queues.
+  std::atomic<size_t> queuedTasks_{0};  // Tracks queued work for wakeups.
+  std::vector<std::thread> workers_;
+  mutable std::mutex waitMutex_;  // Dedicated mutex for condition_variable.
+  std::condition_variable condition_;
+  std::atomic<bool> stop_{false};
+  std::atomic<int> activeTasks_{0};  // In-flight tasks (queued + running).
+  inline static thread_local Scheduler* currentScheduler_ = nullptr;
+  inline static thread_local int workerIndex_ = -1;
+  std::atomic<size_t> nextWorker_{0};  // Round-robin distributor.
+
+  /**
+   * @brief Worker loop: wait for tasks, run them, and fulfill promises.
+   *
+   * Uses a condition variable to avoid spinning while the queue is empty.
+   * Stops once `stop_` is set and no queued work remains.
+   */
+  void worker_thread(size_t index) {
+    currentScheduler_ = this;
+    workerIndex_ = static_cast<int>(index);
+    while (true) {
+      TaskPtr task;
+      if (!tryPopTask(index, task)) {
+        std::unique_lock<std::mutex> lock(waitMutex_);
+        condition_.wait(lock, [this] {
+          return stop_.load(std::memory_order_acquire) ||
+                 queuedTasks_.load(std::memory_order_acquire) > 0;
+        });
+        if (stop_.load(std::memory_order_acquire) &&
+            queuedTasks_.load(std::memory_order_acquire) == 0) {
+          currentScheduler_ = nullptr;
+          workerIndex_ = -1;
+          return;
+        }
+        continue;
+      }
+
+      try {
+        // Execute the task and set the promise value:
+        if constexpr (std::is_void_v<Y>) {
+          task->job();
+          task->promise.set_value();
+        } else {
+          task->promise.set_value(task->job());
+        }
+      } catch (...) {
+        // On exception, set the exception on the promise:
+        try {
+          task->promise.set_exception(std::current_exception());
+        } catch (...) { /* ignore */
+        }
+      }
+
+      // Decrement active task count and notify waiters.
+      activeTasks_.fetch_sub(1, std::memory_order_release);
+      condition_.notify_all();
+    }
+  }
+
+  /// Attempt to get a task from local or stolen queues.
+  bool tryPopTask(size_t index, TaskPtr& task) {
+    // Prefer local queue, then steal to keep workers busy.
+    if (tryPopLocal(index, task)) return true;
+    if (trySteal(index, task)) return true;
+    return false;
+  }
+
+  /// Try to pop a task from the current worker queue.
+  bool tryPopLocal(size_t index, TaskPtr& task) {
+    WorkerQueue& queue = *queues_[index];
+    std::lock_guard<std::mutex> lock(queue.mutex);
+    if (!Policy::template popLocal<TaskPtr>(queue.queue, task)) return false;
+    queuedTasks_.fetch_sub(1, std::memory_order_release);
+    return true;
+  }
+
+  /// Try to steal a task from another worker queue.
+  bool trySteal(size_t index, TaskPtr& task) {
+    const size_t workerCount = queues_.size();
+    if (workerCount <= 1) return false;
+    // Steal from other workers if local queue is empty.
+    for (size_t offset = 1; offset < workerCount; ++offset) {
+      size_t target = (index + offset) % workerCount;
+      WorkerQueue& queue = *queues_[target];
+      std::unique_lock<std::mutex> lock(queue.mutex, std::try_to_lock);
+      if (!lock.owns_lock()) continue;
+      if (!Policy::template popSteal<TaskPtr>(queue.queue, task)) continue;
+      queuedTasks_.fetch_sub(1, std::memory_order_release);
+      return true;
+    }
+    return false;
+  }
+
+  /// Return true if called on a scheduler worker thread.
+  bool isWorkerThread() const { return currentScheduler_ == this; }
+
+  std::future<Y> scheduleImpl(Metadata metadata, std::function<Y()> job) {
+    if (stop_.load(std::memory_order_acquire)) {
+      std::promise<Y> err_promise;
+      err_promise.set_exception(std::make_exception_ptr(
+          std::runtime_error("Scheduler is stopping or stopped.")));
+      return err_promise.get_future();
+    }
+
+    std::promise<Y> promise;
+    std::future<Y> future = promise.get_future();
+    auto task = std::make_shared<Task>(std::move(metadata), std::move(job),
+                                       std::move(promise));
+
+    WorkerQueue* targetQueue = nullptr;
+    if (isWorkerThread()) {
+      targetQueue = queues_[static_cast<size_t>(workerIndex_)].get();
+    } else {
+      const size_t target =
+          nextWorker_.fetch_add(1, std::memory_order_relaxed) % queues_.size();
+      targetQueue = queues_[target].get();
+    }
+
+    {
+      std::lock_guard<std::mutex> lock(targetQueue->mutex);
+      Policy::template push<TaskPtr>(targetQueue->queue, std::move(task));
+    }
+
+    queuedTasks_.fetch_add(1, std::memory_order_release);
+    activeTasks_.fetch_add(1, std::memory_order_release);
+    condition_.notify_one();
+    return future;
+  }
+
+  template <typename T = Y, typename = std::enable_if_t<std::is_void_v<T>>>
+  void scheduleOrRunInlineImpl(Metadata metadata, std::function<void()> job) {
+    if (stop_.load(std::memory_order_relaxed)) return;
+    if (!isWorkerThread()) {
+      scheduleImpl(std::move(metadata), std::move(job));
+      return;
+    }
+
+    activeTasks_.fetch_add(1, std::memory_order_release);
+    try {
+      job();
+    } catch (...) { /* ignore */
+    }
+    activeTasks_.fetch_sub(1, std::memory_order_release);
+    condition_.notify_all();
+  }
+
+ public:
+  /**
+   * @brief Construct a scheduler with a fixed number of worker threads.
+   *
+   * @param numThreads Number of worker threads to create. If zero, a single
+   * thread is created.
+   */
+  explicit Scheduler(size_t numThreads = std::thread::hardware_concurrency()) {
+    if (numThreads == 0) numThreads = 1;
+    queues_.reserve(numThreads);
+    for (size_t i = 0; i < numThreads; ++i) {
+      queues_.push_back(std::make_unique<WorkerQueue>());
+    }
+    for (size_t i = 0; i < numThreads; ++i) {
+      workers_.emplace_back(&Scheduler::worker_thread, this, i);
+    }
+  }
+
+  /**
+   * @brief Wait for all tasks to finish, then stop worker threads.
+   *
+   * @note The destructor calls `waitForAllTasks` before stopping workers.
+   */
+  ~Scheduler() {
+    waitForAllTasks();
+    stop_.store(true, std::memory_order_release);
+    condition_.notify_all();
+    for (std::thread& worker : workers_) {
+      if (worker.joinable()) worker.join();
+    }
+  }
+
+  /**
+   * @brief Enqueue a task for execution (no metadata).
+   *
+   * Only enabled when `Policy::Metadata` is `std::monostate`.
+   *
+   * @param job Callable returning a `Y`.
+   * @return `std::future<Y>` associated with the task.
+   */
+  template <typename P = Policy, typename = std::enable_if_t<std::is_same_v<
+                                     typename P::Metadata, std::monostate>>>
+  std::future<Y> schedule(std::function<Y()> job) {
+    return scheduleImpl(Metadata{}, std::move(job));
+  }
+
+  /**
+   * @brief Enqueue a task for execution with metadata.
+   *
+   * Enabled when `Policy::Metadata` is not `std::monostate`.
+   *
+   * @param metadata Policy-defined metadata for ordering (e.g., priority).
+   * @param job Callable returning a `Y`.
+   * @return `std::future<Y>` associated with the task.
+   */
+  template <typename P = Policy, typename = std::enable_if_t<!std::is_same_v<
+                                     typename P::Metadata, std::monostate>>>
+  std::future<Y> schedule(Metadata metadata, std::function<Y()> job) {
+    return scheduleImpl(std::move(metadata), std::move(job));
+  }
+
+  /**
+   * @brief Schedule or run inline when called from a worker thread.
+   *
+   * Used to fuse continuations without re-entering the queues.
+   */
+  template <typename T = Y,
+            typename = std::enable_if_t<
+                std::is_void_v<T> && std::is_same_v<Metadata, std::monostate>>>
+  void scheduleOrRunInline(std::function<void()> job) {
+    scheduleOrRunInlineImpl(Metadata{}, std::move(job));
+  }
+
+  /**
+   * @brief Schedule or run inline when called from a worker thread.
+   *
+   * Used to fuse continuations without re-entering the queues.
+   */
+  template <typename T = Y,
+            typename = std::enable_if_t<
+                std::is_void_v<T> && !std::is_same_v<Metadata, std::monostate>>>
+  void scheduleOrRunInline(Metadata metadata, std::function<void()> job) {
+    scheduleOrRunInlineImpl(std::move(metadata), std::move(job));
+  }
+
+  /**
+   * @brief Block until all queued and active tasks complete.
+   *
+   * @note If the scheduler is stopping, this returns early.
+   */
+  void waitForAllTasks() {
+    std::unique_lock<std::mutex> lock(waitMutex_);
+    condition_.wait(lock, [this] {
+      return stop_.load(std::memory_order_acquire) ||
+             (activeTasks_.load(std::memory_order_acquire) == 0 &&
+              queuedTasks_.load(std::memory_order_acquire) == 0);
+    });
+  }
+};
+
+}  // namespace gtsam

--- a/gtsam/base/Scheduler.h
+++ b/gtsam/base/Scheduler.h
@@ -120,9 +120,10 @@ class Scheduler {
         /* ignore */
       }
 
-      // Decrement active task count and notify waiters.
-      activeTasks_.fetch_sub(1, std::memory_order_release);
-      condition_.notify_all();
+      // Notify waiters only when work transitions to "done".
+      if (activeTasks_.fetch_sub(1, std::memory_order_release) == 1) {
+        condition_.notify_all();
+      }
     }
   }
 
@@ -199,8 +200,9 @@ class Scheduler {
       job();
     } catch (...) { /* ignore */
     }
-    activeTasks_.fetch_sub(1, std::memory_order_release);
-    condition_.notify_all();
+    if (activeTasks_.fetch_sub(1, std::memory_order_release) == 1) {
+      condition_.notify_all();
+    }
   }
 
  public:

--- a/gtsam/base/TaskScheduler.h
+++ b/gtsam/base/TaskScheduler.h
@@ -7,21 +7,20 @@
  * -------------------------------------------------------------------------- */
 
 /**
- * @file PriorityScheduler.h
- * @brief Priority-based task scheduler.
+ * @file TaskScheduler.h
+ * @brief Cooperative task scheduler.
  *
  * @details
  * This header defines a small, thread-based scheduler that executes tasks in
- * priority order. A lower numeric priority is executed before a higher numeric
- * priority (min-heap behavior). Tasks return a value of type `Y`, and callers
- * can wait on results via `std::future<Y>`.
+ * a cooperative manner without priority ordering. Tasks return a value of type
+ * `Y`, and callers can wait on results via `std::future<Y>`.
  *
  * This is implemented as a policy specialization of `gtsam::Scheduler`.
  *
  * @par Example
  * @code
- * gtsam::PriorityScheduler<int> scheduler(4);
- * auto future = scheduler.schedule(0, [] { return 42; });
+ * gtsam::TaskScheduler<int> scheduler(4);
+ * auto future = scheduler.schedule([] { return 42; });
  * int value = future.get();
  * @endcode
  *
@@ -36,51 +35,41 @@
 namespace gtsam {
 
 namespace detail {
-
-/// Queue policy for PriorityScheduler: min-heap priority_queue by task
-/// priority.
-struct PrioritySchedulerPolicy {
-  using Metadata = int;
+/// Queue policy for TaskScheduler: deque with local LIFO and stolen FIFO.
+struct TaskSchedulerPolicy {
+  using Metadata = std::monostate;
 
   template <typename TaskPtr>
-  struct Compare {
-    bool operator()(const TaskPtr& a, const TaskPtr& b) const {
-      return a->metadata > b->metadata;
-    }
-  };
-
-  template <typename TaskPtr>
-  using Container =
-      std::priority_queue<TaskPtr, std::vector<TaskPtr>, Compare<TaskPtr>>;
+  using Container = std::deque<TaskPtr>;
 
   template <typename TaskPtr>
   static void push(Container<TaskPtr>& container, TaskPtr task) {
-    container.push(std::move(task));
+    container.push_back(std::move(task));
   }
 
   template <typename TaskPtr>
   static bool popLocal(Container<TaskPtr>& container, TaskPtr& out) {
     if (container.empty()) return false;
-    out = container.top();
-    container.pop();
+    out = container.back();
+    container.pop_back();
     return true;
   }
 
   template <typename TaskPtr>
   static bool popSteal(Container<TaskPtr>& container, TaskPtr& out) {
-    return popLocal(container, out);
+    if (container.empty()) return false;
+    out = container.front();
+    container.pop_front();
+    return true;
   }
 };
-
 }  // namespace detail
 
 /**
- * @brief Thread pool scheduler that prioritizes tasks by numeric priority.
+ * @brief Thread pool scheduler that executes tasks without priority ordering.
  *
  * @details
- * - Lower numeric values are executed first.
- * - Tasks are executed by worker threads created at construction.
- * - `schedule` returns a `std::future<Y>` for the task result.
+ * - Tasks are executed in an efficient deque-based order (LIFO locally).
  * - Per-thread queues reduce contention; workers steal from peers when idle.
  * - External submissions are round-robin distributed across worker queues.
  * - A condition variable parks workers when no work is available.
@@ -88,6 +77,6 @@ struct PrioritySchedulerPolicy {
  * @tparam Y Result type returned by tasks. Use `void` for no return value.
  */
 template <typename Y>
-using PriorityScheduler = Scheduler<Y, detail::PrioritySchedulerPolicy>;
+using TaskScheduler = Scheduler<Y, detail::TaskSchedulerPolicy>;
 
 }  // namespace gtsam

--- a/gtsam/base/TaskScheduler.h
+++ b/gtsam/base/TaskScheduler.h
@@ -50,7 +50,7 @@ struct TaskSchedulerPolicy {
   template <typename TaskPtr>
   static bool popLocal(Container<TaskPtr>& container, TaskPtr& out) {
     if (container.empty()) return false;
-    out = container.back();
+    out = std::move(container.back());
     container.pop_back();
     return true;
   }
@@ -58,7 +58,7 @@ struct TaskSchedulerPolicy {
   template <typename TaskPtr>
   static bool popSteal(Container<TaskPtr>& container, TaskPtr& out) {
     if (container.empty()) return false;
-    out = container.front();
+    out = std::move(container.front());
     container.pop_front();
     return true;
   }

--- a/gtsam/base/tests/testPriorityScheduler.cpp
+++ b/gtsam/base/tests/testPriorityScheduler.cpp
@@ -16,6 +16,9 @@
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/PriorityScheduler.h>
 
+#include <mutex>
+#include <vector>
+
 using namespace gtsam;
 
 /* ************************************************************************* */
@@ -34,6 +37,33 @@ TEST(PriorityScheduler, ReturnValueComposition) {
 
   const size_t expectedSum = 7;
   EXPECT_LONGS_EQUAL(expectedSum, parent.get());
+}
+
+/* ************************************************************************* */
+TEST(PriorityScheduler, VoidPriorityOrderingSingleWorker) {
+  PriorityScheduler<void> scheduler(1);
+
+  std::mutex mutex;
+  std::vector<int> executionOrder;
+
+  scheduler.schedule(5, [&] {
+    std::lock_guard<std::mutex> lock(mutex);
+    executionOrder.push_back(5);
+  });
+  scheduler.schedule(1, [&] {
+    std::lock_guard<std::mutex> lock(mutex);
+    executionOrder.push_back(1);
+  });
+  scheduler.schedule(3, [&] {
+    std::lock_guard<std::mutex> lock(mutex);
+    executionOrder.push_back(3);
+  });
+
+  scheduler.waitForAllTasks();
+  EXPECT_LONGS_EQUAL(3, executionOrder.size());
+  EXPECT_LONGS_EQUAL(1, executionOrder.at(0));
+  EXPECT_LONGS_EQUAL(3, executionOrder.at(1));
+  EXPECT_LONGS_EQUAL(5, executionOrder.at(2));
 }
 
 /* ************************************************************************* */

--- a/gtsam/base/tests/testTaskScheduler.cpp
+++ b/gtsam/base/tests/testTaskScheduler.cpp
@@ -1,0 +1,75 @@
+/* ----------------------------------------------------------------------------
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+ * See LICENSE for the license information
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file testTaskScheduler.cpp
+ * @brief Unit tests for TaskScheduler scheduling behavior.
+ * @author Frank Dellaert
+ * @date Jan, 2026
+ */
+
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/TaskScheduler.h>
+
+#include <atomic>
+#include <mutex>
+#include <vector>
+
+using namespace gtsam;
+
+/* ************************************************************************* */
+// Compose child return values inside a parent task
+TEST(TaskScheduler, ReturnValueComposition) {
+  // Use multiple workers so parent tasks can wait without stalling the pool.
+  TaskScheduler<size_t> scheduler(2);
+
+  auto left = scheduler.schedule([] { return size_t{3}; }).share();
+  auto right = scheduler.schedule([] { return size_t{4}; }).share();
+
+  auto parent = scheduler.schedule(
+      [left, right]() mutable { return left.get() + right.get(); });
+
+  const size_t expectedSum = 7;
+  EXPECT_LONGS_EQUAL(expectedSum, parent.get());
+}
+
+/* ************************************************************************* */
+TEST(TaskScheduler, EnqueueFireAndForget) {
+  TaskScheduler<void> scheduler(2);
+
+  std::atomic<size_t> counter{0};
+  const size_t taskCount = 256;
+
+  for (size_t i = 0; i < taskCount; ++i) {
+    scheduler.enqueue([&counter] { counter.fetch_add(1); });
+  }
+
+  scheduler.waitForAllTasks();
+  EXPECT_LONGS_EQUAL(taskCount, counter.load());
+}
+
+/* ************************************************************************* */
+TEST(TaskScheduler, EnqueueOrRunInlineOnWorker) {
+  TaskScheduler<void> scheduler(1);
+
+  std::atomic<size_t> inlineCounter{0};
+  auto future = scheduler.schedule([&] {
+    scheduler.enqueueOrRunInline([&] { inlineCounter.fetch_add(1); });
+  });
+
+  future.get();
+  scheduler.waitForAllTasks();
+  EXPECT_LONGS_EQUAL(1, inlineCounter.load());
+}
+
+/* ************************************************************************* */
+int main() {
+  TestResult tr;
+  return TestRegistry::runAllTests(tr);
+}
+/* ************************************************************************* */


### PR DESCRIPTION
With some help, created one "core" scheduler, specialized using a Policy class to either task traversal or priority (which I need in other places). Some refactoring of the core scheduler to make it faster. One particular change, to drastically decrease the use of `condition_.notify_all();` made a 5-fold difference on Linux

Now, on Linux, the new MixIn implementation alone delivers large speedups over classic GTSAM (up to ~26× on large chain problems). While TBB still achieves the lowest absolute MultifrontalSolver times, both backends now show strong performance improvements on the largest BAL and chain benchmarks.

| OS    | Backend | Problem              | Multifrontal (s) | Classic GTSAM (s) | Speedup (×) |
|------ |---------|----------------------|------------------|-------------------|-------------|
| macOS | MixIn   | BAL dubrovnik-135    | 3.03961          | 5.81504           | 1.91308     |
| macOS | TBB     | BAL dubrovnik-135    | **2.64705**      | 4.07572           | 1.53972     |
| Linux | MixIn   | BAL dubrovnik-135    | 1.85265          | 4.47684           | 2.41646     |
| Linux | TBB     | BAL dubrovnik-135    | **1.78422**      | 2.16964           | 1.21602     |
| macOS | MixIn   | Chain T=5000         | 0.52494          | 10.2654           | 19.5554     |
| macOS | TBB     | Chain T=5000         | **0.465384**     | 7.72200           | 16.5928     |
| Linux | MixIn   | Chain T=5000         | 0.272993         | 7.12812           | 26.1110     |
| Linux | TBB     | Chain T=5000         | **0.214422**     | 4.85482           | 22.6415     |