### PR TITLE
Minimize the number of workflows

### DIFF
--- a/.github/workflows/build-cibw.yml
+++ b/.github/workflows/build-cibw.yml
@@ -1,7 +1,7 @@
 # This workflow builds the Python wheels using cibuildwheel and uploads them to TestPyPI.
 # It can be triggered on push to the develop branch or manually via Github Actions.
 
-name: Build Wheels for Develop
+name: Build Python Wheels for Develop
 
 on:
   push:

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -3,10 +3,9 @@ name: Linux CI
 on:
   pull_request:
     paths-ignore:
-      - "**.md"
-      - "**.ipynb"
-      - "myst.yml"
-      
+      - '**.md'
+      - '**.ipynb'
+      - 'myst.yml'
 
 # Cancels any in-progress workflow runs for the same PR when a new push is made,
 # allowing the runner to become available more quickly for the latest changes.

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -6,6 +6,7 @@ on:
       - '**.md'
       - '**.ipynb' 
       - 'myst.yml'
+
 # Cancels any in-progress workflow runs for the same PR when a new push is made,
 # allowing the runner to become available more quickly for the latest changes.
 concurrency:

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -4,13 +4,6 @@ name: Python CI
 # instead of under 'pull_request:'. Otherwise, the check is still required but
 # never runs, and a maintainer must bypass the check in order to merge the PR.
 on:
-  push:
-    branches:
-      - develop
-    paths-ignore:
-      - '**.md'
-      - '**.ipynb'
-      - 'myst.yml'
   pull_request:
     paths-ignore:
       - '**.md'
@@ -24,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Check paths to changed files to see if any are non-ignored.
+  # Check paths of changed files to see if any are non-ignored.
   check-paths:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -4,11 +4,8 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
-      - '**.ipynb' 
+      - '**.ipynb'
       - 'myst.yml'
-  push:
-    # Runs on pushes targeting the develop branch 
-    branches: [develop]
 
 # Cancels any in-progress workflow runs for the same PR when a new push is made,
 # allowing the runner to become available more quickly for the latest changes.

--- a/.github/workflows/prod-cibw.yml
+++ b/.github/workflows/prod-cibw.yml
@@ -1,7 +1,7 @@
 # This workflow builds the Python wheels using cibuildwheel and uploads them to TestPyPI.
 # It can be triggered on push to the develop branch or manually via Github Actions.
 
-name: Build Wheels for Release
+name: Build Python Wheels for Release
 
 on:
   release:

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -1,6 +1,5 @@
 name: vcpkg
 on:
-  pull_request:
   push:
     # Runs on pushes targeting the develop branch
     branches: [develop]


### PR DESCRIPTION
A lot of workflows which are triggered on Pull Requests are also triggered when merged into `develop`. This is redundant since we can't merge into develop unless those workflows pass.

This PR eliminates a lot of these redundant workflows to make the CI system more efficient, and take up less resources when deploying updated builds and wheels.