### PR TITLE
Sampler updates

### DIFF
--- a/gtsam/gtsam.i
+++ b/gtsam/gtsam.i
@@ -178,6 +178,8 @@ void perturbPoint2(gtsam::Values& values, double sigma, int seed = 42u);
 void perturbPose2(gtsam::Values& values, double sigmaT, double sigmaR,
                   int seed = 42u);
 void perturbPoint3(gtsam::Values& values, double sigma, int seed = 42u);
+void perturbPose3(gtsam::Values& values, double sigmaT, double sigmaR,
+                  int seed = 42u);
 void insertBackprojections(gtsam::Values& values,
                            const gtsam::PinholeCamera<gtsam::Cal3_S2>& c,
                            gtsam::Vector J, gtsam::Matrix Z, double depth);

--- a/gtsam/linear/Sampler.cpp
+++ b/gtsam/linear/Sampler.cpp
@@ -25,7 +25,7 @@ namespace gtsam {
 /* ************************************************************************* */
 Sampler::Sampler(const noiseModel::Diagonal::shared_ptr& model,
                  uint_fast64_t seed)
-    : model_(model), generator_(seed) {
+    : model_(model), generator_(seed), externalGenerator_(nullptr) {
   if (!model) {
     throw std::invalid_argument("Sampler::Sampler needs a non-null model.");
   }
@@ -33,7 +33,24 @@ Sampler::Sampler(const noiseModel::Diagonal::shared_ptr& model,
 
 /* ************************************************************************* */
 Sampler::Sampler(const Vector& sigmas, uint_fast64_t seed)
-    : model_(noiseModel::Diagonal::Sigmas(sigmas, true)), generator_(seed) {}
+    : model_(noiseModel::Diagonal::Sigmas(sigmas, true)),
+      generator_(seed),
+      externalGenerator_(nullptr) {}
+
+/* ************************************************************************* */
+Sampler::Sampler(const noiseModel::Diagonal::shared_ptr& model,
+                 std::mt19937_64& rng)
+    : model_(model), generator_(0u), externalGenerator_(&rng) {
+  if (!model) {
+    throw std::invalid_argument("Sampler::Sampler needs a non-null model.");
+  }
+}
+
+/* ************************************************************************* */
+Sampler::Sampler(const Vector& sigmas, std::mt19937_64& rng)
+    : model_(noiseModel::Diagonal::Sigmas(sigmas, true)),
+      generator_(0u),
+      externalGenerator_(&rng) {}
 
 /* ************************************************************************* */
 Vector Sampler::sampleDiagonal(const Vector& sigmas, std::mt19937_64* rng) {
@@ -55,7 +72,8 @@ Vector Sampler::sampleDiagonal(const Vector& sigmas, std::mt19937_64* rng) {
 
 /* ************************************************************************* */
 Vector Sampler::sampleDiagonal(const Vector& sigmas) const {
-  return sampleDiagonal(sigmas, &generator_);
+  std::mt19937_64* rng = externalGenerator_ ? externalGenerator_ : &generator_;
+  return sampleDiagonal(sigmas, rng);
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/Sampler.h
+++ b/gtsam/linear/Sampler.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <gtsam/base/Manifold.h>
 #include <gtsam/linear/NoiseModel.h>
 
 #include <random>
@@ -102,6 +103,16 @@ class GTSAM_EXPORT Sampler {
 
   /// sample from distribution
   Vector sample() const;
+
+  /**
+   * Perturb a value by sampling in its tangent space and applying `retract`.
+   *
+   * The supplied noise model must match the dimensionality expected by `T`.
+   */
+  template <typename T>
+  T perturb(const T& value) const {
+    return traits<T>::Retract(value, sample());
+  }
 
   /// sample with given random number generator
   static Vector sampleDiagonal(const Vector& sigmas, std::mt19937_64* rng);

--- a/gtsam/linear/Sampler.h
+++ b/gtsam/linear/Sampler.h
@@ -30,11 +30,14 @@ namespace gtsam {
  */
 class GTSAM_EXPORT Sampler {
  protected:
-  /** noiseModel created at generation */
+  /// noiseModel created at generation
   noiseModel::Diagonal::shared_ptr model_;
 
-  /** generator */
+  /// generator
   mutable std::mt19937_64 generator_;
+
+  /// Non-owning optional external generator. If non-null, sampling uses this.
+  mutable std::mt19937_64* externalGenerator_ = nullptr;
 
  public:
   typedef std::shared_ptr<Sampler> shared_ptr;
@@ -44,20 +47,44 @@ class GTSAM_EXPORT Sampler {
 
   /**
    * Create a sampler for the distribution specified by a diagonal NoiseModel
-   * with a manually specified seed
+   * with a manually specified seed.
    *
-   * NOTE: do not use zero as a seed, it will break the generator
+   * This constructor is convenient for deterministic, throw-away sampling.
+   * If you need stateful sampling across calls or across multiple Sampler
+   * instances, prefer the RNG-based constructor and manage the RNG yourself.
+   *
+   * NOTE: do not use zero as a seed, it will break the generator.
    */
   explicit Sampler(const noiseModel::Diagonal::shared_ptr& model,
                    uint_fast64_t seed = 42u);
 
   /**
-   * Create a sampler for a distribution specified by a vector of sigmas
-   * directly
+   * Create a sampler that draws from a caller-supplied RNG (stateful).
    *
-   * NOTE: do not use zero as a seed, it will break the generator
+   * The RNG is non-owning and must outlive this Sampler.
+   */
+  explicit Sampler(const noiseModel::Diagonal::shared_ptr& model,
+                   std::mt19937_64& rng);
+
+  /**
+   * Create a sampler for a distribution specified by a vector of sigmas
+   * directly.
+   *
+   * This constructor is convenient for deterministic, throw-away sampling.
+   * If you need stateful sampling across calls or across multiple Sampler
+   * instances, prefer the RNG-based constructor and manage the RNG yourself.
+   *
+   * NOTE: do not use zero as a seed, it will break the generator.
    */
   explicit Sampler(const Vector& sigmas, uint_fast64_t seed = 42u);
+
+  /**
+   * Create a sampler for sigmas that draws from a caller-supplied RNG
+   * (stateful).
+   *
+   * The RNG is non-owning and must outlive this Sampler.
+   */
+  explicit Sampler(const Vector& sigmas, std::mt19937_64& rng);
 
   /// @}
   /// @name access functions
@@ -81,7 +108,10 @@ class GTSAM_EXPORT Sampler {
   /// @}
 
  protected:
-  /** given sigmas for a diagonal model, returns a sample */
+  /**
+   * Given sigmas for a diagonal model, returns a sample.
+   * Uses external RNG if available.
+   * */
   Vector sampleDiagonal(const Vector& sigmas) const;
 };
 

--- a/gtsam/linear/tests/testSampler.cpp
+++ b/gtsam/linear/tests/testSampler.cpp
@@ -17,7 +17,6 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
-
 #include <gtsam/linear/Sampler.h>
 
 using namespace gtsam;
@@ -38,6 +37,18 @@ TEST(testSampler, basic) {
   Vector actual1 = sampler1.sample();
   EXPECT_DOUBLES_EQUAL(0.0, actual1(2), tol);
   EXPECT(assert_equal(sampler2.sample(), sampler3.sample(), tol));
+
+  // RNG-based constructor should be stateful and match the same sequence as a
+  // seeded sampler.
+  std::mt19937_64 rng(1);
+  Sampler sampler_rng(model, rng);
+  Sampler sampler_seed(model, 1);
+  Vector s1 = sampler_rng.sample();
+  Vector s1_ref = sampler_seed.sample();
+  EXPECT(assert_equal(s1, s1_ref, tol));
+  Vector s2 = sampler_rng.sample();
+  Vector s2_ref = sampler_seed.sample();
+  EXPECT(assert_equal(s2, s2_ref, tol));
 }
 
 /* ************************************************************************* */

--- a/gtsam/nonlinear/tests/testUtilities.cpp
+++ b/gtsam/nonlinear/tests/testUtilities.cpp
@@ -19,6 +19,7 @@
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/geometry/Point2.h>
+#include <gtsam/geometry/Pose2.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/nonlinear/utilities.h>
@@ -27,6 +28,8 @@ using namespace gtsam;
 using gtsam::symbol_shorthand::L;
 using gtsam::symbol_shorthand::R;
 using gtsam::symbol_shorthand::X;
+
+static constexpr double kTol = 1e-9;
 
 /* ************************************************************************* */
 TEST(Utilities, ExtractPoint2) {
@@ -52,6 +55,92 @@ TEST(Utilities, ExtractPoint3) {
 
   Matrix all_points = utilities::extractPoint3(values);
   EXPECT_LONGS_EQUAL(2, all_points.rows());
+}
+
+/* ************************************************************************* */
+TEST(Utilities, PerturbPoint2) {
+  Values base;
+  base.insert<Point2>(L(0), Point2(1.0, 2.0));
+  base.insert<Vector>(L(1), (Vector(2) << 3.0, 4.0).finished());
+
+  Values v1 = base, v2 = base;
+  utilities::perturbPoint2(v1, /*sigma=*/0.1, /*seed=*/42u);
+  utilities::perturbPoint2(v2, /*sigma=*/0.1, /*seed=*/42u);
+  EXPECT(assert_equal(v1, v2, kTol));
+
+  const Point2 p0 = base.at<Point2>(L(0));
+  const Point2 p1 = v1.at<Point2>(L(0));
+  EXPECT((p1 - p0).norm() > 0.0);
+
+  const Vector w0 = base.at<Vector>(L(1));
+  const Vector w1 = v1.at<Vector>(L(1));
+  EXPECT((w1 - w0).norm() > 0.0);
+
+  Values v3 = base;
+  utilities::perturbPoint2(v3, /*sigma=*/0.0, /*seed=*/42u);
+  EXPECT(assert_equal(v3, base, kTol));
+}
+
+/* ************************************************************************* */
+TEST(Utilities, PerturbPoint3) {
+  Values base;
+  base.insert<Point3>(L(0), Point3(1.0, 2.0, 3.0));
+  base.insert<Vector>(L(1), (Vector(3) << 4.0, 5.0, 6.0).finished());
+
+  Values v1 = base, v2 = base;
+  utilities::perturbPoint3(v1, /*sigma=*/0.1, /*seed=*/42u);
+  utilities::perturbPoint3(v2, /*sigma=*/0.1, /*seed=*/42u);
+  EXPECT(assert_equal(v1, v2, kTol));
+
+  const Point3 p0 = base.at<Point3>(L(0));
+  const Point3 p1 = v1.at<Point3>(L(0));
+  EXPECT((p1 - p0).norm() > 0.0);
+
+  const Vector w0 = base.at<Vector>(L(1));
+  const Vector w1 = v1.at<Vector>(L(1));
+  EXPECT((w1 - w0).norm() > 0.0);
+
+  Values v3 = base;
+  utilities::perturbPoint3(v3, /*sigma=*/0.0, /*seed=*/42u);
+  EXPECT(assert_equal(v3, base, kTol));
+}
+
+/* ************************************************************************* */
+TEST(Utilities, PerturbPose2) {
+  Values base;
+  const Pose2 pose0(1.0, 2.0, 0.3);
+  base.insert<Pose2>(X(0), pose0);
+
+  Values v1 = base, v2 = base;
+  utilities::perturbPose2(v1, /*sigmaT=*/0.1, /*sigmaR=*/0.2, /*seed=*/42u);
+  utilities::perturbPose2(v2, /*sigmaT=*/0.1, /*sigmaR=*/0.2, /*seed=*/42u);
+  EXPECT(assert_equal(v1, v2, kTol));
+
+  const Pose2 pose1 = v1.at<Pose2>(X(0));
+  EXPECT(!pose1.equals(pose0, kTol));
+
+  Values v3 = base;
+  utilities::perturbPose2(v3, /*sigmaT=*/0.0, /*sigmaR=*/0.0, /*seed=*/42u);
+  EXPECT(assert_equal(v3, base, kTol));
+}
+
+/* ************************************************************************* */
+TEST(Utilities, PerturbPose3) {
+  Values base;
+  const Pose3 pose0;
+  base.insert<Pose3>(X(0), pose0);
+
+  Values v1 = base, v2 = base;
+  utilities::perturbPose3(v1, /*sigmaT=*/0.1, /*sigmaR=*/0.2, /*seed=*/42u);
+  utilities::perturbPose3(v2, /*sigmaT=*/0.1, /*sigmaR=*/0.2, /*seed=*/42u);
+  EXPECT(assert_equal(v1, v2, kTol));
+
+  const Pose3 pose1 = v1.at<Pose3>(X(0));
+  EXPECT(!pose1.equals(pose0, kTol));
+
+  Values v3 = base;
+  utilities::perturbPose3(v3, /*sigmaT=*/0.0, /*sigmaR=*/0.0, /*seed=*/42u);
+  EXPECT(assert_equal(v3, base, kTol));
 }
 
 /* ************************************************************************* */

--- a/gtsam/nonlinear/utilities.h
+++ b/gtsam/nonlinear/utilities.h
@@ -196,7 +196,17 @@ Matrix extractVectors(const Values& values, char c) {
   return result;
 }
 
-/// Perturb all Point2 values using normally distributed noise
+/**
+ * Perturbs all 2D point values in a Values container using isotropic Gaussian
+ * noise.
+ *
+ * This updates in-place both Point2 entries and any Vector entries of size 2
+ * by adding zero-mean Gaussian noise with the given standard deviation.
+ *
+ * @param values Values whose Point2/2D Vector entries will be perturbed.
+ * @param sigma Standard deviation of the isotropic Gaussian noise applied.
+ * @param seed Random seed used by the Sampler (default 42u).
+ */
 void perturbPoint2(Values& values, double sigma, int32_t seed = 42u) {
   auto model = noiseModel::Isotropic::Sigma(2, sigma);
   Sampler sampler(model, seed);
@@ -208,11 +218,40 @@ void perturbPoint2(Values& values, double sigma, int32_t seed = 42u) {
       values.update<gtsam::Vector>(key, sampler.perturb(value));
     }
   }
+}
+
+/**
+ * Perturbs all 2D pose values (Pose2) in a Values container using diagonal
+ * Gaussian noise.
+ *
+ * The translational components (x, y) are perturbed with sigmaT, and the
+ * rotational component (theta) is perturbed with sigmaR.
+ *
+ * @param values Values container whose Pose2 entries will be perturbed.
+ * @param sigmaT Standard deviation for translational noise.
+ * @param sigmaR Standard deviation for rotational noise (applied to theta).
+ * @param seed Random seed used by the Sampler (default 42u).
+ */
+void perturbPose2(Values& values, double sigmaT, double sigmaR,
+                  int32_t seed = 42u) {
   auto model = noiseModel::Diagonal::Sigmas(Vector3(sigmaT, sigmaT, sigmaR));
   Sampler sampler(model, seed);
   for (const auto& [key, value] : values.extract<Pose2>()) {
     values.update<Pose2>(key, sampler.perturb(value));
   }
+}
+
+/**
+ * Perturbs all 3D point values in a Values container using isotropic Gaussian
+ * noise.
+ *
+ * This updates in-place both Point3 entries and any Vector entries of size 3
+ * by adding zero-mean Gaussian noise with the given standard deviation.
+ *
+ * @param values Values whose Point3 and 3D Vector entries will be perturbed.
+ * @param sigma Standard deviation of the isotropic Gaussian noise applied.
+ * @param seed Random seed used by the Sampler (default 42u).
+ */
 void perturbPoint3(Values& values, double sigma, int32_t seed = 42u) {
   auto model = noiseModel::Isotropic::Sigma(3, sigma);
   Sampler sampler(model, seed);
@@ -224,6 +263,28 @@ void perturbPoint3(Values& values, double sigma, int32_t seed = 42u) {
       values.update<gtsam::Vector>(key, sampler.perturb(value));
     }
   }
+}
+
+/**
+ * Perturbs all 3D pose values (Pose3) in a Values container using diagonal
+ * Gaussian noise.
+ *
+ * The noise is applied in the tangent space order [rx, ry, rz, tx, ty, tz],
+ * where rotational components are perturbed with sigmaR and translational
+ * components with sigmaT.
+ *
+ * @param values Values container whose Pose3 entries will be perturbed.
+ * @param sigmaT Standard deviation for translational noise.
+ * @param sigmaR Standard deviation for rotational noise.
+ * @param seed Random seed used by the Sampler (default 42u).
+ */
+void perturbPose3(Values& values, double sigmaT, double sigmaR,
+                  int32_t seed = 42u) {
+  auto model = noiseModel::Diagonal::Sigmas(
+      (Vector6() << sigmaR, sigmaR, sigmaR, sigmaT, sigmaT, sigmaT).finished());
+  Sampler sampler(model, seed);
+  for (const auto& [key, value] : values.extract<Pose3>()) {
+    values.update<Pose3>(key, sampler.perturb(value));
   }
 }
 
@@ -333,4 +394,3 @@ Values localToWorld(const Values& local, const Pose2& base,
 } // namespace utilities
 
 }
-

--- a/gtsam/nonlinear/utilities.h
+++ b/gtsam/nonlinear/utilities.h
@@ -198,46 +198,32 @@ Matrix extractVectors(const Values& values, char c) {
 
 /// Perturb all Point2 values using normally distributed noise
 void perturbPoint2(Values& values, double sigma, int32_t seed = 42u) {
-  noiseModel::Isotropic::shared_ptr model =
-      noiseModel::Isotropic::Sigma(2, sigma);
+  auto model = noiseModel::Isotropic::Sigma(2, sigma);
   Sampler sampler(model, seed);
-  for (const auto& key_value : values.extract<Point2>()) {
-    values.update<Point2>(key_value.first,
-                          key_value.second + Point2(sampler.sample()));
+  for (const auto& [key, value] : values.extract<Point2>()) {
+    values.update<Point2>(key, sampler.perturb(value));
   }
-  for (const auto& key_value : values.extract<gtsam::Vector>()) {
-    if (key_value.second.rows() == 2) {
-      values.update<gtsam::Vector>(key_value.first,
-                                   key_value.second + Point2(sampler.sample()));
+  for (const auto& [key, value] : values.extract<gtsam::Vector>()) {
+    if (value.rows() == 2) {
+      values.update<gtsam::Vector>(key, sampler.perturb(value));
     }
   }
-}
-
-/// Perturb all Pose2 values using normally distributed noise
-void perturbPose2(Values& values, double sigmaT, double sigmaR, int32_t seed =
-    42u) {
-  noiseModel::Diagonal::shared_ptr model = noiseModel::Diagonal::Sigmas(
-      Vector3(sigmaT, sigmaT, sigmaR));
+  auto model = noiseModel::Diagonal::Sigmas(Vector3(sigmaT, sigmaT, sigmaR));
   Sampler sampler(model, seed);
-  for(const auto& key_value: values.extract<Pose2>()) {
-    values.update<Pose2>(key_value.first, key_value.second.retract(sampler.sample()));
+  for (const auto& [key, value] : values.extract<Pose2>()) {
+    values.update<Pose2>(key, sampler.perturb(value));
   }
-}
-
-/// Perturb all Point3 values using normally distributed noise
 void perturbPoint3(Values& values, double sigma, int32_t seed = 42u) {
-  noiseModel::Isotropic::shared_ptr model =
-      noiseModel::Isotropic::Sigma(3, sigma);
+  auto model = noiseModel::Isotropic::Sigma(3, sigma);
   Sampler sampler(model, seed);
-  for (const auto& key_value : values.extract<Point3>()) {
-    values.update<Point3>(key_value.first,
-                          key_value.second + Point3(sampler.sample()));
+  for (const auto& [key, value] : values.extract<Point3>()) {
+    values.update<Point3>(key, sampler.perturb(value));
   }
-  for (const auto& key_value : values.extract<gtsam::Vector>()) {
-    if (key_value.second.rows() == 3) {
-      values.update<gtsam::Vector>(key_value.first,
-                                   key_value.second + Point3(sampler.sample()));
+  for (const auto& [key, value] : values.extract<gtsam::Vector>()) {
+    if (value.rows() == 3) {
+      values.update<gtsam::Vector>(key, sampler.perturb(value));
     }
+  }
   }
 }
 

--- a/gtsam/slam/dataset.cpp
+++ b/gtsam/slam/dataset.cpp
@@ -370,7 +370,7 @@ template <> struct ParseMeasurement<Pose2> {
     // Get pose and optionally add noise
     Pose2 &pose = edge->second;
     if (sampler)
-      pose = pose.retract(sampler->sample());
+      pose = sampler->perturb(pose);
 
     // emplace measurement
     auto modelFromFile =
@@ -835,7 +835,7 @@ template <> struct ParseMeasurement<Pose3> {
       Pose3 T12(R, {x, y, z});
       //  optionally add noise
       if (sampler)
-        T12 = T12.retract(sampler->sample());
+        T12 = sampler->perturb(T12);
 
       return BinaryMeasurement<Pose3>(id1, id2, T12,
                                       noiseModel::Gaussian::Information(m));
@@ -847,7 +847,7 @@ template <> struct ParseMeasurement<Pose3> {
       Pose3 T12(q, {x, y, z});
       //  optionally add noise
       if (sampler)
-        T12 = T12.retract(sampler->sample());
+        T12 = sampler->perturb(T12);
 
       // g2o's EDGE_SE3:QUAT stores information/precision of Pose3 in t,R order, unlike GTSAM:
       Matrix6 mgtsam;

--- a/gtsam_unstable/geometry/SimWall2D.cpp
+++ b/gtsam_unstable/geometry/SimWall2D.cpp
@@ -163,7 +163,7 @@ std::pair<Pose2, bool> moveWithBounce(const Pose2& cur_pose, double step_size,
     pose = Pose2(closest_wall.reflection(cur_pose.t(), intersection), intersection + inside_bias * norm);
 
     // perturb the rotation for better exploration
-    pose = pose.retract(reflect_noise.sample());
+    pose = reflect_noise.perturb(pose);
   }
 
   return make_pair(pose, collision);

--- a/python/gtsam/tests/test_Utilities.py
+++ b/python/gtsam/tests/test_Utilities.py
@@ -17,7 +17,7 @@ from gtsam.utils.test_case import GtsamTestCase
 import gtsam
 
 
-class TestUtilites(GtsamTestCase):
+class TestUtilities(GtsamTestCase):
     """Test various GTSAM utilities."""
 
     def test_createKeyList(self):
@@ -142,7 +142,7 @@ class TestUtilites(GtsamTestCase):
         values = gtsam.Values()
         values.insert(0, gtsam.Pose3())
         values.insert(1, gtsam.Point2(1, 1))
-        gtsam.utilities.perturbPoint2(values, 1.0)
+        gtsam.utilities.perturbPoint2(values, 1.0, 42)
         self.assertTrue(
             not np.allclose(values.atPoint2(1), gtsam.Point2(1, 1)))
 
@@ -151,7 +151,7 @@ class TestUtilites(GtsamTestCase):
         values = gtsam.Values()
         values.insert(0, gtsam.Pose2())
         values.insert(1, gtsam.Point2(1, 1))
-        gtsam.utilities.perturbPose2(values, 1, 1)
+        gtsam.utilities.perturbPose2(values, 1, 1, 42)
         self.assertTrue(values.atPose2(0) != gtsam.Pose2())
 
     def test_perturbPoint3(self):
@@ -160,8 +160,17 @@ class TestUtilites(GtsamTestCase):
         point3 = gtsam.Point3(0, 0, 0)
         values.insert(0, gtsam.Pose2())
         values.insert(1, point3)
-        gtsam.utilities.perturbPoint3(values, 1)
+        gtsam.utilities.perturbPoint3(values, 1, 42)
         self.assertTrue(not np.allclose(values.atPoint3(1), point3))
+
+    def test_perturbPose3(self):
+        """Test perturbPose3."""
+        values = gtsam.Values()
+        pose3 = gtsam.Pose3()
+        values.insert(0, pose3)
+        values.insert(1, gtsam.Point2(1, 1))
+        gtsam.utilities.perturbPose3(values, 1, 1, 42)
+        self.assertTrue(not values.atPose3(0).equals(pose3, 1e-9))
 
     def test_insertBackprojections(self):
         """Test insertBackprojections."""

--- a/tests/testNonlinearISAM.cpp
+++ b/tests/testNonlinearISAM.cpp
@@ -54,7 +54,7 @@ TEST(testNonlinearISAM, markov_chain ) {
     Values new_init;
 
     cur_pose = cur_pose.compose(z);
-    new_init.insert(i, cur_pose.retract(sampler.sample()));
+    new_init.insert(i, sampler.perturb(cur_pose));
     expected.insert(i, cur_pose);
     isamChol.update(new_factors, new_init);
     isamQR.update(new_factors, new_init);
@@ -110,7 +110,7 @@ TEST(testNonlinearISAM, markov_chain_with_disconnects ) {
     Values new_init;
 
     cur_pose = cur_pose.compose(z);
-    new_init.insert(i, cur_pose.retract(sampler.sample()));
+    new_init.insert(i, sampler.perturb(cur_pose));
     expected.insert(i, cur_pose);
 
     // Add a floating landmark constellation
@@ -187,7 +187,7 @@ TEST(testNonlinearISAM, markov_chain_with_reconnect ) {
     Values new_init;
 
     cur_pose = cur_pose.compose(z);
-    new_init.insert(i, cur_pose.retract(sampler.sample()));
+    new_init.insert(i, sampler.perturb(cur_pose));
     expected.insert(i, cur_pose);
 
     // Add a floating landmark constellation

--- a/timing/timeLago.cpp
+++ b/timing/timeLago.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[]) {
   auto noise = noiseModel::Diagonal::Sigmas((Vector(3) << 0.5, 0.5, 15.0 * M_PI / 180.0).finished());
   Sampler sampler(noise);
   for(const auto& [key,pose]: solution->extract<Pose2>())
-    initial.insert(key, pose.retract(sampler.sample()));
+    initial.insert(key, sampler.perturb(pose));
 
   // Add prior on the pose having index (key) = 0
   noiseModel::Diagonal::shared_ptr priorModel = //


### PR DESCRIPTION
The GTSAm `Sampler` is a handy little class to create noisy versions of anything. I added a perturb method, templated on a generic type `T`, that will call `retract` using a sampled noisy tangent space vector. Wherever I could, I used this new template. I also added a `perturbPose3` method along with unit tests in C++ and Python. 