### PR TITLE
perf: TBB with memory growth control.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -239,6 +239,10 @@ Here are some tips to get the best possible performance out of GTSAM.
     optimization by 30-50%. Please note that this may not be true for very small
     problems where the overhead of dispatching work to multiple threads outweighs
     the benefit. We recommend that you benchmark your problem with/without TBB.
+    Note: TBB's parallel tree traversal can significantly increase memory usage
+    (e.g., from ~4GB to ~12GB in tested scenarios). If memory is a concern, you
+    can set `-DGTSAM_TBB_BOUNDED_MEMORY_GROWTH=ON` to disable parallel tree
+    traversal while keeping other TBB benefits.
 3. Use `GTSAM_BUILD_WITH_MARCH_NATIVE`. A performance gain of
     25-30% can be expected on modern processors. Note that this affects the portability
     of your executable. It may not run when copied to another system with older/different

--- a/cmake/HandleGeneralOptions.cmake
+++ b/cmake/HandleGeneralOptions.cmake
@@ -42,6 +42,7 @@ option(GTSAM_HYBRID_TIMING                  "Enable the timing of hybrid factor 
 option(GTSAM_ENABLE_CONSISTENCY_CHECKS      "Enable/Disable expensive consistency checks" OFF)
 option(GTSAM_ENABLE_MEMORY_SANITIZER        "Enable/Disable memory sanitizer" OFF)
 option(GTSAM_WITH_TBB                       "Use Intel Threaded Building Blocks (TBB) if available" ON)
+option(GTSAM_TBB_BOUNDED_MEMORY_GROWTH      "Avoid large increase in memory usage due to parallel tree traversal" OFF)
 option(GTSAM_WITH_EIGEN_MKL                 "Eigen will use Intel MKL if available" OFF)
 option(GTSAM_WITH_EIGEN_MKL_OPENMP          "Eigen, when using Intel MKL, will also use OpenMP for multithreading if available" OFF)
 option(GTSAM_THROW_CHEIRALITY_EXCEPTION     "Throw exception when a triangulated point is behind a camera" ON)

--- a/cmake/HandleTBB.cmake
+++ b/cmake/HandleTBB.cmake
@@ -6,6 +6,9 @@ if (GTSAM_WITH_TBB)
     # Set up variables if we're using TBB
     if(TBB_FOUND)
         set(GTSAM_USE_TBB 1)  # This will go into config.h
+        if (GTSAM_TBB_BOUNDED_MEMORY_GROWTH)
+            set(GTSAM_TBB_BOUNDED_MEMORY_GROWTH_FLAG 1)
+        endif()
 
         if ((${TBB_VERSION_MAJOR} GREATER 2020) OR (${TBB_VERSION_MAJOR} EQUAL 2020))
             set(TBB_GREATER_EQUAL_2020 1)

--- a/gtsam/base/SymmetricBlockMatrix.h
+++ b/gtsam/base/SymmetricBlockMatrix.h
@@ -25,6 +25,7 @@
 #include <boost/serialization/nvp.hpp>
 #endif
 #include <cassert>
+#include <cstring>
 #include <stdexcept>
 #include <array>
 #include <vector>
@@ -304,6 +305,25 @@ namespace gtsam {
     /// Set entire matrix zero.
     void setAllZero() {
       matrix_.setZero();
+    }
+
+    /// Set the block columns between beginCol (inclusive) and endCol (exclusive) to zero. 
+    void setZeroColumns(DenseIndex beginCol, DenseIndex endCol) {
+      assert(beginCol < endCol);
+      assert(beginCol >= 0);
+      assert(endCol >= 0);
+      assert(beginCol < nBlocks());
+      assert(endCol <= nBlocks());
+      static_assert(Matrix::IsRowMajor == 0, "setZeroColumns requires column-major storage.");
+
+      const DenseIndex denseBeginCol = offset(beginCol);
+      const DenseIndex denseEndCol = offset(endCol);
+
+      double *begin = matrix_.data() + denseBeginCol * matrix_.rows();
+      double *end = matrix_.data() + denseEndCol * matrix_.rows();
+
+      // Using memset for maximal compiler optimization.
+      memset(begin, 0, (end - begin) * sizeof(*begin));
     }
 
     /// Negate the entire active matrix.

--- a/gtsam/base/tests/testSymmetricBlockMatrix.cpp
+++ b/gtsam/base/tests/testSymmetricBlockMatrix.cpp
@@ -80,6 +80,28 @@ TEST(SymmetricBlockMatrix, WriteBlocks)
 }
 
 /* ************************************************************************* */
+TEST(SymmetricBlockMatrix, setZeroColumns) {
+  // Expected: columns 3 and 4 are zero
+  Matrix expected = testBlockMatrix.selfadjointView().toDenseMatrix().eval();
+  expected.col(3).setZero();
+  expected.col(4).setZero();
+  expected = expected.triangularView<Eigen::Upper>().toDenseMatrix().eval();
+
+  SymmetricBlockMatrix bm = testBlockMatrix;
+
+  // Zero out the middle block (block 1, columns 3-4)
+  bm.setZeroColumns(1, 2);
+
+  Matrix result = bm.selfadjointView()
+                      .toDenseMatrix()
+                      .triangularView<Eigen::Upper>()
+                      .toDenseMatrix()
+                      .eval();
+
+  EXPECT(assert_equal(expected, result));
+}
+
+/* ************************************************************************* */
 // Verify block range access.
 TEST(SymmetricBlockMatrix, Ranges)
 {

--- a/gtsam/base/treeTraversal-inst.h
+++ b/gtsam/base/treeTraversal-inst.h
@@ -181,8 +181,11 @@ template<class FOREST, typename DATA, typename VISITOR_PRE,
 void DepthFirstForestParallel(FOREST& forest, DATA& rootData,
     VISITOR_PRE& visitorPre, VISITOR_POST& visitorPost,
     int problemSizeThreshold = 10) {
-#ifdef GTSAM_USE_TBB
-  // Typedefs
+
+#if defined(GTSAM_USE_TBB) && !defined(GTSAM_TBB_BOUNDED_MEMORY_GROWTH_FLAG)
+  // Note: Parallel tree traversal (the default) causes a large increase in memory footprint.
+  // In a tested use case, memory grew from approximately 4 GB to 12 GB.
+
   typedef typename FOREST::Node Node;
 
   internal::CreateRootTask<Node>(forest.roots(), rootData, visitorPre,
@@ -203,7 +206,9 @@ void DepthFirstForestParallel(FOREST& forest, DATA& rootData,
 template<class FOREST, typename VISITOR_POST>
 void PostOrderForestParallel(FOREST& forest, VISITOR_POST& visitorPost,
                              int problemSizeThreshold = 10) {
-#ifdef GTSAM_USE_TBB
+#if defined(GTSAM_USE_TBB) && !defined(GTSAM_TBB_BOUNDED_MEMORY_GROWTH_FLAG)
+  // Note: Parallel tree traversal (the default) causes a large increase in memory footprint.
+
   typedef typename FOREST::Node Node;
   internal::CreateRootPostOrderTask<Node>(forest.roots(), visitorPost,
                                           problemSizeThreshold);

--- a/gtsam/config.h.in
+++ b/gtsam/config.h.in
@@ -56,6 +56,9 @@
 // Whether we are using a TBB version higher than 2020
 #cmakedefine TBB_GREATER_EQUAL_2020
 
+// Whether to use bounded memory growth for TBB parallel tree traversal
+#cmakedefine GTSAM_TBB_BOUNDED_MEMORY_GROWTH_FLAG
+
 // Whether we are using system-Eigen or our own patched version
 #cmakedefine GTSAM_USE_SYSTEM_EIGEN
 

--- a/gtsam/linear/GaussianFactor.h
+++ b/gtsam/linear/GaussianFactor.h
@@ -157,6 +157,18 @@ namespace gtsam {
     virtual void updateHessian(const KeyVector& keys,
                            SymmetricBlockMatrix* info) const = 0;
 
+    /** Update an information matrix by adding the information corresponding to this factor
+     * (used internally during elimination), restricted to a range of block columns,
+     * useful for parallelization.
+     * @param keys The ordered vector of keys for the information matrix to be updated
+     * @param info The information matrix to be updated
+     * @param beginCol First block column index (inclusive) in the range to update
+     * @param endCol Last block column index (exclusive) in the range to update
+     */
+    virtual void updateHessian(const KeyVector& keys,
+                           SymmetricBlockMatrix* info,
+                           DenseIndex beginCol, DenseIndex endCol) const = 0;
+
     /// @}
     /// @name Operator interface
     /// @{

--- a/gtsam/linear/HessianFactor.cpp
+++ b/gtsam/linear/HessianFactor.cpp
@@ -34,6 +34,14 @@
 #include <cassert>
 #include <limits>
 
+#ifdef GTSAM_USE_TBB
+  #include <tbb/blocked_range.h>
+  #include <tbb/parallel_for.h>
+  #include <oneapi/tbb/global_control.h>
+  #include <oneapi/tbb/task_arena.h>
+  #include <algorithm>
+#endif
+
 using namespace std;
 
 namespace gtsam {
@@ -241,16 +249,64 @@ HessianFactor::HessianFactor(const GaussianFactorGraph& factors,
     const Scatter& scatter) {
   gttic(HessianFactor_MergeConstructor);
 
+  gttic(Allocate);
   Allocate(scatter);
+  gttoc(Allocate);
+
+  // Only parallelize the inner loop if GTSAM_TBB_BOUNDED_MEMORY_GROWTH_FLAG is
+  // defined. Without this flag, multiple HessianFactor constructions are
+  // already running in parallel (e.g., when constructing multiple factors
+  // concurrently), so there's no need to parallelize the inner
+  // updateHessian loop here as well.
+#if defined(GTSAM_USE_TBB) && defined(GTSAM_TBB_BOUNDED_MEMORY_GROWTH_FLAG)
+  constexpr DenseIndex kParallelThresholdHeuristic = 50;
+  if (info_.rows() > kParallelThresholdHeuristic) {
+    gttic(updateHessian_TBB);
+
+    const DenseIndex M = info_.nBlocks();
+
+    auto numThreads = std::min(
+        static_cast<int>(oneapi::tbb::global_control::active_value(
+            oneapi::tbb::global_control::max_allowed_parallelism)),
+        static_cast<int>(oneapi::tbb::this_task_arena::max_concurrency()));
+
+    if (numThreads > 1) {
+      DenseIndex grain = std::max<DenseIndex>(1, M / (2 * numThreads));
+      tbb::parallel_for(tbb::blocked_range<DenseIndex>(0, M, grain),
+                        [&, M](const tbb::blocked_range<DenseIndex>& range) {
+                          // reverse the range to start from the end because
+                          // matrix is upper triangular and therefore end is
+                          // larger than begin so we would like to start with
+                          // the last column that is the most work and go to the
+                          // first column that is least.
+                          DenseIndex beginCol = M - range.end();
+                          DenseIndex endCol = M - range.begin();
+                          info_.setZeroColumns(beginCol, endCol);
+                          for (const auto& factor : factors) {
+                            if (factor) {
+                              factor->updateHessian(keys_, &info_, beginCol,
+                                                    endCol);
+                            }
+                          }
+                        });
+      return;
+    }
+  }
+#endif
+  gttic(setAllZero);
+  info_.setAllZero();
+  gttoc(setAllZero);
+
+  gttic(updateHessian);
 
   // Form A' * A
-  gttic(update);
-  info_.setAllZero();
-  for(const auto& factor: factors)
-    if (factor)
+  for (const auto& factor : factors) {
+    if (factor) {
       factor->updateHessian(keys_, &info_);
-  gttoc(update);
+    }
+  }
 }
+
 
 /* ************************************************************************* */
 void HessianFactor::print(const std::string& s,
@@ -362,12 +418,56 @@ void HessianFactor::updateHessian(const KeyVector& infoKeys,
   gttic(updateHessian_HessianFactor);
   const DenseIndex nrVariablesInThisFactor = size();
 
+  gttic(slots);
   vector<DenseIndex> slots(nrVariablesInThisFactor + 1);
   for (DenseIndex j = 0; j < nrVariablesInThisFactor; ++j)
     slots[j] = Slot(infoKeys, keys_[j]);
+  
   slots[nrVariablesInThisFactor] = info->nBlocks() - 1;
+  gttoc(slots);
 
   info->updateFromMappedBlocks(info_, slots);
+}
+
+/* ************************************************************************* */
+void HessianFactor::updateHessian(const KeyVector& infoKeys,
+                                  SymmetricBlockMatrix* info,
+                                  DenseIndex beginCol,
+                                  DenseIndex endCol) const {
+  assert(info);
+  const DenseIndex nrVariablesInThisFactor = size();
+
+  vector<DenseIndex> slots;
+  slots.reserve(nrVariablesInThisFactor + 1);
+
+  for (DenseIndex j = 0; j < nrVariablesInThisFactor; ++j) {
+    slots.push_back(Slot(infoKeys, keys_[j]));
+  }
+  slots.push_back(info->nBlocks() - 1);
+
+  for (DenseIndex j = 0; j <= nrVariablesInThisFactor; ++j) {
+    const DenseIndex J = slots[j];
+    // Update diagonal block if J is in range
+    if (J >= beginCol && J < endCol) {
+      info->updateDiagonalBlock(J, info_.diagonalBlock(j));
+    }
+
+    // Update off-diagonal blocks where column max(I, J) is in range
+    // Note: We process all blocks and let the maxCol check filter them,
+    // because I and J may be in different orders (slots are not necessarily sorted)
+    for (DenseIndex i = 0; i < j; ++i) {
+      const DenseIndex I = slots[i];
+      assert(i < j);
+      assert(I != J);
+
+      // The physical column index in the symmetric matrix is max(I, J)
+      const DenseIndex maxCol = std::max(I, J);
+
+      if (maxCol >= beginCol && maxCol < endCol) {
+        info->updateOffDiagonalBlock(I, J, info_.aboveDiagonalBlock(i, j));
+      }
+    }
+  }
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/HessianFactor.cpp
+++ b/gtsam/linear/HessianFactor.cpp
@@ -253,12 +253,7 @@ HessianFactor::HessianFactor(const GaussianFactorGraph& factors,
   Allocate(scatter);
   gttoc(Allocate);
 
-  // Only parallelize the inner loop if GTSAM_TBB_BOUNDED_MEMORY_GROWTH_FLAG is
-  // defined. Without this flag, multiple HessianFactor constructions are
-  // already running in parallel (e.g., when constructing multiple factors
-  // concurrently), so there's no need to parallelize the inner
-  // updateHessian loop here as well.
-#if defined(GTSAM_USE_TBB) && defined(GTSAM_TBB_BOUNDED_MEMORY_GROWTH_FLAG)
+#if defined(GTSAM_USE_TBB)
   constexpr DenseIndex kParallelThresholdHeuristic = 50;
   if (info_.rows() > kParallelThresholdHeuristic) {
     gttic(updateHessian_TBB);

--- a/gtsam/linear/HessianFactor.h
+++ b/gtsam/linear/HessianFactor.h
@@ -333,6 +333,17 @@ namespace gtsam {
      */
     void updateHessian(const KeyVector& keys, SymmetricBlockMatrix* info) const override;
 
+    /** Update an information matrix by adding the information corresponding to this factor
+     * (used internally during elimination), restricted to a range of block columns,
+     * useful for parallelization.
+     * @param keys The ordered vector of keys for the information matrix to be updated
+     * @param info The information matrix to be updated
+     * @param beginCol First block column index (inclusive) in the range to update
+     * @param endCol Last block column index (exclusive) in the range to update
+     */
+    void updateHessian(const KeyVector& keys, SymmetricBlockMatrix* info,
+                       DenseIndex beginCol, DenseIndex endCol) const override;
+
     /** Update another Hessian factor
      * @param other the HessianFactor to be updated
      */

--- a/gtsam/linear/JacobianFactor.cpp
+++ b/gtsam/linear/JacobianFactor.cpp
@@ -705,6 +705,72 @@ void JacobianFactor::updateHessian(const KeyVector& infoKeys,
 }
 
 /* ************************************************************************* */
+static void whitenedUpdateHessian(SymmetricBlockMatrix* info, std::vector<DenseIndex> slots, 
+  const VerticalBlockMatrix& Ab_, DenseIndex beginCol, DenseIndex endCol) {
+  const DenseIndex n = Ab_.nBlocks() - 1;
+
+  for (DenseIndex j = 0; j <= n; ++j) {
+    const DenseIndex J = slots[j];
+    Eigen::Block<const Matrix> Ab_j = Ab_(j);
+    
+    // Update diagonal block if J is in range
+    if (J >= beginCol && J < endCol) {
+      info->diagonalBlock(J).rankUpdate(Ab_j.transpose());
+    }
+    
+    // Fill off-diagonal blocks with Ai'*Aj where column max(I, J) is in range
+    for (DenseIndex i = 0; i < j; ++i) {
+      const DenseIndex I = slots[i];
+      
+      // The physical column index in the symmetric matrix is max(I, J)
+      const DenseIndex maxCol = std::max(I, J);
+      if (maxCol >= beginCol && maxCol < endCol) {
+        // Pass original indices - updateOffDiagonalBlock handles swapping internally
+        info->updateOffDiagonalBlock(I, J, Ab_(i).transpose() * Ab_j);
+      }
+    }
+  }
+}
+
+void JacobianFactor::updateHessian(const KeyVector& infoKeys,
+                                   SymmetricBlockMatrix* info,
+                                   DenseIndex beginCol, DenseIndex endCol) const {
+  if (rows() == 0) return;
+
+  // Ab_ is the augmented Jacobian matrix A, and we perform I += A'*A below.
+  DenseIndex n = Ab_.nBlocks() - 1;
+
+  // Pre-calculate slots
+  vector<DenseIndex> slots;
+  slots.reserve(n + 1);
+  bool foundCol = false;
+  for (DenseIndex j = 0; j < n; ++j) {
+    slots.push_back(Slot(infoKeys, keys_[j]));
+    if (slots[j] >= beginCol && slots[j] < endCol) {
+      foundCol = true;
+    }
+  }
+  slots.push_back(info->nBlocks() - 1);
+  if (slots[n] >= beginCol && slots[n] < endCol) {
+    foundCol = true;
+  }
+  if (!foundCol) return;
+
+  // Whiten the factor if it has a noise model
+  const SharedDiagonal& model = get_model();
+  if (model && !model->isUnit()) {
+    if (model->isConstrained())
+      throw invalid_argument(
+          "JacobianFactor::updateHessian: cannot update information with "
+          "constrained noise model");
+    JacobianFactor whitenedFactor = whiten();
+    whitenedUpdateHessian(info, std::move(slots), whitenedFactor.Ab_, beginCol, endCol);
+  } else {
+    whitenedUpdateHessian(info, std::move(slots), Ab_, beginCol, endCol);
+  }
+}
+
+/* ************************************************************************* */
 Vector JacobianFactor::operator*(const VectorValues& x) const {
   Vector Ax(Ab_.rows());
   Ax.setZero();

--- a/gtsam/linear/JacobianFactor.h
+++ b/gtsam/linear/JacobianFactor.h
@@ -371,6 +371,17 @@ namespace gtsam {
      */
     void updateHessian(const KeyVector& keys, SymmetricBlockMatrix* info) const override;
 
+    /** Update an information matrix by adding the information corresponding to this factor
+     * (used internally during elimination), restricted to a range of block columns,
+     * useful for parallelization.
+     * @param keys The ordered vector of keys for the information matrix to be updated
+     * @param info The information matrix to be updated
+     * @param beginCol First block column index (inclusive) in the range to update
+     * @param endCol Last block column index (exclusive) in the range to update
+     */
+    void updateHessian(const KeyVector& keys, SymmetricBlockMatrix* info,
+                       DenseIndex beginCol, DenseIndex endCol) const override;
+
     /** Return A*x */
     Vector operator*(const VectorValues& x) const;
 

--- a/gtsam/linear/tests/testHessianFactor.cpp
+++ b/gtsam/linear/tests/testHessianFactor.cpp
@@ -590,6 +590,73 @@ TEST(HessianFactor, Solve)
   EXPECT(assert_equal(expected, factor.solve()));
 }
 
+
+/* ************************************************************************* */
+TEST(HessianFactor, updateHessianWithColumnRangeOnlyUpdatesSpecifiedBlocks) {
+  // Create a simple 2x2 HessianFactor on keys 0 and 1
+  Matrix G00 = (Matrix(2, 2) << 1, 2, 2, 3).finished();
+  Matrix G01 = (Matrix(2, 2) << 4, 5, 6, 7).finished();
+  Matrix G11 = (Matrix(2, 2) << 8, 9, 9, 10).finished();
+  Vector g0 = Vector2(1, 2);
+  Vector g1 = Vector2(3, 4);
+  double f = 5.0;
+
+  HessianFactor factor(0, 1, G00, G01, g0, G11, g1, f);
+
+  // Destination matrix: 3 blocks (key 0: size 2, key 1: size 2, RHS: size 1)
+  KeyVector infoKeys{0, 1};
+  Dims dims{2, 2, 1};
+
+  // Initialize to zero
+  SymmetricBlockMatrix info(dims);
+  info.setZero();
+
+  // Update only block column 0 (first variable)
+  factor.updateHessian(infoKeys, &info, 0, 1);
+
+  // Block 0 (diagonal for key 0) should be updated (non-zero)
+  Matrix block0 = info.diagonalBlock(0);
+  EXPECT(assert_equal(G00, block0, 0));
+
+  // Block 1 (diagonal for key 1) should still be zero
+  Matrix block1 = info.diagonalBlock(1);
+  Matrix expected_zero_2x2 = Matrix::Zero(2, 2);
+  EXPECT(assert_equal(expected_zero_2x2, block1, 0));
+
+  // Block 2 (RHS) should still be zero
+  Matrix block2 = info.diagonalBlock(2);
+  Matrix expected_zero_1x1 = Matrix::Zero(1, 1);
+  EXPECT(assert_equal(expected_zero_1x1, block2, 0));
+
+  // Off-diagonal block (0,1) should still be zero
+  // Note: aboveDiagonalBlock gets the upper triangular part
+  Matrix block01 = info.aboveDiagonalBlock(0, 1);
+  EXPECT(assert_equal(expected_zero_2x2, block01, 0));
+
+  // Now update block column 1
+  factor.updateHessian(infoKeys, &info, 1, 2);
+
+  // Block 1 should now be updated
+  EXPECT(assert_equal(G11, info.diagonalBlock(1), 0));
+
+  // Off-diagonal block (0,1) should now be updated
+  EXPECT(assert_equal(G01, info.aboveDiagonalBlock(0, 1), 0));
+
+  // Block 2 (RHS) should still be zero (not updated yet)
+  EXPECT(assert_equal(expected_zero_1x1, info.diagonalBlock(2), 0));
+
+  // Finally update the RHS column
+  factor.updateHessian(infoKeys, &info, 2, 3);
+
+  // Now verify the full matrix matches what we'd get from a full update
+  SymmetricBlockMatrix infoFull(dims);
+  infoFull.setZero();
+  factor.updateHessian(infoKeys, &infoFull);
+
+  EXPECT(assert_equal(Matrix(infoFull.selfadjointView()),
+                      Matrix(info.selfadjointView()), 0));
+}
+
 /* ************************************************************************* */
 int main() { TestResult tr; return TestRegistry::runAllTests(tr);}
 /* ************************************************************************* */

--- a/gtsam/linear/tests/testJacobianFactor.cpp
+++ b/gtsam/linear/tests/testJacobianFactor.cpp
@@ -24,6 +24,7 @@
 #include <gtsam/linear/GaussianFactorGraph.h>
 #include <gtsam/linear/GaussianConditional.h>
 #include <gtsam/linear/VectorValues.h>
+#include <gtsam/base/SymmetricBlockMatrix.h>
 
 using namespace std;
 using namespace gtsam;
@@ -791,6 +792,76 @@ TEST(JacobianFactor, OverdeterminedEliminate) {
                                           noiseModel::Unit::Create(3));
   EXPECT(assert_equal(expectedConditional, *actual.first, 1e-4));
   EXPECT(actual.second->empty());
+}
+
+/* ************************************************************************* */
+TEST(JacobianFactor, updateHessianWithColumnRangeOnlyUpdatesSpecifiedBlocks) {
+  const double tol = 0;
+
+  // Create a simple 2x2 JacobianFactor on keys 0 and 1
+  // A0 is 2x2 matrix for key 0, A1 is 2x2 matrix for key 1, b is 2x1 vector
+  Matrix A0 = (Matrix(2, 2) << 1, 2, 3, 4).finished();
+  Matrix A1 = (Matrix(2, 2) << 5, 6, 7, 8).finished();
+  Vector b = Vector2(1, 2);
+
+  JacobianFactor factor(0, A0, 1, A1, b);
+
+  // Destination matrix: 3 blocks (key 0: size 2, key 1: size 2, RHS: size 1)
+  KeyVector infoKeys{0, 1};
+  Dims dims{2, 2, 1};
+
+  // Initialize to zero
+  SymmetricBlockMatrix info(dims);
+  info.setZero();
+
+  // Update only block column 0 (first variable)
+  factor.updateHessian(infoKeys, &info, 0, 1);
+
+  // Block 0 (diagonal for key 0) should be updated (non-zero)
+  // The diagonal block should be A0'*A0
+  Matrix expected_G00 = A0.transpose() * A0;
+  Matrix block0 = info.diagonalBlock(0);
+  EXPECT(assert_equal(expected_G00, block0, tol));
+
+  // Block 1 (diagonal for key 1) should still be zero
+  Matrix block1 = info.diagonalBlock(1);
+  Matrix expected_zero_2x2 = Matrix::Zero(2, 2);
+  EXPECT(assert_equal(expected_zero_2x2, block1, tol));
+
+  // Block 2 (RHS) should still be zero
+  Matrix block2 = info.diagonalBlock(2);
+  Matrix expected_zero_1x1 = Matrix::Zero(1, 1);
+  EXPECT(assert_equal(expected_zero_1x1, block2, tol));
+
+  // Off-diagonal block (0,1) should still be zero
+  // Note: aboveDiagonalBlock gets the upper triangular part
+  Matrix block01 = info.aboveDiagonalBlock(0, 1);
+  EXPECT(assert_equal(expected_zero_2x2, block01, tol));
+
+  // Now update block column 1
+  factor.updateHessian(infoKeys, &info, 1, 2);
+
+  // Block 1 should now be updated (A1'*A1)
+  Matrix expected_G11 = A1.transpose() * A1;
+  EXPECT(assert_equal(expected_G11, info.diagonalBlock(1), tol));
+
+  // Off-diagonal block (0,1) should now be updated (A0'*A1)
+  Matrix expected_G01 = A0.transpose() * A1;
+  EXPECT(assert_equal(expected_G01, info.aboveDiagonalBlock(0, 1), tol));
+
+  // Block 2 (RHS) should still be zero (not updated yet)
+  EXPECT(assert_equal(expected_zero_1x1, info.diagonalBlock(2), tol));
+
+  // Finally update the RHS column
+  factor.updateHessian(infoKeys, &info, 2, 3);
+
+  // Now verify the full matrix matches what we'd get from a full update
+  SymmetricBlockMatrix infoFull(dims);
+  infoFull.setZero();
+  factor.updateHessian(infoKeys, &infoFull);
+
+  EXPECT(assert_equal(Matrix(infoFull.selfadjointView()),
+                      Matrix(info.selfadjointView()), tol));
 }
 
 /* ************************************************************************* */

--- a/gtsam/slam/RegularImplicitSchurFactor.h
+++ b/gtsam/slam/RegularImplicitSchurFactor.h
@@ -138,16 +138,24 @@ public:
   void updateHessian(const KeyVector& keys,
                          SymmetricBlockMatrix* info) const override {
     throw std::runtime_error(
-        "RegularImplicitSchurFactor::updateHessian non implemented");
+        "RegularImplicitSchurFactor::updateHessian not implemented");
   }
+
+  void updateHessian(const KeyVector& keys,
+                         SymmetricBlockMatrix* info,
+                         DenseIndex beginCol, DenseIndex endCol) const override {
+    throw std::runtime_error(
+        "RegularImplicitSchurFactor::updateHessian not implemented");
+  }
+
   Matrix augmentedJacobian() const override {
     throw std::runtime_error(
-        "RegularImplicitSchurFactor::augmentedJacobian non implemented");
+        "RegularImplicitSchurFactor::augmentedJacobian not implemented");
     return Matrix();
   }
   std::pair<Matrix, Vector> jacobian() const override {
     throw std::runtime_error(
-        "RegularImplicitSchurFactor::jacobian non implemented");
+        "RegularImplicitSchurFactor::jacobian not implemented");
     return {Matrix(), Vector()};
   }
 
@@ -257,14 +265,14 @@ public:
     return std::make_shared<RegularImplicitSchurFactor<CAMERA> >(keys_,
         FBlocks_, PointCovariance_, E_, b_);
     throw std::runtime_error(
-        "RegularImplicitSchurFactor::clone non implemented");
+        "RegularImplicitSchurFactor::clone not implemented");
   }
 
   GaussianFactor::shared_ptr negate() const override {
     return std::make_shared<RegularImplicitSchurFactor<CAMERA> >(keys_,
         FBlocks_, PointCovariance_, E_, b_);
     throw std::runtime_error(
-        "RegularImplicitSchurFactor::negate non implemented");
+        "RegularImplicitSchurFactor::negate not implemented");
   }
 
   // Raw Vector version of y += F'*alpha*(I - E*P*E')*F*x, for testing


### PR DESCRIPTION
This MR introduces TBB parallelization for HessianFactor operations and adds a compile-time option to control TBB memory growth.

## Changes

### 1. TBB Parallelization for HessianFactor
- Parallelizes `updateHessian` operation when forming A'*A in the HessianFactor merge constructor
- For large matrices (>50 rows), work is split across columns using TBB `parallel_for`, with each thread updating a disjoint set of block columns
- **Performance improvement**: Reduced `updateHessian` time from ~72s to ~41s in tested scenarios (with 10 threads)


### 2. Compile-time Option to Limit TBB Memory Growth
- Introduces `GTSAM_TBB_BOUNDED_MEMORY_GROWTH` CMake option (OFF by default)
- Disables parallel tree traversal when memory usage is a concern
- Addresses significant memory growth observed in some scenarios (e.g., ~4GB to ~12GB)

