### PR TITLE
Add vcpkg mkl

### DIFF
--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -25,12 +25,14 @@ jobs:
             test_target: RUN_TESTS
             binary_cache: C:\Users\runneradmin\AppData\Local\vcpkg\archives
             python: python
+            additional_vcpkg_ports: intel-mkl
           - os: ubuntu-latest
             triplet: x64-linux-release
             build_type: Release
             test_target: test
             binary_cache: /home/runner/.cache/vcpkg/archives
             python: python3
+            additional_vcpkg_ports: intel-mkl
           - os: macos-latest
             triplet: arm64-osx-release
             build_type: Release
@@ -112,6 +114,7 @@ jobs:
           pybind11
           geographiclib
           eigen3
+          ${{ matrix.additional_vcpkg_ports }}
 
       - name: On Failure, upload vcpkg logs
         if: failure()
@@ -178,6 +181,8 @@ jobs:
               -DGTSAM_USE_SYSTEM_PYBIND=ON \
               -DGTSAM_ENABLE_GEOGRAPHICLIB=ON \
               -DGTSAM_SUPPORT_NESTED_DISSECTION=ON \
+              -DGTSAM_WITH_EIGEN_MKL=ON \
+              -DGTSAM_WITH_EIGEN_MKL_OPENMP=ON \
               -DCTEST_EXTRA_ARGS='${{ matrix.ctest_extra_flags }}' \
               -DPYTEST_EXTRA_ARGS='${{ matrix.pytest_extra_flags }}'
 

--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -21,6 +21,18 @@
 # OPEN - Open MPI library
 # SGI - SGI MPT Library
 
+# vcpkg
+if(DEFINED VCPKG_INSTALLED_DIR)
+    find_package(MKL CONFIG)
+    if(MKL_FOUND)
+        add_library(mkl-gtsam-if INTERFACE)
+        target_link_libraries(mkl-gtsam-if INTERFACE MKL::MKL)
+        set(MKL_LIBRARIES mkl-gtsam-if)
+        list(APPEND GTSAM_EXPORTED_TARGETS mkl-gtsam-if)
+        install(TARGETS mkl-gtsam-if EXPORT GTSAM-exports ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    endif()
+else()
+
 # linux
 IF(UNIX AND NOT APPLE)
     IF(${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "x86_64")
@@ -266,5 +278,7 @@ find_package_handle_standard_args(MKL DEFAULT_MSG MKL_INCLUDE_DIR MKL_LIBRARIES)
 #if(MKL_FOUND)
 #        LINK_DIRECTORIES(${MKL_ROOT_DIR}/lib/${MKL_ARCH_DIR}) # hack
 #endif()
+
+endif() # end of vcpkg
 
 MARK_AS_ADVANCED(MKL_INCLUDE_DIR MKL_LIBRARIES)

--- a/cmake/HandleMKL.cmake
+++ b/cmake/HandleMKL.cmake
@@ -15,3 +15,28 @@ else()
     set(GTSAM_USE_EIGEN_MKL 0)
     set(EIGEN_USE_MKL_ALL 0)
 endif()
+
+if(WIN32 AND GTSAM_USE_EIGEN_MKL AND DEFINED VCPKG_INSTALLED_DIR)
+    get_target_property(MKL_TARGETS "MKL::MKL" INTERFACE_LINK_LIBRARIES)
+    set(RUNTIME_DLL_DIRS "")
+    foreach(MKL_TARGET ${MKL_TARGETS})
+        if(TARGET ${MKL_TARGET})
+            get_target_property(MKL_DLL "${MKL_TARGET}" IMPORTED_LOCATION)
+            if(MKL_DLL)
+                cmake_path(GET MKL_DLL PARENT_PATH MKL_DLL_DIR)
+                list (APPEND RUNTIME_DLL_DIRS "${MKL_DLL_DIR}/mkl_*.dll")
+            endif()
+        endif()
+    endforeach()
+    list(REMOVE_DUPLICATES RUNTIME_DLL_DIRS)
+    file(GLOB MKL_DLLS CONFIGURE_DEPENDS ${RUNTIME_DLL_DIRS})
+    list(REMOVE_DUPLICATES MKL_DLLS)
+    add_custom_target(copy_mkl_dlls
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${MKL_DLLS}"
+        "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}"
+        COMMAND_EXPAND_LISTS
+        VERBATIM
+    )
+    add_dependencies(check copy_mkl_dlls)
+endif()

--- a/gtsam/linear/HessianFactor.cpp
+++ b/gtsam/linear/HessianFactor.cpp
@@ -339,8 +339,8 @@ double HessianFactor::error(const VectorValues& c) const {
   // NOTE may not be as efficient
   const Vector x = c.vector(keys());
   const double xtg = x.dot(linearTerm().col(0));
-  auto AtA = informationView();
-  const double xGx = x.transpose() * AtA * x;
+  const auto AtA = informationView();
+  const double xGx = x.dot(AtA * x);
   return 0.5 * (f - 2.0 * xtg + xGx);
 }
 

--- a/gtsam/linear/tests/testHessianFactor.cpp
+++ b/gtsam/linear/tests/testHessianFactor.cpp
@@ -108,7 +108,8 @@ TEST(HessianFactor, Constructor1)
   // error 0.5*(f - 2*x'*g + x'*G*x)
   double expected = 80.375;
   double actual = factor.error(dx);
-  double expected_manual = 0.5 * (f - 2.0 * dx[0].dot(g) + dx[0].transpose() * G.selfadjointView<Eigen::Upper>() * dx[0]);
+  const double xGx = dx[0].dot(G * dx[0]);
+  double expected_manual = 0.5 * (f - 2.0 * dx[0].dot(g) + xGx);
   EXPECT_DOUBLES_EQUAL(expected, expected_manual, 1e-10);
   EXPECT_DOUBLES_EQUAL(expected, actual, 1e-10);
 }

--- a/gtsam/nonlinear/tests/testLinearContainerFactor.cpp
+++ b/gtsam/nonlinear/tests/testLinearContainerFactor.cpp
@@ -219,7 +219,8 @@ TEST(TestLinearContainerFactor, hessian_factor_withlinpoints) {
   // Check linearization with corrections for updated linearization point
   Vector g1_prime = g_prime.head(3);
   Vector g2_prime = g_prime.tail(2);
-  double f_prime = f + dv.transpose() * G.selfadjointView<Eigen::Upper>() * dv - 2.0 * dv.transpose() * g;
+  const auto Gsym = G.selfadjointView<Eigen::Upper>();
+  double f_prime = f + dv.dot(Gsym * dv) - 2.0 * dv.dot(g);
   HessianFactor expNewFactor(x1, l1, G11, G12, g1_prime, G22, g2_prime, f_prime);
   EXPECT(assert_equal(*expNewFactor.clone(), *actFactor.linearize(noisyValues), tol));
 }

--- a/gtsam_unstable/nonlinear/LinearizedFactor.cpp
+++ b/gtsam_unstable/nonlinear/LinearizedFactor.cpp
@@ -194,7 +194,7 @@ double LinearizedHessianFactor::error(const Values& c) const {
   // error 0.5*(f - 2*x'*g + x'*G*x)
   double f = constantTerm();
   double xtg = dx.dot(linearTerm());
-  double xGx = dx.transpose() * squaredTerm() * dx;
+  double xGx = dx.dot(squaredTerm() * dx);
 
   return 0.5 * (f - 2.0 * xtg +  xGx);
 }
@@ -216,7 +216,7 @@ LinearizedHessianFactor::linearize(const Values& c) const {
 
   // f2 = f1 - 2*dx'*g1 + dx'*G1*dx
   //newInfo(this->size(), this->size())(0,0) += -2*dx.dot(linearTerm()) + dx.transpose() * squaredTerm().selfadjointView<Eigen::Upper>() * dx;
-  double f = constantTerm() - 2*dx.dot(linearTerm()) + dx.transpose() * squaredTerm() * dx;
+  double f = constantTerm() - 2*dx.dot(linearTerm()) + dx.dot(squaredTerm() * dx);
 
   // g2 = g1 - G1*dx
   //newInfo.rangeColumn(0, this->size(), this->size(), 0) -= squaredTerm().selfadjointView<Eigen::Upper>() * dx;

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -149,6 +149,15 @@ if(WIN32)
         COMMAND_EXPAND_LISTS
         VERBATIM
     )
+    if(GTSAM_USE_EIGEN_MKL AND DEFINED VCPKG_INSTALLED_DIR)
+        ADD_CUSTOM_COMMAND(TARGET ${GTSAM_PYTHON_TARGET} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${MKL_DLLS}"
+            "${GTSAM_PYTHON_BUILD_DIRECTORY}/gtsam/"
+            COMMAND_EXPAND_LISTS
+            VERBATIM
+        )
+    endif()
 endif()
 
 # Set the path for the GTSAM python module
@@ -263,6 +272,15 @@ if(GTSAM_UNSTABLE_BUILD_PYTHON)
             COMMAND_EXPAND_LISTS
             VERBATIM
         )
+        if(GTSAM_USE_EIGEN_MKL AND DEFINED VCPKG_INSTALLED_DIR)
+            ADD_CUSTOM_COMMAND(TARGET ${GTSAM_PYTHON_UNSTABLE_TARGET} POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "${MKL_DLLS}"
+                "${GTSAM_PYTHON_BUILD_DIRECTORY}/gtsam_unstable/"
+                COMMAND_EXPAND_LISTS
+                VERBATIM
+            )
+        endif()
     endif()
 
     add_custom_target(


### PR DESCRIPTION
Add vcpkg mkl. For windows and linux. intel stop support mkl for osx.
I change tests and other files because it had compilation errors on mkl with eigen3 v5.x, Similar errors we had with eigen3 v5.x PR. 
I let the AI fix these errors. Please review these correction and verify that they are correct.