### PR TITLE
deltaError replaces 2 error calls

### DIFF
--- a/gtsam/linear/GaussianFactor.cpp
+++ b/gtsam/linear/GaussianFactor.cpp
@@ -28,6 +28,20 @@ double GaussianFactor::error(const VectorValues& c) const {
   throw std::runtime_error("GaussianFactor::error is not implemented");
 }
 
+double GaussianFactor::deltaError(const VectorValues& c, double* oldError,
+                                  double* newError) const {
+  const VectorValues zero = VectorValues::Zero(c);
+  const double oldValue = error(zero);
+  const double newValue = error(c);
+  if (oldError) {
+    *oldError = oldValue;
+  }
+  if (newError) {
+    *newError = newValue;
+  }
+  return oldValue - newValue;
+}
+
 double GaussianFactor::error(const HybridValues& c) const {
   return this->error(c.continuous());
 }

--- a/gtsam/linear/GaussianFactor.h
+++ b/gtsam/linear/GaussianFactor.h
@@ -79,6 +79,13 @@ namespace gtsam {
     virtual double error(const VectorValues& c) const;
 
     /**
+     * Compute the change in error from zero to c. Optionally return the old
+     * and new errors for reuse by callers.
+     */
+    virtual double deltaError(const VectorValues& c, double* oldError = nullptr,
+                              double* newError = nullptr) const;
+
+    /**
      * The Factor::error simply extracts the \class VectorValues from the
      * \class HybridValues and calculates the error.
      */

--- a/gtsam/linear/GaussianFactorGraph.cpp
+++ b/gtsam/linear/GaussianFactorGraph.cpp
@@ -78,6 +78,35 @@ namespace gtsam {
   }
 
   /* ************************************************************************* */
+  double GaussianFactorGraph::deltaError(const VectorValues& x, double* oldError,
+                                         double* newError) const {
+    double oldTotal = 0.0;
+    double newTotal = 0.0;
+    double deltaTotal = 0.0;
+    for (const sharedFactor& factor : *this) {
+      if (!factor) {
+        continue;
+      }
+      if (oldError || newError) {
+        double factorOld = 0.0;
+        double factorNew = 0.0;
+        deltaTotal += factor->deltaError(x, &factorOld, &factorNew);
+        oldTotal += factorOld;
+        newTotal += factorNew;
+      } else {
+        deltaTotal += factor->deltaError(x, nullptr, nullptr);
+      }
+    }
+    if (oldError) {
+      *oldError = oldTotal;
+    }
+    if (newError) {
+      *newError = newTotal;
+    }
+    return deltaTotal;
+  }
+
+  /* ************************************************************************* */
   double GaussianFactorGraph::probPrime(const VectorValues& c) const {
     // NOTE the 0.5 constant is handled by the factor error.
     return exp(-error(c));

--- a/gtsam/linear/GaussianFactorGraph.h
+++ b/gtsam/linear/GaussianFactorGraph.h
@@ -167,6 +167,13 @@ namespace gtsam {
     /** unnormalized error */
     double error(const VectorValues& x) const;
 
+    /**
+     * Compute the change in error from zero to x, using a single pass
+     * over the factors. Optionally returns the old and new errors.
+     */
+    double deltaError(const VectorValues& x, double* oldError = nullptr,
+                      double* newError = nullptr) const;
+
     /** Unnormalized probability. O(n) */
     double probPrime(const VectorValues& c) const;
 

--- a/gtsam/linear/HessianFactor.cpp
+++ b/gtsam/linear/HessianFactor.cpp
@@ -335,14 +335,24 @@ double HessianFactor::error(const VectorValues& c) const {
   if (empty()) {
     return 0.5 * f;
   }
-  double xtg = 0, xGx = 0;
   // extract the relevant subset of the VectorValues
   // NOTE may not be as efficient
   const Vector x = c.vector(keys());
-  xtg = x.dot(linearTerm().col(0));
+  const double xtg = x.dot(linearTerm().col(0));
   auto AtA = informationView();
-  xGx = x.transpose() * AtA * x;
+  const double xGx = x.transpose() * AtA * x;
   return 0.5 * (f - 2.0 * xtg + xGx);
+}
+
+/* ************************************************************************* */
+double HessianFactor::deltaError(const VectorValues& c, double* oldError,
+                                 double* newError) const {
+  const double f = constantTerm();
+  const double oldValue = 0.5 * f;
+  double newValue = error(c);
+  if (oldError) *oldError = oldValue;
+  if (newError) *newError = newValue;
+  return oldValue - newValue;
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/HessianFactor.h
+++ b/gtsam/linear/HessianFactor.h
@@ -203,6 +203,13 @@ namespace gtsam {
      */
     double error(const VectorValues& c) const override;
 
+    /**
+     * Compute the change in error from zero to c, optionally returning
+     * the old and new errors.
+     */
+    double deltaError(const VectorValues& c, double* oldError = nullptr,
+                      double* newError = nullptr) const override;
+
     /** Return the dimension of the variable pointed to by the given key iterator
      * todo: Remove this in favor of keeping track of dimensions with variables?
      * @param variable An iterator pointing to the slot in this factor.  You can

--- a/gtsam/linear/JacobianFactor.cpp
+++ b/gtsam/linear/JacobianFactor.cpp
@@ -557,6 +557,20 @@ double JacobianFactor::error(const VectorValues& c) const {
 }
 
 /* ************************************************************************* */
+double JacobianFactor::deltaError(const VectorValues& c, double* oldError,
+                                  double* newError) const {
+  const Vector e = unweighted_error(c);
+  const Vector b = getb();
+  double oldValue =
+      model_ ? 0.5 * model_->squaredMahalanobisDistance(b) : 0.5 * b.dot(b);
+  double newValue =
+      model_ ? 0.5 * model_->squaredMahalanobisDistance(e) : 0.5 * e.dot(e);
+  if (oldError) *oldError = oldValue;
+  if (newError) *newError = newValue;
+  return oldValue - newValue;
+}
+
+/* ************************************************************************* */
 Matrix JacobianFactor::augmentedInformation() const {
   if (model_) {
     Matrix Ab = Ab_.full();

--- a/gtsam/linear/JacobianFactor.h
+++ b/gtsam/linear/JacobianFactor.h
@@ -245,6 +245,13 @@ namespace gtsam {
     /// 0.5*(A*x-b)'*D*(A*x-b).
     double error(const VectorValues& c) const override; 
 
+    /**
+     * Compute the change in error from zero to c, optionally returning
+     * the old and new errors.
+     */
+    double deltaError(const VectorValues& c, double* oldError = nullptr,
+                      double* newError = nullptr) const override;
+
     /** Return the augmented information matrix represented by this GaussianFactor.
      * The augmented information matrix contains the information matrix with an
      * additional column holding the information vector, and an additional row

--- a/gtsam/linear/tests/testGaussianFactorGraph.cpp
+++ b/gtsam/linear/tests/testGaussianFactorGraph.cpp
@@ -322,6 +322,28 @@ static GaussianFactorGraph createGaussianFactorGraphWithHessianFactor() {
 }
 
 /* ************************************************************************* */
+TEST(GaussianFactorGraph, deltaError) {
+  GaussianFactorGraph gfg = createGaussianFactorGraphWithHessianFactor();
+
+  VectorValues values{{0, Vector2(0.1, -0.2)},
+                      {1, Vector2(1.0, 0.5)},
+                      {2, Vector2(-0.3, 0.8)}};
+  VectorValues zero = VectorValues::Zero(values);
+
+  double expectedOld = gfg.error(zero);
+  double expectedNew = gfg.error(values);
+  double expectedDelta = expectedOld - expectedNew;
+
+  double oldValue = 0.0;
+  double newValue = 0.0;
+  double delta = gfg.deltaError(values, &oldValue, &newValue);
+
+  DOUBLES_EQUAL(expectedOld, oldValue, 1e-10);
+  DOUBLES_EQUAL(expectedNew, newValue, 1e-10);
+  DOUBLES_EQUAL(expectedDelta, delta, 1e-10);
+}
+
+/* ************************************************************************* */
 TEST(GaussianFactorGraph, multiplyHessianAdd2) {
   GaussianFactorGraph gfg = createGaussianFactorGraphWithHessianFactor();
 

--- a/gtsam/linear/tests/testHessianFactor.cpp
+++ b/gtsam/linear/tests/testHessianFactor.cpp
@@ -114,6 +114,30 @@ TEST(HessianFactor, Constructor1)
 }
 
 /* ************************************************************************* */
+TEST(HessianFactor, deltaError)
+{
+  Matrix G = (Matrix(2,2) << 3.0, 5.0, 5.0, 6.0).finished();
+  Vector g = Vector2(-8.0, -9.0);
+  double f = 10.0;
+  HessianFactor factor(0, G, g, f);
+
+  VectorValues values{{0, Vector2(1.5, 2.5)}};
+  VectorValues zero = VectorValues::Zero(values);
+
+  double expectedOld = factor.error(zero);
+  double expectedNew = factor.error(values);
+  double expectedDelta = expectedOld - expectedNew;
+
+  double oldValue = 0.0;
+  double newValue = 0.0;
+  double delta = factor.deltaError(values, &oldValue, &newValue);
+
+  DOUBLES_EQUAL(expectedOld, oldValue, 1e-10);
+  DOUBLES_EQUAL(expectedNew, newValue, 1e-10);
+  DOUBLES_EQUAL(expectedDelta, delta, 1e-10);
+}
+
+/* ************************************************************************* */
 TEST(HessianFactor, Constructor1b)
 {
   Vector mu = Vector2(1.0,2.0);

--- a/gtsam/linear/tests/testJacobianFactor.cpp
+++ b/gtsam/linear/tests/testJacobianFactor.cpp
@@ -256,6 +256,30 @@ TEST(JacobianFactor, error)
 }
 
 /* ************************************************************************* */
+TEST(JacobianFactor, deltaError)
+{
+  JacobianFactor factor(simple::terms, simple::b, simple::noise);
+
+  VectorValues values;
+  values.insert(5, Vector::Constant(3, 1.0));
+  values.insert(10, Vector::Constant(3, 0.5));
+  values.insert(15, Vector::Constant(3, 1.0/3.0));
+
+  VectorValues zero = VectorValues::Zero(values);
+  double expectedOld = factor.error(zero);
+  double expectedNew = factor.error(values);
+  double expectedDelta = expectedOld - expectedNew;
+
+  double oldValue = 0.0;
+  double newValue = 0.0;
+  double delta = factor.deltaError(values, &oldValue, &newValue);
+
+  DOUBLES_EQUAL(expectedOld, oldValue, 1e-10);
+  DOUBLES_EQUAL(expectedNew, newValue, 1e-10);
+  DOUBLES_EQUAL(expectedDelta, delta, 1e-10);
+}
+
+/* ************************************************************************* */
 TEST(JacobianFactor, matrices_NULL)
 {
   // Make sure everything works with nullptr noise model

--- a/gtsam/nonlinear/LevenbergMarquardtOptimizer.cpp
+++ b/gtsam/nonlinear/LevenbergMarquardtOptimizer.cpp
@@ -166,13 +166,14 @@ bool LevenbergMarquardtOptimizer::tryLambda(const GaussianFactorGraph& linear,
 
     // Compute the old linearized error as it is not the same
     // as the nonlinear error when robust noise models are used.
-    double oldLinearizedError = linear.error(VectorValues::Zero(delta));
-    double newlinearizedError = linear.error(delta);
+    double oldLinearizedError = 0.0;
+    double newLinearizedError = 0.0;
+    double linearizedCostChange =
+        linear.deltaError(delta, &oldLinearizedError, &newLinearizedError);
 
     // cost change in the linearized system (old - new)
-    double linearizedCostChange = oldLinearizedError - newlinearizedError;
     if (verbose)
-      cout << "newlinearizedError = " << newlinearizedError
+      cout << "newLinearizedError = " << newLinearizedError
            << "  linearizedCostChange = " << linearizedCostChange << endl;
 
     if (linearizedCostChange >= 0) {  // step is valid


### PR DESCRIPTION
In the nonlinear optimizer, we're calling the quite expensive `error` function twice. And essentially, we're doing double the work needed. The new `deltaError` method avoids this, and does the most optimal thing in the factors themselves. This reduces the number of work in each iteration. At least a couple of percent gain total.

The bigger gain is for the new solver - in a PR to come, which will basically do this for free. 