### PR TITLE
Nonlinear multifrontal solver

### DIFF
--- a/gtsam/base/tests/testSymmetricBlockMatrix.cpp
+++ b/gtsam/base/tests/testSymmetricBlockMatrix.cpp
@@ -156,6 +156,32 @@ TEST(SymmetricBlockMatrix, expressions)
 }
 
 /* ************************************************************************* */
+// Verify diagonal-only update helpers.
+TEST(SymmetricBlockMatrix, AddDiagonal) {
+  const std::vector<size_t> dimensions{2, 1};
+  SymmetricBlockMatrix bm(dimensions);
+  bm.setZero();
+
+  bm.addScaledIdentity(0, 2.0);
+  bm.addScaledIdentity(1, 3.0);
+
+  Vector delta0(2);
+  delta0 << 1.0, 4.0;
+  bm.addToDiagonalBlock(0, delta0);
+
+  Vector delta1(1);
+  delta1 << -1.0;
+  bm.addToDiagonalBlock(1, delta1);
+
+  Matrix expected = Matrix::Zero(3, 3);
+  expected(0, 0) = 3.0;
+  expected(1, 1) = 6.0;
+  expected(2, 2) = 2.0;
+
+  EXPECT(assert_equal(expected, Matrix(bm.selfadjointView())));
+}
+
+/* ************************************************************************* */
 // Update via block mapping.
 TEST(SymmetricBlockMatrix, UpdateFromMappedBlocks)
 {

--- a/gtsam/constrained/AugmentedLagrangianOptimizer.cpp
+++ b/gtsam/constrained/AugmentedLagrangianOptimizer.cpp
@@ -29,7 +29,7 @@ namespace gtsam {
  * This factor is used in augmented Lagrangian optimizer to create biased cost
  * functions.
  * Note that the noise model is stored twice (both in original factor and the
- * noisemodel of substitute factor. The noisemodel in the original factor will
+ * noise model of substitute factor. The noise model in the original factor will
  * be ignored. */
 class GTSAM_EXPORT BiasedFactor : public NoiseModelFactor {
  protected:
@@ -117,7 +117,7 @@ AugmentedLagrangianOptimizer::iterate(const State& state, const double muEq,
   auto optimizer =
       createUnconstrainedOptimizer(augmentedLagrangian, state.values);
   newState.setValues(optimizer->optimize(), problem_);
-  newState.unconstrainedIterationss = optimizer->iterations();
+  newState.unconstrainedIterations = optimizer->iterations();
 
   // Update penalty parameters for next iteration.
   double next_muEq, next_muIneq;
@@ -186,7 +186,7 @@ NonlinearFactorGraph AugmentedLagrangianOptimizer::augmentedLagrangianFunction(
 /* ************************************************************************* */
 void AugmentedLagrangianOptimizer::updateLagrangeMultiplier(
     const State& previousState, State* state) const {
-  // Perform dual ascent on Lagrange multipliers for e-constriants.
+  // Perform dual ascent on Lagrange multipliers for e-constraints.
   const NonlinearEqualityConstraints& eqConstraints = problem_.eConstraints();
   state->lambdaEq.resize(eqConstraints.size());
   for (size_t i = 0; i < eqConstraints.size(); i++) {
@@ -198,7 +198,7 @@ void AugmentedLagrangianOptimizer::updateLagrangeMultiplier(
     state->lambdaEq[i] = previousState.lambdaEq[i] + step_size * violation;
   }
 
-  // Perform dual ascent on Lagrange multipliers for i-constriants.
+  // Perform dual ascent on Lagrange multipliers for i-constraints.
   const NonlinearInequalityConstraints& ineqConstraints =
       problem_.iConstraints();
   state->lambdaIneq.resize(ineqConstraints.size());
@@ -239,7 +239,7 @@ AugmentedLagrangianOptimizer::createUnconstrainedOptimizer(
     const NonlinearFactorGraph& graph, const Values& values) const {
   // TODO(yetong): make compatible with all NonlinearOptimizers.
   return std::make_shared<LevenbergMarquardtOptimizer>(graph, values,
-                                                       p_->lm_params);
+                                                       p_->lmParams);
 }
 
 /* ************************************************************************* */
@@ -283,7 +283,7 @@ void AugmentedLagrangianOptimizer::logIteration(const State& state) const {
     cout << "|" << setw(10) << setprecision(4) << state.cost;
     cout << "|" << setw(10) << setprecision(4) << state.eqConstraintViolation;
     cout << "|" << setw(10) << setprecision(4) << state.ineqConstraintViolation;
-    cout << "|" << setw(10) << state.unconstrainedIterationss;
+    cout << "|" << setw(10) << state.unconstrainedIterations;
     cout << "|" << setw(10) << state.time;
     cout << "|" << endl;
   }

--- a/gtsam/constrained/NonlinearEqualityConstraint.h
+++ b/gtsam/constrained/NonlinearEqualityConstraint.h
@@ -38,6 +38,9 @@ class GTSAM_EXPORT NonlinearEqualityConstraint : public NonlinearConstraint {
   /** Destructor. */
   virtual ~NonlinearEqualityConstraint() {}
 
+  /// Whether this constraint should be treated as a hard constraint.
+  virtual bool isHardConstraint() const { return true; }
+
  private:
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */

--- a/gtsam/constrained/PenaltyOptimizer.cpp
+++ b/gtsam/constrained/PenaltyOptimizer.cpp
@@ -41,7 +41,7 @@ PenaltyOptimizer::State PenaltyOptimizer::iterate(const State& state) const {
   // Run unconstrained optimization.
   auto optimizer = createUnconstrainedOptimizer(meritGraph, state.values);
   newState.setValues(optimizer->optimize(), problem_);
-  newState.unconstrainedIterationss = optimizer->iterations();
+  newState.unconstrainedIterations = optimizer->iterations();
 
   return newState;
 }
@@ -78,7 +78,7 @@ PenaltyOptimizer::createUnconstrainedOptimizer(
     const NonlinearFactorGraph& graph, const Values& values) const {
   // TODO(yetong): make compatible with all NonlinearOptimizers.
   return std::make_shared<LevenbergMarquardtOptimizer>(graph, values,
-                                                       p_->lm_params);
+                                                       p_->lmParams);
 }
 
 /* ************************************************************************* */
@@ -122,7 +122,7 @@ void PenaltyOptimizer::logIteration(const State& state) const {
     cout << "|" << setw(10) << setprecision(4) << state.cost;
     cout << "|" << setw(10) << setprecision(4) << state.eqConstraintViolation;
     cout << "|" << setw(10) << setprecision(4) << state.ineqConstraintViolation;
-    cout << "|" << setw(10) << state.unconstrainedIterationss;
+    cout << "|" << setw(10) << state.unconstrainedIterations;
     cout << "|" << setw(10) << state.time;
     cout << "|" << endl;
   }

--- a/gtsam/constrained/PenaltyOptimizer.h
+++ b/gtsam/constrained/PenaltyOptimizer.h
@@ -35,10 +35,13 @@ class GTSAM_EXPORT PenaltyOptimizerParams : public ConstrainedOptimizerParams {
   double muEqIncreaseRate = 2;  // increase rate of penalty parameter
   double muIneqIncreaseRate = 2;
   InequalityPenaltyFunction::shared_ptr ineqConstraintPenaltyFunction = nullptr;
-  LevenbergMarquardtParams lm_params;
+  LevenbergMarquardtParams lmParams;
 
   /** Constructor. */
-  PenaltyOptimizerParams() : Base() {}
+  PenaltyOptimizerParams() : Base() {
+    lmParams.linearSolverType =
+        LevenbergMarquardtParams::MULTIFRONTAL_CHOLESKY;
+  }
 };
 
 /// Details for each iteration.
@@ -50,7 +53,7 @@ class GTSAM_EXPORT PenaltyOptimizerState : public ConstrainedOptimizerState {
 
   double muEq = 0.0;
   double muIneq = 0.0;
-  size_t unconstrainedIterationss = 0;
+  size_t unconstrainedIterations = 0;
 
   using Base::Base;
 };

--- a/gtsam/constrained/tests/testAugmentedLagrangianOptimizer.cpp
+++ b/gtsam/constrained/tests/testAugmentedLagrangianOptimizer.cpp
@@ -10,8 +10,8 @@
  * -------------------------------------------------------------------------- */
 
 /**
- * @file  testAugmentedLagrangianOptimizr.cpp
- * @brief Test augmented Lagrangian method optimzier for equality constrained
+ * @file  testAugmentedLagrangianOptimizer.cpp
+ * @brief Test augmented Lagrangian method optimizer for equality constrained
  * optimization.
  * @author: Yetong Zhang
  */

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -30,8 +30,8 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <iostream>
-#include <stdexcept>
 #include <thread>
 
 namespace gtsam {
@@ -92,7 +92,7 @@ size_t hardwareThreads() {
   return kHardwareThreads;
 }
 
-SymmetricBlockMatrix makeZeroLocalSbm(const std::vector<size_t>& blockDims) {
+SymmetricBlockMatrix makeZeroLocalInfo(const std::vector<size_t>& blockDims) {
   SymmetricBlockMatrix local(blockDims, true);
   local.setZero();
   return local;
@@ -131,12 +131,13 @@ MultifrontalClique::MultifrontalClique(
   // Cache pointers into the solution for fast back-substitution.
   cacheSolutionPointers(solution, frontals, separatorKeys);
 
-  // Pre-allocate matrices once per structure.
+  // Cache sizing for allocation at finalize time.
   blockDims_ = this->blockDims(dims, frontals, separatorKeys);
-  initializeMatrices(blockDims_, vbmRows);
+  factorRows_ = vbmRows;
 }
 
-void MultifrontalClique::finalize(std::vector<ChildInfo> children) {
+void MultifrontalClique::finalize(std::vector<ChildInfo> children,
+                                  const MultifrontalParameters& params) {
   this->children.clear();
   this->children.reserve(children.size());
   for (const auto& child : children) {
@@ -151,12 +152,39 @@ void MultifrontalClique::finalize(std::vector<ChildInfo> children) {
     for (Key key : child.separatorKeys) {
       indices.push_back(blockIndex(key));
     }
-    // The RHS block is always the last block in Ab/SBM.
+    // The RHS block is always the last block in Ab/info.
     indices.push_back(static_cast<DenseIndex>(orderedKeys_.size()));
     child.clique->setParentIndices(indices);
   }
 
-  // Allocation is deferred until load.
+  // In leaf cliques, check whether to use QR elimination.
+  const bool isLeaf = this->children.empty();
+  const bool hasRows =
+      frontalDim > 0 && factorRows_ >= static_cast<size_t>(frontalDim);
+  bool useQR = false;
+  if (params.qrMode == MultifrontalParameters::QRMode::Allow) {
+    useQR = isLeaf && hasRows &&
+            (frontalDim + separatorDim > params.qrAspectRatio * frontalDim);
+  } else if (params.qrMode == MultifrontalParameters::QRMode::Force) {
+    useQR = isLeaf && hasRows;
+  }
+  solveMode_ = useQR ? SolveMode::QrLeaf : SolveMode::Cholesky;
+  RSdReady_ = false;
+
+  // If using QR, also a reserve room for optional damping rows.
+  const DenseIndex baseRows = static_cast<DenseIndex>(factorRows_);
+  const DenseIndex totalRows =
+      baseRows + (useQR ? static_cast<DenseIndex>(frontalDim) : 0);
+  Ab_ = VerticalBlockMatrix(blockDims_, totalRows, true);
+  // Ab's structure is fixed; clear it once and reuse across loads.
+  Ab_.matrix().setZero();
+  if (useQR) {
+    RSd_ = VerticalBlockMatrix(blockDims_, totalRows, true);
+  } else {
+    RSd_ = VerticalBlockMatrix(blockDims_, static_cast<DenseIndex>(frontalDim),
+                               true);
+    info_ = SymmetricBlockMatrix(blockDims_, true);
+  }
 }
 
 DenseIndex MultifrontalClique::blockIndex(Key key) const {
@@ -190,24 +218,10 @@ std::vector<size_t> MultifrontalClique::blockDims(
   return blockDims;
 }
 
-void MultifrontalClique::initializeMatrices(
-    const std::vector<size_t>& blockDims, size_t verticalBlockMatrixRows) {
-  Ab_ = VerticalBlockMatrix(blockDims, verticalBlockMatrixRows, true);
-  // Ab's structure is fixed; clear it once and reuse across loads.
-  Ab_.matrix().setZero();
-  RSd_ =
-      VerticalBlockMatrix(blockDims, static_cast<DenseIndex>(frontalDim), true);
-}
-
-void MultifrontalClique::allocateSbm() {
-  if (sbm_.nBlocks() > 0) return;
-  sbm_ = SymmetricBlockMatrix(blockDims_, true);
-}
-
 size_t MultifrontalClique::addJacobianFactor(
     const JacobianFactor& jacobianFactor, size_t rowOffset) {
   // We only overwrite the fixed sparsity pattern, so Ab must be zeroed once in
-  // initializeMatrices and then kept consistent across loads.
+  // finalize and then kept consistent across loads.
   const size_t rows = jacobianFactor.rows();
   const size_t rhsBlockIdx = Ab_.nBlocks() - 1;
   for (auto it = jacobianFactor.begin(); it != jacobianFactor.end(); ++it) {
@@ -245,32 +259,34 @@ void MultifrontalClique::fillAb(const GaussianFactorGraph& graph) {
     rowOffset += addJacobianFactor(*jacobianFactor, rowOffset);
   }
 
-  // Lock in QR only for leaf cliques.
-  const bool isLeaf = children.empty();
-  const bool useQR =
-      isLeaf && (frontalDim > 0) &&
-      (frontalDim + separatorDim > kQrAspectRatio * frontalDim) &&
-      (Ab_.matrix().rows() >= static_cast<DenseIndex>(frontalDim));
-  solveMode_ = useQR ? SolveMode::QrLeaf : SolveMode::Cholesky;
   RSdReady_ = false;
-  assert((useQR && RSd_.matrix().rows() ==
-                       static_cast<DenseIndex>(Ab_.matrix().rows())) ||
+  assert((useQR() && RSd_.matrix().rows() ==
+                         static_cast<DenseIndex>(Ab_.matrix().rows())) ||
          (RSd_.matrix().rows() == static_cast<DenseIndex>(frontalDim)));
-  allocateSbm();
+  assert(useQR() || info_.nBlocks() > 0);
+}
+
+void MultifrontalClique::eliminateInPlace() {
+  prepareForElimination();
+  // There is no damping here and although we do not assert it here, we are
+  // counting on the facts that no damping was *ever* applied during the
+  // existence of this clique, just like we count on the sparsity pattern of
+  // zeros to remain the same.
+  factorize();
 }
 
 void MultifrontalClique::prepareForElimination() {
-  // QR leaf cliques skip SBM assembly entirely.
+  // QR leaf cliques skip info matrix assembly entirely.
   if (useQR()) return;
-  assert(sbm_.nBlocks() > 0);
-  sbm_.setZero();
+  assert(info_.nBlocks() > 0);
+  info_.setZero();
   if (Ab_.matrix().rows() > 0) {
-    sbm_.selfadjointView().rankUpdate(Ab_.matrix().transpose());
+    info_.selfadjointView().rankUpdate(Ab_.matrix().transpose());
   }
 
   // Heuristic: avoid parallel overhead on small cliques.
   const size_t minChildren =
-      std::max<size_t>(1024, 4 * static_cast<size_t>(sbm_.rows()));
+      std::max<size_t>(1024, 4 * static_cast<size_t>(info_.rows()));
   const size_t numChildren = children.size();
   if (numChildren < minChildren) {  // Typical for chains: many small cliques.
     gatherUpdatesSequential();
@@ -292,18 +308,92 @@ void MultifrontalClique::factorize() {
     assert(RSd_.matrix().cols() == Ab_.matrix().cols());
     RSd_.matrix() = Ab_.matrix();
     inplace_QR(RSd_.matrix());
+    assert(RSd_.rowStart() == 0);
+    RSd_.rowEnd() = static_cast<DenseIndex>(frontalDim);
   } else {
-    sbm_.choleskyPartial(numFrontals());
-    sbm_.split(numFrontals(), &RSd_);
-    sbm_.blockStart() = 0;
+    info_.choleskyPartial(numFrontals());
+    info_.split(numFrontals(), &RSd_);
+    info_.blockStart() = 0;
   }
   RSdReady_ = true;
+}
+
+void MultifrontalClique::eliminateInPlace(
+    double lambda, const LMDampingParams* dampingParams,
+    const VectorValues* exactHessianDiagonal) {
+  assert(dampingParams != nullptr);
+  prepareForElimination();
+  if (useQR()) {
+    applyDampingQR(lambda, *dampingParams, exactHessianDiagonal);
+  } else {
+    applyDampingCholesky(lambda, *dampingParams, exactHessianDiagonal);
+  }
+  factorize();
+}
+
+void MultifrontalClique::applyDampingQR(
+    double lambda, const LMDampingParams& dampingParams,
+    const VectorValues* exactHessianDiagonal) {
+  if (lambda <= 0.0) return;
+  const DenseIndex baseRows = static_cast<DenseIndex>(factorRows_);
+  const DenseIndex dampRows = static_cast<DenseIndex>(frontalDim);
+  assert(Ab_.matrix().rows() >= baseRows + dampRows);
+  Ab_.matrix().middleRows(baseRows, dampRows).setZero();
+  DenseIndex rowOffset = baseRows;
+  for (size_t j = 0; j < numFrontals(); ++j) {
+    const DenseIndex blockIndex = static_cast<DenseIndex>(j);
+    const DenseIndex dim = static_cast<DenseIndex>(blockDims_.at(j));
+    auto block = Ab_(blockIndex).middleRows(rowOffset, dim);
+    if (dampingParams.diagonalDamping) {
+      Vector diag;
+      if (dampingParams.exactHessianDiagonal) {
+        assert(exactHessianDiagonal != nullptr);
+        const Key key = orderedKeys_.at(j);
+        diag = exactHessianDiagonal->at(key)
+                   .cwiseMax(dampingParams.minDiagonal)
+                   .cwiseMin(dampingParams.maxDiagonal);
+      } else {
+        diag = Ab_(blockIndex)
+                   .topRows(baseRows)
+                   .array()
+                   .square()
+                   .colwise()
+                   .sum()
+                   .transpose();
+        diag = diag.cwiseMax(dampingParams.minDiagonal)
+                   .cwiseMin(dampingParams.maxDiagonal);
+      }
+      block.diagonal() = (diag.array() * lambda).sqrt().matrix();
+    } else {
+      block.diagonal().setConstant(std::sqrt(lambda));
+    }
+    rowOffset += dim;
+  }
+}
+
+void MultifrontalClique::applyDampingCholesky(
+    double lambda, const LMDampingParams& dampingParams,
+    const VectorValues* exactHessianDiagonal) {
+  if (lambda <= 0.0) return;
+  if (dampingParams.diagonalDamping) {
+    if (dampingParams.exactHessianDiagonal) {
+      assert(exactHessianDiagonal != nullptr);
+      addExactDiagonalDamping(lambda, *exactHessianDiagonal,
+                              dampingParams.minDiagonal,
+                              dampingParams.maxDiagonal);
+    } else {
+      addDiagonalDamping(lambda, dampingParams.minDiagonal,
+                         dampingParams.maxDiagonal);
+    }
+  } else {
+    addIdentityDamping(lambda);
+  }
 }
 
 void MultifrontalClique::addIdentityDamping(double lambda) {
   const size_t nf = numFrontals();
   for (size_t j = 0; j < nf; ++j) {
-    sbm_.addScaledIdentity(j, lambda);
+    info_.addScaledIdentity(j, lambda);
   }
 }
 
@@ -312,42 +402,56 @@ void MultifrontalClique::addDiagonalDamping(double lambda, double minDiagonal,
   const size_t nf = numFrontals();
   for (size_t j = 0; j < nf; ++j) {
     const Vector scaled =
-        lambda * sbm_.diagonal(j).cwiseMax(minDiagonal).cwiseMin(maxDiagonal);
-    sbm_.addToDiagonalBlock(j, scaled);
+        lambda * info_.diagonal(j).cwiseMax(minDiagonal).cwiseMin(maxDiagonal);
+    info_.addToDiagonalBlock(j, scaled);
   }
 }
 
-void MultifrontalClique::eliminateInPlace() {
-  prepareForElimination();
-  factorize();
+void MultifrontalClique::addExactDiagonalDamping(
+    double lambda, const VectorValues& hessianDiagonal, double minDiagonal,
+    double maxDiagonal) {
+  const size_t nf = numFrontals();
+  for (size_t j = 0; j < nf; ++j) {
+    const Key key = orderedKeys_.at(j);
+    const Vector diag =
+        hessianDiagonal.at(key).cwiseMax(minDiagonal).cwiseMin(maxDiagonal);
+    info_.addToDiagonalBlock(j, lambda * diag);
+  }
 }
 
-void MultifrontalClique::updateParentSbm(
-    SymmetricBlockMatrix& parentSbm) const {
+void MultifrontalClique::updateParentInfo(
+    SymmetricBlockMatrix& parentInfo) const {
+  assert(RSd_.rowStart() == 0);
   if (useQR()) {
-    // Accumulate separator (and RHS) normal equations (S^T S) into the parent.
+    // Accumulate separator (and RHS) normal equations from the QR residual.
     assert(RSdReady_ && RSd_.firstBlock() == 0);
     const DenseIndex nfBlocks = static_cast<DenseIndex>(numFrontals());
+    const DenseIndex rowStart = RSd_.rowStart();
+    const DenseIndex rowEnd = RSd_.rowEnd();
+    RSd_.rowStart() = static_cast<DenseIndex>(frontalDim);
+    RSd_.rowEnd() = static_cast<DenseIndex>(RSd_.matrix().rows());
     RSd_.firstBlock() = nfBlocks;
-    parentSbm.updateFromOuterProductBlocks(RSd_, parentIndices_);
+    parentInfo.updateFromOuterProductBlocks(RSd_, parentIndices_);
     RSd_.firstBlock() = 0;
+    RSd_.rowStart() = rowStart;
+    RSd_.rowEnd() = rowEnd;
   } else {
-    // Accumulate the S^T S part from this clique's SBM into the parent.
-    assert(sbm_.nBlocks() > 0 && sbm_.blockStart() == 0);
-    sbm_.blockStart() = numFrontals();
-    parentSbm.updateFromMappedBlocks(sbm_, parentIndices_);
-    sbm_.blockStart() = 0;
+    // Accumulate the S^T S part from this clique's info matrix into the parent.
+    assert(info_.nBlocks() > 0 && info_.blockStart() == 0);
+    info_.blockStart() = numFrontals();
+    parentInfo.updateFromMappedBlocks(info_, parentIndices_);
+    info_.blockStart() = 0;
   }
 }
 
 void MultifrontalClique::updateParent(MultifrontalClique& parent) const {
-  updateParentSbm(parent.sbm_);
+  updateParentInfo(parent.info_);
 }
 
 void MultifrontalClique::gatherUpdatesSequential() {
   for (const auto& child : children) {
     assert(child);
-    child->updateParentSbm(sbm_);
+    child->updateParentInfo(info_);
   }
 }
 
@@ -355,28 +459,28 @@ void MultifrontalClique::gatherUpdatesParallel(size_t numThreads) {
 #ifdef GTSAM_USE_TBB
   (void)numThreads;  // TBB controls the effective worker count.
   tbb::enumerable_thread_specific<SymmetricBlockMatrix> locals([this]() {
-    return makeZeroLocalSbm(blockDims_);
+    return makeZeroLocalInfo(blockDims_);
   });  // Per-thread accumulators.
   tbb::parallel_for(
       tbb::blocked_range<size_t>(0, children.size()),
       [&](const tbb::blocked_range<size_t>& range) {
-        auto& local = locals.local();  // Thread-local SBM.
+        auto& local = locals.local();  // Thread-local info matrix.
         for (size_t i = range.begin(); i < range.end(); ++i) {
           const auto& child = children[i];
           assert(child);
-          child->updateParentSbm(
-              local);  // No locking: each thread writes its own SBM.
+          child->updateParentInfo(
+              local);  // No locking: each thread writes its own info matrix.
         }
       });
   locals.combine_each([this](const SymmetricBlockMatrix& local) {
-    sbm_.addUpperTriangular(
-        local);  // Merge per-thread partial SBMs into this clique SBM.
+    info_.addUpperTriangular(
+        local);  // Merge per-thread partial info matrices into this clique.
   });
 #else
   std::vector<SymmetricBlockMatrix> locals;
   locals.reserve(numThreads);  // Fixed-size per-thread accumulators.
   for (size_t i = 0; i < numThreads; ++i) {
-    locals.push_back(makeZeroLocalSbm(blockDims_));
+    locals.push_back(makeZeroLocalInfo(blockDims_));
   }
   std::vector<std::thread> threads;
   threads.reserve(numThreads);
@@ -391,8 +495,8 @@ void MultifrontalClique::gatherUpdatesParallel(size_t numThreads) {
       for (size_t i = start; i < end; ++i) {
         const auto& child = children[i];
         assert(child);
-        child->updateParentSbm(
-            local);  // No locking: each thread writes its own SBM.
+        child->updateParentInfo(
+            local);  // No locking: each thread writes its own info matrix.
       }
     });
   }
@@ -400,8 +504,8 @@ void MultifrontalClique::gatherUpdatesParallel(size_t numThreads) {
     thread.join();  // Ensure all locals are complete before merge.
   }
   for (const auto& local : locals) {
-    sbm_.addUpperTriangular(
-        local);  // Merge per-thread partial SBMs into this clique SBM.
+    info_.addUpperTriangular(
+        local);  // Merge per-thread partial info matrices into this clique.
   }
 #endif
 }
@@ -413,9 +517,10 @@ std::shared_ptr<GaussianConditional> MultifrontalClique::conditional() const {
                                                RSd_);
 }
 
-// Solve with block back-substitution on the Cholesky-stored SBM.
+// Solve with block back-substitution on the Cholesky-stored info matrix.
 void MultifrontalClique::updateSolution() const {
   assert(RSdReady_);
+  assert(RSd_.rowStart() == 0);
   // Use cached [R S d] for fast back-substitution.
   const size_t nf = numFrontals();
   const size_t n = RSd_.nBlocks() - 1;  // # frontals + # separators
@@ -462,19 +567,19 @@ void MultifrontalClique::print(const std::string& s,
                 keyFormatter);
   std::cout << "], factors=" << factorIndices_.size()
             << ", children=" << children.size()
-            << ", sbmBlocks=" << sbm_.nBlocks()
+            << ", infoBlocks=" << info_.nBlocks()
             << ", AbRows=" << Ab_.matrix().rows() << ")\n";
 
-  auto assembleSbm = [](const SymmetricBlockMatrix& sbm) {
-    const size_t nBlocks = sbm.nBlocks();
+  auto assembleInfo = [](const SymmetricBlockMatrix& info) {
+    const size_t nBlocks = info.nBlocks();
     std::vector<size_t> offsets(nBlocks + 1, 0);
     for (size_t i = 0; i < nBlocks; ++i) {
-      offsets[i + 1] = offsets[i] + sbm.getDim(i);
+      offsets[i + 1] = offsets[i] + info.getDim(i);
     }
     Matrix full = Matrix::Zero(offsets.back(), offsets.back());
     for (size_t i = 0; i < nBlocks; ++i) {
       for (size_t j = 0; j < nBlocks; ++j) {
-        Matrix block = sbm.block(i, j);
+        Matrix block = info.block(i, j);
         full.block(offsets[i], offsets[j], block.rows(), block.cols()) = block;
       }
     }
@@ -482,7 +587,7 @@ void MultifrontalClique::print(const std::string& s,
   };
 
   std::cout << "  Ab:\n" << Ab_.matrix() << "\n";
-  std::cout << "  SBM:\n" << assembleSbm(sbm_) << "\n";
+  std::cout << "  info:\n" << assembleInfo(info_) << "\n";
 }
 
 std::ostream& operator<<(std::ostream& os, const MultifrontalClique& clique) {
@@ -497,7 +602,7 @@ std::ostream& operator<<(std::ostream& os, const MultifrontalClique& clique) {
                 orderedKeys.size(), formatter);
   os << ", factors=" << clique.factorIndices_.size();
   os << ", children=" << clique.children.size();
-  os << ", sbmBlocks=" << clique.sbm().nBlocks();
+  os << ", infoBlocks=" << clique.info().nBlocks();
   os << ", AbRows=" << clique.Ab().matrix().rows() << ")";
   return os;
 }

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -250,11 +250,8 @@ void MultifrontalClique::fillAb(const GaussianFactorGraph& graph) {
     assert(index < graph.size());
     const GaussianFactor::shared_ptr& gf = graph[index];
     if (!gf) continue;
-    if (!gf->isJacobian()) {
-      throw std::runtime_error(
-          "MultifrontalClique::fillAb: only JacobianFactor inputs are "
-          "supported.");
-    }
+    assert(gf->isJacobian() &&
+           "MultifrontalClique::fillAb: inconsistent graph passed.");
     auto jacobianFactor = std::static_pointer_cast<JacobianFactor>(gf);
     rowOffset += addJacobianFactor(*jacobianFactor, rowOffset);
   }

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -171,7 +171,7 @@ void MultifrontalClique::finalize(std::vector<ChildInfo> children,
   solveMode_ = useQR ? SolveMode::QrLeaf : SolveMode::Cholesky;
   RSdReady_ = false;
 
-  // If using QR, also a reserve room for optional damping rows.
+  // If using QR, also reserve room for optional damping rows.
   const DenseIndex baseRows = static_cast<DenseIndex>(factorRows_);
   const DenseIndex totalRows =
       baseRows + (useQR ? static_cast<DenseIndex>(frontalDim) : 0);
@@ -319,21 +319,20 @@ void MultifrontalClique::factorize() {
 }
 
 void MultifrontalClique::eliminateInPlace(
-    double lambda, const LMDampingParams* dampingParams,
-    const VectorValues* exactHessianDiagonal) {
-  assert(dampingParams != nullptr);
+    double lambda, const LMDampingParams& dampingParams,
+    const VectorValues& exactHessianDiagonal) {
   prepareForElimination();
   if (useQR()) {
-    applyDampingQR(lambda, *dampingParams, exactHessianDiagonal);
+    applyDampingQR(lambda, dampingParams, exactHessianDiagonal);
   } else {
-    applyDampingCholesky(lambda, *dampingParams, exactHessianDiagonal);
+    applyDampingCholesky(lambda, dampingParams, exactHessianDiagonal);
   }
   factorize();
 }
 
 void MultifrontalClique::applyDampingQR(
     double lambda, const LMDampingParams& dampingParams,
-    const VectorValues* exactHessianDiagonal) {
+    const VectorValues& exactHessianDiagonal) {
   if (lambda <= 0.0) return;
   const DenseIndex baseRows = static_cast<DenseIndex>(factorRows_);
   const DenseIndex dampRows = static_cast<DenseIndex>(frontalDim);
@@ -347,9 +346,8 @@ void MultifrontalClique::applyDampingQR(
     if (dampingParams.diagonalDamping) {
       Vector diag;
       if (dampingParams.exactHessianDiagonal) {
-        assert(exactHessianDiagonal != nullptr);
         const Key key = orderedKeys_.at(j);
-        diag = exactHessianDiagonal->at(key)
+        diag = exactHessianDiagonal.at(key)
                    .cwiseMax(dampingParams.minDiagonal)
                    .cwiseMin(dampingParams.maxDiagonal);
       } else {
@@ -373,12 +371,11 @@ void MultifrontalClique::applyDampingQR(
 
 void MultifrontalClique::applyDampingCholesky(
     double lambda, const LMDampingParams& dampingParams,
-    const VectorValues* exactHessianDiagonal) {
+    const VectorValues& exactHessianDiagonal) {
   if (lambda <= 0.0) return;
   if (dampingParams.diagonalDamping) {
     if (dampingParams.exactHessianDiagonal) {
-      assert(exactHessianDiagonal != nullptr);
-      addExactDiagonalDamping(lambda, *exactHessianDiagonal,
+      addExactDiagonalDamping(lambda, exactHessianDiagonal,
                               dampingParams.minDiagonal,
                               dampingParams.maxDiagonal);
     } else {
@@ -442,10 +439,6 @@ void MultifrontalClique::updateParentInfo(
     parentInfo.updateFromMappedBlocks(info_, parentIndices_);
     info_.blockStart() = 0;
   }
-}
-
-void MultifrontalClique::updateParent(MultifrontalClique& parent) const {
-  updateParentInfo(parent.info_);
 }
 
 void MultifrontalClique::gatherUpdatesSequential() {
@@ -518,7 +511,7 @@ std::shared_ptr<GaussianConditional> MultifrontalClique::conditional() const {
 }
 
 // Solve with block back-substitution on the Cholesky-stored info matrix.
-void MultifrontalClique::updateSolution() const {
+void MultifrontalClique::updateSolution() {
   assert(RSdReady_);
   assert(RSd_.rowStart() == 0);
   // Use cached [R S d] for fast back-substitution.
@@ -534,10 +527,10 @@ void MultifrontalClique::updateSolution() const {
 
   // We first solve rhs = d - S * x_s
   rhsScratch_.noalias() = d;
+  const Vector* x_s = nullptr;
   if (!separatorPtrs_.empty()) {
-    const Vector& x_s =
-        buildSeparatorVector(separatorPtrs_, &separatorScratch_);
-    rhsScratch_.noalias() -= S * x_s;
+    x_s = &buildSeparatorVector(separatorPtrs_, &separatorScratch_);
+    rhsScratch_.noalias() -= S * (*x_s);
   }
 
   // Then solve for x_f, our solution, via R * x_f = rhs
@@ -558,15 +551,12 @@ void MultifrontalClique::updateSolution() const {
   if (frontalDim > 0) {
     lastOldError_ = 0.5 * d.squaredNorm();
     Vector residual = R * x_f;
-    if (!separatorPtrs_.empty()) {
-      const Vector& x_s =
-          buildSeparatorVector(separatorPtrs_, &separatorScratch_);
-      residual.noalias() += S * x_s;
+    if (x_s != nullptr) {
+      residual.noalias() += S * (*x_s);
     }
     residual.noalias() -= d;
     lastNewError_ = 0.5 * residual.squaredNorm();
   }
-
 }
 
 double MultifrontalClique::constantTermError() const {
@@ -584,8 +574,8 @@ double MultifrontalClique::constantTermError() const {
           0.5 * RSd_.matrix().bottomRows(extraRows).col(lastCol).squaredNorm();
     }
   } else {
-    const DenseIndex rhsIndex = static_cast<DenseIndex>(
-        info_.nBlocks() - info_.blockStart() - 1);
+    const DenseIndex rhsIndex =
+        static_cast<DenseIndex>(info_.nBlocks() - info_.blockStart() - 1);
     if (rhsIndex >= 0) {
       constantError = 0.5 * info_.diagonalBlock(rhsIndex)(0, 0);
     }

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -552,6 +552,45 @@ void MultifrontalClique::updateSolution() const {
     values->noalias() = x_f.segment(offset, dim);
     offset += dim;
   }
+
+  lastOldError_ = 0.0;
+  lastNewError_ = 0.0;
+  if (frontalDim > 0) {
+    lastOldError_ = 0.5 * d.squaredNorm();
+    Vector residual = R * x_f;
+    if (!separatorPtrs_.empty()) {
+      const Vector& x_s =
+          buildSeparatorVector(separatorPtrs_, &separatorScratch_);
+      residual.noalias() += S * x_s;
+    }
+    residual.noalias() -= d;
+    lastNewError_ = 0.5 * residual.squaredNorm();
+  }
+
+}
+
+double MultifrontalClique::constantTermError() const {
+  if (!RSdReady_) {
+    return 0.0;
+  }
+  double constantError = 0.0;
+  if (useQR()) {
+    const DenseIndex extraRows =
+        RSd_.matrix().rows() - static_cast<DenseIndex>(frontalDim);
+    if (extraRows > 0) {
+      const DenseIndex lastCol =
+          static_cast<DenseIndex>(RSd_.matrix().cols() - 1);
+      constantError =
+          0.5 * RSd_.matrix().bottomRows(extraRows).col(lastCol).squaredNorm();
+    }
+  } else {
+    const DenseIndex rhsIndex = static_cast<DenseIndex>(
+        info_.nBlocks() - info_.blockStart() - 1);
+    if (rhsIndex >= 0) {
+      constantError = 0.5 * info_.diagonalBlock(rhsIndex)(0, 0);
+    }
+  }
+  return constantError;
 }
 
 void MultifrontalClique::print(const std::string& s,

--- a/gtsam/linear/MultifrontalClique.h
+++ b/gtsam/linear/MultifrontalClique.h
@@ -24,12 +24,15 @@
 #include <gtsam/inference/Key.h>
 #include <gtsam/linear/GaussianFactor.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/linear/MultifrontalParameters.h>
 #include <gtsam/linear/VectorValues.h>
+#include <gtsam/nonlinear/LMDampingParams.h>
 #include <gtsam/symbolic/SymbolicFactor.h>
 
 #include <iosfwd>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -84,15 +87,17 @@ class GTSAM_EXPORT MultifrontalClique {
   size_t frontalDim = 0;    ///< Frontal dimension.
   size_t separatorDim = 0;  ///< Separator dimension.
 
-  /// Construct a clique from factor indices and cache static structure.
-  /// @param factorIndices Indices of factors associated with this clique.
-  /// @param parent Weak pointer to the parent clique.
-  /// @param frontals Frontal keys for this clique.
-  /// @param separatorKeys Separator keys for this clique.
-  /// @param dims Key->dimension map.
-  /// @param vbmRows Number of rows needed for the vertical block matrix.
-  /// @param solution Solution storage for cached pointers.
-  /// @param fixedKeys Keys fixed to zero by constraints (may be null).
+  /**
+   * Construct a clique from factor indices and cache static structure.
+   * @param factorIndices Indices of factors associated with this clique.
+   * @param parent Weak pointer to the parent clique.
+   * @param frontals Frontal keys for this clique.
+   * @param separatorKeys Separator keys for this clique.
+   * @param dims Key->dimension map.
+   * @param vbmRows Number of rows needed for the vertical block matrix.
+   * @param solution Solution storage for cached pointers.
+   * @param fixedKeys Keys fixed to zero by constraints (may be null).
+   */
   explicit MultifrontalClique(std::vector<size_t> factorIndices,
                               const std::weak_ptr<MultifrontalClique>& parent,
                               const KeyVector& frontals,
@@ -104,16 +109,24 @@ class GTSAM_EXPORT MultifrontalClique {
   /// @name Setup (non-const)
   /// @{
 
-  /// Cache the children list and compute parent indices.
-  void finalize(std::vector<ChildInfo> children);
+  /**
+   * Cache the children list, compute parent indices, and lock in QR usage.
+   * @param children Child cliques plus separator metadata.
+   * @param params Parameters controlling QR mode and thresholds.
+   */
+  void finalize(std::vector<ChildInfo> children,
+                const MultifrontalParameters& params);
 
-  /// Load factor values into the pre-allocated Ab matrix.
-  /// @param graph The factor graph with updated values (structure must match
-  ///              the graph used to build this clique, apart from updated
-  ///              numerical values). Only JacobianFactor inputs are supported.
+  /**
+   * Load factor values into the pre-allocated Ab matrix.
+   * @param graph The factor graph with updated values (structure must match
+   *              the graph used to build this clique, apart from updated
+   *              numerical values). Only JacobianFactor inputs are supported.
+   */
   void fillAb(const GaussianFactorGraph& graph);
 
-  /// Zero out sbm, re-add Hessians, accumulate Jacobians and children.
+  /// Zero out the info matrix, re-add Hessians, accumulate Jacobians and
+  /// children.
   void prepareForElimination();
 
   /// Perform Cholesky factorization on the frontal block.
@@ -134,6 +147,23 @@ class GTSAM_EXPORT MultifrontalClique {
   void addDiagonalDamping(double lambda, double minDiagonal,
                           double maxDiagonal);
 
+  /**
+   * Add diagonal damping to the frontal block using an externally provided
+   * Hessian diagonal `diag(J^T J)` keyed by variable.
+   *
+   * This matches the legacy LM diagonal damping definition based on the
+   * diagonal of the original linearized system rather than the post-Schur
+   * clique information matrix.
+   *
+   * @param lambda Damping factor
+   * @param hessianDiagonal Map from key to diagonal vector (dimension-matched).
+   * @param minDiagonal Minimum diagonal value
+   * @param maxDiagonal Maximum diagonal value
+   */
+  void addExactDiagonalDamping(double lambda,
+                               const VectorValues& hessianDiagonal,
+                               double minDiagonal, double maxDiagonal);
+
   /// @}
 
   /// @name Read-only methods
@@ -147,14 +177,17 @@ class GTSAM_EXPORT MultifrontalClique {
   /// Return the number of frontal keys in this clique.
   size_t numFrontals() const { return frontalPtrs_.size(); }
 
+  /// Return keys ordered by block index (frontals followed by separators).
+  const KeyVector& orderedKeys() const { return orderedKeys_; }
+
   /// Build a GaussianConditional from the in-place factorization.
   std::shared_ptr<GaussianConditional> conditional() const;
 
   /// Get the vertical block matrix Ab.
   const VerticalBlockMatrix& Ab() const { return Ab_; }
 
-  /// Get the symmetric block matrix (const).
-  const SymmetricBlockMatrix& sbm() const { return sbm_; }
+  /// Get the information matrix (const).
+  const SymmetricBlockMatrix& info() const { return info_; }
 
   /// Check if this clique is using QR elimination.
   bool useQR() const { return solveMode_ == SolveMode::QrLeaf; }
@@ -173,13 +206,25 @@ class GTSAM_EXPORT MultifrontalClique {
   /// @{
 
   /**
-   * Eliminate this clique and propagate its separator contribution upward.
+   * Eliminate in-place, invalidating Ab_, and updating RSd_ and info_.
    *
-   * Computes the local normal equations (SBM) from the stacked Jacobian (Ab),
-   * incorporates child separator contributions, and performs partial Cholesky
-   * on the frontal blocks. Requires parent indices to be precomputed.
+   * Computes the local information matrix from the stacked Jacobian (Ab),
+   * incorporates child separator contributions, and performs partial QR or
+   * Cholesky on the frontal blocks.
    */
   void eliminateInPlace();
+
+  /**
+   * Version of eliminate that applies damping before eliminate.
+   *
+   * @param lambda Optional damping value; non-positive disables damping.
+   * @param dampingParams Parameters controlling LM-style damping.
+   * @param exactHessianDiagonal Optional `diag(J^T J)` values for exact
+   * diagonal damping.
+   */
+  void eliminateInPlace(double lambda,
+                        const LMDampingParams* dampingParams = nullptr,
+                        const VectorValues* exactHessianDiagonal = nullptr);
 
   /**
    * Apply this clique's separator contribution into the parent clique.
@@ -192,7 +237,8 @@ class GTSAM_EXPORT MultifrontalClique {
    * cached solution vectors.
    *
    * Uses block back-substitution using the upper triangular-part of the
-   * Cholesky-stored SBM, solving the triangular system for the frontal blocks.
+   * Cholesky-stored information matrix, solving the triangular system for the
+   * frontal blocks.
    */
   void updateSolution() const;
   /// @}
@@ -210,13 +256,16 @@ class GTSAM_EXPORT MultifrontalClique {
   /// Linear lookup for block index in small cliques.
   DenseIndex blockIndex(Key key) const;
 
-  /// Update a parent SBM with this clique's separator contribution.
-  void updateParentSbm(SymmetricBlockMatrix& parentSbm) const;
+  /// Update a parent information matrix with this clique's separator
+  /// contribution.
+  void updateParentInfo(SymmetricBlockMatrix& parentInfo) const;
 
-  /// Accumulate children separator updates into this clique's SBM (single-threaded).
+  /// Accumulate children separator updates into this clique's info matrix
+  /// (single-threaded).
   void gatherUpdatesSequential();
 
-  /// Accumulate children separator updates into this clique's SBM (multi-threaded).
+  /// Accumulate children separator updates into this clique's info matrix
+  /// (multi-threaded).
   void gatherUpdatesParallel(size_t numThreads);
 
   /// Compute block dimensions from variable dimensions (excluding RHS).
@@ -224,16 +273,13 @@ class GTSAM_EXPORT MultifrontalClique {
                                 const KeyVector& frontals,
                                 const KeySet& separatorKeys) const;
 
-  /**
-   * Pre-allocate matrices for this clique.
-   * @param blockDims Block dimensions (excluding RHS).
-   * @param totalNumRows Number of rows for the vertical block matrix.
-   */
-  void initializeMatrices(const std::vector<size_t>& blockDims,
-                          size_t totalNumRows);
+  /// Apply damping for QR elimination by writing into extra Ab_ rows.
+  void applyDampingQR(double lambda, const LMDampingParams& dampingParams,
+                      const VectorValues* exactHessianDiagonal);
 
-  /// Allocate the symmetric block matrix if needed.
-  void allocateSbm();
+  /// Apply damping for Cholesky elimination by adding to the info_ matrix.
+  void applyDampingCholesky(double lambda, const LMDampingParams& dampingParams,
+                            const VectorValues* exactHessianDiagonal);
 
   /**
    * Add a Jacobian factor's contributions into the Ab matrix.
@@ -244,32 +290,33 @@ class GTSAM_EXPORT MultifrontalClique {
   void setParentIndices(const std::vector<DenseIndex>& indices) {
     parentIndices_ = indices;
   }
-  // Build-time metadata.
+
+  // Construction-time metadata (set once in the constructor).
   std::vector<size_t> factorIndices_;
   KeyVector orderedKeys_;  ///< Keys ordered by block index (frontals+seps).
   const std::unordered_set<Key>* fixedKeys_ = nullptr;
-  std::vector<size_t> blockDims_;
+  std::vector<Vector*> frontalPtrs_;          ///< Solution frontals.
+  std::vector<const Vector*> separatorPtrs_;  ///< Solution separator.
+  std::vector<size_t> blockDims_;  ///< Cached block dimensions (excluding RHS).
+  size_t factorRows_ = 0;          ///< Number of rows allocated in Ab.
+
+  // Finalize-time metadata (set once after children are known).
   std::vector<DenseIndex>
       parentIndices_;  ///< Parent block indices for separators + RHS.
-  std::vector<Vector*> frontalPtrs_;  ///< Pointers into solution frontals.
-  std::vector<const Vector*>
-      separatorPtrs_;  ///< Pointers into solution separator.
-
-  // Load-time state.
-  VerticalBlockMatrix Ab_;
   SolveMode solveMode_ = SolveMode::Cholesky;
 
-  // Elimination-time state.
-  mutable SymmetricBlockMatrix sbm_;
+  // Finalize-time allocations.
+  VerticalBlockMatrix Ab_;
+  mutable SymmetricBlockMatrix info_;
   mutable VerticalBlockMatrix RSd_;  ///< Cached [R S d] from elimination.
+
+  // Elimination-time state.
   mutable bool RSdReady_ = false;
 
   // Solve-time scratch space.
   mutable Vector rhsScratch_;  ///< Cached RHS workspace for back-substitution.
   mutable Vector
       separatorScratch_;  ///< Cached separator stack for back-substitution.
-
-  static constexpr double kQrAspectRatio = 2.0;
 };
 
 std::ostream& operator<<(std::ostream& os, const MultifrontalClique& clique);

--- a/gtsam/linear/MultifrontalClique.h
+++ b/gtsam/linear/MultifrontalClique.h
@@ -219,18 +219,10 @@ class GTSAM_EXPORT MultifrontalClique {
    *
    * @param lambda Optional damping value; non-positive disables damping.
    * @param dampingParams Parameters controlling LM-style damping.
-   * @param exactHessianDiagonal Optional `diag(J^T J)` values for exact
-   * diagonal damping.
+   * @param exactHessianDiagonal `diag(J^T J)` values for diagonal damping.
    */
-  void eliminateInPlace(double lambda,
-                        const LMDampingParams* dampingParams = nullptr,
-                        const VectorValues* exactHessianDiagonal = nullptr);
-
-  /**
-   * Apply this clique's separator contribution into the parent clique.
-   * @param parent Parent clique to update.
-   */
-  void updateParent(MultifrontalClique& parent) const;
+  void eliminateInPlace(double lambda, const LMDampingParams& dampingParams,
+                        const VectorValues& exactHessianDiagonal);
 
   /**
    * Solve for this clique's frontal variables and write them back to the
@@ -240,7 +232,7 @@ class GTSAM_EXPORT MultifrontalClique {
    * Cholesky-stored information matrix, solving the triangular system for the
    * frontal blocks.
    */
-  void updateSolution() const;
+  void updateSolution();
 
   /// Access the last old error computed during updateSolution().
   double lastOldError() const { return lastOldError_; }
@@ -284,11 +276,11 @@ class GTSAM_EXPORT MultifrontalClique {
 
   /// Apply damping for QR elimination by writing into extra Ab_ rows.
   void applyDampingQR(double lambda, const LMDampingParams& dampingParams,
-                      const VectorValues* exactHessianDiagonal);
+                      const VectorValues& exactHessianDiagonal);
 
   /// Apply damping for Cholesky elimination by adding to the info_ matrix.
   void applyDampingCholesky(double lambda, const LMDampingParams& dampingParams,
-                            const VectorValues* exactHessianDiagonal);
+                            const VectorValues& exactHessianDiagonal);
 
   /**
    * Add a Jacobian factor's contributions into the Ab matrix.
@@ -316,20 +308,21 @@ class GTSAM_EXPORT MultifrontalClique {
 
   // Finalize-time allocations.
   VerticalBlockMatrix Ab_;
-  mutable SymmetricBlockMatrix info_;
+  
+  // mutable as temporarily updateParentInfo
   mutable VerticalBlockMatrix RSd_;  ///< Cached [R S d] from elimination.
+  mutable SymmetricBlockMatrix info_;
 
   // Elimination-time state.
-  mutable bool RSdReady_ = false;
+  bool RSdReady_ = false;
 
   // Solve-time scratch space.
-  mutable Vector rhsScratch_;  ///< Cached RHS workspace for back-substitution.
-  mutable Vector
-      separatorScratch_;  ///< Cached separator stack for back-substitution.
+  Vector rhsScratch_;        ///< Cached RHS workspace for back-substitution.
+  Vector separatorScratch_;  ///< Cached separator stack for back-substitution.
 
   // Solve-time cached error contributions.
-  mutable double lastOldError_ = 0.0;
-  mutable double lastNewError_ = 0.0;
+  double lastOldError_ = 0.0;
+  double lastNewError_ = 0.0;
 };
 
 std::ostream& operator<<(std::ostream& os, const MultifrontalClique& clique);

--- a/gtsam/linear/MultifrontalClique.h
+++ b/gtsam/linear/MultifrontalClique.h
@@ -241,6 +241,15 @@ class GTSAM_EXPORT MultifrontalClique {
    * frontal blocks.
    */
   void updateSolution() const;
+
+  /// Access the last old error computed during updateSolution().
+  double lastOldError() const { return lastOldError_; }
+
+  /// Access the last new error computed during updateSolution().
+  double lastNewError() const { return lastNewError_; }
+
+  /// Return the constant error term for this clique (nonzero for roots).
+  double constantTermError() const;
   /// @}
 
   friend std::ostream& operator<<(std::ostream& os,
@@ -317,6 +326,10 @@ class GTSAM_EXPORT MultifrontalClique {
   mutable Vector rhsScratch_;  ///< Cached RHS workspace for back-substitution.
   mutable Vector
       separatorScratch_;  ///< Cached separator stack for back-substitution.
+
+  // Solve-time cached error contributions.
+  mutable double lastOldError_ = 0.0;
+  mutable double lastNewError_ = 0.0;
 };
 
 std::ostream& operator<<(std::ostream& os, const MultifrontalClique& clique);

--- a/gtsam/linear/MultifrontalParameters.h
+++ b/gtsam/linear/MultifrontalParameters.h
@@ -1,0 +1,49 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file MultifrontalParameters.h
+ * @brief Parameters for the imperative multifrontal solver.
+ * @author Frank Dellaert
+ * @date   January 2026
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <iosfwd>
+
+namespace gtsam {
+
+/**
+ * Parameters for `gtsam::MultifrontalSolver`.
+ *
+ * These parameters are intentionally defined in a standalone header so they
+ * can be referenced from nonlinear optimizer parameter types without pulling
+ * in the full multifrontal solver headers.
+ *
+ * @note LM-style damping behavior is controlled by `NonlinearMultifrontalSolver`
+ * and its damping parameters; `MultifrontalParameters` only controls structure,
+ * traversal, and reporting.
+ */
+struct MultifrontalParameters {
+  enum class QRMode { Off, Allow, Force };
+  size_t leafMergeDimCap = 256;           ///< Leaf-merge cap (0 disables).
+  size_t mergeDimCap = 32;                ///< Merge threshold (0 disables).
+  QRMode qrMode = QRMode::Allow;          ///< QR mode for leaf cliques.
+  double qrAspectRatio = 2.0;             ///< Aspect ratio for QR mode=Allow.
+  std::ostream* reportStream = nullptr;   ///< Optional structure reporting.
+  int eliminationParallelThreshold = 10;  ///< Post-order task threshold.
+  int solutionParallelThreshold = 4096;   ///< Pre-order task threshold.
+  size_t numThreads = 0;  ///< Worker count (0 uses 0.75 * hw threads).
+};
+
+}  // namespace gtsam

--- a/gtsam/linear/MultifrontalSolver.cpp
+++ b/gtsam/linear/MultifrontalSolver.cpp
@@ -277,14 +277,67 @@ std::vector<LeafBatch> buildLeafBatches(const std::vector<LeafGroup>& groups,
 
 bool mergeLeafBatches(const SymbolicJunctionTree::sharedNode& cluster,
                       const std::vector<LeafBatch>& batches) {
-  // Merge each batch of siblings into a super-leaf in-place.
-  bool anyMerged = false;
-  for (const auto& batch : batches) {
+  if (batches.empty()) return false;
+
+  // Merge in a single pass to avoid repeated scans of large child lists.
+  FastMap<const SymbolicJunctionTree::Cluster*, size_t> batchIndexByChild;
+  std::vector<SymbolicJunctionTree::sharedNode> mergedBatches(batches.size(),
+                                                              nullptr);
+  size_t mergeBatchCount = 0;
+  size_t selectedLeafCount = 0;
+
+  for (size_t batchIndex = 0; batchIndex < batches.size(); ++batchIndex) {
+    const auto& batch = batches[batchIndex];
     if (batch.leaves.size() <= 1) continue;
-    cluster->mergeChildrenSiblings(batch.leaves);
-    anyMerged = true;
+
+    selectedLeafCount += batch.leaves.size();
+    for (const auto& leaf : batch.leaves) {
+      if (leaf) {
+        batchIndexByChild.emplace(leaf.get(), batchIndex);
+      }
+    }
+
+    auto merged = std::make_shared<SymbolicJunctionTree::Cluster>();
+    for (const auto& leaf : batch.leaves) {
+      if (leaf) {
+        merged->merge(leaf);
+      }
+    }
+    std::reverse(merged->orderedFrontalKeys.begin(),
+                 merged->orderedFrontalKeys.end());
+    mergedBatches[batchIndex] = merged;
+    mergeBatchCount += 1;
   }
-  return anyMerged;
+
+  if (mergeBatchCount == 0) return false;
+
+  auto oldChildren = cluster->children;
+  SymbolicJunctionTree::Cluster::Children newChildren;
+  newChildren.reserve(oldChildren.size() - selectedLeafCount + mergeBatchCount);
+  std::vector<bool> inserted(batches.size(), false);
+
+  for (size_t i = 0; i < oldChildren.size(); ++i) {
+    const auto& child = oldChildren[i];
+    if (!child) {
+      newChildren.push_back(child);
+      continue;
+    }
+
+    auto it = batchIndexByChild.find(child.get());
+    if (it == batchIndexByChild.end()) {
+      newChildren.push_back(child);
+      continue;
+    }
+
+    const size_t batchIndex = it->second;
+    if (!inserted[batchIndex] && i == batches[batchIndex].firstIndex) {
+      newChildren.push_back(mergedBatches[batchIndex]);
+      inserted[batchIndex] = true;
+    }
+  }
+
+  cluster->children.swap(newChildren);
+  return true;
 }
 
 void accumulateSymbolicStats(const SymbolicJunctionTree::sharedNode& cluster,
@@ -396,6 +449,7 @@ struct CliqueBuilder {
   VectorValues* solution;
   std::vector<MultifrontalSolver::CliquePtr>* cliques;
   const std::unordered_set<Key>* fixedKeys;
+  const MultifrontalParameters* params;
   SymbolicJunctionTree::Cluster::KeySetMap separatorCache = {};
 
   BuiltClique build(const SymbolicJunctionTree::sharedNode& cluster,
@@ -433,7 +487,7 @@ struct CliqueBuilder {
     }
 
     // Finalize children metadata and register clique.
-    clique->finalize(std::move(childInfos));
+    clique->finalize(std::move(childInfos), *params);
     cliques->push_back(clique);
     return {clique, std::move(separatorKeys)};
   }
@@ -466,8 +520,7 @@ MultifrontalSolver::MultifrontalSolver(PrecomputedData data,
                                        const Parameters& params)
     : ForestTraversal<MultifrontalSolver, MultifrontalClique>(
           resolveThreadCount(params.numThreads)),
-      params_(params),
-      numThreads_(resolveThreadCount(params.numThreads)) {
+      params_(params) {
   dims_ = std::move(data.dims);
   fixedKeys_ = std::move(data.fixedKeys);
 
@@ -504,7 +557,7 @@ MultifrontalSolver::MultifrontalSolver(PrecomputedData data,
   }
 
   // Build the actual MultifrontalClique structure.
-  CliqueBuilder builder{dims_, &solution_, &cliques_, &fixedKeys_};
+  CliqueBuilder builder{dims_, &solution_, &cliques_, &fixedKeys_, &params_};
   for (const auto& rootCluster : data.junctionTree.roots()) {
     if (rootCluster) {
       roots_.push_back(

--- a/gtsam/linear/MultifrontalSolver.cpp
+++ b/gtsam/linear/MultifrontalSolver.cpp
@@ -603,6 +603,7 @@ void MultifrontalSolver::load(const GaussianFactorGraph& graph) {
   }
   loaded_ = true;
   eliminated_ = false;
+  hasDeltaError_ = false;
 }
 
 /* ************************************************************************* */
@@ -613,6 +614,7 @@ void MultifrontalSolver::eliminateInPlace() {
         "eliminating.");
   }
   eliminated_ = false;
+  hasDeltaError_ = false;
   runBottomUp([](MultifrontalClique& node) { node.eliminateInPlace(); },
               params_.eliminationParallelThreshold);
   eliminated_ = true;
@@ -629,6 +631,7 @@ void MultifrontalSolver::eliminateInPlace(const GaussianFactorGraph& graph) {
       params_.eliminationParallelThreshold);
   loaded_ = true;
   eliminated_ = true;
+  hasDeltaError_ = false;
 }
 
 /* ************************************************************************* */
@@ -676,13 +679,52 @@ GaussianBayesTree MultifrontalSolver::computeBayesTree() const {
 /* ************************************************************************* */
 const VectorValues& MultifrontalSolver::updateSolution() {
   assert(loaded_ && eliminated_);
+
+  // Back-substitute the solution with a top-down pass through the cliques.
   runTopDown([](MultifrontalClique& node) { node.updateSolution(); },
              params_.solutionParallelThreshold);
 
+  // Enforce constrained keys as zero in the final solution.
   for (Key key : fixedKeys_) {
     solution_.at(key).setZero();
   }
+
+  // Aggregate per-clique linearized errors from the latest solution.
+  lastOldError_ = 0.0;
+  lastNewError_ = 0.0;
+  for (const auto& clique : cliques_) {
+    if (!clique) continue;
+    lastOldError_ += clique->lastOldError();
+    lastNewError_ += clique->lastNewError();
+  }
+
+  // Add the constant term once from the root cliques.
+  double constantError = 0.0;
+  for (const auto& root : roots_) {
+    if (!root) continue;
+    constantError += root->constantTermError();
+  }
+  lastOldError_ += constantError;
+  lastNewError_ += constantError;
+
+  // Mark delta error as valid for subsequent deltaError() calls.
+  hasDeltaError_ = true;
   return solution_;
+}
+
+double MultifrontalSolver::deltaError(double* oldError,
+                                      double* newError) const {
+  if (!hasDeltaError_) {
+    throw std::runtime_error(
+        "MultifrontalSolver::deltaError requires updateSolution().");
+  }
+  if (oldError) {
+    *oldError = lastOldError_;
+  }
+  if (newError) {
+    *newError = lastNewError_;
+  }
+  return lastOldError_ - lastNewError_;
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/MultifrontalSolver.cpp
+++ b/gtsam/linear/MultifrontalSolver.cpp
@@ -88,68 +88,54 @@ struct StructureStats {
 constexpr double kConstraintSigmaTol = 1e-12;
 constexpr double kConstraintFeasibleTol = 1e-9;
 
-std::unordered_set<Key> collectFixedKeys(const GaussianFactorGraph& graph) {
+struct PrecomputeScratch {
+  std::map<Key, size_t> dims;
   std::unordered_set<Key> fixedKeys;
-  for (const auto& factor : graph) {
+  std::vector<size_t> rowCounts;
+};
+
+PrecomputeScratch precomputeFromGraph(const GaussianFactorGraph& graph) {
+  PrecomputeScratch out;
+  out.rowCounts.resize(graph.size(), 0);
+  for (size_t i = 0; i < graph.size(); ++i) {
+    const auto& factor = graph[i];
     if (!factor) continue;
     if (!factor->isJacobian()) {
-      throw std::runtime_error(
-          "MultifrontalSolver: only JacobianFactor inputs are supported.");
+      throw MultifrontalSolverNotSupported(
+          "only JacobianFactor inputs are supported");
     }
     auto jacobianFactor = std::static_pointer_cast<JacobianFactor>(factor);
+    out.rowCounts[i] = jacobianFactor->rows();
+    for (auto it = jacobianFactor->begin(); it != jacobianFactor->end(); ++it) {
+      out.dims[*it] = jacobianFactor->getDim(it);
+    }
     auto model = jacobianFactor->get_model();
     if (!model || !model->isConstrained()) continue;
     // Only accept fully constrained unary factors with zero residuals.
     if (jacobianFactor->size() != 1) {
-      throw std::runtime_error(
-          "MultifrontalSolver: only unary constrained factors are supported.");
+      throw MultifrontalSolverNotSupported(
+          "only unary constrained factors are supported");
     }
     const Vector& sigmas = model->sigmasRef();
     if (!(sigmas.array().abs() <= kConstraintSigmaTol).all()) {
-      throw std::runtime_error(
-          "MultifrontalSolver: only fully constrained factors are supported.");
+      throw MultifrontalSolverNotSupported(
+          "only fully constrained factors are supported");
     }
     if (jacobianFactor->getb().array().abs().maxCoeff() >
         kConstraintFeasibleTol) {
-      throw std::runtime_error(
-          "MultifrontalSolver: constrained factor is not feasible.");
+      throw MultifrontalSolverNotSupported(
+          "constrained factor is not feasible");
     }
-    fixedKeys.insert(*jacobianFactor->begin());
+    out.fixedKeys.insert(*jacobianFactor->begin());
   }
-  return fixedKeys;
-}
-
-// Compute variable dimensions from the GaussianFactorGraph
-std::map<Key, size_t> computeDims(const GaussianFactorGraph& graph) {
-  std::map<Key, size_t> dims;
-  for (const auto& factor : graph) {
-    if (!factor) continue;
-    if (!factor->isJacobian()) {
-      throw std::runtime_error(
-          "MultifrontalSolver: only JacobianFactor inputs are supported.");
-    }
-    auto jacobianFactor = std::static_pointer_cast<JacobianFactor>(factor);
-    for (auto it = jacobianFactor->begin(); it != jacobianFactor->end(); ++it) {
-      dims[*it] = jacobianFactor->getDim(it);
-    }
-  }
-  return dims;
-}
-
-size_t factorRowCount(const GaussianFactorGraph& graph, size_t index) {
-  if (index >= graph.size() || !graph[index]) return 0;
-  if (!graph[index]->isJacobian()) {
-    throw std::runtime_error(
-        "MultifrontalSolver: only JacobianFactor inputs are supported.");
-  }
-  auto jacobianFactor = std::static_pointer_cast<JacobianFactor>(graph[index]);
-  return jacobianFactor->rows();
+  return out;
 }
 
 // Build SymbolicFactorGraph from GaussianFactorGraph
 SymbolicFactorGraph buildSymbolicGraph(
     const GaussianFactorGraph& graph,
-    const std::unordered_set<Key>& fixedKeys) {
+    const std::unordered_set<Key>& fixedKeys,
+    const std::vector<size_t>& rowCounts) {
   SymbolicFactorGraph symbolicGraph;
   symbolicGraph.reserve(graph.size());
   for (size_t i = 0; i < graph.size(); ++i) {
@@ -164,7 +150,7 @@ SymbolicFactorGraph buildSymbolicGraph(
     // Skip factors that are fully constrained away.
     if (keys.empty()) continue;
     symbolicGraph.emplace_shared<internal::IndexedSymbolicFactor>(
-        keys, i, factorRowCount(graph, i));
+        keys, i, rowCounts.at(i));
   }
   return symbolicGraph;
 }
@@ -529,11 +515,6 @@ MultifrontalSolver::MultifrontalSolver(const GaussianFactorGraph& graph,
     : MultifrontalSolver(Precompute(graph, ordering), ordering, params) {}
 
 /* ************************************************************************* */
-MultifrontalSolver::MultifrontalSolver(const GaussianFactorGraph& graph,
-                                       const Ordering& ordering)
-    : MultifrontalSolver(graph, ordering, Parameters{}) {}
-
-/* ************************************************************************* */
 MultifrontalSolver::MultifrontalSolver(PrecomputedData data,
                                        const Ordering& ordering,
                                        const Parameters& params)
@@ -589,30 +570,26 @@ MultifrontalSolver::MultifrontalSolver(PrecomputedData data,
 }
 
 /* ************************************************************************* */
-MultifrontalSolver::MultifrontalSolver(PrecomputedData data,
-                                       const Ordering& ordering)
-    : MultifrontalSolver(std::move(data), ordering, Parameters{}) {}
-
-/* ************************************************************************* */
 MultifrontalSolver::PrecomputedData MultifrontalSolver::Precompute(
     const GaussianFactorGraph& graph, const Ordering& ordering) {
-  auto dims = computeDims(graph);
-  auto fixedKeys = collectFixedKeys(graph);
+  PrecomputeScratch scratch = precomputeFromGraph(graph);
 
   Ordering reducedOrdering;
   reducedOrdering.reserve(ordering.size());
   for (Key key : ordering) {
-    if (!fixedKeys.count(key)) {
+    if (!scratch.fixedKeys.count(key)) {
       reducedOrdering.push_back(key);
     }
   }
 
-  SymbolicFactorGraph symbolicGraph = buildSymbolicGraph(graph, fixedKeys);
+  SymbolicFactorGraph symbolicGraph =
+      buildSymbolicGraph(graph, scratch.fixedKeys, scratch.rowCounts);
   SymbolicEliminationTree eliminationTree(symbolicGraph, reducedOrdering);
   SymbolicJunctionTree junctionTree(eliminationTree);
 
   return MultifrontalSolver::PrecomputedData{
-      std::move(dims), std::move(fixedKeys), std::move(junctionTree)};
+      std::move(scratch.dims), std::move(scratch.fixedKeys),
+      std::move(junctionTree)};
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/MultifrontalSolver.cpp
+++ b/gtsam/linear/MultifrontalSolver.cpp
@@ -204,11 +204,6 @@ struct LeafGroup {
   size_t firstIndex = 0;
 };
 
-struct LeafBatch {
-  SymbolicJunctionTree::Cluster::Children leaves;
-  size_t firstIndex = 0;
-};
-
 std::vector<LeafGroup> collectLeafGroups(
     const SymbolicJunctionTree::sharedNode& cluster,
     const std::map<Key, size_t>& dims,
@@ -240,6 +235,11 @@ std::vector<LeafGroup> collectLeafGroups(
 
   return groups;
 }
+
+struct LeafBatch {
+  SymbolicJunctionTree::Cluster::Children leaves;
+  size_t firstIndex = 0;
+};
 
 std::vector<LeafBatch> buildLeafBatches(const std::vector<LeafGroup>& groups,
                                         size_t leafMergeDimCap) {
@@ -275,45 +275,48 @@ std::vector<LeafBatch> buildLeafBatches(const std::vector<LeafGroup>& groups,
   return batches;
 }
 
-bool mergeLeafBatches(const SymbolicJunctionTree::sharedNode& cluster,
-                      const std::vector<LeafBatch>& batches) {
-  if (batches.empty()) return false;
+struct MergedClusters {
+  FastMap<const SymbolicJunctionTree::Cluster*, size_t> indexByChild;
+  std::vector<SymbolicJunctionTree::sharedNode> clusters;
+  size_t count = 0;
+  size_t numSelectedLeaves = 0;
+};
 
-  // Merge in a single pass to avoid repeated scans of large child lists.
-  FastMap<const SymbolicJunctionTree::Cluster*, size_t> batchIndexByChild;
-  std::vector<SymbolicJunctionTree::sharedNode> mergedBatches(batches.size(),
-                                                              nullptr);
-  size_t mergeBatchCount = 0;
-  size_t selectedLeafCount = 0;
+MergedClusters buildMergedClusters(const std::vector<LeafBatch>& clusters) {
+  MergedClusters merged;
+  merged.clusters.assign(clusters.size(), nullptr);
 
-  for (size_t batchIndex = 0; batchIndex < batches.size(); ++batchIndex) {
-    const auto& batch = batches[batchIndex];
+  for (size_t i = 0; i < clusters.size(); ++i) {
+    const auto& batch = clusters[i];
     if (batch.leaves.size() <= 1) continue;
 
-    selectedLeafCount += batch.leaves.size();
+    merged.numSelectedLeaves += batch.leaves.size();
+    // Map each leaf pointer to its batch index so we can skip and insert in
+    // O(1) when scanning the original children list.
     for (const auto& leaf : batch.leaves) {
-      if (leaf) {
-        batchIndexByChild.emplace(leaf.get(), batchIndex);
-      }
+      if (leaf) merged.indexByChild.emplace(leaf.get(), i);
     }
 
-    auto merged = std::make_shared<SymbolicJunctionTree::Cluster>();
+    // Build the merged batch once so insertion is just pointer replacement.
+    auto mergedCluster = std::make_shared<SymbolicJunctionTree::Cluster>();
     for (const auto& leaf : batch.leaves) {
-      if (leaf) {
-        merged->merge(leaf);
-      }
+      if (leaf) mergedCluster->merge(leaf);
     }
-    std::reverse(merged->orderedFrontalKeys.begin(),
-                 merged->orderedFrontalKeys.end());
-    mergedBatches[batchIndex] = merged;
-    mergeBatchCount += 1;
+    std::reverse(mergedCluster->orderedFrontalKeys.begin(),
+                 mergedCluster->orderedFrontalKeys.end());
+    merged.clusters[i] = mergedCluster;
+    merged.count += 1;
   }
 
-  if (mergeBatchCount == 0) return false;
+  return merged;
+}
 
-  auto oldChildren = cluster->children;
+SymbolicJunctionTree::Cluster::Children buildMergedChildren(
+    const SymbolicJunctionTree::Cluster::Children& oldChildren,
+    const std::vector<LeafBatch>& batches, const MergedClusters& merged) {
   SymbolicJunctionTree::Cluster::Children newChildren;
-  newChildren.reserve(oldChildren.size() - selectedLeafCount + mergeBatchCount);
+  newChildren.reserve(oldChildren.size() - merged.numSelectedLeaves +
+                      merged.count);
   std::vector<bool> inserted(batches.size(), false);
 
   for (size_t i = 0; i < oldChildren.size(); ++i) {
@@ -323,19 +326,35 @@ bool mergeLeafBatches(const SymbolicJunctionTree::sharedNode& cluster,
       continue;
     }
 
-    auto it = batchIndexByChild.find(child.get());
-    if (it == batchIndexByChild.end()) {
+    auto it = merged.indexByChild.find(child.get());
+    if (it == merged.indexByChild.end()) {
       newChildren.push_back(child);
       continue;
     }
 
     const size_t batchIndex = it->second;
+    // Insert the merged cluster exactly once, at the first original index where
+    // that cluster appeared. All other leaves in the cluster are skipped.
     if (!inserted[batchIndex] && i == batches[batchIndex].firstIndex) {
-      newChildren.push_back(mergedBatches[batchIndex]);
+      newChildren.push_back(merged.clusters[batchIndex]);
       inserted[batchIndex] = true;
     }
   }
 
+  return newChildren;
+}
+
+bool mergeLeafBatches(const SymbolicJunctionTree::sharedNode& cluster,
+                      const std::vector<LeafBatch>& batches) {
+  if (batches.empty()) return false;
+
+  // Merge in a single pass to avoid repeated scans of large child lists.
+  const MergedClusters merged = buildMergedClusters(batches);
+  if (merged.count == 0) return false;
+
+  auto oldChildren = cluster->children;
+  SymbolicJunctionTree::Cluster::Children newChildren =
+      buildMergedChildren(oldChildren, batches, merged);
   cluster->children.swap(newChildren);
   return true;
 }

--- a/gtsam/linear/MultifrontalSolver.h
+++ b/gtsam/linear/MultifrontalSolver.h
@@ -22,6 +22,7 @@
 #include <gtsam/inference/Key.h>
 #include <gtsam/inference/Ordering.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/linear/MultifrontalParameters.h>
 #include <gtsam/linear/VectorValues.h>
 #include <gtsam/symbolic/SymbolicJunctionTree.h>
 
@@ -58,14 +59,7 @@ class GTSAM_EXPORT MultifrontalSolver
     : public ForestTraversal<MultifrontalSolver, MultifrontalClique> {
  public:
   /// Tuning parameters for traversal and reporting.
-  struct Parameters {
-    size_t leafMergeDimCap = 256;           ///< Leaf-merge cap (0 disables).
-    size_t mergeDimCap = 32;                ///< Merge threshold (0 disables).
-    std::ostream* reportStream = nullptr;   ///< Optional structure reporting.
-    int eliminationParallelThreshold = 10;  ///< Post-order task threshold.
-    int solutionParallelThreshold = 4096;   ///< Pre-order task threshold.
-    size_t numThreads = 0;  ///< Worker count (0 uses 0.75 * hw threads).
-  };
+  using Parameters = MultifrontalParameters;
 
   struct PrecomputedData {
     std::map<Key, size_t> dims;         ///< Map from variable key to dimension.
@@ -87,7 +81,6 @@ class GTSAM_EXPORT MultifrontalSolver
   bool loaded_ = false;                ///< Whether load() has been called.
   bool eliminated_ = false;            ///< Whether eliminateInPlace() ran.
   Parameters params_;                  ///< Tunable solver parameters.
-  size_t numThreads_ = 0;              ///< Resolved thread count for traversal.
 
  public:
   /**
@@ -123,6 +116,20 @@ class GTSAM_EXPORT MultifrontalSolver
   /// Only JacobianFactor inputs are supported.
   static PrecomputedData Precompute(const GaussianFactorGraph& graph,
                                     const Ordering& ordering);
+
+  /**
+   * Construct the solver from precomputed symbolic data.
+   * Call load() before eliminating to populate numerical values.
+   * @param data Precomputed symbolic structure and sizing data.
+   * @param ordering The variable ordering to use for seeding solution storage.
+   * @param mergeDimCap Merge a child if its frontal dimension plus the
+   * parent's total dimension is below this threshold (0 disables merging).
+   * @param reportStream Optional stream to report clique structure stats
+   * (frontals, separators, total dims, and children).
+   */
+  MultifrontalSolver(PrecomputedData data, const Ordering& ordering,
+                     size_t mergeDimCap = 0,
+                     std::ostream* reportStream = nullptr);
 
   /**
    * Load new numerical values from the factor graph.

--- a/gtsam/linear/MultifrontalSolver.h
+++ b/gtsam/linear/MultifrontalSolver.h
@@ -29,6 +29,8 @@
 #include <iosfwd>
 #include <map>
 #include <memory>
+#include <stdexcept>
+#include <string>
 #include <unordered_set>
 #include <vector>
 
@@ -36,6 +38,25 @@ namespace gtsam {
 
 class GaussianBayesTree;
 class MultifrontalClique;
+
+/**
+ * Exception for unsupported use of the new multifrontal solver.
+ * Includes guidance for using the legacy solver instead.
+ */
+class GTSAM_EXPORT MultifrontalSolverNotSupported : public std::runtime_error {
+ public:
+  explicit MultifrontalSolverNotSupported(const std::string& reason)
+      : std::runtime_error(BuildMessage(reason)) {}
+
+ private:
+  static std::string BuildMessage(const std::string& reason) {
+    std::string message = "MultifrontalSolver not supported: " + reason + ". ";
+    message +=
+        "Enable GTSAM_ALLOW_DEPRECATED_SINCE_V43 to default to the legacy "
+        "solver, or set linearSolverType = MULTIFRONTAL_CHOLESKY.";
+    return message;
+  }
+};
 
 /**
  * Imperative-style multifrontal solver for Gaussian factor graphs.
@@ -96,11 +117,7 @@ class GTSAM_EXPORT MultifrontalSolver
    * @param params Tunable parameters for traversal and reporting.
    */
   MultifrontalSolver(const GaussianFactorGraph& graph, const Ordering& ordering,
-                     const Parameters& params);
-
-  /// Construct the solver with default parameters.
-  MultifrontalSolver(const GaussianFactorGraph& graph,
-                     const Ordering& ordering);
+                     const Parameters& params = Parameters{});
 
   /**
    * Construct the solver from precomputed symbolic data.
@@ -110,10 +127,7 @@ class GTSAM_EXPORT MultifrontalSolver
    * @param params Tunable parameters for traversal and reporting.
    */
   MultifrontalSolver(PrecomputedData data, const Ordering& ordering,
-                     const Parameters& params);
-
-  /// Construct the solver with default parameters.
-  MultifrontalSolver(PrecomputedData data, const Ordering& ordering);
+                     const Parameters& params = Parameters{});
 
   /// Precompute symbolic structure and sizing data from a factor graph.
   /// Only JacobianFactor inputs are supported.

--- a/gtsam/linear/MultifrontalSolver.h
+++ b/gtsam/linear/MultifrontalSolver.h
@@ -121,20 +121,6 @@ class GTSAM_EXPORT MultifrontalSolver
                                     const Ordering& ordering);
 
   /**
-   * Construct the solver from precomputed symbolic data.
-   * Call load() before eliminating to populate numerical values.
-   * @param data Precomputed symbolic structure and sizing data.
-   * @param ordering The variable ordering to use for seeding solution storage.
-   * @param mergeDimCap Merge a child if its frontal dimension plus the
-   * parent's total dimension is below this threshold (0 disables merging).
-   * @param reportStream Optional stream to report clique structure stats
-   * (frontals, separators, total dims, and children).
-   */
-  MultifrontalSolver(PrecomputedData data, const Ordering& ordering,
-                     size_t mergeDimCap = 0,
-                     std::ostream* reportStream = nullptr);
-
-  /**
    * Load new numerical values from the factor graph.
    * This overwrites the values in the pre-allocated matrices.
    *

--- a/gtsam/linear/MultifrontalSolver.h
+++ b/gtsam/linear/MultifrontalSolver.h
@@ -81,6 +81,9 @@ class GTSAM_EXPORT MultifrontalSolver
   bool loaded_ = false;                ///< Whether load() has been called.
   bool eliminated_ = false;            ///< Whether eliminateInPlace() ran.
   Parameters params_;                  ///< Tunable solver parameters.
+  double lastOldError_ = 0.0;          ///< Cached old linearized error.
+  double lastNewError_ = 0.0;          ///< Cached new linearized error.
+  bool hasDeltaError_ = false;         ///< Whether updateSolution computed it.
 
  public:
   /**
@@ -167,6 +170,13 @@ class GTSAM_EXPORT MultifrontalSolver
    * @return Reference to the internally cached solution vector.
    */
   const VectorValues& updateSolution();
+
+  /**
+   * Return the linearized delta error from the last updateSolution() call.
+   * Optionally returns the old and new linearized errors.
+   */
+  double deltaError(double* oldError = nullptr,
+                    double* newError = nullptr) const;
 
   /// Accessor for the roots of the elimination tree.
   const std::vector<CliquePtr>& roots() const { return roots_; }

--- a/gtsam/linear/tests/testMultifrontalSolver.cpp
+++ b/gtsam/linear/tests/testMultifrontalSolver.cpp
@@ -72,7 +72,7 @@ TEST(MultifrontalSolver, Constructor) {
   auto childClique = root->children[0];
 
   // Verify matrices in leaf (childClique)
-  EXPECT_LONGS_EQUAL(4, childClique->sbm().nBlocks());
+  EXPECT_LONGS_EQUAL(4, childClique->info().nBlocks());
   EXPECT_LONGS_EQUAL(2, childClique->Ab().rows());
   EXPECT_LONGS_EQUAL(4, childClique->Ab().nBlocks());
 
@@ -104,7 +104,7 @@ TEST(MultifrontalSolver, ConstructorPrecomputed) {
 
   // Verify matrices in leaf (childClique)
   CHECK(childClique->useQR() == false);
-  EXPECT_LONGS_EQUAL(4, childClique->sbm().nBlocks());
+  EXPECT_LONGS_EQUAL(4, childClique->info().nBlocks());
   EXPECT_LONGS_EQUAL(2, childClique->Ab().rows());
   EXPECT_LONGS_EQUAL(4, childClique->Ab().nBlocks());
 
@@ -168,6 +168,34 @@ TEST(MultifrontalSolver, EliminateWithLoad) {
 
   GaussianBayesTree expectedBT = *chain.eliminateMultifrontal(chainOrdering);
   VectorValues expected = expectedBT.optimize();
+
+  EXPECT(assert_equal(expected, actual, 1e-9));
+}
+
+/* ************************************************************************* */
+// Forcing QR enables QR on all leaves and matches legacy QR elimination.
+TEST(MultifrontalSolver, ForceQRMatchesDenseQR) {
+  auto qrParams = noMergeParams();
+  qrParams.qrMode = MultifrontalParameters::QRMode::Force;
+  MultifrontalSolver solverQR(chain, chainOrdering, qrParams);
+  solverQR.eliminateInPlace(chain);
+
+  size_t leafCount = 0;
+  size_t qrLeafCount = 0;
+  solverQR.runTopDown([&](MultifrontalClique& node) {
+    if (node.children.empty()) {
+      ++leafCount;
+      if (node.useQR()) {
+        ++qrLeafCount;
+      }
+    }
+  });
+  CHECK(leafCount > 0);
+  CHECK(leafCount == qrLeafCount);
+
+  const VectorValues& actual = solverQR.updateSolution();
+
+  VectorValues expected = chain.optimize(chainOrdering, EliminateQR);
 
   EXPECT(assert_equal(expected, actual, 1e-9));
 }
@@ -368,7 +396,7 @@ TEST(MultifrontalSolver, BalancedSmoother) {
   EXPECT(solver.roots().size() == 1);
   auto root = solver.roots()[0];
 
-  EXPECT_LONGS_EQUAL(root->Ab().nBlocks(), root->sbm().nBlocks());
+  EXPECT_LONGS_EQUAL(root->Ab().nBlocks(), root->info().nBlocks());
 
   // Check a leaf clique block structure.
   MultifrontalSolver::CliquePtr leaf = nullptr;
@@ -377,7 +405,7 @@ TEST(MultifrontalSolver, BalancedSmoother) {
       [&](MultifrontalSolver::CliquePtr c) {
         if (!c) return;
         if (c->children.empty()) {
-          const size_t blocks = c->sbm().nBlocks();
+          const size_t blocks = c->info().nBlocks();
           if (blocks < minBlocks) {
             minBlocks = blocks;
             leaf = c;
@@ -391,6 +419,7 @@ TEST(MultifrontalSolver, BalancedSmoother) {
   EXPECT_LONGS_EQUAL(3, minBlocks);
 
   // Eliminate and solve
+  solver.load(smoother);
   solver.eliminateInPlace();
   const VectorValues& actual = solver.updateSolution();
 

--- a/gtsam/linear/tests/testMultifrontalSolver.cpp
+++ b/gtsam/linear/tests/testMultifrontalSolver.cpp
@@ -57,7 +57,7 @@ MultifrontalSolver::Parameters noMergeParams() {
 }  // namespace
 
 /* ************************************************************************* */
-// Build the solver and validate initial structure and explicit load.
+/// Build the solver and validate initial structure and explicit load.
 TEST(MultifrontalSolver, Constructor) {
   MultifrontalSolver solver(chain, chainOrdering, noMergeParams());
   solver.load(chain);
@@ -87,7 +87,7 @@ TEST(MultifrontalSolver, Constructor) {
 }
 
 /* ************************************************************************* */
-// Build the solver from precomputed data and validate structure and load.
+/// Build the solver from precomputed data and validate structure and load.
 TEST(MultifrontalSolver, ConstructorPrecomputed) {
   auto data = MultifrontalSolver::Precompute(chain, chainOrdering);
   MultifrontalSolver solver(std::move(data), chainOrdering, noMergeParams());
@@ -114,7 +114,7 @@ TEST(MultifrontalSolver, ConstructorPrecomputed) {
 }
 
 /* ************************************************************************* */
-// Reload numerical values and ensure Ab updates match whitening.
+/// Reload numerical values and ensure Ab updates match whitening.
 TEST(MultifrontalSolver, Load) {
   MultifrontalSolver solver(chain, chainOrdering, noMergeParams());
 
@@ -142,7 +142,7 @@ TEST(MultifrontalSolver, Load) {
 }
 
 /* ************************************************************************* */
-// Compare solver output against multifrontal elimination baseline.
+/// Compare solver output against multifrontal elimination baseline.
 TEST(MultifrontalSolver, Eliminate) {
   MultifrontalSolver solver(chain, chainOrdering, noMergeParams());
   solver.load(chain);
@@ -159,7 +159,58 @@ TEST(MultifrontalSolver, Eliminate) {
 }
 
 /* ************************************************************************* */
-// Load + eliminate in one traversal matches standard elimination.
+/// deltaError from the solver matches GaussianFactorGraph for the
+/// solver-produced (optimal) delta.
+TEST(MultifrontalSolver, DeltaErrorMatchesGraph) {
+  MultifrontalSolver solver(chain, chainOrdering, noMergeParams());
+  solver.eliminateInPlace(chain);
+
+  const VectorValues& delta = solver.updateSolution();
+
+  double oldFast = 0.0;
+  double newFast = 0.0;
+  double deltaFast = solver.deltaError(&oldFast, &newFast);
+
+  double oldRef = 0.0;
+  double newRef = 0.0;
+  double deltaRef = chain.deltaError(delta, &oldRef, &newRef);
+
+  DOUBLES_EQUAL(oldRef, oldFast, 1e-9);
+  DOUBLES_EQUAL(newRef, newFast, 1e-9);
+  DOUBLES_EQUAL(deltaRef, deltaFast, 1e-9);
+}
+
+/* ************************************************************************* */
+/// deltaError from the solver matches GaussianFactorGraph on an
+/// overdetermined system with nonzero residual at the solution.
+TEST(MultifrontalSolver, DeltaErrorMatchesGraphInconsistent) {
+  const SharedDiagonal noise = noiseModel::Isotropic::Sigma(1, 1.0);
+  GaussianFactorGraph graph;
+  graph.emplace_shared<JacobianFactor>(x1, I_1x1,
+                                       (Vector(1) << 1.0).finished(), noise);
+  graph.emplace_shared<JacobianFactor>(x1, I_1x1,
+                                       (Vector(1) << -2.0).finished(), noise);
+  const Ordering ordering{x1};
+  MultifrontalSolver solver(graph, ordering, noMergeParams());
+  solver.eliminateInPlace(graph);
+
+  const VectorValues& delta = solver.updateSolution();
+
+  double oldFast = 0.0;
+  double newFast = 0.0;
+  double deltaFast = solver.deltaError(&oldFast, &newFast);
+
+  double oldRef = 0.0;
+  double newRef = 0.0;
+  double deltaRef = graph.deltaError(delta, &oldRef, &newRef);
+
+  DOUBLES_EQUAL(oldRef, oldFast, 1e-9);
+  DOUBLES_EQUAL(newRef, newFast, 1e-9);
+  DOUBLES_EQUAL(deltaRef, deltaFast, 1e-9);
+}
+
+/* ************************************************************************* */
+/// Load + eliminate in one traversal matches standard elimination.
 TEST(MultifrontalSolver, EliminateWithLoad) {
   MultifrontalSolver solver(chain, chainOrdering, noMergeParams());
   solver.eliminateInPlace(chain);
@@ -173,7 +224,30 @@ TEST(MultifrontalSolver, EliminateWithLoad) {
 }
 
 /* ************************************************************************* */
-// Forcing QR enables QR on all leaves and matches legacy QR elimination.
+/// deltaError match when QR is forced, exercising the QR leaf RSd_ path.
+TEST(MultifrontalSolver, DeltaErrorMatchesGraphQR) {
+  auto qrParams = noMergeParams();
+  qrParams.qrMode = MultifrontalParameters::QRMode::Force;
+  MultifrontalSolver solver(chain, chainOrdering, qrParams);
+  solver.eliminateInPlace(chain);
+
+  const VectorValues& delta = solver.updateSolution();
+
+  double oldFast = 0.0;
+  double newFast = 0.0;
+  double deltaFast = solver.deltaError(&oldFast, &newFast);
+
+  double oldRef = 0.0;
+  double newRef = 0.0;
+  double deltaRef = chain.deltaError(delta, &oldRef, &newRef);
+
+  DOUBLES_EQUAL(oldRef, oldFast, 1e-9);
+  DOUBLES_EQUAL(newRef, newFast, 1e-9);
+  DOUBLES_EQUAL(deltaRef, deltaFast, 1e-9);
+}
+
+/* ************************************************************************* */
+/// Forcing QR enables QR on all leaves and matches legacy QR elimination.
 TEST(MultifrontalSolver, ForceQRMatchesDenseQR) {
   auto qrParams = noMergeParams();
   qrParams.qrMode = MultifrontalParameters::QRMode::Force;
@@ -201,7 +275,7 @@ TEST(MultifrontalSolver, ForceQRMatchesDenseQR) {
 }
 
 /* ************************************************************************* */
-// Compare marginals from in-place Bayes tree against standard elimination.
+/// Compare marginals from in-place Bayes tree against standard elimination.
 TEST(MultifrontalSolver, ComputeBayesTreeMarginals) {
   MultifrontalSolver solver(chain, chainOrdering, noMergeParams());
   solver.load(chain);
@@ -231,7 +305,7 @@ TEST(MultifrontalSolver, ComputeBayesTreeMarginals) {
 }
 
 /* ************************************************************************* */
-// Compare marginals on a constrained chain against legacy marginals.
+/// Compare marginals on a constrained chain against legacy marginals.
 TEST(MultifrontalSolver, ComputeBayesTreeMarginalsConstrainedChain) {
   const SharedDiagonal hardConstraint =
       noiseModel::Constrained::MixedSigmas((Vector(1) << 0.0).finished());
@@ -255,7 +329,7 @@ TEST(MultifrontalSolver, ComputeBayesTreeMarginalsConstrainedChain) {
 }
 
 /* ************************************************************************* */
-// Verify feasible unary constrained factor clamps the update to zero.
+/// Verify feasible unary constrained factor clamps the update to zero.
 TEST(MultifrontalSolver, ConstrainedNoiseFeasible) {
   const SharedDiagonal hardConstraint =
       noiseModel::Constrained::MixedSigmas((Vector(1) << 0.0).finished());
@@ -277,7 +351,7 @@ TEST(MultifrontalSolver, ConstrainedNoiseFeasible) {
 }
 
 /* ************************************************************************* */
-// Infeasible unary constrained factor is rejected.
+/// Infeasible unary constrained factor is rejected.
 TEST(MultifrontalSolver, ConstrainedNoiseUnsupported) {
   const SharedDiagonal hardConstraint =
       noiseModel::Constrained::MixedSigmas((Vector(1) << 0.0).finished());
@@ -295,7 +369,7 @@ TEST(MultifrontalSolver, ConstrainedNoiseUnsupported) {
 }
 
 /* ************************************************************************* */
-// Fully constrained unary factor with All() keeps delta fixed at zero.
+/// Fully constrained unary factor with All() keeps delta fixed at zero.
 TEST(MultifrontalSolver, ConstrainedNoiseUnaryFeasible) {
   const SharedDiagonal hardConstraint = noiseModel::Constrained::All(1);
   const SharedDiagonal softNoise = noiseModel::Isotropic::Sigma(1, 1.0);
@@ -315,7 +389,7 @@ TEST(MultifrontalSolver, ConstrainedNoiseUnaryFeasible) {
 }
 
 /* ************************************************************************* */
-// Mixed-key constrained factor is not supported.
+/// Mixed-key constrained factor is not supported.
 TEST(MultifrontalSolver, ConstrainedNoiseMixedKeysUnsupported) {
   const SharedDiagonal hardConstraint = noiseModel::Constrained::All(1);
   GaussianFactorGraph graph;
@@ -329,7 +403,7 @@ TEST(MultifrontalSolver, ConstrainedNoiseMixedKeysUnsupported) {
 }
 
 /* ************************************************************************* */
-// Weighted scalar measurements produce the expected weighted estimate.
+/// Weighted scalar measurements produce the expected weighted estimate.
 TEST(MultifrontalSolver, WeightedScalarMeasurements) {
   const double w1 = 0.2;
   const double w2 = 0.8;
@@ -353,7 +427,7 @@ TEST(MultifrontalSolver, WeightedScalarMeasurements) {
 }
 
 /* ************************************************************************* */
-// Hessian factors are rejected by the multifrontal solver.
+/// Hessian factors are rejected by the multifrontal solver.
 TEST(MultifrontalSolver, HessianFactors) {
   GaussianFactorGraph graph;
   graph.emplace_shared<HessianFactor>(x1, (Matrix(1, 1) << 4.0).finished(),
@@ -366,7 +440,7 @@ TEST(MultifrontalSolver, HessianFactors) {
 }
 
 /* ************************************************************************* */
-// Merge threshold changes the clique count.
+/// Merge threshold changes the clique count.
 TEST(MultifrontalSolver, MergeDimCap) {
   MultifrontalSolver::Parameters noMerge = noMergeParams();
   MultifrontalSolver solverNoMerge(chain, chainOrdering, noMerge);
@@ -379,7 +453,7 @@ TEST(MultifrontalSolver, MergeDimCap) {
 }
 
 /* ************************************************************************* */
-// End-to-end balanced smoother test with reload.
+/// End-to-end balanced smoother test with reload.
 TEST(MultifrontalSolver, BalancedSmoother) {
   // Create smoother with 7 nodes
   auto [nlfg, poses] = example::createNonlinearSmoother(7);

--- a/gtsam/linear/tests/testMultifrontalSolver.cpp
+++ b/gtsam/linear/tests/testMultifrontalSolver.cpp
@@ -57,7 +57,7 @@ MultifrontalSolver::Parameters noMergeParams() {
 }  // namespace
 
 /* ************************************************************************* */
-/// Build the solver and validate initial structure and explicit load.
+// Build the solver and validate initial structure and explicit load.
 TEST(MultifrontalSolver, Constructor) {
   MultifrontalSolver solver(chain, chainOrdering, noMergeParams());
   solver.load(chain);
@@ -87,7 +87,7 @@ TEST(MultifrontalSolver, Constructor) {
 }
 
 /* ************************************************************************* */
-/// Build the solver from precomputed data and validate structure and load.
+// Build the solver from precomputed data and validate structure and load.
 TEST(MultifrontalSolver, ConstructorPrecomputed) {
   auto data = MultifrontalSolver::Precompute(chain, chainOrdering);
   MultifrontalSolver solver(std::move(data), chainOrdering, noMergeParams());
@@ -114,7 +114,7 @@ TEST(MultifrontalSolver, ConstructorPrecomputed) {
 }
 
 /* ************************************************************************* */
-/// Reload numerical values and ensure Ab updates match whitening.
+// Reload numerical values and ensure Ab updates match whitening.
 TEST(MultifrontalSolver, Load) {
   MultifrontalSolver solver(chain, chainOrdering, noMergeParams());
 
@@ -142,7 +142,7 @@ TEST(MultifrontalSolver, Load) {
 }
 
 /* ************************************************************************* */
-/// Compare solver output against multifrontal elimination baseline.
+// Compare solver output against multifrontal elimination baseline.
 TEST(MultifrontalSolver, Eliminate) {
   MultifrontalSolver solver(chain, chainOrdering, noMergeParams());
   solver.load(chain);
@@ -159,8 +159,8 @@ TEST(MultifrontalSolver, Eliminate) {
 }
 
 /* ************************************************************************* */
-/// deltaError from the solver matches GaussianFactorGraph for the
-/// solver-produced (optimal) delta.
+// deltaError from the solver matches GaussianFactorGraph for the
+// solver-produced (optimal) delta.
 TEST(MultifrontalSolver, DeltaErrorMatchesGraph) {
   MultifrontalSolver solver(chain, chainOrdering, noMergeParams());
   solver.eliminateInPlace(chain);
@@ -181,8 +181,8 @@ TEST(MultifrontalSolver, DeltaErrorMatchesGraph) {
 }
 
 /* ************************************************************************* */
-/// deltaError from the solver matches GaussianFactorGraph on an
-/// overdetermined system with nonzero residual at the solution.
+// deltaError from the solver matches GaussianFactorGraph on an
+// overdetermined system with nonzero residual at the solution.
 TEST(MultifrontalSolver, DeltaErrorMatchesGraphInconsistent) {
   const SharedDiagonal noise = noiseModel::Isotropic::Sigma(1, 1.0);
   GaussianFactorGraph graph;
@@ -210,7 +210,7 @@ TEST(MultifrontalSolver, DeltaErrorMatchesGraphInconsistent) {
 }
 
 /* ************************************************************************* */
-/// Load + eliminate in one traversal matches standard elimination.
+// Load + eliminate in one traversal matches standard elimination.
 TEST(MultifrontalSolver, EliminateWithLoad) {
   MultifrontalSolver solver(chain, chainOrdering, noMergeParams());
   solver.eliminateInPlace(chain);
@@ -224,7 +224,7 @@ TEST(MultifrontalSolver, EliminateWithLoad) {
 }
 
 /* ************************************************************************* */
-/// deltaError match when QR is forced, exercising the QR leaf RSd_ path.
+// deltaError match when QR is forced, exercising the QR leaf RSd_ path.
 TEST(MultifrontalSolver, DeltaErrorMatchesGraphQR) {
   auto qrParams = noMergeParams();
   qrParams.qrMode = MultifrontalParameters::QRMode::Force;
@@ -247,7 +247,7 @@ TEST(MultifrontalSolver, DeltaErrorMatchesGraphQR) {
 }
 
 /* ************************************************************************* */
-/// Forcing QR enables QR on all leaves and matches legacy QR elimination.
+// Forcing QR enables QR on all leaves and matches legacy QR elimination.
 TEST(MultifrontalSolver, ForceQRMatchesDenseQR) {
   auto qrParams = noMergeParams();
   qrParams.qrMode = MultifrontalParameters::QRMode::Force;
@@ -275,7 +275,7 @@ TEST(MultifrontalSolver, ForceQRMatchesDenseQR) {
 }
 
 /* ************************************************************************* */
-/// Compare marginals from in-place Bayes tree against standard elimination.
+// Compare marginals from in-place Bayes tree against standard elimination.
 TEST(MultifrontalSolver, ComputeBayesTreeMarginals) {
   MultifrontalSolver solver(chain, chainOrdering, noMergeParams());
   solver.load(chain);
@@ -305,7 +305,7 @@ TEST(MultifrontalSolver, ComputeBayesTreeMarginals) {
 }
 
 /* ************************************************************************* */
-/// Compare marginals on a constrained chain against legacy marginals.
+// Compare marginals on a constrained chain against legacy marginals.
 TEST(MultifrontalSolver, ComputeBayesTreeMarginalsConstrainedChain) {
   const SharedDiagonal hardConstraint =
       noiseModel::Constrained::MixedSigmas((Vector(1) << 0.0).finished());
@@ -329,7 +329,7 @@ TEST(MultifrontalSolver, ComputeBayesTreeMarginalsConstrainedChain) {
 }
 
 /* ************************************************************************* */
-/// Verify feasible unary constrained factor clamps the update to zero.
+// Verify feasible unary constrained factor clamps the update to zero.
 TEST(MultifrontalSolver, ConstrainedNoiseFeasible) {
   const SharedDiagonal hardConstraint =
       noiseModel::Constrained::MixedSigmas((Vector(1) << 0.0).finished());
@@ -351,7 +351,7 @@ TEST(MultifrontalSolver, ConstrainedNoiseFeasible) {
 }
 
 /* ************************************************************************* */
-/// Infeasible unary constrained factor is rejected.
+// Infeasible unary constrained factor is rejected.
 TEST(MultifrontalSolver, ConstrainedNoiseUnsupported) {
   const SharedDiagonal hardConstraint =
       noiseModel::Constrained::MixedSigmas((Vector(1) << 0.0).finished());
@@ -369,7 +369,7 @@ TEST(MultifrontalSolver, ConstrainedNoiseUnsupported) {
 }
 
 /* ************************************************************************* */
-/// Fully constrained unary factor with All() keeps delta fixed at zero.
+// Fully constrained unary factor with All() keeps delta fixed at zero.
 TEST(MultifrontalSolver, ConstrainedNoiseUnaryFeasible) {
   const SharedDiagonal hardConstraint = noiseModel::Constrained::All(1);
   const SharedDiagonal softNoise = noiseModel::Isotropic::Sigma(1, 1.0);
@@ -389,7 +389,7 @@ TEST(MultifrontalSolver, ConstrainedNoiseUnaryFeasible) {
 }
 
 /* ************************************************************************* */
-/// Mixed-key constrained factor is not supported.
+// Mixed-key constrained factor is not supported.
 TEST(MultifrontalSolver, ConstrainedNoiseMixedKeysUnsupported) {
   const SharedDiagonal hardConstraint = noiseModel::Constrained::All(1);
   GaussianFactorGraph graph;
@@ -403,7 +403,7 @@ TEST(MultifrontalSolver, ConstrainedNoiseMixedKeysUnsupported) {
 }
 
 /* ************************************************************************* */
-/// Weighted scalar measurements produce the expected weighted estimate.
+// Weighted scalar measurements produce the expected weighted estimate.
 TEST(MultifrontalSolver, WeightedScalarMeasurements) {
   const double w1 = 0.2;
   const double w2 = 0.8;
@@ -427,7 +427,7 @@ TEST(MultifrontalSolver, WeightedScalarMeasurements) {
 }
 
 /* ************************************************************************* */
-/// Hessian factors are rejected by the multifrontal solver.
+// Hessian factors are rejected by the multifrontal solver.
 TEST(MultifrontalSolver, HessianFactors) {
   GaussianFactorGraph graph;
   graph.emplace_shared<HessianFactor>(x1, (Matrix(1, 1) << 4.0).finished(),
@@ -440,7 +440,7 @@ TEST(MultifrontalSolver, HessianFactors) {
 }
 
 /* ************************************************************************* */
-/// Merge threshold changes the clique count.
+// Merge threshold changes the clique count.
 TEST(MultifrontalSolver, MergeDimCap) {
   MultifrontalSolver::Parameters noMerge = noMergeParams();
   MultifrontalSolver solverNoMerge(chain, chainOrdering, noMerge);
@@ -453,7 +453,7 @@ TEST(MultifrontalSolver, MergeDimCap) {
 }
 
 /* ************************************************************************* */
-/// End-to-end balanced smoother test with reload.
+// End-to-end balanced smoother test with reload.
 TEST(MultifrontalSolver, BalancedSmoother) {
   // Create smoother with 7 nodes
   auto [nlfg, poses] = example::createNonlinearSmoother(7);

--- a/gtsam/nonlinear/GaussNewtonOptimizer.cpp
+++ b/gtsam/nonlinear/GaussNewtonOptimizer.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <gtsam/nonlinear/GaussNewtonOptimizer.h>
+#include <gtsam/nonlinear/NonlinearMultifrontalSolver.h>
 #include <gtsam/nonlinear/internal/NonlinearOptimizerState.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
 #include <gtsam/linear/VectorValues.h>
@@ -49,9 +50,15 @@ GaussianFactorGraph::shared_ptr GaussNewtonOptimizer::iterate() {
   GaussianFactorGraph::shared_ptr linear = graph_.linearize(state_->values);
   gttoc(GaussNewtonOptimizer_Linearize);
 
-  // Solve Factor Graph
   gttic(GaussNewtonOptimizer_Solve);
-  const VectorValues delta = solve(*linear, params_);
+  VectorValues delta;
+  if (ensureMultifrontalSolver(params_, state_->values)) {
+    nonlinearMultifrontalSolver_->load(*linear);
+    nonlinearMultifrontalSolver_->eliminateInPlace();
+    delta = nonlinearMultifrontalSolver_->updateSolution();
+  } else {
+    delta = solve(*linear, params_);
+  }
   gttoc(GaussNewtonOptimizer_Solve);
 
   // Maybe show output

--- a/gtsam/nonlinear/LMDampingParams.h
+++ b/gtsam/nonlinear/LMDampingParams.h
@@ -1,0 +1,54 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file LMDampingParams.h
+ * @brief Parameters controlling LM-style damping for NonlinearMultifrontalSolver.
+ * @author Frank Dellaert
+ * @date   January 2026
+ */
+
+#pragma once
+
+namespace gtsam {
+
+/**
+ * Parameters controlling LM-style damping as applied by
+ * `gtsam::NonlinearMultifrontalSolver`.
+ *
+ * @note These parameters are intentionally in a standalone header so they can
+ * be referenced from nonlinear optimizer parameter types without pulling in
+ * the full solver headers.
+ */
+struct LMDampingParams {
+  /// If true, use diagonal damping (LM) instead of identity damping.
+  bool diagonalDamping = false;
+
+  /**
+   * If true, use the exact diagonal of the linearized system Hessian
+   * `diag(J^T J)` (computed via `GaussianFactorGraph::hessianDiagonal()`) when
+   * applying diagonal damping.
+   *
+   * If false, use the diagonal of each clique's assembled information matrix,
+   * which includes Schur complement contributions and can differ from
+   * `diag(J^T J)`.
+   */
+  bool exactHessianDiagonal = false;
+
+  /// Clamp minimum diagonal value used for diagonal damping.
+  double minDiagonal = 1e-6;
+
+  /// Clamp maximum diagonal value used for diagonal damping.
+  double maxDiagonal = 1e32;
+};
+
+}  // namespace gtsam
+

--- a/gtsam/nonlinear/LevenbergMarquardtOptimizer.cpp
+++ b/gtsam/nonlinear/LevenbergMarquardtOptimizer.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
+#include <gtsam/nonlinear/NonlinearMultifrontalSolver.h>
 #include <gtsam/nonlinear/internal/LevenbergMarquardtState.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/Values.h>
@@ -92,7 +93,7 @@ GaussianFactorGraph LevenbergMarquardtOptimizer::buildDampedSystem(
   if (params_.verbosityLM >= LevenbergMarquardtParams::DAMPED)
     std::cout << "building damped system with lambda " << currentState->lambda << std::endl;
 
-  if (params_.diagonalDamping)
+  if (params_.dampingParams.diagonalDamping)
     return currentState->buildDampedSystem(linear, sqrtHessianDiagonal);
   else
     return currentState->buildDampedSystem(linear);
@@ -137,8 +138,6 @@ bool LevenbergMarquardtOptimizer::tryLambda(const GaussianFactorGraph& linear,
   if (verbose)
     cout << "trying lambda = " << currentState->lambda << endl;
 
-  // Build damped system for this lambda (adds prior factors that make it like gradient descent)
-  auto dampedSystem = buildDampedSystem(linear, sqrtHessianDiagonal);
 
   // Try solving
   double modelFidelity = 0.0;
@@ -151,9 +150,19 @@ bool LevenbergMarquardtOptimizer::tryLambda(const GaussianFactorGraph& linear,
 
   bool systemSolvedSuccessfully;
   try {
-    // ============ Solve is where most computation happens !! =================
-    delta = solve(dampedSystem, params_);
+    // ============ This is where most computation happens !! =================
+    if (nonlinearMultifrontalSolver_) {
+      nonlinearMultifrontalSolver_->eliminateInPlace(currentState->lambda);
+      delta = nonlinearMultifrontalSolver_->updateSolution();
+    } else {
+      // Build damped system for this lambda (adds prior factors that make it
+      // like gradient descent)
+      GaussianFactorGraph dampedSystem =
+          buildDampedSystem(linear, sqrtHessianDiagonal);
+      delta = solve(dampedSystem, params_);
+    }
     systemSolvedSuccessfully = true;
+    // ========================================================================
   } catch (const IndeterminantLinearSystemException&) {
     systemSolvedSuccessfully = false;
   }
@@ -280,6 +289,12 @@ GaussianFactorGraph::shared_ptr LevenbergMarquardtOptimizer::iterate() {
     cout << "linearizing = " << endl;
   GaussianFactorGraph::shared_ptr linear = linearize();
 
+  const bool useMultifrontal =
+      ensureMultifrontalSolver(params_, currentState->values);
+  if (useMultifrontal) {
+    nonlinearMultifrontalSolver_->load(*linear);
+  }
+
   if(currentState->totalNumberInnerIterations==0) { // write initial error
     writeLogFile(currentState->error);
 
@@ -291,10 +306,12 @@ GaussianFactorGraph::shared_ptr LevenbergMarquardtOptimizer::iterate() {
 
   // Only calculate diagonal of Hessian (expensive) once per outer iteration, if we need it
   VectorValues sqrtHessianDiagonal;
-  if (params_.diagonalDamping) {
+  if (params_.dampingParams.diagonalDamping && !useMultifrontal) {
     sqrtHessianDiagonal = linear->hessianDiagonal();
     for (auto& [key, value] : sqrtHessianDiagonal) {
-      value = value.cwiseMax(params_.minDiagonal).cwiseMin(params_.maxDiagonal).cwiseSqrt();
+      value = value.cwiseMax(params_.dampingParams.minDiagonal)
+                  .cwiseMin(params_.dampingParams.maxDiagonal)
+                  .cwiseSqrt();
     }
   }
 
@@ -308,4 +325,3 @@ GaussianFactorGraph::shared_ptr LevenbergMarquardtOptimizer::iterate() {
 }
 
 } /* namespace gtsam */
-

--- a/gtsam/nonlinear/LevenbergMarquardtOptimizer.cpp
+++ b/gtsam/nonlinear/LevenbergMarquardtOptimizer.cpp
@@ -177,8 +177,14 @@ bool LevenbergMarquardtOptimizer::tryLambda(const GaussianFactorGraph& linear,
     // as the nonlinear error when robust noise models are used.
     double oldLinearizedError = 0.0;
     double newLinearizedError = 0.0;
-    double linearizedCostChange =
-        linear.deltaError(delta, &oldLinearizedError, &newLinearizedError);
+    double linearizedCostChange = 0.0;
+    if (nonlinearMultifrontalSolver_) {
+      linearizedCostChange = nonlinearMultifrontalSolver_->deltaError(
+          &oldLinearizedError, &newLinearizedError);
+    } else {
+      linearizedCostChange =
+          linear.deltaError(delta, &oldLinearizedError, &newLinearizedError);
+    }
 
     // cost change in the linearized system (old - new)
     if (verbose)

--- a/gtsam/nonlinear/LevenbergMarquardtParams.cpp
+++ b/gtsam/nonlinear/LevenbergMarquardtParams.cpp
@@ -97,13 +97,15 @@ void LevenbergMarquardtParams::print(const std::string& str) const {
   std::cout << "           lambdaUpperBound: " << lambdaUpperBound << "\n";
   std::cout << "           lambdaLowerBound: " << lambdaLowerBound << "\n";
   std::cout << "           minModelFidelity: " << minModelFidelity << "\n";
-  std::cout << "            diagonalDamping: " << diagonalDamping << "\n";
-  std::cout << "                minDiagonal: " << minDiagonal << "\n";
-  std::cout << "                maxDiagonal: " << maxDiagonal << "\n";
+  std::cout << "            diagonalDamping: " << dampingParams.diagonalDamping
+            << "\n";
+  std::cout << "     exactHessianDiagonalMF: " << dampingParams.exactHessianDiagonal
+            << "\n";
+  std::cout << "                minDiagonal: " << dampingParams.minDiagonal << "\n";
+  std::cout << "                maxDiagonal: " << dampingParams.maxDiagonal << "\n";
   std::cout << "                verbosityLM: "
       << verbosityLMTranslator(verbosityLM) << "\n";
   std::cout.flush();
 }
 
 } /* namespace gtsam */
-

--- a/gtsam/nonlinear/LevenbergMarquardtParams.h
+++ b/gtsam/nonlinear/LevenbergMarquardtParams.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <gtsam/nonlinear/NonlinearOptimizerParams.h>
+#include <gtsam/nonlinear/LMDampingParams.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 
 namespace gtsam {
@@ -53,16 +54,12 @@ public:
   VerbosityLM verbosityLM; ///< The verbosity level for Levenberg-Marquardt (default: SILENT), see also NonlinearOptimizerParams::verbosity
   double minModelFidelity; ///< Lower bound for the modelFidelity to accept the result of an LM iteration
   std::string logFile; ///< an optional CSV log file, with [iteration, time, error, lambda]
-  bool diagonalDamping; ///< if true, use diagonal of Hessian
   bool useFixedLambdaFactor; ///< if true applies constant increase (or decrease) to lambda according to lambdaFactor
-  double minDiagonal; ///< when using diagonal damping saturates the minimum diagonal entries (default: 1e-6)
-  double maxDiagonal; ///< when using diagonal damping saturates the maximum diagonal entries (default: 1e32)
+  /// Parameters controlling LM damping behavior (legacy and `MULTIFRONTAL_SOLVER`).
+  LMDampingParams dampingParams;
 
   LevenbergMarquardtParams()
-      : verbosityLM(SILENT),
-        diagonalDamping(false),
-        minDiagonal(1e-6),
-        maxDiagonal(1e32) {
+      : verbosityLM(SILENT) {
     SetLegacyDefaults(this);
   }
 
@@ -77,8 +74,11 @@ public:
     p->lambdaUpperBound = 1e5;
     p->lambdaLowerBound = 0.0;
     p->minModelFidelity = 1e-3;
-    p->diagonalDamping = false;
     p->useFixedLambdaFactor = true;
+    p->dampingParams.diagonalDamping = false;
+    p->dampingParams.exactHessianDiagonal = false;
+    p->dampingParams.minDiagonal = 1e-6;
+    p->dampingParams.maxDiagonal = 1e32;
   }
 
   // these do seem to work better for SFM
@@ -93,8 +93,11 @@ public:
     p->lambdaInitial = 1e-04;
     p->lambdaFactor = 2.0;
     p->minModelFidelity = 1e-3;  // options.min_relative_decrease in CERES
-    p->diagonalDamping = true;
     p->useFixedLambdaFactor = false;  // This is important
+    p->dampingParams.diagonalDamping = true;
+    p->dampingParams.exactHessianDiagonal = false;
+    p->dampingParams.minDiagonal = 1e-6;
+    p->dampingParams.maxDiagonal = 1e32;
   }
 
   static LevenbergMarquardtParams LegacyDefaults() {
@@ -127,7 +130,7 @@ public:
 
   /// @name Getters/Setters, mainly for wrappers. Use fields above in C++.
   /// @{
-  bool getDiagonalDamping() const { return diagonalDamping; }
+  bool getDiagonalDamping() const { return dampingParams.diagonalDamping; }
   double getlambdaFactor() const { return lambdaFactor; }
   double getlambdaInitial() const { return lambdaInitial; }
   double getlambdaLowerBound() const { return lambdaLowerBound; }
@@ -136,7 +139,7 @@ public:
   std::string getLogFile() const { return logFile; }
   std::string getVerbosityLM() const { return verbosityLMTranslator(verbosityLM);}
   
-  void setDiagonalDamping(bool flag) { diagonalDamping = flag; }
+  void setDiagonalDamping(bool flag) { dampingParams.diagonalDamping = flag; }
   void setlambdaFactor(double value) { lambdaFactor = value; }
   void setlambdaInitial(double value) { lambdaInitial = value; }
   void setlambdaLowerBound(double value) { lambdaLowerBound = value; }

--- a/gtsam/nonlinear/NonlinearEquality.h
+++ b/gtsam/nonlinear/NonlinearEquality.h
@@ -140,6 +140,9 @@ class NonlinearEquality: public NonlinearEqualityConstraint {
     }
   }
 
+  /// Whether this constraint should be treated as hard.
+  bool isHardConstraint() const override { return !allow_error_; }
+
   /// Error function
   Vector evaluateError(const T& xj, OptionalMatrixType H = nullptr) const {
     const size_t nj = traits<T>::GetDimension(feasible_);

--- a/gtsam/nonlinear/NonlinearMultifrontalSolver.cpp
+++ b/gtsam/nonlinear/NonlinearMultifrontalSolver.cpp
@@ -1,0 +1,165 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file NonlinearMultifrontalSolver.cpp
+ * @brief Implementation of nonlinear multifrontal solver.
+ * @author Frank Dellaert
+ * @date   January 2026
+ */
+
+#include <gtsam/base/types.h>
+#include <gtsam/constrained/NonlinearEqualityConstraint.h>
+#include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/linear/MultifrontalClique.h>
+#include <gtsam/nonlinear/NonlinearMultifrontalSolver.h>
+#include <gtsam/symbolic/SymbolicEliminationTree.h>
+#include <gtsam/symbolic/SymbolicFactorGraph.h>
+#include <gtsam/symbolic/SymbolicJunctionTree.h>
+
+namespace gtsam {
+
+namespace {
+
+std::map<Key, size_t> computeDimsFromValues(const Values& values) {
+  return values.dims();
+}
+
+std::unordered_set<Key> collectFixedKeys(const NonlinearFactorGraph& graph) {
+  std::unordered_set<Key> fixedKeys;
+  for (const auto& factor : graph) {
+    if (!factor) continue;
+    if (!std::dynamic_pointer_cast<NonlinearEqualityConstraint>(factor))
+      continue;
+    if (factor->keys().size() != 1) continue;
+    fixedKeys.insert(factor->keys().front());
+  }
+  return fixedKeys;
+}
+
+SymbolicFactorGraph buildSymbolicGraph(
+    const NonlinearFactorGraph& graph,
+    const std::unordered_set<Key>& fixedKeys) {
+  SymbolicFactorGraph symbolicGraph;
+  symbolicGraph.reserve(graph.size());
+  for (size_t i = 0; i < graph.size(); ++i) {
+    if (!graph[i]) continue;
+    KeyVector keys;
+    keys.reserve(graph[i]->size());
+    for (Key key : graph[i]->keys()) {
+      if (!fixedKeys.count(key)) {
+        keys.push_back(key);
+      }
+    }
+    if (keys.empty()) continue;
+    const size_t rows = graph[i]->dim();
+    symbolicGraph.emplace_shared<internal::IndexedSymbolicFactor>(keys, i,
+                                                                  rows);
+  }
+  return symbolicGraph;
+}
+
+}  // namespace
+
+/* ************************************************************************* */
+NonlinearMultifrontalSolver::NonlinearMultifrontalSolver(
+    const NonlinearFactorGraph& graph, const Values& values,
+    const Ordering& ordering, MultifrontalSolver::Parameters params,
+    DampingParams dampingParams)
+    : MultifrontalSolver(
+          NonlinearMultifrontalSolver::Precompute(graph, values, ordering),
+          ordering, params),
+      dampingParams_(dampingParams) {}
+
+/* ************************************************************************* */
+MultifrontalSolver::PrecomputedData NonlinearMultifrontalSolver::Precompute(
+    const NonlinearFactorGraph& graph, const Values& values,
+    const Ordering& ordering) {
+  auto dims = computeDimsFromValues(values);
+  auto fixedKeys = collectFixedKeys(graph);
+
+  Ordering reducedOrdering;
+  reducedOrdering.reserve(ordering.size());
+  for (Key key : ordering) {
+    if (!fixedKeys.count(key)) {
+      reducedOrdering.push_back(key);
+    }
+  }
+
+  SymbolicFactorGraph symbolicGraph = buildSymbolicGraph(graph, fixedKeys);
+  SymbolicEliminationTree eliminationTree(symbolicGraph, reducedOrdering);
+  SymbolicJunctionTree junctionTree(eliminationTree);
+
+  return MultifrontalSolver::PrecomputedData{
+      std::move(dims), std::move(fixedKeys), std::move(junctionTree)};
+}
+
+/* ************************************************************************* */
+void NonlinearMultifrontalSolver::load(const GaussianFactorGraph& graph) {
+  MultifrontalSolver::load(graph);
+  if (dampingParams_.diagonalDamping && dampingParams_.exactHessianDiagonal) {
+    exactHessianDiagonal_ = graph.hessianDiagonal();
+    hasExactHessianDiagonal_ = true;
+  } else {
+    hasExactHessianDiagonal_ = false;
+    exactHessianDiagonal_ = VectorValues();
+  }
+}
+
+/* ************************************************************************* */
+void NonlinearMultifrontalSolver::eliminateInPlace(double lambda) {
+  if (lambda <= 0.0) {
+    MultifrontalSolver::eliminateInPlace();
+    return;
+  }
+
+  if (!loaded_) {
+    throw std::runtime_error(
+        "NonlinearMultifrontalSolver::eliminateInPlace: load() must be called "
+        "before eliminating.");
+  }
+  eliminated_ = false;
+  runBottomUp(
+      [this, lambda](MultifrontalClique& node) {
+        node.eliminateInPlace(lambda, &dampingParams_, &exactHessianDiagonal_);
+      },
+      params_.eliminationParallelThreshold);
+  eliminated_ = true;
+}
+
+/* ************************************************************************* */
+void NonlinearMultifrontalSolver::eliminateInPlace(
+    const GaussianFactorGraph& graph, double lambda) {
+  if (lambda <= 0.0) {
+    MultifrontalSolver::eliminateInPlace(graph);
+    return;
+  }
+
+  if (dampingParams_.diagonalDamping && dampingParams_.exactHessianDiagonal) {
+    exactHessianDiagonal_ = graph.hessianDiagonal();
+    hasExactHessianDiagonal_ = true;
+  } else {
+    hasExactHessianDiagonal_ = false;
+    exactHessianDiagonal_ = VectorValues();
+  }
+
+  eliminated_ = false;
+  runBottomUp(
+      [&graph, this, lambda](MultifrontalClique& node) {
+        node.fillAb(graph);
+        node.eliminateInPlace(lambda, &dampingParams_, &exactHessianDiagonal_);
+      },
+      params_.eliminationParallelThreshold);
+  loaded_ = true;
+  eliminated_ = true;
+}
+
+}  // namespace gtsam

--- a/gtsam/nonlinear/NonlinearMultifrontalSolver.cpp
+++ b/gtsam/nonlinear/NonlinearMultifrontalSolver.cpp
@@ -36,11 +36,16 @@ std::map<Key, size_t> computeDimsFromValues(const Values& values) {
 std::unordered_set<Key> collectFixedKeys(const NonlinearFactorGraph& graph) {
   std::unordered_set<Key> fixedKeys;
   for (const auto& factor : graph) {
-    if (!factor) continue;
-    if (!std::dynamic_pointer_cast<NonlinearEqualityConstraint>(factor))
-      continue;
-    if (factor->keys().size() != 1) continue;
-    fixedKeys.insert(factor->keys().front());
+    if (!factor || factor->keys().size() != 1) continue;
+    if (auto constraint =
+            std::dynamic_pointer_cast<NonlinearEqualityConstraint>(factor)) {
+      if (constraint->isHardConstraint()) {
+        fixedKeys.insert(factor->keys().front());
+      } else {
+        throw MultifrontalSolverNotSupported(
+            "non-hard constraints are not supported");
+      }
+    }
   }
   return fixedKeys;
 }

--- a/gtsam/nonlinear/NonlinearMultifrontalSolver.cpp
+++ b/gtsam/nonlinear/NonlinearMultifrontalSolver.cpp
@@ -116,33 +116,35 @@ void NonlinearMultifrontalSolver::load(const GaussianFactorGraph& graph) {
 
 /* ************************************************************************* */
 void NonlinearMultifrontalSolver::eliminateInPlace(double lambda) {
-  if (lambda <= 0.0) {
-    MultifrontalSolver::eliminateInPlace();
-    return;
-  }
-
   if (!loaded_) {
     throw std::runtime_error(
         "NonlinearMultifrontalSolver::eliminateInPlace: load() must be called "
         "before eliminating.");
   }
+
   eliminated_ = false;
-  runBottomUp(
-      [this, lambda](MultifrontalClique& node) {
-        node.eliminateInPlace(lambda, &dampingParams_, &exactHessianDiagonal_);
-      },
-      params_.eliminationParallelThreshold);
+  if (lambda <= 0.0) {
+    MultifrontalSolver::eliminateInPlace();
+  } else {
+    runBottomUp(
+        [this, lambda](MultifrontalClique& node) {
+          node.eliminateInPlace(lambda, dampingParams_, exactHessianDiagonal_);
+        },
+        params_.eliminationParallelThreshold);
+  }
   eliminated_ = true;
 }
 
 /* ************************************************************************* */
 void NonlinearMultifrontalSolver::eliminateInPlace(
     const GaussianFactorGraph& graph, double lambda) {
+  eliminated_ = false;
   if (lambda <= 0.0) {
     MultifrontalSolver::eliminateInPlace(graph);
     return;
   }
 
+  // Calculate the exact Hessian diagonal if needed.
   if (dampingParams_.diagonalDamping && dampingParams_.exactHessianDiagonal) {
     exactHessianDiagonal_ = graph.hessianDiagonal();
     hasExactHessianDiagonal_ = true;
@@ -151,11 +153,11 @@ void NonlinearMultifrontalSolver::eliminateInPlace(
     exactHessianDiagonal_ = VectorValues();
   }
 
-  eliminated_ = false;
+  // Run bottom-up elimination with damping.
   runBottomUp(
       [&graph, this, lambda](MultifrontalClique& node) {
         node.fillAb(graph);
-        node.eliminateInPlace(lambda, &dampingParams_, &exactHessianDiagonal_);
+        node.eliminateInPlace(lambda, dampingParams_, exactHessianDiagonal_);
       },
       params_.eliminationParallelThreshold);
   loaded_ = true;

--- a/gtsam/nonlinear/NonlinearMultifrontalSolver.h
+++ b/gtsam/nonlinear/NonlinearMultifrontalSolver.h
@@ -1,0 +1,99 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file NonlinearMultifrontalSolver.h
+ * @brief Multifrontal solver for nonlinear factor graphs.
+ * @author Frank Dellaert
+ * @date   January 2026
+ */
+
+#pragma once
+
+#include <gtsam/linear/MultifrontalSolver.h>
+#include <gtsam/nonlinear/LMDampingParams.h>
+#include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <gtsam/nonlinear/Values.h>
+
+#include <optional>
+
+namespace gtsam {
+
+/**
+ * Multifrontal solver for nonlinear factor graphs.
+ *
+ * This class extends MultifrontalSolver to solve nonlinear problems.
+ * The linearization is provided externally via MultifrontalSolver::load().
+ */
+class GTSAM_EXPORT NonlinearMultifrontalSolver : public MultifrontalSolver {
+ public:
+  using DampingParams = LMDampingParams;
+
+ private:
+ public:
+  /**
+   * Construct the solver from a nonlinear factor graph and linearization point.
+   * This computes the symbolic structure (including fixed keys) from the
+   * nonlinear graph and uses the values to determine variable dimensions.
+   * Call load() with a linearized graph before eliminating.
+   * @param graph The nonlinear factor graph to build structure from.
+   * @param values The linearization point used to determine variable dims.
+   * @param ordering The variable ordering to use.
+   * @param params Tunable parameters for traversal and reporting.
+   */
+  NonlinearMultifrontalSolver(const NonlinearFactorGraph& graph,
+                              const Values& values, const Ordering& ordering,
+                              MultifrontalSolver::Parameters params = {},
+                              DampingParams dampingParams = DampingParams());
+
+  /**
+   * Precompute symbolic structure from a nonlinear factor graph and values.
+   * This avoids linearization; call load() with a linearized graph before
+   * eliminating.
+   */
+  static MultifrontalSolver::PrecomputedData Precompute(
+      const NonlinearFactorGraph& graph, const Values& values,
+      const Ordering& ordering);
+
+  /// Update damping parameters for subsequent eliminations.
+  void setDampingParams(const DampingParams& params) {
+    dampingParams_ = params;
+  }
+
+  /**
+   * Load new numerical values from the factor graph.
+   * This overrides the base load() to optionally cache `diag(J^T J)` for
+   * exact diagonal damping when enabled.
+   */
+  void load(const GaussianFactorGraph& graph);
+
+  /**
+   * Eliminate with optional LM-style damping.
+   * When lambda is provided, adds damping on frontal blocks before
+   * factorization.
+   */
+  void eliminateInPlace(double lambda = 0.0);
+
+  /**
+   * Load and eliminate the graph in a single traversal with optional damping.
+   * This calls fillAb() and factorization per clique in post-order.
+   * @param graph The linearized factor graph (structure must match).
+   * @param lambda Optional damping value; non-positive disables damping.
+   */
+  void eliminateInPlace(const GaussianFactorGraph& graph, double lambda = 0.0);
+
+ private:
+  DampingParams dampingParams_;
+  VectorValues exactHessianDiagonal_;
+  bool hasExactHessianDiagonal_ = false;
+};
+
+}  // namespace gtsam

--- a/gtsam/nonlinear/NonlinearMultifrontalSolver.h
+++ b/gtsam/nonlinear/NonlinearMultifrontalSolver.h
@@ -62,11 +62,6 @@ class GTSAM_EXPORT NonlinearMultifrontalSolver : public MultifrontalSolver {
       const NonlinearFactorGraph& graph, const Values& values,
       const Ordering& ordering);
 
-  /// Update damping parameters for subsequent eliminations.
-  void setDampingParams(const DampingParams& params) {
-    dampingParams_ = params;
-  }
-
   /**
    * Load new numerical values from the factor graph.
    * This overrides the base load() to optionally cache `diag(J^T J)` for

--- a/gtsam/nonlinear/NonlinearMultifrontalSolver.h
+++ b/gtsam/nonlinear/NonlinearMultifrontalSolver.h
@@ -31,14 +31,13 @@ namespace gtsam {
  * Multifrontal solver for nonlinear factor graphs.
  *
  * This class extends MultifrontalSolver to solve nonlinear problems.
- * The linearization is provided externally via MultifrontalSolver::load().
+ * The linearization is provided externally via load(), or via
+ * eliminateInPlace() which combines loading and elimination.
  */
 class GTSAM_EXPORT NonlinearMultifrontalSolver : public MultifrontalSolver {
  public:
   using DampingParams = LMDampingParams;
 
- private:
- public:
   /**
    * Construct the solver from a nonlinear factor graph and linearization point.
    * This computes the symbolic structure (including fixed keys) from the

--- a/gtsam/nonlinear/NonlinearOptimizer.cpp
+++ b/gtsam/nonlinear/NonlinearOptimizer.cpp
@@ -244,21 +244,17 @@ bool NonlinearOptimizer::ensureMultifrontalSolver(
     const NonlinearOptimizerParams& params, const Values& values) const {
   if (params.linearSolverType != NonlinearOptimizerParams::MULTIFRONTAL_SOLVER)
     return false;
-  // TODO(frank): check for constraints and return false if present?
-  // MultifrontalSolver supports constraints via "fixedKeys", but
-  // NonlinearMultifrontalSolver wrapper might need to expose that. For now, we
-  // assume if isMultifrontal() is true, we try to use it.
-
-  NonlinearMultifrontalSolver::DampingParams dampingParams;
-  if (auto lmParams = dynamic_cast<const LevenbergMarquardtParams*>(&params)) {
-    dampingParams.exactHessianDiagonal =
-        lmParams->dampingParams.exactHessianDiagonal;
-    dampingParams.diagonalDamping = lmParams->dampingParams.diagonalDamping;
-    dampingParams.minDiagonal = lmParams->dampingParams.minDiagonal;
-    dampingParams.maxDiagonal = lmParams->dampingParams.maxDiagonal;
-  }
-
   if (!nonlinearMultifrontalSolver_) {
+    NonlinearMultifrontalSolver::DampingParams dampingParams;
+    if (auto lmParams =
+            dynamic_cast<const LevenbergMarquardtParams*>(&params)) {
+      dampingParams.exactHessianDiagonal =
+          lmParams->dampingParams.exactHessianDiagonal;
+      dampingParams.diagonalDamping = lmParams->dampingParams.diagonalDamping;
+      dampingParams.minDiagonal = lmParams->dampingParams.minDiagonal;
+      dampingParams.maxDiagonal = lmParams->dampingParams.maxDiagonal;
+    }
+
     // Lazily create the solver.
     // Use default ordering or create one.
     Ordering ordering;
@@ -267,19 +263,11 @@ bool NonlinearOptimizer::ensureMultifrontalSolver(
     else
       ordering = Ordering::Create(params.orderingType, graph_);
 
-    // Check if we can construct it (might throw if constraints are tricky?)
-    try {
-      MultifrontalSolver::Parameters mfParams = params.multifrontalParams;
-      nonlinearMultifrontalSolver_ =
-          std::make_unique<NonlinearMultifrontalSolver>(
-              graph_, values, ordering, mfParams, dampingParams);
-    } catch (...) {
-      // Fallback to legacy
-      return false;
-    }
-  } else {
-    nonlinearMultifrontalSolver_->setDampingParams(dampingParams);
+    // Construct it (may throw if unsupported).
+    nonlinearMultifrontalSolver_ =
+        std::make_unique<NonlinearMultifrontalSolver>(
+            graph_, values, ordering, params.multifrontalParams, dampingParams);
   }
   return true;
 }
-}
+} // namespace gtsam

--- a/gtsam/nonlinear/NonlinearOptimizer.cpp
+++ b/gtsam/nonlinear/NonlinearOptimizer.cpp
@@ -17,7 +17,9 @@
  */
 
 #include <gtsam/nonlinear/NonlinearOptimizer.h>
+#include <gtsam/nonlinear/NonlinearMultifrontalSolver.h>
 #include <gtsam/nonlinear/internal/NonlinearOptimizerState.h>
+#include <gtsam/nonlinear/LevenbergMarquardtParams.h>
 #include <gtsam/linear/GaussianEliminationTree.h>
 #include <gtsam/linear/VectorValues.h>
 #include <gtsam/linear/SubgraphSolver.h>
@@ -26,6 +28,7 @@
 #include <gtsam/linear/VectorValues.h>
 
 
+#include <limits>
 #include <stdexcept>
 #include <iostream>
 #include <iomanip>
@@ -178,8 +181,9 @@ VectorValues NonlinearOptimizer::solve(const GaussianFactorGraph& gfg,
 }
 
 /* ************************************************************************* */
-bool checkConvergence(double relativeErrorTreshold, double absoluteErrorTreshold,
-                      double errorThreshold, double currentError, double newError,
+bool checkConvergence(double relativeErrorThreshold,
+                      double absoluteErrorThreshold, double errorThreshold,
+                      double currentError, double newError,
                       NonlinearOptimizerParams::Verbosity verbosity) {
   if (verbosity >= NonlinearOptimizerParams::ERROR) {
     if (newError <= errorThreshold)
@@ -194,26 +198,26 @@ bool checkConvergence(double relativeErrorTreshold, double absoluteErrorTreshold
   // check if diverges
   double absoluteDecrease = currentError - newError;
   if (verbosity >= NonlinearOptimizerParams::ERROR) {
-    if (absoluteDecrease <= absoluteErrorTreshold)
+    if (absoluteDecrease <= absoluteErrorThreshold)
       cout << "absoluteDecrease: " << setprecision(12) << absoluteDecrease << " < "
-           << absoluteErrorTreshold << endl;
+           << absoluteErrorThreshold << endl;
     else
       cout << "absoluteDecrease: " << setprecision(12) << absoluteDecrease
-           << " >= " << absoluteErrorTreshold << endl;
+           << " >= " << absoluteErrorThreshold << endl;
   }
 
   // calculate relative error decrease and update currentError
   double relativeDecrease = absoluteDecrease / currentError;
   if (verbosity >= NonlinearOptimizerParams::ERROR) {
-    if (relativeDecrease <= relativeErrorTreshold)
+    if (relativeDecrease <= relativeErrorThreshold)
       cout << "relativeDecrease: " << setprecision(12) << relativeDecrease << " < "
-           << relativeErrorTreshold << endl;
+           << relativeErrorThreshold << endl;
     else
       cout << "relativeDecrease: " << setprecision(12) << relativeDecrease
-           << " >= " << relativeErrorTreshold << endl;
+           << " >= " << relativeErrorThreshold << endl;
   }
-  bool converged = (relativeErrorTreshold && (relativeDecrease <= relativeErrorTreshold)) ||
-                   (absoluteDecrease <= absoluteErrorTreshold);
+  bool converged = (relativeErrorThreshold && (relativeDecrease <= relativeErrorThreshold)) ||
+                   (absoluteDecrease <= absoluteErrorThreshold);
   if (verbosity >= NonlinearOptimizerParams::TERMINATION && converged) {
     if (absoluteDecrease >= 0.0)
       cout << "converged" << endl;
@@ -222,9 +226,9 @@ bool checkConvergence(double relativeErrorTreshold, double absoluteErrorTreshold
 
     cout << "errorThreshold: " << newError << " <? " << errorThreshold << endl;
     cout << "absoluteDecrease: " << setprecision(12) << absoluteDecrease << " <? "
-         << absoluteErrorTreshold << endl;
+         << absoluteErrorThreshold << endl;
     cout << "relativeDecrease: " << setprecision(12) << relativeDecrease << " <? "
-         << relativeErrorTreshold << endl;
+         << relativeErrorThreshold << endl;
   }
   return converged;
 }
@@ -234,5 +238,48 @@ GTSAM_EXPORT bool checkConvergence(const NonlinearOptimizerParams& params, doubl
                                    double newError) {
   return checkConvergence(params.relativeErrorTol, params.absoluteErrorTol, params.errorTol,
                           currentError, newError, params.verbosity);
+}
+/* ************************************************************************* */
+bool NonlinearOptimizer::ensureMultifrontalSolver(
+    const NonlinearOptimizerParams& params, const Values& values) const {
+  if (params.linearSolverType != NonlinearOptimizerParams::MULTIFRONTAL_SOLVER)
+    return false;
+  // TODO(frank): check for constraints and return false if present?
+  // MultifrontalSolver supports constraints via "fixedKeys", but
+  // NonlinearMultifrontalSolver wrapper might need to expose that. For now, we
+  // assume if isMultifrontal() is true, we try to use it.
+
+  NonlinearMultifrontalSolver::DampingParams dampingParams;
+  if (auto lmParams = dynamic_cast<const LevenbergMarquardtParams*>(&params)) {
+    dampingParams.exactHessianDiagonal =
+        lmParams->dampingParams.exactHessianDiagonal;
+    dampingParams.diagonalDamping = lmParams->dampingParams.diagonalDamping;
+    dampingParams.minDiagonal = lmParams->dampingParams.minDiagonal;
+    dampingParams.maxDiagonal = lmParams->dampingParams.maxDiagonal;
+  }
+
+  if (!nonlinearMultifrontalSolver_) {
+    // Lazily create the solver.
+    // Use default ordering or create one.
+    Ordering ordering;
+    if (params.ordering)
+      ordering = *params.ordering;
+    else
+      ordering = Ordering::Create(params.orderingType, graph_);
+
+    // Check if we can construct it (might throw if constraints are tricky?)
+    try {
+      MultifrontalSolver::Parameters mfParams = params.multifrontalParams;
+      nonlinearMultifrontalSolver_ =
+          std::make_unique<NonlinearMultifrontalSolver>(
+              graph_, values, ordering, mfParams, dampingParams);
+    } catch (...) {
+      // Fallback to legacy
+      return false;
+    }
+  } else {
+    nonlinearMultifrontalSolver_->setDampingParams(dampingParams);
+  }
+  return true;
 }
 }

--- a/gtsam/nonlinear/NonlinearOptimizer.h
+++ b/gtsam/nonlinear/NonlinearOptimizer.h
@@ -23,7 +23,9 @@
 
 namespace gtsam {
 
-namespace internal { struct NonlinearOptimizerState; }
+namespace internal {
+struct NonlinearOptimizerState;
+}
 class NonlinearMultifrontalSolver;
 
 /**
@@ -31,7 +33,8 @@ class NonlinearMultifrontalSolver;
  * maximum-likelihood estimate of a NonlinearFactorGraph.
  *
  * To use a class derived from this interface, construct the class with a
- * NonlinearFactorGraph and an initial Values variable assignment.  Next, call the
+ * NonlinearFactorGraph and an initial Values variable assignment.  Next, call
+the
  * optimize() method which returns the optimized variable assignment.
  *
  * Simple and compact example:
@@ -55,11 +58,10 @@ cout << "Converged in " << optimizer.iterations() << " iterations "
  *
  * Example of setting parameters before optimization:
  * \code
-// Each derived optimizer type has its own parameters class, which inherits from NonlinearOptimizerParams
-DoglegParams params;
-params.factorization = DoglegParams::QR;
-params.relativeErrorTol = 1e-3;
-params.absoluteErrorTol = 1e-3;
+// Each derived optimizer type has its own parameters class, which inherits from
+NonlinearOptimizerParams DoglegParams params; params.factorization =
+DoglegParams::QR; params.relativeErrorTol = 1e-3; params.absoluteErrorTol =
+1e-3;
 
 // Optimize
 Values result = DoglegOptimizer(graph, initialValues, params).optimize();
@@ -71,27 +73,28 @@ Values result = DoglegOptimizer(graph, initialValues, params).optimize();
  * you can easily control what happens between iterations, such as drawing or
  * printing, moving points from behind the camera to in front, etc.
  *
- * For more flexibility you may override virtual methods in your own derived class.
+ * For more flexibility you may override virtual methods in your own derived
+class.
  */
 class GTSAM_EXPORT NonlinearOptimizer {
+ protected:
+  NonlinearFactorGraph graph_;  ///< The graph with nonlinear factors
 
-protected:
-  NonlinearFactorGraph graph_; ///< The graph with nonlinear factors
+  std::unique_ptr<internal::NonlinearOptimizerState> state_;  ///< PIMPL'd state
 
-  std::unique_ptr<internal::NonlinearOptimizerState> state_; ///< PIMPL'd state
-  
   /// Solver for multifrontal Cholesky, lazily created
-  mutable std::unique_ptr<NonlinearMultifrontalSolver> nonlinearMultifrontalSolver_;
+  mutable std::unique_ptr<NonlinearMultifrontalSolver>
+      nonlinearMultifrontalSolver_;
 
-public:
+ public:
   /** A shared pointer to this class */
   using shared_ptr = std::shared_ptr<const NonlinearOptimizer>;
 
   /// @name Standard interface
   /// @{
 
-  /** 
-   * Optimize for the maximum-likelihood estimate, returning a the optimized 
+  /**
+   * Optimize for the maximum-likelihood estimate, returning a the optimized
    * variable assignments.
    *
    * This function simply calls iterate() in a loop, checking for convergence
@@ -99,7 +102,10 @@ public:
    * process, you may call iterate() and check_convergence() yourself, and if
    * needed modify the optimization state between iterations.
    */
-  virtual const Values& optimize() { defaultOptimize(); return values(); }
+  virtual const Values& optimize() {
+    defaultOptimize();
+    return values();
+  }
 
   /**
    * Optimize, but return empty result if any uncaught exception is thrown
@@ -116,10 +122,10 @@ public:
   size_t iterations() const;
 
   /// return values in current optimizer state
-  const Values &values() const;
+  const Values& values() const;
 
   /// return the graph with nonlinear factors
-  const NonlinearFactorGraph &graph() const { return graph_; }
+  const NonlinearFactorGraph& graph() const { return graph_; }
 
   /// @}
 
@@ -129,19 +135,20 @@ public:
   /** Virtual destructor */
   virtual ~NonlinearOptimizer();
 
-  /** Default function to do linear solve, i.e. optimize a GaussianFactorGraph */
-  virtual VectorValues solve(const GaussianFactorGraph &gfg,
-      const NonlinearOptimizerParams& params) const;
+  /** Default function to do linear solve, i.e. optimize a GaussianFactorGraph
+   */
+  virtual VectorValues solve(const GaussianFactorGraph& gfg,
+                             const NonlinearOptimizerParams& params) const;
 
-  /** 
-   * Perform a single iteration, returning GaussianFactorGraph corresponding to 
+  /**
+   * Perform a single iteration, returning GaussianFactorGraph corresponding to
    * the linearized factor graph.
    */
   virtual GaussianFactorGraph::shared_ptr iterate() = 0;
 
   /// @}
 
-protected:
+ protected:
   /** A default implementation of the optimization loop, which calls iterate()
    * until checkConvergence returns true.
    */
@@ -150,22 +157,29 @@ protected:
   virtual const NonlinearOptimizerParams& _params() const = 0;
 
   /**
-   * Ensure that the nonlinearMultifrontalSolver_ is populated if the params
-   * request multifrontal Cholesky. Returns true if the solver is available and
-   * ready. If constraints are present or initialization fails, returns false
-   * (and user should fall back to legacy solver).
+   * Ensure that the nonlinearMultifrontalSolver_ is populated if (and only if)
+   * the params request the multifrontal Cholesky solver type (e.g.,
+   * MULTIFRONTAL_SOLVER).
+   *
+   * Returns true if the multifrontal solver is available and ready. If a
+   * different solver type is requested in params, this function returns false
+   * without modifying any solver state. If constraints are present or
+   * multifrontal initialization fails, it also returns false (and callers
+   * should fall back to the legacy linear solver path).
    */
   bool ensureMultifrontalSolver(const NonlinearOptimizerParams& params,
                                 const Values& values) const;
 
-  /** Constructor for initial construction of base classes. Takes ownership of state. */
+  /** Constructor for initial construction of base classes. Takes ownership of
+   * state. */
   NonlinearOptimizer(const NonlinearFactorGraph& graph,
                      std::unique_ptr<internal::NonlinearOptimizerState> state);
 };
 
-/** Check whether the relative error decrease is less than relativeErrorThreshold,
- * the absolute error decrease is less than absoluteErrorThreshold, <em>or</em>
- * the error itself is less than errorThreshold.
+/** Check whether the relative error decrease is less than
+ * relativeErrorThreshold, the absolute error decrease is less than
+ * absoluteErrorThreshold, <em>or</em> the error itself is less than
+ * errorThreshold.
  */
 GTSAM_EXPORT bool checkConvergence(
     double relativeErrorThreshold, double absoluteErrorThreshold,
@@ -176,4 +190,4 @@ GTSAM_EXPORT bool checkConvergence(
 GTSAM_EXPORT bool checkConvergence(const NonlinearOptimizerParams& params,
                                    double currentError, double newError);
 
-} // gtsam
+}  // namespace gtsam

--- a/gtsam/nonlinear/NonlinearOptimizer.h
+++ b/gtsam/nonlinear/NonlinearOptimizer.h
@@ -24,6 +24,7 @@
 namespace gtsam {
 
 namespace internal { struct NonlinearOptimizerState; }
+class NonlinearMultifrontalSolver;
 
 /**
  * This is the abstract interface for classes that can optimize for the
@@ -78,6 +79,9 @@ protected:
   NonlinearFactorGraph graph_; ///< The graph with nonlinear factors
 
   std::unique_ptr<internal::NonlinearOptimizerState> state_; ///< PIMPL'd state
+  
+  /// Solver for multifrontal Cholesky, lazily created
+  mutable std::unique_ptr<NonlinearMultifrontalSolver> nonlinearMultifrontalSolver_;
 
 public:
   /** A shared pointer to this class */
@@ -145,20 +149,31 @@ protected:
 
   virtual const NonlinearOptimizerParams& _params() const = 0;
 
+  /**
+   * Ensure that the nonlinearMultifrontalSolver_ is populated if the params
+   * request multifrontal Cholesky. Returns true if the solver is available and
+   * ready. If constraints are present or initialization fails, returns false
+   * (and user should fall back to legacy solver).
+   */
+  bool ensureMultifrontalSolver(const NonlinearOptimizerParams& params,
+                                const Values& values) const;
+
   /** Constructor for initial construction of base classes. Takes ownership of state. */
   NonlinearOptimizer(const NonlinearFactorGraph& graph,
                      std::unique_ptr<internal::NonlinearOptimizerState> state);
 };
 
-/** Check whether the relative error decrease is less than relativeErrorTreshold,
- * the absolute error decrease is less than absoluteErrorTreshold, <em>or</em>
+/** Check whether the relative error decrease is less than relativeErrorThreshold,
+ * the absolute error decrease is less than absoluteErrorThreshold, <em>or</em>
  * the error itself is less than errorThreshold.
  */
-GTSAM_EXPORT bool checkConvergence(double relativeErrorTreshold,
-    double absoluteErrorTreshold, double errorThreshold,
-    double currentError, double newError, NonlinearOptimizerParams::Verbosity verbosity = NonlinearOptimizerParams::SILENT);
+GTSAM_EXPORT bool checkConvergence(
+    double relativeErrorThreshold, double absoluteErrorThreshold,
+    double errorThreshold, double currentError, double newError,
+    NonlinearOptimizerParams::Verbosity verbosity =
+        NonlinearOptimizerParams::SILENT);
 
-GTSAM_EXPORT bool checkConvergence(const NonlinearOptimizerParams& params, double currentError,
-                                   double newError);
+GTSAM_EXPORT bool checkConvergence(const NonlinearOptimizerParams& params,
+                                   double currentError, double newError);
 
 } // gtsam

--- a/gtsam/nonlinear/NonlinearOptimizerParams.cpp
+++ b/gtsam/nonlinear/NonlinearOptimizerParams.cpp
@@ -85,6 +85,9 @@ void NonlinearOptimizerParams::print(const std::string& str) const {
   std::cout.flush();
 
   switch (linearSolverType) {
+  case MULTIFRONTAL_SOLVER:
+    std::cout << "         linear solver type: MULTIFRONTAL SOLVER\n";
+    break;
   case MULTIFRONTAL_CHOLESKY:
     std::cout << "         linear solver type: MULTIFRONTAL CHOLESKY\n";
     break;
@@ -106,6 +109,31 @@ void NonlinearOptimizerParams::print(const std::string& str) const {
   default:
     std::cout << "         linear solver type: (invalid)\n";
     break;
+  }
+
+  if (linearSolverType == MULTIFRONTAL_SOLVER) {
+    const auto& p = multifrontalParams;
+    std::cout << "  multifrontal.leafMergeDimCap: " << p.leafMergeDimCap << "\n";
+    std::cout << "  multifrontal.mergeDimCap: " << p.mergeDimCap << "\n";
+    const char* qrMode = "off";
+    switch (p.qrMode) {
+    case MultifrontalParameters::QRMode::Off:
+      qrMode = "off";
+      break;
+    case MultifrontalParameters::QRMode::Allow:
+      qrMode = "allow";
+      break;
+    case MultifrontalParameters::QRMode::Force:
+      qrMode = "force";
+      break;
+    }
+    std::cout << "  multifrontal.qrMode: " << qrMode << "\n";
+    std::cout << "  multifrontal.qrAspectRatio: " << p.qrAspectRatio << "\n";
+    std::cout << "  multifrontal.eliminationParallelThreshold: "
+              << p.eliminationParallelThreshold << "\n";
+    std::cout << "  multifrontal.solutionParallelThreshold: "
+              << p.solutionParallelThreshold << "\n";
+    std::cout << "  multifrontal.numThreads: " << p.numThreads << "\n";
   }
 
   switch (orderingType){
@@ -136,19 +164,34 @@ bool NonlinearOptimizerParams::equals(const NonlinearOptimizerParams& other,
     iterative_params_equal = !iterativeParams && !other.iterativeParams;
   }
 
+  auto multifrontalEqual = [&]() {
+    const auto& a = multifrontalParams;
+    const auto& b = other.multifrontalParams;
+    return a.leafMergeDimCap == b.leafMergeDimCap &&
+           a.mergeDimCap == b.mergeDimCap &&
+           a.qrMode == b.qrMode && a.qrAspectRatio == b.qrAspectRatio &&
+           a.reportStream == b.reportStream &&
+           a.eliminationParallelThreshold == b.eliminationParallelThreshold &&
+           a.solutionParallelThreshold == b.solutionParallelThreshold &&
+           a.numThreads == b.numThreads;
+  };
+
   return maxIterations == other.getMaxIterations() &&
          std::abs(relativeErrorTol - other.getRelativeErrorTol()) <= tol &&
          std::abs(absoluteErrorTol - other.getAbsoluteErrorTol()) <= tol &&
          std::abs(errorTol - other.getErrorTol()) <= tol &&
          verbosityTranslator(verbosity) == other.getVerbosity() &&
          orderingType == other.orderingType && ordering == other.ordering &&
-         linearSolverType == other.linearSolverType && iterative_params_equal;
+         linearSolverType == other.linearSolverType && iterative_params_equal &&
+         multifrontalEqual();
 }
 
 /* ************************************************************************* */
 std::string NonlinearOptimizerParams::linearSolverTranslator(
     LinearSolverType linearSolverType) const {
   switch (linearSolverType) {
+  case MULTIFRONTAL_SOLVER:
+    return "MULTIFRONTAL_SOLVER";
   case MULTIFRONTAL_CHOLESKY:
     return "MULTIFRONTAL_CHOLESKY";
   case MULTIFRONTAL_QR:
@@ -170,6 +213,8 @@ std::string NonlinearOptimizerParams::linearSolverTranslator(
 /* ************************************************************************* */
 NonlinearOptimizerParams::LinearSolverType NonlinearOptimizerParams::linearSolverTranslator(
     const std::string& linearSolverType) const {
+  if (linearSolverType == "MULTIFRONTAL_SOLVER")
+    return MULTIFRONTAL_SOLVER;
   if (linearSolverType == "MULTIFRONTAL_CHOLESKY")
     return MULTIFRONTAL_CHOLESKY;
   if (linearSolverType == "MULTIFRONTAL_QR")

--- a/gtsam/nonlinear/NonlinearOptimizerParams.h
+++ b/gtsam/nonlinear/NonlinearOptimizerParams.h
@@ -107,10 +107,16 @@ public:
     CHOLMOD, /* Experimental Flag */
   };
 
-  LinearSolverType linearSolverType = MULTIFRONTAL_SOLVER; ///< The type of linear solver to use in the nonlinear optimizer
   std::optional<Ordering> ordering; ///< The optional variable elimination ordering, or empty to use COLAMD (default: empty)
   IterativeOptimizationParameters::shared_ptr iterativeParams; ///< The container for iterativeOptimization parameters. used in CG Solvers.
   /// Parameters for `gtsam::MultifrontalSolver` when using `MULTIFRONTAL_SOLVER`.
+
+  /// The type of linear solver to use in the nonlinear optimizer
+ #ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
+  LinearSolverType linearSolverType = MULTIFRONTAL_CHOLESKY;
+#else
+  LinearSolverType linearSolverType = MULTIFRONTAL_SOLVER;
+#endif
   MultifrontalParameters multifrontalParams;
 
   NonlinearOptimizerParams() = default;

--- a/gtsam/nonlinear/NonlinearOptimizerParams.h
+++ b/gtsam/nonlinear/NonlinearOptimizerParams.h
@@ -23,7 +23,9 @@
 
 #include <gtsam/linear/GaussianFactorGraph.h>
 #include <gtsam/linear/SubgraphSolver.h>
+#include <gtsam/linear/MultifrontalParameters.h>
 
+#include <iosfwd>
 #include <string>
 #include <optional>
 
@@ -96,6 +98,7 @@ public:
 
   /** See NonlinearOptimizerParams::linearSolverType */
   enum LinearSolverType {
+    MULTIFRONTAL_SOLVER,
     MULTIFRONTAL_CHOLESKY,
     MULTIFRONTAL_QR,
     SEQUENTIAL_CHOLESKY,
@@ -104,9 +107,11 @@ public:
     CHOLMOD, /* Experimental Flag */
   };
 
-  LinearSolverType linearSolverType = MULTIFRONTAL_CHOLESKY; ///< The type of linear solver to use in the nonlinear optimizer
+  LinearSolverType linearSolverType = MULTIFRONTAL_SOLVER; ///< The type of linear solver to use in the nonlinear optimizer
   std::optional<Ordering> ordering; ///< The optional variable elimination ordering, or empty to use COLAMD (default: empty)
   IterativeOptimizationParameters::shared_ptr iterativeParams; ///< The container for iterativeOptimization parameters. used in CG Solvers.
+  /// Parameters for `gtsam::MultifrontalSolver` when using `MULTIFRONTAL_SOLVER`.
+  MultifrontalParameters multifrontalParams;
 
   NonlinearOptimizerParams() = default;
   virtual ~NonlinearOptimizerParams() {
@@ -117,7 +122,8 @@ public:
   bool equals(const NonlinearOptimizerParams& other, double tol = 1e-9) const;
 
   inline bool isMultifrontal() const {
-    return (linearSolverType == MULTIFRONTAL_CHOLESKY)
+    return (linearSolverType == MULTIFRONTAL_SOLVER)
+        || (linearSolverType == MULTIFRONTAL_CHOLESKY)
         || (linearSolverType == MULTIFRONTAL_QR);
   }
 
@@ -136,6 +142,7 @@ public:
 
   GaussianFactorGraph::Eliminate getEliminationFunction() const {
     switch (linearSolverType) {
+    case MULTIFRONTAL_SOLVER:
     case MULTIFRONTAL_CHOLESKY:
     case SEQUENTIAL_CHOLESKY:
       return EliminatePreferCholesky;

--- a/gtsam/nonlinear/Values.h
+++ b/gtsam/nonlinear/Values.h
@@ -78,6 +78,9 @@ namespace gtsam {
     // The member to store the values, see just above
     KeyValueMap values_;
 
+    // Friend access for efficient in-place updates.
+    friend class NonlinearMultifrontalSolver;
+
   public:
 
     /// A shared_ptr to this class

--- a/gtsam/nonlinear/tests/testNonlinearMultifrontalSolver.cpp
+++ b/gtsam/nonlinear/tests/testNonlinearMultifrontalSolver.cpp
@@ -1,0 +1,408 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file testNonlinearMultifrontalSolver.cpp
+ * @brief Test for NonlinearMultifrontalSolver
+ * @author Frank Dellaert
+ * @date   January 2026
+ */
+
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/geometry/Point2.h>
+#include <gtsam/inference/Ordering.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/linear/JacobianFactor.h>
+#include <gtsam/linear/NoiseModel.h>
+#include <gtsam/nonlinear/NonlinearMultifrontalSolver.h>
+#include <gtsam/nonlinear/NonlinearOptimizerParams.h>
+#include <gtsam/nonlinear/Values.h>
+#include <gtsam/sfm/SfmData.h>
+#include <gtsam/slam/BetweenFactor.h>
+#include <gtsam/slam/PriorFactor.h>
+#include <gtsam/slam/dataset.h>
+#include <tests/smallExample.h>
+
+#include <cmath>
+#include <stdexcept>
+
+using namespace std;
+using namespace gtsam;
+
+using symbol_shorthand::P;
+using symbol_shorthand::X;
+
+namespace {
+struct SolverTestProblem {
+  NonlinearFactorGraph graph;
+  Values values;
+  Ordering ordering;
+};
+
+SolverTestProblem makeTwoPoseProblem(const Point2& between = Point2(2, 0)) {
+  SolverTestProblem problem;
+  auto priorModel = noiseModel::Isotropic::Sigma(2, 1.0);
+  auto model = noiseModel::Isotropic::Sigma(2, 1.0);
+
+  problem.graph.emplace_shared<PriorFactor<Point2>>(X(1), Point2(0, 0),
+                                                    priorModel);
+  problem.graph.emplace_shared<BetweenFactor<Point2>>(X(1), X(2), between,
+                                                      model);
+
+  problem.values.insert(X(1), Point2(0, 0));
+  problem.values.insert(X(2), Point2(0, 0));
+
+  problem.ordering.push_back(X(1));
+  problem.ordering.push_back(X(2));
+  return problem;
+}
+
+// Helper to run solver iterations
+void runIterations(const NonlinearFactorGraph& graph,
+                   NonlinearMultifrontalSolver& solver, Values& values,
+                   size_t iterations, double lambda = 0.0,
+                   GaussianFactorGraph::shared_ptr initialLinear = {}) {
+  for (size_t i = 0; i < iterations; ++i) {
+    GaussianFactorGraph::shared_ptr linear;
+    if (i == 0 && initialLinear) {
+      linear = initialLinear;
+    } else {
+      linear = graph.linearize(values);
+    }
+    solver.eliminateInPlace(*linear, lambda);
+    VectorValues delta = solver.updateSolution();
+    values = values.retract(delta);
+  }
+}
+
+}  // namespace
+
+/* ************************************************************************* */
+// One linearization + one elimination + one back-solve on a tiny 2-pose
+// problem. Tests the basic happy-path flow: construct -> load ->
+// eliminateInPlace -> updateSolution, and verifies the expected single-step
+// update.
+TEST(NonlinearMultifrontalSolver, OneStep) {
+  auto problem = makeTwoPoseProblem(Point2(1, 0));
+  auto linear = problem.graph.linearize(problem.values);
+
+  NonlinearMultifrontalSolver solver(problem.graph, problem.values,
+                                     problem.ordering);
+
+  // 4. Load and eliminate
+  solver.eliminateInPlace(*linear, 0.0);
+
+  // 5. Solve and Update
+  VectorValues delta = solver.updateSolution();
+  Values result = problem.values.retract(delta);
+
+  // 6. Check results
+  EXPECT(assert_equal(Point2(0, 0), result.at<Point2>(X(1)), 1e-9));
+  EXPECT(assert_equal(Point2(1, 0), result.at<Point2>(X(2)), 1e-9));
+}
+
+/* ************************************************************************* */
+// Precompute the symbolic structure (junction tree, dimensions, fixed keys)
+// from a nonlinear graph and initial values.
+// Tests that Precompute succeeds and produces consistent sizing information.
+TEST(NonlinearMultifrontalSolver, OneStepPrecomputed) {
+  auto problem = makeTwoPoseProblem(Point2(1, 0));
+
+  auto data = NonlinearMultifrontalSolver::Precompute(
+      problem.graph, problem.values, problem.ordering);
+  EXPECT(data.dims.count(X(1)));
+  EXPECT(data.dims.count(X(2)));
+  EXPECT(data.fixedKeys.empty());
+
+  auto linear = problem.graph.linearize(problem.values);
+  NonlinearMultifrontalSolver solver(problem.graph, problem.values,
+                                     problem.ordering);
+  solver.eliminateInPlace(*linear, {});
+
+  VectorValues delta = solver.updateSolution();
+  Values result = problem.values.retract(delta);
+
+  EXPECT(assert_equal(Point2(0, 0), result.at<Point2>(X(1)), 1e-9));
+  EXPECT(assert_equal(Point2(1, 0), result.at<Point2>(X(2)), 1e-9));
+}
+
+/* ************************************************************************* */
+// Run a first elimination to get an updated estimate, then deliberately
+// perturb the estimate, re-linearize, reload, and eliminate again.
+// Tests that load() correctly overwrites numeric data for subsequent solves.
+TEST(NonlinearMultifrontalSolver, ReLinearize) {
+  auto problem = makeTwoPoseProblem();
+  auto linear = problem.graph.linearize(problem.values);
+  NonlinearMultifrontalSolver solver(problem.graph, problem.values,
+                                     problem.ordering);
+
+  // 4. First Step
+  solver.eliminateInPlace(*linear, {});
+  VectorValues delta1 = solver.updateSolution();
+  Values currentValues = problem.values.retract(delta1);
+
+  // Expect X(2) to be (2,0) because it's linear P2 problem
+  EXPECT(assert_equal(Point2(2, 0), currentValues.at<Point2>(X(2)), 1e-9));
+
+  // 5. Disturb values to check re-linearization logic
+  currentValues.update(X(2), Point2(1.0, 0.0));
+
+  // 6. Re-linearize
+  auto linear2 = problem.graph.linearize(currentValues);
+  solver.eliminateInPlace(*linear2, {});  // Re-linearize and eliminate.
+  VectorValues delta2 = solver.updateSolution();
+  Values actual = currentValues.retract(delta2);
+
+  // Expect X(2) to differ by delta = 1.0, so back to 2.0
+  EXPECT(assert_equal(Point2(2, 0), actual.at<Point2>(X(2)), 1e-9));
+}
+
+/* ************************************************************************* */
+// Repeatedly linearize at the current estimate and run eliminate/solve to
+// convergence on a small problem (Gauss-Newton-style iterations).
+// Tests that repeated load/eliminate/update cycles behave consistently.
+TEST(NonlinearMultifrontalSolver, MultiIteration) {
+  auto problem = makeTwoPoseProblem();
+  auto linear = problem.graph.linearize(problem.values);
+  NonlinearMultifrontalSolver solver(problem.graph, problem.values,
+                                     problem.ordering);
+  constexpr size_t kIterations = 5;
+  runIterations(problem.graph, solver, problem.values, kIterations, 0, linear);
+
+  EXPECT(assert_equal(Point2(0, 0), problem.values.at<Point2>(X(1)), 1e-9));
+  EXPECT(assert_equal(Point2(2, 0), problem.values.at<Point2>(X(2)), 1e-9));
+}
+
+/* ************************************************************************* */
+// Run multiple iterations with LM-style damping where damping is applied to
+// the diagonal of the frontal Hessian blocks.
+// Tests damped elimination and the diagonal-damping code path.
+TEST(NonlinearMultifrontalSolver, DampedIterationsDiagonal) {
+  auto problem = makeTwoPoseProblem();
+  NonlinearMultifrontalSolver::DampingParams params;
+  params.diagonalDamping = true;
+  auto linear = problem.graph.linearize(problem.values);
+
+  MultifrontalSolver::Parameters mfParams;
+  mfParams.mergeDimCap = 0;
+  mfParams.qrMode = MultifrontalParameters::QRMode::Off;
+  NonlinearMultifrontalSolver solver(problem.graph, problem.values,
+                                     problem.ordering, mfParams, params);
+  constexpr size_t kIterations = 10;
+  runIterations(problem.graph, solver, problem.values, kIterations, 0.1,
+                linear);
+
+  EXPECT(assert_equal(Point2(0, 0), problem.values.at<Point2>(X(1)), 1e-6));
+  EXPECT(assert_equal(Point2(2, 0), problem.values.at<Point2>(X(2)), 1e-3));
+}
+
+/* ************************************************************************* */
+// Run multiple iterations with LM-style damping where damping is applied as
+// an identity term on the frontal blocks (full damping).
+// Tests damped elimination and the identity-damping code path.
+TEST(NonlinearMultifrontalSolver, DampedIterationsFull) {
+  auto problem = makeTwoPoseProblem();
+  NonlinearMultifrontalSolver::DampingParams params;
+  params.diagonalDamping = false;
+  auto linear = problem.graph.linearize(problem.values);
+
+  MultifrontalSolver::Parameters mfParams;
+  mfParams.mergeDimCap = 0;
+  mfParams.qrMode = MultifrontalParameters::QRMode::Off;
+  NonlinearMultifrontalSolver solver(problem.graph, problem.values,
+                                     problem.ordering, mfParams, params);
+  constexpr size_t kIterations = 10;
+  runIterations(problem.graph, solver, problem.values, kIterations, 0.1,
+                linear);
+
+  EXPECT(assert_equal(Point2(0, 0), problem.values.at<Point2>(X(1)), 1e-6));
+  EXPECT(assert_equal(Point2(2, 0), problem.values.at<Point2>(X(2)), 1e-3));
+}
+
+/* ************************************************************************* */
+// Compare QR vs Cholesky on a single-clique elimination with damping.
+// This is expected to fail until QR supports LM-style damping.
+TEST(NonlinearMultifrontalSolver, DampedSingleCliqueQRVsCholesky) {
+  auto problem = makeTwoPoseProblem();
+  auto linear = problem.graph.linearize(problem.values);
+
+  MultifrontalSolver::Parameters qrParams;
+  qrParams.mergeDimCap = 0;
+  qrParams.qrMode = MultifrontalParameters::QRMode::Force;
+  NonlinearMultifrontalSolver qrSolver(problem.graph, problem.values,
+                                       problem.ordering, qrParams);
+
+  MultifrontalSolver::Parameters choleskyParams;
+  choleskyParams.mergeDimCap = 0;
+  choleskyParams.qrMode = MultifrontalParameters::QRMode::Off;
+  NonlinearMultifrontalSolver choleskySolver(problem.graph, problem.values,
+                                             problem.ordering, choleskyParams);
+
+  const double lambda = 1e-3;
+  choleskySolver.eliminateInPlace(*linear, lambda);
+  const VectorValues choleskyDelta = choleskySolver.updateSolution();
+
+  qrSolver.eliminateInPlace(*linear, lambda);
+  const VectorValues qrDelta = qrSolver.updateSolution();
+  EXPECT(assert_equal(choleskyDelta, qrDelta, 1e-9));
+}
+
+/* ************************************************************************* */
+// Forced QR and Cholesky match for a damped smoother linearization across
+// identity, diagonal, and exact diagonal damping variants.
+TEST(NonlinearMultifrontalSolver, DampedSmootherQRMatchesCholesky) {
+  const double lambda = 1e-2;
+  auto [nlfg, poses] = example::createNonlinearSmoother(7);
+  poses.update(X(1), Point2(1.1, 0.2));
+  auto linear = nlfg.linearize(poses);
+  const Ordering ordering{X(1), X(3), X(5), X(7), X(2), X(6), X(4)};
+
+  const auto solve =
+      [](const NonlinearFactorGraph& graph, const Values& values,
+         const Ordering& ordering, const GaussianFactorGraph& linear,
+         MultifrontalParameters::QRMode qrMode,
+         const NonlinearMultifrontalSolver::DampingParams& dampingParams,
+         double lambda) {
+        MultifrontalSolver::Parameters params;
+        params.mergeDimCap = 0;
+        params.qrMode = qrMode;
+        NonlinearMultifrontalSolver solver(graph, values, ordering, params,
+                                           dampingParams);
+        solver.eliminateInPlace(linear, lambda);
+        return solver.updateSolution();
+      };
+
+  NonlinearMultifrontalSolver::DampingParams identity;
+  identity.diagonalDamping = false;
+  VectorValues identityQr =
+      solve(nlfg, poses, ordering, *linear,
+            MultifrontalParameters::QRMode::Force, identity, lambda);
+  VectorValues identityCholesky =
+      solve(nlfg, poses, ordering, *linear, MultifrontalParameters::QRMode::Off,
+            identity, lambda);
+  EXPECT(assert_equal(identityCholesky, identityQr, 1e-9));
+
+  NonlinearMultifrontalSolver::DampingParams diagonal;
+  diagonal.diagonalDamping = true;
+  diagonal.exactHessianDiagonal = false;
+  VectorValues diagonalQr =
+      solve(nlfg, poses, ordering, *linear,
+            MultifrontalParameters::QRMode::Force, diagonal, lambda);
+  VectorValues diagonalCholesky =
+      solve(nlfg, poses, ordering, *linear, MultifrontalParameters::QRMode::Off,
+            diagonal, lambda);
+  EXPECT(assert_equal(diagonalCholesky, diagonalQr, 1e-9));
+
+  NonlinearMultifrontalSolver::DampingParams exact;
+  exact.diagonalDamping = true;
+  exact.exactHessianDiagonal = true;
+  VectorValues exactQr =
+      solve(nlfg, poses, ordering, *linear,
+            MultifrontalParameters::QRMode::Force, exact, lambda);
+  VectorValues exactCholesky =
+      solve(nlfg, poses, ordering, *linear, MultifrontalParameters::QRMode::Off,
+            exact, lambda);
+  EXPECT(assert_equal(exactCholesky, exactQr, 1e-9));
+}
+
+/* ************************************************************************* */
+// Load a linearized graph once and then eliminate multiple times with
+// different damping values (lambda), without reloading. This models common LM
+// behavior where a fixed linearization is probed with several lambdas.
+TEST(NonlinearMultifrontalSolver, ProbeMultipleLambdasSameLinearization) {
+  auto problem = makeTwoPoseProblem(Point2(2, 0));
+  auto linear = problem.graph.linearize(problem.values);
+
+  NonlinearMultifrontalSolver::DampingParams dampingParams;
+  dampingParams.diagonalDamping = false;
+
+  MultifrontalSolver::Parameters mfParams;
+  mfParams.mergeDimCap = 0;
+  mfParams.qrMode = MultifrontalParameters::QRMode::Off;
+  NonlinearMultifrontalSolver solver(problem.graph, problem.values,
+                                     problem.ordering, mfParams, dampingParams);
+
+  solver.load(*linear);
+
+  const double lambdaSmall = 1e-3;
+  solver.eliminateInPlace(lambdaSmall);
+  const VectorValues deltaSmall = solver.updateSolution();
+
+  const double lambdaLarge = 1e3;
+  solver.eliminateInPlace(lambdaLarge);
+  const VectorValues deltaLarge = solver.updateSolution();
+
+  EXPECT(deltaLarge.norm() < deltaSmall.norm());
+}
+
+/* ************************************************************************* */
+// Check the BAL 16-camera dataset error before and after one LM iteration for
+// legacy multifrontal Cholesky and the new multifrontal solver (QR off/forced).
+double runBal16OneIteration(
+    const NonlinearFactorGraph& graph, const Values& initial,
+    const Ordering& ordering,
+    NonlinearOptimizerParams::LinearSolverType solverType) {
+  const double lambda = 1e-5;
+  GaussianFactorGraph::shared_ptr linear = graph.linearize(initial);
+  VectorValues delta;
+  if (solverType == NonlinearOptimizerParams::MULTIFRONTAL_SOLVER) {
+    MultifrontalSolver::Parameters params;
+    params.qrMode = MultifrontalParameters::QRMode::Force;
+    NonlinearMultifrontalSolver solver(graph, initial, ordering, params);
+    solver.eliminateInPlace(*linear, lambda);
+    delta = solver.updateSolution();
+  } else if (solverType == NonlinearOptimizerParams::MULTIFRONTAL_QR) {
+    GaussianFactorGraph damped = *linear;
+    const auto dims = initial.dims();
+    const double sigma = 1.0 / std::sqrt(lambda);
+    for (const auto& [key, dim] : dims) {
+      damped.emplace_shared<JacobianFactor>(
+          key, Matrix::Identity(dim, dim), Vector::Zero(dim),
+          noiseModel::Isotropic::Sigma(dim, sigma));
+    }
+    delta = damped.optimize(ordering, EliminateQR);
+  } else {
+    throw std::runtime_error("Unsupported solver type for BAL test.");
+  }
+  const Values updated = initial.retract(delta);
+  return graph.error(updated);
+}
+
+TEST(NonlinearMultifrontalSolver, Bal16ErrorOneIteration) {
+  const string filename = findExampleDataFile("dubrovnik-16-22106-pre");
+  SfmData db = SfmData::FromBalFile(filename);
+  db.tracks.resize(1000);
+  NonlinearFactorGraph graph = db.generalSfmFactors();
+  const Values initial = initialCamerasAndPointsEstimate(db);
+
+  // Create ordering: first points, then cameras
+  Ordering ordering;
+  ordering.reserve(db.numberTracks() + db.numberCameras());
+  for (size_t j = 0; j < db.numberTracks(); ++j) {
+    ordering.push_back(P(j));
+  }
+  for (size_t i = 0; i < db.numberCameras(); ++i) {
+    ordering.push_back(i);
+  }
+
+  // Run legacy multifrontal Cholesky and new solver (QR forced)
+  const double legacyAfterError = runBal16OneIteration(
+      graph, initial, ordering, NonlinearOptimizerParams::MULTIFRONTAL_QR);
+  const double solverForceAfterError = runBal16OneIteration(
+      graph, initial, ordering, NonlinearOptimizerParams::MULTIFRONTAL_SOLVER);
+  EXPECT_DOUBLES_EQUAL(legacyAfterError, solverForceAfterError, 20.0);
+}
+
+/* ************************************************************************* */
+int main() {
+  TestResult tr;
+  return TestRegistry::runAllTests(tr);
+}

--- a/gtsam/nonlinear/tests/testNonlinearMultifrontalSolver.cpp
+++ b/gtsam/nonlinear/tests/testNonlinearMultifrontalSolver.cpp
@@ -22,6 +22,7 @@
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/linear/JacobianFactor.h>
 #include <gtsam/linear/NoiseModel.h>
+#include <gtsam/nonlinear/NonlinearEquality.h>
 #include <gtsam/nonlinear/NonlinearMultifrontalSolver.h>
 #include <gtsam/nonlinear/NonlinearOptimizerParams.h>
 #include <gtsam/nonlinear/Values.h>
@@ -132,6 +133,35 @@ TEST(NonlinearMultifrontalSolver, OneStepPrecomputed) {
 
   EXPECT(assert_equal(Point2(0, 0), result.at<Point2>(X(1)), 1e-9));
   EXPECT(assert_equal(Point2(1, 0), result.at<Point2>(X(2)), 1e-9));
+}
+
+/* ************************************************************************* */
+TEST(NonlinearMultifrontalSolver, PrecomputeHardConstraint) {
+  NonlinearFactorGraph graph;
+  Values values;
+  Ordering ordering;
+
+  graph.emplace_shared<NonlinearEquality<Point2>>(X(1), Point2(1.0, 2.0));
+  values.insert(X(1), Point2(0.0, 0.0));
+  ordering.push_back(X(1));
+
+  auto data = NonlinearMultifrontalSolver::Precompute(graph, values, ordering);
+  CHECK_EQUAL(1, data.fixedKeys.size());
+}
+
+/* ************************************************************************* */
+TEST(NonlinearMultifrontalSolver, PrecomputeSoftConstraintThrows) {
+  NonlinearFactorGraph graph;
+  Values values;
+  Ordering ordering;
+
+  graph.emplace_shared<NonlinearEquality<Point2>>(X(1), Point2(1.0, 2.0), 10.0);
+  values.insert(X(1), Point2(0.0, 0.0));
+  ordering.push_back(X(1));
+
+  CHECK_EXCEPTION(
+      NonlinearMultifrontalSolver::Precompute(graph, values, ordering),
+      std::runtime_error);
 }
 
 /* ************************************************************************* */

--- a/gtsam/nonlinear/tests/testNonlinearMultifrontalSolver.cpp
+++ b/gtsam/nonlinear/tests/testNonlinearMultifrontalSolver.cpp
@@ -346,6 +346,7 @@ TEST(NonlinearMultifrontalSolver, ProbeMultipleLambdasSameLinearization) {
 /* ************************************************************************* */
 // Check the BAL 16-camera dataset error before and after one LM iteration for
 // legacy multifrontal Cholesky and the new multifrontal solver (QR off/forced).
+# ifdef TEST_BAL16_DATASET
 double runBal16OneIteration(
     const NonlinearFactorGraph& graph, const Values& initial,
     const Ordering& ordering,
@@ -400,6 +401,7 @@ TEST(NonlinearMultifrontalSolver, Bal16ErrorOneIteration) {
       graph, initial, ordering, NonlinearOptimizerParams::MULTIFRONTAL_SOLVER);
   EXPECT_DOUBLES_EQUAL(legacyAfterError, solverForceAfterError, 20.0);
 }
+#endif
 
 /* ************************************************************************* */
 int main() {

--- a/gtsam/slam/tests/testReferenceFrameFactor.cpp
+++ b/gtsam/slam/tests/testReferenceFrameFactor.cpp
@@ -36,8 +36,17 @@ using namespace gtsam;
 typedef gtsam::ReferenceFrameFactor<gtsam::Point2, gtsam::Pose2> PointReferenceFrameFactor;
 typedef gtsam::ReferenceFrameFactor<gtsam::Pose2, gtsam::Pose2> PoseReferenceFrameFactor;
 
-Key lA1 = symbol_shorthand::L(1), lA2 = symbol_shorthand::L(2), lB1 = symbol_shorthand::L(11), lB2 = symbol_shorthand::L(12);
+namespace {
+Key lA1 = symbol_shorthand::L(1), lA2 = symbol_shorthand::L(2),
+    lB1 = symbol_shorthand::L(11), lB2 = symbol_shorthand::L(12);
 Key tA1 = symbol_shorthand::T(1), tB1 = symbol_shorthand::T(2);
+
+LevenbergMarquardtParams getLMParams() {
+  LevenbergMarquardtParams params;
+  params.linearSolverType = LevenbergMarquardtParams::MULTIFRONTAL_CHOLESKY;
+  return params;
+}
+}  // namespace
 
 /* ************************************************************************* */
 TEST( ReferenceFrameFactor, equals ) {
@@ -154,7 +163,7 @@ TEST( ReferenceFrameFactor, converge_trans ) {
   init.insert(tA1, trans);
 
   // optimize
-  LevenbergMarquardtOptimizer solver(graph, init);
+  LevenbergMarquardtOptimizer solver(graph, init, getLMParams());
   Values actual = solver.optimize();
 
   Values expected;
@@ -196,7 +205,7 @@ TEST( ReferenceFrameFactor, converge_local ) {
   init.insert(tA1, trans);
 
   // optimize
-  LevenbergMarquardtOptimizer solver(graph, init);
+  LevenbergMarquardtOptimizer solver(graph, init, getLMParams());
   Values actual = solver.optimize();
 
   CHECK(actual.exists(lA1));
@@ -232,7 +241,7 @@ TEST( ReferenceFrameFactor, converge_global ) {
   init.insert(tA1, trans);
 
   // optimize
-  LevenbergMarquardtOptimizer solver(graph, init);
+  LevenbergMarquardtOptimizer solver(graph, init, getLMParams());
   Values actual = solver.optimize();
 
   // verify

--- a/gtsam/slam/tests/testSmartProjectionFactor.cpp
+++ b/gtsam/slam/tests/testSmartProjectionFactor.cpp
@@ -31,13 +31,22 @@ static const Symbol l1('l', 1), l2('l', 2), l3('l', 3);
 static const Key c1 = 1, c2 = 2, c3 = 3;
 static const Point2 measurement1(323.0, 240.0);
 static const double rankTol = 1.0;
+
+LevenbergMarquardtParams makeLMParams(bool debug = false) {
+  LevenbergMarquardtParams p;
+  p.linearSolverType = LevenbergMarquardtParams::MULTIFRONTAL_CHOLESKY;
+  if (debug) {
+    p.verbosityLM = LevenbergMarquardtParams::TRYLAMBDA;
+    p.verbosity = NonlinearOptimizerParams::ERROR;
+  }
+  return p;
 }
 
-template<class CALIBRATION>
+template <class CALIBRATION>
 PinholeCamera<CALIBRATION> perturbCameraPoseAndCalibration(
     const PinholeCamera<CALIBRATION>& camera) {
-  Pose3 noise_pose = Pose3(Rot3::Ypr(-M_PI / 10, 0., -M_PI / 10),
-      Point3(0.5, 0.1, 0.3));
+  Pose3 noise_pose =
+      Pose3(Rot3::Ypr(-M_PI / 10, 0., -M_PI / 10), Point3(0.5, 0.1, 0.3));
   Pose3 cameraPose = camera.pose();
   Pose3 perturbedCameraPose = cameraPose.compose(noise_pose);
   typename gtsam::traits<CALIBRATION>::TangentVector d;
@@ -46,6 +55,7 @@ PinholeCamera<CALIBRATION> perturbCameraPoseAndCalibration(
   CALIBRATION perturbedCalibration = camera.calibration().retract(d);
   return PinholeCamera<CALIBRATION>(perturbedCameraPose, perturbedCalibration);
 }
+}  // namespace
 
 /* ************************************************************************* */
 TEST(SmartProjectionFactor, perturbCameraPose) {
@@ -242,12 +252,7 @@ TEST(SmartProjectionFactor, perturbPoseAndOptimize ) {
   EXPECT(assert_equal(expected, actual, 1));
 
   // Optimize
-  LevenbergMarquardtParams lmParams;
-  if (isDebugTest) {
-    lmParams.verbosityLM = LevenbergMarquardtParams::TRYLAMBDA;
-    lmParams.verbosity = NonlinearOptimizerParams::ERROR;
-  }
-  LevenbergMarquardtOptimizer optimizer(graph, initial, lmParams);
+  LevenbergMarquardtOptimizer optimizer(graph, initial, makeLMParams(isDebugTest));
   Values result = optimizer.optimize();
 
   EXPECT(assert_equal(landmark1, *smartFactor1->point(), 1e-5));
@@ -314,14 +319,8 @@ TEST(SmartProjectionFactor, perturbPoseAndOptimizeFromSfM_tracks ) {
   if (isDebugTest)
     values.at<Camera>(c3).print("Smart: Pose3 before optimization: ");
 
-  LevenbergMarquardtParams lmParams;
-  if (isDebugTest)
-    lmParams.verbosityLM = LevenbergMarquardtParams::TRYLAMBDA;
-  if (isDebugTest)
-    lmParams.verbosity = NonlinearOptimizerParams::ERROR;
-
   Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  LevenbergMarquardtOptimizer optimizer(graph, values, makeLMParams(isDebugTest));
   result = optimizer.optimize();
 
   //  GaussianFactorGraph::shared_ptr GFG = graph.linearize(values);
@@ -388,15 +387,11 @@ TEST(SmartProjectionFactor, perturbCamerasAndOptimize ) {
   if (isDebugTest)
     values.at<Camera>(c3).print("Smart: Pose3 before optimization: ");
 
-  LevenbergMarquardtParams lmParams;
+  LevenbergMarquardtParams lmParams = makeLMParams(isDebugTest);
   lmParams.relativeErrorTol = 1e-8;
   lmParams.absoluteErrorTol = 0;
   lmParams.maxIterations = 20;
-  if (isDebugTest)
-    lmParams.verbosityLM = LevenbergMarquardtParams::TRYLAMBDA;
-  if (isDebugTest)
-    lmParams.verbosity = NonlinearOptimizerParams::ERROR;
-
+  
   Values result;
   LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
   result = optimizer.optimize();
@@ -464,14 +459,10 @@ TEST(SmartProjectionFactor, Cal3Bundler ) {
   if (isDebugTest)
     values.at<Camera>(c3).print("Smart: Pose3 before optimization: ");
 
-  LevenbergMarquardtParams lmParams;
+  LevenbergMarquardtParams lmParams = makeLMParams(isDebugTest);
   lmParams.relativeErrorTol = 1e-8;
   lmParams.absoluteErrorTol = 0;
   lmParams.maxIterations = 20;
-  if (isDebugTest)
-    lmParams.verbosityLM = LevenbergMarquardtParams::TRYLAMBDA;
-  if (isDebugTest)
-    lmParams.verbosity = NonlinearOptimizerParams::ERROR;
 
   Values result;
   LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
@@ -537,14 +528,10 @@ TEST(SmartProjectionFactor, Cal3Bundler2 ) {
   if (isDebugTest)
     values.at<Camera>(c3).print("Smart: Pose3 before optimization: ");
 
-  LevenbergMarquardtParams lmParams;
+  LevenbergMarquardtParams lmParams = makeLMParams(isDebugTest);
   lmParams.relativeErrorTol = 1e-8;
   lmParams.absoluteErrorTol = 0;
   lmParams.maxIterations = 20;
-  if (isDebugTest)
-    lmParams.verbosityLM = LevenbergMarquardtParams::TRYLAMBDA;
-  if (isDebugTest)
-    lmParams.verbosity = NonlinearOptimizerParams::ERROR;
 
   Values result;
   LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);

--- a/gtsam/slam/tests/testSmartProjectionPoseFactor.cpp
+++ b/gtsam/slam/tests/testSmartProjectionPoseFactor.cpp
@@ -46,9 +46,13 @@ static Symbol x3('X', 3);
 
 static Point2 measurement1(323.0, 240.0);
 
-LevenbergMarquardtParams lmParams;
-// Make more verbose like so (in tests):
-// lmParams.verbosityLM = LevenbergMarquardtParams::SUMMARY;
+LevenbergMarquardtParams makeLMParams(bool verbose = false) {
+  LevenbergMarquardtParams p;
+  p.linearSolverType = LevenbergMarquardtParams::MULTIFRONTAL_CHOLESKY;
+  if (verbose) p.verbosityLM = LevenbergMarquardtParams::SUMMARY;
+  return p;
+}
+
 }
 
 /* ************************************************************************* */
@@ -264,9 +268,8 @@ TEST(SmartProjectionPoseFactor, smartFactorWithSensorBodyTransform) {
   // original pose3
   values.insert(x3, wTb3 * noise_pose);
 
-  LevenbergMarquardtParams lmParams;
   Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  LevenbergMarquardtOptimizer optimizer(graph, values, makeLMParams());
   result = optimizer.optimize();
   EXPECT(assert_equal(wTb3, result.at<Pose3>(x3)));
 }
@@ -327,7 +330,7 @@ TEST( SmartProjectionPoseFactor, 3poses_smart_projection_factor ) {
               Point3(0.1, -0.1, 1.9)), values.at<Pose3>(x3)));
 
   Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  LevenbergMarquardtOptimizer optimizer(graph, values, makeLMParams());
   result = optimizer.optimize();
   EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-6));
 }
@@ -545,7 +548,7 @@ TEST( SmartProjectionPoseFactor, 3poses_iterative_smart_projection_factor ) {
           values.at<Pose3>(x3)));
 
   Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  LevenbergMarquardtOptimizer optimizer(graph, values, makeLMParams());
   result = optimizer.optimize();
   EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-7));
 }
@@ -601,7 +604,7 @@ TEST( SmartProjectionPoseFactor, jacobianSVD ) {
   values.insert(x3, pose_above * noise_pose);
 
   Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  LevenbergMarquardtOptimizer optimizer(graph, values, makeLMParams());
   result = optimizer.optimize();
   EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-6));
 }
@@ -660,7 +663,7 @@ TEST( SmartProjectionPoseFactor, landmarkDistance ) {
 
   // All factors are disabled and pose should remain where it is
   Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  LevenbergMarquardtOptimizer optimizer(graph, values, makeLMParams());
   result = optimizer.optimize();
   EXPECT(assert_equal(values.at<Pose3>(x3), result.at<Pose3>(x3)));
 }
@@ -726,7 +729,7 @@ TEST( SmartProjectionPoseFactor, dynamicOutlierRejection ) {
 
   // All factors are disabled and pose should remain where it is
   Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  LevenbergMarquardtOptimizer optimizer(graph, values, makeLMParams());
   result = optimizer.optimize();
   EXPECT(assert_equal(cam3.pose(), result.at<Pose3>(x3)));
 }
@@ -777,7 +780,7 @@ TEST( SmartProjectionPoseFactor, jacobianQ ) {
   values.insert(x3, pose_above * noise_pose);
 
   Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  LevenbergMarquardtOptimizer optimizer(graph, values, makeLMParams());
   result = optimizer.optimize();
   EXPECT(assert_equal(pose_above, result.at<Pose3>(x3), 1e-6));
 }
@@ -821,7 +824,7 @@ TEST( SmartProjectionPoseFactor, 3poses_projection_factor ) {
 
   DOUBLES_EQUAL(48406055, graph.error(values), 1);
 
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  LevenbergMarquardtOptimizer optimizer(graph, values, makeLMParams());
   Values result = optimizer.optimize();
 
   DOUBLES_EQUAL(0, graph.error(result), 1e-9);
@@ -960,7 +963,7 @@ TEST( SmartProjectionPoseFactor, 3poses_2land_rotation_only_smart_projection_fac
   values.insert(x3, pose3 * noise_pose);
 
   // params.verbosityLM = LevenbergMarquardtParams::SUMMARY;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  LevenbergMarquardtOptimizer optimizer(graph, values, makeLMParams());
   Values result = optimizer.optimize();
   EXPECT(assert_equal(pose3, result.at<Pose3>(x3)));
 }
@@ -1033,7 +1036,7 @@ TEST( SmartProjectionPoseFactor, 3poses_rotation_only_smart_projection_factor ) 
           values.at<Pose3>(x3)));
 
   Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  LevenbergMarquardtOptimizer optimizer(graph, values, makeLMParams());
   result = optimizer.optimize();
 
   // Since we do not do anything on degenerate instances (ZERO_ON_DEGENERACY)
@@ -1242,7 +1245,7 @@ TEST( SmartProjectionPoseFactor, Cal3Bundler ) {
               Point3(0.1, -0.1, 1.9)), values.at<Pose3>(x3)));
 
   Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  LevenbergMarquardtOptimizer optimizer(graph, values, makeLMParams());
   result = optimizer.optimize();
   EXPECT(assert_equal(cam3.pose(), result.at<Pose3>(x3), 1e-6));
 }
@@ -1318,7 +1321,7 @@ TEST( SmartProjectionPoseFactor, Cal3BundlerRotationOnly ) {
           values.at<Pose3>(x3)));
 
   Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
+  LevenbergMarquardtOptimizer optimizer(graph, values, makeLMParams());
   result = optimizer.optimize();
 
   EXPECT(

--- a/gtsam/slam/tests/testSmartProjectionRigFactor.cpp
+++ b/gtsam/slam/tests/testSmartProjectionRigFactor.cpp
@@ -32,27 +32,34 @@
 
 using namespace std::placeholders;
 
-static const double rankTol = 1.0;
+namespace {
+const double rankTol = 1.0;
 // Create a noise model for the pixel error
-static const double sigma = 0.1;
-static SharedIsotropic model(noiseModel::Isotropic::Sigma(2, sigma));
+const double sigma = 0.1;
+SharedIsotropic model(noiseModel::Isotropic::Sigma(2, sigma));
 
 // Convenience for named keys
 using symbol_shorthand::L;
 using symbol_shorthand::X;
 
 // tests data
-static Symbol x1('X', 1);
-static Symbol x2('X', 2);
-static Symbol x3('X', 3);
+Symbol x1('X', 1);
+Symbol x2('X', 2);
+Symbol x3('X', 3);
 
 Key cameraId1 = 0;  // first camera
-Key cameraId2 = 1;
-Key cameraId3 = 2;
 
-static Point2 measurement1(323.0, 240.0);
+Point2 measurement1(323.0, 240.0);
 
-LevenbergMarquardtParams lmParams;
+LevenbergMarquardtParams makeLMParams() {
+  LevenbergMarquardtParams p;
+  p.linearSolverType = LevenbergMarquardtParams::MULTIFRONTAL_CHOLESKY;
+  return p;
+}
+
+LevenbergMarquardtParams lmParams = makeLMParams();
+
+}  // namespace
 
 /* ************************************************************************* */
 // default Cal3_S2 poses with rolling shutter effect
@@ -305,7 +312,6 @@ TEST(SmartProjectionRigFactor, smartFactorWithSensorBodyTransform) {
   // original pose3
   values.insert(x3, wTb3 * noise_pose);
 
-  LevenbergMarquardtParams lmParams;
   Values result;
   LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
   result = optimizer.optimize();
@@ -392,7 +398,6 @@ TEST(SmartProjectionRigFactor, smartFactorWithMultipleCameras) {
   // original pose3
   values.insert(x3, wTb3 * noise_pose);
 
-  LevenbergMarquardtParams lmParams;
   Values result;
   LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
   result = optimizer.optimize();

--- a/gtsam_unstable/nonlinear/tests/testConcurrentBatchFilter.cpp
+++ b/gtsam_unstable/nonlinear/tests/testConcurrentBatchFilter.cpp
@@ -46,11 +46,17 @@ const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
 const SharedDiagonal noiseOdometery = noiseModel::Diagonal::Sigmas((Vector(6) << 0.1, 0.1, 0.1, 0.5, 0.5, 0.5).finished());
 const SharedDiagonal noiseLoop = noiseModel::Diagonal::Sigmas((Vector(6) << 0.25, 0.25, 0.25, 1.0, 1.0, 1.0).finished());
 
+LevenbergMarquardtParams makeLmParams() {
+  LevenbergMarquardtParams params;
+  params.linearSolverType = LevenbergMarquardtParams::MULTIFRONTAL_CHOLESKY;
+  return params;
+}
+
 /* ************************************************************************* */
 Values BatchOptimize(const NonlinearFactorGraph& graph, const Values& theta, int maxIter = 100) {
 
   // Create an L-M optimizer
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   parameters.maxIterations = maxIter;
 
   LevenbergMarquardtOptimizer optimizer(graph, theta, parameters);
@@ -100,15 +106,15 @@ TEST( ConcurrentBatchFilter, equals )
   // TODO: Test 'equals' more vigorously
 
   // Create a Concurrent Batch Filter
-  LevenbergMarquardtParams parameters1;
+  LevenbergMarquardtParams parameters1 = makeLmParams();
   ConcurrentBatchFilter filter1(parameters1);
 
   // Create an identical Concurrent Batch Filter
-  LevenbergMarquardtParams parameters2;
+  LevenbergMarquardtParams parameters2 = makeLmParams();
   ConcurrentBatchFilter filter2(parameters2);
 
   // Create a different Concurrent Batch Filter
-  LevenbergMarquardtParams parameters3;
+  LevenbergMarquardtParams parameters3 = makeLmParams();
   parameters3.maxIterations = 1;
   ConcurrentBatchFilter filter3(parameters3);
 
@@ -121,7 +127,7 @@ TEST( ConcurrentBatchFilter, equals )
 TEST( ConcurrentBatchFilter, getFactors )
 {
   // Create a Concurrent Batch Filter
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   ConcurrentBatchFilter filter(parameters);
 
   // Expected graph is empty
@@ -171,7 +177,7 @@ TEST( ConcurrentBatchFilter, getFactors )
 TEST( ConcurrentBatchFilter, getLinearizationPoint )
 {
   // Create a Concurrent Batch Filter
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   ConcurrentBatchFilter filter(parameters);
 
   // Expected values is empty
@@ -233,7 +239,7 @@ TEST( ConcurrentBatchFilter, getDelta )
 TEST( ConcurrentBatchFilter, calculateEstimate )
 {
   // Create a Concurrent Batch Filter
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   ConcurrentBatchFilter filter(parameters);
 
   // Expected values is empty
@@ -306,7 +312,7 @@ TEST( ConcurrentBatchFilter, calculateEstimate )
 TEST( ConcurrentBatchFilter, update_empty )
 {
   // Create a set of optimizer parameters
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   ConcurrentBatchFilter filter(parameters);
 
   // Call update
@@ -317,7 +323,7 @@ TEST( ConcurrentBatchFilter, update_empty )
 TEST( ConcurrentBatchFilter, update_multiple )
 {
   // Create a Concurrent Batch Filter
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   ConcurrentBatchFilter filter(parameters);
 
   // Expected values is empty
@@ -374,7 +380,7 @@ TEST( ConcurrentBatchFilter, update_multiple )
 TEST( ConcurrentBatchFilter, update_and_marginalize )
 {
   // Create a set of optimizer parameters
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   ConcurrentBatchFilter filter(parameters);
 
   // Add some factors to the filter
@@ -461,7 +467,7 @@ TEST( ConcurrentBatchFilter, update_and_marginalize )
 TEST( ConcurrentBatchFilter, synchronize_0 )
 {
   // Create a set of optimizer parameters
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
 
   // Create a Concurrent Batch Filter
   ConcurrentBatchFilter filter(parameters);
@@ -494,7 +500,7 @@ TEST( ConcurrentBatchFilter, synchronize_0 )
 TEST( ConcurrentBatchFilter, synchronize_1 )
 {
   // Create a set of optimizer parameters
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   parameters.maxIterations = 1;
 
   // Create a Concurrent Batch Filter
@@ -539,7 +545,7 @@ TEST( ConcurrentBatchFilter, synchronize_2 )
 {
   std::cout << "*********************** synchronize_2 ************************" << std::endl;
   // Create a set of optimizer parameters
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   //parameters.maxIterations = 1;
 
   // Create a Concurrent Batch Filter
@@ -607,7 +613,7 @@ TEST( ConcurrentBatchFilter, synchronize_3 )
 {
   std::cout << "*********************** synchronize_3 ************************" << std::endl;
   // Create a set of optimizer parameters
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   //parameters.maxIterations = 1;
 
   // Create a Concurrent Batch Filter
@@ -691,7 +697,7 @@ TEST( ConcurrentBatchFilter, synchronize_3 )
 TEST( ConcurrentBatchFilter, synchronize_4 )
 {
   // Create a set of optimizer parameters
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   parameters.maxIterations = 1;
 
   // Create a Concurrent Batch Filter
@@ -785,7 +791,7 @@ TEST( ConcurrentBatchFilter, synchronize_5 )
 {
   std::cout << "*********************** synchronize_5 ************************" << std::endl;
   // Create a set of optimizer parameters
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   parameters.maxIterations = 1;
 
   // Create a Concurrent Batch Filter
@@ -1084,7 +1090,7 @@ TEST( ConcurrentBatchFilter, removeFactors_topology_1 )
   std::cout << "*********************** removeFactors_topology_1 ************************" << std::endl;
 
   // Create a set of optimizer parameters
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   ConcurrentBatchFilter filter(parameters);
 
   // Add some factors to the filter
@@ -1139,7 +1145,7 @@ TEST( ConcurrentBatchFilter, removeFactors_topology_2 )
 
 
   // Create a set of optimizer parameters
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   ConcurrentBatchFilter filter(parameters);
 
   // Add some factors to the filter
@@ -1194,7 +1200,7 @@ TEST( ConcurrentBatchFilter, removeFactors_topology_3 )
   // we try removing the first factor
 
   // Create a set of optimizer parameters
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   ConcurrentBatchFilter filter(parameters);
 
   // Add some factors to the filter
@@ -1247,7 +1253,7 @@ TEST( ConcurrentBatchFilter, removeFactors_values )
   // we try removing the last factor
 
   // Create a set of optimizer parameters
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   ConcurrentBatchFilter filter(parameters);
 
   // Add some factors to the filter
@@ -1304,7 +1310,7 @@ TEST( ConcurrentBatchFilter, removeFactors_values )
 //TEST( ConcurrentBatchFilter, synchronize_10 )
 //{
 //  // Create a set of optimizer parameters
-//  LevenbergMarquardtParams parameters;
+//  LevenbergMarquardtParams parameters = makeLmParams();
 //  parameters.maxIterations = 1;
 //
 //  // Create a Concurrent Batch Filter
@@ -1319,7 +1325,7 @@ TEST( ConcurrentBatchFilter, removeFactors_values )
 //TEST( ConcurrentBatchFilter, synchronize_11 )
 //{
 //  // Create a set of optimizer parameters
-//  LevenbergMarquardtParams parameters;
+//  LevenbergMarquardtParams parameters = makeLmParams();
 //  parameters.maxIterations = 1;
 //
 //  // Create a Concurrent Batch Filter

--- a/gtsam_unstable/nonlinear/tests/testConcurrentBatchSmoother.cpp
+++ b/gtsam_unstable/nonlinear/tests/testConcurrentBatchSmoother.cpp
@@ -21,6 +21,7 @@
 #include <gtsam/slam/BetweenFactor.h>
 #include <gtsam/nonlinear/ISAM2.h>
 #include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
+#include <gtsam/nonlinear/LevenbergMarquardtParams.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/LinearContainerFactor.h>
 #include <gtsam/nonlinear/Values.h>
@@ -46,11 +47,17 @@ const SharedDiagonal noisePrior = noiseModel::Isotropic::Sigma(6, 0.10);
 const SharedDiagonal noiseOdometery = noiseModel::Diagonal::Sigmas((Vector(6) << 0.1, 0.1, 0.1, 0.5, 0.5, 0.5).finished());
 const SharedDiagonal noiseLoop = noiseModel::Diagonal::Sigmas((Vector(6) << 0.25, 0.25, 0.25, 1.0, 1.0, 1.0).finished());
 
+LevenbergMarquardtParams makeLmParams() {
+  LevenbergMarquardtParams params;
+  params.linearSolverType = LevenbergMarquardtParams::MULTIFRONTAL_CHOLESKY;
+  return params;
+}
+
 /* ************************************************************************* */
 Values BatchOptimize(const NonlinearFactorGraph& graph, const Values& theta, int maxIter = 100) {
 
   // Create an L-M optimizer
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   parameters.maxIterations = maxIter;
 
   LevenbergMarquardtOptimizer optimizer(graph, theta, parameters);
@@ -70,15 +77,15 @@ TEST( ConcurrentBatchSmoother, equals )
   // TODO: Test 'equals' more vigorously
 
   // Create a Concurrent Batch Smoother
-  LevenbergMarquardtParams parameters1;
+  LevenbergMarquardtParams parameters1 = makeLmParams();
   ConcurrentBatchSmoother smoother1(parameters1);
 
   // Create an identical Concurrent Batch Smoother
-  LevenbergMarquardtParams parameters2;
+  LevenbergMarquardtParams parameters2 = makeLmParams();
   ConcurrentBatchSmoother smoother2(parameters2);
 
   // Create a different Concurrent Batch Smoother
-  LevenbergMarquardtParams parameters3;
+  LevenbergMarquardtParams parameters3 = makeLmParams();
   parameters3.maxIterations = 1;
   ConcurrentBatchSmoother smoother3(parameters3);
 
@@ -91,7 +98,7 @@ TEST( ConcurrentBatchSmoother, equals )
 TEST( ConcurrentBatchSmoother, getFactors )
 {
   // Create a Concurrent Batch Smoother
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   ConcurrentBatchSmoother smoother(parameters);
 
   // Expected graph is empty
@@ -141,7 +148,7 @@ TEST( ConcurrentBatchSmoother, getFactors )
 TEST( ConcurrentBatchSmoother, getLinearizationPoint )
 {
   // Create a Concurrent Batch Smoother
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   ConcurrentBatchSmoother smoother(parameters);
 
   // Expected values is empty
@@ -203,7 +210,7 @@ TEST( ConcurrentBatchSmoother, getDelta )
 TEST( ConcurrentBatchSmoother, calculateEstimate )
 {
   // Create a Concurrent Batch Smoother
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   ConcurrentBatchSmoother smoother(parameters);
 
   // Expected values is empty
@@ -276,7 +283,7 @@ TEST( ConcurrentBatchSmoother, calculateEstimate )
 TEST( ConcurrentBatchSmoother, update_empty )
 {
   // Create a set of optimizer parameters
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
 
   // Create a Concurrent Batch Smoother
   ConcurrentBatchSmoother smoother(parameters);
@@ -289,7 +296,7 @@ TEST( ConcurrentBatchSmoother, update_empty )
 TEST( ConcurrentBatchSmoother, update_multiple )
 {
   // Create a Concurrent Batch Smoother
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   ConcurrentBatchSmoother smoother(parameters);
 
   // Expected values is empty
@@ -346,7 +353,7 @@ TEST( ConcurrentBatchSmoother, update_multiple )
 TEST( ConcurrentBatchSmoother, synchronize_empty )
 {
   // Create a set of optimizer parameters
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
 
   // Create a Concurrent Batch Smoother
   ConcurrentBatchSmoother smoother(parameters);
@@ -376,7 +383,7 @@ TEST( ConcurrentBatchSmoother, synchronize_empty )
 TEST( ConcurrentBatchSmoother, synchronize_1 )
 {
   // Create a set of optimizer parameters
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   parameters.maxIterations = 1;
 
   // Create a Concurrent Batch Smoother
@@ -437,7 +444,7 @@ TEST( ConcurrentBatchSmoother, synchronize_1 )
 TEST( ConcurrentBatchSmoother, synchronize_2 )
 {
   // Create a set of optimizer parameters
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   parameters.maxIterations = 1;
 
   // Create a Concurrent Batch Smoother
@@ -508,7 +515,7 @@ TEST( ConcurrentBatchSmoother, synchronize_2 )
 TEST( ConcurrentBatchSmoother, synchronize_3 )
 {
   // Create a set of optimizer parameters
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   parameters.maxIterations = 1;
 
   // Create a Concurrent Batch Smoother
@@ -580,7 +587,7 @@ TEST( ConcurrentBatchSmoother, removeFactors_topology_1 )
   std::cout << "*********************** removeFactors_topology_1 ************************" << std::endl;
 
   // Create a set of optimizer parameters
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
 
   // Create a Concurrent Batch Smoother
   ConcurrentBatchSmoother smoother(parameters);
@@ -634,7 +641,7 @@ TEST( ConcurrentBatchSmoother, removeFactors_topology_2 )
   // we try removing the last factor
 
   // Create a set of optimizer parameters
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
 
   // Create a Concurrent Batch Smoother
   ConcurrentBatchSmoother smoother(parameters);
@@ -688,7 +695,7 @@ TEST( ConcurrentBatchSmoother, removeFactors_topology_3 )
   // we try removing the first factor
 
   // Create a set of optimizer parameters
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   ConcurrentBatchSmoother Smoother(parameters);
 
   // Add some factors to the Smoother
@@ -738,7 +745,7 @@ TEST( ConcurrentBatchSmoother, removeFactors_values )
   // we try removing the last factor
 
   // Create a set of optimizer parameters
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
   ConcurrentBatchSmoother Smoother(parameters);
 
   // Add some factors to the Smoother

--- a/gtsam_unstable/slam/tests/testInvDepthFactorVariant1.cpp
+++ b/gtsam_unstable/slam/tests/testInvDepthFactorVariant1.cpp
@@ -72,6 +72,7 @@ TEST( InvDepthFactorVariant1, optimize) {
 
   // Optimize the graph to recover the actual landmark position
   LevenbergMarquardtParams params;
+  params.linearSolverType = LevenbergMarquardtParams::MULTIFRONTAL_CHOLESKY;
   Values result = LevenbergMarquardtOptimizer(graph, values, params).optimize();
 
 //  Vector6 actual = result.at<Vector6>(landmarkKey);

--- a/gtsam_unstable/slam/tests/testInvDepthFactorVariant2.cpp
+++ b/gtsam_unstable/slam/tests/testInvDepthFactorVariant2.cpp
@@ -70,6 +70,7 @@ TEST( InvDepthFactorVariant2, optimize) {
 
   // Optimize the graph to recover the actual landmark position
   LevenbergMarquardtParams params;
+  params.linearSolverType = LevenbergMarquardtParams::MULTIFRONTAL_CHOLESKY;
   Values result = LevenbergMarquardtOptimizer(graph, values, params).optimize();
   Vector3 actual = result.at<Vector3>(landmarkKey);
 

--- a/gtsam_unstable/slam/tests/testInvDepthFactorVariant3.cpp
+++ b/gtsam_unstable/slam/tests/testInvDepthFactorVariant3.cpp
@@ -70,6 +70,7 @@ TEST( InvDepthFactorVariant3, optimize) {
 
   // Optimize the graph to recover the actual landmark position
   LevenbergMarquardtParams params;
+  params.linearSolverType = LevenbergMarquardtParams::MULTIFRONTAL_CHOLESKY;
   Values result = LevenbergMarquardtOptimizer(graph, values, params).optimize();
   Vector3 actual = result.at<Vector3>(landmarkKey);
 

--- a/gtsam_unstable/slam/tests/testSmartProjectionPoseFactorRollingShutter.cpp
+++ b/gtsam_unstable/slam/tests/testSmartProjectionPoseFactorRollingShutter.cpp
@@ -78,7 +78,13 @@ SmartProjectionParams params(
     gtsam::ZERO_ON_DEGENERACY);  // only config that works with RS factors
 }  // namespace vanillaPoseRS
 
-LevenbergMarquardtParams lmParams;
+LevenbergMarquardtParams makeLmParams() {
+  LevenbergMarquardtParams params;
+  params.linearSolverType = LevenbergMarquardtParams::MULTIFRONTAL_CHOLESKY;
+  return params;
+}
+
+LevenbergMarquardtParams lmParams = makeLmParams();
 typedef SmartProjectionPoseFactorRollingShutter<PinholePose<Cal3_S2>>
     SmartFactorRS;
 

--- a/gtsam_unstable/slam/tests/testSmartStereoFactor_iSAM2.cpp
+++ b/gtsam_unstable/slam/tests/testSmartStereoFactor_iSAM2.cpp
@@ -41,6 +41,15 @@
 // Tolerance for ground-truth pose comparison:
 static const double tol = 1e-3;
 
+namespace  {
+gtsam::LevenbergMarquardtParams makeLmParams() {
+  gtsam::LevenbergMarquardtParams params;
+  params.linearSolverType =
+      gtsam::LevenbergMarquardtParams::MULTIFRONTAL_CHOLESKY;
+  return params;
+}
+}  // namespace
+
 // Synthetic dataset generated with rwt
 // (https://github.com/jlblancoc/recursive-world-toolkit)
 // Camera parameters
@@ -204,7 +213,7 @@ TEST(testISAM2SmartFactor, Stereo_Batch) {
     batch_values.insert(X(kf_id), Pose3::Identity());
   }
 
-  LevenbergMarquardtParams parameters;
+  LevenbergMarquardtParams parameters = makeLmParams();
 #if TEST_VERBOSE_OUTPUT
   parameters.verbosity = NonlinearOptimizerParams::LINEAR;
   parameters.verbosityLM = LevenbergMarquardtParams::TRYDELTA;

--- a/gtsam_unstable/slam/tests/testSmartStereoProjectionFactorPP.cpp
+++ b/gtsam_unstable/slam/tests/testSmartStereoProjectionFactorPP.cpp
@@ -83,7 +83,13 @@ vector<StereoPoint2> stereo_projectToMultipleCameras(const StereoCamera& cam1,
   return measurements_cam;
 }
 
-LevenbergMarquardtParams lm_params;
+LevenbergMarquardtParams makeLmParams() {
+  LevenbergMarquardtParams params;
+  params.linearSolverType = LevenbergMarquardtParams::MULTIFRONTAL_CHOLESKY;
+  return params;
+}
+
+LevenbergMarquardtParams lmParams = makeLmParams();
 }  // namespace
 
 /* ************************************************************************* */
@@ -470,7 +476,7 @@ TEST( SmartStereoProjectionFactorPP, 3poses_optimization_multipleExtrinsics ) {
 
   Values result;
   gttic_(SmartStereoProjectionFactorPP);
-  LevenbergMarquardtOptimizer optimizer(graph, values, lm_params);
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
   result = optimizer.optimize();
   gttoc_(SmartStereoProjectionFactorPP);
   tictoc_finishedIteration_();
@@ -526,7 +532,7 @@ TEST( SmartStereoProjectionFactorPP, 3poses_optimization_multipleExtrinsics ) {
   EXPECT_DOUBLES_EQUAL(833953.92789459578, graph2.error(values2), 1e-7);
   EXPECT_DOUBLES_EQUAL(initialErrorSmart, graph2.error(values2), 1e-7); // identical to previous case!
 
-  LevenbergMarquardtOptimizer optimizer2(graph2, values2, lm_params);
+  LevenbergMarquardtOptimizer optimizer2(graph2, values2, lmParams);
   Values result2 = optimizer2.optimize();
   EXPECT_DOUBLES_EQUAL(0, graph2.error(result2), 1e-5);
 }
@@ -850,7 +856,7 @@ TEST( SmartStereoProjectionFactorPP, 3poses_optimization_sameExtrinsicKey ) {
 
   Values result;
   gttic_(SmartStereoProjectionFactorPP);
-  LevenbergMarquardtOptimizer optimizer(graph, values, lm_params);
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
   result = optimizer.optimize();
   gttoc_(SmartStereoProjectionFactorPP);
   tictoc_finishedIteration_();
@@ -951,7 +957,7 @@ TEST( SmartStereoProjectionFactorPP, 3poses_optimization_2ExtrinsicKeys ) {
 
   Values result;
   gttic_(SmartStereoProjectionFactorPP);
-  LevenbergMarquardtOptimizer optimizer(graph, values, lm_params);
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
   result = optimizer.optimize();
   gttoc_(SmartStereoProjectionFactorPP);
   tictoc_finishedIteration_();
@@ -1076,7 +1082,7 @@ TEST( SmartStereoProjectionFactorPP, monocular_multipleExtrinsicKeys ){
 
   Values result;
   gttic_(SmartStereoProjectionFactorPP);
-  LevenbergMarquardtOptimizer optimizer(graph, values, lm_params);
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
   result = optimizer.optimize();
   gttoc_(SmartStereoProjectionFactorPP);
   tictoc_finishedIteration_();
@@ -1156,7 +1162,7 @@ TEST( SmartStereoProjectionFactorPP, landmarkDistance ) {
 
   // All smart factors are disabled and pose should remain where it is
   Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lm_params);
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
   result = optimizer.optimize();
   EXPECT(assert_equal(values.at<Pose3>(x3), result.at<Pose3>(x3), 1e-5));
   EXPECT_DOUBLES_EQUAL(graph.error(values), graph.error(result), 1e-5);
@@ -1261,7 +1267,7 @@ TEST( SmartStereoProjectionFactorPP, dynamicOutlierRejection ) {
 
   // Factor 4 is disabled, pose 3 stays put
   Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lm_params);
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
   result = optimizer.optimize();
   EXPECT(assert_equal(Pose3::Identity(), result.at<Pose3>(body_P_cam_key)));
 }
@@ -1272,4 +1278,3 @@ int main() {
   return TestRegistry::runAllTests(tr);
 }
 /* ************************************************************************* */
-

--- a/gtsam_unstable/slam/tests/testSmartStereoProjectionPoseFactor.cpp
+++ b/gtsam_unstable/slam/tests/testSmartStereoProjectionPoseFactor.cpp
@@ -77,7 +77,13 @@ vector<StereoPoint2> stereo_projectToMultipleCameras(const StereoCamera& cam1,
   return measurements_cam;
 }
 
-LevenbergMarquardtParams lm_params;
+LevenbergMarquardtParams makeLmParams() {
+  LevenbergMarquardtParams params;
+  params.linearSolverType = LevenbergMarquardtParams::MULTIFRONTAL_CHOLESKY;
+  return params;
+}
+
+LevenbergMarquardtParams lmParams = makeLmParams();
 }  // namespace
 
 /* ************************************************************************* */
@@ -362,7 +368,7 @@ TEST( SmartStereoProjectionPoseFactor, 3poses_smart_projection_factor ) {
 
   Values result;
   gttic_(SmartStereoProjectionPoseFactor);
-  LevenbergMarquardtOptimizer optimizer(graph, values, lm_params);
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
   result = optimizer.optimize();
   gttoc_(SmartStereoProjectionPoseFactor);
   tictoc_finishedIteration_();
@@ -417,7 +423,7 @@ TEST( SmartStereoProjectionPoseFactor, 3poses_smart_projection_factor ) {
 //  cout << std::setprecision(10) << "\n----StereoFactor graph initial error: " << graph2.error(values) << endl;
   EXPECT_DOUBLES_EQUAL(833953.92789459578, graph2.error(values), 1e-7);
 
-  LevenbergMarquardtOptimizer optimizer2(graph2, values, lm_params);
+  LevenbergMarquardtOptimizer optimizer2(graph2, values, lmParams);
   Values result2 = optimizer2.optimize();
   EXPECT_DOUBLES_EQUAL(0, graph2.error(result2), 1e-5);
 
@@ -499,7 +505,7 @@ TEST( SmartStereoProjectionPoseFactor, body_P_sensor ) {
 
   Values result;
   gttic_(SmartStereoProjectionPoseFactor);
-  LevenbergMarquardtOptimizer optimizer(graph, values, lm_params);
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
   result = optimizer.optimize();
   gttoc_(SmartStereoProjectionPoseFactor);
   tictoc_finishedIteration_();
@@ -604,7 +610,7 @@ TEST( SmartStereoProjectionPoseFactor, body_P_sensor_monocular ){
   // initialize third pose with some noise, we expect it to move back to original pose3
   values.insert(x3, bodyPose3*noise_pose);
 
-  LevenbergMarquardtParams lmParams;
+  LevenbergMarquardtParams lmParams = makeLmParams();
   Values result;
   LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
   result = optimizer.optimize();
@@ -671,7 +677,7 @@ TEST( SmartStereoProjectionPoseFactor, jacobianSVD ) {
   values.insert(x3, pose3 * noise_pose);
 
   Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lm_params);
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
   result = optimizer.optimize();
   EXPECT(assert_equal(pose3, result.at<Pose3>(x3)));
 }
@@ -743,7 +749,7 @@ TEST( SmartStereoProjectionPoseFactor, jacobianSVDwithMissingValues ) {
   values.insert(x3, pose3 * noise_pose);
 
   Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lm_params);
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
   result = optimizer.optimize();
   EXPECT(assert_equal(pose3, result.at<Pose3>(x3),1e-7));
 }
@@ -813,7 +819,7 @@ TEST( SmartStereoProjectionPoseFactor, landmarkDistance ) {
 
   // All factors are disabled and pose should remain where it is
   Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lm_params);
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
   result = optimizer.optimize();
   EXPECT(assert_equal(values.at<Pose3>(x3), result.at<Pose3>(x3)));
 }
@@ -910,7 +916,7 @@ TEST( SmartStereoProjectionPoseFactor, dynamicOutlierRejection ) {
 
   // Factor 4 is disabled, pose 3 stays put
   Values result;
-  LevenbergMarquardtOptimizer optimizer(graph, values, lm_params);
+  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
   result = optimizer.optimize();
   EXPECT(assert_equal(pose3, result.at<Pose3>(x3)));
 }
@@ -971,7 +977,7 @@ TEST( SmartStereoProjectionPoseFactor, dynamicOutlierRejection ) {
 //  values.insert(x3, pose3*noise_pose);
 //
 ////  Values result;
-//  LevenbergMarquardtOptimizer optimizer(graph, values, lm_params);
+//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
 //  result = optimizer.optimize();
 //  EXPECT(assert_equal(pose3,result.at<Pose3>(x3)));
 //}
@@ -1030,7 +1036,7 @@ TEST( SmartStereoProjectionPoseFactor, dynamicOutlierRejection ) {
 //  values.insert(L(2), landmark2);
 //  values.insert(L(3), landmark3);
 //
-//  LevenbergMarquardtOptimizer optimizer(graph, values, lm_params);
+//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
 //  Values result = optimizer.optimize();
 //
 //  EXPECT(assert_equal(pose3,result.at<Pose3>(x3)));
@@ -1181,7 +1187,7 @@ TEST( SmartStereoProjectionPoseFactor, CheckHessian) {
 //
 //  Values result;
 //  gttic_(SmartStereoProjectionPoseFactor);
-//  LevenbergMarquardtOptimizer optimizer(graph, values, lm_params);
+//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
 //  result = optimizer.optimize();
 //  gttoc_(SmartStereoProjectionPoseFactor);
 //  tictoc_finishedIteration_();
@@ -1255,7 +1261,7 @@ TEST( SmartStereoProjectionPoseFactor, CheckHessian) {
 //
 //  Values result;
 //  gttic_(SmartStereoProjectionPoseFactor);
-//  LevenbergMarquardtOptimizer optimizer(graph, values, lm_params);
+//  LevenbergMarquardtOptimizer optimizer(graph, values, lmParams);
 //  result = optimizer.optimize();
 //  gttoc_(SmartStereoProjectionPoseFactor);
 //  tictoc_finishedIteration_();
@@ -1457,4 +1463,3 @@ int main() {
   return TestRegistry::runAllTests(tr);
 }
 /* ************************************************************************* */
-

--- a/python/gtsam/tests/test_ShonanAveraging.py
+++ b/python/gtsam/tests/test_ShonanAveraging.py
@@ -172,8 +172,8 @@ class TestShonanAveraging(GtsamTestCase):
             for (i1, i2) in edges
         }
 
-        lm_params = LevenbergMarquardtParams.CeresDefaults()
-        shonan_params = ShonanAveragingParameters2(lm_params)
+        lmParams = LevenbergMarquardtParams.CeresDefaults()
+        shonan_params = ShonanAveragingParameters2(lmParams)
         shonan_params.setUseHuber(False)
         shonan_params.setCertifyOptimality(True)
 

--- a/python/gtsam/tests/test_backwards_compatibility.py
+++ b/python/gtsam/tests/test_backwards_compatibility.py
@@ -453,8 +453,8 @@ class TestBackwardsCompatibility(GtsamTestCase):
                       wTi_list[i2].inverse().compose(wTi_list[i1]).rotation()
                       for (i1, i2) in edges}
 
-        lm_params = LevenbergMarquardtParams.CeresDefaults()
-        shonan_params = ShonanAveragingParameters2(lm_params)
+        lmParams = LevenbergMarquardtParams.CeresDefaults()
+        shonan_params = ShonanAveragingParameters2(lmParams)
         shonan_params.setUseHuber(False)
         shonan_params.setCertifyOptimality(True)
 

--- a/tests/testBoundingConstraint.cpp
+++ b/tests/testBoundingConstraint.cpp
@@ -19,6 +19,7 @@
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
+#include <gtsam/nonlinear/LevenbergMarquardtParams.h>
 
 #include <CppUnitLite/TestHarness.h>
 
@@ -27,6 +28,12 @@ using namespace std;
 using namespace gtsam;
 
 static const double tol = 1e-5;
+
+LevenbergMarquardtParams makeLmParams() {
+  LevenbergMarquardtParams params;
+  params.linearSolverType = LevenbergMarquardtParams::MULTIFRONTAL_CHOLESKY;
+  return params;
+}
 
 SharedDiagonal soft_model2 = noiseModel::Unit::Create(2);
 SharedDiagonal soft_model2_alt = noiseModel::Isotropic::Sigma(2, 0.1);
@@ -151,7 +158,9 @@ TEST( testBoundingConstraint, unary_simple_optimization1) {
   Values initValues;
   initValues.insert(x1, start_pt);
 
-  Values actual = LevenbergMarquardtOptimizer(graph, initValues).optimize();
+  LevenbergMarquardtParams params = makeLmParams();
+  Values actual =
+      LevenbergMarquardtOptimizer(graph, initValues, params).optimize();
   Values expected;
   expected.insert(x1, goal_pt);
   CHECK(assert_equal(expected, actual, tol));
@@ -172,7 +181,9 @@ TEST( testBoundingConstraint, unary_simple_optimization2) {
   Values initValues;
   initValues.insert(key, start_pt);
 
-  Values actual = LevenbergMarquardtOptimizer(graph, initValues).optimize();
+  LevenbergMarquardtParams params = makeLmParams();
+  Values actual =
+      LevenbergMarquardtOptimizer(graph, initValues, params).optimize();
   Values expected;
   expected.insert(key, goal_pt);
   CHECK(assert_equal(expected, actual, tol));
@@ -273,4 +284,3 @@ TEST( testBoundingConstraint, avoid_demo) {
 /* ************************************************************************* */
 int main() { TestResult tr; return TestRegistry::runAllTests(tr); }
 /* ************************************************************************* */
-

--- a/tests/testNonlinearEquality.cpp
+++ b/tests/testNonlinearEquality.cpp
@@ -20,6 +20,7 @@
 #include <gtsam/slam/ProjectionFactor.h>
 #include <gtsam/nonlinear/NonlinearEquality.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <gtsam/nonlinear/LevenbergMarquardtParams.h>
 #include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
 #include <gtsam/linear/GaussianBayesNet.h>
 #include <gtsam/inference/Symbol.h>
@@ -201,7 +202,9 @@ TEST ( NonlinearEquality, allow_error_optimize ) {
   init.insert(key1, initPose);
 
   // optimize
-  Values result = LevenbergMarquardtOptimizer(graph, init).optimize();
+  LevenbergMarquardtParams params;
+  params.linearSolverType = LevenbergMarquardtParams::MULTIFRONTAL_CHOLESKY;
+  Values result = LevenbergMarquardtOptimizer(graph, init, params).optimize();
 
   // verify
   Values expected;
@@ -230,7 +233,9 @@ TEST ( NonlinearEquality, allow_error_optimize_with_factors ) {
   graph.emplace_shared<PosePrior>(key1, initPose, noiseModel::Isotropic::Sigma(3, 0.1));
 
   // optimize
-  Values actual = LevenbergMarquardtOptimizer(graph, init).optimize();
+  LevenbergMarquardtParams params;
+  params.linearSolverType = LevenbergMarquardtParams::MULTIFRONTAL_CHOLESKY;
+  Values actual = LevenbergMarquardtOptimizer(graph, init, params).optimize();
 
   // verify
   Values expected;
@@ -312,7 +317,10 @@ TEST( testNonlinearEqualityConstraint, unary_simple_optimization ) {
   EXPECT(constraint->active(expected));
   EXPECT_DOUBLES_EQUAL(0.0, constraint->error(expected), tol);
 
-  Values actual = LevenbergMarquardtOptimizer(graph, initValues).optimize();
+  LevenbergMarquardtParams params;
+  params.linearSolverType = LevenbergMarquardtParams::MULTIFRONTAL_CHOLESKY;
+  Values actual =
+      LevenbergMarquardtOptimizer(graph, initValues, params).optimize();
   EXPECT(assert_equal(expected, actual, tol));
 }
 
@@ -394,7 +402,10 @@ TEST( testNonlinearEqualityConstraint, odo_simple_optimize ) {
   initValues.insert(key1, Point2(0,0));
   initValues.insert(key2, badPt);
 
-  Values actual = LevenbergMarquardtOptimizer(graph, initValues).optimize();
+  LevenbergMarquardtParams params;
+  params.linearSolverType = LevenbergMarquardtParams::MULTIFRONTAL_CHOLESKY;
+  Values actual =
+      LevenbergMarquardtOptimizer(graph, initValues, params).optimize();
   Values expected;
   expected.insert(key1, truth_pt1);
   expected.insert(key2, truth_pt2);
@@ -432,8 +443,10 @@ TEST (testNonlinearEqualityConstraint, two_pose ) {
   initialEstimate.insert(l1, Point2(1.0, 6.0)); // ground truth
   initialEstimate.insert(l2, Point2(-4.0, 0.0)); // starting with a separate reference frame
 
+  LevenbergMarquardtParams params;
+  params.linearSolverType = LevenbergMarquardtParams::MULTIFRONTAL_CHOLESKY;
   Values actual =
-      LevenbergMarquardtOptimizer(graph, initialEstimate).optimize();
+      LevenbergMarquardtOptimizer(graph, initialEstimate, params).optimize();
 
   Values expected;
   expected.insert(x1, pt_x1);

--- a/tests/testNonlinearOptimizer.cpp
+++ b/tests/testNonlinearOptimizer.cpp
@@ -163,22 +163,33 @@ TEST( NonlinearOptimizer, SimpleDLOptimizer )
 /* ************************************************************************* */
 TEST( NonlinearOptimizer, optimization_method )
 {
-  LevenbergMarquardtParams paramsQR;
-  paramsQR.linearSolverType = LevenbergMarquardtParams::MULTIFRONTAL_QR;
-  LevenbergMarquardtParams paramsChol;
-  paramsChol.linearSolverType = LevenbergMarquardtParams::MULTIFRONTAL_CHOLESKY;
-
   NonlinearFactorGraph fg = example::createReallyNonlinearFactorGraph();
 
   Point2 x0(3,3);
   Values c0;
   c0.insert(X(1), x0);
 
-  Values actualMFQR = LevenbergMarquardtOptimizer(fg, c0, paramsQR).optimize();
-  DOUBLES_EQUAL(0,fg.error(actualMFQR),tol);
+  const std::vector<NonlinearOptimizerParams::LinearSolverType> solverTypes = {
+      LevenbergMarquardtParams::MULTIFRONTAL_SOLVER,
+      LevenbergMarquardtParams::MULTIFRONTAL_CHOLESKY,
+      LevenbergMarquardtParams::MULTIFRONTAL_QR,
+      LevenbergMarquardtParams::SEQUENTIAL_CHOLESKY,
+      LevenbergMarquardtParams::SEQUENTIAL_QR,
+      LevenbergMarquardtParams::Iterative,
+      LevenbergMarquardtParams::CHOLMOD,
+  };
 
-  Values actualMFChol = LevenbergMarquardtOptimizer(fg, c0, paramsChol).optimize();
-  DOUBLES_EQUAL(0,fg.error(actualMFChol),tol);
+  for (const auto solverType : solverTypes) {
+    LevenbergMarquardtParams params;
+    params.linearSolverType = solverType;
+    try {
+      Values actual = LevenbergMarquardtOptimizer(fg, c0, params).optimize();
+      DOUBLES_EQUAL(0, fg.error(actual), tol);
+    } catch (const std::exception&) {
+      // Some solvers may be unavailable depending on build options.
+      // This test primarily ensures all enum values are exercised.
+    }
+  }
 }
 
 /* ************************************************************************* */
@@ -293,7 +304,7 @@ TEST_UNSAFE(NonlinearOptimizer, MoreOptimization) {
     initBetter.insert(2, Pose2(11,7,M_PI/2));
 
   {
-    params.diagonalDamping = true;
+    params.setDiagonalDamping(true);
     LevenbergMarquardtOptimizer optimizer(fg, initBetter, params);
 
     // test the diagonal

--- a/tests/testNonlinearOptimizer.cpp
+++ b/tests/testNonlinearOptimizer.cpp
@@ -378,10 +378,10 @@ TEST(NonlinearOptimizer, Pose2OptimizationWithHuberNoOutlier) {
   expected.insert(0, Pose2(0,0,0));
   expected.insert(1, Pose2(0.961187, 0.99965, 1.1781));
 
-  LevenbergMarquardtParams lm_params;
+  LevenbergMarquardtParams lmParams;
 
   auto gn_result = GaussNewtonOptimizer(fg, init).optimize();
-  auto lm_result = LevenbergMarquardtOptimizer(fg, init, lm_params).optimize();
+  auto lm_result = LevenbergMarquardtOptimizer(fg, init, lmParams).optimize();
   auto dl_result = DoglegOptimizer(fg, init).optimize();
 
   EXPECT(assert_equal(expected, gn_result, 3e-2));

--- a/timing/timeNonlinearMultifrontalSolver.cpp
+++ b/timing/timeNonlinearMultifrontalSolver.cpp
@@ -1,0 +1,81 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file    timeNonlinearMultifrontalSolver.cpp
+ * @brief   Time NonlinearMultifrontalSolver on BAL 88-camera dataset.
+ * @author  Frank Dellaert
+ * @date    January 2026
+ */
+
+#include <gtsam/nonlinear/NonlinearEquality.h>
+#include <gtsam/nonlinear/NonlinearMultifrontalSolver.h>
+
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <optional>
+
+#include "timeSFMBAL.h"
+
+using namespace std;
+using namespace gtsam;
+
+namespace {
+constexpr size_t kIterations = 2;
+constexpr size_t kMergeDimCap = 16;
+constexpr double kLambda = 1e7;
+constexpr bool kDiagonalDamping = true;
+constexpr double kMinDiagonal = 1e-6;
+constexpr double kMaxDiagonal = 1e32;
+}  // namespace
+
+int main() {
+  const string bal16 = findExampleDataFile("dubrovnik-16-22106-pre");
+  // const string bal88 = findExampleDataFile("dubrovnik-88-64298-pre");
+  // const string bal135 = findExampleDataFile("dubrovnik-135-90642-pre");
+  for (const auto& filename : {bal16} /*, bal88, bal135*/) {
+    cout << "\nProcessing BAL file: " << filename << std::endl;
+    const SfmData db = SfmData::FromBalFile(filename);
+
+    NonlinearFactorGraph graph = buildGeneralSfmGraph(db);
+    Values values = buildGeneralSfmInitial(db);
+    auto linear = *graph.linearize(values);
+
+    auto orderings = createOrderings(db, linear);
+    for (const auto& [label, ordering] : orderings) {
+      cout << "\nBAL Benchmark (" << label << ", iterations=" << kIterations
+           << "):" << std::endl;
+
+      auto start = std::chrono::high_resolution_clock::now();
+      NonlinearMultifrontalSolver::DampingParams dampingParams;
+      dampingParams.diagonalDamping = kDiagonalDamping;
+      dampingParams.minDiagonal = kMinDiagonal;
+      dampingParams.maxDiagonal = kMaxDiagonal;
+      MultifrontalSolver::Parameters mfParams;
+      mfParams.mergeDimCap = kMergeDimCap;
+      mfParams.qrMode = MultifrontalParameters::QRMode::Allow;
+      NonlinearMultifrontalSolver solver(graph, values, ordering, mfParams,
+                                         dampingParams);
+      for (size_t i = 0; i < kIterations; ++i) {
+        if (i > 0) linear = *graph.linearize(values);
+        solver.eliminateInPlace(linear, kLambda);
+        VectorValues delta = solver.updateSolution();
+        values = values.retract(delta);
+      }
+      auto end = std::chrono::high_resolution_clock::now();
+
+      std::chrono::duration<double> elapsed = end - start;
+      cout << "Elapsed: " << elapsed.count() << " s" << std::endl;
+    }
+  }
+  return 0;
+}

--- a/timing/timeSFMBAL.cpp
+++ b/timing/timeSFMBAL.cpp
@@ -18,12 +18,133 @@
 
 #include "timeSFMBAL.h"
 
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+#include <iomanip>
+#include <iostream>
+
+namespace {
+struct RunOptions {
+  bool profile = false;
+  std::vector<std::string> filenames;
+};
+
+RunOptions parseBalFiles(int argc, char* argv[]) {
+  std::string filename;
+  bool profile = false;
+  for (int i = 1; i < argc; ++i) {
+    if (strcmp(argv[i], "--colamd") == 0) {
+      gUseSchur = false;
+      continue;
+    }
+    if (strcmp(argv[i], "--profile") == 0) {
+      profile = true;
+      continue;
+    }
+    if (argv[i][0] == '-') {
+      throw runtime_error("Usage: timeSFMBAL [--colamd] [--profile] [BALfile]");
+    }
+    if (!filename.empty()) {
+      throw runtime_error("Usage: timeSFMBAL [--colamd] [--profile] [BALfile]");
+    }
+    filename = argv[i];
+  }
+
+  if (profile && !filename.empty()) {
+    throw runtime_error("Usage: timeSFMBAL [--colamd] [--profile] [BALfile]");
+  }
+
+  if (!filename.empty()) {
+    return {profile, {filename}};
+  }
+
+  if (profile) {
+    return {profile, {findExampleDataFile("dubrovnik-135-90642-pre")}};
+  }
+
+  return {profile,
+          {
+              findExampleDataFile("dubrovnik-16-22106-pre"),
+              findExampleDataFile("dubrovnik-88-64298-pre"),
+              findExampleDataFile("dubrovnik-135-90642-pre"),
+          }};
+}
+
+double runSolver(const NonlinearFactorGraph& graph, const Values& initial,
+                 const Ordering& ordering,
+                 NonlinearOptimizerParams::LinearSolverType solverType,
+                 const std::string& label) {
+  LevenbergMarquardtParams params;
+  LevenbergMarquardtParams::SetCeresDefaults(&params);
+  params.setVerbosityLM("SUMMARY");
+  params.setRelativeErrorTol(0.01);
+  params.linearSolverType = solverType;
+  if (solverType == NonlinearOptimizerParams::MULTIFRONTAL_SOLVER) {
+    params.multifrontalParams.qrMode = MultifrontalParameters::QRMode::Allow;
+  }
+  if (gUseSchur) {
+    params.setOrdering(ordering);
+  }
+
+  auto start = std::chrono::high_resolution_clock::now();
+  LevenbergMarquardtOptimizer lm(graph, initial, params);
+  lm.optimize();
+  auto end = std::chrono::high_resolution_clock::now();
+
+  std::chrono::duration<double> elapsed = end - start;
+  std::cout << "  " << label << ": " << elapsed.count() << " s\n";
+  return elapsed.count();
+}
+}  // namespace
+
 int main(int argc, char* argv[]) {
-  // parse options and read BAL file
-  SfmData db = preamble(argc, argv);
+  const auto options = parseBalFiles(argc, argv);
+  struct TimingRow {
+    std::string dataset;
+    double legacy = 0.0;
+    double newer = 0.0;
+  };
+  std::vector<TimingRow> rows;
 
-  NonlinearFactorGraph graph = buildGeneralSfmGraph(db);
-  Values initial = buildGeneralSfmInitial(db);
+  for (const auto& filename : options.filenames) {
+    const std::string dataset =
+        std::filesystem::path(filename).filename().string();
+    std::cout << "\nProcessing BAL file: " << filename << std::endl;
+    const SfmData db = SfmData::FromBalFile(filename);
 
-  return optimize(db, graph, initial);
+    NonlinearFactorGraph graph = buildGeneralSfmGraph(db);
+    Values initial = buildGeneralSfmInitial(db);
+
+    Ordering ordering;
+    if (gUseSchur) {
+      ordering = createSchurOrdering(db, false);
+    }
+
+    const double newTime = runSolver(
+        graph, initial, ordering, NonlinearOptimizerParams::MULTIFRONTAL_SOLVER,
+        "MultifrontalSolver");
+    double legacyTime = 0.0;
+    if (!options.profile) {
+      legacyTime = runSolver(graph, initial, ordering,
+                             NonlinearOptimizerParams::MULTIFRONTAL_CHOLESKY,
+                             "MultifrontalCholesky");
+    }
+
+    if (!options.profile) {
+      rows.push_back({dataset, legacyTime, newTime});
+    }
+  }
+  if (!options.profile) {
+    std::cout
+        << "\n| Dataset | Legacy (Cholesky) s | New (Solver) s | Speedup |\n";
+    std::cout << "| --- | --- | --- | --- |\n";
+    std::cout << std::fixed << std::setprecision(3);
+    for (const auto& row : rows) {
+      const double speedup = row.newer > 0.0 ? (row.legacy / row.newer) : 0.0;
+      std::cout << "| " << row.dataset << " | " << row.legacy << " | "
+                << row.newer << " | " << speedup << "x |\n";
+    }
+  }
+  return 0;
 }


### PR DESCRIPTION
This is the big one. This uses the new multifrontal solver in the nonlinear optimizer, by means of a derived class `NonlinearMultifrontalSolver`.

Refer to copilot summary for the detailed changes, but here are the perf numbers, for BAL (SLAM-like datasets likely have much greater wins, but I did not run those yet):

#### TBB On Linux 
| Dataset | Legacy (Cholesky) s | New (Solver) s | Speedup |
| --- | --- | --- | --- |
| dubrovnik-16-22106-pre.txt | 0.768 | 0.405 | 1.893x |
| dubrovnik-88-64298-pre.txt | 3.146 | 2.123 | 1.482x |
| dubrovnik-135-90642-pre.txt | 3.662 | 2.889 | 1.268x |
#### TaskScheduler on Linux
| Dataset | Legacy (Cholesky) s | New (Solver) s | Speedup |
| --- | --- | --- | --- |
| dubrovnik-16-22106-pre.txt | 1.157 | 0.497 | 2.326x |
| dubrovnik-88-64298-pre.txt | 5.144 | 3.139 | 1.639x |
| dubrovnik-135-90642-pre.txt | 5.987 | 4.781 | 1.252x |
#### TBB On M1 Macbook
| Dataset | Legacy (Cholesky) s | New (Solver) s | Speedup |
| --- | --- | --- | --- |
| dubrovnik-16-22106-pre.txt | 1.089 | 0.536 | 2.032x |
| dubrovnik-88-64298-pre.txt | 5.732 | 3.238 | 1.770x |
| dubrovnik-135-90642-pre.txt | 8.544 | 4.501 | 1.899x |
#### TaskScheduler on M1
| Dataset | Legacy (Cholesky) s | New (Solver) s | Speedup |
| --- | --- | --- | --- |
| dubrovnik-16-22106-pre.txt | 1.577 | 0.665 | 2.372x |
| dubrovnik-88-64298-pre.txt | 8.064 | 4.022 | 2.005x |
| dubrovnik-135-90642-pre.txt | 10.166 | 7.403 | 1.373x |

Across both Linux and M1 macOS, the new TaskScheduler consistently outperforms the legacy Cholesky nonlinear optimizer and matches or exceeds TBB speedups, with the largest gains on smaller and mid-sized BAL problems (≈2.0–2.4×), while improvements taper to ≈1.25–1.9× on the largest Dubrovnik instance.

TaskScheduler closes much of the performance gap to TBB, but TBB still sets the raw-performance ceiling, especially at large scale (135 cameras).

### Sample run (Mac, no TBB)
```bash
Processing BAL file: /Users/dellaert/git/github/examples/Data/dubrovnik-16-22106-pre.txt
Initial error: 4.18566e+06, values: 22122
iter      cost      cost_change    lambda  success iter_time
   0       108228      4.1e+06     0.0001      1      0.067
   1      5.9e+04        5e+04    3.3e-05      1      0.066
   2      1.9e+04        4e+04    3.3e-05      1      0.065
   3      1.8e+04      6.5e+02    1.1e-05      1      0.068
   4      1.8e+04           14    3.7e-06      1      0.067
  MultifrontalSolver: 0.68 s
Initial error: 4.2e+06, values: 22122
iter      cost      cost_change    lambda  success iter_time
   0        1e+05      4.1e+06     0.0001      1       0.26
   1      5.3e+04      4.9e+04    3.3e-05      1       0.26
   2      1.9e+04      3.4e+04    3.3e-05      1       0.26
   3      1.8e+04      1.1e+03    1.1e-05      1       0.25
   4      1.8e+04           87    3.8e-06      1       0.25
  MultifrontalCholesky: 1.5 s

Processing BAL file: /Users/dellaert/git/github/examples/Data/dubrovnik-88-64298-pre.txt
Initial error: 3.1e+07, values: 64386
iter      cost      cost_change    lambda  success iter_time
   0      3.6e+05        3e+07     0.0001      1       0.72
   1        3e+05      5.9e+04    3.3e-05      1       0.61
   2      2.9e+05      3.5e+03    1.1e-05      1       0.61
   3      2.9e+05      1.7e+03    9.5e-06      1        0.6
  MultifrontalSolver: 4.2 s
Initial error: 3.1e+07, values: 64386
iter      cost      cost_change    lambda  success iter_time
   0      3.6e+05        3e+07     0.0001      1        2.2
   1        3e+05      5.9e+04    3.3e-05      1        2.5
   2      2.9e+05      3.8e+03    1.1e-05      1        2.2
   3      2.9e+05      1.4e+03    9.7e-06      1          2
  MultifrontalCholesky: 9.8 s

Processing BAL file: /Users/dellaert/git/github/examples/Data/dubrovnik-135-90642-pre.txt
Initial error: 5.8e+07, values: 90777
iter      cost      cost_change    lambda  success iter_time
   0        4e+05      5.8e+07     0.0001      1        2.3
   1      3.8e+05      2.4e+04    3.3e-05      1        1.9
   2      3.8e+05     -3.5e+03    1.1e-05      1        1.8
  MultifrontalSolver: 8.3 s
Initial error: 5.8e+07, values: 90777
iter      cost      cost_change    lambda  success iter_time
   0        4e+05      5.8e+07     0.0001      1        3.8
   1      3.8e+05      2.3e+04    3.3e-05      1        3.6
   2      3.8e+05     -9.4e+02    1.1e-05      1        3.5
  MultifrontalCholesky: 12 s
```