### PR TITLE
Default noise models and TranslationRecovery patch

### DIFF
--- a/gtsam/linear/NoiseModel.h
+++ b/gtsam/linear/NoiseModel.h
@@ -18,8 +18,9 @@
 
 #pragma once
 
-#include <gtsam/base/Testable.h>
+#include <gtsam/base/Manifold.h>
 #include <gtsam/base/Matrix.h>
+#include <gtsam/base/Testable.h>
 #include <gtsam/base/std_optional_serialization.h>
 #include <gtsam/dllexport.h>
 #include <gtsam/linear/LossFunctions.h>
@@ -32,6 +33,7 @@
 #endif
 
 #include <optional>
+#include <type_traits>
 
 namespace gtsam {
 
@@ -152,6 +154,20 @@ namespace gtsam {
     };
 
     //---------------------------------------------------------------------------------------
+    /**
+     * Return true if the model dimension matches the manifold dimension.
+     */
+    template <class T>
+    inline bool matchesDimension(const Base& model, const T& measured) {
+      static_assert(IsManifold<T>::value,
+                    "noiseModel::matchesDimension requires a manifold type.");
+      if constexpr (traits<T>::dimension == Eigen::Dynamic) {
+        return model.dim() ==
+               static_cast<size_t>(traits<T>::GetDimension(measured));
+      } else {
+        return model.dim() == static_cast<size_t>(traits<T>::dimension);
+      }
+    }
 
     /**
      * Gaussian implements the mathematical model
@@ -636,6 +652,23 @@ namespace gtsam {
        */
       static shared_ptr Create(size_t dim) {
         return shared_ptr(new Unit(dim));
+      }
+
+      /**
+       * Create a unit covariance noise model for a measurement type.
+       * Reuse a cached instance for fixed-size types.
+       */
+      template <class T, std::enable_if_t<!std::is_integral_v<T>, int> = 0>
+      static shared_ptr Create(const T& measured) {
+        static_assert(IsManifold<T>::value,
+                      "noiseModel::Unit::Create requires a manifold type.");
+        if constexpr (traits<T>::dimension == Eigen::Dynamic) {
+          return Create(static_cast<size_t>(traits<T>::GetDimension(measured)));
+        } else {
+          static const shared_ptr kDefault =
+              Create(static_cast<size_t>(traits<T>::dimension));
+          return kDefault;
+        }
       }
 
       /// true if a unit noise model, saves slow/clumsy dynamic casting

--- a/gtsam/linear/tests/testNoiseModel.cpp
+++ b/gtsam/linear/tests/testNoiseModel.cpp
@@ -19,7 +19,9 @@
 
 
 #include <gtsam/linear/NoiseModel.h>
+#include <gtsam/base/Matrix.h>
 #include <gtsam/base/TestableAssertions.h>
+#include <gtsam/geometry/Point2.h>
 
 #include <CppUnitLite/TestHarness.h>
 
@@ -104,6 +106,37 @@ TEST(NoiseModel, Unit)
   Vector v = Vector3(5.0,10.0,15.0);
   Gaussian::shared_ptr u(Unit::Create(3));
   EXPECT(assert_equal(v,u->whiten(v)));
+}
+
+/* ************************************************************************* */
+TEST(NoiseModel, UnitCreateMeasured)
+{
+  Matrix22 fixed = Matrix22::Identity();
+  auto fixedModel = Unit::Create(fixed);
+  EXPECT_LONGS_EQUAL(4, fixedModel->dim());
+  EXPECT(fixedModel == Unit::Create(fixed));
+
+  Matrix dynamic(2, 3);
+  dynamic.setZero();
+  EXPECT_LONGS_EQUAL(6, Unit::Create(dynamic)->dim());
+
+  EXPECT_LONGS_EQUAL(2, Unit::Create(Point2(1.0, 2.0))->dim());
+  EXPECT_LONGS_EQUAL(1, Unit::Create(1.0)->dim());
+}
+
+/* ************************************************************************* */
+TEST(NoiseModel, MatchesDimension)
+{
+  Matrix22 fixed = Matrix22::Identity();
+  EXPECT(matchesDimension(*Unit::Create(4), fixed));
+  EXPECT(!matchesDimension(*Unit::Create(3), fixed));
+
+  Matrix dynamic(2, 3);
+  dynamic.setZero();
+  EXPECT(matchesDimension(*Unit::Create(6), dynamic));
+
+  EXPECT(matchesDimension(*Unit::Create(2), Point2(1.0, 2.0)));
+  EXPECT(matchesDimension(*Unit::Create(1), 1.0));
 }
 
 /* ************************************************************************* */

--- a/gtsam/sfm/BinaryMeasurement.h
+++ b/gtsam/sfm/BinaryMeasurement.h
@@ -33,17 +33,18 @@
 
 namespace gtsam {
 
-template <class T> class BinaryMeasurement : public Factor {
+template <class T>
+class BinaryMeasurement : public Factor {
   // Check that T type is testable
   GTSAM_CONCEPT_ASSERT(IsTestable<T>);
 
-public:
+ public:
   // shorthand for a smart pointer to a measurement
   using shared_ptr = typename std::shared_ptr<BinaryMeasurement>;
 
-private:
-  T measured_;                  ///< The measurement
-  SharedNoiseModel noiseModel_; ///< Noise model
+ private:
+  T measured_;                   ///< The measurement
+  SharedNoiseModel noiseModel_;  ///< Noise model
 
  public:
   BinaryMeasurement(Key key1, Key key2, const T &measured,
@@ -52,12 +53,13 @@ private:
         measured_(measured),
         noiseModel_(model) {
     if (model) {
-      if (static_cast<int>(model->dim()) != traits<T>::GetDimension(measured))
+      if (!noiseModel::matchesDimension(*model, measured)) {
         throw std::runtime_error(
             "BinaryMeasurement: Noise model dimension does not match "
             "measurement dimension.");
+      }
     } else {
-      noiseModel_ = noiseModel::Unit::Create(traits<T>::GetDimension(measured));
+      noiseModel_ = noiseModel::Unit::Create(measured);
     }
   }
 
@@ -90,4 +92,4 @@ private:
   }
   /// @}
 };
-} // namespace gtsam
+}  // namespace gtsam

--- a/gtsam/sfm/BinaryMeasurement.h
+++ b/gtsam/sfm/BinaryMeasurement.h
@@ -50,7 +50,16 @@ private:
                     const SharedNoiseModel &model = nullptr)
       : Factor(std::vector<Key>({key1, key2})),
         measured_(measured),
-        noiseModel_(model) {}
+        noiseModel_(model) {
+    if (model) {
+      if (static_cast<int>(model->dim()) != traits<T>::GetDimension(measured))
+        throw std::runtime_error(
+            "BinaryMeasurement: Noise model dimension does not match "
+            "measurement dimension.");
+    } else {
+      noiseModel_ = noiseModel::Unit::Create(traits<T>::GetDimension(measured));
+    }
+  }
 
   /// @name Standard Interface
   /// @{

--- a/gtsam/sfm/ShonanAveraging.cpp
+++ b/gtsam/sfm/ShonanAveraging.cpp
@@ -827,8 +827,8 @@ Values ShonanAveraging<d>::initializeWithDescent(
   double alphaMin = 1e-2;
   double alpha =
       std::max(1024 * alphaMin, 10 * gradienTolerance / fabs(minEigenValue));
-  vector<double> alphas;
-  vector<double> fvals;
+  std::vector<double> alphas;
+  std::vector<double> fvals;
   // line search
   while ((alpha >= alphaMin)) {
     Values Qplus = LiftwithDescent(p, values, alpha * minEigenVector);
@@ -937,7 +937,7 @@ ShonanAveraging2::ShonanAveraging2(const Measurements &measurements,
     : ShonanAveraging<2>(maybeRobust(measurements, parameters.getUseHuber()),
                          parameters) {}
 
-ShonanAveraging2::ShonanAveraging2(string g2oFile, const Parameters &parameters)
+ShonanAveraging2::ShonanAveraging2(std::string g2oFile, const Parameters &parameters)
     : ShonanAveraging<2>(maybeRobust(parseMeasurements<Rot2>(g2oFile),
                                      parameters.getUseHuber()),
                          parameters) {}
@@ -983,7 +983,7 @@ ShonanAveraging3::ShonanAveraging3(const Measurements &measurements,
     : ShonanAveraging<3>(maybeRobust(measurements, parameters.getUseHuber()),
                          parameters) {}
 
-ShonanAveraging3::ShonanAveraging3(string g2oFile, const Parameters &parameters)
+ShonanAveraging3::ShonanAveraging3(std::string g2oFile, const Parameters &parameters)
     : ShonanAveraging<3>(maybeRobust(parseMeasurements<Rot3>(g2oFile),
                                      parameters.getUseHuber()),
                          parameters) {}

--- a/gtsam/sfm/TranslationRecovery.cpp
+++ b/gtsam/sfm/TranslationRecovery.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <gtsam/base/DSFMap.h>
+#include <gtsam/base/VectorSpace.h>
 #include <gtsam/geometry/Point3.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/geometry/Unit3.h>
@@ -38,8 +39,9 @@
 using namespace gtsam;
 using namespace std;
 
+namespace {
 // In Wrappers we have no access to this so have a default ready.
-static std::mt19937 kPRNG(42);
+std::mt19937 kPRNG(42);
 
 // Some relative translations may be zero. We treat nodes that have a zero
 // relativeTranslation as a single node.
@@ -96,6 +98,23 @@ Values addSameTranslationNodes(const Values &result,
   return final_result;
 }
 
+// A hacky noise conversion function because we really should be optimizing for
+// Unit3s rather than Point3s, in which case the noise model can be whatever it
+// wants. Unfortunately, we are given Unit3 measurements and Point3 unknowns,
+// which is a mismatch in this class' setup.
+using noiseModel::Isotropic;
+Isotropic::shared_ptr convertNoiseModel(
+    const SharedNoiseModel &unit3NoiseModel) {
+  if (auto isotropic = std::dynamic_pointer_cast<Isotropic>(unit3NoiseModel)) {
+    return noiseModel::Isotropic::Sigma(3, isotropic->sigma());
+  } else {
+    throw std::runtime_error(
+        "TranslationRecovery::convertNoiseModel: only isotropic noise model "
+        "supported.");
+  }
+}
+}  // namespace
+
 NonlinearFactorGraph TranslationRecovery::buildGraph(
     const std::vector<BinaryMeasurement<Unit3>> &relativeTranslations) const {
   NonlinearFactorGraph graph;
@@ -103,13 +122,13 @@ NonlinearFactorGraph TranslationRecovery::buildGraph(
   // Add translation factors for input translation directions.
   uint64_t i = 0;
   for (auto edge : relativeTranslations) {
+    auto model = convertNoiseModel(edge.noiseModel());
     if (use_bilinear_translation_factor_) {
       graph.emplace_shared<BilinearAngleTranslationFactor>(
-          edge.key1(), edge.key2(), Symbol('S', i), edge.measured(),
-          edge.noiseModel());
+          edge.key1(), edge.key2(), Symbol('S', i), edge.measured(), model);
     } else {
-      graph.emplace_shared<TranslationFactor>(
-          edge.key1(), edge.key2(), edge.measured(), edge.noiseModel());
+      graph.emplace_shared<TranslationFactor>(edge.key1(), edge.key2(),
+                                              edge.measured(), model);
     }
     i++;
   }
@@ -124,13 +143,12 @@ void TranslationRecovery::addPrior(
     const SharedNoiseModel &priorNoiseModel) const {
   auto edge = relativeTranslations.begin();
   if (edge == relativeTranslations.end()) return;
-  graph->emplace_shared<PriorFactor<Point3>>(edge->key1(), Point3(0, 0, 0),
-                                             priorNoiseModel);
+  graph->addPrior<Point3>(edge->key1(), Point3(0, 0, 0), priorNoiseModel);
 
   // Add a scale prior only if no other between factors were added.
   if (betweenTranslations.empty()) {
-    graph->emplace_shared<PriorFactor<Point3>>(
-        edge->key2(), scale * edge->measured().point3(), edge->noiseModel());
+    auto model = convertNoiseModel(edge->noiseModel());
+    graph->addPrior<Point3>(edge->key2(), scale * edge->measured(), model);
     return;
   }
 
@@ -184,8 +202,8 @@ Values TranslationRecovery::initializeRandomly(
     const std::vector<BinaryMeasurement<Unit3>> &relativeTranslations,
     const std::vector<BinaryMeasurement<Point3>> &betweenTranslations,
     const Values &initialValues) const {
-  return initializeRandomly(relativeTranslations, betweenTranslations,
-                            &kPRNG, initialValues);
+  return initializeRandomly(relativeTranslations, betweenTranslations, &kPRNG,
+                            initialValues);
 }
 
 Values TranslationRecovery::run(
@@ -229,11 +247,9 @@ Values TranslationRecovery::run(
 
 TranslationRecovery::TranslationEdges TranslationRecovery::SimulateMeasurements(
     const Values &poses, const vector<KeyPair> &edges) {
-  auto edgeNoiseModel = noiseModel::Isotropic::Sigma(3, 0.01);
+  auto edgeNoiseModel = noiseModel::Isotropic::Sigma(2, 0.01);
   TranslationEdges relativeTranslations;
-  for (auto edge : edges) {
-    Key a, b;
-    tie(a, b) = edge;
+  for (const auto& [a, b] : edges) {
     const Pose3 wTa = poses.at<Pose3>(a), wTb = poses.at<Pose3>(b);
     const Point3 Ta = wTa.translation(), Tb = wTb.translation();
     const Unit3 w_aZb(Tb - Ta);

--- a/gtsam/sfm/UnaryMeasurement.h
+++ b/gtsam/sfm/UnaryMeasurement.h
@@ -34,39 +34,41 @@ namespace gtsam {
 /**
  * @brief Unary measurement represents a measurement on a single key in a graph.
  */
-template <class T> class UnaryMeasurement : public Factor {
+template <class T>
+class UnaryMeasurement : public Factor {
   // Check that T type is testable
   GTSAM_CONCEPT_ASSERT(IsTestable<T>);
 
-public:
+ public:
   // shorthand for a smart pointer to a measurement
   using shared_ptr = std::shared_ptr<UnaryMeasurement>;
 
-private:
-  T measured_;                  ///< The measurement
-  SharedNoiseModel noiseModel_; ///< Noise model
+ private:
+  T measured_;                   ///< The measurement
+  SharedNoiseModel noiseModel_;  ///< Noise model
 
-public:
+ public:
   /**
    * @brief Constructs a unary measurement with a key, value, and noise model.
    * @param key The key of the measurement.
    * @param measured The measurement value.
    * @param model The noise model (optional).
    */
- UnaryMeasurement(Key key, const T &measured,
-                  const SharedNoiseModel &model = nullptr)
-     : Factor(std::vector<Key>({key})),
-       measured_(measured),
-       noiseModel_(model) {
-   if (model) {
-      if (static_cast<int>(model->dim()) != traits<T>::GetDimension(measured))
-       throw std::runtime_error(
-           "BinaryMeasurement: Noise model dimension does not match "
-           "measurement dimension.");
-   } else {
-     noiseModel_ = noiseModel::Unit::Create(traits<T>::GetDimension(measured));
-   }
- }
+  UnaryMeasurement(Key key, const T &measured,
+                   const SharedNoiseModel &model = nullptr)
+      : Factor(std::vector<Key>({key})),
+        measured_(measured),
+        noiseModel_(model) {
+    if (model) {
+      if (!noiseModel::matchesDimension(*model, measured)) {
+        throw std::runtime_error(
+            "UnaryMeasurement: Noise model dimension does not match "
+            "measurement dimension.");
+      }
+    } else {
+      noiseModel_ = noiseModel::Unit::Create(measured);
+    }
+  }
 
   /// @name Standard Interface
   /// @{
@@ -84,7 +86,7 @@ public:
 
   // Prints the measurement.
   void print(const std::string &s, const KeyFormatter &keyFormatter =
-                                        DefaultKeyFormatter) const override {
+                                       DefaultKeyFormatter) const override {
     std::cout << s << "UnaryMeasurement(" << keyFormatter(this->key()) << ")\n";
     traits<T>::Print(measured_, "  measured: ");
     if (noiseModel_)
@@ -104,4 +106,4 @@ public:
   }
   /// @}
 };
-} // namespace gtsam
+}  // namespace gtsam

--- a/gtsam/sfm/UnaryMeasurement.h
+++ b/gtsam/sfm/UnaryMeasurement.h
@@ -53,9 +53,20 @@ public:
    * @param measured The measurement value.
    * @param model The noise model (optional).
    */
-  UnaryMeasurement(Key key, const T &measured,
-                   const SharedNoiseModel &model = nullptr)
-      : Factor(std::vector<Key>({key})), measured_(measured), noiseModel_(model) {}
+ UnaryMeasurement(Key key, const T &measured,
+                  const SharedNoiseModel &model = nullptr)
+     : Factor(std::vector<Key>({key})),
+       measured_(measured),
+       noiseModel_(model) {
+   if (model) {
+      if (static_cast<int>(model->dim()) != traits<T>::GetDimension(measured))
+       throw std::runtime_error(
+           "BinaryMeasurement: Noise model dimension does not match "
+           "measurement dimension.");
+   } else {
+     noiseModel_ = noiseModel::Unit::Create(traits<T>::GetDimension(measured));
+   }
+ }
 
   /// @name Standard Interface
   /// @{

--- a/gtsam/slam/InitializePose.h
+++ b/gtsam/slam/InitializePose.h
@@ -70,7 +70,8 @@ static Values computePoses(const Values& initialRot,
   }
 
   // add prior on dummy node
-  auto priorModel = noiseModel::Unit::Create(Pose::dimension);
+  auto priorModel =
+      noiseModel::Unit::Create(static_cast<size_t>(Pose::dimension));
   initialPose.insert(kAnchorKey, Pose());
   posegraph->emplace_shared<PriorFactor<Pose> >(kAnchorKey, Pose(), priorModel);
 

--- a/gtsam/slam/KarcherMeanFactor-inl.h
+++ b/gtsam/slam/KarcherMeanFactor-inl.h
@@ -26,11 +26,13 @@ namespace gtsam {
 
 template <class T, class ALLOC>
 T FindKarcherMeanImpl(const std::vector<T, ALLOC>& rotations) {
+  static_assert(T::dimension != Eigen::Dynamic,
+                "FindKarcherMean requires fixed-size manifolds.");
   // Cost function C(R) = \sum PriorFactor(R_i)::error(R)
   // No closed form solution.
   NonlinearFactorGraph graph;
   static const Key kKey(0);
-  auto model = noiseModel::Unit::Create(T::dimension);
+  auto model = noiseModel::Unit::Create(static_cast<size_t>(T::dimension));
   for (const auto& R : rotations) {
     graph.addPrior<T>(kKey, R, model);
   }

--- a/gtsam/slam/KarcherMeanFactor-inl.h
+++ b/gtsam/slam/KarcherMeanFactor-inl.h
@@ -22,18 +22,17 @@
 #include <gtsam/slam/KarcherMeanFactor.h>
 #include <optional>
 
-using namespace std;
-
 namespace gtsam {
 
 template <class T, class ALLOC>
-T FindKarcherMeanImpl(const vector<T, ALLOC>& rotations) {
+T FindKarcherMeanImpl(const std::vector<T, ALLOC>& rotations) {
   // Cost function C(R) = \sum PriorFactor(R_i)::error(R)
   // No closed form solution.
   NonlinearFactorGraph graph;
   static const Key kKey(0);
+  auto model = noiseModel::Unit::Create(T::dimension);
   for (const auto& R : rotations) {
-    graph.addPrior<T>(kKey, R);
+    graph.addPrior<T>(kKey, R, model);
   }
   Values initial;
   initial.insert<T>(kKey, T());

--- a/gtsam/slam/TriangulationFactor.h
+++ b/gtsam/slam/TriangulationFactor.h
@@ -81,7 +81,7 @@ public:
       bool verboseCheirality = false) :
       Base(model, pointKey), camera_(camera), measured_(measured), throwCheirality_(
           throwCheirality), verboseCheirality_(verboseCheirality) {
-    if (model && model->dim() != traits<Measurement>::dimension)
+    if (model && !noiseModel::matchesDimension(*model, measured_))
       throw std::invalid_argument(
           "TriangulationFactor must be created with "
               + std::to_string((int) traits<Measurement>::dimension)
@@ -201,4 +201,3 @@ private:
 #endif
 };
 } // \ namespace gtsam
-

--- a/gtsam/slam/slam.i
+++ b/gtsam/slam/slam.i
@@ -582,22 +582,26 @@ class InitializePose3 {
 };
 
 #include <gtsam/slam/KarcherMeanFactor-inl.h>
-template <T = {gtsam::Point2, gtsam::Rot2, gtsam::Pose2, gtsam::Point3,
-               gtsam::SO3, gtsam::SO4, gtsam::Rot3, gtsam::Pose3, gtsam::Similarity2, gtsam::Similarity3, gtsam::Gal3, gtsam::SL4}>
+template <T = {gtsam::Rot2, gtsam::Pose2, gtsam::SO3, gtsam::SO4, gtsam::Rot3,
+               gtsam::Pose3, gtsam::Similarity2, gtsam::Similarity3,
+               gtsam::Gal3, gtsam::SL4}>
 virtual class KarcherMeanFactor : gtsam::NonlinearFactor {
   KarcherMeanFactor(const gtsam::KeyVector& keys);
   KarcherMeanFactor(const gtsam::KeyVector& keys, int d, double beta);
 };
 
-template <T = {gtsam::Point2, gtsam::Rot2, gtsam::Pose2, gtsam::Point3,
-  gtsam::SO3, gtsam::SO4, gtsam::Rot3, gtsam::Pose3}>
+template <T = {gtsam::Rot2, gtsam::Pose2, gtsam::SO3, gtsam::SO4, gtsam::Rot3,
+               gtsam::Pose3, gtsam::Similarity2, gtsam::Similarity3,
+               gtsam::Gal3, gtsam::SL4}>
 T FindKarcherMean(const std::vector<T>& elements);
 
 #include <gtsam/slam/FrobeniusFactor.h>
 gtsam::noiseModel::Isotropic* ConvertNoiseModel(gtsam::noiseModel::Base* model,
                                                 size_t d);
 
-template <T = {gtsam::Rot2, gtsam::Rot3, gtsam::SO3, gtsam::SO4, gtsam::Pose2, gtsam::Pose3, gtsam::Similarity2, gtsam::Similarity3, gtsam::Gal3, gtsam::SL4}>
+template <T = {gtsam::Rot2, gtsam::Rot3, gtsam::SO3, gtsam::SO4, gtsam::Pose2,
+               gtsam::Pose3, gtsam::Similarity2, gtsam::Similarity3,
+               gtsam::Gal3, gtsam::SL4}>
 class FrobeniusPrior : gtsam::NoiseModelFactor {
   FrobeniusPrior(gtsam::Key j, const gtsam::Matrix& M,
     const gtsam::noiseModel::Base* model);
@@ -605,7 +609,9 @@ class FrobeniusPrior : gtsam::NoiseModelFactor {
     gtsam::Vector evaluateError(const T& g) const;
 };
 
-template <T = {gtsam::Rot2, gtsam::Rot3, gtsam::SO3, gtsam::SO4, gtsam::Pose2, gtsam::Pose3, gtsam::Similarity2, gtsam::Similarity3, gtsam::Gal3, gtsam::SL4}>
+template <T = {gtsam::Rot2, gtsam::Rot3, gtsam::SO3, gtsam::SO4, gtsam::Pose2,
+               gtsam::Pose3, gtsam::Similarity2, gtsam::Similarity3,
+               gtsam::Gal3, gtsam::SL4}>
 virtual class FrobeniusFactor : gtsam::NoiseModelFactor {
   FrobeniusFactor(gtsam::Key key1, gtsam::Key key2);
   FrobeniusFactor(gtsam::Key j1, gtsam::Key j2, gtsam::noiseModel::Base* model);
@@ -614,7 +620,9 @@ virtual class FrobeniusFactor : gtsam::NoiseModelFactor {
 };
 
 // Available for all Matrix Lie groups
-template <T = {gtsam::Rot2, gtsam::Rot3, gtsam::SO3, gtsam::SO4, gtsam::Pose2, gtsam::Pose3, gtsam::Similarity2, gtsam::Similarity3, gtsam::Gal3, gtsam::SL4}>
+template <T = {gtsam::Rot2, gtsam::Rot3, gtsam::SO3, gtsam::SO4, gtsam::Pose2,
+               gtsam::Pose3, gtsam::Similarity2, gtsam::Similarity3,
+               gtsam::Gal3, gtsam::SL4}>
 virtual class FrobeniusBetweenFactorNL : gtsam::NoiseModelFactor {
   FrobeniusBetweenFactorNL(gtsam::Key j1, gtsam::Key j2, const T& T12);
   FrobeniusBetweenFactorNL(gtsam::Key key1, gtsam::Key key2, const T& T12,

--- a/python/gtsam/tests/test_TranslationRecovery.py
+++ b/python/gtsam/tests/test_TranslationRecovery.py
@@ -25,7 +25,7 @@ def SimulateMeasurements(gt_poses, graph_edges):
         Tb = gt_poses.atPose3(edge[1]).translation()
         measurements.append(gtsam.BinaryMeasurementUnit3( \
             edge[0], edge[1], gtsam.Unit3(Tb - Ta), \
-            gtsam.noiseModel.Isotropic.Sigma(3, 0.01)))
+            gtsam.noiseModel.Isotropic.Sigma(2, 0.01)))
     return measurements
 
 


### PR DESCRIPTION
To support the new MF solver, I added default unit noise models in the unary and binary measurements. This broke translation recovery because there was a mismatch between the measurements and noise models.This PR does not address the deeper underlying issue but just patches it up.

It also removes a `using namespace std` in a header (big nono), which necessitated some changes in Shonan averaging. 