### PR TITLE
Fix all noise models

### DIFF
--- a/gtsam/base/tests/testKruskal.cpp
+++ b/gtsam/base/tests/testKruskal.cpp
@@ -51,7 +51,7 @@ gtsam::NonlinearFactorGraph makeTestNonlinearFactorGraph() {
   using namespace symbol_shorthand;
 
   NonlinearFactorGraph nfg;
-  const SharedDiagonal model = noiseModel::Diagonal::Sigmas(Vector2(0.5, 0.5));
+  const SharedDiagonal model = noiseModel::Isotropic::Sigma(3, 0.5);
   nfg.emplace_shared<BetweenFactor<Rot3>>(X(1), X(2), Rot3(), model);
   nfg.emplace_shared<BetweenFactor<Rot3>>(X(1), X(3), Rot3(), model);
   nfg.emplace_shared<BetweenFactor<Rot3>>(X(1), X(4), Rot3(), model);

--- a/gtsam/basis/FitBasis.h
+++ b/gtsam/basis/FitBasis.h
@@ -27,6 +27,7 @@
 #include <gtsam/basis/Basis.h>
 #include <gtsam/basis/BasisFactors.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/linear/NoiseModel.h>
 #include <gtsam/linear/VectorValues.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 
@@ -62,9 +63,10 @@ class FitBasis {
                                              const SharedNoiseModel& model,
                                              size_t N) {
     NonlinearFactorGraph graph;
+    const auto noiseModel = noiseModel::validOrDefault(0.0, model);
     for (const Sample sample : sequence) {
-      graph.emplace_shared<EvaluationFactor<Basis>>(0, sample.second, model, N,
-                                                    sample.first);
+      graph.emplace_shared<EvaluationFactor<Basis>>(
+          0, sample.second, noiseModel, N, sample.first);
     }
     return graph;
   }

--- a/gtsam/geometry/triangulation.h
+++ b/gtsam/geometry/triangulation.h
@@ -459,9 +459,11 @@ Point3 triangulatePoint3(const std::vector<Pose3>& poses,
   }
 
   // Then refine using non-linear optimization
-  if (optimize)
+  if (optimize) {
+    const auto noiseModel = noiseModel::validOrDefault(Point2(0, 0), model);
     point = triangulateNonlinear<CALIBRATION>  //
-        (poses, sharedCal, measurements, point, model);
+        (poses, sharedCal, measurements, point, noiseModel);
+  }
 
 #ifdef GTSAM_THROW_CHEIRALITY_EXCEPTION
   // verify that the triangulated point lies in front of all cameras

--- a/gtsam/linear/GaussianConditional.cpp
+++ b/gtsam/linear/GaussianConditional.cpp
@@ -244,7 +244,7 @@ namespace gtsam {
 
   /* ************************************************************************* */
   VectorValues GaussianConditional::solveOtherRHS(
-    const VectorValues& parents, const VectorValues& rhs) const {
+      const VectorValues& parents, const VectorValues& rhs) const {
     // Concatenate all vector values that correspond to parent variables
     Vector xS = parents.vector(KeyVector(beginParents(), endParents()));
 
@@ -253,17 +253,18 @@ namespace gtsam {
     xS = rhsR - S() * xS;
 
     // Solve Matrix
-    Vector soln = R().triangularView<Eigen::Upper>().solve(xS);
+    Vector solution = R().triangularView<Eigen::Upper>().solve(xS);
 
     // Scale by sigmas
-    if (model_)
-      soln.array() *= model_->sigmas().array();
+    if (model_) solution.array() *= model_->sigmasRef().array();
 
     // Insert solution into a VectorValues
     VectorValues result;
     DenseIndex vectorPosition = 0;
-    for (const_iterator frontal = beginFrontals(); frontal != endFrontals(); ++frontal) {
-      result.emplace(*frontal, soln.segment(vectorPosition, getDim(frontal)));
+    for (const_iterator frontal = beginFrontals(); frontal != endFrontals();
+         ++frontal) {
+      result.emplace(*frontal,
+                     solution.segment(vectorPosition, getDim(frontal)));
       vectorPosition += getDim(frontal);
     }
 
@@ -283,7 +284,7 @@ namespace gtsam {
 
     // Scale by sigmas
     if (model_)
-      frontalVec.array() *= model_->sigmas().array();
+      frontalVec.array() *= model_->sigmasRef().array();
 
     // Write frontal solution into a VectorValues
     DenseIndex vectorPosition = 0;
@@ -367,8 +368,11 @@ namespace gtsam {
 
     // The vector of sigma values for sampling.
     // If no model, initialize sigmas to 1, else to model sigmas
-    const Vector& sigmas = (!model_) ? Vector::Ones(rows()) : model_->sigmas();
-    solution[key] += Sampler::sampleDiagonal(sigmas, rng);
+    if (model_) {
+      solution[key] += Sampler::sampleDiagonal(model_->sigmasRef(), rng);
+    } else {
+      solution[key] += Sampler::sampleDiagonal(Vector::Ones(rows()), rng);
+    }
     return solution;
   }
 

--- a/gtsam/linear/JacobianFactor.cpp
+++ b/gtsam/linear/JacobianFactor.cpp
@@ -262,6 +262,21 @@ FastVector<JacobianFactor::shared_ptr> _convertOrCastToJacobians(
 }
 
 /* ************************************************************************* */
+static std::vector<DenseIndex> _computeRowOffsets(
+    const FastVector<JacobianFactor::shared_ptr>& jacobians) {
+  std::vector<DenseIndex> rowOffsets;
+  rowOffsets.reserve(jacobians.size());
+  DenseIndex nextRow = 0;
+  for (const auto& jacobian : jacobians) {
+    rowOffsets.push_back(nextRow);
+    const DenseIndex rows = jacobian->rows();
+    if (rows > 0) {
+      nextRow += rows;
+    }
+  }
+  return rowOffsets;
+}
+
 void JacobianFactor::JacobianFactorHelper(const GaussianFactorGraph& graph,
     const FastVector<VariableSlots::const_iterator>& orderedSlots) {
 
@@ -271,6 +286,9 @@ void JacobianFactor::JacobianFactorHelper(const GaussianFactorGraph& graph,
 
   // Count dimensions
   const auto [varDims, m, n] = _countDims(jacobians, orderedSlots);
+
+  // Precompute row offsets once to avoid recomputing row starts per slot.
+  std::vector<DenseIndex> rowOffsets = _computeRowOffsets(jacobians);
 
   // Allocate matrix and copy keys in order
   gttic(allocate);
@@ -288,12 +306,12 @@ void JacobianFactor::JacobianFactorHelper(const GaussianFactorGraph& graph,
   for(VariableSlots::const_iterator varslot: orderedSlots) {
     JacobianFactor::ABlock destSlot(this->getA(this->begin() + combinedSlot));
     // Loop over source jacobians
-    DenseIndex nextRow = 0;
     for (size_t factorI = 0; factorI < jacobians.size(); ++factorI) {
       // Slot in source factor
       const size_t sourceSlot = varslot->second[factorI];
       const DenseIndex sourceRows = jacobians[factorI]->rows();
       if (sourceRows > 0) {
+        DenseIndex nextRow = rowOffsets[factorI];
         JacobianFactor::ABlock::RowsBlockXpr destBlock(
             destSlot.middleRows(nextRow, sourceRows));
         // Copy if exists in source factor, otherwise set zero
@@ -302,7 +320,6 @@ void JacobianFactor::JacobianFactorHelper(const GaussianFactorGraph& graph,
               jacobians[factorI]->begin() + sourceSlot);
         else
           destBlock.setZero();
-        nextRow += sourceRows;
       }
     }
     ++combinedSlot;
@@ -314,10 +331,10 @@ void JacobianFactor::JacobianFactorHelper(const GaussianFactorGraph& graph,
   bool anyConstrained = false;
   std::optional<Vector> sigmas;
   // Loop over source jacobians
-  DenseIndex nextRow = 0;
   for (size_t factorI = 0; factorI < jacobians.size(); ++factorI) {
     const DenseIndex sourceRows = jacobians[factorI]->rows();
     if (sourceRows > 0) {
+      DenseIndex nextRow = rowOffsets[factorI];
       this->getb().segment(nextRow, sourceRows) = jacobians[factorI]->getb();
       if (jacobians[factorI]->get_model()) {
         // If the factor has a noise model and we haven't yet allocated sigmas, allocate it.
@@ -328,7 +345,6 @@ void JacobianFactor::JacobianFactorHelper(const GaussianFactorGraph& graph,
         if (jacobians[factorI]->isConstrained())
           anyConstrained = true;
       }
-      nextRow += sourceRows;
     }
   }
   gttoc(copy_vectors);

--- a/gtsam/linear/JacobianFactor.cpp
+++ b/gtsam/linear/JacobianFactor.cpp
@@ -324,7 +324,7 @@ void JacobianFactor::JacobianFactorHelper(const GaussianFactorGraph& graph,
         if (!sigmas)
           sigmas = Vector::Constant(m, 1.0);
         sigmas->segment(nextRow, sourceRows) =
-            jacobians[factorI]->get_model()->sigmas();
+            jacobians[factorI]->get_model()->sigmasRef();
         if (jacobians[factorI]->isConstrained())
           anyConstrained = true;
       }
@@ -931,13 +931,15 @@ GaussianConditional::shared_ptr JacobianFactor::splitConditional(size_t nrFronta
   Ab_.rowEnd() = Ab_.rowStart() + frontalDim;
   SharedDiagonal conditionalNoiseModel;
   conditionalNoiseModel =
-      noiseModel::Diagonal::Sigmas(model_->sigmas().segment(Ab_.rowStart(), Ab_.rows()));
+      noiseModel::Diagonal::Sigmas(
+          model_->sigmasRef().segment(Ab_.rowStart(), Ab_.rows()));
   GaussianConditional::shared_ptr conditional =
       std::make_shared<GaussianConditional>(Base::keys_, nrFrontals, Ab_, conditionalNoiseModel);
 
   const DenseIndex maxRemainingRows =
       std::min(Ab_.cols(), originalRowEnd) - Ab_.rowStart() - frontalDim;
-  const DenseIndex remainingRows = std::min(model_->sigmas().size() - frontalDim, maxRemainingRows);
+  const DenseIndex remainingRows =
+      std::min(model_->sigmasRef().size() - frontalDim, maxRemainingRows);
   Ab_.rowStart() += frontalDim;
   Ab_.rowEnd() = Ab_.rowStart() + remainingRows;
   Ab_.firstBlock() += nrFrontals;
@@ -946,9 +948,11 @@ GaussianConditional::shared_ptr JacobianFactor::splitConditional(size_t nrFronta
   keys_.erase(begin(), begin() + nrFrontals);
   // Set sigmas with the right model
   if (model_->isConstrained())
-    model_ = noiseModel::Constrained::MixedSigmas(model_->sigmas().tail(remainingRows));
+    model_ = noiseModel::Constrained::MixedSigmas(
+        model_->sigmasRef().tail(remainingRows));
   else
-    model_ = noiseModel::Diagonal::Sigmas(model_->sigmas().tail(remainingRows));
+    model_ = noiseModel::Diagonal::Sigmas(
+        model_->sigmasRef().tail(remainingRows));
   assert(model_->dim() == (size_t)Ab_.rows());
 
   return conditional;

--- a/gtsam/linear/MultifrontalSolver.cpp
+++ b/gtsam/linear/MultifrontalSolver.cpp
@@ -104,7 +104,7 @@ std::unordered_set<Key> collectFixedKeys(const GaussianFactorGraph& graph) {
       throw std::runtime_error(
           "MultifrontalSolver: only unary constrained factors are supported.");
     }
-    const Vector sigmas = model->sigmas();
+    const Vector& sigmas = model->sigmasRef();
     if (!(sigmas.array().abs() <= kConstraintSigmaTol).all()) {
       throw std::runtime_error(
           "MultifrontalSolver: only fully constrained factors are supported.");

--- a/gtsam/linear/NoiseModel.cpp
+++ b/gtsam/linear/NoiseModel.cpp
@@ -170,6 +170,14 @@ Vector Gaussian::unwhiten(const Vector& v) const {
   return backSubstituteUpper(thisR(), v);
 }
 
+void Gaussian::unwhitenInPlace(Vector& v) const {
+  thisR().triangularView<Eigen::Upper>().solveInPlace(v);
+}
+
+void Gaussian::unwhitenInPlace(Eigen::Block<Vector>& v) const {
+  thisR().triangularView<Eigen::Upper>().solveInPlace(v);
+}
+
 /* ************************************************************************* */
 Matrix Gaussian::Whiten(const Matrix& H) const {
   return thisR() * H;
@@ -319,6 +327,14 @@ Vector Diagonal::unwhiten(const Vector& v) const {
   return v.cwiseProduct(sigmas_);
 }
 
+void Diagonal::whitenInPlace(Vector& v) const {
+  v.array() *= invsigmas_.array();
+}
+
+void Diagonal::unwhitenInPlace(Vector& v) const {
+  v.array() *= sigmas_.array();
+}
+
 Matrix Diagonal::Whiten(const Matrix& H) const {
   return vector_scale(invsigmas(), H);
 }
@@ -329,6 +345,14 @@ void Diagonal::WhitenInPlace(Matrix& H) const {
 
 void Diagonal::WhitenInPlace(Eigen::Block<Matrix> H) const {
   H = invsigmas().asDiagonal() * H;
+}
+
+void Diagonal::whitenInPlace(Eigen::Block<Vector>& v) const {
+  v.array() *= invsigmas_.array();
+}
+
+void Diagonal::unwhitenInPlace(Eigen::Block<Vector>& v) const {
+  v.array() *= sigmas_.array();
 }
 
 /* *******************************************************************************/
@@ -401,6 +425,26 @@ Vector Constrained::whiten(const Vector& v) const {
     c(i) = (bi==0.0) ? ai : ai/bi; // NOTE: not ediv_()
   }
   return c;
+}
+
+void Constrained::whitenInPlace(Vector& v) const {
+  const size_t n = v.size();
+  for (size_t i = 0; i < n; ++i) {
+    const double si = sigmas_(i);
+    if (si != 0.0) {
+      v(i) /= si;
+    }
+  }
+}
+
+void Constrained::whitenInPlace(Eigen::Block<Vector>& v) const {
+  const DenseIndex n = v.rows();
+  for (DenseIndex i = 0; i < n; ++i) {
+    const double si = sigmas_(static_cast<size_t>(i));
+    if (si != 0.0) {
+      v(i, 0) /= si;
+    }
+  }
 }
 
 /* ************************************************************************* */
@@ -700,6 +744,16 @@ void Isotropic::whitenInPlace(Vector& v) const {
 /* ************************************************************************* */
 void Isotropic::WhitenInPlace(Eigen::Block<Matrix> H) const {
   H *= invsigma_;
+}
+
+/* ************************************************************************* */
+void Isotropic::unwhitenInPlace(Vector& v) const {
+  v *= sigma_;
+}
+
+/* ************************************************************************* */
+void Isotropic::unwhitenInPlace(Eigen::Block<Vector>& v) const {
+  v *= sigma_;
 }
 
 /* *******************************************************************************/

--- a/gtsam/linear/NoiseModel.h
+++ b/gtsam/linear/NoiseModel.h
@@ -362,6 +362,8 @@ namespace gtsam {
 
       void print(const std::string& name) const override;
       Vector sigmas() const override { return sigmas_; }
+      /// Return standard deviations without copying.
+      inline const Vector& sigmasRef() const { return sigmas_; }
       Vector whiten(const Vector& v) const override;
       Vector unwhiten(const Vector& v) const override;
       void whitenInPlace(Vector& v) const override;

--- a/gtsam/linear/NoiseModel.h
+++ b/gtsam/linear/NoiseModel.h
@@ -154,9 +154,7 @@ namespace gtsam {
     };
 
     //---------------------------------------------------------------------------------------
-    /**
-     * Return true if the model dimension matches the manifold dimension.
-     */
+    /// Return true if the model dimension matches the manifold dimension.
     template <class T>
     inline bool matchesDimension(const Base& model, const T& measured) {
       static_assert(IsManifold<T>::value,
@@ -805,6 +803,16 @@ namespace gtsam {
 
     // Helper function
     GTSAM_EXPORT std::optional<Vector> checkIfDiagonal(const Matrix& M);
+
+    /// Create
+    template <class T>
+    Base::shared_ptr validOrDefault(const T& value,
+                                    const Base::shared_ptr& model) {
+      if (!model) return noiseModel::Unit::Create(value);
+      if (noiseModel::matchesDimension(*model, value)) return model;
+      throw std::runtime_error(
+          "noiseModel::validOrDefault: mis-matched model dimension.");
+    }
 
   } // namespace noiseModel
 

--- a/gtsam/linear/NoiseModel.h
+++ b/gtsam/linear/NoiseModel.h
@@ -239,6 +239,8 @@ namespace gtsam {
       Vector sigmas() const override;
       Vector whiten(const Vector& v) const override;
       Vector unwhiten(const Vector& v) const override;
+      void unwhitenInPlace(Vector& v) const override;
+      void unwhitenInPlace(Eigen::Block<Vector>& v) const override;
 
       /**
        * Multiply a derivative with R (derivative of whiten)
@@ -362,9 +364,13 @@ namespace gtsam {
       Vector sigmas() const override { return sigmas_; }
       Vector whiten(const Vector& v) const override;
       Vector unwhiten(const Vector& v) const override;
+      void whitenInPlace(Vector& v) const override;
+      void unwhitenInPlace(Vector& v) const override;
       Matrix Whiten(const Matrix& H) const override;
       void WhitenInPlace(Matrix& H) const override;
       void WhitenInPlace(Eigen::Block<Matrix> H) const override;
+      void whitenInPlace(Eigen::Block<Vector>& v) const override;
+      void unwhitenInPlace(Eigen::Block<Vector>& v) const override;
 
       /**
        * Return standard deviations (sqrt of diagonal)
@@ -511,6 +517,8 @@ namespace gtsam {
 
       /// Calculates error vector with weights applied
       Vector whiten(const Vector& v) const override;
+      void whitenInPlace(Vector& v) const override;
+      void whitenInPlace(Eigen::Block<Vector>& v) const override;
 
       /// Whitening functions will perform partial whitening on rows
       /// with a non-zero sigma.  Other rows remain untouched.
@@ -608,6 +616,8 @@ namespace gtsam {
       void WhitenInPlace(Matrix& H) const override;
       void whitenInPlace(Vector& v) const override;
       void WhitenInPlace(Eigen::Block<Matrix> H) const override;
+      void unwhitenInPlace(Vector& v) const override;
+      void unwhitenInPlace(Eigen::Block<Vector>& v) const override;
 
       /**
        * Return standard deviation
@@ -753,6 +763,7 @@ namespace gtsam {
       { Vector b; Matrix B=A; this->WhitenSystem(B,b); return B; }
       inline Vector unwhiten(const Vector& /*v*/) const override
       { throw std::invalid_argument("unwhiten is not currently supported for robust noise models."); }
+      inline void whitenInPlace(Vector& v) const override { this->WhitenSystem(v); }
       /// Compute loss from the m-estimator using the Mahalanobis distance.
       double loss(const double squared_distance) const override {
         return robust_->loss(std::sqrt(squared_distance));

--- a/gtsam/linear/Sampler.cpp
+++ b/gtsam/linear/Sampler.cpp
@@ -79,7 +79,7 @@ Vector Sampler::sampleDiagonal(const Vector& sigmas) const {
 /* ************************************************************************* */
 Vector Sampler::sample() const {
   assert(model_.get());
-  const Vector& sigmas = model_->sigmas();
+  const Vector& sigmas = model_->sigmasRef();
   return sampleDiagonal(sigmas);
 }
 

--- a/gtsam/linear/tests/testJacobianFactor.cpp
+++ b/gtsam/linear/tests/testJacobianFactor.cpp
@@ -233,6 +233,110 @@ TEST( JacobianFactor, construct_from_graph)
 }
 
 /* ************************************************************************* */
+TEST(JacobianFactor, construct_from_graph_no_model)
+{
+  const Key keyX = 1, keyY = 2;
+  Matrix A11 = I_2x2;
+  Matrix A22 = 2 * I_2x2;
+  Vector2 b1(1.0, 2.0);
+  Vector2 b2(3.0, 4.0);
+
+  auto factor1 = std::make_shared<JacobianFactor>(keyX, A11, b1);
+  auto factor2 = std::make_shared<JacobianFactor>(keyY, A22, b2);
+
+  GaussianFactorGraph factors{factor1, factor2};
+  Ordering ordering{keyX, keyY};
+
+  Matrix A1(4, 2);
+  A1.setZero();
+  A1.block(0, 0, 2, 2) = A11;
+  Matrix A2(4, 2);
+  A2.setZero();
+  A2.block(2, 0, 2, 2) = A22;
+  Vector b(4);
+  b << b1, b2;
+
+  JacobianFactor expected(keyX, A1, keyY, A2, b);
+  JacobianFactor actual(factors, ordering);
+
+  EXPECT(assert_equal(expected, actual));
+  EXPECT(!actual.get_model());
+}
+
+/* ************************************************************************* */
+TEST(JacobianFactor, construct_from_graph_mixed_models)
+{
+  const Key keyX = 1, keyY = 2;
+  Matrix A11 = I_2x2;
+  Matrix A22 = 2 * I_2x2;
+  Vector2 b1(1.0, 2.0);
+  Vector2 b2(3.0, 4.0);
+  Vector2 sigmas1(0.2, 0.3);
+
+  auto factor1 = std::make_shared<JacobianFactor>(
+      keyX, A11, b1, noiseModel::Diagonal::Sigmas(sigmas1));
+  auto factor2 = std::make_shared<JacobianFactor>(keyY, A22, b2);
+
+  GaussianFactorGraph factors{factor1, factor2};
+  Ordering ordering{keyX, keyY};
+
+  Matrix A1(4, 2);
+  A1.setZero();
+  A1.block(0, 0, 2, 2) = A11;
+  Matrix A2(4, 2);
+  A2.setZero();
+  A2.block(2, 0, 2, 2) = A22;
+  Vector b(4);
+  b << b1, b2;
+  Vector sigmas(4);
+  sigmas << sigmas1, Vector2(1.0, 1.0);
+
+  JacobianFactor expected(keyX, A1, keyY, A2, b,
+                          noiseModel::Diagonal::Sigmas(sigmas));
+  JacobianFactor actual(factors, ordering);
+
+  EXPECT(assert_equal(expected, actual));
+}
+
+/* ************************************************************************* */
+TEST(JacobianFactor, construct_from_graph_constrained)
+{
+  const Key keyX = 1, keyY = 2;
+  Matrix A11 = I_2x2;
+  Matrix A22 = 2 * I_2x2;
+  Vector2 b1(1.0, 2.0);
+  Vector2 b2(3.0, 4.0);
+  Vector2 sigmas1(0.0, 1.0);
+  Vector2 sigmas2(2.0, 3.0);
+
+  auto factor1 = std::make_shared<JacobianFactor>(
+      keyX, A11, b1, noiseModel::Constrained::MixedSigmas(sigmas1));
+  auto factor2 = std::make_shared<JacobianFactor>(
+      keyY, A22, b2, noiseModel::Diagonal::Sigmas(sigmas2));
+
+  GaussianFactorGraph factors{factor1, factor2};
+  Ordering ordering{keyX, keyY};
+
+  Matrix A1(4, 2);
+  A1.setZero();
+  A1.block(0, 0, 2, 2) = A11;
+  Matrix A2(4, 2);
+  A2.setZero();
+  A2.block(2, 0, 2, 2) = A22;
+  Vector b(4);
+  b << b1, b2;
+  Vector sigmas(4);
+  sigmas << sigmas1, sigmas2;
+
+  JacobianFactor expected(keyX, A1, keyY, A2, b,
+                          noiseModel::Constrained::MixedSigmas(sigmas));
+  JacobianFactor actual(factors, ordering);
+
+  EXPECT(actual.isConstrained());
+  EXPECT(assert_equal(expected, actual));
+}
+
+/* ************************************************************************* */
 TEST(JacobianFactor, error)
 {
   JacobianFactor factor(simple::terms, simple::b, simple::noise);

--- a/gtsam/linear/tests/testNoiseModel.cpp
+++ b/gtsam/linear/tests/testNoiseModel.cpp
@@ -511,6 +511,94 @@ TEST(NoiseModel, WhitenInPlace)
 }
 
 /* ************************************************************************* */
+TEST(NoiseModel, InPlaceVectorOperations)
+{
+  SharedGaussian gaussian = Gaussian::SqrtInformation(R, false);
+  Vector v = Vector3(5.0, 10.0, 15.0);
+  Vector expected = gaussian->unwhiten(v);
+  Vector actual = v;
+  gaussian->unwhitenInPlace(actual);
+  EXPECT(assert_equal(expected, actual));
+
+  SharedDiagonal diagonal = Diagonal::Sigmas(kSigmas, false);
+  v = Vector3(10.0, 20.0, 30.0);
+  expected = diagonal->whiten(v);
+  actual = v;
+  diagonal->whitenInPlace(actual);
+  EXPECT(assert_equal(expected, actual));
+
+  v = Vector3(1.0, 2.0, 3.0);
+  expected = diagonal->unwhiten(v);
+  actual = v;
+  diagonal->unwhitenInPlace(actual);
+  EXPECT(assert_equal(expected, actual));
+
+  SharedIsotropic isotropic = Isotropic::Sigma(3, kSigma, false);
+  v = Vector3(1.0, 2.0, 3.0);
+  expected = isotropic->unwhiten(v);
+  actual = v;
+  isotropic->unwhitenInPlace(actual);
+  EXPECT(assert_equal(expected, actual));
+
+  SharedConstrained constrained =
+      Constrained::MixedSigmas(Vector3(kSigma, 0.0, kSigma));
+  v = Vector3(2.0, 3.0, 4.0);
+  expected = constrained->whiten(v);
+  actual = v;
+  constrained->whitenInPlace(actual);
+  EXPECT(assert_equal(expected, actual));
+  EXPECT_DOUBLES_EQUAL(v(1), actual(1), 1e-12);
+
+  SharedNoiseModel robust = Robust::Create(mEstimator::Huber::Create(1.345),
+                                           diagonal);
+  v = Vector3(1.0, 2.0, 3.0);
+  expected = robust->whiten(v);
+  actual = v;
+  robust->whitenInPlace(actual);
+  EXPECT(assert_equal(expected, actual));
+}
+
+/* ************************************************************************* */
+TEST(NoiseModel, InPlaceVectorBlockOperations)
+{
+  SharedGaussian gaussian = Gaussian::SqrtInformation(R, false);
+  SharedDiagonal diagonal = Diagonal::Sigmas(kSigmas, false);
+  SharedIsotropic isotropic = Isotropic::Sigma(3, kSigma, false);
+  SharedConstrained constrained =
+      Constrained::MixedSigmas(Vector3(kSigma, 0.0, kSigma));
+
+  Vector v = Vector::LinSpaced(5, 1.0, 5.0);
+  Eigen::Block<Vector> block(v, 1, 0, 3, 1);
+  Vector expected = diagonal->whiten(Vector(block));
+  diagonal->whitenInPlace(block);
+  EXPECT(assert_equal(expected, Vector(block)));
+
+  v = Vector::LinSpaced(5, 1.0, 5.0);
+  Eigen::Block<Vector> block_unwhiten(v, 1, 0, 3, 1);
+  expected = diagonal->unwhiten(Vector(block_unwhiten));
+  diagonal->unwhitenInPlace(block_unwhiten);
+  EXPECT(assert_equal(expected, Vector(block_unwhiten)));
+
+  v = Vector::LinSpaced(5, 1.0, 5.0);
+  Eigen::Block<Vector> block_constrained(v, 1, 0, 3, 1);
+  expected = constrained->whiten(Vector(block_constrained));
+  constrained->whitenInPlace(block_constrained);
+  EXPECT(assert_equal(expected, Vector(block_constrained)));
+
+  v = Vector::LinSpaced(5, 1.0, 5.0);
+  Eigen::Block<Vector> block_iso(v, 1, 0, 3, 1);
+  expected = isotropic->unwhiten(Vector(block_iso));
+  isotropic->unwhitenInPlace(block_iso);
+  EXPECT(assert_equal(expected, Vector(block_iso)));
+
+  v = Vector::LinSpaced(5, 1.0, 5.0);
+  Eigen::Block<Vector> block_gauss(v, 1, 0, 3, 1);
+  expected = gaussian->unwhiten(Vector(block_gauss));
+  gaussian->unwhitenInPlace(block_gauss);
+  EXPECT(assert_equal(expected, Vector(block_gauss)));
+}
+
+/* ************************************************************************* */
 
 /*
  * These tests are responsible for testing the weight functions for the m-estimators in GTSAM.

--- a/gtsam/nonlinear/NonlinearFactor.h
+++ b/gtsam/nonlinear/NonlinearFactor.h
@@ -239,6 +239,8 @@ public:
 
   /** get the dimension of the factor (number of rows on linearization) */
   size_t dim() const override {
+    if (!noiseModel_)
+      throw std::runtime_error("NoiseModelFactor::dim(): no noise model set");
     return noiseModel_->dim();
   }
 

--- a/gtsam/nonlinear/PriorFactor.h
+++ b/gtsam/nonlinear/PriorFactor.h
@@ -49,7 +49,7 @@ class PriorFactor : public ExtendedPriorFactor<VALUE> {
   /// Constructor
   PriorFactor(Key key, const VALUE& prior,
               const SharedNoiseModel& model = nullptr)
-      : Base(key, prior, model) {}
+      : Base(key, prior, noiseModel::validOrDefault(prior, model)) {}
 
   /// Convenience constructor that takes a full covariance argument
   PriorFactor(Key key, const VALUE& prior, const Matrix& covariance)

--- a/gtsam/nonlinear/nonlinear.i
+++ b/gtsam/nonlinear/nonlinear.i
@@ -625,7 +625,7 @@ template <T = {double,
                gtsam::imuBias::ConstantBias}>
 virtual class PriorFactor : gtsam::NoiseModelFactor {
   PriorFactor(gtsam::Key key, const T& prior,
-              const gtsam::noiseModel::Base* noiseModel);
+              const gtsam::noiseModel::Base* noiseModel = nullptr);
   T prior() const;
 
   // enabling serialization functionality

--- a/gtsam/sfm/BinaryMeasurement.h
+++ b/gtsam/sfm/BinaryMeasurement.h
@@ -51,17 +51,7 @@ class BinaryMeasurement : public Factor {
                     const SharedNoiseModel &model = nullptr)
       : Factor(std::vector<Key>({key1, key2})),
         measured_(measured),
-        noiseModel_(model) {
-    if (model) {
-      if (!noiseModel::matchesDimension(*model, measured)) {
-        throw std::runtime_error(
-            "BinaryMeasurement: Noise model dimension does not match "
-            "measurement dimension.");
-      }
-    } else {
-      noiseModel_ = noiseModel::Unit::Create(measured);
-    }
-  }
+        noiseModel_(noiseModel::validOrDefault(measured, model)) {}
 
   /// @name Standard Interface
   /// @{

--- a/gtsam/sfm/TransferFactor.h
+++ b/gtsam/sfm/TransferFactor.h
@@ -18,12 +18,14 @@
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/geometry/EssentialMatrix.h>
 #include <gtsam/geometry/FundamentalMatrix.h>
+#include <gtsam/linear/NoiseModel.h>
 #include <gtsam/inference/EdgeKey.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/NoiseModelFactorN.h>
 
 #include <cstdint>
+#include <stdexcept>
 
 namespace gtsam {
 
@@ -35,6 +37,14 @@ class TransferEdges {
  protected:
   EdgeKey edge1_, edge2_;  ///< The two EdgeKeys.
   uint32_t c_;             ///< The transfer target
+
+  // Return appropriate noise model
+  static SharedNoiseModel defaultNoiseModel(size_t dim,
+                                            const SharedNoiseModel& model) {
+    if (!model) return noiseModel::Unit::Create(dim);
+    if (model->dim() == dim) return model;
+    throw std::runtime_error("TransferFactor: noise model dimension mismatch.");
+  }
 
  public:
   TransferEdges(EdgeKey edge1, EdgeKey edge2)
@@ -101,12 +111,13 @@ class TransferFactor : public NoiseModelFactorN<F, F>, public TransferEdges<F> {
    * @param edge2 Second EdgeKey specifying F2: (b, c) or (c, b).
    * @param triplets A vector of triplets containing (pa, pb, pc).
    * @param model An optional SharedNoiseModel that defines the noise model
-   *              for this factor. Defaults to nullptr.
+   *              for this factor. Defaults to unit noise.
    */
   TransferFactor(EdgeKey edge1, EdgeKey edge2,
                  const std::vector<Triplet>& triplets,
                  const SharedNoiseModel& model = nullptr)
-      : Base(model, edge1, edge2),
+      : Base(TransferEdges<F>::defaultNoiseModel(2 * triplets.size(), model),
+             edge1, edge2),
         TransferEdges<F>(edge1, edge2),
         triplets_(triplets) {}
 
@@ -247,7 +258,8 @@ class EssentialTransferFactorK
   EssentialTransferFactorK(EdgeKey edge1, EdgeKey edge2,
                            const std::vector<Triplet>& triplets,
                            const SharedNoiseModel& model = nullptr)
-      : Base(model, edge1, edge2,
+      : Base(TransferEdges<EM>::defaultNoiseModel(2 * triplets.size(), model),
+             edge1, edge2,
              Symbol('k', ViewA(edge1, edge2)),   // calibration key for view a
              Symbol('k', ViewB(edge1, edge2)),   // calibration key for view b
              Symbol('k', ViewC(edge1, edge2))),  // calibration key for target c
@@ -268,7 +280,8 @@ class EssentialTransferFactorK
   EssentialTransferFactorK(EdgeKey edge1, EdgeKey edge2, Key keyK,
                            const std::vector<Triplet>& triplets,
                            const SharedNoiseModel& model = nullptr)
-      : Base(model, edge1, edge2, keyK, keyK, keyK),
+      : Base(TransferEdges<EM>::defaultNoiseModel(2 * triplets.size(), model),
+             edge1, edge2, keyK, keyK, keyK),
         TransferEdges<EM>(edge1, edge2),
         triplets_(triplets) {}
 

--- a/gtsam/sfm/UnaryMeasurement.h
+++ b/gtsam/sfm/UnaryMeasurement.h
@@ -58,17 +58,7 @@ class UnaryMeasurement : public Factor {
                    const SharedNoiseModel &model = nullptr)
       : Factor(std::vector<Key>({key})),
         measured_(measured),
-        noiseModel_(model) {
-    if (model) {
-      if (!noiseModel::matchesDimension(*model, measured)) {
-        throw std::runtime_error(
-            "UnaryMeasurement: Noise model dimension does not match "
-            "measurement dimension.");
-      }
-    } else {
-      noiseModel_ = noiseModel::Unit::Create(measured);
-    }
-  }
+        noiseModel_(noiseModel::validOrDefault(measured, model)) {}
 
   /// @name Standard Interface
   /// @{

--- a/gtsam/slam/BetweenFactor.h
+++ b/gtsam/slam/BetweenFactor.h
@@ -72,7 +72,8 @@ namespace gtsam {
     /** Constructor */
     BetweenFactor(Key key1, Key key2, const VALUE& measured,
         const SharedNoiseModel& model = nullptr) :
-      Base(model, key1, key2), measured_(measured) {
+      Base(noiseModel::validOrDefault(measured, model), key1, key2),
+      measured_(measured) {
     }
 
     /// @}

--- a/gtsam/slam/EssentialMatrixFactor.h
+++ b/gtsam/slam/EssentialMatrixFactor.h
@@ -357,7 +357,8 @@ class EssentialMatrixFactor4
    */
   EssentialMatrixFactor4(Key keyE, Key keyK, const Point2& pA, const Point2& pB,
                          const SharedNoiseModel& model = nullptr)
-      : Base(model, keyE, keyK), pA_(pA), pB_(pB) {}
+      : Base(noiseModel::validOrDefault(0.0, model), keyE, keyK),
+        pA_(pA), pB_(pB) {}
 
   /// @return a deep copy of this factor
   gtsam::NonlinearFactor::shared_ptr clone() const override {
@@ -460,7 +461,8 @@ class EssentialMatrixFactor5
   EssentialMatrixFactor5(Key keyE, Key keyKa, Key keyKb, const Point2& pA,
                          const Point2& pB,
                          const SharedNoiseModel& model = nullptr)
-      : Base(model, keyE, keyKa, keyKb), pA_(pA), pB_(pB) {}
+      : Base(noiseModel::validOrDefault(0.0, model), keyE, keyKa, keyKb),
+        pA_(pA), pB_(pB) {}
 
   /// @return a deep copy of this factor
   gtsam::NonlinearFactor::shared_ptr clone() const override {

--- a/gtsam/slam/FrobeniusFactor.h
+++ b/gtsam/slam/FrobeniusFactor.h
@@ -63,7 +63,10 @@ GTSAM_EXPORT SharedNoiseModel ConvertNoiseModel(const SharedNoiseModel& model,
  */
 template <class T, size_t Dim>
 inline SharedNoiseModel ConvertModel(const SharedNoiseModel& model) {
-  if (!model || model->dim() == Dim) {
+  if (!model) {
+    return ConvertNoiseModel(noiseModel::Unit::Create(T()), Dim);
+  }
+  if (model->dim() == Dim) {
     return model;
   }
   if (model->dim() != T::dimension) {

--- a/gtsam/slam/KarcherMeanFactor-inl.h
+++ b/gtsam/slam/KarcherMeanFactor-inl.h
@@ -32,9 +32,8 @@ T FindKarcherMeanImpl(const std::vector<T, ALLOC>& rotations) {
   // No closed form solution.
   NonlinearFactorGraph graph;
   static const Key kKey(0);
-  auto model = noiseModel::Unit::Create(static_cast<size_t>(T::dimension));
   for (const auto& R : rotations) {
-    graph.addPrior<T>(kKey, R, model);
+    graph.addPrior<T>(kKey, R, noiseModel::Unit::Create(R));
   }
   Values initial;
   initial.insert<T>(kKey, T());

--- a/gtsam/slam/slam.i
+++ b/gtsam/slam/slam.i
@@ -21,7 +21,7 @@ template <T = {double, gtsam::Vector, gtsam::Point2, gtsam::Point3, gtsam::Rot2,
                gtsam::Similarity2, gtsam::Similarity3, gtsam::imuBias::ConstantBias}>
 virtual class BetweenFactor : gtsam::NoiseModelFactor {
   BetweenFactor(gtsam::Key key1, gtsam::Key key2, const T& relativePose,
-                const gtsam::noiseModel::Base* noiseModel);
+                const gtsam::noiseModel::Base* noiseModel = nullptr);
   T measured() const;
 
   // enabling serialization functionality
@@ -604,7 +604,7 @@ template <T = {gtsam::Rot2, gtsam::Rot3, gtsam::SO3, gtsam::SO4, gtsam::Pose2,
                gtsam::Gal3, gtsam::SL4}>
 class FrobeniusPrior : gtsam::NoiseModelFactor {
   FrobeniusPrior(gtsam::Key j, const gtsam::Matrix& M,
-    const gtsam::noiseModel::Base* model);
+    const gtsam::noiseModel::Base* model = nullptr);
 
     gtsam::Vector evaluateError(const T& g) const;
 };

--- a/gtsam/slam/tests/testLago.cpp
+++ b/gtsam/slam/tests/testLago.cpp
@@ -35,6 +35,7 @@ using namespace gtsam;
 
 static Symbol x0('x', 0), x1('x', 1), x2('x', 2), x3('x', 3);
 static SharedNoiseModel model(noiseModel::Isotropic::Sigma(3, 0.1));
+static SharedNoiseModel rotModel(noiseModel::Isotropic::Sigma(1, 0.1));
 
 namespace simpleLago {
 // We consider a small graph:
@@ -224,7 +225,7 @@ TEST( Lago, multiplePosePriorsSP ) {
 TEST( Lago, multiplePoseAndRotPriors ) {
   bool useOdometricPath = false;
   NonlinearFactorGraph g = simpleLago::graph();
-  g.addPrior(x1, simpleLago::pose1.theta(), model);
+  g.addPrior(x1, simpleLago::pose1.theta(), rotModel);
   VectorValues initial = lago::initializeOrientations(g, useOdometricPath);
   
   // comparison is up to M_PI, that's why we add some multiples of 2*M_PI
@@ -237,7 +238,7 @@ TEST( Lago, multiplePoseAndRotPriors ) {
 /* *************************************************************************** */
 TEST( Lago, multiplePoseAndRotPriorsSP ) {
   NonlinearFactorGraph g = simpleLago::graph();
-  g.addPrior(x1, simpleLago::pose1.theta(), model);
+  g.addPrior(x1, simpleLago::pose1.theta(), rotModel);
   VectorValues initial = lago::initializeOrientations(g);
 
   // comparison is up to M_PI, that's why we add some multiples of 2*M_PI
@@ -348,4 +349,3 @@ int main() {
   return TestRegistry::runAllTests(tr);
 }
 /* ************************************************************************* */
-

--- a/tests/testGaussianISAM2.cpp
+++ b/tests/testGaussianISAM2.cpp
@@ -1000,7 +1000,7 @@ class FixActiveFactor : public NoiseModelFactorN<Vector2> {
 
 public:
   FixActiveFactor(const gtsam::Key& key, const bool active)
-      : Base(nullptr, key), is_active_(active) {}
+      : Base(noiseModel::Unit::Create(2), key), is_active_(active) {}
 
   virtual bool active(const gtsam::Values &values) const override {
     return is_active_;

--- a/tests/testNonlinearOptimizer.cpp
+++ b/tests/testNonlinearOptimizer.cpp
@@ -637,13 +637,29 @@ struct MyType : public Vector3 {
 namespace gtsam {
 template <>
 struct traits<MyType> {
+  typedef manifold_tag structure_category;
+  inline constexpr static auto dimension = 3;
+  typedef MyType ManifoldType;
+  typedef Vector3 TangentVector;
+  typedef OptionalJacobian<dimension, dimension> ChartJacobian;
+
   static bool Equals(const MyType& a, const MyType& b, double tol) {
     return (a - b).array().abs().maxCoeff() < tol;
   }
   static void Print(const MyType&, const string&) {}
-  static int GetDimension(const MyType&) { return 3; }
-  static MyType Retract(const MyType& a, const Vector3& b) { return a + b; }
-  static Vector3 Local(const MyType& a, const MyType& b) { return b - a; }
+  static int GetDimension(const MyType&) { return dimension; }
+  static MyType Retract(const MyType& a, const TangentVector& v,
+                        ChartJacobian H1 = {}, ChartJacobian H2 = {}) {
+    if (H1) *H1 = Matrix3::Identity();
+    if (H2) *H2 = Matrix3::Identity();
+    return MyType(a + v);
+  }
+  static TangentVector Local(const MyType& a, const MyType& b,
+                             ChartJacobian H1 = {}, ChartJacobian H2 = {}) {
+    if (H1) *H1 = -Matrix3::Identity();
+    if (H2) *H2 = Matrix3::Identity();
+    return b - a;
+  }
 };
 }
 

--- a/tests/testSerializationSlam.cpp
+++ b/tests/testSerializationSlam.cpp
@@ -312,7 +312,6 @@ TEST (testSerializationSLAM, factors) {
   SharedNoiseModel model5 = noiseModel::Isotropic::Sigma(5, 0.3);
   SharedNoiseModel model6 = noiseModel::Isotropic::Sigma(6, 0.3);
   SharedNoiseModel model9 = noiseModel::Isotropic::Sigma(9, 0.3);
-  SharedNoiseModel model11 = noiseModel::Isotropic::Sigma(11, 0.3);
 
   SharedNoiseModel robust1 = noiseModel::Robust::Create(
       noiseModel::mEstimator::Huber::Create(10.0, noiseModel::mEstimator::Huber::Scalar),
@@ -332,7 +331,7 @@ TEST (testSerializationSLAM, factors) {
   PriorFactorCal3_S2 priorFactorCal3_S2(a10, cal3_s2, model5);
   PriorFactorCal3DS2 priorFactorCal3DS2(a11, cal3ds2, model9);
   PriorFactorCalibratedCamera priorFactorCalibratedCamera(a12, calibratedCamera, model6);
-  PriorFactorStereoCamera priorFactorStereoCamera(a14, stereoCamera, model11);
+  PriorFactorStereoCamera priorFactorStereoCamera(a14, stereoCamera, model6);
 
   BetweenFactorPoint2 betweenFactorPoint2(a03, b03, point2, model2);
   BetweenFactorPoint3 betweenFactorPoint3(a05, b05, point3, model3);


### PR DESCRIPTION
In anticipation of the new nonlinear multifrontal solver, all nonlinear factors now need to have a non-null noise model. This PR fixes a bunch of code that did not comply.

Also has a little bit of clean up in the JacobianFactor and the whitening of noise models. 