### PR TITLE
sccache for all os in vcpkg

### DIFF
--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -59,11 +59,9 @@ jobs:
           toolset: 14.40
 
       - name: Install sccache
-        if: runner.os == 'Windows'
         uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Use sccache
-        if: runner.os == 'Windows'
         shell: bash
         run: |
           echo "SCCACHE_GHA_ENABLED=ON" >> "$GITHUB_ENV"


### PR DESCRIPTION
sccache for all os in vcpkg

After running second time on my repo:
https://github.com/talregev/gtsam/pull/56

Windows: 46m 8s
Ubuntu: 9m 27s
Macos: 13m 32s
