### PR TITLE
Simple GNSS Pseudorange Factor

### DIFF
--- a/THANKS.md
+++ b/THANKS.md
@@ -44,6 +44,8 @@ at LAAS-CNRS
 
 * Ellon Paiva
 
+* Sammy Guo
+
 Many thanks for your hard work!!!!
 
 Frank Dellaert

--- a/gtsam/navigation/PseudorangeFactor.cpp
+++ b/gtsam/navigation/PseudorangeFactor.cpp
@@ -33,14 +33,10 @@ PseudorangeFactor::PseudorangeFactor(Key receiverPositionKey,
 //***************************************************************************
 void PseudorangeFactor::print(const std::string& s,
                               const KeyFormatter& keyFormatter) const {
-  std::cout << (s.empty() ? "" : s + " ") << "PseudorangeFactor on "
-            << keyFormatter(this->key<1>()) << ", "
-            << keyFormatter(this->key<2>()) << "\n";
-  std::cout << "  Pseudorange: " << pseudorange_ << " meters\n";
-  std::cout << "  Satellite Position: " << satPos_.transpose()
-            << " meters (ECEF)\n";
-  std::cout << "  Satellite clock bias: " << satClkBias_ << " seconds\n";
-  noiseModel_->print("  noise model: ");
+  Base::print(s, keyFormatter);
+  gtsam::print(pseudorange_, "pseudorange (m): ");
+  gtsam::print(Vector(satPos_), "sat position (ECEF meters): ");
+  gtsam::print(satClkBias_, "sat clock bias (s): ");
 }
 
 //***************************************************************************

--- a/gtsam/navigation/PseudorangeFactor.cpp
+++ b/gtsam/navigation/PseudorangeFactor.cpp
@@ -1,0 +1,78 @@
+/**
+ *  @file   PseudorangeFactor.cpp
+ *  @author Sammy Guo
+ *  @brief  Implementation file for GNSS Pseudorange factor
+ *  @date   January 18, 2026
+ **/
+
+#include "PseudorangeFactor.h"
+
+namespace {
+
+/// Speed of light in a vacuum (m/s):
+constexpr double CLIGHT = 299792458.0;
+
+}  // namespace
+
+namespace gtsam {
+
+PseudorangeFactor::PseudorangeFactor()
+    : Base(), pseudorange_(0.0), sat_pos_(Point3::Zero()), sat_clk_bias_(0.0) {}
+
+PseudorangeFactor::PseudorangeFactor(Key receiver_position_key,
+                                     Key receiver_clock_bias_key,
+                                     const double measured_pseudorange,
+                                     const Point3& satellite_position,
+                                     const double satellite_clock_bias,
+                                     const SharedNoiseModel& model)
+    : Base(model, receiver_position_key, receiver_clock_bias_key),
+      pseudorange_(measured_pseudorange),
+      sat_pos_(satellite_position),
+      sat_clk_bias_(satellite_clock_bias) {}
+
+//***************************************************************************
+// void PseudorangeFactor::print(const std::string& s, const KeyFormatter&
+// keyFormatter) const {
+//  cout << (s.empty() ? "" : s + " ") << "PseudorangeFactor on " <<
+//  keyFormatter(key())
+//       << "\n";
+//  cout << "  GPS measurement: " << nT_ << "\n";
+//  noiseModel_->print("  noise model: ");
+//}
+
+//***************************************************************************
+// bool PseudorangeFactor::equals(const NonlinearFactor& expected, double tol)
+// const {
+//  const This* e = dynamic_cast<const This*>(&expected);
+//  return e != nullptr && Base::equals(*e, tol) /*&&
+//  traits<Point3>::Equals(nT_, e->nT_, tol)*/;
+//}
+
+//***************************************************************************
+Vector PseudorangeFactor::evaluateError(
+    const Point3& receiver_position, const double& receiver_clock_bias,
+    OptionalMatrixType Hreceiver_pos,
+    OptionalMatrixType Hreceiver_clock_bias) const {
+  // Apply pseudorange equation: rho = range + c*[dt_u - dt^s]
+  const Vector3 position_difference = receiver_position - sat_pos_;
+  const double range = position_difference.norm();
+  const double rho = range + CLIGHT * (receiver_clock_bias - sat_clk_bias_);
+  const double error = rho - pseudorange_;
+
+  // Compute associated derivatives:
+  if (Hreceiver_pos) {
+    if (range < std::numeric_limits<double>::epsilon()) {
+      *Hreceiver_pos = Matrix13::Zero();
+    } else {
+      *Hreceiver_pos = position_difference / range;
+    }
+  }
+
+  if (Hreceiver_clock_bias) {
+    *Hreceiver_clock_bias = Matrix11(CLIGHT);
+  }
+
+  return Vector1(error);
+}
+
+}  // namespace gtsam

--- a/gtsam/navigation/PseudorangeFactor.cpp
+++ b/gtsam/navigation/PseudorangeFactor.cpp
@@ -17,18 +17,18 @@ constexpr double CLIGHT = 299792458.0;
 namespace gtsam {
 
 PseudorangeFactor::PseudorangeFactor()
-    : Base(), pseudorange_(0.0), sat_pos_(Point3::Zero()), sat_clk_bias_(0.0) {}
+    : Base(), pseudorange_(0.0), satPos_(Point3::Zero()), satClkBias_(0.0) {}
 
-PseudorangeFactor::PseudorangeFactor(Key receiver_position_key,
-                                     Key receiver_clock_bias_key,
-                                     const double measured_pseudorange,
-                                     const Point3& satellite_position,
-                                     const double satellite_clock_bias,
+PseudorangeFactor::PseudorangeFactor(Key receiverPositionKey,
+                                     Key receiverClockBiasKey,
+                                     const double measuredPseudorange,
+                                     const Point3& satellitePosition,
+                                     const double satelliteClockBias,
                                      const SharedNoiseModel& model)
-    : Base(model, receiver_position_key, receiver_clock_bias_key),
-      pseudorange_(measured_pseudorange),
-      sat_pos_(satellite_position),
-      sat_clk_bias_(satellite_clock_bias) {}
+    : Base(model, receiverPositionKey, receiverClockBiasKey),
+      pseudorange_(measuredPseudorange),
+      satPos_(satellitePosition),
+      satClkBias_(satelliteClockBias) {}
 
 //***************************************************************************
 void PseudorangeFactor::print(const std::string& s,
@@ -37,9 +37,9 @@ void PseudorangeFactor::print(const std::string& s,
             << keyFormatter(this->key<1>()) << ", "
             << keyFormatter(this->key<2>()) << "\n";
   std::cout << "  Pseudorange: " << pseudorange_ << " meters\n";
-  std::cout << "  Satellite Position: " << sat_pos_.transpose()
+  std::cout << "  Satellite Position: " << satPos_.transpose()
             << " meters (ECEF)\n";
-  std::cout << "  Satellite clock bias: " << sat_clk_bias_ << " seconds\n";
+  std::cout << "  Satellite clock bias: " << satClkBias_ << " seconds\n";
   noiseModel_->print("  noise model: ");
 }
 
@@ -49,8 +49,8 @@ bool PseudorangeFactor::equals(const NonlinearFactor& expected,
   const This* e = dynamic_cast<const This*>(&expected);
   return e != nullptr && Base::equals(*e, tol) &&
          traits<double>::Equals(pseudorange_, e->pseudorange_, tol) &&
-         traits<Point3>::Equals(sat_pos_, e->sat_pos_, tol) &&
-         traits<double>::Equals(sat_clk_bias_, e->sat_clk_bias_, tol);
+         traits<Point3>::Equals(satPos_, e->satPos_, tol) &&
+         traits<double>::Equals(satClkBias_, e->satClkBias_, tol);
 }
 
 //***************************************************************************
@@ -59,9 +59,9 @@ Vector PseudorangeFactor::evaluateError(
     OptionalMatrixType Hreceiver_pos,
     OptionalMatrixType Hreceiver_clock_bias) const {
   // Apply pseudorange equation: rho = range + c*[dt_u - dt^s]
-  const Vector3 position_difference = receiver_position - sat_pos_;
+  const Vector3 position_difference = receiver_position - satPos_;
   const double range = position_difference.norm();
-  const double rho = range + CLIGHT * (receiver_clock_bias - sat_clk_bias_);
+  const double rho = range + CLIGHT * (receiver_clock_bias - satClkBias_);
   const double error = rho - pseudorange_;
 
   // Compute associated derivatives:

--- a/gtsam/navigation/PseudorangeFactor.cpp
+++ b/gtsam/navigation/PseudorangeFactor.cpp
@@ -31,22 +31,26 @@ PseudorangeFactor::PseudorangeFactor(Key receiver_position_key,
       sat_clk_bias_(satellite_clock_bias) {}
 
 //***************************************************************************
-// void PseudorangeFactor::print(const std::string& s, const KeyFormatter&
-// keyFormatter) const {
-//  cout << (s.empty() ? "" : s + " ") << "PseudorangeFactor on " <<
-//  keyFormatter(key())
-//       << "\n";
-//  cout << "  GPS measurement: " << nT_ << "\n";
-//  noiseModel_->print("  noise model: ");
-//}
+void PseudorangeFactor::print(const std::string& s,
+                              const KeyFormatter& keyFormatter) const {
+  std::cout << (s.empty() ? "" : s + " ") << "PseudorangeFactor on "
+            << keyFormatter(key()) << "\n";
+  std::cout << "  Pseudorange: " << pseudorange_ << " meters\n";
+  std::cout << "  Satellite Position: " << sat_pos_.transpose()
+            << " meters (ECEF)\n";
+  std::cout << "  Satellite clock bias: " << sat_clk_bias_ << " seconds\n";
+  noiseModel_->print("  noise model: ");
+}
 
 //***************************************************************************
-// bool PseudorangeFactor::equals(const NonlinearFactor& expected, double tol)
-// const {
-//  const This* e = dynamic_cast<const This*>(&expected);
-//  return e != nullptr && Base::equals(*e, tol) /*&&
-//  traits<Point3>::Equals(nT_, e->nT_, tol)*/;
-//}
+bool PseudorangeFactor::equals(const NonlinearFactor& expected,
+                               double tol) const {
+  const This* e = dynamic_cast<const This*>(&expected);
+  return e != nullptr && Base::equals(*e, tol) &&
+         traits<double>::Equals(pseudorange_, e->pseudorange_, tol) &&
+         traits<Point3>::Equals(sat_pos_, e->sat_pos_, tol) &&
+         traits<double>::Equals(sat_clk_bias_, e->sat_clk_bias_, tol);
+}
 
 //***************************************************************************
 Vector PseudorangeFactor::evaluateError(

--- a/gtsam/navigation/PseudorangeFactor.cpp
+++ b/gtsam/navigation/PseudorangeFactor.cpp
@@ -64,7 +64,7 @@ Vector PseudorangeFactor::evaluateError(
     if (range < std::numeric_limits<double>::epsilon()) {
       *Hreceiver_pos = Matrix13::Zero();
     } else {
-      *Hreceiver_pos = position_difference / range;
+      *Hreceiver_pos = (position_difference / range).transpose();
     }
   }
 

--- a/gtsam/navigation/PseudorangeFactor.cpp
+++ b/gtsam/navigation/PseudorangeFactor.cpp
@@ -34,7 +34,8 @@ PseudorangeFactor::PseudorangeFactor(Key receiver_position_key,
 void PseudorangeFactor::print(const std::string& s,
                               const KeyFormatter& keyFormatter) const {
   std::cout << (s.empty() ? "" : s + " ") << "PseudorangeFactor on "
-            << keyFormatter(key()) << "\n";
+            << keyFormatter(this->key<1>()) << ", "
+            << keyFormatter(this->key<2>()) << "\n";
   std::cout << "  Pseudorange: " << pseudorange_ << " meters\n";
   std::cout << "  Satellite Position: " << sat_pos_.transpose()
             << " meters (ECEF)\n";

--- a/gtsam/navigation/PseudorangeFactor.h
+++ b/gtsam/navigation/PseudorangeFactor.h
@@ -1,0 +1,107 @@
+/**
+ *  @file   PseudorangeFactor.h
+ *  @author Sammy Guo
+ *  @brief  Header file for GNSS Pseudorange factor
+ *  @date   January 18, 2026
+ **/
+#pragma once
+
+#include <gtsam/geometry/Point3.h>
+#include <gtsam/nonlinear/NoiseModelFactorN.h>
+#include <gtsam/nonlinear/NonlinearFactor.h>
+
+#include <string>
+
+namespace gtsam {
+
+/**
+ * Simplified GNSS pseudorange model for basic positioning problems.
+ *
+ * This factor implements a simplified version of equation 5.6 [1]
+ * \rho = r + c[\delta t_u - \delta t^s] + I_{\rho} + T_{\rho} + \epsilon_{\rho}
+ * where `\rho` is measured pseudorange (in meters) from the receiver,
+ * `r` true range (in meters) between receiver antenna and satellite,
+ * `c` is speed of light in a vacuum (m/s),
+ * `\delta t_u` is receiver clock bias (seconds),
+ * `\delta t_s` is satellite clock bias (seconds),
+ * and `I_{\rho}`, `T_{\rho}`, and `\epsilon_{\rho}` are ionospheric,
+ * tropospheric, and unmodeled errors respectively.
+ *
+ * Ionospheric and tropospheric terms are omitted in this simplified factor.
+ *
+ * @ingroup navigation
+ *
+ * REFERENCES:
+ * [1] P. Misra et. al., "Global Positioning Systems: Signals, Measurements, and
+ * Performance", Second Edition, 2012.
+ */
+class GTSAM_EXPORT PseudorangeFactor
+    : public NoiseModelFactorN<Point3, double> {
+ private:
+  typedef NoiseModelFactorN<Point3, double> Base;
+
+  const double
+      pseudorange_;  ///< Receiver-reported pseudorange measurement in meters.
+  const Point3 sat_pos_;       ///< Satellite position in WGS84 ECEF meters.
+  const double sat_clk_bias_;  ///< Satellite clock bias in seconds.
+
+ public:
+  // Provide access to the Matrix& version of evaluateError:
+  using Base::evaluateError;
+
+  /// shorthand for a smart pointer to a factor
+  typedef std::shared_ptr<PseudorangeFactor> shared_ptr;
+
+  /// Typedef to this class
+  typedef PseudorangeFactor This;
+
+  /** default constructor - only use for serialization */
+  PseudorangeFactor();
+
+  virtual ~PseudorangeFactor() = default;
+
+  /**
+   * @brief TODO
+   */
+  PseudorangeFactor(Key receiver_position_key, Key receiver_clock_bias_key,
+                    double measured_pseudorange,
+                    const Point3& satellite_position,
+                    double satellite_clock_bias, const SharedNoiseModel& model);
+
+  /// @return a deep copy of this factor
+  gtsam::NonlinearFactor::shared_ptr clone() const override {
+    return std::static_pointer_cast<gtsam::NonlinearFactor>(
+        gtsam::NonlinearFactor::shared_ptr(new This(*this)));
+  }
+
+  /// print
+  //  void print(const std::string& s = "", const KeyFormatter& keyFormatter =
+  //                                            DefaultKeyFormatter) const
+  //                                            override;
+
+  /// equals
+  //  bool equals(const NonlinearFactor& expected, double tol = 1e-9) const
+  //  override;
+
+  /// vector of errors
+  Vector evaluateError(const Point3& receiver_position,
+                       const double& receiver_clock_bias,
+                       OptionalMatrixType Hreceiver_pos,
+                       OptionalMatrixType Hreceiver_clock_bias) const override;
+
+ private:
+#if GTSAM_ENABLE_BOOST_SERIALIZATION  ///
+  /// Serialization function
+  friend class boost::serialization::access;
+  template <class ARCHIVE>
+  void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
+    ar& boost::serialization::make_nvp(
+        "NoiseModelFactor2", boost::serialization::base_object<Base>(*this));
+    ar& BOOST_SERIALIZATION_NVP(pseudorange_);
+    ar& BOOST_SERIALIZATION_NVP(sat_pos_);
+    ar& BOOST_SERIALIZATION_NVP(sat_clk_bias_);
+  }
+#endif
+};
+
+}  // namespace gtsam

--- a/gtsam/navigation/PseudorangeFactor.h
+++ b/gtsam/navigation/PseudorangeFactor.h
@@ -41,10 +41,10 @@ class GTSAM_EXPORT PseudorangeFactor
  private:
   typedef NoiseModelFactorN<Point3, double> Base;
 
-  const double
-      pseudorange_;  ///< Receiver-reported pseudorange measurement in meters.
-  const Point3 satPos_;      ///< Satellite position in WGS84 ECEF meters.
-  const double satClkBias_;  ///< Satellite clock bias in seconds.
+  double
+      pseudorange_;    ///< Receiver-reported pseudorange measurement in meters.
+  Point3 satPos_;      ///< Satellite position in WGS84 ECEF meters.
+  double satClkBias_;  ///< Satellite clock bias in seconds.
 
  public:
   // Provide access to the Matrix& version of evaluateError:
@@ -72,11 +72,11 @@ class GTSAM_EXPORT PseudorangeFactor
    * @param satelliteClockBias Satellite clock bias in seconds.
    * @param model 1-D noise model.
    */
-  PseudorangeFactor(Key receiverPositionKey, Key receiverClockBiasKey,
-                    double measuredPseudorange, const Point3& satellitePosition,
-                    double satelliteClockBias,
-                    const SharedNoiseModel& model =
-                        noiseModel::Diagonal::Sigmas(Vector1(1.0)));
+  PseudorangeFactor(
+      Key receiverPositionKey, Key receiverClockBiasKey,
+      double measuredPseudorange, const Point3& satellitePosition,
+      double satelliteClockBias = 0.0,
+      const SharedNoiseModel& model = noiseModel::Unit::Create(1));
 
   /// @return a deep copy of this factor
   gtsam::NonlinearFactor::shared_ptr clone() const override {
@@ -111,5 +111,9 @@ class GTSAM_EXPORT PseudorangeFactor
   }
 #endif
 };
+
+/// traits
+template <>
+struct traits<PseudorangeFactor> : public Testable<PseudorangeFactor> {};
 
 }  // namespace gtsam

--- a/gtsam/navigation/PseudorangeFactor.h
+++ b/gtsam/navigation/PseudorangeFactor.h
@@ -28,6 +28,7 @@ namespace gtsam {
  * tropospheric, and unmodeled errors respectively.
  *
  * Ionospheric and tropospheric terms are omitted in this simplified factor.
+ * Note that this factor is also designed for code-phase measurements.
  *
  * @ingroup navigation
  *
@@ -61,7 +62,15 @@ class GTSAM_EXPORT PseudorangeFactor
   virtual ~PseudorangeFactor() = default;
 
   /**
-   * @brief TODO
+   * Construct a PseudorangeFactor that models the distance between a receiver
+   * and a satellite.
+   *
+   * @param receiver_position_key Receiver gtsam::Point3 ECEF position node.
+   * @param receiver_clock_bias_key Receiver clock bias node.
+   * @param measured_pseudorange Receiver-measured pseudorange in meters.
+   * @param satellite_position Satellite ECEF position in meters.
+   * @param satellite_clock_bias Satellite clock bias in seconds.
+   * @param model 1-D noise model.
    */
   PseudorangeFactor(Key receiver_position_key, Key receiver_clock_bias_key,
                     double measured_pseudorange,
@@ -75,13 +84,12 @@ class GTSAM_EXPORT PseudorangeFactor
   }
 
   /// print
-  //  void print(const std::string& s = "", const KeyFormatter& keyFormatter =
-  //                                            DefaultKeyFormatter) const
-  //                                            override;
+  void print(const std::string& s = "", const KeyFormatter& keyFormatter =
+                                            DefaultKeyFormatter) const override;
 
   /// equals
-  //  bool equals(const NonlinearFactor& expected, double tol = 1e-9) const
-  //  override;
+  bool equals(const NonlinearFactor& expected,
+              double tol = 1e-9) const override;
 
   /// vector of errors
   Vector evaluateError(const Point3& receiver_position,

--- a/gtsam/navigation/PseudorangeFactor.h
+++ b/gtsam/navigation/PseudorangeFactor.h
@@ -43,8 +43,8 @@ class GTSAM_EXPORT PseudorangeFactor
 
   const double
       pseudorange_;  ///< Receiver-reported pseudorange measurement in meters.
-  const Point3 sat_pos_;       ///< Satellite position in WGS84 ECEF meters.
-  const double sat_clk_bias_;  ///< Satellite clock bias in seconds.
+  const Point3 satPos_;      ///< Satellite position in WGS84 ECEF meters.
+  const double satClkBias_;  ///< Satellite clock bias in seconds.
 
  public:
   // Provide access to the Matrix& version of evaluateError:
@@ -65,17 +65,18 @@ class GTSAM_EXPORT PseudorangeFactor
    * Construct a PseudorangeFactor that models the distance between a receiver
    * and a satellite.
    *
-   * @param receiver_position_key Receiver gtsam::Point3 ECEF position node.
-   * @param receiver_clock_bias_key Receiver clock bias node.
-   * @param measured_pseudorange Receiver-measured pseudorange in meters.
-   * @param satellite_position Satellite ECEF position in meters.
-   * @param satellite_clock_bias Satellite clock bias in seconds.
+   * @param receiverPositionKey Receiver gtsam::Point3 ECEF position node.
+   * @param receiverClockBiasKey Receiver clock bias node.
+   * @param measuredPseudorange Receiver-measured pseudorange in meters.
+   * @param satellitePosition Satellite ECEF position in meters.
+   * @param satelliteClockBias Satellite clock bias in seconds.
    * @param model 1-D noise model.
    */
-  PseudorangeFactor(Key receiver_position_key, Key receiver_clock_bias_key,
-                    double measured_pseudorange,
-                    const Point3& satellite_position,
-                    double satellite_clock_bias, const SharedNoiseModel& model);
+  PseudorangeFactor(Key receiverPositionKey, Key receiverClockBiasKey,
+                    double measuredPseudorange, const Point3& satellitePosition,
+                    double satelliteClockBias,
+                    const SharedNoiseModel& model =
+                        noiseModel::Diagonal::Sigmas(Vector1(1.0)));
 
   /// @return a deep copy of this factor
   gtsam::NonlinearFactor::shared_ptr clone() const override {
@@ -92,10 +93,10 @@ class GTSAM_EXPORT PseudorangeFactor
               double tol = 1e-9) const override;
 
   /// vector of errors
-  Vector evaluateError(const Point3& receiver_position,
-                       const double& receiver_clock_bias,
-                       OptionalMatrixType Hreceiver_pos,
-                       OptionalMatrixType Hreceiver_clock_bias) const override;
+  Vector evaluateError(const Point3& receiverPosition,
+                       const double& receiverClock_bias,
+                       OptionalMatrixType HreceiverPos,
+                       OptionalMatrixType HreceiverClockBias) const override;
 
  private:
 #if GTSAM_ENABLE_BOOST_SERIALIZATION  ///
@@ -103,11 +104,10 @@ class GTSAM_EXPORT PseudorangeFactor
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
-    ar& boost::serialization::make_nvp(
-        "NoiseModelFactor2", boost::serialization::base_object<Base>(*this));
+    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(PseudorangeFactor::Base);
     ar& BOOST_SERIALIZATION_NVP(pseudorange_);
-    ar& BOOST_SERIALIZATION_NVP(sat_pos_);
-    ar& BOOST_SERIALIZATION_NVP(sat_clk_bias_);
+    ar& BOOST_SERIALIZATION_NVP(satPos_);
+    ar& BOOST_SERIALIZATION_NVP(satClkBias_);
   }
 #endif
 };

--- a/gtsam/navigation/doc/PseudorangeFactor.ipynb
+++ b/gtsam/navigation/doc/PseudorangeFactor.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# GNSS Precise Positioning with Factor Graphs\n",
+    "# GNSS Positioning with Factor Graphs\n",
     "\n",
     "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/navigation/doc/PsuedorangeFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
@@ -51,7 +51,7 @@
     }
    ],
    "source": [
-    "%pip install --quiet pyrtklib numpy"
+    "%pip install --quiet numpy"
    ]
   },
   {
@@ -63,23 +63,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([0.])"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import pyrtklib as rtklib\n",
     "\n",
     "# TODO: Remove this before merging!!!\n",
     "import sys\n",
@@ -87,16 +75,7 @@
     "import gtsam\n",
     "from gtsam.symbol_shorthand import X, B\n",
     "\n",
-    "\n",
-    "obs = rtklib.obs_t()\n",
-    "nav = rtklib.nav_t()\n",
-    "sta = rtklib.sta_t()\n",
-    "load_status = rtklib.readrnx(\"/Users/sammy/gtsam-gnss/examples/Data/brdc0180.26n\", 1, \"\", obs, nav, sta)\n",
-    "assert load_status == 1, \"Loading broadcast ephemeris RINEX\"\n",
-    "load_status = rtklib.readrnx(\"/Users/sammy/gtsam-gnss/examples/Data/zoa10180.26o\", 1, \"\", obs, nav, sta)\n",
-    "assert load_status == 1, \"Loading receiver observation RINEX\"\n",
-    "\n",
-    "cb_key = B(0)  # Clock bias variable key.\n",
+    "cb_key = B(0)  # Receiver clock bias variable key.\n",
     "pos_key = X(0) # Receiver position variable key.\n",
     "nm = gtsam.noiseModel.Diagonal.Sigmas(np.array([1.0]))\n",
     "pf = gtsam.PseudorangeFactor(pos_key, cb_key, 123.45, np.array([123.45, 0.0, 0.0]), 0.0, nm)\n",

--- a/gtsam/navigation/doc/PseudorangeFactor.ipynb
+++ b/gtsam/navigation/doc/PseudorangeFactor.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Pseudorange Factor\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/navigation/doc/PsuedorangeFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/navigation/doc/PseudorangeFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "## Overview\n",
     "\n",
@@ -32,26 +32,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-cell"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.0\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.3\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%pip install --quiet gtsam_develop"
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
    ]
   },
   {
@@ -63,21 +56,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([0.])"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
+    "import gtsam\n",
+    "from gtsam.symbol_shorthand import B, X\n",
     "import numpy as np\n",
     "\n",
     "cb_key = B(0)  # Receiver clock bias variable key.\n",

--- a/gtsam/navigation/doc/PseudorangeFactor.ipynb
+++ b/gtsam/navigation/doc/PseudorangeFactor.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "## Overview\n",
     "\n",
-    "The `PseudorangeFactor` family provides factors for incorporating GNSS pseudorange measurements into a GTSAM factor graph. Pseudorange factors model the distance between a satellite and the GNSS receiver along with their associated errors (atmospheric, multipath, clock bias, etc...). This more-tightly couples GNSS positioning within the general probabilistic graphical estimation framework compared to loosely-coupled `GPSFactor`s. In other words, `PseudorangeFactor` integrates GNSS measurements in a \"raw\" form so the factor graph has the opportunity to correct GNSS measurements as part of the overall optimization process. Tighly-coupled GNSS filters also enable partial position observability even if the requisite minimum 4 satellites for an independent position calculation are not met."
+    "The `PseudorangeFactor` family provides factors for incorporating GNSS pseudorange measurements into a GTSAM factor graph. Pseudorange factors model the distance between a satellite and the GNSS receiver along with their associated errors (atmospheric, multipath, clock bias, etc...). This more-tightly couples GNSS positioning within the general probabilistic graphical estimation framework compared to loosely-coupled `GPSFactor`s. In other words, `PseudorangeFactor` integrates GNSS measurements in a \"raw\" form so the factor graph has the opportunity to correct GNSS measurements as part of the overall optimization process. Tightly-coupled GNSS filters also enable partial position observability even if the requisite minimum 4 satellites for an independent position calculation are not met."
    ]
   },
   {

--- a/gtsam/navigation/doc/PseudorangeFactor.ipynb
+++ b/gtsam/navigation/doc/PseudorangeFactor.ipynb
@@ -1,0 +1,137 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GNSS Precise Positioning with Factor Graphs\n",
+    "\n",
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/navigation/doc/PsuedorangeFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "\n",
+    "## Overview\n",
+    "\n",
+    "The `PseudorangeFactor` family provides factors for incorporating GNSS pseudorange measurements into a GTSAM factor graph. Pseudorange factors model the distance between a satellite and the GNSS receiver along with their associated errors (atmospheric, multipath, clock bias, etc...). This more-tightly couples GNSS positioning within the general probabilistic graphical estimation framework compared to loosely-coupled `GPSFactor`s. In other words, `PseudorangeFactor` integrates GNSS measurements in a \"raw\" form so the factor graph has the opportunity to correct GNSS measurements as part of the overall optimization process. Tighly-coupled GNSS filters also enable partial position observability even if the requisite minimum 4 satellites for an independent position calculation are not met."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.0\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.3\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install --quiet pyrtklib numpy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Usage Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0.])"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import pyrtklib as rtklib\n",
+    "\n",
+    "# TODO: Remove this before merging!!!\n",
+    "import sys\n",
+    "sys.path.insert(0, \"/Users/sammy/gtsam-gnss/_build/python/gtsam\")\n",
+    "import gtsam\n",
+    "from gtsam.symbol_shorthand import X, B\n",
+    "\n",
+    "\n",
+    "obs = rtklib.obs_t()\n",
+    "nav = rtklib.nav_t()\n",
+    "sta = rtklib.sta_t()\n",
+    "load_status = rtklib.readrnx(\"/Users/sammy/gtsam-gnss/examples/Data/brdc0180.26n\", 1, \"\", obs, nav, sta)\n",
+    "assert load_status == 1, \"Loading broadcast ephemeris RINEX\"\n",
+    "load_status = rtklib.readrnx(\"/Users/sammy/gtsam-gnss/examples/Data/zoa10180.26o\", 1, \"\", obs, nav, sta)\n",
+    "assert load_status == 1, \"Loading receiver observation RINEX\"\n",
+    "\n",
+    "cb_key = B(0)  # Clock bias variable key.\n",
+    "pos_key = X(0) # Receiver position variable key.\n",
+    "nm = gtsam.noiseModel.Diagonal.Sigmas(np.array([1.0]))\n",
+    "pf = gtsam.PseudorangeFactor(pos_key, cb_key, 123.45, np.array([123.45, 0.0, 0.0]), 0.0, nm)\n",
+    "pf.evaluateError(np.array([0.0, 0.0, 0.0]), 0.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "- [PseudorangeFactor.h](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/PseudorangeFactor.h)\n",
+    "- [PseudorangeFactor.cpp](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/PseudorangeFactor.cpp)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/gtsam/navigation/doc/PseudorangeFactor.ipynb
+++ b/gtsam/navigation/doc/PseudorangeFactor.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# GNSS Positioning with Factor Graphs\n",
+    "# Pseudorange Factor\n",
     "\n",
     "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/navigation/doc/PsuedorangeFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
@@ -51,7 +51,7 @@
     }
    ],
    "source": [
-    "%pip install --quiet numpy"
+    "%pip install --quiet gtsam_develop"
    ]
   },
   {
@@ -63,9 +63,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0.])"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "\n",

--- a/gtsam/navigation/doc/PseudorangeFactor.ipynb
+++ b/gtsam/navigation/doc/PseudorangeFactor.ipynb
@@ -80,12 +80,6 @@
    "source": [
     "import numpy as np\n",
     "\n",
-    "# TODO: Remove this before merging!!!\n",
-    "import sys\n",
-    "sys.path.insert(0, \"/Users/sammy/gtsam-gnss/_build/python/gtsam\")\n",
-    "import gtsam\n",
-    "from gtsam.symbol_shorthand import X, B\n",
-    "\n",
     "cb_key = B(0)  # Receiver clock bias variable key.\n",
     "pos_key = X(0) # Receiver position variable key.\n",
     "nm = gtsam.noiseModel.Diagonal.Sigmas(np.array([1.0]))\n",

--- a/gtsam/navigation/navigation.i
+++ b/gtsam/navigation/navigation.i
@@ -488,20 +488,22 @@ virtual class GPSFactor2ArmCalib : gtsam::NonlinearFactor{
 #include <gtsam/navigation/PseudorangeFactor.h>
 virtual class PseudorangeFactor : gtsam::NonlinearFactor {
   PseudorangeFactor(gtsam::Key receiverPositionKey,
-                    gtsam::Key receiverClockBiasKey,
-                    double measuredPseudorange,
+                    gtsam::Key receiverClockBiasKey, double measuredPseudorange,
                     const gtsam::Point3& satellitePosition,
                     double satelliteClockBias,
                     const gtsam::noiseModel::Base* model);
 
   // Testable
   void print(string s = "", const gtsam::KeyFormatter& keyFormatter =
-                                                         gtsam::DefaultKeyFormatter) const;
+                                gtsam::DefaultKeyFormatter) const;
   bool equals(const gtsam::NonlinearFactor& expected, double tol);
 
   // Standard Interface
   gtsam::Vector evaluateError(const gtsam::Point3& receiverPosition,
                               const double& receiverClock_bias) const;
+
+  // enable serialization functionality
+  void serialize() const;
 };
 
 #include <gtsam/navigation/BarometricFactor.h>

--- a/gtsam/navigation/navigation.i
+++ b/gtsam/navigation/navigation.i
@@ -494,6 +494,12 @@ virtual class PseudorangeFactor : gtsam::NonlinearFactor {
                     double satellite_clock_bias,
                     const gtsam::noiseModel::Base* model);
 
+  // Testable
+  void print(string s = "", const gtsam::KeyFormatter& keyFormatter =
+                                                         gtsam::DefaultKeyFormatter) const;
+  bool equals(const gtsam::NonlinearFactor& expected, double tol);
+
+  // Standard Interface
   gtsam::Vector evaluateError(const gtsam::Point3& receiver_position,
                               const double& receiver_clock_bias) const;
 };

--- a/gtsam/navigation/navigation.i
+++ b/gtsam/navigation/navigation.i
@@ -485,6 +485,19 @@ virtual class GPSFactor2ArmCalib : gtsam::NonlinearFactor{
   void serialize() const;
 };
 
+#include <gtsam/navigation/PseudorangeFactor.h>
+virtual class PseudorangeFactor : gtsam::NonlinearFactor {
+  PseudorangeFactor(gtsam::Key receiver_position_key,
+                    gtsam::Key receiver_clock_bias_key,
+                    double measured_pseudorange,
+                    const gtsam::Point3& satellite_position,
+                    double satellite_clock_bias,
+                    const gtsam::noiseModel::Base* model);
+
+  gtsam::Vector evaluateError(const gtsam::Point3& receiver_position,
+                              const double& receiver_clock_bias) const;
+};
+
 #include <gtsam/navigation/BarometricFactor.h>
 virtual class BarometricFactor : gtsam::NonlinearFactor {
   BarometricFactor();

--- a/gtsam/navigation/navigation.i
+++ b/gtsam/navigation/navigation.i
@@ -487,11 +487,11 @@ virtual class GPSFactor2ArmCalib : gtsam::NonlinearFactor{
 
 #include <gtsam/navigation/PseudorangeFactor.h>
 virtual class PseudorangeFactor : gtsam::NonlinearFactor {
-  PseudorangeFactor(gtsam::Key receiver_position_key,
-                    gtsam::Key receiver_clock_bias_key,
-                    double measured_pseudorange,
-                    const gtsam::Point3& satellite_position,
-                    double satellite_clock_bias,
+  PseudorangeFactor(gtsam::Key receiverPositionKey,
+                    gtsam::Key receiverClockBiasKey,
+                    double measuredPseudorange,
+                    const gtsam::Point3& satellitePosition,
+                    double satelliteClockBias,
                     const gtsam::noiseModel::Base* model);
 
   // Testable
@@ -500,8 +500,8 @@ virtual class PseudorangeFactor : gtsam::NonlinearFactor {
   bool equals(const gtsam::NonlinearFactor& expected, double tol);
 
   // Standard Interface
-  gtsam::Vector evaluateError(const gtsam::Point3& receiver_position,
-                              const double& receiver_clock_bias) const;
+  gtsam::Vector evaluateError(const gtsam::Point3& receiverPosition,
+                              const double& receiverClock_bias) const;
 };
 
 #include <gtsam/navigation/BarometricFactor.h>

--- a/gtsam/navigation/navigation.md
+++ b/gtsam/navigation/navigation.md
@@ -33,6 +33,7 @@ The `navigation` module in GTSAM provides specialized tools for inertial navigat
 
 - **[GPSFactor](doc/GPSFactor.ipynb)**: Factor for incorporating GPS position measurements.
 - **[BarometricFactor](doc/BarometricFactor.ipynb)**: Incorporates barometric altitude measurements.
+- **[PseudorangeFactor](doc/PseudorangeFactor.ipynb)**: Precise GNSS positioning.
 
 ### Magnetic Field Integration
 

--- a/gtsam/navigation/tests/testPseudorangeFactor.cpp
+++ b/gtsam/navigation/tests/testPseudorangeFactor.cpp
@@ -1,0 +1,29 @@
+/**
+ * @file    testPsuedorangeFactor.cpp
+ * @brief   Unit test for PseudorangeFactor
+ * @author  Sammy Guo
+ * @date   January 18, 2026
+ */
+
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/Testable.h>
+#include <gtsam/base/numericalDerivative.h>
+#include <gtsam/navigation/PseudorangeFactor.h>
+
+using namespace gtsam;
+
+// *************************************************************************
+TEST(TestPseudorangeFactor, Constructor) {
+  const auto factor =
+      PseudorangeFactor(Key(0), Key(1), 0.0, Point3::Zero(), 0.0,
+                        noiseModel::Isotropic::Sigma(1, 1.0));
+  const double error = factor.evaluateError(Point3::Zero(), 0.0)[0];
+  EXPECT_DOUBLES_EQUAL(0.0, error, 1e-9);
+}
+
+// *************************************************************************
+int main() {
+  TestResult tr;
+  return TestRegistry::runAllTests(tr);
+}
+// *************************************************************************

--- a/gtsam/navigation/tests/testPseudorangeFactor.cpp
+++ b/gtsam/navigation/tests/testPseudorangeFactor.cpp
@@ -24,16 +24,39 @@ TEST(TestPseudorangeFactor, Constructor) {
       factor.evaluateError(Point3::Zero(), 0.0, Hpos, Hbias)[0];
   EXPECT_DOUBLES_EQUAL(0.0, error, 1e-9);
 
-  // Jacobians are technically undefined if the receiver and satellite positions
-  // are the same. So make sure this corner-case does not numerically explode:
-  CHECK(!Hpos.array().isNaN().any());
-  CHECK(!Hbias.array().isNaN().any());
+  // Derivatives are technically undefined if the receiver and satellite
+  // positions are the same (hopefully that's never the case in reality). But
+  // for all intents and purposes, zero-valued derivatives can substitute for
+  // undefined gradient at that singularity. So make sure this corner-case does
+  // not numerically explode:
+  EXPECT(!Hpos.array().isNaN().any());
+  EXPECT(!Hbias.array().isNaN().any());
   EXPECT_DOUBLES_EQUAL(Hpos.norm(), 0.0, 1e-9);
-  // Clock bias should always be speed-of-light in vacuum:
+  // Clock bias derivative should always be speed-of-light in vacuum:
   EXPECT_DOUBLES_EQUAL(Hbias.norm(), 299792458.0, 1e-9);
 }
 
-TEST(TestPseudorangeFactor, Jacobians) {
+// *************************************************************************
+TEST(TestPseudorangeFactor, Jacobians1) {
+  // Synthetic example with exact error/derivatives:
+  const auto factor = PseudorangeFactor(
+      Key(0), Key(1),  // Receiver position and clock bias keys.
+      4.0,             // Measured pseudorange.
+      // Satellite position:
+      Vector3(0.0, 0.0, 3.0),
+      0.0  // Sat clock drift bias.
+  );
+  const double error = factor.evaluateError(Vector3::Zero(), 0.0)[0];
+  EXPECT_DOUBLES_EQUAL(-1.0, error, 1e-6);
+
+  Values values;
+  values.insert(Key(0), Vector3(1.0, 2.0, 3.0));
+  values.insert(Key(1), 0.0);
+  EXPECT_CORRECT_FACTOR_JACOBIANS(factor, values, 1e-3, 1e-5);
+}
+
+// *************************************************************************
+TEST(TestPseudorangeFactor, Jacobians2) {
   // Example values borrowed from `SinglePointPositioningExample.ipynb`:
   const auto factor = PseudorangeFactor(
       Key(0), Key(1),  // Receiver position and clock bias keys.
@@ -48,6 +71,30 @@ TEST(TestPseudorangeFactor, Jacobians) {
       Key(0), Vector3(-2684418.91084688, -4293361.08683296, 3865365.45451951));
   values.insert(Key(1), 5.377885093511699e-07);
   EXPECT_CORRECT_FACTOR_JACOBIANS(factor, values, 1e-3, 1e-5);
+}
+
+// *************************************************************************
+TEST(TestPseudorangeFactor, print) {
+  // Just make sure `print()` doesn't throw errors
+  // since there's no elegant way to check stdout.
+  const auto factor = PseudorangeFactor();
+  factor.print();
+}
+
+// *************************************************************************
+TEST(TestPseudorangeFactor, equals) {
+  const auto factor1 = PseudorangeFactor();
+  const auto factor2 = PseudorangeFactor(1, 2, 0.0, Point3::Zero(), 0.0);
+  const auto factor3 =
+      PseudorangeFactor(1, 2, 10.0, Point3(1.0, 2.0, 3.0), 20.0);
+
+  CHECK(factor1.equals(factor1));
+  CHECK(factor2.equals(factor2));
+  CHECK(!factor1.equals(factor2));
+  CHECK(factor2.equals(factor3, 1e99));
+
+  // Test print:
+  factor2.print("factor2");
 }
 
 // *************************************************************************

--- a/gtsam/navigation/tests/testPseudorangeFactor.cpp
+++ b/gtsam/navigation/tests/testPseudorangeFactor.cpp
@@ -1,5 +1,5 @@
 /**
- * @file    testPsuedorangeFactor.cpp
+ * @file    testPseudorangeFactor.cpp
  * @brief   Unit test for PseudorangeFactor
  * @author  Sammy Guo
  * @date   January 18, 2026

--- a/gtsam/navigation/tests/testPseudorangeFactor.cpp
+++ b/gtsam/navigation/tests/testPseudorangeFactor.cpp
@@ -9,6 +9,7 @@
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/navigation/PseudorangeFactor.h>
+#include <gtsam/nonlinear/factorTesting.h>
 
 using namespace gtsam;
 
@@ -17,8 +18,36 @@ TEST(TestPseudorangeFactor, Constructor) {
   const auto factor =
       PseudorangeFactor(Key(0), Key(1), 0.0, Point3::Zero(), 0.0,
                         noiseModel::Isotropic::Sigma(1, 1.0));
-  const double error = factor.evaluateError(Point3::Zero(), 0.0)[0];
+
+  Matrix Hpos, Hbias;
+  const double error =
+      factor.evaluateError(Point3::Zero(), 0.0, Hpos, Hbias)[0];
   EXPECT_DOUBLES_EQUAL(0.0, error, 1e-9);
+
+  // Jacobians are technically undefined if the receiver and satellite positions
+  // are the same. So make sure this corner-case does not numerically explode:
+  CHECK(!Hpos.array().isNaN().any());
+  CHECK(!Hbias.array().isNaN().any());
+  EXPECT_DOUBLES_EQUAL(Hpos.norm(), 0.0, 1e-9);
+  // Clock bias should always be speed-of-light in vacuum:
+  EXPECT_DOUBLES_EQUAL(Hbias.norm(), 299792458.0, 1e-9);
+}
+
+TEST(TestPseudorangeFactor, Jacobians) {
+  // Example values borrowed from `SinglePointPositioningExample.ipynb`:
+  const auto factor = PseudorangeFactor(
+      Key(0), Key(1),  // Receiver position and clock bias keys.
+      24874028.989,    // Measured pseudorange.
+      // Satellite position:
+      Vector3(-5824269.46342, -22935011.26952, -12195522.22428),
+      -0.00022743876852667193  // Sat clock drift bias.
+  );
+
+  Values values;
+  values.insert(
+      Key(0), Vector3(-2684418.91084688, -4293361.08683296, 3865365.45451951));
+  values.insert(Key(1), 5.377885093511699e-07);
+  EXPECT_CORRECT_FACTOR_JACOBIANS(factor, values, 1e-3, 1e-5);
 }
 
 // *************************************************************************

--- a/python/gtsam/examples/SinglePointPositioningExample.ipynb
+++ b/python/gtsam/examples/SinglePointPositioningExample.ipynb
@@ -146,19 +146,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# TODO: Remove this before merging!!!\n",
-    "import sys\n",
-    "sys.path.insert(0, \"/Users/sammy/gtsam-gnss/_build/python/gtsam\")\n",
-    "import gtsam\n",
-    "from gtsam.symbol_shorthand import X, B"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/python/gtsam/examples/SinglePointPositioningExample.ipynb
+++ b/python/gtsam/examples/SinglePointPositioningExample.ipynb
@@ -43,26 +43,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-cell"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.0\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.3\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%pip install --quiet pyrtklib numpy gtsam-develop pyproj"
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet pyrtklib numpy gtsam-develop pyproj\n",
+    "except ImportError:\n",
+    "    pass"
    ]
   },
   {
@@ -77,23 +70,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Using temporary directory: /var/folders/v8/j1bl714s0fq9nfrzbl78dvcr0000gn/T/tmpsv6lclaf\n",
-      "Downloading receiver files...\n",
-      "Extracting files...\n",
-      "Parsing RINEX files...\n",
-      "Loading done!\n",
-      "Found 941392 observations\n",
-      "Found 472 navigation messages\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import tempfile\n",
     "import urllib.request\n",
@@ -105,6 +84,9 @@
     "import numpy as np\n",
     "from pyproj import Transformer\n",
     "import pyrtklib as rtklib\n",
+    "\n",
+    "import gtsam\n",
+    "from gtsam.symbol_shorthand import B, X\n",
     "\n",
     "# Create a temporary directory (auto-deleted when closed):\n",
     "with tempfile.TemporaryDirectory() as tmpdir:\n",
@@ -157,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,46 +180,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Satellite 5 ===\n",
-      "Receiver pseudorange: 24874028.989 meters\n",
-      "Observation time (unixtime): 2026/01/18 00:00:01.000 (1768694401)\n",
-      "Satellite position (ECEF): [ -5824.26946342 -22935.01126952 -12195.52222428] km\n",
-      "Satellite clock drift: bias -0.00022743876852667193 seconds, drift 1.8683513937356455e-13 seconds-per-second\n",
-      "\n",
-      "=== Satellite 6 ===\n",
-      "Receiver pseudorange: 22253046.865 meters\n",
-      "Observation time (unixtime): 2026/01/18 00:00:01.000 (1768694401)\n",
-      "Satellite position (ECEF): [  5488.59094499 -14195.33663647  21818.77585526] km\n",
-      "Satellite clock drift: bias -0.0006034356759087012 seconds, drift -3.098107707877329e-12 seconds-per-second\n",
-      "\n",
-      "=== Satellite 11 ===\n",
-      "Receiver pseudorange: 20496303.403 meters\n",
-      "Observation time (unixtime): 2026/01/18 00:00:01.000 (1768694401)\n",
-      "Satellite position (ECEF): [ -8594.38625321 -20716.01787191  14339.02701352] km\n",
-      "Satellite clock drift: bias -0.00047056000758921617 seconds, drift 1.403391292065237e-11 seconds-per-second\n",
-      "\n",
-      "=== Satellite 12 ===\n",
-      "Receiver pseudorange: 20311181.135 meters\n",
-      "Observation time (unixtime): 2026/01/18 00:00:01.000 (1768694401)\n",
-      "Satellite position (ECEF): [-10840.17730125 -14075.33010128  19453.15930531] km\n",
-      "Satellite clock drift: bias -0.0006066614416282843 seconds, drift -3.1693397906096266e-12 seconds-per-second\n",
-      "\n",
-      "=== Satellite 19 ===\n",
-      "Receiver pseudorange: 23324811.427 meters\n",
-      "Observation time (unixtime): 2026/01/18 00:00:01.000 (1768694401)\n",
-      "Satellite position (ECEF): [ 14173.452494   -15497.14651078  15863.86221975] km\n",
-      "Satellite clock drift: bias 0.0006860747484721503 seconds, drift -1.242495689668388e-12 seconds-per-second\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Prepare factor graph:\n",
     "cb_key = B(0)  # Receiver clock bias variable key.\n",
@@ -282,17 +227,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Final clock bias 5.377885093511699e-07 seconds and receiver position [-2684418.91084688 -4293361.08683296  3865365.45451951] (ECEF meters)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Solve the system:\n",
     "initial_values = gtsam.Values()\n",
@@ -315,41 +252,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Latitude: 37.543093010647205 degrees\n",
-      "Longitude: -122.01563340074796 degrees\n",
-      "Altitude: 13.151681120507419 meters\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        <iframe\n",
-       "            width=\"700\"\n",
-       "            height=\"500\"\n",
-       "            src=\"https://www.openstreetmap.org/export/embed.html?bbox=-122.02563340074796%2C37.53309301064721%2C-122.00563340074795%2C37.5530930106472&layer=map&marker=37.543093010647205%2C-122.01563340074796\"\n",
-       "            frameborder=\"0\"\n",
-       "            allowfullscreen\n",
-       "            \n",
-       "        ></iframe>\n",
-       "        "
-      ],
-      "text/plain": [
-       "<IPython.lib.display.IFrame at 0x107a152b0>"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Create a transformer from ECEF (EPSG:4978) to WGS84 LLA (EPSG:4326)\n",
     "ecef2lla = Transformer.from_crs(\"epsg:4978\", \"epsg:4326\", always_xy=True)\n",
@@ -386,17 +291,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Total positioning error: 33.076065433885624 meters\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ground_truth = np.array([-2684436.824, -4293336.957, 3865351.638])\n",
     "error = ground_truth - receiver_position\n",

--- a/python/gtsam/examples/SinglePointPositioningExample.ipynb
+++ b/python/gtsam/examples/SinglePointPositioningExample.ipynb
@@ -9,8 +9,11 @@
     "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/python/gtsam/examples/SinglePointPositioningExample.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "## Overview\n",
+    "Global Navigation Satellite Systems (GNSS) are space-based systems that provide precise positioning, navigation, and timing (PNT) information to users anywhere on or near the Earth. GPS (Global Positioning System), developed and operated by the United States, is the most widely used GNSS, but it is part of a broader family that also includes Russia’s GLONASS, Europe’s Galileo, and China’s BeiDou.\n",
     "\n",
-    "The `PseudorangeFactor` family provides factors for incorporating GNSS pseudorange measurements into a GTSAM factor graph. Pseudorange factors model the distance between a satellite and the GNSS receiver along with their associated errors (atmospheric, multipath, clock bias, etc...). This more-tightly couples GNSS positioning within the general probabilistic graphical estimation framework compared to loosely-coupled `GPSFactor`s. In other words, `PseudorangeFactor` integrates GNSS measurements in a \"raw\" form so the factor graph has the opportunity to correct GNSS measurements as part of the overall optimization process. Tighly-coupled GNSS filters also enable partial position observability even if the requisite minimum 4 satellites for an independent position calculation are not met."
+    "GNSS works by measuring the travel time of radio signals transmitted from multiple satellites to a receiver on the ground. By combining these measurements with accurate satellite orbit and clock information, a receiver can determine its position, velocity, and time with high accuracy. Modern GNSS applications range from everyday uses such as smartphone navigation and time synchronization to advanced scientific, aviation, maritime, and geodetic applications requiring centimeter-level precision.\n",
+    "\n",
+    "GNSS positioning problems can be encoded as factor graphs in GTSAM; this notebook shows an example of identifying a GNSS receiver's position using pseudoranges from a [RINEX file](https://en.wikipedia.org/wiki/RINEX)."
    ]
   },
   {
@@ -28,6 +31,14 @@
     "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
     "\n",
     "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "We'll need to install a couple python packages to help with today's example. We'll be using [python bindings](https://github.com/IPNL-POLYU/pyrtklib) for the [RTKLIB library](https://github.com/tomojitakasu/RTKLIB) to parse RINEX files from an example receiver source. Numpy is also installed here for easy array manipulation."
    ]
   },
   {
@@ -51,14 +62,17 @@
     }
    ],
    "source": [
-    "%pip install --quiet pyrtklib numpy"
+    "%pip install --quiet pyrtklib numpy gtsam-develop pyproj"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Usage Example"
+    "## Premise\n",
+    "Single-point positioning (SPP) is the most basic GNSS positioning technique, in which a receiver determines its position using pseudorange measurements from multiple satellites and broadcast satellite orbit and clock information. It requires only a single receiver and does not rely on external corrections or reference stations, making it simple and widely accessible. While SPP typically provides meter-level accuracy, its performance is limited by errors such as satellite clock and orbit uncertainties, ionospheric and tropospheric delays, and measurement noise.\n",
+    "\n",
+    "We'll be looking at a receiver mounted on top of an FAA air traffic control center; [ZOA1 in Fremont, California](https://geodesy.noaa.gov/CORS/ncn_station_pages/index.html?stationID=ZOA1). It records pseudorange measurements 24/7 as part of a nationwide NOAA Continuously Operating Reference Stations (CORS) network that provides high-accuracy positioning data for geodesy, surveying, and navigation applications. Data from the CORS network can be accessed through the [NOAA CORS Network (NCN) data portal](https://geodesy.noaa.gov/CORS/data.shtml), where we'll download ZOA1's observation and navigation files for January 18th, 2026."
    ]
   },
   {
@@ -70,41 +84,97 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Using temporary directory: /var/folders/v8/j1bl714s0fq9nfrzbl78dvcr0000gn/T/tmpsv6lclaf\n",
+      "Downloading receiver files...\n",
+      "Extracting files...\n",
+      "Parsing RINEX files...\n",
+      "Loading done!\n",
       "Found 941392 observations\n",
       "Found 472 navigation messages\n"
      ]
     }
    ],
    "source": [
+    "import tempfile\n",
+    "import urllib.request\n",
+    "import gzip\n",
+    "from pathlib import Path\n",
+    "import shutil\n",
+    "\n",
+    "from IPython.display import IFrame\n",
     "import numpy as np\n",
+    "from pyproj import Transformer\n",
     "import pyrtklib as rtklib\n",
     "\n",
-    "# TODO: Remove this before merging!!!\n",
-    "import sys\n",
-    "sys.path.insert(0, \"/Users/sammy/gtsam-gnss/_build/python/gtsam\")\n",
-    "import gtsam\n",
-    "from gtsam.symbol_shorthand import X, B\n",
+    "# Create a temporary directory (auto-deleted when closed):\n",
+    "with tempfile.TemporaryDirectory() as tmpdir:\n",
+    "    tmpdir = Path(tmpdir)\n",
+    "    print(f\"Using temporary directory: {str(tmpdir)}\")\n",
+    "    \n",
+    "    navigation_compressed = tmpdir / \"brdc0180.26n.gz\"\n",
+    "    navigation_file = tmpdir / \"brdc0180.26n\"\n",
+    "    observable_compressed = tmpdir / \"zoa10180.26o.gz\"\n",
+    "    observable_file = tmpdir / \"zoa10180.26o\"\n",
     "\n",
+    "    # Download ZOA1's files using built-in HTTP library:\n",
+    "    print(\"Downloading receiver files...\")\n",
+    "    with urllib.request.urlopen(\"https://noaa-cors-pds.s3.amazonaws.com/rinex/2026/018/brdc0180.26n.gz\") as response, open(navigation_compressed, \"wb\") as f:\n",
+    "        f.write(response.read())\n",
+    "    with urllib.request.urlopen(\"https://noaa-cors-pds.s3.amazonaws.com/rinex/2026/018/zoa1/zoa10180.26o.gz\") as response, open(observable_compressed, \"wb\") as f:\n",
+    "        f.write(response.read())\n",
     "\n",
-    "obs = rtklib.obs_t()\n",
-    "nav = rtklib.nav_t()\n",
-    "sta = rtklib.sta_t()\n",
-    "load_status = rtklib.readrnx(\"/Users/sammy/gtsam-gnss/examples/Data/brdc0180.26n\", 1, \"\", obs, nav, sta)\n",
-    "assert load_status == 1, \"Loading broadcast ephemeris RINEX\"\n",
-    "load_status = rtklib.readrnx(\"/Users/sammy/gtsam-gnss/examples/Data/zoa10180.26o\", 1, \"\", obs, nav, sta)\n",
-    "assert load_status == 1, \"Loading receiver observation RINEX\"\n",
+    "    # Extract files:\n",
+    "    print(\"Extracting files...\")\n",
+    "    with gzip.open(navigation_compressed, \"rb\") as gz, open(navigation_file, \"wb\") as out:\n",
+    "        shutil.copyfileobj(gz, out)\n",
+    "    with gzip.open(observable_compressed, \"rb\") as gz, open(observable_file, \"wb\") as out:\n",
+    "        shutil.copyfileobj(gz, out)\n",
     "\n",
+    "    print(\"Parsing RINEX files...\")\n",
+    "    obs = rtklib.obs_t()\n",
+    "    nav = rtklib.nav_t()\n",
+    "    sta = rtklib.sta_t()\n",
+    "    load_status = rtklib.readrnx(str(navigation_file), 1, \"\", obs, nav, sta)\n",
+    "    assert load_status == 1, \"Loading broadcast ephemeris RINEX\"\n",
+    "    load_status = rtklib.readrnx(str(observable_file), 1, \"\", obs, nav, sta)\n",
+    "    assert load_status == 1, \"Loading receiver observation RINEX\"\n",
+    "\n",
+    "# Temporary directory and contents are cleaned up automatically\n",
+    "print(\"Loading done!\")\n",
     "print(f\"Found {obs.n} observations\")\n",
     "print(f\"Found {nav.n} navigation messages\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
-    "n = 11                         # number of observations to process.\n",
+    "# TODO: Remove this before merging!!!\n",
+    "import sys\n",
+    "sys.path.insert(0, \"/Users/sammy/gtsam-gnss/_build/python/gtsam\")\n",
+    "import gtsam\n",
+    "from gtsam.symbol_shorthand import X, B"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compute Satellite Positions\n",
+    "Satellite positions must be computed first before receiver position can be solved. GNSS broadcast ephemerides are orbit and clock parameters transmitted directly by navigation satellites as part of their navigation message. They allow receivers to compute satellite positions and clock corrections in real time using a simplified orbital model. While readily available and sufficient for standard navigation, broadcast ephemerides are less accurate than precise ephemerides due to prediction errors and limited modeling of perturbations.\n",
+    "\n",
+    "The `brdc0180.26n` RINEX file contains orbital parameters we need to compute satellite positions. We won't cover how orbits are stored and modeled in the RINEX files, but you can check out the [RTCM website](https://www.rtcm.org/rtcm-standards) for more information. For now, we'll simply have [RTKLIB's `satposs()` function](https://github.com/tomojitakasu/RTKLIB/blob/71db0ffa0d9735697c6adfd06fdf766d0e5ce807/src/ephemeris.c#L718) do it for us."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = 5                         # number of observations to process.\n",
     "rs = rtklib.Arr1Ddouble(6*n)   # Satellite positions and velocities:\n",
     "                               # rs [(0:2)+i*6] = obs[i] sat position {x,y,z} (m)\n",
     "                               # rs [(3:5)+i*6] = obs[i] sat velocity {vx,vy,vz} (m/s)\n",
@@ -132,10 +202,55 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 37,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
+   "source": [
+    "## Solve Receiver Position and Time\n",
+    "Finally! We're ready for factor graphs. Using the `PseudorangeFactor`, we can build a simple system that estimates receiver clock bias and [3D ECEF](https://en.wikipedia.org/wiki/Earth-centered,_Earth-fixed_coordinate_system) position. The graph topology is fairly straight-forward: One node for clock bias, another node for 3D position, all connected to a series of psuedorange factors that encapsulates satellite positions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Satellite 5 ===\n",
+      "Receiver pseudorange: 24874028.989 meters\n",
+      "Observation time (unixtime): 2026/01/18 00:00:01.000 (1768694401)\n",
+      "Satellite position (ECEF): [ -5824.26946342 -22935.01126952 -12195.52222428] km\n",
+      "Satellite clock drift: bias -0.00022743876852667193 seconds, drift 1.8683513937356455e-13 seconds-per-second\n",
+      "\n",
+      "=== Satellite 6 ===\n",
+      "Receiver pseudorange: 22253046.865 meters\n",
+      "Observation time (unixtime): 2026/01/18 00:00:01.000 (1768694401)\n",
+      "Satellite position (ECEF): [  5488.59094499 -14195.33663647  21818.77585526] km\n",
+      "Satellite clock drift: bias -0.0006034356759087012 seconds, drift -3.098107707877329e-12 seconds-per-second\n",
+      "\n",
+      "=== Satellite 11 ===\n",
+      "Receiver pseudorange: 20496303.403 meters\n",
+      "Observation time (unixtime): 2026/01/18 00:00:01.000 (1768694401)\n",
+      "Satellite position (ECEF): [ -8594.38625321 -20716.01787191  14339.02701352] km\n",
+      "Satellite clock drift: bias -0.00047056000758921617 seconds, drift 1.403391292065237e-11 seconds-per-second\n",
+      "\n",
+      "=== Satellite 12 ===\n",
+      "Receiver pseudorange: 20311181.135 meters\n",
+      "Observation time (unixtime): 2026/01/18 00:00:01.000 (1768694401)\n",
+      "Satellite position (ECEF): [-10840.17730125 -14075.33010128  19453.15930531] km\n",
+      "Satellite clock drift: bias -0.0006066614416282843 seconds, drift -3.1693397906096266e-12 seconds-per-second\n",
+      "\n",
+      "=== Satellite 19 ===\n",
+      "Receiver pseudorange: 23324811.427 meters\n",
+      "Observation time (unixtime): 2026/01/18 00:00:01.000 (1768694401)\n",
+      "Satellite position (ECEF): [ 14173.452494   -15497.14651078  15863.86221975] km\n",
+      "Satellite clock drift: bias 0.0006860747484721503 seconds, drift -1.242495689668388e-12 seconds-per-second\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# Prepare factor graph:\n",
     "cb_key = B(0)  # Receiver clock bias variable key.\n",
@@ -144,10 +259,8 @@
     "graph = gtsam.NonlinearFactorGraph()\n",
     "\n",
     "# Add a PseudorangeFactor for each observation:\n",
-    "sats_used = set()\n",
     "for i in range(n):\n",
     "    obsd = obs.data[i]\n",
-    "    sats_used.add(obsd.sat)\n",
     "    sat_bias = dts[2*i+0]\n",
     "    sat_drift = dts[2*i+1]\n",
     "    sat_pos = np.array([rs[6*i+0], rs[6*i+1], rs[6*i+2]])\n",
@@ -157,60 +270,168 @@
     "        if code == rtklib.CODE_L1C:\n",
     "            pseudorange = obsd.P[j]\n",
     "            break\n",
+    "    else:\n",
+    "        # If no CODE_L1C pseudorange found, skip this observation:\n",
+    "        continue\n",
     "\n",
     "    graph.add(\n",
     "        gtsam.PseudorangeFactor(pos_key, cb_key, pseudorange, sat_pos, sat_bias, nm)\n",
     "    )\n",
-    "\n",
-    "    # Comment to print debug lines below:\n",
-    "    continue\n",
     "    \n",
     "    print(f\"=== Satellite {obsd.sat} ===\")\n",
     "    print(f\"Receiver pseudorange: {pseudorange} meters\")\n",
     "    print(f\"Observation time (unixtime): {rtklib.time_str(obsd.time, 3)} ({obsd.time.time})\")\n",
     "    print(f\"Satellite position (ECEF): {1e-3*sat_pos} km\")\n",
-    "    # print(f\"Satellite velocity (ECEF): {rs[6*i+3]}, {rs[6*i+4]}, {rs[6*i+5]} m/s\")\n",
     "    print(f\"Satellite clock drift: bias {sat_bias} seconds, drift {sat_drift} seconds-per-second\")\n",
-    "    # print(f\"Satellite variance: {var[i]}\")\n",
-    "    # print(f\"Satellite health: {svh[i]}\")\n",
-    "    print()\n",
-    "\n",
-    "# Solve the system:\n",
-    "initial_values = gtsam.Values()\n",
-    "initial_values.insert(cb_key, 0.0)\n",
-    "initial_values.insert(pos_key, np.zeros(3))\n",
-    "result = gtsam.LevenbergMarquardtOptimizer(graph, initial_values).optimize()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 39,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Final clock bias 6.20908953458917e-07 seconds and receiver position [-2684.43802288 -4293.39350686  3865.378281  ] (ECEF km)\n",
-      "Using the following satellites: {5, 6, 11, 12, 19, 21, 22, 24, 25, 28, 29}\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Process the results:\n",
-    "clock_bias = result.atDouble(cb_key)\n",
-    "receiver_position = result.atVector(pos_key)\n",
-    "print(f\"Final clock bias {clock_bias} seconds and receiver position {1e-3*receiver_position} (ECEF km)\")\n",
-    "print(f\"Using the following satellites: {sats_used}\")"
+    "    print()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Source\n",
+    "We initialize receiver position at origin, and then use a LM solver to optimize the system."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Final clock bias 5.377885093511699e-07 seconds and receiver position [-2684418.91084688 -4293361.08683296  3865365.45451951] (ECEF meters)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Solve the system:\n",
+    "initial_values = gtsam.Values()\n",
+    "initial_values.insert(cb_key, 0.0)\n",
+    "initial_values.insert(pos_key, np.zeros(3))\n",
+    "result = gtsam.LevenbergMarquardtOptimizer(graph, initial_values).optimize()\n",
+    "\n",
+    "# Process the results:\n",
+    "clock_bias = result.atDouble(cb_key)\n",
+    "receiver_position = result.atVector(pos_key)\n",
+    "print(f\"Final clock bias {clock_bias} seconds and receiver position {receiver_position} (ECEF meters)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Nice! We see that the solver converged at a reasonable solution. ECEF is difficult to visualize, however. So we'll convert the result to geodetic coordinates and plot it on a map:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Latitude: 37.543093010647205 degrees\n",
+      "Longitude: -122.01563340074796 degrees\n",
+      "Altitude: 13.151681120507419 meters\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <iframe\n",
+       "            width=\"700\"\n",
+       "            height=\"500\"\n",
+       "            src=\"https://www.openstreetmap.org/export/embed.html?bbox=-122.02563340074796%2C37.53309301064721%2C-122.00563340074795%2C37.5530930106472&layer=map&marker=37.543093010647205%2C-122.01563340074796\"\n",
+       "            frameborder=\"0\"\n",
+       "            allowfullscreen\n",
+       "            \n",
+       "        ></iframe>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.lib.display.IFrame at 0x107a152b0>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Create a transformer from ECEF (EPSG:4978) to WGS84 LLA (EPSG:4326)\n",
+    "ecef2lla = Transformer.from_crs(\"epsg:4978\", \"epsg:4326\", always_xy=True)\n",
+    "\n",
+    "# Convert coordinates coordinates (latitude, longitude)\n",
+    "lon, lat, alt = ecef2lla.transform(receiver_position[0], receiver_position[1], receiver_position[2])\n",
+    "print(f\"Latitude: {lat} degrees\")\n",
+    "print(f\"Longitude: {lon} degrees\")\n",
+    "print(f\"Altitude: {alt} meters\")\n",
+    "\n",
+    "# OpenStreetMap embed URL\n",
+    "osm_url = f\"https://www.openstreetmap.org/export/embed.html?bbox={lon-0.01}%2C{lat-0.01}%2C{lon+0.01}%2C{lat+0.01}&layer=map&marker={lat}%2C{lon}\"\n",
+    "\n",
+    "# Embed in notebook\n",
+    "IFrame(osm_url, width=700, height=500)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Validate Results\n",
+    "Our results appear to be roughly in the right place, but CORS stations actually provide ground-truth coordinates we can use as a measure of accuracy in our solutions. ZOA1's full precision-surveyed coordinates are [published in their data portal](https://noaa-cors-pds.s3.amazonaws.com/coord/coord_20/zoa1_20.coord.txt), but we'll examine a just a snippet copied here:\n",
+    "```\n",
+    "| ITRF2020 POSITION (EPOCH 2020.0)                                            |\n",
+    "| Computed in Apr 2025 using data through gpswk 2237.                         |\n",
+    "|     X =  -2684436.824 m     latitude    =  37 32 34.99617 N                 |\n",
+    "|     Y =  -4293336.957 m     longitude   = 122 00 57.42005 W                 |\n",
+    "|     Z =   3865351.638 m     ellipsoid height =   -3.960   m                 |\n",
+    "```\n",
+    "\n",
+    "We can compute a simple error metric by subtracting the two coordinates as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total positioning error: 33.076065433885624 meters\n"
+     ]
+    }
+   ],
+   "source": [
+    "ground_truth = np.array([-2684436.824, -4293336.957, 3865351.638])\n",
+    "error = ground_truth - receiver_position\n",
+    "print(f\"Total positioning error: {np.linalg.norm(error)} meters\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusions\n",
+    "33 meters of error puts us in the same building as the receiver, which is a good starting point for simple positioning. As mentioned above, however, decades of advancements have vastly improved GNSS positioning accuracy down to sub-meter or even centimeter-scale precision and error. The simple `PseudorangeFactor` does not account for atmospheric effects, carrier-phase measurements, nor differential GNSS corrections. So there's a lot more potential for improvement, but this introductory example provides a foundation for expanding GNSS measurements into the broader GTSAM ecosystem."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sources\n",
     "- [PseudorangeFactor.h](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/PseudorangeFactor.h)\n",
-    "- [PseudorangeFactor.cpp](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/PseudorangeFactor.cpp)"
+    "- [PseudorangeFactor.cpp](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/PseudorangeFactor.cpp)\n",
+    "- [PseudorangeFactor.ipynb](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/doc/PseudorangeFactor.ipynb)"
    ]
   }
  ],

--- a/python/gtsam/examples/SinglePointPositioningExample.ipynb
+++ b/python/gtsam/examples/SinglePointPositioningExample.ipynb
@@ -1,0 +1,238 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GNSS Single Point Positioning with Factor Graphs\n",
+    "\n",
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/python/gtsam/examples/SinglePointPositioningExample.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "\n",
+    "## Overview\n",
+    "\n",
+    "The `PseudorangeFactor` family provides factors for incorporating GNSS pseudorange measurements into a GTSAM factor graph. Pseudorange factors model the distance between a satellite and the GNSS receiver along with their associated errors (atmospheric, multipath, clock bias, etc...). This more-tightly couples GNSS positioning within the general probabilistic graphical estimation framework compared to loosely-coupled `GPSFactor`s. In other words, `PseudorangeFactor` integrates GNSS measurements in a \"raw\" form so the factor graph has the opportunity to correct GNSS measurements as part of the overall optimization process. Tighly-coupled GNSS filters also enable partial position observability even if the requisite minimum 4 satellites for an independent position calculation are not met."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.0\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.3\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install --quiet pyrtklib numpy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Usage Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found 941392 observations\n",
+      "Found 472 navigation messages\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import pyrtklib as rtklib\n",
+    "\n",
+    "# TODO: Remove this before merging!!!\n",
+    "import sys\n",
+    "sys.path.insert(0, \"/Users/sammy/gtsam-gnss/_build/python/gtsam\")\n",
+    "import gtsam\n",
+    "from gtsam.symbol_shorthand import X, B\n",
+    "\n",
+    "\n",
+    "obs = rtklib.obs_t()\n",
+    "nav = rtklib.nav_t()\n",
+    "sta = rtklib.sta_t()\n",
+    "load_status = rtklib.readrnx(\"/Users/sammy/gtsam-gnss/examples/Data/brdc0180.26n\", 1, \"\", obs, nav, sta)\n",
+    "assert load_status == 1, \"Loading broadcast ephemeris RINEX\"\n",
+    "load_status = rtklib.readrnx(\"/Users/sammy/gtsam-gnss/examples/Data/zoa10180.26o\", 1, \"\", obs, nav, sta)\n",
+    "assert load_status == 1, \"Loading receiver observation RINEX\"\n",
+    "\n",
+    "print(f\"Found {obs.n} observations\")\n",
+    "print(f\"Found {nav.n} navigation messages\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = 11                         # number of observations to process.\n",
+    "rs = rtklib.Arr1Ddouble(6*n)   # Satellite positions and velocities:\n",
+    "                               # rs [(0:2)+i*6] = obs[i] sat position {x,y,z} (m)\n",
+    "                               # rs [(3:5)+i*6] = obs[i] sat velocity {vx,vy,vz} (m/s)\n",
+    "dts = rtklib.Arr1Ddouble(2*n)  # Satellite clock drift:\n",
+    "                               # dts[(0:1)+i*2] = obs[i] sat clock {bias,drift} (s|s/s)\n",
+    "var = rtklib.Arr1Ddouble(1*n)  # Satellite position and clock variances:\n",
+    "                               # var[i] = obs[i] sat position and clock error variance (m^2)\n",
+    "svh = rtklib.Arr1Dint(1*n)     # Satellite health flag (-1:correction not available):\n",
+    "                               # svh[i] = obs[i] sat health flag\n",
+    "\n",
+    "teph = obs.data[0].time\n",
+    "\n",
+    "# Compute satellite positions:\n",
+    "rtklib.satposs(\n",
+    "    teph,              # gtime_t teph     I   time to select ephemeris (gpst)\n",
+    "    obs.data.ptr,      # obsd_t *obs      I   observation data\n",
+    "    n,                 # int    n         I   number of observation data\n",
+    "    nav,               # nav_t  *nav      I   navigation data\n",
+    "    0,                 # int    ephopt    I   ephemeris option (EPHOPT_???) (EPHOPT_BRDC == 0)\n",
+    "    rs,                # double *rs       O   satellite positions and velocities (ecef)\n",
+    "    dts,               # double *dts      O   satellite clocks\n",
+    "    var,               # double *var      O   sat position and clock error variances (m^2)\n",
+    "    svh                # int    *svh      O   sat health flag (-1:correction not available)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Prepare factor graph:\n",
+    "cb_key = B(0)  # Receiver clock bias variable key.\n",
+    "pos_key = X(0) # Receiver position variable key.\n",
+    "nm = gtsam.noiseModel.Diagonal.Sigmas(np.array([1.0]))\n",
+    "graph = gtsam.NonlinearFactorGraph()\n",
+    "\n",
+    "# Add a PseudorangeFactor for each observation:\n",
+    "sats_used = set()\n",
+    "for i in range(n):\n",
+    "    obsd = obs.data[i]\n",
+    "    sats_used.add(obsd.sat)\n",
+    "    sat_bias = dts[2*i+0]\n",
+    "    sat_drift = dts[2*i+1]\n",
+    "    sat_pos = np.array([rs[6*i+0], rs[6*i+1], rs[6*i+2]])\n",
+    "\n",
+    "    # Identify pseudorange code CODE_L1C:\n",
+    "    for j, code in enumerate(obsd.code):\n",
+    "        if code == rtklib.CODE_L1C:\n",
+    "            pseudorange = obsd.P[j]\n",
+    "            break\n",
+    "\n",
+    "    graph.add(\n",
+    "        gtsam.PseudorangeFactor(pos_key, cb_key, pseudorange, sat_pos, sat_bias, nm)\n",
+    "    )\n",
+    "\n",
+    "    # Comment to print debug lines below:\n",
+    "    continue\n",
+    "    \n",
+    "    print(f\"=== Satellite {obsd.sat} ===\")\n",
+    "    print(f\"Receiver pseudorange: {pseudorange} meters\")\n",
+    "    print(f\"Observation time (unixtime): {rtklib.time_str(obsd.time, 3)} ({obsd.time.time})\")\n",
+    "    print(f\"Satellite position (ECEF): {1e-3*sat_pos} km\")\n",
+    "    # print(f\"Satellite velocity (ECEF): {rs[6*i+3]}, {rs[6*i+4]}, {rs[6*i+5]} m/s\")\n",
+    "    print(f\"Satellite clock drift: bias {sat_bias} seconds, drift {sat_drift} seconds-per-second\")\n",
+    "    # print(f\"Satellite variance: {var[i]}\")\n",
+    "    # print(f\"Satellite health: {svh[i]}\")\n",
+    "    print()\n",
+    "\n",
+    "# Solve the system:\n",
+    "initial_values = gtsam.Values()\n",
+    "initial_values.insert(cb_key, 0.0)\n",
+    "initial_values.insert(pos_key, np.zeros(3))\n",
+    "result = gtsam.LevenbergMarquardtOptimizer(graph, initial_values).optimize()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Final clock bias 6.20908953458917e-07 seconds and receiver position [-2684.43802288 -4293.39350686  3865.378281  ] (ECEF km)\n",
+      "Using the following satellites: {5, 6, 11, 12, 19, 21, 22, 24, 25, 28, 29}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Process the results:\n",
+    "clock_bias = result.atDouble(cb_key)\n",
+    "receiver_position = result.atVector(pos_key)\n",
+    "print(f\"Final clock bias {clock_bias} seconds and receiver position {1e-3*receiver_position} (ECEF km)\")\n",
+    "print(f\"Using the following satellites: {sats_used}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "- [PseudorangeFactor.h](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/PseudorangeFactor.h)\n",
+    "- [PseudorangeFactor.cpp](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/PseudorangeFactor.cpp)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/python/gtsam/tests/test_PseudorangeFactor.py
+++ b/python/gtsam/tests/test_PseudorangeFactor.py
@@ -16,10 +16,41 @@ import gtsam
 from gtsam.utils.test_case import GtsamTestCase
 
 
-class TestPriorFactor(GtsamTestCase):
+class TestPseudorangeFactor(GtsamTestCase):
+    def test_singularity(self):
+        pos = np.zeros(3)
+        values = gtsam.Values()
+        values.insert(0, pos)
+        values.insert(1, 0.0)
 
-    def test_PseudorangeFactor(self):
-        self.assertEqual(1, 0)
+        model = gtsam.noiseModel.Unit.Create(1)
+        factor = gtsam.PseudorangeFactor(0, 1, 0.0, pos, 0.0, model)
+        self.assertEqual(factor.error(values), 0)
+        # test print:
+        factor.print("factor")
+
+    def test_errors(self):
+        satpos = np.array([0.0, 0.0, 3.0])
+        model = gtsam.noiseModel.Unit.Create(1)
+        factor = gtsam.PseudorangeFactor(0, 1, 4.0, satpos, 0.0, model)
+        error = factor.evaluateError(np.zeros(3), 0.0)
+        self.assertEqual(error[0], -1.0)
+
+    def test_equality(self):
+        satpos = np.array([0.0, 0.0, 3.0])
+        model = gtsam.noiseModel.Unit.Create(1)
+        factor1 = gtsam.PseudorangeFactor(0, 1, 4.0, satpos, 0.0, model)
+        factor2 = gtsam.PseudorangeFactor(2, 1, 4.0, satpos, 0.0, model)
+        factor3 = gtsam.PseudorangeFactor(0, 1, 40.0, satpos, 10.0, model)
+        self.assertTrue(factor1.equals(factor1, 1e-6))
+        self.assertFalse(factor1.equals(factor2, 1e-6))
+        self.assertTrue(factor1.equals(factor3, 1e99))
+
+    def test_serialization(self):
+        satpos = np.array([0.0, 0.0, 3.0])
+        model = gtsam.noiseModel.Unit.Create(1)
+        factor = gtsam.PseudorangeFactor(0, 1, 4.0, satpos, 0.0, model)
+        factor.serialize()
 
 
 if __name__ == "__main__":

--- a/python/gtsam/tests/test_PseudorangeFactor.py
+++ b/python/gtsam/tests/test_PseudorangeFactor.py
@@ -1,0 +1,26 @@
+"""
+GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,
+Atlanta, Georgia 30332-0415
+All Rights Reserved
+
+See LICENSE for the license information
+
+PseudorangeFactor python binding unit tests.
+Author: Sammy Guo
+"""
+import unittest
+
+import numpy as np
+
+import gtsam
+from gtsam.utils.test_case import GtsamTestCase
+
+
+class TestPriorFactor(GtsamTestCase):
+
+    def test_PseudorangeFactor(self):
+        self.assertEqual(1, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hi! This PR proposes a simple `PseudorangeFactor` that provides position (and clock timing) constraints from GNSS satellite data to GTSAM estimation problems. So far, the simple pseudorange factor focuses on just clock errors, and omits atmospheric effects. Furthermore, it is designed for code-phase measurements only, so it does not leverage high-precision carrier-phase data from the receiver. Despite that, this simple model already provides decent positioning accuracy on the scale of a city block, and my hope is to contribute several follow-up PRs that gradually improve accuracy/precision with better factor models and examples.

A basic demonstration of `PseudorangeFactor` is provided in the `SinglePointPositioningExample.ipynb` notebook. It captures [ZOA1's position](https://www.ngs.noaa.gov/CORS/ncn_station_pages/index.html?stationID=ZOA1) to ~33 meters of accuracy:
<img width="1502" height="1122" alt="Screenshot 2026-01-23 at 8 13 26 PM" src="https://github.com/user-attachments/assets/f3b59375-d238-42d8-8266-25b7abed75e5" />

I'd like to get some feedback on this proposal while I continue working on the unit tests in the background. I think a family of pseudorange factors is interesting because it enables tightly-coupled GNSS factor graphs, which are more robust compared to `GPSFactor`s. Individual pseudoranges provide fine-grain outlier rejection while offering partial observability when < 4 satellites are visible. Complex multi-station differential-GNSS positioning graphs are also enabled by pseudorange factors.

Anyway, this is my first GTSAM contribution, so please let me know if I'm missing any convention/formatting in my PR. Otherwise, I'm looking forward to exploring precise GNSS positioning with factor graphs!