### PR TITLE
Standardize on KeySet

### DIFF
--- a/gtsam/discrete/DiscreteConditional.cpp
+++ b/gtsam/discrete/DiscreteConditional.cpp
@@ -87,7 +87,7 @@ DiscreteConditional DiscreteConditional::operator*(
   }
 
   // Take union of frontal keys
-  std::set<Key> newFrontals;
+  KeySet newFrontals;
   for (auto&& key : this->frontals()) newFrontals.insert(key);
   for (auto&& key : other.frontals()) newFrontals.insert(key);
 

--- a/gtsam/hybrid/HybridGaussianConditional.cpp
+++ b/gtsam/hybrid/HybridGaussianConditional.cpp
@@ -315,8 +315,8 @@ std::set<DiscreteKey> DiscreteKeysAsSet(const DiscreteKeys &discreteKeys) {
 HybridGaussianConditional::shared_ptr HybridGaussianConditional::prune(
     const DiscreteConditional &discreteProbs) const {
   // Find keys in discreteProbs.keys() but not in this->keys():
-  std::set<Key> mine(this->keys().begin(), this->keys().end());
-  std::set<Key> theirs(discreteProbs.keys().begin(),
+  KeySet mine(this->keys().begin(), this->keys().end());
+  KeySet theirs(discreteProbs.keys().begin(),
                        discreteProbs.keys().end());
   std::vector<Key> diff;
   std::set_difference(theirs.begin(), theirs.end(), mine.begin(), mine.end(),

--- a/gtsam/hybrid/HybridNonlinearFactor.cpp
+++ b/gtsam/hybrid/HybridNonlinearFactor.cpp
@@ -216,8 +216,8 @@ std::shared_ptr<HybridGaussianFactor> HybridNonlinearFactor::linearize(
 HybridNonlinearFactor::shared_ptr HybridNonlinearFactor::prune(
     const DecisionTreeFactor& discreteProbs) const {
   // Find keys in discreteProbs.keys() but not in this->keys():
-  std::set<Key> mine(this->keys().begin(), this->keys().end());
-  std::set<Key> theirs(discreteProbs.keys().begin(),
+  KeySet mine(this->keys().begin(), this->keys().end());
+  KeySet theirs(discreteProbs.keys().begin(),
                        discreteProbs.keys().end());
   std::vector<Key> diff;
   std::set_difference(theirs.begin(), theirs.end(), mine.begin(), mine.end(),

--- a/gtsam/inference/DotWriter.h
+++ b/gtsam/inference/DotWriter.h
@@ -55,7 +55,7 @@ struct GTSAM_EXPORT DotWriter {
   std::map<char, double> positionHints;
 
   /** A set of keys that will be displayed as a box */
-  std::set<Key> boxes;
+  KeySet boxes;
 
   /**
    * Factor positions can be optionally specified and will be included in the

--- a/gtsam/inference/MetisIndex-inl.h
+++ b/gtsam/inference/MetisIndex-inl.h
@@ -29,7 +29,7 @@ template<class FactorGraphType>
 void MetisIndex::augment(const FactorGraphType& factors) {
   std::map<int32_t, std::set<int32_t> > iAdjMap; // Stores a set of keys that are adjacent to key x, with  adjMap.first
   std::map<int32_t, std::set<int32_t> >::iterator iAdjMapIt;
-  std::set<Key> keySet;
+  KeySet keySet;
 
   /* ********** Convert to CSR format ********** */
   // Assuming that vertex numbering starts from 0 (C style),

--- a/gtsam/inference/inference.i
+++ b/gtsam/inference/inference.i
@@ -189,7 +189,7 @@ class DotWriter {
 
   std::map<gtsam::Key, gtsam::Vector2> variablePositions;
   std::map<char, double> positionHints;
-  std::set<gtsam::Key> boxes;
+  gtsam::KeySet boxes;
   std::map<size_t, gtsam::Vector2> factorPositions;
 };
 

--- a/gtsam/nonlinear/BatchFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/BatchFixedLagSmoother.cpp
@@ -345,16 +345,6 @@ void BatchFixedLagSmoother::marginalize(const KeyVector& marginalizeKeys) {
 }
 
 /* ************************************************************************* */
-void BatchFixedLagSmoother::PrintKeySet(const set<Key>& keys,
-    const string& label) {
-  cout << label;
-  for(Key key: keys) {
-    cout << " " << DefaultKeyFormatter(key);
-  }
-  cout << endl;
-}
-
-/* ************************************************************************* */
 void BatchFixedLagSmoother::PrintKeySet(const KeySet& keys,
     const string& label) {
   cout << label;

--- a/gtsam/nonlinear/BatchFixedLagSmoother.h
+++ b/gtsam/nonlinear/BatchFixedLagSmoother.h
@@ -129,7 +129,7 @@ public:
 protected:
 
   /** A typedef defining an Key-Factor mapping **/
-  typedef std::map<Key, std::set<Key> > FactorIndex;
+  typedef std::map<Key, KeySet > FactorIndex;
 
   /** The L-M optimization parameters **/
   LevenbergMarquardtParams parameters_;
@@ -180,8 +180,7 @@ protected:
 
 private:
   /** Private methods for printing debug information */
-  static void PrintKeySet(const std::set<Key>& keys, const std::string& label);
-  static void PrintKeySet(const gtsam::KeySet& keys, const std::string& label);
+  static void PrintKeySet(const KeySet& keys, const std::string& label);
   static void PrintSymbolicFactor(const NonlinearFactor::shared_ptr& factor);
   static void PrintSymbolicFactor(const GaussianFactor::shared_ptr& factor);
   static void PrintSymbolicGraph(const NonlinearFactorGraph& graph, const std::string& label);

--- a/gtsam/nonlinear/Expression-inl.h
+++ b/gtsam/nonlinear/Expression-inl.h
@@ -125,7 +125,7 @@ Expression<T>::Expression(const Expression<A1>& expression1,
 }
 
 template<typename T>
-std::set<Key> Expression<T>::keys() const {
+KeySet Expression<T>::keys() const {
   return root_->keys();
 }
 

--- a/gtsam/nonlinear/Expression.h
+++ b/gtsam/nonlinear/Expression.h
@@ -143,7 +143,7 @@ public:
   }
 
   /// Return keys that play in this expression
-  std::set<Key> keys() const;
+  KeySet keys() const;
 
   /// Return dimensions for each argument, as a map
   void dims(std::map<Key, int>& map) const;

--- a/gtsam/nonlinear/IncrementalFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/IncrementalFixedLagSmoother.cpp
@@ -165,7 +165,7 @@ void IncrementalFixedLagSmoother::createOrderingConstraints(
 }
 
 /* ************************************************************************* */
-void IncrementalFixedLagSmoother::PrintKeySet(const std::set<Key>& keys,
+void IncrementalFixedLagSmoother::PrintKeySet(const KeySet& keys,
     const std::string& label) {
   std::cout << label;
   for(Key key: keys) {

--- a/gtsam/nonlinear/IncrementalFixedLagSmoother.h
+++ b/gtsam/nonlinear/IncrementalFixedLagSmoother.h
@@ -142,7 +142,7 @@ protected:
 
 private:
   /** Private methods for printing debug information */
-  static void PrintKeySet(const std::set<Key>& keys, const std::string& label =
+  static void PrintKeySet(const KeySet& keys, const std::string& label =
       "Keys:");
   static void PrintSymbolicFactor(const GaussianFactor::shared_ptr& factor);
   static void PrintSymbolicGraph(const GaussianFactorGraph& graph,

--- a/gtsam/nonlinear/internal/ExpressionNode.h
+++ b/gtsam/nonlinear/internal/ExpressionNode.h
@@ -92,8 +92,8 @@ public:
   }
 
   /// Return keys that play in this expression as a set
-  virtual std::set<Key> keys() const {
-    std::set<Key> keys;
+  virtual KeySet keys() const {
+    KeySet keys;
     return keys;
   }
 
@@ -182,8 +182,8 @@ public:
   }
 
   /// Return keys that play in this expression
-  std::set<Key> keys() const override {
-    std::set<Key> keys;
+  KeySet keys() const override {
+    KeySet keys;
     keys.insert(key_);
     return keys;
   }
@@ -260,7 +260,7 @@ public:
   }
 
   /// Return keys that play in this expression
-  std::set<Key> keys() const override {
+  KeySet keys() const override {
     return expression1_->keys();
   }
 
@@ -372,9 +372,9 @@ public:
   }
 
   /// Return keys that play in this expression
-  std::set<Key> keys() const override {
-    std::set<Key> keys = expression1_->keys();
-    std::set<Key> myKeys = expression2_->keys();
+  KeySet keys() const override {
+    KeySet keys = expression1_->keys();
+    KeySet myKeys = expression2_->keys();
     keys.insert(myKeys.begin(), myKeys.end());
     return keys;
   }
@@ -480,9 +480,9 @@ public:
   }
 
   /// Return keys that play in this expression
-  std::set<Key> keys() const override {
-    std::set<Key> keys = expression1_->keys();
-    std::set<Key> myKeys = expression2_->keys();
+  KeySet keys() const override {
+    KeySet keys = expression1_->keys();
+    KeySet myKeys = expression2_->keys();
     keys.insert(myKeys.begin(), myKeys.end());
     myKeys = expression3_->keys();
     keys.insert(myKeys.begin(), myKeys.end());
@@ -588,7 +588,7 @@ class ScalarMultiplyNode : public ExpressionNode<T> {
   }
 
   /// Return keys that play in this expression
-  std::set<Key> keys() const override {
+  KeySet keys() const override {
     return expression_->keys();
   }
 
@@ -677,9 +677,9 @@ class BinarySumNode : public ExpressionNode<T> {
   }
 
   /// Return keys that play in this expression
-  std::set<Key> keys() const override {
-    std::set<Key> keys = expression1_->keys();
-    std::set<Key> myKeys = expression2_->keys();
+  KeySet keys() const override {
+    KeySet keys = expression1_->keys();
+    KeySet myKeys = expression2_->keys();
     keys.insert(myKeys.begin(), myKeys.end());
     return keys;
   }

--- a/gtsam/nonlinear/tests/testAdaptAutoDiff.cpp
+++ b/gtsam/nonlinear/tests/testAdaptAutoDiff.cpp
@@ -250,7 +250,7 @@ TEST(AdaptAutoDiff, SnavelyExpression) {
     internal::upAligned(RecordSize) + P.traceSize() + X.traceSize(),
     expression.traceSize());
 
-  const set<Key> expected{1, 2};
+  const KeySet expected{1, 2};
   EXPECT(expected == expression.keys());
 }
 

--- a/gtsam/nonlinear/tests/testExpression.cpp
+++ b/gtsam/nonlinear/tests/testExpression.cpp
@@ -86,7 +86,7 @@ Vector f3(const Point3& p, OptionalJacobian<Eigen::Dynamic, 3> H) {
   return p;
 }
 Point3_ pointExpression(1);
-const set<Key> expected{1};
+const KeySet expected{1};
 }  // namespace unary
 
 // Create a unary expression that takes another expression as a single argument.
@@ -186,7 +186,7 @@ TEST(Expression, BinaryToDouble) {
 /* ************************************************************************* */
 // Check keys of an expression created from class method.
 TEST(Expression, BinaryKeys) {
-  const set<Key> expected{1, 2};
+  const KeySet expected{1, 2};
   EXPECT(expected == binary::p_cam.keys())
 }
 
@@ -223,7 +223,7 @@ Expression<Point2> uv_hat(uncalibrate<Cal3_S2>, K, projection);
 /* ************************************************************************* */
 // keys
 TEST(Expression, TreeKeys) {
-  const set<Key> expected{1, 2, 3};
+  const KeySet expected{1, 2, 3};
   EXPECT(expected == tree::uv_hat.keys())
 }
 
@@ -261,7 +261,7 @@ TEST(Expression, compose1) {
   Rot3_ R3 = R1 * R2;
 
   // Check keys
-  const set<Key> expected{1, 2};
+  const KeySet expected{1, 2};
   EXPECT(expected == R3.keys())
 }
 
@@ -273,7 +273,7 @@ TEST(Expression, compose2) {
   Rot3_ R3 = R1 * R2;
 
   // Check keys
-  const set<Key> expected{1};
+  const KeySet expected{1};
   EXPECT(expected == R3.keys())
 }
 
@@ -285,7 +285,7 @@ TEST(Expression, compose3) {
   Rot3_ R3 = R1 * R2;
 
   // Check keys
-  const set<Key> expected{3};
+  const KeySet expected{3};
   EXPECT(expected == R3.keys())
 }
 
@@ -298,7 +298,7 @@ TEST(Expression, compose4) {
   Double_ R3 = R1 * R2;
 
   // Check keys
-  const set<Key> expected{1};
+  const KeySet expected{1};
   EXPECT(expected == R3.keys())
 }
 
@@ -322,7 +322,7 @@ TEST(Expression, ternary) {
   Rot3_ ABC(composeThree, A, B, C);
 
   // Check keys
-  const set<Key> expected {1, 2, 3};
+  const KeySet expected {1, 2, 3};
   EXPECT(expected == ABC.keys())
 }
 
@@ -332,7 +332,7 @@ TEST(Expression, ScalarMultiply) {
   const Key key(67);
   const Point3_ expr = 23 * Point3_(key);
 
-  const set<Key> expected_keys{key};
+  const KeySet expected_keys{key};
   EXPECT(expected_keys == expr.keys())
 
   map<Key, int> actual_dims, expected_dims {{key, 3}};
@@ -363,7 +363,7 @@ TEST(Expression, BinarySum) {
   const Key key(67);
   const Point3_ sum_ = Point3_(key) + Point3_(Point3(1, 1, 1));
 
-  const set<Key> expected_keys{key};
+  const KeySet expected_keys{key};
   EXPECT(expected_keys == sum_.keys())
 
   map<Key, int> actual_dims, expected_dims {{key, 3}};
@@ -508,7 +508,7 @@ TEST(Expression, Subtract) {
   values.insert(0, p);
   values.insert(1, q);
   const Vector3_ expression = Vector3_(0) - Vector3_(1);
-  set<Key> expected_keys = {0, 1};
+  KeySet expected_keys = {0, 1};
   EXPECT(expression.keys() == expected_keys)
 
   // Check value + Jacobians

--- a/gtsam/sfm/ShonanAveraging.cpp
+++ b/gtsam/sfm/ShonanAveraging.cpp
@@ -98,7 +98,7 @@ template <size_t d>
 static size_t NrUnknowns(
     const typename ShonanAveraging<d>::Measurements &measurements) {
   Key maxKey = 0;
-  std::set<Key> keys;
+  KeySet keys;
   for (const auto &measurement : measurements) {
     for (const Key &key : measurement.keys()) {
       maxKey = std::max(key, maxKey);

--- a/gtsam_unstable/nonlinear/ConcurrentBatchFilter.cpp
+++ b/gtsam_unstable/nonlinear/ConcurrentBatchFilter.cpp
@@ -211,8 +211,8 @@ void ConcurrentBatchFilter::synchronize(const NonlinearFactorGraph& smootherSumm
   if(debug) { PrintNonlinearFactorGraph(smootherSummarization_, "ConcurrentBatchFilter::synchronize  ", "Previous Smoother Summarization:", DefaultKeyFormatter); }
 
 #ifndef NDEBUG
-  std::set<Key> oldKeys = smootherSummarization_.keys();
-  std::set<Key> newKeys = smootherSummarization.keys();
+  KeySet oldKeys = smootherSummarization_.keys();
+  KeySet newKeys = smootherSummarization.keys();
   assert(oldKeys.size() == newKeys.size());
   assert(std::equal(oldKeys.begin(), oldKeys.end(), newKeys.begin()));
 #endif

--- a/gtsam_unstable/nonlinear/ConcurrentIncrementalFilter.cpp
+++ b/gtsam_unstable/nonlinear/ConcurrentIncrementalFilter.cpp
@@ -91,7 +91,7 @@ ConcurrentIncrementalFilter::Result ConcurrentIncrementalFilter::update(const No
   // Mark additional keys between the 'keys to move' and the leaves
   std::optional<FastList<Key> > additionalKeys = {};
   if(keysToMove && keysToMove->size() > 0) {
-    std::set<Key> markedKeys;
+    KeySet markedKeys;
     for(Key key: *keysToMove) {
       if(isam2_.getLinearizationPoint().exists(key)) {
         ISAM2Clique::shared_ptr clique = isam2_[key];
@@ -265,7 +265,7 @@ void ConcurrentIncrementalFilter::postsync() {
 
 
 /* ************************************************************************* */
-void ConcurrentIncrementalFilter::RecursiveMarkAffectedKeys(const Key& key, const ISAM2Clique::shared_ptr& clique, std::set<Key>& additionalKeys) {
+void ConcurrentIncrementalFilter::RecursiveMarkAffectedKeys(const Key& key, const ISAM2Clique::shared_ptr& clique, KeySet& additionalKeys) {
 
   // Check if the separator keys of the current clique contain the specified key
   if(std::find(clique->conditional()->beginParents(), clique->conditional()->endParents(), key) != clique->conditional()->endParents()) {
@@ -367,7 +367,7 @@ NonlinearFactorGraph ConcurrentIncrementalFilter::calculateFilterSummarization()
     for(size_t slot: isam2_.getVariableIndex()[key]) {
       const NonlinearFactor::shared_ptr& factor = isam2_.getFactorsUnsafe().at(slot);
       if(factor) {
-        std::set<Key> factorKeys(factor->begin(), factor->end());
+        KeySet factorKeys(factor->begin(), factor->end());
         if(std::includes(cliqueKeys.begin(), cliqueKeys.end(), factorKeys.begin(), factorKeys.end())) {
           cliqueFactorSlots.insert(slot);
         }

--- a/gtsam_unstable/nonlinear/ConcurrentIncrementalFilter.h
+++ b/gtsam_unstable/nonlinear/ConcurrentIncrementalFilter.h
@@ -180,7 +180,7 @@ protected:
 private:
 
   /** Traverse the iSAM2 Bayes Tree, inserting all descendants of the provided index/key into 'additionalKeys' */
-  static void RecursiveMarkAffectedKeys(const Key& key, const ISAM2Clique::shared_ptr& clique, std::set<Key>& additionalKeys);
+  static void RecursiveMarkAffectedKeys(const Key& key, const ISAM2Clique::shared_ptr& clique, KeySet& additionalKeys);
 
   /** Find the set of iSAM2 factors adjacent to 'keys' */
   static FactorIndices FindAdjacentFactors(const ISAM2& isam2, const FastList<Key>& keys, const FactorIndices& factorsToIgnore);

--- a/gtsam_unstable/nonlinear/ConcurrentIncrementalSmoother.cpp
+++ b/gtsam_unstable/nonlinear/ConcurrentIncrementalSmoother.cpp
@@ -208,7 +208,7 @@ void ConcurrentIncrementalSmoother::updateSmootherSummarization() {
     for(size_t slot: isam2_.getVariableIndex()[key]) {
       const NonlinearFactor::shared_ptr& factor = isam2_.getFactorsUnsafe().at(slot);
       if(factor) {
-        std::set<Key> factorKeys(factor->begin(), factor->end());
+        KeySet factorKeys(factor->begin(), factor->end());
         if(std::includes(cliqueKeys.begin(), cliqueKeys.end(), factorKeys.begin(), factorKeys.end())) {
           cliqueFactorSlots.insert(slot);
         }

--- a/gtsam_unstable/nonlinear/tests/testConcurrentBatchFilter.cpp
+++ b/gtsam_unstable/nonlinear/tests/testConcurrentBatchFilter.cpp
@@ -68,7 +68,7 @@ Values BatchOptimize(const NonlinearFactorGraph& graph, const Values& theta, int
 NonlinearFactorGraph CalculateMarginals(const NonlinearFactorGraph& factorGraph, const Values& linPoint, const FastList<Key>& keysToMarginalize){
 
 
-  std::set<Key> KeysToKeep;
+  KeySet KeysToKeep;
   for(const auto key: linPoint.keys()) { // we cycle over all the keys of factorGraph
     KeysToKeep.insert(key);
   } // so far we are keeping all keys, but we want to delete the ones that we are going to marginalize

--- a/gtsam_unstable/nonlinear/tests/testConcurrentIncrementalFilter.cpp
+++ b/gtsam_unstable/nonlinear/tests/testConcurrentIncrementalFilter.cpp
@@ -79,7 +79,7 @@ Values BatchOptimize(const NonlinearFactorGraph& graph, const Values& theta, int
 NonlinearFactorGraph CalculateMarginals(const NonlinearFactorGraph& factorGraph, const Values& linPoint, const FastList<Key>& keysToMarginalize){
 
 
-  std::set<Key> KeysToKeep;
+  KeySet KeysToKeep;
   for(const auto key: linPoint.keys()) { // we cycle over all the keys of factorGraph
     KeysToKeep.insert(key);
   } // so far we are keeping all keys, but we want to delete the ones that we are going to marginalize

--- a/tests/testExpressionFactor.cpp
+++ b/tests/testExpressionFactor.cpp
@@ -499,7 +499,7 @@ TEST(Expression, testMultipleCompositions) {
   //   Leaf, key = 1
   //   Leaf, key = 2
   Expression<double> sum1_(Combine(1, 2), v1_, v2_);
-  EXPECT((sum1_.keys() == std::set<Key>{1, 2}))
+  EXPECT((sum1_.keys() == KeySet{1, 2}))
   EXPECT_CORRECT_EXPRESSION_JACOBIANS(sum1_, values, fd_step, tolerance)
 
   // BinaryExpression(3,4)
@@ -508,7 +508,7 @@ TEST(Expression, testMultipleCompositions) {
   //     Leaf, key = 2
   //   Leaf, key = 1
   Expression<double> sum2_(Combine(3, 4), sum1_, v1_);
-  EXPECT((sum2_.keys() == std::set<Key>{1, 2}))
+  EXPECT((sum2_.keys() == KeySet{1, 2}))
   EXPECT_CORRECT_EXPRESSION_JACOBIANS(sum2_, values, fd_step, tolerance)
 
   // BinaryExpression(5,6)
@@ -521,7 +521,7 @@ TEST(Expression, testMultipleCompositions) {
   //     Leaf, key = 1
   //     Leaf, key = 2
   Expression<double> sum3_(Combine(5, 6), sum1_, sum2_);
-  EXPECT((sum3_.keys() == std::set<Key>{1, 2}))
+  EXPECT((sum3_.keys() == KeySet{1, 2}))
   EXPECT_CORRECT_EXPRESSION_JACOBIANS(sum3_, values, fd_step, tolerance)
 }
 
@@ -550,19 +550,19 @@ TEST(Expression, testMultipleCompositions2) {
   Expression<double> v3_(Key(3));
 
   Expression<double> sum1_(Combine(4,5), v1_, v2_);
-  EXPECT((sum1_.keys() == std::set<Key>{1, 2}))
+  EXPECT((sum1_.keys() == KeySet{1, 2}))
   EXPECT_CORRECT_EXPRESSION_JACOBIANS(sum1_, values, fd_step, tolerance)
 
   Expression<double> sum2_(combine3, v1_, v2_, v3_);
-  EXPECT((sum2_.keys() == std::set<Key>{1, 2, 3}))
+  EXPECT((sum2_.keys() == KeySet{1, 2, 3}))
   EXPECT_CORRECT_EXPRESSION_JACOBIANS(sum2_, values, fd_step, tolerance)
 
   Expression<double> sum3_(combine3, v3_, v2_, v1_);
-  EXPECT((sum3_.keys() == std::set<Key>{1, 2, 3}))
+  EXPECT((sum3_.keys() == KeySet{1, 2, 3}))
   EXPECT_CORRECT_EXPRESSION_JACOBIANS(sum3_, values, fd_step, tolerance)
 
   Expression<double> sum4_(combine3, sum1_, sum2_, sum3_);
-  EXPECT((sum4_.keys() == std::set<Key>{1, 2, 3}))
+  EXPECT((sum4_.keys() == KeySet{1, 2, 3}))
   EXPECT_CORRECT_EXPRESSION_JACOBIANS(sum4_, values, fd_step, tolerance)
 }
 


### PR DESCRIPTION
We were using `gtsam::KeySet` in some places and `std::set<Key>` in other places. This did not show up as a problem, but became a problem with new functionality in GTDynamics. This PR standardizes on `gtsam::KeySet`. 