### PR TITLE
Fix mac install 

### DIFF
--- a/cmake/HandleGlobalBuildFlags.cmake
+++ b/cmake/HandleGlobalBuildFlags.cmake
@@ -20,7 +20,7 @@ endif()
 
 if (APPLE AND GTSAM_SHARED_LIB)
     # Set the default install directory on macOS
-    set(CMAKE_INSTALL_NAME_DIR "lib")
+    set(CMAKE_INSTALL_NAME_DIR "@rpath")
 endif()
 
 ###############################################################################


### PR DESCRIPTION
There was a change to this line 2 months ago that broke linking in GTDynamics. Changing this line to use @rpath fixes it.