### PR TITLE
Fix Eigen issue in PseudorangeFactor

### DIFF
--- a/gtsam/navigation/PseudorangeFactor.cpp
+++ b/gtsam/navigation/PseudorangeFactor.cpp
@@ -70,7 +70,7 @@ Vector PseudorangeFactor::evaluateError(
   }
 
   if (Hreceiver_clock_bias) {
-    *Hreceiver_clock_bias = Matrix11(CLIGHT);
+    Hreceiver_clock_bias->setConstant(CLIGHT);
   }
 
   return Vector1(error);

--- a/gtsam/navigation/PseudorangeFactor.cpp
+++ b/gtsam/navigation/PseudorangeFactor.cpp
@@ -70,7 +70,7 @@ Vector PseudorangeFactor::evaluateError(
   }
 
   if (Hreceiver_clock_bias) {
-    *Hreceiver_clock_bias << I_1x1 * CLIGHT;
+    *Hreceiver_clock_bias = I_1x1 * CLIGHT;
   }
 
   return Vector1(error);

--- a/gtsam/navigation/PseudorangeFactor.cpp
+++ b/gtsam/navigation/PseudorangeFactor.cpp
@@ -70,7 +70,7 @@ Vector PseudorangeFactor::evaluateError(
   }
 
   if (Hreceiver_clock_bias) {
-    Hreceiver_clock_bias->setConstant(CLIGHT);
+    *Hreceiver_clock_bias << I_1x1 * CLIGHT;
   }
 
   return Vector1(error);


### PR DESCRIPTION
Compilation with GCC 14 fails due to a small issue with setting `Hreceiver_clock_bias`.

The issue is that Eigen's matrix initialization can trigger SSE-based operations on small matrices, and GCC 14's bounds checker flags this as unsafe, resulting in a warning which our CMake config treats as an error.

cc @masoug for future reference.