### PR TITLE
Add continuous benchmarking workflow

### DIFF
--- a/.github/scripts/compare_time_sfmbal_benchmarks.py
+++ b/.github/scripts/compare_time_sfmbal_benchmarks.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Compare timeSFMBAL benchmark JSON files and render a PR-friendly markdown body."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict
+
+
+def _load_result(path: Path) -> Dict[str, float]:
+    with path.open("r", encoding="utf-8") as f:
+        payload = json.load(f)
+    if not isinstance(payload, list):
+        raise ValueError(f"{path} is not a JSON array")
+
+    metrics: Dict[str, float] = {}
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        value = item.get("value")
+        if not isinstance(name, str):
+            continue
+        if not isinstance(value, (int, float)):
+            continue
+        metrics[name] = float(value)
+    return metrics
+
+
+def _collect_results(folder: Path) -> Dict[str, Dict[str, float]]:
+    if not folder.exists():
+        return {}
+
+    results: Dict[str, Dict[str, float]] = {}
+    for path in sorted(folder.glob("*.json")):
+        runner_id = path.stem
+        results[runner_id] = _load_result(path)
+    return results
+
+
+def _fmt_seconds(value: float | None) -> str:
+    if value is None:
+        return "N/A"
+    return f"{value:.6f}"
+
+
+def _fmt_delta(head: float | None, base: float | None) -> str:
+    if head is None or base is None:
+        return "N/A"
+    delta = head - base
+    return f"{delta:+.6f}"
+
+
+def _fmt_percent(head: float | None, base: float | None) -> str:
+    if head is None or base is None or base == 0.0:
+        return "N/A"
+    pct = (head - base) / base * 100.0
+    return f"{pct:+.2f}%"
+
+
+def render_markdown(
+    head_results: Dict[str, Dict[str, float]],
+    base_results: Dict[str, Dict[str, float]],
+    head_sha: str,
+    base_sha: str,
+) -> str:
+    lines = ["<!-- time-sfmbal-benchmark -->", "## timeSFMBAL benchmark", ""]
+    lines.append(f"- Head: `{head_sha}`")
+    if base_sha:
+        lines.append(f"- Base: `{base_sha}`")
+    lines.append("")
+
+    if not head_results:
+        lines.append("No head benchmark results were found.")
+        return "\n".join(lines) + "\n"
+
+    lines.append(
+        "| Runner | Metric | Base (s) | Head (s) | Delta (s) | Change |"
+    )
+    lines.append("| --- | --- | ---: | ---: | ---: | ---: |")
+
+    missing_base_runners = []
+    for runner_id in sorted(head_results):
+        head_metrics = head_results[runner_id]
+        base_metrics = base_results.get(runner_id, {})
+        if not base_metrics:
+            missing_base_runners.append(runner_id)
+
+        metric_names = sorted(set(head_metrics) | set(base_metrics))
+        for metric_name in metric_names:
+            head_value = head_metrics.get(metric_name)
+            base_value = base_metrics.get(metric_name)
+            lines.append(
+                "| "
+                + f"{runner_id} | `{metric_name}` | {_fmt_seconds(base_value)} | "
+                + f"{_fmt_seconds(head_value)} | {_fmt_delta(head_value, base_value)} | "
+                + f"{_fmt_percent(head_value, base_value)} |"
+            )
+
+    if missing_base_runners:
+        lines.append("")
+        lines.append(
+            "Missing base benchmark cache for: "
+            + ", ".join(f"`{runner}`" for runner in missing_base_runners)
+            + "."
+        )
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compare per-runner timeSFMBAL benchmark JSON files."
+    )
+    parser.add_argument("--head-dir", required=True, help="Directory with head JSON files")
+    parser.add_argument("--base-dir", required=True, help="Directory with base JSON files")
+    parser.add_argument("--head-sha", required=True, help="Head commit SHA")
+    parser.add_argument("--base-sha", default="", help="Base commit SHA")
+    parser.add_argument("--output", required=True, help="Output markdown file")
+    args = parser.parse_args()
+
+    head_dir = Path(args.head_dir)
+    base_dir = Path(args.base_dir)
+    output = Path(args.output)
+
+    head_results = _collect_results(head_dir)
+    base_results = _collect_results(base_dir)
+    markdown = render_markdown(head_results, base_results, args.head_sha, args.base_sha)
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(markdown, encoding="utf-8")
+    print(markdown, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/time-sfmbal-benchmark-runner.yml
+++ b/.github/workflows/time-sfmbal-benchmark-runner.yml
@@ -1,0 +1,254 @@
+name: timeSFMBAL Benchmark Runner
+run-name: timeSFMBAL worker ${{ inputs.group_id }} ${{ inputs.runner_id }} ${{ inputs.target_sha }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      group_id:
+        description: Unique dispatch group ID used by orchestrator
+        required: true
+        type: string
+      runner_id:
+        description: Runner profile ID
+        required: true
+        type: string
+      os_name:
+        description: OS label used in cache key
+        required: true
+        type: string
+      arch:
+        description: Architecture label used in cache key
+        required: true
+        type: string
+      checkout_ref:
+        description: Git ref/SHA to checkout for benchmarking
+        required: true
+        type: string
+      target_sha:
+        description: Commit SHA used in cache key
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark_linux_x64:
+    if: inputs.runner_id == 'linux-x64'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout target ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.checkout_ref }}
+          fetch-depth: 0
+
+      - name: Restore BAL dataset archive cache
+        id: dataset_cache_restore
+        uses: actions/cache/restore@v4
+        with:
+          path: examples/Data/problem-16-22106-pre.txt.bz2
+          key: bal-problem-16-22106-pre-txt-bz2-v1
+
+      - name: Download BAL dataset archive
+        if: steps.dataset_cache_restore.outputs.cache-hit != 'true'
+        run: |
+          curl --fail --location --show-error \
+            --output examples/Data/problem-16-22106-pre.txt.bz2 \
+            https://grail.cs.washington.edu/projects/bal/data/dubrovnik/problem-16-22106-pre.txt.bz2
+
+      - name: Save BAL dataset archive cache
+        if: steps.dataset_cache_restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        continue-on-error: true
+        with:
+          path: examples/Data/problem-16-22106-pre.txt.bz2
+          key: bal-problem-16-22106-pre-txt-bz2-v1
+
+      - name: Extract BAL dataset
+        run: |
+          bzip2 -dc examples/Data/problem-16-22106-pre.txt.bz2 > examples/Data/dubrovnik-16-22106-pre.txt
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build
+
+      - name: Configure
+        run: |
+          cmake -S . -B build -GNinja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_FLAGS="-w" \
+            -DGTSAM_BUILD_TESTS=OFF \
+            -DGTSAM_BUILD_UNSTABLE=ON \
+            -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF \
+            -DGTSAM_BUILD_TIMING_ALWAYS=ON \
+            -DGTSAM_BUILD_WITH_MARCH_NATIVE=OFF \
+            -DGTSAM_USE_BOOST_FEATURES=OFF \
+            -DGTSAM_ENABLE_BOOST_SERIALIZATION=OFF
+
+      - name: Build timeSFMBAL
+        run: cmake --build build --target timeSFMBAL -j2
+
+      - name: Run benchmark
+        run: ./build/timing/timeSFMBAL --benchmark-action-json benchmark-results.json
+
+      - name: Prepare cache payload
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p benchmark-cache
+          cp benchmark-results.json "benchmark-cache/${{ inputs.os_name }}-${{ inputs.arch }}-${{ inputs.target_sha }}.json"
+
+      - name: Save benchmark cache
+        uses: actions/cache/save@v4
+        continue-on-error: true
+        with:
+          path: benchmark-cache/${{ inputs.os_name }}-${{ inputs.arch }}-${{ inputs.target_sha }}.json
+          key: timeSFMBAL-benchmark-v3-${{ inputs.os_name }}-${{ inputs.arch }}-${{ inputs.target_sha }}
+
+  benchmark_linux_arm64:
+    if: inputs.runner_id == 'linux-arm64'
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout target ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.checkout_ref }}
+          fetch-depth: 0
+
+      - name: Restore BAL dataset archive cache
+        id: dataset_cache_restore
+        uses: actions/cache/restore@v4
+        with:
+          path: examples/Data/problem-16-22106-pre.txt.bz2
+          key: bal-problem-16-22106-pre-txt-bz2-v1
+
+      - name: Download BAL dataset archive
+        if: steps.dataset_cache_restore.outputs.cache-hit != 'true'
+        run: |
+          curl --fail --location --show-error \
+            --output examples/Data/problem-16-22106-pre.txt.bz2 \
+            https://grail.cs.washington.edu/projects/bal/data/dubrovnik/problem-16-22106-pre.txt.bz2
+
+      - name: Save BAL dataset archive cache
+        if: steps.dataset_cache_restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        continue-on-error: true
+        with:
+          path: examples/Data/problem-16-22106-pre.txt.bz2
+          key: bal-problem-16-22106-pre-txt-bz2-v1
+
+      - name: Extract BAL dataset
+        run: |
+          bzip2 -dc examples/Data/problem-16-22106-pre.txt.bz2 > examples/Data/dubrovnik-16-22106-pre.txt
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build
+
+      - name: Configure
+        run: |
+          cmake -S . -B build -GNinja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_FLAGS="-w" \
+            -DGTSAM_BUILD_TESTS=OFF \
+            -DGTSAM_BUILD_UNSTABLE=ON \
+            -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF \
+            -DGTSAM_BUILD_TIMING_ALWAYS=ON \
+            -DGTSAM_BUILD_WITH_MARCH_NATIVE=OFF \
+            -DGTSAM_USE_BOOST_FEATURES=OFF \
+            -DGTSAM_ENABLE_BOOST_SERIALIZATION=OFF
+
+      - name: Build timeSFMBAL
+        run: cmake --build build --target timeSFMBAL -j2
+
+      - name: Run benchmark
+        run: ./build/timing/timeSFMBAL --benchmark-action-json benchmark-results.json
+
+      - name: Prepare cache payload
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p benchmark-cache
+          cp benchmark-results.json "benchmark-cache/${{ inputs.os_name }}-${{ inputs.arch }}-${{ inputs.target_sha }}.json"
+
+      - name: Save benchmark cache
+        uses: actions/cache/save@v4
+        continue-on-error: true
+        with:
+          path: benchmark-cache/${{ inputs.os_name }}-${{ inputs.arch }}-${{ inputs.target_sha }}.json
+          key: timeSFMBAL-benchmark-v3-${{ inputs.os_name }}-${{ inputs.arch }}-${{ inputs.target_sha }}
+
+  benchmark_macos_arm64:
+    if: inputs.runner_id == 'macos-arm64'
+    runs-on: macos-14
+    steps:
+      - name: Checkout target ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.checkout_ref }}
+          fetch-depth: 0
+
+      - name: Restore BAL dataset archive cache
+        id: dataset_cache_restore
+        uses: actions/cache/restore@v4
+        with:
+          path: examples/Data/problem-16-22106-pre.txt.bz2
+          key: bal-problem-16-22106-pre-txt-bz2-v1
+
+      - name: Download BAL dataset archive
+        if: steps.dataset_cache_restore.outputs.cache-hit != 'true'
+        run: |
+          curl --fail --location --show-error \
+            --output examples/Data/problem-16-22106-pre.txt.bz2 \
+            https://grail.cs.washington.edu/projects/bal/data/dubrovnik/problem-16-22106-pre.txt.bz2
+
+      - name: Save BAL dataset archive cache
+        if: steps.dataset_cache_restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        continue-on-error: true
+        with:
+          path: examples/Data/problem-16-22106-pre.txt.bz2
+          key: bal-problem-16-22106-pre-txt-bz2-v1
+
+      - name: Extract BAL dataset
+        run: |
+          bzip2 -dc examples/Data/problem-16-22106-pre.txt.bz2 > examples/Data/dubrovnik-16-22106-pre.txt
+
+      - name: Install dependencies
+        run: brew install ninja || true
+
+      - name: Configure
+        run: |
+          cmake -S . -B build -GNinja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_FLAGS="-w" \
+            -DGTSAM_BUILD_TESTS=OFF \
+            -DGTSAM_BUILD_UNSTABLE=ON \
+            -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF \
+            -DGTSAM_BUILD_TIMING_ALWAYS=ON \
+            -DGTSAM_BUILD_WITH_MARCH_NATIVE=OFF \
+            -DGTSAM_USE_BOOST_FEATURES=OFF \
+            -DGTSAM_ENABLE_BOOST_SERIALIZATION=OFF
+
+      - name: Build timeSFMBAL
+        run: cmake --build build --target timeSFMBAL -j2
+
+      - name: Run benchmark
+        run: ./build/timing/timeSFMBAL --benchmark-action-json benchmark-results.json
+
+      - name: Prepare cache payload
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p benchmark-cache
+          cp benchmark-results.json "benchmark-cache/${{ inputs.os_name }}-${{ inputs.arch }}-${{ inputs.target_sha }}.json"
+
+      - name: Save benchmark cache
+        uses: actions/cache/save@v4
+        continue-on-error: true
+        with:
+          path: benchmark-cache/${{ inputs.os_name }}-${{ inputs.arch }}-${{ inputs.target_sha }}.json
+          key: timeSFMBAL-benchmark-v3-${{ inputs.os_name }}-${{ inputs.arch }}-${{ inputs.target_sha }}

--- a/.github/workflows/time-sfmbal-benchmark-trigger.yml
+++ b/.github/workflows/time-sfmbal-benchmark-trigger.yml
@@ -1,0 +1,37 @@
+name: Trigger timeSFMBAL Benchmark
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  dispatch:
+    if: github.event.issue.pull_request != null
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch benchmark workflow for /bench
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.comment.body.trim();
+            if (body !== "/bench") {
+              core.info("Skipping dispatch: comment is not /bench.");
+              return;
+            }
+
+            const prNumber = context.payload.issue.number;
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: "time-sfmbal-benchmark.yml",
+              ref: context.payload.repository.default_branch,
+              inputs: {
+                pr_number: String(prNumber),
+              },
+            });
+            core.info(`Dispatched time-sfmbal-benchmark.yml for PR #${prNumber}.`);

--- a/.github/workflows/time-sfmbal-benchmark.yml
+++ b/.github/workflows/time-sfmbal-benchmark.yml
@@ -1,0 +1,376 @@
+name: timeSFMBAL Benchmark
+
+on:
+  pull_request:
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to benchmark
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  context:
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+      head_sha: ${{ steps.resolve.outputs.head_sha }}
+      base_sha: ${{ steps.resolve.outputs.base_sha }}
+      head_checkout_ref: ${{ steps.resolve.outputs.head_checkout_ref }}
+      should_comment: ${{ steps.resolve.outputs.should_comment }}
+      group_id: ${{ steps.resolve.outputs.group_id }}
+    steps:
+      - name: Resolve PR context
+        id: resolve
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const eventName = context.eventName;
+            let prNumber = "";
+            let headSha = "";
+            let baseSha = "";
+            let headCheckoutRef = "";
+
+            if (eventName === "pull_request") {
+              const pr = context.payload.pull_request;
+              prNumber = String(pr.number);
+              headSha = pr.head.sha;
+              baseSha = pr.base.sha;
+              headCheckoutRef = `refs/pull/${pr.number}/head`;
+            } else if (eventName === "workflow_dispatch") {
+              prNumber = String((context.payload.inputs?.pr_number || "").trim());
+              if (!prNumber) {
+                core.setFailed("workflow_dispatch requires pr_number.");
+                return;
+              }
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: Number(prNumber),
+              });
+              headSha = pr.data.head.sha;
+              baseSha = pr.data.base.sha;
+              headCheckoutRef = `refs/pull/${pr.data.number}/head`;
+            } else {
+              core.setFailed(`Unsupported event: ${eventName}`);
+              return;
+            }
+
+            const groupId = `${context.runId}-${Date.now()}`;
+
+            core.setOutput("pr_number", prNumber);
+            core.setOutput("head_sha", headSha);
+            core.setOutput("base_sha", baseSha);
+            core.setOutput("head_checkout_ref", headCheckoutRef);
+            core.setOutput("should_comment", "true");
+            core.setOutput("group_id", groupId);
+
+  dispatch_and_wait:
+    needs: context
+    runs-on: ubuntu-latest
+    outputs:
+      run_statuses: ${{ steps.dispatch.outputs.run_statuses }}
+    steps:
+      - name: Dispatch benchmark runner workflows and wait
+        id: dispatch
+        uses: actions/github-script@v7
+        env:
+          WORKFLOW_ID: time-sfmbal-benchmark-runner.yml
+        with:
+          script: |
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+            const workflowId = process.env.WORKFLOW_ID;
+            const groupId = "${{ needs.context.outputs.group_id }}";
+            const headSha = "${{ needs.context.outputs.head_sha }}";
+            const baseSha = "${{ needs.context.outputs.base_sha }}";
+            const headCheckoutRef = "${{ needs.context.outputs.head_checkout_ref }}";
+
+            const runners = [
+              { id: "linux-x64", os_name: "linux", arch: "x64" },
+              { id: "linux-arm64", os_name: "linux", arch: "arm64" },
+              { id: "macos-arm64", os_name: "macos", arch: "arm64" },
+            ];
+
+            const specs = [];
+            for (const runner of runners) {
+              specs.push({
+                role: "head",
+                sha: headSha,
+                checkout_ref: headCheckoutRef,
+                ...runner,
+              });
+              specs.push({
+                role: "base",
+                sha: baseSha,
+                checkout_ref: baseSha,
+                ...runner,
+              });
+            }
+
+            // Dispatch all unprivileged benchmark worker runs.
+            for (const spec of specs) {
+              spec.group_token = `${groupId}-${spec.role}-${spec.id}`;
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: workflowId,
+                ref: context.payload.repository.default_branch,
+                inputs: {
+                  group_id: spec.group_token,
+                  runner_id: spec.id,
+                  os_name: spec.os_name,
+                  arch: spec.arch,
+                  checkout_ref: spec.checkout_ref,
+                  target_sha: spec.sha,
+                },
+              });
+            }
+
+            const createdAfter = Date.now() - 2 * 60 * 1000;
+            const findMatchingRun = async (token) => {
+              let page = 1;
+              while (page <= 5) {
+                const resp = await github.rest.actions.listWorkflowRuns({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: workflowId,
+                  event: "workflow_dispatch",
+                  per_page: 100,
+                  page,
+                });
+                for (const run of resp.data.workflow_runs) {
+                  const createdAt = Date.parse(run.created_at || "");
+                  if (!Number.isNaN(createdAt) && createdAt < createdAfter) {
+                    continue;
+                  }
+                  const title = run.display_title || "";
+                  if (title.includes(token)) {
+                    return run;
+                  }
+                }
+                if (resp.data.workflow_runs.length < 100) break;
+                page += 1;
+              }
+              return null;
+            };
+
+            // Wait for each dispatched run to appear so we can track by run_id.
+            for (let attempt = 0; attempt < 80; attempt++) {
+              let allResolved = true;
+              for (const spec of specs) {
+                if (spec.run_id) continue;
+                const run = await findMatchingRun(spec.group_token);
+                if (run) {
+                  spec.run_id = run.id;
+                  spec.html_url = run.html_url;
+                } else {
+                  allResolved = false;
+                }
+              }
+              if (allResolved) break;
+              await sleep(5000);
+            }
+
+            // Wait for completion (success/failure) of all found runs.
+            for (let attempt = 0; attempt < 240; attempt++) {
+              let allCompleted = true;
+              for (const spec of specs) {
+                if (!spec.run_id || spec.conclusion) continue;
+                const run = await github.rest.actions.getWorkflowRun({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: spec.run_id,
+                });
+                const status = run.data.status;
+                if (status === "completed") {
+                  spec.conclusion = run.data.conclusion || "unknown";
+                  spec.html_url = run.data.html_url;
+                } else {
+                  allCompleted = false;
+                }
+              }
+              if (allCompleted) break;
+              await sleep(15000);
+            }
+
+            for (const spec of specs) {
+              if (!spec.run_id) spec.conclusion = "not_found";
+              if (!spec.conclusion) spec.conclusion = "timed_out";
+            }
+
+            const summary = specs.map((spec) => ({
+              role: spec.role,
+              runner_id: spec.id,
+              sha: spec.sha,
+              conclusion: spec.conclusion,
+              run_id: spec.run_id || null,
+              html_url: spec.html_url || null,
+            }));
+
+            core.setOutput("run_statuses", JSON.stringify(summary));
+
+  collect:
+    needs: [context, dispatch_and_wait]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: linux-x64
+            os_name: linux
+            arch: x64
+          - id: linux-arm64
+            os_name: linux
+            arch: arm64
+          - id: macos-arm64
+            os_name: macos
+            arch: arm64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Restore head benchmark cache
+        id: restore_head
+        uses: actions/cache/restore@v4
+        with:
+          path: benchmark-cache/${{ matrix.os_name }}-${{ matrix.arch }}-${{ needs.context.outputs.head_sha }}.json
+          key: timeSFMBAL-benchmark-v3-${{ matrix.os_name }}-${{ matrix.arch }}-${{ needs.context.outputs.head_sha }}
+
+      - name: Restore base benchmark cache
+        id: restore_base
+        uses: actions/cache/restore@v4
+        with:
+          path: benchmark-cache/${{ matrix.os_name }}-${{ matrix.arch }}-${{ needs.context.outputs.base_sha }}.json
+          key: timeSFMBAL-benchmark-v3-${{ matrix.os_name }}-${{ matrix.arch }}-${{ needs.context.outputs.base_sha }}
+
+      - name: Stage collected files
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifact
+          echo "head cache-hit: ${{ steps.restore_head.outputs.cache-hit }}"
+          echo "base cache-hit: ${{ steps.restore_base.outputs.cache-hit }}"
+          if [[ "${{ steps.restore_head.outputs.cache-hit }}" == "true" ]] && [[ -f "benchmark-cache/${{ matrix.os_name }}-${{ matrix.arch }}-${{ needs.context.outputs.head_sha }}.json" ]]; then
+            cp "benchmark-cache/${{ matrix.os_name }}-${{ matrix.arch }}-${{ needs.context.outputs.head_sha }}.json" "artifact/head-${{ matrix.id }}.json"
+          else
+            : > "artifact/head-miss-${{ matrix.id }}.txt"
+          fi
+          if [[ "${{ steps.restore_base.outputs.cache-hit }}" == "true" ]] && [[ -f "benchmark-cache/${{ matrix.os_name }}-${{ matrix.arch }}-${{ needs.context.outputs.base_sha }}.json" ]]; then
+            cp "benchmark-cache/${{ matrix.os_name }}-${{ matrix.arch }}-${{ needs.context.outputs.base_sha }}.json" "artifact/base-${{ matrix.id }}.json"
+          else
+            : > "artifact/base-miss-${{ matrix.id }}.txt"
+          fi
+
+      - name: Upload collected files
+        uses: actions/upload-artifact@v4
+        with:
+          name: time-sfmbal-collected-${{ matrix.id }}
+          path: artifact/*
+          if-no-files-found: error
+
+  summarize:
+    needs: [context, dispatch_and_wait, collect]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download collected artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: time-sfmbal-collected-*
+          path: collected
+          merge-multiple: true
+
+      - name: Organize compare input
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p collected/head collected/base
+          shopt -s nullglob
+          for file in collected/head-*.json; do
+            name="$(basename "${file}" .json)"
+            runner_id="${name#head-}"
+            cp "${file}" "collected/head/${runner_id}.json"
+          done
+          for file in collected/base-*.json; do
+            name="$(basename "${file}" .json)"
+            runner_id="${name#base-}"
+            cp "${file}" "collected/base/${runner_id}.json"
+          done
+
+      - name: Generate markdown
+        run: |
+          python3 .github/scripts/compare_time_sfmbal_benchmarks.py \
+            --head-dir collected/head \
+            --base-dir collected/base \
+            --head-sha "${{ needs.context.outputs.head_sha }}" \
+            --base-sha "${{ needs.context.outputs.base_sha }}" \
+            --output benchmark-comment.md
+
+      - name: Append worker status details
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          status_raw = """${{ needs.dispatch_and_wait.outputs.run_statuses }}"""
+          statuses = json.loads(status_raw) if status_raw.strip() else []
+          lines = ["", "### Worker runs", "", "| Role | Runner | SHA | Conclusion |", "| --- | --- | --- | --- |"]
+          for item in statuses:
+            lines.append(
+              f"| {item.get('role','')} | {item.get('runner_id','')} | `{item.get('sha','')}` | {item.get('conclusion','')} |"
+            )
+
+          path = Path("benchmark-comment.md")
+          path.write_text(path.read_text(encoding="utf-8") + "\n".join(lines) + "\n", encoding="utf-8")
+          PY
+          cat benchmark-comment.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post or update PR comment
+        if: needs.context.outputs.should_comment == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const marker = "<!-- time-sfmbal-benchmark -->";
+            const body = fs.readFileSync("benchmark-comment.md", "utf8");
+            const issue_number = Number("${{ needs.context.outputs.pr_number }}");
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existing = comments.find(
+              (comment) => comment.user?.type === "Bot" && comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body,
+              });
+            }

--- a/timing/timeSFMBAL.cpp
+++ b/timing/timeSFMBAL.cpp
@@ -21,18 +21,94 @@
 #include <chrono>
 #include <cstring>
 #include <filesystem>
+#include <fstream>
 #include <iomanip>
 #include <iostream>
 
 namespace {
+constexpr const char* kDefaultBenchmarkDataset = "dubrovnik-16-22106-pre";
+constexpr const char* kProfileDataset = "dubrovnik-135-90642-pre";
+
+std::string usage() {
+  return "Usage: timeSFMBAL [--colamd] [--profile] "
+         "[--benchmark-action-json FILE] [BALfile]";
+}
+
+struct TimingRow {
+  std::string dataset;
+  double legacy = 0.0;
+  double newer = 0.0;
+};
+
 struct RunOptions {
   bool profile = false;
+  bool benchmarkActionJson = false;
+  std::string benchmarkActionJsonPath;
   std::vector<std::string> filenames;
 };
+
+std::string escapeJson(std::string value) {
+  std::string escaped;
+  escaped.reserve(value.size());
+  for (const char c : value) {
+    switch (c) {
+      case '\\':
+        escaped += "\\\\";
+        break;
+      case '"':
+        escaped += "\\\"";
+        break;
+      case '\n':
+        escaped += "\\n";
+        break;
+      case '\r':
+        escaped += "\\r";
+        break;
+      case '\t':
+        escaped += "\\t";
+        break;
+      default:
+        escaped += c;
+        break;
+    }
+  }
+  return escaped;
+}
+
+void writeBenchmarkActionJson(const std::vector<TimingRow>& rows,
+                              const std::string& outputPath) {
+  std::ofstream out(outputPath);
+  if (!out) {
+    throw runtime_error("Unable to open benchmark JSON output file: " +
+                        outputPath);
+  }
+
+  out << "[\n";
+  bool first = true;
+  const auto appendEntry = [&](const std::string& name, const double value) {
+    if (!first) out << ",\n";
+    first = false;
+    out << "  {\n";
+    out << "    \"name\": \"" << escapeJson(name) << "\",\n";
+    out << "    \"unit\": \"s\",\n";
+    out << "    \"value\": " << std::fixed << std::setprecision(9) << value
+        << "\n";
+    out << "  }";
+  };
+
+  for (const auto& row : rows) {
+    appendEntry("timeSFMBAL/" + row.dataset + "/MultifrontalCholesky",
+                row.legacy);
+    appendEntry("timeSFMBAL/" + row.dataset + "/MultifrontalSolver", row.newer);
+  }
+  out << "\n]\n";
+}
 
 RunOptions parseBalFiles(int argc, char* argv[]) {
   std::string filename;
   bool profile = false;
+  bool benchmarkActionJson = false;
+  std::string benchmarkActionJsonPath;
   for (int i = 1; i < argc; ++i) {
     if (strcmp(argv[i], "--colamd") == 0) {
       gUseSchur = false;
@@ -42,28 +118,45 @@ RunOptions parseBalFiles(int argc, char* argv[]) {
       profile = true;
       continue;
     }
+    if (strcmp(argv[i], "--benchmark-action-json") == 0) {
+      if (++i >= argc || argv[i][0] == '-') {
+        throw runtime_error(usage());
+      }
+      benchmarkActionJson = true;
+      benchmarkActionJsonPath = argv[i];
+      continue;
+    }
     if (argv[i][0] == '-') {
-      throw runtime_error("Usage: timeSFMBAL [--colamd] [--profile] [BALfile]");
+      throw runtime_error(usage());
     }
     if (!filename.empty()) {
-      throw runtime_error("Usage: timeSFMBAL [--colamd] [--profile] [BALfile]");
+      throw runtime_error(usage());
     }
     filename = argv[i];
   }
 
   if (profile && !filename.empty()) {
-    throw runtime_error("Usage: timeSFMBAL [--colamd] [--profile] [BALfile]");
+    throw runtime_error(usage());
+  }
+  if (profile && benchmarkActionJson) {
+    throw runtime_error(usage());
   }
 
   if (!filename.empty()) {
-    return {profile, {filename}};
+    return {profile, benchmarkActionJson, benchmarkActionJsonPath, {filename}};
   }
 
   if (profile) {
-    return {profile, {findExampleDataFile("dubrovnik-135-90642-pre")}};
+    return {profile, benchmarkActionJson, benchmarkActionJsonPath,
+            {findExampleDataFile(kProfileDataset)}};
   }
 
-  return {profile,
+  if (benchmarkActionJson) {
+    return {profile, benchmarkActionJson, benchmarkActionJsonPath,
+            {findExampleDataFile(kDefaultBenchmarkDataset)}};
+  }
+
+  return {profile, benchmarkActionJson, benchmarkActionJsonPath,
           {
               findExampleDataFile("dubrovnik-16-22106-pre"),
               findExampleDataFile("dubrovnik-88-64298-pre"),
@@ -100,11 +193,6 @@ double runSolver(const NonlinearFactorGraph& graph, const Values& initial,
 
 int main(int argc, char* argv[]) {
   const auto options = parseBalFiles(argc, argv);
-  struct TimingRow {
-    std::string dataset;
-    double legacy = 0.0;
-    double newer = 0.0;
-  };
   std::vector<TimingRow> rows;
 
   for (const auto& filename : options.filenames) {
@@ -145,6 +233,15 @@ int main(int argc, char* argv[]) {
       std::cout << "| " << row.dataset << " | " << row.legacy << " | "
                 << row.newer << " | " << speedup << "x |\n";
     }
+  }
+
+  if (options.benchmarkActionJson) {
+    if (rows.empty()) {
+      throw runtime_error("No benchmark rows found to write.");
+    }
+    writeBenchmarkActionJson(rows, options.benchmarkActionJsonPath);
+    std::cout << "\nWrote benchmark-action JSON to "
+              << options.benchmarkActionJsonPath << "\n";
   }
   return 0;
 }


### PR DESCRIPTION

## Summary

This PR adds a safe, two-tier benchmark pipeline for `timeSFMBAL` and enables PR performance reporting without using third-party benchmark actions. Note this will not work before merged (as the "workflow_dispatch" action can only be invoked when on the primary branch).

A demo can be seen at https://github.com/ProfFan/gtsam/pull/14

Sample:

## timeSFMBAL benchmark

- Head: `b48c5f0896925232d9fb283a033c446272aecf5c`
- Base: `38f71129194d85b4d4c50a5109d1218948a2578b`

| Runner | Metric | Base (s) | Head (s) | Delta (s) | Change |
| --- | --- | ---: | ---: | ---: | ---: |
| linux-arm64 | `timeSFMBAL/dubrovnik-16-22106-pre.txt/MultifrontalCholesky` | 2.068122 | 2.135078 | +0.066957 | +3.24% |
| linux-arm64 | `timeSFMBAL/dubrovnik-16-22106-pre.txt/MultifrontalSolver` | 1.225473 | 1.254750 | +0.029278 | +2.39% |
| linux-x64 | `timeSFMBAL/dubrovnik-16-22106-pre.txt/MultifrontalCholesky` | 2.170932 | 2.222575 | +0.051643 | +2.38% |
| linux-x64 | `timeSFMBAL/dubrovnik-16-22106-pre.txt/MultifrontalSolver` | 1.616237 | 1.639115 | +0.022878 | +1.42% |
| macos-arm64 | `timeSFMBAL/dubrovnik-16-22106-pre.txt/MultifrontalCholesky` | N/A | 2.256323 | N/A | N/A |
| macos-arm64 | `timeSFMBAL/dubrovnik-16-22106-pre.txt/MultifrontalSolver` | N/A | 1.469075 | N/A | N/A |

Missing base benchmark cache for: `macos-arm64`.

### Worker runs

| Role | Runner | SHA | Conclusion |
| --- | --- | --- | --- |
| head | linux-x64 | `b48c5f0896925232d9fb283a033c446272aecf5c` | success |
| base | linux-x64 | `38f71129194d85b4d4c50a5109d1218948a2578b` | success |
| head | linux-arm64 | `b48c5f0896925232d9fb283a033c446272aecf5c` | success |
| base | linux-arm64 | `38f71129194d85b4d4c50a5109d1218948a2578b` | success |
| head | macos-arm64 | `b48c5f0896925232d9fb283a033c446272aecf5c` | success |
| base | macos-arm64 | `38f71129194d85b4d4c50a5109d1218948a2578b` | timed_out |


## What Changed

### 1) `timeSFMBAL` JSON benchmark output
- Extended `timing/timeSFMBAL.cpp` with a benchmark JSON mode:
  - `--benchmark-action-json <output_file>`
- JSON output contains per-metric entries for:
  - `MultifrontalCholesky`
  - `MultifrontalSolver`

### 2) New benchmark comparison script
- Added `.github/scripts/compare_time_sfmbal_benchmarks.py`
- Compares per-runner JSON results (OS/arch), computes deltas/percent change, and generates markdown suitable for PR comments.
- Handles missing base data gracefully (reports `N/A` and missing base cache notes).

### 3) Safe split workflow design
- Added unprivileged worker workflow:
  - `.github/workflows/time-sfmbal-benchmark-runner.yml`
  - Trigger: `workflow_dispatch` only
  - Permission: read-only contents
  - Runs benchmark for a specific runner/commit and caches JSON as:
    - `timeSFMBAL-benchmark-v3-<os>-<arch>-<sha>`
- Updated orchestrator workflow:
  - `.github/workflows/time-sfmbal-benchmark.yml`
  - Triggers:
    - `pull_request` on `opened`
    - `workflow_dispatch` with `pr_number`
  - Dispatches worker runs for head/base across all configured runners, waits for completion, restores cached JSONs, generates markdown, and posts/updates PR comment.
- `/bench` trigger workflow:
  - `.github/workflows/time-sfmbal-benchmark-trigger.yml`
  - On PR issue comment `/bench`, dispatches orchestrator.

### 4) Dataset handling in worker runs
- Worker now uses BAL dataset archive:
  - `https://grail.cs.washington.edu/projects/bal/data/dubrovnik/problem-16-22106-pre.txt.bz2`
- Flow:
  1. Restore `problem-16-22106-pre.txt.bz2` from cache
  2. Download+cache on miss
  3. Extract into repo data dir as:
     - `examples/Data/dubrovnik-16-22106-pre.txt`

## Why

- Limits privileged operations to orchestration/commenting; benchmark execution remains unprivileged.
- Improves reproducibility with explicit per-OS/arch/SHA benchmark caches.
- Supports PR-open and manual `/bench` flows with consistent reporting.
