### PR TITLE
Use vcpkg manifest

### DIFF
--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -28,33 +28,20 @@ jobs:
             triplet: x64-windows-release
             build_type: Release
             test_target: RUN_TESTS
-            binary_cache: C:\Users\runneradmin\AppData\Local\vcpkg\archives
             python: python
-            additional_vcpkg_ports: intel-mkl
           - os: ubuntu-latest
             triplet: x64-linux-release
             build_type: Release
             test_target: test
-            binary_cache: /home/runner/.cache/vcpkg/archives
             python: python3
-            additional_vcpkg_ports: intel-mkl
           - os: macos-latest
             triplet: arm64-osx-release
             build_type: Release
             test_target: test
-            binary_cache: /Users/runner/.cache/vcpkg/archives
             python: python3
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Restore cache dependencies
-        id: cache-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: ${{ matrix.binary_cache }}
-          key: ${{ matrix.os }}
-          restore-keys: ${{ matrix.os }}
 
       - name: Setup MSVC
         if: runner.os == 'Windows'
@@ -83,68 +70,20 @@ jobs:
         run: |
           brew install autoconf autoconf-archive automake libtool
 
-      - name: Set vcpkg installtion root env
-        shell: bash
-        run: |
-          VCPKG_BASH_PATH=${VCPKG_INSTALLATION_ROOT//\\//}
-          echo "VCPKG_INSTALLATION_ROOT=$VCPKG_BASH_PATH" >> "$GITHUB_ENV"
-
-      - name: "Install dependencies"
-        run: >
-          vcpkg x-set-installed --triplet ${{ matrix.triplet }} --host-triplet ${{ matrix.triplet }}
-          boost-assign
-          boost-bimap
-          boost-chrono
-          boost-date-time
-          boost-filesystem
-          boost-format
-          boost-graph
-          boost-math
-          boost-program-options
-          boost-regex
-          boost-serialization
-          boost-system
-          boost-thread
-          boost-timer
-          tbb
-          pybind11
-          geographiclib
-          eigen3
-          ${{ matrix.additional_vcpkg_ports }}
-
-      - name: On Failure, upload vcpkg logs
-        if: failure()
-        uses: actions/upload-artifact@v4
+      - name: Set up vcpkg
+        uses: lukka/run-vcpkg@v11.5
         with:
-          name: logs_${{ matrix.os }}_${{ github.event.pull_request.head.sha }}
-          path: |
-            ${{ env.VCPKG_INSTALLATION_ROOT }}/buildtrees/**/*.log
+          vcpkgDirectory: ${{ github.workspace }}/vcpkg
+        env:
+          VCPKG_BINARY_SOURCES: default,rw
 
-      - name: copy files for hash
-        shell: bash
-        run: |
-          echo $VCPKG_INSTALLATION_ROOT
-          mkdir -p vcpkg-info
-          find $VCPKG_INSTALLATION_ROOT/installed/ -type f -name 'vcpkg_abi_info.txt' | \
-          while read filepath; do
-            triplet=$(echo "$filepath" | awk -F/ '{print $(NF-3)}')
-            port=$(echo "$filepath" | awk -F/ '{print $(NF-1)}')
-            cp "$filepath" "vcpkg-info/${triplet}_${port}.txt"
-          done
-
-      - name: Save cache dependencies
-        # Don't save if it's the exact same
-        if: steps.cache-restore.outputs.cache-matched-key != format('{0}-{1}', matrix.os, hashFiles('vcpkg-info/*'))
-        uses: actions/cache/save@v4
+      - name: Restore cache dependencies
+        id: cache-restore
+        uses: actions/cache/restore@v3
         with:
-          path: ${{ matrix.binary_cache }}
-          key: ${{ matrix.os }}-${{ hashFiles('vcpkg-info/*') }}
-
-      - name: Install python packages
-        shell: bash
-        run: |
-          $VCPKG_INSTALLATION_ROOT/installed/${{ matrix.triplet }}/tools/python3/${{ matrix.python }} -m ensurepip --upgrade
-          $VCPKG_INSTALLATION_ROOT/installed/${{ matrix.triplet }}/tools/python3/${{ matrix.python }} -m pip install -r python/dev_requirements.txt
+          path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+          key: ${{ matrix.os }}-${{ hashFiles('vcpkg.json') }}
+          restore-keys: ${{ matrix.os }}-${{ hashFiles('vcpkg.json') }}
 
       - name: Set Swap Space (Linux)
         if: runner.os == 'Linux'
@@ -153,16 +92,13 @@ jobs:
           swap-size-gb: 6
 
       - name: cmake config
-        if: success()
         shell: bash
         run: |
-          export CL=-openmp
-
           cmake -B build -G Ninja \
-              -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake \
+              -DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake \
               -DCMAKE_C_COMPILER_LAUNCHER=sccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
-              -DVCPKG_INSTALLED_DIR=$VCPKG_INSTALLATION_ROOT/installed \
+              -DVCPKG_INSTALLED_DIR=$GITHUB_WORKSPACE/vcpkg_installed \
               -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }} \
               -DVCPKG_HOST_TRIPLET=${{ matrix.triplet }} \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
@@ -185,6 +121,27 @@ jobs:
               -DCTEST_EXTRA_ARGS='${{ matrix.ctest_extra_flags }}' \
               -DPYTEST_EXTRA_ARGS='${{ matrix.pytest_extra_flags }}'
 
+      - name: On Failure, upload vcpkg logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs_${{ matrix.os }}_${{ github.event.pull_request.head.sha }}
+          path: vcpkg/buildtrees/**/*.log
+
+      - name: Cache dependencies
+        # Don't save if it's the exact same
+        if: steps.cache-restore.outputs.cache-matched-key != format('{0}-{1}-{2}', matrix.os, hashFiles('vcpkg.json'), hashFiles('vcpkg_installed/**/vcpkg_abi_info.txt'))
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+          key: ${{ matrix.os }}-${{ hashFiles('vcpkg.json') }}-${{ hashFiles('vcpkg_installed/**/vcpkg_abi_info.txt') }}
+
+      - name: Install python packages
+        shell: bash
+        run: |
+          vcpkg_installed/${{ matrix.triplet }}/tools/python3/${{ matrix.python }} -m ensurepip --upgrade
+          vcpkg_installed/${{ matrix.triplet }}/tools/python3/${{ matrix.python }} -m pip install -r python/dev_requirements.txt
+
       - name: cmake build
         shell: bash
         run: |
@@ -193,7 +150,7 @@ jobs:
       - name: Run Python tests
         shell: bash
         run: |
-          export PATH="$PATH:$VCPKG_INSTALLATION_ROOT/installed/${{ matrix.triplet }}/bin"
+          export PATH="$PATH:$GITHUB_WORKSPACE/vcpkg_installed/${{ matrix.triplet }}/bin"
           cmake --build build --target python-install
           cmake --build build --target python-test
           cmake --build build --target python-test-unstable

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -89,7 +89,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: pierotofy/set-swap-space@master
         with:
-          swap-size-gb: 6
+          swap-size-gb: 7
 
       - name: cmake config
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 .vscode
 .env
 /.vs/
+vcpkg_installed/
 /CMakeSettings.json
 # for QtCreator:
 CMakeLists.txt.user*

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -289,58 +289,50 @@ or
 when importing GTSAM using the python wrapper.
 
 
-## Compile gtsam with vcpkg. (For linux/wsl)
-Install python dependencies + ninja + build essential in linux:   
-```
+## Compile gtsam with vcpkg
+
+vcpkg is an easy, cross-platform way to install all the dependencies gtsam uses, including Boost, MKL, and pybind11. It will calculate the proper [triplet for your system](https://learn.microsoft.com/en-us/vcpkg/concepts/triplets), like x64-linux, x64-windows, or arm64-osx, and install dependencies accordingly. That triplet will be referred to as `<triplet>` in this guide.
+
+To get started, install some base dependencies.
+
+On Linux, install Python dependencies + ninja + build-essential:
+
+```bash
 sudo apt update
 sudo apt-get install autoconf automake autoconf-archive ninja-build build-essential -y
 ```
 
-On your home dir near gtsam dir:   
-Setup vcpkg   
+On Windows, see [the Prerequisites section earlier](#Prerequisites).
+
+On Mac, install Python dependencies + ninja:
+
+```bash
+brew install autoconf autoconf-archive automake libtool
+```
+
+Go to your gtsam folder `cd gtsam`, and set up vcpkg:
+
 ```bash
 git clone https://github.com/microsoft/vcpkg
-cd vcpkg
-./bootstrap-vcpkg.sh
+./vcpkg/bootstrap-vcpkg.sh # or ./vcpkg/bootstrap-vcpkg.bat on Windows
 ```
 
-vcpkg install dependencies   
-on vcpkg dir:   
+Setup vcpkg and Python dependencies
+
 ```bash
-./vcpkg x-set-installed         \
-          boost-assign          \
-          boost-bimap           \
-          boost-chrono          \
-          boost-date-time       \
-          boost-filesystem      \
-          boost-format          \
-          boost-graph           \
-          boost-math            \
-          boost-program-options \
-          boost-regex           \
-          boost-serialization   \
-          boost-system          \
-          boost-thread          \
-          boost-timer           \
-          tbb                   \
-          pybind11
+./vcpkg/vcpkg install
+# The Python executable is called python, not python3 on Windows
+./vcpkg_installed/<triplet>/tools/python3/python3 -m ensurepip --upgrade
+./vcpkg_installed/<triplet>/tools/python3/python3 -m pip install -r python/dev_requirements.txt
 ```
 
-Setup python dependencies   
-Go to your gtsam folder `cd gtsam`:   
-```bash
-../vcpkg/installed/x64-linux/tools/python3/python3 -m ensurepip --upgrade
-../vcpkg/installed/x64-linux/tools/python3/python3 -m pip install -r python/dev_requirements.txt
-```
-
-Cmake config:   
-In gtsam folder   
+Configure CMake build:
 ```bash
 cmake -B build -G Ninja \
-    -DCMAKE_TOOLCHAIN_FILE=../scripts/buildsystems/vcpkg.cmake \
-    -DVCPKG_INSTALLED_DIR=../installed \
-    -DVCPKG_TARGET_TRIPLET=x64-linux \
-    -DVCPKG_HOST_TRIPLET=x64-linux \
+    -DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake \
+    -DVCPKG_INSTALLED_DIR=vcpkg_installed \
+    -DVCPKG_TARGET_TRIPLET=<triplet> \
+    -DVCPKG_HOST_TRIPLET=<triplet> \
     -DCMAKE_BUILD_TYPE=Release \
     -DGTSAM_BUILD_EXAMPLES_ALWAYS=ON \
     -DGTSAM_ROT3_EXPMAP=ON \
@@ -355,22 +347,32 @@ cmake -B build -G Ninja \
     -DGTSAM_SUPPORT_NESTED_DISSECTION=ON
 ```
 
-cmake compile:   
-In gtsam folder:   
+Build gtsam:
+
 ```bash
 cmake --build build
 ```
 
-Run python tests:   
+Add vcpkg libraries to PATH:
+
+Linux/Mac:
+```bash
+export PATH="$PATH:/path/to/gtsam/vcpkg_installed/<triplet>/bin"
 ```
-VCPKG_INSTALLATION_ROOT=<abs path to vcpkg root dir>
-export PATH="$PATH:$VCPKG_INSTALLATION_ROOT/installed/x64-linux/bin"
+
+Windows (PowerShell):
+```pwsh
+$env:Path = "$env:Path;\path\to\gtsam\vcpkg_installed\<triplet>\bin"
+```
+
+Run Python tests:
+```bash
 cmake --build build --target python-install
 cmake --build build --target python-test
 cmake --build build --target python-test-unstable
 ```
 
-Run gtsam tests:   
+Run gtsam tests:
 ```bash
 cmake --build build --target check
 ```

--- a/cmake/HandleBoost.cmake
+++ b/cmake/HandleBoost.cmake
@@ -39,6 +39,7 @@ endif()
 ################################################################################
 
 # Set minimum required Boost version and components.
+# Note: Keep this in sync with vcpkg.json.
 # optional, program_options, random, range are all used in tests/examples/Python, but are not library dependencies. timer/chrono is used conditionally.
 # concept_check, fusion, move, phoenix, pool, smart_ptr, spirit, tokenizer, type_traits, optional, range are header only and are not components.
 set(BOOST_FIND_MINIMUM_VERSION 1.70)

--- a/doc/workflows.md
+++ b/doc/workflows.md
@@ -12,7 +12,12 @@ The `.github/workflows` directory contains definitions for the various CI/CD pro
 -   **`build-python.yml`**: Verifies the Python wrapper compilation across Linux, macOS, and Windows.
 -   **`build-cibw.yml`**: Builds distributable Python wheels using `cibuildwheel`. It builds dependencies (like Boost) from source to ensure ABI compatibility.
 -   **`prod-cibw.yml`**: Used for production wheel builds (often triggered on release).
+-   **`vcpkg.yml`**: Compiles and tests GTSAM on Linux, macOS, and Windows using `vcpkg` to install all dependencies.
 -   **`deploy.yml`**: Handles deployment tasks (e.g., docs, release artifacts).
+
+## Updating vcpkg dependencies
+
+`vcpkg` supports a manifest in the form of `vcpkg.json`, which specifies all the dependencies to install, and a "baseline", which is just a commit hash from https://github.com/microsoft/vcpkg. Instead of upgrading individual library versions which might be incompatible, you upgrade baselines, which are a set of library versions that have been tested to work together. This also means library versions are pinned to the baseline, so the baseline needs to periodically updated to get the latest libraries. Updating is not *strictly* necessary, as old library versions should work for a while, but it can be good to ensure compatibility with the latest libraies. To update the baseline, simply go to https://github.com/microsoft/vcpkg and copy the full commit hash for the version you want (could be HEAD for the day, or if you prefer tags, you can use the commit hash for a tag instead) and update the `builtin-baseline` field in `vcpkg.json` at the root of this repo.
 
 ## Docker CI Images (Linux Only)
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "$baseline_comment": [
+    "`builtin-baseline` pins the vcpkg *registry snapshot* (a commit in the vcpkg repo).",
+    "It makes dependency resolution reproducible across machines/CI.",
+    "Policy suggestion for GTSAM: only bump this SHA in a dedicated PR (with CI green), so upgrades are deliberate.",
+    "Current commit is from 2025-01-16."
+  ],
+  "builtin-baseline": "66c0373dc7fca549e5803087b9487edfe3aca0a1",
+
+  "dependencies": [
+    {
+      "$mkl_comment": [
+        "MKL is only used on Windows/Linux (not macOS).",
+        "The platform expression uses OR; `windows,linux` is equivalent to `windows | linux`.",
+        "If we later want a different BLAS/LAPACK backend on macOS, add it as a separate dependency with `platform: osx`."
+      ],
+      "name": "intel-mkl",
+      "platform": "windows | linux"
+    },
+    "tbb",
+    "pybind11",
+    "geographiclib",
+    "eigen3",
+    "boost-concept-check",
+    "boost-fusion",
+    "boost-graph",
+    "boost-move",
+    "boost-optional",
+    "boost-phoenix",
+    "boost-pool",
+    "boost-program-options",
+    "boost-random",
+    "boost-range",
+    "boost-serialization",
+    "boost-smart-ptr",
+    "boost-spirit",
+    "boost-timer",
+    "boost-tokenizer",
+    "boost-type-traits"
+  ]
+}


### PR DESCRIPTION
[vcpkg manifest mode is the recommended way to use vcpkg.](https://learn.microsoft.com/en-us/vcpkg/concepts/manifest-mode) The main benefit is being able to pin dependencies for reproducible builds, so if something fails in CI, you can just `./vcpkg install` and start diagnosing sooner and not have to worry about pulling in a different set of dependencies, or worse, running CI over and over again. It also prevents CI failures from dependencies updating beneath you and then having to deal with that while you have an unrelated PR ready. Random CI failures don't make for a good developer experience when you're trying to get work done. One of the motivators behind this PR was watching you repeatedly disable and enable Eigen because they kept force pushing tags...

It does require manual updates, but that's always the tradeoff when you pin dependencies.  When you choose to update is up to you. You could update on every new Boost version, only when someone reports an issue with a new Boost version, etc. Speaking from experience, you could stay on the same version for over a year if you want. You don't _need_ to be on the latest version of all the libraries, all the time. Like I mentioned before, that tends to end up being a recipe for CI failing on some random day in the future until you fix it immediately, which is no good for getting work done. Pinning reduces the risk that a dependency updates between a PR passing and then getting merged, which could cause the CI to fail on subsequent PRs (and on the main branch) until someone is forced to fix it. Updating libraries should be done with thought and good reasoning. Update when you think it's a good time to, instead of being forced to by external forces, and then having to scramble to fix it.

Other nice things about a manifest include allowing developers to more easily set up a full gtsam build with Boost, pybind11, and friends by using that same `./vcpkg install` invocation. The installation doc has been updated to reflect that as well. It's definitely much easier than having to hunt down all the dependencies yourself, especially on Windows, which has no package manager.

This also changes the vcpkg caching mechanism to also include a hash of the manifest file itself in order to purge out the old cache. The current caching mechanism will cause the cache to only grow in size, since the binary cache is never cleared of old packages. The current cache has about 1.2 GB (~400 MB per platform) of dead weight in old binary packages. Working around that is... tricky, since vcpkg doesn't include a way to purge old binaries, so I figured a good compromise would be to make it so that updating the manifest would clear out everything, since you're likely going to be requesting a new set of libraries if you do that, so may as well get rid of the old cached ones. This is actually the main reason for this PR. The alternative would've been to have a maintainer just... click the delete button on caches, or wait a week for the cache to expire. But that's kinda silly, and I personally think the overall benefits of manifest mode outweigh having to just update the baseline every once in a while.