### PR TITLE
Clean up Boost dependencies

### DIFF
--- a/cmake/HandleBoost.cmake
+++ b/cmake/HandleBoost.cmake
@@ -39,11 +39,10 @@ endif()
 ################################################################################
 
 # Set minimum required Boost version and components.
-# NOTE: "system" is intentionally omitted. It is a transitive dependency of other
-# components (like filesystem) and will be found automatically. Explicitly
-# requesting it can cause issues with modern header-only versions of Boost.
+# optional, program_options, random, range are all used in tests/examples/Python, but are not library dependencies. timer/chrono is used conditionally.
+# concept_check, fusion, move, phoenix, pool, smart_ptr, spirit, tokenizer, type_traits, optional, range are header only and are not components.
 set(BOOST_FIND_MINIMUM_VERSION 1.70)
-set(BOOST_FIND_MINIMUM_COMPONENTS serialization filesystem thread program_options date_time timer chrono regex)
+set(BOOST_FIND_MINIMUM_COMPONENTS graph serialization program_options random timer chrono)
 
 # Find the Boost package. On systems with modern installations (vcpkg, Homebrew),
 # this will use CMake's "Config mode". With manual installations (especially on
@@ -52,22 +51,15 @@ find_package(Boost ${BOOST_FIND_MINIMUM_VERSION} REQUIRED
              COMPONENTS ${BOOST_FIND_MINIMUM_COMPONENTS}
              )
 
+set(GTSAM_BOOST_LIBRARIES Boost::graph Boost::serialization)
 # Verify that the required Boost component targets were successfully found and imported.
-foreach(_t IN ITEMS Boost::serialization Boost::filesystem Boost::thread Boost::date_time)
+foreach(_t IN ITEMS ${GTSAM_BOOST_LIBRARIES})
   if(NOT TARGET ${_t})
     message(FATAL_ERROR "Missing required Boost component target: ${_t}. Please install/upgrade Boost or set BOOST_ROOT/Boost_DIR correctly.")
   endif()
 endforeach()
 
 option(GTSAM_DISABLE_NEW_TIMERS "Disables using Boost.chrono for timing" OFF)
-
-set(GTSAM_BOOST_LIBRARIES
-  Boost::serialization
-  Boost::filesystem
-  Boost::thread
-  Boost::date_time
-  Boost::regex
-)
 
 if(GTSAM_DISABLE_NEW_TIMERS)
   message("WARNING:  GTSAM timing instrumentation manually disabled")

--- a/gtsam/base/serializationTestHelpers.h
+++ b/gtsam/base/serializationTestHelpers.h
@@ -23,6 +23,7 @@
 
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
 
+#include <filesystem>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -31,7 +32,6 @@
 #include <gtsam/base/TestableAssertions.h>
 
 #include <boost/serialization/serialization.hpp>
-#include <boost/filesystem.hpp>
 
 
 // whether to print the serialized text to stdout
@@ -47,10 +47,10 @@ T create() {
 }
 
 // Creates or empties a folder in the build folder and returns the relative path
-inline boost::filesystem::path resetFilesystem(
-    boost::filesystem::path folder = "actual") {
-  boost::filesystem::remove_all(folder);
-  boost::filesystem::create_directory(folder);
+inline std::filesystem::path resetFilesystem(
+    std::filesystem::path folder = "actual") {
+  std::filesystem::remove_all(folder);
+  std::filesystem::create_directory(folder);
   return folder;
 }
 
@@ -65,7 +65,7 @@ void roundtrip(const T& input, T& output) {
 // Templated round-trip serialization using a file
 template<class T>
 void roundtripFile(const T& input, T& output) {
-  boost::filesystem::path path = resetFilesystem()/"graph.dat";
+  std::filesystem::path path = resetFilesystem()/"graph.dat";
   serializeToFile(input, path.string());
   deserializeFromFile(path.string(), output);
 }
@@ -106,7 +106,7 @@ void roundtripXML(const T& input, T& output) {
 // Templated round-trip serialization using XML File
 template<class T>
 void roundtripXMLFile(const T& input, T& output) {
-  boost::filesystem::path path = resetFilesystem()/"graph.xml";
+  std::filesystem::path path = resetFilesystem()/"graph.xml";
   serializeToXMLFile(input, path.string());
   deserializeFromXMLFile(path.string(), output);
 }
@@ -147,7 +147,7 @@ void roundtripBinary(const T& input, T& output) {
 // Templated round-trip serialization using Binary file
 template<class T>
 void roundtripBinaryFile(const T& input, T& output) {
-  boost::filesystem::path path = resetFilesystem()/"graph.bin";
+  std::filesystem::path path = resetFilesystem()/"graph.bin";
   serializeToBinaryFile(input, path.string());
   deserializeFromBinaryFile(path.string(), output);
 }

--- a/gtsam_unstable/linear/QPSParser.cpp
+++ b/gtsam_unstable/linear/QPSParser.cpp
@@ -32,7 +32,6 @@
 
 #include <boost/fusion/include/vector.hpp>
 #include <boost/fusion/sequence.hpp>
-#include <boost/lambda/lambda.hpp>
 #include <boost/phoenix/bind.hpp>
 #include <boost/spirit/include/classic.hpp>
 #include <boost/spirit/include/qi.hpp>

--- a/gtsam_unstable/slam/tests/testSerialization.cpp
+++ b/gtsam_unstable/slam/tests/testSerialization.cpp
@@ -17,8 +17,7 @@
 
 #include <CppUnitLite/TestHarness.h>
 
-#include <boost/filesystem.hpp>
-
+#include <filesystem>
 #include <iostream>
 #include <cstdlib>
 #include <fstream>
@@ -26,7 +25,7 @@
 
 using namespace std;
 using namespace gtsam;
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 #ifdef TOPSRCDIR
 static string topdir = TOPSRCDIR;
 #else


### PR DESCRIPTION
Split from #2388. Replaces Boost.Filesystem with `std::filesystem`, available since C++17 and [widely available across compilers](https://en.cppreference.com/w/cpp/compiler_support/17.html). Removes checks for Boost.Thread, Boost.Regex, and Boost.DateTime since none of those are used, and adds checks for Boost.Graph and Boost.Random. Also removes an unused Boost.Lambda include.