### PR TITLE
removed unnecessary DiscreteKeys constructor

### DIFF
--- a/gtsam/discrete/DiscreteKey.h
+++ b/gtsam/discrete/DiscreteKey.h
@@ -43,9 +43,6 @@ namespace gtsam {
     // Forward all constructors.
     using std::vector<DiscreteKey>::vector;
 
-    /// Constructor for serialization
-    DiscreteKeys() : std::vector<DiscreteKey>::vector() {}
-
     /// Construct from a key
     explicit DiscreteKeys(const DiscreteKey& key) { push_back(key); }
 


### PR DESCRIPTION
Since the constructors for `std::vector<DiscreteKey>::vector are all forwarded already, this line was unnecessary.