### PR TITLE
Fix wrap w/o boost

### DIFF
--- a/.github/scripts/python.sh
+++ b/.github/scripts/python.sh
@@ -24,6 +24,7 @@ if [ -z ${PYTHON_VERSION+x} ]; then
 fi
 
 export PYTHON="python${PYTHON_VERSION}"
+NO_BOOST_BUILD=OFF
 
 function install_dependencies()
 {
@@ -45,10 +46,17 @@ function build()
 {
   export CMAKE_GENERATOR=Ninja
   BUILD_PYBIND="ON"
+  USE_BOOST_FEATURES="ON"
+  ENABLE_BOOST_SERIALIZATION="ON"
+
+  if [ "${NO_BOOST_BUILD}" == "ON" ]; then
+    USE_BOOST_FEATURES="OFF"
+    ENABLE_BOOST_SERIALIZATION="OFF"
+  fi
 
   # Add Boost hints on Windows
   BOOST_CMAKE_ARGS=""
-  if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" || "$OSTYPE" == "cygwin" ]]; then
+  if [ "${NO_BOOST_BUILD}" != "ON" ] && [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" || "$OSTYPE" == "cygwin" ]]; then
     if [ -n "${BOOST_ROOT}" ]; then
      BOOST_ROOT_UNIX=$(echo "$BOOST_ROOT" | sed 's/\\/\//g')
      BOOST_CMAKE_ARGS="-DBOOST_ROOT=${BOOST_ROOT_UNIX} -DBOOST_INCLUDEDIR=${BOOST_ROOT_UNIX}/include -DBOOST_LIBRARYDIR=${BOOST_ROOT_UNIX}/lib"
@@ -68,20 +76,28 @@ function build()
       -DGTSAM_UNSTABLE_BUILD_PYTHON=${GTSAM_BUILD_UNSTABLE:-ON} \
       -DGTSAM_PYTHON_VERSION=$PYTHON_VERSION \
       -DPYTHON_EXECUTABLE:FILEPATH=$(which $PYTHON) \
-      -DGTSAM_USE_BOOST_FEATURES=ON \
-      -DGTSAM_ENABLE_BOOST_SERIALIZATION=ON \
+      -DGTSAM_USE_BOOST_FEATURES=${USE_BOOST_FEATURES} \
+      -DGTSAM_ENABLE_BOOST_SERIALIZATION=${ENABLE_BOOST_SERIALIZATION} \
       -DGTSAM_ALLOW_DEPRECATED_SINCE_V43=OFF \
       -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/gtsam_install \
       $BOOST_CMAKE_ARGS
 
-  # Set to 2 cores so that Actions does not error out during resource provisioning.
-  cmake --build build -j2
-
-  cmake --build build --target python-install
+  if [ "${NO_BOOST_BUILD}" == "ON" ]; then
+    # Build only wrapper targets for the no-Boost verification lane.
+    cmake --build build -j2 --target gtsam_py gtsam_unstable_py
+  else
+    # Set to 2 cores so that Actions does not error out during resource provisioning.
+    cmake --build build -j2
+    cmake --build build --target python-install
+  fi
 }
 
 function test()
 {
+  if [ "${NO_BOOST_BUILD}" == "ON" ]; then
+    export PYTHONPATH="$GITHUB_WORKSPACE/build/python:$PYTHONPATH"
+  fi
+
   cd $GITHUB_WORKSPACE/python/gtsam/tests
   $PYTHON -m unittest discover -v
   cd $GITHUB_WORKSPACE
@@ -94,8 +110,30 @@ function test()
   # cmake --build build --target python-test-unstable
 }
 
+# Parse optional flags.
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 {-d|-b|-t} [--no-boost]"
+  exit 2
+fi
+
+ACTION="$1"
+shift
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --no-boost)
+      NO_BOOST_BUILD=ON
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 2
+      ;;
+  esac
+  shift
+done
+
 # select between build or test
-case $1 in
+case $ACTION in
   -d)
     install_dependencies
     ;;

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -61,6 +61,7 @@ jobs:
         name:
           [
             ubuntu-22.04-gcc-11,
+            ubuntu-22.04-gcc-11-noboost,
             ubuntu-22.04-clang-11,
             macos-14-xcode-15.4,
             macos-15-xcode-16,
@@ -71,6 +72,11 @@ jobs:
         python_version: [3]
         include:
           - name: ubuntu-22.04-gcc-11
+            os: ubuntu-22.04
+            compiler: gcc
+            version: "11"
+
+          - name: ubuntu-22.04-gcc-11-noboost
             os: ubuntu-22.04
             compiler: gcc
             version: "11"
@@ -113,7 +119,11 @@ jobs:
           fi
 
           sudo apt-get -y update
-          sudo apt-get -y install cmake build-essential pkg-config libpython3-dev python3-numpy libboost-all-dev ninja-build
+          if [ "${{ matrix.name }}" = "ubuntu-22.04-gcc-11-noboost" ]; then
+            sudo apt-get -y install cmake build-essential pkg-config libpython3-dev python3-numpy ninja-build
+          else
+            sudo apt-get -y install cmake build-essential pkg-config libpython3-dev python3-numpy libboost-all-dev ninja-build
+          fi
 
           if [ "${{ matrix.compiler }}" = "gcc" ]; then
             sudo apt-get install -y g++-${{ matrix.version }} g++-${{ matrix.version }}-multilib
@@ -220,10 +230,24 @@ jobs:
 
       - name: Build
         shell: bash
+        if: matrix.name != 'ubuntu-22.04-gcc-11-noboost'
         run: |
           bash .github/scripts/python.sh -b
 
-      - name: Test
+      - name: Build (No Boost Wrapper Check)
+        if: matrix.name == 'ubuntu-22.04-gcc-11-noboost'
         shell: bash
         run: |
+          bash .github/scripts/python.sh -b --no-boost
+
+      - name: Test
+        shell: bash
+        if: matrix.name != 'ubuntu-22.04-gcc-11-noboost'
+        run: |
           bash .github/scripts/python.sh -t
+
+      - name: Test (No Boost Wrapper Check)
+        if: matrix.name == 'ubuntu-22.04-gcc-11-noboost'
+        shell: bash
+        run: |
+          bash .github/scripts/python.sh -t --no-boost

--- a/python/gtsam/gtsam.tpl
+++ b/python/gtsam/gtsam.tpl
@@ -22,7 +22,9 @@
 
 // These are the included headers listed in `gtsam.i`
 {includes}
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/export.hpp>
+#endif
 
 // Export classes for serialization
 {boost_class_export}
@@ -47,4 +49,3 @@ namespace py = pybind11;
 {wrapped_namespace}
 
 }}
-

--- a/python/gtsam/tests/test_PseudorangeFactor.py
+++ b/python/gtsam/tests/test_PseudorangeFactor.py
@@ -30,26 +30,27 @@ class TestPseudorangeFactor(GtsamTestCase):
         factor.print("factor")
 
     def test_errors(self):
-        satpos = np.array([0.0, 0.0, 3.0])
+        sat_pos = np.array([0.0, 0.0, 3.0])
         model = gtsam.noiseModel.Unit.Create(1)
-        factor = gtsam.PseudorangeFactor(0, 1, 4.0, satpos, 0.0, model)
+        factor = gtsam.PseudorangeFactor(0, 1, 4.0, sat_pos, 0.0, model)
         error = factor.evaluateError(np.zeros(3), 0.0)
         self.assertEqual(error[0], -1.0)
 
     def test_equality(self):
-        satpos = np.array([0.0, 0.0, 3.0])
+        sat_pos = np.array([0.0, 0.0, 3.0])
         model = gtsam.noiseModel.Unit.Create(1)
-        factor1 = gtsam.PseudorangeFactor(0, 1, 4.0, satpos, 0.0, model)
-        factor2 = gtsam.PseudorangeFactor(2, 1, 4.0, satpos, 0.0, model)
-        factor3 = gtsam.PseudorangeFactor(0, 1, 40.0, satpos, 10.0, model)
+        factor1 = gtsam.PseudorangeFactor(0, 1, 4.0, sat_pos, 0.0, model)
+        factor2 = gtsam.PseudorangeFactor(2, 1, 4.0, sat_pos, 0.0, model)
+        factor3 = gtsam.PseudorangeFactor(0, 1, 40.0, sat_pos, 10.0, model)
         self.assertTrue(factor1.equals(factor1, 1e-6))
         self.assertFalse(factor1.equals(factor2, 1e-6))
         self.assertTrue(factor1.equals(factor3, 1e99))
 
+    @unittest.skipUnless(hasattr(gtsam.PseudorangeFactor, "serialize"), "Serialization not enabled")
     def test_serialization(self):
-        satpos = np.array([0.0, 0.0, 3.0])
+        sat_pos = np.array([0.0, 0.0, 3.0])
         model = gtsam.noiseModel.Unit.Create(1)
-        factor = gtsam.PseudorangeFactor(0, 1, 4.0, satpos, 0.0, model)
+        factor = gtsam.PseudorangeFactor(0, 1, 4.0, sat_pos, 0.0, model)
         factor.serialize()
 
 

--- a/python/gtsam_unstable/gtsam_unstable.tpl
+++ b/python/gtsam_unstable/gtsam_unstable.tpl
@@ -18,7 +18,9 @@
 
 // These are the included headers listed in `gtsam_unstable.i`
 {includes}
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/export.hpp>
+#endif
 
 {boost_class_export}
 
@@ -39,4 +41,3 @@ PYBIND11_MODULE({module_name}, m_) {{
 #include "python/gtsam_unstable/specializations/gtsam_unstable.h"
 
 }}
-


### PR DESCRIPTION
Building the python wrapper without boost installed failed even when we turned off boost during CMake. The reason is that the templates still include an unguarded boost header. I fixed that and also added a path to the CI to exercise this combination. 