### PR TITLE
Remove macOS 14 from CI

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -31,39 +31,33 @@ jobs:
         # Github Actions requires a single row to be added to the build matrix.
         # See https://help.github.com/en/articles/workflow-syntax-for-github-actions.
         name: [
-          macos-14-xcode-15.4,
           macos-15-xcode-16,
-          macos-14-xcode-15.4-boost,
-          macos-14-xcode-15.4-geographiclib,
+          macos-15-xcode-16-boost,
+          macos-15-xcode-16-geographiclib,
         ]
 
         build_type: [Debug, Release]
         build_unstable: [ON]
         include:
-          - name: macos-14-xcode-15.4
-            os: macos-14
-            compiler: xcode
-            version: "15.4"
-
           - name: macos-15-xcode-16
             os: macos-15
             compiler: xcode
             version: "16"
 
-          - name: macos-14-xcode-15.4-boost
-            os: macos-14
+          - name: macos-15-xcode-16-boost
+            os: macos-15
             compiler: xcode
-            version: "15.4"
+            version: "16"
 
-          - name: macos-14-xcode-15.4-geographiclib
-            os: macos-14
+          - name: macos-15-xcode-16-geographiclib
+            os: macos-15
             compiler: xcode
-            version: "15.4"
+            version: "16"
 
         exclude:
-          - name: macos-14-xcode-15.4-boost
+          - name: macos-15-xcode-16-boost
             build_type: Debug
-          - name: macos-14-xcode-15.4-geographiclib
+          - name: macos-15-xcode-16-geographiclib
             build_type: Debug
 
     steps:

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -63,7 +63,6 @@ jobs:
             ubuntu-22.04-gcc-11,
             ubuntu-22.04-gcc-11-noboost,
             ubuntu-22.04-clang-11,
-            macos-14-xcode-15.4,
             macos-15-xcode-16,
             windows-2022-msvc,
           ]
@@ -85,11 +84,6 @@ jobs:
             os: ubuntu-22.04
             compiler: clang
             version: "11"
-
-          - name: macos-14-xcode-15.4
-            os: macos-14
-            compiler: xcode
-            version: "15.4"
 
           - name: macos-15-xcode-16
             os: macos-15

--- a/.github/workflows/time-sfmbal-benchmark-runner.yml
+++ b/.github/workflows/time-sfmbal-benchmark-runner.yml
@@ -263,7 +263,7 @@ jobs:
 
   benchmark_macos_arm64:
     if: inputs.runner_id == 'macos-arm64'
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Checkout target ref
         uses: actions/checkout@v4


### PR DESCRIPTION
EOL by the end of this year: see https://github.com/actions/runner-images/issues/13518. Removing these jobs also helps to unjam CI, and we have coverage for newer Mac compilers in other places.

This will require the required macOS 14 job to be updated to macOS 15 and Xcode 16; sorry for the two required job changes in a row!🥲 