### PR TITLE
Optimize cibuildwheel build times

### DIFF
--- a/.github/scripts/python_wheels/cibw_before_all.sh
+++ b/.github/scripts/python_wheels/cibw_before_all.sh
@@ -33,9 +33,13 @@ BOOST_PREFIX="$HOME/opt/boost"
 ./bootstrap.sh --prefix=${BOOST_PREFIX}
 
 if [ "$(uname)" == "Linux" ]; then
-    ./b2 install --prefix=${BOOST_PREFIX} --with=all -d0
+    ./b2 install --prefix=${BOOST_PREFIX} -d0 --with-graph \
+        --with-move --with-optional --with-program_options --with-random \
+        --with-serialization --with-smart_ptr --with-timer --with-chrono
 elif [ "$(uname)" == "Darwin" ]; then
-    ./b2 install --prefix=${BOOST_PREFIX} --with=all -d0 \
+    ./b2 install --prefix=${BOOST_PREFIX} -d0 --with-graph \
+        --with-move --with-optional --with-program_options --with-random \
+        --with-serialization --with-smart_ptr --with-timer --with-chrono \
         cxxflags="-mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}" \
         linkflags="-mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}"
 fi

--- a/.github/scripts/python_wheels/cibw_before_all.sh
+++ b/.github/scripts/python_wheels/cibw_before_all.sh
@@ -8,7 +8,6 @@ set -x
 
 PYTHON_VERSION="$1"
 PROJECT_DIR="$2"
-ARCH=$(uname -m)
 
 export PYTHON="python${PYTHON_VERSION}"
 
@@ -40,8 +39,19 @@ elif [ "$(uname)" == "Darwin" ]; then
     ./b2 install --prefix=${BOOST_PREFIX} -d0 --with-graph \
         --with-move --with-optional --with-program_options --with-random \
         --with-serialization --with-smart_ptr --with-timer --with-chrono \
+        architecture=arm \
         cxxflags="-mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}" \
         linkflags="-mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}"
+    ./b2 install --prefix=${BOOST_PREFIX}/x86 -d0 --with-graph \
+        --with-move --with-optional --with-program_options --with-random \
+        --with-serialization --with-smart_ptr --with-timer --with-chrono \
+        architecture=x86 \
+        cxxflags="-mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}" \
+        linkflags="-mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}"
+    for dylib in ${BOOST_PREFIX}/lib/*.dylib; do
+        lipo -create -output $dylib $dylib ${BOOST_PREFIX}/x86/lib/$(basename $dylib)
+    done
+    rm -r ${BOOST_PREFIX}/x86
 fi
 cd ..
 
@@ -71,6 +81,7 @@ rm -rf CMakeCache.txt CMakeFiles
 cmake $PROJECT_DIR \
     -B build \
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
+    -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
     -DGTSAM_BUILD_TESTS=OFF \
     -DGTSAM_BUILD_UNSTABLE=${GTSAM_BUILD_UNSTABLE:-ON} \
     -DGTSAM_USE_QUATERNIONS=OFF \

--- a/.github/workflows/build-cibw.yml
+++ b/.github/workflows/build-cibw.yml
@@ -33,11 +33,6 @@ jobs:
         include:
           # Linux x86_64
           - os: ubuntu-latest
-            python_version: "3.10"
-            cibw_python_version: 310
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-          - os: ubuntu-latest
             python_version: "3.11"
             cibw_python_version: 311
             platform_id: manylinux_x86_64
@@ -50,16 +45,16 @@ jobs:
           - os: ubuntu-latest
             python_version: "3.13"
             cibw_python_version: 313
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python_version: "3.14"
+            cibw_python_version: 314
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
 
           # Linux aarch64
           - os: ubuntu-24.04-arm
-            python_version: "3.10"
-            cibw_python_version: 310
-            platform_id: manylinux_aarch64
-            manylinux_image: manylinux2014
-          - os: ubuntu-24.04-arm
             python_version: "3.11"
             cibw_python_version: 311
             platform_id: manylinux_aarch64
@@ -72,15 +67,16 @@ jobs:
           - os: ubuntu-24.04-arm
             python_version: "3.13"
             cibw_python_version: 313
+            platform_id: manylinux_aarch64
+            manylinux_image: manylinux2014
+          - os: ubuntu-24.04-arm
+            python_version: "3.14"
+            cibw_python_version: 314
             platform_id: manylinux_aarch64
             manylinux_image: manylinux2014
 
           # MacOS arm64
           - os: macos-latest
-            python_version: "3.10"
-            cibw_python_version: 310
-            platform_id: macosx_universal2
-          - os: macos-latest
             python_version: "3.11"
             cibw_python_version: 311
             platform_id: macosx_universal2
@@ -91,6 +87,10 @@ jobs:
           - os: macos-latest
             python_version: "3.13"
             cibw_python_version: 313
+            platform_id: macosx_universal2
+          - os: macos-latest
+            python_version: "3.14"
+            cibw_python_version: 314
             platform_id: macosx_universal2
 
     steps:
@@ -164,6 +164,17 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
 
         run: bash .github/scripts/python_wheels/build_wheels.sh
+
+      - name: Test wheel
+        run: |
+          python3 -m pip install wheelhouse/*.whl
+          python3 -c "import platform; print(platform.machine()); import gtsam"
+          if [ "$RUNNER_OS" == "macOS" ]; then
+            # Uninstall numpy and reinstall wheel to get x86 numpy for smoke test
+            arch -x86_64 python3 -m pip uninstall -y numpy
+            arch -x86_64 python3 -m pip install wheelhouse/*.whl
+            arch -x86_64 python3 -c "import platform; print(platform.machine()); import gtsam;"
+          fi
 
       - name: Store artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-cibw.yml
+++ b/.github/workflows/build-cibw.yml
@@ -132,9 +132,9 @@ jobs:
           python3 -m pip install -r python/dev_requirements.txt
           if [ "$RUNNER_OS" == "Linux" ]; then
             sudo apt update
-            sudo apt-get install -y wget libicu-dev python3-pip python3-setuptools libboost-all-dev
+            sudo apt-get install -y libicu-dev python3-pip python3-setuptools libboost-all-dev
           elif [ "$RUNNER_OS" == "macOS" ]; then
-            brew install wget icu4c boost python-setuptools
+            brew install boost python-setuptools
           else
             echo "$RUNNER_OS not supported"
             exit 1

--- a/.github/workflows/build-cibw.yml
+++ b/.github/workflows/build-cibw.yml
@@ -75,41 +75,23 @@ jobs:
             platform_id: manylinux_aarch64
             manylinux_image: manylinux2014
 
-          # MacOS x86_64
-          - os: macos-15-intel
-            python_version: "3.10"
-            cibw_python_version: 310
-            platform_id: macosx_x86_64
-          - os: macos-15-intel
-            python_version: "3.11"
-            cibw_python_version: 311
-            platform_id: macosx_x86_64
-          - os: macos-15-intel
-            python_version: "3.12"
-            cibw_python_version: 312
-            platform_id: macosx_x86_64
-          - os: macos-15-intel
-            python_version: "3.13"
-            cibw_python_version: 313
-            platform_id: macosx_x86_64
-
           # MacOS arm64
           - os: macos-latest
             python_version: "3.10"
             cibw_python_version: 310
-            platform_id: macosx_arm64
+            platform_id: macosx_universal2
           - os: macos-latest
             python_version: "3.11"
             cibw_python_version: 311
-            platform_id: macosx_arm64
+            platform_id: macosx_universal2
           - os: macos-latest
             python_version: "3.12"
             cibw_python_version: 312
-            platform_id: macosx_arm64
+            platform_id: macosx_universal2
           - os: macos-latest
             python_version: "3.13"
             cibw_python_version: 313
-            platform_id: macosx_arm64
+            platform_id: macosx_universal2
 
     steps:
       - name: Checkout
@@ -164,6 +146,7 @@ jobs:
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}
           CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.manylinux_image }}
           CIBW_ARCHS: all
+          CIBW_ARCHS_MACOS: universal2
           CIBW_ENVIRONMENT_PASS_LINUX: DEVELOP TIMESTAMP
 
           # Set the minimum required MacOS version for the wheels.

--- a/.github/workflows/build-cibw.yml
+++ b/.github/workflows/build-cibw.yml
@@ -131,6 +131,7 @@ jobs:
         run: |
           python3 -m pip install -r python/dev_requirements.txt
           if [ "$RUNNER_OS" == "Linux" ]; then
+            sudo apt update
             sudo apt-get install -y wget libicu-dev python3-pip python3-setuptools libboost-all-dev
           elif [ "$RUNNER_OS" == "macOS" ]; then
             brew install wget icu4c boost python-setuptools

--- a/.github/workflows/prod-cibw.yml
+++ b/.github/workflows/prod-cibw.yml
@@ -18,11 +18,6 @@ jobs:
         include:
           # Linux x86_64
           - os: ubuntu-latest
-            python_version: "3.10"
-            cibw_python_version: 310
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-          - os: ubuntu-latest
             python_version: "3.11"
             cibw_python_version: 311
             platform_id: manylinux_x86_64
@@ -35,16 +30,16 @@ jobs:
           - os: ubuntu-latest
             python_version: "3.13"
             cibw_python_version: 313
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python_version: "3.14"
+            cibw_python_version: 314
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
 
           # Linux aarch64
           - os: ubuntu-24.04-arm
-            python_version: "3.10"
-            cibw_python_version: 310
-            platform_id: manylinux_aarch64
-            manylinux_image: manylinux2014
-          - os: ubuntu-24.04-arm
             python_version: "3.11"
             cibw_python_version: 311
             platform_id: manylinux_aarch64
@@ -57,15 +52,16 @@ jobs:
           - os: ubuntu-24.04-arm
             python_version: "3.13"
             cibw_python_version: 313
+            platform_id: manylinux_aarch64
+            manylinux_image: manylinux2014
+          - os: ubuntu-24.04-arm
+            python_version: "3.14"
+            cibw_python_version: 314
             platform_id: manylinux_aarch64
             manylinux_image: manylinux2014
 
           # MacOS arm64
           - os: macos-latest
-            python_version: "3.10"
-            cibw_python_version: 310
-            platform_id: macosx_universal2
-          - os: macos-latest
             python_version: "3.11"
             cibw_python_version: 311
             platform_id: macosx_universal2
@@ -76,6 +72,10 @@ jobs:
           - os: macos-latest
             python_version: "3.13"
             cibw_python_version: 313
+            platform_id: macosx_universal2
+          - os: macos-latest
+            python_version: "3.14"
+            cibw_python_version: 314
             platform_id: macosx_universal2
 
     steps:
@@ -144,6 +144,16 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
 
         run: bash .github/scripts/python_wheels/build_wheels.sh
+
+      - name: Test wheel
+        run: |
+          python3 -m pip install wheelhouse/*.whl
+          python3 -c "import platform; print(platform.machine()); import gtsam"
+          if [ "$RUNNER_OS" == "macOS" ]; then
+            arch -x86_64 python3 -m pip uninstall -y numpy
+            arch -x86_64 python3 -m pip install wheelhouse/*.whl
+            arch -x86_64 python3 -c "import platform; print(platform.machine()); import gtsam;"
+          fi
 
       - name: Store artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/prod-cibw.yml
+++ b/.github/workflows/prod-cibw.yml
@@ -60,41 +60,23 @@ jobs:
             platform_id: manylinux_aarch64
             manylinux_image: manylinux2014
 
-          # MacOS x86_64
-          - os: macos-15-intel
-            python_version: "3.10"
-            cibw_python_version: 310
-            platform_id: macosx_x86_64
-          - os: macos-15-intel
-            python_version: "3.11"
-            cibw_python_version: 311
-            platform_id: macosx_x86_64
-          - os: macos-15-intel
-            python_version: "3.12"
-            cibw_python_version: 312
-            platform_id: macosx_x86_64
-          - os: macos-15-intel
-            python_version: "3.13"
-            cibw_python_version: 313
-            platform_id: macosx_x86_64
-
           # MacOS arm64
           - os: macos-latest
             python_version: "3.10"
             cibw_python_version: 310
-            platform_id: macosx_arm64
+            platform_id: macosx_universal2
           - os: macos-latest
             python_version: "3.11"
             cibw_python_version: 311
-            platform_id: macosx_arm64
+            platform_id: macosx_universal2
           - os: macos-latest
             python_version: "3.12"
             cibw_python_version: 312
-            platform_id: macosx_arm64
+            platform_id: macosx_universal2
           - os: macos-latest
             python_version: "3.13"
             cibw_python_version: 313
-            platform_id: macosx_arm64
+            platform_id: macosx_universal2
 
     steps:
       - name: Checkout
@@ -145,6 +127,7 @@ jobs:
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}
           CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.manylinux_image }}
           CIBW_ARCHS: all
+          CIBW_ARCHS_MACOS: universal2
 
           # Set the minimum required MacOS version for the wheels.
           MACOSX_DEPLOYMENT_TARGET: 10.15

--- a/.github/workflows/prod-cibw.yml
+++ b/.github/workflows/prod-cibw.yml
@@ -112,6 +112,7 @@ jobs:
         run: |
           python3 -m pip install -r python/dev_requirements.txt
           if [ "$RUNNER_OS" == "Linux" ]; then
+            sudo apt update
             sudo apt-get install -y wget libicu-dev python3-pip python3-setuptools libboost-all-dev
           elif [ "$RUNNER_OS" == "macOS" ]; then
             brew install boost python-setuptools

--- a/.github/workflows/prod-cibw.yml
+++ b/.github/workflows/prod-cibw.yml
@@ -113,7 +113,7 @@ jobs:
           python3 -m pip install -r python/dev_requirements.txt
           if [ "$RUNNER_OS" == "Linux" ]; then
             sudo apt update
-            sudo apt-get install -y wget libicu-dev python3-pip python3-setuptools libboost-all-dev
+            sudo apt-get install -y libicu-dev python3-pip python3-setuptools libboost-all-dev
           elif [ "$RUNNER_OS" == "macOS" ]; then
             brew install boost python-setuptools
           else

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -814,7 +814,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES


### PR DESCRIPTION
Now that we have a list of minimum required Boost dependencies, we can use that list as a reference for building only the Boost libraries we actually use, which saves a few minutes across all runners, which is nice, but really only noticeable on the Linux runners. The big CI jam is caused by spawning 8 Mac runners, and [we only get 5 concurrent Mac runners](https://docs.github.com/en/actions/reference/limits#job-concurrency-limits-for-github-hosted-runners). This has always felt unnecessary to me, since you can build universal binaries trivially in CMake... so I went and did just that and wiped out half the Mac runners by just building universal binaries. The build times jumped to ~1 hour, but the previous equivalent would've been about the same or ~1.5 hours (the times fluctuate a lot). This should significantly help speed up wheel building, since all the Mac jobs don't have to wait so long for a open runner anymore.

I also went ahead and fixed some warnings and the Linux builds failing while I was down there, and silenced Doxygen output since it made it really annoying to trudge through the logs when the job failed, so everything should be nice and spiffy now!