### PR TITLE
iSAM2 Updates to Support riSAM Implementation

### DIFF
--- a/gtsam/inference/BayesTree-inst.h
+++ b/gtsam/inference/BayesTree-inst.h
@@ -590,8 +590,7 @@ namespace gtsam {
       // traverse me
       this->traverseClique(traversedKeys, clique);
       // traverse path above me
-      this->traversePath(traversedKeys, typename sharedClique::shared_ptr(
-                                            clique->parent_.lock()));
+      this->traversePath(traversedKeys, clique->parent_.lock());
     }
   }
 

--- a/gtsam/inference/BayesTree-inst.h
+++ b/gtsam/inference/BayesTree-inst.h
@@ -576,7 +576,7 @@ namespace gtsam {
   /* *********************************************************************** */
   template <class CLIQUE>
   void BayesTree<CLIQUE>::traverseClique(gtsam::KeySet& traversedKeys,
-                                     const sharedClique& clique) const {
+                                         const sharedClique& clique) const {
     traversedKeys.insert(clique->conditional()->frontals().begin(),
                          clique->conditional()->frontals().end());
   }
@@ -584,15 +584,14 @@ namespace gtsam {
   /* *********************************************************************** */
   template <class CLIQUE>
   void BayesTree<CLIQUE>::traversePath(gtsam::KeySet& traversedKeys,
-                                   const sharedClique& clique) const {
+                                       const sharedClique& clique) const {
     // base case is nullptr, if so we do nothing and return empties above
     if (clique) {
       // traverse me
       this->traverseClique(traversedKeys, clique);
       // traverse path above me
-      this->traversePath(
-          traversedKeys,
-          typename sharedClique::shared_ptr(clique->parent_.lock()));
+      this->traversePath(traversedKeys, typename sharedClique::shared_ptr(
+                                            clique->parent_.lock()));
     }
   }
 

--- a/gtsam/inference/BayesTree-inst.h
+++ b/gtsam/inference/BayesTree-inst.h
@@ -573,5 +573,43 @@ namespace gtsam {
     return cliques;
   }
 
+  /* *********************************************************************** */
+  template <class CLIQUE>
+  void BayesTree<CLIQUE>::traverseClique(gtsam::KeySet& traversedKeys,
+                                     const sharedClique& clique) const {
+    traversedKeys.insert(clique->conditional()->frontals().begin(),
+                         clique->conditional()->frontals().end());
+  }
+
+  /* *********************************************************************** */
+  template <class CLIQUE>
+  void BayesTree<CLIQUE>::traversePath(gtsam::KeySet& traversedKeys,
+                                   const sharedClique& clique) const {
+    // base case is nullptr, if so we do nothing and return empties above
+    if (clique) {
+      // traverse me
+      this->traverseClique(traversedKeys, clique);
+      // traverse path above me
+      this->traversePath(
+          traversedKeys,
+          typename sharedClique::shared_ptr(clique->parent_.lock()));
+    }
+  }
+
+  /* *********************************************************************** */
+  template <class CLIQUE>
+  gtsam::KeySet BayesTree<CLIQUE>::traverseTop(
+      const gtsam::KeyVector& keys) const {
+    gtsam::KeySet traversedKeys;
+    // process each key of the new factor
+    for (const gtsam::Key& j : keys) {
+      typename Nodes::const_iterator node = nodes_.find(j);
+      if (node != nodes_.end()) {
+        // traverse path from clique to root
+        this->traversePath(traversedKeys, node->second);
+      }
+    }
+    return traversedKeys;
+  }
 }
 /// namespace gtsam

--- a/gtsam/inference/BayesTree-inst.h
+++ b/gtsam/inference/BayesTree-inst.h
@@ -575,28 +575,21 @@ namespace gtsam {
 
   /* *********************************************************************** */
   template <class CLIQUE>
-  void BayesTree<CLIQUE>::traverseClique(gtsam::KeySet& traversedKeys,
-                                         const sharedClique& clique) const {
-    traversedKeys.insert(clique->conditional()->frontals().begin(),
-                         clique->conditional()->frontals().end());
-  }
-
-  /* *********************************************************************** */
-  template <class CLIQUE>
-  void BayesTree<CLIQUE>::traversePath(gtsam::KeySet& traversedKeys,
-                                       const sharedClique& clique) const {
+  void BayesTree<CLIQUE>::collectAffectedPathKeys(
+      gtsam::KeySet& traversedKeys, const sharedClique& clique) const {
     // base case is nullptr, if so we do nothing and return empties above
     if (clique) {
       // traverse me
-      this->traverseClique(traversedKeys, clique);
+      traversedKeys.insert(clique->conditional()->frontals().begin(),
+                           clique->conditional()->frontals().end());
       // traverse path above me
-      this->traversePath(traversedKeys, clique->parent_.lock());
+      this->collectAffectedPathKeys(traversedKeys, clique->parent_.lock());
     }
   }
 
   /* *********************************************************************** */
   template <class CLIQUE>
-  gtsam::KeySet BayesTree<CLIQUE>::traverseTop(
+  gtsam::KeySet BayesTree<CLIQUE>::collectAffectedKeys(
       const gtsam::KeyVector& keys) const {
     gtsam::KeySet traversedKeys;
     // process each key of the new factor
@@ -604,7 +597,7 @@ namespace gtsam {
       typename Nodes::const_iterator node = nodes_.find(j);
       if (node != nodes_.end()) {
         // traverse path from clique to root
-        this->traversePath(traversedKeys, node->second);
+        this->collectAffectedPathKeys(traversedKeys, node->second);
       }
     }
     return traversedKeys;

--- a/gtsam/inference/BayesTree.h
+++ b/gtsam/inference/BayesTree.h
@@ -246,15 +246,16 @@ namespace gtsam {
     void addFactorsToGraph(FactorGraph<FactorType>* graph) const;
 
     /**
-     * @brief Returns the set of keys in a "contaminated" part of the tree
-     * @param keys: The keys defining a "contaminated" part of the tree
-     * @returns The keys affected by the factor graph computed by removeTop
-     * @note Allows one step look-ahead for what removeTop will modify
+     * @brief Returns the set of keys from the tree that are affected by a
+     * update to 'keys'
+     * @param keys: The keys updated and in-turn affecting the tree
+     * @returns The set of keys from the tree that are affected
+     * @note Note: Return matches contents of BayesNet from removeTop without
+     * affecting the tree
      */
-    gtsam::KeySet traverseTop(const gtsam::KeyVector& keys) const;
-  
+    gtsam::KeySet collectAffectedKeys(const gtsam::KeyVector& keys) const;
 
-  protected:
+   protected:
 
     /** private helper method for saving the Tree to a text file in GraphViz format */
     void dot(std::ostream &s, sharedClique clique, const KeyFormatter& keyFormatter,
@@ -269,12 +270,10 @@ namespace gtsam {
     /** Fill the nodes index for a subtree */
     void fillNodesIndex(const sharedClique& subtree);
 
-    /// @brief Traversal helper for a path used by traverseTop
-    void traversePath(gtsam::KeySet& traversedKeys,
-                      const sharedClique& clique) const;
-    /// @brief Traversal helper for clique used by traverseTop
-    void traverseClique(gtsam::KeySet& traversedKeys,
-                        const sharedClique& clique) const;
+    /// @brief Helper for collectAffectedKeys that recursively aggregates
+    /// affected keys from a path from 'clique' to the root of tree
+    void collectAffectedPathKeys(gtsam::KeySet& traversedKeys,
+                                 const sharedClique& clique) const;
 
     // Friend JunctionTree because it directly fills roots and nodes index.
     template<class BAYESTREE, class GRAPH> friend class EliminatableClusterTree;

--- a/gtsam/inference/BayesTree.h
+++ b/gtsam/inference/BayesTree.h
@@ -245,6 +245,15 @@ namespace gtsam {
     /** Add all cliques in this BayesTree to the specified factor graph */
     void addFactorsToGraph(FactorGraph<FactorType>* graph) const;
 
+    /**
+     * @brief Returns the set of keys in a "contaminated" part of the tree
+     * @param keys: The keys defining a "contaminated" part of the tree
+     * @returns The keys affected by the factor graph computed by removeTop
+     * @note Allows one step look-ahead for what removeTop will modify
+     */
+    gtsam::KeySet traverseTop(const gtsam::KeyVector& keys) const;
+  
+
   protected:
 
     /** private helper method for saving the Tree to a text file in GraphViz format */
@@ -259,6 +268,13 @@ namespace gtsam {
 
     /** Fill the nodes index for a subtree */
     void fillNodesIndex(const sharedClique& subtree);
+
+    /// @brief Traversal helper for a path used by traverseTop
+    void traversePath(gtsam::KeySet& traversedKeys,
+                      const sharedClique& clique) const;
+    /// @brief Traversal helper for clique used by traverseTop
+    void traverseClique(gtsam::KeySet& traversedKeys,
+                        const sharedClique& clique) const;
 
     // Friend JunctionTree because it directly fills roots and nodes index.
     template<class BAYESTREE, class GRAPH> friend class EliminatableClusterTree;

--- a/gtsam/nonlinear/DoglegOptimizerImpl.h
+++ b/gtsam/nonlinear/DoglegOptimizerImpl.h
@@ -258,14 +258,22 @@ typename DoglegOptimizerImpl::IterationResult DoglegOptimizerImpl::Iterate(
  * trust region is not correlated between algorithm iterations.
  */
 struct GTSAM_EXPORT DoglegLineSearchImpl {
+  struct Params {
+    double minDelta;  ///< Minimum allowed small delta
+    double maxDelta;  ///< Maximum allowed delta
+    double stepSize;  ///< Increase of trust region for outward steps
+    double sufficientDecreaseCoeff;  ///< Coefficient for suff. decrease check
+    bool verbose;                    ///< Whether to print debug information
+  };
+
   /**
    * Compute the update point for one iteration of the Dogleg Line Search
-   * algorithm, starting with a trust region of |N| * min_delta the algorithm
-   * searches trust regions from |N| * min_delta to max_delta where |N| is the
+   * algorithm, starting with a trust region of |N| * minDelta the algorithm
+   * searches trust regions from |N| * minDelta to maxDelta where |N| is the
    * number of variables in the system. The algorithm returns the search point
    * with minimum cost that meets the Wolfe Conditions. Evaluation points for
    * the line search are computed according to a geometric series step_{k+1} =
-   * step_size * step_k.
+   * stepSize * step_k.
    *
    *
    * @tparam M The type of the Bayes' net or tree, currently
@@ -274,12 +282,7 @@ struct GTSAM_EXPORT DoglegLineSearchImpl {
    * @tparam F For normal usage this will be NonlinearFactorGraph<VALUES>.
    * @tparam VALUES The Values or TupleValues to pass to F::error() to evaluate
    * the error function.
-   * @param min_delta The minimum trust region size (scaled by size of system)
-   * @param max_delta The maximum trust region size (scaled by size of system)
-   * @param step_size The multiplicative factor for the geometric series that
-   * defines the evaluation points for the line search
-   * @param sufficient_decrease_coeff The coefficient for sufficient decrease to
-   * ensure that the linesearch meets the Wolfe conditions
+   * @param params The parameters for dogleg line search
    * @param Rd The Bayes' net or tree as described above.
    * @param f The original nonlinear factor graph with which to evaluate the
    * accuracy of \f$ M(\delta x) \f$ to adjust \f$ \delta \f$.
@@ -289,83 +292,81 @@ struct GTSAM_EXPORT DoglegLineSearchImpl {
    * update \c dx_d, and the resulting nonlinear error \c f_error.
    */
   template <class M, class F, class VALUES>
-  static DoglegOptimizerImpl::IterationResult Iterate(
-      const double min_delta, const double max_delta, const double step_size,
-      const double sufficient_decrease_coeff, const VectorValues& dx_u,
-      const VectorValues& dx_n, const M& Rd, const F& f, const VALUES& x0,
-      const bool verbose = false);
+  static DoglegOptimizerImpl::IterationResult Iterate(const Params& params,
+                                                      const VectorValues& dx_u,
+                                                      const VectorValues& dx_n,
+                                                      const M& Rd, const F& f,
+                                                      const VALUES& x0);
 };
 
 /* ************************************************************************* */
 template <class M, class F, class VALUES>
 typename DoglegOptimizerImpl::IterationResult DoglegLineSearchImpl::Iterate(
-    const double min_delta, const double max_delta, const double step_size,
-    const double sufficient_decrease_coeff, const VectorValues& dx_u,
-    const VectorValues& dx_n, const M& Rd, const F& f, const VALUES& x0,
-    const bool verbose) {
-  if (verbose)
-    std::cout << "DoglegLineSearch | minDelta: " << min_delta
-              << " maxDelta: " << max_delta << " stepSize: " << step_size
-              << std::endl;
-  const double F_init_error = f.error(x0);
-  const double gn_step = dx_n.norm();
-  const size_t num_vars = dx_n.size();
+    const Params& params, const VectorValues& dx_u, const VectorValues& dx_n,
+    const M& Rd, const F& f, const VALUES& x0) {
+  if (params.verbose)
+    std::cout << "DoglegLineSearch | minDelta: " << params.minDelta
+              << " maxDelta: " << params.maxDelta
+              << " stepSize: " << params.stepSize << std::endl;
+  const double fInitError = f.error(x0);
+  const double gnStep = dx_n.norm();
+  const size_t numVars = dx_n.size();
 
-  double max_step, step;
+  double maxStep, step;
   /// The search bounds are scaled by the number of variables in the system
-  max_step = std::min(max_delta * num_vars, gn_step);
-  step = std::min(min_delta * num_vars, gn_step);
-  step = std::min(step, max_step);  // Edge case min_step > max_step
+  maxStep = std::min(params.maxDelta * numVars, gnStep);
+  step = std::min(params.minDelta * numVars, gnStep);
+  step = std::min(step, maxStep);  // Edge case min_step > maxStep
 
-  if (verbose)
-    std::cout << "Search Region: [ " << step << " -> " << max_step << "]"
+  if (params.verbose)
+    std::cout << "Search Region: [ " << step << " -> " << maxStep << "]"
               << std::endl;
 
   DoglegOptimizerImpl::IterationResult result;
   result.dx_d =
-      DoglegOptimizerImpl::ComputeDoglegPoint(step, dx_u, dx_n, verbose);
+      DoglegOptimizerImpl::ComputeDoglegPoint(step, dx_u, dx_n, params.verbose);
   result.f_error = f.error(x0.retract(result.dx_d));
   result.delta = step;
-  if (verbose)
+  if (params.verbose)
     std::cout << "Initial Step Error: " << result.f_error << std::endl;
 
   // Validate Step size will terminate search
-  if (step < 1e-12 || step_size < 1.0)
+  if (step < 1e-12 || params.stepSize < 1.0)
     throw std::runtime_error(
         "Invalid DoglegLineSearch configuration. Would cause infinite search.");
 
   // Search Increase delta
   double eps = std::numeric_limits<double>::epsilon();
-  while (step < max_step - eps) {
+  while (step < maxStep - eps) {
     // Compute the trust region for the evaluation point according to the
     // Geometric Series
-    step = std::min(max_step, step * step_size);
+    step = std::min(maxStep, step * params.stepSize);
 
     // Compute the Evaluation Point and evaluate the error
-    VectorValues dx_d =
-        DoglegOptimizerImpl::ComputeDoglegPoint(step, dx_u, dx_n, verbose);
+    VectorValues dx_d = DoglegOptimizerImpl::ComputeDoglegPoint(
+        step, dx_u, dx_n, params.verbose);
     VALUES x_d(x0.retract(dx_d));
-    double new_F_error = f.error(x_d);
+    double fNewError = f.error(x_d);
 
-    if (verbose)
-      std::cout << "Step: " << step << " | Error: " << new_F_error << std::endl;
+    if (params.verbose)
+      std::cout << "Step: " << step << " | Error: " << fNewError << std::endl;
 
     // Check step acceptance conditions
-    bool update_decreased_error = new_F_error < result.f_error;
-    bool update_has_sufficient_decrease =
-        new_F_error < (F_init_error - sufficient_decrease_coeff * step);
+    bool updateDecreasedError = fNewError < result.f_error;
+    bool updateHasSufficientDecrease =
+        fNewError < (fInitError - params.sufficientDecreaseCoeff * step);
 
-    if (verbose)
-      std::cout << "Decrease Error: " << update_decreased_error
-                << " | Suff. Dec.: " << update_has_sufficient_decrease
+    if (params.verbose)
+      std::cout << "Decrease Error: " << updateDecreasedError
+                << " | Suff. Dec.: " << updateHasSufficientDecrease
                 << std::endl;
 
-    if (update_decreased_error && update_has_sufficient_decrease) {
-      result.f_error = new_F_error;
+    if (updateDecreasedError && updateHasSufficientDecrease) {
+      result.f_error = fNewError;
       result.dx_d = dx_d;
       result.delta = step;
 
-      if (verbose) std::cout << "Step Accepted" << std::endl;
+      if (params.verbose) std::cout << "Step Accepted" << std::endl;
     }
   }
 

--- a/gtsam/nonlinear/DoglegOptimizerImpl.h
+++ b/gtsam/nonlinear/DoglegOptimizerImpl.h
@@ -329,6 +329,11 @@ typename DoglegOptimizerImpl::IterationResult DoglegLineSearchImpl::Iterate(
   if (verbose)
     std::cout << "Initial Step Error: " << result.f_error << std::endl;
 
+  // Validate Step size will terminate search
+  if (step < 1e-12 || step_size < 1.0)
+    throw std::runtime_error(
+        "Invalid DoglegLineSearch configuration. Would cause infinite search.");
+
   // Search Increase delta
   double eps = std::numeric_limits<double>::epsilon();
   while (step < max_step - eps) {

--- a/gtsam/nonlinear/DoglegOptimizerImpl.h
+++ b/gtsam/nonlinear/DoglegOptimizerImpl.h
@@ -343,8 +343,7 @@ typename DoglegOptimizerImpl::IterationResult DoglegLineSearchImpl::Iterate(
     double new_F_error = f.error(x_d);
 
     if (verbose)
-      std::cout << "Step: " << step << " | Error: " << new_F_error
-                << std::endl;
+      std::cout << "Step: " << step << " | Error: " << new_F_error << std::endl;
 
     // Check step acceptance conditions
     bool update_decreased_error = new_F_error < result.f_error;

--- a/gtsam/nonlinear/DoglegOptimizerImpl.h
+++ b/gtsam/nonlinear/DoglegOptimizerImpl.h
@@ -252,4 +252,119 @@ typename DoglegOptimizerImpl::IterationResult DoglegOptimizerImpl::Iterate(
   return result;
 }
 
+/** This class contains an extension of the Dogleg Algorithm where a line search
+ * is performed across the Dogleg arc (interpolation of gradient and
+ * Gauss-Newton directions). This algorithm is applicable to cases where the
+ * trust region is not correlated between algorithm iterations.
+ */
+struct GTSAM_EXPORT DoglegLineSearchImpl {
+  /**
+   * Compute the update point for one iteration of the Dogleg Line Search
+   * algorithm, starting with a trust region of |N| * min_delta the algorithm
+   * searches trust regions from |N| * min_delta to max_delta where |N| is the
+   * number of variables in the system. The algorithm returns the search point
+   * with minimum cost that meets the Wolfe Conditions. Evaluation points for
+   * the line search are computed according to a geometric series step_{k+1} =
+   * step_size * step_k.
+   *
+   *
+   * @tparam M The type of the Bayes' net or tree, currently
+   * either BayesNet<GaussianConditional> (or GaussianBayesNet) or
+   * BayesTree<GaussianConditional>.
+   * @tparam F For normal usage this will be NonlinearFactorGraph<VALUES>.
+   * @tparam VALUES The Values or TupleValues to pass to F::error() to evaluate
+   * the error function.
+   * @param min_delta The minimum trust region size (scaled by size of system)
+   * @param max_delta The maximum trust region size (scaled by size of system)
+   * @param step_size The multiplicative factor for the geometric series that
+   * defines the evaluation points for the line search
+   * @param sufficient_decrease_coeff The coefficient for sufficient decrease to
+   * ensure that the linesearch meets the Wolfe conditions
+   * @param Rd The Bayes' net or tree as described above.
+   * @param f The original nonlinear factor graph with which to evaluate the
+   * accuracy of \f$ M(\delta x) \f$ to adjust \f$ \delta \f$.
+   * @param x0 The linearization point about which \f$ \bayesNet \f$ was created
+   * @param verbose Flag to write debug information.
+   * @return A DoglegIterationResult containing the new \c delta, the linear
+   * update \c dx_d, and the resulting nonlinear error \c f_error.
+   */
+  template <class M, class F, class VALUES>
+  static DoglegOptimizerImpl::IterationResult Iterate(
+      const double min_delta, const double max_delta, const double step_size,
+      const double sufficient_decrease_coeff, const VectorValues& dx_u,
+      const VectorValues& dx_n, const M& Rd, const F& f, const VALUES& x0,
+      const bool verbose = false);
+};
+
+/* ************************************************************************* */
+template <class M, class F, class VALUES>
+typename DoglegOptimizerImpl::IterationResult DoglegLineSearchImpl::Iterate(
+    const double min_delta, const double max_delta, const double step_size,
+    const double sufficient_decrease_coeff, const VectorValues& dx_u,
+    const VectorValues& dx_n, const M& Rd, const F& f, const VALUES& x0,
+    const bool verbose) {
+  if (verbose)
+    std::cout << "DoglegLineSearch | minDelta: " << min_delta
+              << " maxDelta: " << max_delta << " stepSize: " << step_size
+              << std::endl;
+  const double F_init_error = f.error(x0);
+  const double gn_step = dx_n.norm();
+  const size_t num_vars = dx_n.size();
+
+  double max_step, step;
+  /// The search bounds are scaled by the number of variables in the system
+  max_step = std::min(max_delta * num_vars, gn_step);
+  step = std::min(min_delta * num_vars, gn_step);
+  step = std::min(step, max_step);  // Edge case min_step > max_step
+
+  if (verbose)
+    std::cout << "Search Region: [ " << step << " -> " << max_step << "]"
+              << std::endl;
+
+  DoglegOptimizerImpl::IterationResult result;
+  result.dx_d =
+      DoglegOptimizerImpl::ComputeDoglegPoint(step, dx_u, dx_n, verbose);
+  result.f_error = f.error(x0.retract(result.dx_d));
+  result.delta = step;
+  if (verbose)
+    std::cout << "Initial Step Error: " << result.f_error << std::endl;
+
+  // Search Increase delta
+  double eps = std::numeric_limits<double>::epsilon();
+  while (step < max_step - eps) {
+    // Compute the trust region for the evaluation point according to the
+    // Geometric Series
+    step = std::min(max_step, step * step_size);
+
+    // Compute the Evaluation Point and evaluate the error
+    VectorValues dx_d =
+        DoglegOptimizerImpl::ComputeDoglegPoint(step, dx_u, dx_n, verbose);
+    VALUES x_d(x0.retract(dx_d));
+    double new_F_error = f.error(x_d);
+
+    if (verbose)
+      std::cout << "Step: " << step << " | Error: " << new_F_error
+                << std::endl;
+
+    // Check step acceptance conditions
+    bool update_decreased_error = new_F_error < result.f_error;
+    bool update_has_sufficient_decrease =
+        new_F_error < (F_init_error - sufficient_decrease_coeff * step);
+
+    if (verbose)
+      std::cout << "Decrease Error: " << update_decreased_error
+                << " | Suff. Dec.: " << update_has_sufficient_decrease
+                << std::endl;
+
+    if (update_decreased_error && update_has_sufficient_decrease) {
+      result.f_error = new_F_error;
+      result.dx_d = dx_d;
+      result.delta = step;
+
+      if (verbose) std::cout << "Step Accepted" << std::endl;
+    }
+  }
+
+  return result;
+}
 }

--- a/gtsam/nonlinear/ISAM2.cpp
+++ b/gtsam/nonlinear/ISAM2.cpp
@@ -900,7 +900,7 @@ std::pair<KeySet, bool> ISAM2::predictUpdateInfo(
   // Add the new keys to get the entire set of keys affected by the update
   KeySet newKeys = newFactors.keys();
   affectedKeys.insert(newKeys.begin(), newKeys.end());
-  // Return the affected keys and wether or not this will be a batch update
+  // Return the affected keys and whether or not this will be a batch update
   return std::make_pair(affectedKeys,
                         affectedKeys.size() >= theta_.size() * 0.65);
 }

--- a/gtsam/nonlinear/ISAM2.cpp
+++ b/gtsam/nonlinear/ISAM2.cpp
@@ -779,10 +779,10 @@ void ISAM2::updateDelta(bool forceFullSolve) const {
     gttoc(Copy_dx_d);
   } else if (std::holds_alternative<ISAM2DoglegLineSearchParams>(
                  params_.optimizationParams)) {
-    const ISAM2DoglegLineSearchParams& dlls_params =
+    const ISAM2DoglegLineSearchParams& isamDllsParams =
         std::get<ISAM2DoglegLineSearchParams>(params_.optimizationParams);
     const double effectiveWildfireThreshold =
-        forceFullSolve ? 0.0 : dlls_params.getWildfireThreshold();
+        forceFullSolve ? 0.0 : isamDllsParams.getWildfireThreshold();
 
     // Timer start
     gttic(DoglegLineSearch_Iterate);
@@ -803,11 +803,9 @@ void ISAM2::updateDelta(bool forceFullSolve) const {
 
     // Do the DogLeg Line Search
     DoglegOptimizerImpl::IterationResult doglegResult(
-        DoglegLineSearchImpl::Iterate(
-            dlls_params.getMinDelta(), dlls_params.getMaxDelta(),
-            dlls_params.getStepSize(), dlls_params.getSufficientDecreaseCoeff(),
-            dx_u, deltaNewton_, *this, nonlinearFactors_, theta_,
-            dlls_params.isVerbose()));
+        DoglegLineSearchImpl::Iterate(isamDllsParams.dllsParams, dx_u,
+                                      deltaNewton_, *this, nonlinearFactors_,
+                                      theta_));
 
     // Update Delta and linear step
     delta_ = doglegResult.dx_d;

--- a/gtsam/nonlinear/ISAM2.cpp
+++ b/gtsam/nonlinear/ISAM2.cpp
@@ -756,9 +756,9 @@ void ISAM2::updateDelta(bool forceFullSolve) const {
     const VectorValues gradAtZero = this->gradientAtZero();  // Compute gradient
     DeltaImpl::UpdateRgProd(roots_, deltaReplacedMask_, gradAtZero,
                             &RgProd_);  // Update RgProd
-    const VectorValues dx_u = DeltaImpl::ComputeGradientSearch(
-        gradAtZero, RgProd_);  // Compute gradient search point
-
+    const VectorValues dx_u =
+        VectorValues::Zero(deltaNewton_)
+            .update(DeltaImpl::ComputeGradientSearch(gradAtZero, RgProd_));
     // Clear replaced keys mask because now we've updated deltaNewton_ and
     // RgProd_
     deltaReplacedMask_.clear();
@@ -797,7 +797,8 @@ void ISAM2::updateDelta(bool forceFullSolve) const {
     const VectorValues gradAtZero = this->gradientAtZero();
     DeltaImpl::UpdateRgProd(roots_, deltaReplacedMask_, gradAtZero, &RgProd_);
     const VectorValues dx_u =
-        DeltaImpl::ComputeGradientSearch(gradAtZero, RgProd_);
+        VectorValues::Zero(deltaNewton_)
+            .update(DeltaImpl::ComputeGradientSearch(gradAtZero, RgProd_));
     deltaReplacedMask_.clear();
 
     // Do the DogLeg Line Search

--- a/gtsam/nonlinear/ISAM2.cpp
+++ b/gtsam/nonlinear/ISAM2.cpp
@@ -431,7 +431,7 @@ ISAM2Result ISAM2::update(const NonlinearFactorGraph& newFactors,
   addVariables(newTheta, result.details());
 
   // Update delta if we need it to check relinearization later
-  if (update.relinarizationNeeded(update_count_))
+  if (update.relinarizationNeeded(update_count_) && !deltaReplacedMask_.empty())
     updateDelta(updateParams.forceFullSolve);
 
   // 1. Add any new factors \Factors:=\Factors\cup\Factors'.

--- a/gtsam/nonlinear/ISAM2.cpp
+++ b/gtsam/nonlinear/ISAM2.cpp
@@ -806,7 +806,8 @@ void ISAM2::updateDelta(bool forceFullSolve) const {
         DoglegLineSearchImpl::Iterate(
             dlls_params.getMinDelta(), dlls_params.getMaxDelta(),
             dlls_params.getStepSize(), dlls_params.getSufficientDecreaseCoeff(),
-            dx_u, deltaNewton_, *this, nonlinearFactors_, theta_, dlls_params.isVerbose()));
+            dx_u, deltaNewton_, *this, nonlinearFactors_, theta_,
+            dlls_params.isVerbose()));
 
     // Update Delta and linear step
     delta_ = doglegResult.dx_d;

--- a/gtsam/nonlinear/ISAM2.cpp
+++ b/gtsam/nonlinear/ISAM2.cpp
@@ -895,7 +895,7 @@ std::pair<KeySet, bool> ISAM2::predictUpdateInfo(
       update.findFluid(roots_, relinKeys, &result.markedKeys, result.details());
   }
   // Get the top of the bayes tree affected by all the involved keys
-  KeySet affectedKeys = traverseTop(
+  KeySet affectedKeys = collectAffectedKeys(
       KeyVector(result.markedKeys.begin(), result.markedKeys.end()));
   // Add the new keys to get the entire set of keys affected by the update
   KeySet newKeys = newFactors.keys();

--- a/gtsam/nonlinear/ISAM2.cpp
+++ b/gtsam/nonlinear/ISAM2.cpp
@@ -901,8 +901,7 @@ std::pair<KeySet, bool> ISAM2::predictUpdateInfo(
   KeySet newKeys = newFactors.keys();
   affectedKeys.insert(newKeys.begin(), newKeys.end());
   // Return the affected keys and whether or not this will be a batch update
-  return std::make_pair(affectedKeys,
-                        affectedKeys.size() >= theta_.size() * 0.65);
+  return {affectedKeys, affectedKeys.size() >= theta_.size() * 0.65};
 }
 
 }  // namespace gtsam

--- a/gtsam/nonlinear/ISAM2.cpp
+++ b/gtsam/nonlinear/ISAM2.cpp
@@ -874,6 +874,9 @@ std::pair<KeySet, bool> ISAM2::predictUpdateInfo(
   ISAM2Result result;
   UpdateImpl update(params_, updateParams);
 
+  if (update.relinarizationNeeded(update_count_) && !deltaReplacedMask_.empty())
+    updateDelta(updateParams.forceFullSolve);
+
   // Gather the Keys involved from update params
   update.computeUnusedKeys(newFactors, variableIndex_,
                            result.keysWithRemovedFactors, &result.unusedKeys);

--- a/gtsam/nonlinear/ISAM2.cpp
+++ b/gtsam/nonlinear/ISAM2.cpp
@@ -777,6 +777,39 @@ void ISAM2::updateDelta(bool forceFullSolve) const {
     // Copy the VectorValues containing with the linear solution
     delta_ = doglegResult.dx_d;
     gttoc(Copy_dx_d);
+  } else if (std::holds_alternative<ISAM2DoglegLineSearchParams>(
+                 params_.optimizationParams)) {
+    const ISAM2DoglegLineSearchParams& dlls_params =
+        std::get<ISAM2DoglegLineSearchParams>(params_.optimizationParams);
+    const double effectiveWildfireThreshold =
+        forceFullSolve ? 0.0 : dlls_params.getWildfireThreshold();
+
+    // Timer start
+    gttic(DoglegLineSearch_Iterate);
+
+    // Compute Newton's method step
+    gttic(Wildfire_update);
+    DeltaImpl::UpdateGaussNewtonDelta(
+        roots_, deltaReplacedMask_, effectiveWildfireThreshold, &deltaNewton_);
+    gttoc(Wildfire_update);
+
+    // Compute steepest descent step
+    const VectorValues gradAtZero = this->gradientAtZero();
+    DeltaImpl::UpdateRgProd(roots_, deltaReplacedMask_, gradAtZero, &RgProd_);
+    const VectorValues dx_u =
+        DeltaImpl::ComputeGradientSearch(gradAtZero, RgProd_);
+    deltaReplacedMask_.clear();
+
+    // Do the DogLeg Line Search
+    DoglegOptimizerImpl::IterationResult doglegResult(
+        DoglegLineSearchImpl::Iterate(
+            dlls_params.getMinDelta(), dlls_params.getMaxDelta(),
+            dlls_params.getStepSize(), dlls_params.getSufficientDecreaseCoeff(),
+            dx_u, deltaNewton_, *this, nonlinearFactors_, theta_, dlls_params.isVerbose()));
+
+    // Update Delta and linear step
+    delta_ = doglegResult.dx_d;
+    gttoc(DoglegLineSearch_Iterate);
   } else {
     throw std::runtime_error("iSAM2: unknown ISAM2Params type");
   }
@@ -830,6 +863,41 @@ VectorValues ISAM2::gradientAtZero() const {
   for (const auto& root : this->roots()) root->addGradientAtZero(&g);
 
   return g;
+}
+
+/* ************************************************************************* */
+std::pair<KeySet, bool> ISAM2::predictUpdateInfo(
+    const NonlinearFactorGraph& newFactors, const Values& newTheta,
+    const ISAM2UpdateParams& updateParams) const {
+  // Temp variables required by inputs below
+  ISAM2Result result;
+  UpdateImpl update(params_, updateParams);
+
+  // Gather the Keys involved from update params
+  update.computeUnusedKeys(newFactors, variableIndex_,
+                           result.keysWithRemovedFactors, &result.unusedKeys);
+  update.gatherInvolvedKeys(newFactors, nonlinearFactors_,
+                            result.keysWithRemovedFactors, &result.markedKeys);
+  update.updateKeys(result.markedKeys, &result);
+
+  // Gather keys involved due to relinearization threshold
+  // Note: increment by one as we are performing a one step look ahead
+  KeySet relinKeys;
+  if (update.relinarizationNeeded(update_count_ + 1)) {
+    relinKeys = update.gatherRelinearizeKeys(roots_, delta_, fixedVariables_,
+                                             &result.markedKeys);
+    if (!relinKeys.empty())
+      update.findFluid(roots_, relinKeys, &result.markedKeys, result.details());
+  }
+  // Get the top of the bayes tree affected by all the involved keys
+  KeySet affectedKeys = traverseTop(
+      KeyVector(result.markedKeys.begin(), result.markedKeys.end()));
+  // Add the new keys to get the entire set of keys affected by the update
+  KeySet newKeys = newFactors.keys();
+  affectedKeys.insert(newKeys.begin(), newKeys.end());
+  // Return the affected keys and wether or not this will be a batch update
+  return std::make_pair(affectedKeys,
+                        affectedKeys.size() >= theta_.size() * 0.65);
 }
 
 }  // namespace gtsam

--- a/gtsam/nonlinear/ISAM2.h
+++ b/gtsam/nonlinear/ISAM2.h
@@ -297,15 +297,7 @@ class GTSAM_EXPORT ISAM2 : public BayesTree<ISAM2Clique> {
    * @returns The set of all affected keys, and a flag indicating if this would
    * be a batch update
    *
-   * WARN: To be accurate the internal delta_ must be updated. This can be
-   * guaranteed if calculateEstimate is called first. While this is clunky, it
-   * is typical for users to calculateEstimate after every update. If the
-   * internal delta_ is not up-to-date this function may not return variables
-   * involved due to relinearization.
-   *
-   * NOTE: Update does not  mutate any internal iSAM2 state, this function
-   * simply provides a one-step look ahead to check the effect of an update
-   * before it is applied.
+   * NOTE: Update may mutate the mutable field delta_
    */
   std::pair<KeySet, bool> predictUpdateInfo(
       const NonlinearFactorGraph& newFactors, const Values& newTheta,

--- a/gtsam/nonlinear/ISAM2.h
+++ b/gtsam/nonlinear/ISAM2.h
@@ -290,6 +290,22 @@ class GTSAM_EXPORT ISAM2 : public BayesTree<ISAM2Clique> {
    */
   VectorValues gradientAtZero() const;
 
+  /** @brief Predicts the updated variables for a hypothetical update.
+   * @param newFactors The factors for the hypothetical update
+   * @param newTheta The estimates for new variables in the hypothetical update
+   * @param updateParams The update params for the hypothetical update
+   * @returns The set of all affected keys, and a flag indicating if this would
+   * be a batch update
+   *
+   * NOTE: Update does not mutate any internal iSAM2 state,
+   * this function simply provides a one-step look ahead to check the effect 
+   * of an update before it is applied.
+   */
+  std::pair<KeySet, bool> predictUpdateInfo(
+      const NonlinearFactorGraph& newFactors,
+      const Values& newTheta,
+      const ISAM2UpdateParams& updateParams) const;
+
   /// @}
 
  protected:

--- a/gtsam/nonlinear/ISAM2.h
+++ b/gtsam/nonlinear/ISAM2.h
@@ -297,13 +297,18 @@ class GTSAM_EXPORT ISAM2 : public BayesTree<ISAM2Clique> {
    * @returns The set of all affected keys, and a flag indicating if this would
    * be a batch update
    *
-   * NOTE: Update does not mutate any internal iSAM2 state,
-   * this function simply provides a one-step look ahead to check the effect 
-   * of an update before it is applied.
+   * WARN: To be accurate the internal delta_ must be updated. This can be
+   * guaranteed if calculateEstimate is called first. While this is clunky, it
+   * is typical for users to calculateEstimate after every update. If the
+   * internal delta_ is not up-to-date this function may not return variables
+   * involved due to relinearization.
+   *
+   * NOTE: Update does not  mutate any internal iSAM2 state, this function
+   * simply provides a one-step look ahead to check the effect of an update
+   * before it is applied.
    */
   std::pair<KeySet, bool> predictUpdateInfo(
-      const NonlinearFactorGraph& newFactors,
-      const Values& newTheta,
+      const NonlinearFactorGraph& newFactors, const Values& newTheta,
       const ISAM2UpdateParams& updateParams) const;
 
   /// @}

--- a/gtsam/nonlinear/ISAM2Params.h
+++ b/gtsam/nonlinear/ISAM2Params.h
@@ -144,15 +144,21 @@ struct GTSAM_EXPORT ISAM2DoglegLineSearchParams {
   /** Specify parameters as constructor arguments */
   ISAM2DoglegLineSearchParams(double min_delta = 0.02, double max_delta = 0.5,
                               double step_size = 1.5,
-                              double wildfire_threshold = 1e-4,
                               double sufficient_decrease_coeff = 1e-3,
+                              double wildfire_threshold = 1e-4,
                               bool verbose = false)
       : _min_delta(min_delta),
         _max_delta(max_delta),
         _step_size(step_size),
         _sufficient_decrease_coeff(sufficient_decrease_coeff),
         _wildfire_threshold(wildfire_threshold),
-        _verbose(verbose) {}
+        _verbose(verbose) {
+    if (min_delta < 1e-12 || max_delta < 1e-12 || step_size < 1.0) {
+      throw std::invalid_argument(
+          "ISAM2DoglegLineSearchParams constructed with invalid configuration. "
+          "Search Bounds [min_delta, max_delta] ~ 0 or step_size < 1.0");
+    }
+  }
 
   void print(const std::string str = "") const {
     using std::cout;

--- a/gtsam/nonlinear/ISAM2Params.h
+++ b/gtsam/nonlinear/ISAM2Params.h
@@ -134,25 +134,18 @@ struct GTSAM_EXPORT ISAM2DoglegParams {
  * ISAM2(const ISAM2Params&).
  */
 struct GTSAM_EXPORT ISAM2DoglegLineSearchParams {
-  double minDelta;  ///< Minimum allowed small delta
-  double maxDelta;  ///< Maximum allowed delta
-  double stepSize;  ///< Increase of trust region for outward steps
-  double sufficientDecreaseCoeff;  ///< Coefficient for suff. decrease check
+  DoglegLineSearchImpl::Params dllsParams;  ///< Params for DoglegLineSearch
   double wildfireThreshold;  ///< Update delta when changes are above thresh
-  bool verbose;              ///< Whether to print debug information
 
   /** Specify parameters as constructor arguments */
   ISAM2DoglegLineSearchParams(double minDelta = 0.02, double maxDelta = 0.5,
                               double stepSize = 1.5,
                               double sufficientDecreaseCoeff = 1e-3,
-                              double wildfireThreshold = 1e-4,
-                              bool verbose = false)
-      : minDelta(minDelta),
-        maxDelta(maxDelta),
-        stepSize(stepSize),
-        sufficientDecreaseCoeff(sufficientDecreaseCoeff),
-        wildfireThreshold(wildfireThreshold),
-        verbose(verbose) {
+                              bool verbose = false,
+                              double wildfireThreshold = 1e-4)
+      : dllsParams{minDelta, maxDelta, stepSize, sufficientDecreaseCoeff,
+                   verbose},
+        wildfireThreshold(wildfireThreshold) {
     if (minDelta < 1e-12 || maxDelta < 1e-12 || stepSize < 1.0) {
       throw std::invalid_argument(
           "ISAM2DoglegLineSearchParams constructed with invalid configuration. "
@@ -163,33 +156,37 @@ struct GTSAM_EXPORT ISAM2DoglegLineSearchParams {
   void print(const std::string str = "") const {
     using std::cout;
     cout << str << "type:                      ISAM2DoglegLineSearchParams\n";
-    cout << str << "minDelta:                 " << minDelta << "\n";
-    cout << str << "maxDelta:                 " << maxDelta << "\n";
-    cout << str << "stepSize:                 " << stepSize << "\n";
-    cout << str << "sufficientDecreaseCoeff: " << sufficientDecreaseCoeff
+    cout << str << "minDelta:                 " << dllsParams.minDelta << "\n";
+    cout << str << "maxDelta:                 " << dllsParams.maxDelta << "\n";
+    cout << str << "stepSize:                 " << dllsParams.stepSize << "\n";
+    cout << str
+         << "sufficientDecreaseCoeff: " << dllsParams.sufficientDecreaseCoeff
          << "\n";
+    cout << str << "verbose:        " << dllsParams.verbose << "\n";
     cout << str << "wildfireThreshold:        " << wildfireThreshold << "\n";
     cout.flush();
   }
   /** Getters **/
-  double getMinDelta() const { return minDelta; }
-  double getMaxDelta() const { return maxDelta; }
-  double getStepSize() const { return stepSize; }
-  double getSufficientDecreaseCoeff() const { return sufficientDecreaseCoeff; }
+  double getMinDelta() const { return dllsParams.minDelta; }
+  double getMaxDelta() const { return dllsParams.maxDelta; }
+  double getStepSize() const { return dllsParams.stepSize; }
+  double getSufficientDecreaseCoeff() const {
+    return dllsParams.sufficientDecreaseCoeff;
+  }
+  bool isVerbose() const { return dllsParams.verbose; }
   double getWildfireThreshold() const { return wildfireThreshold; }
-  bool isVerbose() const { return verbose; }
 
   /** Setters */
-  void setMinDelta(double minDelta) { this->minDelta = minDelta; }
-  void setMaxDelta(double maxDelta) { this->maxDelta = maxDelta; }
-  void setStepSize(double stepSize) { this->stepSize = stepSize; }
+  void setMinDelta(double minDelta) { this->dllsParams.minDelta = minDelta; }
+  void setMaxDelta(double maxDelta) { this->dllsParams.maxDelta = maxDelta; }
+  void setStepSize(double stepSize) { this->dllsParams.stepSize = stepSize; }
   void setSufficientDecreaseCoeff(double sufficientDecreaseCoeff) {
-    this->sufficientDecreaseCoeff = sufficientDecreaseCoeff;
+    this->dllsParams.sufficientDecreaseCoeff = sufficientDecreaseCoeff;
   }
+  void setVerbose(bool verbose) { this->dllsParams.verbose = verbose; }
   void setWildfireThreshold(double wildfireThreshold) {
     this->wildfireThreshold = wildfireThreshold;
   }
-  void setVerbose(bool verbose) { this->verbose = verbose; }
 };
 
 /**

--- a/gtsam/nonlinear/ISAM2Params.h
+++ b/gtsam/nonlinear/ISAM2Params.h
@@ -128,15 +128,80 @@ struct GTSAM_EXPORT ISAM2DoglegParams {
 
 /**
  * @ingroup isam2
+ * Parameters for ISAM2 using Dogleg Line Search optimization.  Either this
+ * class, ISAM2GaussNewtonParams, or ISAM2DoglegParams should be specified as
+ * the optimizationParams in ISAM2Params, which should in turn be passed to
+ * ISAM2(const ISAM2Params&).
+ */
+struct GTSAM_EXPORT ISAM2DoglegLineSearchParams {
+  double _min_delta{0.02};  ///< Minimum allowed small delta
+  double _max_delta{0.5};   ///< Maximum allowed delta
+  double _step_size{1.5};   ///< Increase of trust region for outward steps
+  double _sufficient_decrease_coeff{
+      1e-4};  ///< Coefficient for sufficient decrease check
+  double _wildfire_threshold{
+      1e-3};             ///< Continue updating the linear delta only when
+                         ///< changes are above this threshold (default: 1e-3)
+  bool _verbose{false};  ///< Whether to print debug information
+
+  /** Specify parameters as constructor arguments */
+  ISAM2DoglegLineSearchParams(double min_delta, double max_delta,
+                              double step_size, double wildfire_threshold,
+                              double sufficient_decrease_coeff, bool verbose)
+      : _min_delta(min_delta),
+        _max_delta(max_delta),
+        _step_size(step_size),
+        _sufficient_decrease_coeff(sufficient_decrease_coeff),
+        _wildfire_threshold(wildfire_threshold),
+        _verbose(verbose) {}
+
+  void print(const std::string str = "") const {
+    using std::cout;
+    cout << str << "type:                      ISAM2DoglegLineSearchParams\n";
+    cout << str << "min_delta:                 " << _min_delta << "\n";
+    cout << str << "max_delta:                 " << _max_delta << "\n";
+    cout << str << "step_size:                 " << _step_size << "\n";
+    cout << str << "sufficient_decrease_coeff: " << _sufficient_decrease_coeff
+         << "\n";
+    cout << str << "wildfire_threshold:        " << _wildfire_threshold << "\n";
+    cout.flush();
+  }
+  /** Getters **/
+  double getMinDelta() const { return _min_delta; }
+  double getMaxDelta() const { return _max_delta; }
+  double getStepSize() const { return _step_size; }
+  double getSufficientDecreaseCoeff() const {
+    return _sufficient_decrease_coeff;
+  }
+  double getWildfireThreshold() const { return _wildfire_threshold; }
+  bool isVerbose() const { return _verbose; }
+
+  /** Setters */
+  void setMinDelta(double min_delta) { this->_min_delta = min_delta; }
+  void setMaxDelta(double max_delta) { this->_max_delta = max_delta; }
+  void setStepSize(double step_size) { this->_step_size = step_size; }
+  void setSufficientDecreaseCoeff(double sufficient_decrease_coeff) {
+    this->_sufficient_decrease_coeff = sufficient_decrease_coeff;
+  }
+  void setWildfireThreshold(double wildfire_threshold) {
+    this->_wildfire_threshold = wildfire_threshold;
+  }
+  void setVerbose(bool verbose) { this->_verbose = verbose; }
+};
+
+/**
+ * @ingroup isam2
  * Parameters for the ISAM2 algorithm.  Default parameter values are listed
  * below.
  */
 typedef FastMap<char, Vector> ISAM2ThresholdMap;
 typedef ISAM2ThresholdMap::value_type ISAM2ThresholdMapValue;
 struct GTSAM_EXPORT ISAM2Params {
-  typedef std::variant<ISAM2GaussNewtonParams, ISAM2DoglegParams>
+  typedef std::variant<ISAM2GaussNewtonParams, ISAM2DoglegParams,
+                       ISAM2DoglegLineSearchParams>
       OptimizationParams;  ///< Either ISAM2GaussNewtonParams or
-                           ///< ISAM2DoglegParams
+                           ///< ISAM2DoglegParams or
+                           ///< ISAM2DoglegLineSearchParams
   typedef std::variant<double, FastMap<char, Vector> >
       RelinearizationThreshold;  ///< Either a constant relinearization
                                  ///< threshold or a per-variable-type set of

--- a/gtsam/nonlinear/ISAM2Params.h
+++ b/gtsam/nonlinear/ISAM2Params.h
@@ -134,64 +134,62 @@ struct GTSAM_EXPORT ISAM2DoglegParams {
  * ISAM2(const ISAM2Params&).
  */
 struct GTSAM_EXPORT ISAM2DoglegLineSearchParams {
-  double _min_delta;  ///< Minimum allowed small delta
-  double _max_delta;  ///< Maximum allowed delta
-  double _step_size;  ///< Increase of trust region for outward steps
-  double _sufficient_decrease_coeff;  ///< Coefficient for suff. decrease check
-  double _wildfire_threshold;  ///< Update delta when changes are above thresh
-  bool _verbose;               ///< Whether to print debug information
+  double minDelta;  ///< Minimum allowed small delta
+  double maxDelta;  ///< Maximum allowed delta
+  double stepSize;  ///< Increase of trust region for outward steps
+  double sufficientDecreaseCoeff;  ///< Coefficient for suff. decrease check
+  double wildfireThreshold;  ///< Update delta when changes are above thresh
+  bool verbose;              ///< Whether to print debug information
 
   /** Specify parameters as constructor arguments */
-  ISAM2DoglegLineSearchParams(double min_delta = 0.02, double max_delta = 0.5,
-                              double step_size = 1.5,
-                              double sufficient_decrease_coeff = 1e-3,
-                              double wildfire_threshold = 1e-4,
+  ISAM2DoglegLineSearchParams(double minDelta = 0.02, double maxDelta = 0.5,
+                              double stepSize = 1.5,
+                              double sufficientDecreaseCoeff = 1e-3,
+                              double wildfireThreshold = 1e-4,
                               bool verbose = false)
-      : _min_delta(min_delta),
-        _max_delta(max_delta),
-        _step_size(step_size),
-        _sufficient_decrease_coeff(sufficient_decrease_coeff),
-        _wildfire_threshold(wildfire_threshold),
-        _verbose(verbose) {
-    if (min_delta < 1e-12 || max_delta < 1e-12 || step_size < 1.0) {
+      : minDelta(minDelta),
+        maxDelta(maxDelta),
+        stepSize(stepSize),
+        sufficientDecreaseCoeff(sufficientDecreaseCoeff),
+        wildfireThreshold(wildfireThreshold),
+        verbose(verbose) {
+    if (minDelta < 1e-12 || maxDelta < 1e-12 || stepSize < 1.0) {
       throw std::invalid_argument(
           "ISAM2DoglegLineSearchParams constructed with invalid configuration. "
-          "Search Bounds [min_delta, max_delta] ~ 0 or step_size < 1.0");
+          "Search Bounds [minDelta, maxDelta] ~ 0 or stepSize < 1.0");
     }
   }
 
   void print(const std::string str = "") const {
     using std::cout;
     cout << str << "type:                      ISAM2DoglegLineSearchParams\n";
-    cout << str << "min_delta:                 " << _min_delta << "\n";
-    cout << str << "max_delta:                 " << _max_delta << "\n";
-    cout << str << "step_size:                 " << _step_size << "\n";
-    cout << str << "sufficient_decrease_coeff: " << _sufficient_decrease_coeff
+    cout << str << "minDelta:                 " << minDelta << "\n";
+    cout << str << "maxDelta:                 " << maxDelta << "\n";
+    cout << str << "stepSize:                 " << stepSize << "\n";
+    cout << str << "sufficientDecreaseCoeff: " << sufficientDecreaseCoeff
          << "\n";
-    cout << str << "wildfire_threshold:        " << _wildfire_threshold << "\n";
+    cout << str << "wildfireThreshold:        " << wildfireThreshold << "\n";
     cout.flush();
   }
   /** Getters **/
-  double getMinDelta() const { return _min_delta; }
-  double getMaxDelta() const { return _max_delta; }
-  double getStepSize() const { return _step_size; }
-  double getSufficientDecreaseCoeff() const {
-    return _sufficient_decrease_coeff;
-  }
-  double getWildfireThreshold() const { return _wildfire_threshold; }
-  bool isVerbose() const { return _verbose; }
+  double getMinDelta() const { return minDelta; }
+  double getMaxDelta() const { return maxDelta; }
+  double getStepSize() const { return stepSize; }
+  double getSufficientDecreaseCoeff() const { return sufficientDecreaseCoeff; }
+  double getWildfireThreshold() const { return wildfireThreshold; }
+  bool isVerbose() const { return verbose; }
 
   /** Setters */
-  void setMinDelta(double min_delta) { this->_min_delta = min_delta; }
-  void setMaxDelta(double max_delta) { this->_max_delta = max_delta; }
-  void setStepSize(double step_size) { this->_step_size = step_size; }
-  void setSufficientDecreaseCoeff(double sufficient_decrease_coeff) {
-    this->_sufficient_decrease_coeff = sufficient_decrease_coeff;
+  void setMinDelta(double minDelta) { this->minDelta = minDelta; }
+  void setMaxDelta(double maxDelta) { this->maxDelta = maxDelta; }
+  void setStepSize(double stepSize) { this->stepSize = stepSize; }
+  void setSufficientDecreaseCoeff(double sufficientDecreaseCoeff) {
+    this->sufficientDecreaseCoeff = sufficientDecreaseCoeff;
   }
-  void setWildfireThreshold(double wildfire_threshold) {
-    this->_wildfire_threshold = wildfire_threshold;
+  void setWildfireThreshold(double wildfireThreshold) {
+    this->wildfireThreshold = wildfireThreshold;
   }
-  void setVerbose(bool verbose) { this->_verbose = verbose; }
+  void setVerbose(bool verbose) { this->verbose = verbose; }
 };
 
 /**

--- a/gtsam/nonlinear/ISAM2Params.h
+++ b/gtsam/nonlinear/ISAM2Params.h
@@ -134,20 +134,19 @@ struct GTSAM_EXPORT ISAM2DoglegParams {
  * ISAM2(const ISAM2Params&).
  */
 struct GTSAM_EXPORT ISAM2DoglegLineSearchParams {
-  double _min_delta{0.02};  ///< Minimum allowed small delta
-  double _max_delta{0.5};   ///< Maximum allowed delta
-  double _step_size{1.5};   ///< Increase of trust region for outward steps
-  double _sufficient_decrease_coeff{
-      1e-4};  ///< Coefficient for sufficient decrease check
-  double _wildfire_threshold{
-      1e-3};             ///< Continue updating the linear delta only when
-                         ///< changes are above this threshold (default: 1e-3)
-  bool _verbose{false};  ///< Whether to print debug information
+  double _min_delta;  ///< Minimum allowed small delta
+  double _max_delta;  ///< Maximum allowed delta
+  double _step_size;  ///< Increase of trust region for outward steps
+  double _sufficient_decrease_coeff;  ///< Coefficient for suff. decrease check
+  double _wildfire_threshold;  ///< Update delta when changes are above thresh
+  bool _verbose;               ///< Whether to print debug information
 
   /** Specify parameters as constructor arguments */
-  ISAM2DoglegLineSearchParams(double min_delta, double max_delta,
-                              double step_size, double wildfire_threshold,
-                              double sufficient_decrease_coeff, bool verbose)
+  ISAM2DoglegLineSearchParams(double min_delta = 0.02, double max_delta = 0.5,
+                              double step_size = 1.5,
+                              double wildfire_threshold = 1e-4,
+                              double sufficient_decrease_coeff = 1e-3,
+                              bool verbose = false)
       : _min_delta(min_delta),
         _max_delta(max_delta),
         _step_size(step_size),

--- a/gtsam/nonlinear/nonlinear.i
+++ b/gtsam/nonlinear/nonlinear.i
@@ -437,14 +437,14 @@ class ISAM2DoglegLineSearchParams {
   double getMaxDelta() const;
   double getStepSize() const;
   double getSufficientDecreaseCoeff() const;
-  double getWildfireThreshold() const;
   bool isVerbose() const;
+  double getWildfireThreshold() const;
   void setMinDelta(double min_delta);
   void setMaxDelta(double max_delta);
   void setStepSize(double step_size);
   void setSufficientDecreaseCoeff(double sufficient_decrease_coeff);
-  void setWildfireThreshold(double wildfire_threshold);
   void setVerbose(bool verbose);
+  void setWildfireThreshold(double wildfire_threshold);
 };
 
 class ISAM2ThresholdMapValue {

--- a/gtsam/nonlinear/nonlinear.i
+++ b/gtsam/nonlinear/nonlinear.i
@@ -430,7 +430,7 @@ class ISAM2DoglegParams {
 class ISAM2DoglegLineSearchParams {
   ISAM2DoglegLineSearchParams();
 
-  void print(const std::string str = "") const 
+  void print(const std::string str = "") const;
 
   /** Getters and Setters for all properties */
   double getMinDelta() const;

--- a/gtsam/nonlinear/nonlinear.i
+++ b/gtsam/nonlinear/nonlinear.i
@@ -427,6 +427,26 @@ class ISAM2DoglegParams {
   void setVerbose(bool verbose);
 };
 
+class ISAM2DoglegLineSearchParams {
+  ISAM2DoglegLineSearchParams();
+
+  void print(const std::string str = "") const 
+
+  /** Getters and Setters for all properties */
+  double getMinDelta() const;
+  double getMaxDelta() const;
+  double getStepSize() const;
+  double getSufficientDecreaseCoeff() const;
+  double getWildfireThreshold() const;
+  bool isVerbose() const;
+  void setMinDelta(double min_delta);
+  void setMaxDelta(double max_delta);
+  void setStepSize(double step_size) ;
+  void setSufficientDecreaseCoeff(double sufficient_decrease_coeff);
+  void setWildfireThreshold(double wildfire_threshold);
+  void setVerbose(bool verbose);
+};
+
 class ISAM2ThresholdMapValue {
   ISAM2ThresholdMapValue(char c, gtsam::Vector thresholds);
   ISAM2ThresholdMapValue(const gtsam::ISAM2ThresholdMapValue& other);
@@ -456,6 +476,7 @@ class ISAM2Params {
   void setOptimizationParams(
       const gtsam::ISAM2GaussNewtonParams& gauss_newton__params);
   void setOptimizationParams(const gtsam::ISAM2DoglegParams& optimizationParams);
+  void setOptimizationParams(const gtsam::ISAM2DoglegLineSearchParams& optimizationParams);
   void setRelinearizeThreshold(double relinearizeThreshold);
   void setRelinearizeThreshold(const gtsam::ISAM2ThresholdMap& threshold_map);
   string getFactorization() const;
@@ -560,6 +581,9 @@ class ISAM2 {
 
   void printStats() const;
   gtsam::VectorValues gradientAtZero() const;
+  std::pair<gtsam::KeySet, bool> predictUpdateInfo(
+      const gtsam::NonlinearFactorGraph& newFactors, const gtsam::Values& newTheta,
+      const gtsam::ISAM2UpdateParams& updateParams) const;
 
   string dot(const gtsam::KeyFormatter& keyFormatter =
                  gtsam::DefaultKeyFormatter) const;

--- a/gtsam/nonlinear/nonlinear.i
+++ b/gtsam/nonlinear/nonlinear.i
@@ -441,7 +441,7 @@ class ISAM2DoglegLineSearchParams {
   bool isVerbose() const;
   void setMinDelta(double min_delta);
   void setMaxDelta(double max_delta);
-  void setStepSize(double step_size) ;
+  void setStepSize(double step_size);
   void setSufficientDecreaseCoeff(double sufficient_decrease_coeff);
   void setWildfireThreshold(double wildfire_threshold);
   void setVerbose(bool verbose);

--- a/gtsam/symbolic/tests/testSymbolicBayesTree.cpp
+++ b/gtsam/symbolic/tests/testSymbolicBayesTree.cpp
@@ -357,11 +357,11 @@ TEST(BayesTree, removeTop5) {
 }
 
 /* ************************************************************************* */
-TEST(BayesTree, traverseTop1) {
+TEST(BayesTree, collectAffectedKeys1) {
   SymbolicBayesTree bayesTree = asiaBayesTree;
 
   // Traverse Top
-  KeySet result = bayesTree.traverseTop(Keys(_T_));
+  KeySet result = bayesTree.collectAffectedKeys(Keys(_T_));
 
   // Remove top to get expected result
   SymbolicBayesNet bn;
@@ -372,14 +372,14 @@ TEST(BayesTree, traverseTop1) {
 }
 
 /* ************************************************************************* */
-TEST(BayesTree, traverseTop2) {
+TEST(BayesTree, collectAffectedKeys2) {
   auto graph = SymbolicFactorGraph(SymbolicFactor(L(5)))(SymbolicFactor(
       X(4), L(5)))(SymbolicFactor(X(2), X(4)))(SymbolicFactor(X(3), X(2)));
   Ordering ordering{X(3), X(2), X(4), L(5)};
   SymbolicBayesTree bayesTree = *graph.eliminateMultifrontal(ordering);
 
   // Traverse Top
-  KeySet result = bayesTree.traverseTop(Keys(X(2))(L(5))(X(4))(X(3)));
+  KeySet result = bayesTree.collectAffectedKeys(Keys(X(2))(L(5))(X(4))(X(3)));
 
   // remove all
   SymbolicBayesNet bn;

--- a/gtsam/symbolic/tests/testSymbolicBayesTree.cpp
+++ b/gtsam/symbolic/tests/testSymbolicBayesTree.cpp
@@ -357,6 +357,39 @@ TEST(BayesTree, removeTop5) {
 }
 
 /* ************************************************************************* */
+TEST(BayesTree, traverseTop1) {
+  SymbolicBayesTree bayesTree = asiaBayesTree;
+
+  // Traverse Top
+  KeySet result = bayesTree.traverseTop(Keys(_T_));
+
+  // Remove top to get expected result
+  SymbolicBayesNet bn;
+  SymbolicBayesTree::Cliques orphans;
+  bayesTree.removeTop(Keys(_T_), &bn, &orphans);
+
+  CHECK(assert_container_equality(result, bn.keys()));
+}
+
+/* ************************************************************************* */
+TEST(BayesTree, traverseTop2) {
+  auto graph = SymbolicFactorGraph(SymbolicFactor(L(5)))(SymbolicFactor(
+      X(4), L(5)))(SymbolicFactor(X(2), X(4)))(SymbolicFactor(X(3), X(2)));
+  Ordering ordering{X(3), X(2), X(4), L(5)};
+  SymbolicBayesTree bayesTree = *graph.eliminateMultifrontal(ordering);
+
+  // Traverse Top
+  KeySet result = bayesTree.traverseTop(Keys(X(2))(L(5))(X(4))(X(3)));
+
+  // remove all
+  SymbolicBayesNet bn;
+  SymbolicBayesTree::Cliques orphans;
+  bayesTree.removeTop(Keys(X(2))(L(5))(X(4))(X(3)), &bn, &orphans);
+
+  CHECK(assert_container_equality(result, bn.keys()));
+}
+
+/* ************************************************************************* */
 TEST(SymbolicBayesTree, thinTree) {
   // create a thin-tree Bayes net, a la Jean-Guillaume
   SymbolicBayesNet bayesNet;

--- a/tests/testDoglegOptimizer.cpp
+++ b/tests/testDoglegOptimizer.cpp
@@ -186,7 +186,7 @@ TEST(DoglegOptimizer, IterateLineSearch) {
     VectorValues dx_u = gbn->optimizeGradientSearch();
     VectorValues dx_n = gbn->optimize();
     DoglegOptimizerImpl::IterationResult result = DoglegLineSearchImpl::Iterate(
-        0.02, 0.5, 1.5, 1e-3, dx_u, dx_n, *gbn, fg, config);
+        {0.02, 0.5, 1.5, 1e-3, false}, dx_u, dx_n, *gbn, fg, config);
     EXPECT(result.f_error < fg.error(config));  // Check that error decreases
 
     Values newConfig(config.retract(result.dx_d));

--- a/tests/testDoglegOptimizer.cpp
+++ b/tests/testDoglegOptimizer.cpp
@@ -358,5 +358,51 @@ TEST(DogLegOptimizer, VariableUpdate) {
 }
 
 /* ************************************************************************* */
+/**
+ * Validate computeblend when Newton delta is mis-matched with gradient delta
+ * 
+ * To enable variable changes to smart factors the fix to issue:
+ * https://github.com/borglab/gtsam/issues/301
+ * ISAM2 was updated to add variables before updating the delta. 
+ * This however can cause a structural miss-match between dx_n and dx_u during
+ * ComputeBlend causing this test to crash with an error before the fix.
+ */
+TEST(DogLegOptimizer, ComputeBlend) {
+  auto model = noiseModel::Diagonal::Sigmas(Vector3(0.2, 0.2, 0.1));
+  ISAM2DoglegParams doglegparams = ISAM2DoglegParams();
+  doglegparams.initialDelta = 1e-2;
+  doglegparams.verbose = false;
+  ISAM2Params isam2_params;
+  isam2_params.evaluateNonlinearError = true;
+  isam2_params.relinearizeThreshold = 0.0;
+  isam2_params.enableRelinearization = true;
+  isam2_params.optimizationParams = doglegparams;
+  isam2_params.relinearizeSkip = 1;
+  ISAM2 isam2(isam2_params);
+
+  ISAM2UpdateParams update_params;
+  update_params.force_relinearize = true;
+
+  {
+    NonlinearFactorGraph graph;
+    graph.emplace_shared<PriorFactor<Pose2>>(0, Pose2(), model);
+    Values values;
+    values.insert(0, Pose2(5, 5, 3));
+    isam2.update(graph, values, update_params);
+  }
+  for (size_t i = 0; i < 3; i++) {
+    NonlinearFactorGraph graph;
+    graph.emplace_shared<BetweenFactor<Pose2>>(i, i+1, Pose2(1,0,0), model);
+    Values values;
+    values.insert(i+1, Pose2(i + 5, i + 5, 3));
+    isam2.update(graph, values, update_params);
+  }
+
+  // Check is trivial as test validates no runtime error
+  Values computed = isam2.calculateEstimate();
+  CHECK(computed.size() == 4);
+}
+
+/* ************************************************************************* */
 int main() { TestResult tr; return TestRegistry::runAllTests(tr); }
 /* ************************************************************************* */

--- a/tests/testDoglegOptimizer.cpp
+++ b/tests/testDoglegOptimizer.cpp
@@ -360,12 +360,12 @@ TEST(DogLegOptimizer, VariableUpdate) {
 /* ************************************************************************* */
 /**
  * Validate computeblend when Newton delta is mis-matched with gradient delta
- * 
- * To enable variable changes to smart factors the fix to issue:
- * https://github.com/borglab/gtsam/issues/301
- * ISAM2 was updated to add variables before updating the delta. 
- * This however can cause a structural miss-match between dx_n and dx_u during
- * ComputeBlend causing this test to crash with an error before the fix.
+ *
+ * To enable variable changes to smart factors, ISAM2 was updated to add
+ * variables before updating the delta. This however can cause a structural
+ * miss-match between dx_n and dx_u during ComputeBlend causing this test to
+ * crash with an error before the fix. 
+ * ref: https://github.com/borglab/gtsam/issues/301
  */
 TEST(DogLegOptimizer, ComputeBlend) {
   auto model = noiseModel::Diagonal::Sigmas(Vector3(0.2, 0.2, 0.1));

--- a/tests/testDoglegOptimizer.cpp
+++ b/tests/testDoglegOptimizer.cpp
@@ -364,7 +364,7 @@ TEST(DogLegOptimizer, VariableUpdate) {
  * To enable variable changes to smart factors, ISAM2 was updated to add
  * variables before updating the delta. This however can cause a structural
  * miss-match between dx_n and dx_u during ComputeBlend causing this test to
- * crash with an error before the fix. 
+ * crash with an error before the fix.
  * ref: https://github.com/borglab/gtsam/issues/301
  */
 TEST(DogLegOptimizer, ComputeBlend) {
@@ -392,9 +392,9 @@ TEST(DogLegOptimizer, ComputeBlend) {
   }
   for (size_t i = 0; i < 3; i++) {
     NonlinearFactorGraph graph;
-    graph.emplace_shared<BetweenFactor<Pose2>>(i, i+1, Pose2(1,0,0), model);
+    graph.emplace_shared<BetweenFactor<Pose2>>(i, i + 1, Pose2(1, 0, 0), model);
     Values values;
-    values.insert(i+1, Pose2(i + 5, i + 5, 3));
+    values.insert(i + 1, Pose2(i + 5, i + 5, 3));
     isam2.update(graph, values, update_params);
   }
 

--- a/tests/testDoglegOptimizer.cpp
+++ b/tests/testDoglegOptimizer.cpp
@@ -164,6 +164,39 @@ TEST(DoglegOptimizer, Iterate) {
 }
 
 /* ************************************************************************* */
+TEST(DoglegOptimizer, IterateLineSearch) {
+  // really non-linear factor graph
+  NonlinearFactorGraph fg = example::createReallyNonlinearFactorGraph();
+
+  // config far from minimum
+  Point2 x0(3, 0);
+  Values config;
+  config.insert(X(1), x0);
+
+  for (size_t it = 0; it < 10; ++it) {
+    auto linearized = fg.linearize(config);
+
+    // Iterate assumes that linear error = nonlinear error at the linearization
+    // point, and this should be true
+    double nonlinearError = fg.error(config);
+    double linearError = linearized->error(config.zeroVectors());
+    DOUBLES_EQUAL(nonlinearError, linearError, 1e-5);
+
+    auto gbn = linearized->eliminateSequential();
+    VectorValues dx_u = gbn->optimizeGradientSearch();
+    VectorValues dx_n = gbn->optimize();
+    DoglegOptimizerImpl::IterationResult result = DoglegLineSearchImpl::Iterate(
+        0.02, 0.5, 1.5, 1e-3, dx_u, dx_n, *gbn, fg, config);
+    EXPECT(result.f_error < fg.error(config));  // Check that error decreases
+
+    Values newConfig(config.retract(result.dx_d));
+    config = newConfig;
+    DOUBLES_EQUAL(fg.error(config), result.f_error,
+                  1e-5);  // Check that error is correctly filled in
+  }
+}
+
+/* ************************************************************************* */
 TEST(DoglegOptimizer, Constraint) {
   // Create a pose-graph graph with a constraint on the first pose
   NonlinearFactorGraph graph;

--- a/tests/testGaussianISAM2.cpp
+++ b/tests/testGaussianISAM2.cpp
@@ -318,7 +318,7 @@ TEST(ISAM2, slamlike_solution_dogleg)
 }
 
 /* ************************************************************************* */
-TEST(ISAM2, slamlike_solution_dogleglinesearch) {
+TEST(ISAM2, slamlikeSolutionDoglegLineSearch) {
   // These variables will be reused and accumulate factors and values
   Values fullinit;
   NonlinearFactorGraph fullgraph;
@@ -356,7 +356,7 @@ TEST(ISAM2, slamlike_solution_dogleg_qr)
 }
 
 /* ************************************************************************* */
-TEST(ISAM2, slamlike_solution_dogleglinesearch_qr) {
+TEST(ISAM2, slamlikeSolutionDoglegLineSearchQr) {
   // These variables will be reused and accumulate factors and values
   Values fullinit;
   NonlinearFactorGraph fullgraph;
@@ -1023,7 +1023,7 @@ TEST(ISAM2, calculate_nnz)
 }
 
 /* ************************************************************************* */
-TEST(ISAM2, predict_update_info) {
+TEST(ISAM2, predictUpdateInfo) {
   // Setup iSAM2
   ISAM2Params params;
   params.findUnusedFactorSlots = true;

--- a/tests/testGaussianISAM2.cpp
+++ b/tests/testGaussianISAM2.cpp
@@ -324,7 +324,7 @@ TEST(ISAM2, slamlike_solution_dogleglinesearch) {
   NonlinearFactorGraph fullgraph;
   ISAM2 isam = createSlamlikeISAM2(
       &fullinit, &fullgraph,
-      ISAM2Params(ISAM2DoglegLineSearchParams(0.1, 1.0, 3, 1e-3, 1e-4, false),
+      ISAM2Params(ISAM2DoglegLineSearchParams(0.1, 1.0, 3, 1e-4, 1e-3, false),
                   0.0, 0, false));
 
   // Compare solutions
@@ -362,7 +362,7 @@ TEST(ISAM2, slamlike_solution_dogleglinesearch_qr) {
   NonlinearFactorGraph fullgraph;
   ISAM2 isam = createSlamlikeISAM2(
       &fullinit, &fullgraph,
-      ISAM2Params(ISAM2DoglegLineSearchParams(0.1, 10.0, 3, 1e-3, 1e-4, false),
+      ISAM2Params(ISAM2DoglegLineSearchParams(0.1, 10.0, 3, 1e-4, 1e-3, false),
                   0.0, 0, false, false, ISAM2Params::QR));
 
   // Compare solutions
@@ -1068,7 +1068,7 @@ TEST(ISAM2, predict_update_info) {
 
     // Validate
     if (result.details()->variableStatus.size() == size_t(i + 1)) {
-      EXPECT(predicted.second)
+      EXPECT(predicted.second);
     } else {
       for (auto kvp : result.details()->variableStatus) {
         if (kvp.second.isReeliminated) {

--- a/tests/testGaussianISAM2.cpp
+++ b/tests/testGaussianISAM2.cpp
@@ -318,13 +318,13 @@ TEST(ISAM2, slamlike_solution_dogleg)
 }
 
 /* ************************************************************************* */
-TEST(ISAM2, slamlikeSolutionDoglegLineSearch) {
+TEST(ISAM2, SlamlikeSolutionDoglegLineSearch) {
   // These variables will be reused and accumulate factors and values
   Values fullinit;
   NonlinearFactorGraph fullgraph;
   ISAM2 isam = createSlamlikeISAM2(
       &fullinit, &fullgraph,
-      ISAM2Params(ISAM2DoglegLineSearchParams(0.1, 1.0, 3, 1e-4, 1e-3, false),
+      ISAM2Params(ISAM2DoglegLineSearchParams(0.1, 1.0, 3, 1e-4, false, 1e-3),
                   0.0, 0, false));
 
   // Compare solutions
@@ -356,13 +356,13 @@ TEST(ISAM2, slamlike_solution_dogleg_qr)
 }
 
 /* ************************************************************************* */
-TEST(ISAM2, slamlikeSolutionDoglegLineSearchQr) {
+TEST(ISAM2, SlamlikeSolutionDoglegLineSearchQr) {
   // These variables will be reused and accumulate factors and values
   Values fullinit;
   NonlinearFactorGraph fullgraph;
   ISAM2 isam = createSlamlikeISAM2(
       &fullinit, &fullgraph,
-      ISAM2Params(ISAM2DoglegLineSearchParams(0.1, 10.0, 3, 1e-4, 1e-3, false),
+      ISAM2Params(ISAM2DoglegLineSearchParams(0.1, 10.0, 3, 1e-4, false, 1e-3),
                   0.0, 0, false, false, ISAM2Params::QR));
 
   // Compare solutions
@@ -1023,7 +1023,7 @@ TEST(ISAM2, calculate_nnz)
 }
 
 /* ************************************************************************* */
-TEST(ISAM2, predictUpdateInfo) {
+TEST(ISAM2, PredictUpdateInfo) {
   // Setup iSAM2
   ISAM2Params params;
   params.findUnusedFactorSlots = true;

--- a/tests/testGaussianISAM2.cpp
+++ b/tests/testGaussianISAM2.cpp
@@ -324,9 +324,8 @@ TEST(ISAM2, slamlike_solution_dogleglinesearch) {
   NonlinearFactorGraph fullgraph;
   ISAM2 isam = createSlamlikeISAM2(
       &fullinit, &fullgraph,
-      ISAM2Params(
-          ISAM2DoglegLineSearchParams(0.1, 1.0, 3, 1e-3, 1e-4, false), 0.0,
-          0, false));
+      ISAM2Params(ISAM2DoglegLineSearchParams(0.1, 1.0, 3, 1e-3, 1e-4, false),
+                  0.0, 0, false));
 
   // Compare solutions
   CHECK(isam_check(fullgraph, fullinit, isam, *this, result_));
@@ -363,9 +362,8 @@ TEST(ISAM2, slamlike_solution_dogleglinesearch_qr) {
   NonlinearFactorGraph fullgraph;
   ISAM2 isam = createSlamlikeISAM2(
       &fullinit, &fullgraph,
-      ISAM2Params(
-          ISAM2DoglegLineSearchParams(0.1, 10.0, 3, 1e-3, 1e-4, false), 0.0,
-          0, false, false, ISAM2Params::QR));
+      ISAM2Params(ISAM2DoglegLineSearchParams(0.1, 10.0, 3, 1e-3, 1e-4, false),
+                  0.0, 0, false, false, ISAM2Params::QR));
 
   // Compare solutions
   CHECK(isam_check(fullgraph, fullinit, isam, *this, result_));

--- a/tests/testGaussianISAM2.cpp
+++ b/tests/testGaussianISAM2.cpp
@@ -318,6 +318,21 @@ TEST(ISAM2, slamlike_solution_dogleg)
 }
 
 /* ************************************************************************* */
+TEST(ISAM2, slamlike_solution_dogleglinesearch) {
+  // These variables will be reused and accumulate factors and values
+  Values fullinit;
+  NonlinearFactorGraph fullgraph;
+  ISAM2 isam = createSlamlikeISAM2(
+      &fullinit, &fullgraph,
+      ISAM2Params(
+          ISAM2DoglegLineSearchParams(0.1, 10.0, 1.5, 1e-3, 1e-4, false), 0.0,
+          0, false));
+
+  // Compare solutions
+  CHECK(isam_check(fullgraph, fullinit, isam, *this, result_));
+}
+
+/* ************************************************************************* */
 TEST(ISAM2, slamlike_solution_gaussnewton_qr)
 {
   // These variables will be reused and accumulate factors and values
@@ -336,6 +351,21 @@ TEST(ISAM2, slamlike_solution_dogleg_qr)
   Values fullinit;
   NonlinearFactorGraph fullgraph;
   ISAM2 isam = createSlamlikeISAM2(&fullinit, &fullgraph, ISAM2Params(ISAM2DoglegParams(1.0), 0.0, 0, false, false, ISAM2Params::QR));
+
+  // Compare solutions
+  CHECK(isam_check(fullgraph, fullinit, isam, *this, result_));
+}
+
+/* ************************************************************************* */
+TEST(ISAM2, slamlike_solution_dogleglinesearch_qr) {
+  // These variables will be reused and accumulate factors and values
+  Values fullinit;
+  NonlinearFactorGraph fullgraph;
+  ISAM2 isam = createSlamlikeISAM2(
+      &fullinit, &fullgraph,
+      ISAM2Params(
+          ISAM2DoglegLineSearchParams(0.1, 10.0, 1.5, 1e-3, 1e-4, false), 0.0,
+          0, false, false, ISAM2Params::QR));
 
   // Compare solutions
   CHECK(isam_check(fullgraph, fullinit, isam, *this, result_));
@@ -994,6 +1024,65 @@ TEST(ISAM2, calculate_nnz)
   EXPECT_LONGS_EQUAL(expected, actual);
 }
 
+/* ************************************************************************* */
+TEST(ISAM2, predict_update_info) {
+  // Setup iSAM2
+  ISAM2Params params;
+  params.findUnusedFactorSlots = true;
+  params.enableDetailedResults = true;
+
+  ISAM2 isam{params};
+
+  // Generate scenario - Straight motion along X w/ loop closures at 3 points
+  for (int i = 0; i < 50; i++) {
+    ISAM2UpdateParams update_params;
+    NonlinearFactorGraph factors;
+    Values values;
+    // Add Values
+    values.insert(i, Pose2(i, 0, 0));
+
+    // Add Odometry
+    if (i == 0) {
+      factors.emplace_shared<PriorFactor<Pose2>>(0, Pose2(), odoNoise);
+    } else {
+      factors.emplace_shared<BetweenFactor<Pose2>>(i - 1, i, Pose2(1, 0, 0),
+                                                   odoNoise);
+    }
+
+    // Add Loop Closures at various points
+    if (i == 10)
+      factors.emplace_shared<BetweenFactor<Pose2>>(10, 0, Pose2(-10, 0, 0),
+                                                   odoNoise);
+    if (i == 20)
+      factors.emplace_shared<BetweenFactor<Pose2>>(20, 5, Pose2(-15, 0, 0),
+                                                   odoNoise);
+    if (i == 40)
+      factors.emplace_shared<BetweenFactor<Pose2>>(40, 35, Pose2(5, 0, 0),
+                                                   odoNoise);
+
+    // Predict the Update
+    std::pair<KeySet, bool> predicted =
+        isam.predictUpdateInfo(factors, values, update_params);
+
+    // Actually perform the update
+    ISAM2Result result = isam.update(factors, values, update_params);
+    isam.calculateEstimate();
+
+    // Validate
+    if (result.details()->variableStatus.size() == size_t(i + 1)) {
+      EXPECT(predicted.second)
+    } else {
+      for (auto kvp : result.details()->variableStatus) {
+        if (kvp.second.isReeliminated) {
+          EXPECT(predicted.first.count(kvp.first) == 1 ||
+                 kvp.second.isAboveRelinThreshold);
+        }
+      }
+    }
+  }
+}
+
+/* ************************************************************************* */
 class FixActiveFactor : public NoiseModelFactorN<Vector2> {
   using Base = NoiseModelFactorN<Vector2>;
   bool is_active_;

--- a/tests/testGaussianISAM2.cpp
+++ b/tests/testGaussianISAM2.cpp
@@ -325,7 +325,7 @@ TEST(ISAM2, slamlike_solution_dogleglinesearch) {
   ISAM2 isam = createSlamlikeISAM2(
       &fullinit, &fullgraph,
       ISAM2Params(
-          ISAM2DoglegLineSearchParams(0.1, 10.0, 1.5, 1e-3, 1e-4, false), 0.0,
+          ISAM2DoglegLineSearchParams(0.1, 1.0, 3, 1e-3, 1e-4, false), 0.0,
           0, false));
 
   // Compare solutions
@@ -364,7 +364,7 @@ TEST(ISAM2, slamlike_solution_dogleglinesearch_qr) {
   ISAM2 isam = createSlamlikeISAM2(
       &fullinit, &fullgraph,
       ISAM2Params(
-          ISAM2DoglegLineSearchParams(0.1, 10.0, 1.5, 1e-3, 1e-4, false), 0.0,
+          ISAM2DoglegLineSearchParams(0.1, 10.0, 3, 1e-3, 1e-4, false), 0.0,
           0, false, false, ISAM2Params::QR));
 
   // Compare solutions


### PR DESCRIPTION
This is the first of 3 PRs that support the integration of [riSAM](https://arxiv.org/abs/2209.14359) into GTSAM. This PR is focused on updating iSAM2 with some additional functionality to support riSAM's implementation, and also fixes issue #2405 as the bug significantly affected the new DoglegLineSearch optimizer. Below are details on the changes:

## Feature 1 - One Step Look Ahead
riSAM relies on predicting the effect of an update on the bayes tree structure to identify which factors to re-convexify. To support this this PR adds `predictUpdateInfo` to the iSAM2 interface and a helper function `traverseTop` to the BayesTree interface. Tests can be found in `testGaussianISAM2` and `testSymbolicBayesTree`

## Feature 2 - DoglegLineSearch
In riSAM, factors are routinely re-convexified, causing the region of trust (a-la Dogleg) to be uncorrelated between time-steps. At the same time we require a trust region optimizer to ensure wild steps are not taken. DoglegLineSearch functions as a line-search along the dog-leg arc. The search is performed independently for each optimziation step supporting cases like riSAM where the underlying cost function is changing significantly between optimization steps. While this was motivated by riSAM, I think there are additional scenarios where this could be useful (e.g. using smart-factors to significantly change the cost function on updates).

While testing this feature I ran across the same bug identified in #2405 as DoglegLineSearch runs compute blend often. The cause is just as identified by @william-swarmbotics, adding variables in `ISAM2::update` before the bayes tree is actually updated causes a dimensionality mis-match between the the gradient and newton directions. This was fixed in `updateDelta` by ensuring the vectors match structure.

## Feature 3 - Skip redundant `updateDelta`
In `iSAM2::update`, `delta` is updated, but the check to identify when updates are needed ignores the `deltaReplaceMask` this causes redundant `updateDelta` calls especially in the case that `relinearizationSkip = 1` (which is used for riSAM). To avoid this redundent work I added a check for the `deltaReplaceMask`. Though It may be better to move this check into `relinarizationNeeded`, let me know if there is a preference on the location of this check.

## Final Notes
All functionality is tested, and I believe tests have full coverage. Notably I also added a test that is able to deterministically recreate the error in #2405 in `TEST(DogLegOptimizer, ComputeBlend)`. Additionally, the python interface file is updated (though not tested locally due to a cmake version issue. I am trusting the CI to catch any issues there)