### PR TITLE
Allowing Non Noise Model Factors for Gnc

### DIFF
--- a/gtsam/nonlinear/GncOptimizer.h
+++ b/gtsam/nonlinear/GncOptimizer.h
@@ -29,7 +29,6 @@
 #include <gtsam/nonlinear/GncParams.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/internal/ChiSquaredInverse.h>
-#include <set>
 
 namespace gtsam {
 /*
@@ -38,6 +37,35 @@ namespace gtsam {
  */
 static double Chi2inv(const double alpha, const size_t dofs) {
   return internal::chiSquaredQuantile(dofs, alpha);
+}
+
+/**
+ * @enum Type
+ * @brief Enum to classify factor types in GNC optimization.
+ */
+enum class Type {
+  Normal,         ///< Normal case.
+  Inlier,         ///< Factor is a known inlier.
+  Outlier,        ///< Factor is a known outlier.
+  NonNoiseModel,  ///< Factor does not have a noise model
+  NullPointer,     ///< Factor pointer is null.
+  InlierNonNoiseModel ///< Factor is an inlier and does not have a noise model
+};
+
+bool isNullType(Type type) {
+  return type == Type::NullPointer;
+}
+
+bool isNonNoiseModelType(Type type) {
+  return type == Type::NonNoiseModel;
+}
+
+bool needsWeightUpdate(Type type) {
+  return type == Type::Normal;
+}
+
+bool hasNoise(Type type) {
+  return type == Type::Normal || type == Type::Inlier || type == Type::Outlier;
 }
 
 /* ************************************************************************* */
@@ -53,7 +81,7 @@ class GncOptimizer {
   GncParameters params_; ///< GNC parameters.
   Vector weights_;  ///< Weights associated to each factor in GNC (this could be a local variable in optimize, but it is useful to make it accessible from outside).
   Vector barcSq_;  ///< Inlier thresholds. A factor is considered an inlier if factor.error() < barcSq_[i] (where i is the position of the factor in the factor graph. Note that factor.error() whitens by the covariance.
-  std::set<size_t> knownInliers_; ///< Set of known Inliers for the Gnc Optimization process
+  std::vector<Type> factorTypes_;  ///< Cached factor types for GNC.
 
  public:
   /// Constructor.
@@ -63,52 +91,57 @@ class GncOptimizer {
         params_(params) {
 
     // make sure all noiseModels are Gaussian or convert to Gaussian
-    knownInliers_.insert(params.knownInliers.begin(), params.knownInliers.end());
     nfg_.resize(graph.size());
+    factorTypes_.assign(graph.size(), Type::NullPointer);
     for (size_t i = 0; i < graph.size(); i++) {
-      if (graph[i]) {
-        NoiseModelFactor::shared_ptr factor = graph.at<NoiseModelFactor>(i);
-        if (!factor) {
-          if (!params.allow_non_noisemodel_factors) {
-            throw std::runtime_error("GncOptimizer::constructor: the user must set allow_non_noisemodel_factors as "
-              " true if the factor graph contains factors without noise model.");
-          }
-          nfg_[i] = graph[i];
-          knownInliers_.insert(i);
-          continue;
-        }
-        auto robust =
-            std::dynamic_pointer_cast<noiseModel::Robust>(factor->noiseModel());
-        // if the factor has a robust loss, we remove the robust loss
-        nfg_[i] = robust ? factor-> cloneWithNewNoiseModel(robust->noise()) : factor;
+      if (!graph[i]) {
+        factorTypes_[i] = Type::NullPointer;
+        continue;
       }
+      NoiseModelFactor::shared_ptr factor = graph.at<NoiseModelFactor>(i);
+      if (!factor) {
+        if (!params.allowNonNoiseModelFactors) {
+          throw std::runtime_error("GncOptimizer::constructor: the user must set allowNonNoiseModelFactors as"
+            " true if the factor graph contains factors without noise model.");
+        }
+        nfg_[i] = graph[i];
+        factorTypes_[i] = Type::NonNoiseModel;
+        continue;
+      }
+      auto robust =
+            std::dynamic_pointer_cast<noiseModel::Robust>(factor->noiseModel());
+      // if the factor has a robust loss, we remove the robust loss
+      nfg_[i] = robust ? factor-> cloneWithNewNoiseModel(robust->noise()) : factor;
+      factorTypes_[i] = Type::Normal;
     }
 
-    // check that known inliers and outliers make sense:
-    std::vector<size_t> inconsistentlySpecifiedWeights; // measurements the user has incorrectly specified
-    // to be BOTH known inliers and known outliers
-    std::set_intersection(knownInliers_.begin(), knownInliers_.end(),
-                        params.knownOutliers.begin(),params.knownOutliers.end(),
-                        std::inserter(inconsistentlySpecifiedWeights, inconsistentlySpecifiedWeights.begin()));
-    if(inconsistentlySpecifiedWeights.size() > 0){ // if we have inconsistently specified weights, we throw an exception
-      params.print("params\n");
-      throw std::runtime_error("GncOptimizer::constructor: the user has selected one or more measurements"
-          " to be BOTH a known inlier and a known outlier.");
-    }
     // check that known inliers are in the graph
-    for (size_t i: knownInliers_){
-      if( i > nfg_.size()-1 ){ // outside graph
+    for (size_t i = 0; i < params.knownInliers.size(); i++){
+      if( params.knownInliers[i] > nfg_.size()-1 || isNullType(factorTypes_[params.knownInliers[i]])) { // outside graph
         throw std::runtime_error("GncOptimizer::constructor: the user has selected one or more measurements"
                   "that are not in the factor graph to be known inliers.");
+      }
+      if (isNonNoiseModelType(factorTypes_[params.knownInliers[i]])) {
+        factorTypes_[params.knownInliers[i]] = Type::InlierNonNoiseModel;
+      }
+      else {
+        factorTypes_[params.knownInliers[i]] = Type::Inlier;
       }
     }
     // check that known outliers are in the graph
     for (size_t i = 0; i < params.knownOutliers.size(); i++){
-      if( params.knownOutliers[i] > nfg_.size()-1 ){ // outside graph
+      if( params.knownOutliers[i] > nfg_.size()-1 || isNullType(factorTypes_[params.knownOutliers[i]])) { // outside graph
         throw std::runtime_error("GncOptimizer::constructor: the user has selected one or more measurements"
                   "that are not in the factor graph to be known outliers.");
       }
+      if (!needsWeightUpdate(factorTypes_[params.knownOutliers[i]])) {
+        // it can only be normal, InlierNonNoiseModel, Inlier or NonNoiseModel here so this statement works
+        throw std::runtime_error("GncOptimizer::constructor: the user has selected one or more measurements"
+                  " to be an outlier that is either an inlier or a non noise model factor.");
+      }
+      factorTypes_[params.knownOutliers[i]] = Type::Outlier;
     }
+
     // initialize weights (if we don't have prior knowledge of inliers/outliers
     // the weights are all initialized to 1.
     weights_ = initializeWeightsFromKnownInliersAndOutliers();
@@ -142,20 +175,14 @@ class GncOptimizer {
   void setInlierCostThresholdsAtProbability(const double alpha) {
     barcSq_  = Vector::Ones(nfg_.size()); // initialize
     for (size_t k = 0; k < nfg_.size(); k++) {
-      if (nfg_[k]) {
-        auto nf = std::dynamic_pointer_cast<NoiseModelFactor>(nfg_[k]);
-        if (!nf) {
-          // Non-NoiseModelFactor: exclude from GNC thresholding.
-          barcSq_[k] = 0.0;
-          continue;
-        }
+      if (hasNoise(factorTypes_[k])) {
         barcSq_[k] = 0.5 * Chi2inv(alpha, nfg_[k]->dim()); // 0.5 derives from the error definition in gtsam
       }
     }
   }
 
   /** Set weights for each factor. This is typically not needed, but
-   * provides an extra interface for the user to initialize the weightst
+   * provides an extra interface for the user to initialize the weights
    * */
   void setWeights(const Vector w) {
     if (size_t(w.size()) != nfg_.size()) {
@@ -191,6 +218,7 @@ class GncOptimizer {
 
   Vector initializeWeightsFromKnownInliersAndOutliers() const{
     Vector weights = Vector::Ones(nfg_.size());
+    // we do not loop through the factorTypes_ vector because in general params_.knownOutliers will always be smaller
     for (size_t i = 0; i < params_.knownOutliers.size(); i++){
       weights[ params_.knownOutliers[i] ] = 0.0; // known to be outliers
     }
@@ -211,7 +239,12 @@ class GncOptimizer {
     // maximum residual errors at initialization
     // For GM: if residual error is small, mu -> 0
     // For TLS: if residual error is small, mu -> -1
-    int nrUnknownInOrOut = nfg_.size() - ( knownInliers_.size() + params_.knownOutliers.size() );
+    int nrUnknownInOrOut = 0;
+    for (Type t : factorTypes_) {
+      if (needsWeightUpdate(t)) {
+        nrUnknownInOrOut++;
+      }
+    }
     // ^^ number of measurements that are not known to be inliers or outliers (GNC will need to figure them out)
     if (mu <= 0 || nrUnknownInOrOut == 0) { // no need to even call GNC in this case
       if (mu <= 0 && params_.verbosity >= GncParameters::Verbosity::SUMMARY) {
@@ -297,9 +330,7 @@ class GncOptimizer {
          Since barcSq_ can be different for each factor, we compute the max of the quantity in remark 5 in GNC paper
          */
         for (size_t k = 0; k < nfg_.size(); k++) {
-          if (nfg_[k]) {
-            auto nf = std::dynamic_pointer_cast<NoiseModelFactor>(nfg_[k]);
-            if (!nf) continue;
+          if (hasNoise(factorTypes_[k])) {
             mu_init = std::max(mu_init, 2 * nfg_[k]->error(state_) / barcSq_[k]);
           }
         }
@@ -313,9 +344,7 @@ class GncOptimizer {
          */
         mu_init = std::numeric_limits<double>::infinity();
         for (size_t k = 0; k < nfg_.size(); k++) {
-          if (nfg_[k]) {
-            auto nf = std::dynamic_pointer_cast<NoiseModelFactor>(nfg_[k]);
-            if (!nf) continue;
+          if (hasNoise(factorTypes_[k])) {
             double rk = nfg_[k]->error(state_);
             mu_init = (2 * rk - barcSq_[k]) > 0 ? // if positive, update mu, otherwise keep same
                 std::min(mu_init, barcSq_[k] / (2 * rk - barcSq_[k]) ) : mu_init;
@@ -420,13 +449,13 @@ class GncOptimizer {
     NonlinearFactorGraph newGraph;
     newGraph.resize(nfg_.size());
     for (size_t i = 0; i < nfg_.size(); i++) {
-      if (nfg_[i]) {
-        auto factor = nfg_.at<NoiseModelFactor>(i);
-        if (!factor) {
-          // Keep non-NoiseModel factors same.
+      if (!isNullType(factorTypes_[i])) {
+        if (!hasNoise(factorTypes_[i])) {
+          // Keep non NoiseModel factors same.
           newGraph[i] = nfg_[i];
           continue;
         }
+        auto factor = std::static_pointer_cast<NoiseModelFactor>(nfg_[i]);
         auto noiseModel = std::dynamic_pointer_cast<noiseModel::Gaussian>(
             factor->noiseModel());
         if (noiseModel) {
@@ -446,26 +475,11 @@ class GncOptimizer {
   Vector calculateWeights(const Values& currentEstimate, const double mu) {
     Vector weights = initializeWeightsFromKnownInliersAndOutliers();
 
-    // do not update the weights that the user has decided are known inliers
-    std::vector<size_t> allWeights;
-    for (size_t k = 0; k < nfg_.size(); k++) {
-      allWeights.push_back(k);
-    }
-    std::vector<size_t> knownWeights;
-    std::set_union(knownInliers_.begin(), knownInliers_.end(),
-                   params_.knownOutliers.begin(), params_.knownOutliers.end(),
-                   std::inserter(knownWeights, knownWeights.begin()));
-
-    std::vector<size_t> unknownWeights;
-    std::set_difference(allWeights.begin(), allWeights.end(),
-                        knownWeights.begin(), knownWeights.end(),
-                        std::inserter(unknownWeights, unknownWeights.begin()));
-
-    // update weights of known inlier/outlier measurements
+    // update weights of unknown measurements
     switch (params_.lossType) {
       case GncLossType::GM: {  // use eq (12) in GNC paper
-        for (size_t k : unknownWeights) {
-          if (nfg_[k]) {
+        for (size_t k = 0; k < nfg_.size(); k++) {
+          if (needsWeightUpdate(factorTypes_[k])) {
             double u2_k = nfg_[k]->error(currentEstimate);  // squared (and whitened) residual
             weights[k] = std::pow(
                 (mu * barcSq_[k]) / (u2_k + mu * barcSq_[k]), 2);
@@ -474,8 +488,8 @@ class GncOptimizer {
         return weights;
       }
       case GncLossType::TLS: {  // use eq (14) in GNC paper
-        for (size_t k : unknownWeights) {
-          if (nfg_[k]) {
+        for (size_t k = 0; k < nfg_.size(); k++) {
+          if (needsWeightUpdate(factorTypes_[k])) {
             double u2_k = nfg_[k]->error(currentEstimate);  // squared (and whitened) residual
             double upperbound = (mu + 1) / mu * barcSq_[k];
             double lowerbound = mu / (mu + 1) * barcSq_[k];

--- a/gtsam/nonlinear/GncOptimizer.h
+++ b/gtsam/nonlinear/GncOptimizer.h
@@ -65,12 +65,24 @@ class GncOptimizer {
     for (size_t i = 0; i < graph.size(); i++) {
       if (graph[i]) {
         NoiseModelFactor::shared_ptr factor = graph.at<NoiseModelFactor>(i);
+        if (!factor) {
+          // Non-NoiseModelFactor (e.g. KarcherMeanFactorPose3).
+          nfg_[i] = graph[i];
+          params_.knownInliers.push_back(i);
+          continue;
+        }
         auto robust =
             std::dynamic_pointer_cast<noiseModel::Robust>(factor->noiseModel());
         // if the factor has a robust loss, we remove the robust loss
         nfg_[i] = robust ? factor-> cloneWithNewNoiseModel(robust->noise()) : factor;
       }
     }
+
+    // Ensure known inliers are sorted/unique before set operations.
+    std::sort(params_.knownInliers.begin(), params_.knownInliers.end());
+    params_.knownInliers.erase(
+        std::unique(params_.knownInliers.begin(), params_.knownInliers.end()),
+        params_.knownInliers.end());
 
     // check that known inliers and outliers make sense:
     std::vector<size_t> inconsistentlySpecifiedWeights; // measurements the user has incorrectly specified
@@ -131,6 +143,12 @@ class GncOptimizer {
     barcSq_  = Vector::Ones(nfg_.size()); // initialize
     for (size_t k = 0; k < nfg_.size(); k++) {
       if (nfg_[k]) {
+        auto nf = std::dynamic_pointer_cast<NoiseModelFactor>(nfg_[k]);
+        if (!nf) {
+          // Non-NoiseModelFactor: exclude from GNC thresholding.
+          barcSq_[k] = 0.0;
+          continue;
+        }
         barcSq_[k] = 0.5 * Chi2inv(alpha, nfg_[k]->dim()); // 0.5 derives from the error definition in gtsam
       }
     }
@@ -280,6 +298,10 @@ class GncOptimizer {
          */
         for (size_t k = 0; k < nfg_.size(); k++) {
           if (nfg_[k]) {
+            auto nf = std::dynamic_pointer_cast<NoiseModelFactor>(nfg_[k]);
+            if (!nf) {
+              continue;
+            }
             mu_init = std::max(mu_init, 2 * nfg_[k]->error(state_) / barcSq_[k]);
           }
         }
@@ -294,6 +316,10 @@ class GncOptimizer {
         mu_init = std::numeric_limits<double>::infinity();
         for (size_t k = 0; k < nfg_.size(); k++) {
           if (nfg_[k]) {
+            auto nf = std::dynamic_pointer_cast<NoiseModelFactor>(nfg_[k]);
+            if (!nf) {
+              continue;
+            }
             double rk = nfg_[k]->error(state_);
             mu_init = (2 * rk - barcSq_[k]) > 0 ? // if positive, update mu, otherwise keep same
                 std::min(mu_init, barcSq_[k] / (2 * rk - barcSq_[k]) ) : mu_init;
@@ -400,6 +426,11 @@ class GncOptimizer {
     for (size_t i = 0; i < nfg_.size(); i++) {
       if (nfg_[i]) {
         auto factor = nfg_.at<NoiseModelFactor>(i);
+        if (!factor) {
+          // Keep non-NoiseModel factors as-is.
+          newGraph[i] = nfg_[i];
+          continue;
+        }
         auto noiseModel = std::dynamic_pointer_cast<noiseModel::Gaussian>(
             factor->noiseModel());
         if (noiseModel) {

--- a/gtsam/nonlinear/GncOptimizer.h
+++ b/gtsam/nonlinear/GncOptimizer.h
@@ -48,8 +48,7 @@ enum class Type {
   Inlier,         ///< Factor is a known inlier.
   Outlier,        ///< Factor is a known outlier.
   NonNoiseModel,  ///< Factor does not have a noise model
-  NullPointer,     ///< Factor pointer is null.
-  InlierNonNoiseModel ///< Factor is an inlier and does not have a noise model
+  NullPointer      ///< Factor pointer is null.
 };
 
 bool isNullType(Type type) {
@@ -76,12 +75,24 @@ class GncOptimizer {
   typedef typename GncParameters::OptimizerType BaseOptimizer;
 
  private:
-  NonlinearFactorGraph nfg_; ///< Original factor graph to be solved by GNC.
-  Values state_; ///< Initial values to be used at each iteration by GNC.
-  GncParameters params_; ///< GNC parameters.
-  Vector weights_;  ///< Weights associated to each factor in GNC (this could be a local variable in optimize, but it is useful to make it accessible from outside).
-  Vector barcSq_;  ///< Inlier thresholds. A factor is considered an inlier if factor.error() < barcSq_[i] (where i is the position of the factor in the factor graph. Note that factor.error() whitens by the covariance.
-  std::vector<Type> factorTypes_;  ///< Cached factor types for GNC.
+  /// Original factor graph to be solved by GNC.
+  NonlinearFactorGraph nfg_;
+
+  /// Initial values to be used at each iteration by GNC.
+  Values state_;
+
+  /// GNC parameters.
+  GncParameters params_;
+
+  /// Weights associated to each factor in GNC (accessible from outside).
+  Vector weights_;
+
+  /// Inlier thresholds. A factor is considered an inlier if factor.error() <
+  /// barcSq_[i]. Note: factor.error() whitens by the covariance.
+  Vector barcSq_;
+
+  /// Cached factor types for GNC.
+  std::vector<Type> factorTypes_;
 
  public:
   /// Constructor.
@@ -121,10 +132,7 @@ class GncOptimizer {
         throw std::runtime_error("GncOptimizer::constructor: the user has selected one or more measurements"
                   "that are not in the factor graph to be known inliers.");
       }
-      if (isNonNoiseModelType(factorTypes_[params.knownInliers[i]])) {
-        factorTypes_[params.knownInliers[i]] = Type::InlierNonNoiseModel;
-      }
-      else {
+      if (!isNonNoiseModelType(factorTypes_[params.knownInliers[i]])) {
         factorTypes_[params.knownInliers[i]] = Type::Inlier;
       }
     }
@@ -135,7 +143,7 @@ class GncOptimizer {
                   "that are not in the factor graph to be known outliers.");
       }
       if (!needsWeightUpdate(factorTypes_[params.knownOutliers[i]])) {
-        // it can only be normal, InlierNonNoiseModel, Inlier or NonNoiseModel here so this statement works
+        // it can only be Normal, Inlier, or NonNoiseModel here so this works
         throw std::runtime_error("GncOptimizer::constructor: the user has selected one or more measurements"
                   " to be an outlier that is either an inlier or a non noise model factor.");
       }

--- a/gtsam/nonlinear/GncOptimizer.h
+++ b/gtsam/nonlinear/GncOptimizer.h
@@ -299,9 +299,7 @@ class GncOptimizer {
         for (size_t k = 0; k < nfg_.size(); k++) {
           if (nfg_[k]) {
             auto nf = std::dynamic_pointer_cast<NoiseModelFactor>(nfg_[k]);
-            if (!nf) {
-              continue;
-            }
+            if (!nf) continue;
             mu_init = std::max(mu_init, 2 * nfg_[k]->error(state_) / barcSq_[k]);
           }
         }
@@ -317,9 +315,7 @@ class GncOptimizer {
         for (size_t k = 0; k < nfg_.size(); k++) {
           if (nfg_[k]) {
             auto nf = std::dynamic_pointer_cast<NoiseModelFactor>(nfg_[k]);
-            if (!nf) {
-              continue;
-            }
+            if (!nf) continue;
             double rk = nfg_[k]->error(state_);
             mu_init = (2 * rk - barcSq_[k]) > 0 ? // if positive, update mu, otherwise keep same
                 std::min(mu_init, barcSq_[k] / (2 * rk - barcSq_[k]) ) : mu_init;

--- a/gtsam/nonlinear/GncOptimizer.h
+++ b/gtsam/nonlinear/GncOptimizer.h
@@ -29,6 +29,7 @@
 #include <gtsam/nonlinear/GncParams.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/internal/ChiSquaredInverse.h>
+#include <set>
 
 namespace gtsam {
 /*
@@ -52,6 +53,7 @@ class GncOptimizer {
   GncParameters params_; ///< GNC parameters.
   Vector weights_;  ///< Weights associated to each factor in GNC (this could be a local variable in optimize, but it is useful to make it accessible from outside).
   Vector barcSq_;  ///< Inlier thresholds. A factor is considered an inlier if factor.error() < barcSq_[i] (where i is the position of the factor in the factor graph. Note that factor.error() whitens by the covariance.
+  std::set<size_t> knownInliers_; ///< Set of known Inliers for the Gnc Optimization process
 
  public:
   /// Constructor.
@@ -61,14 +63,18 @@ class GncOptimizer {
         params_(params) {
 
     // make sure all noiseModels are Gaussian or convert to Gaussian
+    knownInliers_.insert(params.knownInliers.begin(), params.knownInliers.end());
     nfg_.resize(graph.size());
     for (size_t i = 0; i < graph.size(); i++) {
       if (graph[i]) {
         NoiseModelFactor::shared_ptr factor = graph.at<NoiseModelFactor>(i);
         if (!factor) {
-          // Non-NoiseModelFactor (e.g. KarcherMeanFactorPose3).
+          if (!params.allow_non_noisemodel_factors) {
+            throw std::runtime_error("GncOptimizer::constructor: the user must set allow_non_noisemodel_factors as "
+              " true if the factor graph contains factors without noise model.");
+          }
           nfg_[i] = graph[i];
-          params_.knownInliers.push_back(i);
+          knownInliers_.insert(i);
           continue;
         }
         auto robust =
@@ -78,16 +84,10 @@ class GncOptimizer {
       }
     }
 
-    // Ensure known inliers are sorted/unique before set operations.
-    std::sort(params_.knownInliers.begin(), params_.knownInliers.end());
-    params_.knownInliers.erase(
-        std::unique(params_.knownInliers.begin(), params_.knownInliers.end()),
-        params_.knownInliers.end());
-
     // check that known inliers and outliers make sense:
     std::vector<size_t> inconsistentlySpecifiedWeights; // measurements the user has incorrectly specified
     // to be BOTH known inliers and known outliers
-    std::set_intersection(params.knownInliers.begin(),params.knownInliers.end(),
+    std::set_intersection(knownInliers_.begin(), knownInliers_.end(),
                         params.knownOutliers.begin(),params.knownOutliers.end(),
                         std::inserter(inconsistentlySpecifiedWeights, inconsistentlySpecifiedWeights.begin()));
     if(inconsistentlySpecifiedWeights.size() > 0){ // if we have inconsistently specified weights, we throw an exception
@@ -96,8 +96,8 @@ class GncOptimizer {
           " to be BOTH a known inlier and a known outlier.");
     }
     // check that known inliers are in the graph
-    for (size_t i = 0; i < params.knownInliers.size(); i++){
-      if( params.knownInliers[i] > nfg_.size()-1 ){ // outside graph
+    for (size_t i: knownInliers_){
+      if( i > nfg_.size()-1 ){ // outside graph
         throw std::runtime_error("GncOptimizer::constructor: the user has selected one or more measurements"
                   "that are not in the factor graph to be known inliers.");
       }
@@ -211,7 +211,7 @@ class GncOptimizer {
     // maximum residual errors at initialization
     // For GM: if residual error is small, mu -> 0
     // For TLS: if residual error is small, mu -> -1
-    int nrUnknownInOrOut = nfg_.size() - ( params_.knownInliers.size() + params_.knownOutliers.size() );
+    int nrUnknownInOrOut = nfg_.size() - ( knownInliers_.size() + params_.knownOutliers.size() );
     // ^^ number of measurements that are not known to be inliers or outliers (GNC will need to figure them out)
     if (mu <= 0 || nrUnknownInOrOut == 0) { // no need to even call GNC in this case
       if (mu <= 0 && params_.verbosity >= GncParameters::Verbosity::SUMMARY) {
@@ -427,7 +427,7 @@ class GncOptimizer {
       if (nfg_[i]) {
         auto factor = nfg_.at<NoiseModelFactor>(i);
         if (!factor) {
-          // Keep non-NoiseModel factors as-is.
+          // Keep non-NoiseModel factors same.
           newGraph[i] = nfg_[i];
           continue;
         }
@@ -456,7 +456,7 @@ class GncOptimizer {
       allWeights.push_back(k);
     }
     std::vector<size_t> knownWeights;
-    std::set_union(params_.knownInliers.begin(), params_.knownInliers.end(),
+    std::set_union(knownInliers_.begin(), knownInliers_.end(),
                    params_.knownOutliers.begin(), params_.knownOutliers.end(),
                    std::inserter(knownWeights, knownWeights.begin()));
 

--- a/gtsam/nonlinear/GncParams.h
+++ b/gtsam/nonlinear/GncParams.h
@@ -72,7 +72,7 @@ class GncParams {
   double relativeCostTol = 1e-5;  ///< If relative cost change is below this threshold, stop iterating
   double weightsTol = 1e-4;  ///< If the weights are within weightsTol from being binary, stop iterating (only for TLS)
   Verbosity verbosity = SILENT;  ///< Verbosity level
-  bool allow_non_noisemodel_factors = false;  ///< If true, factors without noise model are not reweighted and not not included in mu calculation
+  bool allowNonNoiseModelFactors = false;  ///< If true, factors without noise model are not reweighted and not not included in mu calculation
 
   /// Use IndexVector for inliers and outliers since it is fast
   using IndexVector = FastVector<uint64_t>;
@@ -139,7 +139,7 @@ class GncParams {
   }
 
   void setAllowNonNoiseModelFactors(bool allow) {
-    allow_non_noisemodel_factors = allow;
+    allowNonNoiseModelFactors = allow;
   }
 
   /// Equals.
@@ -149,7 +149,7 @@ class GncParams {
         && std::fabs(muStep - other.muStep) <= tol
         && verbosity == other.verbosity && knownInliers == other.knownInliers
         && knownOutliers == other.knownOutliers
-        && allow_non_noisemodel_factors == other.allow_non_noisemodel_factors;
+        && allowNonNoiseModelFactors == other.allowNonNoiseModelFactors;
   }
 
   /// Print.
@@ -174,7 +174,7 @@ class GncParams {
       std::cout << "knownInliers: " << knownInliers[i] << "\n";
     for (size_t i = 0; i < knownOutliers.size(); i++)
       std::cout << "knownOutliers: " << knownOutliers[i] << "\n";
-    std::cout << "allow_non_noisemodel_factors: " << allow_non_noisemodel_factors << "\n";
+    std::cout << "allowNonNoiseModelFactors: " << allowNonNoiseModelFactors << "\n";
     baseOptimizerParams.print("Base optimizer params: ");
   }
 };

--- a/gtsam/nonlinear/GncParams.h
+++ b/gtsam/nonlinear/GncParams.h
@@ -72,6 +72,7 @@ class GncParams {
   double relativeCostTol = 1e-5;  ///< If relative cost change is below this threshold, stop iterating
   double weightsTol = 1e-4;  ///< If the weights are within weightsTol from being binary, stop iterating (only for TLS)
   Verbosity verbosity = SILENT;  ///< Verbosity level
+  bool allow_non_noisemodel_factors = false;  ///< If true, factors without noise model are not reweighted and not not included in mu calculation
 
   /// Use IndexVector for inliers and outliers since it is fast
   using IndexVector = FastVector<uint64_t>;
@@ -137,13 +138,18 @@ class GncParams {
     std::sort(knownOutliers.begin(), knownOutliers.end());
   }
 
+  void setAllowNonNoiseModelFactors(bool allow) {
+    allow_non_noisemodel_factors = allow;
+  }
+
   /// Equals.
   bool equals(const GncParams& other, double tol = 1e-9) const {
     return baseOptimizerParams.equals(other.baseOptimizerParams)
         && lossType == other.lossType && maxIterations == other.maxIterations
         && std::fabs(muStep - other.muStep) <= tol
         && verbosity == other.verbosity && knownInliers == other.knownInliers
-        && knownOutliers == other.knownOutliers;
+        && knownOutliers == other.knownOutliers
+        && allow_non_noisemodel_factors == other.allow_non_noisemodel_factors;
   }
 
   /// Print.
@@ -168,6 +174,7 @@ class GncParams {
       std::cout << "knownInliers: " << knownInliers[i] << "\n";
     for (size_t i = 0; i < knownOutliers.size(); i++)
       std::cout << "knownOutliers: " << knownOutliers[i] << "\n";
+    std::cout << "allow_non_noisemodel_factors: " << allow_non_noisemodel_factors << "\n";
     baseOptimizerParams.print("Base optimizer params: ");
   }
 };

--- a/gtsam/nonlinear/nonlinear.i
+++ b/gtsam/nonlinear/nonlinear.i
@@ -313,6 +313,7 @@ virtual class GncParams {
   gtsam::This::Verbosity verbosity;
   gtsam::This::IndexVector knownInliers;
   gtsam::This::IndexVector knownOutliers;
+  bool allowNonNoiseModelFactors;
 
   void setLossType(const gtsam::GncLossType type);
   void setMaxIterations(const size_t maxIter);
@@ -322,6 +323,7 @@ virtual class GncParams {
   void setVerbosityGNC(const gtsam::This::Verbosity value);
   void setKnownInliers(const gtsam::This::IndexVector& knownIn);
   void setKnownOutliers(const gtsam::This::IndexVector& knownOut);
+  void setAllowNonNoiseModelFactors(bool allow);
   void print(const string& str = "GncParams: ") const;
   
   enum Verbosity {

--- a/gtsam/sfm/sfm.i
+++ b/gtsam/sfm/sfm.i
@@ -22,6 +22,7 @@ class SfmTrack2d {
 virtual class SfmTrack : gtsam::SfmTrack2d {
   SfmTrack();
   SfmTrack(const gtsam::Point3& pt);
+  SfmTrack(const gtsam::Point3& pt, float r, float g, float b);
   const Point3& point3() const;
 
   Point3 p;

--- a/tests/testGncOptimizer.cpp
+++ b/tests/testGncOptimizer.cpp
@@ -704,10 +704,16 @@ TEST(GncOptimizer, nonNoiseFactorBehavior) {
   GncParams<LevenbergMarquardtParams> gncParams;
   gncParams.setLossType(GncLossType::GM);
   gncParams.setAllowNonNoiseModelFactors(true);
+  GncParams<LevenbergMarquardtParams>::IndexVector knownInliers;
+  knownInliers.push_back(1);
+  knownInliers.push_back(
+      1);  // duplicate should still keep factor 1 as non-noise
+  gncParams.setKnownInliers(knownInliers);
   auto gnc = GncOptimizer<GncParams<LevenbergMarquardtParams>>(nfg, initial,
                                                                gncParams);
 
-  // check if the weight is carried correctly and non noise model factor is unchanged
+  // check if the weight is carried correctly and non noise model factor is
+  // unchanged
   Vector weights = Vector::Ones(nfg.size());
   weights[1] = 0.0;
   NonlinearFactorGraph weighted = gnc.makeWeightedGraph(weights);
@@ -717,18 +723,19 @@ TEST(GncOptimizer, nonNoiseFactorBehavior) {
 
   // checks if knownInliers (our non noise model factor) is not reweighted
   double mu = 1.5;
-  double expected_weight = 1.0;
+  double expectedWeight = 1.0;
   Vector w = gnc.calculateWeights(initial, mu);
-  DOUBLES_EQUAL(expected_weight, w[1], tol);
+  DOUBLES_EQUAL(expectedWeight, w[1], tol);
   CHECK(w[0] < 1.0);
 
   // checks if non noise model factors are ignored is calculating mu
   double err0 = gnc.getFactors().at(0)->error(initial);
   Vector barcSq = gnc.getInlierCostThresholds();
-  double expected_mu = 2.0 * err0 / barcSq[0];
-  EXPECT_DOUBLES_EQUAL(expected_mu, gnc.initializeMu(), 1e-6);
+  double expectedMu = 2.0 * err0 / barcSq[0];
+  EXPECT_DOUBLES_EQUAL(expectedMu, gnc.initializeMu(), 1e-6);
 
-  // checks if gnc optimization runs and keeps the non noise model factor weight fixed at 1
+  // checks if gnc optimization runs and keeps the non noise model factor weight
+  // fixed at 1
   Values result = gnc.optimize();
   CHECK(result.exists(X(0)));
   Vector finalWeights = gnc.getWeights();

--- a/tests/testGncOptimizer.cpp
+++ b/tests/testGncOptimizer.cpp
@@ -30,7 +30,10 @@
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/nonlinear/GncOptimizer.h>
 #include <gtsam/nonlinear/LinearContainerFactor.h>
+#include <gtsam/geometry/Pose3.h>
 #include <gtsam/slam/dataset.h>
+#include <gtsam/slam/KarcherMeanFactor.h>
+#include <gtsam/slam/KarcherMeanFactor-inl.h>
 #include <tests/smallExample.h>
 
 #include <gtsam/sam/BearingFactor.h>
@@ -681,6 +684,53 @@ TEST(GncOptimizer, barcsq_heterogeneousFactors) {
   // extra test:
   // fg.add( PriorFactor<Pose2>(  0, Pose2(0.0, 0.0, 0.0) )); // works if we add model3D as noise model
   // std::cout <<  "fg[3]->dim() " << fg[3]->dim() << std::endl; // this segfaults?
+}
+
+/* ************************************************************************* */
+TEST(GncOptimizer, nonNoiseFactorBehavior) {
+  NonlinearFactorGraph nfg;
+  SharedNoiseModel pose_noise = noiseModel::Isotropic::Sigma(6, 0.5);
+  nfg.add(PriorFactor<Pose3>(X(0), Pose3(), pose_noise));
+
+  KeyVector keys;
+  keys.push_back(X(0));
+  keys.push_back(X(1));
+  nfg.emplace_shared<KarcherMeanFactor<Pose3>>(keys, 6, 1000.0);
+
+  Values initial;
+  initial.insert(X(0), Pose3(Rot3(), Point3(7.0, 0.0, 0.0)));
+  initial.insert(X(1), Pose3());
+
+  GncParams<LevenbergMarquardtParams> gncParams;
+  gncParams.setLossType(GncLossType::GM);
+  auto gnc = GncOptimizer<GncParams<LevenbergMarquardtParams>>(nfg, initial,
+                                                               gncParams);
+
+  // checks if non noise model factors as set as knownInliers
+  const auto& known = gnc.getParams().knownInliers;
+  CHECK(known.size() == 1);
+  CHECK(known[0] == 1);
+
+  // check if the weight is carried correctly and non noise model factor is unchanged
+  Vector weights = Vector::Ones(nfg.size());
+  weights[1] = 0.0;
+  NonlinearFactorGraph weighted = gnc.makeWeightedGraph(weights);
+  CHECK(!weighted.at<NoiseModelFactor>(1));
+  CHECK(weighted.at<NoiseModelFactor>(0));
+  CHECK(weighted.at(1).get() == nfg.at(1).get());
+
+  // checks if knownInliers (our non noise model factor) is not reweighted
+  double mu = 1.5;
+  double expected_weight = 1.0;
+  Vector w = gnc.calculateWeights(initial, mu);
+  DOUBLES_EQUAL(expected_weight, w[1], tol);
+  CHECK(w[0] < 1.0);
+
+  // checks if non noise model factors are ignored is calculating mu
+  double err0 = gnc.getFactors().at(0)->error(initial);
+  Vector barcSq = gnc.getInlierCostThresholds();
+  double expected_mu = 2.0 * err0 / barcSq[0];
+  EXPECT_DOUBLES_EQUAL(expected_mu, gnc.initializeMu(), 1e-6);
 }
 
 /* ************************************************************************* */

--- a/tests/testGncOptimizer.cpp
+++ b/tests/testGncOptimizer.cpp
@@ -727,6 +727,12 @@ TEST(GncOptimizer, nonNoiseFactorBehavior) {
   Vector barcSq = gnc.getInlierCostThresholds();
   double expected_mu = 2.0 * err0 / barcSq[0];
   EXPECT_DOUBLES_EQUAL(expected_mu, gnc.initializeMu(), 1e-6);
+
+  // checks if gnc optimization runs and keeps the non noise model factor weight fixed at 1
+  Values result = gnc.optimize();
+  CHECK(result.exists(X(0)));
+  Vector finalWeights = gnc.getWeights();
+  DOUBLES_EQUAL(1.0, finalWeights[1], tol);
 }
 
 /* ************************************************************************* */

--- a/tests/testGncOptimizer.cpp
+++ b/tests/testGncOptimizer.cpp
@@ -703,13 +703,9 @@ TEST(GncOptimizer, nonNoiseFactorBehavior) {
 
   GncParams<LevenbergMarquardtParams> gncParams;
   gncParams.setLossType(GncLossType::GM);
+  gncParams.setAllowNonNoiseModelFactors(true);
   auto gnc = GncOptimizer<GncParams<LevenbergMarquardtParams>>(nfg, initial,
                                                                gncParams);
-
-  // checks if non noise model factors as set as knownInliers
-  const auto& known = gnc.getParams().knownInliers;
-  CHECK(known.size() == 1);
-  CHECK(known[0] == 1);
 
   // check if the weight is carried correctly and non noise model factor is unchanged
   Vector weights = Vector::Ones(nfg.size());


### PR DESCRIPTION
This PR makes sure that non NoiseModel factors do not throw errors during initialization for Gnc Optimization.
Earlier in the GncOptimizer initialization, if the factor is not a  NoiseModelFactor, then the line `graph.at<NoiseModelFactor>(i)` returns a null pointer, which later causes a segmentation fault. 
In this PR, we add fallbacks so that instead of a segmentation fault, those factors are considered as known inliers, and while they contribute to the loss, their weights are fixed.