### PR TITLE
Weight update in Gnc GM through static function in LossFunctions

### DIFF
--- a/gtsam/linear/LossFunctions.cpp
+++ b/gtsam/linear/LossFunctions.cpp
@@ -324,6 +324,13 @@ double GemanMcClure::weight(double distance) const {
   return c4/(c2error*c2error);
 }
 
+double GemanMcClure::Weight(double distance, double c) {
+  const double c2 = c*c;
+  const double c4 = c2*c2;
+  const double c2error = c2 + distance*distance;
+  return c4/(c2error*c2error);
+}
+
 double GemanMcClure::loss(double distance) const {
   const double c2 = c_*c_;
   const double error2 = distance*distance;

--- a/gtsam/linear/LossFunctions.cpp
+++ b/gtsam/linear/LossFunctions.cpp
@@ -314,24 +314,22 @@ Welsch::shared_ptr Welsch::Create(double c, const ReweightScheme reweight) {
 // GemanMcClure
 /* ************************************************************************* */
 GemanMcClure::GemanMcClure(double c, const ReweightScheme reweight)
-  : Base(reweight), c_(c) {
+  : Base(reweight), c_(c), csquared_(c * c) {
 }
 
 double GemanMcClure::weight(double distance) const {
-  return Weight(distance, c_);
+  return Weight(distance*distance, csquared_);
 }
 
-double GemanMcClure::Weight(double distance, double c) {
-  const double c2 = c*c;
+double GemanMcClure::Weight(double distance2, double c2) {
   const double c4 = c2*c2;
-  const double c2error = c2 + distance*distance;
+  const double c2error = c2 + distance2;
   return c4/(c2error*c2error);
 }
 
 double GemanMcClure::loss(double distance) const {
-  const double c2 = c_*c_;
   const double error2 = distance*distance;
-  return 0.5 * (c2 * error2) / (c2 + error2);
+  return 0.5 * (csquared_ * error2) / (csquared_ + error2);
 }
 
 void GemanMcClure::print(const std::string &s="") const {

--- a/gtsam/linear/LossFunctions.cpp
+++ b/gtsam/linear/LossFunctions.cpp
@@ -318,10 +318,7 @@ GemanMcClure::GemanMcClure(double c, const ReweightScheme reweight)
 }
 
 double GemanMcClure::weight(double distance) const {
-  const double c2 = c_*c_;
-  const double c4 = c2*c2;
-  const double c2error = c2 + distance*distance;
-  return c4/(c2error*c2error);
+  return Weight(distance, c_);
 }
 
 double GemanMcClure::Weight(double distance, double c) {

--- a/gtsam/linear/LossFunctions.h
+++ b/gtsam/linear/LossFunctions.h
@@ -373,9 +373,21 @@ class GTSAM_EXPORT GemanMcClure : public Base {
   double loss(double distance) const override;
   void print(const std::string &s) const override;
   bool equals(const Base &expected, double tol = 1e-8) const override;
-  static double Weight(double distance2, double c2);
   static shared_ptr Create(double k, const ReweightScheme reweight = Block);
   double modelParameter() const { return c_; }
+  /** @brief A static helper function to compute the Geman-McClure robust weight.
+   * The static function takes the squared value of the residual and the scale parameter.
+   * The weight member function now calls the this function, while the member function takes the residual as input, 
+   * it passes r² and c² to the static helper.
+   * 
+   *w(d², c²) = \phi(d)/d = c⁴/(c²+d²)²
+   * 
+   * 
+   * @param distance2 Squared residual magnitude.
+   * @param c2 Squared scale parameter.
+   * @return Weight w(x) in (0, 1]
+   */
+  static double Weight(double distance2, double c2);
 
  protected:
   double c_;

--- a/gtsam/linear/LossFunctions.h
+++ b/gtsam/linear/LossFunctions.h
@@ -373,6 +373,7 @@ class GTSAM_EXPORT GemanMcClure : public Base {
   double loss(double distance) const override;
   void print(const std::string &s) const override;
   bool equals(const Base &expected, double tol = 1e-8) const override;
+  static double Weight(double distance, double c);
   static shared_ptr Create(double k, const ReweightScheme reweight = Block);
   double modelParameter() const { return c_; }
 

--- a/gtsam/linear/LossFunctions.h
+++ b/gtsam/linear/LossFunctions.h
@@ -377,10 +377,10 @@ class GTSAM_EXPORT GemanMcClure : public Base {
   double modelParameter() const { return c_; }
   /** @brief A static helper function to compute the Geman-McClure robust weight.
    * The static function takes the squared value of the residual and the scale parameter.
-   * The weight member function now calls the this function, while the member function takes the residual as input, 
-   * it passes r² and c² to the static helper.
+   * The weight member function now calls this function. While the member function takes the residual as input, 
+   * it passes x² and c² to the static helper.
    * 
-   *w(d², c²) = \phi(d)/d = c⁴/(c²+d²)²
+   * w(x², c²) = \phi(x)/x = c⁴/(c²+x²)²
    * 
    * 
    * @param distance2 Squared residual magnitude.

--- a/gtsam/linear/LossFunctions.h
+++ b/gtsam/linear/LossFunctions.h
@@ -373,12 +373,13 @@ class GTSAM_EXPORT GemanMcClure : public Base {
   double loss(double distance) const override;
   void print(const std::string &s) const override;
   bool equals(const Base &expected, double tol = 1e-8) const override;
-  static double Weight(double distance, double c);
+  static double Weight(double distance2, double c2);
   static shared_ptr Create(double k, const ReweightScheme reweight = Block);
   double modelParameter() const { return c_; }
 
  protected:
   double c_;
+  double csquared_;
 
  private:
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
@@ -388,6 +389,7 @@ class GTSAM_EXPORT GemanMcClure : public Base {
   void serialize(ARCHIVE &ar, const unsigned int /*version*/) {
     ar &BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     ar &BOOST_SERIALIZATION_NVP(c_);
+    ar &BOOST_SERIALIZATION_NVP(csquared_);
   }
 #endif
 };

--- a/gtsam/nonlinear/GncOptimizer.h
+++ b/gtsam/nonlinear/GncOptimizer.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <gtsam/linear/LossFunctions.h>
 #include <gtsam/nonlinear/GncParams.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/internal/ChiSquaredInverse.h>
@@ -489,8 +490,9 @@ class GncOptimizer {
         for (size_t k = 0; k < nfg_.size(); k++) {
           if (needsWeightUpdate(factorTypes_[k])) {
             double u2_k = nfg_[k]->error(currentEstimate);  // squared (and whitened) residual
-            weights[k] = std::pow(
-                (mu * barcSq_[k]) / (u2_k + mu * barcSq_[k]), 2);
+            const double distance = std::sqrt(2.0 * u2_k);
+            const double c = std::sqrt(2.0 * mu * barcSq_[k]);
+            weights[k] = noiseModel::mEstimator::GemanMcClure::Weight(distance, c);
           }
         }
         return weights;

--- a/gtsam/nonlinear/GncOptimizer.h
+++ b/gtsam/nonlinear/GncOptimizer.h
@@ -490,9 +490,7 @@ class GncOptimizer {
         for (size_t k = 0; k < nfg_.size(); k++) {
           if (needsWeightUpdate(factorTypes_[k])) {
             double u2_k = nfg_[k]->error(currentEstimate);  // squared (and whitened) residual
-            const double distance2_k = 2.0 * u2_k;
-            const double c2_k = 2.0 * mu * barcSq_[k];
-            weights[k] = noiseModel::mEstimator::GemanMcClure::Weight(distance2_k, c2_k);
+            weights[k] = noiseModel::mEstimator::GemanMcClure::Weight(u2_k, mu * barcSq_[k]);
           }
         }
         return weights;

--- a/gtsam/nonlinear/GncOptimizer.h
+++ b/gtsam/nonlinear/GncOptimizer.h
@@ -490,9 +490,9 @@ class GncOptimizer {
         for (size_t k = 0; k < nfg_.size(); k++) {
           if (needsWeightUpdate(factorTypes_[k])) {
             double u2_k = nfg_[k]->error(currentEstimate);  // squared (and whitened) residual
-            const double distance = std::sqrt(2.0 * u2_k);
-            const double c = std::sqrt(2.0 * mu * barcSq_[k]);
-            weights[k] = noiseModel::mEstimator::GemanMcClure::Weight(distance, c);
+            const double distance2_k = 2.0 * u2_k;
+            const double c2_k = 2.0 * mu * barcSq_[k];
+            weights[k] = noiseModel::mEstimator::GemanMcClure::Weight(distance2_k, c2_k);
           }
         }
         return weights;


### PR DESCRIPTION
In this branch, I add a static function to LossFunctions for the GemanMcClure loss so that GNC can use the parameter convention and naming from the loss functions. Static helper enables us to call the function without actually creating an object.
To reduce the calls to the std::sqrt function, the static function takes the squared value of the error and the scale parameter.
A scale factor squared in also added in the constructor since c^2 is used in a lot of member functions.
The weight member function now calls the static helper function, while it takes the error as input, it passes e^2 and c^2 to the static helper.
Unit tests pass locally.