### PR TITLE
TLS loss and Rene Vidal TLS implementation

### DIFF
--- a/gtsam/linear/LossFunctions.cpp
+++ b/gtsam/linear/LossFunctions.cpp
@@ -347,6 +347,52 @@ GemanMcClure::shared_ptr GemanMcClure::Create(double c, const ReweightScheme rew
 }
 
 /* ************************************************************************* */
+// TruncatedLeastSquares
+/* ************************************************************************* */
+
+TruncatedLeastSquares::TruncatedLeastSquares(double c, const ReweightScheme reweight)
+  : Base(reweight), c_(c), csquared_(c * c) {
+  if (c_ <= 0) {
+    throw runtime_error("mEstimator TruncatedLeastSquares takes only positive double in constructor.");
+  }
+}
+
+double TruncatedLeastSquares::weight(double distance) const {
+  return Weight(distance * distance, csquared_, csquared_, 0.0);
+}
+
+double TruncatedLeastSquares::Weight(double distance2, double lowerbound, double upperbound, double transition_weight) {
+  if (distance2 <= lowerbound) return 1.0;
+  if (distance2 >= upperbound) return 0.0;
+
+  // Clamping
+  if (transition_weight < 0.0) return 0.0;
+  if (transition_weight > 1.0) return 1.0;
+  return transition_weight;
+}
+
+double TruncatedLeastSquares::loss(double distance) const {
+  if (std::abs(distance) <= c_) {
+    return 0.5 * distance * distance;
+  }
+  return 0.5 * csquared_;
+}
+
+void TruncatedLeastSquares::print(const std::string &s="") const {
+  std::cout << s << ": TLS (" << c_ << ")" << std::endl;
+}
+
+bool TruncatedLeastSquares::equals(const Base &expected, double tol) const {
+  const TruncatedLeastSquares* p = dynamic_cast<const TruncatedLeastSquares*>(&expected);
+  if (p == nullptr) return false;
+  return std::abs(c_ - p->c_) < tol;
+}
+
+TruncatedLeastSquares::shared_ptr TruncatedLeastSquares::Create(double c, const ReweightScheme reweight) {
+  return shared_ptr(new TruncatedLeastSquares(c, reweight));
+}
+
+/* ************************************************************************* */
 // DCS
 /* ************************************************************************* */
 DCS::DCS(double c, const ReweightScheme reweight)

--- a/gtsam/linear/LossFunctions.cpp
+++ b/gtsam/linear/LossFunctions.cpp
@@ -19,6 +19,7 @@
 #include <gtsam/linear/LossFunctions.h>
 
 #include <iostream>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -358,17 +359,14 @@ TruncatedLeastSquares::TruncatedLeastSquares(double c, const ReweightScheme rewe
 }
 
 double TruncatedLeastSquares::weight(double distance) const {
-  return Weight(distance * distance, csquared_, csquared_, 0.0);
+  const auto w = Weight(distance * distance, csquared_, csquared_);
+  return w.value();
 }
 
-double TruncatedLeastSquares::Weight(double distance2, double lowerbound, double upperbound, double transition_weight) {
+std::optional<double> TruncatedLeastSquares::Weight(double distance2, double lowerbound, double upperbound) {
   if (distance2 <= lowerbound) return 1.0;
   if (distance2 >= upperbound) return 0.0;
-
-  // Clamping
-  if (transition_weight < 0.0) return 0.0;
-  if (transition_weight > 1.0) return 1.0;
-  return transition_weight;
+  return std::nullopt;
 }
 
 double TruncatedLeastSquares::loss(double distance) const {

--- a/gtsam/linear/LossFunctions.h
+++ b/gtsam/linear/LossFunctions.h
@@ -431,7 +431,7 @@ class GTSAM_EXPORT TruncatedLeastSquares : public Base {
    * This helper returns a optional<double> because it is also used for GNC, and we encounter transition weight cases,
    * where the weight is not strictly binary (0 or 1) when the residual is within the transition region between inliers and outliers.
    * The weight member function now calls the this function.
-   * While the member function takes the residual as input, it passes x², c² and c²to the static helper.
+   * While the member function takes the residual as input, it passes x², c² and c² to the static helper.
    * 
    * @param distance2 Squared residual magnitude.
    * @param lowerbound Squared lower bound.

--- a/gtsam/linear/LossFunctions.h
+++ b/gtsam/linear/LossFunctions.h
@@ -406,6 +406,59 @@ class GTSAM_EXPORT GemanMcClure : public Base {
 #endif
 };
 
+/** Truncated Least Squares (TLS) robust error model.
+ *
+ *  This model has a scalar parameter "c" (threshold).
+ *
+ * - Loss       \rho(x) = 0.5 x^2  if |x|<=c, 0.5 c^2 otherwise
+ * - Derivative \phi(x) = x        if |x|<=c, 0 otherwise
+ * - Weight     w(x) = \phi(x)/x = 1 if |x|<=c, 0 otherwise
+ */
+class GTSAM_EXPORT TruncatedLeastSquares : public Base {
+ public:
+  typedef std::shared_ptr<TruncatedLeastSquares> shared_ptr;
+
+  TruncatedLeastSquares(double c = 1.0, const ReweightScheme reweight = Block);
+  double weight(double distance) const override;
+  double loss(double distance) const override;
+  void print(const std::string &s) const override;
+  bool equals(const Base &expected, double tol = 1e-8) const override;
+  static shared_ptr Create(double c, const ReweightScheme reweight = Block);
+  double modelParameter() const { return c_; }
+  /** @brief A static helper function to compute the TLS robust weight.
+   * The static function takes the squared value of the residual, the squared lower bound, the squared upper bound, 
+   * and the transition weight (used in GNC).
+   * This helper is mainly useful for GNC, where the weight is not strictly binary (0 or 1) 
+   * when the residual is within the transition region between inliers and outliers.
+   * The weight member function now calls the this function.
+   * While the member function takes the residual as input, it passes x², c², c² and 0 to the static helper.
+   * 
+   * 
+   * @param distance2 Squared residual magnitude.
+   * @param lowerbound Squared lower bound.
+   * @param upperbound Squared upper bound.
+   * @param transition_weight weight when residual within the transition region.
+   * @return Weight w(x) in [0, 1]
+   */
+   static double Weight(double distance2, double lowerbound, double upperbound, double transition_weight);
+
+ protected:
+  double c_;
+  double csquared_;
+
+ private:
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
+  friend class boost::serialization::access;
+  template <class ARCHIVE>
+  void serialize(ARCHIVE &ar, const unsigned int /*version*/) {
+    ar &BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
+    ar &BOOST_SERIALIZATION_NVP(c_);
+    ar &BOOST_SERIALIZATION_NVP(csquared_);
+  }
+#endif
+};
+
 /** DCS implements the Dynamic Covariance Scaling robust error model
  *  from the paper Robust Map Optimization (Agarwal13icra).
  *

--- a/gtsam/linear/LossFunctions.h
+++ b/gtsam/linear/LossFunctions.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <optional>
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/dllexport.h>
@@ -426,21 +427,18 @@ class GTSAM_EXPORT TruncatedLeastSquares : public Base {
   static shared_ptr Create(double c, const ReweightScheme reweight = Block);
   double modelParameter() const { return c_; }
   /** @brief A static helper function to compute the TLS robust weight.
-   * The static function takes the squared value of the residual, the squared lower bound, the squared upper bound, 
-   * and the transition weight (used in GNC).
-   * This helper is mainly useful for GNC, where the weight is not strictly binary (0 or 1) 
-   * when the residual is within the transition region between inliers and outliers.
+   * The static function takes the squared value of the residual, the squared lower bound, the squared upper bound.
+   * This helper returns a optional<double> because it is also used for GNC, and we encounter transition weight cases,
+   * where the weight is not strictly binary (0 or 1) when the residual is within the transition region between inliers and outliers.
    * The weight member function now calls the this function.
-   * While the member function takes the residual as input, it passes x², c², c² and 0 to the static helper.
-   * 
+   * While the member function takes the residual as input, it passes x², c² and c²to the static helper.
    * 
    * @param distance2 Squared residual magnitude.
    * @param lowerbound Squared lower bound.
    * @param upperbound Squared upper bound.
-   * @param transition_weight weight when residual within the transition region.
-   * @return Weight w(x) in [0, 1]
+   * @return Weight w(x) is {0, 1} or None if the residual is between lowerbound and upperbound.
    */
-   static double Weight(double distance2, double lowerbound, double upperbound, double transition_weight);
+   static std::optional<double> Weight(double distance2, double lowerbound, double upperbound);
 
  protected:
   double c_;

--- a/gtsam/linear/linear.i
+++ b/gtsam/linear/linear.i
@@ -176,6 +176,21 @@ virtual class GemanMcClure: gtsam::noiseModel::mEstimator::Base {
   double loss(double error) const;
 };
 
+virtual class TruncatedLeastSquares: gtsam::noiseModel::mEstimator::Base {
+  TruncatedLeastSquares(double c);
+  TruncatedLeastSquares(double c, gtsam::noiseModel::mEstimator::Base::ReweightScheme reweight);
+  static gtsam::noiseModel::mEstimator::TruncatedLeastSquares* Create(double c);
+  static gtsam::noiseModel::mEstimator::TruncatedLeastSquares* Create(
+      double c, gtsam::noiseModel::mEstimator::Base::ReweightScheme reweight);
+
+  // enabling serialization functionality
+  void serializable() const;
+
+  double weight(double error) const;
+  double loss(double error) const;
+};
+
+
 virtual class DCS: gtsam::noiseModel::mEstimator::Base {
   DCS(double c);
   DCS(double c, gtsam::noiseModel::mEstimator::Base::ReweightScheme reweight);

--- a/gtsam/linear/tests/testNoiseModel.cpp
+++ b/gtsam/linear/tests/testNoiseModel.cpp
@@ -687,6 +687,21 @@ TEST(NoiseModel, robustFunctionGemanMcClure)
   DOUBLES_EQUAL(0.2500, gmc->loss(error4), 1e-8);
 }
 
+TEST(NoiseModel, robustFunctionTLS)
+{
+  const double k = 4.0, error1 = 0.5, error2 = 10.0, error3 = -10.0, error4 = -0.5;
+  const mEstimator::TruncatedLeastSquares::shared_ptr tls = mEstimator::TruncatedLeastSquares::Create(k);
+  DOUBLES_EQUAL(1.0, tls->weight(error1), 1e-8);
+  DOUBLES_EQUAL(0.0, tls->weight(error2), 1e-8);
+  DOUBLES_EQUAL(0.0, tls->weight(error3), 1e-8);
+  DOUBLES_EQUAL(1.0, tls->weight(error4), 1e-8);
+
+  DOUBLES_EQUAL(0.1250, tls->loss(error1), 1e-8);
+  DOUBLES_EQUAL(8.0, tls->loss(error2), 1e-8);
+  DOUBLES_EQUAL(8.0, tls->loss(error3), 1e-8);
+  DOUBLES_EQUAL(0.1250, tls->loss(error4), 1e-8);
+}
+
 TEST(NoiseModel, robustFunctionWelsch)
 {
   const double k = 5.0, error1 = 1.0, error2 = 10.0, error3 = -10.0, error4 = -1.0;
@@ -806,6 +821,30 @@ TEST(NoiseModel, robustNoiseGemanMcClure)
 
   const double sqrt_weight_error1 = sqrt(0.25);
   const double sqrt_weight_error2 = sqrt(k4/(k2error*k2error));
+
+  DOUBLES_EQUAL(sqrt_weight_error1*error1, b(0), 1e-8);
+  DOUBLES_EQUAL(sqrt_weight_error2*error2, b(1), 1e-8);
+
+  DOUBLES_EQUAL(sqrt_weight_error1*a00, A(0,0), 1e-8);
+  DOUBLES_EQUAL(sqrt_weight_error1*a01, A(0,1), 1e-8);
+  DOUBLES_EQUAL(sqrt_weight_error2*a10, A(1,0), 1e-8);
+  DOUBLES_EQUAL(sqrt_weight_error2*a11, A(1,1), 1e-8);
+}
+
+TEST(NoiseModel, robustNoiseTLS)
+{
+  const double k = 1.0, error1 = 1.0, error2 = 100.0;
+  const double a00 = 1.0, a01 = 10.0, a10 = 100.0, a11 = 1000.0;
+  Matrix A = (Matrix(2, 2) << a00, a01, a10, a11).finished();
+  Vector b = Vector2(error1, error2);
+  const Robust::shared_ptr robust = Robust::Create(
+    mEstimator::TruncatedLeastSquares::Create(k, mEstimator::TruncatedLeastSquares::Scalar),
+    Unit::Create(2));
+
+  robust->WhitenSystem(A, b);
+
+  const double sqrt_weight_error1 = 1.0;
+  const double sqrt_weight_error2 = 0.0;
 
   DOUBLES_EQUAL(sqrt_weight_error1*error1, b(0), 1e-8);
   DOUBLES_EQUAL(sqrt_weight_error2*error2, b(1), 1e-8);

--- a/gtsam/nonlinear/GncOptimizer.h
+++ b/gtsam/nonlinear/GncOptimizer.h
@@ -524,32 +524,29 @@ class GncOptimizer {
         for (size_t k = 0; k < nfg_.size(); k++) {
           if (needsWeightUpdate(factorTypes_[k])) {
             double u2_k = nfg_[k]->error(currentEstimate);  // squared (and whitened) residual
-            double lowerbound = 0.0;
-            double upperbound = 0.0;
-            double transition_weight = 0.0;
             switch (params_.scheduler) {
               case GncScheduler::SuperLinear: {
-                lowerbound = barcSq_[k];
-                upperbound = ((mu + 1.0) * (mu + 1.0) / (mu * mu)) * barcSq_[k];
+                double lowerbound = barcSq_[k];
+                double upperbound = ((mu + 1.0) * (mu + 1.0) / (mu * mu)) * barcSq_[k];
                 auto w = noiseModel::mEstimator::TruncatedLeastSquares::Weight(u2_k, lowerbound, upperbound);
                 if (w) {
                   weights[k] = *w;
                 }
                 else {
-                  transition_weight = std::sqrt(barcSq_[k] / u2_k) * (mu + 1.0)  - mu;
+                  double transition_weight = std::sqrt(barcSq_[k] / u2_k) * (mu + 1.0)  - mu;
                   weights[k] = std::clamp(transition_weight, 0.0, 1.0);
                 }
                 break;
               }
               case GncScheduler::Linear: {  // use eq (14) in GNC paper
-                upperbound = (mu + 1.0) / mu * barcSq_[k];
-                lowerbound = mu / (mu + 1.0) * barcSq_[k];
+                double upperbound = ((mu + 1.0) / mu) * barcSq_[k];
+                double lowerbound = (mu / (mu + 1.0)) * barcSq_[k];
                 auto w = noiseModel::mEstimator::TruncatedLeastSquares::Weight(u2_k, lowerbound, upperbound);
                 if (w) {
                   weights[k] = *w;
                 }
                 else {
-                  transition_weight = std::sqrt(barcSq_[k] * mu * (mu + 1.0) / u2_k) - mu;
+                  double transition_weight = std::sqrt(barcSq_[k] * mu * (mu + 1.0) / u2_k) - mu;
                   weights[k] = std::clamp(transition_weight, 0.0, 1.0);
                 }
                 break;

--- a/gtsam/nonlinear/GncOptimizer.h
+++ b/gtsam/nonlinear/GncOptimizer.h
@@ -501,12 +501,8 @@ class GncOptimizer {
             double u2_k = nfg_[k]->error(currentEstimate);  // squared (and whitened) residual
             double upperbound = (mu + 1) / mu * barcSq_[k];
             double lowerbound = mu / (mu + 1) * barcSq_[k];
-            weights[k] = std::sqrt(barcSq_[k] * mu * (mu + 1) / u2_k) - mu;
-            if (u2_k >= upperbound || weights[k] < 0) {
-              weights[k] = 0;
-            } else if (u2_k <= lowerbound || weights[k] > 1) {
-              weights[k] = 1;
-            }
+            const double transition_weight = std::sqrt(barcSq_[k] * mu * (mu + 1) / u2_k) - mu;
+            weights[k] = noiseModel::mEstimator::TruncatedLeastSquares::Weight(u2_k, lowerbound, upperbound, transition_weight);
           }
         }
         return weights;

--- a/gtsam/nonlinear/GncOptimizer.h
+++ b/gtsam/nonlinear/GncOptimizer.h
@@ -398,8 +398,8 @@ class GncOptimizer {
         // increases mu at each iteration (original cost is recovered for mu -> inf)
         switch (params_.scheduler) {
           case GncScheduler::SuperLinear: {
-            if (mu < 1) return std::min(std::sqrt(mu) * params_.muStep, 1e16);
-            return std::min(mu * params_.muStep, 1e16);
+            if (mu < 1) return std::min(std::sqrt(mu) * params_.muStep, params_.muMax);
+            return std::min(mu * params_.muStep, params_.muMax);
           }
           case GncScheduler::Linear: {
             return mu * params_.muStep;

--- a/gtsam/nonlinear/GncOptimizer.h
+++ b/gtsam/nonlinear/GncOptimizer.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include <gtsam/linear/LossFunctions.h>
 #include <gtsam/nonlinear/GncParams.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
@@ -236,6 +238,7 @@ class GncOptimizer {
 
   /// Compute optimal solution using graduated non-convexity.
   Values optimize() {
+    validateLossSchedulerCombination();
     NonlinearFactorGraph graph_initial = this->makeWeightedGraph(weights_);
     BaseOptimizer baseOptimizer(
         graph_initial, state_, params_.baseOptimizerParams);
@@ -328,6 +331,18 @@ class GncOptimizer {
     return result;
   }
 
+  void validateLossSchedulerCombination() const {
+    if (params_.lossType == GncLossType::GM &&
+        params_.scheduler != GncScheduler::Linear) {
+      throw std::runtime_error(
+          "GncOptimizer::optimize: scheduler must be Linear for GM.");
+    }
+    if (params_.lossType == GncLossType::TLS) {
+      // Linear and SuperLinear are both valid for TLS.
+      return;
+    }
+  }
+
   /// Initialize the gnc parameter mu such that loss is approximately convex (remark 5 in GNC paper).
   double initializeMu() const {
 
@@ -381,7 +396,17 @@ class GncOptimizer {
         return std::max(1.0, mu / params_.muStep);
       case GncLossType::TLS:
         // increases mu at each iteration (original cost is recovered for mu -> inf)
-        return mu * params_.muStep;
+        switch (params_.scheduler) {
+          case GncScheduler::SuperLinear: {
+            if (mu < 1) return std::min(std::sqrt(mu) * params_.muStep, 1e16);
+            return std::min(mu * params_.muStep, 1e16);
+          }
+          case GncScheduler::Linear: {
+            return mu * params_.muStep;
+          }
+          default:
+            throw std::runtime_error("GncOptimizer::updateMu: unknown scheduler type.");
+        }
       default:
         throw std::runtime_error(
             "GncOptimizer::updateMu: called with unknown loss type.");
@@ -495,14 +520,43 @@ class GncOptimizer {
         }
         return weights;
       }
-      case GncLossType::TLS: {  // use eq (14) in GNC paper
+      case GncLossType::TLS: {
         for (size_t k = 0; k < nfg_.size(); k++) {
           if (needsWeightUpdate(factorTypes_[k])) {
             double u2_k = nfg_[k]->error(currentEstimate);  // squared (and whitened) residual
-            double upperbound = (mu + 1) / mu * barcSq_[k];
-            double lowerbound = mu / (mu + 1) * barcSq_[k];
-            const double transition_weight = std::sqrt(barcSq_[k] * mu * (mu + 1) / u2_k) - mu;
-            weights[k] = noiseModel::mEstimator::TruncatedLeastSquares::Weight(u2_k, lowerbound, upperbound, transition_weight);
+            double lowerbound = 0.0;
+            double upperbound = 0.0;
+            double transition_weight = 0.0;
+            switch (params_.scheduler) {
+              case GncScheduler::SuperLinear: {
+                lowerbound = barcSq_[k];
+                upperbound = ((mu + 1.0) * (mu + 1.0) / (mu * mu)) * barcSq_[k];
+                auto w = noiseModel::mEstimator::TruncatedLeastSquares::Weight(u2_k, lowerbound, upperbound);
+                if (w) {
+                  weights[k] = *w;
+                }
+                else {
+                  transition_weight = std::sqrt(barcSq_[k] / u2_k) * (mu + 1.0)  - mu;
+                  weights[k] = std::clamp(transition_weight, 0.0, 1.0);
+                }
+                break;
+              }
+              case GncScheduler::Linear: {  // use eq (14) in GNC paper
+                upperbound = (mu + 1.0) / mu * barcSq_[k];
+                lowerbound = mu / (mu + 1.0) * barcSq_[k];
+                auto w = noiseModel::mEstimator::TruncatedLeastSquares::Weight(u2_k, lowerbound, upperbound);
+                if (w) {
+                  weights[k] = *w;
+                }
+                else {
+                  transition_weight = std::sqrt(barcSq_[k] * mu * (mu + 1.0) / u2_k) - mu;
+                  weights[k] = std::clamp(transition_weight, 0.0, 1.0);
+                }
+                break;
+              }
+              default:
+                throw std::runtime_error("GncOptimizer::calculateWeights: unknown scheduler type.");
+            }
           }
         }
         return weights;

--- a/gtsam/nonlinear/GncParams.h
+++ b/gtsam/nonlinear/GncParams.h
@@ -79,6 +79,7 @@ class GncParams {
   double muStep = 1.4;  ///< Multiplicative factor to reduce/increase the mu in gnc
   double relativeCostTol = 1e-5;  ///< If relative cost change is below this threshold, stop iterating
   double weightsTol = 1e-4;  ///< If the weights are within weightsTol from being binary, stop iterating (only for TLS)
+  double muMax = 1e16;  ///< Maximum value of mu in GNC, acts as a cap (only for TLS)
   Verbosity verbosity = SILENT;  ///< Verbosity level
   bool allowNonNoiseModelFactors = false;  ///< If true, factors without noise model are not reweighted and not not included in mu calculation
 

--- a/gtsam/nonlinear/GncParams.h
+++ b/gtsam/nonlinear/GncParams.h
@@ -28,6 +28,7 @@
 
 #include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
 #include <gtsam/nonlinear/GaussNewtonOptimizer.h>
+#include <limits>
 
 namespace gtsam {
 
@@ -36,6 +37,13 @@ namespace gtsam {
 enum GncLossType {
   GM /*Geman McClure*/,
   TLS /*Truncated least squares*/
+};
+
+/// Choice of GNC scheduling strategy.
+/// SuperLinear reference https://openaccess.thecvf.com/content/CVPR2023/papers/Peng_On_the_Convergence_of_IRLS_and_Its_Variants_in_Outlier-Robust_CVPR_2023_paper.pdf
+enum class GncScheduler {
+  Linear,
+  SuperLinear
 };
 
 template<class BaseOptimizerParameters>
@@ -67,6 +75,7 @@ class GncParams {
   BaseOptimizerParameters baseOptimizerParams;  ///< Optimization parameters used to solve the weighted least squares problem at each GNC iteration
   /// any other specific GNC parameters:
   GncLossType lossType = TLS;  ///< Default loss
+  GncScheduler scheduler = GncScheduler::Linear;  ///< Default scheduler
   size_t maxIterations = 100;  ///<  Maximum number of iterations
   double muStep = 1.4;  ///< Multiplicative factor to reduce/increase the mu in gnc
   double relativeCostTol = 1e-5;  ///< If relative cost change is below this threshold, stop iterating
@@ -84,6 +93,11 @@ class GncParams {
   /// Set the robust loss function to be used in GNC (chosen among the ones in GncLossType).
   void setLossType(const GncLossType type) {
     lossType = type;
+  }
+
+  /// Set the scheduler type.
+  void setScheduler(const GncScheduler s) {
+    scheduler = s;
   }
 
   /// Set the maximum number of iterations in GNC (changing the max nr of iters might lead to less accurate solutions and is not recommended).
@@ -147,6 +161,7 @@ class GncParams {
     return baseOptimizerParams.equals(other.baseOptimizerParams)
         && lossType == other.lossType && maxIterations == other.maxIterations
         && std::fabs(muStep - other.muStep) <= tol
+        && scheduler == other.scheduler
         && verbosity == other.verbosity && knownInliers == other.knownInliers
         && knownOutliers == other.knownOutliers
         && allowNonNoiseModelFactors == other.allowNonNoiseModelFactors;
@@ -164,6 +179,16 @@ class GncParams {
         break;
       default:
         throw std::runtime_error("GncParams::print: unknown loss type.");
+    }
+    switch (scheduler) {
+      case GncScheduler::Linear:
+        std::cout << "scheduler: Linear" << "\n";
+        break;
+      case GncScheduler::SuperLinear:
+        std::cout << "scheduler: SuperLinear" << "\n";
+        break;
+      default:
+        throw std::runtime_error("GncParams::print: unknown scheduler type.");
     }
     std::cout << "maxIterations: " << maxIterations << "\n";
     std::cout << "muStep: " << muStep << "\n";

--- a/gtsam/nonlinear/GncParams.h
+++ b/gtsam/nonlinear/GncParams.h
@@ -28,7 +28,6 @@
 
 #include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
 #include <gtsam/nonlinear/GaussNewtonOptimizer.h>
-#include <limits>
 
 namespace gtsam {
 

--- a/gtsam/nonlinear/nonlinear.i
+++ b/gtsam/nonlinear/nonlinear.i
@@ -300,6 +300,11 @@ enum GncLossType {
   TLS /*Truncated least squares*/
 };
 
+enum GncScheduler {
+  Linear,
+  SuperLinear
+};
+
 template<PARAMS>
 virtual class GncParams {
   GncParams(const PARAMS& baseOptimizerParams);
@@ -314,6 +319,7 @@ virtual class GncParams {
   gtsam::This::IndexVector knownInliers;
   gtsam::This::IndexVector knownOutliers;
   bool allowNonNoiseModelFactors;
+  gtsam::GncScheduler scheduler;
 
   void setLossType(const gtsam::GncLossType type);
   void setMaxIterations(const size_t maxIter);
@@ -324,6 +330,7 @@ virtual class GncParams {
   void setKnownInliers(const gtsam::This::IndexVector& knownIn);
   void setKnownOutliers(const gtsam::This::IndexVector& knownOut);
   void setAllowNonNoiseModelFactors(bool allow);
+  void setScheduler(const gtsam::GncScheduler scheduler);
   void print(const string& str = "GncParams: ") const;
   
   enum Verbosity {

--- a/tests/testGncOptimizer.cpp
+++ b/tests/testGncOptimizer.cpp
@@ -216,6 +216,29 @@ TEST(GncOptimizer, updateMuTLS) {
 }
 
 /* ************************************************************************* */
+TEST(GncOptimizer, updateMuTLSSuperLinear) {
+  // has to have Gaussian noise models !
+  auto fg = example::createReallyNonlinearFactorGraph();
+
+  Point2 p0(3, 3);
+  Values initial;
+  initial.insert(X(1), p0);
+
+  GncParams<LevenbergMarquardtParams> gncParams;
+  gncParams.setMuStep(4.0);
+  gncParams.setLossType(GncLossType::TLS);
+  gncParams.setScheduler(GncScheduler::SuperLinear);
+  auto gnc = GncOptimizer<GncParams<LevenbergMarquardtParams>>(fg, initial,
+                                                               gncParams);
+
+  double mu = 0.25;
+  EXPECT_DOUBLES_EQUAL(gnc.updateMu(mu), 2.0, tol);
+
+  mu = 5.0;
+  EXPECT_DOUBLES_EQUAL(gnc.updateMu(mu), 20.0, tol);
+}
+
+/* ************************************************************************* */
 TEST(GncOptimizer, checkMuConvergence) {
   // has to have Gaussian noise models !
   auto fg = example::createReallyNonlinearFactorGraph();
@@ -412,6 +435,31 @@ TEST(GncOptimizer, calculateWeightsTLS) {
 }
 
 /* ************************************************************************* */
+TEST(GncOptimizer, calculateWeightsTLSSuperLinear) {
+  auto fg = example::sharedNonRobustFactorGraphWithOutliers();
+
+  Point2 p0(0, 0);
+  Values initial;
+  initial.insert(X(1), p0);
+
+  // we have 4 factors, 3 with zero errors (inliers), 1 with error
+  Vector weights_expected = Vector::Zero(4);
+  weights_expected[0] = 1.0;                             // zero error
+  weights_expected[1] = 1.0;                             // zero error
+  weights_expected[2] = 1.0;                             // zero error
+  weights_expected[3] = 0;                               // outliers
+
+  GaussNewtonParams gnParams;
+  GncParams<GaussNewtonParams> gncParams(gnParams);
+  gncParams.setLossType(GncLossType::TLS);
+  gncParams.setScheduler(GncScheduler::SuperLinear);
+  auto gnc = GncOptimizer<GncParams<GaussNewtonParams>>(fg, initial, gncParams);
+  double mu = 1.0;
+  Vector weights_actual = gnc.calculateWeights(initial, mu);
+  CHECK(assert_equal(weights_expected, weights_actual, tol));
+}
+
+/* ************************************************************************* */
 TEST(GncOptimizer, calculateWeightsTLS2) {
 
   // create values
@@ -477,6 +525,79 @@ TEST(GncOptimizer, calculateWeightsTLS2) {
     double mu = 1e6;  // very large mu recovers original TLS cost
     Vector weights_actual = gnc.calculateWeights(initial, mu);
     CHECK(assert_equal(weights_expected, weights_actual, 1e-5));
+  }
+}
+
+/* ************************************************************************* */
+TEST(GncOptimizer, calculateWeightsTLSSuperLinear2) {
+
+  // create values
+  Point2 x_val(0.0, 0.0);
+  Point2 x_prior(1.0, 0.0);
+  Values initial;
+  initial.insert(X(1), x_val);
+
+  // create very simple factor graph with a single factor 0.5 * 1/sigma^2 * || x - [1;0] ||^2
+  double sigma = 1;
+  SharedDiagonal noise = noiseModel::Diagonal::Sigmas(Vector2(sigma, sigma));
+  NonlinearFactorGraph nfg;
+  nfg.add(PriorFactor<Point2>(X(1), x_prior, noise));
+
+  // cost of the factor:
+  DOUBLES_EQUAL(0.5 * 1 / (sigma * sigma), nfg.error(initial), tol);
+
+  // check the TLS weights are correct: CASE 1: residual below barcsq
+  {
+    // expected:
+    Vector weights_expected = Vector::Zero(1);
+    weights_expected[0] = 1.0;  // inlier
+    // actual:
+    GaussNewtonParams gnParams;
+    GncParams<GaussNewtonParams> gncParams(gnParams);
+    gncParams.setLossType(GncLossType::TLS);
+    gncParams.setScheduler(GncScheduler::SuperLinear);
+    auto gnc = GncOptimizer<GncParams<GaussNewtonParams>>(nfg, initial,
+                                                          gncParams);
+    gnc.setInlierCostThresholds(0.51);  // if inlier threshold is slightly larger than 0.5, then measurement is inlier
+
+    double mu = 1e6;
+    Vector weights_actual = gnc.calculateWeights(initial, mu);
+    CHECK(assert_equal(weights_expected, weights_actual, tol));
+  }
+  // check the TLS weights are correct: CASE 2: residual above barcsq
+  {
+    // expected:
+    Vector weights_expected = Vector::Zero(1);
+    weights_expected[0] = 0.0;  // outlier
+    // actual:
+    GaussNewtonParams gnParams;
+    GncParams<GaussNewtonParams> gncParams(gnParams);
+    gncParams.setLossType(GncLossType::TLS);
+    gncParams.setScheduler(GncScheduler::SuperLinear);
+    auto gnc = GncOptimizer<GncParams<GaussNewtonParams>>(nfg, initial,
+                                                          gncParams);
+    gnc.setInlierCostThresholds(0.49);  // if inlier threshold is slightly below 0.5, then measurement is outlier
+    double mu = 1e6;
+    Vector weights_actual = gnc.calculateWeights(initial, mu);
+    CHECK(assert_equal(weights_expected, weights_actual, tol));
+  }
+  // check the TLS weights are correct: CASE 3: residual in transition region
+  {
+    // expected:
+    Vector weights_expected = Vector::Zero(1);
+    double barcSq = 0.4;
+    double mu = 1.0;
+    weights_expected[0] = std::sqrt(barcSq / 0.5) * (mu + 1.0) - mu;
+    // actual:
+    GaussNewtonParams gnParams;
+    GncParams<GaussNewtonParams> gncParams(gnParams);
+    gncParams.setLossType(GncLossType::TLS);
+    gncParams.setScheduler(GncScheduler::SuperLinear);
+    auto gnc = GncOptimizer<GncParams<GaussNewtonParams>>(nfg, initial,
+                                                          gncParams);
+    gnc.setInlierCostThresholds(barcSq);
+    Vector weights_actual = gnc.calculateWeights(initial, mu);
+    CHECK(assert_equal(weights_expected, weights_actual, tol));
   }
 }
 


### PR DESCRIPTION
This PR adds the TLS loss to the LossFunctions.cpp with all the functions. It also adds an static optional helper function. 
This PR also adds the implementation of Rene Vidal's MS-GNC-TLS from https://openaccess.thecvf.com/content/CVPR2023/html/Peng_On_the_Convergence_of_IRLS_and_Its_Variants_in_Outlier-Robust_CVPR_2023_paper.html and their open-source code (https://github.com/liangzu/IRLS-CVPR2023/blob/main/example.m).

The static helper function is optional because in GNC the weight is not fixed to be binary when the residual lies between the lower and upper bound. Returning a null helps us avoid calculating the transition weight which involves std::sqrt unless necessary.

We show the Bundle Adjustment optimization time taken using the linear schedule and the new superlinear schedule from the paper mentioned above on VGGT outputs.
```
|   optimization_elapsed_sec_linear |   optimization_elapsed_sec_superlinear |   Time_delta |
|----------------------------------:|---------------------------------------:|-------------:|
|                        12.7473    |                             10.0275    |  2.7198      |
|                        16.3292    |                              3.88969   | 12.4395      |
|                        28.1229    |                             29.0461    | -0.923177    |
|                        17.3703    |                             10.1856    |  7.18468     |
|                        19.1635    |                             14.7553    |  4.40828     |
|                         6.46747   |                              4.05104   |  2.41643     |
|                         4.03978   |                              1.09345   |  2.94633     |
|                        14.7906    |                             12.2772    |  2.51336     |
|                        34.0067    |                             30.0004    |  4.00628     |
|                        51.4098    |                             44.1873    |  7.22252     |
|                        16.8787    |                              9.84329   |  7.03542     |
|                        34.9439    |                             27.0866    |  7.85738     |
|                         7.59508   |                              3.4724    |  4.12268     |
|                         8.65977   |                              1.30969   |  7.35008     |
|                        27.1634    |                             24.7345    |  2.42895     |
|                         2.61481   |                              1.81978   |  0.795027    |
|                        12.271     |                             10.8528    |  1.41822     |
|                         0.0403302 |                              0.0404067 | -7.65324e-05 |
|                         0.248113  |                              0.0572624 |  0.19085     |
|                       296.505     |                            291.804     |  4.70096     |
|                         6.94001   |                              0.923486  |  6.01652     |
|                        49.6498    |                             42.6054    |  7.04438     |
|                         6.8331    |                              1.22982   |  5.60328     |
|                        20.6839    |                              3.2465    | 17.4374      |
|                        97.3713    |                             48.7261    | 48.6452      |
|                        48.2717    |                             40.4872    |  7.78454     |
|                         5.27395   |                              1.05924   |  4.2147      |
|                         4.07045   |                              0.896459  |  3.17399     |
|                        51.1264    |                             47.2578    |  3.86862     |
|                         2.33988   |                              0.532375  |  1.80751     |
|                        40.4717    |                             36.4044    |  4.06733     |
|                         1.57979   |                              0.26594   |  1.31385     |
|                         5.80616   |                              0.896831  |  4.90933     |
|                         9.1657    |                              9.18485   | -0.0191562   |
|                         7.91638   |                              3.74087   |  4.17551     |
|                         2.51318   |                              3.72928   | -1.2161      |
|                         1.82045   |                              1.04536   |  0.775087    |
|                        18.4826    |                             15.6553    |  2.82732     |
|                         0.492838  |                              0.0991347 |  0.393703    |
|                         0.0771108 |                              0.0769136 |  0.000197172 |
```
All unit tests passed locally.