### PR TITLE
variable dimension product groups

### DIFF
--- a/cmake/GtsamBuildTypes.cmake
+++ b/cmake/GtsamBuildTypes.cmake
@@ -136,6 +136,7 @@ else()
     -Wall                                          # Enable common warnings
     -Wpedantic                                     # Enable pedantic warnings
     $<$<COMPILE_LANGUAGE:CXX>:-Wextra -Wno-unused-parameter> # Enable extra warnings, but ignore no-unused-parameter (as we ifdef out chunks of code)
+    $<$<CXX_COMPILER_ID:GNU>:-Wno-psabi>                     # GCC 10 emits non-actionable psABI notes for some value-returning wrappers under C++17
     $<$<CXX_COMPILER_ID:GNU>:-Wreturn-local-addr>            # Error: return local address
     $<$<CXX_COMPILER_ID:Clang>:-Wreturn-stack-address>       # Error: return local address
     $<$<CXX_COMPILER_ID:Clang>:-Wno-weak-template-vtables>   # TODO(dellaert): don't know how to resolve

--- a/gtsam/base/Manifold.h
+++ b/gtsam/base/Manifold.h
@@ -74,11 +74,11 @@ template<class Class, int N>
 struct GetDimensionImpl {
   // Get dimension at compile-time for fixed-size manifolds, and at
   // run-time for dynamic-size manifolds.
-  static int GetDimension(const Class& m) {
+  static size_t GetDimension(const Class& m) {
     if constexpr (N == Eigen::Dynamic) {
       return m.dim();
     } else {
-      return N;
+      return static_cast<size_t>(N);
     }
   }
 };

--- a/gtsam/base/ProductLieGroup-inl.h
+++ b/gtsam/base/ProductLieGroup-inl.h
@@ -1,0 +1,666 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file ProductLieGroup-inl.h
+ * @date March, 2026
+ * @author Frank Dellaert
+ * @brief Internals for ProductLieGroup.h, not for general consumption
+ */
+
+#pragma once
+
+namespace gtsam {
+
+template <typename G, typename H>
+ProductLieGroup<G, H> ProductLieGroup<G, H>::operator*(
+    const ProductLieGroup& other) const {
+  checkMatchingDimensions(firstDim(), secondDim(), other.firstDim(),
+                          other.secondDim(), "operator*");
+  return ProductLieGroup(traits<G>::Compose(this->first, other.first),
+                         traits<H>::Compose(this->second, other.second));
+}
+
+template <typename G, typename H>
+ProductLieGroup<G, H> ProductLieGroup<G, H>::inverse() const {
+  return ProductLieGroup(traits<G>::Inverse(this->first),
+                         traits<H>::Inverse(this->second));
+}
+
+template <typename G, typename H>
+ProductLieGroup<G, H> ProductLieGroup<G, H>::retract(const TangentVector& v,
+                                                     ChartJacobian H1,
+                                                     ChartJacobian H2) const {
+  if (H1 || H2) {
+    throw std::runtime_error(
+        "ProductLieGroup::retract derivatives not implemented yet");
+  }
+  const size_t firstDimension = firstDim();
+  const size_t secondDimension = secondDim();
+  if (static_cast<size_t>(v.size()) !=
+      combinedDimension(firstDimension, secondDimension)) {
+    throw std::invalid_argument(
+        "ProductLieGroup::retract tangent dimension does not match product "
+        "dimension");
+  }
+  G g =
+      traits<G>::Retract(this->first, tangentSegment<G>(v, 0, firstDimension));
+  H h = traits<H>::Retract(
+      this->second, tangentSegment<H>(v, firstDimension, secondDimension));
+  return ProductLieGroup(g, h);
+}
+
+template <typename G, typename H>
+typename ProductLieGroup<G, H>::TangentVector
+ProductLieGroup<G, H>::localCoordinates(const ProductLieGroup& g,
+                                        ChartJacobian H1,
+                                        ChartJacobian H2) const {
+  if (H1 || H2) {
+    throw std::runtime_error(
+        "ProductLieGroup::localCoordinates derivatives not implemented yet");
+  }
+  checkMatchingDimensions(firstDim(), secondDim(), g.firstDim(), g.secondDim(),
+                          "localCoordinates");
+  const size_t firstDimension = firstDim();
+  const size_t secondDimension = secondDim();
+  typename traits<G>::TangentVector v1 = traits<G>::Local(this->first, g.first);
+  typename traits<H>::TangentVector v2 =
+      traits<H>::Local(this->second, g.second);
+  return makeTangentVector(v1, v2, firstDimension, secondDimension);
+}
+
+template <typename G, typename H>
+ProductLieGroup<G, H> ProductLieGroup<G, H>::compose(
+    const ProductLieGroup& other, ChartJacobian H1, ChartJacobian H2) const {
+  checkMatchingDimensions(firstDim(), secondDim(), other.firstDim(),
+                          other.secondDim(), "compose");
+  const size_t firstDimension = firstDim();
+  const size_t secondDimension = secondDim();
+  const size_t productDimension =
+      combinedDimension(firstDimension, secondDimension);
+  Jacobian1 D_g_first;
+  Jacobian2 D_h_second;
+  G g = traits<G>::Compose(this->first, other.first, H1 ? &D_g_first : nullptr);
+  H h = traits<H>::Compose(this->second, other.second,
+                           H1 ? &D_h_second : nullptr);
+  if (H1) {
+    *H1 = zeroJacobian(productDimension);
+    H1->block(0, 0, firstDimension, firstDimension) = D_g_first;
+    H1->block(firstDimension, firstDimension, secondDimension,
+              secondDimension) = D_h_second;
+  }
+  if (H2) *H2 = identityJacobian(productDimension);
+  return ProductLieGroup(g, h);
+}
+
+template <typename G, typename H>
+ProductLieGroup<G, H> ProductLieGroup<G, H>::between(
+    const ProductLieGroup& other, ChartJacobian H1, ChartJacobian H2) const {
+  checkMatchingDimensions(firstDim(), secondDim(), other.firstDim(),
+                          other.secondDim(), "between");
+  const size_t firstDimension = firstDim();
+  const size_t secondDimension = secondDim();
+  const size_t productDimension =
+      combinedDimension(firstDimension, secondDimension);
+  Jacobian1 D_g_first;
+  Jacobian2 D_h_second;
+  G g = traits<G>::Between(this->first, other.first, H1 ? &D_g_first : nullptr);
+  H h = traits<H>::Between(this->second, other.second,
+                           H1 ? &D_h_second : nullptr);
+  if (H1) {
+    *H1 = zeroJacobian(productDimension);
+    H1->block(0, 0, firstDimension, firstDimension) = D_g_first;
+    H1->block(firstDimension, firstDimension, secondDimension,
+              secondDimension) = D_h_second;
+  }
+  if (H2) *H2 = identityJacobian(productDimension);
+  return ProductLieGroup(g, h);
+}
+
+template <typename G, typename H>
+ProductLieGroup<G, H> ProductLieGroup<G, H>::inverse(ChartJacobian D) const {
+  const size_t firstDimension = firstDim();
+  const size_t secondDimension = secondDim();
+  const size_t productDimension =
+      combinedDimension(firstDimension, secondDimension);
+  Jacobian1 D_g_first;
+  Jacobian2 D_h_second;
+  G g = traits<G>::Inverse(this->first, D ? &D_g_first : nullptr);
+  H h = traits<H>::Inverse(this->second, D ? &D_h_second : nullptr);
+  if (D) {
+    *D = zeroJacobian(productDimension);
+    D->block(0, 0, firstDimension, firstDimension) = D_g_first;
+    D->block(firstDimension, firstDimension, secondDimension, secondDimension) =
+        D_h_second;
+  }
+  return ProductLieGroup(g, h);
+}
+
+template <typename G, typename H>
+ProductLieGroup<G, H> ProductLieGroup<G, H>::Expmap(const TangentVector& v,
+                                                    ChartJacobian Hv) {
+  if constexpr (firstDynamic && secondDynamic) {
+    if (v.size() == 0) {
+      if (Hv) *Hv = Matrix::Zero(0, 0);
+      return ProductLieGroup();
+    }
+    throw std::invalid_argument(
+        "ProductLieGroup::Expmap requires split tangent vectors when both "
+        "factors are dynamic");
+  } else if constexpr (firstDynamic) {
+    if (v.size() < dimension2) {
+      throw std::invalid_argument(
+          "ProductLieGroup::Expmap tangent dimension is too small for the "
+          "fixed second factor");
+    }
+    const size_t firstDimension = static_cast<size_t>(v.size() - dimension2);
+    return expmapWithDimensions(v, firstDimension,
+                                static_cast<size_t>(dimension2), Hv);
+  } else if constexpr (secondDynamic) {
+    if (v.size() < dimension1) {
+      throw std::invalid_argument(
+          "ProductLieGroup::Expmap tangent dimension is too small for the "
+          "fixed first factor");
+    }
+    const size_t secondDimension = static_cast<size_t>(v.size() - dimension1);
+    return expmapWithDimensions(v, static_cast<size_t>(dimension1),
+                                secondDimension, Hv);
+  } else {
+    return expmapWithDimensions(v, static_cast<size_t>(dimension1),
+                                static_cast<size_t>(dimension2), Hv);
+  }
+}
+
+template <typename G, typename H>
+ProductLieGroup<G, H> ProductLieGroup<G, H>::Expmap(
+    const Eigen::Ref<const typename traits<G>::TangentVector>& v1,
+    const Eigen::Ref<const typename traits<H>::TangentVector>& v2,
+    ChartJacobian Hv) {
+  const size_t firstDimension = static_cast<size_t>(v1.size());
+  const size_t secondDimension = static_cast<size_t>(v2.size());
+  Jacobian1 D_g_first;
+  Jacobian2 D_h_second;
+  G g = traits<G>::Expmap(v1, Hv ? &D_g_first : nullptr);
+  H h = traits<H>::Expmap(v2, Hv ? &D_h_second : nullptr);
+  if (Hv) {
+    *Hv = zeroJacobian(combinedDimension(firstDimension, secondDimension));
+    Hv->block(0, 0, firstDimension, firstDimension) = D_g_first;
+    Hv->block(firstDimension, firstDimension, secondDimension,
+              secondDimension) = D_h_second;
+  }
+  return ProductLieGroup(g, h);
+}
+
+template <typename G, typename H>
+ProductLieGroup<G, H> ProductLieGroup<G, H>::expmap(
+    const TangentVector& v) const {
+  return compose(expmapWithDimensions(v, firstDim(), secondDim()));
+}
+
+template <typename G, typename H>
+typename ProductLieGroup<G, H>::Jacobian ProductLieGroup<G, H>::AdjointMap()
+    const {
+  const auto adjG = traits<G>::AdjointMap(this->first);
+  const auto adjH = traits<H>::AdjointMap(this->second);
+  const size_t d1 = static_cast<size_t>(adjG.rows());
+  const size_t d2 = static_cast<size_t>(adjH.rows());
+  Jacobian adj = zeroJacobian(d1 + d2);
+  adj.block(0, 0, d1, d1) = adjG;
+  adj.block(d1, d1, d2, d2) = adjH;
+  return adj;
+}
+
+template <typename G, typename H>
+template <typename T>
+T ProductLieGroup<G, H>::defaultIdentity() {
+  if constexpr (traits<T>::dimension == Eigen::Dynamic) {
+    return T();
+  } else {
+    return traits<T>::Identity();
+  }
+}
+
+template <typename G, typename H>
+template <typename T, int Dim>
+typename traits<T>::TangentVector ProductLieGroup<G, H>::tangentSegment(
+    const TangentVector& v, size_t start, size_t runtimeDimension) {
+  const int startIndex = static_cast<int>(start);
+  const int runtimeIndex = static_cast<int>(runtimeDimension);
+  if constexpr (Dim == Eigen::Dynamic) {
+    return v.segment(startIndex, runtimeIndex);
+  } else {
+    static_cast<void>(runtimeDimension);
+    return v.template segment<Dim>(startIndex);
+  }
+}
+
+template <typename G, typename H>
+typename ProductLieGroup<G, H>::TangentVector
+ProductLieGroup<G, H>::makeTangentVector(
+    const typename traits<G>::TangentVector& v1,
+    const typename traits<H>::TangentVector& v2, size_t firstDimension,
+    size_t secondDimension) {
+  const int firstIndex = static_cast<int>(firstDimension);
+  const int secondIndex = static_cast<int>(secondDimension);
+  if constexpr (dimension == Eigen::Dynamic) {
+    TangentVector v(combinedDimension(firstDimension, secondDimension));
+    v.segment(0, firstIndex) = v1;
+    v.segment(firstIndex, secondIndex) = v2;
+    return v;
+  } else {
+    static_cast<void>(firstDimension);
+    static_cast<void>(secondDimension);
+    TangentVector v;
+    v << v1, v2;
+    return v;
+  }
+}
+
+template <typename G, typename H>
+typename ProductLieGroup<G, H>::Jacobian ProductLieGroup<G, H>::zeroJacobian(
+    size_t productDimension) {
+  if constexpr (dimension == Eigen::Dynamic) {
+    return Jacobian::Zero(productDimension, productDimension);
+  } else {
+    static_cast<void>(productDimension);
+    return Jacobian::Zero();
+  }
+}
+
+template <typename G, typename H>
+typename ProductLieGroup<G, H>::Jacobian
+ProductLieGroup<G, H>::identityJacobian(size_t productDimension) {
+  if constexpr (dimension == Eigen::Dynamic) {
+    return Jacobian::Identity(productDimension, productDimension);
+  } else {
+    static_cast<void>(productDimension);
+    return Jacobian::Identity();
+  }
+}
+
+template <typename G, typename H>
+void ProductLieGroup<G, H>::checkMatchingDimensions(size_t first1,
+                                                    size_t second1,
+                                                    size_t first2,
+                                                    size_t second2,
+                                                    const char* operation) {
+  if (first1 != first2 || second1 != second2) {
+    throw std::invalid_argument(std::string("ProductLieGroup::") + operation +
+                                " requires matching component dimensions");
+  }
+}
+
+template <typename G, typename H>
+ProductLieGroup<G, H> ProductLieGroup<G, H>::expmapWithDimensions(
+    const TangentVector& v, size_t firstDimension, size_t secondDimension,
+    ChartJacobian Hv) {
+  if (static_cast<size_t>(v.size()) !=
+      combinedDimension(firstDimension, secondDimension)) {
+    throw std::invalid_argument(
+        "ProductLieGroup::Expmap tangent dimension does not match requested "
+        "component dimensions");
+  }
+  Jacobian1 D_g_first;
+  Jacobian2 D_h_second;
+  G g = traits<G>::Expmap(tangentSegment<G>(v, 0, firstDimension),
+                          Hv ? &D_g_first : nullptr);
+  H h = traits<H>::Expmap(tangentSegment<H>(v, firstDimension, secondDimension),
+                          Hv ? &D_h_second : nullptr);
+  if (Hv) {
+    *Hv = zeroJacobian(combinedDimension(firstDimension, secondDimension));
+    Hv->block(0, 0, firstDimension, firstDimension) = D_g_first;
+    Hv->block(firstDimension, firstDimension, secondDimension,
+              secondDimension) = D_h_second;
+  }
+  return ProductLieGroup(g, h);
+}
+
+template <typename G, typename H>
+typename ProductLieGroup<G, H>::TangentVector
+ProductLieGroup<G, H>::logmapWithDimensions(const ProductLieGroup& p,
+                                            size_t firstDimension,
+                                            size_t secondDimension,
+                                            ChartJacobian Hp) {
+  const size_t productDimension =
+      combinedDimension(firstDimension, secondDimension);
+  Jacobian1 D_g_first;
+  Jacobian2 D_h_second;
+  typename traits<G>::TangentVector v1 =
+      traits<G>::Logmap(p.first, Hp ? &D_g_first : nullptr);
+  typename traits<H>::TangentVector v2 =
+      traits<H>::Logmap(p.second, Hp ? &D_h_second : nullptr);
+  TangentVector v = makeTangentVector(v1, v2, firstDimension, secondDimension);
+  if (Hp) {
+    *Hp = zeroJacobian(productDimension);
+    Hp->block(0, 0, firstDimension, firstDimension) = D_g_first;
+    Hp->block(firstDimension, firstDimension, secondDimension,
+              secondDimension) = D_h_second;
+  }
+  return v;
+}
+
+template <typename G, typename H>
+void ProductLieGroup<G, H>::print(const std::string& s) const {
+  std::cout << s << "ProductLieGroup" << std::endl;
+  traits<G>::Print(this->first, "  first");
+  traits<H>::Print(this->second, "  second");
+}
+
+template <typename G, int N, typename Derived>
+void PowerLieGroupBase<G, N, Derived>::checkDynamicTangentSize(
+    const TangentVector& v, size_t count, const char* operation) {
+  if constexpr (isDynamic) {
+    if (static_cast<size_t>(v.size()) != totalDimension(count)) {
+      throw std::invalid_argument(std::string("PowerLieGroup::") + operation +
+                                  " tangent dimension does not match group "
+                                  "dimension");
+    }
+  } else {
+    static_cast<void>(v);
+    static_cast<void>(count);
+    static_cast<void>(operation);
+  }
+}
+
+template <typename G, int N, typename Derived>
+void PowerLieGroupBase<G, N, Derived>::checkMatchingCounts(
+    const Derived& other, const char* operation) const {
+  if constexpr (isDynamic) {
+    if (derived().size() != other.size()) {
+      throw std::invalid_argument(std::string("PowerLieGroup::") + operation +
+                                  " requires matching component counts");
+    }
+  } else {
+    static_cast<void>(other);
+    static_cast<void>(operation);
+  }
+}
+
+template <typename G, int N, typename Derived>
+typename traits<G>::TangentVector
+PowerLieGroupBase<G, N, Derived>::tangentSegment(const TangentVector& v,
+                                                 size_t i) {
+  if constexpr (isDynamic) {
+    return v.segment(offset(i), baseDimension);
+  } else {
+    return v.template segment<baseDimension>(i * baseDimension);
+  }
+}
+
+template <typename G, int N, typename Derived>
+Derived PowerLieGroupBase<G, N, Derived>::makeResult(size_t count) {
+  if constexpr (isDynamic) {
+    return Derived(count);
+  } else {
+    static_cast<void>(count);
+    return Derived();
+  }
+}
+
+template <typename G, int N, typename Derived>
+typename PowerLieGroupBase<G, N, Derived>::JacobianStorage
+PowerLieGroupBase<G, N, Derived>::makeJacobianStorage(size_t count) {
+  if constexpr (isDynamic) {
+    return JacobianStorage(count);
+  } else {
+    static_cast<void>(count);
+    return JacobianStorage();
+  }
+}
+
+template <typename G, int N, typename Derived>
+void PowerLieGroupBase<G, N, Derived>::assignTangentSegment(
+    TangentVector& v, size_t i, const typename traits<G>::TangentVector& vi) {
+  if constexpr (isDynamic) {
+    v.segment(offset(i), baseDimension) = vi;
+  } else {
+    v.template segment<baseDimension>(i * baseDimension) = vi;
+  }
+}
+
+template <typename G, int N, typename Derived>
+template <typename MatrixType>
+void PowerLieGroupBase<G, N, Derived>::assignJacobianBlock(
+    MatrixType& H, size_t i, const BaseJacobian& block) {
+  if constexpr (isDynamic) {
+    H.block(offset(i), offset(i), baseDimension, baseDimension) = block;
+  } else {
+    H.template block<baseDimension, baseDimension>(i * baseDimension,
+                                                   i * baseDimension) = block;
+  }
+}
+
+template <typename G, int N, typename Derived>
+void PowerLieGroupBase<G, N, Derived>::fillJacobianBlocks(
+    ChartJacobian H, const JacobianStorage& jacobians, size_t count) {
+  if (!H) return;
+  *H = zeroJacobian(count);
+  for (size_t i = 0; i < count; ++i) {
+    assignJacobianBlock(*H, i, jacobians[i]);
+  }
+}
+
+template <typename G, int N, typename Derived>
+Derived PowerLieGroupBase<G, N, Derived>::operator*(
+    const Derived& other) const {
+  checkMatchingCounts(other, "operator*");
+  Derived result = makeResult(componentCount());
+  for (size_t i = 0; i < componentCount(); ++i) {
+    result[i] = traits<G>::Compose(derived()[i], other[i]);
+  }
+  return result;
+}
+
+template <typename G, int N, typename Derived>
+Derived PowerLieGroupBase<G, N, Derived>::inverse() const {
+  Derived result = makeResult(componentCount());
+  for (size_t i = 0; i < componentCount(); ++i) {
+    result[i] = traits<G>::Inverse(derived()[i]);
+  }
+  return result;
+}
+
+template <typename G, int N, typename Derived>
+Derived PowerLieGroupBase<G, N, Derived>::retract(const TangentVector& v,
+                                                  ChartJacobian H1,
+                                                  ChartJacobian H2) const {
+  if (H1 || H2) {
+    throw std::runtime_error(
+        "PowerLieGroup::retract derivatives not implemented yet");
+  }
+  const size_t count = componentCount();
+  checkDynamicTangentSize(v, count, "retract");
+  Derived result = makeResult(count);
+  for (size_t i = 0; i < count; ++i) {
+    result[i] = traits<G>::Retract(derived()[i], tangentSegment(v, i));
+  }
+  return result;
+}
+
+template <typename G, int N, typename Derived>
+typename PowerLieGroupBase<G, N, Derived>::TangentVector
+PowerLieGroupBase<G, N, Derived>::localCoordinates(const Derived& g,
+                                                   ChartJacobian H1,
+                                                   ChartJacobian H2) const {
+  if (H1 || H2) {
+    throw std::runtime_error(
+        "PowerLieGroup::localCoordinates derivatives not implemented yet");
+  }
+  checkMatchingCounts(g, "localCoordinates");
+  TangentVector v = zeroTangent(componentCount());
+  for (size_t i = 0; i < componentCount(); ++i) {
+    assignTangentSegment(v, i, traits<G>::Local(derived()[i], g[i]));
+  }
+  return v;
+}
+
+template <typename G, int N, typename Derived>
+Derived PowerLieGroupBase<G, N, Derived>::compose(const Derived& other,
+                                                  ChartJacobian H1,
+                                                  ChartJacobian H2) const {
+  checkMatchingCounts(other, "compose");
+  const size_t count = componentCount();
+  JacobianStorage jacobians = makeJacobianStorage(count);
+  Derived result = makeResult(count);
+  for (size_t i = 0; i < count; ++i) {
+    result[i] = traits<G>::Compose(derived()[i], other[i],
+                                   H1 ? &jacobians[i] : nullptr);
+  }
+  fillJacobianBlocks(H1, jacobians, count);
+  if (H2) *H2 = identityJacobian(count);
+  return result;
+}
+
+template <typename G, int N, typename Derived>
+Derived PowerLieGroupBase<G, N, Derived>::between(const Derived& other,
+                                                  ChartJacobian H1,
+                                                  ChartJacobian H2) const {
+  checkMatchingCounts(other, "between");
+  const size_t count = componentCount();
+  JacobianStorage jacobians = makeJacobianStorage(count);
+  Derived result = makeResult(count);
+  for (size_t i = 0; i < count; ++i) {
+    result[i] = traits<G>::Between(derived()[i], other[i],
+                                   H1 ? &jacobians[i] : nullptr);
+  }
+  fillJacobianBlocks(H1, jacobians, count);
+  if (H2) *H2 = identityJacobian(count);
+  return result;
+}
+
+template <typename G, int N, typename Derived>
+Derived PowerLieGroupBase<G, N, Derived>::inverse(ChartJacobian D) const {
+  const size_t count = componentCount();
+  JacobianStorage jacobians = makeJacobianStorage(count);
+  Derived result = makeResult(count);
+  for (size_t i = 0; i < count; ++i) {
+    result[i] = traits<G>::Inverse(derived()[i], D ? &jacobians[i] : nullptr);
+  }
+  fillJacobianBlocks(D, jacobians, count);
+  return result;
+}
+
+template <typename G, int N, typename Derived>
+Derived PowerLieGroupBase<G, N, Derived>::Expmap(const TangentVector& v,
+                                                 ChartJacobian Hv) {
+  size_t count = 0;
+  if constexpr (isDynamic) {
+    if (v.size() % baseDimension != 0) {
+      throw std::invalid_argument(
+          "PowerLieGroup::Expmap tangent dimension must be divisible by base "
+          "group dimension");
+    }
+    count = static_cast<size_t>(v.size() /
+                                static_cast<Eigen::Index>(baseDimension));
+  } else {
+    count = N;
+  }
+  JacobianStorage jacobians = makeJacobianStorage(count);
+  Derived result = makeResult(count);
+  for (size_t i = 0; i < count; ++i) {
+    result[i] =
+        traits<G>::Expmap(tangentSegment(v, i), Hv ? &jacobians[i] : nullptr);
+  }
+  fillJacobianBlocks(Hv, jacobians, count);
+  return result;
+}
+
+template <typename G, int N, typename Derived>
+typename PowerLieGroupBase<G, N, Derived>::TangentVector
+PowerLieGroupBase<G, N, Derived>::Logmap(const Derived& p, ChartJacobian Hp) {
+  const size_t count = isDynamic ? p.size() : N;
+  TangentVector v = zeroTangent(count);
+  JacobianStorage jacobians = makeJacobianStorage(count);
+  for (size_t i = 0; i < count; ++i) {
+    assignTangentSegment(v, i,
+                         traits<G>::Logmap(p[i], Hp ? &jacobians[i] : nullptr));
+  }
+  fillJacobianBlocks(Hp, jacobians, count);
+  return v;
+}
+
+template <typename G, int N, typename Derived>
+typename PowerLieGroupBase<G, N, Derived>::Jacobian
+PowerLieGroupBase<G, N, Derived>::AdjointMap() const {
+  Jacobian adj = zeroJacobian(componentCount());
+  for (size_t i = 0; i < componentCount(); ++i) {
+    assignJacobianBlock(adj, i, traits<G>::AdjointMap(derived()[i]));
+  }
+  return adj;
+}
+
+template <typename G, int N, typename Derived>
+void PowerLieGroupBase<G, N, Derived>::print(const std::string& s) const {
+  std::cout << s << "PowerLieGroup" << std::endl;
+  for (size_t i = 0; i < componentCount(); ++i) {
+    traits<G>::Print(derived()[i], "  component[" + std::to_string(i) + "]");
+  }
+}
+
+template <typename G, int N, typename Derived>
+bool PowerLieGroupBase<G, N, Derived>::equals(const Derived& other,
+                                              double tol) const {
+  if constexpr (isDynamic) {
+    if (derived().size() != other.size()) {
+      return false;
+    }
+  }
+  for (size_t i = 0; i < componentCount(); ++i) {
+    if (!traits<G>::Equals(derived()[i], other[i], tol)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <typename G, int N, typename Derived>
+typename PowerLieGroupBase<G, N, Derived>::TangentVector
+PowerLieGroupBase<G, N, Derived>::zeroTangent(size_t count) {
+  if constexpr (isDynamic) {
+    return TangentVector::Zero(totalDimension(count));
+  } else {
+    static_cast<void>(count);
+    return TangentVector::Zero();
+  }
+}
+
+template <typename G, int N, typename Derived>
+typename PowerLieGroupBase<G, N, Derived>::Jacobian
+PowerLieGroupBase<G, N, Derived>::zeroJacobian(size_t count) {
+  if constexpr (isDynamic) {
+    return Jacobian::Zero(totalDimension(count), totalDimension(count));
+  } else {
+    static_cast<void>(count);
+    return Jacobian::Zero();
+  }
+}
+
+template <typename G, int N, typename Derived>
+typename PowerLieGroupBase<G, N, Derived>::Jacobian
+PowerLieGroupBase<G, N, Derived>::identityJacobian(size_t count) {
+  if constexpr (isDynamic) {
+    return Jacobian::Identity(totalDimension(count), totalDimension(count));
+  } else {
+    static_cast<void>(count);
+    return Jacobian::Identity();
+  }
+}
+
+template <typename G, int N>
+PowerLieGroup<G, N>::PowerLieGroup(const std::initializer_list<G>& elements) {
+  if (elements.size() != N) {
+    throw std::invalid_argument(
+        "PowerLieGroup: initializer list size must equal N");
+  }
+  std::copy(elements.begin(), elements.end(), this->begin());
+}
+
+}  // namespace gtsam

--- a/gtsam/base/ProductLieGroup-inl.h
+++ b/gtsam/base/ProductLieGroup-inl.h
@@ -23,8 +23,7 @@ namespace gtsam {
 template <typename G, typename H>
 ProductLieGroup<G, H> ProductLieGroup<G, H>::operator*(
     const ProductLieGroup& other) const {
-  checkMatchingDimensions(firstDim(), secondDim(), other.firstDim(),
-                          other.secondDim(), "operator*");
+  checkMatchingDimensions(other, "operator*");
   return ProductLieGroup(traits<G>::Compose(this->first, other.first),
                          traits<H>::Compose(this->second, other.second));
 }
@@ -67,8 +66,7 @@ ProductLieGroup<G, H>::localCoordinates(const ProductLieGroup& g,
     throw std::runtime_error(
         "ProductLieGroup::localCoordinates derivatives not implemented yet");
   }
-  checkMatchingDimensions(firstDim(), secondDim(), g.firstDim(), g.secondDim(),
-                          "localCoordinates");
+  checkMatchingDimensions(g, "localCoordinates");
   const size_t firstDimension = firstDim();
   const size_t secondDimension = secondDim();
   typename traits<G>::TangentVector v1 = traits<G>::Local(this->first, g.first);
@@ -80,8 +78,7 @@ ProductLieGroup<G, H>::localCoordinates(const ProductLieGroup& g,
 template <typename G, typename H>
 ProductLieGroup<G, H> ProductLieGroup<G, H>::compose(
     const ProductLieGroup& other, ChartJacobian H1, ChartJacobian H2) const {
-  checkMatchingDimensions(firstDim(), secondDim(), other.firstDim(),
-                          other.secondDim(), "compose");
+  checkMatchingDimensions(other, "compose");
   const size_t firstDimension = firstDim();
   const size_t secondDimension = secondDim();
   const size_t productDimension =
@@ -104,8 +101,7 @@ ProductLieGroup<G, H> ProductLieGroup<G, H>::compose(
 template <typename G, typename H>
 ProductLieGroup<G, H> ProductLieGroup<G, H>::between(
     const ProductLieGroup& other, ChartJacobian H1, ChartJacobian H2) const {
-  checkMatchingDimensions(firstDim(), secondDim(), other.firstDim(),
-                          other.secondDim(), "between");
+  checkMatchingDimensions(other, "between");
   const size_t firstDimension = firstDim();
   const size_t secondDimension = secondDim();
   const size_t productDimension =
@@ -147,6 +143,8 @@ ProductLieGroup<G, H> ProductLieGroup<G, H>::inverse(ChartJacobian D) const {
 template <typename G, typename H>
 ProductLieGroup<G, H> ProductLieGroup<G, H>::Expmap(const TangentVector& v,
                                                     ChartJacobian Hv) {
+  size_t firstDimension = 0;
+  size_t secondDimension = 0;
   if constexpr (firstDynamic && secondDynamic) {
     if (v.size() == 0) {
       if (Hv) *Hv = Matrix::Zero(0, 0);
@@ -161,48 +159,99 @@ ProductLieGroup<G, H> ProductLieGroup<G, H>::Expmap(const TangentVector& v,
           "ProductLieGroup::Expmap tangent dimension is too small for the "
           "fixed second factor");
     }
-    const size_t firstDimension = static_cast<size_t>(v.size() - dimension2);
-    return expmapWithDimensions(v, firstDimension,
-                                static_cast<size_t>(dimension2), Hv);
+    firstDimension = static_cast<size_t>(v.size() - dimension2);
+    secondDimension = static_cast<size_t>(dimension2);
   } else if constexpr (secondDynamic) {
     if (v.size() < dimension1) {
       throw std::invalid_argument(
           "ProductLieGroup::Expmap tangent dimension is too small for the "
           "fixed first factor");
     }
-    const size_t secondDimension = static_cast<size_t>(v.size() - dimension1);
-    return expmapWithDimensions(v, static_cast<size_t>(dimension1),
-                                secondDimension, Hv);
+    firstDimension = static_cast<size_t>(dimension1);
+    secondDimension = static_cast<size_t>(v.size() - dimension1);
   } else {
-    return expmapWithDimensions(v, static_cast<size_t>(dimension1),
-                                static_cast<size_t>(dimension2), Hv);
+    firstDimension = static_cast<size_t>(dimension1);
+    secondDimension = static_cast<size_t>(dimension2);
   }
+  if (static_cast<size_t>(v.size()) !=
+      combinedDimension(firstDimension, secondDimension)) {
+    throw std::invalid_argument(
+        "ProductLieGroup::Expmap tangent dimension does not match product "
+        "dimension");
+  }
+  Matrix D_g_first;
+  Matrix D_h_second;
+  const auto v1 = tangentSegment<G>(v, 0, firstDimension);
+  const auto v2 = tangentSegment<H>(v, firstDimension, secondDimension);
+  ProductLieGroup result =
+      Expmap(v1, v2,
+             Hv ? OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic>(D_g_first)
+                : OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic>(),
+             Hv ? OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic>(D_h_second)
+                : OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic>());
+  if (Hv) {
+    const size_t productDimension =
+        combinedDimension(firstDimension, secondDimension);
+    *Hv = zeroJacobian(productDimension);
+    Hv->block(0, 0, productDimension, firstDimension) = D_g_first;
+    Hv->block(0, firstDimension, productDimension, secondDimension) =
+        D_h_second;
+  }
+  return result;
 }
 
 template <typename G, typename H>
 ProductLieGroup<G, H> ProductLieGroup<G, H>::Expmap(
     const Eigen::Ref<const typename traits<G>::TangentVector>& v1,
     const Eigen::Ref<const typename traits<H>::TangentVector>& v2,
-    ChartJacobian Hv) {
+    OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H1,
+    OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H2) {
   const size_t firstDimension = static_cast<size_t>(v1.size());
   const size_t secondDimension = static_cast<size_t>(v2.size());
+  const size_t productDimension =
+      combinedDimension(firstDimension, secondDimension);
   Jacobian1 D_g_first;
   Jacobian2 D_h_second;
-  G g = traits<G>::Expmap(v1, Hv ? &D_g_first : nullptr);
-  H h = traits<H>::Expmap(v2, Hv ? &D_h_second : nullptr);
-  if (Hv) {
-    *Hv = zeroJacobian(combinedDimension(firstDimension, secondDimension));
-    Hv->block(0, 0, firstDimension, firstDimension) = D_g_first;
-    Hv->block(firstDimension, firstDimension, secondDimension,
-              secondDimension) = D_h_second;
+  G g = traits<G>::Expmap(v1, H1 ? &D_g_first : nullptr);
+  H h = traits<H>::Expmap(v2, H2 ? &D_h_second : nullptr);
+  if (H1) {
+    *H1 = Matrix::Zero(productDimension, firstDimension);
+    H1->block(0, 0, firstDimension, firstDimension) = D_g_first;
+  }
+  if (H2) {
+    *H2 = Matrix::Zero(productDimension, secondDimension);
+    H2->block(firstDimension, 0, secondDimension, secondDimension) = D_h_second;
   }
   return ProductLieGroup(g, h);
 }
 
 template <typename G, typename H>
+typename ProductLieGroup<G, H>::TangentVector ProductLieGroup<G, H>::Logmap(
+    const ProductLieGroup& p, ChartJacobian Hp) {
+  const size_t firstDimension = p.firstDim();
+  const size_t secondDimension = p.secondDim();
+  const size_t productDimension =
+      combinedDimension(firstDimension, secondDimension);
+  Jacobian1 D_g_first;
+  Jacobian2 D_h_second;
+  typename traits<G>::TangentVector v1 =
+      traits<G>::Logmap(p.first, Hp ? &D_g_first : nullptr);
+  typename traits<H>::TangentVector v2 =
+      traits<H>::Logmap(p.second, Hp ? &D_h_second : nullptr);
+  TangentVector v = makeTangentVector(v1, v2, firstDimension, secondDimension);
+  if (Hp) {
+    *Hp = zeroJacobian(productDimension);
+    Hp->block(0, 0, firstDimension, firstDimension) = D_g_first;
+    Hp->block(firstDimension, firstDimension, secondDimension,
+              secondDimension) = D_h_second;
+  }
+  return v;
+}
+
+template <typename G, typename H>
 ProductLieGroup<G, H> ProductLieGroup<G, H>::expmap(
     const TangentVector& v) const {
-  return compose(expmapWithDimensions(v, firstDim(), secondDim()));
+  return compose(ProductLieGroup::Expmap(v));
 }
 
 template <typename G, typename H>
@@ -287,64 +336,12 @@ ProductLieGroup<G, H>::identityJacobian(size_t productDimension) {
 }
 
 template <typename G, typename H>
-void ProductLieGroup<G, H>::checkMatchingDimensions(size_t first1,
-                                                    size_t second1,
-                                                    size_t first2,
-                                                    size_t second2,
-                                                    const char* operation) {
-  if (first1 != first2 || second1 != second2) {
+void ProductLieGroup<G, H>::checkMatchingDimensions(
+    const ProductLieGroup& other, const char* operation) const {
+  if (firstDim() != other.firstDim() || secondDim() != other.secondDim()) {
     throw std::invalid_argument(std::string("ProductLieGroup::") + operation +
                                 " requires matching component dimensions");
   }
-}
-
-template <typename G, typename H>
-ProductLieGroup<G, H> ProductLieGroup<G, H>::expmapWithDimensions(
-    const TangentVector& v, size_t firstDimension, size_t secondDimension,
-    ChartJacobian Hv) {
-  if (static_cast<size_t>(v.size()) !=
-      combinedDimension(firstDimension, secondDimension)) {
-    throw std::invalid_argument(
-        "ProductLieGroup::Expmap tangent dimension does not match requested "
-        "component dimensions");
-  }
-  Jacobian1 D_g_first;
-  Jacobian2 D_h_second;
-  G g = traits<G>::Expmap(tangentSegment<G>(v, 0, firstDimension),
-                          Hv ? &D_g_first : nullptr);
-  H h = traits<H>::Expmap(tangentSegment<H>(v, firstDimension, secondDimension),
-                          Hv ? &D_h_second : nullptr);
-  if (Hv) {
-    *Hv = zeroJacobian(combinedDimension(firstDimension, secondDimension));
-    Hv->block(0, 0, firstDimension, firstDimension) = D_g_first;
-    Hv->block(firstDimension, firstDimension, secondDimension,
-              secondDimension) = D_h_second;
-  }
-  return ProductLieGroup(g, h);
-}
-
-template <typename G, typename H>
-typename ProductLieGroup<G, H>::TangentVector
-ProductLieGroup<G, H>::logmapWithDimensions(const ProductLieGroup& p,
-                                            size_t firstDimension,
-                                            size_t secondDimension,
-                                            ChartJacobian Hp) {
-  const size_t productDimension =
-      combinedDimension(firstDimension, secondDimension);
-  Jacobian1 D_g_first;
-  Jacobian2 D_h_second;
-  typename traits<G>::TangentVector v1 =
-      traits<G>::Logmap(p.first, Hp ? &D_g_first : nullptr);
-  typename traits<H>::TangentVector v2 =
-      traits<H>::Logmap(p.second, Hp ? &D_h_second : nullptr);
-  TangentVector v = makeTangentVector(v1, v2, firstDimension, secondDimension);
-  if (Hp) {
-    *Hp = zeroJacobian(productDimension);
-    Hp->block(0, 0, firstDimension, firstDimension) = D_g_first;
-    Hp->block(firstDimension, firstDimension, secondDimension,
-              secondDimension) = D_h_second;
-  }
-  return v;
 }
 
 template <typename G, typename H>

--- a/gtsam/base/ProductLieGroup.h
+++ b/gtsam/base/ProductLieGroup.h
@@ -26,6 +26,7 @@
 #include <stdexcept>
 #include <string>
 #include <utility>  // pair
+#include <vector>
 
 namespace gtsam {
 
@@ -478,23 +479,392 @@ class ProductLieGroup : public std::pair<G, H> {
 };
 
 /**
+ * @brief Shared implementation for fixed-size and dynamic-count PowerLieGroup
+ */
+template <typename T, int N>
+struct PowerLieGroupJacobianStorage {
+  using type = std::array<T, N>;
+};
+
+template <typename T>
+struct PowerLieGroupJacobianStorage<T, Eigen::Dynamic> {
+  using type = std::vector<T>;
+};
+
+template <typename G, int N, typename Derived>
+class PowerLieGroupBase {
+ protected:
+  static constexpr bool isDynamic = (N == Eigen::Dynamic);
+  static constexpr int baseDimension = traits<G>::dimension;
+
+ public:
+  typedef multiplicative_group_tag group_flavor;
+
+  static constexpr int dimension =
+      isDynamic ? Eigen::Dynamic : N * baseDimension;
+
+  typedef std::conditional_t<isDynamic, Vector,
+                             Eigen::Matrix<double, dimension, 1>>
+      TangentVector;
+
+  typedef std::conditional_t<isDynamic,
+                             OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic>,
+                             OptionalJacobian<dimension, dimension>>
+      ChartJacobian;
+
+  typedef std::conditional_t<isDynamic, Matrix,
+                             Eigen::Matrix<double, dimension, dimension>>
+      Jacobian;
+
+  using BaseJacobian = typename traits<G>::Jacobian;
+  using JacobianStorage =
+      typename PowerLieGroupJacobianStorage<BaseJacobian, N>::type;
+
+ protected:
+  const Derived& derived() const { return static_cast<const Derived&>(*this); }
+
+  Derived& derived() { return static_cast<Derived&>(*this); }
+
+  static size_t totalDimension(size_t count) {
+    return count * static_cast<size_t>(baseDimension);
+  }
+
+  static Eigen::Index offset(size_t i) {
+    return static_cast<Eigen::Index>(i * static_cast<size_t>(baseDimension));
+  }
+
+  size_t componentCount() const {
+    if constexpr (isDynamic) {
+      return derived().size();
+    } else {
+      return N;
+    }
+  }
+
+  static void checkDynamicTangentSize(const TangentVector& v, size_t count,
+                                      const char* operation) {
+    if constexpr (isDynamic) {
+      if (static_cast<size_t>(v.size()) != totalDimension(count)) {
+        throw std::invalid_argument(
+            std::string("PowerLieGroup::") + operation +
+            " tangent dimension does not match group dimension");
+      }
+    } else {
+      static_cast<void>(v);
+      static_cast<void>(count);
+      static_cast<void>(operation);
+    }
+  }
+
+  void checkMatchingCounts(const Derived& other, const char* operation) const {
+    if constexpr (isDynamic) {
+      if (derived().size() != other.size()) {
+        throw std::invalid_argument(std::string("PowerLieGroup::") + operation +
+                                    " requires matching component counts");
+      }
+    } else {
+      static_cast<void>(other);
+      static_cast<void>(operation);
+    }
+  }
+
+  static typename traits<G>::TangentVector tangentSegment(
+      const TangentVector& v, size_t i) {
+    if constexpr (isDynamic) {
+      return v.segment(offset(i), baseDimension);
+    } else {
+      return v.template segment<baseDimension>(i * baseDimension);
+    }
+  }
+
+  static Derived makeResult(size_t count) {
+    if constexpr (isDynamic) {
+      return Derived(count);
+    } else {
+      static_cast<void>(count);
+      return Derived();
+    }
+  }
+
+  static JacobianStorage makeJacobianStorage(size_t count) {
+    if constexpr (isDynamic) {
+      return JacobianStorage(count);
+    } else {
+      static_cast<void>(count);
+      return JacobianStorage();
+    }
+  }
+
+  static void assignTangentSegment(
+      TangentVector& v, size_t i, const typename traits<G>::TangentVector& vi) {
+    if constexpr (isDynamic) {
+      v.segment(offset(i), baseDimension) = vi;
+    } else {
+      v.template segment<baseDimension>(i * baseDimension) = vi;
+    }
+  }
+
+  template <typename MatrixType>
+  static void assignJacobianBlock(MatrixType& H, size_t i,
+                                  const BaseJacobian& block) {
+    if constexpr (isDynamic) {
+      H.block(offset(i), offset(i), baseDimension, baseDimension) = block;
+    } else {
+      H.template block<baseDimension, baseDimension>(i * baseDimension,
+                                                     i * baseDimension) = block;
+    }
+  }
+
+  static void fillJacobianBlocks(ChartJacobian H,
+                                 const JacobianStorage& jacobians,
+                                 size_t count) {
+    if (!H) return;
+    *H = zeroJacobian(count);
+    for (size_t i = 0; i < count; ++i) {
+      assignJacobianBlock(*H, i, jacobians[i]);
+    }
+  }
+
+ public:
+  /// Return manifold dimension
+  static constexpr int Dim() { return dimension; }
+
+  /// Return manifold dimension
+  size_t dim() const { return totalDimension(componentCount()); }
+
+  /// Group multiplication
+  Derived operator*(const Derived& other) const {
+    checkMatchingCounts(other, "operator*");
+    Derived result = makeResult(componentCount());
+    for (size_t i = 0; i < componentCount(); ++i) {
+      result[i] = traits<G>::Compose(derived()[i], other[i]);
+    }
+    return result;
+  }
+
+  /// Group inverse
+  Derived inverse() const {
+    Derived result = makeResult(componentCount());
+    for (size_t i = 0; i < componentCount(); ++i) {
+      result[i] = traits<G>::Inverse(derived()[i]);
+    }
+    return result;
+  }
+
+  /// Compose with another element (same as operator*)
+  Derived compose(const Derived& g) const { return (*this) * g; }
+
+  /// Calculate relative transformation
+  Derived between(const Derived& g) const { return this->inverse() * g; }
+
+  /// Retract to manifold
+  Derived retract(const TangentVector& v, ChartJacobian H1 = {},
+                  ChartJacobian H2 = {}) const {
+    if (H1 || H2) {
+      throw std::runtime_error(
+          "PowerLieGroup::retract derivatives not implemented yet");
+    }
+    const size_t count = componentCount();
+    checkDynamicTangentSize(v, count, "retract");
+    Derived result = makeResult(count);
+    for (size_t i = 0; i < count; ++i) {
+      result[i] = traits<G>::Retract(derived()[i], tangentSegment(v, i));
+    }
+    return result;
+  }
+
+  /// Local coordinates on manifold
+  TangentVector localCoordinates(const Derived& g, ChartJacobian H1 = {},
+                                 ChartJacobian H2 = {}) const {
+    if (H1 || H2) {
+      throw std::runtime_error(
+          "PowerLieGroup::localCoordinates derivatives not implemented yet");
+    }
+    checkMatchingCounts(g, "localCoordinates");
+    TangentVector v = zeroTangent(componentCount());
+    for (size_t i = 0; i < componentCount(); ++i) {
+      assignTangentSegment(v, i, traits<G>::Local(derived()[i], g[i]));
+    }
+    return v;
+  }
+
+  /// Compose with Jacobians
+  Derived compose(const Derived& other, ChartJacobian H1,
+                  ChartJacobian H2 = {}) const {
+    checkMatchingCounts(other, "compose");
+    const size_t count = componentCount();
+    JacobianStorage jacobians = makeJacobianStorage(count);
+    Derived result = makeResult(count);
+    for (size_t i = 0; i < count; ++i) {
+      result[i] = traits<G>::Compose(derived()[i], other[i],
+                                     H1 ? &jacobians[i] : nullptr);
+    }
+    fillJacobianBlocks(H1, jacobians, count);
+    if (H2) *H2 = identityJacobian(count);
+    return result;
+  }
+
+  /// Between with Jacobians
+  Derived between(const Derived& other, ChartJacobian H1,
+                  ChartJacobian H2 = {}) const {
+    checkMatchingCounts(other, "between");
+    const size_t count = componentCount();
+    JacobianStorage jacobians = makeJacobianStorage(count);
+    Derived result = makeResult(count);
+    for (size_t i = 0; i < count; ++i) {
+      result[i] = traits<G>::Between(derived()[i], other[i],
+                                     H1 ? &jacobians[i] : nullptr);
+    }
+    fillJacobianBlocks(H1, jacobians, count);
+    if (H2) *H2 = identityJacobian(count);
+    return result;
+  }
+
+  /// Inverse with Jacobian
+  Derived inverse(ChartJacobian D) const {
+    const size_t count = componentCount();
+    JacobianStorage jacobians = makeJacobianStorage(count);
+    Derived result = makeResult(count);
+    for (size_t i = 0; i < count; ++i) {
+      result[i] = traits<G>::Inverse(derived()[i], D ? &jacobians[i] : nullptr);
+    }
+    fillJacobianBlocks(D, jacobians, count);
+    return result;
+  }
+
+  /// Exponential map
+  static Derived Expmap(const TangentVector& v, ChartJacobian Hv = {}) {
+    size_t count = 0;
+    if constexpr (isDynamic) {
+      if (v.size() % baseDimension != 0) {
+        throw std::invalid_argument(
+            "PowerLieGroup::Expmap tangent dimension must be divisible by base "
+            "group dimension");
+      }
+      count = static_cast<size_t>(v.size() /
+                                  static_cast<Eigen::Index>(baseDimension));
+    } else {
+      count = N;
+    }
+    JacobianStorage jacobians = makeJacobianStorage(count);
+    Derived result = makeResult(count);
+    for (size_t i = 0; i < count; ++i) {
+      result[i] =
+          traits<G>::Expmap(tangentSegment(v, i), Hv ? &jacobians[i] : nullptr);
+    }
+    fillJacobianBlocks(Hv, jacobians, count);
+    return result;
+  }
+
+  /// Logarithmic map
+  static TangentVector Logmap(const Derived& p, ChartJacobian Hp = {}) {
+    const size_t count = isDynamic ? p.size() : N;
+    TangentVector v = zeroTangent(count);
+    JacobianStorage jacobians = makeJacobianStorage(count);
+    for (size_t i = 0; i < count; ++i) {
+      assignTangentSegment(
+          v, i, traits<G>::Logmap(p[i], Hp ? &jacobians[i] : nullptr));
+    }
+    fillJacobianBlocks(Hp, jacobians, count);
+    return v;
+  }
+
+  /// Local coordinates (same as Logmap)
+  static TangentVector LocalCoordinates(const Derived& p,
+                                        ChartJacobian Hp = {}) {
+    return Logmap(p, Hp);
+  }
+
+  /// Right multiplication by exponential map
+  Derived expmap(const TangentVector& v) const { return compose(Expmap(v)); }
+
+  /// Logarithmic map for relative transformation
+  TangentVector logmap(const Derived& g) const { return Logmap(between(g)); }
+
+  /// Adjoint map
+  Jacobian AdjointMap() const {
+    Jacobian adj = zeroJacobian(componentCount());
+    for (size_t i = 0; i < componentCount(); ++i) {
+      assignJacobianBlock(adj, i, traits<G>::AdjointMap(derived()[i]));
+    }
+    return adj;
+  }
+
+  /// Print for debugging
+  void print(const std::string& s = "") const {
+    std::cout << s << "PowerLieGroup" << std::endl;
+    for (size_t i = 0; i < componentCount(); ++i) {
+      traits<G>::Print(derived()[i], "  component[" + std::to_string(i) + "]");
+    }
+  }
+
+  /// Equality with tolerance
+  bool equals(const Derived& other, double tol = 1e-9) const {
+    if constexpr (isDynamic) {
+      if (derived().size() != other.size()) {
+        return false;
+      }
+    }
+    for (size_t i = 0; i < componentCount(); ++i) {
+      if (!traits<G>::Equals(derived()[i], other[i], tol)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+ protected:
+  static TangentVector zeroTangent(size_t count) {
+    if constexpr (isDynamic) {
+      return TangentVector::Zero(totalDimension(count));
+    } else {
+      static_cast<void>(count);
+      return TangentVector::Zero();
+    }
+  }
+
+  static Jacobian zeroJacobian(size_t count) {
+    if constexpr (isDynamic) {
+      return Jacobian::Zero(totalDimension(count), totalDimension(count));
+    } else {
+      static_cast<void>(count);
+      return Jacobian::Zero();
+    }
+  }
+
+  static Jacobian identityJacobian(size_t count) {
+    if constexpr (isDynamic) {
+      return Jacobian::Identity(totalDimension(count), totalDimension(count));
+    } else {
+      static_cast<void>(count);
+      return Jacobian::Identity();
+    }
+  }
+};
+
+/**
  * @brief Template to construct the N-fold power of a Lie group
  * Represents the group G^N = G x G x ... x G (N times)
- * Assumes Lie group structure for G and N >= 2
+ * Assumes Lie group structure for fixed-size G and fixed N >= 1
  */
-template <typename G, size_t N>
-class PowerLieGroup : public std::array<G, N> {
+template <typename G, int N>
+class PowerLieGroup : public std::array<G, N>,
+                      public PowerLieGroupBase<G, N, PowerLieGroup<G, N>> {
   static_assert(N >= 1, "PowerLieGroup requires N >= 1");
   GTSAM_CONCEPT_ASSERT(IsLieGroup<G>);
   GTSAM_CONCEPT_ASSERT(IsTestable<G>);
+  static_assert(traits<G>::dimension != Eigen::Dynamic,
+                "PowerLieGroup requires a fixed-size base group");
 
  public:
   /// Base array type
   typedef std::array<G, N> Base;
-
- protected:
-  /// Dimension of the base group
-  static constexpr size_t baseDimension = traits<G>::dimension;
+  typedef PowerLieGroupBase<G, N, PowerLieGroup> Helper;
+  using typename Helper::BaseJacobian;
+  using typename Helper::ChartJacobian;
+  using typename Helper::Jacobian;
+  using typename Helper::TangentVector;
+  static constexpr int dimension = Helper::dimension;
 
  public:
   /// @name Standard Constructors
@@ -519,234 +889,81 @@ class PowerLieGroup : public std::array<G, N> {
   /// @name Group Operations
   /// @{
 
-  typedef multiplicative_group_tag group_flavor;
-
   /// Identity element
   static PowerLieGroup Identity() { return PowerLieGroup(); }
-
-  /// Group multiplication
-  PowerLieGroup operator*(const PowerLieGroup& other) const {
-    PowerLieGroup result;
-    for (size_t i = 0; i < N; ++i) {
-      result[i] = traits<G>::Compose((*this)[i], other[i]);
-    }
-    return result;
-  }
-
-  /// Group inverse
-  PowerLieGroup inverse() const {
-    PowerLieGroup result;
-    for (size_t i = 0; i < N; ++i) {
-      result[i] = traits<G>::Inverse((*this)[i]);
-    }
-    return result;
-  }
-
-  /// Compose with another element (same as operator*)
-  PowerLieGroup compose(const PowerLieGroup& g) const { return (*this) * g; }
-
-  /// Calculate relative transformation
-  PowerLieGroup between(const PowerLieGroup& g) const {
-    return this->inverse() * g;
-  }
 
   /// @}
   /// @name Manifold Operations
   /// @{
 
-  /// Manifold dimension
-  static constexpr size_t dimension = N * baseDimension;
-
   /// Return manifold dimension
-  static size_t Dim() { return dimension; }
-
-  /// Return manifold dimension
-  size_t dim() const { return dimension; }
-
-  /// Tangent vector type
-  typedef Eigen::Matrix<double, dimension, 1> TangentVector;
-
-  /// Chart Jacobian type
-  typedef OptionalJacobian<dimension, dimension> ChartJacobian;
-
-  /// Retract to manifold
-  PowerLieGroup retract(const TangentVector& v, ChartJacobian H1 = {},
-                        ChartJacobian H2 = {}) const {
-    if (H1 || H2) {
-      throw std::runtime_error(
-          "PowerLieGroup::retract derivatives not implemented yet");
-    }
-    PowerLieGroup result;
-    for (size_t i = 0; i < N; ++i) {
-      const auto vi = v.template segment<baseDimension>(i * baseDimension);
-      result[i] = traits<G>::Retract((*this)[i], vi);
-    }
-    return result;
-  }
-
-  /// Local coordinates on manifold
-  TangentVector localCoordinates(const PowerLieGroup& g, ChartJacobian H1 = {},
-                                 ChartJacobian H2 = {}) const {
-    if (H1 || H2) {
-      throw std::runtime_error(
-          "PowerLieGroup::localCoordinates derivatives not implemented yet");
-    }
-    TangentVector v;
-    for (size_t i = 0; i < N; ++i) {
-      const auto vi = traits<G>::Local((*this)[i], g[i]);
-      v.template segment<baseDimension>(i * baseDimension) = vi;
-    }
-    return v;
-  }
+  static constexpr int Dim() { return dimension; }
 
   /// @}
   /// @name Lie Group Operations
   /// @{
 
+  /// @}
+};
+
+/**
+ * @brief Dynamic-count specialization of PowerLieGroup
+ * Represents G^N for runtime-sized N while keeping G fixed-size
+ */
+template <typename G>
+class PowerLieGroup<G, Eigen::Dynamic>
+    : public std::vector<G>,
+      public PowerLieGroupBase<G, Eigen::Dynamic,
+                               PowerLieGroup<G, Eigen::Dynamic>> {
+  GTSAM_CONCEPT_ASSERT(IsLieGroup<G>);
+  GTSAM_CONCEPT_ASSERT(IsTestable<G>);
+  static_assert(traits<G>::dimension != Eigen::Dynamic,
+                "PowerLieGroup requires a fixed-size base group");
+
  public:
-  /// Jacobian types for internal use
-  typedef Eigen::Matrix<double, dimension, dimension> Jacobian;
-  typedef Eigen::Matrix<double, baseDimension, baseDimension> BaseJacobian;
+  /// Base vector type
+  typedef std::vector<G> Base;
+  typedef PowerLieGroupBase<G, Eigen::Dynamic, PowerLieGroup> Helper;
+  using typename Helper::BaseJacobian;
+  using typename Helper::ChartJacobian;
+  using typename Helper::Jacobian;
+  using typename Helper::TangentVector;
+  static constexpr int dimension = Helper::dimension;
 
-  /// Compose with Jacobians
-  PowerLieGroup compose(const PowerLieGroup& other, ChartJacobian H1,
-                        ChartJacobian H2 = {}) const {
-    std::array<BaseJacobian, N> jacobians;
-    PowerLieGroup result;
-    for (size_t i = 0; i < N; ++i) {
-      result[i] = traits<G>::Compose((*this)[i], other[i],
-                                     H1 ? &jacobians[i] : nullptr);
-    }
-    if (H1) {
-      H1->setZero();
-      for (size_t i = 0; i < N; ++i) {
-        H1->template block<baseDimension, baseDimension>(
-            i * baseDimension, i * baseDimension) = jacobians[i];
-      }
-    }
-    if (H2) *H2 = Jacobian::Identity();
-    return result;
-  }
+ public:
+  /// @name Standard Constructors
+  /// @{
 
-  /// Between with Jacobians
-  PowerLieGroup between(const PowerLieGroup& other, ChartJacobian H1,
-                        ChartJacobian H2 = {}) const {
-    std::array<BaseJacobian, N> jacobians;
-    PowerLieGroup result;
-    for (size_t i = 0; i < N; ++i) {
-      result[i] = traits<G>::Between((*this)[i], other[i],
-                                     H1 ? &jacobians[i] : nullptr);
-    }
-    if (H1) {
-      H1->setZero();
-      for (size_t i = 0; i < N; ++i) {
-        H1->template block<baseDimension, baseDimension>(
-            i * baseDimension, i * baseDimension) = jacobians[i];
-      }
-    }
-    if (H2) *H2 = Jacobian::Identity();
-    return result;
-  }
+  /// Default constructor yields a zero-length placeholder identity
+  PowerLieGroup() = default;
 
-  /// Inverse with Jacobian
-  PowerLieGroup inverse(ChartJacobian D) const {
-    std::array<BaseJacobian, N> jacobians;
-    PowerLieGroup result;
-    for (size_t i = 0; i < N; ++i) {
-      result[i] = traits<G>::Inverse((*this)[i], D ? &jacobians[i] : nullptr);
-    }
-    if (D) {
-      D->setZero();
-      for (size_t i = 0; i < N; ++i) {
-        D->template block<baseDimension, baseDimension>(
-            i * baseDimension, i * baseDimension) = jacobians[i];
-      }
-    }
-    return result;
-  }
+  /// Construct a runtime-sized identity element
+  explicit PowerLieGroup(size_t count) : Base(count, traits<G>::Identity()) {}
 
-  /// Exponential map
-  static PowerLieGroup Expmap(const TangentVector& v, ChartJacobian Hv = {}) {
-    std::array<BaseJacobian, N> jacobians;
-    PowerLieGroup result;
-    for (size_t i = 0; i < N; ++i) {
-      const auto vi = v.template segment<baseDimension>(i * baseDimension);
-      result[i] = traits<G>::Expmap(vi, Hv ? &jacobians[i] : nullptr);
-    }
-    if (Hv) {
-      Hv->setZero();
-      for (size_t i = 0; i < N; ++i) {
-        Hv->template block<baseDimension, baseDimension>(
-            i * baseDimension, i * baseDimension) = jacobians[i];
-      }
-    }
-    return result;
-  }
+  /// Construct from vector of group elements
+  PowerLieGroup(const Base& elements) : Base(elements) {}
 
-  /// Logarithmic map
-  static TangentVector Logmap(const PowerLieGroup& p, ChartJacobian Hp = {}) {
-    std::array<BaseJacobian, N> jacobians;
-    TangentVector v;
-    for (size_t i = 0; i < N; ++i) {
-      const auto vi = traits<G>::Logmap(p[i], Hp ? &jacobians[i] : nullptr);
-      v.template segment<baseDimension>(i * baseDimension) = vi;
-    }
-    if (Hp) {
-      Hp->setZero();
-      for (size_t i = 0; i < N; ++i) {
-        Hp->template block<baseDimension, baseDimension>(
-            i * baseDimension, i * baseDimension) = jacobians[i];
-      }
-    }
-    return v;
-  }
-
-  /// Local coordinates (same as Logmap)
-  static TangentVector LocalCoordinates(const PowerLieGroup& p,
-                                        ChartJacobian Hp = {}) {
-    return Logmap(p, Hp);
-  }
-
-  /// Right multiplication by exponential map
-  PowerLieGroup expmap(const TangentVector& v) const {
-    return compose(PowerLieGroup::Expmap(v));
-  }
-
-  /// Logarithmic map for relative transformation
-  TangentVector logmap(const PowerLieGroup& g) const {
-    return PowerLieGroup::Logmap(between(g));
-  }
-
-  /// Adjoint map
-  Jacobian AdjointMap() const {
-    Jacobian adj = Jacobian::Zero();
-    for (size_t i = 0; i < N; ++i) {
-      const auto adjGi = traits<G>::AdjointMap((*this)[i]);
-      adj.template block<baseDimension, baseDimension>(
-          i * baseDimension, i * baseDimension) = adjGi;
-    }
-    return adj;
-  }
+  /// Construct from initializer list
+  PowerLieGroup(const std::initializer_list<G>& elements) : Base(elements) {}
 
   /// @}
-
-  /// @name Testable interface
+  /// @name Group Operations
   /// @{
-  void print(const std::string& s = "") const {
-    std::cout << s << "PowerLieGroup" << std::endl;
-    for (size_t i = 0; i < N; ++i) {
-      traits<G>::Print((*this)[i], "  component[" + std::to_string(i) + "]");
-    }
-  }
 
-  bool equals(const PowerLieGroup& other, double tol = 1e-9) const {
-    for (size_t i = 0; i < N; ++i) {
-      if (!traits<G>::Equals((*this)[i], other[i], tol)) {
-        return false;
-      }
-    }
-    return true;
-  }
+  /// Identity element
+  static PowerLieGroup Identity() { return PowerLieGroup(); }
+
+  /// @}
+  /// @name Manifold Operations
+  /// @{
+
+  /// Return manifold dimension
+  static constexpr int Dim() { return dimension; }
+
+  /// @}
+  /// @name Lie Group Operations
+  /// @{
+
   /// @}
 };
 
@@ -756,7 +973,7 @@ struct traits<ProductLieGroup<G, H>>
     : internal::LieGroup<ProductLieGroup<G, H>> {};
 
 /// Traits specialization for PowerLieGroup
-template <typename G, size_t N>
+template <typename G, int N>
 struct traits<PowerLieGroup<G, N>> : internal::LieGroup<PowerLieGroup<G, N>> {};
 
 }  // namespace gtsam

--- a/gtsam/base/ProductLieGroup.h
+++ b/gtsam/base/ProductLieGroup.h
@@ -21,6 +21,7 @@
 #include <gtsam/base/Lie.h>
 #include <gtsam/base/Testable.h>
 
+#include <algorithm>
 #include <array>
 #include <iostream>
 #include <stdexcept>
@@ -97,18 +98,10 @@ class ProductLieGroup : public std::pair<G, H> {
   static ProductLieGroup Identity() { return ProductLieGroup(); }
 
   /// Group multiplication
-  ProductLieGroup operator*(const ProductLieGroup& other) const {
-    checkMatchingDimensions(firstDim(), secondDim(), other.firstDim(),
-                            other.secondDim(), "operator*");
-    return ProductLieGroup(traits<G>::Compose(this->first, other.first),
-                           traits<H>::Compose(this->second, other.second));
-  }
+  ProductLieGroup operator*(const ProductLieGroup& other) const;
 
   /// Group inverse
-  ProductLieGroup inverse() const {
-    return ProductLieGroup(traits<G>::Inverse(this->first),
-                           traits<H>::Inverse(this->second));
-  }
+  ProductLieGroup inverse() const;
 
   /// Compose with another element (same as operator*)
   ProductLieGroup compose(const ProductLieGroup& g) const {
@@ -135,44 +128,12 @@ class ProductLieGroup : public std::pair<G, H> {
 
   /// Retract to manifold
   ProductLieGroup retract(const TangentVector& v, ChartJacobian H1 = {},
-                          ChartJacobian H2 = {}) const {
-    if (H1 || H2) {
-      throw std::runtime_error(
-          "ProductLieGroup::retract derivatives not implemented yet");
-    }
-    const size_t firstDimension = firstDim();
-    const size_t secondDimension = secondDim();
-    if (static_cast<size_t>(v.size()) !=
-        combinedDimension(firstDimension, secondDimension)) {
-      throw std::invalid_argument(
-          "ProductLieGroup::retract tangent dimension does not match product "
-          "dimension");
-    }
-    G g = traits<G>::Retract(this->first,
-                             tangentSegment<G>(v, 0, firstDimension));
-    H h = traits<H>::Retract(
-        this->second, tangentSegment<H>(v, firstDimension, secondDimension));
-    return ProductLieGroup(g, h);
-  }
+                          ChartJacobian H2 = {}) const;
 
   /// Local coordinates on manifold
   TangentVector localCoordinates(const ProductLieGroup& g,
                                  ChartJacobian H1 = {},
-                                 ChartJacobian H2 = {}) const {
-    if (H1 || H2) {
-      throw std::runtime_error(
-          "ProductLieGroup::localCoordinates derivatives not implemented yet");
-    }
-    checkMatchingDimensions(firstDim(), secondDim(), g.firstDim(),
-                            g.secondDim(), "localCoordinates");
-    const size_t firstDimension = firstDim();
-    const size_t secondDimension = secondDim();
-    typename traits<G>::TangentVector v1 =
-        traits<G>::Local(this->first, g.first);
-    typename traits<H>::TangentVector v2 =
-        traits<H>::Local(this->second, g.second);
-    return makeTangentVector(v1, v2, firstDimension, secondDimension);
-  }
+                                 ChartJacobian H2 = {}) const;
 
   /// @}
   /// @name Lie Group Operations
@@ -180,126 +141,23 @@ class ProductLieGroup : public std::pair<G, H> {
 
   /// Compose with Jacobians
   ProductLieGroup compose(const ProductLieGroup& other, ChartJacobian H1,
-                          ChartJacobian H2 = {}) const {
-    checkMatchingDimensions(firstDim(), secondDim(), other.firstDim(),
-                            other.secondDim(), "compose");
-    const size_t firstDimension = firstDim();
-    const size_t secondDimension = secondDim();
-    const size_t productDimension =
-        combinedDimension(firstDimension, secondDimension);
-    Jacobian1 D_g_first;
-    Jacobian2 D_h_second;
-    G g =
-        traits<G>::Compose(this->first, other.first, H1 ? &D_g_first : nullptr);
-    H h = traits<H>::Compose(this->second, other.second,
-                             H1 ? &D_h_second : nullptr);
-    if (H1) {
-      *H1 = zeroJacobian(productDimension);
-      H1->block(0, 0, firstDimension, firstDimension) = D_g_first;
-      H1->block(firstDimension, firstDimension, secondDimension,
-                secondDimension) = D_h_second;
-    }
-    if (H2) *H2 = identityJacobian(productDimension);
-    return ProductLieGroup(g, h);
-  }
+                          ChartJacobian H2 = {}) const;
 
   /// Between with Jacobians
   ProductLieGroup between(const ProductLieGroup& other, ChartJacobian H1,
-                          ChartJacobian H2 = {}) const {
-    checkMatchingDimensions(firstDim(), secondDim(), other.firstDim(),
-                            other.secondDim(), "between");
-    const size_t firstDimension = firstDim();
-    const size_t secondDimension = secondDim();
-    const size_t productDimension =
-        combinedDimension(firstDimension, secondDimension);
-    Jacobian1 D_g_first;
-    Jacobian2 D_h_second;
-    G g =
-        traits<G>::Between(this->first, other.first, H1 ? &D_g_first : nullptr);
-    H h = traits<H>::Between(this->second, other.second,
-                             H1 ? &D_h_second : nullptr);
-    if (H1) {
-      *H1 = zeroJacobian(productDimension);
-      H1->block(0, 0, firstDimension, firstDimension) = D_g_first;
-      H1->block(firstDimension, firstDimension, secondDimension,
-                secondDimension) = D_h_second;
-    }
-    if (H2) *H2 = identityJacobian(productDimension);
-    return ProductLieGroup(g, h);
-  }
+                          ChartJacobian H2 = {}) const;
 
   /// Inverse with Jacobian
-  ProductLieGroup inverse(ChartJacobian D) const {
-    const size_t firstDimension = firstDim();
-    const size_t secondDimension = secondDim();
-    const size_t productDimension =
-        combinedDimension(firstDimension, secondDimension);
-    Jacobian1 D_g_first;
-    Jacobian2 D_h_second;
-    G g = traits<G>::Inverse(this->first, D ? &D_g_first : nullptr);
-    H h = traits<H>::Inverse(this->second, D ? &D_h_second : nullptr);
-    if (D) {
-      *D = zeroJacobian(productDimension);
-      D->block(0, 0, firstDimension, firstDimension) = D_g_first;
-      D->block(firstDimension, firstDimension, secondDimension,
-               secondDimension) = D_h_second;
-    }
-    return ProductLieGroup(g, h);
-  }
+  ProductLieGroup inverse(ChartJacobian D) const;
 
   /// Exponential map
-  static ProductLieGroup Expmap(const TangentVector& v, ChartJacobian Hv = {}) {
-    if constexpr (firstDynamic && secondDynamic) {
-      if (v.size() == 0) {
-        if (Hv) *Hv = Matrix::Zero(0, 0);
-        return ProductLieGroup();
-      }
-      throw std::invalid_argument(
-          "ProductLieGroup::Expmap requires split tangent vectors when both "
-          "factors are dynamic");
-    } else if constexpr (firstDynamic) {
-      if (v.size() < dimension2) {
-        throw std::invalid_argument(
-            "ProductLieGroup::Expmap tangent dimension is too small for the "
-            "fixed second factor");
-      }
-      const size_t firstDimension = static_cast<size_t>(v.size() - dimension2);
-      return expmapWithDimensions(v, firstDimension,
-                                  static_cast<size_t>(dimension2), Hv);
-    } else if constexpr (secondDynamic) {
-      if (v.size() < dimension1) {
-        throw std::invalid_argument(
-            "ProductLieGroup::Expmap tangent dimension is too small for the "
-            "fixed first factor");
-      }
-      const size_t secondDimension = static_cast<size_t>(v.size() - dimension1);
-      return expmapWithDimensions(v, static_cast<size_t>(dimension1),
-                                  secondDimension, Hv);
-    } else {
-      return expmapWithDimensions(v, static_cast<size_t>(dimension1),
-                                  static_cast<size_t>(dimension2), Hv);
-    }
-  }
+  static ProductLieGroup Expmap(const TangentVector& v, ChartJacobian Hv = {});
 
   /// Exponential map from subgroup tangent vectors
   static ProductLieGroup Expmap(
       const Eigen::Ref<const typename traits<G>::TangentVector>& v1,
       const Eigen::Ref<const typename traits<H>::TangentVector>& v2,
-      ChartJacobian Hv) {
-    const size_t firstDimension = static_cast<size_t>(v1.size());
-    const size_t secondDimension = static_cast<size_t>(v2.size());
-    Jacobian1 D_g_first;
-    Jacobian2 D_h_second;
-    G g = traits<G>::Expmap(v1, Hv ? &D_g_first : nullptr);
-    H h = traits<H>::Expmap(v2, Hv ? &D_h_second : nullptr);
-    if (Hv) {
-      *Hv = zeroJacobian(combinedDimension(firstDimension, secondDimension));
-      Hv->block(0, 0, firstDimension, firstDimension) = D_g_first;
-      Hv->block(firstDimension, firstDimension, secondDimension,
-                secondDimension) = D_h_second;
-    }
-    return ProductLieGroup(g, h);
-  }
+      ChartJacobian Hv);
 
   /// Exponential map from subgroup tangent vectors
   static ProductLieGroup Expmap(
@@ -312,23 +170,7 @@ class ProductLieGroup : public std::pair<G, H> {
   static TangentVector Logmap(const ProductLieGroup& p, ChartJacobian Hp = {}) {
     const size_t firstDimension = p.firstDim();
     const size_t secondDimension = p.secondDim();
-    const size_t productDimension =
-        combinedDimension(firstDimension, secondDimension);
-    Jacobian1 D_g_first;
-    Jacobian2 D_h_second;
-    typename traits<G>::TangentVector v1 =
-        traits<G>::Logmap(p.first, Hp ? &D_g_first : nullptr);
-    typename traits<H>::TangentVector v2 =
-        traits<H>::Logmap(p.second, Hp ? &D_h_second : nullptr);
-    TangentVector v =
-        makeTangentVector(v1, v2, firstDimension, secondDimension);
-    if (Hp) {
-      *Hp = zeroJacobian(productDimension);
-      Hp->block(0, 0, firstDimension, firstDimension) = D_g_first;
-      Hp->block(firstDimension, firstDimension, secondDimension,
-                secondDimension) = D_h_second;
-    }
-    return v;
+    return logmapWithDimensions(p, firstDimension, secondDimension, Hp);
   }
 
   /// Local coordinates (same as Logmap)
@@ -338,9 +180,7 @@ class ProductLieGroup : public std::pair<G, H> {
   }
 
   /// Right multiplication by exponential map
-  ProductLieGroup expmap(const TangentVector& v) const {
-    return compose(expmapWithDimensions(v, firstDim(), secondDim()));
-  }
+  ProductLieGroup expmap(const TangentVector& v) const;
 
   /// Logarithmic map for relative transformation
   TangentVector logmap(const ProductLieGroup& g) const {
@@ -348,128 +188,59 @@ class ProductLieGroup : public std::pair<G, H> {
   }
 
   /// Adjoint map
-  Jacobian AdjointMap() const {
-    const auto adjG = traits<G>::AdjointMap(this->first);
-    const auto adjH = traits<H>::AdjointMap(this->second);
-    const size_t d1 = static_cast<size_t>(adjG.rows());
-    const size_t d2 = static_cast<size_t>(adjH.rows());
-    Jacobian adj = zeroJacobian(d1 + d2);
-    adj.block(0, 0, d1, d1) = adjG;
-    adj.block(d1, d1, d2, d2) = adjH;
-    return adj;
-  }
+  Jacobian AdjointMap() const;
 
   /// @}
 
  protected:
+  /// Return default identity for fixed-size factors and a placeholder for
+  /// dynamic ones.
   template <typename T>
-  static T defaultIdentity() {
-    if constexpr (traits<T>::dimension == Eigen::Dynamic) {
-      return T();
-    } else {
-      return traits<T>::Identity();
-    }
-  }
+  static T defaultIdentity();
 
   size_t firstDim() const { return traits<G>::GetDimension(this->first); }
   size_t secondDim() const { return traits<H>::GetDimension(this->second); }
 
   static size_t combinedDimension(size_t d1, size_t d2) { return d1 + d2; }
 
+  /// Extract a tangent segment for one factor.
   template <typename T, int Dim = traits<T>::dimension>
   static typename traits<T>::TangentVector tangentSegment(
-      const TangentVector& v, size_t start, size_t runtimeDimension) {
-    const int startIndex = static_cast<int>(start);
-    const int runtimeIndex = static_cast<int>(runtimeDimension);
-    if constexpr (Dim == Eigen::Dynamic) {
-      return v.segment(startIndex, runtimeIndex);
-    } else {
-      static_cast<void>(runtimeDimension);
-      return v.template segment<Dim>(startIndex);
-    }
-  }
+      const TangentVector& v, size_t start, size_t runtimeDimension);
 
+  /// Concatenate subgroup tangent vectors into the product tangent.
   static TangentVector makeTangentVector(
       const typename traits<G>::TangentVector& v1,
       const typename traits<H>::TangentVector& v2, size_t firstDimension,
-      size_t secondDimension) {
-    const int firstIndex = static_cast<int>(firstDimension);
-    const int secondIndex = static_cast<int>(secondDimension);
-    if constexpr (dimension == Eigen::Dynamic) {
-      TangentVector v(combinedDimension(firstDimension, secondDimension));
-      v.segment(0, firstIndex) = v1;
-      v.segment(firstIndex, secondIndex) = v2;
-      return v;
-    } else {
-      static_cast<void>(firstDimension);
-      static_cast<void>(secondDimension);
-      TangentVector v;
-      v << v1, v2;
-      return v;
-    }
-  }
+      size_t secondDimension);
 
-  static Jacobian zeroJacobian(size_t productDimension) {
-    if constexpr (dimension == Eigen::Dynamic) {
-      return Jacobian::Zero(productDimension, productDimension);
-    } else {
-      static_cast<void>(productDimension);
-      return Jacobian::Zero();
-    }
-  }
+  /// Create a zero Jacobian with the requested runtime size.
+  static Jacobian zeroJacobian(size_t productDimension);
 
-  static Jacobian identityJacobian(size_t productDimension) {
-    if constexpr (dimension == Eigen::Dynamic) {
-      return Jacobian::Identity(productDimension, productDimension);
-    } else {
-      static_cast<void>(productDimension);
-      return Jacobian::Identity();
-    }
-  }
+  /// Create an identity Jacobian with the requested runtime size.
+  static Jacobian identityJacobian(size_t productDimension);
 
+  /// Check that two products have matching runtime dimensions.
   static void checkMatchingDimensions(size_t first1, size_t second1,
                                       size_t first2, size_t second2,
-                                      const char* operation) {
-    if (first1 != first2 || second1 != second2) {
-      throw std::invalid_argument(std::string("ProductLieGroup::") + operation +
-                                  " requires matching component dimensions");
-    }
-  }
+                                      const char* operation);
 
+  /// Exponential map with an explicit tangent split.
   static ProductLieGroup expmapWithDimensions(const TangentVector& v,
                                               size_t firstDimension,
                                               size_t secondDimension,
-                                              ChartJacobian Hv = {}) {
-    if (static_cast<size_t>(v.size()) !=
-        combinedDimension(firstDimension, secondDimension)) {
-      throw std::invalid_argument(
-          "ProductLieGroup::Expmap tangent dimension does not match requested "
-          "component dimensions");
-    }
-    Jacobian1 D_g_first;
-    Jacobian2 D_h_second;
-    G g = traits<G>::Expmap(tangentSegment<G>(v, 0, firstDimension),
-                            Hv ? &D_g_first : nullptr);
-    H h =
-        traits<H>::Expmap(tangentSegment<H>(v, firstDimension, secondDimension),
-                          Hv ? &D_h_second : nullptr);
-    if (Hv) {
-      *Hv = zeroJacobian(combinedDimension(firstDimension, secondDimension));
-      Hv->block(0, 0, firstDimension, firstDimension) = D_g_first;
-      Hv->block(firstDimension, firstDimension, secondDimension,
-                secondDimension) = D_h_second;
-    }
-    return ProductLieGroup(g, h);
-  }
+                                              ChartJacobian Hv = {});
+
+  /// Logarithmic map with an explicit runtime dimension split.
+  static TangentVector logmapWithDimensions(const ProductLieGroup& p,
+                                            size_t firstDimension,
+                                            size_t secondDimension,
+                                            ChartJacobian Hp = {});
 
  public:
   /// @name Testable interface
   /// @{
-  void print(const std::string& s = "") const {
-    std::cout << s << "ProductLieGroup" << std::endl;
-    traits<G>::Print(this->first, "  first");
-    traits<H>::Print(this->second, "  second");
-  }
+  void print(const std::string& s = "") const;
 
   bool equals(const ProductLieGroup& other, double tol = 1e-9) const {
     return traits<G>::Equals(this->first, other.first, tol) &&
@@ -483,11 +254,13 @@ class ProductLieGroup : public std::pair<G, H> {
  */
 template <typename T, int N>
 struct PowerLieGroupJacobianStorage {
+  /// Container type for per-component Jacobians.
   using type = std::array<T, N>;
 };
 
 template <typename T>
 struct PowerLieGroupJacobianStorage<T, Eigen::Dynamic> {
+  /// Container type for per-component Jacobians.
   using type = std::vector<T>;
 };
 
@@ -521,18 +294,23 @@ class PowerLieGroupBase {
       typename PowerLieGroupJacobianStorage<BaseJacobian, N>::type;
 
  protected:
+  /// Downcast to the derived storage type.
   const Derived& derived() const { return static_cast<const Derived&>(*this); }
 
+  /// Downcast to the derived storage type.
   Derived& derived() { return static_cast<Derived&>(*this); }
 
+  /// Total tangent dimension for a given component count.
   static size_t totalDimension(size_t count) {
     return count * static_cast<size_t>(baseDimension);
   }
 
+  /// Starting offset of one component inside the concatenated tangent.
   static Eigen::Index offset(size_t i) {
     return static_cast<Eigen::Index>(i * static_cast<size_t>(baseDimension));
   }
 
+  /// Runtime component count.
   size_t componentCount() const {
     if constexpr (isDynamic) {
       return derived().size();
@@ -541,89 +319,36 @@ class PowerLieGroupBase {
     }
   }
 
+  /// Validate tangent size for dynamic-count groups.
   static void checkDynamicTangentSize(const TangentVector& v, size_t count,
-                                      const char* operation) {
-    if constexpr (isDynamic) {
-      if (static_cast<size_t>(v.size()) != totalDimension(count)) {
-        throw std::invalid_argument(
-            std::string("PowerLieGroup::") + operation +
-            " tangent dimension does not match group dimension");
-      }
-    } else {
-      static_cast<void>(v);
-      static_cast<void>(count);
-      static_cast<void>(operation);
-    }
-  }
+                                      const char* operation);
 
-  void checkMatchingCounts(const Derived& other, const char* operation) const {
-    if constexpr (isDynamic) {
-      if (derived().size() != other.size()) {
-        throw std::invalid_argument(std::string("PowerLieGroup::") + operation +
-                                    " requires matching component counts");
-      }
-    } else {
-      static_cast<void>(other);
-      static_cast<void>(operation);
-    }
-  }
+  /// Validate matching component counts for binary operations.
+  void checkMatchingCounts(const Derived& other, const char* operation) const;
 
+  /// Extract one component tangent from the concatenated tangent.
   static typename traits<G>::TangentVector tangentSegment(
-      const TangentVector& v, size_t i) {
-    if constexpr (isDynamic) {
-      return v.segment(offset(i), baseDimension);
-    } else {
-      return v.template segment<baseDimension>(i * baseDimension);
-    }
-  }
+      const TangentVector& v, size_t i);
 
-  static Derived makeResult(size_t count) {
-    if constexpr (isDynamic) {
-      return Derived(count);
-    } else {
-      static_cast<void>(count);
-      return Derived();
-    }
-  }
+  /// Create a result object with the requested component count.
+  static Derived makeResult(size_t count);
 
-  static JacobianStorage makeJacobianStorage(size_t count) {
-    if constexpr (isDynamic) {
-      return JacobianStorage(count);
-    } else {
-      static_cast<void>(count);
-      return JacobianStorage();
-    }
-  }
+  /// Create per-component Jacobian storage.
+  static JacobianStorage makeJacobianStorage(size_t count);
 
-  static void assignTangentSegment(
-      TangentVector& v, size_t i, const typename traits<G>::TangentVector& vi) {
-    if constexpr (isDynamic) {
-      v.segment(offset(i), baseDimension) = vi;
-    } else {
-      v.template segment<baseDimension>(i * baseDimension) = vi;
-    }
-  }
+  /// Write one component tangent into the concatenated tangent.
+  static void assignTangentSegment(TangentVector& v, size_t i,
+                                   const typename traits<G>::TangentVector& vi);
 
+  /// Write one component block into a block-diagonal Jacobian.
   template <typename MatrixType>
   static void assignJacobianBlock(MatrixType& H, size_t i,
-                                  const BaseJacobian& block) {
-    if constexpr (isDynamic) {
-      H.block(offset(i), offset(i), baseDimension, baseDimension) = block;
-    } else {
-      H.template block<baseDimension, baseDimension>(i * baseDimension,
-                                                     i * baseDimension) = block;
-    }
-  }
+                                  const BaseJacobian& block);
 
+  /// Assemble a block-diagonal Jacobian from per-component blocks.
   static void fillJacobianBlocks(ChartJacobian H,
                                  const JacobianStorage& jacobians,
-                                 size_t count) {
-    if (!H) return;
-    *H = zeroJacobian(count);
-    for (size_t i = 0; i < count; ++i) {
-      assignJacobianBlock(*H, i, jacobians[i]);
-    }
-  }
+                                 size_t count);
 
  public:
   /// Return manifold dimension
@@ -633,23 +358,10 @@ class PowerLieGroupBase {
   size_t dim() const { return totalDimension(componentCount()); }
 
   /// Group multiplication
-  Derived operator*(const Derived& other) const {
-    checkMatchingCounts(other, "operator*");
-    Derived result = makeResult(componentCount());
-    for (size_t i = 0; i < componentCount(); ++i) {
-      result[i] = traits<G>::Compose(derived()[i], other[i]);
-    }
-    return result;
-  }
+  Derived operator*(const Derived& other) const;
 
   /// Group inverse
-  Derived inverse() const {
-    Derived result = makeResult(componentCount());
-    for (size_t i = 0; i < componentCount(); ++i) {
-      result[i] = traits<G>::Inverse(derived()[i]);
-    }
-    return result;
-  }
+  Derived inverse() const;
 
   /// Compose with another element (same as operator*)
   Derived compose(const Derived& g) const { return (*this) * g; }
@@ -659,115 +371,28 @@ class PowerLieGroupBase {
 
   /// Retract to manifold
   Derived retract(const TangentVector& v, ChartJacobian H1 = {},
-                  ChartJacobian H2 = {}) const {
-    if (H1 || H2) {
-      throw std::runtime_error(
-          "PowerLieGroup::retract derivatives not implemented yet");
-    }
-    const size_t count = componentCount();
-    checkDynamicTangentSize(v, count, "retract");
-    Derived result = makeResult(count);
-    for (size_t i = 0; i < count; ++i) {
-      result[i] = traits<G>::Retract(derived()[i], tangentSegment(v, i));
-    }
-    return result;
-  }
+                  ChartJacobian H2 = {}) const;
 
   /// Local coordinates on manifold
   TangentVector localCoordinates(const Derived& g, ChartJacobian H1 = {},
-                                 ChartJacobian H2 = {}) const {
-    if (H1 || H2) {
-      throw std::runtime_error(
-          "PowerLieGroup::localCoordinates derivatives not implemented yet");
-    }
-    checkMatchingCounts(g, "localCoordinates");
-    TangentVector v = zeroTangent(componentCount());
-    for (size_t i = 0; i < componentCount(); ++i) {
-      assignTangentSegment(v, i, traits<G>::Local(derived()[i], g[i]));
-    }
-    return v;
-  }
+                                 ChartJacobian H2 = {}) const;
 
   /// Compose with Jacobians
   Derived compose(const Derived& other, ChartJacobian H1,
-                  ChartJacobian H2 = {}) const {
-    checkMatchingCounts(other, "compose");
-    const size_t count = componentCount();
-    JacobianStorage jacobians = makeJacobianStorage(count);
-    Derived result = makeResult(count);
-    for (size_t i = 0; i < count; ++i) {
-      result[i] = traits<G>::Compose(derived()[i], other[i],
-                                     H1 ? &jacobians[i] : nullptr);
-    }
-    fillJacobianBlocks(H1, jacobians, count);
-    if (H2) *H2 = identityJacobian(count);
-    return result;
-  }
+                  ChartJacobian H2 = {}) const;
 
   /// Between with Jacobians
   Derived between(const Derived& other, ChartJacobian H1,
-                  ChartJacobian H2 = {}) const {
-    checkMatchingCounts(other, "between");
-    const size_t count = componentCount();
-    JacobianStorage jacobians = makeJacobianStorage(count);
-    Derived result = makeResult(count);
-    for (size_t i = 0; i < count; ++i) {
-      result[i] = traits<G>::Between(derived()[i], other[i],
-                                     H1 ? &jacobians[i] : nullptr);
-    }
-    fillJacobianBlocks(H1, jacobians, count);
-    if (H2) *H2 = identityJacobian(count);
-    return result;
-  }
+                  ChartJacobian H2 = {}) const;
 
   /// Inverse with Jacobian
-  Derived inverse(ChartJacobian D) const {
-    const size_t count = componentCount();
-    JacobianStorage jacobians = makeJacobianStorage(count);
-    Derived result = makeResult(count);
-    for (size_t i = 0; i < count; ++i) {
-      result[i] = traits<G>::Inverse(derived()[i], D ? &jacobians[i] : nullptr);
-    }
-    fillJacobianBlocks(D, jacobians, count);
-    return result;
-  }
+  Derived inverse(ChartJacobian D) const;
 
   /// Exponential map
-  static Derived Expmap(const TangentVector& v, ChartJacobian Hv = {}) {
-    size_t count = 0;
-    if constexpr (isDynamic) {
-      if (v.size() % baseDimension != 0) {
-        throw std::invalid_argument(
-            "PowerLieGroup::Expmap tangent dimension must be divisible by base "
-            "group dimension");
-      }
-      count = static_cast<size_t>(v.size() /
-                                  static_cast<Eigen::Index>(baseDimension));
-    } else {
-      count = N;
-    }
-    JacobianStorage jacobians = makeJacobianStorage(count);
-    Derived result = makeResult(count);
-    for (size_t i = 0; i < count; ++i) {
-      result[i] =
-          traits<G>::Expmap(tangentSegment(v, i), Hv ? &jacobians[i] : nullptr);
-    }
-    fillJacobianBlocks(Hv, jacobians, count);
-    return result;
-  }
+  static Derived Expmap(const TangentVector& v, ChartJacobian Hv = {});
 
   /// Logarithmic map
-  static TangentVector Logmap(const Derived& p, ChartJacobian Hp = {}) {
-    const size_t count = isDynamic ? p.size() : N;
-    TangentVector v = zeroTangent(count);
-    JacobianStorage jacobians = makeJacobianStorage(count);
-    for (size_t i = 0; i < count; ++i) {
-      assignTangentSegment(
-          v, i, traits<G>::Logmap(p[i], Hp ? &jacobians[i] : nullptr));
-    }
-    fillJacobianBlocks(Hp, jacobians, count);
-    return v;
-  }
+  static TangentVector Logmap(const Derived& p, ChartJacobian Hp = {});
 
   /// Local coordinates (same as Logmap)
   static TangentVector LocalCoordinates(const Derived& p,
@@ -782,64 +407,23 @@ class PowerLieGroupBase {
   TangentVector logmap(const Derived& g) const { return Logmap(between(g)); }
 
   /// Adjoint map
-  Jacobian AdjointMap() const {
-    Jacobian adj = zeroJacobian(componentCount());
-    for (size_t i = 0; i < componentCount(); ++i) {
-      assignJacobianBlock(adj, i, traits<G>::AdjointMap(derived()[i]));
-    }
-    return adj;
-  }
+  Jacobian AdjointMap() const;
 
   /// Print for debugging
-  void print(const std::string& s = "") const {
-    std::cout << s << "PowerLieGroup" << std::endl;
-    for (size_t i = 0; i < componentCount(); ++i) {
-      traits<G>::Print(derived()[i], "  component[" + std::to_string(i) + "]");
-    }
-  }
+  void print(const std::string& s = "") const;
 
   /// Equality with tolerance
-  bool equals(const Derived& other, double tol = 1e-9) const {
-    if constexpr (isDynamic) {
-      if (derived().size() != other.size()) {
-        return false;
-      }
-    }
-    for (size_t i = 0; i < componentCount(); ++i) {
-      if (!traits<G>::Equals(derived()[i], other[i], tol)) {
-        return false;
-      }
-    }
-    return true;
-  }
+  bool equals(const Derived& other, double tol = 1e-9) const;
 
  protected:
-  static TangentVector zeroTangent(size_t count) {
-    if constexpr (isDynamic) {
-      return TangentVector::Zero(totalDimension(count));
-    } else {
-      static_cast<void>(count);
-      return TangentVector::Zero();
-    }
-  }
+  /// Create a zero tangent with the requested runtime size.
+  static TangentVector zeroTangent(size_t count);
 
-  static Jacobian zeroJacobian(size_t count) {
-    if constexpr (isDynamic) {
-      return Jacobian::Zero(totalDimension(count), totalDimension(count));
-    } else {
-      static_cast<void>(count);
-      return Jacobian::Zero();
-    }
-  }
+  /// Create a zero Jacobian with the requested runtime size.
+  static Jacobian zeroJacobian(size_t count);
 
-  static Jacobian identityJacobian(size_t count) {
-    if constexpr (isDynamic) {
-      return Jacobian::Identity(totalDimension(count), totalDimension(count));
-    } else {
-      static_cast<void>(count);
-      return Jacobian::Identity();
-    }
-  }
+  /// Create an identity Jacobian with the requested runtime size.
+  static Jacobian identityJacobian(size_t count);
 };
 
 /**
@@ -877,13 +461,7 @@ class PowerLieGroup : public std::array<G, N>,
   PowerLieGroup(const Base& elements) : Base(elements) {}
 
   /// Construct from initializer list
-  PowerLieGroup(const std::initializer_list<G>& elements) {
-    if (elements.size() != N) {
-      throw std::invalid_argument(
-          "PowerLieGroup: initializer list size must equal N");
-    }
-    std::copy(elements.begin(), elements.end(), this->begin());
-  }
+  PowerLieGroup(const std::initializer_list<G>& elements);
 
   /// @}
   /// @name Group Operations
@@ -977,3 +555,5 @@ template <typename G, int N>
 struct traits<PowerLieGroup<G, N>> : internal::LieGroup<PowerLieGroup<G, N>> {};
 
 }  // namespace gtsam
+
+#include <gtsam/base/ProductLieGroup-inl.h>

--- a/gtsam/base/ProductLieGroup.h
+++ b/gtsam/base/ProductLieGroup.h
@@ -370,13 +370,8 @@ class ProductLieGroup : public std::pair<G, H> {
     }
   }
 
-  template <typename T>
-  static size_t dimensionOf(const T& value) {
-    return static_cast<size_t>(traits<T>::GetDimension(value));
-  }
-
-  size_t firstDim() const { return dimensionOf(this->first); }
-  size_t secondDim() const { return dimensionOf(this->second); }
+  size_t firstDim() const { return traits<G>::GetDimension(this->first); }
+  size_t secondDim() const { return traits<H>::GetDimension(this->second); }
 
   static size_t combinedDimension(size_t d1, size_t d2) { return d1 + d2; }
 

--- a/gtsam/base/ProductLieGroup.h
+++ b/gtsam/base/ProductLieGroup.h
@@ -73,98 +73,6 @@ class ProductLieGroup : public std::pair<G, H> {
   using Jacobian1 = typename traits<G>::Jacobian;
   using Jacobian2 = typename traits<H>::Jacobian;
 
- protected:
-  template <typename T>
-  static T defaultIdentity() {
-    if constexpr (traits<T>::dimension == Eigen::Dynamic) {
-      return T();
-    } else {
-      return traits<T>::Identity();
-    }
-  }
-
-  template <typename T>
-  static int dimensionOf(const T& value) {
-    return static_cast<int>(traits<T>::GetDimension(value));
-  }
-
-  int firstDim() const { return dimensionOf(this->first); }
-  int secondDim() const { return dimensionOf(this->second); }
-
-  static int combinedDimension(int d1, int d2) { return d1 + d2; }
-
-  template <typename T, int Dim = traits<T>::dimension>
-  static typename traits<T>::TangentVector tangentSegment(
-      const TangentVector& v, int start, int runtimeDimension) {
-    if constexpr (Dim == Eigen::Dynamic) {
-      return v.segment(start, runtimeDimension);
-    } else {
-      static_cast<void>(runtimeDimension);
-      return v.template segment<Dim>(start);
-    }
-  }
-
-  static TangentVector makeTangentVector(
-      const typename traits<G>::TangentVector& v1,
-      const typename traits<H>::TangentVector& v2, int firstDimension,
-      int secondDimension) {
-    if constexpr (dimension == Eigen::Dynamic) {
-      TangentVector v(combinedDimension(firstDimension, secondDimension));
-      v.segment(0, firstDimension) = v1;
-      v.segment(firstDimension, secondDimension) = v2;
-      return v;
-    } else {
-      static_cast<void>(firstDimension);
-      static_cast<void>(secondDimension);
-      TangentVector v;
-      v << v1, v2;
-      return v;
-    }
-  }
-
-  static Jacobian zeroJacobian(int productDimension) {
-    if constexpr (dimension == Eigen::Dynamic) {
-      return Jacobian::Zero(productDimension, productDimension);
-    } else {
-      static_cast<void>(productDimension);
-      return Jacobian::Zero();
-    }
-  }
-
-  static Jacobian identityJacobian(int productDimension) {
-    if constexpr (dimension == Eigen::Dynamic) {
-      return Jacobian::Identity(productDimension, productDimension);
-    } else {
-      static_cast<void>(productDimension);
-      return Jacobian::Identity();
-    }
-  }
-
-  static ProductLieGroup expmapWithDimensions(const TangentVector& v,
-                                              int firstDimension,
-                                              int secondDimension,
-                                              ChartJacobian Hv = {}) {
-    if (v.size() != combinedDimension(firstDimension, secondDimension)) {
-      throw std::invalid_argument(
-          "ProductLieGroup::Expmap tangent dimension does not match requested "
-          "component dimensions");
-    }
-    Jacobian1 D_g_first;
-    Jacobian2 D_h_second;
-    G g = traits<G>::Expmap(tangentSegment<G>(v, 0, firstDimension),
-                            Hv ? &D_g_first : nullptr);
-    H h =
-        traits<H>::Expmap(tangentSegment<H>(v, firstDimension, secondDimension),
-                          Hv ? &D_h_second : nullptr);
-    if (Hv) {
-      *Hv = zeroJacobian(combinedDimension(firstDimension, secondDimension));
-      Hv->block(0, 0, firstDimension, firstDimension) = D_g_first;
-      Hv->block(firstDimension, firstDimension, secondDimension,
-                secondDimension) = D_h_second;
-    }
-    return ProductLieGroup(g, h);
-  }
-
  public:
   /// @name Standard Constructors
   /// @{
@@ -189,10 +97,8 @@ class ProductLieGroup : public std::pair<G, H> {
 
   /// Group multiplication
   ProductLieGroup operator*(const ProductLieGroup& other) const {
-    if (firstDim() != other.firstDim() || secondDim() != other.secondDim()) {
-      throw std::invalid_argument(
-          "ProductLieGroup::operator* requires matching component dimensions");
-    }
+    checkMatchingDimensions(firstDim(), secondDim(), other.firstDim(),
+                            other.secondDim(), "operator*");
     return ProductLieGroup(traits<G>::Compose(this->first, other.first),
                            traits<H>::Compose(this->second, other.second));
   }
@@ -224,7 +130,7 @@ class ProductLieGroup : public std::pair<G, H> {
   static constexpr int Dim() { return manifoldDimension; }
 
   /// Return manifold dimension
-  int dim() const { return combinedDimension(firstDim(), secondDim()); }
+  size_t dim() const { return combinedDimension(firstDim(), secondDim()); }
 
   /// Retract to manifold
   ProductLieGroup retract(const TangentVector& v, ChartJacobian H1 = {},
@@ -233,9 +139,10 @@ class ProductLieGroup : public std::pair<G, H> {
       throw std::runtime_error(
           "ProductLieGroup::retract derivatives not implemented yet");
     }
-    const int firstDimension = firstDim();
-    const int secondDimension = secondDim();
-    if (v.size() != combinedDimension(firstDimension, secondDimension)) {
+    const size_t firstDimension = firstDim();
+    const size_t secondDimension = secondDim();
+    if (static_cast<size_t>(v.size()) !=
+        combinedDimension(firstDimension, secondDimension)) {
       throw std::invalid_argument(
           "ProductLieGroup::retract tangent dimension does not match product "
           "dimension");
@@ -255,13 +162,10 @@ class ProductLieGroup : public std::pair<G, H> {
       throw std::runtime_error(
           "ProductLieGroup::localCoordinates derivatives not implemented yet");
     }
-    if (firstDim() != g.firstDim() || secondDim() != g.secondDim()) {
-      throw std::invalid_argument(
-          "ProductLieGroup::localCoordinates requires matching component "
-          "dimensions");
-    }
-    const int firstDimension = firstDim();
-    const int secondDimension = secondDim();
+    checkMatchingDimensions(firstDim(), secondDim(), g.firstDim(),
+                            g.secondDim(), "localCoordinates");
+    const size_t firstDimension = firstDim();
+    const size_t secondDimension = secondDim();
     typename traits<G>::TangentVector v1 =
         traits<G>::Local(this->first, g.first);
     typename traits<H>::TangentVector v2 =
@@ -276,13 +180,11 @@ class ProductLieGroup : public std::pair<G, H> {
   /// Compose with Jacobians
   ProductLieGroup compose(const ProductLieGroup& other, ChartJacobian H1,
                           ChartJacobian H2 = {}) const {
-    if (firstDim() != other.firstDim() || secondDim() != other.secondDim()) {
-      throw std::invalid_argument(
-          "ProductLieGroup::compose requires matching component dimensions");
-    }
-    const int firstDimension = firstDim();
-    const int secondDimension = secondDim();
-    const int productDimension =
+    checkMatchingDimensions(firstDim(), secondDim(), other.firstDim(),
+                            other.secondDim(), "compose");
+    const size_t firstDimension = firstDim();
+    const size_t secondDimension = secondDim();
+    const size_t productDimension =
         combinedDimension(firstDimension, secondDimension);
     Jacobian1 D_g_first;
     Jacobian2 D_h_second;
@@ -303,13 +205,11 @@ class ProductLieGroup : public std::pair<G, H> {
   /// Between with Jacobians
   ProductLieGroup between(const ProductLieGroup& other, ChartJacobian H1,
                           ChartJacobian H2 = {}) const {
-    if (firstDim() != other.firstDim() || secondDim() != other.secondDim()) {
-      throw std::invalid_argument(
-          "ProductLieGroup::between requires matching component dimensions");
-    }
-    const int firstDimension = firstDim();
-    const int secondDimension = secondDim();
-    const int productDimension =
+    checkMatchingDimensions(firstDim(), secondDim(), other.firstDim(),
+                            other.secondDim(), "between");
+    const size_t firstDimension = firstDim();
+    const size_t secondDimension = secondDim();
+    const size_t productDimension =
         combinedDimension(firstDimension, secondDimension);
     Jacobian1 D_g_first;
     Jacobian2 D_h_second;
@@ -329,9 +229,9 @@ class ProductLieGroup : public std::pair<G, H> {
 
   /// Inverse with Jacobian
   ProductLieGroup inverse(ChartJacobian D) const {
-    const int firstDimension = firstDim();
-    const int secondDimension = secondDim();
-    const int productDimension =
+    const size_t firstDimension = firstDim();
+    const size_t secondDimension = secondDim();
+    const size_t productDimension =
         combinedDimension(firstDimension, secondDimension);
     Jacobian1 D_g_first;
     Jacobian2 D_h_second;
@@ -362,18 +262,21 @@ class ProductLieGroup : public std::pair<G, H> {
             "ProductLieGroup::Expmap tangent dimension is too small for the "
             "fixed second factor");
       }
-      const int firstDimension = v.size() - dimension2;
-      return expmapWithDimensions(v, firstDimension, dimension2, Hv);
+      const size_t firstDimension = static_cast<size_t>(v.size() - dimension2);
+      return expmapWithDimensions(v, firstDimension,
+                                  static_cast<size_t>(dimension2), Hv);
     } else if constexpr (secondDynamic) {
       if (v.size() < dimension1) {
         throw std::invalid_argument(
             "ProductLieGroup::Expmap tangent dimension is too small for the "
             "fixed first factor");
       }
-      const int secondDimension = v.size() - dimension1;
-      return expmapWithDimensions(v, dimension1, secondDimension, Hv);
+      const size_t secondDimension = static_cast<size_t>(v.size() - dimension1);
+      return expmapWithDimensions(v, static_cast<size_t>(dimension1),
+                                  secondDimension, Hv);
     } else {
-      return expmapWithDimensions(v, dimension1, dimension2, Hv);
+      return expmapWithDimensions(v, static_cast<size_t>(dimension1),
+                                  static_cast<size_t>(dimension2), Hv);
     }
   }
 
@@ -382,8 +285,8 @@ class ProductLieGroup : public std::pair<G, H> {
       const Eigen::Ref<const typename traits<G>::TangentVector>& v1,
       const Eigen::Ref<const typename traits<H>::TangentVector>& v2,
       ChartJacobian Hv) {
-    const int firstDimension = v1.size();
-    const int secondDimension = v2.size();
+    const size_t firstDimension = static_cast<size_t>(v1.size());
+    const size_t secondDimension = static_cast<size_t>(v2.size());
     Jacobian1 D_g_first;
     Jacobian2 D_h_second;
     G g = traits<G>::Expmap(v1, Hv ? &D_g_first : nullptr);
@@ -406,9 +309,9 @@ class ProductLieGroup : public std::pair<G, H> {
 
   /// Logarithmic map
   static TangentVector Logmap(const ProductLieGroup& p, ChartJacobian Hp = {}) {
-    const int firstDimension = p.firstDim();
-    const int secondDimension = p.secondDim();
-    const int productDimension =
+    const size_t firstDimension = p.firstDim();
+    const size_t secondDimension = p.secondDim();
+    const size_t productDimension =
         combinedDimension(firstDimension, secondDimension);
     Jacobian1 D_g_first;
     Jacobian2 D_h_second;
@@ -447,8 +350,8 @@ class ProductLieGroup : public std::pair<G, H> {
   Jacobian AdjointMap() const {
     const auto adjG = traits<G>::AdjointMap(this->first);
     const auto adjH = traits<H>::AdjointMap(this->second);
-    const int d1 = adjG.rows();
-    const int d2 = adjH.rows();
+    const size_t d1 = static_cast<size_t>(adjG.rows());
+    const size_t d2 = static_cast<size_t>(adjH.rows());
     Jacobian adj = zeroJacobian(d1 + d2);
     adj.block(0, 0, d1, d1) = adjG;
     adj.block(d1, d1, d2, d2) = adjH;
@@ -457,6 +360,113 @@ class ProductLieGroup : public std::pair<G, H> {
 
   /// @}
 
+ protected:
+  template <typename T>
+  static T defaultIdentity() {
+    if constexpr (traits<T>::dimension == Eigen::Dynamic) {
+      return T();
+    } else {
+      return traits<T>::Identity();
+    }
+  }
+
+  template <typename T>
+  static size_t dimensionOf(const T& value) {
+    return static_cast<size_t>(traits<T>::GetDimension(value));
+  }
+
+  size_t firstDim() const { return dimensionOf(this->first); }
+  size_t secondDim() const { return dimensionOf(this->second); }
+
+  static size_t combinedDimension(size_t d1, size_t d2) { return d1 + d2; }
+
+  template <typename T, int Dim = traits<T>::dimension>
+  static typename traits<T>::TangentVector tangentSegment(
+      const TangentVector& v, size_t start, size_t runtimeDimension) {
+    const int startIndex = static_cast<int>(start);
+    const int runtimeIndex = static_cast<int>(runtimeDimension);
+    if constexpr (Dim == Eigen::Dynamic) {
+      return v.segment(startIndex, runtimeIndex);
+    } else {
+      static_cast<void>(runtimeDimension);
+      return v.template segment<Dim>(startIndex);
+    }
+  }
+
+  static TangentVector makeTangentVector(
+      const typename traits<G>::TangentVector& v1,
+      const typename traits<H>::TangentVector& v2, size_t firstDimension,
+      size_t secondDimension) {
+    const int firstIndex = static_cast<int>(firstDimension);
+    const int secondIndex = static_cast<int>(secondDimension);
+    if constexpr (dimension == Eigen::Dynamic) {
+      TangentVector v(combinedDimension(firstDimension, secondDimension));
+      v.segment(0, firstIndex) = v1;
+      v.segment(firstIndex, secondIndex) = v2;
+      return v;
+    } else {
+      static_cast<void>(firstDimension);
+      static_cast<void>(secondDimension);
+      TangentVector v;
+      v << v1, v2;
+      return v;
+    }
+  }
+
+  static Jacobian zeroJacobian(size_t productDimension) {
+    if constexpr (dimension == Eigen::Dynamic) {
+      return Jacobian::Zero(productDimension, productDimension);
+    } else {
+      static_cast<void>(productDimension);
+      return Jacobian::Zero();
+    }
+  }
+
+  static Jacobian identityJacobian(size_t productDimension) {
+    if constexpr (dimension == Eigen::Dynamic) {
+      return Jacobian::Identity(productDimension, productDimension);
+    } else {
+      static_cast<void>(productDimension);
+      return Jacobian::Identity();
+    }
+  }
+
+  static void checkMatchingDimensions(size_t first1, size_t second1,
+                                      size_t first2, size_t second2,
+                                      const char* operation) {
+    if (first1 != first2 || second1 != second2) {
+      throw std::invalid_argument(std::string("ProductLieGroup::") + operation +
+                                  " requires matching component dimensions");
+    }
+  }
+
+  static ProductLieGroup expmapWithDimensions(const TangentVector& v,
+                                              size_t firstDimension,
+                                              size_t secondDimension,
+                                              ChartJacobian Hv = {}) {
+    if (static_cast<size_t>(v.size()) !=
+        combinedDimension(firstDimension, secondDimension)) {
+      throw std::invalid_argument(
+          "ProductLieGroup::Expmap tangent dimension does not match requested "
+          "component dimensions");
+    }
+    Jacobian1 D_g_first;
+    Jacobian2 D_h_second;
+    G g = traits<G>::Expmap(tangentSegment<G>(v, 0, firstDimension),
+                            Hv ? &D_g_first : nullptr);
+    H h =
+        traits<H>::Expmap(tangentSegment<H>(v, firstDimension, secondDimension),
+                          Hv ? &D_h_second : nullptr);
+    if (Hv) {
+      *Hv = zeroJacobian(combinedDimension(firstDimension, secondDimension));
+      Hv->block(0, 0, firstDimension, firstDimension) = D_g_first;
+      Hv->block(firstDimension, firstDimension, secondDimension,
+                secondDimension) = D_h_second;
+    }
+    return ProductLieGroup(g, h);
+  }
+
+ public:
   /// @name Testable interface
   /// @{
   void print(const std::string& s = "") const {

--- a/gtsam/base/ProductLieGroup.h
+++ b/gtsam/base/ProductLieGroup.h
@@ -157,21 +157,11 @@ class ProductLieGroup : public std::pair<G, H> {
   static ProductLieGroup Expmap(
       const Eigen::Ref<const typename traits<G>::TangentVector>& v1,
       const Eigen::Ref<const typename traits<H>::TangentVector>& v2,
-      ChartJacobian Hv);
-
-  /// Exponential map from subgroup tangent vectors
-  static ProductLieGroup Expmap(
-      const Eigen::Ref<const typename traits<G>::TangentVector>& v1,
-      const Eigen::Ref<const typename traits<H>::TangentVector>& v2) {
-    return Expmap(v1, v2, {});
-  }
+      OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H1 = {},
+      OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H2 = {});
 
   /// Logarithmic map
-  static TangentVector Logmap(const ProductLieGroup& p, ChartJacobian Hp = {}) {
-    const size_t firstDimension = p.firstDim();
-    const size_t secondDimension = p.secondDim();
-    return logmapWithDimensions(p, firstDimension, secondDimension, Hp);
-  }
+  static TangentVector Logmap(const ProductLieGroup& p, ChartJacobian Hp = {});
 
   /// Local coordinates (same as Logmap)
   static TangentVector LocalCoordinates(const ProductLieGroup& p,
@@ -220,22 +210,9 @@ class ProductLieGroup : public std::pair<G, H> {
   /// Create an identity Jacobian with the requested runtime size.
   static Jacobian identityJacobian(size_t productDimension);
 
-  /// Check that two products have matching runtime dimensions.
-  static void checkMatchingDimensions(size_t first1, size_t second1,
-                                      size_t first2, size_t second2,
-                                      const char* operation);
-
-  /// Exponential map with an explicit tangent split.
-  static ProductLieGroup expmapWithDimensions(const TangentVector& v,
-                                              size_t firstDimension,
-                                              size_t secondDimension,
-                                              ChartJacobian Hv = {});
-
-  /// Logarithmic map with an explicit runtime dimension split.
-  static TangentVector logmapWithDimensions(const ProductLieGroup& p,
-                                            size_t firstDimension,
-                                            size_t secondDimension,
-                                            ChartJacobian Hp = {});
+  /// Check that another product has matching runtime dimensions.
+  void checkMatchingDimensions(const ProductLieGroup& other,
+                               const char* operation) const;
 
  public:
   /// @name Testable interface

--- a/gtsam/base/ProductLieGroup.h
+++ b/gtsam/base/ProductLieGroup.h
@@ -23,6 +23,7 @@
 
 #include <array>
 #include <iostream>
+#include <stdexcept>
 #include <string>
 #include <utility>  // pair
 
@@ -45,15 +46,131 @@ class ProductLieGroup : public std::pair<G, H> {
 
  protected:
   /// Dimensions of the two subgroups
-  static constexpr size_t dimension1 = traits<G>::dimension;
-  static constexpr size_t dimension2 = traits<H>::dimension;
+  inline constexpr static int dimension1 = traits<G>::dimension;
+  inline constexpr static int dimension2 = traits<H>::dimension;
+  inline constexpr static bool firstDynamic = dimension1 == Eigen::Dynamic;
+  inline constexpr static bool secondDynamic = dimension2 == Eigen::Dynamic;
+
+ public:
+  /// Manifold dimension
+  inline constexpr static int dimension =
+      firstDynamic || secondDynamic ? Eigen::Dynamic : dimension1 + dimension2;
+
+  /// Tangent vector type
+  using TangentVector = std::conditional_t<dimension == Eigen::Dynamic, Vector,
+                                           Eigen::Matrix<double, dimension, 1>>;
+
+  /// Chart Jacobian type
+  using ChartJacobian =
+      std::conditional_t<dimension == Eigen::Dynamic,
+                         OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic>,
+                         OptionalJacobian<dimension, dimension>>;
+
+  /// Jacobian types for internal use
+  using Jacobian =
+      std::conditional_t<dimension == Eigen::Dynamic, Matrix,
+                         Eigen::Matrix<double, dimension, dimension>>;
+  using Jacobian1 = typename traits<G>::Jacobian;
+  using Jacobian2 = typename traits<H>::Jacobian;
+
+ protected:
+  template <typename T>
+  static T defaultIdentity() {
+    if constexpr (traits<T>::dimension == Eigen::Dynamic) {
+      return T();
+    } else {
+      return traits<T>::Identity();
+    }
+  }
+
+  template <typename T>
+  static int dimensionOf(const T& value) {
+    return static_cast<int>(traits<T>::GetDimension(value));
+  }
+
+  int firstDim() const { return dimensionOf(this->first); }
+  int secondDim() const { return dimensionOf(this->second); }
+
+  static int combinedDimension(int d1, int d2) { return d1 + d2; }
+
+  template <typename T, int Dim = traits<T>::dimension>
+  static typename traits<T>::TangentVector tangentSegment(
+      const TangentVector& v, int start, int runtimeDimension) {
+    if constexpr (Dim == Eigen::Dynamic) {
+      return v.segment(start, runtimeDimension);
+    } else {
+      static_cast<void>(runtimeDimension);
+      return v.template segment<Dim>(start);
+    }
+  }
+
+  static TangentVector makeTangentVector(
+      const typename traits<G>::TangentVector& v1,
+      const typename traits<H>::TangentVector& v2, int firstDimension,
+      int secondDimension) {
+    if constexpr (dimension == Eigen::Dynamic) {
+      TangentVector v(combinedDimension(firstDimension, secondDimension));
+      v.segment(0, firstDimension) = v1;
+      v.segment(firstDimension, secondDimension) = v2;
+      return v;
+    } else {
+      static_cast<void>(firstDimension);
+      static_cast<void>(secondDimension);
+      TangentVector v;
+      v << v1, v2;
+      return v;
+    }
+  }
+
+  static Jacobian zeroJacobian(int productDimension) {
+    if constexpr (dimension == Eigen::Dynamic) {
+      return Jacobian::Zero(productDimension, productDimension);
+    } else {
+      static_cast<void>(productDimension);
+      return Jacobian::Zero();
+    }
+  }
+
+  static Jacobian identityJacobian(int productDimension) {
+    if constexpr (dimension == Eigen::Dynamic) {
+      return Jacobian::Identity(productDimension, productDimension);
+    } else {
+      static_cast<void>(productDimension);
+      return Jacobian::Identity();
+    }
+  }
+
+  static ProductLieGroup expmapWithDimensions(const TangentVector& v,
+                                              int firstDimension,
+                                              int secondDimension,
+                                              ChartJacobian Hv = {}) {
+    if (v.size() != combinedDimension(firstDimension, secondDimension)) {
+      throw std::invalid_argument(
+          "ProductLieGroup::Expmap tangent dimension does not match requested "
+          "component dimensions");
+    }
+    Jacobian1 D_g_first;
+    Jacobian2 D_h_second;
+    G g = traits<G>::Expmap(tangentSegment<G>(v, 0, firstDimension),
+                            Hv ? &D_g_first : nullptr);
+    H h =
+        traits<H>::Expmap(tangentSegment<H>(v, firstDimension, secondDimension),
+                          Hv ? &D_h_second : nullptr);
+    if (Hv) {
+      *Hv = zeroJacobian(combinedDimension(firstDimension, secondDimension));
+      Hv->block(0, 0, firstDimension, firstDimension) = D_g_first;
+      Hv->block(firstDimension, firstDimension, secondDimension,
+                secondDimension) = D_h_second;
+    }
+    return ProductLieGroup(g, h);
+  }
 
  public:
   /// @name Standard Constructors
   /// @{
 
   /// Default constructor yields identity
-  ProductLieGroup() : Base(traits<G>::Identity(), traits<H>::Identity()) {}
+  ProductLieGroup() : Base(defaultIdentity<G>(), defaultIdentity<H>()) {}
 
   /// Construct from two subgroup elements
   ProductLieGroup(const G& g, const H& h) : Base(g, h) {}
@@ -72,6 +189,10 @@ class ProductLieGroup : public std::pair<G, H> {
 
   /// Group multiplication
   ProductLieGroup operator*(const ProductLieGroup& other) const {
+    if (firstDim() != other.firstDim() || secondDim() != other.secondDim()) {
+      throw std::invalid_argument(
+          "ProductLieGroup::operator* requires matching component dimensions");
+    }
     return ProductLieGroup(traits<G>::Compose(this->first, other.first),
                            traits<H>::Compose(this->second, other.second));
   }
@@ -97,19 +218,13 @@ class ProductLieGroup : public std::pair<G, H> {
   /// @{
 
   /// Manifold dimension
-  static constexpr size_t dimension = dimension1 + dimension2;
+  inline constexpr static int manifoldDimension = dimension;
 
   /// Return manifold dimension
-  static size_t Dim() { return dimension; }
+  static constexpr int Dim() { return manifoldDimension; }
 
   /// Return manifold dimension
-  size_t dim() const { return dimension; }
-
-  /// Tangent vector type
-  using TangentVector = Eigen::Matrix<double, static_cast<int>(dimension), 1>;
-
-  /// Chart Jacobian type
-  using ChartJacobian = OptionalJacobian<dimension, dimension>;
+  int dim() const { return combinedDimension(firstDim(), secondDim()); }
 
   /// Retract to manifold
   ProductLieGroup retract(const TangentVector& v, ChartJacobian H1 = {},
@@ -118,8 +233,17 @@ class ProductLieGroup : public std::pair<G, H> {
       throw std::runtime_error(
           "ProductLieGroup::retract derivatives not implemented yet");
     }
-    G g = traits<G>::Retract(this->first, v.template head<dimension1>());
-    H h = traits<H>::Retract(this->second, v.template tail<dimension2>());
+    const int firstDimension = firstDim();
+    const int secondDimension = secondDim();
+    if (v.size() != combinedDimension(firstDimension, secondDimension)) {
+      throw std::invalid_argument(
+          "ProductLieGroup::retract tangent dimension does not match product "
+          "dimension");
+    }
+    G g = traits<G>::Retract(this->first,
+                             tangentSegment<G>(v, 0, firstDimension));
+    H h = traits<H>::Retract(
+        this->second, tangentSegment<H>(v, firstDimension, secondDimension));
     return ProductLieGroup(g, h);
   }
 
@@ -131,100 +255,174 @@ class ProductLieGroup : public std::pair<G, H> {
       throw std::runtime_error(
           "ProductLieGroup::localCoordinates derivatives not implemented yet");
     }
+    if (firstDim() != g.firstDim() || secondDim() != g.secondDim()) {
+      throw std::invalid_argument(
+          "ProductLieGroup::localCoordinates requires matching component "
+          "dimensions");
+    }
+    const int firstDimension = firstDim();
+    const int secondDimension = secondDim();
     typename traits<G>::TangentVector v1 =
         traits<G>::Local(this->first, g.first);
     typename traits<H>::TangentVector v2 =
         traits<H>::Local(this->second, g.second);
-    TangentVector v;
-    v << v1, v2;
-    return v;
+    return makeTangentVector(v1, v2, firstDimension, secondDimension);
   }
 
   /// @}
   /// @name Lie Group Operations
   /// @{
 
- public:
-  /// Jacobian types for internal use
-  using Jacobian = Eigen::Matrix<double, static_cast<int>(dimension), static_cast<int>(dimension)>;
-  using Jacobian1 = Eigen::Matrix<double, static_cast<int>(dimension1), static_cast<int>(dimension1)>;
-  using Jacobian2 = Eigen::Matrix<double, static_cast<int>(dimension2), static_cast<int>(dimension2)>;
-
   /// Compose with Jacobians
   ProductLieGroup compose(const ProductLieGroup& other, ChartJacobian H1,
                           ChartJacobian H2 = {}) const {
-    Jacobian1 D_g_first = Jacobian1::Zero();
-    Jacobian2 D_h_second;
-    G g = traits<G>::Compose(this->first, other.first, H1 ? &D_g_first : 0);
-    H h = traits<H>::Compose(this->second, other.second, H1 ? &D_h_second : 0);
-    if (H1) {
-      H1->setZero();
-      H1->template topLeftCorner<dimension1, dimension1>() = D_g_first;
-      H1->template bottomRightCorner<dimension2, dimension2>() = D_h_second;
+    if (firstDim() != other.firstDim() || secondDim() != other.secondDim()) {
+      throw std::invalid_argument(
+          "ProductLieGroup::compose requires matching component dimensions");
     }
-    if (H2) *H2 = Jacobian::Identity();
+    const int firstDimension = firstDim();
+    const int secondDimension = secondDim();
+    const int productDimension =
+        combinedDimension(firstDimension, secondDimension);
+    Jacobian1 D_g_first;
+    Jacobian2 D_h_second;
+    G g =
+        traits<G>::Compose(this->first, other.first, H1 ? &D_g_first : nullptr);
+    H h = traits<H>::Compose(this->second, other.second,
+                             H1 ? &D_h_second : nullptr);
+    if (H1) {
+      *H1 = zeroJacobian(productDimension);
+      H1->block(0, 0, firstDimension, firstDimension) = D_g_first;
+      H1->block(firstDimension, firstDimension, secondDimension,
+                secondDimension) = D_h_second;
+    }
+    if (H2) *H2 = identityJacobian(productDimension);
     return ProductLieGroup(g, h);
   }
 
   /// Between with Jacobians
   ProductLieGroup between(const ProductLieGroup& other, ChartJacobian H1,
                           ChartJacobian H2 = {}) const {
+    if (firstDim() != other.firstDim() || secondDim() != other.secondDim()) {
+      throw std::invalid_argument(
+          "ProductLieGroup::between requires matching component dimensions");
+    }
+    const int firstDimension = firstDim();
+    const int secondDimension = secondDim();
+    const int productDimension =
+        combinedDimension(firstDimension, secondDimension);
     Jacobian1 D_g_first;
     Jacobian2 D_h_second;
-    G g = traits<G>::Between(this->first, other.first, H1 ? &D_g_first : 0);
-    H h = traits<H>::Between(this->second, other.second, H1 ? &D_h_second : 0);
+    G g =
+        traits<G>::Between(this->first, other.first, H1 ? &D_g_first : nullptr);
+    H h = traits<H>::Between(this->second, other.second,
+                             H1 ? &D_h_second : nullptr);
     if (H1) {
-      H1->setZero();
-      H1->template topLeftCorner<dimension1, dimension1>() = D_g_first;
-      H1->template bottomRightCorner<dimension2, dimension2>() = D_h_second;
+      *H1 = zeroJacobian(productDimension);
+      H1->block(0, 0, firstDimension, firstDimension) = D_g_first;
+      H1->block(firstDimension, firstDimension, secondDimension,
+                secondDimension) = D_h_second;
     }
-    if (H2) *H2 = Jacobian::Identity();
+    if (H2) *H2 = identityJacobian(productDimension);
     return ProductLieGroup(g, h);
   }
 
   /// Inverse with Jacobian
   ProductLieGroup inverse(ChartJacobian D) const {
+    const int firstDimension = firstDim();
+    const int secondDimension = secondDim();
+    const int productDimension =
+        combinedDimension(firstDimension, secondDimension);
     Jacobian1 D_g_first;
     Jacobian2 D_h_second;
-    G g = traits<G>::Inverse(this->first, D ? &D_g_first : 0);
-    H h = traits<H>::Inverse(this->second, D ? &D_h_second : 0);
+    G g = traits<G>::Inverse(this->first, D ? &D_g_first : nullptr);
+    H h = traits<H>::Inverse(this->second, D ? &D_h_second : nullptr);
     if (D) {
-      D->setZero();
-      D->template topLeftCorner<dimension1, dimension1>() = D_g_first;
-      D->template bottomRightCorner<dimension2, dimension2>() = D_h_second;
+      *D = zeroJacobian(productDimension);
+      D->block(0, 0, firstDimension, firstDimension) = D_g_first;
+      D->block(firstDimension, firstDimension, secondDimension,
+               secondDimension) = D_h_second;
     }
     return ProductLieGroup(g, h);
   }
 
   /// Exponential map
   static ProductLieGroup Expmap(const TangentVector& v, ChartJacobian Hv = {}) {
+    if constexpr (firstDynamic && secondDynamic) {
+      if (v.size() == 0) {
+        if (Hv) *Hv = Matrix::Zero(0, 0);
+        return ProductLieGroup();
+      }
+      throw std::invalid_argument(
+          "ProductLieGroup::Expmap requires split tangent vectors when both "
+          "factors are dynamic");
+    } else if constexpr (firstDynamic) {
+      if (v.size() < dimension2) {
+        throw std::invalid_argument(
+            "ProductLieGroup::Expmap tangent dimension is too small for the "
+            "fixed second factor");
+      }
+      const int firstDimension = v.size() - dimension2;
+      return expmapWithDimensions(v, firstDimension, dimension2, Hv);
+    } else if constexpr (secondDynamic) {
+      if (v.size() < dimension1) {
+        throw std::invalid_argument(
+            "ProductLieGroup::Expmap tangent dimension is too small for the "
+            "fixed first factor");
+      }
+      const int secondDimension = v.size() - dimension1;
+      return expmapWithDimensions(v, dimension1, secondDimension, Hv);
+    } else {
+      return expmapWithDimensions(v, dimension1, dimension2, Hv);
+    }
+  }
+
+  /// Exponential map from subgroup tangent vectors
+  static ProductLieGroup Expmap(
+      const Eigen::Ref<const typename traits<G>::TangentVector>& v1,
+      const Eigen::Ref<const typename traits<H>::TangentVector>& v2,
+      ChartJacobian Hv) {
+    const int firstDimension = v1.size();
+    const int secondDimension = v2.size();
     Jacobian1 D_g_first;
     Jacobian2 D_h_second;
-    G g = traits<G>::Expmap(v.template head<dimension1>(), Hv ? &D_g_first : 0);
-    H h =
-        traits<H>::Expmap(v.template tail<dimension2>(), Hv ? &D_h_second : 0);
+    G g = traits<G>::Expmap(v1, Hv ? &D_g_first : nullptr);
+    H h = traits<H>::Expmap(v2, Hv ? &D_h_second : nullptr);
     if (Hv) {
-      Hv->setZero();
-      Hv->template topLeftCorner<dimension1, dimension1>() = D_g_first;
-      Hv->template bottomRightCorner<dimension2, dimension2>() = D_h_second;
+      *Hv = zeroJacobian(combinedDimension(firstDimension, secondDimension));
+      Hv->block(0, 0, firstDimension, firstDimension) = D_g_first;
+      Hv->block(firstDimension, firstDimension, secondDimension,
+                secondDimension) = D_h_second;
     }
     return ProductLieGroup(g, h);
   }
 
+  /// Exponential map from subgroup tangent vectors
+  static ProductLieGroup Expmap(
+      const Eigen::Ref<const typename traits<G>::TangentVector>& v1,
+      const Eigen::Ref<const typename traits<H>::TangentVector>& v2) {
+    return Expmap(v1, v2, {});
+  }
+
   /// Logarithmic map
   static TangentVector Logmap(const ProductLieGroup& p, ChartJacobian Hp = {}) {
+    const int firstDimension = p.firstDim();
+    const int secondDimension = p.secondDim();
+    const int productDimension =
+        combinedDimension(firstDimension, secondDimension);
     Jacobian1 D_g_first;
     Jacobian2 D_h_second;
     typename traits<G>::TangentVector v1 =
-        traits<G>::Logmap(p.first, Hp ? &D_g_first : 0);
+        traits<G>::Logmap(p.first, Hp ? &D_g_first : nullptr);
     typename traits<H>::TangentVector v2 =
-        traits<H>::Logmap(p.second, Hp ? &D_h_second : 0);
-    TangentVector v;
-    v << v1, v2;
+        traits<H>::Logmap(p.second, Hp ? &D_h_second : nullptr);
+    TangentVector v =
+        makeTangentVector(v1, v2, firstDimension, secondDimension);
     if (Hp) {
-      Hp->setZero();
-      Hp->template topLeftCorner<dimension1, dimension1>() = D_g_first;
-      Hp->template bottomRightCorner<dimension2, dimension2>() = D_h_second;
+      *Hp = zeroJacobian(productDimension);
+      Hp->block(0, 0, firstDimension, firstDimension) = D_g_first;
+      Hp->block(firstDimension, firstDimension, secondDimension,
+                secondDimension) = D_h_second;
     }
     return v;
   }
@@ -237,7 +435,7 @@ class ProductLieGroup : public std::pair<G, H> {
 
   /// Right multiplication by exponential map
   ProductLieGroup expmap(const TangentVector& v) const {
-    return compose(ProductLieGroup::Expmap(v));
+    return compose(expmapWithDimensions(v, firstDim(), secondDim()));
   }
 
   /// Logarithmic map for relative transformation
@@ -247,10 +445,11 @@ class ProductLieGroup : public std::pair<G, H> {
 
   /// Adjoint map
   Jacobian AdjointMap() const {
-    const auto& adjG = traits<G>::AdjointMap(this->first);
-    const auto& adjH = traits<H>::AdjointMap(this->second);
-    size_t d1 = adjG.rows(), d2 = adjH.rows();
-    Matrix adj = Matrix::Zero(d1 + d2, d1 + d2);
+    const auto adjG = traits<G>::AdjointMap(this->first);
+    const auto adjH = traits<H>::AdjointMap(this->second);
+    const int d1 = adjG.rows();
+    const int d2 = adjH.rows();
+    Jacobian adj = zeroJacobian(d1 + d2);
     adj.block(0, 0, d1, d1) = adjG;
     adj.block(d1, d1, d2, d2) = adjH;
     return adj;

--- a/gtsam/base/VectorSpace.h
+++ b/gtsam/base/VectorSpace.h
@@ -432,9 +432,23 @@ struct DynamicTraits {
     return result;
   }
 
-  static Dynamic Expmap(const TangentVector& /*v*/, ChartJacobian H = {}) {
-    static_cast<void>(H);
-    throw std::runtime_error("Expmap not defined for dynamic types");
+  static Dynamic Expmap(const TangentVector& v, ChartJacobian H = {}) {
+    if constexpr (M == Eigen::Dynamic && N == Eigen::Dynamic) {
+      static_cast<void>(v);
+      static_cast<void>(H);
+      throw std::runtime_error("Expmap not defined for fully dynamic matrices");
+    } else {
+      const int rows = (M == Eigen::Dynamic) ? v.size() / N : M;
+      const int cols = (N == Eigen::Dynamic) ? v.size() / M : N;
+      if (rows * cols != v.size()) {
+        throw std::invalid_argument(
+            "Dynamic Expmap tangent dimension does not match matrix shape");
+      }
+      Dynamic result(rows, cols);
+      Eigen::Map<Dynamic>(result.data(), rows, cols) = v;
+      if (H) *H = Jacobian::Identity(v.size(), v.size());
+      return result;
+    }
   }
 
   static Dynamic Inverse(const Dynamic& m, ChartJacobian H = {}) {

--- a/gtsam/base/VectorSpace.h
+++ b/gtsam/base/VectorSpace.h
@@ -29,7 +29,7 @@ struct VectorSpaceImpl {
   typedef Eigen::Matrix<double, N, 1> TangentVector;
   typedef OptionalJacobian<N, N> ChartJacobian;
   typedef Eigen::Matrix<double, N, N> Jacobian;
-  static int GetDimension(const Class&) { return N;}
+  static size_t GetDimension(const Class&) { return static_cast<size_t>(N);}
 
   static TangentVector Local(const Class& origin, const Class& other,
       ChartJacobian H1 = {}, ChartJacobian H2 = {}) {
@@ -107,10 +107,10 @@ struct VectorSpaceImpl<Class,Eigen::Dynamic> {
   /// @{
   typedef Eigen::VectorXd TangentVector;
   typedef OptionalJacobian<Eigen::Dynamic,Eigen::Dynamic> ChartJacobian;
-  static int GetDimension(const Class& m) { return m.dim();}
+  static size_t GetDimension(const Class& m) { return m.dim();}
 
   static Eigen::MatrixXd Eye(const Class& m) {
-    int dim = GetDimension(m);
+    size_t dim = GetDimension(m);
     return Eigen::MatrixXd::Identity(dim, dim);
   }
 
@@ -395,12 +395,12 @@ struct DynamicTraits {
   typedef OptionalJacobian<dimension, dimension> ChartJacobian;
   typedef Dynamic ManifoldType;
 
-  static int GetDimension(const Dynamic& m) {
-    return m.rows() * m.cols();
+  static size_t GetDimension(const Dynamic& m) {
+    return static_cast<size_t>(m.rows() * m.cols());
   }
 
   static Jacobian Eye(const Dynamic& m) {
-    int dim = GetDimension(m);
+    size_t dim = GetDimension(m);
     return Eigen::Matrix<double, dimension, dimension>::Identity(dim, dim);
   }
 

--- a/gtsam/base/VectorSpace.h
+++ b/gtsam/base/VectorSpace.h
@@ -141,7 +141,7 @@ struct VectorSpaceImpl<Class,Eigen::Dynamic> {
 
   static Class Expmap(const TangentVector& v, ChartJacobian Hv = {}) {
     Class result(v);
-    if (Hv) *Hv = Eye(v);
+    if (Hv) *Hv = Eye(result);
     return result;
   }
 
@@ -445,7 +445,7 @@ struct DynamicTraits {
             "Dynamic Expmap tangent dimension does not match matrix shape");
       }
       Dynamic result(rows, cols);
-      Eigen::Map<Dynamic>(result.data(), rows, cols) = v;
+      result = Eigen::Map<const Dynamic>(v.data(), rows, cols);
       if (H) *H = Jacobian::Identity(v.size(), v.size());
       return result;
     }

--- a/gtsam/linear/NoiseModel.h
+++ b/gtsam/linear/NoiseModel.h
@@ -160,8 +160,7 @@ namespace gtsam {
       static_assert(IsManifold<T>::value,
                     "noiseModel::matchesDimension requires a manifold type.");
       if constexpr (traits<T>::dimension == Eigen::Dynamic) {
-        return model.dim() ==
-               static_cast<size_t>(traits<T>::GetDimension(measured));
+        return model.dim() == traits<T>::GetDimension(measured);
       } else {
         return model.dim() == static_cast<size_t>(traits<T>::dimension);
       }
@@ -673,7 +672,7 @@ namespace gtsam {
         static_assert(IsManifold<T>::value,
                       "noiseModel::Unit::Create requires a manifold type.");
         if constexpr (traits<T>::dimension == Eigen::Dynamic) {
-          return Create(static_cast<size_t>(traits<T>::GetDimension(measured)));
+          return Create(traits<T>::GetDimension(measured));
         } else {
           static const shared_ptr kDefault =
               Create(static_cast<size_t>(traits<T>::dimension));

--- a/gtsam/navigation/ManifoldEKF.h
+++ b/gtsam/navigation/ManifoldEKF.h
@@ -73,7 +73,7 @@ class ManifoldEKF {
     n_ = traits<M>::GetDimension(X0);
     if constexpr (Dim == Eigen::Dynamic) {
       // Validate dimensions of initial covariance P0.
-      if (P0.rows() != n_ || P0.cols() != n_) {
+      if (!isMatrixOfSize(P0, n_, n_)) {
         throw std::invalid_argument(
             "ManifoldEKF: Initial covariance P0 dimensions (" +
             std::to_string(P0.rows()) + "x" + std::to_string(P0.cols()) +
@@ -115,8 +115,7 @@ class ManifoldEKF {
    */
   void predict(const M& X_next, const Jacobian& F, const Covariance& Q) {
     if constexpr (Dim == Eigen::Dynamic) {
-      if (F.rows() != n_ || F.cols() != n_ || Q.rows() != n_ ||
-          Q.cols() != n_) {
+      if (!isMatrixOfSize(F, n_, n_) || !isMatrixOfSize(Q, n_, n_)) {
         throw std::invalid_argument(
             "ManifoldEKF::predict: Dynamic F/Q dimensions must match state "
             "dimension " +
@@ -257,22 +256,30 @@ class ManifoldEKF {
   /// Validate inputs to update.
   void validateInputs(const gtsam::Vector& prediction, const Matrix& H,
                       const gtsam::Vector& z, const Matrix& R) {
-    const int m = static_cast<int>(prediction.size());
-    if (static_cast<int>(z.size()) != m) {
+    const size_t m = static_cast<size_t>(prediction.size());
+    if (static_cast<size_t>(z.size()) != m) {
       throw std::invalid_argument(
           "ManifoldEKF::updateWithVector: prediction and z must have same "
           "length.");
     }
-    if (H.rows() != m || H.cols() != n_) {
+    if (!isMatrixOfSize(H, m, n_)) {
       throw std::invalid_argument(
           "ManifoldEKF::updateWithVector: H must be m x n where m = "
           "measurement size and n = state dimension.");
     }
-    if (R.rows() != m || R.cols() != m) {
+    if (!isMatrixOfSize(R, m, m)) {
       throw std::invalid_argument(
           "ManifoldEKF::updateWithVector: R must be m x m where m = "
           "measurement size.");
     }
+  }
+
+  /// Check whether a matrix has the expected runtime dimensions.
+  template <typename MatrixType>
+  static bool isMatrixOfSize(const MatrixType& matrix, size_t rows,
+                             size_t cols) {
+    return static_cast<size_t>(matrix.rows()) == rows &&
+           static_cast<size_t>(matrix.cols()) == cols;
   }
 
  protected:

--- a/gtsam/navigation/ManifoldEKF.h
+++ b/gtsam/navigation/ManifoldEKF.h
@@ -97,7 +97,7 @@ class ManifoldEKF {
   const Covariance& covariance() const { return P_; }
 
   /// @return runtime dimension of the manifold.
-  int dimension() const { return n_; }
+  size_t dimension() const { return n_; }
 
   /**
    * Basic predict step: Updates state and covariance given the predicted next
@@ -279,7 +279,7 @@ class ManifoldEKF {
   M X_;           ///< Manifold state estimate.
   Covariance P_;  ///< Covariance (Eigen::Matrix<double, Dim, Dim>).
   Jacobian I_;    ///< Identity matrix sized to the state dimension.
-  int n_;         ///< Runtime tangent space dimension of M.
+  size_t n_;      ///< Runtime tangent space dimension of M.
 
  private:
   // Detection helper: check if traits<T>::Retract(x, v, Jacobian*) is valid.

--- a/gtsam/navigation/navigation.i
+++ b/gtsam/navigation/navigation.i
@@ -676,7 +676,7 @@ virtual class ManifoldEKF {
   // Accessors
   M state() const;
   gtsam::Matrix covariance() const;
-  int dimension() const;
+  size_t dimension() const;
 
   // Predict with provided next state and Jacobian
   void predict(const M& X_next, gtsam::Matrix F, gtsam::Matrix Q);

--- a/gtsam/nonlinear/ExtendedKalmanFilter-inl.h
+++ b/gtsam/nonlinear/ExtendedKalmanFilter-inl.h
@@ -70,7 +70,7 @@ namespace gtsam {
     // Create a Jacobian Prior Factor directly P_initial.
     // Since x0 is set to the provided mean, the b vector in the prior will be zero
     // TODO(Frank): is there a reason why noiseModel is not simply P_initial?
-    int n = traits<T>::GetDimension(x_initial);
+    size_t n = traits<T>::GetDimension(x_initial);
     priorFactor_ = JacobianFactor::shared_ptr(
         new JacobianFactor(key_initial, P_initial->R(), Vector::Zero(n),
             noiseModel::Unit::Create(n)));

--- a/gtsam/slam/PoseTranslationPrior.h
+++ b/gtsam/slam/PoseTranslationPrior.h
@@ -66,8 +66,8 @@ public:
   Vector evaluateError(const Pose& pose, OptionalMatrixType H) const override {
     const Translation& newTrans = pose.translation();
     const Rotation& R = pose.rotation();
-    const int tDim = traits<Translation>::GetDimension(newTrans);
-    const int xDim = traits<Pose>::GetDimension(pose);
+    const size_t tDim = traits<Translation>::GetDimension(newTrans);
+    const size_t xDim = traits<Pose>::GetDimension(pose);
     if (H) {
       *H = Matrix::Zero(tDim, xDim);
       std::pair<size_t, size_t> transInterval = POSE::translationInterval();
@@ -106,7 +106,6 @@ private:
 };
 
 } // \namespace gtsam
-
 
 
 

--- a/gtsam_unstable/geometry/ABC.h
+++ b/gtsam_unstable/geometry/ABC.h
@@ -61,7 +61,7 @@ inline Vector6 toInputVector(const Vector3& w) {
 }
 
 /// Bundle of calibration rotations modeled as a Lie group
-template <size_t N>
+template <int N>
 using Calibrations = PowerLieGroup<Rot3, N>;
 
 //========================================================================
@@ -72,7 +72,7 @@ using Calibrations = PowerLieGroup<Rot3, N>;
  * Minimal state manifold for the biased attitude system: ξ = (R, b, S).
  * Template parameter N is the number of calibrated sensors.
  */
-template <size_t N>
+template <int N>
 struct State {
   Rot3 R;             // Attitude rotation matrix R
   Vector3 b;          // Gyroscope bias b
@@ -148,11 +148,11 @@ struct State {
  * Symmetry group G = Pose3 × Calibrations<n>. Pose3 handles the SE(3)-like
  * part acting on (R, b) and Calibrations<n> handles the N extrinsic rotations.
  */
-template <size_t n>
+template <int n>
 using Group = ProductLieGroup<Pose3, Calibrations<n>>;
 
 /// @brief Unpack g into A, a, and B
-template <size_t N>
+template <int N>
 auto asTriple = [](const Group<N>& g)
     -> std::tuple<const Rot3&, const Vector3&, const Calibrations<N>&> {
   return std::tie(g.first.rotation(), g.first.translation(), g.second);
@@ -168,7 +168,7 @@ auto asTriple = [](const Group<N>& g)
  * ξ=(R,b,C). This is the discrete version of the homogeneous-space action in
  * Eq. (4) of Fornasier et al. (2022).
  */
-template <size_t N>
+template <int N>
 struct Symmetry : public GroupAction<Symmetry<N>, Group<N>, State<N>> {
   using M = State<N>;
   using G = gtsam::abc::Group<N>;
@@ -249,7 +249,7 @@ struct Symmetry : public GroupAction<Symmetry<N>, Group<N>, State<N>> {
  *   Ṡ_i = 0
  * We represent the tangent as a vector with components (δθ, δb, δσ_i).
  */
-template <size_t N>
+template <int N>
 inline typename State<N>::TangentVector dynamics(const Vector3& omega,
                                                  const State<N>& xi) {
   typename State<N>::TangentVector xi_dot;
@@ -266,7 +266,7 @@ inline typename State<N>::TangentVector dynamics(const Vector3& omega,
  * Fornasier et al., this corresponds to Eq. (7), written in the so(3)≃ℝ³
  * identification.
  */
-template <size_t N>
+template <int N>
 struct Lift {
   using M = State<N>;
   using G = Group<N>;
@@ -312,7 +312,7 @@ struct Lift {
  * yields ψ_u(X) = (A^{-1}(ω - a), 0). The matrices A(X,u) and Φ(X,u) here match
  * the linearization in Eqs. (20) and (21), using ω̃ = Aᵀ(ω − a).
  */
-template <size_t N>
+template <int N>
 struct InputAction : public GroupAction<InputAction<N>, Group<N>, Vector6> {
   using G = Group<N>;
   static constexpr ActionType type = ActionType::Right;
@@ -328,7 +328,7 @@ struct InputAction : public GroupAction<InputAction<N>, Group<N>, Vector6> {
 };
 
 // Embed a 6x6 Sigma into full DimU by appending small calibration noise.
-template <size_t N>
+template <int N>
 inline Matrix inputProcessNoise(const Matrix& Sigma6) {
   std::vector<Matrix> blocks{Sigma6};
   blocks.insert(blocks.end(), N, 1e-9 * I_3x3);
@@ -336,7 +336,7 @@ inline Matrix inputProcessNoise(const Matrix& Sigma6) {
 }
 
 /// Compute the state matrix A(X_hat).
-template <size_t N>
+template <int N>
 inline Matrix stateMatrixA(const typename InputAction<N>::Orbit& psi_u,
                            const Group<N>& X_hat) {
   const Vector6 u0 = psi_u(X_hat.inverse());  // ψ_u(X)^ω (omega, 0)
@@ -352,7 +352,7 @@ inline Matrix stateMatrixA(const typename InputAction<N>::Orbit& psi_u,
 }
 
 /// Compute the input matrix B(X_hat).
-template <size_t N>
+template <int N>
 inline Matrix inputMatrixB(const Group<N>& g) {
   const Rot3& A = g.first.rotation();
   const Calibrations<N>& B = g.second;
@@ -371,7 +371,7 @@ inline Matrix inputMatrixB(const Group<N>& g) {
  * parameterized by the sensor index. Use index = -1 for an uncalibrated
  * sensor measured directly in the body frame.
  */
-template <size_t N>
+template <int N>
 struct OutputAction : public GroupAction<OutputAction<N>, Group<N>, Vector3> {
   using G = Group<N>;
   static constexpr ActionType type = ActionType::Right;
@@ -400,7 +400,7 @@ struct OutputAction : public GroupAction<OutputAction<N>, Group<N>, Vector3> {
 };
 
 /// Compute the measurement matrix C(φ_y).
-template <size_t N>
+template <int N>
 inline Matrix measurementMatrixC(const Unit3& d, int index) {
   Matrix Cc = Matrix::Zero(3, 3 * N);
 
@@ -417,7 +417,7 @@ inline Matrix measurementMatrixC(const Unit3& d, int index) {
   return wedge_d * temp;
 }
 
-template <size_t N>
+template <int N>
 struct Innovation {
   using M = State<N>;
 
@@ -462,7 +462,7 @@ struct Innovation {
   int index_;
 };
 
-template <size_t N>
+template <int N>
 inline Matrix3 outputMatrixD(const Group<N>& X_hat, int index) {
   auto [A, a, B] = asTriple<N>(X_hat);
   if (index >= 0) {
@@ -474,17 +474,17 @@ inline Matrix3 outputMatrixD(const Group<N>& X_hat, int index) {
 
 }  // namespace abc
 
-template <size_t N>
+template <int N>
 struct traits<abc::State<N>> : public internal::Manifold<abc::State<N>> {};
 
-template <size_t N>
+template <int N>
 struct traits<const abc::State<N>> : public internal::Manifold<abc::State<N>> {
 };
 
-template <size_t N>
+template <int N>
 struct traits<abc::Group<N>> : internal::LieGroup<abc::Group<N>> {};
 
-template <size_t N>
+template <int N>
 struct traits<const abc::Group<N>> : internal::LieGroup<abc::Group<N>> {};
 
 }  // namespace gtsam

--- a/gtsam_unstable/geometry/ABC.h
+++ b/gtsam_unstable/geometry/ABC.h
@@ -61,8 +61,8 @@ inline Vector6 toInputVector(const Vector3& w) {
 }
 
 /// Bundle of calibration rotations modeled as a Lie group
-template <int N>
-using Calibrations = PowerLieGroup<Rot3, N>;
+template <size_t N>
+using Calibrations = PowerLieGroup<Rot3, static_cast<int>(N)>;
 
 //========================================================================
 // State Manifold
@@ -72,13 +72,13 @@ using Calibrations = PowerLieGroup<Rot3, N>;
  * Minimal state manifold for the biased attitude system: ξ = (R, b, S).
  * Template parameter N is the number of calibrated sensors.
  */
-template <int N>
+template <size_t N>
 struct State {
   Rot3 R;             // Attitude rotation matrix R
   Vector3 b;          // Gyroscope bias b
   Calibrations<N> S;  // Sensor calibrations S
 
-  static constexpr int dimension = 6 + 3 * N;
+  static constexpr int dimension = 6 + 3 * static_cast<int>(N);
   using TangentVector = Eigen::Matrix<double, dimension, 1>;
 
   /// Constructor
@@ -148,11 +148,11 @@ struct State {
  * Symmetry group G = Pose3 × Calibrations<n>. Pose3 handles the SE(3)-like
  * part acting on (R, b) and Calibrations<n> handles the N extrinsic rotations.
  */
-template <int n>
+template <size_t n>
 using Group = ProductLieGroup<Pose3, Calibrations<n>>;
 
 /// @brief Unpack g into A, a, and B
-template <int N>
+template <size_t N>
 auto asTriple = [](const Group<N>& g)
     -> std::tuple<const Rot3&, const Vector3&, const Calibrations<N>&> {
   return std::tie(g.first.rotation(), g.first.translation(), g.second);
@@ -168,7 +168,7 @@ auto asTriple = [](const Group<N>& g)
  * ξ=(R,b,C). This is the discrete version of the homogeneous-space action in
  * Eq. (4) of Fornasier et al. (2022).
  */
-template <int N>
+template <size_t N>
 struct Symmetry : public GroupAction<Symmetry<N>, Group<N>, State<N>> {
   using M = State<N>;
   using G = gtsam::abc::Group<N>;
@@ -249,7 +249,7 @@ struct Symmetry : public GroupAction<Symmetry<N>, Group<N>, State<N>> {
  *   Ṡ_i = 0
  * We represent the tangent as a vector with components (δθ, δb, δσ_i).
  */
-template <int N>
+template <size_t N>
 inline typename State<N>::TangentVector dynamics(const Vector3& omega,
                                                  const State<N>& xi) {
   typename State<N>::TangentVector xi_dot;
@@ -266,7 +266,7 @@ inline typename State<N>::TangentVector dynamics(const Vector3& omega,
  * Fornasier et al., this corresponds to Eq. (7), written in the so(3)≃ℝ³
  * identification.
  */
-template <int N>
+template <size_t N>
 struct Lift {
   using M = State<N>;
   using G = Group<N>;
@@ -312,7 +312,7 @@ struct Lift {
  * yields ψ_u(X) = (A^{-1}(ω - a), 0). The matrices A(X,u) and Φ(X,u) here match
  * the linearization in Eqs. (20) and (21), using ω̃ = Aᵀ(ω − a).
  */
-template <int N>
+template <size_t N>
 struct InputAction : public GroupAction<InputAction<N>, Group<N>, Vector6> {
   using G = Group<N>;
   static constexpr ActionType type = ActionType::Right;
@@ -328,7 +328,7 @@ struct InputAction : public GroupAction<InputAction<N>, Group<N>, Vector6> {
 };
 
 // Embed a 6x6 Sigma into full DimU by appending small calibration noise.
-template <int N>
+template <size_t N>
 inline Matrix inputProcessNoise(const Matrix& Sigma6) {
   std::vector<Matrix> blocks{Sigma6};
   blocks.insert(blocks.end(), N, 1e-9 * I_3x3);
@@ -336,7 +336,7 @@ inline Matrix inputProcessNoise(const Matrix& Sigma6) {
 }
 
 /// Compute the state matrix A(X_hat).
-template <int N>
+template <size_t N>
 inline Matrix stateMatrixA(const typename InputAction<N>::Orbit& psi_u,
                            const Group<N>& X_hat) {
   const Vector6 u0 = psi_u(X_hat.inverse());  // ψ_u(X)^ω (omega, 0)
@@ -352,7 +352,7 @@ inline Matrix stateMatrixA(const typename InputAction<N>::Orbit& psi_u,
 }
 
 /// Compute the input matrix B(X_hat).
-template <int N>
+template <size_t N>
 inline Matrix inputMatrixB(const Group<N>& g) {
   const Rot3& A = g.first.rotation();
   const Calibrations<N>& B = g.second;
@@ -371,7 +371,7 @@ inline Matrix inputMatrixB(const Group<N>& g) {
  * parameterized by the sensor index. Use index = -1 for an uncalibrated
  * sensor measured directly in the body frame.
  */
-template <int N>
+template <size_t N>
 struct OutputAction : public GroupAction<OutputAction<N>, Group<N>, Vector3> {
   using G = Group<N>;
   static constexpr ActionType type = ActionType::Right;
@@ -400,7 +400,7 @@ struct OutputAction : public GroupAction<OutputAction<N>, Group<N>, Vector3> {
 };
 
 /// Compute the measurement matrix C(φ_y).
-template <int N>
+template <size_t N>
 inline Matrix measurementMatrixC(const Unit3& d, int index) {
   Matrix Cc = Matrix::Zero(3, 3 * N);
 
@@ -417,7 +417,7 @@ inline Matrix measurementMatrixC(const Unit3& d, int index) {
   return wedge_d * temp;
 }
 
-template <int N>
+template <size_t N>
 struct Innovation {
   using M = State<N>;
 
@@ -462,7 +462,7 @@ struct Innovation {
   int index_;
 };
 
-template <int N>
+template <size_t N>
 inline Matrix3 outputMatrixD(const Group<N>& X_hat, int index) {
   auto [A, a, B] = asTriple<N>(X_hat);
   if (index >= 0) {
@@ -474,17 +474,11 @@ inline Matrix3 outputMatrixD(const Group<N>& X_hat, int index) {
 
 }  // namespace abc
 
-template <int N>
+template <size_t N>
 struct traits<abc::State<N>> : public internal::Manifold<abc::State<N>> {};
 
-template <int N>
+template <size_t N>
 struct traits<const abc::State<N>> : public internal::Manifold<abc::State<N>> {
 };
-
-template <int N>
-struct traits<abc::Group<N>> : internal::LieGroup<abc::Group<N>> {};
-
-template <int N>
-struct traits<const abc::Group<N>> : internal::LieGroup<abc::Group<N>> {};
 
 }  // namespace gtsam

--- a/gtsam_unstable/geometry/ABCEquivariantFilter.h
+++ b/gtsam_unstable/geometry/ABCEquivariantFilter.h
@@ -37,7 +37,7 @@ namespace abc {
  *
  * @tparam N Number of calibrated sensors (typically 1 or more)
  */
-template <size_t N>
+template <int N>
 class AbcEquivariantFilter
     : public gtsam::EquivariantFilter<State<N>, Symmetry<N>> {
  public:

--- a/gtsam_unstable/geometry/ABCEquivariantFilter.h
+++ b/gtsam_unstable/geometry/ABCEquivariantFilter.h
@@ -37,7 +37,7 @@ namespace abc {
  *
  * @tparam N Number of calibrated sensors (typically 1 or more)
  */
-template <int N>
+template <size_t N>
 class AbcEquivariantFilter
     : public gtsam::EquivariantFilter<State<N>, Symmetry<N>> {
  public:

--- a/gtsam_unstable/geometry/tests/testABC.cpp
+++ b/gtsam_unstable/geometry/tests/testABC.cpp
@@ -410,7 +410,7 @@ TEST(ABC, LiftEquivariance) {
 TEST(ABC, InputAction_stateMatrixA) {
   using namespace abc_input_action_example;
 
-  Matrix A_matrix = abc::stateMatrixA(psi_u, X_hat);
+  Matrix A_matrix = abc::stateMatrixA<2>(psi_u, X_hat);
   Matrix3 W0 = Rot3::Hat(psi_u(X_hat.inverse()).head<3>());
 
   Matrix expected_A1 = Matrix::Zero(6, 6);
@@ -441,7 +441,7 @@ TEST(ABC, ComputeErrorDynamicsMatrixMatchesLegacy) {
   // A_provided should now be the Manifold-space matrix
   // stateMatrixA returns the correct Manifold-space matrix (DimM x DimM)
   InputOrbit psi_u(u);
-  Matrix expected_A = abc::stateMatrixA(psi_u, X_hat);
+  Matrix expected_A = abc::stateMatrixA<2>(psi_u, X_hat);
 
   // A_computed is now computed on Manifold (D_act * D_lift)
   Matrix A_computed = filter.computeErrorDynamicsMatrix<Lift>(psi_u);
@@ -574,7 +574,7 @@ TEST(ABC, InputAction_stateTransitionMatchesLieGroupEKF) {
   Matrix Phi_expected = stateTransitionMatrix<2>(psi_u, X_hat, dt);
 
   Group::Jacobian ad_xi = adjointMap(xi);
-  Group::Jacobian Df = abc::stateMatrixA(psi_u, X_hat) + ad_xi;
+  Group::Jacobian Df = abc::stateMatrixA<2>(psi_u, X_hat) + ad_xi;
   Group::Jacobian P0 = Group::Jacobian::Identity();
   LieGroupEKF<Group> ekf(X_hat, P0);
 
@@ -598,7 +598,7 @@ TEST(ABC, InputAction_stateTransitionMatchesLieGroupEKF_K1) {
 
   double dt = 1e-4;
 
-  Group::Jacobian Df = abc::stateMatrixA(psi_u, X_hat) + adjointMap(xi);
+  Group::Jacobian Df = abc::stateMatrixA<2>(psi_u, X_hat) + adjointMap(xi);
   Group::Jacobian P0 = Group::Jacobian::Identity();
   LieGroupEKF<Group> ekf(X_hat, P0);
 
@@ -619,7 +619,7 @@ TEST(ABC, InputAction_inputMatrix) {
   using abc_examples::A1;
   using abc_examples::B1;
 
-  Matrix input_matrix = abc::inputMatrixB(X_hat);
+  Matrix input_matrix = abc::inputMatrixB<2>(X_hat);
 
   const Matrix3 A = A1.matrix();
   Matrix expected_B1 = gtsam::diag({A, A});
@@ -805,7 +805,7 @@ TEST(ABC, EqFilter) {
   Matrix Sigma = I_6x6;
   double dt = 0.01;
   Matrix Q = abc::inputProcessNoise<2>(Sigma);
-  Matrix B = abc::inputMatrixB(g_0);
+  Matrix B = abc::inputMatrixB<2>(g_0);
   Matrix Qc = B * Q * B.transpose();  // manifold continuous-time covariance
   Lift lift_u(u2);
   InputOrbit psi_u(u2);
@@ -853,12 +853,12 @@ TEST(ABC, EqFilter_BespokeDynamics) {
   Matrix Sigma = I_6x6;
   double dt = 0.01;
   Matrix Q = abc::inputProcessNoise<2>(Sigma);
-  Matrix B = abc::inputMatrixB(g_0);
+  Matrix B = abc::inputMatrixB<2>(g_0);
   Matrix Qc = B * Q * B.transpose();
   Lift lift_u(u2);
   InputOrbit psi_u(u2);
 
-  Matrix A = abc::stateMatrixA(psi_u, g_0);
+  Matrix A = abc::stateMatrixA<2>(psi_u, g_0);
   filter.predictWithJacobian<2>(lift_u, A, Qc, dt);
 
   EXPECT(assert_equal(expected_predict, filter.groupEstimate(), 1e-4));

--- a/tests/testNonlinearOptimizer.cpp
+++ b/tests/testNonlinearOptimizer.cpp
@@ -658,7 +658,7 @@ struct traits<MyType> {
     return (a - b).array().abs().maxCoeff() < tol;
   }
   static void Print(const MyType&, const string&) {}
-  static int GetDimension(const MyType&) { return dimension; }
+  static size_t GetDimension(const MyType&) { return dimension; }
   static MyType Retract(const MyType& a, const TangentVector& v,
                         ChartJacobian H1 = {}, ChartJacobian H2 = {}) {
     if (H1) *H1 = Matrix3::Identity();

--- a/tests/testProductLieGroup.cpp
+++ b/tests/testProductLieGroup.cpp
@@ -34,9 +34,11 @@ constexpr double kTol = 1e-9;
 using Product = ProductLieGroup<Point2, Pose2>;
 using ProductVR = ProductLieGroup<Vector, Rot3>;
 using ProductVV = ProductLieGroup<Vector, Vector>;
-constexpr size_t kPowerComponents = 2;
+constexpr int kPowerComponents = 2;
 using Power = PowerLieGroup<Pose2, kPowerComponents>;
 using PowerTangent = Power::TangentVector;
+using DynamicPower = PowerLieGroup<Pose2, Eigen::Dynamic>;
+using DynamicPowerTangent = DynamicPower::TangentVector;
 
 namespace gtsam {
 template <>
@@ -64,6 +66,27 @@ struct traits<Power> : internal::LieGroupTraits<Power> {
   }
   static bool Equals(const Power& m1, const Power& m2, double tol = 1e-8) {
     for (size_t i = 0; i < kPowerComponents; ++i) {
+      if (!m1[i].equals(m2[i], tol)) return false;
+    }
+    return true;
+  }
+};
+
+template <>
+struct traits<DynamicPower> : internal::LieGroupTraits<DynamicPower> {
+  static void Print(const DynamicPower& m, const std::string& s = "") {
+    std::cout << s << "[";
+    for (size_t i = 0; i < m.size(); ++i) {
+      if (i > 0) std::cout << ", ";
+      std::cout << "Pose2(" << m[i].x() << "," << m[i].y() << ","
+                << m[i].theta() << ")";
+    }
+    std::cout << "]" << std::endl;
+  }
+  static bool Equals(const DynamicPower& m1, const DynamicPower& m2,
+                     double tol = 1e-8) {
+    if (m1.size() != m2.size()) return false;
+    for (size_t i = 0; i < m1.size(); ++i) {
       if (!m1[i].equals(m2[i], tol)) return false;
     }
     return true;
@@ -136,6 +159,28 @@ Power inversePowerProxy(const Power& A) { return A.inverse(); }
 Power powerExpmapProxy(const PowerTangent& vec) { return Power::Expmap(vec); }
 
 PowerTangent powerLogmapProxy(const Power& p) { return Power::Logmap(p); }
+
+DynamicPower composeDynamicPowerProxy(const DynamicPower& A,
+                                      const DynamicPower& B) {
+  return A.compose(B);
+}
+
+DynamicPower betweenDynamicPowerProxy(const DynamicPower& A,
+                                      const DynamicPower& B) {
+  return A.between(B);
+}
+
+DynamicPower inverseDynamicPowerProxy(const DynamicPower& A) {
+  return A.inverse();
+}
+
+DynamicPower dynamicPowerExpmapProxy(const DynamicPowerTangent& vec) {
+  return DynamicPower::Expmap(vec);
+}
+
+DynamicPowerTangent dynamicPowerLogmapProxy(const DynamicPower& p) {
+  return DynamicPower::Logmap(p);
+}
 }  // namespace
 
 /* ************************************************************************* */
@@ -570,6 +615,145 @@ TEST(testPower, AdjointMap) {
   expected.block<3, 3>(3, 3) = state[1].AdjointMap();
 
   EXPECT(assert_equal(expected, actual, kTol));
+}
+
+/* ************************************************************************* */
+TEST(Lie, PowerLieGroupDynamicCount) {
+  GTSAM_CONCEPT_ASSERT(IsGroup<DynamicPower>);
+  GTSAM_CONCEPT_ASSERT(IsManifold<DynamicPower>);
+  GTSAM_CONCEPT_ASSERT(IsLieGroup<DynamicPower>);
+
+  DynamicPower identity;
+  EXPECT_LONGS_EQUAL(Eigen::Dynamic, DynamicPower::dimension);
+  EXPECT_LONGS_EQUAL(0, identity.size());
+  EXPECT_LONGS_EQUAL(0, identity.dim());
+  EXPECT_LONGS_EQUAL(0, DynamicPower::Identity().size());
+  EXPECT(assert_equal(Vector::Zero(0), DynamicPower::Logmap(identity), kTol));
+  const Matrix emptyAdj = identity.AdjointMap();
+  EXPECT_LONGS_EQUAL(0, emptyAdj.rows());
+  EXPECT_LONGS_EQUAL(0, emptyAdj.cols());
+
+  DynamicPower sizedIdentity(2);
+  EXPECT_LONGS_EQUAL(2, sizedIdentity.size());
+  EXPECT(assert_equal(Pose2(), sizedIdentity[0], kTol));
+  EXPECT(assert_equal(Pose2(), sizedIdentity[1], kTol));
+
+  DynamicPowerTangent xi = makeVector({0.1, 0.2, 0.3, 0.4, 0.5, 0.6});
+  DynamicPower expected(
+      {Pose2::Expmap(xi.head<3>()), Pose2::Expmap(xi.tail<3>())});
+  DynamicPower actual = DynamicPower::Expmap(xi);
+  EXPECT(assert_equal(expected, actual, kTol));
+  EXPECT(assert_equal(xi, DynamicPower::Logmap(actual), kTol));
+  EXPECT_LONGS_EQUAL(6, actual.dim());
+}
+
+/* ************************************************************************* */
+TEST(testPowerDynamic, compose) {
+  DynamicPower state1({Pose2(1, 2, 3), Pose2(4, 5, 6)});
+  DynamicPower state2({Pose2(-0.5, 4, -1.0), Pose2(2.0, -3.0, 0.25)});
+
+  Matrix actH1, actH2;
+  state1.compose(state2, actH1, actH2);
+  Matrix numericH1 =
+      numericalDerivative21<DynamicPower, DynamicPower, DynamicPower, 6>(
+          composeDynamicPowerProxy, state1, state2);
+  Matrix numericH2 =
+      numericalDerivative22<DynamicPower, DynamicPower, DynamicPower, 6>(
+          composeDynamicPowerProxy, state1, state2);
+  EXPECT(assert_equal(numericH1, actH1, kTol));
+  EXPECT(assert_equal(numericH2, actH2, kTol));
+}
+
+/* ************************************************************************* */
+TEST(testPowerDynamic, between) {
+  DynamicPower state1({Pose2(1, 2, 3), Pose2(4, 5, 6)});
+  DynamicPower state2({Pose2(-0.5, 4, -1.0), Pose2(2.0, -3.0, 0.25)});
+
+  Matrix actH1, actH2;
+  state1.between(state2, actH1, actH2);
+  Matrix numericH1 =
+      numericalDerivative21<DynamicPower, DynamicPower, DynamicPower, 6>(
+          betweenDynamicPowerProxy, state1, state2);
+  Matrix numericH2 =
+      numericalDerivative22<DynamicPower, DynamicPower, DynamicPower, 6>(
+          betweenDynamicPowerProxy, state1, state2);
+  EXPECT(assert_equal(numericH1, actH1, kTol));
+  EXPECT(assert_equal(numericH2, actH2, kTol));
+}
+
+/* ************************************************************************* */
+TEST(testPowerDynamic, inverse) {
+  DynamicPower state({Pose2(1, 2, 3), Pose2(4, 5, 6)});
+
+  Matrix actH;
+  state.inverse(actH);
+  Matrix numericH =
+      numericalDerivative11<DynamicPower, DynamicPower, 6>(
+          inverseDynamicPowerProxy, state);
+  EXPECT(assert_equal(numericH, actH, kTol));
+}
+
+/* ************************************************************************* */
+TEST(testPowerDynamic, retractAndLocalCoordinates) {
+  DynamicPower state({Pose2(1, 2, 3), Pose2(4, 5, 6)});
+  DynamicPowerTangent delta = makeVector({0.1, 0.2, 0.3, -0.2, 0.1, -0.1});
+
+  DynamicPower updated = state.retract(delta);
+  DynamicPower expected(
+      {state[0].retract(delta.head<3>()), state[1].retract(delta.tail<3>())});
+  EXPECT(assert_equal(expected, updated, kTol));
+  EXPECT(assert_equal(delta, state.localCoordinates(updated), kTol));
+}
+
+/* ************************************************************************* */
+TEST(testPowerDynamic, Expmap) {
+  DynamicPowerTangent vec = makeVector({0.1, 0.2, 0.3, 0.4, 0.5, 0.6});
+  DynamicPower expected(
+      {Pose2::Expmap(vec.head<3>()), Pose2::Expmap(vec.tail<3>())});
+
+  Matrix actH;
+  DynamicPower actual = DynamicPower::Expmap(vec, actH);
+  Matrix numericH =
+      numericalDerivative11<DynamicPower, DynamicPowerTangent, 6>(
+          dynamicPowerExpmapProxy, vec);
+  EXPECT(assert_equal(expected, actual, kTol));
+  EXPECT(assert_equal(numericH, actH, kTol));
+}
+
+/* ************************************************************************* */
+TEST(testPowerDynamic, Logmap) {
+  DynamicPower state({Pose2(1, 2, 3), Pose2(4, 5, 6)});
+
+  Matrix actH;
+  DynamicPower::Logmap(state, actH);
+  Matrix numericH =
+      numericalDerivative11<DynamicPowerTangent, DynamicPower, 6>(
+          dynamicPowerLogmapProxy, state);
+  EXPECT(assert_equal(numericH, actH, kTol));
+}
+
+/* ************************************************************************* */
+TEST(testPowerDynamic, AdjointMap) {
+  DynamicPower state({Pose2(1, 2, 3), Pose2(4, 5, 6)});
+  const Matrix actual = state.AdjointMap();
+
+  Matrix expected = Matrix::Zero(6, 6);
+  expected.block<3, 3>(0, 0) = state[0].AdjointMap();
+  expected.block<3, 3>(3, 3) = state[1].AdjointMap();
+
+  EXPECT(assert_equal(expected, actual, kTol));
+}
+
+/* ************************************************************************* */
+TEST(testPowerDynamic, Exceptions) {
+  DynamicPower state1({Pose2(1, 2, 3), Pose2(4, 5, 6)});
+  DynamicPower state2({Pose2(1, 2, 3)});
+  CHECK_EXCEPTION(state1.compose(state2), std::invalid_argument);
+  CHECK_EXCEPTION(state1.between(state2), std::invalid_argument);
+  CHECK_EXCEPTION(state1.localCoordinates(state2), std::invalid_argument);
+
+  DynamicPowerTangent vec = makeVector({0.1, 0.2, 0.3, 0.4, 0.5});
+  CHECK_EXCEPTION(DynamicPower::Expmap(vec), std::invalid_argument);
 }
 
 //******************************************************************************

--- a/tests/testProductLieGroup.cpp
+++ b/tests/testProductLieGroup.cpp
@@ -23,6 +23,7 @@
 #include <gtsam/base/testLie.h>
 #include <gtsam/geometry/Point2.h>
 #include <gtsam/geometry/Pose2.h>
+#include <gtsam/geometry/Rot3.h>
 
 #include <iostream>
 
@@ -31,6 +32,8 @@ using namespace gtsam;
 constexpr double kTol = 1e-9;
 
 using Product = ProductLieGroup<Point2, Pose2>;
+using ProductVR = ProductLieGroup<Vector, Rot3>;
+using ProductVV = ProductLieGroup<Vector, Vector>;
 constexpr size_t kPowerComponents = 2;
 using Power = PowerLieGroup<Pose2, kPowerComponents>;
 using PowerTangent = Power::TangentVector;
@@ -69,6 +72,15 @@ struct traits<Power> : internal::LieGroupTraits<Power> {
 }  // namespace gtsam
 
 namespace {
+Vector makeVector(std::initializer_list<double> values) {
+  Vector vector(static_cast<Eigen::Index>(values.size()));
+  Eigen::Index index = 0;
+  for (double value : values) {
+    vector(index++) = value;
+  }
+  return vector;
+}
+
 Product composeProductProxy(const Product& A, const Product& B) {
   return A.compose(B);
 }
@@ -82,6 +94,36 @@ Product inverseProductProxy(const Product& A) { return A.inverse(); }
 Product expmapProductProxy(const Vector5& vec) { return Product::Expmap(vec); }
 
 Vector5 logmapProductProxy(const Product& p) { return Product::Logmap(p); }
+
+ProductVR composeProductVRProxy(const ProductVR& A, const ProductVR& B) {
+  return A.compose(B);
+}
+
+ProductVR betweenProductVRProxy(const ProductVR& A, const ProductVR& B) {
+  return A.between(B);
+}
+
+ProductVR inverseProductVRProxy(const ProductVR& A) { return A.inverse(); }
+
+ProductVR expmapProductVRProxy(const Vector& vec) { return ProductVR::Expmap(vec); }
+
+Vector logmapProductVRProxy(const ProductVR& p) { return ProductVR::Logmap(p); }
+
+ProductVV composeProductVVProxy(const ProductVV& A, const ProductVV& B) {
+  return A.compose(B);
+}
+
+ProductVV betweenProductVVProxy(const ProductVV& A, const ProductVV& B) {
+  return A.between(B);
+}
+
+ProductVV inverseProductVVProxy(const ProductVV& A) { return A.inverse(); }
+
+ProductVV expmapProductVVProxy(const Vector& vec) {
+  return ProductVV::Expmap(Vector(vec.head(2)), Vector(vec.tail(3)));
+}
+
+Vector logmapProductVVProxy(const ProductVV& p) { return ProductVV::Logmap(p); }
 
 Power composePowerProxy(const Power& A, const Power& B) { return A.compose(B); }
 
@@ -176,6 +218,228 @@ TEST(testProduct, AdjointMap) {
   expected.bottomRightCorner<3, 3>() = state.second.AdjointMap();
 
   EXPECT(assert_equal(expected, actual, kTol));
+}
+
+/* ************************************************************************* */
+TEST(Lie, ProductLieGroupDynamicVectorRot3) {
+  GTSAM_CONCEPT_ASSERT(IsGroup<ProductVR>);
+  GTSAM_CONCEPT_ASSERT(IsManifold<ProductVR>);
+  GTSAM_CONCEPT_ASSERT(IsLieGroup<ProductVR>);
+
+  ProductVR pair1(Vector::Zero(2), Rot3::Identity());
+  Vector d = makeVector({1.0, 2.0, 0.1, 0.2, 0.3});
+  ProductVR expected(makeVector({1.0, 2.0}), Rot3::Expmap(Vector3(0.1, 0.2, 0.3)));
+  ProductVR pair2 = pair1.expmap(d);
+
+  EXPECT_LONGS_EQUAL(Eigen::Dynamic, ProductVR::dimension);
+  EXPECT_LONGS_EQUAL(5, pair1.dim());
+  EXPECT(assert_equal(expected, pair2, kTol));
+  EXPECT(assert_equal(d, pair1.logmap(pair2), kTol));
+
+  const Matrix adj = pair1.AdjointMap();
+  EXPECT_LONGS_EQUAL(5, adj.rows());
+  EXPECT_LONGS_EQUAL(5, adj.cols());
+}
+
+/* ************************************************************************* */
+TEST(testProductDynamicVR, compose) {
+  ProductVR state1(makeVector({1.0, 2.0}), Rot3::RzRyRx(0.1, 0.2, 0.3));
+  ProductVR state2(makeVector({-0.5, 4.0}), Rot3::RzRyRx(-0.3, 0.1, -0.2));
+
+  Matrix actH1, actH2;
+  state1.compose(state2, actH1, actH2);
+  Matrix numericH1 =
+      numericalDerivative21<ProductVR, ProductVR, ProductVR, 5>(
+          composeProductVRProxy, state1, state2);
+  Matrix numericH2 =
+      numericalDerivative22<ProductVR, ProductVR, ProductVR, 5>(
+          composeProductVRProxy, state1, state2);
+  EXPECT(assert_equal(numericH1, actH1, kTol));
+  EXPECT(assert_equal(numericH2, actH2, kTol));
+}
+
+/* ************************************************************************* */
+TEST(testProductDynamicVR, between) {
+  ProductVR state1(makeVector({1.0, 2.0}), Rot3::RzRyRx(0.1, 0.2, 0.3));
+  ProductVR state2(makeVector({-0.5, 4.0}), Rot3::RzRyRx(-0.3, 0.1, -0.2));
+
+  Matrix actH1, actH2;
+  state1.between(state2, actH1, actH2);
+  Matrix numericH1 =
+      numericalDerivative21<ProductVR, ProductVR, ProductVR, 5>(
+          betweenProductVRProxy, state1, state2);
+  Matrix numericH2 =
+      numericalDerivative22<ProductVR, ProductVR, ProductVR, 5>(
+          betweenProductVRProxy, state1, state2);
+  EXPECT(assert_equal(numericH1, actH1, kTol));
+  EXPECT(assert_equal(numericH2, actH2, kTol));
+}
+
+/* ************************************************************************* */
+TEST(testProductDynamicVR, inverse) {
+  ProductVR state(makeVector({1.0, 2.0}), Rot3::RzRyRx(0.1, 0.2, 0.3));
+
+  Matrix actH;
+  state.inverse(actH);
+  Matrix numericH = numericalDerivative11<ProductVR, ProductVR, 5>(
+      inverseProductVRProxy, state);
+  EXPECT(assert_equal(numericH, actH, kTol));
+}
+
+/* ************************************************************************* */
+TEST(testProductDynamicVR, Expmap) {
+  Vector vec = makeVector({1.0, 2.0, 0.1, 0.2, 0.3});
+
+  Matrix actH;
+  ProductVR::Expmap(vec, actH);
+  Matrix numericH =
+      numericalDerivative11<ProductVR, Vector, 5>(expmapProductVRProxy, vec);
+  EXPECT(assert_equal(numericH, actH, kTol));
+}
+
+/* ************************************************************************* */
+TEST(testProductDynamicVR, Logmap) {
+  ProductVR state(makeVector({1.0, 2.0}), Rot3::RzRyRx(0.1, 0.2, 0.3));
+
+  Matrix actH;
+  ProductVR::Logmap(state, actH);
+  Matrix numericH =
+      numericalDerivative11<Vector, ProductVR, 5>(logmapProductVRProxy, state);
+  EXPECT(assert_equal(numericH, actH, kTol));
+}
+
+/* ************************************************************************* */
+TEST(testProductDynamicVR, AdjointMap) {
+  ProductVR state(makeVector({1.0, 2.0}), Rot3::RzRyRx(0.1, 0.2, 0.3));
+  const Matrix actual = state.AdjointMap();
+
+  Matrix expected = Matrix::Zero(5, 5);
+  expected.topLeftCorner(2, 2) = Matrix::Identity(2, 2);
+  expected.bottomRightCorner(3, 3) = state.second.AdjointMap();
+
+  EXPECT(assert_equal(expected, actual, kTol));
+}
+
+/* ************************************************************************* */
+TEST(Lie, ProductLieGroupDynamicVectorVector) {
+  GTSAM_CONCEPT_ASSERT(IsGroup<ProductVV>);
+  GTSAM_CONCEPT_ASSERT(IsManifold<ProductVV>);
+  GTSAM_CONCEPT_ASSERT(IsLieGroup<ProductVV>);
+
+  ProductVV pair1(makeVector({0.0, 0.0}), makeVector({0.0, 0.0, 0.0}));
+  Vector d = makeVector({1.0, 2.0, 3.0, 4.0, 5.0});
+  ProductVV expected(makeVector({1.0, 2.0}), makeVector({3.0, 4.0, 5.0}));
+  ProductVV pair2 = ProductVV::Expmap(Vector(d.head(2)), Vector(d.tail(3)));
+
+  EXPECT_LONGS_EQUAL(Eigen::Dynamic, ProductVV::dimension);
+  EXPECT_LONGS_EQUAL(5, pair1.dim());
+  EXPECT(assert_equal(expected, pair2, kTol));
+  EXPECT(assert_equal(d, pair1.logmap(pair2), kTol));
+}
+
+/* ************************************************************************* */
+TEST(testProductDynamicVV, compose) {
+  ProductVV state1(makeVector({1.0, 2.0}), makeVector({3.0, 4.0, 5.0}));
+  ProductVV state2(makeVector({-0.5, 4.0}), makeVector({-1.0, 2.0, 1.5}));
+
+  Matrix actH1, actH2;
+  state1.compose(state2, actH1, actH2);
+  Matrix numericH1 =
+      numericalDerivative21<ProductVV, ProductVV, ProductVV, 5>(
+          composeProductVVProxy, state1, state2);
+  Matrix numericH2 =
+      numericalDerivative22<ProductVV, ProductVV, ProductVV, 5>(
+          composeProductVVProxy, state1, state2);
+  EXPECT(assert_equal(numericH1, actH1, kTol));
+  EXPECT(assert_equal(numericH2, actH2, kTol));
+}
+
+/* ************************************************************************* */
+TEST(testProductDynamicVV, between) {
+  ProductVV state1(makeVector({1.0, 2.0}), makeVector({3.0, 4.0, 5.0}));
+  ProductVV state2(makeVector({-0.5, 4.0}), makeVector({-1.0, 2.0, 1.5}));
+
+  Matrix actH1, actH2;
+  state1.between(state2, actH1, actH2);
+  Matrix numericH1 =
+      numericalDerivative21<ProductVV, ProductVV, ProductVV, 5>(
+          betweenProductVVProxy, state1, state2);
+  Matrix numericH2 =
+      numericalDerivative22<ProductVV, ProductVV, ProductVV, 5>(
+          betweenProductVVProxy, state1, state2);
+  EXPECT(assert_equal(numericH1, actH1, kTol));
+  EXPECT(assert_equal(numericH2, actH2, kTol));
+}
+
+/* ************************************************************************* */
+TEST(testProductDynamicVV, inverse) {
+  ProductVV state(makeVector({1.0, 2.0}), makeVector({3.0, 4.0, 5.0}));
+
+  Matrix actH;
+  state.inverse(actH);
+  Matrix numericH = numericalDerivative11<ProductVV, ProductVV, 5>(
+      inverseProductVVProxy, state);
+  EXPECT(assert_equal(numericH, actH, kTol));
+}
+
+/* ************************************************************************* */
+TEST(testProductDynamicVV, retractAndLocalCoordinates) {
+  ProductVV state(makeVector({1.0, 2.0}), makeVector({3.0, 4.0, 5.0}));
+  Vector delta = makeVector({0.1, -0.2, 0.3, -0.4, 0.5});
+
+  ProductVV updated = state.retract(delta);
+  EXPECT(assert_equal(delta, state.localCoordinates(updated), kTol));
+  EXPECT(assert_equal(updated,
+                      state.compose(ProductVV::Expmap(Vector(delta.head(2)),
+                                                      Vector(delta.tail(3)))),
+                      kTol));
+}
+
+/* ************************************************************************* */
+TEST(testProductDynamicVV, Expmap) {
+  Vector vec = makeVector({1.0, 2.0, 3.0, 4.0, 5.0});
+  ProductVV expected(makeVector({1.0, 2.0}), makeVector({3.0, 4.0, 5.0}));
+
+  Matrix actH;
+  ProductVV actual =
+      ProductVV::Expmap(Vector(vec.head(2)), Vector(vec.tail(3)), actH);
+  Matrix numericH =
+      numericalDerivative11<ProductVV, Vector, 5>(expmapProductVVProxy, vec);
+  EXPECT(assert_equal(expected, actual, kTol));
+  EXPECT(assert_equal(vec, ProductVV::Logmap(actual), kTol));
+  EXPECT(assert_equal(numericH, actH, kTol));
+}
+
+/* ************************************************************************* */
+TEST(testProductDynamicVV, Logmap) {
+  ProductVV state(makeVector({1.0, 2.0}), makeVector({3.0, 4.0, 5.0}));
+
+  Matrix actH;
+  ProductVV::Logmap(state, actH);
+  Matrix numericH =
+      numericalDerivative11<Vector, ProductVV, 5>(logmapProductVVProxy, state);
+  EXPECT(assert_equal(numericH, actH, kTol));
+}
+
+/* ************************************************************************* */
+TEST(testProductDynamicVV, AdjointMap) {
+  ProductVV state(makeVector({1.0, 2.0}), makeVector({3.0, 4.0, 5.0}));
+  const Matrix actual = state.AdjointMap();
+  const Matrix expected = Matrix::Identity(5, 5);
+
+  EXPECT(assert_equal(expected, actual, kTol));
+}
+
+/* ************************************************************************* */
+TEST(testProductDynamicVV, Exceptions) {
+  ProductVV state1(makeVector({1.0, 2.0}), makeVector({3.0, 4.0, 5.0}));
+  ProductVV state2(makeVector({1.0, 2.0, 3.0}), makeVector({4.0, 5.0}));
+  Vector vec = makeVector({1.0, 2.0, 3.0, 4.0, 5.0});
+
+  CHECK_EXCEPTION(ProductVV::Expmap(vec), std::invalid_argument);
+  CHECK_EXCEPTION(state1.compose(state2), std::invalid_argument);
+  CHECK_EXCEPTION(state1.between(state2), std::invalid_argument);
+  CHECK_EXCEPTION(state1.localCoordinates(state2), std::invalid_argument);
 }
 
 /* ************************************************************************* */

--- a/tests/testProductLieGroup.cpp
+++ b/tests/testProductLieGroup.cpp
@@ -144,10 +144,6 @@ ProductVV betweenProductVVProxy(const ProductVV& A, const ProductVV& B) {
 
 ProductVV inverseProductVVProxy(const ProductVV& A) { return A.inverse(); }
 
-ProductVV expmapProductVVProxy(const Vector& vec) {
-  return ProductVV::Expmap(Vector(vec.head(2)), Vector(vec.tail(3)));
-}
-
 Vector logmapProductVVProxy(const ProductVV& p) { return ProductVV::Logmap(p); }
 
 Power composePowerProxy(const Power& A, const Power& B) { return A.compose(B); }
@@ -440,14 +436,17 @@ TEST(testProductDynamicVV, Expmap) {
   Vector vec = makeVector({1.0, 2.0, 3.0, 4.0, 5.0});
   ProductVV expected(makeVector({1.0, 2.0}), makeVector({3.0, 4.0, 5.0}));
 
-  Matrix actH;
+  Matrix actH1, actH2;
   ProductVV actual =
-      ProductVV::Expmap(Vector(vec.head(2)), Vector(vec.tail(3)), actH);
-  Matrix numericH =
-      numericalDerivative11<ProductVV, Vector, 5>(expmapProductVVProxy, vec);
+      ProductVV::Expmap(Vector(vec.head(2)), Vector(vec.tail(3)), actH1, actH2);
+  Matrix expectedH1 = Matrix::Zero(5, 2);
+  Matrix expectedH2 = Matrix::Zero(5, 3);
+  expectedH1.block(0, 0, 2, 2).setIdentity();
+  expectedH2.block(2, 0, 3, 3).setIdentity();
   EXPECT(assert_equal(expected, actual, kTol));
   EXPECT(assert_equal(vec, ProductVV::Logmap(actual), kTol));
-  EXPECT(assert_equal(numericH, actH, kTol));
+  EXPECT(assert_equal(expectedH1, actH1, kTol));
+  EXPECT(assert_equal(expectedH2, actH2, kTol));
 }
 
 /* ************************************************************************* */
@@ -687,9 +686,8 @@ TEST(testPowerDynamic, inverse) {
 
   Matrix actH;
   state.inverse(actH);
-  Matrix numericH =
-      numericalDerivative11<DynamicPower, DynamicPower, 6>(
-          inverseDynamicPowerProxy, state);
+  Matrix numericH = numericalDerivative11<DynamicPower, DynamicPower, 6>(
+      inverseDynamicPowerProxy, state);
   EXPECT(assert_equal(numericH, actH, kTol));
 }
 
@@ -713,9 +711,8 @@ TEST(testPowerDynamic, Expmap) {
 
   Matrix actH;
   DynamicPower actual = DynamicPower::Expmap(vec, actH);
-  Matrix numericH =
-      numericalDerivative11<DynamicPower, DynamicPowerTangent, 6>(
-          dynamicPowerExpmapProxy, vec);
+  Matrix numericH = numericalDerivative11<DynamicPower, DynamicPowerTangent, 6>(
+      dynamicPowerExpmapProxy, vec);
   EXPECT(assert_equal(expected, actual, kTol));
   EXPECT(assert_equal(numericH, actH, kTol));
 }
@@ -726,9 +723,8 @@ TEST(testPowerDynamic, Logmap) {
 
   Matrix actH;
   DynamicPower::Logmap(state, actH);
-  Matrix numericH =
-      numericalDerivative11<DynamicPowerTangent, DynamicPower, 6>(
-          dynamicPowerLogmapProxy, state);
+  Matrix numericH = numericalDerivative11<DynamicPowerTangent, DynamicPower, 6>(
+      dynamicPowerLogmapProxy, state);
   EXPECT(assert_equal(numericH, actH, kTol));
 }
 

--- a/tests/testProductLieGroup.cpp
+++ b/tests/testProductLieGroup.cpp
@@ -105,7 +105,9 @@ ProductVR betweenProductVRProxy(const ProductVR& A, const ProductVR& B) {
 
 ProductVR inverseProductVRProxy(const ProductVR& A) { return A.inverse(); }
 
-ProductVR expmapProductVRProxy(const Vector& vec) { return ProductVR::Expmap(vec); }
+ProductVR expmapProductVRProxy(const Vector& vec) {
+  return ProductVR::Expmap(vec);
+}
 
 Vector logmapProductVRProxy(const ProductVR& p) { return ProductVR::Logmap(p); }
 
@@ -228,7 +230,8 @@ TEST(Lie, ProductLieGroupDynamicVectorRot3) {
 
   ProductVR pair1(Vector::Zero(2), Rot3::Identity());
   Vector d = makeVector({1.0, 2.0, 0.1, 0.2, 0.3});
-  ProductVR expected(makeVector({1.0, 2.0}), Rot3::Expmap(Vector3(0.1, 0.2, 0.3)));
+  ProductVR expected(makeVector({1.0, 2.0}),
+                     Rot3::Expmap(Vector3(0.1, 0.2, 0.3)));
   ProductVR pair2 = pair1.expmap(d);
 
   EXPECT_LONGS_EQUAL(Eigen::Dynamic, ProductVR::dimension);
@@ -248,12 +251,10 @@ TEST(testProductDynamicVR, compose) {
 
   Matrix actH1, actH2;
   state1.compose(state2, actH1, actH2);
-  Matrix numericH1 =
-      numericalDerivative21<ProductVR, ProductVR, ProductVR, 5>(
-          composeProductVRProxy, state1, state2);
-  Matrix numericH2 =
-      numericalDerivative22<ProductVR, ProductVR, ProductVR, 5>(
-          composeProductVRProxy, state1, state2);
+  Matrix numericH1 = numericalDerivative21<ProductVR, ProductVR, ProductVR, 5>(
+      composeProductVRProxy, state1, state2);
+  Matrix numericH2 = numericalDerivative22<ProductVR, ProductVR, ProductVR, 5>(
+      composeProductVRProxy, state1, state2);
   EXPECT(assert_equal(numericH1, actH1, kTol));
   EXPECT(assert_equal(numericH2, actH2, kTol));
 }
@@ -265,12 +266,10 @@ TEST(testProductDynamicVR, between) {
 
   Matrix actH1, actH2;
   state1.between(state2, actH1, actH2);
-  Matrix numericH1 =
-      numericalDerivative21<ProductVR, ProductVR, ProductVR, 5>(
-          betweenProductVRProxy, state1, state2);
-  Matrix numericH2 =
-      numericalDerivative22<ProductVR, ProductVR, ProductVR, 5>(
-          betweenProductVRProxy, state1, state2);
+  Matrix numericH1 = numericalDerivative21<ProductVR, ProductVR, ProductVR, 5>(
+      betweenProductVRProxy, state1, state2);
+  Matrix numericH2 = numericalDerivative22<ProductVR, ProductVR, ProductVR, 5>(
+      betweenProductVRProxy, state1, state2);
   EXPECT(assert_equal(numericH1, actH1, kTol));
   EXPECT(assert_equal(numericH2, actH2, kTol));
 }
@@ -344,12 +343,10 @@ TEST(testProductDynamicVV, compose) {
 
   Matrix actH1, actH2;
   state1.compose(state2, actH1, actH2);
-  Matrix numericH1 =
-      numericalDerivative21<ProductVV, ProductVV, ProductVV, 5>(
-          composeProductVVProxy, state1, state2);
-  Matrix numericH2 =
-      numericalDerivative22<ProductVV, ProductVV, ProductVV, 5>(
-          composeProductVVProxy, state1, state2);
+  Matrix numericH1 = numericalDerivative21<ProductVV, ProductVV, ProductVV, 5>(
+      composeProductVVProxy, state1, state2);
+  Matrix numericH2 = numericalDerivative22<ProductVV, ProductVV, ProductVV, 5>(
+      composeProductVVProxy, state1, state2);
   EXPECT(assert_equal(numericH1, actH1, kTol));
   EXPECT(assert_equal(numericH2, actH2, kTol));
 }
@@ -361,12 +358,10 @@ TEST(testProductDynamicVV, between) {
 
   Matrix actH1, actH2;
   state1.between(state2, actH1, actH2);
-  Matrix numericH1 =
-      numericalDerivative21<ProductVV, ProductVV, ProductVV, 5>(
-          betweenProductVVProxy, state1, state2);
-  Matrix numericH2 =
-      numericalDerivative22<ProductVV, ProductVV, ProductVV, 5>(
-          betweenProductVVProxy, state1, state2);
+  Matrix numericH1 = numericalDerivative21<ProductVV, ProductVV, ProductVV, 5>(
+      betweenProductVVProxy, state1, state2);
+  Matrix numericH2 = numericalDerivative22<ProductVV, ProductVV, ProductVV, 5>(
+      betweenProductVVProxy, state1, state2);
   EXPECT(assert_equal(numericH1, actH1, kTol));
   EXPECT(assert_equal(numericH2, actH2, kTol));
 }


### PR DESCRIPTION
- adds support for variable-size (dynamic dimension) ProductLieGroup compositions 
- adds support for PowerLieGroup variable N (G is still fixed-size)
- propagates GetDimension()'s return type to size_t across the library and bindings.

All tests pass, c++ and python. New c++ tests that test variable size capabilities.
