### PR TITLE
Fix published notebook/doc links to website routes

### DIFF
--- a/gtsam/geometry/doc/Pose2.ipynb
+++ b/gtsam/geometry/doc/Pose2.ipynb
@@ -787,7 +787,7 @@
       },
       "source": [
         "## Example: SLAM\n",
-        "`Pose2` can be used as the basis to perform simultaneous localization and mapping (SLAM), as seen in the example [here](https://github.com/borglab/gtsam/blob/develop/python/gtsam/examples/Pose2SLAMExample.ipynb).\n"
+        "`Pose2` can be used as the basis to perform simultaneous localization and mapping (SLAM), as seen in the example [here](https://borglab.github.io/gtsam/pose2slamexample/).\n"
       ]
     }
   ],

--- a/gtsam/navigation/doc/EKF-variants.md
+++ b/gtsam/navigation/doc/EKF-variants.md
@@ -173,12 +173,12 @@ The `LeftLinearEKF` class implements a `predict` method that takes `W`, a functo
 
 ## NavStateImuEKF: NavState + IMU EKF
 
-The **[NavStateImuEKF](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/doc/NavStateImuEKF.ipynb)** is a left-invariant EKF specialized to GTSAM’s NavState $X=(R,p,v)$ that uses IMU measurements to form a NavState increment and composes it onto the current state.
+The **[NavStateImuEKF](https://borglab.github.io/gtsam/navstateimuekf/)** is a left-invariant EKF specialized to GTSAM’s NavState $X=(R,p,v)$ that uses IMU measurements to form a NavState increment and composes it onto the current state.
 
 - Predict: `ekf.predict(omega_b, f_b, dt)` uses continuous-time process noise Q scaled by `dt` and composes the IMU-driven increment. Increments for position and velocity are expressed in the body frame, consistent with GTSAM.
 - Update: Use the standard EKF update with a measurement model `h(X)` or the vector bridge `updateWithVector(prediction, H, z, R)`. For a world-position measurement, the Jacobian in the EKF local coordinates `[δθ, δp_body, δv_body]` is `H = [0, R, 0]`.
 
-More: **[Full tutorial (with plots)](https://github.com/borglab/gtsam/blob/develop/python/gtsam/examples/NavStateImuExample.ipynb)**, Source: [NavStateImuEKF.h](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/NavStateImuEKF.h), [NavStateImuEKF.cpp](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/NavStateImuEKF.cpp)
+More: **[Full tutorial (with plots)](https://borglab.github.io/gtsam/navstateimuexample/)**, Source: [NavStateImuEKF.h](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/NavStateImuEKF.h), [NavStateImuEKF.cpp](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/NavStateImuEKF.cpp)
 
 ## EquivariantFilter
 The **[EquivariantFilter](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/EquivariantFilter.h)** class implements the Equivariant Filter (EqF) for state estimation on Lie groups. It estimates a Lie group state $g \in G$ and a manifold state $\xi \in M$, using a symmetry principle where the error dynamics are autonomous in a specific frame. This class inherits from ```ManifoldEKF```.
@@ -211,7 +211,7 @@ Below are four examples of these filters in action.
 1) **[IEKF_SE2Example](https://github.com/borglab/gtsam/blob/develop/examples/IEKF_SE2Example.cpp)**: implements ```InvariantEKF``` on a SE(2) Lie Group with odometry as a Lie group increment and a 2D GPS measurement update.
 2) **[IEKF_NavstateExample](https://github.com/borglab/gtsam/blob/develop/examples/IEKF_NavstateExample.cpp)**: implements ```InvariantEKF``` on a NavState Lie Group with a tangent space increment based on IMU measurements, and a 3D GPS measuremnt update.
 3) **[GEKF_Rot3Example](https://github.com/borglab/gtsam/blob/develop/examples/GEKF_Rot3Example.cpp)**: implements ```LieGroupEKF``` on a Rot3 Lie Group using a state dependent dynamics function and a magnetometer update.
-4) **[NavStateImuExample](https://github.com/borglab/gtsam/blob/develop/examples/NavStateImuExample.cpp)** and the accompanying notebooks: [user guide](gtsam/navigation/doc/NavStateImuEKF.ipynb) and a [full tutorial](python/gtsam/examples/NavStateImuExample.ipynb) demonstrate the NavStateImuEKF.
+4) **[NavStateImuExample](https://github.com/borglab/gtsam/blob/develop/examples/NavStateImuExample.cpp)** and the accompanying notebooks: [user guide](https://borglab.github.io/gtsam/navstateimuekf/) and a [full tutorial](https://borglab.github.io/gtsam/navstateimuexample/) demonstrate the NavStateImuEKF.
 5) **[testEquivariantFilter](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/tests/testEquivariantFilter.cpp)**: implements ```EquivariantFilter``` on a SO(3) attitude-only system. A more complex **[ABC example](https://github.com/borglab/gtsam/blob/develop/examples/AbcEquivariantFilterExample.cpp)** is also available.
 
 
@@ -498,7 +498,6 @@ classDiagram
   LieGroupEKF~G~ <|-- LeftLinearEKF~G~
   LeftLinearEKF~G~ <|-- InvariantEKF~G~
 ```
-
 
 
 

--- a/gtsam/navigation/doc/Gal3ImuEKF.ipynb
+++ b/gtsam/navigation/doc/Gal3ImuEKF.ipynb
@@ -298,7 +298,7 @@
         "## Full examples and plotting\n",
         "\n",
         "For a step-by-step tutorial with scenarios, plots, and uncertainty bands, see:\n",
-        "- Gal3 IMU EKF Tutorial: https://github.com/borglab/gtsam/blob/develop/python/gtsam/examples/Gal3ImuExample.ipynb"
+        "- Gal3 IMU EKF Tutorial: https://borglab.github.io/gtsam/gal3imuexample/"
       ]
     },
     {

--- a/gtsam/navigation/doc/InvariantEKF.ipynb
+++ b/gtsam/navigation/doc/InvariantEKF.ipynb
@@ -105,11 +105,11 @@
         "## Where it is used today\n",
         "- C++ tests: [gtsam/navigation/tests/testInvariantEKF.cpp](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/tests/testInvariantEKF.cpp) exercises `predict(U, Q)` and the `dt` overload.\n",
         "- C++ examples: [examples/IEKF_NavstateExample.cpp](https://github.com/borglab/gtsam/blob/develop/examples/IEKF_NavstateExample.cpp) (NavState), [examples/GEKF_Rot3Example.cpp](https://github.com/borglab/gtsam/blob/develop/examples/GEKF_Rot3Example.cpp) (LieGroupEKF on SO(3)).\n",
-        "- Docs: [gtsam/navigation/doc/InvariantEKF.md](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/doc/InvariantEKF.md) (math/background).\n",
+        "- Docs: [EKF Variants](https://borglab.github.io/gtsam/ekf-variants/) (math/background).\n",
         "- Python notebooks with IMU-specialized EKFs built on the same interface:\n",
-        "  - [python/gtsam/examples/NavStateImuASVExample.ipynb](https://github.com/borglab/gtsam/blob/develop/python/gtsam/examples/NavStateImuASVExample.ipynb)\n",
-        "  - [python/gtsam/examples/Gal3ImuExample.ipynb](https://github.com/borglab/gtsam/blob/develop/python/gtsam/examples/Gal3ImuExample.ipynb)\n",
-        "  - [python/gtsam/examples/Gal3ImuASVExample.ipynb](https://github.com/borglab/gtsam/blob/develop/python/gtsam/examples/Gal3ImuASVExample.ipynb)\n",
+        "  - [python/gtsam/examples/NavStateImuASVExample.ipynb](https://borglab.github.io/gtsam/navstateimuasvexample/)\n",
+        "  - [python/gtsam/examples/Gal3ImuExample.ipynb](https://borglab.github.io/gtsam/gal3imuexample/)\n",
+        "  - [python/gtsam/examples/Gal3ImuASVExample.ipynb](https://borglab.github.io/gtsam/gal3imuasvexample/)\n",
         "\n",
         "If you add new examples that use `predict(W, U, Q)`, please link them here for discoverability."
       ]

--- a/gtsam/navigation/doc/NavStateImuEKF.ipynb
+++ b/gtsam/navigation/doc/NavStateImuEKF.ipynb
@@ -19,7 +19,7 @@
         "- Adding a world-position measurement with the correct Jacobian H = [0, R, 0].\n",
         "- Visualizing results with ±2σ uncertainty bands and basic tuning.\n",
         "\n",
-        "See also: [NavState IMU EKF Tutorial](https://github.com/borglab/gtsam/blob/develop/python/gtsam/examples/NavStateImuExample.ipynb) for a longer, step-by-step walkthrough."
+        "See also: [NavState IMU EKF Tutorial](https://borglab.github.io/gtsam/navstateimuexample/) for a longer, step-by-step walkthrough."
       ]
     },
     {
@@ -241,7 +241,7 @@
         "## Full examples and plotting\n",
         "\n",
         "For a step-by-step tutorial with scenarios, plots, and uncertainty bands, see:\n",
-        "- NavState IMU EKF Tutorial: https://github.com/borglab/gtsam/blob/develop/python/gtsam/examples/NavStateImuExample.ipynb"
+        "- NavState IMU EKF Tutorial: https://borglab.github.io/gtsam/navstateimuexample/"
       ]
     },
     {

--- a/python/gtsam/examples/DifferentialPseudorangeExample.ipynb
+++ b/python/gtsam/examples/DifferentialPseudorangeExample.ipynb
@@ -371,7 +371,7 @@
     "## Sources\n",
     "- [PseudorangeFactor.h](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/PseudorangeFactor.h)\n",
     "- [PseudorangeFactor.cpp](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/PseudorangeFactor.cpp)\n",
-    "- [PseudorangeFactor.ipynb](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/doc/PseudorangeFactor.ipynb)\n",
+    "- [PseudorangeFactor.ipynb](https://borglab.github.io/gtsam/pseudorangefactor/)\n",
     "- [SinglePointPositioningExample.ipynb](https://borglab.github.io/gtsam/singlepointpositioningexample/)"
    ]
   }

--- a/python/gtsam/examples/SinglePointPositioningExample.ipynb
+++ b/python/gtsam/examples/SinglePointPositioningExample.ipynb
@@ -242,7 +242,7 @@
     "## Sources\n",
     "- [PseudorangeFactor.h](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/PseudorangeFactor.h)\n",
     "- [PseudorangeFactor.cpp](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/PseudorangeFactor.cpp)\n",
-    "- [PseudorangeFactor.ipynb](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/doc/PseudorangeFactor.ipynb)"
+    "- [PseudorangeFactor.ipynb](https://borglab.github.io/gtsam/pseudorangefactor/)"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- replace published doc/notebook GitHub blob links with verified `https://borglab.github.io/gtsam/` routes where the live page exists
- fix the broken repo-root notebook links in `gtsam/navigation/doc/EKF-variants.md` to use published-site routes
- keep source code links (`.h`, `.cpp`, tests, examples) on GitHub

## Changed files
- `gtsam/geometry/doc/Pose2.ipynb`
- `gtsam/navigation/doc/EKF-variants.md`
- `gtsam/navigation/doc/Gal3ImuEKF.ipynb`
- `gtsam/navigation/doc/InvariantEKF.ipynb`
- `gtsam/navigation/doc/NavStateImuEKF.ipynb`
- `python/gtsam/examples/DifferentialPseudorangeExample.ipynb`
- `python/gtsam/examples/SinglePointPositioningExample.ipynb`

## Intentionally unchanged blob links
- `README.md` -> `matlab/README.md`: no published MyST site route exists
- `README.md` -> `python/README.md`: no published MyST site route exists
- all source file links (`.h`, `.cpp`, tests, examples): intentionally remain GitHub links

## Verification
- confirmed each replacement target returns HTTP 200 on the live site
- ran `myst build --html --check-links --strict`
- the project-wide MyST build still fails on many pre-existing warnings/errors and GitHub 429 rate limits unrelated to this change, but the touched pages built and the new site-route links resolved
