### PR TITLE
Move free functions definitions to `GncOptimizer.cpp`

### DIFF
--- a/gtsam/nonlinear/GncOptimizer.cpp
+++ b/gtsam/nonlinear/GncOptimizer.cpp
@@ -26,17 +26,24 @@ double Chi2inv(const double alpha, const size_t dofs) {
 }
 
 /* ************************************************************************* */
-bool isNullType(Type type) { return type == Type::NullPointer; }
+bool isNullType(GncFactorType type) {
+  return type == GncFactorType::NullPointer;
+}
 
 /* ************************************************************************* */
-bool isNonNoiseModelType(Type type) { return type == Type::NonNoiseModel; }
+bool isNonNoiseModelType(GncFactorType type) {
+  return type == GncFactorType::NonNoiseModel;
+}
 
 /* ************************************************************************* */
-bool needsWeightUpdate(Type type) { return type == Type::Normal; }
+bool needsWeightUpdate(GncFactorType type) {
+  return type == GncFactorType::Normal;
+}
 
 /* ************************************************************************* */
-bool hasNoise(Type type) {
-  return type == Type::Normal || type == Type::Inlier || type == Type::Outlier;
+bool hasNoise(GncFactorType type) {
+  return type == GncFactorType::Normal || type == GncFactorType::Inlier ||
+         type == GncFactorType::Outlier;
 }
 
 }  // namespace gtsam

--- a/gtsam/nonlinear/GncOptimizer.cpp
+++ b/gtsam/nonlinear/GncOptimizer.cpp
@@ -19,12 +19,16 @@
 
 namespace gtsam {
 
+/* ************************************************************************* */
 bool isNullType(Type type) { return type == Type::NullPointer; }
 
+/* ************************************************************************* */
 bool isNonNoiseModelType(Type type) { return type == Type::NonNoiseModel; }
 
+/* ************************************************************************* */
 bool needsWeightUpdate(Type type) { return type == Type::Normal; }
 
+/* ************************************************************************* */
 bool hasNoise(Type type) {
   return type == Type::Normal || type == Type::Inlier || type == Type::Outlier;
 }

--- a/gtsam/nonlinear/GncOptimizer.cpp
+++ b/gtsam/nonlinear/GncOptimizer.cpp
@@ -1,0 +1,32 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file    GncOptimizer.cpp
+ * @brief   Definitions of functions declared in header file
+ * @author  Varun Agrawal
+ */
+
+#include <gtsam/nonlinear/GncOptimizer.h>
+
+namespace gtsam {
+
+bool isNullType(Type type) { return type == Type::NullPointer; }
+
+bool isNonNoiseModelType(Type type) { return type == Type::NonNoiseModel; }
+
+bool needsWeightUpdate(Type type) { return type == Type::Normal; }
+
+bool hasNoise(Type type) {
+  return type == Type::Normal || type == Type::Inlier || type == Type::Outlier;
+}
+
+}  // namespace gtsam

--- a/gtsam/nonlinear/GncOptimizer.cpp
+++ b/gtsam/nonlinear/GncOptimizer.cpp
@@ -16,8 +16,14 @@
  */
 
 #include <gtsam/nonlinear/GncOptimizer.h>
+#include <gtsam/nonlinear/internal/ChiSquaredInverse.h>
 
 namespace gtsam {
+
+/* ************************************************************************* */
+double Chi2inv(const double alpha, const size_t dofs) {
+  return internal::chiSquaredQuantile(dofs, alpha);
+}
 
 /* ************************************************************************* */
 bool isNullType(Type type) { return type == Type::NullPointer; }

--- a/gtsam/nonlinear/GncOptimizer.h
+++ b/gtsam/nonlinear/GncOptimizer.h
@@ -54,13 +54,13 @@ enum class Type {
   NullPointer      ///< Factor pointer is null.
 };
 
-bool isNullType(Type type);
+GTSAM_EXPORT bool isNullType(Type type);
 
-bool isNonNoiseModelType(Type type);
+GTSAM_EXPORT bool isNonNoiseModelType(Type type);
 
-bool needsWeightUpdate(Type type);
+GTSAM_EXPORT bool needsWeightUpdate(Type type);
 
-bool hasNoise(Type type);
+GTSAM_EXPORT bool hasNoise(Type type);
 
 /* ************************************************************************* */
 template<class GncParameters>

--- a/gtsam/nonlinear/GncOptimizer.h
+++ b/gtsam/nonlinear/GncOptimizer.h
@@ -40,24 +40,24 @@ namespace gtsam {
 GTSAM_EXPORT double Chi2inv(const double alpha, const size_t dofs);
 
 /**
- * @enum Type
+ * @enum GncFactorType
  * @brief Enum to classify factor types in GNC optimization.
  */
-enum class Type {
+enum class GncFactorType {
   Normal,         ///< Normal case.
   Inlier,         ///< Factor is a known inlier.
   Outlier,        ///< Factor is a known outlier.
   NonNoiseModel,  ///< Factor does not have a noise model
-  NullPointer      ///< Factor pointer is null.
+  NullPointer     ///< Factor pointer is null.
 };
 
-GTSAM_EXPORT bool isNullType(Type type);
+GTSAM_EXPORT bool isNullType(GncFactorType type);
 
-GTSAM_EXPORT bool isNonNoiseModelType(Type type);
+GTSAM_EXPORT bool isNonNoiseModelType(GncFactorType type);
 
-GTSAM_EXPORT bool needsWeightUpdate(Type type);
+GTSAM_EXPORT bool needsWeightUpdate(GncFactorType type);
 
-GTSAM_EXPORT bool hasNoise(Type type);
+GTSAM_EXPORT bool hasNoise(GncFactorType type);
 
 /* ************************************************************************* */
 template<class GncParameters>
@@ -84,7 +84,7 @@ class GncOptimizer {
   Vector barcSq_;
 
   /// Cached factor types for GNC.
-  std::vector<Type> factorTypes_;
+  std::vector<GncFactorType> factorTypes_;
 
  public:
   /// Constructor.
@@ -95,10 +95,10 @@ class GncOptimizer {
 
     // make sure all noiseModels are Gaussian or convert to Gaussian
     nfg_.resize(graph.size());
-    factorTypes_.assign(graph.size(), Type::NullPointer);
+    factorTypes_.assign(graph.size(), GncFactorType::NullPointer);
     for (size_t i = 0; i < graph.size(); i++) {
       if (!graph[i]) {
-        factorTypes_[i] = Type::NullPointer;
+        factorTypes_[i] = GncFactorType::NullPointer;
         continue;
       }
       NoiseModelFactor::shared_ptr factor = graph.at<NoiseModelFactor>(i);
@@ -108,14 +108,14 @@ class GncOptimizer {
             " true if the factor graph contains factors without noise model.");
         }
         nfg_[i] = graph[i];
-        factorTypes_[i] = Type::NonNoiseModel;
+        factorTypes_[i] = GncFactorType::NonNoiseModel;
         continue;
       }
       auto robust =
             std::dynamic_pointer_cast<noiseModel::Robust>(factor->noiseModel());
       // if the factor has a robust loss, we remove the robust loss
       nfg_[i] = robust ? factor-> cloneWithNewNoiseModel(robust->noise()) : factor;
-      factorTypes_[i] = Type::Normal;
+      factorTypes_[i] = GncFactorType::Normal;
     }
 
     // check that known inliers are in the graph
@@ -125,7 +125,7 @@ class GncOptimizer {
                   "that are not in the factor graph to be known inliers.");
       }
       if (!isNonNoiseModelType(factorTypes_[params.knownInliers[i]])) {
-        factorTypes_[params.knownInliers[i]] = Type::Inlier;
+        factorTypes_[params.knownInliers[i]] = GncFactorType::Inlier;
       }
     }
     // check that known outliers are in the graph
@@ -139,7 +139,7 @@ class GncOptimizer {
         throw std::runtime_error("GncOptimizer::constructor: the user has selected one or more measurements"
                   " to be an outlier that is either an inlier or a non noise model factor.");
       }
-      factorTypes_[params.knownOutliers[i]] = Type::Outlier;
+      factorTypes_[params.knownOutliers[i]] = GncFactorType::Outlier;
     }
 
     // initialize weights (if we don't have prior knowledge of inliers/outliers
@@ -241,7 +241,7 @@ class GncOptimizer {
     // For GM: if residual error is small, mu -> 0
     // For TLS: if residual error is small, mu -> -1
     int nrUnknownInOrOut = 0;
-    for (Type t : factorTypes_) {
+    for (GncFactorType t : factorTypes_) {
       if (needsWeightUpdate(t)) {
         nrUnknownInOrOut++;
       }

--- a/gtsam/nonlinear/GncOptimizer.h
+++ b/gtsam/nonlinear/GncOptimizer.h
@@ -38,7 +38,7 @@ namespace gtsam {
  * Quantile of chi-squared distribution with given degrees of freedom at probability alpha.
  * Equivalent to chi2inv in Matlab.
  */
-static double Chi2inv(const double alpha, const size_t dofs) {
+inline double Chi2inv(const double alpha, const size_t dofs) {
   return internal::chiSquaredQuantile(dofs, alpha);
 }
 

--- a/gtsam/nonlinear/GncOptimizer.h
+++ b/gtsam/nonlinear/GncOptimizer.h
@@ -31,16 +31,13 @@
 #include <gtsam/linear/LossFunctions.h>
 #include <gtsam/nonlinear/GncParams.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
-#include <gtsam/nonlinear/internal/ChiSquaredInverse.h>
 
 namespace gtsam {
 /*
  * Quantile of chi-squared distribution with given degrees of freedom at probability alpha.
  * Equivalent to chi2inv in Matlab.
  */
-inline double Chi2inv(const double alpha, const size_t dofs) {
-  return internal::chiSquaredQuantile(dofs, alpha);
-}
+GTSAM_EXPORT double Chi2inv(const double alpha, const size_t dofs);
 
 /**
  * @enum Type

--- a/gtsam/nonlinear/GncOptimizer.h
+++ b/gtsam/nonlinear/GncOptimizer.h
@@ -54,21 +54,13 @@ enum class Type {
   NullPointer      ///< Factor pointer is null.
 };
 
-bool isNullType(Type type) {
-  return type == Type::NullPointer;
-}
+bool isNullType(Type type);
 
-bool isNonNoiseModelType(Type type) {
-  return type == Type::NonNoiseModel;
-}
+bool isNonNoiseModelType(Type type);
 
-bool needsWeightUpdate(Type type) {
-  return type == Type::Normal;
-}
+bool needsWeightUpdate(Type type);
 
-bool hasNoise(Type type) {
-  return type == Type::Normal || type == Type::Inlier || type == Type::Outlier;
-}
+bool hasNoise(Type type);
 
 /* ************************************************************************* */
 template<class GncParameters>

--- a/tests/testGncOptimizer.cpp
+++ b/tests/testGncOptimizer.cpp
@@ -47,18 +47,18 @@ using symbol_shorthand::X;
 static double tol = 1e-7;
 
 /* ************************************************************************* */
-TEST(GncOptimizer, Type) {
-  Type null = Type::NullPointer;
+TEST(GncOptimizer, GncFactorType) {
+  GncFactorType null = GncFactorType::NullPointer;
   CHECK(isNullType(null));
 
-  Type nonNoiseModel = Type::NonNoiseModel;
+  GncFactorType nonNoiseModel = GncFactorType::NonNoiseModel;
   CHECK(isNonNoiseModelType(nonNoiseModel));
 
-  Type normal = Type::Normal;
+  GncFactorType normal = GncFactorType::Normal;
   CHECK(needsWeightUpdate(normal));
 
-  Type inlier = Type::Inlier;
-  Type outlier = Type::Outlier;
+  GncFactorType inlier = GncFactorType::Inlier;
+  GncFactorType outlier = GncFactorType::Outlier;
   CHECK(hasNoise(normal));
   CHECK(hasNoise(inlier));
   CHECK(hasNoise(outlier));

--- a/tests/testGncOptimizer.cpp
+++ b/tests/testGncOptimizer.cpp
@@ -52,7 +52,7 @@ TEST(GncOptimizer, Type) {
   CHECK(isNullType(null));
 
   Type nonNoiseModel = Type::NonNoiseModel;
-  CHECK(isNonNoiseModelType(normal));
+  CHECK(isNonNoiseModelType(nonNoiseModel));
 
   Type normal = Type::Normal;
   CHECK(needsWeightUpdate(normal));

--- a/tests/testGncOptimizer.cpp
+++ b/tests/testGncOptimizer.cpp
@@ -47,6 +47,24 @@ using symbol_shorthand::X;
 static double tol = 1e-7;
 
 /* ************************************************************************* */
+TEST(GncOptimizer, Type) {
+  Type null = Type::NullPointer;
+  CHECK(isNullType(null));
+
+  Type nonNoiseModel = Type::NonNoiseModel;
+  CHECK(isNonNoiseModelType(normal));
+
+  Type normal = Type::Normal;
+  CHECK(needsWeightUpdate(normal));
+
+  Type inlier = Type::Inlier;
+  Type outlier = Type::Outlier;
+  CHECK(hasNoise(normal));
+  CHECK(hasNoise(inlier));
+  CHECK(hasNoise(outlier));
+}
+
+/* ************************************************************************* */
 TEST(GncOptimizer, gncParamsConstructor) {
   // check params are correctly parsed
   LevenbergMarquardtParams lmParams;


### PR DESCRIPTION
Added a new file called `GncOptimizer.cpp` so that I could move the free function definitions to it. These were originally added and defined erroneously in #2410.

This resolves the duplicate symbol error reported in #2460.