### PR TITLE
Fix incorrect key in cheirality error message for PPP/PPPC factors

### DIFF
--- a/gtsam_unstable/slam/ProjectionFactorPPP.h
+++ b/gtsam_unstable/slam/ProjectionFactorPPP.h
@@ -144,7 +144,7 @@ namespace gtsam {
         if (H3) *H3 = Matrix::Zero(2,3);
         if (verboseCheirality_)
             std::cout << e.what() << ": Landmark "
-                      << DefaultKeyFormatter(this->key2())
+                      << DefaultKeyFormatter(this->key3())
                       << " moved behind camera "
                       << DefaultKeyFormatter(this->key1())
                       << std::endl;

--- a/gtsam_unstable/slam/ProjectionFactorPPPC.h
+++ b/gtsam_unstable/slam/ProjectionFactorPPPC.h
@@ -131,7 +131,7 @@ class ProjectionFactorPPPC
         if (H3) *H3 = Matrix::Zero(2,3);
         if (H4) *H4 = Matrix::Zero(2,CALIBRATION::dimension);
         if (verboseCheirality_)
-          std::cout << e.what() << ": Landmark "<< DefaultKeyFormatter(this->key2()) <<
+          std::cout << e.what() << ": Landmark "<< DefaultKeyFormatter(this->key3()) <<
               " moved behind camera " << DefaultKeyFormatter(this->key1()) << std::endl;
         if (throwCheirality_)
           throw e;


### PR DESCRIPTION
## Summary

`ProjectionFactorPPP` and `ProjectionFactorPPPC` print the wrong key in the verbose cheirality exception message. Both factors use `key2()` (the body-camera transform key) instead of `key3()` (the landmark key) when reporting which landmark moved behind the camera.

The key ordering is:
- `key1()` = body pose
- `key2()` = body-camera transform
- `key3()` = landmark
- `key4()` = calibration (PPPC only)

Fixes #849