### PR TITLE
Reject negative sigma values in noise model constructors

### DIFF
--- a/gtsam/linear/NoiseModel.cpp
+++ b/gtsam/linear/NoiseModel.cpp
@@ -277,6 +277,10 @@ Diagonal::Diagonal(const Vector& sigmas)
       sigmas_(sigmas),
       invsigmas_(sigmas.array().inverse()),
       precisions_(invsigmas_.array().square()) {
+  if ((sigmas.array() < 0).any()) {
+    throw invalid_argument(
+        "Diagonal noise model: sigma values must be non-negative");
+  }
 }
 
 /* ************************************************************************* */
@@ -696,12 +700,16 @@ SharedDiagonal Constrained::QR(Matrix& Ab) const {
 // Isotropic
 /* ************************************************************************* */
 Isotropic::shared_ptr Isotropic::Sigma(size_t dim, double sigma, bool smart)  {
+  if (sigma < 0)
+    throw invalid_argument("Isotropic::Sigma: sigma value must be non-negative");
   if (smart && std::abs(sigma-1.0)<1e-9) return Unit::Create(dim);
   return shared_ptr(new Isotropic(dim, sigma));
 }
 
 /* ************************************************************************* */
 Isotropic::shared_ptr Isotropic::Variance(size_t dim, double variance, bool smart)  {
+  if (variance < 0)
+    throw invalid_argument("Isotropic::Variance: variance must be non-negative");
   if (smart && std::abs(variance-1.0)<1e-9) return Unit::Create(dim);
   return shared_ptr(new Isotropic(dim, sqrt(variance)));
 }

--- a/gtsam/linear/tests/testNoiseModel.cpp
+++ b/gtsam/linear/tests/testNoiseModel.cpp
@@ -1075,5 +1075,13 @@ TEST(NoiseModel, NegLogNormalizationConstant3D) {
 }
 
 /* ************************************************************************* */
+// Negative sigma values should throw (#695)
+TEST(NoiseModel, NegativeSigmaThrows) {
+  CHECK_EXCEPTION(noiseModel::Isotropic::Sigma(2, -2.0), std::invalid_argument);
+  CHECK_EXCEPTION(noiseModel::Isotropic::Variance(2, -1.0), std::invalid_argument);
+  CHECK_EXCEPTION(noiseModel::Diagonal::Sigmas(Vector3(-1.0, 2.0, 3.0)), std::invalid_argument);
+}
+
+/* ************************************************************************* */
 int main() {  TestResult tr; return TestRegistry::runAllTests(tr); }
 /* ************************************************************************* */


### PR DESCRIPTION
## Summary

Creating a noise model with negative sigma values (e.g., `noiseModel::Isotropic::Sigma(2, -2.0)`) was silently accepted, producing a nonsensical noise model that behaves as a "repulsion" factor.

Added validation checks that throw `std::invalid_argument` for negative values in:
- `Diagonal` constructor (catches all diagonal-based models)
- `Isotropic::Sigma`
- `Isotropic::Variance`

Added unit test `NegativeSigmaThrows` to verify.

Fixes #695