### PR TITLE
Validate rotation matrix in Rot3 constructor to prevent segfault

### DIFF
--- a/gtsam/geometry/Rot3.cpp
+++ b/gtsam/geometry/Rot3.cpp
@@ -34,7 +34,7 @@ namespace gtsam {
 /* ************************************************************************* */
 void Rot3::IsValid(const Matrix3& R) {
   // Check R'R ≈ I (orthonormality)
-  if ((R.transpose() * R - Matrix3::Identity()).norm() > 1e-5) {
+  if ((R.transpose() * R - Matrix3::Identity()).norm() > 1e-3) {
     throw std::invalid_argument(
         "Rot3 constructor: matrix is not orthonormal. "
         "Use Rot3::ClosestTo() to find the closest valid rotation.");

--- a/gtsam/geometry/Rot3.cpp
+++ b/gtsam/geometry/Rot3.cpp
@@ -25,10 +25,26 @@
 #include <cmath>
 #include <cassert>
 #include <random>
+#include <stdexcept>
 
 using namespace std;
 
 namespace gtsam {
+
+/* ************************************************************************* */
+void Rot3::IsValid(const Matrix3& R) {
+  // Check R'R ≈ I (orthonormality)
+  if ((R.transpose() * R - Matrix3::Identity()).norm() > 1e-5) {
+    throw std::invalid_argument(
+        "Rot3 constructor: matrix is not orthonormal. "
+        "Use Rot3::ClosestTo() to find the closest valid rotation.");
+  }
+  // Check det(R) ≈ +1 (proper rotation, not reflection)
+  if (R.determinant() < 0) {
+    throw std::invalid_argument(
+        "Rot3 constructor: matrix has negative determinant (reflection, not rotation).");
+  }
+}
 
 /* ************************************************************************* */
 void Rot3::print(const std::string& s) const {

--- a/gtsam/geometry/Rot3.h
+++ b/gtsam/geometry/Rot3.h
@@ -97,10 +97,13 @@ class GTSAM_EXPORT Rot3 : public MatrixLieGroup<Rot3, 3, 3> {
     template <typename Derived>
 #ifdef GTSAM_USE_QUATERNIONS
     explicit Rot3(const Eigen::MatrixBase<Derived>& R) {
-      quaternion_ = Matrix3(R);
+      const Matrix3 M(R);
+      IsValid(M);
+      quaternion_ = M;
     }
 #else
-    explicit Rot3(const Eigen::MatrixBase<Derived>& R) : rot_(R) {
+    explicit Rot3(const Eigen::MatrixBase<Derived>& R) : rot_(Matrix3(R)) {
+      IsValid(Matrix3(R));
     }
 #endif
 
@@ -109,9 +112,9 @@ class GTSAM_EXPORT Rot3 : public MatrixLieGroup<Rot3, 3, 3> {
      * Overload version for Matrix3 to avoid casting in quaternion mode.
      */
 #ifdef GTSAM_USE_QUATERNIONS
-    explicit Rot3(const Matrix3& R) : quaternion_(R) {}
+    explicit Rot3(const Matrix3& R) : quaternion_(R) { IsValid(R); }
 #else
-    explicit Rot3(const Matrix3& R) : rot_(R) {}
+    explicit Rot3(const Matrix3& R) : rot_(R) { IsValid(R); }
 #endif
 
     /**
@@ -547,6 +550,9 @@ class GTSAM_EXPORT Rot3 : public MatrixLieGroup<Rot3, 3, 3> {
     /// @}
 
    private:
+    /// Throw if R is not a valid rotation matrix (orthonormal with det +1).
+    static void IsValid(const Matrix3& R);
+
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
     /** Serialization function */
     friend class boost::serialization::access;

--- a/gtsam/geometry/tests/testRot3.cpp
+++ b/gtsam/geometry/tests/testRot3.cpp
@@ -1025,6 +1025,16 @@ TEST(Rot3, expmapChainRule) {
 }
 
 /* ************************************************************************* */
+// Invalid rotation matrix should throw, not segfault (#2300)
+TEST(Rot3, InvalidMatrixThrows) {
+  Matrix3 M;
+  M << 0.57, 0.44, 0.87,
+       0.94, 0.06, 0.60,
+       0.92, 0.44, 0.20;
+  CHECK_EXCEPTION(Rot3{M}, std::invalid_argument);
+}
+
+/* ************************************************************************* */
 int main() {
   TestResult tr;
   return TestRegistry::runAllTests(tr);


### PR DESCRIPTION
## Summary

Constructing a `Rot3` from a non-orthonormal 3x3 matrix causes a hard segfault that kills the Python interpreter with no traceback. This is especially painful in Jupyter notebooks.

Added validation in the `Matrix3` and template matrix constructors that checks orthonormality (`R'R ≈ I`) and determinant sign (`det > 0`), throwing `std::invalid_argument` with a helpful message suggesting `Rot3::ClosestTo()` as an alternative.

```python
# Before: segfault, kernel dies
gtsam.Rot3(invalid_matrix)

# After: clean exception
# RuntimeError: Rot3 constructor: matrix is not orthonormal.
# Use Rot3::ClosestTo() to find the closest valid rotation.
```

Fixes #2300