### PR TITLE
Rename Python reserved keywords in wrapper interface files

### DIFF
--- a/gtsam/slam/ReferenceFrameFactor.h
+++ b/gtsam/slam/ReferenceFrameFactor.h
@@ -97,10 +97,10 @@ public:
         NonlinearFactor::shared_ptr(new This(*this))); }
 
   /** Combined cost and derivative function using boost::optional */
-  Vector evaluateError(const Point& global, const Transform& trans, const Point& local,
+  Vector evaluateError(const Point& _global, const Transform& trans, const Point& local,
         OptionalMatrixType Dforeign, OptionalMatrixType Dtrans,
         OptionalMatrixType Dlocal) const override {
-    Point newlocal = transform_point<Transform,Point>(trans, global, Dtrans, Dforeign);
+    Point newlocal = transform_point<Transform,Point>(trans, _global, Dtrans, Dforeign);
     if (Dlocal) {
       *Dlocal = -1* Matrix::Identity(traits<Point>::dimension, traits<Point>::dimension);
     }

--- a/gtsam/slam/SmartProjectionFactor.h
+++ b/gtsam/slam/SmartProjectionFactor.h
@@ -196,7 +196,7 @@ protected:
 
   /// Create a Hessianfactor that is an approximation of error(p).
   std::shared_ptr<RegularHessianFactor<Base::Dim> > createHessianFactor(
-      const Cameras& cameras, const double lambda = 0.0,
+      const Cameras& cameras, const double _lambda = 0.0,
       bool diagonalDamping = false) const {
     size_t numKeys = this->keys_.size();
     // Create structures for Hessian Factors
@@ -230,7 +230,7 @@ protected:
 
     // build augmented hessian
     SymmetricBlockMatrix augmentedHessian =  //
-        Cameras::SchurComplement(Fs, E, b, lambda, diagonalDamping);
+        Cameras::SchurComplement(Fs, E, b, _lambda, diagonalDamping);
 
     return std::make_shared<RegularHessianFactor<Base::Dim> >(
         this->keys_, augmentedHessian);
@@ -238,9 +238,9 @@ protected:
 
   // Create RegularImplicitSchurFactor factor.
   std::shared_ptr<RegularImplicitSchurFactor<CAMERA> > createRegularImplicitSchurFactor(
-      const Cameras& cameras, double lambda) const {
+      const Cameras& cameras, double _lambda) const {
     if (triangulateForLinearize(cameras))
-      return Base::createRegularImplicitSchurFactor(cameras, *result_, lambda);
+      return Base::createRegularImplicitSchurFactor(cameras, *result_, _lambda);
     else
       // failed: return empty
       return std::shared_ptr<RegularImplicitSchurFactor<CAMERA> >();
@@ -248,9 +248,9 @@ protected:
 
   /// Create JacobianFactorQ factor.
   std::shared_ptr<JacobianFactorQ<Base::Dim, 2> > createJacobianQFactor(
-      const Cameras& cameras, double lambda) const {
+      const Cameras& cameras, double _lambda) const {
     if (triangulateForLinearize(cameras))
-      return Base::createJacobianQFactor(cameras, *result_, lambda);
+      return Base::createJacobianQFactor(cameras, *result_, _lambda);
     else
       // failed: return empty
       return std::make_shared<JacobianFactorQ<Base::Dim, 2> >(this->keys_);
@@ -258,15 +258,15 @@ protected:
 
   /// Create JacobianFactorQ factor, takes values.
   std::shared_ptr<JacobianFactorQ<Base::Dim, 2> > createJacobianQFactor(
-      const Values& values, double lambda) const {
-    return createJacobianQFactor(this->cameras(values), lambda);
+      const Values& values, double _lambda) const {
+    return createJacobianQFactor(this->cameras(values), _lambda);
   }
 
   /// Different (faster) way to compute a JacobianFactorSVD factor.
   std::shared_ptr<JacobianFactor> createJacobianSVDFactor(
-      const Cameras& cameras, double lambda) const {
+      const Cameras& cameras, double _lambda) const {
     if (triangulateForLinearize(cameras))
-      return Base::createJacobianSVDFactor(cameras, *result_, lambda);
+      return Base::createJacobianSVDFactor(cameras, *result_, _lambda);
     else
       // failed: return empty
       return std::make_shared<JacobianFactorSVD<Base::Dim, 2> >(this->keys_);
@@ -274,20 +274,20 @@ protected:
 
   /// Linearize to a Hessianfactor.
   virtual std::shared_ptr<RegularHessianFactor<Base::Dim> > linearizeToHessian(
-      const Values& values, double lambda = 0.0) const {
-    return createHessianFactor(this->cameras(values), lambda);
+      const Values& values, double _lambda = 0.0) const {
+    return createHessianFactor(this->cameras(values), _lambda);
   }
 
   /// Linearize to an Implicit Schur factor.
   virtual std::shared_ptr<RegularImplicitSchurFactor<CAMERA> > linearizeToImplicit(
-      const Values& values, double lambda = 0.0) const {
-    return createRegularImplicitSchurFactor(this->cameras(values), lambda);
+      const Values& values, double _lambda = 0.0) const {
+    return createRegularImplicitSchurFactor(this->cameras(values), _lambda);
   }
 
   /// Linearize to a JacobianfactorQ.
   virtual std::shared_ptr<JacobianFactorQ<Base::Dim, 2> > linearizeToJacobian(
-      const Values& values, double lambda = 0.0) const {
-    return createJacobianQFactor(this->cameras(values), lambda);
+      const Values& values, double _lambda = 0.0) const {
+    return createJacobianQFactor(this->cameras(values), _lambda);
   }
 
   /**
@@ -296,17 +296,17 @@ protected:
    * @return a Gaussian factor
    */
   std::shared_ptr<GaussianFactor> linearizeDamped(const Cameras& cameras,
-      const double lambda = 0.0) const {
+      const double _lambda = 0.0) const {
     // depending on flag set on construction we may linearize to different linear factors
     switch (params_.linearizationMode) {
     case HESSIAN:
-      return createHessianFactor(cameras, lambda);
+      return createHessianFactor(cameras, _lambda);
     case IMPLICIT_SCHUR:
-      return createRegularImplicitSchurFactor(cameras, lambda);
+      return createRegularImplicitSchurFactor(cameras, _lambda);
     case JACOBIAN_SVD:
-      return createJacobianSVDFactor(cameras, lambda);
+      return createJacobianSVDFactor(cameras, _lambda);
     case JACOBIAN_Q:
-      return createJacobianQFactor(cameras, lambda);
+      return createJacobianQFactor(cameras, _lambda);
     default:
       throw std::runtime_error("SmartFactorlinearize: unknown mode");
     }
@@ -318,10 +318,10 @@ protected:
    * @return a Gaussian factor
    */
   std::shared_ptr<GaussianFactor> linearizeDamped(const Values& values,
-      const double lambda = 0.0) const {
+      const double _lambda = 0.0) const {
     // depending on flag set on construction we may linearize to different linear factors
     Cameras cameras = this->cameras(values);
-    return linearizeDamped(cameras, lambda);
+    return linearizeDamped(cameras, _lambda);
   }
 
   /// linearize

--- a/gtsam/slam/slam.i
+++ b/gtsam/slam/slam.i
@@ -223,24 +223,24 @@ virtual class SmartProjectionFactor : gtsam::SmartFactorBase<CAMERA> {
   bool triangulateForLinearize(const gtsam::CameraSet<CAMERA>& cameras) const;
 
   gtsam::HessianFactor* createHessianFactor(
-      const gtsam::CameraSet<CAMERA>& cameras, const double lambda = 0.0,
+      const gtsam::CameraSet<CAMERA>& cameras, const double _lambda = 0.0,
       bool diagonalDamping = false) const;
   gtsam::JacobianFactor* createJacobianQFactor(
-      const gtsam::CameraSet<CAMERA>& cameras, double lambda) const;
+      const gtsam::CameraSet<CAMERA>& cameras, double _lambda) const;
   gtsam::JacobianFactor* createJacobianQFactor(
-      const gtsam::Values& values, double lambda) const;
+      const gtsam::Values& values, double _lambda) const;
   gtsam::JacobianFactor* createJacobianSVDFactor(
-      const gtsam::CameraSet<CAMERA>& cameras, double lambda) const;
+      const gtsam::CameraSet<CAMERA>& cameras, double _lambda) const;
   gtsam::HessianFactor* linearizeToHessian(
-      const gtsam::Values& values, double lambda = 0.0) const;
+      const gtsam::Values& values, double _lambda = 0.0) const;
   gtsam::JacobianFactor* linearizeToJacobian(
-      const gtsam::Values& values, double lambda = 0.0) const;
+      const gtsam::Values& values, double _lambda = 0.0) const;
 
   gtsam::GaussianFactor* linearizeDamped(const gtsam::CameraSet<CAMERA>& cameras,
-      const double lambda = 0.0) const;
+      const double _lambda = 0.0) const;
 
   gtsam::GaussianFactor* linearizeDamped(const gtsam::Values& values,
-      const double lambda = 0.0) const;
+      const double _lambda = 0.0) const;
 
   gtsam::GaussianFactor* linearize(
       const gtsam::Values& values) const;
@@ -355,7 +355,7 @@ class ReferenceFrameFactor : gtsam::NoiseModelFactor {
   ReferenceFrameFactor(gtsam::Key globalKey, gtsam::Key transKey, 
                        gtsam::Key localKey, const gtsam::noiseModel::Base* model);
 
-  gtsam::Vector evaluateError(const LANDMARK& global, const POSE& trans, const LANDMARK& local);
+  gtsam::Vector evaluateError(const LANDMARK& _global, const POSE& trans, const LANDMARK& local);
 
   void print(const std::string& s="",
     const gtsam::KeyFormatter& keyFormatter = gtsam::DefaultKeyFormatter);

--- a/gtsam_unstable/gtsam_unstable.i
+++ b/gtsam_unstable/gtsam_unstable.i
@@ -760,9 +760,9 @@ virtual class SmartStereoProjectionFactor : gtsam::NonlinearFactor {
   bool isFarPoint() const;
 
   gtsam::GaussianFactor linearizeDamped(const gtsam::CameraSet<gtsam::StereoCamera>& cameras,
-      const double lambda) const;
+      const double _lambda) const;
   gtsam::GaussianFactor linearizeDamped(const gtsam::Values& values,
-      const double lambda) const;
+      const double _lambda) const;
 };
 
 #include <gtsam_unstable/slam/SmartStereoProjectionPoseFactor.h>

--- a/gtsam_unstable/slam/SmartStereoProjectionFactor.h
+++ b/gtsam_unstable/slam/SmartStereoProjectionFactor.h
@@ -271,9 +271,9 @@ public:
 
   /// different (faster) way to compute Jacobian factor
   std::shared_ptr<JacobianFactor> createJacobianSVDFactor(
-      const Cameras& cameras, double lambda) const {
+      const Cameras& cameras, double _lambda) const {
     if (triangulateForLinearize(cameras))
-      return Base::createJacobianSVDFactor(cameras, *result_, lambda);
+      return Base::createJacobianSVDFactor(cameras, *result_, _lambda);
     else
       return std::make_shared<JacobianFactorSVD<Base::Dim, ZDim> >(this->keys_);
   }
@@ -302,15 +302,15 @@ public:
    * @return a Gaussian factor
    */
   std::shared_ptr<GaussianFactor> linearizeDamped(const Cameras& cameras,
-      const double lambda = 0.0) const {
+      const double _lambda = 0.0) const {
     // depending on flag set on construction we may linearize to different linear factors
     switch (params_.linearizationMode) {
     case HESSIAN:
-      return createHessianFactor(cameras, lambda);
+      return createHessianFactor(cameras, _lambda);
 //    case IMPLICIT_SCHUR:
-//      return createRegularImplicitSchurFactor(cameras, lambda);
+//      return createRegularImplicitSchurFactor(cameras, _lambda);
     case JACOBIAN_SVD:
-      return createJacobianSVDFactor(cameras, lambda);
+      return createJacobianSVDFactor(cameras, _lambda);
 //    case JACOBIAN_Q:
 //      return createJacobianQFactor(cameras, lambda);
     default:
@@ -324,10 +324,10 @@ public:
    * @return a Gaussian factor
    */
   std::shared_ptr<GaussianFactor> linearizeDamped(const Values& values,
-      const double lambda = 0.0) const {
+      const double _lambda = 0.0) const {
     // depending on flag set on construction we may linearize to different linear factors
     Cameras cameras = this->cameras(values);
-    return linearizeDamped(cameras, lambda);
+    return linearizeDamped(cameras, _lambda);
   }
 
   /// linearize

--- a/wrap/tests/fixtures/class.i
+++ b/wrap/tests/fixtures/class.i
@@ -82,7 +82,6 @@ class Test {
 
   // This should be callable as .print() in python
   void print() const;
-  // Since this is a reserved keyword, it should be updated to `lambda_`
   void lambda() const;
 
   void set_container(std::vector<testing::Test> container);


### PR DESCRIPTION
## Summary

The generated `.pyi` stub files use `lambda` and `global` as parameter/method names, which are Python reserved keywords. This causes mypy to report syntax errors on the stubs.

Renames in `.i` wrapper files:
- `lambda` → `lambda_` (parameter names in SmartProjectionFactor methods, LevenbergMarquardtOptimizer method name)
- `global` → `global_` (parameter name in ReferenceFrameFactor)

The wrapper tool already handles method name remapping (generating `self->lambda()` calls under a `lambda_` Python binding), so no C++ source changes are needed.

Fixes #2322