### PR TITLE
Fix IncrementalFixedLagSmoother with factor removal

### DIFF
--- a/gtsam/nonlinear/ISAM2.cpp
+++ b/gtsam/nonlinear/ISAM2.cpp
@@ -199,8 +199,23 @@ void ISAM2::recalculateBatch(const ISAM2UpdateParams& updateParams,
   gttic(ordering);
   Ordering order;
   if (updateParams.constrainedKeys) {
-    order = Ordering::ColamdConstrained(affectedFactorsVarIndex,
-                                        *updateParams.constrainedKeys);
+    // Need to check for unusedKeys and filter them out from constrainedKeys
+    FastMap<Key, int> constraintGroups;
+    if (result->unusedKeys.empty()) {
+      // All keys being used, no need to filter
+      constraintGroups = *updateParams.constrainedKeys;
+    } else {
+      // Remove unused keys from the constraints
+      for (auto it = updateParams.constrainedKeys->begin(),
+                last = updateParams.constrainedKeys->end();
+           it != last; it++) {
+        if (result->unusedKeys.find(it->first) == result->unusedKeys.end()) {
+          constraintGroups.insert(*it);
+        }
+      }
+    }
+    order =
+        Ordering::ColamdConstrained(affectedFactorsVarIndex, constraintGroups);
   } else {
     if (theta_.size() > result->observedKeys.size()) {
       // Only if some variables are unconstrained

--- a/gtsam/nonlinear/IncrementalFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/IncrementalFixedLagSmoother.cpp
@@ -103,6 +103,16 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
       factorsToRemove, constrainedKeys, {}, additionalMarkedKeys);
 
   if (debug) {
+    std::cout << "Unused Keys After Update: ";
+    if (not isamResult_.unusedKeys.empty()) {
+      for (auto key : isamResult_.unusedKeys) {
+        std::cout << DefaultKeyFormatter(key) << "  ";
+      }
+    }
+    std::cout << std::endl;
+  }
+
+  if (debug) {
     PrintSymbolicTree(isam_,
         "Bayes Tree After Update, Before Marginalization:");
     std::cout << "END" << std::endl;

--- a/gtsam/nonlinear/IncrementalFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/IncrementalFixedLagSmoother.cpp
@@ -112,6 +112,13 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
     std::cout << std::endl;
   }
 
+  if (not isamResult_.unusedKeys.empty()) {
+    // Remove keys that became unused after update from the key-timestamp
+    // database
+    eraseKeyTimestampMap(KeyVector{isamResult_.unusedKeys.begin(),
+                                   isamResult_.unusedKeys.end()});
+  }
+
   if (debug) {
     PrintSymbolicTree(isam_,
         "Bayes Tree After Update, Before Marginalization:");

--- a/gtsam/nonlinear/IncrementalFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/IncrementalFixedLagSmoother.cpp
@@ -117,6 +117,18 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
     // database
     eraseKeyTimestampMap(KeyVector{isamResult_.unusedKeys.begin(),
                                    isamResult_.unusedKeys.end()});
+
+    if (marginalizableKeys.size() > 0) {
+      // Remove keys that became unused after update from the marginalizable
+      // keys to avoid marginalizing keys that have been removed from ISAM2.
+      marginalizableKeys.erase(
+          std::remove_if(marginalizableKeys.begin(), marginalizableKeys.end(),
+                         [&](const auto& key) {
+                           return isamResult_.unusedKeys.find(key) !=
+                                  isamResult_.unusedKeys.end();
+                         }),
+          marginalizableKeys.end());
+    }
   }
 
   if (debug) {

--- a/gtsam/nonlinear/tests/testIncrementalFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/tests/testIncrementalFixedLagSmoother.cpp
@@ -355,6 +355,153 @@ TEST(IncrementalFixedLagSmoother, Example) {
   }
 }
 
+/* ************************************************************************* */
+TEST( IncrementalFixedLagSmoother, ExampleWithFactorRemoval )
+{
+  // Test the IncrementalFixedLagSmoother in a pure linear environment. Thus, full optimization and
+  // the IncrementalFixedLagSmoother should be identical (even with the linearized approximations at
+  // the end of the smoothing lag)
+
+  SETDEBUG("IncrementalFixedLagSmoother update", true);
+
+  // Set up parameters
+  SharedDiagonal noise = noiseModel::Diagonal::Sigmas(Vector2(0.1, 0.1));
+
+  // Create a Fixed-Lag Smoother
+  typedef IncrementalFixedLagSmoother::KeyTimestampMap Timestamps;
+  IncrementalFixedLagSmoother smoother(5.0, ISAM2Params());
+
+  // Create containers to keep the full graph
+  Values fullinit;
+  NonlinearFactorGraph fullgraph;
+
+  // i keeps track of the time step
+  size_t i = 0;
+
+  // Add a prior at time 0 and update the HMF
+  {
+    Key key0 = X(0);
+
+    NonlinearFactorGraph newFactors;
+    Values newValues;
+    Timestamps newTimestamps;
+
+    newFactors.addPrior(key0, Point2(0.0, 0.0), noise);
+    newValues.insert(key0, Point2(0.01, 0.01));
+    newTimestamps[key0] = 0.0;
+
+    fullgraph.push_back(newFactors);
+    fullinit.insert(newValues);
+
+    // Update the smoother
+    smoother.update(newFactors, newValues, newTimestamps);
+
+    // Check
+    CHECK(check_smoother(fullgraph, fullinit, smoother, key0));
+
+    ++i;
+  }
+
+  FactorIndices factorsToRemove;
+  size_t ref_i = 0;
+  Key prev_key = 0;
+
+  // The lambda below helps to set up a usage pattern of the smoother where we
+  // add new values and update at a certain frequency, but do not keep all added
+  // values in the smoother in the long term. This is achieved by storing the
+  // indices of the new factors being added, and using them to remove the
+  // factors later. The removal of factors may cause keys to become unused and
+  // be removed from the smoother.
+  const auto add_x_check_keep_every_y = [&](size_t num_new_values,
+                                      size_t keep_every) {
+    for (size_t j = 0; j < num_new_values; ++j) {
+      Key key1 = X(ref_i);
+      Key key2 = X(i);
+
+      NonlinearFactorGraph newFactors;
+      Values newValues;
+      Timestamps newTimestamps;
+
+      newFactors.push_back(
+          BetweenFactor<Point2>(key1, key2, Point2(i - ref_i, 0.0), noise));
+      newFactors.addPrior(key2, Point2(double(i), 0.0), noise);
+      newValues.insert(key2, Point2(double(i) + 0.1, -0.1));
+      newTimestamps[key2] = double(i);
+
+      auto fullNewFactorIndices = fullgraph.add_factors(newFactors);
+      fullinit.insert(newValues);
+
+      // Update the smoother
+      smoother.update(newFactors, newValues, newTimestamps, factorsToRemove);
+
+      // Check that removed factors are not there.
+      //
+      // NOTE: this test only work when factor slots are not being reused.
+      const NonlinearFactorGraph& actual = smoother.getFactors();
+      for (auto factor_i : factorsToRemove) {
+        EXPECT(not actual[factor_i]);
+      }
+
+      if (not factorsToRemove.empty()) {
+        // Check that the previously added value is not in the smoother
+        // anymore.
+        EXPECT(not smoother.getLinearizationPoint().exists(prev_key));
+      }
+
+      // Store indexes of new factors so we're able to remove them later, if
+      // needed.
+      factorsToRemove = smoother.getISAM2Result().newFactorsIndices;
+
+      // Check
+      CHECK(check_smoother(fullgraph, fullinit, smoother, key2));
+
+      // Decide if we want to keep the new value in the smoother
+      if ((j + 1) % keep_every == 0) {
+        // We want to keep it. Clear factorsToRemove so newValue stays
+        // connected to the graph.
+        factorsToRemove.clear();
+        // Store new reference
+        ref_i = i;
+      } else {
+        // We do not want to keep it. Remove value and factors from the
+        // full* structures, preparing them for the next pass.
+        for (const auto index : fullNewFactorIndices) {
+          fullgraph.remove(index);
+        }
+        fullinit.erase(key2);
+      }
+
+      prev_key = key2;
+      ++i;
+    }
+  };
+
+  // NOTE: The call below adds 9 values, keeping every 3rd value. This setup
+  // exposed 2 bugs:
+  //
+  //   1. A bug in the IncrementalFixedLagSmoother that happened whenever a
+  //      marginalization occurred while keys became unused due to factor
+  //      removal.
+  //
+  //   2. A bug in ISAM2 (but caused by IncrementalFixedLagSmoother) that
+  //      happened whenever the following conditions held:
+  //
+  //      1. Keys were being marginalized during the update;
+  //
+  //      2. Factors were being removed during the same update, and removing
+  //         them made some keys to become unused;
+  //
+  //      3. More than 65% of keys were being affected by the update (see
+  //         kBatchThreshold in ISAM2.cpp), making ISAM2 prefer to call
+  //         ISAM2::recalculateBatch instead of ISAM2::recalculateIncremental.
+  //
+  //      The first bug appeared in this setup when i == 7. The second appeared
+  //      when i == 9, but only after the first bug was fixed.
+  //
+  // Both bugs were fixed in PR #2474.
+  add_x_check_keep_every_y(9, 3);
+}
+
 int main() {
   TestResult tr;
   return TestRegistry::runAllTests(tr);

--- a/gtsam/nonlinear/tests/testIncrementalFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/tests/testIncrementalFixedLagSmoother.cpp
@@ -500,6 +500,19 @@ TEST( IncrementalFixedLagSmoother, ExampleWithFactorRemoval )
   //
   // Both bugs were fixed in PR #2474.
   add_x_check_keep_every_y(9, 3);
+
+  // In the lines below:
+  //
+  //   - First we add a new value, and leave it ready to be removed in the
+  //     following update;
+  //
+  //   - Then we advance the time enough so that this value becomes both unused
+  //     and marginalizable.
+  //
+  // This setup exposed another bug, also fixed on PR #2474.
+  add_x_check_keep_every_y(1, 3);
+  i = 16;
+  add_x_check_keep_every_y(1, 1);
 }
 
 int main() {


### PR DESCRIPTION
Hi,

I was working with the `IncrementalFixedLagSmoother` in a setup where the smoother is updated frequently with new values, but only a subset of these values are kept in the long term. The values are removed by removing all the factors connecting them to the rest of the graph, using the argument `factorsToRemove` of the smoother's `update(...)` method.

While at it I found two bugs related to factor removals and unused values. In this PR I added a test that reproduces my setup and exposes the bugs, and two other commits fixing each one of them.

I hope it is good enough for a merge, otherwise let me know what can be improved.

Cheers,

EDIT: force-pushed changes to simplify the test file.