### PR TITLE
[gtsam-4.2] Fix missing <bitset> include for hybrid test

### DIFF
--- a/gtsam/hybrid/tests/testHybridEstimation.cpp
+++ b/gtsam/hybrid/tests/testHybridEstimation.cpp
@@ -35,6 +35,8 @@
 // Include for test suite
 #include <CppUnitLite/TestHarness.h>
 
+#include <bitset>
+
 #include "Switching.h"
 
 using namespace std;


### PR DESCRIPTION
This PR adds a missing include to the test file `gtsam/hybrid/tests/testHybridEstimation.cpp`. Test builds were falling on my PC with 18.1.3 due to the absence of this include.