### PR TITLE
MATLAB CustomFactor

### DIFF
--- a/matlab/+gtsam/CustomFactor.m
+++ b/matlab/+gtsam/CustomFactor.m
@@ -1,0 +1,79 @@
+classdef CustomFactor < gtsam.MatlabCustomFactor
+  properties(Access = private)
+    % Registry key for the MATLAB callback associated with this factor.
+    callbackId = uint64(0)
+  end
+
+  methods
+    function obj = CustomFactor(varargin)
+      % Public constructor:
+      %   CustomFactor(noiseModel, keys, errorFunc)
+      %
+      % Internal pointer constructor:
+      %   CustomFactor(uint64_magic, ptr[, 'void'])
+      %
+      % The public path registers the MATLAB function handle first, then
+      % passes only a numeric callback ID into the native wrapper. After the
+      % superclass constructor returns, this MATLAB object binds itself into
+      % the registry so future evaluations call:
+      %   errorFunc(this, values)
+      % or
+      %   [error, H] = errorFunc(this, values)
+      constructedArgs = {};
+      callbackId = uint64(0);
+
+      if (nargin == 2 || (nargin == 3 && strcmp(varargin{3}, 'void'))) && ...
+          isa(varargin{1}, 'uint64') && ...
+          varargin{1} == uint64(5139824614673773682)
+        constructedArgs = varargin;
+      else
+        if nargin ~= 3
+          error(['Arguments do not match any overload of gtsam.CustomFactor ', ...
+                 'constructor']);
+        end
+
+        noiseModel = varargin{1};
+        keys = gtsam.CustomFactor.normalizeKeys(varargin{2});
+        callbackId = gtsam.customFactorRegistry('register', varargin{3});
+        constructedArgs = {noiseModel, keys, callbackId};
+      end
+
+      obj = obj@gtsam.MatlabCustomFactor(constructedArgs{:});
+      obj.callbackId = callbackId;
+      if callbackId ~= 0
+        gtsam.customFactorRegistry('bind', callbackId, obj);
+      end
+    end
+
+    function delete(obj)
+      for i = 1:numel(obj)
+        if obj(i).callbackId ~= 0
+          % Remove the MATLAB-side registry entry before the native handle is
+          % torn down so repeated test runs do not leave stale callbacks behind.
+          gtsam.customFactorRegistry('remove', obj(i).callbackId);
+          obj(i).callbackId = uint64(0);
+        end
+        delete@gtsam.MatlabCustomFactor(obj(i));
+      end
+    end
+  end
+
+  methods(Static, Access = private)
+    function keyVector = normalizeKeys(keys)
+      % Accept the common MATLAB shorthand of numeric keys while preserving the
+      % wrapped KeyVector path for callers that already use toolbox utilities.
+      if isa(keys, 'gtsam.KeyVector')
+        keyVector = keys;
+        return
+      end
+
+      if isnumeric(keys)
+        keyVector = gtsam.utilities.createKeyVector(double(keys(:)));
+        return
+      end
+
+      error(['CustomFactor keys must be either a numeric array or a ', ...
+             'gtsam.KeyVector']);
+    end
+  end
+end

--- a/matlab/+gtsam/CustomFactor.m
+++ b/matlab/+gtsam/CustomFactor.m
@@ -68,7 +68,12 @@ classdef CustomFactor < gtsam.MatlabCustomFactor
       end
 
       if isnumeric(keys)
-        keyVector = gtsam.utilities.createKeyVector(double(keys(:)));
+        % Explicitly use KeyVector and push_back to avoid losing precision
+        % with double-precision Vector utilities, which mangles Symbol keys.
+        keyVector = gtsam.KeyVector();
+        for i = 1:numel(keys)
+          keyVector.push_back(uint64(keys(i)));
+        end
         return
       end
 

--- a/matlab/+gtsam/customFactorRegistry.m
+++ b/matlab/+gtsam/customFactorRegistry.m
@@ -1,0 +1,85 @@
+function varargout = customFactorRegistry(operation, varargin)
+% customFactorRegistry MATLAB-side storage for CustomFactor callbacks.
+%
+% C++ stores only a numeric callback ID. This registry owns:
+%   1. the original MATLAB function handle
+%   2. the MATLAB gtsam.CustomFactor object to pass back as `this`
+%
+% The split matters because the native factor can be copied and kept alive by
+% optimizer-owned C++ objects, while MATLAB objects follow different lifetime
+% rules. Keeping the authoritative callback state in one persistent registry
+% avoids storing raw MATLAB handles in C++.
+persistent callbacks nextId
+
+if isempty(callbacks)
+    callbacks = containers.Map('KeyType', 'char', 'ValueType', 'any');
+    nextId = uint64(1);
+end
+
+switch operation
+    case 'register'
+        callback = varargin{1};
+        if ~isa(callback, 'function_handle')
+            error('CustomFactor callback must be a function handle');
+        end
+        % Allocate a stable ID before the native factor is constructed. The
+        % MATLAB object itself is bound later, after the superclass constructor
+        % returns and the final wrapper object exists.
+        callbackId = nextId;
+        nextId = nextId + uint64(1);
+        callbacks(callbackKey(callbackId)) = struct('callback', callback, ...
+                                                    'factor', []);
+        varargout{1} = callbackId;
+
+    case 'bind'
+        callbackId = varargin{1};
+        entry = lookupEntry(callbacks, callbackId);
+        % Store the user-visible MATLAB factor handle so invoke() can preserve
+        % the callback signature errorFunc(this, values[, ...]).
+        entry.factor = varargin{2};
+        callbacks(callbackKey(callbackId)) = entry;
+
+    case 'invoke'
+        callbackId = varargin{1};
+        entry = lookupEntry(callbacks, callbackId);
+        if isempty(entry.factor)
+            error('CustomFactor callback %s is not bound to a factor', ...
+                  callbackKey(callbackId));
+        end
+        % Forward all remaining arguments so C++ can request either:
+        %   err = callback(this, values)
+        % or:
+        %   [err, H] = callback(this, values)
+        if nargout > 1
+            [varargout{1:nargout}] = entry.callback(entry.factor, varargin{2:end});
+        else
+            varargout{1} = entry.callback(entry.factor, varargin{2:end});
+        end
+
+    case 'remove'
+        callbackId = varargin{1};
+        key = callbackKey(callbackId);
+        if isKey(callbacks, key)
+            remove(callbacks, key);
+        end
+
+    case 'count'
+        varargout{1} = uint64(callbacks.Count);
+
+    otherwise
+        error('Unknown CustomFactor registry operation: %s', operation);
+end
+
+end
+
+function entry = lookupEntry(callbacks, callbackId)
+key = callbackKey(callbackId);
+if ~isKey(callbacks, key)
+    error('CustomFactor callback %s is not registered', key);
+end
+entry = callbacks(key);
+end
+
+function key = callbackKey(callbackId)
+key = char(string(uint64(callbackId)));
+end

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -85,10 +85,22 @@ set(interface_files
     ${GTSAM_SOURCE_DIR}/gtsam/slam/slam.i
     ${GTSAM_SOURCE_DIR}/gtsam/sfm/sfm.i
     ${GTSAM_SOURCE_DIR}/gtsam/navigation/navigation.i
+    # matlab/custom.i lives outside the main gtsam/ tree, see comment below.
+    ${GTSAM_SOURCE_DIR}/matlab/custom.i
 )
-# Wrap
+# The fourth matlab_wrap() argument contains extra include directories for the
+# generated mex target. We point it at matlab/ because matlab/custom.i includes
+# MatlabCustomFactor.h from there.
 matlab_wrap("${interface_files}" "gtsam" "${GTSAM_ADDITIONAL_LIBRARIES}"
-            "" "${mexFlags}" "${ignore}" "${GTSAM_ENABLE_BOOST_SERIALIZATION}")
+            "${GTSAM_SOURCE_DIR}/matlab" "${mexFlags}" "${ignore}" "${GTSAM_ENABLE_BOOST_SERIALIZATION}")
+# Keep the runtime loader fix in GTSAM instead of the wrap subtree. The mex
+# module links against shared libgtsam and needs an rpath back to the install
+# lib directory so MATLAB can load it on macOS/Linux.
+set_target_properties(
+  gtsam_matlab_wrapper
+  PROPERTIES BUILD_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
+             INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
+             INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 # Wrap version for gtsam_unstable
 if(GTSAM_UNSTABLE_INSTALL_MATLAB_TOOLBOX)
@@ -101,6 +113,11 @@ if(GTSAM_UNSTABLE_INSTALL_MATLAB_TOOLBOX)
   # Wrap
   matlab_wrap(${GTSAM_SOURCE_DIR}/gtsam_unstable/gtsam_unstable.i "gtsam_unstable"
               "${GTSAM_ADDITIONAL_LIBRARIES}" "" "${mexFlags}" "${ignore}" "${GTSAM_ENABLE_BOOST_SERIALIZATION}")
+  set_target_properties(
+    gtsam_unstable_matlab_wrapper
+    PROPERTIES BUILD_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
+               INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
+               INSTALL_RPATH_USE_LINK_PATH TRUE)
 endif(GTSAM_UNSTABLE_INSTALL_MATLAB_TOOLBOX)
 
 # Record the root dir for gtsam - needed during external builds, e.g., ROS

--- a/matlab/MatlabCustomFactor.h
+++ b/matlab/MatlabCustomFactor.h
@@ -1,0 +1,156 @@
+#pragma once
+
+#include <gtsam/nonlinear/CustomFactor.h>
+
+#ifdef GTSAM_USE_TBB
+#include <tbb/global_control.h>
+#endif
+
+namespace gtsam {
+
+/**
+ * MATLAB-only adapter for gtsam::CustomFactor.
+ *
+ * The core GTSAM CustomFactor stores a C++ callback. For MATLAB we cannot
+ * store a raw mxArray* or function handle directly inside the factor because
+ * the factor can outlive temporary MATLAB objects and can be copied by the
+ * optimizer. Instead, the MATLAB layer registers the callback in a MATLAB-side
+ * registry, passes only a numeric callback ID into C++, and this class calls
+ * back into MATLAB through that registry when error() or linearize() requests
+ * factor evaluation.
+ */
+class MatlabCustomFactor : public CustomFactor {
+ private:
+  /// Stable registry key owned by the MATLAB toolbox.
+  size_t callback_id_;
+
+#ifdef GTSAM_USE_TBB
+  // MATLAB callback execution is not a good place to discover hidden
+  // parallelism bugs. Serializing CustomFactor callback execution keeps the
+  // MATLAB path predictable while debugging wrapper issues.
+  std::shared_ptr<tbb::global_control> tbb_serial_guard_;
+#endif
+
+  static std::string registryFunctionName() {
+    return "gtsam.customFactorRegistry";
+  }
+
+  static void destroyCallbackArgs(mxArray** args, size_t count) {
+    for (size_t i = 0; i < count; ++i) {
+      if (args[i]) {
+        mxDestroyArray(args[i]);
+      }
+    }
+  }
+
+  Vector invokeCallback(const Values& values, JacobianVector* jacobians) const {
+    // Call back into MATLAB through a single registry entry point:
+    //   gtsam.customFactorRegistry('invoke', callbackId, values)
+    // The registry owns the original MATLAB function handle and the MATLAB
+    // CustomFactor proxy object, so C++ never needs to manufacture a MATLAB
+    // object for `this`.
+    mxArray* args[4] = {
+        mxCreateString(registryFunctionName().c_str()),
+        mxCreateString("invoke"),
+        wrap<size_t>(callback_id_),
+        wrap_shared_ptr(std::make_shared<Values>(values), "gtsam.Values", false),
+    };
+
+    mxArray* outputs[2] = {nullptr, nullptr};
+    mexCallMATLAB(jacobians ? 2 : 1, outputs, 4, args, "feval");
+    destroyCallbackArgs(args, 4);
+
+    // The registry returns the residual as the first output in both calling
+    // modes. Validate the dimension here so MATLAB callback bugs fail close to
+    // the wrapper boundary rather than later in the optimizer.
+    Vector error = unwrap<Vector>(outputs[0]);
+    if (error.size() != static_cast<Eigen::Index>(this->dim())) {
+      mxDestroyArray(outputs[0]);
+      if (outputs[1]) {
+        mxDestroyArray(outputs[1]);
+      }
+      mexErrMsgIdAndTxt(
+          "gtsam:CustomFactor:invalidResidual",
+          "CustomFactor callback returned a residual with the wrong dimension.");
+    }
+
+    if (jacobians) {
+      // MATLAB must return one Jacobian block per key, in factor key order.
+      // Using a cell array keeps the MATLAB side simple and matches existing
+      // wrapper conventions for heterogeneous matrix outputs.
+      if (!mxIsCell(outputs[1])) {
+        mxDestroyArray(outputs[0]);
+        mxDestroyArray(outputs[1]);
+        mexErrMsgIdAndTxt(
+            "gtsam:CustomFactor:invalidJacobians",
+            "CustomFactor callback must return Jacobians as a cell array.");
+      }
+
+      const size_t expected = this->keys().size();
+      if (mxGetNumberOfElements(outputs[1]) != expected) {
+        mxDestroyArray(outputs[0]);
+        mxDestroyArray(outputs[1]);
+        mexErrMsgIdAndTxt(
+            "gtsam:CustomFactor:invalidJacobianCount",
+            "CustomFactor callback returned the wrong number of Jacobian blocks.");
+      }
+
+      jacobians->resize(expected);
+      for (size_t i = 0; i < expected; ++i) {
+        const mxArray* cell = mxGetCell(outputs[1], i);
+        if (!cell) {
+          mxDestroyArray(outputs[0]);
+          mxDestroyArray(outputs[1]);
+          mexErrMsgIdAndTxt(
+              "gtsam:CustomFactor:emptyJacobian",
+              "CustomFactor callback returned an empty Jacobian block.");
+        }
+        (*jacobians)[i] = unwrap<Matrix>(cell);
+      }
+    }
+
+    mxDestroyArray(outputs[0]);
+    if (outputs[1]) {
+      mxDestroyArray(outputs[1]);
+    }
+
+    return error;
+  }
+
+ public:
+  /**
+   * Construct a MATLAB-backed CustomFactor.
+   *
+   * @param noiseModel Shared noise model used by the factor.
+   * @param keys Factor keys in callback Jacobian order.
+   * @param callbackId Registry ID previously allocated in MATLAB.
+   */
+  MatlabCustomFactor(const noiseModel::Base::shared_ptr& noiseModel,
+                     const KeyVector& keys, size_t callbackId)
+      : CustomFactor(
+            noiseModel, keys,
+            [callbackId](const CustomFactor& factor, const Values& values,
+                         const JacobianVector* jacobians) {
+              const auto& matlabFactor =
+                  static_cast<const MatlabCustomFactor&>(factor);
+              return matlabFactor.invokeCallback(
+                  values, const_cast<JacobianVector*>(jacobians));
+            }),
+        callback_id_(callbackId)
+#ifdef GTSAM_USE_TBB
+        ,
+        tbb_serial_guard_(std::make_shared<tbb::global_control>(
+            tbb::global_control::max_allowed_parallelism, 1))
+#endif
+  {
+    // Keep the mex module loaded for the rest of the MATLAB session once a
+    // MATLAB CustomFactor exists. Without this, MATLAB can unload the wrapper
+    // while callback-backed factors are still reachable through optimizer-owned
+    // C++ objects, which caused unload-time crashes during debugging.
+    mexLock();
+  }
+
+  ~MatlabCustomFactor() override = default;
+};
+
+}  // namespace gtsam

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -140,4 +140,93 @@ the relevant directory is usually `<install-prefix>/lib`:
 export LD_LIBRARY_PATH=<install-prefix>/lib:$LD_LIBRARY_PATH
 ```
 
+## MATLAB CustomFactor User Guide
 
+The MATLAB toolbox supports callback-backed `CustomFactor` objects with the
+same basic usage pattern as Python:
+
+```matlab
+import gtsam.*
+
+key = 42;
+model = noiseModel.Unit.Create(1);
+
+factor = CustomFactor(model, key, @myErrorFunction);
+
+graph = NonlinearFactorGraph;
+graph.add(factor);
+```
+
+The callback signature is:
+
+```matlab
+function varargout = myErrorFunction(this, values)
+  residual = values.atVector(42) - [3];
+  if nargout > 1
+    varargout{1} = residual;
+    varargout{2} = {1};
+  else
+    varargout{1} = residual;
+  end
+end
+```
+
+Rules for MATLAB `CustomFactor` callbacks:
+
+- `this` is the MATLAB `gtsam.CustomFactor` object.
+- `values` is a wrapped `gtsam.Values` object.
+- The first output must be the unwhitened residual vector.
+- If Jacobians are requested, the second output must be a cell array with one numeric matrix per factor key, in factor key order.
+- The residual dimension must match the noise model dimension.
+- Keys may be passed either as a numeric array or as a `gtsam.KeyVector`.
+
+Practical notes:
+
+- `unwhitenedError(...)` exercises the residual-only path.
+- Optimization usually exercises both the residual and Jacobian paths.
+- Deleting the MATLAB factor removes its callback from the MATLAB-side registry, so repeated tests in one session do not accumulate stale entries.
+- Once a MATLAB `CustomFactor` has been constructed, the mex module is intentionally kept loaded for the rest of the MATLAB session to avoid unload-time crashes while callback-backed native factors are still reachable from C++.
+
+## MATLAB CustomFactor Under the Hood
+
+The MATLAB `CustomFactor` support is implemented as a MATLAB-specific layer on
+top of the existing C++ `gtsam::CustomFactor`.
+
+Files involved:
+
+- [`matlab/custom.i`](custom.i): declares the MATLAB-only native helper so it is included in the generated toolbox.
+- [`matlab/MatlabCustomFactor.h`](MatlabCustomFactor.h): native adapter class derived from `gtsam::CustomFactor`.
+- [`matlab/+gtsam/CustomFactor.m`](+gtsam/CustomFactor.m): user-facing MATLAB facade.
+- [`matlab/+gtsam/customFactorRegistry.m`](+gtsam/customFactorRegistry.m): persistent MATLAB registry that owns callbacks and MATLAB factor handles.
+
+Call path:
+
+1. `gtsam.CustomFactor(noiseModel, keys, errorFunc)` registers `errorFunc` in `gtsam.customFactorRegistry` and gets back a numeric callback ID.
+2. The MATLAB facade constructs the native `gtsam.MatlabCustomFactor`, passing only the noise model, keys, and callback ID into C++.
+3. After construction, the MATLAB facade binds the final MATLAB `gtsam.CustomFactor` object into the registry under the same callback ID.
+4. When GTSAM evaluates the factor in C++, `MatlabCustomFactor` calls back into MATLAB with:
+   `gtsam.customFactorRegistry('invoke', callbackId, values)`.
+5. The registry looks up the stored MATLAB factor object and function handle, then invokes:
+   `errorFunc(this, values)` or `[error, H] = errorFunc(this, values)`.
+6. The native wrapper validates the residual size and Jacobian count, converts the outputs back into GTSAM types, and returns them to the optimizer.
+
+Why there is a registry instead of storing the MATLAB function handle directly
+in C++:
+
+- the native factor can be copied and retained by optimizer-owned C++ objects
+- MATLAB object lifetimes do not match C++ shared pointer lifetimes
+- storing only a numeric callback ID in C++ avoids keeping raw MATLAB objects in core GTSAM state
+- the registry lets the callback receive the original MATLAB `gtsam.CustomFactor` object as `this`
+
+Debugging checklist for `CustomFactor`:
+
+- Constructor fails:
+  verify the toolbox contains both `gtsam.CustomFactor` and `gtsam.MatlabCustomFactor`.
+- Callback is never called:
+  check that the factor was added to a graph and that the graph path you are exercising actually evaluates it.
+- Callback gets wrong argument types:
+  inspect `matlab/+gtsam/CustomFactor.m` and `matlab/+gtsam/customFactorRegistry.m` first.
+- MATLAB reports wrong residual or Jacobian dimensions:
+  the callback contract is being violated; inspect the callback outputs before suspecting the optimizer.
+- MATLAB crashes or errors while unloading the wrapper:
+  remember that creating a MATLAB `CustomFactor` intentionally locks the mex module for the rest of the session.

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -161,7 +161,9 @@ The callback signature is:
 
 ```matlab
 function varargout = myErrorFunction(this, values)
-  residual = values.atVector(42) - [3];
+  % Retrieve keys from the factor object ('this')
+  keys = this.keys();
+  residual = values.atVector(keys.at(0)) - [3];
   if nargout > 1
     varargout{1} = residual;
     varargout{2} = {1};

--- a/matlab/custom.i
+++ b/matlab/custom.i
@@ -1,0 +1,17 @@
+namespace gtsam {
+
+// MATLAB-only declarations that are merged into the generated toolbox in
+// addition to the normal GTSAM interfaces. This file exposes the native helper
+// class that bridges gtsam::CustomFactor to the MATLAB callback registry.
+//
+// The constructor intentionally accepts gtsam::noiseModel::Base* here because
+// that matches the generated MATLAB wrapper surface. The corresponding C++
+// constructor takes noiseModel::Base::shared_ptr after unwrap.
+#include <MatlabCustomFactor.h>
+virtual class MatlabCustomFactor : gtsam::NoiseModelFactor {
+  MatlabCustomFactor(gtsam::noiseModel::Base* noiseModel,
+                     const gtsam::KeyVector& keys,
+                     size_t callbackId);
+};
+
+}  // namespace gtsam

--- a/matlab/gtsam_examples/CustomFactorExample.m
+++ b/matlab/gtsam_examples/CustomFactorExample.m
@@ -1,0 +1,149 @@
+import gtsam.*;
+
+X = simulate_car();
+fprintf('Simulated car trajectory: [%s]\n', num2str(X));
+
+add_noise = true;
+
+% GPS measurements
+sigma_gps = 3.0;
+gps_noise_model = noiseModel.Isotropic.Sigma(1, sigma_gps);
+gps_sampler = Sampler(gps_noise_model, 42);
+gps_measurements = zeros(1, 5);
+for k=1:5
+    gps_measurements(k) = X(k) + (add_noise * gps_sampler.sample());
+end
+
+% Odometry measurements
+sigma_odo = 0.1;
+odo_noise_model = noiseModel.Isotropic.Sigma(1, sigma_odo);
+odo_sampler = Sampler(odo_noise_model, 42);
+odometry_measurements = zeros(1, 4);
+X_diff = diff(X);
+for k=1:4
+    odometry_measurements(k) = X_diff(k) + (add_noise * odo_sampler.sample());
+end
+
+% Landmark measurements:
+sigma_lm = 1;
+lm_noise_model = noiseModel.Isotropic.Sigma(1, sigma_lm);
+lm_sampler = Sampler(lm_noise_model, 42);
+
+lm_0 = 5.0;
+landmark0_measurement = X(1) - lm_0 + (add_noise * lm_sampler.sample());
+lm_3 = 28.0;
+landmark3_measurement = X(4) - lm_3 + (add_noise * lm_sampler.sample());
+
+unknown = [];
+for k=0:4
+    unknown = [unknown symbol('x', k)];
+end
+
+% 1. Result with only GPS
+factor_graph = NonlinearFactorGraph;
+factors = {}; % Keep alive
+for k=1:5
+    error_func = make_gps_callback(gps_measurements(k));
+    gps_factor = CustomFactor(gps_noise_model, unknown(k), error_func);
+    factor_graph.add(gps_factor);
+    factors{end+1} = gps_factor;
+end
+
+v = Values;
+for i=1:5
+    v.insert(unknown(i), [0.0]);
+end
+
+params = GaussNewtonParams;
+result = GaussNewtonOptimizer(factor_graph, v, params).optimize();
+
+vals = zeros(1, 5);
+for i=1:5, vals(i) = result.atVector(unknown(i)); end
+fprintf('Result with only GPS: [%s], Error: %f\n', num2str(round(vals, 2)), factor_graph.error(result));
+
+% 2. Result with GPS+Odometry
+for k=1:4
+    error_func = make_odom_callback(odometry_measurements(k));
+    odometry_factor = CustomFactor(odo_noise_model, [unknown(k), unknown(k + 1)], error_func);
+    factor_graph.add(odometry_factor);
+    factors{end+1} = odometry_factor;
+end
+
+result = GaussNewtonOptimizer(factor_graph, v, params).optimize();
+vals = zeros(1, 5);
+for i=1:5, vals(i) = result.atVector(unknown(i)); end
+fprintf('Result with GPS+Odometry: [%s], Error: %f\n', num2str(round(vals, 2)), factor_graph.error(result));
+
+% 3. Result with GPS+Odometry+Landmark
+error_func0 = make_lm_callback(lm_0 + landmark0_measurement);
+factor0 = CustomFactor(lm_noise_model, unknown(1), error_func0);
+factor_graph.add(factor0);
+factors{end+1} = factor0;
+
+error_func3 = make_lm_callback(lm_3 + landmark3_measurement);
+factor3 = CustomFactor(lm_noise_model, unknown(4), error_func3);
+factor_graph.add(factor3);
+factors{end+1} = factor3;
+
+result = GaussNewtonOptimizer(factor_graph, v, params).optimize();
+vals = zeros(1, 5);
+for i=1:5, vals(i) = result.atVector(unknown(i)); end
+fprintf('Result with GPS+Odometry+Landmark: [%s], Error: %f\n', num2str(round(vals, 2)), factor_graph.error(result));
+
+%% Callback Factory Helpers
+function f = make_gps_callback(measurement)
+    f = @(varargin) error_gps(measurement, varargin{:});
+end
+
+function f = make_odom_callback(measurement)
+    f = @(varargin) error_odom(measurement, varargin{:});
+end
+
+function f = make_lm_callback(measurement)
+    f = @(varargin) error_lm(measurement, varargin{:});
+end
+
+%% Helper Functions
+function x = simulate_car()
+    x0 = 0;
+    dt = 0.25;
+    v = 144 * 1000 / 3600;
+    x = x0 + v * dt * (0:4);
+end
+
+function varargout = error_gps(measurement, this, values)
+    keys = this.keys();
+    estimate = values.atVector(keys.at(0));
+    residual = estimate - measurement;
+    if nargout > 1
+        varargout{1} = residual;
+        varargout{2} = {1};
+    else
+        varargout{1} = residual;
+    end
+end
+
+function varargout = error_odom(measurement, this, values)
+    keys = this.keys();
+    pos1 = values.atVector(keys.at(0));
+    pos2 = values.atVector(keys.at(1));
+    residual = (pos2 - pos1) - measurement;
+    if nargout > 1
+        varargout{1} = residual;
+        varargout{2} = {-1, 1};
+    else
+        varargout{1} = residual;
+    end
+end
+
+function varargout = error_lm(measurement, this, values)
+    keys = this.keys();
+    pos = values.atVector(keys.at(0));
+    residual = pos - measurement;
+    if nargout > 1
+        varargout{1} = residual;
+        varargout{2} = {1}; % Jacobian w.r.t. x
+    else
+        varargout{1} = residual;
+    end
+end

--- a/matlab/gtsam_tests/testCustomFactor.m
+++ b/matlab/gtsam_tests/testCustomFactor.m
@@ -1,0 +1,78 @@
+import gtsam.*;
+
+% Regression coverage for the MATLAB CustomFactor bridge. This test checks the
+% end-to-end path:
+%   MATLAB callback registration -> native factor evaluation -> optimizer use
+% and then verifies the registry is cleaned up when MATLAB objects are deleted.
+
+global gtsamCustomFactorCalls;
+global gtsamCustomFactorJacobianCalls;
+global gtsamCustomFactorSawWrappedInputs;
+
+gtsamCustomFactorCalls = 0;
+gtsamCustomFactorJacobianCalls = 0;
+gtsamCustomFactorSawWrappedInputs = false;
+
+tol = 1e-9;
+key = 42;
+target = [3];
+initial = Values;
+initial.insert(key, [0]);
+
+baselineCallbacks = gtsam.customFactorRegistry('count');
+model = noiseModel.Unit.Create(1);
+factor = CustomFactor(model, key, @customFactorError);
+
+EXPECT('registry create', gtsam.customFactorRegistry('count') == baselineCallbacks + 1);
+
+errorVector = factor.unwhitenedError(initial);
+EQUALITY('custom residual', [0] - target, errorVector, tol);
+
+graph = NonlinearFactorGraph;
+graph.add(factor);
+optimizer = LevenbergMarquardtOptimizer(graph, initial);
+result = optimizer.optimize();
+
+EQUALITY('custom factor optimize', target, result.atVector(key), 1e-6);
+EXPECT('callback invoked', gtsamCustomFactorCalls > 0);
+EXPECT('jacobians requested', gtsamCustomFactorJacobianCalls > 0);
+EXPECT('wrapped inputs', gtsamCustomFactorSawWrappedInputs);
+
+delete(result);
+delete(optimizer);
+delete(graph);
+delete(factor);
+delete(initial);
+clear result optimizer graph factor initial;
+
+EXPECT('registry cleanup', gtsam.customFactorRegistry('count') == baselineCallbacks);
+
+factor = CustomFactor(model, [key], @customFactorError);
+EXPECT('registry recreate', gtsam.customFactorRegistry('count') == baselineCallbacks + 1);
+delete(factor);
+clear factor;
+EXPECT('registry final cleanup', gtsam.customFactorRegistry('count') == baselineCallbacks);
+
+function varargout = customFactorError(this, values)
+% Simple 1D residual used to verify both residual-only and Jacobian callback
+% paths. The callback also checks that MATLAB receives wrapped toolbox objects,
+% not raw numeric stand-ins.
+global gtsamCustomFactorCalls;
+global gtsamCustomFactorJacobianCalls;
+global gtsamCustomFactorSawWrappedInputs;
+
+gtsamCustomFactorCalls = gtsamCustomFactorCalls + 1;
+gtsamCustomFactorSawWrappedInputs = isa(this, 'gtsam.CustomFactor') && ...
+    isa(values, 'gtsam.Values');
+
+current = values.atVector(42);
+residual = current - [3];
+
+if nargout > 1
+    gtsamCustomFactorJacobianCalls = gtsamCustomFactorJacobianCalls + 1;
+    varargout{1} = residual;
+    varargout{2} = {1};
+else
+    varargout{1} = residual;
+end
+end

--- a/matlab/gtsam_tests/testCustomFactor.m
+++ b/matlab/gtsam_tests/testCustomFactor.m
@@ -65,7 +65,11 @@ gtsamCustomFactorCalls = gtsamCustomFactorCalls + 1;
 gtsamCustomFactorSawWrappedInputs = isa(this, 'gtsam.CustomFactor') && ...
     isa(values, 'gtsam.Values');
 
-current = values.atVector(42);
+keys = this.keys();
+if keys.at(0) ~= 42
+    error('CustomFactor:incorrectKey', 'Expected key 42, but got %d', keys.at(0));
+end
+current = values.atVector(keys.at(0));
 residual = current - [3];
 
 if nargout > 1

--- a/matlab/gtsam_tests/test_gtsam.m
+++ b/matlab/gtsam_tests/test_gtsam.m
@@ -15,6 +15,9 @@ testJacobianFactor
 display 'Starting: testValues'
 testValues
 
+display 'Starting: testCustomFactor'
+testCustomFactor
+
 %% SLAM
 display 'Starting: testPriorFactor'
 testPriorFactor

--- a/python/gtsam/examples/CustomFactorExample.py
+++ b/python/gtsam/examples/CustomFactorExample.py
@@ -15,7 +15,7 @@ from typing import List, Optional
 import gtsam
 import numpy as np
 
-I = np.eye(1) # Creates a 1-element, 2D array
+Id_1x1 = np.eye(1)
 
 
 def simulate_car() -> List[float]:
@@ -28,178 +28,146 @@ def simulate_car() -> List[float]:
     return x
 
 
-def error_gps(measurement: np.ndarray, this: gtsam.CustomFactor,
-              values: gtsam.Values,
-              jacobians: Optional[List[np.ndarray]]) -> np.ndarray:
-    """GPS Factor error function
-    :param measurement: GPS measurement, to be filled with `partial`
-    :param this: gtsam.CustomFactor handle
-    :param values: gtsam.Values
-    :param jacobians: Optional list of Jacobians
-    :return: the unwhitened error
-    """
+def error_gps(
+    measurement: np.ndarray,
+    this: gtsam.CustomFactor,
+    values: gtsam.Values,
+    jacobians: Optional[List[np.ndarray]],
+) -> np.ndarray:
     key = this.keys()[0]
     estimate = values.atVector(key)
     error = estimate - measurement
     if jacobians is not None:
-        jacobians[0] = I
+        jacobians[0] = Id_1x1
+    return error
 
-    return error # with input types this is a 1D np.ndarray
 
-
-def error_odom(measurement: np.ndarray, this: gtsam.CustomFactor,
-               values: gtsam.Values,
-               jacobians: Optional[List[np.ndarray]]) -> np.ndarray:
-    """Odometry Factor error function
-    :param measurement: Odometry measurement, to be filled with `partial`
-    :param this: gtsam.CustomFactor handle
-    :param values: gtsam.Values
-    :param jacobians: Optional list of Jacobians
-    :return: the unwhitened error
-    """
+def error_odom(
+    measurement: np.ndarray,
+    this: gtsam.CustomFactor,
+    values: gtsam.Values,
+    jacobians: Optional[List[np.ndarray]],
+) -> np.ndarray:
     key1 = this.keys()[0]
     key2 = this.keys()[1]
     pos1, pos2 = values.atVector(key1), values.atVector(key2)
     error = (pos2 - pos1) - measurement
     if jacobians is not None:
-        jacobians[0] = -I
-        jacobians[1] = I
-
+        jacobians[0] = -Id_1x1
+        jacobians[1] = Id_1x1
     return error
 
 
-def error_lm(measurement: np.ndarray, this: gtsam.CustomFactor,
-             values: gtsam.Values,
-             jacobians: Optional[List[np.ndarray]]) -> np.ndarray:
-    """Landmark Factor error function
-    :param measurement: Landmark measurement, to be filled with `partial`
-    :param this: gtsam.CustomFactor handle
-    :param values: gtsam.Values
-    :param jacobians: Optional list of Jacobians
-    :return: the unwhitened error
-    """
+def error_lm(
+    measurement: np.ndarray,
+    this: gtsam.CustomFactor,
+    values: gtsam.Values,
+    jacobians: Optional[List[np.ndarray]],
+) -> np.ndarray:
     key = this.keys()[0]
     pos = values.atVector(key)
     error = pos - measurement
     if jacobians is not None:
-        jacobians[0] = I
-
+        jacobians[0] = Id_1x1
     return error
 
 
 def main():
-    """Main runner."""
+    X = simulate_car()
+    print(f"Simulated car trajectory: {X}")
 
-    x = simulate_car()
-    print(f"Simulated car trajectory: {x}")
-
-    add_noise = True  # set this to False to run with "perfect" measurements
+    add_noise = True
 
     # GPS measurements
-    sigma_gps = 3.0  # assume GPS is +/- 3m
-    g = [
-        x[k] + (np.random.normal(scale=sigma_gps) if add_noise else 0)
-        for k in range(5)
+    sigma_gps = 3.0
+    gps_noise_model = gtsam.noiseModel.Isotropic.Sigma(1, sigma_gps)
+    gps_sampler = gtsam.Sampler(gps_noise_model, 42)
+    gps_measurements = [
+        X[k] + (gps_sampler.sample()[0] if add_noise else 0) for k in range(5)
     ]
 
     # Odometry measurements
-    sigma_odo = 0.1  # assume Odometry is 10cm accurate at 4Hz
-    o = [
-        x[k + 1] - x[k] +
-        (np.random.normal(scale=sigma_odo) if add_noise else 0)
+    sigma_odo = 0.1
+    odo_noise_model = gtsam.noiseModel.Isotropic.Sigma(1, sigma_odo)
+    odo_sampler = gtsam.Sampler(odo_noise_model, 42)
+    odometry_measurements = [
+        X[k + 1] - X[k] + (odo_sampler.sample()[0] if add_noise else 0)
         for k in range(4)
     ]
 
     # Landmark measurements:
-    sigma_lm = 1  # assume landmark measurement is accurate up to 1m
+    sigma_lm = 1
+    lm_noise_model = gtsam.noiseModel.Isotropic.Sigma(1, sigma_lm)
+    lm_sampler = gtsam.Sampler(lm_noise_model, 42)
 
-    # Assume first landmark is at x=5, we measure it at time k=0
     lm_0 = 5.0
-    z_0 = x[0] - lm_0 + (np.random.normal(scale=sigma_lm) if add_noise else 0)
-
-    # Assume other landmark is at x=28, we measure it at time k=3
+    landmark0_measurement = X[0] - lm_0 + (lm_sampler.sample()[0] if add_noise else 0)
     lm_3 = 28.0
-    z_3 = x[3] - lm_3 + (np.random.normal(scale=sigma_lm) if add_noise else 0)
+    landmark3_measurement = X[3] - lm_3 + (lm_sampler.sample()[0] if add_noise else 0)
 
-    unknown = [gtsam.symbol('x', k) for k in range(5)]
-
+    unknown = [gtsam.symbol("x", k) for k in range(5)]
     print("unknowns = ", list(map(gtsam.DefaultKeyFormatter, unknown)))
 
-    # We now can use nonlinear factor graphs
+    # 1. Result with only GPS
     factor_graph = gtsam.NonlinearFactorGraph()
-
-    # Add factors for GPS measurements
-    gps_model = gtsam.noiseModel.Isotropic.Sigma(1, sigma_gps)
-
-    # Add the GPS factors
     for k in range(5):
-        gf = gtsam.CustomFactor(gps_model, [unknown[k]],
-                                partial(error_gps, np.array([g[k]])))
-        factor_graph.add(gf)
+        factor_graph.add(
+            gtsam.CustomFactor(
+                gps_noise_model,
+                [unknown[k]],
+                partial(error_gps, np.array([gps_measurements[k]])),
+            )
+        )
 
-    # New Values container
     v = gtsam.Values()
-
-    # Add initial estimates to the Values container
     for i in range(5):
         v.insert(unknown[i], np.array([0.0]))
 
-    # Initialize optimizer
     params = gtsam.GaussNewtonParams()
-    optimizer = gtsam.GaussNewtonOptimizer(factor_graph, v, params)
+    result = gtsam.GaussNewtonOptimizer(factor_graph, v, params).optimize()
 
-    # Optimize the factor graph
-    result = optimizer.optimize()
+    vals = [result.atVector(unknown[k])[0] for k in range(5)]
+    print(
+        f"Result with only GPS: {np.round(vals, 2)}, Error: {factor_graph.error(result):.6f}"
+    )
 
-    # calculate the error from ground truth
-    error = np.array([(result.atVector(unknown[k]) - x[k])[0]
-                      for k in range(5)])
-
-    print("Result with only GPS")
-    print(result, np.round(error, 2),
-          f"\nJ(X)={0.5 * np.sum(np.square(error))}")
-
-    # Adding odometry will improve things a lot
-    odo_model = gtsam.noiseModel.Isotropic.Sigma(1, sigma_odo)
-
+    # 2. Result with GPS+Odometry
     for k in range(4):
-        odof = gtsam.CustomFactor(odo_model, [unknown[k], unknown[k + 1]],
-                                  partial(error_odom, np.array([o[k]])))
-        factor_graph.add(odof)
+        factor_graph.add(
+            gtsam.CustomFactor(
+                odo_noise_model,
+                [unknown[k], unknown[k + 1]],
+                partial(error_odom, np.array([odometry_measurements[k]])),
+            )
+        )
 
-    params = gtsam.GaussNewtonParams()
-    optimizer = gtsam.GaussNewtonOptimizer(factor_graph, v, params)
+    result = gtsam.GaussNewtonOptimizer(factor_graph, v, params).optimize()
+    vals = [result.atVector(unknown[k])[0] for k in range(5)]
+    print(
+        f"Result with GPS+Odometry: {np.round(vals, 2)}, Error: {factor_graph.error(result):.6f}"
+    )
 
-    result = optimizer.optimize()
-
-    error = np.array([(result.atVector(unknown[k]) - x[k])[0]
-                      for k in range(5)])
-
-    print("Result with GPS+Odometry")
-    print(result, np.round(error, 2),
-          f"\nJ(X)={0.5 * np.sum(np.square(error))}")
-
-    # This is great, but GPS noise is still apparent, so now we add the two landmarks
-    lm_model = gtsam.noiseModel.Isotropic.Sigma(1, sigma_lm)
-
+    # 3. Result with GPS+Odometry+Landmark
     factor_graph.add(
-        gtsam.CustomFactor(lm_model, [unknown[0]],
-                           partial(error_lm, np.array([lm_0 + z_0]))))
+        gtsam.CustomFactor(
+            lm_noise_model,
+            [unknown[0]],
+            partial(error_lm, np.array([lm_0 + landmark0_measurement])),
+        )
+    )
     factor_graph.add(
-        gtsam.CustomFactor(lm_model, [unknown[3]],
-                           partial(error_lm, np.array([lm_3 + z_3]))))
+        gtsam.CustomFactor(
+            lm_noise_model,
+            [unknown[3]],
+            partial(error_lm, np.array([lm_3 + landmark3_measurement])),
+        )
+    )
 
-    params = gtsam.GaussNewtonParams()
-    optimizer = gtsam.GaussNewtonOptimizer(factor_graph, v, params)
-
-    result = optimizer.optimize()
-
-    error = np.array([(result.atVector(unknown[k]) - x[k])[0]
-                      for k in range(5)])
-
-    print("Result with GPS+Odometry+Landmark")
-    print(result, np.round(error, 2),
-          f"\nJ(X)={0.5 * np.sum(np.square(error))}")
+    result = gtsam.GaussNewtonOptimizer(factor_graph, v, params).optimize()
+    vals = [result.atVector(unknown[k])[0] for k in range(5)]
+    print(
+        f"Result with GPS+Odometry+Landmark: {np.round(vals, 2)}, Error: {factor_graph.error(result):.6f}"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Codex implemented a MATLAB equivalent of the custom factor, using a global callback registry. Tests work.

I also improved the python example, and added a MATLAB version. They match perfectly:
### Python:
```
Simulated car trajectory: [0.0, 10.0, 20.0, 30.0, 40.0]
unknowns =  ['x0', 'x1', 'x2', 'x3', 'x4']
Result with only GPS: [ 3.88 11.19 23.36 25.52 39.07], Error: 0.000000
Result with GPS+Odometry: [ 0.47 10.6  20.63 30.74 40.59], Error: 2.719555
Result with GPS+Odometry+Landmark: [ 0.67 10.79 20.82 30.92 40.77], Error: 3.064092
```

### MATLAB:
```
>> CustomFactorExample
Simulated car trajectory: [0  10  20  30  40]
Result with only GPS: [3.88        11.19        23.36        25.52        39.07], Error: 0.000000
Result with GPS+Odometry: [0.47         10.6        20.63        30.74        40.59], Error: 2.719555
Result with GPS+Odometry+Landmark: [0.67        10.79        20.82        30.92        40.77], Error: 3.064092
```