### PR TITLE
numerical derivatives in MATLAB

### DIFF
--- a/matlab/+gtsam/numericalDerivative.m
+++ b/matlab/+gtsam/numericalDerivative.m
@@ -20,13 +20,27 @@ classdef numericalDerivative
             if isnumeric(a)
                 res = a + xi;
             elseif isa(a, 'gtsam.Values')
-                % Values.retract expects VectorValues or specialized vector input
-                % The wrapped retract(VectorValues) is most direct.
-                % We assume xi is a plain vector here, matching numericalDerivative11.
-                % We need to convert the plain vector back to VectorValues.
-                % This is tricky without knowing the structure, but Values.retract(vector)
-                % might be available if wrapped.
-                res = a.retract(xi);
+                % xi is a plain column vector.
+                % We need to convert it to a VectorValues object.
+                % VectorValues.vector() concatenates vectors in key-sorted order,
+                % so we must iterate through the keys in the same order.
+                vv = gtsam.VectorValues();
+                keys = a.keys();
+                key_array = zeros(1, keys.size());
+                for i = 0:keys.size()-1
+                    key_array(i+1) = keys.at(i);
+                end
+                key_array = sort(key_array);
+                
+                zeros_vv = a.zeroVectors();
+                offset = 1;
+                for i = 1:length(key_array)
+                    key = key_array(i);
+                    d = zeros_vv.dim(key);
+                    vv.insert(key, xi(offset:offset+d-1));
+                    offset = offset + d;
+                end
+                res = a.retract(vv);
             else
                 % GTSAM objects usually provide retract
                 res = a.retract(xi);

--- a/matlab/+gtsam/numericalDerivative.m
+++ b/matlab/+gtsam/numericalDerivative.m
@@ -1,0 +1,102 @@
+classdef numericalDerivative
+    % Numerical derivative functions for GTSAM.
+    % Translated from python/gtsam/utils/numerical_derivative.py
+    
+    methods(Static)
+        function delta_vec = local(a, b)
+            if isnumeric(a)
+                delta_vec = b - a;
+            elseif isa(a, 'gtsam.Values')
+                % Values.localCoordinates(Values) returns a VectorValues,
+                % we need to convert it to a plain vector.
+                delta_vec = a.localCoordinates(b).vector();
+            else
+                % GTSAM objects usually provide localCoordinates
+                delta_vec = a.localCoordinates(b);
+            end
+        end
+        
+        function res = retract(a, xi)
+            if isnumeric(a)
+                res = a + xi;
+            elseif isa(a, 'gtsam.Values')
+                % Values.retract expects VectorValues or specialized vector input
+                % The wrapped retract(VectorValues) is most direct.
+                % We assume xi is a plain vector here, matching numericalDerivative11.
+                % We need to convert the plain vector back to VectorValues.
+                % This is tricky without knowing the structure, but Values.retract(vector)
+                % might be available if wrapped.
+                res = a.retract(xi);
+            else
+                % GTSAM objects usually provide retract
+                res = a.retract(xi);
+            end
+        end
+        
+        function H = numericalDerivative11(h, x, delta)
+            if nargin < 3, delta = 1e-5; end
+            hx = h(x);
+            zeroY = gtsam.numericalDerivative.local(hx, hx);
+            m = length(zeroY);
+            zeroX = gtsam.numericalDerivative.local(x, x);
+            n = length(zeroX);
+            dx = zeros(n, 1);
+            H = zeros(m, n);
+            factor = 1.0 / (2.0 * delta);
+            for j = 1:n
+                dx(j) = delta;
+                dy1 = gtsam.numericalDerivative.local(hx, h(gtsam.numericalDerivative.retract(x, dx)));
+                dx(j) = -delta;
+                dy2 = gtsam.numericalDerivative.local(hx, h(gtsam.numericalDerivative.retract(x, dx)));
+                dx(j) = 0;
+                H(:, j) = (dy1 - dy2) * factor;
+            end
+        end
+        
+        function H = numericalDerivative21(h, x1, x2, delta)
+            if nargin < 4, delta = 1e-5; end
+            H = gtsam.numericalDerivative.numericalDerivative11(@(x) h(x, x2), x1, delta);
+        end
+        
+        function H = numericalDerivative22(h, x1, x2, delta)
+            if nargin < 4, delta = 1e-5; end
+            H = gtsam.numericalDerivative.numericalDerivative11(@(x) h(x1, x), x2, delta);
+        end
+        
+        function H = numericalDerivative31(h, x1, x2, x3, delta)
+            if nargin < 5, delta = 1e-5; end
+            H = gtsam.numericalDerivative.numericalDerivative11(@(x) h(x, x2, x3), x1, delta);
+        end
+        
+        function H = numericalDerivative32(h, x1, x2, x3, delta)
+            if nargin < 5, delta = 1e-5; end
+            H = gtsam.numericalDerivative.numericalDerivative11(@(x) h(x1, x, x3), x2, delta);
+        end
+        
+        function H = numericalDerivative33(h, x1, x2, x3, delta)
+            if nargin < 5, delta = 1e-5; end
+            H = gtsam.numericalDerivative.numericalDerivative11(@(x) h(x1, x2, x), x3, delta);
+        end
+        
+        % Add more as needed, but following the same pattern as python
+        function H = numericalDerivative41(h, x1, x2, x3, x4, delta)
+            if nargin < 6, delta = 1e-5; end
+            H = gtsam.numericalDerivative.numericalDerivative11(@(x) h(x, x2, x3, x4), x1, delta);
+        end
+        
+        function H = numericalDerivative42(h, x1, x2, x3, x4, delta)
+            if nargin < 6, delta = 1e-5; end
+            H = gtsam.numericalDerivative.numericalDerivative11(@(x) h(x1, x, x3, x4), x2, delta);
+        end
+        
+        function H = numericalDerivative43(h, x1, x2, x3, x4, delta)
+            if nargin < 6, delta = 1e-5; end
+            H = gtsam.numericalDerivative.numericalDerivative11(@(x) h(x1, x2, x, x4), x3, delta);
+        end
+        
+        function H = numericalDerivative44(h, x1, x2, x3, x4, delta)
+            if nargin < 6, delta = 1e-5; end
+            H = gtsam.numericalDerivative.numericalDerivative11(@(x) h(x1, x2, x3, x), x4, delta);
+        end
+    end
+end

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -194,6 +194,9 @@ actual_H = factor.linearize(initial).jacobian();
 EQUALITY('custom jacobian', expected_H, actual_H, 1e-5);
 ```
 
+Wrapped overloaded methods such as `factor.unwhitenedError` still need an
+explicit lambda when passed as callbacks in MATLAB.
+
 - Optimization usually exercises both the residual and Jacobian paths.
 - Deleting the MATLAB factor removes its callback from the MATLAB-side registry, so repeated tests in one session do not accumulate stale entries.
 - Once a MATLAB `CustomFactor` has been constructed, the mex module is intentionally kept loaded for the rest of the MATLAB session to avoid unload-time crashes while callback-backed native factors are still reachable from C++.

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -185,6 +185,15 @@ Rules for MATLAB `CustomFactor` callbacks:
 Practical notes:
 
 - `unwhitenedError(...)` exercises the residual-only path.
+- Jacobians should always be verified using numerical derivatives during development. The `gtsam.numericalDerivative` utility is provided for this purpose:
+
+```matlab
+% Verify Jacobians using numerical derivative
+expected_H = numericalDerivative.numericalDerivative11(@(v) factor.unwhitenedError(v), initial);
+actual_H = factor.linearize(initial).jacobian();
+EQUALITY('custom jacobian', expected_H, actual_H, 1e-5);
+```
+
 - Optimization usually exercises both the residual and Jacobian paths.
 - Deleting the MATLAB factor removes its callback from the MATLAB-side registry, so repeated tests in one session do not accumulate stale entries.
 - Once a MATLAB `CustomFactor` has been constructed, the mex module is intentionally kept loaded for the rest of the MATLAB session to avoid unload-time crashes while callback-backed native factors are still reachable from C++.

--- a/matlab/gtsam_tests/testCustomFactor.m
+++ b/matlab/gtsam_tests/testCustomFactor.m
@@ -28,6 +28,11 @@ EXPECT('registry create', gtsam.customFactorRegistry('count') == baselineCallbac
 errorVector = factor.unwhitenedError(initial);
 EQUALITY('custom residual', [0] - target, errorVector, tol);
 
+% Verify Jacobians using numerical derivative
+expected_H = numericalDerivative.numericalDerivative11(@(v) factor.unwhitenedError(v), initial);
+actual_H = factor.linearize(initial).jacobian();
+EQUALITY('custom jacobian', expected_H, actual_H, 1e-5);
+
 graph = NonlinearFactorGraph;
 graph.add(factor);
 optimizer = LevenbergMarquardtOptimizer(graph, initial);

--- a/matlab/gtsam_tests/testCustomFactor.m
+++ b/matlab/gtsam_tests/testCustomFactor.m
@@ -28,7 +28,7 @@ EXPECT('registry create', gtsam.customFactorRegistry('count') == baselineCallbac
 errorVector = factor.unwhitenedError(initial);
 EQUALITY('custom residual', [0] - target, errorVector, tol);
 
-% Verify Jacobians using numerical derivative
+% Wrapped overloaded methods still need an explicit lambda in MATLAB.
 expected_H = numericalDerivative.numericalDerivative11(@(v) factor.unwhitenedError(v), initial);
 actual_H = factor.linearize(initial).jacobian();
 EQUALITY('custom jacobian', expected_H, actual_H, 1e-5);

--- a/matlab/gtsam_tests/testNumericalDerivative.m
+++ b/matlab/gtsam_tests/testNumericalDerivative.m
@@ -1,0 +1,71 @@
+import gtsam.*;
+
+%% test_numericalDerivative11_scalar
+% Test function of one variable
+h = @(x) x^2;
+x = 3.0;
+% Analytical derivative: dh/dx = 2x
+analytical_derivative = 2.0 * x;
+% Compute numerical derivative
+numerical_derivative = numericalDerivative.numericalDerivative11(h, x);
+EQUALITY('test_numericalDerivative11_scalar', analytical_derivative, numerical_derivative, 1e-5);
+
+%% test_numericalDerivative11_vector
+% Test function of one vector variable
+h = @(x) x.^2;
+x = [1.0; 2.0; 3.0];
+% Analytical derivative: dh/dx = 2x
+analytical_derivative = diag(2.0 * x);
+numerical_derivative = numericalDerivative.numericalDerivative11(h, x);
+EQUALITY('test_numericalDerivative11_vector', analytical_derivative, numerical_derivative, 1e-5);
+
+%% test_numericalDerivative21
+% Test function of two variables, derivative with respect to first variable
+h = @(x1, x2) x1 * sin(x2);
+x1 = 2.0;
+x2 = pi / 4;
+% Analytical derivative: dh/dx1 = sin(x2)
+analytical_derivative = sin(x2);
+numerical_derivative = numericalDerivative.numericalDerivative21(h, x1, x2);
+EQUALITY('test_numericalDerivative21', analytical_derivative, numerical_derivative, 1e-5);
+
+%% test_numericalDerivative22
+% Test function of two variables, derivative with respect to second variable
+h = @(x1, x2) x1 * sin(x2);
+x1 = 2.0;
+x2 = pi / 4;
+% Analytical derivative: dh/dx2 = x1 * cos(x2)
+analytical_derivative = x1 * cos(x2);
+numerical_derivative = numericalDerivative.numericalDerivative22(h, x1, x2);
+EQUALITY('test_numericalDerivative22', analytical_derivative, numerical_derivative, 1e-5);
+
+%% test_numericalDerivative33
+% Test function of three variables, derivative with respect to third variable
+h = @(x1, x2, x3) x1 * x2 + exp(x3);
+x1 = 1.0;
+x2 = 2.0;
+x3 = 0.5;
+% Analytical derivative: dh/dx3 = exp(x3)
+analytical_derivative = exp(x3);
+numerical_derivative = numericalDerivative.numericalDerivative33(h, x1, x2, x3);
+EQUALITY('test_numericalDerivative33', analytical_derivative, numerical_derivative, 1e-5);
+
+%% test_numericalDerivative_with_pose
+% Test function with manifold and vector inputs
+h = @(pose, point) pose.transformFrom(point);
+
+% Values from testPose3.cpp
+P = Point3(0.2, 0.7, -2);
+R = Rot3.Rodrigues(0.3, 0, 0);
+P2 = Point3(3.5, -8.2, 4.2);
+T = Pose3(R, P2);
+
+analytic_H1 = zeros(3, 6);
+analytic_H2 = zeros(3, 3);
+y = T.transformFrom(P, analytic_H1, analytic_H2);
+
+numerical_H1 = numericalDerivative.numericalDerivative21(h, T, P);
+numerical_H2 = numericalDerivative.numericalDerivative22(h, T, P);
+
+EQUALITY('test_numericalDerivative_with_pose_H1', analytic_H1, numerical_H1, 1e-5);
+EQUALITY('test_numericalDerivative_with_pose_H2', analytic_H2, numerical_H2, 1e-5);

--- a/matlab/gtsam_tests/testNumericalDerivative.m
+++ b/matlab/gtsam_tests/testNumericalDerivative.m
@@ -60,9 +60,15 @@ R = Rot3.Rodrigues(0.3, 0, 0);
 P2 = Point3(3.5, -8.2, 4.2);
 T = Pose3(R, P2);
 
-analytic_H1 = zeros(3, 6);
-analytic_H2 = zeros(3, 3);
-y = T.transformFrom(P, analytic_H1, analytic_H2);
+% Compute analytical Jacobians manually, as in C++
+R = T.rotation().matrix();
+skew = [  0      -P(3)   P(2);
+	       P(3)    0      -P(1);
+        -P(2)  P(1)     0   ];
+analytic_H1 = zeros(3,6);
+analytic_H1(:,1:3) = R * (-skew); % leftCols<3>()
+analytic_H1(:,4:6) = R;           % rightCols<3>()
+analytic_H2 = R;
 
 numerical_H1 = numericalDerivative.numericalDerivative21(h, T, P);
 numerical_H2 = numericalDerivative.numericalDerivative22(h, T, P);

--- a/matlab/gtsam_tests/testNumericalDerivative.m
+++ b/matlab/gtsam_tests/testNumericalDerivative.m
@@ -19,6 +19,19 @@ analytical_derivative = diag(2.0 * x);
 numerical_derivative = numericalDerivative.numericalDerivative11(h, x);
 EQUALITY('test_numericalDerivative11_vector', analytical_derivative, numerical_derivative, 1e-5);
 
+%% test_numericalDerivative11_values
+% Test function of one Values variable with mixed dimensions and key sorting
+key_a = 42;
+key_b = 7;
+values = Values;
+values.insert(key_a, [1.0; 2.0]);
+values.insert(key_b, [3.0]);
+h = @(v) valuesLinearCombination(v, key_a, key_b);
+analytical_derivative = [3.0, 1.0, 2.0;
+                         5.0, -4.0, 0.0];
+numerical_derivative = numericalDerivative.numericalDerivative11(h, values);
+EQUALITY('test_numericalDerivative11_values', analytical_derivative, numerical_derivative, 1e-5);
+
 %% test_numericalDerivative21
 % Test function of two variables, derivative with respect to first variable
 h = @(x1, x2) x1 * sin(x2);
@@ -75,3 +88,10 @@ numerical_H2 = numericalDerivative.numericalDerivative22(h, T, P);
 
 EQUALITY('test_numericalDerivative_with_pose_H1', analytic_H1, numerical_H1, 1e-5);
 EQUALITY('test_numericalDerivative_with_pose_H2', analytic_H2, numerical_H2, 1e-5);
+
+function y = valuesLinearCombination(values, key_a, key_b)
+a = values.atVector(key_a);
+b = values.atVector(key_b);
+y = [a(1) + 2.0 * a(2) + 3.0 * b;
+     -4.0 * a(1) + 5.0 * b];
+end

--- a/matlab/gtsam_tests/test_gtsam.m
+++ b/matlab/gtsam_tests/test_gtsam.m
@@ -54,6 +54,9 @@ testProperties
 display 'Starting: testUtilities'
 testUtilities
 
+display 'Starting: testNumericalDerivative'
+testNumericalDerivative
+
 if(exist('testSerialization.m','file') && ...
    ismethod('gtsam.Pose2', 'string_serialize') && ...
    ismethod('gtsam.Values', 'string_serialize') && ...


### PR DESCRIPTION
To support creating custom factors, I added the MATLAB equivalent of numerical derivatives

Both matlab/README and matlab/gtsam_tests/testNumericalDerivative.m have an example, and it works. 

I created a new issue (#2492), as it seems we cannot retrieve analytical derivatives via our normal output argument mechanism - which works in Python - but it does not work in MATLAB. This should not prevent people from checking the numerical derivatives for using the custom factors, however. 