### PR TITLE
Added GlobalPositioner Class

### DIFF
--- a/gtsam/sfm/GlobalPositioner.cpp
+++ b/gtsam/sfm/GlobalPositioner.cpp
@@ -24,37 +24,14 @@
 using namespace gtsam;
 using namespace std;
 
-namespace {
-std::mt19937 kPRNG(42);
-}  // namespace
-
-NonlinearFactorGraph GlobalPositioner::buildGraph(
-    const CameraPointDirections &cameraPointDirections) const {
-  return LocationRecovery::buildGraph(cameraPointDirections,
-                                     /*bilinear=*/true);
-}
-
-void GlobalPositioner::addPrior(
-    Key anchorCameraKey, NonlinearFactorGraph *graph,
-    const SharedNoiseModel &priorNoiseModel) const {
-  addAnchorPrior(anchorCameraKey, graph, priorNoiseModel);
-}
-
 Values GlobalPositioner::initializeRandomly(
     const std::set<Key> &cameraKeys, const std::set<Key> &landmarkKeys,
-    size_t numEdges, std::mt19937 *rng, const Values &initialValues) const {
+    const CameraPointDirections &cameraPointDirections,
+    const Values &initialValues) const {
   std::set<Key> allKeys(cameraKeys);
   allKeys.insert(landmarkKeys.begin(), landmarkKeys.end());
-  return LocationRecovery::initializeRandomly(allKeys, numEdges,
-                                              /*bilinear=*/true, rng,
-                                              initialValues);
-}
-
-Values GlobalPositioner::initializeRandomly(
-    const std::set<Key> &cameraKeys, const std::set<Key> &landmarkKeys,
-    size_t numEdges, const Values &initialValues) const {
-  return initializeRandomly(cameraKeys, landmarkKeys, numEdges, &kPRNG,
-                            initialValues);
+  return LocationRecovery::initializeRandomly(allKeys,
+      cameraPointDirections.size(), true, initialValues);
 }
 
 Values GlobalPositioner::run(
@@ -66,11 +43,11 @@ Values GlobalPositioner::run(
         "GlobalPositioner::run: anchorCameraKey must be in cameraKeys.");
   }
 
-  NonlinearFactorGraph graph = buildGraph(cameraPointDirections);
-  addPrior(anchorCameraKey, &graph);
-  Values initial = initializeRandomly(cameraKeys, landmarkKeys,
-                                      cameraPointDirections.size(),
-                                      initialValues);
+  NonlinearFactorGraph graph = buildGraph(cameraPointDirections, true);
+  addAnchorPrior(anchorCameraKey, &graph);
+  Values initial =
+      initializeRandomly(cameraKeys, landmarkKeys, cameraPointDirections,
+                          initialValues);
 
   LevenbergMarquardtOptimizer lm(graph, initial, lmParams_);
   return lm.optimize();

--- a/gtsam/sfm/GlobalPositioner.cpp
+++ b/gtsam/sfm/GlobalPositioner.cpp
@@ -1,0 +1,161 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010-2020, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file GlobalPositioner.cpp
+ * @author Kathir Gounder
+ * @date 2026
+ * @brief GLOMAP-style joint estimation of camera positions and 3D landmark
+ *        positions from camera-to-point direction measurements.
+ */
+
+#include <gtsam/base/Vector.h>
+#include <gtsam/geometry/Point3.h>
+#include <gtsam/geometry/Unit3.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/linear/NoiseModel.h>
+#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
+#include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <gtsam/nonlinear/Values.h>
+#include <gtsam/sfm/GlobalPositioner.h>
+#include <gtsam/sfm/TranslationFactor.h>  // for BilinearAngleTranslationFactor
+#include <gtsam/slam/PriorFactor.h>
+
+#include <random>
+#include <stdexcept>
+
+using namespace gtsam;
+using namespace std;
+
+namespace {
+// Default RNG for the wrapper-friendly initializeRandomly overload, mirroring
+// TranslationRecovery's pattern. Using a fixed seed makes results reproducible.
+std::mt19937 kPRNG(42);
+
+// Convert a Unit3 noise model (2D, on the manifold) to a Point3 noise model
+// (3D, in the ambient space). BilinearAngleTranslationFactor's residual lives
+// in R^3 (it computes scale * (Xk - ci) - measurement which is a Point3
+// difference), so we need a 3D noise model.
+//
+// The input direction measurements come with 2D noise on the Unit3 manifold,
+// but the factor's residual is 3D in the ambient space.
+SharedNoiseModel convertDirectionNoiseModel(
+    const SharedNoiseModel &unit3NoiseModel) {
+  using noiseModel::Isotropic;
+  if (auto isotropic =
+          std::dynamic_pointer_cast<Isotropic>(unit3NoiseModel)) {
+    return noiseModel::Isotropic::Sigma(3, isotropic->sigma());
+  }
+  if (auto robust = std::dynamic_pointer_cast<noiseModel::Robust>(
+          unit3NoiseModel)) {
+    return noiseModel::Robust::Create(robust->robust(),
+                                      convertDirectionNoiseModel(robust->noise()));
+  }
+  throw std::runtime_error(
+      "GlobalPositioner::convertDirectionNoiseModel: only isotropic "
+      "(optionally robust-wrapped) noise models are supported.");
+}
+}  // namespace
+
+NonlinearFactorGraph GlobalPositioner::buildGraph(
+    const CameraPointDirections &cameraPointDirections) const {
+  NonlinearFactorGraph graph;
+
+  // One BilinearAngleTranslationFactor per camera-to-point direction.
+  // Each factor connects: camera key (key1), landmark key (key2), and a
+  // per-observation scale variable (Symbol 'S', edge_index).
+  uint64_t i = 0;
+  for (const auto &edge : cameraPointDirections) {
+    auto model = convertDirectionNoiseModel(edge.noiseModel());
+    graph.emplace_shared<BilinearAngleTranslationFactor>(
+        edge.key1(), edge.key2(), Symbol('S', i), edge.measured(), model);
+    ++i;
+  }
+  return graph;
+}
+
+void GlobalPositioner::addPrior(
+    Key anchorCameraKey, NonlinearFactorGraph *graph,
+    const SharedNoiseModel &priorNoiseModel) const {
+  // Pin the anchor camera to the origin to fix the 3 translation DOF.
+  // Scale is *not* fixed here — the BATA per-observation scale variables
+  // handle scale through their joint optimization.
+  graph->addPrior<Point3>(anchorCameraKey, Point3(0, 0, 0), priorNoiseModel);
+}
+
+Values GlobalPositioner::initializeRandomly(
+    const std::set<Key> &cameraKeys, const std::set<Key> &landmarkKeys,
+    size_t numEdges, std::mt19937 *rng, const Values &initialValues) const {
+  uniform_real_distribution<double> randomVal(-1, 1);
+  Values initial;
+
+  // Helper: insert a random Point3 if the key isn't already in initialValues.
+  auto insertPosition = [&](Key key) {
+    if (initialValues.exists(key)) {
+      initial.insert<Point3>(key, initialValues.at<Point3>(key));
+    } else {
+      initial.insert<Point3>(
+          key, Point3(randomVal(*rng), randomVal(*rng), randomVal(*rng)));
+    }
+  };
+
+  // Initialize all camera positions.
+  for (const Key &cameraKey : cameraKeys) {
+    insertPosition(cameraKey);
+  }
+
+  // Initialize all landmark positions.
+  for (const Key &landmarkKey : landmarkKeys) {
+    insertPosition(landmarkKey);
+  }
+
+  // Initialize per-observation BATA scale variables to 1.0.
+  // One scale variable per edge, named with Symbol('S', edge_index).
+  for (size_t i = 0; i < numEdges; ++i) {
+    initial.insert<Vector1>(Symbol('S', i), Vector1(1.0));
+  }
+
+  return initial;
+}
+
+Values GlobalPositioner::initializeRandomly(
+    const std::set<Key> &cameraKeys, const std::set<Key> &landmarkKeys,
+    size_t numEdges, const Values &initialValues) const {
+  return initializeRandomly(cameraKeys, landmarkKeys, numEdges, &kPRNG,
+                            initialValues);
+}
+
+Values GlobalPositioner::run(
+    const CameraPointDirections &cameraPointDirections,
+    const std::set<Key> &cameraKeys, const std::set<Key> &landmarkKeys,
+    Key anchorCameraKey, const Values &initialValues) const {
+  // Sanity check: the anchor must actually be in the camera key set.
+  if (cameraKeys.find(anchorCameraKey) == cameraKeys.end()) {
+    throw std::invalid_argument(
+        "GlobalPositioner::run: anchorCameraKey must be in cameraKeys.");
+  }
+
+  // Build the BATA factor graph from camera-to-point direction measurements.
+  NonlinearFactorGraph graph = buildGraph(cameraPointDirections);
+
+  // Anchor one camera at the origin to fix translation gauge.
+  // Scale gauge is handled by the BATA scale variables (no landmark prior).
+  addPrior(anchorCameraKey, &graph);
+
+  // Random initialization for cameras, landmarks, and BATA scale variables.
+  Values initial = initializeRandomly(cameraKeys, landmarkKeys,
+                                      cameraPointDirections.size(),
+                                      initialValues);
+
+  // Run Levenberg-Marquardt.
+  LevenbergMarquardtOptimizer lm(graph, initial, lmParams_);
+  return lm.optimize();
+}

--- a/gtsam/sfm/GlobalPositioner.cpp
+++ b/gtsam/sfm/GlobalPositioner.cpp
@@ -13,117 +13,41 @@
  * @file GlobalPositioner.cpp
  * @author Kathir Gounder
  * @date 2026
- * @brief GLOMAP-style joint estimation of camera positions and 3D landmark
- *        positions from camera-to-point direction measurements.
+ * @brief GLOMAP-style joint estimation of camera and landmark positions.
  */
 
-#include <gtsam/base/Vector.h>
-#include <gtsam/geometry/Point3.h>
-#include <gtsam/geometry/Unit3.h>
-#include <gtsam/inference/Symbol.h>
-#include <gtsam/linear/NoiseModel.h>
 #include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
-#include <gtsam/nonlinear/NonlinearFactorGraph.h>
-#include <gtsam/nonlinear/Values.h>
 #include <gtsam/sfm/GlobalPositioner.h>
-#include <gtsam/sfm/TranslationFactor.h>  // for BilinearAngleTranslationFactor
-#include <gtsam/slam/PriorFactor.h>
 
-#include <random>
 #include <stdexcept>
 
 using namespace gtsam;
 using namespace std;
 
 namespace {
-// Default RNG for the wrapper-friendly initializeRandomly overload, mirroring
-// TranslationRecovery's pattern. Using a fixed seed makes results reproducible.
 std::mt19937 kPRNG(42);
-
-// Convert a Unit3 noise model (2D, on the manifold) to a Point3 noise model
-// (3D, in the ambient space). BilinearAngleTranslationFactor's residual lives
-// in R^3 (it computes scale * (Xk - ci) - measurement which is a Point3
-// difference), so we need a 3D noise model.
-//
-// The input direction measurements come with 2D noise on the Unit3 manifold,
-// but the factor's residual is 3D in the ambient space.
-SharedNoiseModel convertDirectionNoiseModel(
-    const SharedNoiseModel &unit3NoiseModel) {
-  using noiseModel::Isotropic;
-  if (auto isotropic =
-          std::dynamic_pointer_cast<Isotropic>(unit3NoiseModel)) {
-    return noiseModel::Isotropic::Sigma(3, isotropic->sigma());
-  }
-  if (auto robust = std::dynamic_pointer_cast<noiseModel::Robust>(
-          unit3NoiseModel)) {
-    return noiseModel::Robust::Create(robust->robust(),
-                                      convertDirectionNoiseModel(robust->noise()));
-  }
-  throw std::runtime_error(
-      "GlobalPositioner::convertDirectionNoiseModel: only isotropic "
-      "(optionally robust-wrapped) noise models are supported.");
-}
 }  // namespace
 
 NonlinearFactorGraph GlobalPositioner::buildGraph(
     const CameraPointDirections &cameraPointDirections) const {
-  NonlinearFactorGraph graph;
-
-  // One BilinearAngleTranslationFactor per camera-to-point direction.
-  // Each factor connects: camera key (key1), landmark key (key2), and a
-  // per-observation scale variable (Symbol 'S', edge_index).
-  uint64_t i = 0;
-  for (const auto &edge : cameraPointDirections) {
-    auto model = convertDirectionNoiseModel(edge.noiseModel());
-    graph.emplace_shared<BilinearAngleTranslationFactor>(
-        edge.key1(), edge.key2(), Symbol('S', i), edge.measured(), model);
-    ++i;
-  }
-  return graph;
+  return LocationRecovery::buildGraph(cameraPointDirections,
+                                     /*bilinear=*/true);
 }
 
 void GlobalPositioner::addPrior(
     Key anchorCameraKey, NonlinearFactorGraph *graph,
     const SharedNoiseModel &priorNoiseModel) const {
-  // Pin the anchor camera to the origin to fix the 3 translation DOF.
-  // Scale is *not* fixed here — the BATA per-observation scale variables
-  // handle scale through their joint optimization.
-  graph->addPrior<Point3>(anchorCameraKey, Point3(0, 0, 0), priorNoiseModel);
+  addAnchorPrior(anchorCameraKey, graph, priorNoiseModel);
 }
 
 Values GlobalPositioner::initializeRandomly(
     const std::set<Key> &cameraKeys, const std::set<Key> &landmarkKeys,
     size_t numEdges, std::mt19937 *rng, const Values &initialValues) const {
-  uniform_real_distribution<double> randomVal(-1, 1);
-  Values initial;
-
-  // Helper: insert a random Point3 if the key isn't already in initialValues.
-  auto insertPosition = [&](Key key) {
-    if (initialValues.exists(key)) {
-      initial.insert<Point3>(key, initialValues.at<Point3>(key));
-    } else {
-      initial.insert<Point3>(
-          key, Point3(randomVal(*rng), randomVal(*rng), randomVal(*rng)));
-    }
-  };
-
-  // Initialize all camera positions.
-  for (const Key &cameraKey : cameraKeys) {
-    insertPosition(cameraKey);
-  }
-
-  // Initialize all landmark positions.
-  for (const Key &landmarkKey : landmarkKeys) {
-    insertPosition(landmarkKey);
-  }
-
-  // Initialize per-observation BATA scale variables to 1.0.
-  // One scale variable per edge, named with Symbol('S', edge_index).
-  for (size_t i = 0; i < numEdges; ++i) {
-    initial.insert<Vector1>(Symbol('S', i), Vector1(1.0));
-  }
-
-  return initial;
+  std::set<Key> allKeys(cameraKeys);
+  allKeys.insert(landmarkKeys.begin(), landmarkKeys.end());
+  return LocationRecovery::initializeRandomly(allKeys, numEdges,
+                                              /*bilinear=*/true, rng,
+                                              initialValues);
 }
 
 Values GlobalPositioner::initializeRandomly(
@@ -137,25 +61,17 @@ Values GlobalPositioner::run(
     const CameraPointDirections &cameraPointDirections,
     const std::set<Key> &cameraKeys, const std::set<Key> &landmarkKeys,
     Key anchorCameraKey, const Values &initialValues) const {
-  // Sanity check: the anchor must actually be in the camera key set.
   if (cameraKeys.find(anchorCameraKey) == cameraKeys.end()) {
     throw std::invalid_argument(
         "GlobalPositioner::run: anchorCameraKey must be in cameraKeys.");
   }
 
-  // Build the BATA factor graph from camera-to-point direction measurements.
   NonlinearFactorGraph graph = buildGraph(cameraPointDirections);
-
-  // Anchor one camera at the origin to fix translation gauge.
-  // Scale gauge is handled by the BATA scale variables (no landmark prior).
   addPrior(anchorCameraKey, &graph);
-
-  // Random initialization for cameras, landmarks, and BATA scale variables.
   Values initial = initializeRandomly(cameraKeys, landmarkKeys,
                                       cameraPointDirections.size(),
                                       initialValues);
 
-  // Run Levenberg-Marquardt.
   LevenbergMarquardtOptimizer lm(graph, initial, lmParams_);
   return lm.optimize();
 }

--- a/gtsam/sfm/GlobalPositioner.h
+++ b/gtsam/sfm/GlobalPositioner.h
@@ -15,145 +15,62 @@
  * @file GlobalPositioner.h
  * @author Kathir Gounder
  * @date 2026
- * @brief GLOMAP-style joint estimation of camera positions and 3D landmark
- *        positions from camera-to-point direction measurements.
+ * @brief GLOMAP-style joint estimation of camera and landmark positions
+ *        from camera-to-point direction measurements.
  */
 
-#include <gtsam/geometry/Unit3.h>
-#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
-#include <gtsam/nonlinear/Values.h>
-#include <gtsam/sfm/BinaryMeasurement.h>
+#include <gtsam/sfm/LocationRecovery.h>
 
-#include <random>
 #include <set>
-#include <vector>
 
 namespace gtsam {
 
-/**
- * @brief Joint estimation of camera positions and 3D landmark positions from
- * camera-to-point direction measurements (GLOMAP-style global positioning).
- *
- * Unlike TranslationRecovery (which solves the camera-camera translation
- * synchronization problem), GlobalPositioner solves a bipartite estimation
- * problem with two distinct kinds of unknowns:
- *   - Camera positions  c_i \in R^3  (from camera key set)
- *   - Landmark positions X_k \in R^3 (from landmark key set)
- *
- * The graph is structurally bipartite: every measurement is a unit direction
- * from one camera to one landmark, expressed in the world frame. Cameras
- * never directly measure other cameras and landmarks never directly measure
- * other landmarks. This is fundamentally different from synchronization
- * problems like rotation averaging or translation averaging, where all nodes
- * live in the same space and edges connect nodes of the same kind.
- *
- * The measurement equation, following BATA (Zhuang et al., CVPR 2018) and
- * GLOMAP (Pan et al., ECCV 2024), is:
- *
- *    w_iZk = Unit3(s_ik * (X_k - c_i))
- *
- * where w_iZk is the measured world-frame direction from camera i to landmark
- * k, and s_ik is a per-observation scale variable that is jointly optimized.
- * The bilinear residual is bounded, which gives the optimization a smooth
- * landscape that tolerates random initialization (in contrast to the
- * unbounded reprojection cost which requires careful initialization).
- *
- * Gauge freedom: the problem has 3 translation DOF (overall position of the
- * reconstruction) and 1 scale DOF (overall size of the reconstruction). We
- * fix translation by anchoring one camera to the origin via a strong prior.
- * We do *not* fix scale by pinning a landmark; instead, the BATA per-
- * observation scale variables establish scale through the consensus of all
- * observations. This is how GLOMAP handles gauge and is different from
- * TranslationRecovery's strategy of pinning the second key of the first edge.
- *
- * Internally uses BilinearAngleTranslationFactor (the existing GTSAM factor
- * that already implements the BATA residual). No new factor types are
- * introduced by this class.
- *
- * Relationship to TranslationRecovery: TranslationRecovery solves
- * translation synchronization (camera-camera relative translation directions
- * to camera positions). GlobalPositioner solves the bipartite camera+landmark
- * estimation problem. The two classes share the same underlying factor
- * (BilinearAngleTranslationFactor when TranslationRecovery is configured
- * with use_bilinear_translation_factor=true) but the fundamental graph structure,
- * gauge handling, and actual use-case in a full structure-from-motion pipeline is different.
- *
- * Reference: Pan, L., Barath, D., Pollefeys, M., Schonberger, J.L.,
- * "Global Structure-from-Motion Revisited," ECCV 2024.
- */
-class GTSAM_EXPORT GlobalPositioner {
+// Opinionated composition of LocationRecovery for the bipartite
+// camera+landmark estimation problem (GLOMAP-style global positioning).
+// Enforces:
+//   - Explicit separation of camera keys and landmark keys
+//   - Validation that the anchor key is a camera
+//   - BILINEAR (BATA) cost function exclusively
+//   - No DSFMap handling (not applicable to camera-landmark edges)
+//
+// For custom graph configurations (mixed edges, custom gauge, etc.),
+// use LocationRecovery directly.
+//
+// Reference: Pan, L. et al., "Global Structure-from-Motion Revisited,"
+// ECCV 2024.
+class GTSAM_EXPORT GlobalPositioner : public LocationRecovery {
  public:
   using CameraPointDirection = BinaryMeasurement<Unit3>;
   using CameraPointDirections = std::vector<CameraPointDirection>;
 
- private:
-  // Parameters for the underlying Levenberg-Marquardt optimizer.
-  LevenbergMarquardtParams lmParams_;
-
- public:
   /**
-   * @brief Construct a GlobalPositioner with optimizer parameters.
-   * @param lmParams Levenberg-Marquardt parameters for the inner optimization.
+   * @brief Construct with LM parameters.
    */
   explicit GlobalPositioner(const LevenbergMarquardtParams &lmParams)
-      : lmParams_(lmParams) {}
+      : LocationRecovery(lmParams) {}
 
   /**
-   * @brief Default constructor with default LM parameters.
+   * @brief Default constructor.
    */
   GlobalPositioner() = default;
 
   /**
-   * @brief Build the factor graph for joint camera+landmark optimization.
-   *
-   * Each input edge contributes one BilinearAngleTranslationFactor connecting
-   * a camera key, a landmark key, and a per-observation scale variable
-   * (Symbol 'S', i) where i is the edge index.
-   *
-   * @param cameraPointDirections  unit direction measurements from cameras to
-   *                  landmarks, expressed in the world frame. Each edge's key1
-   *                  must be a camera key and key2 must be a landmark key.
-   * @return NonlinearFactorGraph containing one BATA factor per edge.
+   * @brief Build BATA factor graph from camera-to-point directions.
+   * Delegates to LocationRecovery::buildGraph with bilinear=true.
    */
   NonlinearFactorGraph buildGraph(
       const CameraPointDirections &cameraPointDirections) const;
 
   /**
-   * @brief Add a gauge-fixing prior on a single anchor camera.
-   *
-   * Pins the specified anchor camera to the origin via a strong prior on its
-   * Point3 position. This fixes the 3 translation DOF of the reconstruction.
-   *
-   * Scale is *not* fixed by a landmark prior. Scale is established jointly
-   * by the BATA per-observation scale variables (one Vector1 per edge) which
-   * are initialized to 1.0 and optimized with the rest of the variables.
-   * The consensus of these scale variables across all observations determines
-   * the overall scale of the reconstruction.
-   *
-   * @param anchorCameraKey  the camera key to anchor at the origin.
-   * @param graph            factor graph to which the prior is added.
-   * @param priorNoiseModel  noise model for the anchor prior (default: tight
-   *                         isotropic to make it effectively a hard constraint).
+   * @brief Anchor one camera at the origin.
+   * Scale is handled by BATA scale variables — no landmark prior needed.
    */
   void addPrior(Key anchorCameraKey, NonlinearFactorGraph *graph,
                 const SharedNoiseModel &priorNoiseModel =
-                    noiseModel::Isotropic::Sigma(3, 1e-3)) const;
+                    noiseModel::Isotropic::Sigma(3, 0.01)) const;
 
   /**
-   * @brief Random initialization of camera positions, landmark positions, and
-   * BATA scale variables.
-   *
-   * Camera and landmark positions are initialized uniformly in [-1, 1]^3,
-   * matching GLOMAP's initialization-free claim. BATA scale variables (one
-   * per edge) are initialized to 1.0. The bounded BATA residual makes this
-   * random initialization sufficient in practice.
-   *
-   * @param cameraKeys     set of camera keys to initialize.
-   * @param landmarkKeys   set of landmark keys to initialize.
-   * @param numEdges       number of direction edges (used to create scale vars).
-   * @param rng            random number generator.
-   * @param initialValues  optional partial initial values to seed specific keys.
-   * @return Values containing initial estimates for all unknowns.
+   * @brief Initialize cameras, landmarks, and BATA scale variables.
    */
   Values initializeRandomly(const std::set<Key> &cameraKeys,
                             const std::set<Key> &landmarkKeys, size_t numEdges,
@@ -166,18 +83,10 @@ class GTSAM_EXPORT GlobalPositioner {
                             const Values &initialValues = Values()) const;
 
   /**
-   * @brief Build the factor graph, fix gauge, and run LM optimization.
+   * @brief Build graph, fix gauge, initialize, and optimize.
    *
-   * @param cameraPointDirections  unit direction measurements from cameras to
-   *                               landmarks in world frame.
-   * @param cameraKeys       explicit set of camera keys.
-   * @param landmarkKeys     explicit set of landmark keys.
-   * @param anchorCameraKey  camera key to anchor at the origin (must be in
-   *                         cameraKeys).
-   * @param initialValues    optional partial initial values; missing keys are
-   *                         initialized randomly.
-   * @return Values containing optimized camera positions (Point3), landmark
-   *         positions (Point3), and BATA scale variables (Vector1).
+   * Enforces bipartite structure: anchorCameraKey must be in cameraKeys.
+   * For custom configurations, use LocationRecovery directly.
    */
   Values run(const CameraPointDirections &cameraPointDirections,
              const std::set<Key> &cameraKeys,

--- a/gtsam/sfm/GlobalPositioner.h
+++ b/gtsam/sfm/GlobalPositioner.h
@@ -55,32 +55,13 @@ class GTSAM_EXPORT GlobalPositioner : public LocationRecovery {
   GlobalPositioner() = default;
 
   /**
-   * @brief Build BATA factor graph from camera-to-point directions.
-   * Delegates to LocationRecovery::buildGraph with bilinear=true.
-   */
-  NonlinearFactorGraph buildGraph(
-      const CameraPointDirections &cameraPointDirections) const;
-
-  /**
-   * @brief Anchor one camera at the origin.
-   * Scale is handled by BATA scale variables — no landmark prior needed.
-   */
-  void addPrior(Key anchorCameraKey, NonlinearFactorGraph *graph,
-                const SharedNoiseModel &priorNoiseModel =
-                    noiseModel::Isotropic::Sigma(3, 0.01)) const;
-
-  /**
    * @brief Initialize cameras, landmarks, and BATA scale variables.
+   * Unions cameraKeys and landmarkKeys, derives numEdges from measurements.
    */
-  Values initializeRandomly(const std::set<Key> &cameraKeys,
-                            const std::set<Key> &landmarkKeys, size_t numEdges,
-                            std::mt19937 *rng,
-                            const Values &initialValues = Values()) const;
-
-  /// Version with a fixed default RNG seed.
-  Values initializeRandomly(const std::set<Key> &cameraKeys,
-                            const std::set<Key> &landmarkKeys, size_t numEdges,
-                            const Values &initialValues = Values()) const;
+  Values initializeRandomly(
+      const std::set<Key> &cameraKeys, const std::set<Key> &landmarkKeys,
+      const CameraPointDirections &cameraPointDirections,
+      const Values &initialValues = Values()) const;
 
   /**
    * @brief Build graph, fix gauge, initialize, and optimize.

--- a/gtsam/sfm/GlobalPositioner.h
+++ b/gtsam/sfm/GlobalPositioner.h
@@ -1,0 +1,188 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010-2020, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+#pragma once
+
+/**
+ * @file GlobalPositioner.h
+ * @author Kathir Gounder
+ * @date 2026
+ * @brief GLOMAP-style joint estimation of camera positions and 3D landmark
+ *        positions from camera-to-point direction measurements.
+ */
+
+#include <gtsam/geometry/Unit3.h>
+#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
+#include <gtsam/nonlinear/Values.h>
+#include <gtsam/sfm/BinaryMeasurement.h>
+
+#include <random>
+#include <set>
+#include <vector>
+
+namespace gtsam {
+
+/**
+ * @brief Joint estimation of camera positions and 3D landmark positions from
+ * camera-to-point direction measurements (GLOMAP-style global positioning).
+ *
+ * Unlike TranslationRecovery (which solves the camera-camera translation
+ * synchronization problem), GlobalPositioner solves a bipartite estimation
+ * problem with two distinct kinds of unknowns:
+ *   - Camera positions  c_i \in R^3  (from camera key set)
+ *   - Landmark positions X_k \in R^3 (from landmark key set)
+ *
+ * The graph is structurally bipartite: every measurement is a unit direction
+ * from one camera to one landmark, expressed in the world frame. Cameras
+ * never directly measure other cameras and landmarks never directly measure
+ * other landmarks. This is fundamentally different from synchronization
+ * problems like rotation averaging or translation averaging, where all nodes
+ * live in the same space and edges connect nodes of the same kind.
+ *
+ * The measurement equation, following BATA (Zhuang et al., CVPR 2018) and
+ * GLOMAP (Pan et al., ECCV 2024), is:
+ *
+ *    w_iZk = Unit3(s_ik * (X_k - c_i))
+ *
+ * where w_iZk is the measured world-frame direction from camera i to landmark
+ * k, and s_ik is a per-observation scale variable that is jointly optimized.
+ * The bilinear residual is bounded, which gives the optimization a smooth
+ * landscape that tolerates random initialization (in contrast to the
+ * unbounded reprojection cost which requires careful initialization).
+ *
+ * Gauge freedom: the problem has 3 translation DOF (overall position of the
+ * reconstruction) and 1 scale DOF (overall size of the reconstruction). We
+ * fix translation by anchoring one camera to the origin via a strong prior.
+ * We do *not* fix scale by pinning a landmark; instead, the BATA per-
+ * observation scale variables establish scale through the consensus of all
+ * observations. This is how GLOMAP handles gauge and is different from
+ * TranslationRecovery's strategy of pinning the second key of the first edge.
+ *
+ * Internally uses BilinearAngleTranslationFactor (the existing GTSAM factor
+ * that already implements the BATA residual). No new factor types are
+ * introduced by this class.
+ *
+ * Relationship to TranslationRecovery: TranslationRecovery solves
+ * translation synchronization (camera-camera relative translation directions
+ * to camera positions). GlobalPositioner solves the bipartite camera+landmark
+ * estimation problem. The two classes share the same underlying factor
+ * (BilinearAngleTranslationFactor when TranslationRecovery is configured
+ * with use_bilinear_translation_factor=true) but the fundamental graph structure,
+ * gauge handling, and actual use-case in a full structure-from-motion pipeline is different.
+ *
+ * Reference: Pan, L., Barath, D., Pollefeys, M., Schonberger, J.L.,
+ * "Global Structure-from-Motion Revisited," ECCV 2024.
+ */
+class GTSAM_EXPORT GlobalPositioner {
+ public:
+  using CameraPointDirection = BinaryMeasurement<Unit3>;
+  using CameraPointDirections = std::vector<CameraPointDirection>;
+
+ private:
+  // Parameters for the underlying Levenberg-Marquardt optimizer.
+  LevenbergMarquardtParams lmParams_;
+
+ public:
+  /**
+   * @brief Construct a GlobalPositioner with optimizer parameters.
+   * @param lmParams Levenberg-Marquardt parameters for the inner optimization.
+   */
+  explicit GlobalPositioner(const LevenbergMarquardtParams &lmParams)
+      : lmParams_(lmParams) {}
+
+  /**
+   * @brief Default constructor with default LM parameters.
+   */
+  GlobalPositioner() = default;
+
+  /**
+   * @brief Build the factor graph for joint camera+landmark optimization.
+   *
+   * Each input edge contributes one BilinearAngleTranslationFactor connecting
+   * a camera key, a landmark key, and a per-observation scale variable
+   * (Symbol 'S', i) where i is the edge index.
+   *
+   * @param cameraPointDirections  unit direction measurements from cameras to
+   *                  landmarks, expressed in the world frame. Each edge's key1
+   *                  must be a camera key and key2 must be a landmark key.
+   * @return NonlinearFactorGraph containing one BATA factor per edge.
+   */
+  NonlinearFactorGraph buildGraph(
+      const CameraPointDirections &cameraPointDirections) const;
+
+  /**
+   * @brief Add a gauge-fixing prior on a single anchor camera.
+   *
+   * Pins the specified anchor camera to the origin via a strong prior on its
+   * Point3 position. This fixes the 3 translation DOF of the reconstruction.
+   *
+   * Scale is *not* fixed by a landmark prior. Scale is established jointly
+   * by the BATA per-observation scale variables (one Vector1 per edge) which
+   * are initialized to 1.0 and optimized with the rest of the variables.
+   * The consensus of these scale variables across all observations determines
+   * the overall scale of the reconstruction.
+   *
+   * @param anchorCameraKey  the camera key to anchor at the origin.
+   * @param graph            factor graph to which the prior is added.
+   * @param priorNoiseModel  noise model for the anchor prior (default: tight
+   *                         isotropic to make it effectively a hard constraint).
+   */
+  void addPrior(Key anchorCameraKey, NonlinearFactorGraph *graph,
+                const SharedNoiseModel &priorNoiseModel =
+                    noiseModel::Isotropic::Sigma(3, 1e-3)) const;
+
+  /**
+   * @brief Random initialization of camera positions, landmark positions, and
+   * BATA scale variables.
+   *
+   * Camera and landmark positions are initialized uniformly in [-1, 1]^3,
+   * matching GLOMAP's initialization-free claim. BATA scale variables (one
+   * per edge) are initialized to 1.0. The bounded BATA residual makes this
+   * random initialization sufficient in practice.
+   *
+   * @param cameraKeys     set of camera keys to initialize.
+   * @param landmarkKeys   set of landmark keys to initialize.
+   * @param numEdges       number of direction edges (used to create scale vars).
+   * @param rng            random number generator.
+   * @param initialValues  optional partial initial values to seed specific keys.
+   * @return Values containing initial estimates for all unknowns.
+   */
+  Values initializeRandomly(const std::set<Key> &cameraKeys,
+                            const std::set<Key> &landmarkKeys, size_t numEdges,
+                            std::mt19937 *rng,
+                            const Values &initialValues = Values()) const;
+
+  /// Version with a fixed default RNG seed.
+  Values initializeRandomly(const std::set<Key> &cameraKeys,
+                            const std::set<Key> &landmarkKeys, size_t numEdges,
+                            const Values &initialValues = Values()) const;
+
+  /**
+   * @brief Build the factor graph, fix gauge, and run LM optimization.
+   *
+   * @param cameraPointDirections  unit direction measurements from cameras to
+   *                               landmarks in world frame.
+   * @param cameraKeys       explicit set of camera keys.
+   * @param landmarkKeys     explicit set of landmark keys.
+   * @param anchorCameraKey  camera key to anchor at the origin (must be in
+   *                         cameraKeys).
+   * @param initialValues    optional partial initial values; missing keys are
+   *                         initialized randomly.
+   * @return Values containing optimized camera positions (Point3), landmark
+   *         positions (Point3), and BATA scale variables (Vector1).
+   */
+  Values run(const CameraPointDirections &cameraPointDirections,
+             const std::set<Key> &cameraKeys,
+             const std::set<Key> &landmarkKeys, Key anchorCameraKey,
+             const Values &initialValues = Values()) const;
+};
+
+}  // namespace gtsam

--- a/gtsam/sfm/LocationRecovery.cpp
+++ b/gtsam/sfm/LocationRecovery.cpp
@@ -1,0 +1,115 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010-2020, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file LocationRecovery.cpp
+ * @author Kathir Gounder, Frank Dellaert
+ * @date April 2026
+ * @brief Recover absolute Point3 locations from pairwise Unit3 direction
+ *        measurements.
+ */
+
+#include <gtsam/geometry/Point3.h>
+#include <gtsam/geometry/Unit3.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/linear/NoiseModel.h>
+#include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <gtsam/nonlinear/Values.h>
+#include <gtsam/sfm/LocationRecovery.h>
+#include <gtsam/sfm/TranslationFactor.h>
+#include <gtsam/slam/PriorFactor.h>
+
+#include <random>
+#include <set>
+
+using namespace gtsam;
+using namespace std;
+
+namespace {
+// In Wrappers we have no access to this so have a default ready.
+std::mt19937 kPRNG(42);
+}  // namespace
+
+SharedNoiseModel LocationRecovery::convertNoiseModel(
+    const SharedNoiseModel &unit3NoiseModel) {
+  using noiseModel::Isotropic;
+  if (auto isotropic =
+          std::dynamic_pointer_cast<Isotropic>(unit3NoiseModel)) {
+    return noiseModel::Isotropic::Sigma(3, isotropic->sigma());
+  }
+  if (auto robust = std::dynamic_pointer_cast<noiseModel::Robust>(
+          unit3NoiseModel)) {
+    return noiseModel::Robust::Create(robust->robust(),
+                                      convertNoiseModel(robust->noise()));
+  }
+  throw std::runtime_error(
+      "LocationRecovery::convertNoiseModel: only isotropic (optionally "
+      "robust-wrapped) noise model supported.");
+}
+
+NonlinearFactorGraph LocationRecovery::buildGraph(
+    const DirectionEdges &edges, bool bilinear) const {
+  NonlinearFactorGraph graph;
+  uint64_t i = 0;
+  for (const auto &edge : edges) {
+    auto model = convertNoiseModel(edge.noiseModel());
+    if (bilinear) {
+      graph.emplace_shared<BilinearAngleTranslationFactor>(
+          edge.key1(), edge.key2(), Symbol('S', i), edge.measured(), model);
+    } else {
+      graph.emplace_shared<TranslationFactor>(edge.key1(), edge.key2(),
+                                              edge.measured(), model);
+    }
+    i++;
+  }
+  return graph;
+}
+
+void LocationRecovery::addAnchorPrior(
+    Key anchorKey, NonlinearFactorGraph *graph,
+    const SharedNoiseModel &priorNoiseModel) const {
+  graph->addPrior<Point3>(anchorKey, Point3(0, 0, 0), priorNoiseModel);
+}
+
+Values LocationRecovery::initializeRandomly(
+    const std::set<Key> &keys, size_t numEdges, bool bilinear,
+    std::mt19937 *rng, const Values &initialValues) const {
+  uniform_real_distribution<double> randomVal(-1, 1);
+  Values initial;
+
+  auto insert = [&](Key j) {
+    if (initial.exists(j)) return;
+    if (initialValues.exists(j)) {
+      initial.insert<Point3>(j, initialValues.at<Point3>(j));
+    } else {
+      initial.insert<Point3>(
+          j, Point3(randomVal(*rng), randomVal(*rng), randomVal(*rng)));
+    }
+  };
+
+  for (const Key &key : keys) {
+    insert(key);
+  }
+
+  if (bilinear) {
+    for (uint64_t i = 0; i < numEdges; i++) {
+      initial.insert<Vector1>(Symbol('S', i), Vector1(1.0));
+    }
+  }
+
+  return initial;
+}
+
+Values LocationRecovery::initializeRandomly(
+    const std::set<Key> &keys, size_t numEdges, bool bilinear,
+    const Values &initialValues) const {
+  return initializeRandomly(keys, numEdges, bilinear, &kPRNG, initialValues);
+}

--- a/gtsam/sfm/LocationRecovery.h
+++ b/gtsam/sfm/LocationRecovery.h
@@ -13,7 +13,7 @@
 
 /**
  * @file LocationRecovery.h
- * @author Kathir Gounder, Frank Dellaert
+ * @author Kathir Gounder, Akshay Krishnan, Frank Dellaert
  * @date April 2026
  * @brief Recover absolute Point3 locations from pairwise Unit3 direction
  *        measurements, using either chordal or bilinear (BATA) cost functions.

--- a/gtsam/sfm/LocationRecovery.h
+++ b/gtsam/sfm/LocationRecovery.h
@@ -1,0 +1,116 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010-2020, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+#pragma once
+
+/**
+ * @file LocationRecovery.h
+ * @author Kathir Gounder, Frank Dellaert
+ * @date April 2026
+ * @brief Recover absolute Point3 locations from pairwise Unit3 direction
+ *        measurements, using either chordal or bilinear (BATA) cost functions.
+ */
+
+#include <gtsam/geometry/Unit3.h>
+#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
+#include <gtsam/nonlinear/Values.h>
+#include <gtsam/sfm/BinaryMeasurement.h>
+
+#include <random>
+#include <set>
+#include <vector>
+
+namespace gtsam {
+
+// Recover absolute Point3 locations from pairwise Unit3 direction
+// measurements. This base class is unopinionated about graph structure:
+// measurements can connect any pair of Point3 unknowns (cameras, landmarks,
+// sensors, etc.). Subclasses add problem-specific opinions:
+//   - GlobalPositioner: bipartite camera+landmark, anchor-only gauge.
+//   - TranslationRecovery: homogeneous camera-camera, DSFMap, two-key gauge.
+//
+// Supports two cost functions via the bilinear flag:
+//   false — TranslationFactor: normalized(Tb-Ta) - measured  (chordal)
+//   true  — BilinearAngleTranslationFactor: scale*(Tb-Ta) - measured  (BATA)
+class GTSAM_EXPORT LocationRecovery {
+ public:
+  using DirectionEdges = std::vector<BinaryMeasurement<Unit3>>;
+
+ protected:
+  LevenbergMarquardtParams lmParams_;
+
+  /// Convert Unit3 (2D manifold) noise to Point3 (3D ambient) noise.
+  static SharedNoiseModel convertNoiseModel(
+      const SharedNoiseModel &unit3NoiseModel);
+
+ public:
+  /**
+   * @brief Construct with LM parameters.
+   */
+  explicit LocationRecovery(const LevenbergMarquardtParams &lmParams)
+      : lmParams_(lmParams) {}
+
+  /**
+   * @brief Default constructor.
+   */
+  LocationRecovery() = default;
+
+  /**
+   * @brief Build factor graph from direction measurements.
+   *
+   * If bilinear is true, uses BilinearAngleTranslationFactor (BATA) with
+   * per-observation scale variables Symbol('S', i). Otherwise uses the
+   * chordal TranslationFactor.
+   *
+   * @param edges    Unit3 direction measurements between Point3 unknowns.
+   * @param bilinear if true, use BATA factors (default: true).
+   * @return NonlinearFactorGraph
+   */
+  NonlinearFactorGraph buildGraph(const DirectionEdges &edges,
+                                  bool bilinear = true) const;
+
+  /**
+   * @brief Add a prior pinning one key to the origin.
+   *
+   * Fixes 3 translation DOF. Does not assume the key is a camera or
+   * landmark — it just pins a Point3.
+   */
+  void addAnchorPrior(
+      Key anchorKey, NonlinearFactorGraph *graph,
+      const SharedNoiseModel &priorNoiseModel =
+          noiseModel::Isotropic::Sigma(3, 0.01)) const;
+
+  /**
+   * @brief Random initialization of Point3 keys and BATA scale variables.
+   *
+   * Point3 keys are initialized uniformly in [-1, 1]^3. If bilinear is
+   * true, also creates numEdges scale variables initialized to 1.0.
+   *
+   * @param keys          Point3 keys to initialize.
+   * @param numEdges      number of edges (for scale variable count).
+   * @param bilinear      whether to create BATA scale variables.
+   * @param rng           random number generator.
+   * @param initialValues optional seed values for specific keys.
+   * @return Values
+   */
+  Values initializeRandomly(const std::set<Key> &keys, size_t numEdges,
+                             bool bilinear, std::mt19937 *rng,
+                             const Values &initialValues = Values()) const;
+
+  /**
+   * @brief Version of initializeRandomly with a fixed seed.
+   */
+  Values initializeRandomly(const std::set<Key> &keys, size_t numEdges,
+                             bool bilinear,
+                             const Values &initialValues = Values()) const;
+};
+
+}  // namespace gtsam

--- a/gtsam/sfm/TranslationRecovery.cpp
+++ b/gtsam/sfm/TranslationRecovery.cpp
@@ -17,21 +17,16 @@
  */
 
 #include <gtsam/base/DSFMap.h>
-#include <gtsam/base/VectorSpace.h>
 #include <gtsam/geometry/Point3.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/geometry/Unit3.h>
 #include <gtsam/linear/NoiseModel.h>
-#include <gtsam/nonlinear/ExpressionFactor.h>
 #include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
-#include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/Values.h>
-#include <gtsam/sfm/TranslationFactor.h>
 #include <gtsam/sfm/TranslationRecovery.h>
 #include <gtsam/slam/BetweenFactor.h>
 #include <gtsam/slam/PriorFactor.h>
-#include <gtsam/slam/expressions.h>
 
 #include <set>
 #include <utility>
@@ -97,46 +92,12 @@ Values addSameTranslationNodes(const Values &result,
   }
   return final_result;
 }
-
-// A hacky noise conversion function because we really should be optimizing for
-// Unit3s rather than Point3s, in which case the noise model can be whatever it
-// wants. Unfortunately, we are given Unit3 measurements and Point3 unknowns,
-// which is a mismatch in this class' setup.
-using noiseModel::Isotropic;
-SharedNoiseModel convertNoiseModel(const SharedNoiseModel &unit3NoiseModel) {
-  if (auto isotropic = std::dynamic_pointer_cast<Isotropic>(unit3NoiseModel)) {
-    return noiseModel::Isotropic::Sigma(3, isotropic->sigma());
-  }
-  if (auto robust =
-          std::dynamic_pointer_cast<noiseModel::Robust>(unit3NoiseModel)) {
-    // Preserve the robust kernel while converting the wrapped noise model.
-    return noiseModel::Robust::Create(robust->robust(),
-                                      convertNoiseModel(robust->noise()));
-  }
-  throw std::runtime_error(
-      "TranslationRecovery::convertNoiseModel: only isotropic (optionally "
-      "robust-wrapped) noise model supported.");
-}
 }  // namespace
 
 NonlinearFactorGraph TranslationRecovery::buildGraph(
     const std::vector<BinaryMeasurement<Unit3>> &relativeTranslations) const {
-  NonlinearFactorGraph graph;
-
-  // Add translation factors for input translation directions.
-  uint64_t i = 0;
-  for (auto edge : relativeTranslations) {
-    auto model = convertNoiseModel(edge.noiseModel());
-    if (use_bilinear_translation_factor_) {
-      graph.emplace_shared<BilinearAngleTranslationFactor>(
-          edge.key1(), edge.key2(), Symbol('S', i), edge.measured(), model);
-    } else {
-      graph.emplace_shared<TranslationFactor>(edge.key1(), edge.key2(),
-                                              edge.measured(), model);
-    }
-    i++;
-  }
-  return graph;
+  return LocationRecovery::buildGraph(relativeTranslations,
+                                     use_bilinear_translation_factor_);
 }
 
 void TranslationRecovery::addPrior(
@@ -168,38 +129,20 @@ Values TranslationRecovery::initializeRandomly(
     const std::vector<BinaryMeasurement<Unit3>> &relativeTranslations,
     const std::vector<BinaryMeasurement<Point3>> &betweenTranslations,
     std::mt19937 *rng, const Values &initialValues) const {
-  uniform_real_distribution<double> randomVal(-1, 1);
-  // Create a lambda expression that checks whether value exists and randomly
-  // initializes if not.
-  Values initial;
-  auto insert = [&](Key j) {
-    if (initial.exists(j)) return;
-    if (initialValues.exists(j)) {
-      initial.insert<Point3>(j, initialValues.at<Point3>(j));
-    } else {
-      initial.insert<Point3>(
-          j, Point3(randomVal(*rng), randomVal(*rng), randomVal(*rng)));
-    }
-    // Assumes all nodes connected by zero-edges have the same initialization.
-  };
-
-  // Loop over measurements and add a random translation
-  for (auto edge : relativeTranslations) {
-    insert(edge.key1());
-    insert(edge.key2());
+  // Collect all keys from edges.
+  std::set<Key> keys;
+  for (const auto &edge : relativeTranslations) {
+    keys.insert(edge.key1());
+    keys.insert(edge.key2());
   }
-  // There may be nodes in betweenTranslations that do not have a measurement.
-  for (auto edge : betweenTranslations) {
-    insert(edge.key1());
-    insert(edge.key2());
+  for (const auto &edge : betweenTranslations) {
+    keys.insert(edge.key1());
+    keys.insert(edge.key2());
   }
 
-  if (use_bilinear_translation_factor_) {
-    for (uint64_t i = 0; i < relativeTranslations.size(); i++) {
-      initial.insert<Vector1>(Symbol('S', i), Vector1(1.0));
-    }
-  }
-  return initial;
+  return LocationRecovery::initializeRandomly(
+      keys, relativeTranslations.size(), use_bilinear_translation_factor_, rng,
+      initialValues);
 }
 
 Values TranslationRecovery::initializeRandomly(

--- a/gtsam/sfm/TranslationRecovery.h
+++ b/gtsam/sfm/TranslationRecovery.h
@@ -16,10 +16,7 @@
  * @brief Recovering translations in an epipolar graph when rotations are given.
  */
 
-#include <gtsam/geometry/Unit3.h>
-#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
-#include <gtsam/nonlinear/Values.h>
-#include <gtsam/sfm/BinaryMeasurement.h>
+#include <gtsam/sfm/LocationRecovery.h>
 
 #include <map>
 #include <set>
@@ -48,7 +45,7 @@ namespace gtsam {
 // where s is an arbitrary scale that can be supplied, default 1.0. Hence, two
 // versions are supplied below corresponding to whether we have initial values
 // or not.
-class GTSAM_EXPORT TranslationRecovery {
+class GTSAM_EXPORT TranslationRecovery : public LocationRecovery {
  public:
   using KeyPair = std::pair<Key, Key>;
   using TranslationEdges = std::vector<BinaryMeasurement<Unit3>>;
@@ -56,9 +53,6 @@ class GTSAM_EXPORT TranslationRecovery {
  private:
   // Translation directions between camera pairs.
   TranslationEdges relativeTranslations_;
-
-  // Parameters.
-  LevenbergMarquardtParams lmParams_;
 
   const bool use_bilinear_translation_factor_ = false;
 
@@ -70,7 +64,7 @@ class GTSAM_EXPORT TranslationRecovery {
    */
   TranslationRecovery(const LevenbergMarquardtParams &lmParams,
                       bool use_bilinear_translation_factor = false)
-      : lmParams_(lmParams),
+      : LocationRecovery(lmParams),
         use_bilinear_translation_factor_(use_bilinear_translation_factor) {}
 
   /**

--- a/gtsam/sfm/sfm.i
+++ b/gtsam/sfm/sfm.i
@@ -377,6 +377,38 @@ class TranslationRecovery {
                     const double scale = 1.0) const;
 };
 
+#include <gtsam/sfm/GlobalPositioner.h>
+
+class GlobalPositioner {
+  GlobalPositioner(const gtsam::LevenbergMarquardtParams& lmParams);
+  GlobalPositioner();
+  gtsam::NonlinearFactorGraph buildGraph(
+      const gtsam::BinaryMeasurementsUnit3& cameraPointDirections) const;
+  void addPrior(gtsam::Key anchorCameraKey,
+                gtsam::NonlinearFactorGraph @graph,
+                const gtsam::SharedNoiseModel& priorNoiseModel) const;
+  void addPrior(gtsam::Key anchorCameraKey,
+                gtsam::NonlinearFactorGraph @graph) const;
+  gtsam::Values initializeRandomly(
+      const gtsam::KeySet& cameraKeys,
+      const gtsam::KeySet& landmarkKeys,
+      size_t numEdges,
+      const gtsam::Values& initialValues) const;
+  gtsam::Values initializeRandomly(
+      const gtsam::KeySet& cameraKeys,
+      const gtsam::KeySet& landmarkKeys,
+      size_t numEdges) const;
+  gtsam::Values run(const gtsam::BinaryMeasurementsUnit3& cameraPointDirections,
+                    const gtsam::KeySet& cameraKeys,
+                    const gtsam::KeySet& landmarkKeys,
+                    gtsam::Key anchorCameraKey,
+                    const gtsam::Values& initialValues) const;
+  gtsam::Values run(const gtsam::BinaryMeasurementsUnit3& cameraPointDirections,
+                    const gtsam::KeySet& cameraKeys,
+                    const gtsam::KeySet& landmarkKeys,
+                    gtsam::Key anchorCameraKey) const;
+};
+
 namespace gtsfm {
 
 #include <gtsam/sfm/DsfTrackGenerator.h>

--- a/gtsam/sfm/sfm.i
+++ b/gtsam/sfm/sfm.i
@@ -345,9 +345,31 @@ class MFAS {
   gtsam::KeyVector computeOrdering() const;
 };
 
+#include <gtsam/sfm/LocationRecovery.h>
+
+class LocationRecovery {
+  LocationRecovery(const gtsam::LevenbergMarquardtParams& lmParams);
+  LocationRecovery();
+  gtsam::NonlinearFactorGraph buildGraph(
+      const gtsam::BinaryMeasurementsUnit3& edges,
+      bool bilinear) const;
+  gtsam::NonlinearFactorGraph buildGraph(
+      const gtsam::BinaryMeasurementsUnit3& edges) const;
+  void addAnchorPrior(gtsam::Key anchorKey,
+                      gtsam::NonlinearFactorGraph @graph,
+                      const gtsam::SharedNoiseModel& priorNoiseModel) const;
+  void addAnchorPrior(gtsam::Key anchorKey,
+                      gtsam::NonlinearFactorGraph @graph) const;
+  gtsam::Values initializeRandomly(
+      const gtsam::KeySet& keys, size_t numEdges, bool bilinear,
+      const gtsam::Values& initialValues) const;
+  gtsam::Values initializeRandomly(
+      const gtsam::KeySet& keys, size_t numEdges, bool bilinear) const;
+};
+
 #include <gtsam/sfm/TranslationRecovery.h>
 
-class TranslationRecovery {
+class TranslationRecovery : gtsam::LocationRecovery {
   TranslationRecovery(const gtsam::LevenbergMarquardtParams& lmParams,
                       const bool use_bilinear_translation_factor);
   TranslationRecovery(const gtsam::LevenbergMarquardtParams& lmParams);
@@ -379,25 +401,18 @@ class TranslationRecovery {
 
 #include <gtsam/sfm/GlobalPositioner.h>
 
-class GlobalPositioner {
+class GlobalPositioner : gtsam::LocationRecovery {
   GlobalPositioner(const gtsam::LevenbergMarquardtParams& lmParams);
   GlobalPositioner();
-  gtsam::NonlinearFactorGraph buildGraph(
-      const gtsam::BinaryMeasurementsUnit3& cameraPointDirections) const;
-  void addPrior(gtsam::Key anchorCameraKey,
-                gtsam::NonlinearFactorGraph @graph,
-                const gtsam::SharedNoiseModel& priorNoiseModel) const;
-  void addPrior(gtsam::Key anchorCameraKey,
-                gtsam::NonlinearFactorGraph @graph) const;
   gtsam::Values initializeRandomly(
       const gtsam::KeySet& cameraKeys,
       const gtsam::KeySet& landmarkKeys,
-      size_t numEdges,
+      const gtsam::BinaryMeasurementsUnit3& cameraPointDirections,
       const gtsam::Values& initialValues) const;
   gtsam::Values initializeRandomly(
       const gtsam::KeySet& cameraKeys,
       const gtsam::KeySet& landmarkKeys,
-      size_t numEdges) const;
+      const gtsam::BinaryMeasurementsUnit3& cameraPointDirections) const;
   gtsam::Values run(const gtsam::BinaryMeasurementsUnit3& cameraPointDirections,
                     const gtsam::KeySet& cameraKeys,
                     const gtsam::KeySet& landmarkKeys,

--- a/tests/testGlobalPositioner.cpp
+++ b/tests/testGlobalPositioner.cpp
@@ -1,0 +1,130 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010-2020, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file testGlobalPositioner.cpp
+ * @author Kathir Gounder
+ * @date April 2026
+ * @brief Test global positioning: recover camera and landmark positions
+ *        from camera-to-point direction measurements.
+ */
+
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/geometry/Point3.h>
+#include <gtsam/geometry/Unit3.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/sfm/GlobalPositioner.h>
+
+using namespace std;
+using namespace gtsam;
+using symbol_shorthand::L;
+using symbol_shorthand::X;
+
+// Synthetic bipartite scene: 3 cameras looking at 4 landmarks.
+// Cameras are in a triangle, landmarks are in front of them.
+static const Point3 kCam0(0, 0, 0);
+static const Point3 kCam1(2, 0, 0);
+static const Point3 kCam2(1, -1, 0);
+static const Point3 kPt0(0.5, 0.5, 5);
+static const Point3 kPt1(1.5, 0.5, 5);
+static const Point3 kPt2(1.0, -0.5, 5);
+static const Point3 kPt3(1.0, 0.5, 8);
+
+// Build ground-truth direction measurements from known positions.
+GlobalPositioner::CameraPointDirections SimulateDirections(
+    const vector<Point3>& cameras, const vector<Point3>& landmarks) {
+  auto noiseModel = noiseModel::Isotropic::Sigma(2, 0.01);
+  GlobalPositioner::CameraPointDirections measurements;
+  for (size_t i = 0; i < cameras.size(); i++) {
+    for (size_t j = 0; j < landmarks.size(); j++) {
+      Unit3 direction(landmarks[j] - cameras[i]);
+      measurements.emplace_back(X(i), L(j), direction, noiseModel);
+    }
+  }
+  return measurements;
+}
+
+/* ************************************************************************* */
+// Test that GlobalPositioner recovers camera and landmark positions from
+// clean direction measurements in a simple bipartite scene.
+TEST(GlobalPositioner, ThreeCamerasFourLandmarks) {
+  vector<Point3> cameras = {kCam0, kCam1, kCam2};
+  vector<Point3> landmarks = {kPt0, kPt1, kPt2, kPt3};
+  auto measurements = SimulateDirections(cameras, landmarks);
+
+  set<Key> cameraKeys = {X(0), X(1), X(2)};
+  set<Key> landmarkKeys = {L(0), L(1), L(2), L(3)};
+
+  GlobalPositioner gp;
+  const auto result = gp.run(measurements, cameraKeys, landmarkKeys, X(0));
+
+  // Anchor camera should be at origin.
+  EXPECT(assert_equal(Point3(0, 0, 0), result.at<Point3>(X(0)), 1e-3));
+
+  // Check relative positions are correct (up to global scale).
+  // The scale is determined by BATA consensus, so we compare directions
+  // and relative distances rather than absolute positions.
+  Point3 estimated_cam1 = result.at<Point3>(X(1));
+  Point3 estimated_pt0 = result.at<Point3>(L(0));
+
+  // Camera 1 should be roughly along the +X direction from camera 0.
+  Unit3 expected_dir_01(kCam1 - kCam0);
+  Unit3 actual_dir_01(estimated_cam1);
+  EXPECT(assert_equal(expected_dir_01, actual_dir_01, 1e-2));
+
+  // Landmark 0 should be in front of camera 0 (positive Z).
+  EXPECT(estimated_pt0(2) > 0);
+}
+
+/* ************************************************************************* */
+// Test that the anchor camera validation works.
+TEST(GlobalPositioner, AnchorValidation) {
+  vector<Point3> cameras = {kCam0, kCam1};
+  vector<Point3> landmarks = {kPt0};
+  auto measurements = SimulateDirections(cameras, landmarks);
+
+  set<Key> cameraKeys = {X(0), X(1)};
+  set<Key> landmarkKeys = {L(0)};
+
+  GlobalPositioner gp;
+
+  // Passing a landmark key as anchor should throw.
+  CHECK_EXCEPTION(gp.run(measurements, cameraKeys, landmarkKeys, L(0)),
+                  invalid_argument);
+
+  // Passing a nonexistent key as anchor should throw.
+  CHECK_EXCEPTION(gp.run(measurements, cameraKeys, landmarkKeys, X(99)),
+                  invalid_argument);
+}
+
+/* ************************************************************************* */
+// Test initializeRandomly produces the right number of variables.
+TEST(GlobalPositioner, InitializeRandomly) {
+  vector<Point3> cameras = {kCam0, kCam1};
+  vector<Point3> landmarks = {kPt0, kPt1};
+  auto measurements = SimulateDirections(cameras, landmarks);
+
+  set<Key> cameraKeys = {X(0), X(1)};
+  set<Key> landmarkKeys = {L(0), L(1)};
+
+  GlobalPositioner gp;
+  const auto initial =
+      gp.initializeRandomly(cameraKeys, landmarkKeys, measurements);
+
+  // Should have 2 cameras + 2 landmarks + 4 scale variables = 8 entries.
+  EXPECT_LONGS_EQUAL(8, initial.size());
+}
+
+/* ************************************************************************* */
+int main() {
+  TestResult tr;
+  return TestRegistry::runAllTests(tr);
+}

--- a/tests/testLocationRecovery.cpp
+++ b/tests/testLocationRecovery.cpp
@@ -1,0 +1,145 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010-2020, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file testLocationRecovery.cpp
+ * @author Kathir Gounder
+ * @date April 2026
+ * @brief Test LocationRecovery base class: recover Point3 positions from
+ *        Unit3 direction measurements with both chordal and bilinear costs.
+ */
+
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/geometry/Point3.h>
+#include <gtsam/geometry/Unit3.h>
+#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
+#include <gtsam/sfm/LocationRecovery.h>
+
+using namespace std;
+using namespace gtsam;
+
+// Simple 3-node problem: three points with known directions between them.
+static const Point3 kP0(0, 0, 0);
+static const Point3 kP1(2, 0, 0);
+static const Point3 kP2(1, -1, 0);
+
+// Build direction measurements between all pairs.
+LocationRecovery::DirectionEdges SimulateEdges(
+    const vector<pair<Key, Key>>& pairs,
+    const map<Key, Point3>& positions) {
+  auto noiseModel = noiseModel::Isotropic::Sigma(2, 0.01);
+  LocationRecovery::DirectionEdges edges;
+  for (const auto& [a, b] : pairs) {
+    Unit3 direction(positions.at(b) - positions.at(a));
+    edges.emplace_back(a, b, direction, noiseModel);
+  }
+  return edges;
+}
+
+/* ************************************************************************* */
+// Test buildGraph with bilinear (BATA) factors.
+TEST(LocationRecovery, BuildGraphBilinear) {
+  map<Key, Point3> positions = {{0, kP0}, {1, kP1}, {2, kP2}};
+  auto edges = SimulateEdges({{0, 1}, {0, 2}, {1, 2}}, positions);
+
+  LocationRecovery lr;
+  auto graph = lr.buildGraph(edges, /*bilinear=*/true);
+  // 3 BATA factors (each connects 3 variables: two Point3 + one scale).
+  EXPECT_LONGS_EQUAL(3, graph.size());
+}
+
+/* ************************************************************************* */
+// Test buildGraph with chordal factors.
+TEST(LocationRecovery, BuildGraphChordal) {
+  map<Key, Point3> positions = {{0, kP0}, {1, kP1}, {2, kP2}};
+  auto edges = SimulateEdges({{0, 1}, {0, 2}, {1, 2}}, positions);
+
+  LocationRecovery lr;
+  auto graph = lr.buildGraph(edges, /*bilinear=*/false);
+  // 3 chordal factors (each connects 2 variables).
+  EXPECT_LONGS_EQUAL(3, graph.size());
+}
+
+/* ************************************************************************* */
+// Test that the base class can solve a complete problem end-to-end
+// using the bilinear (BATA) cost function.
+TEST(LocationRecovery, SolveBilinear) {
+  map<Key, Point3> positions = {{0, kP0}, {1, kP1}, {2, kP2}};
+  auto edges = SimulateEdges({{0, 1}, {0, 2}, {1, 2}}, positions);
+
+  LocationRecovery lr;
+  auto graph = lr.buildGraph(edges, /*bilinear=*/true);
+  lr.addAnchorPrior(0, &graph);
+
+  set<Key> keys = {0, 1, 2};
+  auto initial = lr.initializeRandomly(keys, edges.size(), /*bilinear=*/true);
+
+  LevenbergMarquardtOptimizer lm(graph, initial);
+  Values result = lm.optimize();
+
+  // Anchor at origin.
+  EXPECT(assert_equal(Point3(0, 0, 0), result.at<Point3>(0), 1e-3));
+
+  // Check relative direction from key 0 to key 1 is along +X.
+  Unit3 expected_dir(kP1 - kP0);
+  Unit3 actual_dir(result.at<Point3>(1) - result.at<Point3>(0));
+  EXPECT(assert_equal(expected_dir, actual_dir, 1e-2));
+}
+
+/* ************************************************************************* */
+// Test that the base class can solve a complete problem end-to-end
+// using the chordal cost function.
+TEST(LocationRecovery, SolveChordal) {
+  map<Key, Point3> positions = {{0, kP0}, {1, kP1}, {2, kP2}};
+  auto edges = SimulateEdges({{0, 1}, {0, 2}, {1, 2}}, positions);
+
+  LocationRecovery lr;
+  auto graph = lr.buildGraph(edges, /*bilinear=*/false);
+  lr.addAnchorPrior(0, &graph);
+
+  set<Key> keys = {0, 1, 2};
+  auto initial = lr.initializeRandomly(keys, edges.size(), /*bilinear=*/false);
+
+  LevenbergMarquardtOptimizer lm(graph, initial);
+  Values result = lm.optimize();
+
+  // Anchor at origin.
+  EXPECT(assert_equal(Point3(0, 0, 0), result.at<Point3>(0), 1e-3));
+
+  // Check relative direction from key 0 to key 1 is along +X.
+  Unit3 expected_dir(kP1 - kP0);
+  Unit3 actual_dir(result.at<Point3>(1) - result.at<Point3>(0));
+  EXPECT(assert_equal(expected_dir, actual_dir, 1e-2));
+}
+
+/* ************************************************************************* */
+// Test initializeRandomly creates correct number of variables.
+TEST(LocationRecovery, InitializeRandomly) {
+  map<Key, Point3> positions = {{0, kP0}, {1, kP1}};
+  auto edges = SimulateEdges({{0, 1}}, positions);
+
+  LocationRecovery lr;
+
+  // Bilinear: 2 Point3 + 1 scale = 3 entries.
+  set<Key> keys = {0, 1};
+  auto init_bilinear = lr.initializeRandomly(keys, edges.size(), true);
+  EXPECT_LONGS_EQUAL(3, init_bilinear.size());
+
+  // Chordal: 2 Point3 + 0 scales = 2 entries.
+  auto init_chordal = lr.initializeRandomly(keys, edges.size(), false);
+  EXPECT_LONGS_EQUAL(2, init_chordal.size());
+}
+
+/* ************************************************************************* */
+int main() {
+  TestResult tr;
+  return TestRegistry::runAllTests(tr);
+}


### PR DESCRIPTION
## Status

- [x] Base class refactor: `LocationRecovery` → `GlobalPositioner` / `TranslationRecovery`
- [x] Tested end-to-end with GTSFM (baseline + GP + mixed configs)
- [x] Commit and push tests
- [x] Concise documentation

---

## TLDR

Extracts a `LocationRecovery` base class from `TranslationRecovery`. The base class is an unopinionated, directly instantiable solver: direction measurements in, Point3 positions out. Two opinionated subclasses enforce specific graph structures:

```
LocationRecovery        — any Point3-from-directions problem
├── GlobalPositioner    — bipartite camera+landmark (GLOMAP)
└── TranslationRecovery — homogeneous camera-camera (1DSFM)
```

`TranslationRecovery` API is unchanged. No regressions. Ran end to end benchmark tests locally, with gtsam-develop master branch and my local build, same numbers for both.

---

## What's in this PR

| File | Action |
|------|--------|
| `LocationRecovery.h/cpp` | **NEW** — base class (~170 lines) |
| `GlobalPositioner.h/cpp` | **MODIFIED** — inherits from `LocationRecovery` |
| `TranslationRecovery.h/cpp` | **MODIFIED** — inherits from `LocationRecovery`, API unchanged |
| `sfm.i` | **MODIFIED** — bindings for all three classes |

---

## Why a base class?

`LocationRecovery` can express problems directly as well, I used it to test "MixedGlobalPositioning" (GP with additional camera-camera BATA Factors). In GTSFM, we use all three tiers:

**Opinionated GP** (bipartite camera+landmark, one-liner):
```python
gp = gtsam.GlobalPositioner(lm_params)
result = gp.run(cameraPointDirections, camera_keys, landmark_keys, anchor_camera_key)
```

**Opinionated TA** (unchanged from before this PR):
```python
tr = gtsam.TranslationRecovery(lm_params)
result = tr.run(relative_translations, 1.0)
```

**Unopinionated base** (custom mixed-edge experiment):
```python
lr = gtsam.LocationRecovery(lm_params)
graph = lr.buildGraph(all_measurements, True)  # CP + CC edges in one graph
lr.addAnchorPrior(anchor_key, graph)
initial = lr.initializeRandomly(all_keys, total_edges, True)
result = gtsam.LevenbergMarquardtOptimizer(graph, initial, lm_params).optimize()
```

## Downstream GTSFM Benchmark Experiments

Configs compared:
- **GP (CP only)** — `GlobalPositioner` with camera–point edges only
- **Mixed (CC+CP)** — `LocationRecovery` base class with camera–camera + camera–point edges
- **GP no 2vBA** — `GlobalPositioner` without 2-view bundle adjustment
- **Baseline** — `TranslationRecovery` (1DSFM, pre-refactor)

### door-12
```
Config                  Cams  Tracks   Reproj     Rot   Trans   AUC@1  AUC@2.5   AUC@5  AUC@10  AUC@20   BA(s)
-------------------------------------------------------------------------------------------------------------------
GP (CP only)              12    7089   0.1210   0.100   0.045   0.845    0.938   0.969   0.985   0.992     3.1
Mixed (CC+CP)             12    7089   0.1210   0.100   0.045   0.845    0.938   0.969   0.985   0.992     3.1
GP no 2vBA                                                          MISSING
Baseline                  12    7106   0.1210   0.098   0.046   0.849    0.940   0.970   0.985   0.993     6.0
```

### skydio-8
```
Config                  Cams  Tracks   Reproj     Rot   Trans   AUC@1  AUC@2.5   AUC@5  AUC@10  AUC@20   BA(s)
-------------------------------------------------------------------------------------------------------------------
GP (CP only)               8     290   0.2547   0.382   0.432   0.358    0.731   0.865   0.933   0.966     3.8
Mixed (CC+CP)              8     289   0.2589   0.389   0.334   0.323    0.716   0.858   0.929   0.965     1.3
GP no 2vBA                 6      14   0.5321   0.118  41.874   0.000    0.000   0.000   0.000   0.025    24.6
Baseline                   8     301   0.2547   0.309   0.382   0.553    0.821   0.910   0.955   0.978     2.2
```

### gerrard-100
```
Config                  Cams  Tracks   Reproj     Rot   Trans   AUC@1  AUC@2.5   AUC@5  AUC@10  AUC@20   BA(s)
-------------------------------------------------------------------------------------------------------------------
GP (CP only)             100   13948   0.1951   0.060   0.029   0.906    0.962   0.981   0.991   0.995    14.7
Mixed (CC+CP)            100   13948   0.1952   0.054   0.029   0.913    0.965   0.982   0.991   0.996    15.9
GP no 2vBA               100   13914   0.1997   0.117   0.065   0.843    0.937   0.968   0.984   0.992    20.2
Baseline                 100   14259   0.1996   0.091   0.040   0.826    0.929   0.964   0.982   0.991    15.0
```

### south-128
```
Config                  Cams  Tracks   Reproj     Rot   Trans   AUC@1  AUC@2.5   AUC@5  AUC@10  AUC@20   BA(s)
-------------------------------------------------------------------------------------------------------------------
GP (CP only)             128   20929   0.1958   0.051   0.049   0.890    0.956   0.978   0.989   0.995    18.7
Mixed (CC+CP)            128   20902   0.1953   0.219   0.143   0.727    0.888   0.944   0.972   0.986    19.9
GP no 2vBA               128   20732   0.1997   0.070   0.053   0.874    0.949   0.975   0.987   0.994    18.7
Baseline                 128   21364   0.1981   0.061   0.029   0.898    0.959   0.980   0.990   0.995    27.6
```

### palace-281
```
Config                  Cams  Tracks   Reproj     Rot   Trans   AUC@1  AUC@2.5   AUC@5  AUC@10  AUC@20   BA(s)
-------------------------------------------------------------------------------------------------------------------
GP (CP only)             281   12209   0.3439   0.153   0.153   0.595    0.822   0.909   0.954   0.977    34.5
Mixed (CC+CP)              9       3   0.6073   0.346  45.646   0.000    0.000   0.000   0.000   0.000  1133.4
GP no 2vBA                 9       3   0.0000   0.274  13.651   0.000    0.000   0.000   0.000   0.000   704.7
Baseline                 281   12261   0.6068   0.238   0.132   0.431    0.742   0.866   0.931   0.965    15.8
```

---
## Tests
All pass locally (`testLocationRecovery`, `testGlobalPositioner`, `testTranslationRecovery`):

- **testLocationRecovery** — base class solves end-to-end with both BATA and chordal costs; verifies graph construction and initialization for each factor type
- **testGlobalPositioner** — recovers camera + landmark positions from synthetic bipartite scene; validates anchor-must-be-camera constraint
- **testTranslationRecovery** — existing tests pass unchanged (backward compatible)

---
## References

- Pan et al., "Global Structure-from-Motion Revisited," ECCV 2024.
- Zhuang et al., "Baseline Desensitizing in Translation Averaging," CVPR 2018.
