### PR TITLE
[codex] Refactor RangeFactor to remove expression overhead

### DIFF
--- a/gtsam/sam/RangeFactor.h
+++ b/gtsam/sam/RangeFactor.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <gtsam/nonlinear/ExpressionFactor.h>
+#include <gtsam/nonlinear/NoiseModelFactorN.h>
 
 namespace gtsam {
 
@@ -32,19 +32,20 @@ struct Range;
  * @ingroup sam
  */
 template <typename A1, typename A2 = A1, typename T = double>
-class RangeFactor : public ExpressionFactorN<T, A1, A2> {
+class RangeFactor : public NoiseModelFactorN<A1, A2> {
  private:
-  typedef RangeFactor<A1, A2> This;
-  typedef ExpressionFactorN<T, A1, A2> Base;
+  typedef RangeFactor<A1, A2, T> This;
+  typedef NoiseModelFactorN<A1, A2> Base;
+
+  T measured_;  ///< The measured range
 
  public:
   /// default constructor
-  RangeFactor() {}
+  RangeFactor() = default;
 
+  /// Construct from keys, a range measurement, and a noise model.
   RangeFactor(Key key1, Key key2, T measured, const SharedNoiseModel& model)
-      : Base({key1, key2}, model, measured) {
-    this->initialize(expression({key1, key2}));
-  }
+      : Base(model, key1, key2), measured_(measured) {}
 
   /// @return a deep copy of this factor
   gtsam::NonlinearFactor::shared_ptr clone() const override {
@@ -52,23 +53,20 @@ class RangeFactor : public ExpressionFactorN<T, A1, A2> {
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }
 
-  // Return measurement expression
-  Expression<T> expression(const typename Base::ArrayNKeys& keys) const override {
-    Expression<A1> a1_(keys[0]);
-    Expression<A2> a2_(keys[1]);
-    return Expression<T>(Range<A1, A2>(), a1_, a2_);
-  }
+  /// @return the measurement
+  const T& measured() const { return measured_; }
 
-  Vector evaluateError(const A1& a1, const A2& a2, 
-      OptionalMatrixType H1 = OptionalNone,
-      OptionalMatrixType H2 = OptionalNone) const {
-    std::vector<Matrix> Hs(2);
-    const auto& keys = Factor::keys();
-    const Vector error = Base::unwhitenedError(
-        {{keys[0], genericValue(a1)}, {keys[1], genericValue(a2)}},
-        Hs);
-    if (H1) *H1 = Hs[0];
-    if (H2) *H2 = Hs[1];
+  /// Evaluate the unwhitened range error and optional Jacobians.
+  Vector evaluateError(const A1& a1, const A2& a2,
+                       OptionalMatrixType H1 = OptionalNone,
+                       OptionalMatrixType H2 = OptionalNone) const override {
+    Matrix Hpred1, Hpred2, Hlocal;
+    const T predicted =
+        Range<A1, A2>()(a1, a2, H1 ? &Hpred1 : nullptr, H2 ? &Hpred2 : nullptr);
+    const Vector error =
+        -traits<T>::Local(predicted, measured_, (H1 || H2) ? &Hlocal : nullptr);
+    if (H1) *H1 = -Hlocal * Hpred1;
+    if (H2) *H2 = -Hlocal * Hpred2;
     return error;
   }
 
@@ -77,15 +75,25 @@ class RangeFactor : public ExpressionFactorN<T, A1, A2> {
              const KeyFormatter& kf = DefaultKeyFormatter) const override {
     std::cout << s << "RangeFactor" << std::endl;
     Base::print(s, kf);
+    traits<T>::Print(measured_, "  measured: ");
+  }
+
+  /// Check equality up to a tolerance.
+  bool equals(const NonlinearFactor& f, double tol) const override {
+    const This* p = dynamic_cast<const This*>(&f);
+    return p != nullptr && Base::equals(f, tol) &&
+           traits<T>::Equals(measured_, p->measured_, tol);
   }
 
  private:
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
+  /// Serialize this factor.
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
     ar& boost::serialization::make_nvp(
-        "Base", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactor2", boost::serialization::base_object<Base>(*this));
+    ar& BOOST_SERIALIZATION_NVP(measured_);
   }
 #endif
 };  // \ RangeFactor
@@ -101,24 +109,27 @@ struct traits<RangeFactor<A1, A2, T> >
  */
 template <typename A1, typename A2 = A1,
           typename T = typename Range<A1, A2>::result_type>
-class RangeFactorWithTransform : public ExpressionFactorN<T, A1, A2> {
+class RangeFactorWithTransform : public NoiseModelFactorN<A1, A2> {
  private:
-  typedef RangeFactorWithTransform<A1, A2> This;
-  typedef ExpressionFactorN<T, A1, A2> Base;
+  typedef RangeFactorWithTransform<A1, A2, T> This;
+  typedef NoiseModelFactorN<A1, A2> Base;
 
+  T measured_;        ///< The measured range
   A1 body_T_sensor_;  ///< The pose of the sensor in the body frame
 
  public:
   /// Default constructor
-  RangeFactorWithTransform() {}
+  RangeFactorWithTransform() = default;
 
+  /// Construct from keys, a range measurement, a noise model, and transform.
   RangeFactorWithTransform(Key key1, Key key2, T measured,
                            const SharedNoiseModel& model,
                            const A1& body_T_sensor)
-      : Base({key1, key2}, model, measured), body_T_sensor_(body_T_sensor) {
-    this->initialize(expression({key1, key2}));
-  }
+      : Base(model, key1, key2),
+        measured_(measured),
+        body_T_sensor_(body_T_sensor) {}
 
+  /// Destroy this factor.
   ~RangeFactorWithTransform() override {}
 
   /// @return a deep copy of this factor
@@ -127,54 +138,61 @@ class RangeFactorWithTransform : public ExpressionFactorN<T, A1, A2> {
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }
 
-  // Return measurement expression
-  Expression<T> expression(const typename Base::ArrayNKeys& keys) const override {
-    Expression<A1> body_T_sensor__(body_T_sensor_);
-    Expression<A1> nav_T_body_(keys[0]);
-    Expression<A1> nav_T_sensor_(traits<A1>::Compose, nav_T_body_,
-                                 body_T_sensor__);
-    Expression<A2> a2_(keys[1]);
-    return Expression<T>(Range<A1, A2>(), nav_T_sensor_, a2_);
-  }
+  /// @return the measurement
+  const T& measured() const { return measured_; }
 
+  /// Evaluate the unwhitened range error and optional Jacobians.
   Vector evaluateError(const A1& a1, const A2& a2,
-      OptionalMatrixType H1 = OptionalNone, OptionalMatrixType H2 = OptionalNone) const {
-    std::vector<Matrix> Hs(2);
-    const auto &keys = Factor::keys();
-    const Vector error = Base::unwhitenedError(
-      {{keys[0], genericValue(a1)}, {keys[1], genericValue(a2)}}, 
-      Hs);
-    if (H1) *H1 = Hs[0];
-    if (H2) *H2 = Hs[1];
+                       OptionalMatrixType H1 = OptionalNone,
+                       OptionalMatrixType H2 = OptionalNone) const override {
+    Matrix HposeCompose, HsensorRange, H2Range, Hlocal;
+    const A1 nav_T_sensor =
+        a1.compose(body_T_sensor_, H1 ? &HposeCompose : nullptr);
+    const T predicted =
+        Range<A1, A2>()(nav_T_sensor, a2, H1 ? &HsensorRange : nullptr,
+                        H2 ? &H2Range : nullptr);
+    const Vector error =
+        -traits<T>::Local(predicted, measured_, (H1 || H2) ? &Hlocal : nullptr);
+    if (H1) *H1 = -Hlocal * HsensorRange * HposeCompose;
+    if (H2) *H2 = -Hlocal * H2Range;
     return error;
   }
 
   // An evaluateError overload to accept matrices (Matrix&) and pass it to the
   // OptionalMatrixType evaluateError overload
-  Vector evaluateError(const A1& a1, const A2& a2, Matrix& H1, Matrix& H2) const {
-	return evaluateError(a1, a2, &H1, &H2);
+  Vector evaluateError(const A1& a1, const A2& a2, Matrix& H1,
+                       Matrix& H2) const {
+    return evaluateError(a1, a2, &H1, &H2);
   }
 
-  /** print contents */
-  void print(const std::string& s = "",
-             const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override {
+  /// print contents
+  void print(
+      const std::string& s = "",
+      const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override {
     std::cout << s << "RangeFactorWithTransform" << std::endl;
     this->body_T_sensor_.print("  sensor pose in body frame: ");
     Base::print(s, keyFormatter);
+    traits<T>::Print(measured_, "  measured: ");
+  }
+
+  /// Check equality up to a tolerance.
+  bool equals(const NonlinearFactor& f, double tol) const override {
+    const This* p = dynamic_cast<const This*>(&f);
+    return p != nullptr && Base::equals(f, tol) &&
+           traits<T>::Equals(measured_, p->measured_, tol) &&
+           traits<A1>::Equals(body_T_sensor_, p->body_T_sensor_, tol);
   }
 
  private:
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
-  /** Serialization function */
+  /// Serialize this factor.
   template <typename ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
-    // **IMPORTANT** We need to (de)serialize parameters before the base class,
-    // since it calls expression() and we need all parameters ready at that
-    // point.
-    ar& BOOST_SERIALIZATION_NVP(body_T_sensor_);
     ar& boost::serialization::make_nvp(
-        "Base", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactor2", boost::serialization::base_object<Base>(*this));
+    ar& BOOST_SERIALIZATION_NVP(measured_);
+    ar& BOOST_SERIALIZATION_NVP(body_T_sensor_);
   }
 #endif
 };  // \ RangeFactorWithTransform
@@ -184,4 +202,4 @@ template <typename A1, typename A2, typename T>
 struct traits<RangeFactorWithTransform<A1, A2, T> >
     : public Testable<RangeFactorWithTransform<A1, A2, T> > {};
 
-}  // \ namespace gtsam
+}  // namespace gtsam

--- a/timing/README.md
+++ b/timing/README.md
@@ -2,6 +2,46 @@
 
 This directory contains timing executables and helper scripts for GTSAM.
 
+## RangeFactor Plaza2 Benchmark
+
+This benchmark isolates the current range-only Plaza2 incremental SLAM workload
+used by `RangeFactor<Pose2, Point2>`. It exists to support before/after
+performance comparisons when changing the `RangeFactor` implementation.
+
+### Build
+
+From the build directory:
+
+```bash
+make -j6 timeRangeFactorPlaza2
+```
+
+### Run the benchmark executable
+
+Run from `build/`:
+
+```bash
+./timing/timeRangeFactorPlaza2 --warmup 1 --repeats 5 \
+  --output ../timing/results/range_factor_plaza2.csv
+```
+
+This prints aggregate timing statistics and writes one CSV row per measured run.
+
+### Run the helper script
+
+Run from the repository root with the `py312` conda environment:
+
+```bash
+conda run -n py312 python timing/benchmark_range_factor_plaza2.py \
+  --build-dir build \
+  --warmup 1 \
+  --repeats 5 \
+  --output timing/results/range_factor_plaza2.csv
+```
+
+The helper script runs the benchmark executable, preserves the CSV, and prints a
+short summary that can be copied into a PR description.
+
 ## Bayes-Tree Covariance Results
 
 The Bayes-tree covariance paper uses generated benchmark output rather than

--- a/timing/benchmark_range_factor_plaza2.py
+++ b/timing/benchmark_range_factor_plaza2.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Run the Plaza2 RangeFactor benchmark and print a PR-friendly summary."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import statistics
+import subprocess
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run timing/timeRangeFactorPlaza2 and summarize the results."
+    )
+    parser.add_argument(
+        "--build-dir",
+        type=Path,
+        default=Path("build"),
+        help="Build directory that contains timing/timeRangeFactorPlaza2.",
+    )
+    parser.add_argument(
+        "--benchmark",
+        type=Path,
+        default=None,
+        help="Optional explicit path to the benchmark executable.",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=1,
+        help="Number of warmup runs to discard.",
+    )
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=5,
+        help="Number of measured runs.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("timing/results/range_factor_plaza2.csv"),
+        help="CSV file written by the benchmark executable.",
+    )
+    parser.add_argument(
+        "--no-robust",
+        action="store_true",
+        help="Disable the robust range noise model to match non-robust runs.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed forwarded to the benchmark executable.",
+    )
+    return parser.parse_args()
+
+
+def load_rows(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def float_column(rows: list[dict[str, str]], key: str) -> list[float]:
+    return [float(row[key]) for row in rows]
+
+
+def main() -> int:
+    args = parse_args()
+    benchmark = (
+        args.benchmark
+        if args.benchmark is not None
+        else args.build_dir / "timing" / "timeRangeFactorPlaza2"
+    )
+    if not benchmark.exists():
+        raise SystemExit(f"Benchmark executable not found: {benchmark}")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    command = [
+        str(benchmark),
+        "--warmup",
+        str(args.warmup),
+        "--repeats",
+        str(args.repeats),
+        "--seed",
+        str(args.seed),
+        "--output",
+        str(args.output),
+    ]
+    if args.no_robust:
+        command.append("--no-robust")
+
+    completed = subprocess.run(command, check=True, text=True, capture_output=True)
+    print(completed.stdout, end="")
+
+    rows = load_rows(args.output)
+    if not rows:
+        raise SystemExit(f"No measured rows written to {args.output}")
+
+    solve_seconds = float_column(rows, "solve_seconds")
+    total_seconds = float_column(rows, "total_seconds")
+    batch_seconds = float_column(rows, "batch_initialization_seconds")
+    update_seconds = float_column(rows, "update_seconds")
+    estimate_seconds = float_column(rows, "calculate_estimate_seconds")
+
+    shape = rows[0]
+    print()
+    print("PR summary")
+    print(
+        "Plaza2 range-only benchmark: "
+        f"median solve {statistics.median(solve_seconds):.3f}s, "
+        f"median total {statistics.median(total_seconds):.3f}s "
+        f"across {len(rows)} measured runs."
+    )
+    print(
+        "Per-run means: "
+        f"batch init {statistics.mean(batch_seconds):.3f}s, "
+        f"ISAM2 update {statistics.mean(update_seconds):.3f}s, "
+        f"estimate {statistics.mean(estimate_seconds):.3f}s."
+    )
+    print(
+        "Workload shape: "
+        f"{shape['odometry_entries']} odometry entries, "
+        f"{shape['range_factors_added']} range factors, "
+        f"{shape['update_count']} updates, "
+        f"{shape['initialized_landmarks']} landmarks."
+    )
+    print(f"CSV written to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/timing/timeRangeFactorPlaza2.cpp
+++ b/timing/timeRangeFactorPlaza2.cpp
@@ -1,0 +1,423 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file    timeRangeFactorPlaza2.cpp
+ * @brief   Benchmark the range-only Plaza2 incremental SLAM workload.
+ * @date    April 2026
+ * @author  Codex 5.4, prompted by Frank Dellaert
+ */
+
+#include <gtsam/base/Vector.h>
+#include <gtsam/geometry/Pose2.h>
+#include <gtsam/geometry/Point2.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/nonlinear/ISAM2.h>
+#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
+#include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <gtsam/nonlinear/PriorFactor.h>
+#include <gtsam/nonlinear/Values.h>
+#include <gtsam/sam/RangeFactor.h>
+#include <gtsam/slam/BetweenFactor.h>
+#include <gtsam/slam/dataset.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cmath>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <numeric>
+#include <optional>
+#include <random>
+#include <set>
+#include <string>
+#include <tuple>
+#include <vector>
+
+using gtsam::Point2;
+using gtsam::Pose2;
+using gtsam::Symbol;
+using gtsam::Vector;
+using gtsam::Vector3;
+using std::cout;
+using std::endl;
+using std::ofstream;
+using std::optional;
+using std::pair;
+using std::set;
+using std::size_t;
+using std::string;
+using std::tuple;
+using std::vector;
+
+namespace NM = gtsam::noiseModel;
+
+namespace {
+
+using Clock = std::chrono::steady_clock;
+using Seconds = std::chrono::duration<double>;
+using TimedOdometry = pair<double, Pose2>;
+using RangeTriple = tuple<double, size_t, double>;
+
+struct Dataset {
+  vector<TimedOdometry> odometry;
+  vector<RangeTriple> triples;
+};
+
+struct BenchmarkOptions {
+  size_t warmupRuns = 1;
+  size_t measuredRuns = 5;
+  size_t minRanges = 150;
+  size_t incrementRanges = 25;
+  bool robust = true;
+  uint64_t seed = 42;
+  optional<string> outputPath;
+};
+
+struct RunResult {
+  size_t runIndex = 0;
+  double solveSeconds = 0.0;
+  double totalSeconds = 0.0;
+  double batchInitializationSeconds = 0.0;
+  double updateSeconds = 0.0;
+  double calculateEstimateSeconds = 0.0;
+  double finalEstimateSeconds = 0.0;
+  size_t odometryEntries = 0;
+  size_t rangeTriples = 0;
+  size_t rangeFactorsAdded = 0;
+  size_t updateCount = 0;
+  size_t initializedLandmarks = 0;
+  size_t finalVariableCount = 0;
+};
+
+string argumentOrDefault(char** begin, char** end, const string& flag,
+                         const string& defaultValue) {
+  for (auto it = begin; it != end; ++it) {
+    if (string(*it) == flag && it + 1 != end) {
+      return *(it + 1);
+    }
+  }
+  return defaultValue;
+}
+
+size_t sizeTArgumentOrDefault(char** begin, char** end, const string& flag,
+                              size_t defaultValue) {
+  return static_cast<size_t>(
+      std::stoull(argumentOrDefault(begin, end, flag, std::to_string(defaultValue))));
+}
+
+uint64_t uint64ArgumentOrDefault(char** begin, char** end, const string& flag,
+                                 uint64_t defaultValue) {
+  return static_cast<uint64_t>(std::stoull(
+      argumentOrDefault(begin, end, flag, std::to_string(defaultValue))));
+}
+
+bool hasFlag(char** begin, char** end, const string& flag) {
+  for (auto it = begin; it != end; ++it) {
+    if (string(*it) == flag) {
+      return true;
+    }
+  }
+  return false;
+}
+
+vector<TimedOdometry> readOdometry() {
+  vector<TimedOdometry> odometry;
+  const string dataFile = gtsam::findExampleDataFile("Plaza2_DR.txt");
+  std::ifstream input(dataFile.c_str());
+  if (!input) {
+    throw std::runtime_error("Plaza2_DR.txt file not found");
+  }
+
+  while (input) {
+    double time = 0.0;
+    double distanceTraveled = 0.0;
+    double deltaHeading = 0.0;
+    input >> time >> distanceTraveled >> deltaHeading;
+    if (!input) {
+      break;
+    }
+    odometry.emplace_back(time, Pose2(distanceTraveled, 0.0, deltaHeading));
+  }
+  return odometry;
+}
+
+vector<RangeTriple> readTriples() {
+  vector<RangeTriple> triples;
+  const string dataFile = gtsam::findExampleDataFile("Plaza2_TD.txt");
+  std::ifstream input(dataFile.c_str());
+  if (!input) {
+    throw std::runtime_error("Plaza2_TD.txt file not found");
+  }
+
+  while (input) {
+    double time = 0.0;
+    double sender = 0.0;
+    double receiver = 0.0;
+    double range = 0.0;
+    input >> time >> sender >> receiver >> range;
+    if (!input) {
+      break;
+    }
+    triples.emplace_back(time, static_cast<size_t>(receiver), range);
+  }
+  return triples;
+}
+
+Dataset loadDataset() {
+  return Dataset{readOdometry(), readTriples()};
+}
+
+template <class T>
+double mean(const vector<T>& values) {
+  if (values.empty()) {
+    return 0.0;
+  }
+  const double sum = std::accumulate(values.begin(), values.end(), 0.0);
+  return sum / static_cast<double>(values.size());
+}
+
+template <class T>
+double median(vector<T> values) {
+  if (values.empty()) {
+    return 0.0;
+  }
+  const size_t middle = values.size() / 2;
+  std::nth_element(values.begin(), values.begin() + middle, values.end());
+  const double upper = static_cast<double>(values[middle]);
+  if (values.size() % 2 == 1) {
+    return upper;
+  }
+  std::nth_element(values.begin(), values.begin() + middle - 1, values.end());
+  return 0.5 * (upper + static_cast<double>(values[middle - 1]));
+}
+
+RunResult runOnce(const Dataset& dataset, const BenchmarkOptions& options,
+                  size_t runIndex) {
+  RunResult result;
+  result.runIndex = runIndex;
+  result.odometryEntries = dataset.odometry.size();
+  result.rangeTriples = dataset.triples.size();
+
+  Vector priorSigmas = Vector3(1.0, 1.0, M_PI);
+  Vector odoSigmas = Vector3(0.05, 0.01, 0.1);
+  const double sigmaR = 100.0;
+  const NM::Base::shared_ptr priorNoise =
+      NM::Diagonal::Sigmas(priorSigmas);
+  const NM::Base::shared_ptr looseNoise =
+      NM::Isotropic::Sigma(2, 1000.0);
+  const NM::Base::shared_ptr odoNoise =
+      NM::Diagonal::Sigmas(odoSigmas);
+  const NM::Base::shared_ptr gaussian =
+      NM::Isotropic::Sigma(1, sigmaR);
+  const NM::Base::shared_ptr tukey =
+      NM::Robust::Create(NM::mEstimator::Tukey::Create(15), gaussian);
+  const NM::Base::shared_ptr rangeNoise = options.robust ? tukey : gaussian;
+
+  gtsam::ISAM2 isam;
+  Pose2 pose0(-34.2086489999201, 45.3007639991120, M_PI - 2.021089);
+  gtsam::NonlinearFactorGraph newFactors;
+  newFactors.addPrior(0, pose0, priorNoise);
+  gtsam::Values initial;
+  initial.insert(0, pose0);
+
+  std::mt19937_64 rng(options.seed);
+  std::normal_distribution<double> normal(0.0, 100.0);
+  set<Symbol> initializedLandmarks;
+
+  size_t i = 1;
+  size_t k = 0;
+  bool initialized = false;
+  Pose2 lastPose = pose0;
+  size_t countK = 0;
+
+  const auto totalStart = Clock::now();
+  const auto solveStart = totalStart;
+  for (const TimedOdometry& timedOdometry : dataset.odometry) {
+    double time = 0.0;
+    Pose2 odometry;
+    std::tie(time, odometry) = timedOdometry;
+
+    newFactors.emplace_shared<gtsam::BetweenFactor<Pose2>>(i - 1, i, odometry,
+                                                           odoNoise);
+
+    Pose2 predictedPose = lastPose.compose(odometry);
+    lastPose = predictedPose;
+    initial.insert(i, predictedPose);
+
+    while (k < dataset.triples.size() && time >= std::get<0>(dataset.triples[k])) {
+      const size_t landmarkId = std::get<1>(dataset.triples[k]);
+      const Symbol landmarkKey('L', landmarkId);
+      const double range = std::get<2>(dataset.triples[k]);
+
+      newFactors.emplace_shared<gtsam::RangeFactor<Pose2, Point2>>(
+          i, landmarkKey, range, rangeNoise);
+      ++result.rangeFactorsAdded;
+
+      if (initializedLandmarks.count(landmarkKey) == 0) {
+        initial.insert(landmarkKey, Point2(normal(rng), normal(rng)));
+        initializedLandmarks.insert(landmarkKey);
+        newFactors.emplace_shared<gtsam::PriorFactor<Point2>>(landmarkKey,
+                                                              Point2(0.0, 0.0),
+                                                              looseNoise);
+      }
+
+      ++k;
+      ++countK;
+    }
+
+    if (k > options.minRanges && countK > options.incrementRanges) {
+      if (!initialized) {
+        const auto batchStart = Clock::now();
+        gtsam::LevenbergMarquardtOptimizer batchOptimizer(newFactors, initial);
+        initial = batchOptimizer.optimize();
+        result.batchInitializationSeconds +=
+            Seconds(Clock::now() - batchStart).count();
+        initialized = true;
+      }
+
+      const auto updateStart = Clock::now();
+      isam.update(newFactors, initial);
+      result.updateSeconds += Seconds(Clock::now() - updateStart).count();
+
+      const auto estimateStart = Clock::now();
+      const gtsam::Values estimate = isam.calculateEstimate();
+      result.calculateEstimateSeconds +=
+          Seconds(Clock::now() - estimateStart).count();
+      lastPose = estimate.at<Pose2>(i);
+
+      newFactors = gtsam::NonlinearFactorGraph();
+      initial = gtsam::Values();
+      countK = 0;
+      ++result.updateCount;
+    }
+
+    ++i;
+  }
+  result.solveSeconds = Seconds(Clock::now() - solveStart).count();
+
+  const auto finalEstimateStart = Clock::now();
+  const gtsam::Values finalResult = isam.calculateEstimate();
+  result.finalEstimateSeconds =
+      Seconds(Clock::now() - finalEstimateStart).count();
+  result.totalSeconds = Seconds(Clock::now() - totalStart).count();
+
+  result.initializedLandmarks = initializedLandmarks.size();
+  result.finalVariableCount = finalResult.size();
+  return result;
+}
+
+void writeCsv(const vector<RunResult>& results, const string& outputPath) {
+  const std::filesystem::path path(outputPath);
+  if (!path.parent_path().empty()) {
+    std::filesystem::create_directories(path.parent_path());
+  }
+  ofstream output(path);
+  if (!output) {
+    throw std::runtime_error("Could not open output file: " + outputPath);
+  }
+
+  output << "run_index,solve_seconds,total_seconds,batch_initialization_seconds,"
+            "update_seconds,calculate_estimate_seconds,final_estimate_seconds,"
+            "odometry_entries,range_triples,range_factors_added,update_count,"
+            "initialized_landmarks,final_variable_count\n";
+  output << std::fixed << std::setprecision(6);
+  for (const RunResult& result : results) {
+    output << result.runIndex << ',' << result.solveSeconds << ','
+           << result.totalSeconds << ',' << result.batchInitializationSeconds
+           << ',' << result.updateSeconds << ','
+           << result.calculateEstimateSeconds << ','
+           << result.finalEstimateSeconds << ',' << result.odometryEntries
+           << ',' << result.rangeTriples << ',' << result.rangeFactorsAdded
+           << ',' << result.updateCount << ',' << result.initializedLandmarks
+           << ',' << result.finalVariableCount << '\n';
+  }
+}
+
+void printSummary(const BenchmarkOptions& options, const Dataset& dataset,
+                  const vector<RunResult>& measuredResults) {
+  vector<double> solveSeconds;
+  vector<double> totalSeconds;
+  vector<double> batchSeconds;
+  vector<double> updateSeconds;
+  vector<double> estimateSeconds;
+  for (const RunResult& result : measuredResults) {
+    solveSeconds.push_back(result.solveSeconds);
+    totalSeconds.push_back(result.totalSeconds);
+    batchSeconds.push_back(result.batchInitializationSeconds);
+    updateSeconds.push_back(result.updateSeconds);
+    estimateSeconds.push_back(result.calculateEstimateSeconds);
+  }
+
+  const RunResult& shape = measuredResults.front();
+  cout << std::fixed << std::setprecision(6);
+  cout << "RangeFactor Plaza2 benchmark\n";
+  cout << "dataset=Plaza2"
+       << " warmup_runs=" << options.warmupRuns
+       << " measured_runs=" << options.measuredRuns
+       << " robust=" << (options.robust ? "true" : "false")
+       << " seed=" << options.seed << '\n';
+  cout << "odometry_entries=" << dataset.odometry.size()
+       << " range_triples=" << dataset.triples.size()
+       << " range_factors_added=" << shape.rangeFactorsAdded
+       << " updates=" << shape.updateCount
+       << " initialized_landmarks=" << shape.initializedLandmarks << '\n';
+  cout << "solve_seconds_mean=" << mean(solveSeconds)
+       << " solve_seconds_median=" << median(solveSeconds) << '\n';
+  cout << "total_seconds_mean=" << mean(totalSeconds)
+       << " total_seconds_median=" << median(totalSeconds) << '\n';
+  cout << "batch_initialization_seconds_mean=" << mean(batchSeconds) << '\n';
+  cout << "update_seconds_mean=" << mean(updateSeconds) << '\n';
+  cout << "calculate_estimate_seconds_mean=" << mean(estimateSeconds) << '\n';
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  const BenchmarkOptions options{
+      sizeTArgumentOrDefault(argv, argv + argc, "--warmup", 1),
+      sizeTArgumentOrDefault(argv, argv + argc, "--repeats", 5),
+      sizeTArgumentOrDefault(argv, argv + argc, "--min-ranges", 150),
+      sizeTArgumentOrDefault(argv, argv + argc, "--inc-ranges", 25),
+      !hasFlag(argv, argv + argc, "--no-robust"),
+      uint64ArgumentOrDefault(argv, argv + argc, "--seed", 42),
+      [&]() -> optional<string> {
+        const string output =
+            argumentOrDefault(argv, argv + argc, "--output", "");
+        return output.empty() ? optional<string>() : optional<string>(output);
+      }(),
+  };
+
+  if (options.measuredRuns == 0) {
+    throw std::invalid_argument("--repeats must be at least 1");
+  }
+
+  const Dataset dataset = loadDataset();
+
+  for (size_t warmupIndex = 0; warmupIndex < options.warmupRuns; ++warmupIndex) {
+    static_cast<void>(runOnce(dataset, options, warmupIndex));
+  }
+
+  vector<RunResult> measuredResults;
+  measuredResults.reserve(options.measuredRuns);
+  for (size_t runIndex = 0; runIndex < options.measuredRuns; ++runIndex) {
+    measuredResults.push_back(runOnce(dataset, options, runIndex));
+  }
+
+  if (options.outputPath) {
+    writeCsv(measuredResults, *options.outputPath);
+  }
+  printSummary(options, dataset, measuredResults);
+  return 0;
+}


### PR DESCRIPTION
## Summary
This PR replaces `RangeFactor` and `RangeFactorWithTransform` with direct handwritten `NoiseModelFactorN` implementations instead of routing through `ExpressionFactor`.

It also adds a dedicated Plaza2 timing benchmark under `timing/` so the performance change can be measured directly on the range-only workload.

## What Changed
- refactor `gtsam/sam/RangeFactor.h` to remove the stored expression tree path
- preserve the existing public factor API while evaluating the range error and Jacobians directly
- add `timing/timeRangeFactorPlaza2.cpp`
- add `timing/benchmark_range_factor_plaza2.py`
- document the benchmark workflow in `timing/README.md`

This change *does* break serialization compatibility.

## Why
`RangeFactor` was inheriting from `ExpressionFactor`, which adds persistent expression-tree allocation and extra reverse-AD machinery for a factor whose prediction path is already available directly through `Range<A1, A2>()`.

For this factor, the expression layer was convenient but unnecessary overhead.

## Performance
Plaza2 range-only benchmark, 5 measured runs after 1 warmup:

- before: median solve `0.178s`, median total `0.178s`
- after: median solve `0.143s`, median total `0.143s`

This is about a 20% reduction in median solve time on the same workload shape:
- `4090` odometry entries
- `1816` range factors
- `65` updates
- `4` landmarks

Benchmark command:

```bash
python timing/benchmark_range_factor_plaza2.py \
  --build-dir build \
  --warmup 1 \
  --repeats 5 \
  --output timing/results/range_factor_plaza2.csv
```

## Validation
- `make -j6 testRangeFactor.run`
- `make -j6 timeRangeFactorPlaza2`
- Plaza2 benchmark command above
