### PR TITLE
Simplify SAM factors

### DIFF
--- a/gtsam/sam/BearingFactor.h
+++ b/gtsam/sam/BearingFactor.h
@@ -18,13 +18,17 @@
 
 #pragma once
 
-#include <gtsam/nonlinear/ExpressionFactor.h>
+#include <gtsam/base/numericalDerivative.h>
+#include <gtsam/nonlinear/NoiseModelFactorN.h>
+
+#include <type_traits>
 
 namespace gtsam {
 
 // forward declaration of Bearing functor, assumed partially specified
 template <typename A1, typename A2>
 struct Bearing;
+class Unit3;
 
 /**
  * Binary factor for a bearing measurement
@@ -34,53 +38,86 @@ struct Bearing;
  */
 template <typename A1, typename A2,
           typename T = typename Bearing<A1, A2>::result_type>
-struct BearingFactor : public ExpressionFactorN<T, A1, A2> {
-  typedef ExpressionFactorN<T, A1, A2> Base;
+struct BearingFactor : public NoiseModelFactorN<A1, A2> {
+  typedef BearingFactor<A1, A2, T> This;
+  typedef NoiseModelFactorN<A1, A2> Base;
+
+  T measured_;
 
   /// default constructor
-  BearingFactor() {}
+  BearingFactor() = default;
 
-  /// primary constructor
+  /// Construct from keys, a bearing measurement, and a noise model.
   BearingFactor(Key key1, Key key2, const T& measured,
                 const SharedNoiseModel& model)
-      : Base({key1, key2}, model, measured) {
-    this->initialize(expression({key1, key2}));
+      : Base(model, key1, key2), measured_(measured) {}
+
+  /// @return a deep copy of this factor
+  gtsam::NonlinearFactor::shared_ptr clone() const override {
+    return std::static_pointer_cast<gtsam::NonlinearFactor>(
+        gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }
 
-  // Return measurement expression
-  Expression<T> expression(const typename Base::ArrayNKeys &keys) const override {
-    Expression<A1> a1_(keys[0]);
-    Expression<A2> a2_(keys[1]);
-    return Expression<T>(Bearing<A1, A2>(), a1_, a2_);
-  }
+  /// @return the measurement
+  const T& measured() const { return measured_; }
 
   /// print
   void print(const std::string& s = "",
              const KeyFormatter& kf = DefaultKeyFormatter) const override {
     std::cout << s << "BearingFactor" << std::endl;
     Base::print(s, kf);
-  }
-  
-  Vector evaluateError(const A1& a1, const A2& a2,
-    OptionalMatrixType H1 = OptionalNone, OptionalMatrixType H2 = OptionalNone) const {
-    std::vector<Matrix> Hs(2);
-    const auto &keys = Factor::keys();
-    const Vector error = unwhitenedError(
-      {{keys[0], genericValue(a1)}, {keys[1], genericValue(a2)}}, 
-      Hs);
-    if (H1) *H1 = Hs[0];
-    if (H2) *H2 = Hs[1];
-    return error;
+    traits<T>::Print(measured_, "  measured: ");
   }
 
+  /// Check equality up to a tolerance.
+  bool equals(const NonlinearFactor& f, double tol = 1e-9) const override {
+    const This* p = dynamic_cast<const This*>(&f);
+    return p != nullptr && Base::equals(f, tol) &&
+           traits<T>::Equals(measured_, p->measured_, tol);
+  }
+
+  /// Evaluate the unwhitened bearing error and optional Jacobians.
+  Vector evaluateError(const A1& a1, const A2& a2,
+                       OptionalMatrixType H1 = OptionalNone,
+                       OptionalMatrixType H2 = OptionalNone) const override {
+    Matrix Hpred1, Hpred2;
+    const T predicted = Bearing<A1, A2>()(a1, a2, H1 ? &Hpred1 : nullptr,
+                                          H2 ? &Hpred2 : nullptr);
+    if constexpr (std::is_same_v<T, Unit3>) {
+      const auto localError = [&](const T& value) -> Vector {
+        return -traits<T>::Local(value, measured_);
+      };
+      const Vector error = localError(predicted);
+      if (H1) {
+        const Matrix HerrorPred =
+            numericalDerivative11<Vector, T>(localError, predicted);
+        *H1 = HerrorPred * Hpred1;
+      }
+      if (H2) {
+        const Matrix HerrorPred =
+            numericalDerivative11<Vector, T>(localError, predicted);
+        *H2 = HerrorPred * Hpred2;
+      }
+      return error;
+    } else {
+      Matrix Hlocal;
+      const Vector error = -traits<T>::Local(
+          predicted, measured_, (H1 || H2) ? &Hlocal : nullptr, OptionalNone);
+      if (H1) *H1 = -Hlocal * Hpred1;
+      if (H2) *H2 = -Hlocal * Hpred2;
+      return error;
+    }
+  }
 
  private:
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
+  /// Serialize this factor.
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
     ar& boost::serialization::make_nvp(
-        "Base", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactor2", boost::serialization::base_object<Base>(*this));
+    ar& BOOST_SERIALIZATION_NVP(measured_);
   }
 #endif
 };  // BearingFactor

--- a/gtsam/sam/BearingFactor.h
+++ b/gtsam/sam/BearingFactor.h
@@ -18,17 +18,13 @@
 
 #pragma once
 
-#include <gtsam/base/numericalDerivative.h>
 #include <gtsam/nonlinear/NoiseModelFactorN.h>
-
-#include <type_traits>
 
 namespace gtsam {
 
 // forward declaration of Bearing functor, assumed partially specified
 template <typename A1, typename A2>
 struct Bearing;
-class Unit3;
 
 /**
  * Binary factor for a bearing measurement
@@ -80,33 +76,8 @@ struct BearingFactor : public NoiseModelFactorN<A1, A2> {
   Vector evaluateError(const A1& a1, const A2& a2,
                        OptionalMatrixType H1 = OptionalNone,
                        OptionalMatrixType H2 = OptionalNone) const override {
-    Matrix Hpred1, Hpred2;
-    const T predicted = Bearing<A1, A2>()(a1, a2, H1 ? &Hpred1 : nullptr,
-                                          H2 ? &Hpred2 : nullptr);
-    if constexpr (std::is_same_v<T, Unit3>) {
-      const auto localError = [&](const T& value) -> Vector {
-        return -traits<T>::Local(value, measured_);
-      };
-      const Vector error = localError(predicted);
-      if (H1) {
-        const Matrix HerrorPred =
-            numericalDerivative11<Vector, T>(localError, predicted);
-        *H1 = HerrorPred * Hpred1;
-      }
-      if (H2) {
-        const Matrix HerrorPred =
-            numericalDerivative11<Vector, T>(localError, predicted);
-        *H2 = HerrorPred * Hpred2;
-      }
-      return error;
-    } else {
-      Matrix Hlocal;
-      const Vector error = -traits<T>::Local(
-          predicted, measured_, (H1 || H2) ? &Hlocal : nullptr, OptionalNone);
-      if (H1) *H1 = -Hlocal * Hpred1;
-      if (H2) *H2 = -Hlocal * Hpred2;
-      return error;
-    }
+    const T predicted = Bearing<A1, A2>()(a1, a2, H1, H2);
+    return -traits<T>::Local(predicted, measured_);
   }
 
  private:

--- a/gtsam/sam/BearingRangeFactor.h
+++ b/gtsam/sam/BearingRangeFactor.h
@@ -19,10 +19,15 @@
 
 #pragma once
 
-#include <gtsam/nonlinear/ExpressionFactor.h>
+#include <gtsam/base/numericalDerivative.h>
 #include <gtsam/geometry/BearingRange.h>
+#include <gtsam/nonlinear/NoiseModelFactorN.h>
+
+#include <type_traits>
 
 namespace gtsam {
+
+class Unit3;
 
 /**
  * Binary factor for a bearing/range measurement
@@ -31,33 +36,35 @@ namespace gtsam {
 template <typename A1, typename A2,
           typename B = typename Bearing<A1, A2>::result_type,
           typename R = typename Range<A1, A2>::result_type>
-class BearingRangeFactor
-    : public ExpressionFactorN<BearingRange<A1, A2>, A1, A2> {
+class BearingRangeFactor : public NoiseModelFactorN<A1, A2> {
  private:
   typedef BearingRange<A1, A2> T;
-  typedef ExpressionFactorN<T, A1, A2> Base;
-  typedef BearingRangeFactor<A1, A2> This;
+  typedef NoiseModelFactorN<A1, A2> Base;
+  typedef BearingRangeFactor<A1, A2, B, R> This;
 
  public:
   typedef std::shared_ptr<This> shared_ptr;
 
+ private:
+  T measured_;
+
+ public:
   /// Default constructor
-  BearingRangeFactor() {}
+  BearingRangeFactor() = default;
 
-  /// Construct from BearingRange instance
-  BearingRangeFactor(Key key1, Key key2, const T &bearingRange,
-                     const SharedNoiseModel &model)
-      : Base({{key1, key2}}, model, T(bearingRange)) {
-    this->initialize(expression({{key1, key2}}));
-  }
+  /// Construct from keys, a combined bearing-range measurement, and a noise
+  /// model.
+  BearingRangeFactor(Key key1, Key key2, const T& bearingRange,
+                     const SharedNoiseModel& model)
+      : Base(model, key1, key2), measured_(bearingRange) {}
 
-  /// Construct from separate bearing and range
-  BearingRangeFactor(Key key1, Key key2, const B &measuredBearing,
-                     const R &measuredRange, const SharedNoiseModel &model)
-      : Base({{key1, key2}}, model, T(measuredBearing, measuredRange)) {
-    this->initialize(expression({{key1, key2}}));
-  }
+  /// Construct from keys, separate bearing/range measurements, and a noise
+  /// model.
+  BearingRangeFactor(Key key1, Key key2, const B& measuredBearing,
+                     const R& measuredRange, const SharedNoiseModel& model)
+      : Base(model, key1, key2), measured_(measuredBearing, measuredRange) {}
 
+  /// Destroy this factor.
   ~BearingRangeFactor() override {}
 
   /// @return a deep copy of this factor
@@ -66,38 +73,90 @@ class BearingRangeFactor
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }
 
-  // Return measurement expression
-  Expression<T> expression(const typename Base::ArrayNKeys& keys) const override {
-    return Expression<T>(T::Measure, Expression<A1>(keys[0]),
-                         Expression<A2>(keys[1]));
+  /// @return the measurement
+  const T& measured() const { return measured_; }
+
+  /// Check equality up to a tolerance.
+  bool equals(const NonlinearFactor& f, double tol = 1e-9) const override {
+    const This* p = dynamic_cast<const This*>(&f);
+    return p != nullptr && Base::equals(f, tol) &&
+           traits<T>::Equals(measured_, p->measured_, tol);
   }
 
+  /// Evaluate the unwhitened bearing-range error and optional Jacobians.
   Vector evaluateError(const A1& a1, const A2& a2,
-      OptionalMatrixType H1 = OptionalNone, OptionalMatrixType H2 = OptionalNone) const {
-    std::vector<Matrix> Hs(2);
-    const auto &keys = Factor::keys();
-    const Vector error = this->unwhitenedError(
-        {{keys[0], genericValue(a1)}, {keys[1], genericValue(a2)}}, Hs);
-    if (H1) *H1 = Hs[0];
-    if (H2) *H2 = Hs[1];
+                       OptionalMatrixType H1 = OptionalNone,
+                       OptionalMatrixType H2 = OptionalNone) const override {
+    constexpr int dimB = traits<B>::dimension;
+    constexpr int dimR = traits<R>::dimension;
+    constexpr int dim1 = traits<A1>::dimension;
+    constexpr int dim2 = traits<A2>::dimension;
+
+    typename MakeJacobian<B, A1>::type HB1;
+    typename MakeJacobian<B, A2>::type HB2;
+    typename MakeJacobian<R, A1>::type HR1;
+    typename MakeJacobian<R, A2>::type HR2;
+    typename traits<R>::ChartJacobian::Jacobian HlocalR;
+
+    const B predictedBearing =
+        Bearing<A1, A2>()(a1, a2, H1 ? &HB1 : nullptr, H2 ? &HB2 : nullptr);
+    const R predictedRange =
+        Range<A1, A2>()(a1, a2, H1 ? &HR1 : nullptr, H2 ? &HR2 : nullptr);
+
+    Vector error(dimB + dimR);
+    Matrix HerrorBearing;
+    if constexpr (std::is_same_v<B, Unit3>) {
+      const auto localBearingError = [&](const B& value) -> Vector {
+        return -traits<B>::Local(value, measured_.bearing());
+      };
+      error.head(dimB) = localBearingError(predictedBearing);
+      if (H1 || H2) {
+        HerrorBearing = numericalDerivative11<Vector, B>(localBearingError,
+                                                         predictedBearing);
+      }
+    } else {
+      typename traits<B>::ChartJacobian::Jacobian HlocalB;
+      error.head(dimB) =
+          -traits<B>::Local(predictedBearing, measured_.bearing(),
+                            (H1 || H2) ? &HlocalB : nullptr, OptionalNone);
+      if (H1 || H2) {
+        HerrorBearing = -HlocalB;
+      }
+    }
+    error.tail(dimR) =
+        -traits<R>::Local(predictedRange, measured_.range(),
+                          (H1 || H2) ? &HlocalR : nullptr, OptionalNone);
+
+    if (H1) {
+      H1->resize(dimB + dimR, dim1);
+      H1->topRows(dimB) = HerrorBearing * HB1;
+      H1->bottomRows(dimR) = -HlocalR * HR1;
+    }
+    if (H2) {
+      H2->resize(dimB + dimR, dim2);
+      H2->topRows(dimB) = HerrorBearing * HB2;
+      H2->bottomRows(dimR) = -HlocalR * HR2;
+    }
     return error;
   }
 
   /// print
   void print(const std::string& s = "",
-                     const KeyFormatter& kf = DefaultKeyFormatter) const override {
+             const KeyFormatter& kf = DefaultKeyFormatter) const override {
     std::cout << s << "BearingRangeFactor" << std::endl;
     Base::print(s, kf);
+    traits<T>::Print(measured_, "  measured: ");
   }
-
 
  private:
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
   friend class boost::serialization::access;
+  /// Serialize this factor.
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
     ar& boost::serialization::make_nvp(
-        "Base", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactor2", boost::serialization::base_object<Base>(*this));
+    ar& BOOST_SERIALIZATION_NVP(measured_);
   }
 #endif
 };  // BearingRangeFactor

--- a/gtsam/sam/BearingRangeFactor.h
+++ b/gtsam/sam/BearingRangeFactor.h
@@ -19,15 +19,10 @@
 
 #pragma once
 
-#include <gtsam/base/numericalDerivative.h>
 #include <gtsam/geometry/BearingRange.h>
 #include <gtsam/nonlinear/NoiseModelFactorN.h>
 
-#include <type_traits>
-
 namespace gtsam {
-
-class Unit3;
 
 /**
  * Binary factor for a bearing/range measurement
@@ -96,7 +91,6 @@ class BearingRangeFactor : public NoiseModelFactorN<A1, A2> {
     typename MakeJacobian<B, A2>::type HB2;
     typename MakeJacobian<R, A1>::type HR1;
     typename MakeJacobian<R, A2>::type HR2;
-    typename traits<R>::ChartJacobian::Jacobian HlocalR;
 
     const B predictedBearing =
         Bearing<A1, A2>()(a1, a2, H1 ? &HB1 : nullptr, H2 ? &HB2 : nullptr);
@@ -104,38 +98,18 @@ class BearingRangeFactor : public NoiseModelFactorN<A1, A2> {
         Range<A1, A2>()(a1, a2, H1 ? &HR1 : nullptr, H2 ? &HR2 : nullptr);
 
     Vector error(dimB + dimR);
-    Matrix HerrorBearing;
-    if constexpr (std::is_same_v<B, Unit3>) {
-      const auto localBearingError = [&](const B& value) -> Vector {
-        return -traits<B>::Local(value, measured_.bearing());
-      };
-      error.head(dimB) = localBearingError(predictedBearing);
-      if (H1 || H2) {
-        HerrorBearing = numericalDerivative11<Vector, B>(localBearingError,
-                                                         predictedBearing);
-      }
-    } else {
-      typename traits<B>::ChartJacobian::Jacobian HlocalB;
-      error.head(dimB) =
-          -traits<B>::Local(predictedBearing, measured_.bearing(),
-                            (H1 || H2) ? &HlocalB : nullptr, OptionalNone);
-      if (H1 || H2) {
-        HerrorBearing = -HlocalB;
-      }
-    }
-    error.tail(dimR) =
-        -traits<R>::Local(predictedRange, measured_.range(),
-                          (H1 || H2) ? &HlocalR : nullptr, OptionalNone);
+    error.head(dimB) = -traits<B>::Local(predictedBearing, measured_.bearing());
+    error.tail(dimR) = -traits<R>::Local(predictedRange, measured_.range());
 
     if (H1) {
       H1->resize(dimB + dimR, dim1);
-      H1->topRows(dimB) = HerrorBearing * HB1;
-      H1->bottomRows(dimR) = -HlocalR * HR1;
+      H1->topRows(dimB) = HB1;
+      H1->bottomRows(dimR) = HR1;
     }
     if (H2) {
       H2->resize(dimB + dimR, dim2);
-      H2->topRows(dimB) = HerrorBearing * HB2;
-      H2->bottomRows(dimR) = -HlocalR * HR2;
+      H2->topRows(dimB) = HB2;
+      H2->bottomRows(dimR) = HR2;
     }
     return error;
   }

--- a/gtsam/sam/RangeFactor.h
+++ b/gtsam/sam/RangeFactor.h
@@ -202,4 +202,106 @@ template <typename A1, typename A2, typename T>
 struct traits<RangeFactorWithTransform<A1, A2, T> >
     : public Testable<RangeFactorWithTransform<A1, A2, T> > {};
 
+/**
+ * Ternary factor for a range measurement with a fixed sensor transform and
+ * an additive bias term.
+ * @ingroup sam
+ */
+template <typename A1, typename A2 = A1,
+          typename T = typename Range<A1, A2>::result_type>
+class RangeFactorWithTransformBias : public NoiseModelFactorN<A1, A2, T> {
+ private:
+  typedef RangeFactorWithTransformBias<A1, A2, T> This;
+  typedef NoiseModelFactorN<A1, A2, T> Base;
+
+  T measured_;        ///< The measured range.
+  A1 body_T_sensor_;  ///< The pose of the sensor in the body frame.
+
+ public:
+  /// Default constructor.
+  RangeFactorWithTransformBias() = default;
+
+  /// Construct from keys, a range measurement, a noise model, and transform.
+  RangeFactorWithTransformBias(Key key1, Key key2, Key key3, T measured,
+                               const SharedNoiseModel& noiseModel,
+                               const A1& body_T_sensor)
+      : Base(noiseModel, key1, key2, key3),
+        measured_(measured),
+        body_T_sensor_(body_T_sensor) {}
+
+  /// Destroy this factor.
+  ~RangeFactorWithTransformBias() override = default;
+
+  /// @return a deep copy of this factor
+  gtsam::NonlinearFactor::shared_ptr clone() const override {
+    return std::static_pointer_cast<gtsam::NonlinearFactor>(
+        gtsam::NonlinearFactor::shared_ptr(new This(*this)));
+  }
+
+  /// @return the measurement
+  const T& measured() const { return measured_; }
+
+  /// Evaluate the unwhitened range error and optional Jacobians.
+  Vector evaluateError(const A1& a1, const A2& a2, const T& bias,
+                       OptionalMatrixType H1 = OptionalNone,
+                       OptionalMatrixType H2 = OptionalNone,
+                       OptionalMatrixType H3 = OptionalNone) const override {
+    Matrix HposeCompose, HsensorRange, H2Range, Hlocal;
+    const A1 nav_T_sensor =
+        a1.compose(body_T_sensor_, H1 ? &HposeCompose : nullptr);
+    const T predictedRange =
+        Range<A1, A2>()(nav_T_sensor, a2, H1 ? &HsensorRange : nullptr,
+                        H2 ? &H2Range : nullptr);
+    const T predictedMeasurement = predictedRange + bias;
+    const Vector error = -traits<T>::Local(
+        predictedMeasurement, measured_, (H1 || H2 || H3) ? &Hlocal : nullptr);
+    if (H1) *H1 = -Hlocal * HsensorRange * HposeCompose;
+    if (H2) *H2 = -Hlocal * H2Range;
+    if (H3) *H3 = -Hlocal;
+    return error;
+  }
+
+  /// Matrix-reference overload for evaluateError.
+  Vector evaluateError(const A1& a1, const A2& a2, const T& bias, Matrix& H1,
+                       Matrix& H2, Matrix& H3) const {
+    return evaluateError(a1, a2, bias, &H1, &H2, &H3);
+  }
+
+  /// Print contents.
+  void print(
+      const std::string& s = "",
+      const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override {
+    std::cout << s << "RangeFactorWithTransformBias" << std::endl;
+    body_T_sensor_.print("  sensor pose in body frame: ");
+    Base::print(s, keyFormatter);
+    traits<T>::Print(measured_, "  measured: ");
+  }
+
+  /// Check equality up to a tolerance.
+  bool equals(const NonlinearFactor& f, double tol) const override {
+    const This* p = dynamic_cast<const This*>(&f);
+    return p != nullptr && Base::equals(f, tol) &&
+           traits<T>::Equals(measured_, p->measured_, tol) &&
+           traits<A1>::Equals(body_T_sensor_, p->body_T_sensor_, tol);
+  }
+
+ private:
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
+  friend class boost::serialization::access;
+  /// Serialize this factor.
+  template <typename ARCHIVE>
+  void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
+    ar& boost::serialization::make_nvp(
+        "NoiseModelFactor3", boost::serialization::base_object<Base>(*this));
+    ar& BOOST_SERIALIZATION_NVP(measured_);
+    ar& BOOST_SERIALIZATION_NVP(body_T_sensor_);
+  }
+#endif
+};  // \ RangeFactorWithTransformBias
+
+/// traits
+template <typename A1, typename A2, typename T>
+struct traits<RangeFactorWithTransformBias<A1, A2, T> >
+    : public Testable<RangeFactorWithTransformBias<A1, A2, T> > {};
+
 }  // namespace gtsam

--- a/gtsam/sam/RangeFactor.h
+++ b/gtsam/sam/RangeFactor.h
@@ -20,6 +20,8 @@
 
 #include <gtsam/nonlinear/NoiseModelFactorN.h>
 
+#include <type_traits>
+
 namespace gtsam {
 
 // forward declaration of Range functor, assumed partially specified
@@ -60,14 +62,8 @@ class RangeFactor : public NoiseModelFactorN<A1, A2> {
   Vector evaluateError(const A1& a1, const A2& a2,
                        OptionalMatrixType H1 = OptionalNone,
                        OptionalMatrixType H2 = OptionalNone) const override {
-    Matrix Hpred1, Hpred2, Hlocal;
-    const T predicted =
-        Range<A1, A2>()(a1, a2, H1 ? &Hpred1 : nullptr, H2 ? &Hpred2 : nullptr);
-    const Vector error =
-        -traits<T>::Local(predicted, measured_, (H1 || H2) ? &Hlocal : nullptr);
-    if (H1) *H1 = -Hlocal * Hpred1;
-    if (H2) *H2 = -Hlocal * Hpred2;
-    return error;
+    const T predicted = Range<A1, A2>()(a1, a2, H1, H2);
+    return -traits<T>::Local(predicted, measured_);
   }
 
   /// print
@@ -145,17 +141,12 @@ class RangeFactorWithTransform : public NoiseModelFactorN<A1, A2> {
   Vector evaluateError(const A1& a1, const A2& a2,
                        OptionalMatrixType H1 = OptionalNone,
                        OptionalMatrixType H2 = OptionalNone) const override {
-    Matrix HposeCompose, HsensorRange, H2Range, Hlocal;
+    Matrix HposeCompose;
     const A1 nav_T_sensor =
         a1.compose(body_T_sensor_, H1 ? &HposeCompose : nullptr);
-    const T predicted =
-        Range<A1, A2>()(nav_T_sensor, a2, H1 ? &HsensorRange : nullptr,
-                        H2 ? &H2Range : nullptr);
-    const Vector error =
-        -traits<T>::Local(predicted, measured_, (H1 || H2) ? &Hlocal : nullptr);
-    if (H1) *H1 = -Hlocal * HsensorRange * HposeCompose;
-    if (H2) *H2 = -Hlocal * H2Range;
-    return error;
+    const T predicted = Range<A1, A2>()(nav_T_sensor, a2, H1, H2);
+    if (H1) *H1 *= HposeCompose;
+    return -traits<T>::Local(predicted, measured_);
   }
 
   // An evaluateError overload to accept matrices (Matrix&) and pass it to the
@@ -246,19 +237,20 @@ class RangeFactorWithTransformBias : public NoiseModelFactorN<A1, A2, T> {
                        OptionalMatrixType H1 = OptionalNone,
                        OptionalMatrixType H2 = OptionalNone,
                        OptionalMatrixType H3 = OptionalNone) const override {
-    Matrix HposeCompose, HsensorRange, H2Range, Hlocal;
+    Matrix HposeCompose;
     const A1 nav_T_sensor =
         a1.compose(body_T_sensor_, H1 ? &HposeCompose : nullptr);
-    const T predictedRange =
-        Range<A1, A2>()(nav_T_sensor, a2, H1 ? &HsensorRange : nullptr,
-                        H2 ? &H2Range : nullptr);
-    const T predictedMeasurement = predictedRange + bias;
-    const Vector error = -traits<T>::Local(
-        predictedMeasurement, measured_, (H1 || H2 || H3) ? &Hlocal : nullptr);
-    if (H1) *H1 = -Hlocal * HsensorRange * HposeCompose;
-    if (H2) *H2 = -Hlocal * H2Range;
-    if (H3) *H3 = -Hlocal;
-    return error;
+    const T predictedRange = Range<A1, A2>()(nav_T_sensor, a2, H1, H2);
+    if (H1) *H1 *= HposeCompose;
+    if (H3) {
+      if constexpr (std::is_same_v<T, double>) {
+        *H3 = Matrix1::Identity();
+      } else {
+        const int dimension = traits<T>::GetDimension(measured_);
+        *H3 = Matrix::Identity(dimension, dimension);
+      }
+    }
+    return -traits<T>::Local(predictedRange + bias, measured_);
   }
 
   /// Matrix-reference overload for evaluateError.

--- a/gtsam/sam/sam.i
+++ b/gtsam/sam/sam.i
@@ -70,6 +70,25 @@ typedef gtsam::RangeFactorWithTransform<gtsam::Pose2, gtsam::Pose2>
 typedef gtsam::RangeFactorWithTransform<gtsam::Pose3, gtsam::Pose3>
     RangeFactorWithTransformPose3;
 
+#include <gtsam/sam/RangeFactor.h>
+template <POSE, POINT>
+virtual class RangeFactorWithTransformBias : gtsam::NoiseModelFactor {
+  RangeFactorWithTransformBias(gtsam::Key key1, gtsam::Key key2,
+                               gtsam::Key key3, double measured,
+                               const gtsam::noiseModel::Base* noiseModel,
+                               const POSE& body_T_sensor);
+
+  // enabling serialization functionality
+  void serialize() const;
+
+  const double measured() const;
+};
+
+typedef gtsam::RangeFactorWithTransformBias<gtsam::Pose2, gtsam::Point2>
+    RangeFactorWithTransformBias2D;
+typedef gtsam::RangeFactorWithTransformBias<gtsam::Pose3, gtsam::Point3>
+    RangeFactorWithTransformBias3D;
+
 #include <gtsam/sam/BearingFactor.h>
 template <POSE, POINT, BEARING>
 virtual class BearingFactor : gtsam::NoiseModelFactor {

--- a/gtsam/sam/tests/testBearingFactor.cpp
+++ b/gtsam/sam/tests/testBearingFactor.cpp
@@ -16,13 +16,11 @@
  *  @date July 2015
  */
 
-#include <gtsam/sam/BearingFactor.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/nonlinear/factorTesting.h>
-#include <gtsam/nonlinear/expressionTesting.h>
-
-#include <CppUnitLite/TestHarness.h>
+#include <gtsam/sam/BearingFactor.h>
 
 using namespace std;
 using namespace gtsam;
@@ -40,7 +38,7 @@ typedef BearingFactor<Pose3, Point3> BearingFactor3D;
 Unit3 measurement3D = Pose3().bearing(Point3(1, 0, 0));  // has to match values!
 static SharedNoiseModel model3D(noiseModel::Isotropic::Sigma(2, 0.5));
 BearingFactor3D factor3D(poseKey, pointKey, measurement3D, model3D);
-}
+}  // namespace
 
 /* ************************************************************************* */
 TEST(BearingFactor, 2D) {
@@ -49,8 +47,6 @@ TEST(BearingFactor, 2D) {
   values.insert(poseKey, Pose2(1.0, 2.0, 0.57));
   values.insert(pointKey, Point2(-4.0, 11.0));
 
-  EXPECT_CORRECT_EXPRESSION_JACOBIANS(factor2D.expression({poseKey, pointKey}),
-                                      values, 1e-7, 1e-5);
   EXPECT_CORRECT_FACTOR_JACOBIANS(factor2D, values, 1e-7, 1e-5);
 }
 
@@ -59,7 +55,7 @@ TEST(BearingFactor, 2D) {
 // incompatible with the Unit3 localCoordinates. The issue is the following:
 // For factors, we want to use Local(value, measured), because we need the error
 // to be expressed in the tangent space of value. This surfaced in the Unit3 case
-// where the tangent space can be radically didfferent from one value to the next.
+// where the tangent space can be radically different from one value to the next.
 // For derivatives, we want Local(constant, varying), because we need a derivative
 // in a constant tangent space. But since the macros below call whitenedError
 // which calls Local(value,measured), we actually call the reverse. This does not
@@ -78,8 +74,6 @@ TEST(BearingFactor, 2D) {
 //  values.insert(poseKey, Pose3());
 //  values.insert(pointKey, Point3(1, 0, 0));
 //
-//  EXPECT_CORRECT_EXPRESSION_JACOBIANS(factor.expression({poseKey, pointKey}),
-//                                      values, 1e-7, 1e-5);
 //  EXPECT_CORRECT_FACTOR_JACOBIANS(factor, values, 1e-7, 1e-5);
 //}
 

--- a/gtsam/sam/tests/testBearingRangeFactor.cpp
+++ b/gtsam/sam/tests/testBearingRangeFactor.cpp
@@ -19,7 +19,6 @@
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/geometry/Pose3.h>
-#include <gtsam/nonlinear/expressionTesting.h>
 #include <gtsam/nonlinear/factorTesting.h>
 #include <gtsam/sam/BearingRangeFactor.h>
 
@@ -42,8 +41,6 @@ TEST(BearingRangeFactor, 2D) {
   values.insert(poseKey, Pose2(1.0, 2.0, 0.57));
   values.insert(pointKey, Point2(-4.0, 11.0));
 
-  EXPECT_CORRECT_EXPRESSION_JACOBIANS(factor2D.expression({poseKey, pointKey}),
-                                      values, 1e-7, 1e-5);
   EXPECT_CORRECT_FACTOR_JACOBIANS(factor2D, values, 1e-7, 1e-5);
 }
 
@@ -55,7 +52,7 @@ TEST(BearingRangeFactor, 3D) {
   const Unit3 bearing = Pose3().bearing(Point3(1, 0, 0));
   const double range = 1.0;
   BearingRangeFactor3D factor3D(poseKey, pointKey, bearing, range, model3D);
-  
+
   // Set the linearization point
   Values values;
   values.insert(poseKey, Pose3());
@@ -67,8 +64,6 @@ TEST(BearingRangeFactor, 3D) {
 
   // TODO(frank): this test is disabled (for now) because the macros below are
   // incompatible with the Unit3 localCoordinates. See testBearingFactor...
-  // EXPECT_CORRECT_EXPRESSION_JACOBIANS(factor3D.expression({poseKey, pointKey}),
-  //                                     values, 1e-7, 1e-5);
   // EXPECT_CORRECT_FACTOR_JACOBIANS(factor3D, values, 1e-7, 1e-5);
 }  // namespace
 

--- a/gtsam/sam/tests/testRangeFactor.cpp
+++ b/gtsam/sam/tests/testRangeFactor.cpp
@@ -34,6 +34,8 @@ typedef RangeFactor<Pose2, Point2> RangeFactor2D;
 typedef RangeFactor<Pose3, Point3> RangeFactor3D;
 typedef RangeFactorWithTransform<Pose2, Point2> RangeFactorWithTransform2D;
 typedef RangeFactorWithTransform<Pose3, Point3> RangeFactorWithTransform3D;
+typedef RangeFactorWithTransformBias<Pose2, Point2>
+    RangeFactorWithTransformBias2D;
 
 // Keys are deliberately *not* in sorted order to test that case.
 namespace {
@@ -42,6 +44,7 @@ static SharedNoiseModel model(noiseModel::Unit::Create(1));
 
 constexpr Key poseKey(2);
 constexpr Key pointKey(1);
+constexpr Key biasKey(3);
 constexpr double measurement(10.0);
 
 Vector factorError2D(const Pose2& pose, const Point2& point,
@@ -62,6 +65,12 @@ Vector factorErrorWithTransform2D(const Pose2& pose, const Point2& point,
 Vector factorErrorWithTransform3D(const Pose3& pose, const Point3& point,
                                   const RangeFactorWithTransform3D& factor) {
   return factor.evaluateError(pose, point);
+}
+
+Vector factorErrorWithTransformBias2D(
+    const Pose2& pose, const Point2& point, const double& bias,
+    const RangeFactorWithTransformBias2D& factor) {
+  return factor.evaluateError(pose, point, bias);
 }
 }  // namespace
 
@@ -315,6 +324,51 @@ TEST( RangeFactor, Jacobian3DWithTransform ) {
   // Verify the Jacobians are correct
   CHECK(assert_equal(H1Expected, H1Actual, 1e-9));
   CHECK(assert_equal(H2Expected, H2Actual, 1e-9));
+}
+
+/* ************************************************************************* */
+TEST(RangeFactor, ErrorAndJacobian2DWithTransformBias) {
+  Pose2 body_P_sensor(0.25, -0.10, -M_PI_2);
+  RangeFactorWithTransformBias2D factor(poseKey, pointKey, biasKey, measurement,
+                                        model, body_P_sensor);
+
+  KeyVector expectedKeys{poseKey, pointKey, biasKey};
+  CHECK(factor.keys() == expectedKeys);
+
+  Rot2 R(0.57);
+  Point2 t = Point2(1.0, 2.0) - R.rotate(body_P_sensor.translation());
+  Pose2 pose(R, t);
+  Point2 point(-4.0, 11.0);
+  const double bias = 0.5;
+
+  Values values;
+  values.insert(poseKey, pose);
+  values.insert(pointKey, point);
+  values.insert(biasKey, bias);
+
+  Vector actualError = factor.unwhitenedError(values);
+  Vector expectedError = (Vector(1) << 0.795630141).finished();
+  CHECK(assert_equal(expectedError, actualError, 1e-9));
+
+  Matrix H1Actual, H2Actual, H3Actual;
+  factor.evaluateError(pose, point, bias, H1Actual, H2Actual, H3Actual);
+
+  const std::function<Vector(const Pose2&, const Point2&, const double&)> h =
+      [&factor](const Pose2& poseValue, const Point2& pointValue,
+                const double& biasValue) {
+        return factorErrorWithTransformBias2D(poseValue, pointValue, biasValue,
+                                              factor);
+      };
+  Matrix H1Expected = numericalDerivative31<Vector, Pose2, Point2, double>(
+      h, pose, point, bias);
+  Matrix H2Expected = numericalDerivative32<Vector, Pose2, Point2, double>(
+      h, pose, point, bias);
+  Matrix H3Expected = numericalDerivative33<Vector, Pose2, Point2, double>(
+      h, pose, point, bias);
+
+  CHECK(assert_equal(H1Expected, H1Actual, 1e-9));
+  CHECK(assert_equal(H2Expected, H2Actual, 1e-9));
+  CHECK(assert_equal(H3Expected, H3Actual, 1e-9));
 }
 
 /* ************************************************************************* */

--- a/gtsam/sam/tests/testRangeFactor.cpp
+++ b/gtsam/sam/tests/testRangeFactor.cpp
@@ -21,12 +21,11 @@
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/geometry/PinholeCamera.h>
 #include <gtsam/geometry/Cal3_S2.h>
-#include <gtsam/base/numericalDerivative.h>
 #include <gtsam/base/TestableAssertions.h>
+#include <gtsam/nonlinear/factorTesting.h>
 
 #include <CppUnitLite/TestHarness.h>
 
-using namespace std::placeholders;
 using namespace std;
 using namespace gtsam;
 
@@ -46,32 +45,6 @@ constexpr Key poseKey(2);
 constexpr Key pointKey(1);
 constexpr Key biasKey(3);
 constexpr double measurement(10.0);
-
-Vector factorError2D(const Pose2& pose, const Point2& point,
-                     const RangeFactor2D& factor) {
-  return factor.evaluateError(pose, point);
-}
-
-Vector factorError3D(const Pose3& pose, const Point3& point,
-                     const RangeFactor3D& factor) {
-  return factor.evaluateError(pose, point);
-}
-
-Vector factorErrorWithTransform2D(const Pose2& pose, const Point2& point,
-                                  const RangeFactorWithTransform2D& factor) {
-  return factor.evaluateError(pose, point);
-}
-
-Vector factorErrorWithTransform3D(const Pose3& pose, const Point3& point,
-                                  const RangeFactorWithTransform3D& factor) {
-  return factor.evaluateError(pose, point);
-}
-
-Vector factorErrorWithTransformBias2D(
-    const Pose2& pose, const Point2& point, const double& bias,
-    const RangeFactorWithTransformBias2D& factor) {
-  return factor.evaluateError(pose, point, bias);
-}
 }  // namespace
 
 /* ************************************************************************* */
@@ -217,23 +190,11 @@ TEST( RangeFactor, Jacobian2D ) {
   RangeFactor2D factor(poseKey, pointKey, measurement, model);
 
   // Set the linearization point
-  Pose2 pose(1.0, 2.0, 0.57);
-  Point2 point(-4.0, 11.0);
+  Values values;
+  values.insert(poseKey, Pose2(1.0, 2.0, 0.57));
+  values.insert(pointKey, Point2(-4.0, 11.0));
 
-  // Use the factor to calculate the Jacobians
-  Matrix H1Actual, H2Actual;
-  factor.evaluateError(pose, point, &H1Actual, &H2Actual);
-
-  // Use numerical derivatives to calculate the Jacobians
-  Matrix H1Expected, H2Expected;
-  H1Expected = numericalDerivative11<Vector, Pose2>(
-      std::bind(&factorError2D, std::placeholders::_1, point, factor), pose);
-  H2Expected = numericalDerivative11<Vector, Point2>(
-      std::bind(&factorError2D, pose, std::placeholders::_1, factor), point);
-
-  // Verify the Jacobians are correct
-  CHECK(assert_equal(H1Expected, H1Actual, 1e-9));
-  CHECK(assert_equal(H2Expected, H2Actual, 1e-9));
+  EXPECT_CORRECT_FACTOR_JACOBIANS(factor, values, 1e-7, 1e-5);
 }
 
 /* ************************************************************************* */
@@ -246,25 +207,11 @@ TEST( RangeFactor, Jacobian2DWithTransform ) {
   // Set the linearization point
   Rot2 R(0.57);
   Point2 t = Point2(1.0, 2.0) - R.rotate(body_P_sensor.translation());
-  Pose2 pose(R, t);
-  Point2 point(-4.0, 11.0);
+  Values values;
+  values.insert(poseKey, Pose2(R, t));
+  values.insert(pointKey, Point2(-4.0, 11.0));
 
-  // Use the factor to calculate the Jacobians
-  std::vector<Matrix> actualHs(2);
-  factor.unwhitenedError({{poseKey, genericValue(pose)}, {pointKey, genericValue(point)}}, actualHs); 
-  const Matrix& H1Actual = actualHs.at(0);
-  const Matrix& H2Actual = actualHs.at(1);
-
-  // Use numerical derivatives to calculate the Jacobians
-  Matrix H1Expected, H2Expected;
-  H1Expected = numericalDerivative11<Vector, Pose2>(
-      std::bind(&factorErrorWithTransform2D, std::placeholders::_1, point, factor), pose);
-  H2Expected = numericalDerivative11<Vector, Point2>(
-      std::bind(&factorErrorWithTransform2D, pose, std::placeholders::_1, factor), point);
-
-  // Verify the Jacobians are correct
-  CHECK(assert_equal(H1Expected, H1Actual, 1e-9));
-  CHECK(assert_equal(H2Expected, H2Actual, 1e-9));
+  EXPECT_CORRECT_FACTOR_JACOBIANS(factor, values, 1e-7, 1e-5);
 }
 
 /* ************************************************************************* */
@@ -273,25 +220,12 @@ TEST( RangeFactor, Jacobian3D ) {
   RangeFactor3D factor(poseKey, pointKey, measurement, model);
 
   // Set the linearization point
-  Pose3 pose(Rot3::RzRyRx(0.2, -0.3, 1.75), Point3(1.0, 2.0, -3.0));
-  Point3 point(-2.0, 11.0, 1.0);
+  Values values;
+  values.insert(poseKey,
+                Pose3(Rot3::RzRyRx(0.2, -0.3, 1.75), Point3(1.0, 2.0, -3.0)));
+  values.insert(pointKey, Point3(-2.0, 11.0, 1.0));
 
-  // Use the factor to calculate the Jacobians
-  std::vector<Matrix> actualHs(2);
-  factor.unwhitenedError({{poseKey, genericValue(pose)}, {pointKey, genericValue(point)}}, actualHs); 
-  const Matrix& H1Actual = actualHs.at(0);
-  const Matrix& H2Actual = actualHs.at(1);
-
-  // Use numerical derivatives to calculate the Jacobians
-  Matrix H1Expected, H2Expected;
-  H1Expected = numericalDerivative11<Vector, Pose3>(
-      std::bind(&factorError3D, std::placeholders::_1, point, factor), pose);
-  H2Expected = numericalDerivative11<Vector, Point3>(
-      std::bind(&factorError3D, pose, std::placeholders::_1, factor), point);
-
-  // Verify the Jacobians are correct
-  CHECK(assert_equal(H1Expected, H1Actual, 1e-9));
-  CHECK(assert_equal(H2Expected, H2Actual, 1e-9));
+  EXPECT_CORRECT_FACTOR_JACOBIANS(factor, values, 1e-7, 1e-5);
 }
 
 /* ************************************************************************* */
@@ -305,25 +239,11 @@ TEST( RangeFactor, Jacobian3DWithTransform ) {
   // Set the linearization point
   Rot3 R = Rot3::RzRyRx(0.2, -0.3, 1.75);
   Point3 t = Point3(1.0, 2.0, -3.0) - R.rotate(body_P_sensor.translation());
-  Pose3 pose(R, t);
-  Point3 point(-2.0, 11.0, 1.0);
+  Values values;
+  values.insert(poseKey, Pose3(R, t));
+  values.insert(pointKey, Point3(-2.0, 11.0, 1.0));
 
-  // Use the factor to calculate the Jacobians
-  std::vector<Matrix> actualHs(2);
-  factor.unwhitenedError({{poseKey, genericValue(pose)}, {pointKey, genericValue(point)}}, actualHs); 
-  const Matrix& H1Actual = actualHs.at(0);
-  const Matrix& H2Actual = actualHs.at(1);
-
-  // Use numerical derivatives to calculate the Jacobians
-  Matrix H1Expected, H2Expected;
-  H1Expected = numericalDerivative11<Vector, Pose3>(
-      std::bind(&factorErrorWithTransform3D, std::placeholders::_1, point, factor), pose);
-  H2Expected = numericalDerivative11<Vector, Point3>(
-      std::bind(&factorErrorWithTransform3D, pose, std::placeholders::_1, factor), point);
-
-  // Verify the Jacobians are correct
-  CHECK(assert_equal(H1Expected, H1Actual, 1e-9));
-  CHECK(assert_equal(H2Expected, H2Actual, 1e-9));
+  EXPECT_CORRECT_FACTOR_JACOBIANS(factor, values, 1e-7, 1e-5);
 }
 
 /* ************************************************************************* */
@@ -350,25 +270,7 @@ TEST(RangeFactor, ErrorAndJacobian2DWithTransformBias) {
   Vector expectedError = (Vector(1) << 0.795630141).finished();
   CHECK(assert_equal(expectedError, actualError, 1e-9));
 
-  Matrix H1Actual, H2Actual, H3Actual;
-  factor.evaluateError(pose, point, bias, H1Actual, H2Actual, H3Actual);
-
-  const std::function<Vector(const Pose2&, const Point2&, const double&)> h =
-      [&factor](const Pose2& poseValue, const Point2& pointValue,
-                const double& biasValue) {
-        return factorErrorWithTransformBias2D(poseValue, pointValue, biasValue,
-                                              factor);
-      };
-  Matrix H1Expected = numericalDerivative31<Vector, Pose2, Point2, double>(
-      h, pose, point, bias);
-  Matrix H2Expected = numericalDerivative32<Vector, Pose2, Point2, double>(
-      h, pose, point, bias);
-  Matrix H3Expected = numericalDerivative33<Vector, Pose2, Point2, double>(
-      h, pose, point, bias);
-
-  CHECK(assert_equal(H1Expected, H1Actual, 1e-9));
-  CHECK(assert_equal(H2Expected, H2Actual, 1e-9));
-  CHECK(assert_equal(H3Expected, H3Actual, 1e-9));
+  EXPECT_CORRECT_FACTOR_JACOBIANS(factor, values, 1e-7, 1e-5);
 }
 
 /* ************************************************************************* */


### PR DESCRIPTION
## Summary
This PR simplifies/speeds up the SAM factor implementations by no longer using ExpressionFactor.

The main changes are:
- refactor `RangeFactor`, `RangeFactorWithTransform`, and `RangeFactorWithTransformBias` to use direct handwritten `NoiseModelFactorN` implementations
- refactor `BearingFactor` and `BearingRangeFactor` to direct handwritten implementations as well
- simplify the plain binary factors so they forward Jacobians directly from `Range(...)` and `Bearing(...)` where possible

Also includes new factor proposed in #2109, and *adds a test* 😄 

## Impact
Much smaller heap memory footprint if many factors.  However, serialization is not backwards compatible.

## Validation
Ran focused SAM factor tests:
- `make -j6 testRangeFactor.run`
- `make -j6 testBearingFactor.run`
- `make -j6 testBearingRangeFactor.run`
