### PR TITLE
Generalize AttitudeFactor

### DIFF
--- a/gtsam/geometry/ExtendedPose3.h
+++ b/gtsam/geometry/ExtendedPose3.h
@@ -45,13 +45,14 @@ class ExtendedPose3;
  * The manifold dimension is 3+3k and the homogeneous matrix size is 3+k.
  * Template parameter K can be fixed (K >= 1) or Eigen::Dynamic.
  */
-template <int K, class Derived>
-class ExtendedPose3
-    : public MatrixLieGroup<std::conditional_t<std::is_void_v<Derived>,
-                                               ExtendedPose3<K, void>, Derived>,
-                            (K == Eigen::Dynamic) ? Eigen::Dynamic : 3 + 3 * K,
-                            (K == Eigen::Dynamic) ? Eigen::Dynamic : 3 + K> {
+template <int K_, class Derived>
+class ExtendedPose3 : public MatrixLieGroup<
+                          std::conditional_t<std::is_void_v<Derived>,
+                                             ExtendedPose3<K_, void>, Derived>,
+                          (K_ == Eigen::Dynamic) ? Eigen::Dynamic : 3 + 3 * K_,
+                          (K_ == Eigen::Dynamic) ? Eigen::Dynamic : 3 + K_> {
  public:
+  static constexpr int K = K_;
   using This = std::conditional_t<std::is_void_v<Derived>,
                                   ExtendedPose3<K, void>, Derived>;
   inline constexpr static int dimension =
@@ -80,10 +81,10 @@ class ExtendedPose3
   Rot3 R_;      ///< Rotation component.
   Matrix3K t_;  ///< K translation-like columns in world frame.
 
-  template <int K_>
-  using IsDynamic = typename std::enable_if<K_ == Eigen::Dynamic, void>::type;
-  template <int K_>
-  using IsFixed = typename std::enable_if<K_ >= 1, void>::type;
+  template <int K__>
+  using IsDynamic = typename std::enable_if<K__ == Eigen::Dynamic, void>::type;
+  template <int K__>
+  using IsFixed = typename std::enable_if<K__ >= 1, void>::type;
 
  public:
   /// @name Constructors
@@ -95,7 +96,7 @@ class ExtendedPose3
    * For fixed K, this creates R=I and x_i=0 for i=1..k.
    * The manifold dimension is 3+3k and matrix size is (3+k)x(3+k).
    */
-  template <int K_ = K, typename = IsFixed<K_>>
+  template <int K__ = K_, typename = IsFixed<K__>>
   ExtendedPose3() : R_(Rot3::Identity()), t_(Matrix3K::Zero()) {}
 
   /**
@@ -105,7 +106,7 @@ class ExtendedPose3
    * Creates R=I and x_i=0 for i=1..k.
    * The manifold dimension is 3+3k and matrix size is (3+k)x(3+k).
    */
-  template <int K_ = K, typename = IsDynamic<K_>>
+  template <int K__ = K_, typename = IsDynamic<K__>>
   explicit ExtendedPose3(size_t k = 0)
       : R_(Rot3::Identity()), t_(3, static_cast<Eigen::Index>(k)) {
     t_.setZero();
@@ -211,7 +212,7 @@ class ExtendedPose3
    *
    * @return Identity with manifold dimension 3+3k and matrix size 3+k.
    */
-  template <int K_ = K, typename = IsFixed<K_>>
+  template <int K__ = K_, typename = IsFixed<K__>>
   static This Identity() {
     return MakeReturn(ExtendedPose3());
   }
@@ -222,7 +223,7 @@ class ExtendedPose3
    * @param k Number of R^3 blocks.
    * @return Identity with manifold dimension 3+3k and matrix size 3+k.
    */
-  template <int K_ = K, typename = IsDynamic<K_>>
+  template <int K__ = K_, typename = IsDynamic<K__>>
   static This Identity(size_t k = 0) {
     return MakeReturn(ExtendedPose3(k));
   }

--- a/gtsam/navigation/AttitudeFactor.cpp
+++ b/gtsam/navigation/AttitudeFactor.cpp
@@ -18,62 +18,13 @@
 
 #include "AttitudeFactor.h"
 
-using namespace std;
-
 namespace gtsam {
 
-//***************************************************************************
-Vector AttitudeFactor::attitudeError(const Rot3& nRb,
-    OptionalJacobian<2, 3> H) const {
-  if (H) {
-    Matrix23 D_nRotated_R;
-    Matrix22 D_e_nRotated;
-    Unit3 nRotated = nRb.rotate(bMeasured_, D_nRotated_R);
-    Vector e = nRef_.errorVector(nRotated, {}, D_e_nRotated);
+template class AttitudeFactor<Rot3>;
+template class AttitudeFactor<Pose3>;
+template class AttitudeFactor<NavState>;
+template class AttitudeFactor<Gal3>;
+template class AttitudeFactor<Se23>;
+template class AttitudeFactor<ExtendedPose3d>;
 
-    (*H) = D_e_nRotated * D_nRotated_R;
-    return e;
-  } else {
-    Unit3 nRotated = nRb * bMeasured_;
-    return nRef_.errorVector(nRotated);
-  }
-}
-
-//***************************************************************************
-void Rot3AttitudeFactor::print(const string& s,
-    const KeyFormatter& keyFormatter) const {
-  cout << (s.empty() ? "" : s + " ") << "Rot3AttitudeFactor on "
-       << keyFormatter(this->key()) << "\n";
-  nRef_.print("  reference direction in nav frame: ");
-  bMeasured_.print("  measured direction in body frame: ");
-  this->noiseModel_->print("  noise model: ");
-}
-
-//***************************************************************************
-bool Rot3AttitudeFactor::equals(const NonlinearFactor& expected,
-    double tol) const {
-  const This* e = dynamic_cast<const This*>(&expected);
-  return e != nullptr && Base::equals(*e, tol) && this->nRef_.equals(e->nRef_, tol)
-      && this->bMeasured_.equals(e->bMeasured_, tol);
-}
-
-//***************************************************************************
-void Pose3AttitudeFactor::print(const string& s,
-    const KeyFormatter& keyFormatter) const {
-  cout << s << "Pose3AttitudeFactor on " << keyFormatter(this->key()) << "\n";
-  nRef_.print("  reference direction in nav frame: ");
-  bMeasured_.print("  measured direction in body frame: ");
-  this->noiseModel_->print("  noise model: ");
-}
-
-//***************************************************************************
-bool Pose3AttitudeFactor::equals(const NonlinearFactor& expected,
-    double tol) const {
-  const This* e = dynamic_cast<const This*>(&expected);
-  return e != nullptr && Base::equals(*e, tol) && this->nRef_.equals(e->nRef_, tol)
-      && this->bMeasured_.equals(e->bMeasured_, tol);
-}
-
-//***************************************************************************
-
-}/// namespace gtsam
+}  // namespace gtsam

--- a/gtsam/navigation/AttitudeFactor.h
+++ b/gtsam/navigation/AttitudeFactor.h
@@ -17,35 +17,68 @@
  **/
 #pragma once
 
+#include <gtsam/geometry/ExtendedPose3.h>
+#include <gtsam/geometry/Gal3.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/geometry/Unit3.h>
-#include <gtsam/nonlinear/NonlinearFactor.h>
+#include <gtsam/navigation/NavState.h>
 #include <gtsam/nonlinear/NoiseModelFactorN.h>
 
+#include <type_traits>
+
 namespace gtsam {
+
+namespace detail {
+
+template <class VALUE>
+inline std::string attitudeFactorName() {
+  if constexpr (std::is_same_v<VALUE, Rot3>) {
+    return "Rot3AttitudeFactor";
+  } else if constexpr (std::is_same_v<VALUE, Pose3>) {
+    return "Pose3AttitudeFactor";
+  } else if constexpr (std::is_same_v<VALUE, NavState>) {
+    return "NavStateAttitudeFactor";
+  } else if constexpr (std::is_same_v<VALUE, Gal3>) {
+    return "Gal3AttitudeFactor";
+  } else if constexpr (std::is_same_v<VALUE, Se23>) {
+    return "Se23AttitudeFactor";
+  } else if constexpr (std::is_same_v<VALUE, ExtendedPose3d>) {
+    return "ExtendedPose3dAttitudeFactor";
+  } else {
+    return "AttitudeFactor";
+  }
+}
+
+}  // namespace detail
 
 /**
  * @class AttitudeFactor
  *
- * @brief Base class for an attitude factor that constrains the rotation between
- * body and navigation frames.
+ * @brief Unary factor that constrains the rotation component of a value.
  *
- * This factor enforces that when the measured direction in the body frame
- * (e.g., from an IMU accelerometer) is rotated into the navigation frame using the
- * rotation variable, it should align with a known reference direction in the
- * navigation frame (e.g., gravity vector).
+ * The error is zero when the measured body-frame direction, rotated into the
+ * navigation frame by the value's rotation, aligns with the known navigation
+ * frame reference direction:
+ *   R * bMeasured == nRef
  *
- * Mathematically, the error is zero when:
- *   nRb * bMeasured == nRef
- *
- * This is useful for incorporating absolute orientation measurements into the
- * factor graph.
+ * @tparam VALUE Value type with a `rotation(OptionalJacobian<3, dim>)` method.
+ * `Rot3` is supported as a special case.
  *
  * @ingroup navigation
  */
-class AttitudeFactor {
+template <class VALUE>
+class GTSAM_EXPORT AttitudeFactor : public NoiseModelFactorN<VALUE> {
+ public:
+  typedef AttitudeFactor<VALUE> This;
+  typedef NoiseModelFactorN<VALUE> Base;
+
+  using Base::evaluateError;
+
+  /// shorthand for a smart pointer to a factor
+  typedef std::shared_ptr<This> shared_ptr;
+
  protected:
-  Unit3 nRef_, bMeasured_;  ///< Position measurement in
+  Unit3 nRef_, bMeasured_;
 
  public:
   /** default constructor - only use for serialization */
@@ -53,194 +86,118 @@ class AttitudeFactor {
 
   /**
    * @brief Constructor
+   * @param key of the variable that will be constrained
    * @param nRef Reference direction in the navigation frame (e.g., gravity).
+   * @param model Gaussian noise model
    * @param bMeasured Measured direction in the body frame (e.g., from IMU
    * accelerometer). Default is Unit3(0, 0, 1).
    */
-  AttitudeFactor(const Unit3& nRef, const Unit3& bMeasured = Unit3(0, 0, 1))
-      : nRef_(nRef), bMeasured_(bMeasured) {}
+  AttitudeFactor(Key key, const Unit3& nRef, const SharedNoiseModel& model,
+                 const Unit3& bMeasured = Unit3(0, 0, 1))
+      : Base(model, key), nRef_(nRef), bMeasured_(bMeasured) {}
+
+  ~AttitudeFactor() override {}
 
   /** vector of errors */
-  Vector attitudeError(const Rot3& p, OptionalJacobian<2, 3> H = {}) const;
+  Vector attitudeError(const Rot3& nRb, OptionalJacobian<2, 3> H = {}) const {
+    if (H) {
+      Matrix23 D_nMeasured_R;
+      const Unit3 nMeasured = nRb.rotate(bMeasured_, D_nMeasured_R);
+      Matrix22 D_e_nMeasured;
+      const Vector error = nRef_.errorVector(nMeasured, {}, D_e_nMeasured);
+      *H = D_e_nMeasured * D_nMeasured_R;
+      return error;
+    } else {
+      return nRef_.errorVector(nRb * bMeasured_);
+    }
+  }
 
   const Unit3& nRef() const { return nRef_; }
   const Unit3& bMeasured() const { return bMeasured_; }
 
 #ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
   [[deprecated("Use nRef() instead")]]
-  const Unit3& nZ() const { return nRef_; }
+  const Unit3& nZ() const {
+    return nRef_;
+  }
 
   [[deprecated("Use bMeasured() instead")]]
-  const Unit3& bRef() const { return bMeasured_; }
+  const Unit3& bRef() const {
+    return bMeasured_;
+  }
 #endif
 
+  /// @return a deep copy of this factor
+  gtsam::NonlinearFactor::shared_ptr clone() const override {
+    return std::static_pointer_cast<gtsam::NonlinearFactor>(
+        gtsam::NonlinearFactor::shared_ptr(new This(*this)));
+  }
+
+  /** print */
+  void print(
+      const std::string& s = "",
+      const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override {
+    std::cout << (s.empty() ? "" : s + " ")
+              << detail::attitudeFactorName<VALUE>() << " on "
+              << keyFormatter(this->key()) << "\n";
+    nRef_.print("  reference direction in nav frame: ");
+    bMeasured_.print("  measured direction in body frame: ");
+    this->noiseModel_->print("  noise model: ");
+  }
+
+  /** equals */
+  bool equals(const NonlinearFactor& expected,
+              double tol = 1e-9) const override {
+    const This* e = dynamic_cast<const This*>(&expected);
+    return e != nullptr && Base::equals(*e, tol) &&
+           nRef_.equals(e->nRef_, tol) && bMeasured_.equals(e->bMeasured_, tol);
+  }
+
+  /** vector of errors */
+  Vector evaluateError(const VALUE& value,
+                       OptionalMatrixType H) const override {
+    if constexpr (std::is_same_v<VALUE, Rot3>) {
+      return attitudeError(value, H);
+    } else {
+      if (H) {
+        Matrix H_rotation_value;
+        const Rot3 nRb = value.rotation(H_rotation_value);
+        Matrix23 H_error_rotation;
+        const Vector error = attitudeError(nRb, H_error_rotation);
+        *H = H_error_rotation * H_rotation_value;
+        return error;
+      } else {
+        return attitudeError(value.rotation());
+      }
+    }
+  }
+
+ private:
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
+    ar& boost::serialization::make_nvp(
+        "NoiseModelFactor1", boost::serialization::base_object<Base>(*this));
     ar& boost::serialization::make_nvp("nRef_", nRef_);
     ar& boost::serialization::make_nvp("bMeasured_", bMeasured_);
   }
 #endif
-};
-
-/**
- * Version of AttitudeFactor for Rot3
- * @ingroup navigation
- */
-class GTSAM_EXPORT Rot3AttitudeFactor : public NoiseModelFactorN<Rot3>,
-                                        public AttitudeFactor {
-  typedef NoiseModelFactorN<Rot3> Base;
-
- public:
-  // Provide access to the Matrix& version of evaluateError:
-  using Base::evaluateError;
-
-  /// shorthand for a smart pointer to a factor
-  typedef std::shared_ptr<Rot3AttitudeFactor> shared_ptr;
-
-  /// Typedef to this class
-  typedef Rot3AttitudeFactor This;
-
-  /** default constructor - only use for serialization */
-  Rot3AttitudeFactor() {}
-
-  ~Rot3AttitudeFactor() override {}
-
-  /**
-   * @brief Constructor
-   * @param key of the Rot3 variable that will be constrained
-   * @param nRef reference direction in navigation frame
-   * @param model Gaussian noise model
-   * @param bMeasured measured direction in body frame (default Z-axis)
-   */
-  Rot3AttitudeFactor(Key key, const Unit3& nRef, const SharedNoiseModel& model,
-                     const Unit3& bMeasured = Unit3(0, 0, 1))
-      : Base(model, key), AttitudeFactor(nRef, bMeasured) {}
-
-  /// @return a deep copy of this factor
-  gtsam::NonlinearFactor::shared_ptr clone() const override {
-    return std::static_pointer_cast<gtsam::NonlinearFactor>(
-        gtsam::NonlinearFactor::shared_ptr(new This(*this)));
-  }
-
-  /** print */
-  void print(const std::string& s = "", const KeyFormatter& keyFormatter =
-                                            DefaultKeyFormatter) const override;
-
-  /** equals */
-  bool equals(const NonlinearFactor& expected,
-              double tol = 1e-9) const override;
-
-  /** vector of errors */
-  Vector evaluateError(const Rot3& nRb, OptionalMatrixType H) const override {
-    return attitudeError(nRb, H);
-  }
-
- private:
-#if GTSAM_ENABLE_BOOST_SERIALIZATION
-  /** Serialization function */
-  friend class boost::serialization::access;
-  template <class ARCHIVE>
-  void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
-    // NoiseModelFactor1 instead of NoiseModelFactorN for backward compatibility
-    ar& boost::serialization::make_nvp(
-        "NoiseModelFactor1", boost::serialization::base_object<Base>(*this));
-    ar& boost::serialization::make_nvp(
-        "AttitudeFactor",
-        boost::serialization::base_object<AttitudeFactor>(*this));
-  }
-#endif
 
  public:
   GTSAM_MAKE_ALIGNED_OPERATOR_NEW
 };
 
-/// traits
-template <>
-struct traits<Rot3AttitudeFactor> : public Testable<Rot3AttitudeFactor> {};
+using Rot3AttitudeFactor = AttitudeFactor<Rot3>;
+using Pose3AttitudeFactor = AttitudeFactor<Pose3>;
+using NavStateAttitudeFactor = AttitudeFactor<NavState>;
+using Gal3AttitudeFactor = AttitudeFactor<Gal3>;
+using Se23AttitudeFactor = AttitudeFactor<Se23>;
+using ExtendedPose3dAttitudeFactor = AttitudeFactor<ExtendedPose3d>;
 
-/**
- * Version of AttitudeFactor for Pose3
- * @ingroup navigation
- */
-class GTSAM_EXPORT Pose3AttitudeFactor : public NoiseModelFactorN<Pose3>,
-                                         public AttitudeFactor {
-  typedef NoiseModelFactorN<Pose3> Base;
-
- public:
-  // Provide access to the Matrix& version of evaluateError:
-  using Base::evaluateError;
-
-  /// shorthand for a smart pointer to a factor
-  typedef std::shared_ptr<Pose3AttitudeFactor> shared_ptr;
-
-  /// Typedef to this class
-  typedef Pose3AttitudeFactor This;
-
-  /** default constructor - only use for serialization */
-  Pose3AttitudeFactor() {}
-
-  ~Pose3AttitudeFactor() override {}
-
-  /**
-   * @brief Constructor
-   * @param key of the Pose3 variable that will be constrained
-   * @param nRef reference direction in navigation frame
-   * @param model Gaussian noise model
-   * @param bMeasured measured direction in body frame (default Z-axis)
-   */
-  Pose3AttitudeFactor(Key key, const Unit3& nRef, const SharedNoiseModel& model,
-                      const Unit3& bMeasured = Unit3(0, 0, 1))
-      : Base(model, key), AttitudeFactor(nRef, bMeasured) {}
-
-  /// @return a deep copy of this factor
-  gtsam::NonlinearFactor::shared_ptr clone() const override {
-    return std::static_pointer_cast<gtsam::NonlinearFactor>(
-        gtsam::NonlinearFactor::shared_ptr(new This(*this)));
-  }
-
-  /** print */
-  void print(const std::string& s = "", const KeyFormatter& keyFormatter =
-                                            DefaultKeyFormatter) const override;
-
-  /** equals */
-  bool equals(const NonlinearFactor& expected,
-              double tol = 1e-9) const override;
-
-  /** vector of errors */
-  Vector evaluateError(const Pose3& nTb, OptionalMatrixType H) const override {
-    Vector e = attitudeError(nTb.rotation(), H);
-    if (H) {
-      Matrix H23 = *H;
-      *H = Matrix::Zero(2, 6);
-      H->block<2, 3>(0, 0) = H23;
-    }
-    return e;
-  }
-
- private:
-#if GTSAM_ENABLE_BOOST_SERIALIZATION
-  /** Serialization function */
-  friend class boost::serialization::access;
-  template <class ARCHIVE>
-  void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
-    // NoiseModelFactor1 instead of NoiseModelFactorN for backward compatibility
-    ar& boost::serialization::make_nvp(
-        "NoiseModelFactor1", boost::serialization::base_object<Base>(*this));
-    ar& boost::serialization::make_nvp(
-        "AttitudeFactor",
-        boost::serialization::base_object<AttitudeFactor>(*this));
-  }
-#endif
-
- public:
-  GTSAM_MAKE_ALIGNED_OPERATOR_NEW
+template <class VALUE>
+struct traits<AttitudeFactor<VALUE>> : public Testable<AttitudeFactor<VALUE>> {
 };
-
-/// traits
-template <>
-struct traits<Pose3AttitudeFactor> : public Testable<Pose3AttitudeFactor> {};
 
 }  // namespace gtsam

--- a/gtsam/navigation/AttitudeFactor.h
+++ b/gtsam/navigation/AttitudeFactor.h
@@ -30,6 +30,15 @@ namespace gtsam {
 
 namespace detail {
 
+// Type trait to detect ExtendedPose3 instantiations
+template <typename T>
+struct is_extended_pose3 : std::false_type {};
+
+template <int K, class Derived>
+struct is_extended_pose3<gtsam::ExtendedPose3<K, Derived>> : std::true_type {};
+
+template <typename T>
+constexpr bool is_extended_pose3_v = is_extended_pose3<T>::value;
 template <class VALUE>
 inline std::string attitudeFactorName() {
   if constexpr (std::is_same_v<VALUE, Rot3>) {
@@ -42,8 +51,11 @@ inline std::string attitudeFactorName() {
     return "Gal3AttitudeFactor";
   } else if constexpr (std::is_same_v<VALUE, Se23>) {
     return "Se23AttitudeFactor";
-  } else if constexpr (std::is_same_v<VALUE, ExtendedPose3d>) {
-    return "ExtendedPose3dAttitudeFactor";
+  } else if constexpr (is_extended_pose3_v<VALUE>) {
+    // Extract K from VALUE = ExtendedPose3<K, Derived>
+    constexpr int K = std::remove_reference_t<VALUE>::K;
+    std::string k_str = (K == Eigen::Dynamic) ? "d" : std::to_string(K);
+    return "ExtendedPose3AttitudeFactor<" + k_str + ">";
   } else {
     return "AttitudeFactor";
   }
@@ -193,6 +205,10 @@ using Rot3AttitudeFactor = AttitudeFactor<Rot3>;
 using Pose3AttitudeFactor = AttitudeFactor<Pose3>;
 using NavStateAttitudeFactor = AttitudeFactor<NavState>;
 using Gal3AttitudeFactor = AttitudeFactor<Gal3>;
+
+template <int K>
+using ExtendedPose3AttitudeFactor = AttitudeFactor<ExtendedPose3<K>>;
+
 using Se23AttitudeFactor = AttitudeFactor<Se23>;
 using ExtendedPose3dAttitudeFactor = AttitudeFactor<ExtendedPose3d>;
 

--- a/gtsam/navigation/NavState.h
+++ b/gtsam/navigation/NavState.h
@@ -154,7 +154,9 @@ public:
   /// @{
 
   /// Syntactic sugar
-  const Rot3& rotation() const { return attitude(); };
+  const Rot3& rotation(OptionalJacobian<3, 9> H = {}) const {
+    return attitude(H);
+  };
 
   // Tangent space sugar.
   // TODO(frank): move to private navstate namespace in cpp

--- a/gtsam/navigation/navigation.i
+++ b/gtsam/navigation/navigation.i
@@ -399,6 +399,78 @@ virtual class Pose3AttitudeFactor : gtsam::NoiseModelFactor {
   void serialize() const;
 };
 
+virtual class NavStateAttitudeFactor : gtsam::NoiseModelFactor {
+  NavStateAttitudeFactor(gtsam::Key key, const gtsam::Unit3& nRef,
+                         const gtsam::noiseModel::Diagonal* model,
+                         const gtsam::Unit3& bMeasured);
+  NavStateAttitudeFactor(gtsam::Key key, const gtsam::Unit3& nRef,
+                         const gtsam::noiseModel::Diagonal* model);
+  NavStateAttitudeFactor();
+  void print(string s = "", const gtsam::KeyFormatter& keyFormatter =
+                                gtsam::DefaultKeyFormatter) const;
+  bool equals(const gtsam::NonlinearFactor& expected, double tol) const;
+  gtsam::Unit3 nRef() const;
+  gtsam::Unit3 bMeasured() const;
+  gtsam::Vector evaluateError(const gtsam::NavState& state);
+
+  // enable serialization functionality
+  void serialize() const;
+};
+
+virtual class Gal3AttitudeFactor : gtsam::NoiseModelFactor {
+  Gal3AttitudeFactor(gtsam::Key key, const gtsam::Unit3& nRef,
+                     const gtsam::noiseModel::Diagonal* model,
+                     const gtsam::Unit3& bMeasured);
+  Gal3AttitudeFactor(gtsam::Key key, const gtsam::Unit3& nRef,
+                     const gtsam::noiseModel::Diagonal* model);
+  Gal3AttitudeFactor();
+  void print(string s = "", const gtsam::KeyFormatter& keyFormatter =
+                                gtsam::DefaultKeyFormatter) const;
+  bool equals(const gtsam::NonlinearFactor& expected, double tol) const;
+  gtsam::Unit3 nRef() const;
+  gtsam::Unit3 bMeasured() const;
+  gtsam::Vector evaluateError(const gtsam::Gal3& state);
+
+  // enable serialization functionality
+  void serialize() const;
+};
+
+virtual class Se23AttitudeFactor : gtsam::NoiseModelFactor {
+  Se23AttitudeFactor(gtsam::Key key, const gtsam::Unit3& nRef,
+                     const gtsam::noiseModel::Diagonal* model,
+                     const gtsam::Unit3& bMeasured);
+  Se23AttitudeFactor(gtsam::Key key, const gtsam::Unit3& nRef,
+                     const gtsam::noiseModel::Diagonal* model);
+  Se23AttitudeFactor();
+  void print(string s = "", const gtsam::KeyFormatter& keyFormatter =
+                                gtsam::DefaultKeyFormatter) const;
+  bool equals(const gtsam::NonlinearFactor& expected, double tol) const;
+  gtsam::Unit3 nRef() const;
+  gtsam::Unit3 bMeasured() const;
+  gtsam::Vector evaluateError(const gtsam::Se23& state);
+
+  // enable serialization functionality
+  void serialize() const;
+};
+
+virtual class ExtendedPose3dAttitudeFactor : gtsam::NoiseModelFactor {
+  ExtendedPose3dAttitudeFactor(gtsam::Key key, const gtsam::Unit3& nRef,
+                               const gtsam::noiseModel::Diagonal* model,
+                               const gtsam::Unit3& bMeasured);
+  ExtendedPose3dAttitudeFactor(gtsam::Key key, const gtsam::Unit3& nRef,
+                               const gtsam::noiseModel::Diagonal* model);
+  ExtendedPose3dAttitudeFactor();
+  void print(string s = "", const gtsam::KeyFormatter& keyFormatter =
+                                gtsam::DefaultKeyFormatter) const;
+  bool equals(const gtsam::NonlinearFactor& expected, double tol) const;
+  gtsam::Unit3 nRef() const;
+  gtsam::Unit3 bMeasured() const;
+  gtsam::Vector evaluateError(const gtsam::ExtendedPose3d& state);
+
+  // enable serialization functionality
+  void serialize() const;
+};
+
 #include <gtsam/navigation/GPSFactor.h>
 virtual class GPSFactor : gtsam::NonlinearFactor{
   GPSFactor(gtsam::Key key, const gtsam::Point3& gpsIn,

--- a/gtsam/navigation/tests/testAttitudeFactor.cpp
+++ b/gtsam/navigation/tests/testAttitudeFactor.cpp
@@ -11,9 +11,9 @@
 
 /**
  * @file    testAttitudeFactor.cpp
- * @brief   Unit test for AttitudeFactors (rot3 and Pose3 versions)
+ * @brief   Unit test for AttitudeFactor variants
  * @author  Frank Dellaert
- * @date   January 22, 2014
+ * @date    January 22, 2014
  */
 
 #include <CppUnitLite/TestHarness.h>
@@ -21,114 +21,190 @@
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/navigation/AttitudeFactor.h>
 
-#include <functional>
+#include <type_traits>
 
-#include "gtsam/base/Matrix.h"
-
-using namespace std::placeholders;
-using namespace std;
 using namespace gtsam;
 
-// *************************************************************************
-TEST(Rot3AttitudeFactor, Constructor) {
-  // Example: pitch and roll of aircraft in an ENU Cartesian frame.
-  // If pitch and roll are zero for an aerospace frame,
-  // that means Z is pointing down, i.e., direction of Z = (0,0,-1)
-  Unit3 bMeasured(0, 0, 1);  // measured direction is body Z axis
-  Unit3 nDown(0, 0, -1);     // down, in ENU navigation frame, is "reference"
+namespace {
 
-  // Factor
-  Key key(1);
-  SharedNoiseModel model = noiseModel::Isotropic::Sigma(2, 0.25);
-  Rot3AttitudeFactor factor0(key, nDown, model);
-  Rot3AttitudeFactor factor(key, nDown, model, bMeasured);
-  EXPECT(assert_equal(factor0, factor, 1e-5));
+template <class Factor>
+bool defaultMeasuredAxisMatches(const Unit3& nDown,
+                                const SharedNoiseModel& model) {
+  Unit3 bMeasured(0, 0, 1);
+  Factor factor0(1, nDown, model);
+  Factor factor(1, nDown, model, bMeasured);
+  return assert_equal(factor0, factor, 1e-5);
+}
 
-  // Create a linearization point at the zero-error point
-  Rot3 nRb;
-  EXPECT(assert_equal((Vector)Z_2x1, factor.evaluateError(nRb), 1e-5));
+template <class Factor, class Value>
+bool zeroResidualAndJacobianMatch(const Factor& factor, const Value& value) {
+  if (!assert_equal((Vector)Z_2x1, factor.evaluateError(value), 1e-5)) {
+    return false;
+  }
 
-  auto err_fn = [&factor](const Rot3& r) {
-    return factor.evaluateError(r, OptionalNone);
+  auto err_fn = [&factor](const Value& candidate) {
+    return factor.evaluateError(candidate, OptionalNone);
   };
-  // Calculate numerical derivatives
-  Matrix expectedH = numericalDerivative11<Vector, Rot3>(err_fn, nRb);
+  Matrix expectedH = numericalDerivative11<Vector, Value>(err_fn, value);
 
-  // Use the factor to calculate the derivative
   Matrix actualH;
-  factor.evaluateError(nRb, actualH);
+  factor.evaluateError(value, actualH);
+  return assert_equal(expectedH, actualH, 1e-8);
+}
 
-  // Verify we get the expected error
-  EXPECT(assert_equal(expectedH, actualH, 1e-8));
+template <class Factor>
+bool copyAndMoveWorks(const Factor& factor) {
+  if (!std::is_copy_assignable<Factor>::value) {
+    return false;
+  }
+  Factor factor_copied = factor;
+  if (!assert_equal(factor, factor_copied)) {
+    return false;
+  }
+
+  if (!std::is_move_assignable<Factor>::value) {
+    return false;
+  }
+  Factor factor_moved = std::move(factor_copied);
+  return assert_equal(factor, factor_moved);
+}
+
+template <int N, class Factor, class Value>
+bool zeroResidualAndJacobianMatchDynamic(const Factor& factor,
+                                         const Value& value) {
+  if (!assert_equal((Vector)Z_2x1, factor.evaluateError(value), 1e-5)) {
+    return false;
+  }
+
+  auto err_fn = [&factor](const Value& candidate) {
+    return factor.evaluateError(candidate, OptionalNone);
+  };
+  Matrix expectedH = numericalDerivative11<Vector, Value, N>(err_fn, value);
+
+  Matrix actualH;
+  factor.evaluateError(value, actualH);
+  return assert_equal(expectedH, actualH, 1e-8);
+}
+
+Se23 makeSe23(const Matrix32& x) { return Se23(Rot3(), x); }
+
+ExtendedPose3d makeExtendedPose3d(const Matrix& x) {
+  return ExtendedPose3d(Rot3(), x);
+}
+
+}  // namespace
+
+/* ************************************************************************* */
+TEST(Rot3AttitudeFactor, ConstructorAndJacobian) {
+  Unit3 nDown(0, 0, -1);
+  SharedNoiseModel model = noiseModel::Isotropic::Sigma(2, 0.25);
+  EXPECT(defaultMeasuredAxisMatches<Rot3AttitudeFactor>(nDown, model));
+
+  Rot3AttitudeFactor factor(1, nDown, model);
+  EXPECT(zeroResidualAndJacobianMatch(factor, Rot3()));
 }
 
 /* ************************************************************************* */
 TEST(Rot3AttitudeFactor, CopyAndMove) {
   Unit3 nDown(0, 0, -1);
   SharedNoiseModel model = noiseModel::Isotropic::Sigma(2, 0.25);
-  Rot3AttitudeFactor factor(0, nDown, model);
-
-  // Copy assignable.
-  EXPECT(std::is_copy_assignable<Rot3AttitudeFactor>::value);
-  Rot3AttitudeFactor factor_copied = factor;
-  EXPECT(assert_equal(factor, factor_copied));
-
-  // Move assignable.
-  EXPECT(std::is_move_assignable<Rot3AttitudeFactor>::value);
-  Rot3AttitudeFactor factor_moved = std::move(factor_copied);
-  EXPECT(assert_equal(factor, factor_moved));
+  EXPECT(copyAndMoveWorks(Rot3AttitudeFactor(0, nDown, model)));
 }
 
-// *************************************************************************
-TEST(Pose3AttitudeFactor, Constructor) {
-  // Example: pitch and roll of aircraft in an ENU Cartesian frame.
-  // If pitch and roll are zero for an aerospace frame,
-  // that means Z is pointing down, i.e., direction of Z = (0,0,-1)
-  Unit3 bMeasured(0, 0, 1);  // measured direction is body Z axis
-  Unit3 nDown(0, 0, -1);     // down, in ENU navigation frame, is "reference"
-
-  // Factor
-  Key key(1);
+/* ************************************************************************* */
+TEST(Pose3AttitudeFactor, ConstructorAndJacobian) {
+  Unit3 nDown(0, 0, -1);
   SharedNoiseModel model = noiseModel::Isotropic::Sigma(2, 0.25);
-  Pose3AttitudeFactor factor0(key, nDown, model);
-  Pose3AttitudeFactor factor(key, nDown, model, bMeasured);
-  EXPECT(assert_equal(factor0, factor, 1e-5));
+  EXPECT(defaultMeasuredAxisMatches<Pose3AttitudeFactor>(nDown, model));
 
-  // Create a linearization point at the zero-error point
-  Pose3 T(Rot3(), Point3(-5.0, 8.0, -11.0));
-  EXPECT(assert_equal((Vector)Z_2x1, factor.evaluateError(T), 1e-5));
-
-  Matrix actualH1;
-
-  auto err_fn = [&factor](const Pose3& p) {
-    return factor.evaluateError(p, OptionalNone);
-  };
-  // Calculate numerical derivatives
-  Matrix expectedH = numericalDerivative11<Vector, Pose3>(err_fn, T);
-
-  // Use the factor to calculate the derivative
-  Matrix actualH;
-  factor.evaluateError(T, actualH);
-
-  // Verify we get the expected error
-  EXPECT(assert_equal(expectedH, actualH, 1e-8));
+  Pose3AttitudeFactor factor(1, nDown, model);
+  EXPECT(zeroResidualAndJacobianMatch(factor,
+                                      Pose3(Rot3(), Point3(-5.0, 8.0, -11.0))));
 }
 
 /* ************************************************************************* */
 TEST(Pose3AttitudeFactor, CopyAndMove) {
   Unit3 nDown(0, 0, -1);
   SharedNoiseModel model = noiseModel::Isotropic::Sigma(2, 0.25);
-  Pose3AttitudeFactor factor(0, nDown, model);
+  EXPECT(copyAndMoveWorks(Pose3AttitudeFactor(0, nDown, model)));
+}
 
-  // Copy assignable.
-  EXPECT(std::is_copy_assignable<Pose3AttitudeFactor>::value);
-  Pose3AttitudeFactor factor_copied = factor;
-  EXPECT(assert_equal(factor, factor_copied));
+/* ************************************************************************* */
+TEST(NavStateAttitudeFactor, ConstructorAndJacobian) {
+  Unit3 nDown(0, 0, -1);
+  SharedNoiseModel model = noiseModel::Isotropic::Sigma(2, 0.25);
+  EXPECT(defaultMeasuredAxisMatches<NavStateAttitudeFactor>(nDown, model));
 
-  // Move assignable.
-  EXPECT(std::is_move_assignable<Pose3AttitudeFactor>::value);
-  Pose3AttitudeFactor factor_moved = std::move(factor_copied);
-  EXPECT(assert_equal(factor, factor_moved));
+  NavStateAttitudeFactor factor(1, nDown, model);
+  EXPECT(zeroResidualAndJacobianMatch(
+      factor,
+      NavState(Rot3(), Point3(-5.0, 8.0, -11.0), Vector3(0.2, -0.4, 0.6))));
+}
+
+/* ************************************************************************* */
+TEST(NavStateAttitudeFactor, CopyAndMove) {
+  Unit3 nDown(0, 0, -1);
+  SharedNoiseModel model = noiseModel::Isotropic::Sigma(2, 0.25);
+  EXPECT(copyAndMoveWorks(NavStateAttitudeFactor(0, nDown, model)));
+}
+
+/* ************************************************************************* */
+TEST(Gal3AttitudeFactor, ConstructorAndJacobian) {
+  Unit3 nDown(0, 0, -1);
+  SharedNoiseModel model = noiseModel::Isotropic::Sigma(2, 0.25);
+  EXPECT(defaultMeasuredAxisMatches<Gal3AttitudeFactor>(nDown, model));
+
+  Gal3AttitudeFactor factor(1, nDown, model);
+  EXPECT(zeroResidualAndJacobianMatch(
+      factor,
+      Gal3(Rot3(), Point3(-5.0, 8.0, -11.0), Vector3(0.2, -0.4, 0.6), 1.25)));
+}
+
+/* ************************************************************************* */
+TEST(Gal3AttitudeFactor, CopyAndMove) {
+  Unit3 nDown(0, 0, -1);
+  SharedNoiseModel model = noiseModel::Isotropic::Sigma(2, 0.25);
+  EXPECT(copyAndMoveWorks(Gal3AttitudeFactor(0, nDown, model)));
+}
+
+/* ************************************************************************* */
+TEST(Se23AttitudeFactor, ConstructorAndJacobian) {
+  Unit3 nDown(0, 0, -1);
+  SharedNoiseModel model = noiseModel::Isotropic::Sigma(2, 0.25);
+  EXPECT(defaultMeasuredAxisMatches<Se23AttitudeFactor>(nDown, model));
+
+  Matrix32 x;
+  x << -5.0, 0.2, 8.0, -0.4, -11.0, 0.6;
+  Se23AttitudeFactor factor(1, nDown, model);
+  EXPECT(zeroResidualAndJacobianMatch(factor, makeSe23(x)));
+}
+
+/* ************************************************************************* */
+TEST(Se23AttitudeFactor, CopyAndMove) {
+  Unit3 nDown(0, 0, -1);
+  SharedNoiseModel model = noiseModel::Isotropic::Sigma(2, 0.25);
+  EXPECT(copyAndMoveWorks(Se23AttitudeFactor(0, nDown, model)));
+}
+
+/* ************************************************************************* */
+TEST(ExtendedPose3dAttitudeFactor, ConstructorAndJacobian) {
+  Unit3 nDown(0, 0, -1);
+  SharedNoiseModel model = noiseModel::Isotropic::Sigma(2, 0.25);
+  EXPECT(
+      defaultMeasuredAxisMatches<ExtendedPose3dAttitudeFactor>(nDown, model));
+
+  Matrix x(3, 3);
+  x << -5.0, 0.2, 1.3, 8.0, -0.4, 2.1, -11.0, 0.6, -0.7;
+  ExtendedPose3dAttitudeFactor factor(1, nDown, model);
+  EXPECT(
+      zeroResidualAndJacobianMatchDynamic<12>(factor, makeExtendedPose3d(x)));
+}
+
+/* ************************************************************************* */
+TEST(ExtendedPose3dAttitudeFactor, CopyAndMove) {
+  Unit3 nDown(0, 0, -1);
+  SharedNoiseModel model = noiseModel::Isotropic::Sigma(2, 0.25);
+  EXPECT(copyAndMoveWorks(ExtendedPose3dAttitudeFactor(0, nDown, model)));
 }
 
 // *************************************************************************

--- a/gtsam/navigation/tests/testSerializationNavigation.cpp
+++ b/gtsam/navigation/tests/testSerializationNavigation.cpp
@@ -134,6 +134,50 @@ TEST(Pose3AttitudeFactor, Serialization) {
 }
 
 /* ************************************************************************* */
+TEST(NavStateAttitudeFactor, Serialization) {
+  Unit3 nDown(0, 0, -1);
+  SharedNoiseModel model = noiseModel::Isotropic::Sigma(2, 0.25);
+  NavStateAttitudeFactor factor(0, nDown, model);
+
+  EXPECT(serializationTestHelpers::equalsObj(factor));
+  EXPECT(serializationTestHelpers::equalsXML(factor));
+  EXPECT(serializationTestHelpers::equalsBinary(factor));
+}
+
+/* ************************************************************************* */
+TEST(Gal3AttitudeFactor, Serialization) {
+  Unit3 nDown(0, 0, -1);
+  SharedNoiseModel model = noiseModel::Isotropic::Sigma(2, 0.25);
+  Gal3AttitudeFactor factor(0, nDown, model);
+
+  EXPECT(serializationTestHelpers::equalsObj(factor));
+  EXPECT(serializationTestHelpers::equalsXML(factor));
+  EXPECT(serializationTestHelpers::equalsBinary(factor));
+}
+
+/* ************************************************************************* */
+TEST(Se23AttitudeFactor, Serialization) {
+  Unit3 nDown(0, 0, -1);
+  SharedNoiseModel model = noiseModel::Isotropic::Sigma(2, 0.25);
+  Se23AttitudeFactor factor(0, nDown, model);
+
+  EXPECT(serializationTestHelpers::equalsObj(factor));
+  EXPECT(serializationTestHelpers::equalsXML(factor));
+  EXPECT(serializationTestHelpers::equalsBinary(factor));
+}
+
+/* ************************************************************************* */
+TEST(ExtendedPose3dAttitudeFactor, Serialization) {
+  Unit3 nDown(0, 0, -1);
+  SharedNoiseModel model = noiseModel::Isotropic::Sigma(2, 0.25);
+  ExtendedPose3dAttitudeFactor factor(0, nDown, model);
+
+  EXPECT(serializationTestHelpers::equalsObj(factor));
+  EXPECT(serializationTestHelpers::equalsXML(factor));
+  EXPECT(serializationTestHelpers::equalsBinary(factor));
+}
+
+/* ************************************************************************* */
 int main() {
   TestResult tr;
   return TestRegistry::runAllTests(tr);

--- a/python/gtsam/tests/test_AttitudeFactor.py
+++ b/python/gtsam/tests/test_AttitudeFactor.py
@@ -1,0 +1,84 @@
+"""
+GTSAM Copyright 2010-2019, Georgia Tech Research Corporation,
+Atlanta, Georgia 30332-0415
+All Rights Reserved
+
+See LICENSE for the license information
+
+Wrapper unit tests for attitude factors on rotation-bearing state types.
+"""
+
+import unittest
+
+import numpy as np
+
+import gtsam
+from gtsam.utils.test_case import GtsamTestCase
+
+
+class TestAttitudeFactor(GtsamTestCase):
+    """Test wrapped attitude factor variants."""
+
+    @staticmethod
+    def model():
+        return gtsam.noiseModel.Diagonal.Sigmas(np.array([0.25, 0.25]))
+
+    @staticmethod
+    def n_down():
+        return gtsam.Unit3(np.array([0.0, 0.0, -1.0]))
+
+    def check_factor(self, factor_cls, state):
+        factor0 = factor_cls(0, self.n_down(), self.model())
+        factor = factor_cls(
+            0, self.n_down(), self.model(), gtsam.Unit3(np.array([0.0, 0.0, 1.0]))
+        )
+        self.gtsamAssertEquals(factor0.nRef(), factor.nRef(), 1e-9)
+        self.gtsamAssertEquals(factor0.bMeasured(), factor.bMeasured(), 1e-9)
+        np.testing.assert_allclose(factor.evaluateError(state), np.zeros(2), atol=1e-9)
+
+        values = gtsam.Values()
+        values.insert(0, state)
+        self.assertAlmostEqual(factor.error(values), 0.0, places=9)
+
+    def test_navstate_attitude_factor(self):
+        state = gtsam.NavState(
+            gtsam.Rot3(),
+            np.array([-5.0, 8.0, -11.0]),
+            np.array([0.2, -0.4, 0.6]),
+        )
+        self.check_factor(gtsam.NavStateAttitudeFactor, state)
+
+    def test_gal3_attitude_factor(self):
+        state = gtsam.Gal3(
+            gtsam.Rot3(),
+            np.array([-5.0, 8.0, -11.0]),
+            np.array([0.2, -0.4, 0.6]),
+            1.25,
+        )
+        self.check_factor(gtsam.Gal3AttitudeFactor, state)
+
+    def test_se23_attitude_factor(self):
+        x = np.array(
+            [
+                [-5.0, 0.2],
+                [8.0, -0.4],
+                [-11.0, 0.6],
+            ]
+        )
+        state = gtsam.Se23(gtsam.Rot3(), x)
+        self.check_factor(gtsam.Se23AttitudeFactor, state)
+
+    def test_extended_pose3d_attitude_factor(self):
+        x = np.array(
+            [
+                [-5.0, 0.2, 1.3],
+                [8.0, -0.4, 2.1],
+                [-11.0, 0.6, -0.7],
+            ]
+        )
+        state = gtsam.ExtendedPose3d(gtsam.Rot3(), x)
+        self.check_factor(gtsam.ExtendedPose3dAttitudeFactor, state)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This is the first of a few PRs that generalize sub-state factors, like AttitudeFactor, to types other than Rot3 and Pose3. By templating AttitudeFactor using CRTP, we now have:
```
using Rot3AttitudeFactor = AttitudeFactor<Rot3>;
using Pose3AttitudeFactor = AttitudeFactor<Pose3>;
using NavStateAttitudeFactor = AttitudeFactor<NavState>;
using Gal3AttitudeFactor = AttitudeFactor<Gal3>;

template <int K>
using ExtendedPose3AttitudeFactor = AttitudeFactor<ExtendedPose3<K>>;

using Se23AttitudeFactor = AttitudeFactor<Se23>;
using ExtendedPose3dAttitudeFactor = AttitudeFactor<ExtendedPose3d>;
``` 