### PR TITLE
Geometry enhancements

### DIFF
--- a/gtsam/base/numericalDerivative.h
+++ b/gtsam/base/numericalDerivative.h
@@ -11,76 +11,121 @@
 
 /**
  * @file    numericalDerivative.h
- * @brief   Some functions to compute numerical derivatives
+ * @brief   Numerical derivative helpers for manifold-valued functions
+ *
+ * This file is organized in three layers:
+ * - `internal` contains small traits that select Jacobian matrix types and
+ *   deduce callable output types.
+ * - `numericalGradient` and `numericalDerivative11` provide the scalar-gradient
+ *   and unary central-difference kernels.
+ * - The higher-arity `numericalDerivativeXY` wrappers adapt multi-argument
+ *   callables onto the unary kernel, while the Hessian helpers at the end build
+ *   on the gradient and Jacobian routines.
  * @author  Frank Dellaert
  */
 
 // \callgraph
 #pragma once
 
-#include <functional>
-
-#include <gtsam/linear/VectorValues.h>
-#include <gtsam/linear/JacobianFactor.h>
-#include <gtsam/nonlinear/Values.h>
 #include <gtsam/base/Lie.h>
+#include <gtsam/linear/JacobianFactor.h>
+#include <gtsam/linear/VectorValues.h>
+#include <gtsam/nonlinear/Values.h>
 
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+/**
+ * @defgroup numerical_derivatives Numerical Derivative Helpers
+ * Finite-difference Jacobian and Hessian utilities for manifold-valued
+ * functions.
+ */
 namespace gtsam {
 
-/*
- * Note that all of these functions have two versions, a boost.function version and a
- * standard C++ function pointer version.  This allows reformulating the arguments of
- * a function to fit the correct structure, which is useful for situations like
- * member functions and functions with arguments not involved in the derivative:
- *
- * Usage of the boost bind version to rearrange arguments:
- *   for a function with one relevant param and an optional derivative:
- *     Foo bar(const Obj& a, OptionalMatrixType H1)
- *   Use boost.bind to restructure:
- *     std::bind(bar, std::placeholders::_1, {})
- *   This syntax will fix the optional argument to {}, while using the first argument provided
- *
- * For member functions, such as below, with an instantiated copy instanceOfSomeClass
- *     Foo SomeClass::bar(const Obj& a)
- * Use boost bind as follows to create a function pointer that uses the member function:
- *       std::bind(&SomeClass::bar, ref(instanceOfSomeClass), std::placeholders::_1)
- *
- * For additional details, see the documentation:
- *     http://www.boost.org/doc/libs/release/libs/bind/bind.html
+/** @addtogroup numerical_derivatives */
+/// @{
+
+/**
+ * The Jacobian helpers accept generic callables. `numericalDerivative11`
+ * implements the central-difference kernel for a unary function. The higher
+ * arity helpers fix the non-differentiated arguments with a small lambda and
+ * forward to that kernel. Thin raw function-reference overloads remain to give
+ * overload resolution context for overloaded free functions.
  */
 
-
-// a quick helper struct to get the appropriate fixed sized matrix from two value types
+/** @name Internal Type Helpers */
+/// @{
 namespace internal {
-template<class Y, class X=double>
+/// Select the fixed-size Jacobian type associated with two manifold types.
+template <class Y, class X = double>
 struct FixedSizeMatrix {
-  typedef Eigen::Matrix<double,traits<Y>::dimension, traits<X>::dimension> type;
+  typedef Eigen::Matrix<double, traits<Y>::dimension, traits<X>::dimension>
+      type;
 };
-}
 
+/// Select a fixed-size matrix from explicit row and column counts.
+template <int M, int N>
+struct MatrixMN {
+  typedef Eigen::Matrix<double, M, N> type;
+};
+
+/// Marker type used when the callable return type should be deduced.
+struct DeducedOutput {};
+
+template <class RequestedY, class F, class... Args>
+using OutputType =
+    std::conditional_t<std::is_same_v<RequestedY, DeducedOutput>,
+                       std::decay_t<std::invoke_result_t<F&, const Args&...>>,
+                       RequestedY>;
+
+template <class F, class... Args>
+using EnableIfInvocable =
+    std::enable_if_t<std::is_invocable_v<F&, const Args&...>, int>;
+}  // namespace internal
+/// @}
+
+/** @name First-Order Derivative Helpers */
+/// @{
+/**
+ * @par Template requirements
+ * - Callable argument: `h` must be invocable with `const` references to the
+ *   corresponding argument types (`const X&`, `const X1&`, ...).
+ * - Output type: `Y` (or the deduced output type when `Y` is omitted) must be
+ *   a manifold type (`traits<Y>::structure_category` derives from
+ *   `manifold_tag`) and support `traits<Y>::Local` and
+ *   `traits<Y>::GetDimension`.
+ * - Differentiated input type: only the argument being differentiated (`X`,
+ *   `X1`, `X2`, ...) must be a manifold type and support `traits<X>::Retract`.
+ * - Other input types: non-differentiated arguments only need to satisfy
+ *   callable invocation of `h`.
+ * - Dimension parameter: `N` must be positive; for variable-size manifold
+ *   types, `N` must be provided explicitly.
+ */
 /**
  * @brief Numerically compute gradient of scalar function
  * @return n-dimensional gradient computed via central differencing
- * Class X is the input argument
- * The class X needs to have dim, expmap, logmap
-  * int N is the dimension of the X input value if variable dimension type but known at test time
+ * @tparam X manifold input type
+ * @tparam N tangent dimension of `X`; provide explicitly for variable-size
+ * manifold types
  */
-
 template <class X, int N = traits<X>::dimension>
 typename Eigen::Matrix<double, N, 1> numericalGradient(
     std::function<double(const X&)> h, const X& x, double delta = 1e-5) {
   double factor = 1.0 / (2.0 * delta);
 
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<X>::structure_category>,
+                "Template argument X must be a manifold type.");
   static_assert(
-      (std::is_base_of<manifold_tag, typename traits<X>::structure_category>::value),
-      "Template argument X must be a manifold type.");
-  static_assert(N>0, "Template argument X must be fixed-size type or N must be specified.");
+      N > 0,
+      "Template argument X must be fixed-size type or N must be specified.");
 
-  // Prepare a tangent vector to perturb x with, only works for fixed size
-  typename traits<X>::TangentVector d;
+  // Prepare a tangent vector to perturb x with.
+  Eigen::Matrix<double, N, 1> d;
   d.setZero();
 
-  Eigen::Matrix<double,N,1> g; 
+  Eigen::Matrix<double, N, 1> g;
   g.setZero();
   for (int j = 0; j < N; j++) {
     d(j) = delta;
@@ -99,35 +144,42 @@ typename Eigen::Matrix<double, N, 1> numericalGradient(
  * @param h unary function yielding m-vector
  * @param x n-dimensional value at which to evaluate h
  * @param delta increment for numerical derivative
- * Class Y is the output argument
- * Class X is the input argument
- * @tparam int N is the dimension of the X input value if variable dimension type but known at test time
+ * @tparam Y output manifold type; defaults to the deduced callable output
+ * @tparam X differentiated manifold input type
+ * @tparam N tangent dimension of `X`; provide explicitly for variable-size
+ * manifold types
  * @return m*n Jacobian computed via central differencing
  */
+template <class Y = internal::DeducedOutput, class X,
+          int N = traits<X>::dimension, class F,
+          internal::EnableIfInvocable<F, X> = 0>
+typename internal::MatrixMN<traits<internal::OutputType<Y, F, X>>::dimension,
+                            N>::type
+numericalDerivative11(F&& h, const X& x, double delta = 1e-5) {
+  using ActualY = internal::OutputType<Y, F, X>;
+  typedef
+      typename internal::MatrixMN<traits<ActualY>::dimension, N>::type Matrix;
 
-template <class Y, class X, int N = traits<X>::dimension>
-// TODO Should compute fixed-size matrix
-typename internal::FixedSizeMatrix<Y, X>::type numericalDerivative11(
-    std::function<Y(const X&)> h, const X& x, double delta = 1e-5) {
-  typedef typename internal::FixedSizeMatrix<Y,X>::type Matrix;
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<ActualY>::structure_category>,
+                "Template argument Y must be a manifold type.");
+  typedef traits<ActualY> TraitsY;
 
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<Y>::structure_category>::value),
-      "Template argument Y must be a manifold type.");
-  typedef traits<Y> TraitsY;
-
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<X>::structure_category>::value),
-      "Template argument X must be a manifold type.");
-  static_assert(N>0, "Template argument X must be fixed-size type or N must be specified.");
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<X>::structure_category>,
+                "Template argument X must be a manifold type.");
+  static_assert(
+      N > 0,
+      "Template argument X must be fixed-size type or N must be specified.");
   typedef traits<X> TraitsX;
 
   // get value at x, and corresponding chart
-  const Y hx = h(x);
+  const ActualY hx = std::invoke(h, x);
 
-  // Bit of a hack for now to find number of rows
-  const typename TraitsY::TangentVector zeroY = TraitsY::Local(hx, hx);
-  const size_t m = zeroY.size();
+  // Find number of rows m
+  const size_t m = TraitsY::GetDimension(hx);
 
-  // Prepare a tangent vector to perturb x with, only works for fixed size
+  // Prepare a tangent vector to perturb x with
   Eigen::Matrix<double, N, 1> dx;
   dx.setZero();
 
@@ -136,21 +188,22 @@ typename internal::FixedSizeMatrix<Y, X>::type numericalDerivative11(
   const double factor = 1.0 / (2.0 * delta);
   for (int j = 0; j < N; j++) {
     dx(j) = delta;
-    const auto dy1 = TraitsY::Local(hx, h(TraitsX::Retract(x, dx)));
+    const auto dy1 =
+        TraitsY::Local(hx, std::invoke(h, TraitsX::Retract(x, dx)));
     dx(j) = -delta;
-    const auto dy2 = TraitsY::Local(hx, h(TraitsX::Retract(x, dx)));
+    const auto dy2 =
+        TraitsY::Local(hx, std::invoke(h, TraitsX::Retract(x, dx)));
     dx(j) = 0;
-    H.col(j) << (dy1 - dy2) * factor;
+    H.col(j) = (dy1 - dy2) * factor;
   }
   return H;
 }
 
-/** use a raw C++ function pointer */
-template<class Y, class X>
-typename internal::FixedSizeMatrix<Y,X>::type numericalDerivative11(Y (*h)(const X&), const X& x,
-    double delta = 1e-5) {
-  return numericalDerivative11<Y, X>(std::bind(h, std::placeholders::_1), x,
-                                     delta);
+template <class Y, class X, int N = traits<X>::dimension>
+typename internal::MatrixMN<traits<Y>::dimension, N>::type
+numericalDerivative11(Y (&h)(const X&), const X& x, double delta = 1e-5) {
+  return numericalDerivative11<Y, X, N>([&](const X& x_) { return h(x_); }, x,
+                                        delta);
 }
 
 /**
@@ -160,26 +213,32 @@ typename internal::FixedSizeMatrix<Y,X>::type numericalDerivative11(Y (*h)(const
  * @param x2 second argument value
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
- * @tparam int N is the dimension of the X1 input value if variable dimension type but known at test time
+ * @tparam int N is the dimension of the X1 input value if variable dimension
+ * type but known at test time
  */
-template<class Y, class X1, class X2, int N = traits<X1>::dimension>
-typename internal::FixedSizeMatrix<Y,X1>::type numericalDerivative21(const std::function<Y(const X1&, const X2&)>& h,
-    const X1& x1, const X2& x2, double delta = 1e-5) {
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<Y>::structure_category>::value),
-      "Template argument Y must be a manifold type.");
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<X1>::structure_category>::value),
-      "Template argument X1 must be a manifold type.");
-  return numericalDerivative11<Y, X1, N>(
-      std::bind(h, std::placeholders::_1, std::cref(x2)), x1, delta);
+template <class Y = internal::DeducedOutput, class X1, class X2,
+          int N = traits<X1>::dimension, class F,
+          internal::EnableIfInvocable<F, X1, X2> = 0>
+typename internal::MatrixMN<
+    traits<internal::OutputType<Y, F, X1, X2>>::dimension, N>::type
+numericalDerivative21(F&& h, const X1& x1, const X2& x2, double delta = 1e-5) {
+  using ActualY = internal::OutputType<Y, F, X1, X2>;
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<ActualY>::structure_category>,
+                "Template argument Y must be a manifold type.");
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<X1>::structure_category>,
+                "Template argument X1 must be a manifold type.");
+  return numericalDerivative11<ActualY, X1, N>(
+      [&](const X1& x1_) { return std::invoke(h, x1_, x2); }, x1, delta);
 }
 
-/** use a raw C++ function pointer */
-template<class Y, class X1, class X2>
-typename internal::FixedSizeMatrix<Y,X1>::type numericalDerivative21(Y (*h)(const X1&, const X2&), const X1& x1,
-    const X2& x2, double delta = 1e-5) {
-  return numericalDerivative21<Y, X1, X2>(
-      std::bind(h, std::placeholders::_1, std::placeholders::_2), x1, x2,
-      delta);
+template <class Y, class X1, class X2, int N = traits<X1>::dimension>
+typename internal::MatrixMN<traits<Y>::dimension, N>::type
+numericalDerivative21(Y (&h)(const X1&, const X2&), const X1& x1, const X2& x2,
+                      double delta = 1e-5) {
+  return numericalDerivative11<Y, X1, N>(
+      [&](const X1& x1_) { return h(x1_, x2); }, x1, delta);
 }
 
 /**
@@ -189,26 +248,32 @@ typename internal::FixedSizeMatrix<Y,X1>::type numericalDerivative21(Y (*h)(cons
  * @param x2 n-dimensional second argument value
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
- * @tparam int N is the dimension of the X2 input value if variable dimension type but known at test time
+ * @tparam int N is the dimension of the X2 input value if variable dimension
+ * type but known at test time
  */
-template<class Y, class X1, class X2, int N = traits<X2>::dimension>
-typename internal::FixedSizeMatrix<Y,X2>::type numericalDerivative22(std::function<Y(const X1&, const X2&)> h,
-    const X1& x1, const X2& x2, double delta = 1e-5) {
-//  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<X1>::structure_category>::value),
-//       "Template argument X1 must be a manifold type.");
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<X2>::structure_category>::value),
-       "Template argument X2 must be a manifold type.");
-  return numericalDerivative11<Y, X2, N>(
-      std::bind(h, std::cref(x1), std::placeholders::_1), x2, delta);
+template <class Y = internal::DeducedOutput, class X1, class X2,
+          int N = traits<X2>::dimension, class F,
+          internal::EnableIfInvocable<F, X1, X2> = 0>
+typename internal::MatrixMN<
+    traits<internal::OutputType<Y, F, X1, X2>>::dimension, N>::type
+numericalDerivative22(F&& h, const X1& x1, const X2& x2, double delta = 1e-5) {
+  using ActualY = internal::OutputType<Y, F, X1, X2>;
+  //  static_assert( (std::is_base_of<gtsam::manifold_tag, typename
+  //  traits<X1>::structure_category>::value),
+  //       "Template argument X1 must be a manifold type.");
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<X2>::structure_category>,
+                "Template argument X2 must be a manifold type.");
+  return numericalDerivative11<ActualY, X2, N>(
+      [&](const X2& x2_) { return std::invoke(h, x1, x2_); }, x2, delta);
 }
 
-/** use a raw C++ function pointer */
-template<class Y, class X1, class X2>
-typename internal::FixedSizeMatrix<Y,X2>::type numericalDerivative22(Y (*h)(const X1&, const X2&), const X1& x1,
-    const X2& x2, double delta = 1e-5) {
-  return numericalDerivative22<Y, X1, X2>(
-      std::bind(h, std::placeholders::_1, std::placeholders::_2), x1, x2,
-      delta);
+template <class Y, class X1, class X2, int N = traits<X2>::dimension>
+typename internal::MatrixMN<traits<Y>::dimension, N>::type
+numericalDerivative22(Y (&h)(const X1&, const X2&), const X1& x1, const X2& x2,
+                      double delta = 1e-5) {
+  return numericalDerivative11<Y, X2, N>(
+      [&](const X2& x2_) { return h(x1, x2_); }, x2, delta);
 }
 
 /**
@@ -219,29 +284,33 @@ typename internal::FixedSizeMatrix<Y,X2>::type numericalDerivative22(Y (*h)(cons
  * @param x3 third argument value
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
- * All classes Y,X1,X2,X3 need dim, expmap, logmap
- * @tparam int N is the dimension of the X1 input value if variable dimension type but known at test time
+ * @tparam int N is the dimension of the X1 input value if variable dimension
+ * type but known at test time
  */
-template<class Y, class X1, class X2, class X3, int N = traits<X1>::dimension>
-typename internal::FixedSizeMatrix<Y,X1>::type numericalDerivative31(
-    std::function<Y(const X1&, const X2&, const X3&)> h, const X1& x1,
-    const X2& x2, const X3& x3, double delta = 1e-5) {
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<Y>::structure_category>::value),
-      "Template argument Y must be a manifold type.");
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<X1>::structure_category>::value),
-      "Template argument X1 must be a manifold type.");
-  return numericalDerivative11<Y, X1, N>(
-      std::bind(h, std::placeholders::_1, std::cref(x2), std::cref(x3)),
-      x1, delta);
+template <class Y = internal::DeducedOutput, class X1, class X2, class X3,
+          int N = traits<X1>::dimension, class F,
+          internal::EnableIfInvocable<F, X1, X2, X3> = 0>
+typename internal::MatrixMN<
+    traits<internal::OutputType<Y, F, X1, X2, X3>>::dimension, N>::type
+numericalDerivative31(F&& h, const X1& x1, const X2& x2, const X3& x3,
+                      double delta = 1e-5) {
+  using ActualY = internal::OutputType<Y, F, X1, X2, X3>;
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<ActualY>::structure_category>,
+                "Template argument Y must be a manifold type.");
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<X1>::structure_category>,
+                "Template argument X1 must be a manifold type.");
+  return numericalDerivative11<ActualY, X1, N>(
+      [&](const X1& x1_) { return std::invoke(h, x1_, x2, x3); }, x1, delta);
 }
 
-template<class Y, class X1, class X2, class X3>
-typename internal::FixedSizeMatrix<Y,X1>::type numericalDerivative31(Y (*h)(const X1&, const X2&, const X3&),
-    const X1& x1, const X2& x2, const X3& x3, double delta = 1e-5) {
-  return numericalDerivative31<Y, X1, X2, X3>(
-      std::bind(h, std::placeholders::_1, std::placeholders::_2,
-                  std::placeholders::_3),
-      x1, x2, x3, delta);
+template <class Y, class X1, class X2, class X3, int N = traits<X1>::dimension>
+typename internal::MatrixMN<traits<Y>::dimension, N>::type
+numericalDerivative31(Y (&h)(const X1&, const X2&, const X3&), const X1& x1,
+                      const X2& x2, const X3& x3, double delta = 1e-5) {
+  return numericalDerivative11<Y, X1, N>(
+      [&](const X1& x1_) { return h(x1_, x2, x3); }, x1, delta);
 }
 
 /**
@@ -252,29 +321,33 @@ typename internal::FixedSizeMatrix<Y,X1>::type numericalDerivative31(Y (*h)(cons
  * @param x3 third argument value
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
- * All classes Y,X1,X2,X3 need dim, expmap, logmap
- * @tparam int N is the dimension of the X2 input value if variable dimension type but known at test time
+ * @tparam int N is the dimension of the X2 input value if variable dimension
+ * type but known at test time
  */
-template<class Y, class X1, class X2, class X3, int N = traits<X2>::dimension>
-typename internal::FixedSizeMatrix<Y,X2>::type numericalDerivative32(
-    std::function<Y(const X1&, const X2&, const X3&)> h, const X1& x1,
-    const X2& x2, const X3& x3, double delta = 1e-5) {
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<Y>::structure_category>::value),
-      "Template argument Y must be a manifold type.");
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<X2>::structure_category>::value),
-      "Template argument X2 must be a manifold type.");
-  return numericalDerivative11<Y, X2, N>(
-      std::bind(h, std::cref(x1), std::placeholders::_1, std::cref(x3)),
-      x2, delta);
+template <class Y = internal::DeducedOutput, class X1, class X2, class X3,
+          int N = traits<X2>::dimension, class F,
+          internal::EnableIfInvocable<F, X1, X2, X3> = 0>
+typename internal::MatrixMN<
+    traits<internal::OutputType<Y, F, X1, X2, X3>>::dimension, N>::type
+numericalDerivative32(F&& h, const X1& x1, const X2& x2, const X3& x3,
+                      double delta = 1e-5) {
+  using ActualY = internal::OutputType<Y, F, X1, X2, X3>;
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<ActualY>::structure_category>,
+                "Template argument Y must be a manifold type.");
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<X2>::structure_category>,
+                "Template argument X2 must be a manifold type.");
+  return numericalDerivative11<ActualY, X2, N>(
+      [&](const X2& x2_) { return std::invoke(h, x1, x2_, x3); }, x2, delta);
 }
 
-template<class Y, class X1, class X2, class X3>
-inline typename internal::FixedSizeMatrix<Y,X2>::type numericalDerivative32(Y (*h)(const X1&, const X2&, const X3&),
-    const X1& x1, const X2& x2, const X3& x3, double delta = 1e-5) {
-  return numericalDerivative32<Y, X1, X2, X3>(
-      std::bind(h, std::placeholders::_1, std::placeholders::_2,
-                  std::placeholders::_3),
-      x1, x2, x3, delta);
+template <class Y, class X1, class X2, class X3, int N = traits<X2>::dimension>
+typename internal::MatrixMN<traits<Y>::dimension, N>::type
+numericalDerivative32(Y (&h)(const X1&, const X2&, const X3&), const X1& x1,
+                      const X2& x2, const X3& x3, double delta = 1e-5) {
+  return numericalDerivative11<Y, X2, N>(
+      [&](const X2& x2_) { return h(x1, x2_, x3); }, x2, delta);
 }
 
 /**
@@ -285,29 +358,33 @@ inline typename internal::FixedSizeMatrix<Y,X2>::type numericalDerivative32(Y (*
  * @param x3 third argument value
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
- * All classes Y,X1,X2,X3 need dim, expmap, logmap
- * @tparam int N is the dimension of the X3 input value if variable dimension type but known at test time
+ * @tparam int N is the dimension of the X3 input value if variable dimension
+ * type but known at test time
  */
-template<class Y, class X1, class X2, class X3, int N = traits<X3>::dimension>
-typename internal::FixedSizeMatrix<Y,X3>::type numericalDerivative33(
-    std::function<Y(const X1&, const X2&, const X3&)> h, const X1& x1,
-    const X2& x2, const X3& x3, double delta = 1e-5) {
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<Y>::structure_category>::value),
-      "Template argument Y must be a manifold type.");
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<X3>::structure_category>::value),
-      "Template argument X3 must be a manifold type.");
-  return numericalDerivative11<Y, X3, N>(
-      std::bind(h, std::cref(x1), std::cref(x2), std::placeholders::_1),
-      x3, delta);
+template <class Y = internal::DeducedOutput, class X1, class X2, class X3,
+          int N = traits<X3>::dimension, class F,
+          internal::EnableIfInvocable<F, X1, X2, X3> = 0>
+typename internal::MatrixMN<
+    traits<internal::OutputType<Y, F, X1, X2, X3>>::dimension, N>::type
+numericalDerivative33(F&& h, const X1& x1, const X2& x2, const X3& x3,
+                      double delta = 1e-5) {
+  using ActualY = internal::OutputType<Y, F, X1, X2, X3>;
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<ActualY>::structure_category>,
+                "Template argument Y must be a manifold type.");
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<X3>::structure_category>,
+                "Template argument X3 must be a manifold type.");
+  return numericalDerivative11<ActualY, X3, N>(
+      [&](const X3& x3_) { return std::invoke(h, x1, x2, x3_); }, x3, delta);
 }
 
-template<class Y, class X1, class X2, class X3>
-inline typename internal::FixedSizeMatrix<Y,X3>::type numericalDerivative33(Y (*h)(const X1&, const X2&, const X3&),
-    const X1& x1, const X2& x2, const X3& x3, double delta = 1e-5) {
-  return numericalDerivative33<Y, X1, X2, X3>(
-      std::bind(h, std::placeholders::_1, std::placeholders::_2,
-                  std::placeholders::_3),
-      x1, x2, x3, delta);
+template <class Y, class X1, class X2, class X3, int N = traits<X3>::dimension>
+typename internal::MatrixMN<traits<Y>::dimension, N>::type
+numericalDerivative33(Y (&h)(const X1&, const X2&, const X3&), const X1& x1,
+                      const X2& x2, const X3& x3, double delta = 1e-5) {
+  return numericalDerivative11<Y, X3, N>(
+      [&](const X3& x3_) { return h(x1, x2, x3_); }, x3, delta);
 }
 
 /**
@@ -319,29 +396,36 @@ inline typename internal::FixedSizeMatrix<Y,X3>::type numericalDerivative33(Y (*
  * @param x4 fourth argument value
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
- * @tparam int N is the dimension of the X1 input value if variable dimension type but known at test time
+ * @tparam int N is the dimension of the X1 input value if variable dimension
+ * type but known at test time
  */
-template<class Y, class X1, class X2, class X3, class X4, int N = traits<X1>::dimension>
-typename internal::FixedSizeMatrix<Y,X1>::type numericalDerivative41(
-    std::function<Y(const X1&, const X2&, const X3&, const X4&)> h, const X1& x1,
-    const X2& x2, const X3& x3, const X4& x4, double delta = 1e-5) {
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<Y>::structure_category>::value),
-      "Template argument Y must be a manifold type.");
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<X1>::structure_category>::value),
-      "Template argument X1 must be a manifold type.");
-  return numericalDerivative11<Y, X1, N>(
-      std::bind(h, std::placeholders::_1, std::cref(x2), std::cref(x3),
-                  std::cref(x4)),
-      x1, delta);
+template <class Y = internal::DeducedOutput, class X1, class X2, class X3,
+          class X4, int N = traits<X1>::dimension, class F,
+          internal::EnableIfInvocable<F, X1, X2, X3, X4> = 0>
+typename internal::MatrixMN<
+    traits<internal::OutputType<Y, F, X1, X2, X3, X4>>::dimension, N>::type
+numericalDerivative41(F&& h, const X1& x1, const X2& x2, const X3& x3,
+                      const X4& x4, double delta = 1e-5) {
+  using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4>;
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<ActualY>::structure_category>,
+                "Template argument Y must be a manifold type.");
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<X1>::structure_category>,
+                "Template argument X1 must be a manifold type.");
+  return numericalDerivative11<ActualY, X1, N>(
+      [&](const X1& x1_) { return std::invoke(h, x1_, x2, x3, x4); }, x1,
+      delta);
 }
 
-template<class Y, class X1, class X2, class X3, class X4>
-inline typename internal::FixedSizeMatrix<Y,X1>::type numericalDerivative41(Y (*h)(const X1&, const X2&, const X3&, const X4&),
-    const X1& x1, const X2& x2, const X3& x3, const X4& x4, double delta = 1e-5) {
-  return numericalDerivative41<Y, X1, X2, X3, X4>(
-      std::bind(h, std::placeholders::_1, std::placeholders::_2,
-                  std::placeholders::_3, std::placeholders::_4),
-      x1, x2, x3, x4);
+template <class Y, class X1, class X2, class X3, class X4,
+          int N = traits<X1>::dimension>
+typename internal::MatrixMN<traits<Y>::dimension, N>::type
+numericalDerivative41(Y (&h)(const X1&, const X2&, const X3&, const X4&),
+                      const X1& x1, const X2& x2, const X3& x3, const X4& x4,
+                      double delta = 1e-5) {
+  return numericalDerivative11<Y, X1, N>(
+      [&](const X1& x1_) { return h(x1_, x2, x3, x4); }, x1, delta);
 }
 
 /**
@@ -353,29 +437,36 @@ inline typename internal::FixedSizeMatrix<Y,X1>::type numericalDerivative41(Y (*
  * @param x4 fourth argument value
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
- * @tparam int N is the dimension of the X2 input value if variable dimension type but known at test time
+ * @tparam int N is the dimension of the X2 input value if variable dimension
+ * type but known at test time
  */
-template<class Y, class X1, class X2, class X3, class X4, int N = traits<X2>::dimension>
-typename internal::FixedSizeMatrix<Y,X2>::type numericalDerivative42(
-    std::function<Y(const X1&, const X2&, const X3&, const X4&)> h, const X1& x1,
-    const X2& x2, const X3& x3, const X4& x4, double delta = 1e-5) {
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<Y>::structure_category>::value),
-      "Template argument Y must be a manifold type.");
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<X2>::structure_category>::value),
-      "Template argument X2 must be a manifold type.");
-  return numericalDerivative11<Y, X2, N>(
-      std::bind(h, std::cref(x1), std::placeholders::_1, std::cref(x3),
-                  std::cref(x4)),
-      x2, delta);
+template <class Y = internal::DeducedOutput, class X1, class X2, class X3,
+          class X4, int N = traits<X2>::dimension, class F,
+          internal::EnableIfInvocable<F, X1, X2, X3, X4> = 0>
+typename internal::MatrixMN<
+    traits<internal::OutputType<Y, F, X1, X2, X3, X4>>::dimension, N>::type
+numericalDerivative42(F&& h, const X1& x1, const X2& x2, const X3& x3,
+                      const X4& x4, double delta = 1e-5) {
+  using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4>;
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<ActualY>::structure_category>,
+                "Template argument Y must be a manifold type.");
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<X2>::structure_category>,
+                "Template argument X2 must be a manifold type.");
+  return numericalDerivative11<ActualY, X2, N>(
+      [&](const X2& x2_) { return std::invoke(h, x1, x2_, x3, x4); }, x2,
+      delta);
 }
 
-template<class Y, class X1, class X2, class X3, class X4>
-inline typename internal::FixedSizeMatrix<Y,X2>::type numericalDerivative42(Y (*h)(const X1&, const X2&, const X3&, const X4&),
-  const X1& x1, const X2& x2, const X3& x3, const X4& x4, double delta = 1e-5) {
-  return numericalDerivative42<Y, X1, X2, X3, X4>(
-      std::bind(h, std::placeholders::_1, std::placeholders::_2,
-                  std::placeholders::_3, std::placeholders::_4),
-      x1, x2, x3, x4);
+template <class Y, class X1, class X2, class X3, class X4,
+          int N = traits<X2>::dimension>
+typename internal::MatrixMN<traits<Y>::dimension, N>::type
+numericalDerivative42(Y (&h)(const X1&, const X2&, const X3&, const X4&),
+                      const X1& x1, const X2& x2, const X3& x3, const X4& x4,
+                      double delta = 1e-5) {
+  return numericalDerivative11<Y, X2, N>(
+      [&](const X2& x2_) { return h(x1, x2_, x3, x4); }, x2, delta);
 }
 
 /**
@@ -387,29 +478,36 @@ inline typename internal::FixedSizeMatrix<Y,X2>::type numericalDerivative42(Y (*
  * @param x4 fourth argument value
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
- * @tparam int N is the dimension of the X3 input value if variable dimension type but known at test time
+ * @tparam int N is the dimension of the X3 input value if variable dimension
+ * type but known at test time
  */
-template<class Y, class X1, class X2, class X3, class X4, int N = traits<X3>::dimension>
-typename internal::FixedSizeMatrix<Y,X3>::type numericalDerivative43(
-    std::function<Y(const X1&, const X2&, const X3&, const X4&)> h, const X1& x1,
-    const X2& x2, const X3& x3, const X4& x4, double delta = 1e-5) {
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<Y>::structure_category>::value),
-      "Template argument Y must be a manifold type.");
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<X3>::structure_category>::value),
-      "Template argument X3 must be a manifold type.");
-  return numericalDerivative11<Y, X3, N>(
-      std::bind(h, std::cref(x1), std::cref(x2), std::placeholders::_1,
-                  std::cref(x4)),
-      x3, delta);
+template <class Y = internal::DeducedOutput, class X1, class X2, class X3,
+          class X4, int N = traits<X3>::dimension, class F,
+          internal::EnableIfInvocable<F, X1, X2, X3, X4> = 0>
+typename internal::MatrixMN<
+    traits<internal::OutputType<Y, F, X1, X2, X3, X4>>::dimension, N>::type
+numericalDerivative43(F&& h, const X1& x1, const X2& x2, const X3& x3,
+                      const X4& x4, double delta = 1e-5) {
+  using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4>;
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<ActualY>::structure_category>,
+                "Template argument Y must be a manifold type.");
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<X3>::structure_category>,
+                "Template argument X3 must be a manifold type.");
+  return numericalDerivative11<ActualY, X3, N>(
+      [&](const X3& x3_) { return std::invoke(h, x1, x2, x3_, x4); }, x3,
+      delta);
 }
 
-template<class Y, class X1, class X2, class X3, class X4>
-inline typename internal::FixedSizeMatrix<Y,X3>::type numericalDerivative43(Y (*h)(const X1&, const X2&, const X3&, const X4&),
-    const X1& x1, const X2& x2, const X3& x3, const X4& x4, double delta = 1e-5) {
-  return numericalDerivative43<Y, X1, X2, X3, X4>(
-      std::bind(h, std::placeholders::_1, std::placeholders::_2,
-                  std::placeholders::_3, std::placeholders::_4),
-      x1, x2, x3, x4);
+template <class Y, class X1, class X2, class X3, class X4,
+          int N = traits<X3>::dimension>
+typename internal::MatrixMN<traits<Y>::dimension, N>::type
+numericalDerivative43(Y (&h)(const X1&, const X2&, const X3&, const X4&),
+                      const X1& x1, const X2& x2, const X3& x3, const X4& x4,
+                      double delta = 1e-5) {
+  return numericalDerivative11<Y, X3, N>(
+      [&](const X3& x3_) { return h(x1, x2, x3_, x4); }, x3, delta);
 }
 
 /**
@@ -421,29 +519,36 @@ inline typename internal::FixedSizeMatrix<Y,X3>::type numericalDerivative43(Y (*
  * @param x4 n-dimensional fourth argument value
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
- * @tparam int N is the dimension of the X4 input value if variable dimension type but known at test time
+ * @tparam int N is the dimension of the X4 input value if variable dimension
+ * type but known at test time
  */
-template<class Y, class X1, class X2, class X3, class X4, int N = traits<X4>::dimension>
-typename internal::FixedSizeMatrix<Y,X4>::type numericalDerivative44(
-    std::function<Y(const X1&, const X2&, const X3&, const X4&)> h, const X1& x1,
-    const X2& x2, const X3& x3, const X4& x4, double delta = 1e-5) {
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<Y>::structure_category>::value),
-      "Template argument Y must be a manifold type.");
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<X4>::structure_category>::value),
-      "Template argument X4 must be a manifold type.");
-  return numericalDerivative11<Y, X4, N>(
-      std::bind(h, std::cref(x1), std::cref(x2), std::cref(x3),
-                  std::placeholders::_1),
-      x4, delta);
+template <class Y = internal::DeducedOutput, class X1, class X2, class X3,
+          class X4, int N = traits<X4>::dimension, class F,
+          internal::EnableIfInvocable<F, X1, X2, X3, X4> = 0>
+typename internal::MatrixMN<
+    traits<internal::OutputType<Y, F, X1, X2, X3, X4>>::dimension, N>::type
+numericalDerivative44(F&& h, const X1& x1, const X2& x2, const X3& x3,
+                      const X4& x4, double delta = 1e-5) {
+  using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4>;
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<ActualY>::structure_category>,
+                "Template argument Y must be a manifold type.");
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<X4>::structure_category>,
+                "Template argument X4 must be a manifold type.");
+  return numericalDerivative11<ActualY, X4, N>(
+      [&](const X4& x4_) { return std::invoke(h, x1, x2, x3, x4_); }, x4,
+      delta);
 }
 
-template<class Y, class X1, class X2, class X3, class X4>
-inline typename internal::FixedSizeMatrix<Y,X4>::type numericalDerivative44(Y (*h)(const X1&, const X2&, const X3&, const X4&),
-  const X1& x1, const X2& x2, const X3& x3, const X4& x4, double delta = 1e-5) {
-  return numericalDerivative44<Y, X1, X2, X3, X4>(
-      std::bind(h, std::placeholders::_1, std::placeholders::_2,
-                  std::placeholders::_3, std::placeholders::_4),
-      x1, x2, x3, x4);
+template <class Y, class X1, class X2, class X3, class X4,
+          int N = traits<X4>::dimension>
+typename internal::MatrixMN<traits<Y>::dimension, N>::type
+numericalDerivative44(Y (&h)(const X1&, const X2&, const X3&, const X4&),
+                      const X1& x1, const X2& x2, const X3& x3, const X4& x4,
+                      double delta = 1e-5) {
+  return numericalDerivative11<Y, X4, N>(
+      [&](const X4& x4_) { return h(x1, x2, x3, x4_); }, x4, delta);
 }
 
 /**
@@ -456,30 +561,37 @@ inline typename internal::FixedSizeMatrix<Y,X4>::type numericalDerivative44(Y (*
  * @param x5 fifth argument value
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
- * @tparam int N is the dimension of the X1 input value if variable dimension type but known at test time
+ * @tparam int N is the dimension of the X1 input value if variable dimension
+ * type but known at test time
  */
-template<class Y, class X1, class X2, class X3, class X4, class X5, int N = traits<X1>::dimension>
-typename internal::FixedSizeMatrix<Y,X1>::type numericalDerivative51(
-    std::function<Y(const X1&, const X2&, const X3&, const X4&, const X5&)> h, const X1& x1,
-    const X2& x2, const X3& x3, const X4& x4, const X5& x5, double delta = 1e-5) {
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<Y>::structure_category>::value),
-      "Template argument Y must be a manifold type.");
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<X1>::structure_category>::value),
-      "Template argument X1 must be a manifold type.");
-  return numericalDerivative11<Y, X1, N>(
-      std::bind(h, std::placeholders::_1, std::cref(x2), std::cref(x3),
-                  std::cref(x4), std::cref(x5)),
-      x1, delta);
+template <class Y = internal::DeducedOutput, class X1, class X2, class X3,
+          class X4, class X5, int N = traits<X1>::dimension, class F,
+          internal::EnableIfInvocable<F, X1, X2, X3, X4, X5> = 0>
+typename internal::MatrixMN<
+    traits<internal::OutputType<Y, F, X1, X2, X3, X4, X5>>::dimension, N>::type
+numericalDerivative51(F&& h, const X1& x1, const X2& x2, const X3& x3,
+                      const X4& x4, const X5& x5, double delta = 1e-5) {
+  using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4, X5>;
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<ActualY>::structure_category>,
+                "Template argument Y must be a manifold type.");
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<X1>::structure_category>,
+                "Template argument X1 must be a manifold type.");
+  return numericalDerivative11<ActualY, X1, N>(
+      [&](const X1& x1_) { return std::invoke(h, x1_, x2, x3, x4, x5); }, x1,
+      delta);
 }
 
-template<class Y, class X1, class X2, class X3, class X4, class X5>
-inline typename internal::FixedSizeMatrix<Y,X1>::type numericalDerivative51(Y (*h)(const X1&, const X2&, const X3&, const X4&, const X5&),
-    const X1& x1, const X2& x2, const X3& x3, const X4& x4, const X5& x5, double delta = 1e-5) {
-  return numericalDerivative51<Y, X1, X2, X3, X4, X5>(
-      std::bind(h, std::placeholders::_1, std::placeholders::_2,
-                  std::placeholders::_3, std::placeholders::_4,
-                  std::placeholders::_5),
-      x1, x2, x3, x4, x5);
+template <class Y, class X1, class X2, class X3, class X4, class X5,
+          int N = traits<X1>::dimension>
+typename internal::MatrixMN<traits<Y>::dimension, N>::type
+numericalDerivative51(Y (&h)(const X1&, const X2&, const X3&, const X4&,
+                             const X5&),
+                      const X1& x1, const X2& x2, const X3& x3, const X4& x4,
+                      const X5& x5, double delta = 1e-5) {
+  return numericalDerivative11<Y, X1, N>(
+      [&](const X1& x1_) { return h(x1_, x2, x3, x4, x5); }, x1, delta);
 }
 
 /**
@@ -492,30 +604,37 @@ inline typename internal::FixedSizeMatrix<Y,X1>::type numericalDerivative51(Y (*
  * @param x5 fifth argument value
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
- * @tparam int N is the dimension of the X2 input value if variable dimension type but known at test time
+ * @tparam int N is the dimension of the X2 input value if variable dimension
+ * type but known at test time
  */
-template<class Y, class X1, class X2, class X3, class X4, class X5, int N = traits<X2>::dimension>
-typename internal::FixedSizeMatrix<Y,X2>::type numericalDerivative52(
-    std::function<Y(const X1&, const X2&, const X3&, const X4&, const X5&)> h, const X1& x1,
-    const X2& x2, const X3& x3, const X4& x4, const X5& x5, double delta = 1e-5) {
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<Y>::structure_category>::value),
-      "Template argument Y must be a manifold type.");
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<X1>::structure_category>::value),
-      "Template argument X1 must be a manifold type.");
-  return numericalDerivative11<Y, X2, N>(
-      std::bind(h, std::cref(x1), std::placeholders::_1, std::cref(x3),
-                  std::cref(x4), std::cref(x5)),
-      x2, delta);
+template <class Y = internal::DeducedOutput, class X1, class X2, class X3,
+          class X4, class X5, int N = traits<X2>::dimension, class F,
+          internal::EnableIfInvocable<F, X1, X2, X3, X4, X5> = 0>
+typename internal::MatrixMN<
+    traits<internal::OutputType<Y, F, X1, X2, X3, X4, X5>>::dimension, N>::type
+numericalDerivative52(F&& h, const X1& x1, const X2& x2, const X3& x3,
+                      const X4& x4, const X5& x5, double delta = 1e-5) {
+  using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4, X5>;
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<ActualY>::structure_category>,
+                "Template argument Y must be a manifold type.");
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<X2>::structure_category>,
+                "Template argument X2 must be a manifold type.");
+  return numericalDerivative11<ActualY, X2, N>(
+      [&](const X2& x2_) { return std::invoke(h, x1, x2_, x3, x4, x5); }, x2,
+      delta);
 }
 
-template<class Y, class X1, class X2, class X3, class X4, class X5>
-inline typename internal::FixedSizeMatrix<Y,X2>::type numericalDerivative52(Y (*h)(const X1&, const X2&, const X3&, const X4&, const X5&),
-    const X1& x1, const X2& x2, const X3& x3, const X4& x4, const X5& x5, double delta = 1e-5) {
-  return numericalDerivative52<Y, X1, X2, X3, X4, X5>(
-      std::bind(h, std::placeholders::_1, std::placeholders::_2,
-                  std::placeholders::_3, std::placeholders::_4,
-                  std::placeholders::_5),
-      x1, x2, x3, x4, x5);
+template <class Y, class X1, class X2, class X3, class X4, class X5,
+          int N = traits<X2>::dimension>
+typename internal::MatrixMN<traits<Y>::dimension, N>::type
+numericalDerivative52(Y (&h)(const X1&, const X2&, const X3&, const X4&,
+                             const X5&),
+                      const X1& x1, const X2& x2, const X3& x3, const X4& x4,
+                      const X5& x5, double delta = 1e-5) {
+  return numericalDerivative11<Y, X2, N>(
+      [&](const X2& x2_) { return h(x1, x2_, x3, x4, x5); }, x2, delta);
 }
 
 /**
@@ -528,30 +647,37 @@ inline typename internal::FixedSizeMatrix<Y,X2>::type numericalDerivative52(Y (*
  * @param x5 fifth argument value
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
- * @tparam int N is the dimension of the X3 input value if variable dimension type but known at test time
+ * @tparam int N is the dimension of the X3 input value if variable dimension
+ * type but known at test time
  */
-template<class Y, class X1, class X2, class X3, class X4, class X5, int N = traits<X3>::dimension>
-typename internal::FixedSizeMatrix<Y,X3>::type numericalDerivative53(
-    std::function<Y(const X1&, const X2&, const X3&, const X4&, const X5&)> h, const X1& x1,
-    const X2& x2, const X3& x3, const X4& x4, const X5& x5, double delta = 1e-5) {
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<Y>::structure_category>::value),
-      "Template argument Y must be a manifold type.");
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<X1>::structure_category>::value),
-      "Template argument X1 must be a manifold type.");
-  return numericalDerivative11<Y, X3, N>(
-      std::bind(h, std::cref(x1), std::cref(x2), std::placeholders::_1,
-                  std::cref(x4), std::cref(x5)),
-      x3, delta);
+template <class Y = internal::DeducedOutput, class X1, class X2, class X3,
+          class X4, class X5, int N = traits<X3>::dimension, class F,
+          internal::EnableIfInvocable<F, X1, X2, X3, X4, X5> = 0>
+typename internal::MatrixMN<
+    traits<internal::OutputType<Y, F, X1, X2, X3, X4, X5>>::dimension, N>::type
+numericalDerivative53(F&& h, const X1& x1, const X2& x2, const X3& x3,
+                      const X4& x4, const X5& x5, double delta = 1e-5) {
+  using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4, X5>;
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<ActualY>::structure_category>,
+                "Template argument Y must be a manifold type.");
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<X3>::structure_category>,
+                "Template argument X3 must be a manifold type.");
+  return numericalDerivative11<ActualY, X3, N>(
+      [&](const X3& x3_) { return std::invoke(h, x1, x2, x3_, x4, x5); }, x3,
+      delta);
 }
 
-template<class Y, class X1, class X2, class X3, class X4, class X5>
-inline typename internal::FixedSizeMatrix<Y,X3>::type numericalDerivative53(Y (*h)(const X1&, const X2&, const X3&, const X4&, const X5&),
-    const X1& x1, const X2& x2, const X3& x3, const X4& x4, const X5& x5, double delta = 1e-5) {
-  return numericalDerivative53<Y, X1, X2, X3, X4, X5>(
-      std::bind(h, std::placeholders::_1, std::placeholders::_2,
-                  std::placeholders::_3, std::placeholders::_4,
-                  std::placeholders::_5),
-      x1, x2, x3, x4, x5);
+template <class Y, class X1, class X2, class X3, class X4, class X5,
+          int N = traits<X3>::dimension>
+typename internal::MatrixMN<traits<Y>::dimension, N>::type
+numericalDerivative53(Y (&h)(const X1&, const X2&, const X3&, const X4&,
+                             const X5&),
+                      const X1& x1, const X2& x2, const X3& x3, const X4& x4,
+                      const X5& x5, double delta = 1e-5) {
+  return numericalDerivative11<Y, X3, N>(
+      [&](const X3& x3_) { return h(x1, x2, x3_, x4, x5); }, x3, delta);
 }
 
 /**
@@ -564,30 +690,37 @@ inline typename internal::FixedSizeMatrix<Y,X3>::type numericalDerivative53(Y (*
  * @param x5 fifth argument value
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
- * @tparam int N is the dimension of the X4 input value if variable dimension type but known at test time
+ * @tparam int N is the dimension of the X4 input value if variable dimension
+ * type but known at test time
  */
-template<class Y, class X1, class X2, class X3, class X4, class X5, int N = traits<X4>::dimension>
-typename internal::FixedSizeMatrix<Y,X4>::type numericalDerivative54(
-    std::function<Y(const X1&, const X2&, const X3&, const X4&, const X5&)> h, const X1& x1,
-    const X2& x2, const X3& x3, const X4& x4, const X5& x5, double delta = 1e-5) {
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<Y>::structure_category>::value),
-      "Template argument Y must be a manifold type.");
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<X1>::structure_category>::value),
-      "Template argument X1 must be a manifold type.");
-  return numericalDerivative11<Y, X4, N>(
-      std::bind(h, std::cref(x1), std::cref(x2), std::cref(x3),
-                  std::placeholders::_1, std::cref(x5)),
-      x4, delta);
+template <class Y = internal::DeducedOutput, class X1, class X2, class X3,
+          class X4, class X5, int N = traits<X4>::dimension, class F,
+          internal::EnableIfInvocable<F, X1, X2, X3, X4, X5> = 0>
+typename internal::MatrixMN<
+    traits<internal::OutputType<Y, F, X1, X2, X3, X4, X5>>::dimension, N>::type
+numericalDerivative54(F&& h, const X1& x1, const X2& x2, const X3& x3,
+                      const X4& x4, const X5& x5, double delta = 1e-5) {
+  using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4, X5>;
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<ActualY>::structure_category>,
+                "Template argument Y must be a manifold type.");
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<X4>::structure_category>,
+                "Template argument X4 must be a manifold type.");
+  return numericalDerivative11<ActualY, X4, N>(
+      [&](const X4& x4_) { return std::invoke(h, x1, x2, x3, x4_, x5); }, x4,
+      delta);
 }
 
-template<class Y, class X1, class X2, class X3, class X4, class X5>
-inline typename internal::FixedSizeMatrix<Y,X4>::type numericalDerivative54(Y (*h)(const X1&, const X2&, const X3&, const X4&, const X5&),
-    const X1& x1, const X2& x2, const X3& x3, const X4& x4, const X5& x5, double delta = 1e-5) {
-  return numericalDerivative54<Y, X1, X2, X3, X4, X5>(
-      std::bind(h, std::placeholders::_1, std::placeholders::_2,
-                  std::placeholders::_3, std::placeholders::_4,
-                  std::placeholders::_5),
-      x1, x2, x3, x4, x5);
+template <class Y, class X1, class X2, class X3, class X4, class X5,
+          int N = traits<X4>::dimension>
+typename internal::MatrixMN<traits<Y>::dimension, N>::type
+numericalDerivative54(Y (&h)(const X1&, const X2&, const X3&, const X4&,
+                             const X5&),
+                      const X1& x1, const X2& x2, const X3& x3, const X4& x4,
+                      const X5& x5, double delta = 1e-5) {
+  return numericalDerivative11<Y, X4, N>(
+      [&](const X4& x4_) { return h(x1, x2, x3, x4_, x5); }, x4, delta);
 }
 
 /**
@@ -600,30 +733,37 @@ inline typename internal::FixedSizeMatrix<Y,X4>::type numericalDerivative54(Y (*
  * @param x5 fifth argument value
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
- * @tparam int N is the dimension of the X5 input value if variable dimension type but known at test time
+ * @tparam int N is the dimension of the X5 input value if variable dimension
+ * type but known at test time
  */
-template<class Y, class X1, class X2, class X3, class X4, class X5, int N = traits<X5>::dimension>
-typename internal::FixedSizeMatrix<Y,X5>::type numericalDerivative55(
-    std::function<Y(const X1&, const X2&, const X3&, const X4&, const X5&)> h, const X1& x1,
-    const X2& x2, const X3& x3, const X4& x4, const X5& x5, double delta = 1e-5) {
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<Y>::structure_category>::value),
-      "Template argument Y must be a manifold type.");
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<X1>::structure_category>::value),
-      "Template argument X1 must be a manifold type.");
-  return numericalDerivative11<Y, X5, N>(
-      std::bind(h, std::cref(x1), std::cref(x2), std::cref(x3),
-                  std::cref(x4), std::placeholders::_1),
-      x5, delta);
+template <class Y = internal::DeducedOutput, class X1, class X2, class X3,
+          class X4, class X5, int N = traits<X5>::dimension, class F,
+          internal::EnableIfInvocable<F, X1, X2, X3, X4, X5> = 0>
+typename internal::MatrixMN<
+    traits<internal::OutputType<Y, F, X1, X2, X3, X4, X5>>::dimension, N>::type
+numericalDerivative55(F&& h, const X1& x1, const X2& x2, const X3& x3,
+                      const X4& x4, const X5& x5, double delta = 1e-5) {
+  using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4, X5>;
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<ActualY>::structure_category>,
+                "Template argument Y must be a manifold type.");
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<X5>::structure_category>,
+                "Template argument X5 must be a manifold type.");
+  return numericalDerivative11<ActualY, X5, N>(
+      [&](const X5& x5_) { return std::invoke(h, x1, x2, x3, x4, x5_); }, x5,
+      delta);
 }
 
-template<class Y, class X1, class X2, class X3, class X4, class X5>
-inline typename internal::FixedSizeMatrix<Y,X5>::type numericalDerivative55(Y (*h)(const X1&, const X2&, const X3&, const X4&, const X5&),
-    const X1& x1, const X2& x2, const X3& x3, const X4& x4, const X5& x5, double delta = 1e-5) {
-  return numericalDerivative55<Y, X1, X2, X3, X4, X5>(
-      std::bind(h, std::placeholders::_1, std::placeholders::_2,
-                  std::placeholders::_3, std::placeholders::_4,
-                  std::placeholders::_5),
-      x1, x2, x3, x4, x5);
+template <class Y, class X1, class X2, class X3, class X4, class X5,
+          int N = traits<X5>::dimension>
+typename internal::MatrixMN<traits<Y>::dimension, N>::type
+numericalDerivative55(Y (&h)(const X1&, const X2&, const X3&, const X4&,
+                             const X5&),
+                      const X1& x1, const X2& x2, const X3& x3, const X4& x4,
+                      const X5& x5, double delta = 1e-5) {
+  return numericalDerivative11<Y, X5, N>(
+      [&](const X5& x5_) { return h(x1, x2, x3, x4, x5_); }, x5, delta);
 }
 
 /**
@@ -637,30 +777,39 @@ inline typename internal::FixedSizeMatrix<Y,X5>::type numericalDerivative55(Y (*
  * @param x6 sixth argument value
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
- * @tparam int N is the dimension of the X1 input value if variable dimension type but known at test time
+ * @tparam int N is the dimension of the X1 input value if variable dimension
+ * type but known at test time
  */
-template<class Y, class X1, class X2, class X3, class X4, class X5, class X6, int N = traits<X1>::dimension>
-typename internal::FixedSizeMatrix<Y,X1>::type numericalDerivative61(
-    std::function<Y(const X1&, const X2&, const X3&, const X4&, const X5&, const X6&)> h, const X1& x1,
-    const X2& x2, const X3& x3, const X4& x4, const X5& x5, const X6& x6, double delta = 1e-5) {
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<Y>::structure_category>::value),
-      "Template argument Y must be a manifold type.");
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<X1>::structure_category>::value),
-      "Template argument X1 must be a manifold type.");
-  return numericalDerivative11<Y, X1, N>(
-      std::bind(h, std::placeholders::_1, std::cref(x2), std::cref(x3),
-                  std::cref(x4), std::cref(x5), std::cref(x6)),
+template <class Y = internal::DeducedOutput, class X1, class X2, class X3,
+          class X4, class X5, class X6, int N = traits<X1>::dimension, class F,
+          internal::EnableIfInvocable<F, X1, X2, X3, X4, X5, X6> = 0>
+typename internal::MatrixMN<
+    traits<internal::OutputType<Y, F, X1, X2, X3, X4, X5, X6>>::dimension,
+    N>::type
+numericalDerivative61(F&& h, const X1& x1, const X2& x2, const X3& x3,
+                      const X4& x4, const X5& x5, const X6& x6,
+                      double delta = 1e-5) {
+  using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4, X5, X6>;
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<ActualY>::structure_category>,
+                "Template argument Y must be a manifold type.");
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<X1>::structure_category>,
+                "Template argument X1 must be a manifold type.");
+  return numericalDerivative11<ActualY, X1, N>(
+      [&](const X1& x1_) { return std::invoke(h, x1_, x2, x3, x4, x5, x6); },
       x1, delta);
 }
 
-template<class Y, class X1, class X2, class X3, class X4, class X5, class X6>
-inline typename internal::FixedSizeMatrix<Y,X1>::type numericalDerivative61(Y (*h)(const X1&, const X2&, const X3&, const X4&, const X5&, const X6&),
-    const X1& x1, const X2& x2, const X3& x3, const X4& x4, const X5& x5, const X6& x6, double delta = 1e-5) {
-  return numericalDerivative61<Y, X1, X2, X3, X4, X5, X6>(
-      std::bind(h, std::placeholders::_1, std::placeholders::_2,
-                  std::placeholders::_3, std::placeholders::_4,
-                  std::placeholders::_5, std::placeholders::_6),
-      x1, x2, x3, x4, x5, x6);
+template <class Y, class X1, class X2, class X3, class X4, class X5, class X6,
+          int N = traits<X1>::dimension>
+typename internal::MatrixMN<traits<Y>::dimension, N>::type
+numericalDerivative61(Y (&h)(const X1&, const X2&, const X3&, const X4&,
+                             const X5&, const X6&),
+                      const X1& x1, const X2& x2, const X3& x3, const X4& x4,
+                      const X5& x5, const X6& x6, double delta = 1e-5) {
+  return numericalDerivative11<Y, X1, N>(
+      [&](const X1& x1_) { return h(x1_, x2, x3, x4, x5, x6); }, x1, delta);
 }
 
 /**
@@ -674,30 +823,39 @@ inline typename internal::FixedSizeMatrix<Y,X1>::type numericalDerivative61(Y (*
  * @param x6 sixth argument value
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
- * @tparam int N is the dimension of the X2 input value if variable dimension type but known at test time
+ * @tparam int N is the dimension of the X2 input value if variable dimension
+ * type but known at test time
  */
-template<class Y, class X1, class X2, class X3, class X4, class X5, class X6, int N = traits<X2>::dimension>
-typename internal::FixedSizeMatrix<Y,X2>::type numericalDerivative62(
-    std::function<Y(const X1&, const X2&, const X3&, const X4&, const X5&, const X6&)> h, const X1& x1,
-    const X2& x2, const X3& x3, const X4& x4, const X5& x5, const X6& x6, double delta = 1e-5) {
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<Y>::structure_category>::value),
-      "Template argument Y must be a manifold type.");
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<X1>::structure_category>::value),
-      "Template argument X1 must be a manifold type.");
-  return numericalDerivative11<Y, X2, N>(
-      std::bind(h, std::cref(x1), std::placeholders::_1, std::cref(x3),
-                  std::cref(x4), std::cref(x5), std::cref(x6)),
+template <class Y = internal::DeducedOutput, class X1, class X2, class X3,
+          class X4, class X5, class X6, int N = traits<X2>::dimension, class F,
+          internal::EnableIfInvocable<F, X1, X2, X3, X4, X5, X6> = 0>
+typename internal::MatrixMN<
+    traits<internal::OutputType<Y, F, X1, X2, X3, X4, X5, X6>>::dimension,
+    N>::type
+numericalDerivative62(F&& h, const X1& x1, const X2& x2, const X3& x3,
+                      const X4& x4, const X5& x5, const X6& x6,
+                      double delta = 1e-5) {
+  using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4, X5, X6>;
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<ActualY>::structure_category>,
+                "Template argument Y must be a manifold type.");
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<X2>::structure_category>,
+                "Template argument X2 must be a manifold type.");
+  return numericalDerivative11<ActualY, X2, N>(
+      [&](const X2& x2_) { return std::invoke(h, x1, x2_, x3, x4, x5, x6); },
       x2, delta);
 }
 
-template<class Y, class X1, class X2, class X3, class X4, class X5, class X6>
-inline typename internal::FixedSizeMatrix<Y,X2>::type numericalDerivative62(Y (*h)(const X1&, const X2&, const X3&, const X4&, const X5&, const X6&),
-    const X1& x1, const X2& x2, const X3& x3, const X4& x4, const X5& x5, const X6& x6, double delta = 1e-5) {
-  return numericalDerivative62<Y, X1, X2, X3, X4, X5, X6>(
-      std::bind(h, std::placeholders::_1, std::placeholders::_2,
-                  std::placeholders::_3, std::placeholders::_4,
-                  std::placeholders::_5, std::placeholders::_6),
-      x1, x2, x3, x4, x5, x6);
+template <class Y, class X1, class X2, class X3, class X4, class X5, class X6,
+          int N = traits<X2>::dimension>
+typename internal::MatrixMN<traits<Y>::dimension, N>::type
+numericalDerivative62(Y (&h)(const X1&, const X2&, const X3&, const X4&,
+                             const X5&, const X6&),
+                      const X1& x1, const X2& x2, const X3& x3, const X4& x4,
+                      const X5& x5, const X6& x6, double delta = 1e-5) {
+  return numericalDerivative11<Y, X2, N>(
+      [&](const X2& x2_) { return h(x1, x2_, x3, x4, x5, x6); }, x2, delta);
 }
 
 /**
@@ -711,30 +869,39 @@ inline typename internal::FixedSizeMatrix<Y,X2>::type numericalDerivative62(Y (*
  * @param x6 sixth argument value
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
- * @tparam int N is the dimension of the X3 input value if variable dimension type but known at test time
+ * @tparam int N is the dimension of the X3 input value if variable dimension
+ * type but known at test time
  */
-template<class Y, class X1, class X2, class X3, class X4, class X5, class X6, int N = traits<X3>::dimension>
-typename internal::FixedSizeMatrix<Y,X3>::type numericalDerivative63(
-    std::function<Y(const X1&, const X2&, const X3&, const X4&, const X5&, const X6&)> h, const X1& x1,
-    const X2& x2, const X3& x3, const X4& x4, const X5& x5, const X6& x6, double delta = 1e-5) {
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<Y>::structure_category>::value),
-      "Template argument Y must be a manifold type.");
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<X1>::structure_category>::value),
-      "Template argument X1 must be a manifold type.");
-  return numericalDerivative11<Y, X3, N>(
-      std::bind(h, std::cref(x1), std::cref(x2), std::placeholders::_1,
-                  std::cref(x4), std::cref(x5), std::cref(x6)),
+template <class Y = internal::DeducedOutput, class X1, class X2, class X3,
+          class X4, class X5, class X6, int N = traits<X3>::dimension, class F,
+          internal::EnableIfInvocable<F, X1, X2, X3, X4, X5, X6> = 0>
+typename internal::MatrixMN<
+    traits<internal::OutputType<Y, F, X1, X2, X3, X4, X5, X6>>::dimension,
+    N>::type
+numericalDerivative63(F&& h, const X1& x1, const X2& x2, const X3& x3,
+                      const X4& x4, const X5& x5, const X6& x6,
+                      double delta = 1e-5) {
+  using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4, X5, X6>;
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<ActualY>::structure_category>,
+                "Template argument Y must be a manifold type.");
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<X3>::structure_category>,
+                "Template argument X3 must be a manifold type.");
+  return numericalDerivative11<ActualY, X3, N>(
+      [&](const X3& x3_) { return std::invoke(h, x1, x2, x3_, x4, x5, x6); },
       x3, delta);
 }
 
-template<class Y, class X1, class X2, class X3, class X4, class X5, class X6>
-inline typename internal::FixedSizeMatrix<Y,X3>::type numericalDerivative63(Y (*h)(const X1&, const X2&, const X3&, const X4&, const X5&, const X6&),
-    const X1& x1, const X2& x2, const X3& x3, const X4& x4, const X5& x5, const X6& x6, double delta = 1e-5) {
-  return numericalDerivative63<Y, X1, X2, X3, X4, X5, X6>(
-      std::bind(h, std::placeholders::_1, std::placeholders::_2,
-                  std::placeholders::_3, std::placeholders::_4,
-                  std::placeholders::_5, std::placeholders::_6),
-      x1, x2, x3, x4, x5, x6);
+template <class Y, class X1, class X2, class X3, class X4, class X5, class X6,
+          int N = traits<X3>::dimension>
+typename internal::MatrixMN<traits<Y>::dimension, N>::type
+numericalDerivative63(Y (&h)(const X1&, const X2&, const X3&, const X4&,
+                             const X5&, const X6&),
+                      const X1& x1, const X2& x2, const X3& x3, const X4& x4,
+                      const X5& x5, const X6& x6, double delta = 1e-5) {
+  return numericalDerivative11<Y, X3, N>(
+      [&](const X3& x3_) { return h(x1, x2, x3_, x4, x5, x6); }, x3, delta);
 }
 
 /**
@@ -748,30 +915,39 @@ inline typename internal::FixedSizeMatrix<Y,X3>::type numericalDerivative63(Y (*
  * @param x6 sixth argument value
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
- * @tparam int N is the dimension of the X4 input value if variable dimension type but known at test time
+ * @tparam int N is the dimension of the X4 input value if variable dimension
+ * type but known at test time
  */
-template<class Y, class X1, class X2, class X3, class X4, class X5, class X6, int N = traits<X4>::dimension>
-typename internal::FixedSizeMatrix<Y,X4>::type numericalDerivative64(
-    std::function<Y(const X1&, const X2&, const X3&, const X4&, const X5&, const X6&)> h, const X1& x1,
-    const X2& x2, const X3& x3, const X4& x4, const X5& x5, const X6& x6, double delta = 1e-5) {
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<Y>::structure_category>::value),
-      "Template argument Y must be a manifold type.");
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<X1>::structure_category>::value),
-      "Template argument X1 must be a manifold type.");
-  return numericalDerivative11<Y, X4, N>(
-      std::bind(h, std::cref(x1), std::cref(x2), std::cref(x3),
-                  std::placeholders::_1, std::cref(x5), std::cref(x6)),
+template <class Y = internal::DeducedOutput, class X1, class X2, class X3,
+          class X4, class X5, class X6, int N = traits<X4>::dimension, class F,
+          internal::EnableIfInvocable<F, X1, X2, X3, X4, X5, X6> = 0>
+typename internal::MatrixMN<
+    traits<internal::OutputType<Y, F, X1, X2, X3, X4, X5, X6>>::dimension,
+    N>::type
+numericalDerivative64(F&& h, const X1& x1, const X2& x2, const X3& x3,
+                      const X4& x4, const X5& x5, const X6& x6,
+                      double delta = 1e-5) {
+  using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4, X5, X6>;
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<ActualY>::structure_category>,
+                "Template argument Y must be a manifold type.");
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<X4>::structure_category>,
+                "Template argument X4 must be a manifold type.");
+  return numericalDerivative11<ActualY, X4, N>(
+      [&](const X4& x4_) { return std::invoke(h, x1, x2, x3, x4_, x5, x6); },
       x4, delta);
 }
 
-template<class Y, class X1, class X2, class X3, class X4, class X5, class X6>
-inline typename internal::FixedSizeMatrix<Y,X4>::type numericalDerivative64(Y (*h)(const X1&, const X2&, const X3&, const X4&, const X5&, const X6&),
-    const X1& x1, const X2& x2, const X3& x3, const X4& x4, const X5& x5, const X6& x6, double delta = 1e-5) {
-  return numericalDerivative64<Y, X1, X2, X3, X4, X5>(
-      std::bind(h, std::placeholders::_1, std::placeholders::_2,
-                  std::placeholders::_3, std::placeholders::_4,
-                  std::placeholders::_5, std::placeholders::_6),
-      x1, x2, x3, x4, x5, x6);
+template <class Y, class X1, class X2, class X3, class X4, class X5, class X6,
+          int N = traits<X4>::dimension>
+typename internal::MatrixMN<traits<Y>::dimension, N>::type
+numericalDerivative64(Y (&h)(const X1&, const X2&, const X3&, const X4&,
+                             const X5&, const X6&),
+                      const X1& x1, const X2& x2, const X3& x3, const X4& x4,
+                      const X5& x5, const X6& x6, double delta = 1e-5) {
+  return numericalDerivative11<Y, X4, N>(
+      [&](const X4& x4_) { return h(x1, x2, x3, x4_, x5, x6); }, x4, delta);
 }
 
 /**
@@ -785,30 +961,39 @@ inline typename internal::FixedSizeMatrix<Y,X4>::type numericalDerivative64(Y (*
  * @param x6 sixth argument value
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
- * @tparam int N is the dimension of the X5 input value if variable dimension type but known at test time
+ * @tparam int N is the dimension of the X5 input value if variable dimension
+ * type but known at test time
  */
-template<class Y, class X1, class X2, class X3, class X4, class X5, class X6, int N = traits<X5>::dimension>
-typename internal::FixedSizeMatrix<Y,X5>::type numericalDerivative65(
-    std::function<Y(const X1&, const X2&, const X3&, const X4&, const X5&, const X6&)> h, const X1& x1,
-    const X2& x2, const X3& x3, const X4& x4, const X5& x5, const X6& x6, double delta = 1e-5) {
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<Y>::structure_category>::value),
-      "Template argument Y must be a manifold type.");
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<X1>::structure_category>::value),
-      "Template argument X1 must be a manifold type.");
-  return numericalDerivative11<Y, X5, N>(
-      std::bind(h, std::cref(x1), std::cref(x2), std::cref(x3),
-                  std::cref(x4), std::placeholders::_1, std::cref(x6)),
+template <class Y = internal::DeducedOutput, class X1, class X2, class X3,
+          class X4, class X5, class X6, int N = traits<X5>::dimension, class F,
+          internal::EnableIfInvocable<F, X1, X2, X3, X4, X5, X6> = 0>
+typename internal::MatrixMN<
+    traits<internal::OutputType<Y, F, X1, X2, X3, X4, X5, X6>>::dimension,
+    N>::type
+numericalDerivative65(F&& h, const X1& x1, const X2& x2, const X3& x3,
+                      const X4& x4, const X5& x5, const X6& x6,
+                      double delta = 1e-5) {
+  using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4, X5, X6>;
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<ActualY>::structure_category>,
+                "Template argument Y must be a manifold type.");
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<X5>::structure_category>,
+                "Template argument X5 must be a manifold type.");
+  return numericalDerivative11<ActualY, X5, N>(
+      [&](const X5& x5_) { return std::invoke(h, x1, x2, x3, x4, x5_, x6); },
       x5, delta);
 }
 
-template<class Y, class X1, class X2, class X3, class X4, class X5, class X6>
-inline typename internal::FixedSizeMatrix<Y,X5>::type numericalDerivative65(Y (*h)(const X1&, const X2&, const X3&, const X4&, const X5&, const X6&),
-    const X1& x1, const X2& x2, const X3& x3, const X4& x4, const X5& x5, const X6& x6, double delta = 1e-5) {
-  return numericalDerivative65<Y, X1, X2, X3, X4, X5, X6>(
-      std::bind(h, std::placeholders::_1, std::placeholders::_2,
-                  std::placeholders::_3, std::placeholders::_4,
-                  std::placeholders::_5, std::placeholders::_6),
-      x1, x2, x3, x4, x5, x6);
+template <class Y, class X1, class X2, class X3, class X4, class X5, class X6,
+          int N = traits<X5>::dimension>
+typename internal::MatrixMN<traits<Y>::dimension, N>::type
+numericalDerivative65(Y (&h)(const X1&, const X2&, const X3&, const X4&,
+                             const X5&, const X6&),
+                      const X1& x1, const X2& x2, const X3& x3, const X4& x4,
+                      const X5& x5, const X6& x6, double delta = 1e-5) {
+  return numericalDerivative11<Y, X5, N>(
+      [&](const X5& x5_) { return h(x1, x2, x3, x4, x5_, x6); }, x5, delta);
 }
 
 /**
@@ -822,33 +1007,44 @@ inline typename internal::FixedSizeMatrix<Y,X5>::type numericalDerivative65(Y (*
  * @param x6 sixth argument value
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
- * @tparam int N is the dimension of the X6 input value if variable dimension type but known at test time
+ * @tparam int N is the dimension of the X6 input value if variable dimension
+ * type but known at test time
  */
-template<class Y, class X1, class X2, class X3, class X4, class X5, class X6, int N = traits<X6>::dimension>
-typename internal::FixedSizeMatrix<Y, X6>::type numericalDerivative66(
-    std::function<Y(const X1&, const X2&, const X3&, const X4&, const X5&, const X6&)> h,
-    const X1& x1, const X2& x2, const X3& x3, const X4& x4, const X5& x5, const X6& x6,
-    double delta = 1e-5) {
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<Y>::structure_category>::value),
-      "Template argument Y must be a manifold type.");
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<X1>::structure_category>::value),
-      "Template argument X1 must be a manifold type.");
-  return numericalDerivative11<Y, X6, N>(
-      std::bind(h, std::cref(x1), std::cref(x2), std::cref(x3),
-                  std::cref(x4), std::cref(x5), std::placeholders::_1),
+template <class Y = internal::DeducedOutput, class X1, class X2, class X3,
+          class X4, class X5, class X6, int N = traits<X6>::dimension, class F,
+          internal::EnableIfInvocable<F, X1, X2, X3, X4, X5, X6> = 0>
+typename internal::MatrixMN<
+    traits<internal::OutputType<Y, F, X1, X2, X3, X4, X5, X6>>::dimension,
+    N>::type
+numericalDerivative66(F&& h, const X1& x1, const X2& x2, const X3& x3,
+                      const X4& x4, const X5& x5, const X6& x6,
+                      double delta = 1e-5) {
+  using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4, X5, X6>;
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<ActualY>::structure_category>,
+                "Template argument Y must be a manifold type.");
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<X6>::structure_category>,
+                "Template argument X6 must be a manifold type.");
+  return numericalDerivative11<ActualY, X6, N>(
+      [&](const X6& x6_) { return std::invoke(h, x1, x2, x3, x4, x5, x6_); },
       x6, delta);
 }
 
-template<class Y, class X1, class X2, class X3, class X4, class X5, class X6>
-inline typename internal::FixedSizeMatrix<Y,X6>::type numericalDerivative66(Y (*h)(const X1&, const X2&, const X3&, const X4&, const X5&, const X6&),
-    const X1& x1, const X2& x2, const X3& x3, const X4& x4, const X5& x5, const X6& x6, double delta = 1e-5) {
-  return numericalDerivative66<Y, X1, X2, X3, X4, X5, X6>(
-      std::bind(h, std::placeholders::_1, std::placeholders::_2,
-                  std::placeholders::_3, std::placeholders::_4,
-                  std::placeholders::_5, std::placeholders::_6),
-      x1, x2, x3, x4, x5, x6);
+template <class Y, class X1, class X2, class X3, class X4, class X5, class X6,
+          int N = traits<X6>::dimension>
+typename internal::MatrixMN<traits<Y>::dimension, N>::type
+numericalDerivative66(Y (&h)(const X1&, const X2&, const X3&, const X4&,
+                             const X5&, const X6&),
+                      const X1& x1, const X2& x2, const X3& x3, const X4& x4,
+                      const X5& x5, const X6& x6, double delta = 1e-5) {
+  return numericalDerivative11<Y, X6, N>(
+      [&](const X6& x6_) { return h(x1, x2, x3, x4, x5, x6_); }, x6, delta);
 }
+/// @}
 
+/** @name Hessian Helpers */
+/// @{
 /**
  * Compute numerical Hessian matrix.  Requires a single-argument Lie->scalar
  * function.  This is implemented simply as the derivative of the gradient.
@@ -857,249 +1053,244 @@ inline typename internal::FixedSizeMatrix<Y,X6>::type numericalDerivative66(Y (*
  * @param delta The numerical derivative step size
  * @return n*n Hessian matrix computed via central differencing
  */
-template<class X>
-inline typename internal::FixedSizeMatrix<X,X>::type numericalHessian(std::function<double(const X&)> f, const X& x,
-    double delta = 1e-5) {
-  static_assert( (std::is_base_of<gtsam::manifold_tag, typename traits<X>::structure_category>::value),
-      "Template argument X must be a manifold type.");
-  typedef Eigen::Matrix<double, traits<X>::dimension, 1> VectorD;
-  typedef std::function<double(const X&)> F;
-  typedef std::function<VectorD(F, const X&, double)> G;
-  G ng = static_cast<G>(numericalGradient<X> );
-  return numericalDerivative11<VectorD, X>(
-      std::bind(ng, f, std::placeholders::_1, delta), x, delta);
+template <class X, int N = traits<X>::dimension>
+inline typename internal::MatrixMN<N, N>::type numericalHessian(
+    std::function<double(const X&)> f, const X& x, double delta = 1e-5) {
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<X>::structure_category>,
+                "Template argument X must be a manifold type.");
+  typedef Eigen::Matrix<double, N, 1> VectorD;
+  return numericalDerivative11<VectorD, X, N>(
+      [&](const X& x) { return numericalGradient<X, N>(f, x, delta); }, x,
+      delta);
 }
 
-template<class X>
-inline typename internal::FixedSizeMatrix<X,X>::type numericalHessian(double (*f)(const X&), const X& x, double delta =
-    1e-5) {
-  return numericalHessian(std::function<double(const X&)>(f), x, delta);
+template <class X, int N = traits<X>::dimension>
+inline typename internal::MatrixMN<N, N>::type numericalHessian(
+    double (*f)(const X&), const X& x, double delta = 1e-5) {
+  return numericalHessian<X, N>(std::function<double(const X&)>(f), x, delta);
 }
 
 /** Helper class that computes the derivative of f w.r.t. x1, centered about
  * x1_, as a function of x2
  */
-template<class X1, class X2>
+template <class X1, class X2, int N1 = traits<X1>::dimension>
 class G_x1 {
   const std::function<double(const X1&, const X2&)>& f_;
   X1 x1_;
   double delta_;
-public:
-  typedef typename internal::FixedSizeMatrix<X1>::type Vector;
+
+ public:
+  typedef Eigen::Matrix<double, N1, 1> Vector;
 
   G_x1(const std::function<double(const X1&, const X2&)>& f, const X1& x1,
-      double delta) :
-      f_(f), x1_(x1), delta_(delta) {
-  }
+       double delta)
+      : f_(f), x1_(x1), delta_(delta) {}
   Vector operator()(const X2& x2) {
-    return numericalGradient<X1>(
+    return numericalGradient<X1, N1>(
         std::bind(f_, std::placeholders::_1, std::cref(x2)), x1_, delta_);
   }
 };
 
-template<class X1, class X2>
-inline typename internal::FixedSizeMatrix<X1,X2>::type numericalHessian212(
+template <class X1, class X2, int N1 = traits<X1>::dimension,
+          int N2 = traits<X2>::dimension>
+inline typename internal::MatrixMN<N1, N2>::type numericalHessian212(
     std::function<double(const X1&, const X2&)> f, const X1& x1, const X2& x2,
     double delta = 1e-5) {
-  typedef typename internal::FixedSizeMatrix<X1>::type Vector;
-  G_x1<X1, X2> g_x1(f, x1, delta);
-  return numericalDerivative11<Vector, X2>(
+  typedef Eigen::Matrix<double, N1, 1> Vector;
+  G_x1<X1, X2, N1> g_x1(f, x1, delta);
+  return numericalDerivative11<Vector, X2, N2>(
       std::function<Vector(const X2&)>(
           std::bind<Vector>(std::ref(g_x1), std::placeholders::_1)),
       x2, delta);
 }
 
-template<class X1, class X2>
-inline typename internal::FixedSizeMatrix<X1,X2>::type numericalHessian212(double (*f)(const X1&, const X2&),
-    const X1& x1, const X2& x2, double delta = 1e-5) {
-  return numericalHessian212(std::function<double(const X1&, const X2&)>(f),
-      x1, x2, delta);
+template <class X1, class X2, int N1 = traits<X1>::dimension,
+          int N2 = traits<X2>::dimension>
+inline typename internal::MatrixMN<N1, N2>::type numericalHessian212(
+    double (*f)(const X1&, const X2&), const X1& x1, const X2& x2,
+    double delta = 1e-5) {
+  return numericalHessian212<X1, X2, N1, N2>(
+      std::function<double(const X1&, const X2&)>(f), x1, x2, delta);
 }
 
-template<class X1, class X2>
-inline typename internal::FixedSizeMatrix<X1,X1>::type numericalHessian211(
+template <class X1, class X2, int N1 = traits<X1>::dimension>
+inline typename internal::MatrixMN<N1, N1>::type numericalHessian211(
     std::function<double(const X1&, const X2&)> f, const X1& x1, const X2& x2,
     double delta = 1e-5) {
-
-  typedef typename internal::FixedSizeMatrix<X1>::type Vector;
-
-  Vector (*numGrad)(std::function<double(const X1&)>, const X1&,
-      double) = &numericalGradient<X1>;
+  typedef Eigen::Matrix<double, N1, 1> Vector;
   std::function<double(const X1&)> f2(
       std::bind(f, std::placeholders::_1, std::cref(x2)));
-
-  return numericalDerivative11<Vector, X1>(
-      std::function<Vector(const X1&)>(
-          std::bind(numGrad, f2, std::placeholders::_1, delta)),
-      x1, delta);
+  return numericalDerivative11<Vector, X1, N1>(
+      [&](const X1& x) { return numericalGradient<X1, N1>(f2, x, delta); }, x1,
+      delta);
 }
 
-template<class X1, class X2>
-inline typename internal::FixedSizeMatrix<X1,X1>::type numericalHessian211(double (*f)(const X1&, const X2&),
-    const X1& x1, const X2& x2, double delta = 1e-5) {
-  return numericalHessian211(std::function<double(const X1&, const X2&)>(f),
-      x1, x2, delta);
+template <class X1, class X2, int N1 = traits<X1>::dimension>
+inline typename internal::MatrixMN<N1, N1>::type numericalHessian211(
+    double (*f)(const X1&, const X2&), const X1& x1, const X2& x2,
+    double delta = 1e-5) {
+  return numericalHessian211<X1, X2, N1>(
+      std::function<double(const X1&, const X2&)>(f), x1, x2, delta);
 }
 
-template<class X1, class X2>
-inline typename internal::FixedSizeMatrix<X2,X2>::type numericalHessian222(
+template <class X1, class X2, int N2 = traits<X2>::dimension>
+inline typename internal::MatrixMN<N2, N2>::type numericalHessian222(
     std::function<double(const X1&, const X2&)> f, const X1& x1, const X2& x2,
     double delta = 1e-5) {
-  typedef typename internal::FixedSizeMatrix<X2>::type Vector;
-  Vector (*numGrad)(std::function<double(const X2&)>, const X2&,
-      double) = &numericalGradient<X2>;
+  typedef Eigen::Matrix<double, N2, 1> Vector;
   std::function<double(const X2&)> f2(
       std::bind(f, std::cref(x1), std::placeholders::_1));
-
-  return numericalDerivative11<Vector, X2>(
-      std::function<Vector(const X2&)>(
-          std::bind(numGrad, f2, std::placeholders::_1, delta)),
-      x2, delta);
+  return numericalDerivative11<Vector, X2, N2>(
+      [&](const X2& x) { return numericalGradient<X2, N2>(f2, x, delta); }, x2,
+      delta);
 }
 
-template<class X1, class X2>
-inline typename internal::FixedSizeMatrix<X2,X2>::type numericalHessian222(double (*f)(const X1&, const X2&),
-    const X1& x1, const X2& x2, double delta = 1e-5) {
-  return numericalHessian222(std::function<double(const X1&, const X2&)>(f),
-      x1, x2, delta);
+template <class X1, class X2, int N2 = traits<X2>::dimension>
+inline typename internal::MatrixMN<N2, N2>::type numericalHessian222(
+    double (*f)(const X1&, const X2&), const X1& x1, const X2& x2,
+    double delta = 1e-5) {
+  return numericalHessian222<X1, X2, N2>(
+      std::function<double(const X1&, const X2&)>(f), x1, x2, delta);
 }
 
 /**
  * Numerical Hessian for tenary functions
  */
 /* **************************************************************** */
-template<class X1, class X2, class X3>
-inline typename internal::FixedSizeMatrix<X1,X1>::type numericalHessian311(
+template <class X1, class X2, class X3, int N1 = traits<X1>::dimension>
+inline typename internal::MatrixMN<N1, N1>::type numericalHessian311(
     std::function<double(const X1&, const X2&, const X3&)> f, const X1& x1,
     const X2& x2, const X3& x3, double delta = 1e-5) {
-  typedef typename internal::FixedSizeMatrix<X1>::type Vector;
-  Vector (*numGrad)(std::function<double(const X1&)>, const X1&,
-      double) = &numericalGradient<X1>;
-  std::function<double(const X1&)> f2(std::bind(
-      f, std::placeholders::_1, std::cref(x2), std::cref(x3)));
+  typedef Eigen::Matrix<double, N1, 1> Vector;
+  std::function<double(const X1&)> f2(
+      std::bind(f, std::placeholders::_1, std::cref(x2), std::cref(x3)));
 
-  return numericalDerivative11<Vector, X1>(
-      std::function<Vector(const X1&)>(
-          std::bind(numGrad, f2, std::placeholders::_1, delta)),
-      x1, delta);
+  return numericalDerivative11<Vector, X1, N1>(
+      [&](const X1& x) { return numericalGradient<X1, N1>(f2, x, delta); }, x1,
+      delta);
 }
 
-template<class X1, class X2, class X3>
-inline typename internal::FixedSizeMatrix<X1,X1>::type numericalHessian311(double (*f)(const X1&, const X2&, const X3&),
-    const X1& x1, const X2& x2, const X3& x3, double delta = 1e-5) {
-  return numericalHessian311(
+template <class X1, class X2, class X3, int N1 = traits<X1>::dimension>
+inline typename internal::MatrixMN<N1, N1>::type numericalHessian311(
+    double (*f)(const X1&, const X2&, const X3&), const X1& x1, const X2& x2,
+    const X3& x3, double delta = 1e-5) {
+  return numericalHessian311<X1, X2, X3, N1>(
       std::function<double(const X1&, const X2&, const X3&)>(f), x1, x2, x3,
       delta);
 }
 
 /* **************************************************************** */
-template<class X1, class X2, class X3>
-inline typename internal::FixedSizeMatrix<X2,X2>::type numericalHessian322(
+template <class X1, class X2, class X3, int N2 = traits<X2>::dimension>
+inline typename internal::MatrixMN<N2, N2>::type numericalHessian322(
     std::function<double(const X1&, const X2&, const X3&)> f, const X1& x1,
     const X2& x2, const X3& x3, double delta = 1e-5) {
-  typedef typename internal::FixedSizeMatrix<X2>::type Vector;
-  Vector (*numGrad)(std::function<double(const X2&)>, const X2&,
-      double) = &numericalGradient<X2>;
-  std::function<double(const X2&)> f2(std::bind(
-      f, std::cref(x1), std::placeholders::_1, std::cref(x3)));
+  typedef Eigen::Matrix<double, N2, 1> Vector;
+  std::function<double(const X2&)> f2(
+      std::bind(f, std::cref(x1), std::placeholders::_1, std::cref(x3)));
 
-  return numericalDerivative11<Vector, X2>(
-      std::function<Vector(const X2&)>(
-          std::bind(numGrad, f2, std::placeholders::_1, delta)),
-      x2, delta);
+  return numericalDerivative11<Vector, X2, N2>(
+      [&](const X2& x) { return numericalGradient<X2, N2>(f2, x, delta); }, x2,
+      delta);
 }
 
-template<class X1, class X2, class X3>
-inline typename internal::FixedSizeMatrix<X2,X2>::type numericalHessian322(double (*f)(const X1&, const X2&, const X3&),
-    const X1& x1, const X2& x2, const X3& x3, double delta = 1e-5) {
-  return numericalHessian322(
+template <class X1, class X2, class X3, int N2 = traits<X2>::dimension>
+inline typename internal::MatrixMN<N2, N2>::type numericalHessian322(
+    double (*f)(const X1&, const X2&, const X3&), const X1& x1, const X2& x2,
+    const X3& x3, double delta = 1e-5) {
+  return numericalHessian322<X1, X2, X3, N2>(
       std::function<double(const X1&, const X2&, const X3&)>(f), x1, x2, x3,
       delta);
 }
 
 /* **************************************************************** */
-template<class X1, class X2, class X3>
-inline typename internal::FixedSizeMatrix<X3,X3>::type numericalHessian333(
+template <class X1, class X2, class X3, int N3 = traits<X3>::dimension>
+inline typename internal::MatrixMN<N3, N3>::type numericalHessian333(
     std::function<double(const X1&, const X2&, const X3&)> f, const X1& x1,
     const X2& x2, const X3& x3, double delta = 1e-5) {
-  typedef typename internal::FixedSizeMatrix<X3>::type Vector;
-  Vector (*numGrad)(std::function<double(const X3&)>, const X3&,
-      double) = &numericalGradient<X3>;
-  std::function<double(const X3&)> f2(std::bind(
-      f, std::cref(x1), std::cref(x2), std::placeholders::_1));
+  typedef Eigen::Matrix<double, N3, 1> Vector;
+  std::function<double(const X3&)> f2(
+      std::bind(f, std::cref(x1), std::cref(x2), std::placeholders::_1));
 
-  return numericalDerivative11<Vector, X3>(
-      std::function<Vector(const X3&)>(
-          std::bind(numGrad, f2, std::placeholders::_1, delta)),
-      x3, delta);
+  return numericalDerivative11<Vector, X3, N3>(
+      [&](const X3& x) { return numericalGradient<X3, N3>(f2, x, delta); }, x3,
+      delta);
 }
 
-template<class X1, class X2, class X3>
-inline typename internal::FixedSizeMatrix<X3,X3>::type numericalHessian333(double (*f)(const X1&, const X2&, const X3&),
-    const X1& x1, const X2& x2, const X3& x3, double delta = 1e-5) {
-  return numericalHessian333(
+template <class X1, class X2, class X3, int N3 = traits<X3>::dimension>
+inline typename internal::MatrixMN<N3, N3>::type numericalHessian333(
+    double (*f)(const X1&, const X2&, const X3&), const X1& x1, const X2& x2,
+    const X3& x3, double delta = 1e-5) {
+  return numericalHessian333<X1, X2, X3, N3>(
       std::function<double(const X1&, const X2&, const X3&)>(f), x1, x2, x3,
       delta);
 }
 
 /* **************************************************************** */
-template<class X1, class X2, class X3>
-inline typename internal::FixedSizeMatrix<X1,X2>::type numericalHessian312(
+template <class X1, class X2, class X3, int N1 = traits<X1>::dimension,
+          int N2 = traits<X2>::dimension>
+inline typename internal::MatrixMN<N1, N2>::type numericalHessian312(
     std::function<double(const X1&, const X2&, const X3&)> f, const X1& x1,
     const X2& x2, const X3& x3, double delta = 1e-5) {
-  return numericalHessian212<X1, X2>(
-      std::function<double(const X1&, const X2&)>(
-          std::bind(f, std::placeholders::_1, std::placeholders::_2,
-                      std::cref(x3))),
+  return numericalHessian212<X1, X2, N1, N2>(
+      std::function<double(const X1&, const X2&)>(std::bind(
+          f, std::placeholders::_1, std::placeholders::_2, std::cref(x3))),
       x1, x2, delta);
 }
 
-template<class X1, class X2, class X3>
-inline typename internal::FixedSizeMatrix<X1,X3>::type numericalHessian313(
+template <class X1, class X2, class X3, int N1 = traits<X1>::dimension,
+          int N3 = traits<X3>::dimension>
+inline typename internal::MatrixMN<N1, N3>::type numericalHessian313(
     std::function<double(const X1&, const X2&, const X3&)> f, const X1& x1,
     const X2& x2, const X3& x3, double delta = 1e-5) {
-  return numericalHessian212<X1, X3>(
-      std::function<double(const X1&, const X3&)>(
-          std::bind(f, std::placeholders::_1, std::cref(x2),
-                      std::placeholders::_2)),
+  return numericalHessian212<X1, X3, N1, N3>(
+      std::function<double(const X1&, const X3&)>(std::bind(
+          f, std::placeholders::_1, std::cref(x2), std::placeholders::_2)),
       x1, x3, delta);
 }
 
-template<class X1, class X2, class X3>
-inline typename internal::FixedSizeMatrix<X2,X3>::type numericalHessian323(
+template <class X1, class X2, class X3, int N2 = traits<X2>::dimension,
+          int N3 = traits<X3>::dimension>
+inline typename internal::MatrixMN<N2, N3>::type numericalHessian323(
     std::function<double(const X1&, const X2&, const X3&)> f, const X1& x1,
     const X2& x2, const X3& x3, double delta = 1e-5) {
-  return numericalHessian212<X2, X3>(
-      std::function<double(const X2&, const X3&)>(
-          std::bind(f, std::cref(x1), std::placeholders::_1,
-                      std::placeholders::_2)),
+  return numericalHessian212<X2, X3, N2, N3>(
+      std::function<double(const X2&, const X3&)>(std::bind(
+          f, std::cref(x1), std::placeholders::_1, std::placeholders::_2)),
       x2, x3, delta);
 }
 
 /* **************************************************************** */
-template<class X1, class X2, class X3>
-inline typename internal::FixedSizeMatrix<X1,X2>::type numericalHessian312(double (*f)(const X1&, const X2&, const X3&),
-    const X1& x1, const X2& x2, const X3& x3, double delta = 1e-5) {
-  return numericalHessian312(
+template <class X1, class X2, class X3, int N1 = traits<X1>::dimension,
+          int N2 = traits<X2>::dimension>
+inline typename internal::MatrixMN<N1, N2>::type numericalHessian312(
+    double (*f)(const X1&, const X2&, const X3&), const X1& x1, const X2& x2,
+    const X3& x3, double delta = 1e-5) {
+  return numericalHessian312<X1, X2, X3, N1, N2>(
       std::function<double(const X1&, const X2&, const X3&)>(f), x1, x2, x3,
       delta);
 }
 
-template<class X1, class X2, class X3>
-inline typename internal::FixedSizeMatrix<X1,X3>::type numericalHessian313(double (*f)(const X1&, const X2&, const X3&),
-    const X1& x1, const X2& x2, const X3& x3, double delta = 1e-5) {
-  return numericalHessian313(
+template <class X1, class X2, class X3, int N1 = traits<X1>::dimension,
+          int N3 = traits<X3>::dimension>
+inline typename internal::MatrixMN<N1, N3>::type numericalHessian313(
+    double (*f)(const X1&, const X2&, const X3&), const X1& x1, const X2& x2,
+    const X3& x3, double delta = 1e-5) {
+  return numericalHessian313<X1, X2, X3, N1, N3>(
       std::function<double(const X1&, const X2&, const X3&)>(f), x1, x2, x3,
       delta);
 }
 
-template<class X1, class X2, class X3>
-inline typename internal::FixedSizeMatrix<X2,X3>::type numericalHessian323(double (*f)(const X1&, const X2&, const X3&),
-    const X1& x1, const X2& x2, const X3& x3, double delta = 1e-5) {
-  return numericalHessian323(
+template <class X1, class X2, class X3, int N2 = traits<X2>::dimension,
+          int N3 = traits<X3>::dimension>
+inline typename internal::MatrixMN<N2, N3>::type numericalHessian323(
+    double (*f)(const X1&, const X2&, const X3&), const X1& x1, const X2& x2,
+    const X3& x3, double delta = 1e-5) {
+  return numericalHessian323<X1, X2, X3, N2, N3>(
       std::function<double(const X1&, const X2&, const X3&)>(f), x1, x2, x3,
       delta);
 }
 
-} // namespace gtsam
-
+/// @}
+/// @}
+}  // namespace gtsam

--- a/gtsam/base/numericalDerivative.h
+++ b/gtsam/base/numericalDerivative.h
@@ -82,6 +82,10 @@ using OutputType =
 template <class F, class... Args>
 using EnableIfInvocable =
     std::enable_if_t<std::is_invocable_v<F&, const Args&...>, int>;
+
+template <class F, class... Args>
+using EnableIfScalarInvocable =
+    std::enable_if_t<std::is_invocable_r_v<double, F&, const Args&...>, int>;
 }  // namespace internal
 /// @}
 
@@ -109,9 +113,10 @@ using EnableIfInvocable =
  * @tparam N tangent dimension of `X`; provide explicitly for variable-size
  * manifold types
  */
-template <class X, int N = traits<X>::dimension>
-typename Eigen::Matrix<double, N, 1> numericalGradient(
-    std::function<double(const X&)> h, const X& x, double delta = 1e-5) {
+template <class X, int N = traits<X>::dimension, class F,
+          internal::EnableIfScalarInvocable<F, X> = 0>
+typename Eigen::Matrix<double, N, 1> numericalGradient(F&& h, const X& x,
+                                                       double delta = 1e-5) {
   double factor = 1.0 / (2.0 * delta);
 
   static_assert(std::is_base_of_v<gtsam::manifold_tag,
@@ -129,13 +134,20 @@ typename Eigen::Matrix<double, N, 1> numericalGradient(
   g.setZero();
   for (int j = 0; j < N; j++) {
     d(j) = delta;
-    double hxplus = h(traits<X>::Retract(x, d));
+    double hxplus = std::invoke(h, traits<X>::Retract(x, d));
     d(j) = -delta;
-    double hxmin = h(traits<X>::Retract(x, d));
+    double hxmin = std::invoke(h, traits<X>::Retract(x, d));
     d(j) = 0;
     g(j) = (hxplus - hxmin) * factor;
   }
   return g;
+}
+
+template <class X, int N = traits<X>::dimension>
+typename Eigen::Matrix<double, N, 1> numericalGradient(double (&h)(const X&),
+                                                       const X& x,
+                                                       double delta = 1e-5) {
+  return numericalGradient<X, N>([&](const X& x_) { return h(x_); }, x, delta);
 }
 
 /**
@@ -1053,210 +1065,207 @@ numericalDerivative66(Y (&h)(const X1&, const X2&, const X3&, const X4&,
  * @param delta The numerical derivative step size
  * @return n*n Hessian matrix computed via central differencing
  */
-template <class X, int N = traits<X>::dimension>
+template <class X, int N = traits<X>::dimension, class F,
+          internal::EnableIfScalarInvocable<F, X> = 0>
 inline typename internal::MatrixMN<N, N>::type numericalHessian(
-    std::function<double(const X&)> f, const X& x, double delta = 1e-5) {
+    F&& f, const X& x, double delta = 1e-5) {
   static_assert(std::is_base_of_v<gtsam::manifold_tag,
                                   typename traits<X>::structure_category>,
                 "Template argument X must be a manifold type.");
   typedef Eigen::Matrix<double, N, 1> VectorD;
   return numericalDerivative11<VectorD, X, N>(
-      [&](const X& x) { return numericalGradient<X, N>(f, x, delta); }, x,
+      [&](const X& x_) { return numericalGradient<X, N>(f, x_, delta); }, x,
       delta);
 }
 
 template <class X, int N = traits<X>::dimension>
 inline typename internal::MatrixMN<N, N>::type numericalHessian(
-    double (*f)(const X&), const X& x, double delta = 1e-5) {
-  return numericalHessian<X, N>(std::function<double(const X&)>(f), x, delta);
+    double (&f)(const X&), const X& x, double delta = 1e-5) {
+  return numericalHessian<X, N>([&](const X& x_) { return f(x_); }, x, delta);
 }
 
-/** Helper class that computes the derivative of f w.r.t. x1, centered about
- * x1_, as a function of x2
- */
-template <class X1, class X2, int N1 = traits<X1>::dimension>
-class G_x1 {
-  const std::function<double(const X1&, const X2&)>& f_;
-  X1 x1_;
-  double delta_;
-
- public:
-  typedef Eigen::Matrix<double, N1, 1> Vector;
-
-  G_x1(const std::function<double(const X1&, const X2&)>& f, const X1& x1,
-       double delta)
-      : f_(f), x1_(x1), delta_(delta) {}
-  Vector operator()(const X2& x2) {
-    return numericalGradient<X1, N1>(
-        std::bind(f_, std::placeholders::_1, std::cref(x2)), x1_, delta_);
-  }
-};
-
 template <class X1, class X2, int N1 = traits<X1>::dimension,
-          int N2 = traits<X2>::dimension>
+          int N2 = traits<X2>::dimension, class F,
+          internal::EnableIfScalarInvocable<F, X1, X2> = 0>
 inline typename internal::MatrixMN<N1, N2>::type numericalHessian212(
-    std::function<double(const X1&, const X2&)> f, const X1& x1, const X2& x2,
-    double delta = 1e-5) {
+    F&& f, const X1& x1, const X2& x2, double delta = 1e-5) {
   typedef Eigen::Matrix<double, N1, 1> Vector;
-  G_x1<X1, X2, N1> g_x1(f, x1, delta);
   return numericalDerivative11<Vector, X2, N2>(
-      std::function<Vector(const X2&)>(
-          std::bind<Vector>(std::ref(g_x1), std::placeholders::_1)),
+      [&](const X2& x2_) {
+        return numericalGradient<X1, N1>(
+            [&](const X1& x1_) { return std::invoke(f, x1_, x2_); }, x1, delta);
+      },
       x2, delta);
 }
 
 template <class X1, class X2, int N1 = traits<X1>::dimension,
           int N2 = traits<X2>::dimension>
 inline typename internal::MatrixMN<N1, N2>::type numericalHessian212(
-    double (*f)(const X1&, const X2&), const X1& x1, const X2& x2,
+    double (&f)(const X1&, const X2&), const X1& x1, const X2& x2,
     double delta = 1e-5) {
   return numericalHessian212<X1, X2, N1, N2>(
-      std::function<double(const X1&, const X2&)>(f), x1, x2, delta);
+      [&](const X1& x1_, const X2& x2_) { return f(x1_, x2_); }, x1, x2, delta);
 }
 
-template <class X1, class X2, int N1 = traits<X1>::dimension>
+template <class X1, class X2, int N1 = traits<X1>::dimension, class F,
+          internal::EnableIfScalarInvocable<F, X1, X2> = 0>
 inline typename internal::MatrixMN<N1, N1>::type numericalHessian211(
-    std::function<double(const X1&, const X2&)> f, const X1& x1, const X2& x2,
-    double delta = 1e-5) {
+    F&& f, const X1& x1, const X2& x2, double delta = 1e-5) {
   typedef Eigen::Matrix<double, N1, 1> Vector;
-  std::function<double(const X1&)> f2(
-      std::bind(f, std::placeholders::_1, std::cref(x2)));
   return numericalDerivative11<Vector, X1, N1>(
-      [&](const X1& x) { return numericalGradient<X1, N1>(f2, x, delta); }, x1,
-      delta);
+      [&](const X1& x1_) {
+        return numericalGradient<X1, N1>(
+            [&](const X1& x1__) { return std::invoke(f, x1__, x2); }, x1_,
+            delta);
+      },
+      x1, delta);
 }
 
 template <class X1, class X2, int N1 = traits<X1>::dimension>
 inline typename internal::MatrixMN<N1, N1>::type numericalHessian211(
-    double (*f)(const X1&, const X2&), const X1& x1, const X2& x2,
+    double (&f)(const X1&, const X2&), const X1& x1, const X2& x2,
     double delta = 1e-5) {
   return numericalHessian211<X1, X2, N1>(
-      std::function<double(const X1&, const X2&)>(f), x1, x2, delta);
+      [&](const X1& x1_, const X2& x2_) { return f(x1_, x2_); }, x1, x2, delta);
 }
 
-template <class X1, class X2, int N2 = traits<X2>::dimension>
+template <class X1, class X2, int N2 = traits<X2>::dimension, class F,
+          internal::EnableIfScalarInvocable<F, X1, X2> = 0>
 inline typename internal::MatrixMN<N2, N2>::type numericalHessian222(
-    std::function<double(const X1&, const X2&)> f, const X1& x1, const X2& x2,
-    double delta = 1e-5) {
+    F&& f, const X1& x1, const X2& x2, double delta = 1e-5) {
   typedef Eigen::Matrix<double, N2, 1> Vector;
-  std::function<double(const X2&)> f2(
-      std::bind(f, std::cref(x1), std::placeholders::_1));
   return numericalDerivative11<Vector, X2, N2>(
-      [&](const X2& x) { return numericalGradient<X2, N2>(f2, x, delta); }, x2,
-      delta);
+      [&](const X2& x2_) {
+        return numericalGradient<X2, N2>(
+            [&](const X2& x2__) { return std::invoke(f, x1, x2__); }, x2_,
+            delta);
+      },
+      x2, delta);
 }
 
 template <class X1, class X2, int N2 = traits<X2>::dimension>
 inline typename internal::MatrixMN<N2, N2>::type numericalHessian222(
-    double (*f)(const X1&, const X2&), const X1& x1, const X2& x2,
+    double (&f)(const X1&, const X2&), const X1& x1, const X2& x2,
     double delta = 1e-5) {
   return numericalHessian222<X1, X2, N2>(
-      std::function<double(const X1&, const X2&)>(f), x1, x2, delta);
+      [&](const X1& x1_, const X2& x2_) { return f(x1_, x2_); }, x1, x2, delta);
 }
 
 /**
  * Numerical Hessian for tenary functions
  */
 /* **************************************************************** */
-template <class X1, class X2, class X3, int N1 = traits<X1>::dimension>
+template <class X1, class X2, class X3, int N1 = traits<X1>::dimension, class F,
+          internal::EnableIfScalarInvocable<F, X1, X2, X3> = 0>
 inline typename internal::MatrixMN<N1, N1>::type numericalHessian311(
-    std::function<double(const X1&, const X2&, const X3&)> f, const X1& x1,
-    const X2& x2, const X3& x3, double delta = 1e-5) {
+    F&& f, const X1& x1, const X2& x2, const X3& x3, double delta = 1e-5) {
   typedef Eigen::Matrix<double, N1, 1> Vector;
-  std::function<double(const X1&)> f2(
-      std::bind(f, std::placeholders::_1, std::cref(x2), std::cref(x3)));
-
   return numericalDerivative11<Vector, X1, N1>(
-      [&](const X1& x) { return numericalGradient<X1, N1>(f2, x, delta); }, x1,
-      delta);
+      [&](const X1& x1_) {
+        return numericalGradient<X1, N1>(
+            [&](const X1& x1__) { return std::invoke(f, x1__, x2, x3); }, x1_,
+            delta);
+      },
+      x1, delta);
 }
 
 template <class X1, class X2, class X3, int N1 = traits<X1>::dimension>
 inline typename internal::MatrixMN<N1, N1>::type numericalHessian311(
-    double (*f)(const X1&, const X2&, const X3&), const X1& x1, const X2& x2,
+    double (&f)(const X1&, const X2&, const X3&), const X1& x1, const X2& x2,
     const X3& x3, double delta = 1e-5) {
   return numericalHessian311<X1, X2, X3, N1>(
-      std::function<double(const X1&, const X2&, const X3&)>(f), x1, x2, x3,
-      delta);
+      [&](const X1& x1_, const X2& x2_, const X3& x3_) {
+        return f(x1_, x2_, x3_);
+      },
+      x1, x2, x3, delta);
 }
 
 /* **************************************************************** */
-template <class X1, class X2, class X3, int N2 = traits<X2>::dimension>
+template <class X1, class X2, class X3, int N2 = traits<X2>::dimension, class F,
+          internal::EnableIfScalarInvocable<F, X1, X2, X3> = 0>
 inline typename internal::MatrixMN<N2, N2>::type numericalHessian322(
-    std::function<double(const X1&, const X2&, const X3&)> f, const X1& x1,
-    const X2& x2, const X3& x3, double delta = 1e-5) {
+    F&& f, const X1& x1, const X2& x2, const X3& x3, double delta = 1e-5) {
   typedef Eigen::Matrix<double, N2, 1> Vector;
-  std::function<double(const X2&)> f2(
-      std::bind(f, std::cref(x1), std::placeholders::_1, std::cref(x3)));
-
   return numericalDerivative11<Vector, X2, N2>(
-      [&](const X2& x) { return numericalGradient<X2, N2>(f2, x, delta); }, x2,
-      delta);
+      [&](const X2& x2_) {
+        return numericalGradient<X2, N2>(
+            [&](const X2& x2__) { return std::invoke(f, x1, x2__, x3); }, x2_,
+            delta);
+      },
+      x2, delta);
 }
 
 template <class X1, class X2, class X3, int N2 = traits<X2>::dimension>
 inline typename internal::MatrixMN<N2, N2>::type numericalHessian322(
-    double (*f)(const X1&, const X2&, const X3&), const X1& x1, const X2& x2,
+    double (&f)(const X1&, const X2&, const X3&), const X1& x1, const X2& x2,
     const X3& x3, double delta = 1e-5) {
   return numericalHessian322<X1, X2, X3, N2>(
-      std::function<double(const X1&, const X2&, const X3&)>(f), x1, x2, x3,
-      delta);
+      [&](const X1& x1_, const X2& x2_, const X3& x3_) {
+        return f(x1_, x2_, x3_);
+      },
+      x1, x2, x3, delta);
 }
 
 /* **************************************************************** */
-template <class X1, class X2, class X3, int N3 = traits<X3>::dimension>
+template <class X1, class X2, class X3, int N3 = traits<X3>::dimension, class F,
+          internal::EnableIfScalarInvocable<F, X1, X2, X3> = 0>
 inline typename internal::MatrixMN<N3, N3>::type numericalHessian333(
-    std::function<double(const X1&, const X2&, const X3&)> f, const X1& x1,
-    const X2& x2, const X3& x3, double delta = 1e-5) {
+    F&& f, const X1& x1, const X2& x2, const X3& x3, double delta = 1e-5) {
   typedef Eigen::Matrix<double, N3, 1> Vector;
-  std::function<double(const X3&)> f2(
-      std::bind(f, std::cref(x1), std::cref(x2), std::placeholders::_1));
-
   return numericalDerivative11<Vector, X3, N3>(
-      [&](const X3& x) { return numericalGradient<X3, N3>(f2, x, delta); }, x3,
-      delta);
+      [&](const X3& x3_) {
+        return numericalGradient<X3, N3>(
+            [&](const X3& x3__) { return std::invoke(f, x1, x2, x3__); }, x3_,
+            delta);
+      },
+      x3, delta);
 }
 
 template <class X1, class X2, class X3, int N3 = traits<X3>::dimension>
 inline typename internal::MatrixMN<N3, N3>::type numericalHessian333(
-    double (*f)(const X1&, const X2&, const X3&), const X1& x1, const X2& x2,
+    double (&f)(const X1&, const X2&, const X3&), const X1& x1, const X2& x2,
     const X3& x3, double delta = 1e-5) {
   return numericalHessian333<X1, X2, X3, N3>(
-      std::function<double(const X1&, const X2&, const X3&)>(f), x1, x2, x3,
-      delta);
+      [&](const X1& x1_, const X2& x2_, const X3& x3_) {
+        return f(x1_, x2_, x3_);
+      },
+      x1, x2, x3, delta);
 }
 
 /* **************************************************************** */
 template <class X1, class X2, class X3, int N1 = traits<X1>::dimension,
-          int N2 = traits<X2>::dimension>
+          int N2 = traits<X2>::dimension, class F,
+          internal::EnableIfScalarInvocable<F, X1, X2, X3> = 0>
 inline typename internal::MatrixMN<N1, N2>::type numericalHessian312(
-    std::function<double(const X1&, const X2&, const X3&)> f, const X1& x1,
-    const X2& x2, const X3& x3, double delta = 1e-5) {
+    F&& f, const X1& x1, const X2& x2, const X3& x3, double delta = 1e-5) {
   return numericalHessian212<X1, X2, N1, N2>(
-      std::function<double(const X1&, const X2&)>(std::bind(
-          f, std::placeholders::_1, std::placeholders::_2, std::cref(x3))),
+      [&](const X1& x1_, const X2& x2_) {
+        return std::invoke(f, x1_, x2_, x3);
+      },
       x1, x2, delta);
 }
 
 template <class X1, class X2, class X3, int N1 = traits<X1>::dimension,
-          int N3 = traits<X3>::dimension>
+          int N3 = traits<X3>::dimension, class F,
+          internal::EnableIfScalarInvocable<F, X1, X2, X3> = 0>
 inline typename internal::MatrixMN<N1, N3>::type numericalHessian313(
-    std::function<double(const X1&, const X2&, const X3&)> f, const X1& x1,
-    const X2& x2, const X3& x3, double delta = 1e-5) {
+    F&& f, const X1& x1, const X2& x2, const X3& x3, double delta = 1e-5) {
   return numericalHessian212<X1, X3, N1, N3>(
-      std::function<double(const X1&, const X3&)>(std::bind(
-          f, std::placeholders::_1, std::cref(x2), std::placeholders::_2)),
+      [&](const X1& x1_, const X3& x3_) {
+        return std::invoke(f, x1_, x2, x3_);
+      },
       x1, x3, delta);
 }
 
 template <class X1, class X2, class X3, int N2 = traits<X2>::dimension,
-          int N3 = traits<X3>::dimension>
+          int N3 = traits<X3>::dimension, class F,
+          internal::EnableIfScalarInvocable<F, X1, X2, X3> = 0>
 inline typename internal::MatrixMN<N2, N3>::type numericalHessian323(
-    std::function<double(const X1&, const X2&, const X3&)> f, const X1& x1,
-    const X2& x2, const X3& x3, double delta = 1e-5) {
+    F&& f, const X1& x1, const X2& x2, const X3& x3, double delta = 1e-5) {
   return numericalHessian212<X2, X3, N2, N3>(
-      std::function<double(const X2&, const X3&)>(std::bind(
-          f, std::cref(x1), std::placeholders::_1, std::placeholders::_2)),
+      [&](const X2& x2_, const X3& x3_) {
+        return std::invoke(f, x1, x2_, x3_);
+      },
       x2, x3, delta);
 }
 
@@ -1264,31 +1273,37 @@ inline typename internal::MatrixMN<N2, N3>::type numericalHessian323(
 template <class X1, class X2, class X3, int N1 = traits<X1>::dimension,
           int N2 = traits<X2>::dimension>
 inline typename internal::MatrixMN<N1, N2>::type numericalHessian312(
-    double (*f)(const X1&, const X2&, const X3&), const X1& x1, const X2& x2,
+    double (&f)(const X1&, const X2&, const X3&), const X1& x1, const X2& x2,
     const X3& x3, double delta = 1e-5) {
   return numericalHessian312<X1, X2, X3, N1, N2>(
-      std::function<double(const X1&, const X2&, const X3&)>(f), x1, x2, x3,
-      delta);
+      [&](const X1& x1_, const X2& x2_, const X3& x3_) {
+        return f(x1_, x2_, x3_);
+      },
+      x1, x2, x3, delta);
 }
 
 template <class X1, class X2, class X3, int N1 = traits<X1>::dimension,
           int N3 = traits<X3>::dimension>
 inline typename internal::MatrixMN<N1, N3>::type numericalHessian313(
-    double (*f)(const X1&, const X2&, const X3&), const X1& x1, const X2& x2,
+    double (&f)(const X1&, const X2&, const X3&), const X1& x1, const X2& x2,
     const X3& x3, double delta = 1e-5) {
   return numericalHessian313<X1, X2, X3, N1, N3>(
-      std::function<double(const X1&, const X2&, const X3&)>(f), x1, x2, x3,
-      delta);
+      [&](const X1& x1_, const X2& x2_, const X3& x3_) {
+        return f(x1_, x2_, x3_);
+      },
+      x1, x2, x3, delta);
 }
 
 template <class X1, class X2, class X3, int N2 = traits<X2>::dimension,
           int N3 = traits<X3>::dimension>
 inline typename internal::MatrixMN<N2, N3>::type numericalHessian323(
-    double (*f)(const X1&, const X2&, const X3&), const X1& x1, const X2& x2,
+    double (&f)(const X1&, const X2&, const X3&), const X1& x1, const X2& x2,
     const X3& x3, double delta = 1e-5) {
   return numericalHessian323<X1, X2, X3, N2, N3>(
-      std::function<double(const X1&, const X2&, const X3&)>(f), x1, x2, x3,
-      delta);
+      [&](const X1& x1_, const X2& x2_, const X3& x3_) {
+        return f(x1_, x2_, x3_);
+      },
+      x1, x2, x3, delta);
 }
 
 /// @}

--- a/gtsam/base/numericalDerivative.h
+++ b/gtsam/base/numericalDerivative.h
@@ -86,6 +86,24 @@ using EnableIfInvocable =
 template <class F, class... Args>
 using EnableIfScalarInvocable =
     std::enable_if_t<std::is_invocable_r_v<double, F&, const Args&...>, int>;
+
+template <class X, int N>
+constexpr void ValidateGradientInput() {
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<X>::structure_category>,
+                "Template argument X must be a manifold type.");
+  static_assert(
+      N > 0,
+      "Template argument X must be fixed-size type or N must be specified.");
+}
+
+template <class Y, class X, int N>
+constexpr void ValidateUnaryDerivativeTypes() {
+  static_assert(std::is_base_of_v<gtsam::manifold_tag,
+                                  typename traits<Y>::structure_category>,
+                "Template argument Y must be a manifold type.");
+  ValidateGradientInput<X, N>();
+}
 }  // namespace internal
 /// @}
 
@@ -117,14 +135,8 @@ template <class X, int N = traits<X>::dimension, class F,
           internal::EnableIfScalarInvocable<F, X> = 0>
 typename Eigen::Matrix<double, N, 1> numericalGradient(F&& h, const X& x,
                                                        double delta = 1e-5) {
+  internal::ValidateGradientInput<X, N>();
   double factor = 1.0 / (2.0 * delta);
-
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<X>::structure_category>,
-                "Template argument X must be a manifold type.");
-  static_assert(
-      N > 0,
-      "Template argument X must be fixed-size type or N must be specified.");
 
   // Prepare a tangent vector to perturb x with.
   Eigen::Matrix<double, N, 1> d;
@@ -134,15 +146,16 @@ typename Eigen::Matrix<double, N, 1> numericalGradient(F&& h, const X& x,
   g.setZero();
   for (int j = 0; j < N; j++) {
     d(j) = delta;
-    double hxplus = std::invoke(h, traits<X>::Retract(x, d));
+    double hx_plus = std::invoke(h, traits<X>::Retract(x, d));
     d(j) = -delta;
-    double hxmin = std::invoke(h, traits<X>::Retract(x, d));
+    double hx_min = std::invoke(h, traits<X>::Retract(x, d));
     d(j) = 0;
-    g(j) = (hxplus - hxmin) * factor;
+    g(j) = (hx_plus - hx_min) * factor;
   }
   return g;
 }
 
+/// Raw-function overload for `numericalGradient`.
 template <class X, int N = traits<X>::dimension>
 typename Eigen::Matrix<double, N, 1> numericalGradient(double (&h)(const X&),
                                                        const X& x,
@@ -169,20 +182,10 @@ typename internal::MatrixMN<traits<internal::OutputType<Y, F, X>>::dimension,
                             N>::type
 numericalDerivative11(F&& h, const X& x, double delta = 1e-5) {
   using ActualY = internal::OutputType<Y, F, X>;
+  internal::ValidateUnaryDerivativeTypes<ActualY, X, N>();
   typedef
-      typename internal::MatrixMN<traits<ActualY>::dimension, N>::type Matrix;
-
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<ActualY>::structure_category>,
-                "Template argument Y must be a manifold type.");
+      typename internal::MatrixMN<traits<ActualY>::dimension, N>::type MatrixYN;
   typedef traits<ActualY> TraitsY;
-
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<X>::structure_category>,
-                "Template argument X must be a manifold type.");
-  static_assert(
-      N > 0,
-      "Template argument X must be fixed-size type or N must be specified.");
   typedef traits<X> TraitsX;
 
   // get value at x, and corresponding chart
@@ -196,7 +199,7 @@ numericalDerivative11(F&& h, const X& x, double delta = 1e-5) {
   dx.setZero();
 
   // Fill in Jacobian H
-  Matrix H = Matrix::Zero(m, N);
+  MatrixYN H = MatrixYN::Zero(m, N);
   const double factor = 1.0 / (2.0 * delta);
   for (int j = 0; j < N; j++) {
     dx(j) = delta;
@@ -211,6 +214,7 @@ numericalDerivative11(F&& h, const X& x, double delta = 1e-5) {
   return H;
 }
 
+/// Raw-function overload for `numericalDerivative11`.
 template <class Y, class X, int N = traits<X>::dimension>
 typename internal::MatrixMN<traits<Y>::dimension, N>::type
 numericalDerivative11(Y (&h)(const X&), const X& x, double delta = 1e-5) {
@@ -221,8 +225,7 @@ numericalDerivative11(Y (&h)(const X&), const X& x, double delta = 1e-5) {
 /**
  * Compute numerical derivative in argument 1 of binary function
  * @param h binary function yielding m-vector
- * @param x1 n-dimensional first argument value
- * @param x2 second argument value
+ * @param x1, x2 argument values; differentiate with respect to `x1`
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
  * @tparam int N is the dimension of the X1 input value if variable dimension
@@ -235,16 +238,11 @@ typename internal::MatrixMN<
     traits<internal::OutputType<Y, F, X1, X2>>::dimension, N>::type
 numericalDerivative21(F&& h, const X1& x1, const X2& x2, double delta = 1e-5) {
   using ActualY = internal::OutputType<Y, F, X1, X2>;
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<ActualY>::structure_category>,
-                "Template argument Y must be a manifold type.");
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<X1>::structure_category>,
-                "Template argument X1 must be a manifold type.");
   return numericalDerivative11<ActualY, X1, N>(
       [&](const X1& x1_) { return std::invoke(h, x1_, x2); }, x1, delta);
 }
 
+/// Raw-function overload for `numericalDerivative21`.
 template <class Y, class X1, class X2, int N = traits<X1>::dimension>
 typename internal::MatrixMN<traits<Y>::dimension, N>::type
 numericalDerivative21(Y (&h)(const X1&, const X2&), const X1& x1, const X2& x2,
@@ -256,8 +254,7 @@ numericalDerivative21(Y (&h)(const X1&, const X2&), const X1& x1, const X2& x2,
 /**
  * Compute numerical derivative in argument 2 of binary function
  * @param h binary function yielding m-vector
- * @param x1 first argument value
- * @param x2 n-dimensional second argument value
+ * @param x1, x2 argument values; differentiate with respect to `x2`
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
  * @tparam int N is the dimension of the X2 input value if variable dimension
@@ -270,16 +267,11 @@ typename internal::MatrixMN<
     traits<internal::OutputType<Y, F, X1, X2>>::dimension, N>::type
 numericalDerivative22(F&& h, const X1& x1, const X2& x2, double delta = 1e-5) {
   using ActualY = internal::OutputType<Y, F, X1, X2>;
-  //  static_assert( (std::is_base_of<gtsam::manifold_tag, typename
-  //  traits<X1>::structure_category>::value),
-  //       "Template argument X1 must be a manifold type.");
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<X2>::structure_category>,
-                "Template argument X2 must be a manifold type.");
   return numericalDerivative11<ActualY, X2, N>(
       [&](const X2& x2_) { return std::invoke(h, x1, x2_); }, x2, delta);
 }
 
+/// Raw-function overload for `numericalDerivative22`.
 template <class Y, class X1, class X2, int N = traits<X2>::dimension>
 typename internal::MatrixMN<traits<Y>::dimension, N>::type
 numericalDerivative22(Y (&h)(const X1&, const X2&), const X1& x1, const X2& x2,
@@ -291,9 +283,7 @@ numericalDerivative22(Y (&h)(const X1&, const X2&), const X1& x1, const X2& x2,
 /**
  * Compute numerical derivative in argument 1 of ternary function
  * @param h ternary function yielding m-vector
- * @param x1 n-dimensional first argument value
- * @param x2 second argument value
- * @param x3 third argument value
+ * @param x1, x2, x3 argument values; differentiate with respect to `x1`
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
  * @tparam int N is the dimension of the X1 input value if variable dimension
@@ -307,16 +297,11 @@ typename internal::MatrixMN<
 numericalDerivative31(F&& h, const X1& x1, const X2& x2, const X3& x3,
                       double delta = 1e-5) {
   using ActualY = internal::OutputType<Y, F, X1, X2, X3>;
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<ActualY>::structure_category>,
-                "Template argument Y must be a manifold type.");
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<X1>::structure_category>,
-                "Template argument X1 must be a manifold type.");
   return numericalDerivative11<ActualY, X1, N>(
       [&](const X1& x1_) { return std::invoke(h, x1_, x2, x3); }, x1, delta);
 }
 
+/// Raw-function overload for `numericalDerivative31`.
 template <class Y, class X1, class X2, class X3, int N = traits<X1>::dimension>
 typename internal::MatrixMN<traits<Y>::dimension, N>::type
 numericalDerivative31(Y (&h)(const X1&, const X2&, const X3&), const X1& x1,
@@ -328,9 +313,7 @@ numericalDerivative31(Y (&h)(const X1&, const X2&, const X3&), const X1& x1,
 /**
  * Compute numerical derivative in argument 2 of ternary function
  * @param h ternary function yielding m-vector
- * @param x1 n-dimensional first argument value
- * @param x2 second argument value
- * @param x3 third argument value
+ * @param x1, x2, x3 argument values; differentiate with respect to `x2`
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
  * @tparam int N is the dimension of the X2 input value if variable dimension
@@ -344,16 +327,11 @@ typename internal::MatrixMN<
 numericalDerivative32(F&& h, const X1& x1, const X2& x2, const X3& x3,
                       double delta = 1e-5) {
   using ActualY = internal::OutputType<Y, F, X1, X2, X3>;
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<ActualY>::structure_category>,
-                "Template argument Y must be a manifold type.");
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<X2>::structure_category>,
-                "Template argument X2 must be a manifold type.");
   return numericalDerivative11<ActualY, X2, N>(
       [&](const X2& x2_) { return std::invoke(h, x1, x2_, x3); }, x2, delta);
 }
 
+/// Raw-function overload for `numericalDerivative32`.
 template <class Y, class X1, class X2, class X3, int N = traits<X2>::dimension>
 typename internal::MatrixMN<traits<Y>::dimension, N>::type
 numericalDerivative32(Y (&h)(const X1&, const X2&, const X3&), const X1& x1,
@@ -365,9 +343,7 @@ numericalDerivative32(Y (&h)(const X1&, const X2&, const X3&), const X1& x1,
 /**
  * Compute numerical derivative in argument 3 of ternary function
  * @param h ternary function yielding m-vector
- * @param x1 n-dimensional first argument value
- * @param x2 second argument value
- * @param x3 third argument value
+ * @param x1, x2, x3 argument values; differentiate with respect to `x3`
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
  * @tparam int N is the dimension of the X3 input value if variable dimension
@@ -381,16 +357,11 @@ typename internal::MatrixMN<
 numericalDerivative33(F&& h, const X1& x1, const X2& x2, const X3& x3,
                       double delta = 1e-5) {
   using ActualY = internal::OutputType<Y, F, X1, X2, X3>;
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<ActualY>::structure_category>,
-                "Template argument Y must be a manifold type.");
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<X3>::structure_category>,
-                "Template argument X3 must be a manifold type.");
   return numericalDerivative11<ActualY, X3, N>(
       [&](const X3& x3_) { return std::invoke(h, x1, x2, x3_); }, x3, delta);
 }
 
+/// Raw-function overload for `numericalDerivative33`.
 template <class Y, class X1, class X2, class X3, int N = traits<X3>::dimension>
 typename internal::MatrixMN<traits<Y>::dimension, N>::type
 numericalDerivative33(Y (&h)(const X1&, const X2&, const X3&), const X1& x1,
@@ -402,10 +373,7 @@ numericalDerivative33(Y (&h)(const X1&, const X2&, const X3&), const X1& x1,
 /**
  * Compute numerical derivative in argument 1 of 4-argument function
  * @param h quartic function yielding m-vector
- * @param x1 n-dimensional first argument value
- * @param x2 second argument value
- * @param x3 third argument value
- * @param x4 fourth argument value
+ * @param x1, x2, x3, x4 argument values; differentiate with respect to `x1`
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
  * @tparam int N is the dimension of the X1 input value if variable dimension
@@ -419,17 +387,12 @@ typename internal::MatrixMN<
 numericalDerivative41(F&& h, const X1& x1, const X2& x2, const X3& x3,
                       const X4& x4, double delta = 1e-5) {
   using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4>;
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<ActualY>::structure_category>,
-                "Template argument Y must be a manifold type.");
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<X1>::structure_category>,
-                "Template argument X1 must be a manifold type.");
   return numericalDerivative11<ActualY, X1, N>(
       [&](const X1& x1_) { return std::invoke(h, x1_, x2, x3, x4); }, x1,
       delta);
 }
 
+/// Raw-function overload for `numericalDerivative41`.
 template <class Y, class X1, class X2, class X3, class X4,
           int N = traits<X1>::dimension>
 typename internal::MatrixMN<traits<Y>::dimension, N>::type
@@ -443,10 +406,7 @@ numericalDerivative41(Y (&h)(const X1&, const X2&, const X3&, const X4&),
 /**
  * Compute numerical derivative in argument 2 of 4-argument function
  * @param h quartic function yielding m-vector
- * @param x1 first argument value
- * @param x2 n-dimensional second argument value
- * @param x3 third argument value
- * @param x4 fourth argument value
+ * @param x1, x2, x3, x4 argument values; differentiate with respect to `x2`
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
  * @tparam int N is the dimension of the X2 input value if variable dimension
@@ -460,17 +420,12 @@ typename internal::MatrixMN<
 numericalDerivative42(F&& h, const X1& x1, const X2& x2, const X3& x3,
                       const X4& x4, double delta = 1e-5) {
   using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4>;
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<ActualY>::structure_category>,
-                "Template argument Y must be a manifold type.");
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<X2>::structure_category>,
-                "Template argument X2 must be a manifold type.");
   return numericalDerivative11<ActualY, X2, N>(
       [&](const X2& x2_) { return std::invoke(h, x1, x2_, x3, x4); }, x2,
       delta);
 }
 
+/// Raw-function overload for `numericalDerivative42`.
 template <class Y, class X1, class X2, class X3, class X4,
           int N = traits<X2>::dimension>
 typename internal::MatrixMN<traits<Y>::dimension, N>::type
@@ -484,10 +439,7 @@ numericalDerivative42(Y (&h)(const X1&, const X2&, const X3&, const X4&),
 /**
  * Compute numerical derivative in argument 3 of 4-argument function
  * @param h quartic function yielding m-vector
- * @param x1 first argument value
- * @param x2 second argument value
- * @param x3 n-dimensional third argument value
- * @param x4 fourth argument value
+ * @param x1, x2, x3, x4 argument values; differentiate with respect to `x3`
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
  * @tparam int N is the dimension of the X3 input value if variable dimension
@@ -501,17 +453,12 @@ typename internal::MatrixMN<
 numericalDerivative43(F&& h, const X1& x1, const X2& x2, const X3& x3,
                       const X4& x4, double delta = 1e-5) {
   using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4>;
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<ActualY>::structure_category>,
-                "Template argument Y must be a manifold type.");
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<X3>::structure_category>,
-                "Template argument X3 must be a manifold type.");
   return numericalDerivative11<ActualY, X3, N>(
       [&](const X3& x3_) { return std::invoke(h, x1, x2, x3_, x4); }, x3,
       delta);
 }
 
+/// Raw-function overload for `numericalDerivative43`.
 template <class Y, class X1, class X2, class X3, class X4,
           int N = traits<X3>::dimension>
 typename internal::MatrixMN<traits<Y>::dimension, N>::type
@@ -525,10 +472,7 @@ numericalDerivative43(Y (&h)(const X1&, const X2&, const X3&, const X4&),
 /**
  * Compute numerical derivative in argument 4 of 4-argument function
  * @param h quartic function yielding m-vector
- * @param x1 first argument value
- * @param x2 second argument value
- * @param x3 third argument value
- * @param x4 n-dimensional fourth argument value
+ * @param x1, x2, x3, x4 argument values; differentiate with respect to `x4`
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
  * @tparam int N is the dimension of the X4 input value if variable dimension
@@ -542,17 +486,12 @@ typename internal::MatrixMN<
 numericalDerivative44(F&& h, const X1& x1, const X2& x2, const X3& x3,
                       const X4& x4, double delta = 1e-5) {
   using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4>;
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<ActualY>::structure_category>,
-                "Template argument Y must be a manifold type.");
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<X4>::structure_category>,
-                "Template argument X4 must be a manifold type.");
   return numericalDerivative11<ActualY, X4, N>(
       [&](const X4& x4_) { return std::invoke(h, x1, x2, x3, x4_); }, x4,
       delta);
 }
 
+/// Raw-function overload for `numericalDerivative44`.
 template <class Y, class X1, class X2, class X3, class X4,
           int N = traits<X4>::dimension>
 typename internal::MatrixMN<traits<Y>::dimension, N>::type
@@ -566,11 +505,7 @@ numericalDerivative44(Y (&h)(const X1&, const X2&, const X3&, const X4&),
 /**
  * Compute numerical derivative in argument 1 of 5-argument function
  * @param h quintic function yielding m-vector
- * @param x1 n-dimensional first argument value
- * @param x2 second argument value
- * @param x3 third argument value
- * @param x4 fourth argument value
- * @param x5 fifth argument value
+ * @param x1, ..., x5 argument values; differentiate with respect to `x1`
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
  * @tparam int N is the dimension of the X1 input value if variable dimension
@@ -584,17 +519,12 @@ typename internal::MatrixMN<
 numericalDerivative51(F&& h, const X1& x1, const X2& x2, const X3& x3,
                       const X4& x4, const X5& x5, double delta = 1e-5) {
   using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4, X5>;
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<ActualY>::structure_category>,
-                "Template argument Y must be a manifold type.");
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<X1>::structure_category>,
-                "Template argument X1 must be a manifold type.");
   return numericalDerivative11<ActualY, X1, N>(
       [&](const X1& x1_) { return std::invoke(h, x1_, x2, x3, x4, x5); }, x1,
       delta);
 }
 
+/// Raw-function overload for `numericalDerivative51`.
 template <class Y, class X1, class X2, class X3, class X4, class X5,
           int N = traits<X1>::dimension>
 typename internal::MatrixMN<traits<Y>::dimension, N>::type
@@ -609,11 +539,7 @@ numericalDerivative51(Y (&h)(const X1&, const X2&, const X3&, const X4&,
 /**
  * Compute numerical derivative in argument 2 of 5-argument function
  * @param h quintic function yielding m-vector
- * @param x1 n-dimensional first argument value
- * @param x2 second argument value
- * @param x3 third argument value
- * @param x4 fourth argument value
- * @param x5 fifth argument value
+ * @param x1, ..., x5 argument values; differentiate with respect to `x2`
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
  * @tparam int N is the dimension of the X2 input value if variable dimension
@@ -627,17 +553,12 @@ typename internal::MatrixMN<
 numericalDerivative52(F&& h, const X1& x1, const X2& x2, const X3& x3,
                       const X4& x4, const X5& x5, double delta = 1e-5) {
   using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4, X5>;
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<ActualY>::structure_category>,
-                "Template argument Y must be a manifold type.");
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<X2>::structure_category>,
-                "Template argument X2 must be a manifold type.");
   return numericalDerivative11<ActualY, X2, N>(
       [&](const X2& x2_) { return std::invoke(h, x1, x2_, x3, x4, x5); }, x2,
       delta);
 }
 
+/// Raw-function overload for `numericalDerivative52`.
 template <class Y, class X1, class X2, class X3, class X4, class X5,
           int N = traits<X2>::dimension>
 typename internal::MatrixMN<traits<Y>::dimension, N>::type
@@ -652,11 +573,7 @@ numericalDerivative52(Y (&h)(const X1&, const X2&, const X3&, const X4&,
 /**
  * Compute numerical derivative in argument 3 of 5-argument function
  * @param h quintic function yielding m-vector
- * @param x1 n-dimensional first argument value
- * @param x2 second argument value
- * @param x3 third argument value
- * @param x4 fourth argument value
- * @param x5 fifth argument value
+ * @param x1, ..., x5 argument values; differentiate with respect to `x3`
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
  * @tparam int N is the dimension of the X3 input value if variable dimension
@@ -670,17 +587,12 @@ typename internal::MatrixMN<
 numericalDerivative53(F&& h, const X1& x1, const X2& x2, const X3& x3,
                       const X4& x4, const X5& x5, double delta = 1e-5) {
   using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4, X5>;
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<ActualY>::structure_category>,
-                "Template argument Y must be a manifold type.");
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<X3>::structure_category>,
-                "Template argument X3 must be a manifold type.");
   return numericalDerivative11<ActualY, X3, N>(
       [&](const X3& x3_) { return std::invoke(h, x1, x2, x3_, x4, x5); }, x3,
       delta);
 }
 
+/// Raw-function overload for `numericalDerivative53`.
 template <class Y, class X1, class X2, class X3, class X4, class X5,
           int N = traits<X3>::dimension>
 typename internal::MatrixMN<traits<Y>::dimension, N>::type
@@ -695,11 +607,7 @@ numericalDerivative53(Y (&h)(const X1&, const X2&, const X3&, const X4&,
 /**
  * Compute numerical derivative in argument 4 of 5-argument function
  * @param h quintic function yielding m-vector
- * @param x1 n-dimensional first argument value
- * @param x2 second argument value
- * @param x3 third argument value
- * @param x4 fourth argument value
- * @param x5 fifth argument value
+ * @param x1, ..., x5 argument values; differentiate with respect to `x4`
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
  * @tparam int N is the dimension of the X4 input value if variable dimension
@@ -713,17 +621,12 @@ typename internal::MatrixMN<
 numericalDerivative54(F&& h, const X1& x1, const X2& x2, const X3& x3,
                       const X4& x4, const X5& x5, double delta = 1e-5) {
   using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4, X5>;
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<ActualY>::structure_category>,
-                "Template argument Y must be a manifold type.");
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<X4>::structure_category>,
-                "Template argument X4 must be a manifold type.");
   return numericalDerivative11<ActualY, X4, N>(
       [&](const X4& x4_) { return std::invoke(h, x1, x2, x3, x4_, x5); }, x4,
       delta);
 }
 
+/// Raw-function overload for `numericalDerivative54`.
 template <class Y, class X1, class X2, class X3, class X4, class X5,
           int N = traits<X4>::dimension>
 typename internal::MatrixMN<traits<Y>::dimension, N>::type
@@ -738,11 +641,7 @@ numericalDerivative54(Y (&h)(const X1&, const X2&, const X3&, const X4&,
 /**
  * Compute numerical derivative in argument 5 of 5-argument function
  * @param h quintic function yielding m-vector
- * @param x1 n-dimensional first argument value
- * @param x2 second argument value
- * @param x3 third argument value
- * @param x4 fourth argument value
- * @param x5 fifth argument value
+ * @param x1, ..., x5 argument values; differentiate with respect to `x5`
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
  * @tparam int N is the dimension of the X5 input value if variable dimension
@@ -756,17 +655,12 @@ typename internal::MatrixMN<
 numericalDerivative55(F&& h, const X1& x1, const X2& x2, const X3& x3,
                       const X4& x4, const X5& x5, double delta = 1e-5) {
   using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4, X5>;
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<ActualY>::structure_category>,
-                "Template argument Y must be a manifold type.");
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<X5>::structure_category>,
-                "Template argument X5 must be a manifold type.");
   return numericalDerivative11<ActualY, X5, N>(
       [&](const X5& x5_) { return std::invoke(h, x1, x2, x3, x4, x5_); }, x5,
       delta);
 }
 
+/// Raw-function overload for `numericalDerivative55`.
 template <class Y, class X1, class X2, class X3, class X4, class X5,
           int N = traits<X5>::dimension>
 typename internal::MatrixMN<traits<Y>::dimension, N>::type
@@ -781,12 +675,7 @@ numericalDerivative55(Y (&h)(const X1&, const X2&, const X3&, const X4&,
 /**
  * Compute numerical derivative in argument 1 of 6-argument function
  * @param h quintic function yielding m-vector
- * @param x1 n-dimensional first argument value
- * @param x2 second argument value
- * @param x3 third argument value
- * @param x4 fourth argument value
- * @param x5 fifth argument value
- * @param x6 sixth argument value
+ * @param x1, ..., x6 argument values; differentiate with respect to `x1`
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
  * @tparam int N is the dimension of the X1 input value if variable dimension
@@ -802,17 +691,12 @@ numericalDerivative61(F&& h, const X1& x1, const X2& x2, const X3& x3,
                       const X4& x4, const X5& x5, const X6& x6,
                       double delta = 1e-5) {
   using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4, X5, X6>;
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<ActualY>::structure_category>,
-                "Template argument Y must be a manifold type.");
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<X1>::structure_category>,
-                "Template argument X1 must be a manifold type.");
   return numericalDerivative11<ActualY, X1, N>(
       [&](const X1& x1_) { return std::invoke(h, x1_, x2, x3, x4, x5, x6); },
       x1, delta);
 }
 
+/// Raw-function overload for `numericalDerivative61`.
 template <class Y, class X1, class X2, class X3, class X4, class X5, class X6,
           int N = traits<X1>::dimension>
 typename internal::MatrixMN<traits<Y>::dimension, N>::type
@@ -827,12 +711,7 @@ numericalDerivative61(Y (&h)(const X1&, const X2&, const X3&, const X4&,
 /**
  * Compute numerical derivative in argument 2 of 6-argument function
  * @param h quintic function yielding m-vector
- * @param x1 n-dimensional first argument value
- * @param x2 second argument value
- * @param x3 third argument value
- * @param x4 fourth argument value
- * @param x5 fifth argument value
- * @param x6 sixth argument value
+ * @param x1, ..., x6 argument values; differentiate with respect to `x2`
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
  * @tparam int N is the dimension of the X2 input value if variable dimension
@@ -848,17 +727,12 @@ numericalDerivative62(F&& h, const X1& x1, const X2& x2, const X3& x3,
                       const X4& x4, const X5& x5, const X6& x6,
                       double delta = 1e-5) {
   using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4, X5, X6>;
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<ActualY>::structure_category>,
-                "Template argument Y must be a manifold type.");
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<X2>::structure_category>,
-                "Template argument X2 must be a manifold type.");
   return numericalDerivative11<ActualY, X2, N>(
       [&](const X2& x2_) { return std::invoke(h, x1, x2_, x3, x4, x5, x6); },
       x2, delta);
 }
 
+/// Raw-function overload for `numericalDerivative62`.
 template <class Y, class X1, class X2, class X3, class X4, class X5, class X6,
           int N = traits<X2>::dimension>
 typename internal::MatrixMN<traits<Y>::dimension, N>::type
@@ -873,12 +747,7 @@ numericalDerivative62(Y (&h)(const X1&, const X2&, const X3&, const X4&,
 /**
  * Compute numerical derivative in argument 3 of 6-argument function
  * @param h quintic function yielding m-vector
- * @param x1 n-dimensional first argument value
- * @param x2 second argument value
- * @param x3 third argument value
- * @param x4 fourth argument value
- * @param x5 fifth argument value
- * @param x6 sixth argument value
+ * @param x1, ..., x6 argument values; differentiate with respect to `x3`
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
  * @tparam int N is the dimension of the X3 input value if variable dimension
@@ -894,17 +763,12 @@ numericalDerivative63(F&& h, const X1& x1, const X2& x2, const X3& x3,
                       const X4& x4, const X5& x5, const X6& x6,
                       double delta = 1e-5) {
   using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4, X5, X6>;
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<ActualY>::structure_category>,
-                "Template argument Y must be a manifold type.");
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<X3>::structure_category>,
-                "Template argument X3 must be a manifold type.");
   return numericalDerivative11<ActualY, X3, N>(
       [&](const X3& x3_) { return std::invoke(h, x1, x2, x3_, x4, x5, x6); },
       x3, delta);
 }
 
+/// Raw-function overload for `numericalDerivative63`.
 template <class Y, class X1, class X2, class X3, class X4, class X5, class X6,
           int N = traits<X3>::dimension>
 typename internal::MatrixMN<traits<Y>::dimension, N>::type
@@ -919,12 +783,7 @@ numericalDerivative63(Y (&h)(const X1&, const X2&, const X3&, const X4&,
 /**
  * Compute numerical derivative in argument 4 of 6-argument function
  * @param h quintic function yielding m-vector
- * @param x1 n-dimensional first argument value
- * @param x2 second argument value
- * @param x3 third argument value
- * @param x4 fourth argument value
- * @param x5 fifth argument value
- * @param x6 sixth argument value
+ * @param x1, ..., x6 argument values; differentiate with respect to `x4`
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
  * @tparam int N is the dimension of the X4 input value if variable dimension
@@ -940,17 +799,12 @@ numericalDerivative64(F&& h, const X1& x1, const X2& x2, const X3& x3,
                       const X4& x4, const X5& x5, const X6& x6,
                       double delta = 1e-5) {
   using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4, X5, X6>;
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<ActualY>::structure_category>,
-                "Template argument Y must be a manifold type.");
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<X4>::structure_category>,
-                "Template argument X4 must be a manifold type.");
   return numericalDerivative11<ActualY, X4, N>(
       [&](const X4& x4_) { return std::invoke(h, x1, x2, x3, x4_, x5, x6); },
       x4, delta);
 }
 
+/// Raw-function overload for `numericalDerivative64`.
 template <class Y, class X1, class X2, class X3, class X4, class X5, class X6,
           int N = traits<X4>::dimension>
 typename internal::MatrixMN<traits<Y>::dimension, N>::type
@@ -965,12 +819,7 @@ numericalDerivative64(Y (&h)(const X1&, const X2&, const X3&, const X4&,
 /**
  * Compute numerical derivative in argument 5 of 6-argument function
  * @param h quintic function yielding m-vector
- * @param x1 n-dimensional first argument value
- * @param x2 second argument value
- * @param x3 third argument value
- * @param x4 fourth argument value
- * @param x5 fifth argument value
- * @param x6 sixth argument value
+ * @param x1, ..., x6 argument values; differentiate with respect to `x5`
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
  * @tparam int N is the dimension of the X5 input value if variable dimension
@@ -986,17 +835,12 @@ numericalDerivative65(F&& h, const X1& x1, const X2& x2, const X3& x3,
                       const X4& x4, const X5& x5, const X6& x6,
                       double delta = 1e-5) {
   using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4, X5, X6>;
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<ActualY>::structure_category>,
-                "Template argument Y must be a manifold type.");
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<X5>::structure_category>,
-                "Template argument X5 must be a manifold type.");
   return numericalDerivative11<ActualY, X5, N>(
       [&](const X5& x5_) { return std::invoke(h, x1, x2, x3, x4, x5_, x6); },
       x5, delta);
 }
 
+/// Raw-function overload for `numericalDerivative65`.
 template <class Y, class X1, class X2, class X3, class X4, class X5, class X6,
           int N = traits<X5>::dimension>
 typename internal::MatrixMN<traits<Y>::dimension, N>::type
@@ -1011,12 +855,7 @@ numericalDerivative65(Y (&h)(const X1&, const X2&, const X3&, const X4&,
 /**
  * Compute numerical derivative in argument 6 of 6-argument function
  * @param h quintic function yielding m-vector
- * @param x1 n-dimensional first argument value
- * @param x2 second argument value
- * @param x3 third argument value
- * @param x4 fourth argument value
- * @param x5 fifth argument value
- * @param x6 sixth argument value
+ * @param x1, ..., x6 argument values; differentiate with respect to `x6`
  * @param delta increment for numerical derivative
  * @return m*n Jacobian computed via central differencing
  * @tparam int N is the dimension of the X6 input value if variable dimension
@@ -1032,17 +871,12 @@ numericalDerivative66(F&& h, const X1& x1, const X2& x2, const X3& x3,
                       const X4& x4, const X5& x5, const X6& x6,
                       double delta = 1e-5) {
   using ActualY = internal::OutputType<Y, F, X1, X2, X3, X4, X5, X6>;
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<ActualY>::structure_category>,
-                "Template argument Y must be a manifold type.");
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<X6>::structure_category>,
-                "Template argument X6 must be a manifold type.");
   return numericalDerivative11<ActualY, X6, N>(
       [&](const X6& x6_) { return std::invoke(h, x1, x2, x3, x4, x5, x6_); },
       x6, delta);
 }
 
+/// Raw-function overload for `numericalDerivative66`.
 template <class Y, class X1, class X2, class X3, class X4, class X5, class X6,
           int N = traits<X6>::dimension>
 typename internal::MatrixMN<traits<Y>::dimension, N>::type
@@ -1069,21 +903,20 @@ template <class X, int N = traits<X>::dimension, class F,
           internal::EnableIfScalarInvocable<F, X> = 0>
 inline typename internal::MatrixMN<N, N>::type numericalHessian(
     F&& f, const X& x, double delta = 1e-5) {
-  static_assert(std::is_base_of_v<gtsam::manifold_tag,
-                                  typename traits<X>::structure_category>,
-                "Template argument X must be a manifold type.");
   typedef Eigen::Matrix<double, N, 1> VectorD;
   return numericalDerivative11<VectorD, X, N>(
       [&](const X& x_) { return numericalGradient<X, N>(f, x_, delta); }, x,
       delta);
 }
 
+/// Raw-function overload for `numericalHessian`.
 template <class X, int N = traits<X>::dimension>
 inline typename internal::MatrixMN<N, N>::type numericalHessian(
     double (&f)(const X&), const X& x, double delta = 1e-5) {
   return numericalHessian<X, N>([&](const X& x_) { return f(x_); }, x, delta);
 }
 
+/// Mixed Hessian with respect to argument 1 then argument 2.
 template <class X1, class X2, int N1 = traits<X1>::dimension,
           int N2 = traits<X2>::dimension, class F,
           internal::EnableIfScalarInvocable<F, X1, X2> = 0>
@@ -1098,6 +931,7 @@ inline typename internal::MatrixMN<N1, N2>::type numericalHessian212(
       x2, delta);
 }
 
+/// Raw-function overload for `numericalHessian212`.
 template <class X1, class X2, int N1 = traits<X1>::dimension,
           int N2 = traits<X2>::dimension>
 inline typename internal::MatrixMN<N1, N2>::type numericalHessian212(
@@ -1107,6 +941,7 @@ inline typename internal::MatrixMN<N1, N2>::type numericalHessian212(
       [&](const X1& x1_, const X2& x2_) { return f(x1_, x2_); }, x1, x2, delta);
 }
 
+/// Hessian with respect to argument 1 of a binary scalar function.
 template <class X1, class X2, int N1 = traits<X1>::dimension, class F,
           internal::EnableIfScalarInvocable<F, X1, X2> = 0>
 inline typename internal::MatrixMN<N1, N1>::type numericalHessian211(
@@ -1121,6 +956,7 @@ inline typename internal::MatrixMN<N1, N1>::type numericalHessian211(
       x1, delta);
 }
 
+/// Raw-function overload for `numericalHessian211`.
 template <class X1, class X2, int N1 = traits<X1>::dimension>
 inline typename internal::MatrixMN<N1, N1>::type numericalHessian211(
     double (&f)(const X1&, const X2&), const X1& x1, const X2& x2,
@@ -1129,6 +965,7 @@ inline typename internal::MatrixMN<N1, N1>::type numericalHessian211(
       [&](const X1& x1_, const X2& x2_) { return f(x1_, x2_); }, x1, x2, delta);
 }
 
+/// Hessian with respect to argument 2 of a binary scalar function.
 template <class X1, class X2, int N2 = traits<X2>::dimension, class F,
           internal::EnableIfScalarInvocable<F, X1, X2> = 0>
 inline typename internal::MatrixMN<N2, N2>::type numericalHessian222(
@@ -1143,6 +980,7 @@ inline typename internal::MatrixMN<N2, N2>::type numericalHessian222(
       x2, delta);
 }
 
+/// Raw-function overload for `numericalHessian222`.
 template <class X1, class X2, int N2 = traits<X2>::dimension>
 inline typename internal::MatrixMN<N2, N2>::type numericalHessian222(
     double (&f)(const X1&, const X2&), const X1& x1, const X2& x2,
@@ -1152,9 +990,10 @@ inline typename internal::MatrixMN<N2, N2>::type numericalHessian222(
 }
 
 /**
- * Numerical Hessian for tenary functions
+ * Numerical Hessian for ternary functions
  */
 /* **************************************************************** */
+/// Hessian with respect to argument 1 of a ternary scalar function.
 template <class X1, class X2, class X3, int N1 = traits<X1>::dimension, class F,
           internal::EnableIfScalarInvocable<F, X1, X2, X3> = 0>
 inline typename internal::MatrixMN<N1, N1>::type numericalHessian311(
@@ -1169,6 +1008,7 @@ inline typename internal::MatrixMN<N1, N1>::type numericalHessian311(
       x1, delta);
 }
 
+/// Raw-function overload for `numericalHessian311`.
 template <class X1, class X2, class X3, int N1 = traits<X1>::dimension>
 inline typename internal::MatrixMN<N1, N1>::type numericalHessian311(
     double (&f)(const X1&, const X2&, const X3&), const X1& x1, const X2& x2,
@@ -1181,6 +1021,7 @@ inline typename internal::MatrixMN<N1, N1>::type numericalHessian311(
 }
 
 /* **************************************************************** */
+/// Hessian with respect to argument 2 of a ternary scalar function.
 template <class X1, class X2, class X3, int N2 = traits<X2>::dimension, class F,
           internal::EnableIfScalarInvocable<F, X1, X2, X3> = 0>
 inline typename internal::MatrixMN<N2, N2>::type numericalHessian322(
@@ -1195,6 +1036,7 @@ inline typename internal::MatrixMN<N2, N2>::type numericalHessian322(
       x2, delta);
 }
 
+/// Raw-function overload for `numericalHessian322`.
 template <class X1, class X2, class X3, int N2 = traits<X2>::dimension>
 inline typename internal::MatrixMN<N2, N2>::type numericalHessian322(
     double (&f)(const X1&, const X2&, const X3&), const X1& x1, const X2& x2,
@@ -1207,6 +1049,7 @@ inline typename internal::MatrixMN<N2, N2>::type numericalHessian322(
 }
 
 /* **************************************************************** */
+/// Hessian with respect to argument 3 of a ternary scalar function.
 template <class X1, class X2, class X3, int N3 = traits<X3>::dimension, class F,
           internal::EnableIfScalarInvocable<F, X1, X2, X3> = 0>
 inline typename internal::MatrixMN<N3, N3>::type numericalHessian333(
@@ -1221,6 +1064,7 @@ inline typename internal::MatrixMN<N3, N3>::type numericalHessian333(
       x3, delta);
 }
 
+/// Raw-function overload for `numericalHessian333`.
 template <class X1, class X2, class X3, int N3 = traits<X3>::dimension>
 inline typename internal::MatrixMN<N3, N3>::type numericalHessian333(
     double (&f)(const X1&, const X2&, const X3&), const X1& x1, const X2& x2,
@@ -1233,6 +1077,8 @@ inline typename internal::MatrixMN<N3, N3>::type numericalHessian333(
 }
 
 /* **************************************************************** */
+/// Mixed Hessian with respect to arguments 1 and 2 of a ternary scalar
+/// function.
 template <class X1, class X2, class X3, int N1 = traits<X1>::dimension,
           int N2 = traits<X2>::dimension, class F,
           internal::EnableIfScalarInvocable<F, X1, X2, X3> = 0>
@@ -1245,6 +1091,8 @@ inline typename internal::MatrixMN<N1, N2>::type numericalHessian312(
       x1, x2, delta);
 }
 
+/// Mixed Hessian with respect to arguments 1 and 3 of a ternary scalar
+/// function.
 template <class X1, class X2, class X3, int N1 = traits<X1>::dimension,
           int N3 = traits<X3>::dimension, class F,
           internal::EnableIfScalarInvocable<F, X1, X2, X3> = 0>
@@ -1257,6 +1105,8 @@ inline typename internal::MatrixMN<N1, N3>::type numericalHessian313(
       x1, x3, delta);
 }
 
+/// Mixed Hessian with respect to arguments 2 and 3 of a ternary scalar
+/// function.
 template <class X1, class X2, class X3, int N2 = traits<X2>::dimension,
           int N3 = traits<X3>::dimension, class F,
           internal::EnableIfScalarInvocable<F, X1, X2, X3> = 0>
@@ -1270,6 +1120,7 @@ inline typename internal::MatrixMN<N2, N3>::type numericalHessian323(
 }
 
 /* **************************************************************** */
+/// Raw-function overload for `numericalHessian312`.
 template <class X1, class X2, class X3, int N1 = traits<X1>::dimension,
           int N2 = traits<X2>::dimension>
 inline typename internal::MatrixMN<N1, N2>::type numericalHessian312(
@@ -1282,6 +1133,7 @@ inline typename internal::MatrixMN<N1, N2>::type numericalHessian312(
       x1, x2, x3, delta);
 }
 
+/// Raw-function overload for `numericalHessian313`.
 template <class X1, class X2, class X3, int N1 = traits<X1>::dimension,
           int N3 = traits<X3>::dimension>
 inline typename internal::MatrixMN<N1, N3>::type numericalHessian313(
@@ -1294,6 +1146,7 @@ inline typename internal::MatrixMN<N1, N3>::type numericalHessian313(
       x1, x2, x3, delta);
 }
 
+/// Raw-function overload for `numericalHessian323`.
 template <class X1, class X2, class X3, int N2 = traits<X2>::dimension,
           int N3 = traits<X3>::dimension>
 inline typename internal::MatrixMN<N2, N3>::type numericalHessian323(

--- a/gtsam/geometry/Gal3.cpp
+++ b/gtsam/geometry/Gal3.cpp
@@ -413,16 +413,23 @@ Gal3::Jacobian Gal3::ExpmapDerivative(const TangentVector& xi) {
 }
 
 //------------------------------------------------------------------------------
+Gal3::Jacobian Gal3::LogmapDerivative(const TangentVector& xi) {
+  // Analytical implementation via the chain rule identity
+  //   Logmap(Expmap(xi)) = xi
+  //   => dLogmap/dg |_{g=Expmap(xi)} * dExpmap/dxi = I
+  //   => LogmapDerivative(xi) = ExpmapDerivative(xi)^{-1}
+  //
+  // ExpmapDerivative is already analytical (computed inside Gal3::Expmap as
+  // Hxi).  Inverting it avoids the Rot3::Logmap singularity at ||theta|| = pi
+  // that the old numerical-perturbation approach inherited.
+  if (xi.norm() < kSmallAngleThreshold) return Jacobian::Identity();
+  return ExpmapDerivative(xi).inverse();
+}
+
+//------------------------------------------------------------------------------
 Gal3::Jacobian Gal3::LogmapDerivative(const Gal3& g) {
-    // Related to the inverse of left Jacobian in Equations 31-36, Pages 10-11
-    // NOTE: Using numerical approximation instead of implementing the analytical
-    // expression for the inverse Jacobian. Future work to replace this
-    // with analytical derivative.
-    TangentVector xi = Gal3::Logmap(g);
-    if (xi.norm() < kSmallAngleThreshold) return Jacobian::Identity();
-    std::function<TangentVector(const Gal3&)> fn =
-        [](const Gal3& g_in) { return Gal3::Logmap(g_in); };
-    return numericalDerivative11<TangentVector, Gal3>(fn, g, 1e-5);
+  TangentVector xi = Gal3::Logmap(g);
+  return LogmapDerivative(xi);
 }
 
 //------------------------------------------------------------------------------

--- a/gtsam/geometry/Gal3.cpp
+++ b/gtsam/geometry/Gal3.cpp
@@ -419,11 +419,36 @@ Gal3::Jacobian Gal3::LogmapDerivative(const TangentVector& xi) {
   //   => dLogmap/dg |_{g=Expmap(xi)} * dExpmap/dxi = I
   //   => LogmapDerivative(xi) = ExpmapDerivative(xi)^{-1}
   //
-  // ExpmapDerivative is already analytical (computed inside Gal3::Expmap as
-  // Hxi).  Inverting it avoids the Rot3::Logmap singularity at ||theta|| = pi
-  // that the old numerical-perturbation approach inherited.
+  // Use the known SO(3) top-left block analytically and treat the remaining
+  // 7x7 block of ExpmapDerivative as opaque. Since the Jacobian is block lower
+  // triangular,
+  //
+  //   J = [Jr  0]
+  //       [L   B]
+  //
+  // with Jr the SO(3) right Jacobian, we can invert it as
+  //
+  //   J^{-1} = [Jr^{-1}                  0]
+  //            [-B^{-1} L Jr^{-1}   B^{-1}]
+  //
+  // This avoids a dense 10x10 inverse while preserving the exact SO(3) block.
   if (xi.norm() < kSmallAngleThreshold) return Jacobian::Identity();
-  return ExpmapDerivative(xi).inverse();
+
+  const Vector3 w = xi_w(xi);
+  const so3::DexpFunctor local(w);
+  const Matrix3 Jr_inv = local.InvJacobian().right();
+
+  const Jacobian J = ExpmapDerivative(xi);  
+  const auto L = J.block<7, 3>(3, 0);
+  const Matrix7 B = J.block<7, 7>(3, 3);
+
+  Eigen::PartialPivLU<Matrix7> lu(B);
+
+  Jacobian H = Jacobian::Zero();
+  H.block<3, 3>(0, 0) = Jr_inv;
+  H.block<7, 7>(3, 3) = lu.solve(Matrix7::Identity());
+  H.block<7, 3>(3, 0) = -lu.solve(L * Jr_inv);
+  return H;
 }
 
 //------------------------------------------------------------------------------

--- a/gtsam/geometry/Gal3.h
+++ b/gtsam/geometry/Gal3.h
@@ -197,6 +197,9 @@ class GTSAM_EXPORT Gal3 : public MatrixLieGroup<Gal3, 10, 5> {
   /// Derivative of Logmap(g) w.r.t. g
   static Jacobian LogmapDerivative(const Gal3& g);
 
+  /// Derivative of Logmap(g), tangent version
+  static Jacobian LogmapDerivative(const TangentVector& xi);
+
   /// Chart at origin, uses Expmap/Logmap for Retract/Local
   struct ChartAtOrigin {
     static Gal3 Retract(const TangentVector& xi, ChartJacobian Hxi = {});

--- a/gtsam/geometry/Pose3.cpp
+++ b/gtsam/geometry/Pose3.cpp
@@ -93,6 +93,9 @@ Pose3 Pose3::interpolateRt(const Pose3& T, double t,
 }
 
 /* ************************************************************************* */
+// Expmap is implemented in so3::ExpmapFunctor::expmap, based on Ethan Eade's
+// elegant Lie group document, at https://www.ethaneade.org/lie.pdf.
+// See also [this document](doc/Jacobians.md)
 Pose3 Pose3::Expmap(const Vector6& xi, OptionalJacobian<6, 6> Hxi) {
   // Get angular velocity omega and translational velocity v from twist xi
   const Vector3 w = xi.head<3>(), v = xi.tail<3>();
@@ -108,6 +111,14 @@ Pose3 Pose3::Expmap(const Vector6& xi, OptionalJacobian<6, 6> Hxi) {
 #endif
 
   // The translation t = local.Jacobian().left() * v.
+  // Here we call local.Jacobian().applyLeft, which is faster if you don't need
+  // Jacobians, and returns Jacobian of t with respect to w if asked.
+  // NOTE(Frank): this does the same as the intuitive formulas:
+  //   t_parallel = w * w.dot(v);  // translation parallel to axis
+  //   w_cross_v = w.cross(v);     // translation orthogonal to axis
+  //   t = (w_cross_v - Rot3::Expmap(w) * w_cross_v + t_parallel) / theta2;
+  // but Local does not need R, deals automatically with the case where theta2
+  // is near zero, and also gives us the machinery for the Jacobians.
   Matrix3 H;
   const Vector3 t = local.Jacobian().applyLeft(v, Hxi ? &H : nullptr);
 

--- a/gtsam/geometry/Quaternion.h
+++ b/gtsam/geometry/Quaternion.h
@@ -46,6 +46,7 @@ struct traits<QUATERNION_TYPE> {
   /// @name Basic manifold traits
   /// @{
   inline constexpr static auto dimension = 3;
+  static int GetDimension(const Q& /* g */) { return 3; }
   typedef OptionalJacobian<3, 3> ChartJacobian;
   typedef Eigen::Matrix<_Scalar, 3, 1, _Options, 3, 1> TangentVector;
 

--- a/gtsam/geometry/SO3.cpp
+++ b/gtsam/geometry/SO3.cpp
@@ -110,8 +110,6 @@ ExpmapFunctor::ExpmapFunctor(const Vector3& axis, double angle)
 }
 
 
-Matrix3 ExpmapFunctor::expmap() const { return I_3x3 + A * W + B * WW; }
-
 DexpFunctor::DexpFunctor(const Vector3& omega, double nearZeroThresholdSq, double nearPiThresholdSq)
   : ExpmapFunctor(nearZeroThresholdSq, omega), omega(omega) {
   // General case or nearPi: Use standard stable formulas first

--- a/gtsam/geometry/SO3.h
+++ b/gtsam/geometry/SO3.h
@@ -143,7 +143,7 @@ struct GTSAM_EXPORT ExpmapFunctor {
 
   // Ethan Eade's constants:
   double A;  // A = sin(theta) / theta
-  double B;  // B = (1 - cos(theta))
+  double B;  // B = (1 - cos(theta)) / theta^2
 
   /// Constructor with element of Lie algebra so(3)
   explicit ExpmapFunctor(const Vector3& omega);
@@ -155,7 +155,7 @@ struct GTSAM_EXPORT ExpmapFunctor {
   ExpmapFunctor(const Vector3& axis, double angle);
 
   /// Rodrigues formula
-  Matrix3 expmap() const;
+  Matrix3 expmap() const { return I_3x3 + A * W + B * WW; }
 
 protected:
   void init(double nearZeroThresholdSq);

--- a/gtsam/geometry/SO3.h
+++ b/gtsam/geometry/SO3.h
@@ -155,7 +155,7 @@ struct GTSAM_EXPORT ExpmapFunctor {
   ExpmapFunctor(const Vector3& axis, double angle);
 
   /// Rodrigues formula
-  Matrix3 expmap() const { return I_3x3 + A * W + B * WW; }
+  inline Matrix3 expmap() const { return I_3x3 + A * W + B * WW; }
 
 protected:
   void init(double nearZeroThresholdSq);

--- a/gtsam/geometry/geometry.i
+++ b/gtsam/geometry/geometry.i
@@ -241,7 +241,7 @@ namespace so3 {
   };
 
   virtual class DexpFunctor : gtsam::so3::ExpmapFunctor {
-    gtsam::Vector3 omega;
+    const gtsam::Vector3 omega;
 
     DexpFunctor(const gtsam::Vector3& omega);
     DexpFunctor(const gtsam::Vector3& omega, double nearZeroThresholdSq, double nearPiThresholdSq);
@@ -1074,6 +1074,7 @@ class Similarity2 {
   // Standard Interface
   bool equals(const gtsam::Similarity2& sim, double tol) const;
   void print(string s = "") const;
+  gtsam::Matrix matrix() const;
   gtsam::Rot2& rotation();
   gtsam::Point2& translation();
   double scale() const;
@@ -1130,6 +1131,7 @@ class Similarity3 {
   // Standard Interface
   bool equals(const gtsam::Similarity3& sim, double tol) const;
   void print(string s = "") const;
+  gtsam::Matrix matrix() const;
   gtsam::Rot3& rotation();
   gtsam::Point3& translation();
   double scale() const;

--- a/gtsam/geometry/tests/testCalibratedCamera.cpp
+++ b/gtsam/geometry/tests/testCalibratedCamera.cpp
@@ -53,8 +53,7 @@ TEST(CalibratedCamera, Create) {
   EXPECT(assert_equal(camera, CalibratedCamera::Create(kDefaultPose, actualH)));
 
   // Check derivative
-  std::function<CalibratedCamera(Pose3)> f =  //
-      std::bind(CalibratedCamera::Create, std::placeholders::_1, nullptr);
+  auto f = std::bind(CalibratedCamera::Create, std::placeholders::_1, nullptr);
   Matrix numericalH = numericalDerivative11<CalibratedCamera, Pose3>(f, kDefaultPose);
   EXPECT(assert_equal(numericalH, actualH, 1e-9));
 }

--- a/gtsam/geometry/tests/testEssentialMatrix.cpp
+++ b/gtsam/geometry/tests/testEssentialMatrix.cpp
@@ -41,7 +41,7 @@ TEST(EssentialMatrix, FromRotationAndDirection) {
       1e-8));
 
   {
-    std::function<EssentialMatrix(const Rot3&)> fn = [](const Rot3& R) {
+    auto fn = [](const Rot3& R) {
       return EssentialMatrix::FromRotationAndDirection(R, trueDirection);
     };
     Matrix expectedH1 = numericalDerivative11<EssentialMatrix, Rot3>(fn, trueRotation);
@@ -49,7 +49,7 @@ TEST(EssentialMatrix, FromRotationAndDirection) {
   }
 
   {
-    std::function<EssentialMatrix(const Unit3&)> fn = [](const Unit3& t) {
+    auto fn = [](const Unit3& t) {
       return EssentialMatrix::FromRotationAndDirection(trueRotation, t);
     };
     Matrix expectedH2 = numericalDerivative11<EssentialMatrix, Unit3>(fn, trueDirection);
@@ -178,7 +178,7 @@ TEST (EssentialMatrix, FromPose3_a) {
   Matrix actualH;
   Pose3 pose(trueRotation, trueTranslation); // Pose between two cameras
   EXPECT(assert_equal(trueE, EssentialMatrix::FromPose3(pose, actualH), 1e-8));
-  std::function<EssentialMatrix(const Pose3&)> fn = [](const Pose3& pose) {
+  auto fn = [](const Pose3& pose) {
     return EssentialMatrix::FromPose3(pose);
   };
   Matrix expectedH = numericalDerivative11<EssentialMatrix, Pose3>(fn, pose);
@@ -193,7 +193,7 @@ TEST (EssentialMatrix, FromPose3_b) {
   EssentialMatrix E(c1Rc2, Unit3(c1Tc2));
   Pose3 pose(c1Rc2, c1Tc2); // Pose between two cameras
   EXPECT(assert_equal(E, EssentialMatrix::FromPose3(pose, actualH), 1e-8));
-  std::function<EssentialMatrix(const Pose3&)> fn = [](const Pose3& pose) {
+  auto fn = [](const Pose3& pose) {
     return EssentialMatrix::FromPose3(pose);
   };
   Matrix expectedH = numericalDerivative11<EssentialMatrix, Pose3>(fn, pose);

--- a/gtsam/geometry/tests/testExtendedPose3.cpp
+++ b/gtsam/geometry/tests/testExtendedPose3.cpp
@@ -171,10 +171,9 @@ TEST(ExtendedPose3, AdjointTranspose) {
   EXPECT(assert_equal(d.AdjointMap().transpose() * x_dynamic,
                       d.AdjointTranspose(x_dynamic)));
 
-  std::function<Vector12(const ExtendedPose33&, const Vector12&)>
-      f_adjoint_transpose = [](const ExtendedPose33& g, const Vector12& v) {
-        return Vector12(g.AdjointTranspose(v));
-      };
+  auto f_adjoint_transpose = [](const ExtendedPose33& g, const Vector12& v) {
+    return Vector12(g.AdjointTranspose(v));
+  };
   Matrix Hf_state, Hf_x;
   f.AdjointTranspose(x, Hf_state, Hf_x);
   EXPECT(assert_equal(numericalDerivative21(f_adjoint_transpose, f, x), Hf_state,
@@ -182,10 +181,9 @@ TEST(ExtendedPose3, AdjointTranspose) {
   EXPECT(
       assert_equal(numericalDerivative22(f_adjoint_transpose, f, x), Hf_x));
 
-  std::function<Vector(const ExtendedPose3d&, const Vector&)>
-      d_adjoint_transpose = [](const ExtendedPose3d& g, const Vector& v) {
-        return g.AdjointTranspose(v);
-      };
+  auto d_adjoint_transpose = [](const ExtendedPose3d& g, const Vector& v) {
+    return g.AdjointTranspose(v);
+  };
   Matrix Hd_state, Hd_x;
   d.AdjointTranspose(x_dynamic, Hd_state, Hd_x);
   EXPECT(assert_equal(
@@ -214,10 +212,9 @@ TEST(ExtendedPose3, adjointTranspose) {
                           y_dynamic,
                       ExtendedPose3d::adjointTranspose(xi_dynamic, y_dynamic)));
 
-  std::function<Vector12(const Vector12&, const Vector12&)>
-      f_adjoint_transpose = [](const Vector12& x, const Vector12& v) {
-        return Vector12(ExtendedPose33::adjointTranspose(x, v));
-      };
+  auto f_adjoint_transpose = [](const Vector12& x, const Vector12& v) {
+    return Vector12(ExtendedPose33::adjointTranspose(x, v));
+  };
   Matrix Hf_xi, Hf_y;
   EXPECT(assert_equal(Vector(ExtendedPose33::adjointTranspose(xi, y, Hf_xi, Hf_y)),
                       Vector(f_adjoint_transpose(xi, y))));
@@ -228,10 +225,9 @@ TEST(ExtendedPose3, adjointTranspose) {
       assert_equal(numericalDerivative22(f_adjoint_transpose, xi, y, 1e-5), Hf_y,
                    1e-5));
 
-  std::function<Vector(const Vector&, const Vector&)> d_adjoint_transpose =
-      [](const Vector& x, const Vector& v) {
-        return ExtendedPose3d::adjointTranspose(x, v);
-      };
+  auto d_adjoint_transpose = [](const Vector& x, const Vector& v) {
+    return ExtendedPose3d::adjointTranspose(x, v);
+  };
   Matrix Hd_xi, Hd_y;
   EXPECT(assert_equal(ExtendedPose3d::adjointTranspose(xi_dynamic, y_dynamic,
                                                        Hd_xi, Hd_y),

--- a/gtsam/geometry/tests/testGal3.cpp
+++ b/gtsam/geometry/tests/testGal3.cpp
@@ -657,6 +657,21 @@ TEST(Gal3, Jacobian_Logmap) {
 }
 
 /* ************************************************************************* */
+TEST(Gal3, LogmapDerivativeInverseConsistency) {
+  Vector10 xi =
+      (Vector10() << 0.3, -0.2, 0.1, 0.5, -0.4, 0.2, -0.3, 0.2, -0.1, 0.05)
+          .finished();
+
+  Gal3::Jacobian Jexp, Jlog;
+
+  Gal3::Expmap(xi, Jexp);
+  Jlog = Gal3::LogmapDerivative(xi);
+
+  Matrix I = Jlog * Jexp;
+  EXPECT(assert_equal(Matrix::Identity(10, 10), I, 1e-6));
+}
+
+/* ************************************************************************* */
 TEST(Gal3, Jacobian_Expmap) {
     // Test data
     Vector10 xi = (Vector10() <<

--- a/gtsam/geometry/tests/testGal3.cpp
+++ b/gtsam/geometry/tests/testGal3.cpp
@@ -93,7 +93,7 @@ TEST(Gal3, RetractJacobians) {
   Matrix actualH1, actualH2;
   traits<Gal3>::Retract(g, v, &actualH1, &actualH2);
 
-  std::function<Gal3(const Gal3&, const Vector10&)> retract_proxy =
+  auto retract_proxy =
       [](const Gal3& g_, const Vector10& v_) { return g_.retract(v_); };
   Matrix expectedH1 =
       numericalDerivative21<Gal3, Gal3, Vector10>(retract_proxy, g, v);
@@ -272,7 +272,7 @@ TEST(Gal3, ExpmapZero) {
     EXPECT(assert_equal(expected, custom_exp_1, kTol));
 
     // Check Jacobian
-    std::function<Gal3(const Vector10&)> f = [](const Vector10& v){ return Gal3::Expmap(v); };
+    auto f = [](const Vector10& v){ return Gal3::Expmap(v); };
     Matrix expectedH = numericalDerivative11(f, xi);
     EXPECT(assert_equal(expectedH, aH, 1e-6));
 }
@@ -288,7 +288,7 @@ TEST(Gal3, ExpmapBoost) {
     EXPECT(assert_equal(expected, custom_exp_1, kTol));
 
     // Check Jacobian
-    std::function<Gal3(const Vector10&)> f = [](const Vector10& v){ return Gal3::Expmap(v); };
+    auto f = [](const Vector10& v){ return Gal3::Expmap(v); };
     Matrix expectedH = numericalDerivative11(f, xi);
     EXPECT(assert_equal(expectedH, aH, 1e-6));
 }
@@ -317,7 +317,7 @@ TEST(Gal3, Expmap) {
     // Check derivatives
     Gal3::Jacobian aH;
     Gal3::Expmap(xi, aH);
-    std::function<Gal3(const Vector10&)> f = [](const Vector10& v){ return Gal3::Expmap(v); };
+    auto f = [](const Vector10& v){ return Gal3::Expmap(v); };
     Matrix expectedH = numericalDerivative11(f, xi);
     EXPECT(assert_equal(expectedH, aH, 1e-6));
 }
@@ -624,8 +624,7 @@ TEST(Gal3, Jacobian_Logmap) {
     EXPECT(assert_equal(expected_log_tau1, log1_gtsam, kTol));
 
     // Verify Jacobian against numerical derivative
-    std::function<Vector10(const Gal3&)> logmap_func1 =
-        [](const Gal3& g_in) { return Gal3::Logmap(g_in); };
+    auto logmap_func1 = [](const Gal3& g_in) { return Gal3::Logmap(g_in); };
     Matrix H_numerical1 = numericalDerivative11<Vector10, Gal3>(logmap_func1, g1, jac_tol);
     EXPECT(assert_equal(H_numerical1, Hg1_gtsam, jac_tol));
 
@@ -652,8 +651,7 @@ TEST(Gal3, Jacobian_Logmap) {
     EXPECT(assert_equal(expected_log_tau2, log2_gtsam, kTol));
 
     // Verify Jacobian against numerical derivative
-    std::function<Vector10(const Gal3&)> logmap_func2 =
-        [](const Gal3& g_in) { return Gal3::Logmap(g_in); };
+    auto logmap_func2 = [](const Gal3& g_in) { return Gal3::Logmap(g_in); };
     Matrix H_numerical2 = numericalDerivative11<Vector10, Gal3>(logmap_func2, g2, jac_tol);
     EXPECT(assert_equal(H_numerical2, Hg2_gtsam, jac_tol));
 }
@@ -672,7 +670,7 @@ TEST(Gal3, Jacobian_Expmap) {
     Gal3::Expmap(xi, aH);
 
     // Check derivatives
-    std::function<Gal3(const Vector10&)> f = [](const Vector10& v){ return Gal3::Expmap(v); };
+    auto f = [](const Vector10& v){ return Gal3::Expmap(v); };
     Matrix expectedH = numericalDerivative11(f, xi);
     EXPECT(assert_equal(expectedH, aH, 1e-6));
 }
@@ -704,8 +702,7 @@ TEST(Gal3, Jacobian_Between) {
     Gal3::Jacobian H1_analytical, H2_analytical;
     g1.between(g2, H1_analytical, H2_analytical);
 
-    std::function<Gal3(const Gal3&, const Gal3&)> between_func =
-        [](const Gal3& g1_in, const Gal3& g2_in) { return g1_in.between(g2_in); };
+    auto between_func = [](const Gal3& g1_in, const Gal3& g2_in) { return g1_in.between(g2_in); };
 
     // Verify H1
     Matrix H1_numerical = numericalDerivative21(between_func, g1, g2, 1e-6);
@@ -736,10 +733,9 @@ TEST(Gal3, Jacobian_AdjointMap) {
     Gal3::Jacobian Ad_analytical = g.AdjointMap();
 
     // Numerical derivative of Adjoint action Ad_g(xi) w.r.t xi should equal Adjoint Map
-    std::function<Vector10(const Gal3&, const Vector10&)> adjoint_action =
-        [](const Gal3& g_in, const Vector10& xi_in) {
-            return g_in.Adjoint(xi_in);
-        };
+    auto adjoint_action = [](const Gal3& g_in, const Vector10& xi_in) {
+      return g_in.Adjoint(xi_in);
+    };
     Matrix H_xi_numerical = numericalDerivative22(adjoint_action, g, xi);
     EXPECT(assert_equal(Ad_analytical, H_xi_numerical, 1e-7)); // Tolerance for numerical diff
 
@@ -748,10 +744,10 @@ TEST(Gal3, Jacobian_AdjointMap) {
     g.Adjoint(xi, H_g_analytical); // Calculate analytical H_g
 
     // Need wrapper that only returns value for numericalDerivative21
-    std::function<Vector10(const Gal3&, const Vector10&)> adjoint_action_wrt_g_val =
-      [](const Gal3& g_in, const Vector10& xi_in) {
-        return g_in.Adjoint(xi_in); // Return only value
-      };
+    auto adjoint_action_wrt_g_val = [](const Gal3& g_in,
+                                       const Vector10& xi_in) {
+      return g_in.Adjoint(xi_in);  // Return only value
+    };
     Matrix H_g_numerical = numericalDerivative21(adjoint_action_wrt_g_val, g, xi);
     EXPECT(assert_equal(H_g_analytical, H_g_numerical, 1e-7));
 }
@@ -785,24 +781,28 @@ TEST(Gal3, Act) {
     EXPECT_DOUBLES_EQUAL(expected_t_out1, e_out1_gtsam.time(), kTol);
 
     // Verify H1g: Derivative of output Event wrt Gal3 g1
-    std::function<Point3(const Gal3&, const Event&)> act_func1_loc_wrt_g =
-        [](const Gal3& g_in, const Event& e_in) { return g_in.act(e_in).location(); };
+    auto act_func1_loc_wrt_g = [](const Gal3& g_in, const Event& e_in) {
+      return g_in.act(e_in).location();
+    };
     Matrix H1g_loc_numerical = numericalDerivative21<Point3, Gal3, Event>(act_func1_loc_wrt_g, g1, e_in1, jac_tol);
     EXPECT(assert_equal(H1g_loc_numerical, H1g_gtsam.block<3, 10>(1, 0), jac_tol));
 
-    std::function<double(const Gal3&, const Event&)> act_func1_time_wrt_g =
-        [](const Gal3& g_in, const Event& e_in) { return g_in.act(e_in).time(); };
+    auto act_func1_time_wrt_g = [](const Gal3& g_in, const Event& e_in) {
+      return g_in.act(e_in).time();
+    };
     Matrix H1g_time_numerical = numericalDerivative21<double, Gal3, Event>(act_func1_time_wrt_g, g1, e_in1, jac_tol);
     EXPECT(assert_equal(H1g_time_numerical, H1g_gtsam.row(0), jac_tol));
 
     // Verify H1e: Derivative of output Event wrt Event e1
-    std::function<Point3(const Gal3&, const Event&)> act_func1_loc_wrt_e =
-        [](const Gal3& g_in, const Event& e_in) { return g_in.act(e_in).location(); };
+    auto act_func1_loc_wrt_e = [](const Gal3& g_in, const Event& e_in) {
+      return g_in.act(e_in).location();
+    };
     Matrix H1e_loc_numerical = numericalDerivative22<Point3, Gal3, Event>(act_func1_loc_wrt_e, g1, e_in1, jac_tol);
     EXPECT(assert_equal(H1e_loc_numerical, H1e_gtsam.block<3, 4>(1, 0), jac_tol));
 
-    std::function<double(const Gal3&, const Event&)> act_func1_time_wrt_e =
-        [](const Gal3& g_in, const Event& e_in) { return g_in.act(e_in).time(); };
+    auto act_func1_time_wrt_e = [](const Gal3& g_in, const Event& e_in) {
+      return g_in.act(e_in).time();
+    };
     Matrix H1e_time_numerical = numericalDerivative22<double, Gal3, Event>(act_func1_time_wrt_e, g1, e_in1, jac_tol);
     EXPECT(assert_equal(H1e_time_numerical, H1e_gtsam.row(0), jac_tol));
 
@@ -830,24 +830,28 @@ TEST(Gal3, Act) {
     EXPECT_DOUBLES_EQUAL(expected_t_out2, e_out2_gtsam.time(), kTol);
 
     // Verify H2g: Derivative of output Event wrt Gal3 g2
-    std::function<Point3(const Gal3&, const Event&)> act_func2_loc_wrt_g =
-        [](const Gal3& g_in, const Event& e_in) { return g_in.act(e_in).location(); };
+    auto act_func2_loc_wrt_g = [](const Gal3& g_in, const Event& e_in) {
+      return g_in.act(e_in).location();
+    };
     Matrix H2g_loc_numerical = numericalDerivative21(act_func2_loc_wrt_g, g2, e_in2, jac_tol);
     EXPECT(assert_equal(H2g_loc_numerical, H2g_gtsam.block<3, 10>(1, 0), jac_tol));
 
-    std::function<double(const Gal3&, const Event&)> act_func2_time_wrt_g =
-        [](const Gal3& g_in, const Event& e_in) { return g_in.act(e_in).time(); };
+    auto act_func2_time_wrt_g = [](const Gal3& g_in, const Event& e_in) {
+      return g_in.act(e_in).time();
+    };
     Matrix H2g_time_numerical = numericalDerivative21(act_func2_time_wrt_g, g2, e_in2, jac_tol);
     EXPECT(assert_equal(H2g_time_numerical, H2g_gtsam.row(0), jac_tol));
 
     // Verify H2e: Derivative of output Event wrt Event e2
-    std::function<Point3(const Gal3&, const Event&)> act_func2_loc_wrt_e =
-        [](const Gal3& g_in, const Event& e_in) { return g_in.act(e_in).location(); };
+    auto act_func2_loc_wrt_e = [](const Gal3& g_in, const Event& e_in) {
+      return g_in.act(e_in).location();
+    };
     Matrix H2e_loc_numerical = numericalDerivative22(act_func2_loc_wrt_e, g2, e_in2, jac_tol);
     EXPECT(assert_equal(H2e_loc_numerical, H2e_gtsam.block<3, 4>(1, 0), jac_tol));
 
-    std::function<double(const Gal3&, const Event&)> act_func2_time_wrt_e =
-        [](const Gal3& g_in, const Event& e_in) { return g_in.act(e_in).time(); };
+    auto act_func2_time_wrt_e = [](const Gal3& g_in, const Event& e_in) {
+      return g_in.act(e_in).time();
+    };
     Matrix H2e_time_numerical = numericalDerivative22(act_func2_time_wrt_e, g2, e_in2, jac_tol);
     EXPECT(assert_equal(H2e_time_numerical, H2e_gtsam.row(0), jac_tol));
 }
@@ -917,10 +921,8 @@ TEST(Gal3, Jacobian_StaticConstructors) {
     Matrix H1_ana, H2_ana, H3_ana, H4_ana;
     Gal3::Create(kTestRot, kTestPos, kTestVel, kTestTime, H1_ana, H2_ana, H3_ana, H4_ana);
 
-    std::function<Gal3(const Rot3&, const Point3&, const Velocity3&, const double&)> create_func =
-        [](const Rot3& R, const Point3& r, const Velocity3& v, const double& t){
-            return Gal3::Create(R, r, v, t); // Call without Jacobians for numerical diff
-        };
+    auto create_func = [](const Rot3& R, const Point3& r, const Velocity3& v,
+                          const double& t) { return Gal3::Create(R, r, v, t); };
 
     const double& time_ref = kTestTime; // Needed for lambda capture if using C++11/14
     Matrix H1_num = numericalDerivative41(create_func, kTestRot, kTestPos, kTestVel, time_ref, jac_tol);
@@ -937,10 +939,10 @@ TEST(Gal3, Jacobian_StaticConstructors) {
     Matrix Hpv1_ana, Hpv2_ana, Hpv3_ana;
     Gal3::FromPoseVelocityTime(kTestPose, kTestVel, kTestTime, Hpv1_ana, Hpv2_ana, Hpv3_ana);
 
-    std::function<Gal3(const Pose3&, const Velocity3&, const double&)> fromPoseVelTime_func =
-        [](const Pose3& pose, const Velocity3& v, const double& t){
-            return Gal3::FromPoseVelocityTime(pose, v, t); // Call without Jacobians
-        };
+    auto fromPoseVelTime_func = [](const Pose3& pose, const Velocity3& v,
+                                   const double& t) {
+      return Gal3::FromPoseVelocityTime(pose, v, t);
+    };
 
     Matrix Hpv1_num = numericalDerivative31(fromPoseVelTime_func, kTestPose, kTestVel, time_ref, jac_tol);
     Matrix Hpv2_num = numericalDerivative32(fromPoseVelTime_func, kTestPose, kTestVel, time_ref, jac_tol);
@@ -960,32 +962,28 @@ TEST(Gal3, Jacobian_Accessors) {
     // Test rotation() / attitude() Jacobian
     Matrix Hrot_ana;
     kTestGal3.rotation(Hrot_ana);
-    std::function<Rot3(const Gal3&)> rot_func =
-        [](const Gal3& g) { return g.rotation(); };
+    auto rot_func = [](const Gal3& g) { return g.rotation(); };
     Matrix Hrot_num = numericalDerivative11(rot_func, kTestGal3, jac_tol);
     EXPECT(assert_equal(Hrot_num, Hrot_ana, jac_tol));
 
     // Test translation() / position() Jacobian
     Matrix Hpos_ana;
     kTestGal3.translation(Hpos_ana);
-    std::function<Point3(const Gal3&)> pos_func =
-        [](const Gal3& g) { return g.translation(); };
+    auto pos_func = [](const Gal3& g) { return g.translation(); };
     Matrix Hpos_num = numericalDerivative11(pos_func, kTestGal3, jac_tol);
     EXPECT(assert_equal(Hpos_num, Hpos_ana, jac_tol));
 
     // Test velocity() Jacobian
     Matrix Hvel_ana;
     kTestGal3.velocity(Hvel_ana);
-    std::function<Velocity3(const Gal3&)> vel_func =
-        [](const Gal3& g) { return g.velocity(); };
+    auto vel_func = [](const Gal3& g) { return g.velocity(); };
     Matrix Hvel_num = numericalDerivative11(vel_func, kTestGal3, jac_tol);
     EXPECT(assert_equal(Hvel_num, Hvel_ana, jac_tol));
 
     // Test time() Jacobian
     Matrix Htime_ana;
     kTestGal3.time(Htime_ana);
-    std::function<double(const Gal3&)> time_func =
-        [](const Gal3& g) { return g.time(); };
+    auto time_func = [](const Gal3& g) { return g.time(); };
     Matrix Htime_num = numericalDerivative11(time_func, kTestGal3, jac_tol);
     EXPECT(assert_equal(Htime_num, Htime_ana, jac_tol));
 }
@@ -1004,10 +1002,10 @@ TEST(Gal3, Jacobian_Interpolate) {
     Matrix H1_ana, H2_ana, Ha_ana;
     interpolate(g1, g2, alpha, H1_ana, H2_ana, Ha_ana);
 
-    std::function<Gal3(const Gal3&, const Gal3&, const double&)> interp_func =
-        [](const Gal3& g1_in, const Gal3& g2_in, const double& a){
-            return interpolate(g1_in, g2_in, a); // Call without Jacobians
-        };
+    auto interp_func = [](const Gal3& g1_in, const Gal3& g2_in,
+                          const double& a) {
+      return interpolate(g1_in, g2_in, a);  // Call without Jacobians
+    };
 
     const double& alpha_ref = alpha; // Needed for lambda capture if using C++11/14
     Matrix H1_num = numericalDerivative31(interp_func, g1, g2, alpha_ref, jac_tol);
@@ -1034,10 +1032,9 @@ TEST(Gal3, StaticAdjoint) {
     EXPECT(assert_equal(ad_xi_map_times_y, ad_xi_y_direct, kTol)); // Check ad(xi)*y == [xi,y]
 
     // Verify d(adjoint(xi,y))/dy == adjointMap(xi) numerically
-    std::function<Vector10(const Vector10&, const Vector10&)> static_adjoint_func =
-        [](const Vector10& xi_in, const Vector10& y_in){
-            return Gal3::adjoint(xi_in, y_in); // Call without Jacobians
-        };
+    auto static_adjoint_func = [](const Vector10& xi_in, const Vector10& y_in) {
+      return Gal3::adjoint(xi_in, y_in);
+    };
     Matrix Hy_num = numericalDerivative22(static_adjoint_func, xi, y, jac_tol);
     EXPECT(assert_equal(ad_xi_map, Hy_num, jac_tol));
 
@@ -1115,10 +1112,8 @@ TEST(Gal3, Vec) {
     // 2. Test the Jacobian
     Eigen::Matrix<double, 25, 10> H_actual;
     gal3.vec(H_actual);
-    auto vec_fun = [](const Gal3& g) -> Vector25 {
-        return g.vec();
-        };
-    Matrix H_numerical = numericalDerivative11<Vector25, Gal3, 10>(vec_fun, gal3);
+    auto f = [](const Gal3& g) -> Vector25 { return g.vec(); };
+    Matrix H_numerical = numericalDerivative11(f, gal3);
     EXPECT(assert_equal(H_numerical, H_actual, 1e-7));
 }
 

--- a/gtsam/geometry/tests/testOrientedPlane3.cpp
+++ b/gtsam/geometry/tests/testOrientedPlane3.cpp
@@ -133,10 +133,9 @@ TEST(OrientedPlane3, errorVector) {
                       Vector2(actual[0], actual[1])));
   EXPECT(assert_equal(plane1.distance() - plane2.distance(), actual[2]));
 
-  std::function<Vector3(const OrientedPlane3&, const OrientedPlane3&)> f =
-    [](const OrientedPlane3& p1, const OrientedPlane3& p2) {
-      return p1.errorVector(p2);
-    };
+  auto f = [](const OrientedPlane3& p1, const OrientedPlane3& p2) {
+    return p1.errorVector(p2);
+  };
   expectedH1 = numericalDerivative21(f, plane1, plane2);
   expectedH2 = numericalDerivative22(f, plane1, plane2);
   EXPECT(assert_equal(expectedH1, actualH1, 1e-5));
@@ -147,9 +146,7 @@ TEST(OrientedPlane3, errorVector) {
 TEST(OrientedPlane3, jacobian_retract) {
   OrientedPlane3 plane(-1, 0.1, 0.2, 5);
   Matrix33 H_actual;
-  std::function<OrientedPlane3(const Vector3&)> f = [&plane](const Vector3& v) {
-    return plane.retract(v);
-  };
+  auto f = [&plane](const Vector3& v) { return plane.retract(v); };
 
   {
       Vector3 v(-0.1, 0.2, 0.3);
@@ -170,9 +167,7 @@ TEST(OrientedPlane3, jacobian_normal) {
   Matrix23 H_actual, H_expected;
   OrientedPlane3 plane(-1, 0.1, 0.2, 5);
 
-  std::function<Unit3(const OrientedPlane3&)> f = [](const OrientedPlane3& p) {
-    return p.normal();
-  };
+  auto f = [](const OrientedPlane3& p) { return p.normal(); };
 
   H_expected = numericalDerivative11(f, plane);
   plane.normal(H_actual);
@@ -184,9 +179,7 @@ TEST(OrientedPlane3, jacobian_distance) {
   Matrix13 H_actual, H_expected;
   OrientedPlane3 plane(-1, 0.1, 0.2, 5);
 
-  std::function<double(const OrientedPlane3&)> f = [](const OrientedPlane3& p) {
-    return p.distance();
-  };
+  auto f = [](const OrientedPlane3& p) { return p.distance(); };
 
   H_expected = numericalDerivative11(f, plane);
   plane.distance(H_actual);

--- a/gtsam/geometry/tests/testPinholeCamera.cpp
+++ b/gtsam/geometry/tests/testPinholeCamera.cpp
@@ -65,9 +65,8 @@ TEST(PinholeCamera, Create) {
   EXPECT(assert_equal(camera, Camera::Create(pose,K, actualH1, actualH2)));
 
   // Check derivative
-  std::function<Camera(Pose3, Cal3_S2)> f =  //
-      std::bind(Camera::Create, std::placeholders::_1, std::placeholders::_2,
-                nullptr, nullptr);
+  auto f = std::bind(Camera::Create, std::placeholders::_1,
+                     std::placeholders::_2, nullptr, nullptr);
   Matrix numericalH1 = numericalDerivative21<Camera,Pose3,Cal3_S2>(f,pose,K);
   EXPECT(assert_equal(numericalH1, actualH1, 1e-9));
   Matrix numericalH2 = numericalDerivative22<Camera,Pose3,Cal3_S2>(f,pose,K);
@@ -81,8 +80,7 @@ TEST(PinholeCamera, Pose) {
   EXPECT(assert_equal(pose, camera.getPose(actualH)));
 
   // Check derivative
-  std::function<Pose3(Camera)> f =  //
-      std::bind(&Camera::getPose, std::placeholders::_1, nullptr);
+  auto f = std::bind(&Camera::getPose, std::placeholders::_1, nullptr);
   Matrix numericalH = numericalDerivative11<Pose3,Camera>(f,camera);
   EXPECT(assert_equal(numericalH, actualH, 1e-9));
 }

--- a/gtsam/geometry/tests/testPinholePose.cpp
+++ b/gtsam/geometry/tests/testPinholePose.cpp
@@ -58,15 +58,14 @@ TEST( PinholePose, constructor)
 }
 
 //******************************************************************************
-/* Already in testPinholeCamera??? 
+/* Already in testPinholeCamera???
 TEST(PinholeCamera, Pose) {
 
   Matrix actualH;
   EXPECT(assert_equal(pose, camera.getPose(actualH)));
 
   // Check derivative
-  std::function<Pose3(Camera)> f = //
-      std::bind(&Camera::getPose,_1,{});
+  auto f = std::bind(&Camera::getPose,_1,{});
   Matrix numericalH = numericalDerivative11<Pose3,Camera>(f,camera);
   EXPECT(assert_equal(numericalH, actualH, 1e-9));
 }

--- a/gtsam/geometry/tests/testPoint3.cpp
+++ b/gtsam/geometry/tests/testPoint3.cpp
@@ -100,8 +100,7 @@ TEST( Point3, dot) {
 
   // Use numerical derivatives to calculate the expected Jacobians
   Matrix H1, H2;
-  std::function<double(const Point3&, const Point3&)> f =
-      [](const Point3& p, const Point3& q) { return gtsam::dot(p, q); };
+  auto f = [](const Point3& p, const Point3& q) { return gtsam::dot(p, q); };
   {
     gtsam::dot(p, q, H1, H2);
     EXPECT(assert_equal(numericalDerivative21<double,Point3>(f, p, q), H1, 1e-9));
@@ -122,8 +121,7 @@ TEST( Point3, dot) {
 /* ************************************************************************* */
 TEST(Point3, cross) {
   Matrix aH1, aH2;
-  std::function<Point3(const Point3&, const Point3&)> f = 
-    [](const Point3& p, const Point3& q) { return gtsam::cross(p, q); };
+  auto f = [](const Point3& p, const Point3& q) { return gtsam::cross(p, q); };
   const Point3 omega(0, 1, 0), theta(4, 6, 8);
   cross(omega, theta, aH1, aH2);
   EXPECT(assert_equal(numericalDerivative21(f, omega, theta), aH1));
@@ -141,8 +139,7 @@ TEST( Point3, cross2) {
 
   // Use numerical derivatives to calculate the expected Jacobians
   Matrix H1, H2;
-  std::function<Point3(const Point3&, const Point3&)> f =
-    [](const Point3& p, const Point3& q) { return gtsam::cross(p, q); };
+  auto f = [](const Point3& p, const Point3& q) { return gtsam::cross(p, q); };
   {
     gtsam::cross(p, q, H1, H2);
     EXPECT(assert_equal(numericalDerivative21<Point3,Point3>(f, p, q), H1, 1e-9));
@@ -158,8 +155,7 @@ TEST( Point3, cross2) {
 /* ************************************************************************* */
 TEST(Point3, doubleCross) {
   Matrix aH1, aH2;
-  std::function<Point3(const Point3&, const Point3&)> f =
-      [](const Point3& p, const Point3& q) { return doubleCross(p, q); };
+  auto f = [](const Point3& p, const Point3& q) { return doubleCross(p, q); };
   const Point3 omega(1, 2, 3), theta(4, 5, 6);
   doubleCross(omega, theta, aH1, aH2);
   EXPECT(assert_equal(numericalDerivative21(f, omega, theta), aH1));
@@ -172,7 +168,7 @@ TEST (Point3, normalize) {
   Point3 point(1, -2, 3); // arbitrary point
   Point3 expected(point / sqrt(14.0));
   EXPECT(assert_equal(expected, normalize(point, actualH), 1e-8));
-  std::function<Point3(const Point3&)> fn = [](const Point3& p) { return normalize(p); };
+  auto fn = [](const Point3& p) { return normalize(p); };
   Matrix expectedH = numericalDerivative11<Point3, Point3>(fn, point);
   EXPECT(assert_equal(expectedH, actualH, 1e-8));
 }

--- a/gtsam/geometry/tests/testPose2.cpp
+++ b/gtsam/geometry/tests/testPose2.cpp
@@ -517,7 +517,7 @@ TEST( Pose2, translation )  {
   Matrix actualH;
   EXPECT(assert_equal((Vector2() << 3.5, -8.2).finished(), pose.translation(actualH), 1e-8));
 
-  std::function<Point2(const Pose2&)> f = [](const Pose2& T) { return T.translation(); };
+  auto f = [](const Pose2& T) { return T.translation(); };
   Matrix numericalH = numericalDerivative11<Point2, Pose2>(f, pose);
   EXPECT(assert_equal(numericalH, actualH, 1e-6));
 }
@@ -529,7 +529,7 @@ TEST( Pose2, rotation ) {
   Matrix actualH(4, 3);
   EXPECT(assert_equal(Rot2(4.2), pose.rotation(actualH), 1e-8));
 
-  std::function<Rot2(const Pose2&)> f = [](const Pose2& T) { return T.rotation(); };
+  auto f = [](const Pose2& T) { return T.rotation(); };
   Matrix numericalH = numericalDerivative11<Rot2, Pose2>(f, pose);
   EXPECT(assert_equal(numericalH, actualH, 1e-6));
 }
@@ -984,7 +984,7 @@ TEST(Pose2, Vec) {
   EXPECT(assert_equal(expected_vec, actual_vec));
 
   // Verify Jacobian with numerical derivatives
-  std::function<Vector9(const Pose2&)> f = [](const Pose2& p) { return p.vec(); };
+  auto f = [](const Pose2& p) { return p.vec(); };
   Matrix93 numericalH = numericalDerivative11<Vector9, Pose2>(f, pose);
   EXPECT(assert_equal(numericalH, actualH, 1e-9));
 }
@@ -1014,8 +1014,7 @@ TEST(Pose2, AdjointTranspose) {
                       Vector(pose.AdjointTranspose(xi))));
 
   Matrix33 actualH1, actualH2;
-  std::function<Vector3(const Pose2&, const Vector3&)> proxy =
-      [](const Pose2& g, const Vector3& x) {
+  auto proxy = [](const Pose2& g, const Vector3& x) {
         return Vector3(g.AdjointTranspose(x));
       };
   pose.AdjointTranspose(xi, actualH1, actualH2);
@@ -1030,8 +1029,7 @@ TEST(Pose2, adjointTranspose) {
 
   Matrix33 Hxi, Hy;
   const Vector3 actual = Pose2::adjointTranspose(xi, y, Hxi, Hy);
-  std::function<Vector3(const Vector3&, const Vector3&)> f =
-      [](const Vector3& x, const Vector3& v) {
+  auto f = [](const Vector3& x, const Vector3& v) {
         return Pose2::adjointTranspose(x, v);
       };
   EXPECT(assert_equal(f(xi, y), actual));

--- a/gtsam/geometry/tests/testPose3.cpp
+++ b/gtsam/geometry/tests/testPose3.cpp
@@ -165,24 +165,23 @@ TEST(Pose3, Adjoint_jacobians)
 
   // Check jacobians
   Matrix6 actualH1, actualH2, expectedH1, expectedH2;
-  std::function<Vector6(const Pose3&, const Vector6&)> Adjoint_proxy =
-      [&](const Pose3& T, const Vector6& xi) { return T.Adjoint(xi); };
+  auto Ad = [&](const Pose3& T, const Vector6& xi) { return T.Adjoint(xi); };
 
   T.Adjoint(xi, actualH1, actualH2);
-  expectedH1 = numericalDerivative21(Adjoint_proxy, T, xi);
-  expectedH2 = numericalDerivative22(Adjoint_proxy, T, xi);
+  expectedH1 = numericalDerivative21(Ad, T, xi);
+  expectedH2 = numericalDerivative22(Ad, T, xi);
   EXPECT(assert_equal(expectedH1, actualH1));
   EXPECT(assert_equal(expectedH2, actualH2));
 
   T2.Adjoint(xi, actualH1, actualH2);
-  expectedH1 = numericalDerivative21(Adjoint_proxy, T2, xi);
-  expectedH2 = numericalDerivative22(Adjoint_proxy, T2, xi);
+  expectedH1 = numericalDerivative21(Ad, T2, xi);
+  expectedH2 = numericalDerivative22(Ad, T2, xi);
   EXPECT(assert_equal(expectedH1, actualH1));
   EXPECT(assert_equal(expectedH2, actualH2));
 
   T3.Adjoint(xi, actualH1, actualH2);
-  expectedH1 = numericalDerivative21(Adjoint_proxy, T3, xi);
-  expectedH2 = numericalDerivative22(Adjoint_proxy, T3, xi);
+  expectedH1 = numericalDerivative21(Ad, T3, xi);
+  expectedH2 = numericalDerivative22(Ad, T3, xi);
   EXPECT(assert_equal(expectedH1, actualH1));
   EXPECT(assert_equal(expectedH2, actualH2));
 }
@@ -203,26 +202,25 @@ TEST(Pose3, AdjointTranspose)
 
   // Check jacobians
   Matrix6 actualH1, actualH2, expectedH1, expectedH2;
-  std::function<Vector6(const Pose3&, const Vector6&)> AdjointTranspose_proxy =
-      [&](const Pose3& T, const Vector6& xi) {
-        return T.AdjointTranspose(xi);
-      };
+  auto AdT = [&](const Pose3& T, const Vector6& xi) {
+    return T.AdjointTranspose(xi);
+  };
 
   T.AdjointTranspose(xi, actualH1, actualH2);
-  expectedH1 = numericalDerivative21(AdjointTranspose_proxy, T, xi);
-  expectedH2 = numericalDerivative22(AdjointTranspose_proxy, T, xi);
+  expectedH1 = numericalDerivative21(AdT, T, xi);
+  expectedH2 = numericalDerivative22(AdT, T, xi);
   EXPECT(assert_equal(expectedH1, actualH1, 1e-8));
   EXPECT(assert_equal(expectedH2, actualH2));
 
   T2.AdjointTranspose(xi, actualH1, actualH2);
-  expectedH1 = numericalDerivative21(AdjointTranspose_proxy, T2, xi);
-  expectedH2 = numericalDerivative22(AdjointTranspose_proxy, T2, xi);
+  expectedH1 = numericalDerivative21(AdT, T2, xi);
+  expectedH2 = numericalDerivative22(AdT, T2, xi);
   EXPECT(assert_equal(expectedH1, actualH1, 1e-8));
   EXPECT(assert_equal(expectedH2, actualH2));
 
   T3.AdjointTranspose(xi, actualH1, actualH2);
-  expectedH1 = numericalDerivative21(AdjointTranspose_proxy, T3, xi);
-  expectedH2 = numericalDerivative22(AdjointTranspose_proxy, T3, xi);
+  expectedH1 = numericalDerivative21(AdT, T3, xi);
+  expectedH2 = numericalDerivative22(AdT, T3, xi);
   EXPECT(assert_equal(expectedH1, actualH1, 1e-8));
   EXPECT(assert_equal(expectedH2, actualH2));
 }
@@ -316,7 +314,7 @@ TEST(Pose3, translation) {
   Matrix actualH;
   EXPECT(assert_equal(Point3(3.5, -8.2, 4.2), T.translation(actualH), 1e-8));
 
-  std::function<Point3(const Pose3&)> f = [](const Pose3& T) { return T.translation(); };
+  auto f = [](const Pose3& T) { return T.translation(); };
   Matrix numericalH = numericalDerivative11<Point3, Pose3>(f, T);
   EXPECT(assert_equal(numericalH, actualH, 1e-6));
 }
@@ -327,7 +325,7 @@ TEST(Pose3, rotation) {
   Matrix actualH;
   EXPECT(assert_equal(R, T.rotation(actualH), 1e-8));
 
-  std::function<Rot3(const Pose3&)> f = [](const Pose3& T) { return T.rotation(); };
+  auto f = [](const Pose3& T) { return T.rotation(); };
   Matrix numericalH = numericalDerivative11<Rot3, Pose3>(f, T);
   EXPECT(assert_equal(numericalH, actualH, 1e-6));
 }
@@ -424,6 +422,7 @@ TEST( Pose3, compose_inverse)
 Point3 transformFrom_(const Pose3& pose, const Point3& point) {
   return pose.transformFrom(point);
 }
+
 TEST(Pose3, Dtransform_from1_a) {
   Matrix actualDtransform_from1;
   T.transformFrom(P, actualDtransform_from1, {});
@@ -797,7 +796,7 @@ TEST(Pose3, PoseToPoseBearing) {
   EXPECT(assert_equal(Unit3(0,1,0), xl1.bearing(xl2, actualH1, actualH2), 1e-9));
 
   // Check numerical derivatives
-  std::function<Unit3(const Pose3&, const Pose3&)> f = [](const Pose3& a, const Pose3& b) { return a.bearing(b); };
+  auto f = [](const Pose3& a, const Pose3& b) { return a.bearing(b); };
   expectedH1 = numericalDerivative21(f, xl1, xl2);
   expectedH2 = numericalDerivative22(f, xl1, xl2);
   EXPECT(assert_equal(expectedH1, actualH1, 1e-5));
@@ -1412,9 +1411,7 @@ TEST(Pose3, Create) {
   Matrix63 actualH1, actualH2;
   Pose3 actual = Pose3::Create(R, P2, actualH1, actualH2);
   EXPECT(assert_equal(T, actual));
-  std::function<Pose3(Rot3, Point3)> create = [](Rot3 R, Point3 t) {
-    return Pose3::Create(R, t);
-  };
+  auto create = [](Rot3 R, Point3 t) { return Pose3::Create(R, t); };
   EXPECT(assert_equal(numericalDerivative21<Pose3,Rot3,Point3>(create, R, P2), actualH1, 1e-9));
   EXPECT(assert_equal(numericalDerivative22<Pose3,Rot3,Point3>(create, R, P2), actualH2, 1e-9));
 }
@@ -1464,7 +1461,7 @@ TEST(Pose3, Vec) {
   EXPECT(assert_equal(expected_vec, actual_vec));
 
   // Verify Jacobian with numerical derivatives
-  std::function<Vector16(const Pose3&)> f = [](const Pose3& p) { return p.vec(); };
+  auto f = [](const Pose3& p) { return p.vec(); };
   Matrix numericalH = numericalDerivative11<Vector16, Pose3>(f, T);
   EXPECT(assert_equal(numericalH, actualH, 1e-9));
 }

--- a/gtsam/geometry/tests/testRot2.cpp
+++ b/gtsam/geometry/tests/testRot2.cpp
@@ -183,7 +183,7 @@ TEST(Rot2, vec) {
   EXPECT(assert_equal(expected_vec, actual_vec));
 
   // Verify Jacobian with numerical derivatives
-  std::function<Vector4(const Rot2&)> f = [](const Rot2& p) { return p.vec(); };
+  auto f = [](const Rot2& p) { return p.vec(); };
   Matrix41 numericalH = numericalDerivative11<Vector4, Rot2>(f, R);
   EXPECT(assert_equal(numericalH, actualH, 1e-9));
 }

--- a/gtsam/geometry/tests/testSO3.cpp
+++ b/gtsam/geometry/tests/testSO3.cpp
@@ -353,8 +353,7 @@ TEST(SO3, JacobianInverses) {
 TEST(SO3, ApplyRightJacobian) {
   Matrix aH1, aH2;
   for (bool nearZero : {true, false}) {
-    std::function<Vector3(const Vector3&, const Vector3&)> f =
-      [nearZero](const Vector3& omega, const Vector3& v) {
+    auto f = [nearZero](const Vector3& omega, const Vector3& v) {
       return so3::DexpFunctor(omega, nearZero ? 1.0 : 0.0, 1e-5).Jacobian().applyRight(v);
       };
     for (const Vector3& omega : so3_test_cases::omegas(nearZero)) {
@@ -374,10 +373,9 @@ TEST(SO3, ApplyRightJacobian) {
 TEST(SO3, ApplyRightJacobianInverse) {
   Matrix aH1, aH2;
   for (bool nearZero : {true, false}) {
-    std::function<Vector3(const Vector3&, const Vector3&)> f =
-      [nearZero](const Vector3& omega, const Vector3& v) {
+    auto f = [nearZero](const Vector3& omega, const Vector3& v) {
       return so3::DexpFunctor(omega, nearZero ? 1.0 : 0.0, 1e-5).InvJacobian().applyRight(v);
-      };
+    };
     for (const Vector3& omega : so3_test_cases::omegas(nearZero)) {
       so3::DexpFunctor local(omega, nearZero ? 1.0 : 0.0, 1e-5);
       Matrix invJr = local.InvJacobian().right();
@@ -396,10 +394,9 @@ TEST(SO3, ApplyRightJacobianInverse) {
 TEST(SO3, ApplyLeftJacobian) {
   Matrix aH1, aH2;
   for (bool nearZero : {true, false}) {
-    std::function<Vector3(const Vector3&, const Vector3&)> f =
-      [nearZero](const Vector3& omega, const Vector3& v) {
+    auto f = [nearZero](const Vector3& omega, const Vector3& v) {
       return so3::DexpFunctor(omega, nearZero ? 1.0 : 0.0, 1e-5).Jacobian().applyLeft(v);
-      };
+    };
     for (const Vector3& omega : so3_test_cases::omegas(nearZero)) {
       so3::DexpFunctor local(omega, nearZero ? 1.0 : 0.0, 1e-5);
       for (const Vector3& v : so3_test_cases::vs) {
@@ -417,10 +414,9 @@ TEST(SO3, ApplyLeftJacobian) {
 TEST(SO3, ApplyLeftJacobianInverse) {
   Matrix aH1, aH2;
   for (bool nearZero : {true, false}) {
-    std::function<Vector3(const Vector3&, const Vector3&)> f =
-      [nearZero](const Vector3& omega, const Vector3& v) {
+    auto f = [nearZero](const Vector3& omega, const Vector3& v) {
       return so3::DexpFunctor(omega, nearZero ? 1.0 : 0.0, 1e-5).InvJacobian().applyLeft(v);
-      };
+    };
     for (const Vector3& omega : so3_test_cases::omegas(nearZero)) {
       so3::DexpFunctor local(omega, nearZero ? 1.0 : 0.0, 1e-5);
       Matrix invJl = local.InvJacobian().left();
@@ -441,7 +437,7 @@ TEST(SO3, vec) {
   Matrix actualH;
   const Vector9 actual = R2.vec(actualH);
   CHECK(assert_equal(expected, actual));
-  std::function<Vector9(const SO3&)> f = [](const SO3& Q) { return Q.vec(); };
+  auto f = [](const SO3& Q) { return Q.vec(); };
   const Matrix numericalH = numericalDerivative11(f, R2, 1e-5);
   CHECK(assert_equal(numericalH, actualH));
 }
@@ -455,9 +451,7 @@ TEST(Matrix, compose) {
   Matrix actualH;
   const Matrix3 actual = so3::compose(M, R, actualH);
   CHECK(assert_equal(expected, actual));
-  std::function<Matrix3(const Matrix3&)> f = [R](const Matrix3& M) {
-    return so3::compose(M, R);
-    };
+  auto f = [R](const Matrix3& M) { return so3::compose(M, R); };
   Matrix numericalH = numericalDerivative11(f, M, 1e-2);
   CHECK(assert_equal(numericalH, actualH));
 }
@@ -483,7 +477,7 @@ TEST(SO3, AdjointMap) {
 TEST(SO3, ApplyGamma) {
   Matrix aH1, aH2;
   for (bool nearZero : {true, false}) {
-    std::function<Vector3(const Vector3&, const Vector3&)> f =
+    auto f =
         [nearZero](const Vector3& omega, const Vector3& v) {
           return so3::DexpFunctor(omega, nearZero ? 1.0 : 0.0, 1e-5).Gamma().applyLeft(v);
         };

--- a/gtsam/geometry/tests/testSO4.cpp
+++ b/gtsam/geometry/tests/testSO4.cpp
@@ -169,7 +169,7 @@ TEST(SO4, Vec) {
   Matrix actualH;
   const Vector16 actual = Q2.vec(actualH);
   EXPECT(assert_equal(expected, actual));
-  std::function<Vector16(const SO4&)> f = [](const SO4& Q) { return Q.vec(); };
+  auto f = [](const SO4& Q) { return Q.vec(); };
   const Matrix numericalH = numericalDerivative11(f, Q2, 1e-5);
   EXPECT(assert_equal(numericalH, actualH));
 }
@@ -180,9 +180,7 @@ TEST(SO4, TopLeft) {
   Matrix actualH;
   const Matrix3 actual = topLeft(Q3, actualH);
   EXPECT(assert_equal(expected, actual));
-  std::function<Matrix3(const SO4&)> f = [](const SO4& Q3) {
-    return topLeft(Q3);
-  };
+  auto f = [](const SO4& Q3) { return topLeft(Q3); };
   const Matrix numericalH = numericalDerivative11(f, Q3, 1e-5);
   EXPECT(assert_equal(numericalH, actualH));
 }
@@ -193,9 +191,7 @@ TEST(SO4, Stiefel) {
   Matrix actualH;
   const Matrix43 actual = stiefel(Q3, actualH);
   EXPECT(assert_equal(expected, actual));
-  std::function<Matrix43(const SO4&)> f = [](const SO4& Q3) {
-    return stiefel(Q3);
-  };
+  auto f = [](const SO4& Q3) { return stiefel(Q3); };
   const Matrix numericalH = numericalDerivative11(f, Q3, 1e-5);
   EXPECT(assert_equal(numericalH, actualH));
 }

--- a/gtsam/geometry/tests/testSOn.cpp
+++ b/gtsam/geometry/tests/testSOn.cpp
@@ -189,7 +189,7 @@ Matrix RetractJacobian(size_t n) { return SOn::VectorizedGenerators(n); }
 /// Test Jacobian of Retract at origin
 TEST(SOn, RetractJacobian) {
   Matrix actualH = RetractJacobian(3);
-  std::function<Matrix(const Vector &)> h = [](const Vector &v) {
+  auto h = [](const Vector &v) {
     return SOn::ChartAtOrigin::Retract(v).matrix();
   };
   Vector3 v;
@@ -205,7 +205,7 @@ TEST(SOn, vec) {
   SOn Q = SOn::ChartAtOrigin::Retract(v);
   Matrix actualH;
   const Vector actual = Q.vec(actualH);
-  std::function<Vector(const SOn &)> h = [](const SOn &Q) { return Q.vec(); };
+  auto h = [](const SOn &Q) { return Q.vec(); };
   const Matrix H = numericalDerivative11<Vector, SOn, 10>(h, Q, 1e-5);
   CHECK(assert_equal(H, actualH));
 }

--- a/gtsam/geometry/tests/testSimilarity2.cpp
+++ b/gtsam/geometry/tests/testSimilarity2.cpp
@@ -215,10 +215,8 @@ TEST(Similarity2, Vec) {
   // 2. Test the Jacobian
   Matrix94 H_actual;
   sim.vec(H_actual);
-  auto vec_fun = [](const Similarity2& sim_arg) -> Vector9 {
-    return sim_arg.vec();
-    };
-  Matrix H_numerical = numericalDerivative11<Vector9, Similarity2, 4>(vec_fun, sim);
+  auto f = [](const Similarity2& g) -> Vector9 { return g.vec(); };
+  Matrix H_numerical = numericalDerivative11(f, sim);
   EXPECT(assert_equal(H_numerical, H_actual, 1e-7));
 }
 
@@ -249,15 +247,13 @@ TEST(Similarity2, AdjointTranspose) {
                       Vector(sim.AdjointTranspose(xi))));
 
   Matrix44 actualH1, actualH2;
-  std::function<Vector4(const Similarity2&, const Vector4&)>
-      adjointTransposeProxy = [](const Similarity2& g, const Vector4& x) {
-        return Vector4(g.AdjointTranspose(x));
-      };
+  auto adjointT = [](const Similarity2& g, const Vector4& x) {
+    return Vector4(g.AdjointTranspose(x));
+  };
   sim.AdjointTranspose(xi, actualH1, actualH2);
-  EXPECT(assert_equal(numericalDerivative21(adjointTransposeProxy, sim, xi),
-                      actualH1, 1e-8));
-  EXPECT(assert_equal(numericalDerivative22(adjointTransposeProxy, sim, xi),
-                      actualH2));
+  EXPECT(
+      assert_equal(numericalDerivative21(adjointT, sim, xi), actualH1, 1e-8));
+  EXPECT(assert_equal(numericalDerivative22(adjointT, sim, xi), actualH2));
 }
 
 //******************************************************************************
@@ -265,10 +261,9 @@ TEST(Similarity2, adjointTranspose) {
   const Vector4 xi(0.2, -0.4, 0.7, -0.1);
   const Vector4 y(-0.3, 0.5, 0.9, -0.2);
 
-  std::function<Vector4(const Vector4&, const Vector4&)> f =
-      [](const Vector4& x, const Vector4& v) {
-        return Vector4(Similarity2::adjointTranspose(x, v));
-      };
+  auto f = [](const Vector4& x, const Vector4& v) {
+    return Vector4(Similarity2::adjointTranspose(x, v));
+  };
 
   Matrix44 Hxi, Hy;
   const Vector4 actual = Similarity2::adjointTranspose(xi, y, Hxi, Hy);
@@ -282,10 +277,9 @@ TEST(Similarity2, adjoint) {
   const Vector4 xi(0.2, -0.4, 0.7, -0.1);
   const Vector4 y(-0.3, 0.5, 0.9, -0.2);
 
-  std::function<Vector4(const Vector4&, const Vector4&)> f =
-      [](const Vector4& x, const Vector4& v) {
-        return Vector4(Similarity2::adjoint(x, v));
-      };
+  auto f = [](const Vector4& x, const Vector4& v) {
+    return Vector4(Similarity2::adjoint(x, v));
+  };
 
   Matrix44 Hxi, Hy;
   const Vector4 actual = Similarity2::adjoint(xi, y, Hxi, Hy);

--- a/gtsam/geometry/tests/testSimilarity3.cpp
+++ b/gtsam/geometry/tests/testSimilarity3.cpp
@@ -86,7 +86,7 @@ TEST(Similarity3, translation) {
   Matrix37 actualH;
   EXPECT(assert_equal(Point3(3.5, -8.2, 4.2), T1.translation(&actualH), 1e-8));
 
-  std::function<Point3(const Similarity3&)> f = [](const Similarity3& T) { return T.translation(); };
+  auto f = [](const Similarity3& T) { return T.translation(); };
   Matrix37 numericalH = numericalDerivative11<Point3, Similarity3>(f, T1);
   EXPECT(assert_equal(numericalH, actualH, 1e-6));
 }
@@ -97,7 +97,7 @@ TEST(Similarity3, scale) {
   Matrix17 actualH;
   EXPECT_DOUBLES_EQUAL(10.0, T5.scale(&actualH), 1e-8);
 
-  std::function<double(const Similarity3&)> f = [](const Similarity3& T) { return T.scale(); };
+  auto f = [](const Similarity3& T) { return T.scale(); };
   Matrix17 numericalH = numericalDerivative11<double, Similarity3>(f, T5);
   EXPECT(assert_equal(numericalH, actualH, 1e-6));
 }
@@ -108,7 +108,7 @@ TEST(Similarity3, rotation) {
   Matrix37 actualH;
   EXPECT(assert_equal(Rot3::Rodrigues(0.3, 0.2, 0.1), T2.rotation(&actualH), 1e-8));
 
-  std::function<Rot3(const Similarity3&)> f = [](const Similarity3& T) { return T.rotation(); };
+  auto f = [](const Similarity3& T) { return T.rotation(); };
   Matrix37 numericalH = numericalDerivative11<Rot3, Similarity3>(f, T2);
   EXPECT(assert_equal(numericalH, actualH, 1e-6));
 }
@@ -302,8 +302,7 @@ TEST(Similarity3, GroupAction) {
 
   // Test derivative
   // Use lambda to resolve overloaded method
-  std::function<Point3(const Similarity3&, const Point3&)>
-      f = [](const Similarity3& S, const Point3& p){ return S.transformFrom(p); };
+  auto f = [](const Similarity3& S, const Point3& p){ return S.transformFrom(p); };
 
   Point3 q(1, 2, 3);
   for (const auto& T : { T1, T2, T3, T4, T5, T6 }) {
@@ -342,8 +341,7 @@ TEST(Similarity3, GroupActionPose3) {
   EXPECT(assert_equal(expected_wTo2, wSe.transformFrom(eTo2)));
 
   Similarity3 wSe2(Rot3::RzRyRx(60 * degree, 50 * degree, 30 * degree), Point3(2, 3, 5), 2.0);
-  std::function<Pose3(const Similarity3&, const Pose3&)>
-      f = [](const Similarity3& S, const Pose3& T){ return S.transformFrom(T); };
+  auto f = [](const Similarity3& S, const Pose3& T){ return S.transformFrom(T); };
 
   {
     Matrix H1 = numericalDerivative21<Pose3, Similarity3, Pose3>(f, wSe2, eTo1);
@@ -628,10 +626,8 @@ TEST(Similarity3, Vec) {
   // 2. Test the Jacobian
   Matrix H_actual(16, 7);
   sim.vec(H_actual);
-  auto vec_fun = [](const Similarity3& sim_arg) -> Similarity3::Vector16 {
-    return sim_arg.vec();
-    };
-  Matrix H_numerical = numericalDerivative11<Similarity3::Vector16, Similarity3, 7>(vec_fun, sim);
+  auto f = [](const Similarity3& g) -> Similarity3::Vector16 { return g.vec(); };
+  Matrix H_numerical = numericalDerivative11(f, sim);
   EXPECT(assert_equal(H_numerical, H_actual, 1e-7));
 }
 
@@ -663,13 +659,12 @@ TEST(Similarity3, AdjointTranspose) {
                       Vector(sim.AdjointTranspose(xi))));
 
   Matrix77 actualH1, actualH2;
-  std::function<Vector7(const Similarity3&, const Vector7&)> proxy =
-      [](const Similarity3& g, const Vector7& x) {
-        return Vector7(g.AdjointTranspose(x));
-      };
+  auto f = [](const Similarity3& g, const Vector7& x) {
+    return Vector7(g.AdjointTranspose(x));
+  };
   sim.AdjointTranspose(xi, actualH1, actualH2);
-  EXPECT(assert_equal(numericalDerivative21(proxy, sim, xi), actualH1, 1e-8));
-  EXPECT(assert_equal(numericalDerivative22(proxy, sim, xi), actualH2));
+  EXPECT(assert_equal(numericalDerivative21(f, sim, xi), actualH1, 1e-8));
+  EXPECT(assert_equal(numericalDerivative22(f, sim, xi), actualH2));
 }
 
 //******************************************************************************
@@ -677,10 +672,9 @@ TEST(Similarity3, adjointTranspose) {
   const Vector7 xi(0.2, -0.4, 0.7, -0.1, 0.3, -0.6, 0.5);
   const Vector7 y(-0.3, 0.5, 0.9, -0.2, 0.4, -0.8, 0.1);
 
-  std::function<Vector7(const Vector7&, const Vector7&)> f =
-      [](const Vector7& x, const Vector7& v) {
-        return Vector7(Similarity3::adjointTranspose(x, v));
-      };
+  auto f = [](const Vector7& x, const Vector7& v) {
+    return Vector7(Similarity3::adjointTranspose(x, v));
+  };
 
   Matrix77 Hxi, Hy;
   const Vector7 actual = Similarity3::adjointTranspose(xi, y, Hxi, Hy);
@@ -694,10 +688,9 @@ TEST(Similarity3, adjoint) {
   const Vector7 xi(0.2, -0.4, 0.7, -0.1, 0.3, -0.6, 0.5);
   const Vector7 y(-0.3, 0.5, 0.9, -0.2, 0.4, -0.8, 0.1);
 
-  std::function<Vector7(const Vector7&, const Vector7&)> f =
-      [](const Vector7& x, const Vector7& v) {
-        return Vector7(Similarity3::adjoint(x, v));
-      };
+  auto f = [](const Vector7& x, const Vector7& v) {
+    return Vector7(Similarity3::adjoint(x, v));
+  };
 
   Matrix77 Hxi, Hy;
   const Vector7 actual = Similarity3::adjoint(xi, y, Hxi, Hy);

--- a/gtsam/geometry/tests/testUnit3.cpp
+++ b/gtsam/geometry/tests/testUnit3.cpp
@@ -114,9 +114,8 @@ TEST(Unit3, Dot) {
 
   // Use numerical derivatives to calculate the expected Jacobians
   Matrix H1, H2;
-  std::function<double(const Unit3&, const Unit3&)> f =
-      std::bind(&Unit3::dot, std::placeholders::_1, std::placeholders::_2,  //
-                nullptr, nullptr);
+  auto f = std::bind(&Unit3::dot, std::placeholders::_1, std::placeholders::_2,
+                     nullptr, nullptr);
   {
     p.dot(q, H1, H2);
     EXPECT(
@@ -380,8 +379,7 @@ TEST(Unit3, Retract) {
 TEST (Unit3, JacobianRetract) {
   Matrix22 H;
   Unit3 p;
-  std::function<Unit3(const Vector2&)> f =
-      std::bind(&Unit3::retract, p, std::placeholders::_1, nullptr);
+  auto f = std::bind(&Unit3::retract, p, std::placeholders::_1, nullptr);
   {
     Vector2 v(-0.2, 0.1);
     p.retract(v, H);
@@ -513,8 +511,7 @@ TEST(actualH, Serialization) {
 /* ************************************************************************* */
 TEST(Unit3, cross) {
   Matrix22 aH1, aH2;
-  std::function<Unit3(const Unit3&, const Unit3&)> f =
-      [](const Unit3& p, const Unit3& q) { return cross(p, q); };
+  auto f = [](const Unit3& p, const Unit3& q) { return cross(p, q); };
   const Unit3 p(0, 1, 4), q(4, 6, 8);
   Unit3 actual = cross(p, q, aH1, aH2);
   EXPECT(assert_equal(p.cross(q), actual, 1e-9));
@@ -538,8 +535,7 @@ TEST(Unit3, MixedCrossUnit3Point3) {
   EXPECT(assert_equal(cross(p.point3(), q), actual, 1e-9));
 
   // Define a lambda function for numerical differentiation
-  std::function<Point3(const Unit3&, const Point3&)> f = [](const Unit3& p,
-                                                            const Point3& q) {
+  auto f = [](const Unit3& p, const Point3& q) {
     return cross(p, q, nullptr, nullptr);
   };
 
@@ -572,8 +568,7 @@ TEST(Unit3, MixedCrossPoint3Unit3) {
   EXPECT(assert_equal(expected, actual, 1e-9));
 
   // Define a lambda function for numerical differentiation
-  std::function<Point3(const Point3&, const Unit3&)> f = [](const Point3& p,
-                                                            const Unit3& q) {
+  auto f = [](const Point3& p, const Unit3& q) {
     return cross(p, q, nullptr, nullptr);
   };
 

--- a/gtsam/navigation/tests/testAHRSFactor.cpp
+++ b/gtsam/navigation/tests/testAHRSFactor.cpp
@@ -161,8 +161,7 @@ TEST(AHRSFactor, PIMComputeError) {
   pim.integrateMeasurement(measuredOmega, deltaT);
 
   // Use a wrapper to call the new PIM::computeError for numerical derivatives
-  std::function<Vector3(const Rot3&, const Rot3&, const Vector3&)> f =
-      [&pim](const Rot3& r1, const Rot3& r2, const Vector3& b) -> Vector3 {
+  auto f = [&pim](const Rot3& r1, const Rot3& r2, const Vector3& b) -> Vector3 {
     return pim.computeError(r1, r2, b);
   };
 
@@ -421,8 +420,7 @@ TEST(AHRSFactor, PIM_predict_and_Jacobians) {
 
   // --- Test Jacobians ---
   // Define a wrapper for numerical derivatives
-  std::function<Rot3(const Rot3&, const Vector3&)> f =
-      [&pim](const Rot3& r, const Vector3& b) { return pim.predict(r, b); };
+  auto f = [&pim](const Rot3& r, const Vector3& b) { return pim.predict(r, b); };
 
   // Get analytical Jacobians from the predict call
   Matrix3 H1_actual, H2_actual;
@@ -458,8 +456,7 @@ TEST(AHRSFactor, PIM_predict_and_Jacobians_with_Coriolis) {
 
   // --- Test Jacobians ---
   // Define a wrapper for numerical derivatives
-  std::function<Rot3(const Rot3&, const Vector3&)> f =
-      [&pim](const Rot3& r, const Vector3& b) { return pim.predict(r, b); };
+  auto f = [&pim](const Rot3& r, const Vector3& b) { return pim.predict(r, b); };
 
   // Get analytical Jacobians from the predict call
   Matrix3 H1_actual, H2_actual;

--- a/gtsam/navigation/tests/testGal3ImuEKF.cpp
+++ b/gtsam/navigation/tests/testGal3ImuEKF.cpp
@@ -87,7 +87,7 @@ TEST(Gal3ImuEKF, DynamicsJacobian) {
   for (auto mode :
        {Gal3ImuEKF::NO_TIME, Gal3ImuEKF::TRACK_TIME_WITH_COVARIANCE}) {
     (void)Gal3ImuEKF::Dynamics(n_g, X0, omega_b, f_b, dt, mode, A);
-    std::function<Gal3(const Gal3&)> f = [&](const Gal3& Xq) -> Gal3 {
+    auto f = [&](const Gal3& Xq) -> Gal3 {
       return Gal3ImuEKF::Dynamics(n_g, Xq, omega_b, f_b, dt, mode);
     };
     Matrix10 expected = numericalDerivative11(f, X0);
@@ -185,9 +185,7 @@ TEST(Gal3ImuEKF, PositionMeasurementJacobian) {
   H.block<3, 1>(0, 9) = X.velocity();
 
   // Numerical Jacobian via central differencing
-  std::function<Point3(const Gal3&)> h = [](const Gal3& Xq) {
-    return Xq.position();
-  };
+  auto h = [](const Gal3& Xq) { return Xq.position(); };
   Matrix310 expected = numericalDerivative11<Point3, Gal3>(h, X);
 
   EXPECT(assert_equal(expected, H, 1e-6));

--- a/gtsam/navigation/tests/testImuBias.cpp
+++ b/gtsam/navigation/tests/testImuBias.cpp
@@ -72,8 +72,7 @@ TEST(ImuBias, operatorSubB) {
 TEST(ImuBias, Correct1) {
   Matrix aH1, aH2;
   const Vector3 measurement(1, 2, 3);
-  std::function<Vector3(const Bias&, const Vector3&)> f =
-      std::bind(&Bias::correctAccelerometer, std::placeholders::_1,
+  auto f = std::bind(&Bias::correctAccelerometer, std::placeholders::_1,
                 std::placeholders::_2, nullptr, nullptr);
   bias1.correctAccelerometer(measurement, aH1, aH2);
   EXPECT(assert_equal(numericalDerivative21(f, bias1, measurement), aH1));
@@ -84,8 +83,7 @@ TEST(ImuBias, Correct1) {
 TEST(ImuBias, Correct2) {
   Matrix aH1, aH2;
   const Vector3 measurement(1, 2, 3);
-  std::function<Vector3(const Bias&, const Vector3&)> f =
-      std::bind(&Bias::correctGyroscope, std::placeholders::_1,
+  auto f = std::bind(&Bias::correctGyroscope, std::placeholders::_1,
                 std::placeholders::_2, nullptr, nullptr);
   bias1.correctGyroscope(measurement, aH1, aH2);
   EXPECT(assert_equal(numericalDerivative21(f, bias1, measurement), aH1));

--- a/gtsam/navigation/tests/testImuFactor.cpp
+++ b/gtsam/navigation/tests/testImuFactor.cpp
@@ -121,8 +121,7 @@ TEST_PIM(ImuFactor, PreintegratedMeasurements) {
   Matrix9 aH1, aH2;
   Matrix96 aH3;
   actual.computeError(x1, x2, bias, aH1, aH2, aH3);
-  std::function<Vector9(const NavState&, const NavState&, const Bias&)> f =
-      std::bind(&PreintegrationBase::computeError, actual,
+  auto f = std::bind(&PreintegrationBase::computeError, actual,
                   std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
                   nullptr, nullptr, nullptr);
   EXPECT(assert_equal(numericalDerivative31(f, x1, x2, bias), aH1, 1e-9));

--- a/gtsam/navigation/tests/testManifoldPreintegration.cpp
+++ b/gtsam/navigation/tests/testManifoldPreintegration.cpp
@@ -31,22 +31,19 @@ using namespace std::placeholders;
 TEST(ManifoldPreintegration, BiasCorrectionJacobians) {
   testing::SomeMeasurements measurements;
 
-  std::function<Rot3(const Vector3&, const Vector3&)> deltaRij =
-      [&](const Vector3& a, const Vector3& w) {
+  auto deltaRij = [&](const Vector3& a, const Vector3& w) {
         ManifoldPreintegration pim(testing::Params(), Bias(a, w));
         testing::integrateMeasurements(measurements, &pim);
         return pim.deltaRij();
       };
 
-  std::function<Point3(const Vector3&, const Vector3&)> deltaPij =
-      [&](const Vector3& a, const Vector3& w) {
+  auto deltaPij = [&](const Vector3& a, const Vector3& w) {
         ManifoldPreintegration pim(testing::Params(), Bias(a, w));
         testing::integrateMeasurements(measurements, &pim);
         return pim.deltaPij();
       };
 
-  std::function<Vector3(const Vector3&, const Vector3&)> deltaVij =
-      [&](const Vector3& a, const Vector3& w) {
+  auto deltaVij = [&](const Vector3& a, const Vector3& w) {
         ManifoldPreintegration pim(testing::Params(), Bias(a, w));
         testing::integrateMeasurements(measurements, &pim);
         return pim.deltaVij();
@@ -86,9 +83,7 @@ TEST(ManifoldPreintegration, computeError) {
   Matrix9 aH1, aH2;
   Matrix96 aH3;
   pim.computeError(x1, x2, bias, aH1, aH2, aH3);
-  std::function<Vector9(const NavState&, const NavState&,
-                        const imuBias::ConstantBias&)>
-      f = std::bind(&ManifoldPreintegration::computeError, pim,
+  auto f = std::bind(&ManifoldPreintegration::computeError, pim,
                     std::placeholders::_1, std::placeholders::_2,
                     std::placeholders::_3, nullptr, nullptr,
                     nullptr);

--- a/gtsam/navigation/tests/testNavState.cpp
+++ b/gtsam/navigation/tests/testNavState.cpp
@@ -69,8 +69,7 @@ TEST(NavState, Concept) {
 
 /* ************************************************************************* */
 TEST(NavState, Constructor) {
-  std::function<NavState(const Rot3&, const Point3&, const Vector3&)> create =
-      std::bind(&NavState::Create, std::placeholders::_1, std::placeholders::_2,
+  auto create = std::bind(&NavState::Create, std::placeholders::_1, std::placeholders::_2,
                 std::placeholders::_3, nullptr, nullptr, nullptr);
   Matrix aH1, aH2, aH3;
   EXPECT(
@@ -89,8 +88,7 @@ assert_equal(
 
 /* ************************************************************************* */
 TEST(NavState, Constructor2) {
-  std::function<NavState(const Pose3&, const Vector3&)> construct =
-      std::bind(&NavState::FromPoseVelocity, std::placeholders::_1,
+  auto construct = std::bind(&NavState::FromPoseVelocity, std::placeholders::_1,
                 std::placeholders::_2, nullptr, nullptr);
   Matrix aH1, aH2;
   EXPECT(
@@ -135,7 +133,7 @@ TEST( NavState, Velocity) {
 /* ************************************************************************* */
 TEST(NavState, PoseJacobian) {
   // NavState::pose() should be a pure projection onto the (R,t) components.
-  std::function<Pose3(const NavState&)> f = [](const NavState& s) {
+  auto f = [](const NavState& s) {
     return s.pose();
   };
 
@@ -186,8 +184,7 @@ TEST( NavState, Manifold ) {
   // Check retract derivatives
   Matrix9 aH1, aH2;
   kState1.retract(xi, aH1, aH2);
-  std::function<NavState(const NavState&, const Vector9&)> retract =
-      std::bind(&NavState::retract, std::placeholders::_1,
+  auto retract = std::bind(&NavState::retract, std::placeholders::_1,
                 std::placeholders::_2, nullptr, nullptr);
   EXPECT(assert_equal(numericalDerivative21(retract, kState1, xi), aH1));
   EXPECT(assert_equal(numericalDerivative22(retract, kState1, xi), aH2));
@@ -199,8 +196,7 @@ TEST( NavState, Manifold ) {
   EXPECT(assert_equal(numericalDerivative22(retract, state2, xi2), aH2));
 
   // Check localCoordinates derivatives
-  std::function<Vector9(const NavState&, const NavState&)> local =
-      std::bind(&NavState::localCoordinates, std::placeholders::_1,
+  auto local = std::bind(&NavState::localCoordinates, std::placeholders::_1,
                 std::placeholders::_2, nullptr, nullptr);
   // from state1 to state2
   kState1.localCoordinates(state2, aH1, aH2);
@@ -355,8 +351,7 @@ TEST(NavState, interpolate) {
 
 /* ************************************************************************* */
 static const double dt = 2.0;
-std::function<Vector9(const NavState&, const bool&)> coriolis =
-    std::bind(&NavState::coriolis, std::placeholders::_1, dt, kOmegaCoriolis,
+auto coriolis = std::bind(&NavState::coriolis, std::placeholders::_1, dt, kOmegaCoriolis,
               std::placeholders::_2, nullptr);
 
 TEST(NavState, Coriolis) {
@@ -450,8 +445,7 @@ TEST(NavState, CorrectPIM) {
   xi << 0.1, 0.1, 0.1, 0.2, 0.3, 0.4, -0.1, -0.2, -0.3;
   double dt = 0.5;
   Matrix9 aH1, aH2;
-  std::function<Vector9(const NavState&, const Vector9&)> correctPIM =
-      std::bind(&NavState::correctPIM, std::placeholders::_1,
+  auto correctPIM = std::bind(&NavState::correctPIM, std::placeholders::_1,
                 std::placeholders::_2, dt, kGravity, kOmegaCoriolis, false,
                 nullptr, nullptr);
   kState1.correctPIM(xi, dt, kGravity, kOmegaCoriolis, false, aH1, aH2);
@@ -762,7 +756,7 @@ TEST(NavState, ExpmapDerivative1) {
   w << 0.1, 0.2, 0.3, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0;
   NavState::Expmap(w, actualH);
 
-  std::function<NavState(const Vector9&)> f = [](const Vector9& w) {
+  [[maybe_unused]] auto f = [](const Vector9& w) {
     return NavState::Expmap(w);
   };
   Matrix expectedH =
@@ -779,7 +773,7 @@ TEST(NavState, LogmapDerivative) {
   NavState p = NavState::Expmap(w);
   EXPECT(assert_equal(w, NavState::Logmap(p, actualH), 1e-5));
 
-  std::function<Vector9(const NavState&)> f = [](const NavState& p) {
+  [[maybe_unused]] auto f = [](const NavState& p) {
     return NavState::Logmap(p);
   };
   Matrix expectedH =
@@ -835,7 +829,7 @@ TEST(NavState, Vec) {
   EXPECT(assert_equal(expected_vec, actual_vec));
 
   // Verify Jacobian with numerical derivatives
-  std::function<Vector25(const NavState&)> f = [](const NavState& p) { return p.vec(); };
+  auto f = [](const NavState& p) { return p.vec(); };
   Eigen::Matrix<double, 25, 9> numericalH = numericalDerivative11<Vector25, NavState>(f, navState);
   EXPECT(assert_equal(numericalH, actualH, 1e-9));
 }

--- a/gtsam/navigation/tests/testNavStateImuEKF.cpp
+++ b/gtsam/navigation/tests/testNavStateImuEKF.cpp
@@ -75,8 +75,7 @@ TEST(NavStateImuEKF, DynamicsJacobian) {
   double dt = 0.01;
   Matrix9 A;
   (void)NavStateImuEKF::Dynamics(params->n_gravity, X0, omega_b, f_b, dt, A);
-  std::function<NavState(const NavState&)> f =
-      [&](const NavState& Xq) -> NavState {
+  auto f = [&](const NavState& Xq) -> NavState {
     return NavStateImuEKF::Dynamics(params->n_gravity, Xq, omega_b, f_b, dt);
   };
   Matrix9 expected = numericalDerivative11(f, X0);
@@ -140,7 +139,7 @@ TEST(NavStateImuEKF, PositionMeasurementJacobian) {
   H.block<3, 3>(0, 3) = X.attitude().matrix();
 
   // Numerical Jacobian via central differencing
-  std::function<Point3(const NavState&)> h = [](const NavState& Xq) {
+  auto h = [](const NavState& Xq) {
     return Xq.position();
   };
   Matrix39 expected = numericalDerivative11<Point3, NavState>(h, X);

--- a/gtsam/navigation/tests/testTangentPreintegration.cpp
+++ b/gtsam/navigation/tests/testTangentPreintegration.cpp
@@ -66,8 +66,7 @@ TEST(TangentPreintegration, UpdateEstimate2) {
 TEST(ImuFactor, BiasCorrectionJacobians) {
   testing::SomeMeasurements measurements;
 
-  std::function<Vector9(const Vector3&, const Vector3&)> preintegrated =
-      [&](const Vector3& a, const Vector3& w) {
+  auto preintegrated = [&](const Vector3& a, const Vector3& w) {
         TangentPreintegration pim(testing::Params(), Bias(a, w));
         testing::integrateMeasurements(measurements, &pim);
         return pim.preintegrated();
@@ -93,9 +92,7 @@ TEST(TangentPreintegration, computeError) {
   Matrix9 aH1, aH2;
   Matrix96 aH3;
   pim.computeError(x1, x2, bias, aH1, aH2, aH3);
-  std::function<Vector9(const NavState&, const NavState&,
-                        const imuBias::ConstantBias&)>
-      f = std::bind(&TangentPreintegration::computeError, pim,
+  auto f = std::bind(&TangentPreintegration::computeError, pim,
                     std::placeholders::_1, std::placeholders::_2,
                     std::placeholders::_3, nullptr, nullptr,
                     nullptr);
@@ -111,8 +108,7 @@ TEST(TangentPreintegration, Compose) {
   TangentPreintegration pim(testing::Params());
   testing::integrateMeasurements(measurements, &pim);
 
-  std::function<Vector9(const Vector9&, const Vector9&)> f =
-      [pim](const Vector9& zeta01, const Vector9& zeta12) {
+  auto f = [pim](const Vector9& zeta01, const Vector9& zeta12) {
         return TangentPreintegration::Compose(zeta01, zeta12, pim.deltaTij());
       };
 


### PR DESCRIPTION
### High-level changes

- Modernized `gtsam/base/numericalDerivative.h`:
  - moved to generic callable-based derivative helpers
  - improved overload behavior for lambdas/free functions
  - added/organized Doxygen groups and explicit template-type requirements
  - removed stale/inaccurate template requirement wording

- Geometry/runtime updates:
  - `Gal3`: added analytical `LogmapDerivative(const TangentVector&)` and routed `LogmapDerivative(const Gal3&)` through it
  - `Quaternion` traits: added `GetDimension`
  - `SO3`: small cleanup (inline `ExpmapFunctor::expmap`, corrected `B` comment)
  - `Pose3`: expanded implementation comments around `Expmap`
  - wrappers (`geometry.i`): exposed `Similarity2::matrix()` / `Similarity3::matrix()` and aligned `DexpFunctor` field constness

- Test/style updates in geometry/navigation:
  - mechanically replaced `std::function<...> var = ...` with `auto var = ...` in test code
  - added `[[maybe_unused]]` only where required to satisfy `-Werror`

### Validation

- `make -j6 check.geometry` ✅
- `make -j6 check.navigation` ✅
