### PR TITLE
Add python wrapper and test for LocalOrientedPlane3Factor

### DIFF
--- a/gtsam_unstable/gtsam_unstable.i
+++ b/gtsam_unstable/gtsam_unstable.i
@@ -815,4 +815,19 @@ virtual class ProjectionFactorRollingShutter : gtsam::NoiseModelFactor {
   void serialize() const;
 };
 
+#include <gtsam_unstable/slam/LocalOrientedPlane3Factor.h>
+
+virtual class LocalOrientedPlane3Factor : gtsam::NonlinearFactor {
+  // Constructor matching the C++ header
+  LocalOrientedPlane3Factor(const gtsam::Vector4& z, 
+                            const gtsam::noiseModel::Base* noiseModel, 
+                            gtsam::Key poseKey, 
+                            gtsam::Key anchorKey, 
+                            gtsam::Key planeKey);
+                            
+  // Enabling serialization
+  void serialize() const;
+};
+
+
 } //\namespace gtsam

--- a/gtsam_unstable/gtsam_unstable.i
+++ b/gtsam_unstable/gtsam_unstable.i
@@ -817,15 +817,17 @@ virtual class ProjectionFactorRollingShutter : gtsam::NoiseModelFactor {
 
 #include <gtsam_unstable/slam/LocalOrientedPlane3Factor.h>
 
-virtual class LocalOrientedPlane3Factor : gtsam::NonlinearFactor {
-  // Constructor matching the C++ header
-  LocalOrientedPlane3Factor(const gtsam::Vector4& z, 
-                            const gtsam::noiseModel::Base* noiseModel, 
-                            gtsam::Key poseKey, 
-                            gtsam::Key anchorKey, 
-                            gtsam::Key planeKey);
-                            
-  // Enabling serialization
+virtual class LocalOrientedPlane3Factor : gtsam::NoiseModelFactor {
+  LocalOrientedPlane3Factor(const gtsam::Vector4& z,
+                            const gtsam::noiseModel::Base* noiseModel,
+                            gtsam::Key poseKey,
+                            gtsam::Key anchorPoseKey,
+                            gtsam::Key landmarkKey);
+  LocalOrientedPlane3Factor(const gtsam::OrientedPlane3& z,
+                            const gtsam::noiseModel::Base* noiseModel,
+                            gtsam::Key poseKey,
+                            gtsam::Key anchorPoseKey,
+                            gtsam::Key landmarkKey);
   void serialize() const;
 };
 

--- a/python/gtsam_unstable/tests/test_LocalOrientedPlane3Factor.py
+++ b/python/gtsam_unstable/tests/test_LocalOrientedPlane3Factor.py
@@ -1,0 +1,31 @@
+import unittest
+import numpy as np
+import gtsam
+from gtsam.utils.test_case import GtsamTestCase
+import gtsam_unstable
+
+class TestLocalOrientedPlane3Factor(GtsamTestCase):
+    def test_factor_error(self):
+        # 1. Create the factor
+        z = np.array([0.0, 0.0, 1.0, 1.5])
+        noise = gtsam.noiseModel.Isotropic.Sigma(3, 0.1)
+        
+        pose_key = gtsam.symbol('x', 1)
+        anchor_key = gtsam.symbol('x', 0)
+        landmark_key = gtsam.symbol('l', 0)
+        
+        factor = gtsam_unstable.LocalOrientedPlane3Factor(
+            z, noise, pose_key, anchor_key, landmark_key)
+
+        # 2. Create Values
+        values = gtsam.Values()
+        values.insert(pose_key, gtsam.Pose3())
+        values.insert(anchor_key, gtsam.Pose3())
+        values.insert(landmark_key, gtsam.OrientedPlane3(0.0, 0.0, 1.0, 1.5))
+        
+        # 3. Check that the error is zero for perfect measurements
+        error = factor.error(values)
+        self.assertAlmostEqual(error, 0.0, places=5)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hi, 

I realized that the `LocalOrientedPlane3Factor` didn't had a wrapper for python.
I hope my PR finds you well. I added a dummy test, not sure if that helps you. For me the test passed