### PR TITLE
navigation: honor configured IMU bias in LeggedFixedLagSmoother

### DIFF
--- a/gtsam/navigation/LeggedEstimator.cpp
+++ b/gtsam/navigation/LeggedEstimator.cpp
@@ -724,13 +724,14 @@ LeggedFixedLagSmoother::LeggedFixedLagSmoother(
       initialFootholds_(footholds0),
       baseCovariance0_(baseCovariance0),
       smoother_(lagSeconds, leggedLmParams()),
-      pim_(params.preintegrationParams, imuBias::ConstantBias()),
+      pim_(params.preintegrationParams, params.imuBias),
       inContact_(numFeet_, false),
       initialized_(numFeet_, false),
       footEpisodes_(numFeet_, 0),
       activeFootKeys_(numFeet_),
       optimizedBaseState_(navState0),
-      deadReckonedState_(navState0) {
+      deadReckonedState_(navState0),
+      biasEstimate_(params.imuBias) {
   throwIfInvalidParams(params_);
   if (footNames_.size() != numFeet_) {
     throw std::invalid_argument(
@@ -947,7 +948,7 @@ bool LeggedFixedLagSmoother::maybeInitializeFromFullContact(
 
   smoother_ =
       BatchFixedLagSmoother(smoother_.smootherLag(), smoother_.params());
-  pim_.resetIntegrationAndSetBias(imuBias::ConstantBias());
+  pim_.resetIntegrationAndSetBias(params_.imuBias);
   step_ = 0;
   currentTime_ = 0.0;
   footEpisodes_.assign(numFeet_, 0);


### PR DESCRIPTION
## Summary

This PR fixes an unintentional zero-bias initialization path in `LeggedFixedLagSmoother`.

The fixed-lag single-bias estimator now consistently uses the configured startup IMU bias from `params.imuBias`.

Specifically, this PR:
- uses `params.imuBias` when constructing the preintegration object (`pim_`)
- initializes `biasEstimate_` from `params.imuBias`
- resets `pim_` with `params_.imuBias` during full-contact reinitialization instead of using a zero bias

## Motivation

`LeggedEstimatorReplayExample` estimates an initial IMU bias and passes it through `params.imuBias`. However, `LeggedFixedLagSmoother` previously initialized some preintegration paths with a zero bias, even when a non-zero startup bias was configured.

This made the `fixed_lag_single_bias` variant inconsistent with the configured initialization and could affect replay results when a non-zero initial bias is provided.

## Validation

Built and ran the relevant legged estimator target/tests locally:

- `cmake --build build -j6 --target LeggedEstimatorReplayExample`
- `cmake --build build -j6 --target testLeggedEstimator`
- `./build/gtsam/navigation/tests/testLeggedEstimator` passes with no test failures.