### PR TITLE
feat(python): TorchFactor — PyTorch autograd bridge for GTSAM factors

### DIFF
--- a/python/gtsam/tests/test_torch_factor.py
+++ b/python/gtsam/tests/test_torch_factor.py
@@ -1,0 +1,168 @@
+"""Tests for TorchFactor — PyTorch autograd bridge for GTSAM."""
+
+import unittest
+
+import numpy as np
+
+try:
+    import torch
+    HAS_TORCH = True
+except ImportError:
+    HAS_TORCH = False
+
+import gtsam
+from gtsam.utils.numerical_derivative import numericalDerivative11
+
+
+@unittest.skipUnless(HAS_TORCH, "PyTorch not installed")
+class TestTorchFactor(unittest.TestCase):
+    """Test TorchFactor produces correct errors and Jacobians."""
+
+    def setUp(self):
+        from gtsam.utils.torch_factor import TorchFactor, extract_vector
+        self.TorchFactor = TorchFactor
+        self.extract_vector = extract_vector
+
+    def test_simple_prior(self):
+        """Test a simple prior factor: error = x - measurement."""
+        measurement = np.array([1.0, 2.0, 3.0])
+
+        def residual_fn(tensors):
+            x = tensors[0]
+            return x - torch.tensor(measurement, dtype=torch.float64)
+
+        noise = gtsam.noiseModel.Unit.Create(3)
+        key = 0
+        tf = self.TorchFactor(
+            noise_model=noise,
+            keys=[key],
+            residual_fn=residual_fn,
+            value_extractors=[self.extract_vector],
+        )
+
+        factor = tf.as_custom_factor()
+        graph = gtsam.NonlinearFactorGraph()
+        graph.add(factor)
+
+        # Test with initial values away from measurement
+        values = gtsam.Values()
+        values.insert(key, np.array([0.0, 0.0, 0.0]))
+
+        # Error should be non-zero
+        self.assertGreater(graph.error(values), 0)
+
+        # Optimize should converge to measurement
+        params = gtsam.LevenbergMarquardtParams()
+        params.setVerbosity("SILENT")
+        optimizer = gtsam.LevenbergMarquardtOptimizer(graph, values, params)
+        result = optimizer.optimize()
+
+        np.testing.assert_allclose(
+            result.atVector(key), measurement, atol=1e-6
+        )
+
+    def test_between_factor(self):
+        """Test a between factor: error = (x1 - x0) - measurement."""
+        measurement = np.array([1.0, 0.5])
+
+        def residual_fn(tensors):
+            x0, x1 = tensors
+            return (x1 - x0) - torch.tensor(measurement, dtype=torch.float64)
+
+        noise = gtsam.noiseModel.Unit.Create(2)
+        key0, key1 = 0, 1
+        tf = self.TorchFactor(
+            noise_model=noise,
+            keys=[key0, key1],
+            residual_fn=residual_fn,
+            value_extractors=[self.extract_vector, self.extract_vector],
+        )
+
+        # Build graph with prior on key0 and between factor
+        graph = gtsam.NonlinearFactorGraph()
+        graph.addPrior(key0, np.array([0.0, 0.0]), noise)
+        graph.add(tf.as_custom_factor())
+
+        values = gtsam.Values()
+        values.insert(key0, np.array([0.0, 0.0]))
+        values.insert(key1, np.array([0.0, 0.0]))
+
+        params = gtsam.LevenbergMarquardtParams()
+        params.setVerbosity("SILENT")
+        optimizer = gtsam.LevenbergMarquardtOptimizer(graph, values, params)
+        result = optimizer.optimize()
+
+        np.testing.assert_allclose(result.atVector(key0), [0.0, 0.0], atol=1e-5)
+        np.testing.assert_allclose(result.atVector(key1), measurement, atol=1e-5)
+
+    def test_jacobian_correctness(self):
+        """Verify autograd Jacobians match numerical derivatives."""
+        measurement = np.array([2.0, 3.0])
+
+        def residual_fn(tensors):
+            x = tensors[0]
+            return x ** 2 - torch.tensor(measurement, dtype=torch.float64)
+
+        noise = gtsam.noiseModel.Unit.Create(2)
+        key = 0
+        tf = self.TorchFactor(
+            noise_model=noise,
+            keys=[key],
+            residual_fn=residual_fn,
+            value_extractors=[self.extract_vector],
+        )
+
+        factor = tf.as_custom_factor()
+
+        values = gtsam.Values()
+        x0 = np.array([1.5, 2.0])
+        values.insert(key, x0)
+
+        # Get Jacobian from autograd via linearize
+        gf = factor.linearize(values)
+        # The linearized factor contains the whitened Jacobian
+        # For unit noise model, whitened == unwhitened
+        jf = gtsam.JacobianFactor(gf)
+        A = jf.getA(jf.find(key))
+
+        # Expected Jacobian: d(x^2)/dx = diag(2x)
+        expected_J = np.diag(2 * x0)
+        np.testing.assert_allclose(A, expected_J, atol=1e-5)
+
+    def test_nonlinear_residual(self):
+        """Test with a nonlinear residual (sin/cos)."""
+        target = np.array([0.5, 0.866])  # sin(pi/6), cos(pi/6) approx
+
+        def residual_fn(tensors):
+            theta = tensors[0]
+            predicted = torch.stack([torch.sin(theta[0]), torch.cos(theta[0])])
+            return predicted - torch.tensor(target, dtype=torch.float64)
+
+        noise = gtsam.noiseModel.Unit.Create(2)
+        key = 0
+        tf = self.TorchFactor(
+            noise_model=noise,
+            keys=[key],
+            residual_fn=residual_fn,
+            value_extractors=[self.extract_vector],
+        )
+
+        graph = gtsam.NonlinearFactorGraph()
+        graph.add(tf.as_custom_factor())
+
+        values = gtsam.Values()
+        values.insert(key, np.array([0.3]))  # Initial guess
+
+        params = gtsam.LevenbergMarquardtParams()
+        params.setVerbosity("SILENT")
+        optimizer = gtsam.LevenbergMarquardtOptimizer(graph, values, params)
+        result = optimizer.optimize()
+
+        # Should converge to pi/6 ~ 0.5236
+        np.testing.assert_allclose(
+            result.atVector(key), [np.pi / 6], atol=1e-4
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/gtsam/utils/torch_factor.py
+++ b/python/gtsam/utils/torch_factor.py
@@ -1,0 +1,164 @@
+"""TorchFactor: Bridge between PyTorch autograd and GTSAM factor graphs.
+
+Allows defining GTSAM factors using PyTorch tensors and automatic
+differentiation, eliminating the need for hand-derived Jacobians.
+
+Requires: pip install torch
+"""
+
+from typing import Callable, List, Optional, Sequence
+
+import numpy as np
+
+try:
+    import torch
+    from torch import Tensor
+except ImportError:
+    raise ImportError(
+        "TorchFactor requires PyTorch. Install with: pip install torch"
+    )
+
+import gtsam
+
+
+class TorchFactor:
+    """A GTSAM factor whose error and Jacobians are computed via PyTorch autograd.
+
+    Usage:
+        def residual_fn(poses: List[Tensor]) -> Tensor:
+            # poses[i] is a tensor for the i-th variable
+            # Return the unwhitened error vector
+            p0, p1 = poses
+            diff = p1 - p0 - measurement
+            return diff
+
+        factor = TorchFactor(
+            noise_model=gtsam.noiseModel.Isotropic.Sigma(3, 0.1),
+            keys=[key0, key1],
+            residual_fn=residual_fn,
+            value_extractors=[extract_pose3, extract_pose3],
+        )
+        graph.add(factor.as_custom_factor())
+
+    The residual_fn receives a list of torch tensors (one per key) and must
+    return a 1-D tensor representing the unwhitened error. Jacobians are
+    computed automatically via torch.autograd.functional.jacobian.
+    """
+
+    def __init__(
+        self,
+        noise_model: gtsam.noiseModel.Base,
+        keys: Sequence[int],
+        residual_fn: Callable[[List[Tensor]], Tensor],
+        value_extractors: Optional[Sequence[Callable]] = None,
+        dtype: torch.dtype = torch.float64,
+    ):
+        """
+        Args:
+            noise_model: GTSAM noise model for this factor.
+            keys: Variable keys this factor connects to.
+            residual_fn: Function mapping list of tensors to error tensor.
+            value_extractors: Functions to extract numpy arrays from Values
+                for each key. If None, assumes all variables are vectors
+                accessed via values.atVector(key).
+            dtype: Torch dtype for computations (float64 for GTSAM compatibility).
+        """
+        self._noise_model = noise_model
+        self._keys = list(keys)
+        self._residual_fn = residual_fn
+        self._dtype = dtype
+
+        if value_extractors is None:
+            self._extractors = [self._default_extractor] * len(keys)
+        else:
+            if len(value_extractors) != len(keys):
+                raise ValueError(
+                    f"Got {len(value_extractors)} extractors for {len(keys)} keys"
+                )
+            self._extractors = list(value_extractors)
+
+    @staticmethod
+    def _default_extractor(values: gtsam.Values, key: int) -> np.ndarray:
+        """Default: extract variable as a flat vector."""
+        return values.atVector(key)
+
+    def _error_fn(
+        self, this: gtsam.CustomFactor, values: gtsam.Values, H
+    ) -> np.ndarray:
+        """Error function passed to CustomFactor."""
+        # Extract numpy values for each key
+        np_values = [
+            self._extractors[i](values, self._keys[i])
+            for i in range(len(self._keys))
+        ]
+
+        if H is not None:
+            # Need Jacobians: use autograd
+            tensors = [
+                torch.tensor(v, dtype=self._dtype, requires_grad=True)
+                for v in np_values
+            ]
+
+            error = self._residual_fn(tensors)
+            error_np = error.detach().numpy()
+
+            # Compute Jacobian for each input
+            for i, t in enumerate(tensors):
+                J = torch.autograd.functional.jacobian(
+                    lambda x: self._residual_fn(
+                        tensors[:i] + [x] + tensors[i + 1:]
+                    ),
+                    t,
+                )
+                H[i] = J.detach().numpy()
+        else:
+            # No Jacobians needed, just compute error
+            tensors = [
+                torch.tensor(v, dtype=self._dtype, requires_grad=False)
+                for v in np_values
+            ]
+            error = self._residual_fn(tensors)
+            error_np = error.detach().numpy()
+
+        return error_np
+
+    def as_custom_factor(self) -> gtsam.CustomFactor:
+        """Create the GTSAM CustomFactor wrapping this TorchFactor."""
+        return gtsam.CustomFactor(
+            self._noise_model, self._keys, self._error_fn
+        )
+
+
+# --- Convenience extractors for common GTSAM types ---
+
+def extract_vector(values: gtsam.Values, key: int) -> np.ndarray:
+    """Extract a Vector variable."""
+    return values.atVector(key)
+
+
+def extract_pose2(values: gtsam.Values, key: int) -> np.ndarray:
+    """Extract Pose2 as [x, y, theta]."""
+    pose = values.atPose2(key)
+    return np.array([pose.x(), pose.y(), pose.theta()])
+
+
+def extract_pose3(values: gtsam.Values, key: int) -> np.ndarray:
+    """Extract Pose3 as 6-vector in tangent space (relative to identity)."""
+    pose = values.atPose3(key)
+    return gtsam.Pose3.Logmap(pose)
+
+
+def extract_point2(values: gtsam.Values, key: int) -> np.ndarray:
+    """Extract Point2 as [x, y]."""
+    return values.atPoint2(key)
+
+
+def extract_point3(values: gtsam.Values, key: int) -> np.ndarray:
+    """Extract Point3 as [x, y, z]."""
+    return values.atPoint3(key)
+
+
+def extract_rot3(values: gtsam.Values, key: int) -> np.ndarray:
+    """Extract Rot3 as 3-vector in tangent space."""
+    rot = values.atRot3(key)
+    return gtsam.Rot3.Logmap(rot)


### PR DESCRIPTION
## Summary

Adds `gtsam.utils.torch_factor.TorchFactor`, a utility class that bridges PyTorch's automatic differentiation with GTSAM's factor graph optimization.

**The problem:** Writing custom GTSAM factors requires hand-deriving Jacobians, which is error-prone and limits adoption for neural/differentiable factors (NeRF-SLAM, 3DGS-SLAM, learned odometry, photometric factors).

**The solution:** Define your residual function using PyTorch tensors, and TorchFactor computes Jacobians automatically via `torch.autograd.functional.jacobian`.

```python
from gtsam.utils.torch_factor import TorchFactor, extract_pose3

def photometric_residual(tensors):
    pose_vec = tensors[0]
    # ... render from pose, compute pixel error ...
    return error_tensor

factor = TorchFactor(
    noise_model=gtsam.noiseModel.Isotropic.Sigma(n_pixels, 1.0),
    keys=[pose_key],
    residual_fn=photometric_residual,
    value_extractors=[extract_pose3],
)
graph.add(factor.as_custom_factor())
```

## What's included

- `TorchFactor` class wrapping `CustomFactor` with autograd Jacobians
- Convenience extractors for common types: `extract_vector`, `extract_pose2`, `extract_pose3`, `extract_point2`, `extract_point3`, `extract_rot3`
- Test suite verifying:
  - Prior factor convergence
  - Between factor with two variables
  - Jacobian correctness (autograd vs analytical)
  - Nonlinear residual (sin/cos) convergence

## Motivation

This came directly from building [gtsam-splatfactors](https://github.com/jashshah999/gtsam-splatfactors), where expressing 3D Gaussian Splatting photometric errors as GTSAM factors required manual Jacobian computation through a differentiable renderer. With TorchFactor, users can leverage PyTorch's autograd for any differentiable residual while getting all the benefits of GTSAM's optimization infrastructure (iSAM2, robust kernels, multi-sensor fusion).

## Design decisions

- **Pure Python, no C++ changes** — works with existing `CustomFactor` infrastructure
- **Optional dependency** — torch is imported lazily, won't break non-torch users
- **float64 by default** — matches GTSAM's internal precision
- **Extractor pattern** — decouples value extraction from residual computation, allowing manifold-aware extraction (e.g., Pose3 → Logmap tangent vector)

## Limitations & future work

- Jacobian computation uses `torch.autograd.functional.jacobian` which recomputes the forward pass per variable — fine for small factors, could use vmap for batched factors
- No GPU dispatch yet (factors evaluated synchronously by GTSAM's optimizer)
- Extractors use Logmap which linearizes at identity — for manifold-correct optimization, a `ManifoldTorchFactor` variant with retract/localCoordinates would be the next step

## Test plan

- [x] Unit tests pass locally (pytest)
- [ ] CI (no torch in GTSAM CI, tests are skipped gracefully via `@unittest.skipUnless`)