### PR TITLE
Use sccache for Windows Python jobs

### DIFF
--- a/.github/scripts/python.sh
+++ b/.github/scripts/python.sh
@@ -25,6 +25,7 @@ fi
 
 export PYTHON="python${PYTHON_VERSION}"
 NO_BOOST_BUILD=OFF
+SCCACHE=OFF
 
 function install_dependencies()
 {
@@ -62,6 +63,11 @@ function build()
     fi
   fi
 
+  SCCACHE_CMAKE_ARGS=""
+  if [ "${SCCACHE}" == "ON" ]; then
+    SCCACHE_CMAKE_ARGS="-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
+  fi
+
   cmake $GITHUB_WORKSPACE \
       -B build -G Ninja \
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
@@ -71,6 +77,7 @@ function build()
       -DGTSAM_WITH_TBB=${GTSAM_WITH_TBB:-OFF} \
       -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF \
       -DGTSAM_BUILD_WITH_MARCH_NATIVE=OFF \
+      -DGTSAM_BUILD_WITH_PRECOMPILED_HEADERS=OFF \
       -DGTSAM_BUILD_PYTHON=${BUILD_PYBIND} \
       -DGTSAM_UNSTABLE_BUILD_PYTHON=${GTSAM_BUILD_UNSTABLE:-ON} \
       -DGTSAM_PYTHON_VERSION=$PYTHON_VERSION \
@@ -79,8 +86,12 @@ function build()
       -DGTSAM_ENABLE_BOOST_SERIALIZATION=${ENABLE_BOOST_SERIALIZATION} \
       -DGTSAM_ALLOW_DEPRECATED_SINCE_V43=OFF \
       -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/gtsam_install \
-      $BOOST_CMAKE_ARGS
+      $BOOST_CMAKE_ARGS \
+      $SCCACHE_CMAKE_ARGS
 
+  # Unset environment variables so sccache can reuse caches.
+  unset PYTHON
+  unset PYTHON_VERSION
   if [ "${NO_BOOST_BUILD}" == "ON" ]; then
     # Build only wrapper targets for the no-Boost verification lane.
     cmake --build build -j2 --target gtsam_py gtsam_unstable_py
@@ -122,6 +133,9 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --no-boost)
       NO_BOOST_BUILD=ON
+      ;;
+    --sccache)
+      SCCACHE=ON
       ;;
     *)
       echo "Unknown option: $1"

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -51,7 +51,7 @@ jobs:
       PYTHON_VERSION: ${{ matrix.python_version }}
       BOOST_VERSION: 1.72.0
       BOOST_EXE: boost_1_72_0-msvc-14.2
-      GTSAM_ALLOW_DEPRECATED_SINCE_V43: OFF
+      SCCACHE_GHA_ENABLED: ON
 
     strategy:
       fail-fast: true
@@ -177,6 +177,10 @@ jobs:
           # Set the BOOST_ROOT variable
           echo "BOOST_ROOT=$BOOST_PATH" >> $env:GITHUB_ENV
 
+      - name: Install sccache
+        if: runner.os == 'Windows'
+        uses: mozilla-actions/sccache-action@v0.0.9
+
       - name: Set GTSAM_WITH_TBB Flag
         if: matrix.flag == 'tbb'
         run: |
@@ -208,9 +212,15 @@ jobs:
 
       - name: Build
         shell: bash
-        if: matrix.name != 'ubuntu-22.04-gcc-11-noboost'
+        if: matrix.name != 'ubuntu-22.04-gcc-11-noboost' && matrix.name != 'windows-2022-msvc'
         run: |
           bash .github/scripts/python.sh -b
+
+      - name: Build
+        shell: bash
+        if: matrix.name == 'windows-2022-msvc'
+        run: |
+          bash .github/scripts/python.sh -b --sccache
 
       - name: Build (No Boost Wrapper Check)
         if: matrix.name == 'ubuntu-22.04-gcc-11-noboost'

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -25,7 +25,6 @@ jobs:
       CTEST_OUTPUT_ON_FAILURE: ON
       CTEST_PARALLEL_LEVEL: 2
       CMAKE_BUILD_TYPE: ${{ matrix.build_type }}
-      GTSAM_BUILD_UNSTABLE: ${{ matrix.build_unstable }}
       BOOST_VERSION: 1.72.0
       BOOST_EXE: boost_1_72_0-msvc-14.2
       SCCACHE_GHA_ENABLED: ON
@@ -44,7 +43,6 @@ jobs:
             Release
           ]
 
-        build_unstable: [ON]
         include:
           - name: windows-2022-cl
             os: windows-2022


### PR DESCRIPTION
With a bit of finagling, we can reuse the caches from build-windows in the Windows build-python job. sccache will take into account environment variables when calculating hashes; care has been taken to ensure environment variables are _exactly_ the same between the two workflows and scripts. With that done, sccache is able to reuse the caches from build-windows, which speeds up the Windows Python build significantly: https://github.com/Gold856/gtsam/actions/runs/25951426921

Note that the run is with a nearly 100% cache hit rate, with the only misses being the actual Python object files. Actual speedups will be much lower, but still significant, and as usual, the lack of precompiled headers will penalize complete cache misses, but those are fairly rare, and on average, it will be faster.

