### PR TITLE
fix: guard size_t template specializations in matlab.h for Win64

### DIFF
--- a/wrap/matlab.h
+++ b/wrap/matlab.h
@@ -160,12 +160,14 @@ mxArray* wrap<bool>(const bool& value) {
 }
 
 // specialization to size_t
+#if !defined(_WIN64) || defined(__CUDACC__)
 template<>
 mxArray* wrap<size_t>(const size_t& value) {
   mxArray *result = scalar(mxUINT32OR64_CLASS);
   *(size_t*)mxGetData(result) = value;
   return result;
 }
+#endif
 
 // specialization to int
 template<>
@@ -345,12 +347,14 @@ uint64_t unwrap<uint64_t>(const mxArray* array) {
   return myGetScalar<uint64_t>(array);
 }
 
-// specialization to size_t
+// specialization to size_t but skip on Win64 where size_t == uint64_t
+#if !defined(_WIN64) || defined(__CUDACC__)
 template<>
 size_t unwrap<size_t>(const mxArray* array) {
   checkScalar(array, "unwrap<size_t>");
   return myGetScalar<size_t>(array);
 }
+#endif
 
 // specialization to double
 template<>


### PR DESCRIPTION
Fixes #2505

While setting up the MATLAB toolbox on Windows x64 following the README, I hit duplicate explicit template specialization errors:

    error C2766: explicit specialization; 'mxArray *wrap<size_t>...'
    has already been defined
    error C2766: explicit specialization; 'uint64_t unwrap<uint64_t>...'
    has already been defined

After investigating, I found this is because on Win64, size_t and uint64_t are typedefs of the same underlying type, making the wrap<size_t> and unwrap<size_t> specializations in matlab.h redundant with the existing uint64_t specializations.

Then I saw the fix from #2505 and applied it to both affected specializations:

    #if !defined(_WIN64) || defined(__CUDACC__)

The __CUDACC__ exception is included to preserve the size_t specializations in CUDA builds on Windows where size_t and uint64_t may still differ.

I verified this was the only change needed and that there were no other specializations in matlab.h have this conflict, and the fix is consistent across both wrap and unwrap.

Tested on:
- Windows x64
- Visual Studio 2026 Community (MSVC 19.51)
- MATLAB R2026a
- All test_gtsam tests pass