### PR TITLE
Modify for QCQP support for the BM methods.

### DIFF
--- a/gtsam/constrained/tests/testQcqpProblem.cpp
+++ b/gtsam/constrained/tests/testQcqpProblem.cpp
@@ -22,6 +22,7 @@
 #include <gtsam/constrained/QcqpProblem.h>
 #include <gtsam/constrained/QpCost.h>
 #include <gtsam/constrained/QuadraticConstraint.h>
+#include <gtsam/geometry/Rot3.h>
 #include <gtsam/geometry/SO3.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/nonlinear/LinearContainerFactor.h>
@@ -566,6 +567,132 @@ TEST(QcqpProblem, Rot2FrobeniusBetweenFactorD3) {
 }
 
 }  // namespace QcqpRot2VariableFixture
+/* ************************************************************************* */
+namespace QcqpTraitExtensionsFixture {
+
+const Key x0 = Symbol('x', 0);
+const Key x1 = Symbol('x', 1);
+
+// Verifies Rot2 QcqpValue at D=4 zero-pads beyond the intrinsic dim.
+TEST(QcqpProblem, Rot2QcqpValueD4Padding) {
+  const Rot2 R = Rot2::fromAngle(0.7);
+  const Matrix X4 = traits<Rot2>::template QcqpValue<4>(R);
+  LONGS_EQUAL(2, X4.rows());
+  LONGS_EQUAL(4, X4.cols());
+  EXPECT(assert_equal(Matrix(R.matrix().transpose()),
+                      Matrix(X4.leftCols<2>()), 1e-12));
+  EXPECT(assert_equal(Matrix(Matrix::Zero(2, 2)),
+                      Matrix(X4.rightCols<2>()), 1e-12));
+  EXPECT(assert_equal(Matrix(Matrix2::Identity()), X4 * X4.transpose(), 1e-12));
+}
+
+// Verifies Rot2 matrix-form constraints are equal across D = 2, 3, 5.
+TEST(QcqpProblem, Rot2QcqpConstraintsAreDIndependent) {
+  const auto cs2 = traits<Rot2>::template QcqpConstraints<2>();
+  const auto cs3 = traits<Rot2>::template QcqpConstraints<3>();
+  const auto cs5 = traits<Rot2>::template QcqpConstraints<5>();
+  LONGS_EQUAL(3, cs2.size());
+  LONGS_EQUAL(cs2.size(), cs3.size());
+  LONGS_EQUAL(cs2.size(), cs5.size());
+  for (size_t i = 0; i < cs2.size(); ++i) {
+    EXPECT(assert_equal(cs2[i].first, cs3[i].first, 1e-12));
+    EXPECT(assert_equal(cs2[i].first, cs5[i].first, 1e-12));
+    EXPECT_DOUBLES_EQUAL(cs2[i].second, cs3[i].second, 1e-12);
+    EXPECT_DOUBLES_EQUAL(cs2[i].second, cs5[i].second, 1e-12);
+  }
+}
+
+// Verifies Rot3 QcqpValue and QcqpConstraints at D=3.
+TEST(QcqpProblem, Rot3D3QcqpValueConstraints) {
+  const Rot3 R = Rot3::Expmap((Vector3() << 0.4, -0.1, 0.7).finished());
+  const Matrix X = traits<Rot3>::template QcqpValue<3>(R);
+  LONGS_EQUAL(3, X.rows());
+  LONGS_EQUAL(3, X.cols());
+  EXPECT(assert_equal(Matrix(R.matrix().transpose()), X, 1e-12));
+  EXPECT(assert_equal(Matrix(Matrix3::Identity()), X * X.transpose(), 1e-12));
+
+  const auto cs = traits<Rot3>::template QcqpConstraints<3>();
+  LONGS_EQUAL(6, cs.size());
+
+  NonlinearEqualityConstraints constraints;
+  InsertQcqpConstraints<Rot3, 3>(x0, &constraints);
+  Values values;
+  values.insert(x0, X);
+  EXPECT_DOUBLES_EQUAL(0.0, constraints.violationNorm(values), 1e-12);
+}
+
+// Verifies Rot3 rejects D=2 for QcqpValue and QcqpConstraints.
+TEST(QcqpProblem, Rot3D2Throws) {
+  const Rot3 R = Rot3::Expmap(Vector3::Zero());
+  CHECK_EXCEPTION(traits<Rot3>::template QcqpValue<2>(R),
+                  std::invalid_argument);
+  CHECK_EXCEPTION(traits<Rot3>::template QcqpConstraints<2>(),
+                  std::invalid_argument);
+}
+
+// Verifies FrobeniusBetweenFactor<Rot3> matches the manifold form at K=3.
+TEST(QcqpProblem, Rot3FrobeniusBetweenFactorD3) {
+  const Rot3 measured = Rot3::Expmap((Vector3() << 0.2, 0.1, -0.3).finished());
+  const Rot3 R0 = Rot3::Expmap((Vector3() << 0.05, 0.10, 0.15).finished());
+  const Rot3 R1 = Rot3::Expmap((Vector3() << 0.10, 0.20, 0.30).finished());
+
+  NonlinearFactorGraph graph;
+  auto noise = noiseModel::Isotropic::Sigma(Rot3::dimension, 1.0);
+  graph.emplace_shared<FrobeniusBetweenFactor<Rot3>>(x0, x1, measured, noise);
+
+  Values manifoldValues;
+  manifoldValues.insert(x0, R0);
+  manifoldValues.insert(x1, R1);
+
+  const QcqpProblem problem(graph, 3);
+  Values qcqpValues;
+  InsertQcqpValue<Rot3, 3>(x0, R0, &qcqpValues);
+  InsertQcqpValue<Rot3, 3>(x1, R1, &qcqpValues);
+  const double qcqpCost = problem.costs().error(qcqpValues);
+
+  EXPECT(std::isfinite(qcqpCost));
+  EXPECT_DOUBLES_EQUAL(graph.error(manifoldValues), qcqpCost, 1e-12);
+  EXPECT_DOUBLES_EQUAL(0.0, problem.eConstraints().violationNorm(qcqpValues),
+                       1e-12);
+}
+
+// Verifies FrobeniusBetweenFactor<Rot2> matches the manifold form at K=4.
+TEST(QcqpProblem, Rot2FrobeniusBetweenFactorD4) {
+  const Rot2 measured = Rot2::fromAngle(0.4);
+  const Rot2 R0 = Rot2::fromAngle(0.3);
+  const Rot2 R1 = Rot2::fromAngle(-0.2);
+
+  NonlinearFactorGraph graph;
+  auto noise = noiseModel::Isotropic::Sigma(1, 1.0);
+  graph.emplace_shared<FrobeniusBetweenFactor<Rot2>>(x0, x1, measured, noise);
+
+  Values manifoldValues;
+  manifoldValues.insert(x0, R0);
+  manifoldValues.insert(x1, R1);
+
+  const QcqpProblem problem(graph, 4);
+  Values qcqpValues;
+  InsertQcqpValue<Rot2, 4>(x0, R0, &qcqpValues);
+  InsertQcqpValue<Rot2, 4>(x1, R1, &qcqpValues);
+  const double qcqpCost = problem.costs().error(qcqpValues);
+
+  EXPECT(std::isfinite(qcqpCost));
+  EXPECT_DOUBLES_EQUAL(graph.error(manifoldValues), qcqpCost, 1e-12);
+  EXPECT_DOUBLES_EQUAL(0.0, problem.eConstraints().violationNorm(qcqpValues),
+                       1e-12);
+}
+
+// Verifies FrobeniusBetweenFactor<Rot3> rejects K=2 at QCQP construction.
+TEST(QcqpProblem, Rot3FrobeniusBetweenFactorK2Rejected) {
+  NonlinearFactorGraph graph;
+  auto noise = noiseModel::Isotropic::Sigma(Rot3::dimension, 1.0);
+  graph.emplace_shared<FrobeniusBetweenFactor<Rot3>>(
+      x0, x1, Rot3::Expmap(Vector3::Zero()), noise);
+  CHECK_EXCEPTION({ QcqpProblem problem(graph, /*K=*/2); },
+                  std::invalid_argument);
+}
+
+}  // namespace QcqpTraitExtensionsFixture
 /* ************************************************************************* */
 int main() {
   TestResult tr;

--- a/gtsam/geometry/Rot2.h
+++ b/gtsam/geometry/Rot2.h
@@ -258,7 +258,7 @@ struct traits<Rot2> : public internal::MatrixLieGroup<Rot2, 2> {
    *
    * D=1 is vectorized SO(2) as a 4-by-1 matrix.
    * D=2 returns R' as a 2-by-2 row-orthonormal matrix.
-   * D=3 returns [R', 0] as a 2-by-3 row-orthonormal matrix.
+   * D>=3 returns [R', 0] as a 2-by-D row-orthonormal matrix.
    */
   template <int D = 1>
   static Matrix QcqpValue(const Rot2& value) {
@@ -267,21 +267,21 @@ struct traits<Rot2> : public internal::MatrixLieGroup<Rot2, 2> {
       return Eigen::Map<const Matrix>(R.data(), 4, 1);
     } else if constexpr (D == 2) {
       return value.matrix().transpose();
-    } else if constexpr (D == 3) {
-      Matrix X = Matrix::Zero(2, 3);
+    } else if constexpr (D >= 3) {
+      Matrix X = Matrix::Zero(2, D);
       X.leftCols<2>() = value.matrix().transpose();
       return X;
     } else {
       throw std::invalid_argument(
-          "traits<Rot2>::QcqpValue only supports D=1, D=2, and D=3.");
+          "traits<Rot2>::QcqpValue only supports D=1, D=2, and D>=3.");
     }
   }
 
   /**
    * Return row-space QCQP equality constraints A, b such that
    * trace(X' A X) = b. For D=1 these are the vec(R) SO(2) constraints,
-   * including orientation. For D=2 and D=3 the same 2-by-2 constraints
-   * enforce row orthonormality.
+   * including orientation. For D>=2 the same 2-by-2 constraints enforce
+   * row orthonormality.
    */
   template <int D = 1>
   static std::vector<std::pair<Matrix, double>> QcqpConstraints() {
@@ -315,7 +315,7 @@ struct traits<Rot2> : public internal::MatrixLieGroup<Rot2, 2> {
       constraints.emplace_back(A, 1.0);
 
       return constraints;
-    } else if constexpr (D == 2 || D == 3) {
+    } else if constexpr (D >= 2) {
       std::vector<std::pair<Matrix, double>> constraints;
       constraints.reserve(3);
 
@@ -335,7 +335,7 @@ struct traits<Rot2> : public internal::MatrixLieGroup<Rot2, 2> {
       return constraints;
     } else {
       throw std::invalid_argument(
-          "traits<Rot2>::QcqpConstraints only supports D=1, D=2, and D=3.");
+          "traits<Rot2>::QcqpConstraints only supports D=1 and D>=2.");
     }
   }
 };

--- a/gtsam/geometry/Rot3.h
+++ b/gtsam/geometry/Rot3.h
@@ -596,9 +596,60 @@ class GTSAM_EXPORT Rot3 : public MatrixLieGroup<Rot3, 3, 3> {
       const Matrix3& A, OptionalJacobian<3, 9> H = {});
 
   template <>
-struct traits<Rot3> : public internal::MatrixLieGroup<Rot3, 3> {};
+struct traits<Rot3> : public internal::MatrixLieGroup<Rot3, 3> {
+  /**
+   * Return a matrix-valued QCQP variable for Rot3.
+   *
+   * D>=3 returns [R', 0] as a 3-by-D row-orthonormal matrix.
+   */
+  template <int D = 1>
+  static Matrix QcqpValue(const Rot3& value) {
+    if constexpr (D >= 3) {
+      Matrix X = Matrix::Zero(3, D);
+      X.template leftCols<3>() = value.matrix().transpose();
+      return X;
+    } else {
+      throw std::invalid_argument(
+          "traits<Rot3>::QcqpValue only supports D>=3.");
+    }
+  }
+
+  /**
+   * Return row-space QCQP equality constraints A, b such that
+   * trace(X' A X) = b. For D>=3 the same 3-by-3 constraints enforce
+   * row orthonormality.
+   */
+  template <int D = 1>
+  static std::vector<std::pair<Matrix, double>> QcqpConstraints() {
+    if constexpr (D >= 3) {
+      std::vector<std::pair<Matrix, double>> constraints;
+      constraints.reserve(6);
+
+      // 3 row-unit-norm: ||row r||^2 = 1.
+      for (int r = 0; r < 3; ++r) {
+        Matrix A = Matrix::Zero(3, 3);
+        A(r, r) = 1.0;
+        constraints.emplace_back(A, 1.0);
+      }
+
+      // 3 row-orthogonality: row r1 . row r2 = 0.
+      for (int r1 = 0; r1 < 3; ++r1) {
+        for (int r2 = r1 + 1; r2 < 3; ++r2) {
+          Matrix A = Matrix::Zero(3, 3);
+          A(r1, r2) = 0.5;
+          A(r2, r1) = 0.5;
+          constraints.emplace_back(A, 0.0);
+        }
+      }
+      return constraints;
+    } else {
+      throw std::invalid_argument(
+          "traits<Rot3>::QcqpConstraints only supports D>=3.");
+    }
+  }
+};
 
 template <>
-struct traits<const Rot3> : public internal::MatrixLieGroup<Rot3, 3> {};
+struct traits<const Rot3> : public traits<Rot3> {};
   
 }  // namespace gtsam

--- a/gtsam/slam/FrobeniusFactor.h
+++ b/gtsam/slam/FrobeniusFactor.h
@@ -266,24 +266,20 @@ class FrobeniusBetweenFactor : public FrobeniusBetweenFactorNL<T> {
     return error;
   }
 
-  /** Add this Frobenius between factor as a QCQP cost when traits exist. */
+  /** Add this Frobenius between factor as a QCQP cost when traits exist.
+   *  Dispatches on the QCQP variable's column dimension K: K=1 takes the
+   *  vec(R) form, K>=2 takes the matrix form. */
   void qcqpFactors(NonlinearFactorGraph* costs,
                    NonlinearEqualityConstraints* constraints,
                    size_t columnDimension = 1) const override {
-    switch (columnDimension) {
-      case 1:
-        qcqpFactorsForDimension<1>(costs, constraints);
-        break;
-      case 2:
-        qcqpFactorsForDimension<2>(costs, constraints);
-        break;
-      case 3:
-        qcqpFactorsForDimension<3>(costs, constraints);
-        break;
-      default:
-        throw std::runtime_error(
-            "FrobeniusBetweenFactor::qcqpFactors only supports "
-            "column dimensions 1, 2, and 3");
+    if (columnDimension == 0) {
+      throw std::invalid_argument(
+          "FrobeniusBetweenFactor::qcqpFactors: columnDimension must be >= 1");
+    }
+    if (columnDimension == 1) {
+      qcqpFactorsForVec(costs, constraints);
+    } else {
+      qcqpFactorsForMatrix(costs, constraints, columnDimension);
     }
   }
 
@@ -301,13 +297,16 @@ class FrobeniusBetweenFactor : public FrobeniusBetweenFactorNL<T> {
     return result;
   }
 
-  template <int QcqpDimension>
-  void qcqpFactorsForDimension(NonlinearFactorGraph* costs,
-                               NonlinearEqualityConstraints* constraints) const {
-    if constexpr (!internal::HasQcqpVariableTraits<T, QcqpDimension>::value) {
+  /// Vec(R) form (K=1): variable is (N*N)x1; accepts any non-robust
+  /// Gaussian noise model.
+  void qcqpFactorsForVec(NonlinearFactorGraph* costs,
+                         NonlinearEqualityConstraints* constraints) const {
+    if constexpr (!internal::HasQcqpVariableTraits<T, 1>::value) {
+      (void)costs;
+      (void)constraints;
       throw std::runtime_error(
           "FrobeniusBetweenFactor::qcqpFactors requires QCQP variable traits "
-          "for this type and column dimension.");
+          "for this type and column dimension 1.");
     } else {
       if (!costs) {
         throw std::invalid_argument(
@@ -320,46 +319,78 @@ class FrobeniusBetweenFactor : public FrobeniusBetweenFactorNL<T> {
             "non-robust quadratic noise model");
       }
 
-      InsertQcqpConstraints<T, QcqpDimension>(this->key1(), constraints);
-      InsertQcqpConstraints<T, QcqpDimension>(this->key2(), constraints);
+      InsertQcqpConstraints<T, 1>(this->key1(), constraints);
+      InsertQcqpConstraints<T, 1>(this->key2(), constraints);
+
+      constexpr int AmbientDim = N * N;
+      const Matrix measurement = this->T12_.matrix();
+      const Matrix A = RightProductMatrix(measurement);
+
+      Matrix B = Matrix::Zero(AmbientDim, 2 * AmbientDim);
+      B.block(0, 0, AmbientDim, AmbientDim) = -A;
+      B.block(0, AmbientDim, AmbientDim, AmbientDim) =
+          Matrix::Identity(AmbientDim, AmbientDim);
+
+      const Matrix whitenedB = this->noiseModel_->Whiten(B);
+      const Matrix Q = whitenedB.transpose() * whitenedB;
+      const SymmetricBlockMatrix blockQ(
+          std::vector<DenseIndex>{AmbientDim, AmbientDim}, Q);
+      costs->push_back(std::make_shared<QpCost>(
+          KeyVector{this->key1(), this->key2()}, blockQ));
+    }
+  }
+
+  /// Matrix form (K>=N, where N is the variable's intrinsic row dim):
+  /// variable is N-by-K row-orthonormal; requires an isotropic noise model.
+  void qcqpFactorsForMatrix(NonlinearFactorGraph* costs,
+                            NonlinearEqualityConstraints* constraints,
+                            size_t columnDimension) const {
+    if constexpr (!internal::HasQcqpVariableTraits<T, N>::value) {
+      (void)costs;
+      (void)constraints;
+      (void)columnDimension;
+      throw std::runtime_error(
+          "FrobeniusBetweenFactor::qcqpFactors requires QCQP variable traits "
+          "for this type and matrix-form column dimensions (>= 2).");
+    } else {
+      if (columnDimension < static_cast<size_t>(N)) {
+        throw std::invalid_argument(
+            "FrobeniusBetweenFactor::qcqpFactors: columnDimension must be "
+            ">= the variable's intrinsic row dimension (e.g. >= 3 for Rot3).");
+      }
+      if (!costs) {
+        throw std::invalid_argument(
+            "FrobeniusBetweenFactor::qcqpFactors costs is null");
+      }
+      if (std::dynamic_pointer_cast<noiseModel::Robust>(this->noiseModel_) ||
+          this->noiseModel_->isConstrained()) {
+        throw std::runtime_error(
+            "FrobeniusBetweenFactor::qcqpFactors requires a "
+            "non-robust quadratic noise model");
+      }
+      const auto isotropic =
+          std::dynamic_pointer_cast<noiseModel::Isotropic>(this->noiseModel_);
+      if (!isotropic) {
+        throw std::runtime_error(
+            "FrobeniusBetweenFactor::qcqpFactors with column dimension > 1 "
+            "requires an isotropic noise model");
+      }
+
+      InsertQcqpConstraints<T, N>(this->key1(), constraints);
+      InsertQcqpConstraints<T, N>(this->key2(), constraints);
 
       const Matrix measurement = this->T12_.matrix();
       const Matrix I = Matrix::Identity(N, N);
+      const double weight = 1.0 / (isotropic->sigma() * isotropic->sigma());
 
-      if constexpr (QcqpDimension == 1) {
-        constexpr int AmbientDim = N * N;
-        const Matrix A = RightProductMatrix(measurement);
+      Matrix B = Matrix::Zero(N, 2 * N);
+      B.block(0, 0, N, N) = -measurement.transpose();
+      B.block(0, N, N, N) = I;
 
-        Matrix B = Matrix::Zero(AmbientDim, 2 * AmbientDim);
-        B.block(0, 0, AmbientDim, AmbientDim) = -A;
-        B.block(0, AmbientDim, AmbientDim, AmbientDim) =
-            Matrix::Identity(AmbientDim, AmbientDim);
-
-        const Matrix whitenedB = this->noiseModel_->Whiten(B);
-        const Matrix Q = whitenedB.transpose() * whitenedB;
-        const SymmetricBlockMatrix blockQ(
-            std::vector<DenseIndex>{AmbientDim, AmbientDim}, Q);
-        costs->push_back(std::make_shared<QpCost>(
-            KeyVector{this->key1(), this->key2()}, blockQ));
-      } else {
-        const auto isotropic =
-            std::dynamic_pointer_cast<noiseModel::Isotropic>(this->noiseModel_);
-        if (!isotropic) {
-          throw std::runtime_error(
-              "FrobeniusBetweenFactor::qcqpFactors with column dimension > 1 "
-              "requires an isotropic noise model");
-        }
-        const double weight = 1.0 / (isotropic->sigma() * isotropic->sigma());
-
-        Matrix B = Matrix::Zero(N, 2 * N);
-        B.block(0, 0, N, N) = -measurement.transpose();
-        B.block(0, N, N, N) = I;
-
-        const Matrix Q = weight * B.transpose() * B;
-        const SymmetricBlockMatrix blockQ(std::vector<DenseIndex>{N, N}, Q);
-        costs->push_back(std::make_shared<QpCost>(
-            KeyVector{this->key1(), this->key2()}, blockQ, QcqpDimension));
-      }
+      const Matrix Q = weight * B.transpose() * B;
+      const SymmetricBlockMatrix blockQ(std::vector<DenseIndex>{N, N}, Q);
+      costs->push_back(std::make_shared<QpCost>(
+          KeyVector{this->key1(), this->key2()}, blockQ, columnDimension));
     }
   }
 };


### PR DESCRIPTION
# PR 1 — Modify QCQP support for BM methods

Branch: `feature/QCQP_BM_support`.

**Summary**: generalize the existing QCQP factor traits so the column
dimension `D` can be **any** value `≥ d` (instead of only specific cases
the code previously hard-coded). The BM staircase needs this because
`D = p` varies across staircase levels.

## Each files

- **`Rot2.h`** — generalized QCQP traits to any `D ≥ 2`.
- **`Rot3.h`** — added QCQP traits (and supports any D).
- **`FrobeniusFactor.h`** — `qcqpFactors` now emits matrix-form factors
  at any column count `D ≥ d`.
