### PR TITLE
cmake: disable Boost by default when building inside colcon (ROS 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,9 +98,16 @@ include(GtsamTesting)
 include(GtsamPrinting)
 
 ############### Decide on BOOST ######################################
-# Enable or disable serialization with GTSAM_ENABLE_BOOST_SERIALIZATION
-option(GTSAM_ENABLE_BOOST_SERIALIZATION "Enable Boost serialization" ON)
-option(GTSAM_USE_BOOST_FEATURES "Enable Features that use Boost" ON)
+# When building inside colcon (ROS 2 build farm or local colcon build),
+# default to no Boost so ROS packages avoid the dependency.
+# Override explicitly with -DGTSAM_USE_BOOST_FEATURES=ON if needed.
+if(DEFINED ENV{COLCON})
+  set(_gtsam_boost_default OFF)
+else()
+  set(_gtsam_boost_default ON)
+endif()
+option(GTSAM_ENABLE_BOOST_SERIALIZATION "Enable Boost serialization" ${_gtsam_boost_default})
+option(GTSAM_USE_BOOST_FEATURES "Enable Features that use Boost" ${_gtsam_boost_default})
 
 if(GTSAM_ENABLE_BOOST_SERIALIZATION OR GTSAM_USE_BOOST_FEATURES)
 include(cmake/HandleBoost.cmake)


### PR DESCRIPTION
The ROS 2 packaging policy discourages introducing Boost as a dependency, and we have had Hdev/JDev/... Jenkins jobs failing to build GTSAM for ages now since package.xml already promises "build without boost" but cmake defaults to "use boost by default".

We have two Boost options (GTSAM_USE_BOOST_FEATURES and GTSAM_ENABLE_BOOST_SERIALIZATION) previously defaulted to ON unconditionally.

colcon unconditionally exports COLCON=1 into every build subprocess, so we can use that as a reliable, zero-configuration signal that we are inside a colcon build (local or CI).  When that variable is detected the two options now default to OFF; for all other build systems (plain cmake, catkin, etc.) the defaults remain ON, preserving backward compatibility.

A downstream integrator who genuinely needs Boost in a colcon build can still opt back in explicitly:
  colcon build --cmake-args -DGTSAM_USE_BOOST_FEATURES=ON

Link to the for-ever failing "Dev" build jobs: https://build.ros2.org/job/Hdev__gtsam__ubuntu_jammy_amd64/