### PR TITLE
[Python] Fix python-unstable-stubs using bare pybind11-stubgen command

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -315,7 +315,7 @@ if(GTSAM_UNSTABLE_BUILD_PYTHON)
         COMMAND
         ${CMAKE_COMMAND} -E env
         "PYTHONPATH=${GTSAM_PYTHON_BUILD_DIRECTORY}/$ENV{PYTHONPATH}"
-        pybind11-stubgen -o . --enum-class-locations \"KernelFunctionType|NoiseFormat:gtsam.gtsam\" --enum-class-locations \"OrderingType:gtsam.gtsam.Ordering\" --numpy-array-use-type-var --ignore-all-errors gtsam_unstable
+        ${PYTHON_EXECUTABLE} -m pybind11_stubgen -o . --enum-class-locations \"KernelFunctionType|NoiseFormat:gtsam.gtsam\" --enum-class-locations \"OrderingType:gtsam.gtsam.Ordering\" --numpy-array-use-type-var --ignore-all-errors gtsam_unstable
         DEPENDS ${GTSAM_PYTHON_DEPENDENCIES} ${GTSAM_PYTHON_TEST_FILES} ${GTSAM_PYTHON_UNSTABLE_TARGET}
         WORKING_DIRECTORY "${GTSAM_PYTHON_BUILD_DIRECTORY}/"
     )

--- a/python/README.md
+++ b/python/README.md
@@ -13,7 +13,7 @@ For instructions on updating the version of the [wrap library](https://github.co
   use the `-DGTSAM_PYTHON_VERSION=3.6` option when running `cmake` otherwise the default interpreter will be used.
 - If the interpreter is inside an environment (such as an anaconda environment or virtualenv environment),
   then the environment should be active while building GTSAM.
-- This wrapper needs [pyparsing(>=2.4.2)](https://github.com/pyparsing/pyparsing), [pybind-stubgen>=2.5.1](https://github.com/sizmailov/pybind11-stubgen) and [numpy(>=1.11.0)](https://numpy.org/). These can all be installed as follows:
+- This wrapper needs [pyparsing(>=2.4.2)](https://github.com/pyparsing/pyparsing), [pybind11-stubgen>=2.5.1](https://github.com/sizmailov/pybind11-stubgen) and [numpy(>=1.11.0)](https://numpy.org/). These can all be installed as follows:
 
   ```bash
   pip install -r <gtsam_folder>/python/dev_requirements.txt


### PR DESCRIPTION
The python-unstable-stubs CMake target invoked pybind11-stubgen as a bare system command, while python-stubs correctly used ${PYTHON_EXECUTABLE} -m pybind11_stubgen. When using a virtual environment (required on systems enforcing PEP 668, e.g. Homebrew Python on macOS and system Python on Ubuntu 23.04+), the bare command is not on PATH and the build fails with "no such file or directory".

Fix: use ${PYTHON_EXECUTABLE} -m pybind11_stubgen consistently, matching the existing python-stubs target.

Also fix a typo in python/README.md: pybind-stubgen -> pybind11-stubgen.