### PR TITLE
Add FromQcqpValue (Rot2/Rot3) and ExtractQcqpValues helpers in feature/convert_to_QCQP

### DIFF
--- a/gtsam/constrained/QcqpProblem.h
+++ b/gtsam/constrained/QcqpProblem.h
@@ -99,6 +99,27 @@ void InsertQcqpConstraints(Key key, NonlinearEqualityConstraints* constraints) {
 }
 
 /**
+ * Project matrix-form QCQP variables back into typed values: scan
+ * `qcqpValues` and apply `traits<T>::FromQcqpValue<D>` to each slice whose
+ * row dim matches `T`. Slices with other row dims are skipped, so
+ * mixed-type graphs are safe.
+ */
+template <typename T, int D>
+std::vector<std::pair<Key, T>> ExtractQcqpValues(const Values& qcqpValues) {
+  static_assert(internal::HasQcqpVariableTraits<T, D>::value,
+                "ExtractQcqpValues requires traits<T>::QcqpValue<D>, "
+                "QcqpConstraints<D>, and FromQcqpValue<D>.");
+  constexpr int expectedRows = T::LieAlgebra::RowsAtCompileTime;
+  std::vector<std::pair<Key, T>> out;
+  for (const auto& [key, M] : qcqpValues.extract<Matrix>()) {
+    if (M.rows() == expectedRows) {
+      out.emplace_back(key, traits<T>::template FromQcqpValue<D>(M));
+    }
+  }
+  return out;
+}
+
+/**
  * Thin constrained optimization problem for QCQPs over Vector or Matrix values.
  */
 class GTSAM_EXPORT QcqpProblem : public ConstrainedOptProblem {

--- a/gtsam/constrained/tests/testQcqpProblem.cpp
+++ b/gtsam/constrained/tests/testQcqpProblem.cpp
@@ -693,6 +693,60 @@ TEST(QcqpProblem, Rot3FrobeniusBetweenFactorK2Rejected) {
 }
 
 }  // namespace QcqpTraitExtensionsFixture
+
+/* ************************************************************************* */
+// Round-trip Rot2 through Insert/ExtractQcqpValues at D=2.
+TEST(QcqpProblem, ExtractQcqpValuesRot2) {
+  Values values;
+  const Rot2 R0 = Rot2::fromAngle(0.25);
+  const Rot2 R1 = Rot2::fromAngle(-1.10);
+  InsertQcqpValue<Rot2, 2>(Symbol('x', 0), R0, &values);
+  InsertQcqpValue<Rot2, 2>(Symbol('x', 1), R1, &values);
+
+  const auto extracted = ExtractQcqpValues<Rot2, 2>(values);
+  LONGS_EQUAL(2, extracted.size());
+
+  Values out;
+  for (auto& [key, R] : extracted) out.insert(key, R);
+  EXPECT(assert_equal(R0, out.at<Rot2>(Symbol('x', 0)), 1e-12));
+  EXPECT(assert_equal(R1, out.at<Rot2>(Symbol('x', 1)), 1e-12));
+}
+
+/* ************************************************************************* */
+// Round-trip Rot3 through Insert/ExtractQcqpValues at D=3.
+TEST(QcqpProblem, ExtractQcqpValuesRot3) {
+  Values values;
+  const Rot3 R0 = Rot3::Rz(0.25);
+  const Rot3 R1 = Rot3::RzRyRx(0.1, -0.4, 0.7);
+  InsertQcqpValue<Rot3, 3>(Symbol('x', 0), R0, &values);
+  InsertQcqpValue<Rot3, 3>(Symbol('x', 1), R1, &values);
+
+  const auto extracted = ExtractQcqpValues<Rot3, 3>(values);
+  LONGS_EQUAL(2, extracted.size());
+
+  Values out;
+  for (auto& [key, R] : extracted) out.insert(key, R);
+  EXPECT(assert_equal(R0, out.at<Rot3>(Symbol('x', 0)), 1e-12));
+  EXPECT(assert_equal(R1, out.at<Rot3>(Symbol('x', 1)), 1e-12));
+}
+
+/* ************************************************************************* */
+// On a mixed Rot2 + Rot3 Values at D=3, ExtractQcqpValues<Rot3, 3> keeps
+// only the row-dim-3 slice.
+TEST(QcqpProblem, ExtractQcqpValuesSkipsForeignSlices) {
+  Values values;
+  const Rot2 R2 = Rot2::fromAngle(0.3);
+  const Rot3 R3 = Rot3::Rz(0.5);
+  InsertQcqpValue<Rot2, 3>(Symbol('a', 0), R2, &values);
+  InsertQcqpValue<Rot2, 3>(Symbol('a', 1), R2, &values);
+  InsertQcqpValue<Rot3, 3>(Symbol('b', 0), R3, &values);
+
+  const auto rot3s = ExtractQcqpValues<Rot3, 3>(values);
+  LONGS_EQUAL(1, rot3s.size());
+  EXPECT(rot3s.front().first == Symbol('b', 0));
+  EXPECT(assert_equal(R3, rot3s.front().second, 1e-12));
+}
+
 /* ************************************************************************* */
 int main() {
   TestResult tr;

--- a/gtsam/geometry/Rot2.h
+++ b/gtsam/geometry/Rot2.h
@@ -338,6 +338,15 @@ struct traits<Rot2> : public internal::MatrixLieGroup<Rot2, 2> {
           "traits<Rot2>::QcqpConstraints only supports D=1 and D>=2.");
     }
   }
+
+  /// Project a 2-by-D matrix back to Rot2 via Rot2::ClosestTo on the
+  /// leading 2-by-2 block.
+  template <int D>
+  static Rot2 FromQcqpValue(const Matrix& X) {
+    static_assert(D >= 2,
+                  "traits<Rot2>::FromQcqpValue requires D >= 2.");
+    return Rot2::ClosestTo(X.template leftCols<2>().transpose());
+  }
 };
 
 template <>

--- a/gtsam/geometry/Rot3.h
+++ b/gtsam/geometry/Rot3.h
@@ -647,6 +647,15 @@ struct traits<Rot3> : public internal::MatrixLieGroup<Rot3, 3> {
           "traits<Rot3>::QcqpConstraints only supports D>=3.");
     }
   }
+
+  /// Project a 3-by-D matrix back to Rot3 via Rot3::ClosestTo on the
+  /// leading 3-by-3 block.
+  template <int D>
+  static Rot3 FromQcqpValue(const Matrix& X) {
+    static_assert(D >= 3,
+                  "traits<Rot3>::FromQcqpValue requires D >= 3.");
+    return Rot3::ClosestTo(X.template leftCols<3>().transpose());
+  }
 };
 
 template <>


### PR DESCRIPTION
## Summary

  Add an extract path from the rounded BM solution to the QCQP variable traits, so matrix-form QCQP values can be projected back into typed `Rot2` / `Rot3`. Needed by the Burer–Monteiro / Riemannian Staircase solver in the follow-up PR, which returns a rank-`d` matrix. A step toward type-agnostic extraction.

  ## Changes

  Add `FromQcqpValue` for `Rot2` and `Rot3` (via `Rot::ClosestTo`), and add `ExtractQcqpValues` in `QcqpProblem`.

  ## Notes

  - Vector form (`D = 1`) is intentionally unsupported by `FromQcqpValue` — one column of a rotation matrix doesn't determine the rotation. A `static_assert` makes this explicit at the call site.





