### PR TITLE
Copy-free matrix views for wrapped batch APIs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,6 +8,7 @@ For reviewing PRs:
 * If we add a C++ function to a `.i` file to expose it to the wrapper, we must ensure that the parameter names match exactly between the declaration in the header file and the declaration in the `.i`. Similarly, if we change any parameter names in a wrapped function in a header file, or change any parameter names in a `.i` file, we must change the corresponding function in the other file to reflect those changes.
 * For templated classes/factors in wrappers, prefer the normal `.i` template mechanism over hand-writing one wrapper class per instantiation. Let the wrapper generate names such as `AttitudeFactorRot3` from `template<...> class AttitudeFactor`.
 * Do not add or keep C++ `using`/`typedef` aliases solely to manufacture wrapper names. Only keep aliases when they are genuinely useful in the C++ API as well.
+* The top-level `wrap/` directory is a git subtree of `borglab/wrap`, not a submodule. The official way to pull in new upstream versions is `./update_wrap.sh` from the GTSAM repo root, optionally passing a branch or tag as the first argument; it defaults to `master`. This creates GTSAM commits, typically a squash plus a merge commit, so do it on a feature branch and open a PR rather than pushing directly to `master` or `develop`. Make code contributions to wrap in the `borglab/wrap` repository.
 * Classes are Uppercase, methods and functions lowerMixedCase.
 * Public fields in structs keep plain names (no trailing underscore).
 * Apart from those naming conventions, we adopt Google C++ style.

--- a/gtsam/base/Matrix.h
+++ b/gtsam/base/Matrix.h
@@ -38,6 +38,9 @@ namespace gtsam {
 
 typedef Eigen::MatrixXd Matrix;
 typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> MatrixRowMajor;
+/// Dynamic-stride const Matrix view for accepting NumPy arrays without copies.
+using ConstMatrixView =
+    Eigen::Ref<const Matrix, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>>;
 
 // Create handy typedefs and constants for square-size matrices
 // MatrixMN, MatrixN = MatrixNN, I_NxN, and Z_NxN, for M,N=1..9

--- a/gtsam/geometry/Pose2.cpp
+++ b/gtsam/geometry/Pose2.cpp
@@ -246,7 +246,7 @@ Point2 Pose2::transformTo(const Point2& point,
   return q;
 }
 
-Matrix Pose2::transformTo(const Matrix& points) const {
+Matrix Pose2::transformTo(ConstMatrixView points) const {
   if (points.rows() != 2) {
     throw std::invalid_argument("Pose2:transformTo expects 2*N matrix.");
   }
@@ -266,7 +266,7 @@ Point2 Pose2::transformFrom(const Point2& point,
 }
 
 
-Matrix Pose2::transformFrom(const Matrix& points) const {
+Matrix Pose2::transformFrom(ConstMatrixView points) const {
   if (points.rows() != 2) {
     throw std::invalid_argument("Pose2:transformFrom expects 2*N matrix.");
   }

--- a/gtsam/geometry/Pose2.cpp
+++ b/gtsam/geometry/Pose2.cpp
@@ -396,7 +396,7 @@ std::optional<Pose2> Pose2::Align(const Point2Pairs &ab_pairs) {
   return Pose2(R, t);
 }
 
-std::optional<Pose2> Pose2::Align(const Matrix& a, const Matrix& b) {
+std::optional<Pose2> Pose2::Align(ConstMatrixView a, ConstMatrixView b) {
   if (a.rows() != 2 || b.rows() != 2 || a.cols() != b.cols()) {
     throw std::invalid_argument(
       "Pose2:Align expects 2*N matrices of equal shape.");

--- a/gtsam/geometry/Pose2.h
+++ b/gtsam/geometry/Pose2.h
@@ -115,7 +115,7 @@ public:
   static std::optional<Pose2> Align(const Point2Pairs& abPointPairs);
 
   // Version of Pose2::Align that takes 2 matrices.
-  static std::optional<Pose2> Align(const Matrix& a, const Matrix& b);
+  static std::optional<Pose2> Align(ConstMatrixView a, ConstMatrixView b);
 
   /// @}
   /// @name Testable

--- a/gtsam/geometry/Pose2.h
+++ b/gtsam/geometry/Pose2.h
@@ -201,7 +201,7 @@ public:
    * @param points 2*N matrix in world coordinates
    * @return points in Pose coordinates, as 2*N Matrix
    */
-  Matrix transformTo(const Matrix& points) const;
+  Matrix transformTo(ConstMatrixView points) const;
 
   /** Return point coordinates in global frame */
   Point2 transformFrom(const Point2& point,
@@ -213,7 +213,7 @@ public:
    * @param points 2*N matrix in Pose coordinates
    * @return points in world coordinates, as 2*N Matrix
    */
-  Matrix transformFrom(const Matrix& points) const;
+  Matrix transformFrom(ConstMatrixView points) const;
 
   /** syntactic sugar for transformFrom */
   inline Point2 operator*(const Point2& point) const { 

--- a/gtsam/geometry/Pose3.cpp
+++ b/gtsam/geometry/Pose3.cpp
@@ -341,7 +341,7 @@ std::optional<Pose3> Pose3::Align(const Point3Pairs &abPointPairs) {
   return Pose3(aRb, aTb);
 }
 
-std::optional<Pose3> Pose3::Align(const Matrix& a, const Matrix& b) {
+std::optional<Pose3> Pose3::Align(ConstMatrixView a, ConstMatrixView b) {
   if (a.rows() != 3 || b.rows() != 3 || a.cols() != b.cols()) {
     throw std::invalid_argument(
         "Pose3:Align expects 3*N matrices of equal shape.");

--- a/gtsam/geometry/Pose3.cpp
+++ b/gtsam/geometry/Pose3.cpp
@@ -204,7 +204,7 @@ Point3 Pose3::transformFrom(const Point3& point, OptionalJacobian<3, 6> Hself,
   return R_ * point + t_;
 }
 
-Matrix Pose3::transformFrom(const Matrix& points) const {
+Matrix Pose3::transformFrom(ConstMatrixView points) const {
   if (points.rows() != 3) {
     throw std::invalid_argument("Pose3:transformFrom expects 3*N matrix.");
   }
@@ -232,7 +232,7 @@ Point3 Pose3::transformTo(const Point3& point, OptionalJacobian<3, 6> Hself,
   return q;
 }
 
-Matrix Pose3::transformTo(const Matrix& points) const {
+Matrix Pose3::transformTo(ConstMatrixView points) const {
   if (points.rows() != 3) {
     throw std::invalid_argument("Pose3:transformTo expects 3*N matrix.");
   }

--- a/gtsam/geometry/Pose3.h
+++ b/gtsam/geometry/Pose3.h
@@ -169,7 +169,7 @@ public:
    * @param points 3*N matrix in Pose coordinates
    * @return points in world coordinates, as 3*N Matrix
    */
-  Matrix transformFrom(const Matrix& points) const;
+  Matrix transformFrom(ConstMatrixView points) const;
 
   /** syntactic sugar for transformFrom */
   inline Point3 operator*(const Point3& point) const {
@@ -191,7 +191,7 @@ public:
    * @param points 3*N matrix in world coordinates
    * @return points in Pose coordinates, as 3*N Matrix
    */
-  Matrix transformTo(const Matrix& points) const;
+  Matrix transformTo(ConstMatrixView points) const;
 
   /// @}
   /// @name Standard Interface

--- a/gtsam/geometry/Pose3.h
+++ b/gtsam/geometry/Pose3.h
@@ -91,7 +91,7 @@ public:
   static std::optional<Pose3> Align(const Point3Pairs& abPointPairs);
 
   // Version of Pose3::Align that takes 2 matrices.
-  static std::optional<Pose3> Align(const Matrix& a, const Matrix& b);
+  static std::optional<Pose3> Align(ConstMatrixView a, ConstMatrixView b);
 
   /// @}
   /// @name Testable

--- a/gtsam/geometry/geometry.i
+++ b/gtsam/geometry/geometry.i
@@ -524,7 +524,7 @@ class Pose2 {
   Pose2(gtsam::Vector v);
 
   static std::optional<gtsam::Pose2> Align(const gtsam::Point2Pairs& abPointPairs);
-  static std::optional<gtsam::Pose2> Align(const gtsam::Matrix& a, const gtsam::Matrix& b);
+  static std::optional<gtsam::Pose2> Align(gtsam::ConstMatrixView a, gtsam::ConstMatrixView b);
 
   // Testable
   void print(string s = "") const;
@@ -616,7 +616,7 @@ class Pose3 {
   Pose3(gtsam::Matrix mat);
 
   static std::optional<gtsam::Pose3> Align(const gtsam::Point3Pairs& abPointPairs);
-  static std::optional<gtsam::Pose3> Align(const gtsam::Matrix& a, const gtsam::Matrix& b);
+  static std::optional<gtsam::Pose3> Align(gtsam::ConstMatrixView a, gtsam::ConstMatrixView b);
 
   // Testable
   void print(string s = "") const;

--- a/gtsam/geometry/geometry.i
+++ b/gtsam/geometry/geometry.i
@@ -584,8 +584,8 @@ class Pose2 {
     Eigen::Ref<Eigen::MatrixXd> H1, Eigen::Ref<Eigen::MatrixXd> H2) const;
 
   // gtsam::Matrix versions
-  gtsam::Matrix transformFrom(const gtsam::Matrix& points) const;
-  gtsam::Matrix transformTo(const gtsam::Matrix& points) const;
+  gtsam::Matrix transformFrom(gtsam::ConstMatrixView points) const;
+  gtsam::Matrix transformTo(gtsam::ConstMatrixView points) const;
 
   // Standard Interface
   double x() const;
@@ -692,8 +692,8 @@ class Pose3 {
                             Eigen::Ref<Eigen::MatrixXd> Hpoint) const;
 
   // gtsam::Matrix versions
-  gtsam::Matrix transformFrom(const gtsam::Matrix& points) const;
-  gtsam::Matrix transformTo(const gtsam::Matrix& points) const;
+  gtsam::Matrix transformFrom(gtsam::ConstMatrixView points) const;
+  gtsam::Matrix transformTo(gtsam::ConstMatrixView points) const;
 
   // Standard Interface
   gtsam::Rot3 rotation() const;

--- a/gtsam/gtsam.i
+++ b/gtsam/gtsam.i
@@ -181,10 +181,12 @@ void perturbPoint3(gtsam::Values& values, double sigma, int seed = 42u);
 void perturbPose3(gtsam::Values& values, double sigmaT, double sigmaR,
                   int seed = 42u);
 void insertBackprojections(gtsam::Values& values,
-                           const gtsam::PinholeCamera<gtsam::Cal3_S2>& c,
-                           gtsam::Vector J, gtsam::Matrix Z, double depth);
+                           const gtsam::PinholeCamera<gtsam::Cal3_S2>& camera,
+                           const gtsam::Vector& J, gtsam::ConstMatrixView Z,
+                           double depth);
 void insertProjectionFactors(
-    gtsam::NonlinearFactorGraph& graph, size_t i, gtsam::Vector J, gtsam::Matrix Z,
+    gtsam::NonlinearFactorGraph& graph, size_t i, const gtsam::Vector& J,
+    gtsam::ConstMatrixView Z,
     const gtsam::noiseModel::Base* model, const gtsam::Cal3_S2* K,
     const gtsam::Pose3& body_P_sensor = gtsam::Pose3());
 gtsam::Matrix reprojectionErrors(const gtsam::NonlinearFactorGraph& graph,

--- a/gtsam/nonlinear/utilities.h
+++ b/gtsam/nonlinear/utilities.h
@@ -298,7 +298,7 @@ void perturbPose3(Values& values, double sigmaT, double sigmaR,
  * @param depth Initial depth value.
  */
 void insertBackprojections(Values& values, const PinholeCamera<Cal3_S2>& camera,
-    const Vector& J, const Matrix& Z, double depth) {
+    const Vector& J, ConstMatrixView Z, double depth) {
   if (Z.rows() != 2)
     throw std::invalid_argument("insertBackProjections: Z must be 2*J");
   if (Z.cols() != J.size())
@@ -323,7 +323,7 @@ void insertBackprojections(Values& values, const PinholeCamera<Cal3_S2>& camera,
  * @param body_P_sensor Pose of the camera sensor in the body frame.
  */
 void insertProjectionFactors(NonlinearFactorGraph& graph, Key i,
-    const Vector& J, const Matrix& Z, const SharedNoiseModel& model,
+    const Vector& J, ConstMatrixView Z, const SharedNoiseModel& model,
     const Cal3_S2::shared_ptr K, const Pose3& body_P_sensor = Pose3()) {
   if (Z.rows() != 2)
     throw std::invalid_argument("addMeasurements: Z must be 2*K");

--- a/gtwrap/matlab_wrapper/mixins.py
+++ b/gtwrap/matlab_wrapper/mixins.py
@@ -20,6 +20,8 @@ class CheckMixin:
     )
     # Ignore the namespace for these datatypes
     ignore_namespace: Tuple = ('Matrix', 'Vector', 'Point2', 'Point3')
+    # Matrix-like view types that can alias MATLAB double matrix storage.
+    matrix_view_types: Tuple = ('ConstMatrixView', )
     # Methods that should be ignored
     ignore_methods: Tuple = ('pickle', )
     # Methods that should not be wrapped directly
@@ -42,6 +44,7 @@ class CheckMixin:
         """
         return (arg_type.typename.name not in self.not_ptr_type
                 and arg_type.typename.name not in self.ignore_namespace
+                and not self.is_matrix_view(arg_type)
                 and arg_type.typename.name != 'string')
 
     def is_shared_ptr(self, arg_type: parser.Type):
@@ -66,6 +69,10 @@ class CheckMixin:
         return arg_type.typename.name not in self.ignore_namespace and \
                arg_type.typename.name not in self.not_ptr_type and \
                arg_type.is_ref
+
+    def is_matrix_view(self, arg_type: parser.Type):
+        """Check if `arg_type` should be unwrapped as a matrix view."""
+        return arg_type.typename.name in self.matrix_view_types
 
     def is_class_enum(self, arg_type: parser.Type, class_: parser.Class):
         """Check if arg_type is an enum in the class `class_`."""

--- a/gtwrap/matlab_wrapper/wrapper.py
+++ b/gtwrap/matlab_wrapper/wrapper.py
@@ -51,6 +51,7 @@ class MatlabWrapper(CheckMixin, FormatMixin):
             'unsigned char': 'unsigned char',
             'Vector': 'double',
             'Matrix': 'double',
+            'ConstMatrixView': 'double',
             'int': 'numeric',
             'size_t': 'numeric',
             'Key': 'numeric',
@@ -69,6 +70,7 @@ class MatlabWrapper(CheckMixin, FormatMixin):
             'Point3': 'double',
             'Vector': 'double',
             'Matrix': 'double',
+            'ConstMatrixView': 'double',
             'Key': 'numeric',
             'bool': 'bool'
         }
@@ -353,6 +355,11 @@ class MatlabWrapper(CheckMixin, FormatMixin):
             enum_type = f"{arg.ctype.typename}"
             arg_type = f"{enum_type}"
             unwrap = f'unwrap_enum<{enum_type}>(in[{arg_id}]);'
+
+        elif self.is_matrix_view(arg.ctype):
+            arg_type = self._format_type_name(arg.ctype.typename)
+            unwrap = 'unwrapMatrixView< {ctype} >(in[{id}]);'.format(
+                ctype=arg_type, id=arg_id)
 
         elif self.is_ref(arg.ctype):  # and not constructor:
             arg_type = "{ctype}&".format(ctype=ctype_sep)

--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -27,6 +27,26 @@ class PybindWrapper:
     Class to generate binding code for Pybind11 specifically.
     """
 
+    ARG_POLICY_SUPPORT = """
+#include <type_traits>
+
+namespace gtwrap {
+namespace internal {
+
+template <typename T>
+struct PyArgPolicy {
+  static pybind11::arg make(const char* name) { return pybind11::arg(name); }
+};
+
+template <typename T>
+pybind11::arg py_arg(const char* name) {
+  return PyArgPolicy<typename std::decay<T>::type>::make(name);
+}
+
+}  // namespace internal
+}  // namespace gtwrap
+"""
+
     def __init__(self,
                  module_name,
                  top_module_namespaces='',
@@ -70,8 +90,11 @@ class PybindWrapper:
                     default = ' = {arg.default}'.format(arg=arg)
                 else:
                     default = ''
-                argument = 'py::arg("{name}"){default}'.format(
-                    name=arg.name, default='{0}'.format(default))
+                argument = (
+                    'gtwrap::internal::py_arg<{ctype}>("{name}"){default}'
+                ).format(ctype=arg.ctype.to_cpp(),
+                         name=arg.name,
+                         default='{0}'.format(default))
                 py_args.append(argument)
             return ", " + ", ".join(py_args)
         else:
@@ -251,6 +274,18 @@ class PybindWrapper:
             method,
             (parser.StaticMethod, instantiator.InstantiatedStaticMethod))
         return_void = method.return_type.is_void()
+        return_type = getattr(method.return_type, 'type1', None)
+        return_ref = getattr(return_type, 'is_ref', False)
+        return_const = getattr(return_type, 'is_const', False)
+
+        # For methods returning const T&, use reference_internal policy
+        # to avoid unnecessary copies and keep the returned reference alive.
+        if return_ref and return_const and is_method:
+            lambda_ret = ' -> const auto&'
+            ref_policy = ', py::return_value_policy::reference_internal'
+        else:
+            lambda_ret = ''
+            ref_policy = ''
 
         caller = cpp_class + "::" if not is_method else "self->"
         function_call = ('{opt_return} {caller}{method_name}'
@@ -263,10 +298,10 @@ class PybindWrapper:
 
         result = (
             '{prefix}.{cdef}("{py_method}",'
-            '[]({opt_self}{opt_comma}{args_signature_with_names}){{'
+            '[]({opt_self}{opt_comma}{args_signature_with_names}){lambda_ret}{{'
             '{function_call}'
             '}}'
-            '{py_args_names}{docstring}){suffix}'.format(
+            '{ref_policy}{py_args_names}{docstring}){suffix}'.format(
                 prefix=prefix,
                 cdef="def_static" if is_static else "def",
                 py_method=py_method,
@@ -275,7 +310,9 @@ class PybindWrapper:
                 opt_comma=', '
                 if is_method and args_signature_with_names else '',
                 args_signature_with_names=args_signature_with_names,
+                lambda_ret=lambda_ret,
                 function_call=function_call,
+                ref_policy=ref_policy,
                 py_args_names=py_args_names,
                 suffix=suffix,
                 # Try to get the function's docstring from the Doxygen XML.
@@ -738,6 +775,8 @@ class PybindWrapper:
         else:
             module_def = "void {0}(py::module_ &m_)".format(module_name)
             submodules = []
+
+        includes += self.ARG_POLICY_SUPPORT
 
         return self.module_template.format(
             module_def=module_def,

--- a/matlab.h
+++ b/matlab.h
@@ -37,6 +37,7 @@ extern "C" {
 #include <mex.h>
 }
 
+#include <limits>
 #include <list>
 #include <set>
 #include <sstream>
@@ -429,6 +430,31 @@ gtsam::Matrix unwrap< gtsam::Matrix >(const mxArray* array) {
   return A;
 }
 
+// unwrap a MATLAB double matrix as a const Eigen matrix view without copying
+template <typename MatrixView>
+MatrixView unwrapMatrixView(const mxArray* array) {
+  if (mxIsDouble(array)==false || mxIsComplex(array) || mxIsSparse(array))
+    error("unwrapMatrixView: not a full real double matrix");
+  const mwSize rows = mxGetM(array), cols = mxGetN(array);
+  const auto maxIndex =
+      static_cast<unsigned long long>((std::numeric_limits<Eigen::Index>::max)());
+  if (static_cast<unsigned long long>(rows) > maxIndex ||
+      static_cast<unsigned long long>(cols) > maxIndex) {
+    error("unwrapMatrixView: matrix dimensions exceed Eigen::Index");
+  }
+  const Eigen::Index m = static_cast<Eigen::Index>(rows);
+  const Eigen::Index n = static_cast<Eigen::Index>(cols);
+#ifdef DEBUG_WRAP
+  mexPrintf("unwrapMatrixView called with %lldx%lld argument\n",
+            static_cast<long long>(m), static_cast<long long>(n));
+#endif
+  using Stride = Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>;
+  using ConstMatrixMap = Eigen::Map<const gtsam::Matrix, 0, Stride>;
+  const double* data = static_cast<const double*>(mxGetData(array));
+  ConstMatrixMap map(data, m, n, Stride(m, 1));
+  return MatrixView(map);
+}
+
 /*
  [create_object] creates a MATLAB proxy class object with a mexhandle
  in the self property. Matlab does not allow the creation of matlab
@@ -547,4 +573,3 @@ Class* unwrap_ptr(const mxArray* obj, const string& propertyName) {
 //  static_assert(unwrap_shared_ptr_Matrix_attempted, "Matrix cannot be unwrapped as a shared pointer");
 //  return Matrix();
 //}
-

--- a/matlab/gtsam_tests/testPose2.m
+++ b/matlab/gtsam_tests/testPose2.m
@@ -14,3 +14,6 @@ CHECK('Pose2.transformTo matrix', ...
 actualWorld = pose.transformFrom(localPoints);
 CHECK('Pose2.transformFrom matrix', ...
     max(abs(actualWorld(:) - worldPoints(:))) < tol);
+
+alignedPose = Pose2.Align(worldPoints, localPoints);
+CHECK('Pose2.Align matrix', alignedPose.equals(pose, tol));

--- a/matlab/gtsam_tests/testPose2.m
+++ b/matlab/gtsam_tests/testPose2.m
@@ -1,0 +1,16 @@
+% test wrapping of Pose2 batch point transforms
+import gtsam.*;
+
+tol = 1e-9;
+pose = Pose2(2, 4, -pi / 2);
+
+worldPoints = [3 5; 2 4];
+localPoints = [2 0; 1 3];
+
+actualLocal = pose.transformTo(worldPoints);
+CHECK('Pose2.transformTo matrix', ...
+    max(abs(actualLocal(:) - localPoints(:))) < tol);
+
+actualWorld = pose.transformFrom(localPoints);
+CHECK('Pose2.transformFrom matrix', ...
+    max(abs(actualWorld(:) - worldPoints(:))) < tol);

--- a/matlab/gtsam_tests/testPose3.m
+++ b/matlab/gtsam_tests/testPose3.m
@@ -1,0 +1,16 @@
+% test wrapping of Pose3 batch point transforms
+import gtsam.*;
+
+tol = 1e-9;
+pose = Pose3(Rot3.Rodrigues(0, 0, -pi / 2), Point3(2, 4, 0));
+
+worldPoints = [3 5; 2 4; 10 11];
+localPoints = [2 0; 1 3; 10 11];
+
+actualLocal = pose.transformTo(worldPoints);
+CHECK('Pose3.transformTo matrix', ...
+    max(abs(actualLocal(:) - localPoints(:))) < tol);
+
+actualWorld = pose.transformFrom(localPoints);
+CHECK('Pose3.transformFrom matrix', ...
+    max(abs(actualWorld(:) - worldPoints(:))) < tol);

--- a/matlab/gtsam_tests/testPose3.m
+++ b/matlab/gtsam_tests/testPose3.m
@@ -14,3 +14,8 @@ CHECK('Pose3.transformTo matrix', ...
 actualWorld = pose.transformFrom(localPoints);
 CHECK('Pose3.transformFrom matrix', ...
     max(abs(actualWorld(:) - worldPoints(:))) < tol);
+
+worldSquare = [0 0 1 1; 0 1 1 0; 0 0 0 0];
+localSquare = pose.transformTo(worldSquare);
+alignedPose = Pose3.Align(worldSquare, localSquare);
+CHECK('Pose3.Align matrix', alignedPose.equals(pose, tol));

--- a/matlab/gtsam_tests/testUtilities.m
+++ b/matlab/gtsam_tests/testUtilities.m
@@ -54,3 +54,18 @@ values.insert(symbol('x', 7), Pose3());
 actual = utilities.extractVectors(values, 'x');
 expected = reshape(1:18, 6, 3)';
 CHECK('extractVectors', all(actual == expected, 'all'));
+
+% test batch measurement matrix wrappers
+tol = 1e-9;
+pixels = [20 30; 20 30];
+indices = [0; 1];
+batchValues = Values();
+camera = PinholeCameraCal3_S2();
+utilities.insertBackprojections(batchValues, camera, indices, pixels, 10);
+CHECK('insertBackprojections matrix', ...
+    norm(batchValues.atPoint3(0) - Point3(200, 200, 10)) < tol);
+
+graph = NonlinearFactorGraph();
+model = noiseModel.Isotropic.Sigma(2, 0.1);
+utilities.insertProjectionFactors(graph, 0, indices, pixels, model, Cal3_S2());
+CHECK('insertProjectionFactors matrix', graph.size == 2);

--- a/matlab/gtsam_tests/test_gtsam.m
+++ b/matlab/gtsam_tests/test_gtsam.m
@@ -4,6 +4,12 @@
 display 'Starting: testCal3Unified'
 testCal3Unified
 
+display 'Starting: testPose2'
+testPose2
+
+display 'Starting: testPose3'
+testPose3
+
 %% linear
 display 'Starting: testKalmanFilter'
 testKalmanFilter

--- a/python/gtsam/preamble/arg_policies.h
+++ b/python/gtsam/preamble/arg_policies.h
@@ -1,0 +1,16 @@
+#include <gtsam/base/Matrix.h>
+
+namespace gtwrap {
+namespace internal {
+
+template <>
+struct PyArgPolicy<gtsam::ConstMatrixView> {
+  static pybind11::arg make(const char* name) {
+    pybind11::arg arg(name);
+    arg.noconvert();
+    return arg;
+  }
+};
+
+}  // namespace internal
+}  // namespace gtwrap

--- a/python/gtsam/preamble/geometry.h
+++ b/python/gtsam/preamble/geometry.h
@@ -1,0 +1,1 @@
+#include "python/gtsam/preamble/arg_policies.h"

--- a/python/gtsam/preamble/gtsam.h
+++ b/python/gtsam/preamble/gtsam.h
@@ -1,3 +1,5 @@
+#include "python/gtsam/preamble/arg_policies.h"
+
 /* Please refer to:
  * https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html
  * These are required to save one copy operation on Python calls.

--- a/python/gtsam/preamble/slam.h
+++ b/python/gtsam/preamble/slam.h
@@ -10,3 +10,5 @@
  * Without this they will be automatically converted to a Python object, and all
  * mutations on Python side will not be reflected on C++.
  */
+
+#include "python/gtsam/preamble/arg_policies.h"

--- a/python/gtsam/tests/test_NonlinearOptimizer.py
+++ b/python/gtsam/tests/test_NonlinearOptimizer.py
@@ -145,9 +145,9 @@ class TestScenario(GtsamTestCase):
             optimizer.setWeights(new_weights)
             self.assertAlmostEqual(optimizer.getWeights(), new_weights)
         optimizer.setInlierCostThresholdsAtProbability(0.9)
-        w1 = optimizer.getInlierCostThresholds()
+        w1 = optimizer.getInlierCostThresholds().item()
         optimizer.setInlierCostThresholdsAtProbability(0.8)
-        w2 = optimizer.getInlierCostThresholds()
+        w2 = optimizer.getInlierCostThresholds().item()
         self.assertLess(w2, w1)
 
     def test_iteration_hook(self):

--- a/python/gtsam/tests/test_Pose2.py
+++ b/python/gtsam/tests/test_Pose2.py
@@ -41,6 +41,15 @@ class TestPose2(GtsamTestCase):
         expected_array = np.stack([expected, expected]).T
         np.testing.assert_allclose(actual_array, expected_array, atol=1e-6)
 
+        # C- and F-contiguous NumPy matrices should map without conversion.
+        for order in ("C", "F"):
+            points = np.array([[3.0, 3.0], [2.0, 2.0]], order=order)
+            np.testing.assert_allclose(
+                pose.transformTo(points), expected_array, atol=1e-6)
+
+        with self.assertRaises(TypeError):
+            pose.transformTo([[3.0, 3.0], [2.0, 2.0]])
+
     def test_transformFrom(self):
         """Test transformFrom method."""
         pose = Pose2(2, 4, -math.pi / 2)
@@ -54,6 +63,15 @@ class TestPose2(GtsamTestCase):
         self.assertEqual(actual_array.shape, (2, 2))
         expected_array = np.stack([expected, expected]).T
         np.testing.assert_allclose(actual_array, expected_array, atol=1e-6)
+
+        # C- and F-contiguous NumPy matrices should map without conversion.
+        for order in ("C", "F"):
+            points = np.array([[2.0, 2.0], [1.0, 1.0]], order=order)
+            np.testing.assert_allclose(
+                pose.transformFrom(points), expected_array, atol=1e-6)
+
+        with self.assertRaises(TypeError):
+            pose.transformFrom([[2.0, 2.0], [1.0, 1.0]])
 
     def test_align(self) -> None:
         """Ensure estimation of the Pose2 element to align two 2d point clouds succeeds.

--- a/python/gtsam/tests/test_Pose2.py
+++ b/python/gtsam/tests/test_Pose2.py
@@ -110,15 +110,20 @@ class TestPose2(GtsamTestCase):
             pt_a_ = aTb.transformFrom(pt_b)
             np.testing.assert_allclose(pt_a, pt_a_)
 
-        # Matrix version
+        # C- and F-contiguous NumPy matrices should map without conversion.
         A = np.array(pts_a).T
         B = np.array(pts_b).T
-        aTb = Pose2.Align(A, B)
-        self.assertIsNotNone(aTb)
+        for order in ("C", "F"):
+            aTb = Pose2.Align(np.array(A, order=order),
+                              np.array(B, order=order))
+            self.assertIsNotNone(aTb)
 
-        for pt_a, pt_b in zip(pts_a, pts_b):
-            pt_a_ = aTb.transformFrom(pt_b)
-            np.testing.assert_allclose(pt_a, pt_a_)
+            for pt_a, pt_b in zip(pts_a, pts_b):
+                pt_a_ = aTb.transformFrom(pt_b)
+                np.testing.assert_allclose(pt_a, pt_a_)
+
+        with self.assertRaises(TypeError):
+            Pose2.Align(A.tolist(), B.tolist())
 
 
 if __name__ == "__main__":

--- a/python/gtsam/tests/test_Pose3.py
+++ b/python/gtsam/tests/test_Pose3.py
@@ -253,9 +253,14 @@ class TestPose3(GtsamTestCase):
         estimated_sTt = Pose3.Align(st_pairs)
         self.gtsamAssertEquals(estimated_sTt, sTt, 1e-10)
 
-        # Matrix version
-        estimated_sTt = Pose3.Align(square, transformed)
-        self.gtsamAssertEquals(estimated_sTt, sTt, 1e-10)
+        # C- and F-contiguous NumPy matrices should map without conversion.
+        for order in ("C", "F"):
+            estimated_sTt = Pose3.Align(np.array(square, order=order),
+                                        np.array(transformed, order=order))
+            self.gtsamAssertEquals(estimated_sTt, sTt, 1e-10)
+
+        with self.assertRaises(TypeError):
+            Pose3.Align(square.tolist(), transformed.tolist())
 
 
 if __name__ == "__main__":

--- a/python/gtsam/tests/test_Pose3.py
+++ b/python/gtsam/tests/test_Pose3.py
@@ -97,6 +97,16 @@ class TestPose3(GtsamTestCase):
         expected_array = np.stack([expected, expected]).T
         np.testing.assert_allclose(actual_array, expected_array, atol=1e-6)
 
+        # C- and F-contiguous NumPy matrices should map without conversion.
+        for order in ("C", "F"):
+            points = np.array([[3.0, 3.0], [2.0, 2.0], [10.0, 10.0]],
+                              order=order)
+            np.testing.assert_allclose(
+                pose.transformTo(points), expected_array, atol=1e-6)
+
+        with self.assertRaises(TypeError):
+            pose.transformTo([[3.0, 3.0], [2.0, 2.0], [10.0, 10.0]])
+
     def test_transformFrom(self):
         """Test transformFrom method."""
         pose = Pose3(Rot3.Rodrigues(0, 0, -math.pi/2), Point3(2, 4, 0))
@@ -120,6 +130,16 @@ class TestPose3(GtsamTestCase):
         self.assertEqual(actual_array.shape, (3, 2))
         expected_array = np.stack([expected, expected]).T
         np.testing.assert_allclose(actual_array, expected_array, atol=1e-6)
+
+        # C- and F-contiguous NumPy matrices should map without conversion.
+        for order in ("C", "F"):
+            points = np.array([[2.0, 2.0], [1.0, 1.0], [10.0, 10.0]],
+                              order=order)
+            np.testing.assert_allclose(
+                pose.transformFrom(points), expected_array, atol=1e-6)
+
+        with self.assertRaises(TypeError):
+            pose.transformFrom([[2.0, 2.0], [1.0, 1.0], [10.0, 10.0]])
 
     def test_range(self):
         """Test range method."""

--- a/python/gtsam/tests/test_Utilities.py
+++ b/python/gtsam/tests/test_Utilities.py
@@ -174,32 +174,43 @@ class TestUtilities(GtsamTestCase):
 
     def test_insertBackprojections(self):
         """Test insertBackprojections."""
-        values = gtsam.Values()
         cam = gtsam.PinholeCameraCal3_S2()
-        gtsam.utilities.insertBackprojections(
-            values, cam, [0, 1, 2], np.asarray([[20, 30, 40], [20, 30, 40]]),
-            10)
-        np.testing.assert_allclose(values.atPoint3(0),
-                                   gtsam.Point3(200, 200, 10))
+        pixels = np.asarray([[20, 30, 40], [20, 30, 40]], dtype=float)
+        for order in ("C", "F"):
+            values = gtsam.Values()
+            gtsam.utilities.insertBackprojections(
+                values, cam, [0, 1, 2], np.array(pixels, order=order), 10)
+            np.testing.assert_allclose(values.atPoint3(0),
+                                       gtsam.Point3(200, 200, 10))
+
+        with self.assertRaises(TypeError):
+            gtsam.utilities.insertBackprojections(
+                gtsam.Values(), cam, [0, 1, 2], pixels.tolist(), 10)
 
     def test_insertProjectionFactors(self):
         """Test insertProjectionFactors."""
+        pixels = np.asarray([[20, 30], [20, 30]], dtype=float)
         graph = gtsam.NonlinearFactorGraph()
         gtsam.utilities.insertProjectionFactors(
-            graph, 0, [0, 1], np.asarray([[20, 30], [20, 30]]),
+            graph, 0, [0, 1], np.array(pixels, order="C"),
             gtsam.noiseModel.Isotropic.Sigma(2, 0.1), gtsam.Cal3_S2())
         self.assertEqual(graph.size(), 2)
 
         graph = gtsam.NonlinearFactorGraph()
         gtsam.utilities.insertProjectionFactors(
-            graph, 0, [0, 1], np.asarray([[20, 30], [20, 30]]),
+            graph, 0, [0, 1], np.array(pixels, order="F"),
             gtsam.noiseModel.Isotropic.Sigma(2, 0.1), gtsam.Cal3_S2(),
             gtsam.Pose3(gtsam.Rot3(), gtsam.Point3(1, 0, 0)))
         self.assertEqual(graph.size(), 2)
 
+        with self.assertRaises(TypeError):
+            gtsam.utilities.insertProjectionFactors(
+                gtsam.NonlinearFactorGraph(), 0, [0, 1], pixels.tolist(),
+                gtsam.noiseModel.Isotropic.Sigma(2, 0.1), gtsam.Cal3_S2())
+
     def test_reprojectionErrors(self):
         """Test reprojectionErrors."""
-        pixels = np.asarray([[20, 30], [20, 30]])
+        pixels = np.asarray([[20, 30], [20, 30]], dtype=float)
         I = [1, 2]
         K = gtsam.Cal3_S2()
         graph = gtsam.NonlinearFactorGraph()

--- a/tests/expected/python/class_pybind.cpp
+++ b/tests/expected/python/class_pybind.cpp
@@ -6,6 +6,24 @@
 
 #include "folder/path/to/Test.h"
 
+#include <type_traits>
+
+namespace gtwrap {
+namespace internal {
+
+template <typename T>
+struct PyArgPolicy {
+  static pybind11::arg make(const char* name) { return pybind11::arg(name); }
+};
+
+template <typename T>
+pybind11::arg py_arg(const char* name) {
+  return PyArgPolicy<typename std::decay<T>::type>::make(name);
+}
+
+}  // namespace internal
+}  // namespace gtwrap
+
 
 
 
@@ -19,41 +37,41 @@ PYBIND11_MODULE(class_py, m_) {
 
     py::class_<FunRange, std::shared_ptr<FunRange>>(m_, "FunRange")
         .def(py::init<>())
-        .def("range",[](FunRange* self, double d){return self->range(d);}, py::arg("d"))
+        .def("range",[](FunRange* self, double d){return self->range(d);}, gtwrap::internal::py_arg<double>("d"))
         .def_static("create",[](){return FunRange::create();});
 
     py::class_<Fun<double>, std::shared_ptr<Fun<double>>>(m_, "FunDouble")
-        .def("templatedMethodString",[](Fun<double>* self, double d, string t){return self->templatedMethod<string>(d, t);}, py::arg("d"), py::arg("t"))
-        .def("multiTemplatedMethodStringSize_t",[](Fun<double>* self, double d, string t, size_t u){return self->multiTemplatedMethod<string,size_t>(d, t, u);}, py::arg("d"), py::arg("t"), py::arg("u"))
+        .def("templatedMethodString",[](Fun<double>* self, double d, string t){return self->templatedMethod<string>(d, t);}, gtwrap::internal::py_arg<double>("d"), gtwrap::internal::py_arg<string>("t"))
+        .def("multiTemplatedMethodStringSize_t",[](Fun<double>* self, double d, string t, size_t u){return self->multiTemplatedMethod<string,size_t>(d, t, u);}, gtwrap::internal::py_arg<double>("d"), gtwrap::internal::py_arg<string>("t"), gtwrap::internal::py_arg<size_t>("u"))
         .def("sets",[](Fun<double>* self){return self->sets();})
         .def_static("staticMethodWithThis",[](){return Fun<double>::staticMethodWithThis();})
-        .def_static("templatedStaticMethodInt",[](const int& m){return Fun<double>::templatedStaticMethod<int>(m);}, py::arg("m"));
+        .def_static("templatedStaticMethodInt",[](const int& m){return Fun<double>::templatedStaticMethod<int>(m);}, gtwrap::internal::py_arg<const int&>("m"));
 
     py::class_<Test, std::shared_ptr<Test>>(m_, "Test")
         .def(py::init<>())
-        .def(py::init<double, const gtsam::Matrix&>(), py::arg("a"), py::arg("b"))
-        .def("return_pair",[](Test* self, const gtsam::Vector& v, const gtsam::Matrix& A){return self->return_pair(v, A);}, py::arg("v"), py::arg("A"))
-        .def("return_pair",[](Test* self, const gtsam::Vector& v){return self->return_pair(v);}, py::arg("v"))
-        .def("return_bool",[](Test* self, bool value){return self->return_bool(value);}, py::arg("value"))
-        .def("return_size_t",[](Test* self, size_t value){return self->return_size_t(value);}, py::arg("value"))
-        .def("return_int",[](Test* self, int value){return self->return_int(value);}, py::arg("value"))
-        .def("return_double",[](Test* self, double value){return self->return_double(value);}, py::arg("value"))
-        .def("return_string",[](Test* self, string value){return self->return_string(value);}, py::arg("value"))
-        .def("return_vector1",[](Test* self, const gtsam::Vector& value){return self->return_vector1(value);}, py::arg("value"))
-        .def("return_matrix1",[](Test* self, const gtsam::Matrix& value){return self->return_matrix1(value);}, py::arg("value"))
-        .def("return_vector2",[](Test* self, const gtsam::Vector& value){return self->return_vector2(value);}, py::arg("value"))
-        .def("return_matrix2",[](Test* self, const gtsam::Matrix& value){return self->return_matrix2(value);}, py::arg("value"))
-        .def("return_vector2",[](Test* self, const gtsam::Vector& value){return self->return_vector2(value);}, py::arg("value"))
-        .def("return_matrix2",[](Test* self, const gtsam::Matrix& value){return self->return_matrix2(value);}, py::arg("value"))
-        .def("arg_EigenConstRef",[](Test* self, const gtsam::Matrix& value){ self->arg_EigenConstRef(value);}, py::arg("value"))
-        .def("push_back",[](Test* self, gtsam::Key key){ self->push_back(key);}, py::arg("key"))
-        .def("return_field",[](Test* self, const Test& t){return self->return_field(t);}, py::arg("t"))
-        .def("return_TestPtr",[](Test* self, const std::shared_ptr<Test> value){return self->return_TestPtr(value);}, py::arg("value"))
-        .def("return_Test",[](Test* self, std::shared_ptr<Test> value){return self->return_Test(value);}, py::arg("value"))
-        .def("return_Point2Ptr",[](Test* self, bool value){return self->return_Point2Ptr(value);}, py::arg("value"))
+        .def(py::init<double, const gtsam::Matrix&>(), gtwrap::internal::py_arg<double>("a"), gtwrap::internal::py_arg<const gtsam::Matrix&>("b"))
+        .def("return_pair",[](Test* self, const gtsam::Vector& v, const gtsam::Matrix& A){return self->return_pair(v, A);}, gtwrap::internal::py_arg<const gtsam::Vector&>("v"), gtwrap::internal::py_arg<const gtsam::Matrix&>("A"))
+        .def("return_pair",[](Test* self, const gtsam::Vector& v){return self->return_pair(v);}, gtwrap::internal::py_arg<const gtsam::Vector&>("v"))
+        .def("return_bool",[](Test* self, bool value){return self->return_bool(value);}, gtwrap::internal::py_arg<bool>("value"))
+        .def("return_size_t",[](Test* self, size_t value){return self->return_size_t(value);}, gtwrap::internal::py_arg<size_t>("value"))
+        .def("return_int",[](Test* self, int value){return self->return_int(value);}, gtwrap::internal::py_arg<int>("value"))
+        .def("return_double",[](Test* self, double value){return self->return_double(value);}, gtwrap::internal::py_arg<double>("value"))
+        .def("return_string",[](Test* self, string value){return self->return_string(value);}, gtwrap::internal::py_arg<string>("value"))
+        .def("return_vector1",[](Test* self, const gtsam::Vector& value){return self->return_vector1(value);}, gtwrap::internal::py_arg<const gtsam::Vector&>("value"))
+        .def("return_matrix1",[](Test* self, const gtsam::Matrix& value){return self->return_matrix1(value);}, gtwrap::internal::py_arg<const gtsam::Matrix&>("value"))
+        .def("return_vector2",[](Test* self, const gtsam::Vector& value){return self->return_vector2(value);}, gtwrap::internal::py_arg<const gtsam::Vector&>("value"))
+        .def("return_matrix2",[](Test* self, const gtsam::Matrix& value){return self->return_matrix2(value);}, gtwrap::internal::py_arg<const gtsam::Matrix&>("value"))
+        .def("return_vector2",[](Test* self, const gtsam::Vector& value) -> const auto&{return self->return_vector2(value);}, py::return_value_policy::reference_internal, gtwrap::internal::py_arg<const gtsam::Vector&>("value"))
+        .def("return_matrix2",[](Test* self, const gtsam::Matrix& value) -> const auto&{return self->return_matrix2(value);}, py::return_value_policy::reference_internal, gtwrap::internal::py_arg<const gtsam::Matrix&>("value"))
+        .def("arg_EigenConstRef",[](Test* self, const gtsam::Matrix& value){ self->arg_EigenConstRef(value);}, gtwrap::internal::py_arg<const gtsam::Matrix&>("value"))
+        .def("push_back",[](Test* self, gtsam::Key key){ self->push_back(key);}, gtwrap::internal::py_arg<gtsam::Key>("key"))
+        .def("return_field",[](Test* self, const Test& t){return self->return_field(t);}, gtwrap::internal::py_arg<const Test&>("t"))
+        .def("return_TestPtr",[](Test* self, const std::shared_ptr<Test> value){return self->return_TestPtr(value);}, gtwrap::internal::py_arg<const std::shared_ptr<Test>>("value"))
+        .def("return_Test",[](Test* self, std::shared_ptr<Test> value){return self->return_Test(value);}, gtwrap::internal::py_arg<std::shared_ptr<Test>>("value"))
+        .def("return_Point2Ptr",[](Test* self, bool value){return self->return_Point2Ptr(value);}, gtwrap::internal::py_arg<bool>("value"))
         .def("create_ptrs",[](Test* self){return self->create_ptrs();})
         .def("create_MixedPtrs",[](Test* self){return self->create_MixedPtrs();})
-        .def("return_ptrs",[](Test* self, std::shared_ptr<Test> p1, std::shared_ptr<Test> p2){return self->return_ptrs(p1, p2);}, py::arg("p1"), py::arg("p2"))
+        .def("return_ptrs",[](Test* self, std::shared_ptr<Test> p1, std::shared_ptr<Test> p2){return self->return_ptrs(p1, p2);}, gtwrap::internal::py_arg<std::shared_ptr<Test>>("p1"), gtwrap::internal::py_arg<std::shared_ptr<Test>>("p2"))
         .def("print",[](Test* self){ py::scoped_ostream_redirect output; self->print();})
         .def("__repr__",
                     [](const Test& self){
@@ -62,18 +80,18 @@ PYBIND11_MODULE(class_py, m_) {
                         return redirect.str();
                     })
         .def("lambda_",[](Test* self){ self->lambda();})
-        .def("set_container",[](Test* self, std::vector<testing::Test> container){ self->set_container(container);}, py::arg("container"))
-        .def("set_container",[](Test* self, std::vector<std::shared_ptr<testing::Test>> container){ self->set_container(container);}, py::arg("container"))
-        .def("set_container",[](Test* self, std::vector<testing::Test&> container){ self->set_container(container);}, py::arg("container"))
+        .def("set_container",[](Test* self, std::vector<testing::Test> container){ self->set_container(container);}, gtwrap::internal::py_arg<std::vector<testing::Test>>("container"))
+        .def("set_container",[](Test* self, std::vector<std::shared_ptr<testing::Test>> container){ self->set_container(container);}, gtwrap::internal::py_arg<std::vector<std::shared_ptr<testing::Test>>>("container"))
+        .def("set_container",[](Test* self, std::vector<testing::Test&> container){ self->set_container(container);}, gtwrap::internal::py_arg<std::vector<testing::Test&>>("container"))
         .def("get_container",[](Test* self){return self->get_container();})
-        .def("_repr_markdown_",[](Test* self, const gtsam::KeyFormatter& keyFormatter){return self->markdown(keyFormatter);}, py::arg("keyFormatter") = gtsam::DefaultKeyFormatter)
+        .def("_repr_markdown_",[](Test* self, const gtsam::KeyFormatter& keyFormatter){return self->markdown(keyFormatter);}, gtwrap::internal::py_arg<const gtsam::KeyFormatter&>("keyFormatter") = gtsam::DefaultKeyFormatter)
         .def_readwrite("model_ptr", &Test::model_ptr)
         .def_readwrite("value", &Test::value)
         .def_readwrite("name", &Test::name);
 
     py::class_<PrimitiveRef<double>, std::shared_ptr<PrimitiveRef<double>>>(m_, "PrimitiveRefDouble")
         .def(py::init<>())
-        .def_static("Brutal",[](const double& t){return PrimitiveRef<double>::Brutal(t);}, py::arg("t"));
+        .def_static("Brutal",[](const double& t){return PrimitiveRef<double>::Brutal(t);}, gtwrap::internal::py_arg<const double&>("t"));
 
     py::class_<MyVector<3>, std::shared_ptr<MyVector<3>>>(m_, "MyVector3")
         .def(py::init<>());
@@ -86,35 +104,35 @@ PYBIND11_MODULE(class_py, m_) {
     py::class_<MultipleTemplates<int, float>, std::shared_ptr<MultipleTemplates<int, float>>>(m_, "MultipleTemplatesIntFloat");
 
     py::class_<ForwardKinematics, std::shared_ptr<ForwardKinematics>>(m_, "ForwardKinematics")
-        .def(py::init<const gtdynamics::Robot&, const string&, const string&, const gtsam::Values&, const gtsam::Pose3&>(), py::arg("robot"), py::arg("start_link_name"), py::arg("end_link_name"), py::arg("joint_angles"), py::arg("l2Tp") = gtsam::Pose3());
+        .def(py::init<const gtdynamics::Robot&, const string&, const string&, const gtsam::Values&, const gtsam::Pose3&>(), gtwrap::internal::py_arg<const gtdynamics::Robot&>("robot"), gtwrap::internal::py_arg<const string&>("start_link_name"), gtwrap::internal::py_arg<const string&>("end_link_name"), gtwrap::internal::py_arg<const gtsam::Values&>("joint_angles"), gtwrap::internal::py_arg<const gtsam::Pose3&>("l2Tp") = gtsam::Pose3());
 
     py::class_<TemplatedConstructor, std::shared_ptr<TemplatedConstructor>>(m_, "TemplatedConstructor")
         .def(py::init<>())
-        .def(py::init<const string&>(), py::arg("arg"))
-        .def(py::init<const int&>(), py::arg("arg"))
-        .def(py::init<const double&>(), py::arg("arg"));
+        .def(py::init<const string&>(), gtwrap::internal::py_arg<const string&>("arg"))
+        .def(py::init<const int&>(), gtwrap::internal::py_arg<const int&>("arg"))
+        .def(py::init<const double&>(), gtwrap::internal::py_arg<const double&>("arg"));
 
     py::class_<FastSet, std::shared_ptr<FastSet>>(m_, "FastSet")
         .def(py::init<>())
         .def("__len__",[](FastSet* self){return std::distance(self->begin(), self->end());})
-        .def("__contains__",[](FastSet* self, size_t key){return std::find(self->begin(), self->end(), key) != self->end();}, py::arg("key"))
+        .def("__contains__",[](FastSet* self, size_t key){return std::find(self->begin(), self->end(), key) != self->end();}, gtwrap::internal::py_arg<size_t>("key"))
         .def("__iter__",[](FastSet* self){return py::make_iterator(self->begin(), self->end());});
 
     py::class_<HessianFactor, gtsam::GaussianFactor, std::shared_ptr<HessianFactor>>(m_, "HessianFactor")
-        .def(py::init<const gtsam::KeyVector&, const std::vector<gtsam::Matrix>&, const std::vector<gtsam::Vector>&, double>(), py::arg("js"), py::arg("Gs"), py::arg("gs"), py::arg("f"));
+        .def(py::init<const gtsam::KeyVector&, const std::vector<gtsam::Matrix>&, const std::vector<gtsam::Vector>&, double>(), gtwrap::internal::py_arg<const gtsam::KeyVector&>("js"), gtwrap::internal::py_arg<const std::vector<gtsam::Matrix>&>("Gs"), gtwrap::internal::py_arg<const std::vector<gtsam::Vector>&>("gs"), gtwrap::internal::py_arg<double>("f"));
 
     py::class_<SmartProjectionRigFactor<gtsam::PinholeCamera<gtsam::Cal3_S2>>, gtsam::SmartProjectionFactor<gtsam::PinholeCamera<gtsam::Cal3_S2>>, std::shared_ptr<SmartProjectionRigFactor<gtsam::PinholeCamera<gtsam::Cal3_S2>>>>(m_, "SmartProjectionRigFactorPinholeCameraCal3_S2")
-        .def("add",[](SmartProjectionRigFactor<gtsam::PinholeCamera<gtsam::Cal3_S2>>* self, const gtsam::PinholeCamera<gtsam::Cal3_S2>::Measurement& measured, const gtsam::Key& poseKey, const size_t& cameraId){ self->add(measured, poseKey, cameraId);}, py::arg("measured"), py::arg("poseKey"), py::arg("cameraId") = 0);
+        .def("add",[](SmartProjectionRigFactor<gtsam::PinholeCamera<gtsam::Cal3_S2>>* self, const gtsam::PinholeCamera<gtsam::Cal3_S2>::Measurement& measured, const gtsam::Key& poseKey, const size_t& cameraId){ self->add(measured, poseKey, cameraId);}, gtwrap::internal::py_arg<const gtsam::PinholeCamera<gtsam::Cal3_S2>::Measurement&>("measured"), gtwrap::internal::py_arg<const gtsam::Key&>("poseKey"), gtwrap::internal::py_arg<const size_t&>("cameraId") = 0);
 
     py::class_<MyFactor<gtsam::Pose2, gtsam::Matrix>, std::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>>>(m_, "MyFactorPosePoint2")
-        .def(py::init<size_t, size_t, double, const std::shared_ptr<gtsam::noiseModel::Base>>(), py::arg("key1"), py::arg("key2"), py::arg("measured"), py::arg("noiseModel"))
-        .def("print",[](MyFactor<gtsam::Pose2, gtsam::Matrix>* self, const string& s, const gtsam::KeyFormatter& keyFormatter){ py::scoped_ostream_redirect output; self->print(s, keyFormatter);}, py::arg("s") = "factor: ", py::arg("keyFormatter") = gtsam::DefaultKeyFormatter)
+        .def(py::init<size_t, size_t, double, const std::shared_ptr<gtsam::noiseModel::Base>>(), gtwrap::internal::py_arg<size_t>("key1"), gtwrap::internal::py_arg<size_t>("key2"), gtwrap::internal::py_arg<double>("measured"), gtwrap::internal::py_arg<const std::shared_ptr<gtsam::noiseModel::Base>>("noiseModel"))
+        .def("print",[](MyFactor<gtsam::Pose2, gtsam::Matrix>* self, const string& s, const gtsam::KeyFormatter& keyFormatter){ py::scoped_ostream_redirect output; self->print(s, keyFormatter);}, gtwrap::internal::py_arg<const string&>("s") = "factor: ", gtwrap::internal::py_arg<const gtsam::KeyFormatter&>("keyFormatter") = gtsam::DefaultKeyFormatter)
         .def("__repr__",
                     [](const MyFactor<gtsam::Pose2, gtsam::Matrix>& self, const string& s, const gtsam::KeyFormatter& keyFormatter){
                         gtsam::RedirectCout redirect;
                         self.print(s, keyFormatter);
                         return redirect.str();
-                    }, py::arg("s") = "factor: ", py::arg("keyFormatter") = gtsam::DefaultKeyFormatter);
+                    }, gtwrap::internal::py_arg<const string&>("s") = "factor: ", gtwrap::internal::py_arg<const gtsam::KeyFormatter&>("keyFormatter") = gtsam::DefaultKeyFormatter);
 
     py::class_<SuperCoolFactor<gtsam::Pose3>, std::shared_ptr<SuperCoolFactor<gtsam::Pose3>>>(m_, "SuperCoolFactorPose3");
 

--- a/tests/expected/python/enum_pybind.cpp
+++ b/tests/expected/python/enum_pybind.cpp
@@ -5,6 +5,24 @@
 #include "gtsam/nonlinear/utilities.h"  // for RedirectCout.
 
 
+#include <type_traits>
+
+namespace gtwrap {
+namespace internal {
+
+template <typename T>
+struct PyArgPolicy {
+  static pybind11::arg make(const char* name) { return pybind11::arg(name); }
+};
+
+template <typename T>
+pybind11::arg py_arg(const char* name) {
+  return PyArgPolicy<typename std::decay<T>::type>::make(name);
+}
+
+}  // namespace internal
+}  // namespace gtwrap
+
 
 
 
@@ -23,8 +41,8 @@ PYBIND11_MODULE(enum_py, m_) {
 
     py::class_<Pet, std::shared_ptr<Pet>> pet(m_, "Pet");
     pet
-        .def(py::init<const string&, Pet::Kind>(), py::arg("name"), py::arg("type"))
-        .def("setColor",[](Pet* self, const Color& color){ self->setColor(color);}, py::arg("color"))
+        .def(py::init<const string&, Pet::Kind>(), gtwrap::internal::py_arg<const string&>("name"), gtwrap::internal::py_arg<Pet::Kind>("type"))
+        .def("setColor",[](Pet* self, const Color& color){ self->setColor(color);}, gtwrap::internal::py_arg<const Color&>("color"))
         .def("getColor",[](Pet* self){return self->getColor();})
         .def_readwrite("name", &Pet::name)
         .def_readwrite("type", &Pet::type);
@@ -67,8 +85,8 @@ PYBIND11_MODULE(enum_py, m_) {
 
     py::class_<gtsam::Optimizer<gtsam::GaussNewtonParams>, std::shared_ptr<gtsam::Optimizer<gtsam::GaussNewtonParams>>> optimizergaussnewtonparams(m_gtsam, "OptimizerGaussNewtonParams");
     optimizergaussnewtonparams
-        .def(py::init<const Optimizer<gtsam::GaussNewtonParams>::Verbosity&>(), py::arg("verbosity"))
-        .def("setVerbosity",[](gtsam::Optimizer<gtsam::GaussNewtonParams>* self, const Optimizer<gtsam::GaussNewtonParams>::Verbosity value){ self->setVerbosity(value);}, py::arg("value"))
+        .def(py::init<const Optimizer<gtsam::GaussNewtonParams>::Verbosity&>(), gtwrap::internal::py_arg<const Optimizer<gtsam::GaussNewtonParams>::Verbosity&>("verbosity"))
+        .def("setVerbosity",[](gtsam::Optimizer<gtsam::GaussNewtonParams>* self, const Optimizer<gtsam::GaussNewtonParams>::Verbosity value){ self->setVerbosity(value);}, gtwrap::internal::py_arg<const Optimizer<gtsam::GaussNewtonParams>::Verbosity>("value"))
         .def("getVerbosity",[](gtsam::Optimizer<gtsam::GaussNewtonParams>* self){return self->getVerbosity();})
         .def("getVerbosity",[](gtsam::Optimizer<gtsam::GaussNewtonParams>* self){return self->getVerbosity();});
 

--- a/tests/expected/python/functions_pybind.cpp
+++ b/tests/expected/python/functions_pybind.cpp
@@ -5,6 +5,24 @@
 #include "gtsam/nonlinear/utilities.h"  // for RedirectCout.
 
 
+#include <type_traits>
+
+namespace gtwrap {
+namespace internal {
+
+template <typename T>
+struct PyArgPolicy {
+  static pybind11::arg make(const char* name) { return pybind11::arg(name); }
+};
+
+template <typename T>
+pybind11::arg py_arg(const char* name) {
+  return PyArgPolicy<typename std::decay<T>::type>::make(name);
+}
+
+}  // namespace internal
+}  // namespace gtwrap
+
 
 
 
@@ -16,27 +34,27 @@ PYBIND11_MODULE(functions_py, m_) {
     m_.doc() = "pybind11 wrapper of functions_py";
 
 
-    m_.def("load2D",[](string filename, std::shared_ptr<Test> model, int maxID, bool addNoise, bool smart){return ::load2D(filename, model, maxID, addNoise, smart);}, py::arg("filename"), py::arg("model"), py::arg("maxID"), py::arg("addNoise"), py::arg("smart"));
-    m_.def("load2D",[](string filename, const std::shared_ptr<gtsam::noiseModel::Diagonal> model, int maxID, bool addNoise, bool smart){return ::load2D(filename, model, maxID, addNoise, smart);}, py::arg("filename"), py::arg("model"), py::arg("maxID"), py::arg("addNoise"), py::arg("smart"));
-    m_.def("load2D",[](string filename, gtsam::noiseModel::Diagonal* model){return ::load2D(filename, model);}, py::arg("filename"), py::arg("model"));
+    m_.def("load2D",[](string filename, std::shared_ptr<Test> model, int maxID, bool addNoise, bool smart){return ::load2D(filename, model, maxID, addNoise, smart);}, gtwrap::internal::py_arg<string>("filename"), gtwrap::internal::py_arg<std::shared_ptr<Test>>("model"), gtwrap::internal::py_arg<int>("maxID"), gtwrap::internal::py_arg<bool>("addNoise"), gtwrap::internal::py_arg<bool>("smart"));
+    m_.def("load2D",[](string filename, const std::shared_ptr<gtsam::noiseModel::Diagonal> model, int maxID, bool addNoise, bool smart){return ::load2D(filename, model, maxID, addNoise, smart);}, gtwrap::internal::py_arg<string>("filename"), gtwrap::internal::py_arg<const std::shared_ptr<gtsam::noiseModel::Diagonal>>("model"), gtwrap::internal::py_arg<int>("maxID"), gtwrap::internal::py_arg<bool>("addNoise"), gtwrap::internal::py_arg<bool>("smart"));
+    m_.def("load2D",[](string filename, gtsam::noiseModel::Diagonal* model){return ::load2D(filename, model);}, gtwrap::internal::py_arg<string>("filename"), gtwrap::internal::py_arg<gtsam::noiseModel::Diagonal*>("model"));
     m_.def("aGlobalFunction",[](){return ::aGlobalFunction();});
-    m_.def("overloadedGlobalFunction",[](int a){return ::overloadedGlobalFunction(a);}, py::arg("a"));
-    m_.def("overloadedGlobalFunction",[](int a, double b){return ::overloadedGlobalFunction(a, b);}, py::arg("a"), py::arg("b"));
-    m_.def("MultiTemplatedFunctionStringSize_tDouble",[](const string& x, size_t y){return ::MultiTemplatedFunction<string,size_t,double>(x, y);}, py::arg("x"), py::arg("y"));
-    m_.def("MultiTemplatedFunctionDoubleSize_tDouble",[](const double& x, size_t y){return ::MultiTemplatedFunction<double,size_t,double>(x, y);}, py::arg("x"), py::arg("y"));
-    m_.def("DefaultFuncInt",[](int a, int b){ ::DefaultFuncInt(a, b);}, py::arg("a") = 123, py::arg("b") = 0);
-    m_.def("DefaultFuncString",[](const string& s, const string& name){ ::DefaultFuncString(s, name);}, py::arg("s") = "hello", py::arg("name") = "");
-    m_.def("DefaultFuncObj",[](const gtsam::KeyFormatter& keyFormatter){ ::DefaultFuncObj(keyFormatter);}, py::arg("keyFormatter") = gtsam::DefaultKeyFormatter);
-    m_.def("DefaultFuncZero",[](int a, int b, double c, int d, bool e){ ::DefaultFuncZero(a, b, c, d, e);}, py::arg("a"), py::arg("b"), py::arg("c") = 0.0, py::arg("d") = 0, py::arg("e") = false);
-    m_.def("DefaultFuncVector",[](const std::vector<int>& i, const std::vector<string>& s){ ::DefaultFuncVector(i, s);}, py::arg("i") = {1, 2, 3}, py::arg("s") = {"borglab", "gtsam"});
-    m_.def("setPose",[](const gtsam::Pose3& pose){ ::setPose(pose);}, py::arg("pose") = gtsam::Pose3());
-    m_.def("EliminateDiscrete",[](const gtsam::DiscreteFactorGraph& factors, const gtsam::Ordering& frontalKeys){return ::EliminateDiscrete(factors, frontalKeys);}, py::arg("factors"), py::arg("frontalKeys"));
-    m_.def("triangulatePoint3Cal3_S2",[](const gtsam::Pose3Vector& poses, std::shared_ptr<gtsam::Cal3_S2> sharedCal, const gtsam::Point2Vector& measurements, double rank_tol, bool optimize, const gtsam::SharedNoiseModel& model){return ::triangulatePoint3<gtsam::Cal3_S2>(poses, sharedCal, measurements, rank_tol, optimize, model);}, py::arg("poses"), py::arg("sharedCal"), py::arg("measurements"), py::arg("rank_tol"), py::arg("optimize"), py::arg("model") = nullptr);
-    m_.def("FindKarcherMeanPoint3",[](const std::vector<gtsam::Point3>& elements){return ::FindKarcherMean<gtsam::Point3>(elements);}, py::arg("elements"));
-    m_.def("FindKarcherMeanSO3",[](const std::vector<gtsam::SO3>& elements){return ::FindKarcherMean<gtsam::SO3>(elements);}, py::arg("elements"));
-    m_.def("FindKarcherMeanSO4",[](const std::vector<gtsam::SO4>& elements){return ::FindKarcherMean<gtsam::SO4>(elements);}, py::arg("elements"));
-    m_.def("FindKarcherMeanPose3",[](const std::vector<gtsam::Pose3>& elements){return ::FindKarcherMean<gtsam::Pose3>(elements);}, py::arg("elements"));
-    m_.def("TemplatedFunctionRot3",[](const gtsam::Rot3& t){ ::TemplatedFunction<gtsam::Rot3>(t);}, py::arg("t"));
+    m_.def("overloadedGlobalFunction",[](int a){return ::overloadedGlobalFunction(a);}, gtwrap::internal::py_arg<int>("a"));
+    m_.def("overloadedGlobalFunction",[](int a, double b){return ::overloadedGlobalFunction(a, b);}, gtwrap::internal::py_arg<int>("a"), gtwrap::internal::py_arg<double>("b"));
+    m_.def("MultiTemplatedFunctionStringSize_tDouble",[](const string& x, size_t y){return ::MultiTemplatedFunction<string,size_t,double>(x, y);}, gtwrap::internal::py_arg<const string&>("x"), gtwrap::internal::py_arg<size_t>("y"));
+    m_.def("MultiTemplatedFunctionDoubleSize_tDouble",[](const double& x, size_t y){return ::MultiTemplatedFunction<double,size_t,double>(x, y);}, gtwrap::internal::py_arg<const double&>("x"), gtwrap::internal::py_arg<size_t>("y"));
+    m_.def("DefaultFuncInt",[](int a, int b){ ::DefaultFuncInt(a, b);}, gtwrap::internal::py_arg<int>("a") = 123, gtwrap::internal::py_arg<int>("b") = 0);
+    m_.def("DefaultFuncString",[](const string& s, const string& name){ ::DefaultFuncString(s, name);}, gtwrap::internal::py_arg<const string&>("s") = "hello", gtwrap::internal::py_arg<const string&>("name") = "");
+    m_.def("DefaultFuncObj",[](const gtsam::KeyFormatter& keyFormatter){ ::DefaultFuncObj(keyFormatter);}, gtwrap::internal::py_arg<const gtsam::KeyFormatter&>("keyFormatter") = gtsam::DefaultKeyFormatter);
+    m_.def("DefaultFuncZero",[](int a, int b, double c, int d, bool e){ ::DefaultFuncZero(a, b, c, d, e);}, gtwrap::internal::py_arg<int>("a"), gtwrap::internal::py_arg<int>("b"), gtwrap::internal::py_arg<double>("c") = 0.0, gtwrap::internal::py_arg<int>("d") = 0, gtwrap::internal::py_arg<bool>("e") = false);
+    m_.def("DefaultFuncVector",[](const std::vector<int>& i, const std::vector<string>& s){ ::DefaultFuncVector(i, s);}, gtwrap::internal::py_arg<const std::vector<int>&>("i") = {1, 2, 3}, gtwrap::internal::py_arg<const std::vector<string>&>("s") = {"borglab", "gtsam"});
+    m_.def("setPose",[](const gtsam::Pose3& pose){ ::setPose(pose);}, gtwrap::internal::py_arg<const gtsam::Pose3&>("pose") = gtsam::Pose3());
+    m_.def("EliminateDiscrete",[](const gtsam::DiscreteFactorGraph& factors, const gtsam::Ordering& frontalKeys){return ::EliminateDiscrete(factors, frontalKeys);}, gtwrap::internal::py_arg<const gtsam::DiscreteFactorGraph&>("factors"), gtwrap::internal::py_arg<const gtsam::Ordering&>("frontalKeys"));
+    m_.def("triangulatePoint3Cal3_S2",[](const gtsam::Pose3Vector& poses, std::shared_ptr<gtsam::Cal3_S2> sharedCal, const gtsam::Point2Vector& measurements, double rank_tol, bool optimize, const gtsam::SharedNoiseModel& model){return ::triangulatePoint3<gtsam::Cal3_S2>(poses, sharedCal, measurements, rank_tol, optimize, model);}, gtwrap::internal::py_arg<const gtsam::Pose3Vector&>("poses"), gtwrap::internal::py_arg<std::shared_ptr<gtsam::Cal3_S2>>("sharedCal"), gtwrap::internal::py_arg<const gtsam::Point2Vector&>("measurements"), gtwrap::internal::py_arg<double>("rank_tol"), gtwrap::internal::py_arg<bool>("optimize"), gtwrap::internal::py_arg<const gtsam::SharedNoiseModel&>("model") = nullptr);
+    m_.def("FindKarcherMeanPoint3",[](const std::vector<gtsam::Point3>& elements){return ::FindKarcherMean<gtsam::Point3>(elements);}, gtwrap::internal::py_arg<const std::vector<gtsam::Point3>&>("elements"));
+    m_.def("FindKarcherMeanSO3",[](const std::vector<gtsam::SO3>& elements){return ::FindKarcherMean<gtsam::SO3>(elements);}, gtwrap::internal::py_arg<const std::vector<gtsam::SO3>&>("elements"));
+    m_.def("FindKarcherMeanSO4",[](const std::vector<gtsam::SO4>& elements){return ::FindKarcherMean<gtsam::SO4>(elements);}, gtwrap::internal::py_arg<const std::vector<gtsam::SO4>&>("elements"));
+    m_.def("FindKarcherMeanPose3",[](const std::vector<gtsam::Pose3>& elements){return ::FindKarcherMean<gtsam::Pose3>(elements);}, gtwrap::internal::py_arg<const std::vector<gtsam::Pose3>&>("elements"));
+    m_.def("TemplatedFunctionRot3",[](const gtsam::Rot3& t){ ::TemplatedFunction<gtsam::Rot3>(t);}, gtwrap::internal::py_arg<const gtsam::Rot3&>("t"));
 
 #include "python/specializations.h"
 

--- a/tests/expected/python/geometry_pybind.cpp
+++ b/tests/expected/python/geometry_pybind.cpp
@@ -7,6 +7,24 @@
 #include "gtsam/geometry/Point2.h"
 #include "gtsam/geometry/Point3.h"
 #include <boost/serialization/export.hpp>
+#include <type_traits>
+
+namespace gtwrap {
+namespace internal {
+
+template <typename T>
+struct PyArgPolicy {
+  static pybind11::arg make(const char* name) { return pybind11::arg(name); }
+};
+
+template <typename T>
+pybind11::arg py_arg(const char* name) {
+  return PyArgPolicy<typename std::decay<T>::type>::make(name);
+}
+
+}  // namespace internal
+}  // namespace gtwrap
+
 
 BOOST_CLASS_EXPORT(gtsam::Point2)
 BOOST_CLASS_EXPORT(gtsam::Point3)
@@ -23,20 +41,20 @@ PYBIND11_MODULE(geometry_py, m_) {
 
     py::class_<gtsam::Point2, std::shared_ptr<gtsam::Point2>>(m_gtsam, "Point2")
         .def(py::init<>())
-        .def(py::init<double, double>(), py::arg("x"), py::arg("y"))
+        .def(py::init<double, double>(), gtwrap::internal::py_arg<double>("x"), gtwrap::internal::py_arg<double>("y"))
         .def("x",[](gtsam::Point2* self){return self->x();})
         .def("y",[](gtsam::Point2* self){return self->y();})
         .def("dim",[](gtsam::Point2* self){return self->dim();})
         .def("returnChar",[](gtsam::Point2* self){return self->returnChar();})
-        .def("argChar",[](gtsam::Point2* self, char a){ self->argChar(a);}, py::arg("a"))
-        .def("argChar",[](gtsam::Point2* self, std::shared_ptr<char> a){ self->argChar(a);}, py::arg("a"))
-        .def("argChar",[](gtsam::Point2* self, char& a){ self->argChar(a);}, py::arg("a"))
-        .def("argChar",[](gtsam::Point2* self, char* a){ self->argChar(a);}, py::arg("a"))
-        .def("argChar",[](gtsam::Point2* self, const std::shared_ptr<char> a){ self->argChar(a);}, py::arg("a"))
-        .def("argChar",[](gtsam::Point2* self, const char& a){ self->argChar(a);}, py::arg("a"))
-        .def("argChar",[](gtsam::Point2* self, const char* a){ self->argChar(a);}, py::arg("a"))
-        .def("argUChar",[](gtsam::Point2* self, unsigned char a){ self->argUChar(a);}, py::arg("a"))
-        .def("eigenArguments",[](gtsam::Point2* self, const gtsam::Vector& v, const gtsam::Matrix& m){ self->eigenArguments(v, m);}, py::arg("v"), py::arg("m"))
+        .def("argChar",[](gtsam::Point2* self, char a){ self->argChar(a);}, gtwrap::internal::py_arg<char>("a"))
+        .def("argChar",[](gtsam::Point2* self, std::shared_ptr<char> a){ self->argChar(a);}, gtwrap::internal::py_arg<std::shared_ptr<char>>("a"))
+        .def("argChar",[](gtsam::Point2* self, char& a){ self->argChar(a);}, gtwrap::internal::py_arg<char&>("a"))
+        .def("argChar",[](gtsam::Point2* self, char* a){ self->argChar(a);}, gtwrap::internal::py_arg<char*>("a"))
+        .def("argChar",[](gtsam::Point2* self, const std::shared_ptr<char> a){ self->argChar(a);}, gtwrap::internal::py_arg<const std::shared_ptr<char>>("a"))
+        .def("argChar",[](gtsam::Point2* self, const char& a){ self->argChar(a);}, gtwrap::internal::py_arg<const char&>("a"))
+        .def("argChar",[](gtsam::Point2* self, const char* a){ self->argChar(a);}, gtwrap::internal::py_arg<const char*>("a"))
+        .def("argUChar",[](gtsam::Point2* self, unsigned char a){ self->argUChar(a);}, gtwrap::internal::py_arg<unsigned char>("a"))
+        .def("eigenArguments",[](gtsam::Point2* self, const gtsam::Vector& v, const gtsam::Matrix& m){ self->eigenArguments(v, m);}, gtwrap::internal::py_arg<const gtsam::Vector&>("v"), gtwrap::internal::py_arg<const gtsam::Matrix&>("m"))
         .def("vectorConfusion",[](gtsam::Point2* self){return self->vectorConfusion();})
         .def("serialize", [](gtsam::Point2* self){ return gtsam::serialize(*self); })
         .def("deserialize", [](gtsam::Point2* self, string serialized){ gtsam::deserialize(serialized, *self); }, py::arg("serialized"))
@@ -45,7 +63,7 @@ PYBIND11_MODULE(geometry_py, m_) {
             [](py::tuple t){ /* __setstate__ */ gtsam::Point2 obj; gtsam::deserialize(t[0].cast<std::string>(), obj); return obj; }));
 
     py::class_<gtsam::Point3, std::shared_ptr<gtsam::Point3>>(m_gtsam, "Point3")
-        .def(py::init<double, double, double>(), py::arg("x"), py::arg("y"), py::arg("z"))
+        .def(py::init<double, double, double>(), gtwrap::internal::py_arg<double>("x"), gtwrap::internal::py_arg<double>("y"), gtwrap::internal::py_arg<double>("z"))
         .def("norm",[](gtsam::Point3* self){return self->norm();})
         .def("serialize", [](gtsam::Point3* self){ return gtsam::serialize(*self); })
         .def("deserialize", [](gtsam::Point3* self, string serialized){ gtsam::deserialize(serialized, *self); }, py::arg("serialized"))
@@ -53,7 +71,7 @@ PYBIND11_MODULE(geometry_py, m_) {
             [](const gtsam::Point3 &a){ /* __getstate__: Returns a string that encodes the state of the object */ return py::make_tuple(gtsam::serialize(a)); },
             [](py::tuple t){ /* __setstate__ */ gtsam::Point3 obj; gtsam::deserialize(t[0].cast<std::string>(), obj); return obj; }))
         .def_static("staticFunction",[](){return gtsam::Point3::staticFunction();})
-        .def_static("StaticFunctionRet",[](double z){return gtsam::Point3::StaticFunctionRet(z);}, py::arg("z"));
+        .def_static("StaticFunctionRet",[](double z){return gtsam::Point3::StaticFunctionRet(z);}, gtwrap::internal::py_arg<double>("z"));
 
 
 #include "python/specializations.h"

--- a/tests/expected/python/inheritance_pybind.cpp
+++ b/tests/expected/python/inheritance_pybind.cpp
@@ -5,6 +5,24 @@
 #include "gtsam/nonlinear/utilities.h"  // for RedirectCout.
 
 
+#include <type_traits>
+
+namespace gtwrap {
+namespace internal {
+
+template <typename T>
+struct PyArgPolicy {
+  static pybind11::arg make(const char* name) { return pybind11::arg(name); }
+};
+
+template <typename T>
+pybind11::arg py_arg(const char* name) {
+  return PyArgPolicy<typename std::decay<T>::type>::make(name);
+}
+
+}  // namespace internal
+}  // namespace gtwrap
+
 
 
 
@@ -20,48 +38,48 @@ PYBIND11_MODULE(inheritance_py, m_) {
 
     py::class_<MyTemplate<gtsam::Point2>, MyBase, std::shared_ptr<MyTemplate<gtsam::Point2>>>(m_, "MyTemplatePoint2")
         .def(py::init<>())
-        .def("templatedMethodPoint2",[](MyTemplate<gtsam::Point2>* self, const gtsam::Point2& t){return self->templatedMethod<gtsam::Point2>(t);}, py::arg("t"))
-        .def("templatedMethodPoint3",[](MyTemplate<gtsam::Point2>* self, const gtsam::Point3& t){return self->templatedMethod<gtsam::Point3>(t);}, py::arg("t"))
-        .def("templatedMethodVector",[](MyTemplate<gtsam::Point2>* self, const gtsam::Vector& t){return self->templatedMethod<gtsam::Vector>(t);}, py::arg("t"))
-        .def("templatedMethodMatrix",[](MyTemplate<gtsam::Point2>* self, const gtsam::Matrix& t){return self->templatedMethod<gtsam::Matrix>(t);}, py::arg("t"))
-        .def("accept_T",[](MyTemplate<gtsam::Point2>* self, const gtsam::Point2& value){ self->accept_T(value);}, py::arg("value"))
-        .def("accept_Tptr",[](MyTemplate<gtsam::Point2>* self, std::shared_ptr<gtsam::Point2> value){ self->accept_Tptr(value);}, py::arg("value"))
-        .def("return_Tptr",[](MyTemplate<gtsam::Point2>* self, std::shared_ptr<gtsam::Point2> value){return self->return_Tptr(value);}, py::arg("value"))
-        .def("return_T",[](MyTemplate<gtsam::Point2>* self, gtsam::Point2* value){return self->return_T(value);}, py::arg("value"))
+        .def("templatedMethodPoint2",[](MyTemplate<gtsam::Point2>* self, const gtsam::Point2& t){return self->templatedMethod<gtsam::Point2>(t);}, gtwrap::internal::py_arg<const gtsam::Point2&>("t"))
+        .def("templatedMethodPoint3",[](MyTemplate<gtsam::Point2>* self, const gtsam::Point3& t){return self->templatedMethod<gtsam::Point3>(t);}, gtwrap::internal::py_arg<const gtsam::Point3&>("t"))
+        .def("templatedMethodVector",[](MyTemplate<gtsam::Point2>* self, const gtsam::Vector& t){return self->templatedMethod<gtsam::Vector>(t);}, gtwrap::internal::py_arg<const gtsam::Vector&>("t"))
+        .def("templatedMethodMatrix",[](MyTemplate<gtsam::Point2>* self, const gtsam::Matrix& t){return self->templatedMethod<gtsam::Matrix>(t);}, gtwrap::internal::py_arg<const gtsam::Matrix&>("t"))
+        .def("accept_T",[](MyTemplate<gtsam::Point2>* self, const gtsam::Point2& value){ self->accept_T(value);}, gtwrap::internal::py_arg<const gtsam::Point2&>("value"))
+        .def("accept_Tptr",[](MyTemplate<gtsam::Point2>* self, std::shared_ptr<gtsam::Point2> value){ self->accept_Tptr(value);}, gtwrap::internal::py_arg<std::shared_ptr<gtsam::Point2>>("value"))
+        .def("return_Tptr",[](MyTemplate<gtsam::Point2>* self, std::shared_ptr<gtsam::Point2> value){return self->return_Tptr(value);}, gtwrap::internal::py_arg<std::shared_ptr<gtsam::Point2>>("value"))
+        .def("return_T",[](MyTemplate<gtsam::Point2>* self, gtsam::Point2* value){return self->return_T(value);}, gtwrap::internal::py_arg<gtsam::Point2*>("value"))
         .def("create_ptrs",[](MyTemplate<gtsam::Point2>* self){return self->create_ptrs();})
         .def("create_MixedPtrs",[](MyTemplate<gtsam::Point2>* self){return self->create_MixedPtrs();})
-        .def("return_ptrs",[](MyTemplate<gtsam::Point2>* self, std::shared_ptr<gtsam::Point2> p1, std::shared_ptr<gtsam::Point2> p2){return self->return_ptrs(p1, p2);}, py::arg("p1"), py::arg("p2"))
-        .def_static("Level",[](const gtsam::Point2& K){return MyTemplate<gtsam::Point2>::Level(K);}, py::arg("K"));
+        .def("return_ptrs",[](MyTemplate<gtsam::Point2>* self, std::shared_ptr<gtsam::Point2> p1, std::shared_ptr<gtsam::Point2> p2){return self->return_ptrs(p1, p2);}, gtwrap::internal::py_arg<std::shared_ptr<gtsam::Point2>>("p1"), gtwrap::internal::py_arg<std::shared_ptr<gtsam::Point2>>("p2"))
+        .def_static("Level",[](const gtsam::Point2& K){return MyTemplate<gtsam::Point2>::Level(K);}, gtwrap::internal::py_arg<const gtsam::Point2&>("K"));
 
     py::class_<MyTemplate<gtsam::Matrix>, MyBase, std::shared_ptr<MyTemplate<gtsam::Matrix>>>(m_, "MyTemplateMatrix")
         .def(py::init<>())
-        .def("templatedMethodPoint2",[](MyTemplate<gtsam::Matrix>* self, const gtsam::Point2& t){return self->templatedMethod<gtsam::Point2>(t);}, py::arg("t"))
-        .def("templatedMethodPoint3",[](MyTemplate<gtsam::Matrix>* self, const gtsam::Point3& t){return self->templatedMethod<gtsam::Point3>(t);}, py::arg("t"))
-        .def("templatedMethodVector",[](MyTemplate<gtsam::Matrix>* self, const gtsam::Vector& t){return self->templatedMethod<gtsam::Vector>(t);}, py::arg("t"))
-        .def("templatedMethodMatrix",[](MyTemplate<gtsam::Matrix>* self, const gtsam::Matrix& t){return self->templatedMethod<gtsam::Matrix>(t);}, py::arg("t"))
-        .def("accept_T",[](MyTemplate<gtsam::Matrix>* self, const gtsam::Matrix& value){ self->accept_T(value);}, py::arg("value"))
-        .def("accept_Tptr",[](MyTemplate<gtsam::Matrix>* self, std::shared_ptr<gtsam::Matrix> value){ self->accept_Tptr(value);}, py::arg("value"))
-        .def("return_Tptr",[](MyTemplate<gtsam::Matrix>* self, std::shared_ptr<gtsam::Matrix> value){return self->return_Tptr(value);}, py::arg("value"))
-        .def("return_T",[](MyTemplate<gtsam::Matrix>* self, gtsam::Matrix* value){return self->return_T(value);}, py::arg("value"))
+        .def("templatedMethodPoint2",[](MyTemplate<gtsam::Matrix>* self, const gtsam::Point2& t){return self->templatedMethod<gtsam::Point2>(t);}, gtwrap::internal::py_arg<const gtsam::Point2&>("t"))
+        .def("templatedMethodPoint3",[](MyTemplate<gtsam::Matrix>* self, const gtsam::Point3& t){return self->templatedMethod<gtsam::Point3>(t);}, gtwrap::internal::py_arg<const gtsam::Point3&>("t"))
+        .def("templatedMethodVector",[](MyTemplate<gtsam::Matrix>* self, const gtsam::Vector& t){return self->templatedMethod<gtsam::Vector>(t);}, gtwrap::internal::py_arg<const gtsam::Vector&>("t"))
+        .def("templatedMethodMatrix",[](MyTemplate<gtsam::Matrix>* self, const gtsam::Matrix& t){return self->templatedMethod<gtsam::Matrix>(t);}, gtwrap::internal::py_arg<const gtsam::Matrix&>("t"))
+        .def("accept_T",[](MyTemplate<gtsam::Matrix>* self, const gtsam::Matrix& value){ self->accept_T(value);}, gtwrap::internal::py_arg<const gtsam::Matrix&>("value"))
+        .def("accept_Tptr",[](MyTemplate<gtsam::Matrix>* self, std::shared_ptr<gtsam::Matrix> value){ self->accept_Tptr(value);}, gtwrap::internal::py_arg<std::shared_ptr<gtsam::Matrix>>("value"))
+        .def("return_Tptr",[](MyTemplate<gtsam::Matrix>* self, std::shared_ptr<gtsam::Matrix> value){return self->return_Tptr(value);}, gtwrap::internal::py_arg<std::shared_ptr<gtsam::Matrix>>("value"))
+        .def("return_T",[](MyTemplate<gtsam::Matrix>* self, gtsam::Matrix* value){return self->return_T(value);}, gtwrap::internal::py_arg<gtsam::Matrix*>("value"))
         .def("create_ptrs",[](MyTemplate<gtsam::Matrix>* self){return self->create_ptrs();})
         .def("create_MixedPtrs",[](MyTemplate<gtsam::Matrix>* self){return self->create_MixedPtrs();})
-        .def("return_ptrs",[](MyTemplate<gtsam::Matrix>* self, std::shared_ptr<gtsam::Matrix> p1, std::shared_ptr<gtsam::Matrix> p2){return self->return_ptrs(p1, p2);}, py::arg("p1"), py::arg("p2"))
-        .def_static("Level",[](const gtsam::Matrix& K){return MyTemplate<gtsam::Matrix>::Level(K);}, py::arg("K"));
+        .def("return_ptrs",[](MyTemplate<gtsam::Matrix>* self, std::shared_ptr<gtsam::Matrix> p1, std::shared_ptr<gtsam::Matrix> p2){return self->return_ptrs(p1, p2);}, gtwrap::internal::py_arg<std::shared_ptr<gtsam::Matrix>>("p1"), gtwrap::internal::py_arg<std::shared_ptr<gtsam::Matrix>>("p2"))
+        .def_static("Level",[](const gtsam::Matrix& K){return MyTemplate<gtsam::Matrix>::Level(K);}, gtwrap::internal::py_arg<const gtsam::Matrix&>("K"));
 
     py::class_<MyTemplate<A>, MyBase, std::shared_ptr<MyTemplate<A>>>(m_, "MyTemplateA")
         .def(py::init<>())
-        .def("templatedMethodPoint2",[](MyTemplate<A>* self, const gtsam::Point2& t){return self->templatedMethod<gtsam::Point2>(t);}, py::arg("t"))
-        .def("templatedMethodPoint3",[](MyTemplate<A>* self, const gtsam::Point3& t){return self->templatedMethod<gtsam::Point3>(t);}, py::arg("t"))
-        .def("templatedMethodVector",[](MyTemplate<A>* self, const gtsam::Vector& t){return self->templatedMethod<gtsam::Vector>(t);}, py::arg("t"))
-        .def("templatedMethodMatrix",[](MyTemplate<A>* self, const gtsam::Matrix& t){return self->templatedMethod<gtsam::Matrix>(t);}, py::arg("t"))
-        .def("accept_T",[](MyTemplate<A>* self, const A& value){ self->accept_T(value);}, py::arg("value"))
-        .def("accept_Tptr",[](MyTemplate<A>* self, std::shared_ptr<A> value){ self->accept_Tptr(value);}, py::arg("value"))
-        .def("return_Tptr",[](MyTemplate<A>* self, std::shared_ptr<A> value){return self->return_Tptr(value);}, py::arg("value"))
-        .def("return_T",[](MyTemplate<A>* self, A* value){return self->return_T(value);}, py::arg("value"))
+        .def("templatedMethodPoint2",[](MyTemplate<A>* self, const gtsam::Point2& t){return self->templatedMethod<gtsam::Point2>(t);}, gtwrap::internal::py_arg<const gtsam::Point2&>("t"))
+        .def("templatedMethodPoint3",[](MyTemplate<A>* self, const gtsam::Point3& t){return self->templatedMethod<gtsam::Point3>(t);}, gtwrap::internal::py_arg<const gtsam::Point3&>("t"))
+        .def("templatedMethodVector",[](MyTemplate<A>* self, const gtsam::Vector& t){return self->templatedMethod<gtsam::Vector>(t);}, gtwrap::internal::py_arg<const gtsam::Vector&>("t"))
+        .def("templatedMethodMatrix",[](MyTemplate<A>* self, const gtsam::Matrix& t){return self->templatedMethod<gtsam::Matrix>(t);}, gtwrap::internal::py_arg<const gtsam::Matrix&>("t"))
+        .def("accept_T",[](MyTemplate<A>* self, const A& value){ self->accept_T(value);}, gtwrap::internal::py_arg<const A&>("value"))
+        .def("accept_Tptr",[](MyTemplate<A>* self, std::shared_ptr<A> value){ self->accept_Tptr(value);}, gtwrap::internal::py_arg<std::shared_ptr<A>>("value"))
+        .def("return_Tptr",[](MyTemplate<A>* self, std::shared_ptr<A> value){return self->return_Tptr(value);}, gtwrap::internal::py_arg<std::shared_ptr<A>>("value"))
+        .def("return_T",[](MyTemplate<A>* self, A* value){return self->return_T(value);}, gtwrap::internal::py_arg<A*>("value"))
         .def("create_ptrs",[](MyTemplate<A>* self){return self->create_ptrs();})
         .def("create_MixedPtrs",[](MyTemplate<A>* self){return self->create_MixedPtrs();})
-        .def("return_ptrs",[](MyTemplate<A>* self, std::shared_ptr<A> p1, std::shared_ptr<A> p2){return self->return_ptrs(p1, p2);}, py::arg("p1"), py::arg("p2"))
-        .def_static("Level",[](const A& K){return MyTemplate<A>::Level(K);}, py::arg("K"));
+        .def("return_ptrs",[](MyTemplate<A>* self, std::shared_ptr<A> p1, std::shared_ptr<A> p2){return self->return_ptrs(p1, p2);}, gtwrap::internal::py_arg<std::shared_ptr<A>>("p1"), gtwrap::internal::py_arg<std::shared_ptr<A>>("p2"))
+        .def_static("Level",[](const A& K){return MyTemplate<A>::Level(K);}, gtwrap::internal::py_arg<const A&>("K"));
 
     py::class_<ForwardKinematicsFactor, gtsam::BetweenFactor<gtsam::Pose3>, std::shared_ptr<ForwardKinematicsFactor>>(m_, "ForwardKinematicsFactor");
 

--- a/tests/expected/python/namespaces_pybind.cpp
+++ b/tests/expected/python/namespaces_pybind.cpp
@@ -11,6 +11,24 @@
 #include "path/to/ns3.h"
 #include "gtsam/nonlinear/Values.h"
 
+#include <type_traits>
+
+namespace gtwrap {
+namespace internal {
+
+template <typename T>
+struct PyArgPolicy {
+  static pybind11::arg make(const char* name) { return pybind11::arg(name); }
+};
+
+template <typename T>
+pybind11::arg py_arg(const char* name) {
+  return PyArgPolicy<typename std::decay<T>::type>::make(name);
+}
+
+}  // namespace internal
+}  // namespace gtwrap
+
 
 
 
@@ -34,8 +52,8 @@ PYBIND11_MODULE(namespaces_py, m_) {
     py::class_<ns2::ClassA, std::shared_ptr<ns2::ClassA>>(m_ns2, "ClassA")
         .def(py::init<>())
         .def("memberFunction",[](ns2::ClassA* self){return self->memberFunction();})
-        .def("nsArg",[](ns2::ClassA* self, const ns1::ClassB& arg){return self->nsArg(arg);}, py::arg("arg"))
-        .def("nsReturn",[](ns2::ClassA* self, double q){return self->nsReturn(q);}, py::arg("q"))
+        .def("nsArg",[](ns2::ClassA* self, const ns1::ClassB& arg){return self->nsArg(arg);}, gtwrap::internal::py_arg<const ns1::ClassB&>("arg"))
+        .def("nsReturn",[](ns2::ClassA* self, double q){return self->nsReturn(q);}, gtwrap::internal::py_arg<double>("q"))
         .def_static("afunction",[](){return ns2::ClassA::afunction();});
     pybind11::module m_ns2_ns3 = m_ns2.def_submodule("ns3", "ns3 submodule");
 
@@ -47,8 +65,8 @@ PYBIND11_MODULE(namespaces_py, m_) {
 
     m_ns2.attr("aNs2Var") = ns2::aNs2Var;
     m_ns2.def("aGlobalFunction",[](){return ns2::aGlobalFunction();});
-    m_ns2.def("overloadedGlobalFunction",[](const ns1::ClassA& a){return ns2::overloadedGlobalFunction(a);}, py::arg("a"));
-    m_ns2.def("overloadedGlobalFunction",[](const ns1::ClassA& a, double b){return ns2::overloadedGlobalFunction(a, b);}, py::arg("a"), py::arg("b"));
+    m_ns2.def("overloadedGlobalFunction",[](const ns1::ClassA& a){return ns2::overloadedGlobalFunction(a);}, gtwrap::internal::py_arg<const ns1::ClassA&>("a"));
+    m_ns2.def("overloadedGlobalFunction",[](const ns1::ClassA& a, double b){return ns2::overloadedGlobalFunction(a, b);}, gtwrap::internal::py_arg<const ns1::ClassA&>("a"), gtwrap::internal::py_arg<double>("b"));
     py::class_<ClassD, std::shared_ptr<ClassD>>(m_, "ClassD")
         .def(py::init<>());
 
@@ -56,11 +74,11 @@ PYBIND11_MODULE(namespaces_py, m_) {
 
     py::class_<gtsam::Values, std::shared_ptr<gtsam::Values>>(m_gtsam, "Values")
         .def(py::init<>())
-        .def(py::init<const gtsam::Values&>(), py::arg("other"))
-        .def("insert_vector",[](gtsam::Values* self, size_t j, const gtsam::Vector& vector){ self->insert(j, vector);}, py::arg("j"), py::arg("vector"))
-        .def("insert",[](gtsam::Values* self, size_t j, const gtsam::Vector& vector){ self->insert(j, vector);}, py::arg("j"), py::arg("vector"))
-        .def("insert_matrix",[](gtsam::Values* self, size_t j, const gtsam::Matrix& matrix){ self->insert(j, matrix);}, py::arg("j"), py::arg("matrix"))
-        .def("insert",[](gtsam::Values* self, size_t j, const gtsam::Matrix& matrix){ self->insert(j, matrix);}, py::arg("j"), py::arg("matrix"));
+        .def(py::init<const gtsam::Values&>(), gtwrap::internal::py_arg<const gtsam::Values&>("other"))
+        .def("insert_vector",[](gtsam::Values* self, size_t j, const gtsam::Vector& vector){ self->insert(j, vector);}, gtwrap::internal::py_arg<size_t>("j"), gtwrap::internal::py_arg<const gtsam::Vector&>("vector"))
+        .def("insert",[](gtsam::Values* self, size_t j, const gtsam::Vector& vector){ self->insert(j, vector);}, gtwrap::internal::py_arg<size_t>("j"), gtwrap::internal::py_arg<const gtsam::Vector&>("vector"))
+        .def("insert_matrix",[](gtsam::Values* self, size_t j, const gtsam::Matrix& matrix){ self->insert(j, matrix);}, gtwrap::internal::py_arg<size_t>("j"), gtwrap::internal::py_arg<const gtsam::Matrix&>("matrix"))
+        .def("insert",[](gtsam::Values* self, size_t j, const gtsam::Matrix& matrix){ self->insert(j, matrix);}, gtwrap::internal::py_arg<size_t>("j"), gtwrap::internal::py_arg<const gtsam::Matrix&>("matrix"));
 
 
 #include "python/specializations.h"

--- a/tests/expected/python/operator_pybind.cpp
+++ b/tests/expected/python/operator_pybind.cpp
@@ -6,6 +6,24 @@
 
 #include "gtsam/geometry/Pose3.h"
 
+#include <type_traits>
+
+namespace gtwrap {
+namespace internal {
+
+template <typename T>
+struct PyArgPolicy {
+  static pybind11::arg make(const char* name) { return pybind11::arg(name); }
+};
+
+template <typename T>
+pybind11::arg py_arg(const char* name) {
+  return PyArgPolicy<typename std::decay<T>::type>::make(name);
+}
+
+}  // namespace internal
+}  // namespace gtwrap
+
 
 
 
@@ -20,7 +38,7 @@ PYBIND11_MODULE(operator_py, m_) {
 
     py::class_<gtsam::Pose3, std::shared_ptr<gtsam::Pose3>>(m_gtsam, "Pose3")
         .def(py::init<>())
-        .def(py::init<gtsam::Rot3, gtsam::Point3>(), py::arg("R"), py::arg("t"))
+        .def(py::init<gtsam::Rot3, gtsam::Point3>(), gtwrap::internal::py_arg<gtsam::Rot3>("R"), gtwrap::internal::py_arg<gtsam::Point3>("t"))
         .def(py::self * py::self);
 
     py::class_<gtsam::Container<gtsam::Matrix>, std::shared_ptr<gtsam::Container<gtsam::Matrix>>>(m_gtsam, "ContainerMatrix")

--- a/tests/expected/python/special_cases_pybind.cpp
+++ b/tests/expected/python/special_cases_pybind.cpp
@@ -6,6 +6,24 @@
 
 #include "gtsam/geometry/Cal3Bundler.h"
 
+#include <type_traits>
+
+namespace gtwrap {
+namespace internal {
+
+template <typename T>
+struct PyArgPolicy {
+  static pybind11::arg make(const char* name) { return pybind11::arg(name); }
+};
+
+template <typename T>
+pybind11::arg py_arg(const char* name) {
+  return PyArgPolicy<typename std::decay<T>::type>::make(name);
+}
+
+}  // namespace internal
+}  // namespace gtwrap
+
 
 
 
@@ -19,7 +37,7 @@ PYBIND11_MODULE(special_cases_py, m_) {
     pybind11::module m_gtsam = m_.def_submodule("gtsam", "gtsam submodule");
 
     py::class_<gtsam::NonlinearFactorGraph, std::shared_ptr<gtsam::NonlinearFactorGraph>>(m_gtsam, "NonlinearFactorGraph")
-        .def("addPriorPinholeCameraCal3Bundler",[](gtsam::NonlinearFactorGraph* self, size_t key, const gtsam::PinholeCamera<gtsam::Cal3Bundler>& prior, const std::shared_ptr<gtsam::noiseModel::Base> noiseModel){ self->addPrior<gtsam::PinholeCamera<gtsam::Cal3Bundler>>(key, prior, noiseModel);}, py::arg("key"), py::arg("prior"), py::arg("noiseModel"));
+        .def("addPriorPinholeCameraCal3Bundler",[](gtsam::NonlinearFactorGraph* self, size_t key, const gtsam::PinholeCamera<gtsam::Cal3Bundler>& prior, const std::shared_ptr<gtsam::noiseModel::Base> noiseModel){ self->addPrior<gtsam::PinholeCamera<gtsam::Cal3Bundler>>(key, prior, noiseModel);}, gtwrap::internal::py_arg<size_t>("key"), gtwrap::internal::py_arg<const gtsam::PinholeCamera<gtsam::Cal3Bundler>&>("prior"), gtwrap::internal::py_arg<const std::shared_ptr<gtsam::noiseModel::Base>>("noiseModel"));
 
     py::class_<gtsam::SfmTrack, std::shared_ptr<gtsam::SfmTrack>>(m_gtsam, "SfmTrack")
         .def_readwrite("measurements", &gtsam::SfmTrack::measurements);

--- a/tests/expected/python/templates_pybind.cpp
+++ b/tests/expected/python/templates_pybind.cpp
@@ -5,6 +5,24 @@
 #include "gtsam/nonlinear/utilities.h"  // for RedirectCout.
 
 
+#include <type_traits>
+
+namespace gtwrap {
+namespace internal {
+
+template <typename T>
+struct PyArgPolicy {
+  static pybind11::arg make(const char* name) { return pybind11::arg(name); }
+};
+
+template <typename T>
+pybind11::arg py_arg(const char* name) {
+  return PyArgPolicy<typename std::decay<T>::type>::make(name);
+}
+
+}  // namespace internal
+}  // namespace gtwrap
+
 
 
 
@@ -18,12 +36,12 @@ PYBIND11_MODULE(templates_py, m_) {
 
     py::class_<TemplatedConstructor, std::shared_ptr<TemplatedConstructor>>(m_, "TemplatedConstructor")
         .def(py::init<>())
-        .def(py::init<const string&>(), py::arg("arg"))
-        .def(py::init<const int&>(), py::arg("arg"))
-        .def(py::init<const double&>(), py::arg("arg"));
+        .def(py::init<const string&>(), gtwrap::internal::py_arg<const string&>("arg"))
+        .def(py::init<const int&>(), gtwrap::internal::py_arg<const int&>("arg"))
+        .def(py::init<const double&>(), gtwrap::internal::py_arg<const double&>("arg"));
 
     py::class_<ScopedTemplate<Result>, std::shared_ptr<ScopedTemplate<Result>>>(m_, "ScopedTemplateResult")
-        .def(py::init<const Result::Value&>(), py::arg("arg"));
+        .def(py::init<const Result::Value&>(), gtwrap::internal::py_arg<const Result::Value&>("arg"));
 
 
 #include "python/specializations.h"

--- a/tests/fixtures/arg_policies.i
+++ b/tests/fixtures/arg_policies.i
@@ -1,0 +1,9 @@
+#include <folder/path/to/ArgPolicyFixture.h>
+
+namespace testing {
+
+class ArgPolicyFixture {
+  void noConvert(const testing::SpecialView& values, int count = 1) const;
+};
+
+}

--- a/tests/fixtures/matrix_views.i
+++ b/tests/fixtures/matrix_views.i
@@ -1,0 +1,11 @@
+#include <folder/path/to/MatrixViewFixture.h>
+
+namespace gtsam {
+
+class MatrixViewFixture {
+  MatrixViewFixture();
+  void acceptView(gtsam::ConstMatrixView points) const;
+  gtsam::Matrix scaleView(gtsam::ConstMatrixView points, double scale = 1.0) const;
+};
+
+}

--- a/tests/fixtures/return_policies.i
+++ b/tests/fixtures/return_policies.i
@@ -1,0 +1,7 @@
+#include <folder/path/to/ReturnPolicyFixture.h>
+
+class ReturnPolicyFixture {
+  gtsam::Matrix return_value(const gtsam::Matrix& value) const;
+  const gtsam::Matrix& return_const_ref(const gtsam::Matrix& value) const;
+  gtsam::Matrix& return_mutable_ref(const gtsam::Matrix& value);
+};

--- a/tests/test_matlab_wrapper.py
+++ b/tests/test_matlab_wrapper.py
@@ -79,6 +79,46 @@ class TestWrap(unittest.TestCase):
             actual = osp.join(self.MATLAB_ACTUAL_DIR, file)
             self.compare_and_diff(file, actual)
 
+    def test_matrix_view_arguments(self):
+        """Test that matrix view arguments use MATLAB double arrays directly."""
+        file = osp.join(self.INTERFACE_DIR, 'matrix_views.i')
+
+        wrapper = MatlabWrapper(module_name='matrix_views',
+                                top_module_namespace=['gtsam'],
+                                ignore_classes=[''])
+
+        wrapper.wrap([file], path=self.MATLAB_ACTUAL_DIR)
+
+        cpp_file = osp.join(self.MATLAB_ACTUAL_DIR, 'matrix_views_wrapper.cpp')
+        with open(cpp_file, 'r', encoding='UTF-8') as f:
+            cpp_content = f.read()
+
+        self.assertIn(
+            'gtsam::ConstMatrixView points = unwrapMatrixView< gtsam::ConstMatrixView >(in[1]);',
+            cpp_content)
+        self.assertIn('obj->acceptView(points);', cpp_content)
+        self.assertIn('obj->scaleView(points,scale)', cpp_content)
+        self.assertNotIn('unwrap< gtsam::ConstMatrixView >', cpp_content)
+        self.assertNotIn('*points', cpp_content)
+
+        m_file = osp.join(self.MATLAB_ACTUAL_DIR, '+gtsam',
+                          'MatrixViewFixture.m')
+        with open(m_file, 'r', encoding='UTF-8') as f:
+            matlab_content = f.read()
+
+        self.assertIn("isa(varargin{1},'double')", matlab_content)
+
+        matlab_header = osp.join(self.TEST_DIR, '..', 'matlab.h')
+        with open(matlab_header, 'r', encoding='UTF-8') as f:
+            header_content = f.read()
+
+        self.assertIn('unwrapMatrixView', header_content)
+        self.assertIn('mxIsSparse(array)', header_content)
+        self.assertIn('mwSize rows', header_content)
+        self.assertIn('static_cast<unsigned long long>(rows)', header_content)
+        self.assertIn('Eigen::Index m', header_content)
+        self.assertIn('Stride(m, 1)', header_content)
+
     def test_functions(self):
         """Test interface file with function info."""
         file = osp.join(self.INTERFACE_DIR, 'functions.i')

--- a/tests/test_pybind_wrapper.py
+++ b/tests/test_pybind_wrapper.py
@@ -35,13 +35,15 @@ class TestWrap(unittest.TestCase):
                      sources,
                      module_name,
                      output_dir,
-                     use_boost_serialization=False):
+                     use_boost_serialization=False,
+                     module_template=None):
         """
         Common function to wrap content in `sources`.
         """
-        with open(osp.join(self.TEST_DIR, "pybind_wrapper.tpl"),
-                  encoding="UTF-8") as template_file:
-            module_template = template_file.read()
+        if module_template is None:
+            with open(osp.join(self.TEST_DIR, "pybind_wrapper.tpl"),
+                      encoding="UTF-8") as template_file:
+                module_template = template_file.read()
 
         # Create Pybind wrapper instance
         wrapper = PybindWrapper(
@@ -158,6 +160,89 @@ class TestWrap(unittest.TestCase):
         output = self.wrap_content([source], 'enum_py', self.PYTHON_ACTUAL_DIR)
 
         self.compare_and_diff('enum_pybind.cpp', output)
+
+    def test_argument_policy_hook(self):
+        """Test that typed args are emitted through the overridable policy hook."""
+        source = osp.join(self.INTERFACE_DIR, 'arg_policies.i')
+        module_template = """#include <pybind11/pybind11.h>
+
+{includes}
+
+#include "python/arg_policy_preamble.h"
+
+namespace py = pybind11;
+
+PYBIND11_MODULE({module_name}, m_) {{
+    m_.doc() = "pybind11 wrapper of {module_name}";
+
+{wrapped_namespace}
+
+}}
+"""
+        output = self.wrap_content([source],
+                                   'arg_policies_py',
+                                   self.PYTHON_ACTUAL_DIR,
+                                   module_template=module_template)
+
+        with open(output, 'r', encoding='UTF-8') as f:
+            content = f.read()
+
+        self.assertLess(content.index('template <typename T>\nstruct PyArgPolicy'),
+                        content.index('#include "python/arg_policy_preamble.h"'))
+        self.assertIn(
+            'gtwrap::internal::py_arg<const testing::SpecialView&>("values")',
+            content)
+        self.assertIn('gtwrap::internal::py_arg<int>("count") = 1', content)
+
+    def test_const_ref_return_policy(self):
+        """Test that methods returning const T& emit reference_internal policy.
+
+        Without this policy, pybind11 defaults to copying the returned reference.
+        With the policy, the binding keeps the reference alive via the parent object.
+
+        Expected emitted code difference:
+          Before: [](Cls* self, ...){return self->method(...);}, py::arg(...))
+          After:  [](Cls* self, ...) -> const auto&{return self->method(...);},
+                  py::return_value_policy::reference_internal, py::arg(...))
+        """
+        source = osp.join(self.INTERFACE_DIR, 'class.i')
+        output = self.wrap_content([source], 'class_py',
+                                   self.PYTHON_ACTUAL_DIR)
+
+        with open(output, 'r') as f:
+            content = f.read()
+
+        # const Vector& return_vector2 should have reference_internal
+        self.assertIn('-> const auto&{return self->return_vector2', content)
+        self.assertIn('py::return_value_policy::reference_internal', content)
+
+        # const Matrix& return_matrix2 should also have reference_internal
+        self.assertIn('-> const auto&{return self->return_matrix2', content)
+
+        # Non-ref returns (e.g. return_vector1 which returns by value) should NOT
+        lines = content.split('\n')
+        for line in lines:
+            if 'return_vector1' in line:
+                self.assertNotIn('reference_internal', line)
+                self.assertNotIn('-> const auto&', line)
+            if 'return_matrix1' in line:
+                self.assertNotIn('reference_internal', line)
+                self.assertNotIn('-> const auto&', line)
+
+        source = osp.join(self.INTERFACE_DIR, 'return_policies.i')
+        output = self.wrap_content([source], 'return_policies_py',
+                                   self.PYTHON_ACTUAL_DIR)
+
+        with open(output, 'r', encoding='UTF-8') as f:
+            content = f.read()
+
+        for line in content.split('\n'):
+            if 'return_const_ref' in line:
+                self.assertIn('reference_internal', line)
+                self.assertIn('-> const auto&', line)
+            if '.def("return_mutable_ref"' in line or '.def("return_value"' in line:
+                self.assertNotIn('reference_internal', line)
+                self.assertNotIn('-> const auto&', line)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

This PR pulls the latest `borglab/wrap` into GTSAM with a single official `./update_wrap.sh master` subtree update, then uses the new wrapper argument policy hook to support copy-free matrix view arguments from Python and MATLAB.

The GTSAM changes add `gtsam::ConstMatrixView`, configure Python wrapper argument policy through shared preamble headers, and convert wrapper-facing batch APIs to use the view type:

- `Pose2::transformFrom` / `Pose2::transformTo`
- `Pose3::transformFrom` / `Pose3::transformTo`
- `Pose2::Align`
- `Pose3::Align`
- `utilities::insertBackprojections`
- `utilities::insertProjectionFactors`

The Python policy marks `ConstMatrixView` arguments as `.noconvert()`, so compatible NumPy arrays map directly while Python lists are rejected. The MATLAB wrapper now unwraps these view arguments through `unwrapMatrixView`.

## Tests

- `conda run -n py312 make -j6 gtsam_py`
- `PYTHONPATH=/Users/dellaert/git/gtsam/build/python conda run -n py312 python -m pytest -q python/gtsam/tests/test_Pose2.py python/gtsam/tests/test_Pose3.py python/gtsam/tests/test_Utilities.py`
- `conda run -n py312 make -j6 testPose2.run testPose3.run testUtilities.run`
- `conda run -n py312 make -j6 gtsam_matlab_wrapper`
- MATLAB: `testPose2; testPose3; testUtilities;`
- `git diff --check`