### PR TITLE
Fix MATLAB 2024a MEX build: resolve size_t and uint64_t template collision

### DIFF
--- a/wrap/matlab.h
+++ b/wrap/matlab.h
@@ -27,6 +27,7 @@
 #include <gtsam/geometry/Point2.h>
 #include <gtsam/geometry/Point3.h>
 #include <gtsam/base/utilities.h>
+#include <type_traits>
 
 using gtsam::Vector;
 using gtsam::Matrix;
@@ -37,7 +38,6 @@ extern "C" {
 #include <mex.h>
 }
 
-#include <limits>
 #include <list>
 #include <set>
 #include <sstream>
@@ -177,12 +177,12 @@ mxArray* wrap<int>(const int& value) {
 }
 
 // specialization to gtsam::Key which is an alias for uint64_t
-template<>
-mxArray* wrap<uint64_t>(const uint64_t& value) {
-  mxArray *result = scalar(mxUINT32OR64_CLASS);
-  *(uint64_t*)mxGetData(result) = value;
-  return result;
-}
+//template<>
+//mxArray* wrap<uint64_t>(const uint64_t& value) {
+//  mxArray *result = scalar(mxUINT32OR64_CLASS);
+//  *(uint64_t*)mxGetData(result) = value;
+//  return result;
+//}
 
 // specialization to double -> just double
 template<>
@@ -347,11 +347,11 @@ uint64_t unwrap<uint64_t>(const mxArray* array) {
 }
 
 // specialization to size_t
-template<>
-size_t unwrap<size_t>(const mxArray* array) {
-  checkScalar(array, "unwrap<size_t>");
-  return myGetScalar<size_t>(array);
-}
+//template<>
+//size_t unwrap<size_t>(const mxArray* array) {
+//  checkScalar(array, "unwrap<size_t>");
+//  return myGetScalar<size_t>(array);
+//}
 
 // specialization to double
 template<>
@@ -573,3 +573,5 @@ Class* unwrap_ptr(const mxArray* obj, const string& propertyName) {
 //  static_assert(unwrap_shared_ptr_Matrix_attempted, "Matrix cannot be unwrapped as a shared pointer");
 //  return Matrix();
 //}
+
+


### PR DESCRIPTION
Description:
I was attempting to build GTSAM with MATLAB 2024a support on Ubuntu using GCC 11.4. The build failed due to a redefinition of template specializations in matlab.h because size_t and uint64_t resolve to the same underlying type on 64-bit Linux.

Changes:

    Added <type_traits>

    Commented out wrap<uint64_t> and unwrap<size_t> to prevent the compiler error.

Note: I am aware that hard-commenting these out might affect Windows builds where the types differ. I am open to suggestions on how to conditionally compile these using #if macros or <type_traits> to ensure cross-platform compatibility.

My Configuration:

    OS: Ubuntu 22.04 (64-bit)

    Compiler: GNU 11.4.0

    MATLAB: R2024a