### PR TITLE
feat(python): Expose BetweenFactor<SOn> to Python wrapper

### DIFF
--- a/gtsam/slam/slam.i
+++ b/gtsam/slam/slam.i
@@ -22,7 +22,8 @@ namespace gtsam {
 template <T = {double, gtsam::Vector, gtsam::Point2, gtsam::Point3, gtsam::Rot2, gtsam::SO3,
                gtsam::SO4, gtsam::SL4, gtsam::Rot3, gtsam::Pose2, gtsam::Pose3,
                gtsam::Similarity2, gtsam::Similarity3, gtsam::Gal3, gtsam::NavState,
-               gtsam::Se23, gtsam::ExtendedPose3d, gtsam::imuBias::ConstantBias}>
+               gtsam::Se23, gtsam::ExtendedPose3d, gtsam::imuBias::ConstantBias,
+               gtsam::SOn}>
 virtual class BetweenFactor : gtsam::NoiseModelFactor {
   BetweenFactor(gtsam::Key key1, gtsam::Key key2, const T& relativePose,
                 const gtsam::noiseModel::Base* noiseModel = nullptr);


### PR DESCRIPTION
### Summary
This PR exposes the `BetweenFactor<SOn>` template instantiation to the Python wrapper in `gtsam/slam/slam.i`. 

While `gtsam::SOn` (the Special Orthogonal Group in $N$ dimensions) is a mathematically valid Lie group with fully defined manifold and Lie traits in the C++ core (`gtsam/geometry/SOn.h`), its corresponding relative measurement factor (`BetweenFactor`) was previously omitted from the Python interface. Exposing this class allows researchers and engineers working in Python to perform rotation averaging and relative orientation optimization on arbitrary $N$-dimensional rotation manifolds directly.

### Changes
* Added `gtsam::SOn` to the template type parameter list `T` of `BetweenFactor` in `gtsam/slam/slam.i`.
* This triggers the auto-generation of the `gtsam.BetweenFactorSOn` binding class during the build phase.

### How This Was Tested
1. Compiled GTSAM from source locally with Python bindings enabled (`-DGTSAM_BUILD_PYTHON=ON`).
2. Verified that the `BetweenFactorSOn` class is correctly generated, exposed, and functional inside a Python 3.10 interpreter:

```python
import gtsam

# Create keys
key1 = 1
key2 = 2

# Create a 3D Identity rotation on the SOn manifold (size 3)
R_son = gtsam.SOn(3)

# Create an isotropic noise model (dimension 3)
noise = gtsam.noiseModel.Isotropic.Precision(3, 100.0)

# Instantiate the newly exposed factor
factor = gtsam.BetweenFactorSOn(key1, key2, R_son, noise)

print(factor)
# Output:
# BetweenFactor(1,2)
# measured: 1 0 0
# 0 1 0
# 0 0 1
# isotropic dim=3 sigma=0.1