### PR TITLE
[Python] Fix Pose3 sigma ordering in test_Pose3SLAMExample

### DIFF
--- a/python/gtsam/tests/test_Pose3SLAMExample.py
+++ b/python/gtsam/tests/test_Pose3SLAMExample.py
@@ -31,7 +31,7 @@ class TestPose3SLAMExample(GtsamTestCase):
         fg.add(gtsam.NonlinearEqualityPose3(0, p0))
         delta = p0.between(p1)
         covariance = gtsam.noiseModel.Diagonal.Sigmas(
-            np.array([0.05, 0.05, 0.05, np.deg2rad(5.), np.deg2rad(5.), np.deg2rad(5.)]))
+            np.array([np.deg2rad(5.), np.deg2rad(5.), np.deg2rad(5.), 0.05, 0.05, 0.05]))
         fg.add(gtsam.BetweenFactorPose3(0, 1, delta, covariance))
         fg.add(gtsam.BetweenFactorPose3(1, 2, delta, covariance))
         fg.add(gtsam.BetweenFactorPose3(2, 3, delta, covariance))


### PR DESCRIPTION
Pose3::Logmap returns [rot, trans], so the diagonal noise model sigmas must follow the same order: [roll_std, pitch_std, yaw_std, tx_std, ty_std, tz_std].

  `Pose3::Logmap` returns a 6-vector in `[rot, trans]` order (rotation indices 0–2,  translation indices 3–5, as documented by `Pose3::rotationInterval()` and  `Pose3::translationInterval()`). The diagonal noise model sigmas passed to `BetweenFactorPose3` must follow the same convention.

  The previous definition had translation sigmas first and rotation sigmas second:
  # Wrong: [tx, ty, tz, roll, pitch, yaw]
  gtsam.noiseModel.Diagonal.Sigmas(np.array([0.05, 0.05, 0.05, np.deg2rad(5.), np.deg2rad(5.), np.deg2rad(5.)]))

  The correct definition puts rotation sigmas first:
  # Correct: [roll, pitch, yaw, tx, ty, tz]
  gtsam.noiseModel.Diagonal.Sigmas(np.array([np.deg2rad(5.), np.deg2rad(5.), np.deg2rad(5.), 0.05, 0.05, 0.05]))