### PR TITLE
Optimize compile times

### DIFF
--- a/examples/AbcEquivariantFilterExample.cpp
+++ b/examples/AbcEquivariantFilterExample.cpp
@@ -18,6 +18,7 @@
  * @date 2025
  */
 
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/slam/dataset.h>
 #include <gtsam_unstable/geometry/ABC.h>
 #include <gtsam_unstable/geometry/ABCEquivariantFilter.h>

--- a/examples/CombinedImuFactorsExample.cpp
+++ b/examples/CombinedImuFactorsExample.cpp
@@ -36,6 +36,7 @@
 #include <boost/program_options.hpp>
 
 // GTSAM related includes.
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/navigation/CombinedImuFactor.h>
 #include <gtsam/navigation/GPSFactor.h>

--- a/examples/IEKF_SE2Example.cpp
+++ b/examples/IEKF_SE2Example.cpp
@@ -31,6 +31,7 @@
  * @date Apr 25, 2025
  * @authors Scott Baker, Matt Kielo, Frank Dellaert
  */
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/navigation/InvariantEKF.h>
 

--- a/examples/IMUKittiExampleGPS.cpp
+++ b/examples/IMUKittiExampleGPS.cpp
@@ -18,6 +18,7 @@
  */
 
 // GTSAM related includes.
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/navigation/CombinedImuFactor.h>
 #include <gtsam/navigation/GPSFactor.h>

--- a/examples/ImuFactorsExample.cpp
+++ b/examples/ImuFactorsExample.cpp
@@ -38,6 +38,7 @@
 #include <boost/program_options.hpp>
 
 // GTSAM related includes.
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/navigation/CombinedImuFactor.h>
 #include <gtsam/navigation/GPSFactor.h>

--- a/examples/ImuFactorsExample2.cpp
+++ b/examples/ImuFactorsExample2.cpp
@@ -15,8 +15,9 @@
  * @author Robert Truax
  */
 
-#include <gtsam/geometry/PinholeCamera.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/geometry/Cal3_S2.h>
+#include <gtsam/geometry/PinholeCamera.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/navigation/ImuBias.h>
 #include <gtsam/navigation/ImuFactor.h>

--- a/examples/InverseKinematicsExampleExpressions.cpp
+++ b/examples/InverseKinematicsExampleExpressions.cpp
@@ -16,6 +16,7 @@
  * @author Frank Dellaert
  */
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/nonlinear/ExpressionFactorGraph.h>
 #include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>

--- a/examples/NavStateImuExample.cpp
+++ b/examples/NavStateImuExample.cpp
@@ -20,6 +20,7 @@
  */
 
 #include <gtsam/base/Matrix.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/geometry/Cal3_S2.h>
 #include <gtsam/geometry/PinholeCamera.h>
 #include <gtsam/geometry/Pose3.h>

--- a/gtsam/base/Matrix.h
+++ b/gtsam/base/Matrix.h
@@ -55,8 +55,6 @@ using Matrix6##N = Eigen::Matrix<double, 6, N>;  \
 using Matrix7##N = Eigen::Matrix<double, 7, N>;  \
 using Matrix8##N = Eigen::Matrix<double, 8, N>;  \
 using Matrix9##N = Eigen::Matrix<double, 9, N>;  \
-static const Eigen::MatrixBase<Matrix##N>::IdentityReturnType I_##N##x##N = Matrix##N::Identity(); \
-static const Eigen::MatrixBase<Matrix##N>::ConstantReturnType Z_##N##x##N = Matrix##N::Constant(0.0);
 
 GTSAM_MAKE_MATRIX_DEFS(1)
 GTSAM_MAKE_MATRIX_DEFS(2)

--- a/gtsam/base/MatrixConstants.h
+++ b/gtsam/base/MatrixConstants.h
@@ -1,0 +1,46 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file    MatrixConstants.h
+ * @brief   Macros for Matrix constants to avoid excessive template
+ * instantiation. Avoid using in headers to prevent name pollution.
+ * @author  Gold856
+ */
+
+#pragma once
+
+#define I_1x1 Matrix1::Identity()
+#define Z_1x1 Matrix1::Constant(0.0)
+
+#define I_2x2 Matrix2::Identity()
+#define Z_2x2 Matrix2::Constant(0.0)
+
+#define I_3x3 Matrix3::Identity()
+#define Z_3x3 Matrix3::Constant(0.0)
+
+#define I_4x4 Matrix4::Identity()
+#define Z_4x4 Matrix4::Constant(0.0)
+
+#define I_5x5 Matrix5::Identity()
+#define Z_5x5 Matrix5::Constant(0.0)
+
+#define I_6x6 Matrix6::Identity()
+#define Z_6x6 Matrix6::Constant(0.0)
+
+#define I_7x7 Matrix7::Identity()
+#define Z_7x7 Matrix7::Constant(0.0)
+
+#define I_8x8 Matrix9::Identity()
+#define Z_8x8 Matrix9::Constant(0.0)
+
+#define I_9x9 Matrix9::Identity()
+#define Z_9x9 Matrix9::Constant(0.0)

--- a/gtsam/base/Vector.h
+++ b/gtsam/base/Vector.h
@@ -42,26 +42,16 @@ typedef Eigen::VectorXd Vector;
 typedef Eigen::Matrix<double, 1, 1> Vector1;
 typedef Eigen::Vector2d Vector2;
 typedef Eigen::Vector3d Vector3;
-
-static const Eigen::MatrixBase<Vector2>::ConstantReturnType Z_2x1 = Vector2::Constant(0.0);
-static const Eigen::MatrixBase<Vector3>::ConstantReturnType Z_3x1 = Vector3::Constant(0.0);
-
-// Create handy typedefs and constants for vectors with N>3
-// VectorN and Z_Nx1, for N=1..9
-#define GTSAM_MAKE_VECTOR_DEFS(N)                \
-  using Vector##N = Eigen::Matrix<double, N, 1>; \
-  static const Eigen::MatrixBase<Vector##N>::ConstantReturnType Z_##N##x1 = Vector##N::Constant(0.0);
-
-GTSAM_MAKE_VECTOR_DEFS(4)
-GTSAM_MAKE_VECTOR_DEFS(5)
-GTSAM_MAKE_VECTOR_DEFS(6)
-GTSAM_MAKE_VECTOR_DEFS(7)
-GTSAM_MAKE_VECTOR_DEFS(8)
-GTSAM_MAKE_VECTOR_DEFS(9)
-GTSAM_MAKE_VECTOR_DEFS(10)
-GTSAM_MAKE_VECTOR_DEFS(11)
-GTSAM_MAKE_VECTOR_DEFS(12)
-GTSAM_MAKE_VECTOR_DEFS(15)
+using Vector4 = Eigen::Matrix<double, 4, 1>;
+using Vector5 = Eigen::Matrix<double, 5, 1>;
+using Vector6 = Eigen::Matrix<double, 6, 1>;
+using Vector7 = Eigen::Matrix<double, 7, 1>;
+using Vector8 = Eigen::Matrix<double, 8, 1>;
+using Vector9 = Eigen::Matrix<double, 9, 1>;
+using Vector10 = Eigen::Matrix<double, 10, 1>;
+using Vector11 = Eigen::Matrix<double, 11, 1>;
+using Vector12 = Eigen::Matrix<double, 12, 1>;
+using Vector15 = Eigen::Matrix<double, 15, 1>;
 
 typedef Eigen::VectorBlock<Vector> SubVector;
 typedef Eigen::VectorBlock<const Vector> ConstSubVector;

--- a/gtsam/base/VectorConstants.h
+++ b/gtsam/base/VectorConstants.h
@@ -1,0 +1,28 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file    VectorConstants.h
+ * @brief   Macros for Vector constants to avoid excessive template
+ * instantiation. Avoid using in headers to prevent name pollution.
+ * @author  Gold856
+ */
+
+#pragma once
+
+#define Z_2x1 Vector2::Constant(0.0)
+#define Z_3x1 Vector3::Constant(0.0)
+#define Z_4x1 Vector4::Constant(0.0)
+#define Z_5x1 Vector5::Constant(0.0)
+#define Z_6x1 Vector6::Constant(0.0)
+#define Z_7x1 Vector7::Constant(0.0)
+#define Z_8x1 Vector7::Constant(0.0)
+#define Z_9x1 Vector9::Constant(0.0)

--- a/gtsam/base/tests/testKruskal.cpp
+++ b/gtsam/base/tests/testKruskal.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/TestableAssertions.h>
 #include <gtsam/base/kruskal.h>
 #include <gtsam/geometry/Rot3.h>

--- a/gtsam/base/tests/testMatrix.cpp
+++ b/gtsam/base/tests/testMatrix.cpp
@@ -18,6 +18,7 @@
 
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/Matrix.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/VectorSpace.h>
 #include <gtsam/base/testLie.h>
 

--- a/gtsam/base/tests/testVector.cpp
+++ b/gtsam/base/tests/testVector.cpp
@@ -15,11 +15,11 @@
  * @author Frank Dellaert
  **/
 
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/Vector.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/VectorSpace.h>
 #include <gtsam/base/testLie.h>
-#include <CppUnitLite/TestHarness.h>
-#include <iostream>
 
 using namespace std;
 using namespace gtsam;

--- a/gtsam/discrete/tests/testDiscreteMarginals.cpp
+++ b/gtsam/discrete/tests/testDiscreteMarginals.cpp
@@ -17,6 +17,7 @@
  * @author Frank Dellaert
  */
 
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/discrete/DiscreteMarginals.h>
 
 #include <CppUnitLite/TestHarness.h>

--- a/gtsam/discrete/tests/testDiscreteMarginals.cpp
+++ b/gtsam/discrete/tests/testDiscreteMarginals.cpp
@@ -17,10 +17,9 @@
  * @author Frank Dellaert
  */
 
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/VectorConstants.h>
 #include <gtsam/discrete/DiscreteMarginals.h>
-
-#include <CppUnitLite/TestHarness.h>
 
 using namespace std;
 using namespace gtsam;

--- a/gtsam/geometry/Cal3_S2.h
+++ b/gtsam/geometry/Cal3_S2.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/geometry/Cal3.h>
 #include <gtsam/geometry/Point2.h>
 

--- a/gtsam/geometry/CalibratedCamera.cpp
+++ b/gtsam/geometry/CalibratedCamera.cpp
@@ -16,8 +16,9 @@
  * @author Frank Dellaert
  */
 
-#include <gtsam/geometry/Pose2.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/geometry/CalibratedCamera.h>
+#include <gtsam/geometry/Pose2.h>
 
 using namespace std;
 

--- a/gtsam/geometry/CalibratedCamera.h
+++ b/gtsam/geometry/CalibratedCamera.h
@@ -18,14 +18,14 @@
 
 #pragma once
 
-#include <gtsam/geometry/BearingRange.h>
-#include <gtsam/geometry/Point2.h>
-#include <gtsam/geometry/Pose3.h>
-#include <gtsam/base/concepts.h>
 #include <gtsam/base/Manifold.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/ThreadsafeException.h>
+#include <gtsam/base/concepts.h>
 #include <gtsam/dllexport.h>
+#include <gtsam/geometry/BearingRange.h>
+#include <gtsam/geometry/Point2.h>
+#include <gtsam/geometry/Pose3.h>
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/nvp.hpp>
 #endif

--- a/gtsam/geometry/CalibratedCamera.h
+++ b/gtsam/geometry/CalibratedCamera.h
@@ -23,6 +23,7 @@
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/base/concepts.h>
 #include <gtsam/base/Manifold.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/ThreadsafeException.h>
 #include <gtsam/dllexport.h>
 #if GTSAM_ENABLE_BOOST_SERIALIZATION

--- a/gtsam/geometry/EssentialMatrix.cpp
+++ b/gtsam/geometry/EssentialMatrix.cpp
@@ -5,7 +5,9 @@
  * @date December 5, 2014
  */
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/geometry/EssentialMatrix.h>
+
 #include <iostream>
 
 using namespace std;

--- a/gtsam/geometry/ExtendedPose3.h
+++ b/gtsam/geometry/ExtendedPose3.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <gtsam/base/MatrixLieGroup.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/geometry/Point3.h>
 #include <gtsam/geometry/Rot3.h>
 

--- a/gtsam/geometry/ExtendedPose3.h
+++ b/gtsam/geometry/ExtendedPose3.h
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include <gtsam/base/MatrixLieGroup.h>
 #include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/MatrixLieGroup.h>
 #include <gtsam/geometry/Point3.h>
 #include <gtsam/geometry/Rot3.h>
 

--- a/gtsam/geometry/Gal3.cpp
+++ b/gtsam/geometry/Gal3.cpp
@@ -27,6 +27,8 @@
 #endif
 
 #include <gtsam/base/Matrix.h>
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/geometry/Event.h>
 #include <gtsam/geometry/Gal3.h>

--- a/gtsam/geometry/Kernel.cpp
+++ b/gtsam/geometry/Kernel.cpp
@@ -16,6 +16,7 @@
  * @date    August 2025
  */
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/geometry/Kernel.h>
 #include <gtsam/geometry/SO3.h>
 

--- a/gtsam/geometry/OrientedPlane3.cpp
+++ b/gtsam/geometry/OrientedPlane3.cpp
@@ -17,6 +17,7 @@
  * @brief  A plane, represented by a normal direction and perpendicular distance
  */
 
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/geometry/OrientedPlane3.h>
 
 #include <iostream>

--- a/gtsam/geometry/OrientedPlane3.h
+++ b/gtsam/geometry/OrientedPlane3.h
@@ -22,8 +22,9 @@
 
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/VectorConstants.h>
-#include <gtsam/geometry/Unit3.h>
 #include <gtsam/geometry/Pose3.h>
+#include <gtsam/geometry/Unit3.h>
+
 #include <string>
 
 namespace gtsam {

--- a/gtsam/geometry/OrientedPlane3.h
+++ b/gtsam/geometry/OrientedPlane3.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/geometry/Unit3.h>
 #include <gtsam/geometry/Pose3.h>
 #include <string>
@@ -144,4 +146,3 @@ OrientedPlane3> {
 };
 
 }  // namespace gtsam
-

--- a/gtsam/geometry/PinholeCamera.h
+++ b/gtsam/geometry/PinholeCamera.h
@@ -19,8 +19,8 @@
 #pragma once
 
 #include <gtsam/base/MatrixConstants.h>
-#include <gtsam/geometry/PinholePose.h>
 #include <gtsam/geometry/BearingRange.h>
+#include <gtsam/geometry/PinholePose.h>
 
 namespace gtsam {
 

--- a/gtsam/geometry/PinholeCamera.h
+++ b/gtsam/geometry/PinholeCamera.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/geometry/PinholePose.h>
 #include <gtsam/geometry/BearingRange.h>
 

--- a/gtsam/geometry/Point3.cpp
+++ b/gtsam/geometry/Point3.cpp
@@ -14,7 +14,9 @@
  * @brief 3D Point
  */
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/geometry/Point3.h>
+
 #include <cmath>
 #include <iostream>
 #include <vector>

--- a/gtsam/geometry/Pose2.cpp
+++ b/gtsam/geometry/Pose2.cpp
@@ -14,16 +14,16 @@
  * @brief 2D Pose
  */
 
-#include <gtsam/geometry/concepts.h>
-#include <gtsam/geometry/Pose2.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/concepts.h>
+#include <gtsam/geometry/Pose2.h>
+#include <gtsam/geometry/concepts.h>
 
-#include <cmath>
 #include <cassert>
-#include <iostream>
+#include <cmath>
 #include <iomanip>
+#include <iostream>
 
 using namespace std;
 

--- a/gtsam/geometry/Pose2.cpp
+++ b/gtsam/geometry/Pose2.cpp
@@ -16,6 +16,7 @@
 
 #include <gtsam/geometry/concepts.h>
 #include <gtsam/geometry/Pose2.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/concepts.h>
 

--- a/gtsam/geometry/Pose3.cpp
+++ b/gtsam/geometry/Pose3.cpp
@@ -14,6 +14,7 @@
  * @brief 3D Pose manifold SO(3) x R^3 and group SE(3)
  */
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/concepts.h>
 #include <gtsam/geometry/Kernel.h>
 #include <gtsam/geometry/Pose2.h>

--- a/gtsam/geometry/Quaternion.h
+++ b/gtsam/geometry/Quaternion.h
@@ -20,9 +20,10 @@
 #include <gtsam/base/Lie.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/concepts.h>
-#include <gtsam/geometry/SO3.h> // Logmap/Expmap derivatives
-#include <limits>
+#include <gtsam/geometry/SO3.h>  // Logmap/Expmap derivatives
+
 #include <iostream>
+#include <limits>
 
 #define QUATERNION_TYPE Eigen::Quaternion<_Scalar,_Options>
 

--- a/gtsam/geometry/Quaternion.h
+++ b/gtsam/geometry/Quaternion.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <gtsam/base/Lie.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/concepts.h>
 #include <gtsam/geometry/SO3.h> // Logmap/Expmap derivatives
 #include <limits>
@@ -199,4 +200,3 @@ struct traits<QUATERNION_TYPE> {
 typedef Eigen::Quaternion<double, Eigen::DontAlign> Quaternion;
 
 } // \namespace gtsam
-

--- a/gtsam/geometry/Rot2.cpp
+++ b/gtsam/geometry/Rot2.cpp
@@ -16,6 +16,7 @@
  * @brief 2D Rotations
  */
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/geometry/Rot2.h>
 
 #include <Eigen/SVD>

--- a/gtsam/geometry/Rot2.h
+++ b/gtsam/geometry/Rot2.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <gtsam/base/Matrix.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/MatrixLieGroup.h>
 #include <gtsam/geometry/Point2.h>
 

--- a/gtsam/geometry/Rot3.cpp
+++ b/gtsam/geometry/Rot3.cpp
@@ -23,8 +23,8 @@
 #include <gtsam/geometry/Rot3.h>
 #include <gtsam/geometry/SO3.h>
 
-#include <cmath>
 #include <cassert>
+#include <cmath>
 #include <random>
 
 using namespace std;

--- a/gtsam/geometry/Rot3.cpp
+++ b/gtsam/geometry/Rot3.cpp
@@ -19,6 +19,7 @@
  * @author  Varun Agrawal
  */
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/geometry/Rot3.h>
 #include <gtsam/geometry/SO3.h>
 

--- a/gtsam/geometry/Rot3M.cpp
+++ b/gtsam/geometry/Rot3M.cpp
@@ -22,8 +22,10 @@
 
 #ifndef GTSAM_USE_QUATERNIONS
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/geometry/Rot3.h>
 #include <gtsam/geometry/SO3.h>
+
 #include <cassert>
 #include <cmath>
 

--- a/gtsam/geometry/Rot3Q.cpp
+++ b/gtsam/geometry/Rot3Q.cpp
@@ -19,7 +19,9 @@
 
 #ifdef GTSAM_USE_QUATERNIONS
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/geometry/Rot3.h>
+
 #include <cassert>
 #include <cmath>
 

--- a/gtsam/geometry/SL4.cpp
+++ b/gtsam/geometry/SL4.cpp
@@ -4,6 +4,7 @@
  * @author: Hyungtae Lim
  */
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/geometry/SL4.h>
 #include <gtsam/geometry/SO4.h>
 

--- a/gtsam/geometry/SO3.cpp
+++ b/gtsam/geometry/SO3.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <gtsam/base/Matrix.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Vector.h>
 #include <gtsam/base/concepts.h>
 #include <gtsam/geometry/Point3.h>

--- a/gtsam/geometry/SO3.h
+++ b/gtsam/geometry/SO3.h
@@ -27,8 +27,8 @@
 #include <gtsam/geometry/Kernel.h>
 #include <gtsam/geometry/SOn.h>
 
-#include <vector>
 #include <optional>
+#include <vector>
 
 namespace gtsam {
 

--- a/gtsam/geometry/SO3.h
+++ b/gtsam/geometry/SO3.h
@@ -22,6 +22,7 @@
 
 #include <gtsam/base/Lie.h>
 #include <gtsam/base/Matrix.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/dllexport.h>
 #include <gtsam/geometry/Kernel.h>
 #include <gtsam/geometry/SOn.h>

--- a/gtsam/geometry/SO4.cpp
+++ b/gtsam/geometry/SO4.cpp
@@ -16,13 +16,14 @@
  * @author  Luca Carlone
  */
 
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/concepts.h>
 #include <gtsam/base/timing.h>
 #include <gtsam/geometry/SO4.h>
 #include <gtsam/geometry/Unit3.h>
 
 #include <Eigen/Eigenvalues>
-
 #include <algorithm>
 #include <cmath>
 #include <iostream>

--- a/gtsam/geometry/Similarity2.cpp
+++ b/gtsam/geometry/Similarity2.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <gtsam/base/Manifold.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/geometry/Rot3.h>
 #include <gtsam/geometry/Similarity2.h>

--- a/gtsam/geometry/Similarity3.cpp
+++ b/gtsam/geometry/Similarity3.cpp
@@ -16,11 +16,10 @@
  * @author John Lambert
  */
 
-#include <gtsam/geometry/Similarity3.h>
-
-#include <gtsam/geometry/Pose3.h>
 #include <gtsam/base/Manifold.h>
 #include <gtsam/base/MatrixConstants.h>
+#include <gtsam/geometry/Pose3.h>
+#include <gtsam/geometry/Similarity3.h>
 #include <gtsam/slam/KarcherMeanFactor-inl.h>
 
 namespace gtsam {

--- a/gtsam/geometry/Similarity3.cpp
+++ b/gtsam/geometry/Similarity3.cpp
@@ -20,6 +20,7 @@
 
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/base/Manifold.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/slam/KarcherMeanFactor-inl.h>
 
 namespace gtsam {

--- a/gtsam/geometry/tests/testCal3_S2.cpp
+++ b/gtsam/geometry/tests/testCal3_S2.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/TestableAssertions.h>
 #include <gtsam/base/numericalDerivative.h>

--- a/gtsam/geometry/tests/testEssentialMatrix.cpp
+++ b/gtsam/geometry/tests/testEssentialMatrix.cpp
@@ -7,6 +7,7 @@
 
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/Testable.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/geometry/CalibratedCamera.h>
 #include <gtsam/geometry/EssentialMatrix.h>

--- a/gtsam/geometry/tests/testFundamentalMatrix.cpp
+++ b/gtsam/geometry/tests/testFundamentalMatrix.cpp
@@ -8,6 +8,7 @@
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/Testable.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/geometry/FundamentalMatrix.h>
 #include <gtsam/geometry/Rot3.h>
 #include <gtsam/geometry/SimpleCamera.h>

--- a/gtsam/geometry/tests/testGal3.cpp
+++ b/gtsam/geometry/tests/testGal3.cpp
@@ -13,20 +13,19 @@
  * @date    April 29, 2025
  */
 
-#include <gtsam/geometry/Gal3.h>
-
-#include <gtsam/base/numericalDerivative.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/TestableAssertions.h>
 #include <gtsam/base/VectorConstants.h>
-#include <gtsam/base/testLie.h> // For CHECK_LIE_GROUP_DERIVATIVES, etc.
-#include <gtsam/geometry/Rot3.h>
+#include <gtsam/base/numericalDerivative.h>
+#include <gtsam/base/testLie.h>  // For CHECK_LIE_GROUP_DERIVATIVES, etc.
+#include <gtsam/geometry/Gal3.h>
 #include <gtsam/geometry/Point3.h>
-#include <gtsam/geometry/Pose3.h> // Included for kTestPose definition
+#include <gtsam/geometry/Pose3.h>  // Included for kTestPose definition
+#include <gtsam/geometry/Rot3.h>
 #include <gtsam/geometry/Unit3.h>
 
-#include <CppUnitLite/TestHarness.h>
+#include <functional>  // For std::bind if using numerical derivatives
 #include <vector>
-#include <functional> // For std::bind if using numerical derivatives
 
 using namespace std;
 using namespace gtsam;

--- a/gtsam/geometry/tests/testGal3.cpp
+++ b/gtsam/geometry/tests/testGal3.cpp
@@ -17,6 +17,7 @@
 
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/base/TestableAssertions.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/testLie.h> // For CHECK_LIE_GROUP_DERIVATIVES, etc.
 #include <gtsam/geometry/Rot3.h>
 #include <gtsam/geometry/Point3.h>

--- a/gtsam/geometry/tests/testOrientedPlane3.cpp
+++ b/gtsam/geometry/tests/testOrientedPlane3.cpp
@@ -17,10 +17,10 @@
  * @brief Tests the OrientedPlane3 class
  */
 
-#include <gtsam/geometry/OrientedPlane3.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
-#include <CppUnitLite/TestHarness.h>
+#include <gtsam/geometry/OrientedPlane3.h>
 
 using namespace std::placeholders;
 using namespace gtsam;

--- a/gtsam/geometry/tests/testOrientedPlane3.cpp
+++ b/gtsam/geometry/tests/testOrientedPlane3.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <gtsam/geometry/OrientedPlane3.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <CppUnitLite/TestHarness.h>
 

--- a/gtsam/geometry/tests/testPinholeCamera.cpp
+++ b/gtsam/geometry/tests/testPinholeCamera.cpp
@@ -15,15 +15,14 @@
  * @brief test PinholeCamera class
  */
 
-#include <gtsam/geometry/PinholeCamera.h>
-#include <gtsam/geometry/Cal3_S2.h>
-#include <gtsam/geometry/Cal3Bundler.h>
-#include <gtsam/geometry/Pose2.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/numericalDerivative.h>
-
-#include <CppUnitLite/TestHarness.h>
+#include <gtsam/geometry/Cal3Bundler.h>
+#include <gtsam/geometry/Cal3_S2.h>
+#include <gtsam/geometry/PinholeCamera.h>
+#include <gtsam/geometry/Pose2.h>
 
 #include <cmath>
 #include <iostream>

--- a/gtsam/geometry/tests/testPinholeCamera.cpp
+++ b/gtsam/geometry/tests/testPinholeCamera.cpp
@@ -19,6 +19,7 @@
 #include <gtsam/geometry/Cal3_S2.h>
 #include <gtsam/geometry/Cal3Bundler.h>
 #include <gtsam/geometry/Pose2.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/numericalDerivative.h>
 

--- a/gtsam/geometry/tests/testPinholePose.cpp
+++ b/gtsam/geometry/tests/testPinholePose.cpp
@@ -20,6 +20,7 @@
 #include <gtsam/geometry/Cal3_S2.h>
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/geometry/Cal3Bundler.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/numericalDerivative.h>
 

--- a/gtsam/geometry/tests/testPinholePose.cpp
+++ b/gtsam/geometry/tests/testPinholePose.cpp
@@ -16,15 +16,14 @@
  * @date   Feb 20, 2015
  */
 
-#include <gtsam/geometry/PinholePose.h>
-#include <gtsam/geometry/Cal3_S2.h>
-#include <gtsam/geometry/Pose2.h>
-#include <gtsam/geometry/Cal3Bundler.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/numericalDerivative.h>
-
-#include <CppUnitLite/TestHarness.h>
+#include <gtsam/geometry/Cal3Bundler.h>
+#include <gtsam/geometry/Cal3_S2.h>
+#include <gtsam/geometry/PinholePose.h>
+#include <gtsam/geometry/Pose2.h>
 
 #include <cmath>
 #include <iostream>

--- a/gtsam/geometry/tests/testPoint1.cpp
+++ b/gtsam/geometry/tests/testPoint1.cpp
@@ -16,6 +16,7 @@
  **/
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/lieProxies.h>
 #include <gtsam/base/numericalDerivative.h>

--- a/gtsam/geometry/tests/testPoint2.cpp
+++ b/gtsam/geometry/tests/testPoint2.cpp
@@ -16,6 +16,7 @@
  **/
 
 #include <gtsam/geometry/Point2.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/base/lieProxies.h>

--- a/gtsam/geometry/tests/testPoint2.cpp
+++ b/gtsam/geometry/tests/testPoint2.cpp
@@ -15,12 +15,12 @@
  * @author Frank Dellaert
  **/
 
-#include <gtsam/geometry/Point2.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
-#include <gtsam/base/numericalDerivative.h>
 #include <gtsam/base/lieProxies.h>
-#include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/numericalDerivative.h>
+#include <gtsam/geometry/Point2.h>
 
 using namespace std;
 using namespace gtsam;

--- a/gtsam/geometry/tests/testPoint3.cpp
+++ b/gtsam/geometry/tests/testPoint3.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/geometry/Point3.h>

--- a/gtsam/geometry/tests/testPose2.cpp
+++ b/gtsam/geometry/tests/testPose2.cpp
@@ -25,9 +25,9 @@
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/geometry/Rot2.h>
 
-#include <optional>
 #include <cmath>
 #include <iostream>
+#include <optional>
 
 using namespace gtsam;
 using namespace std;

--- a/gtsam/geometry/tests/testPose2.cpp
+++ b/gtsam/geometry/tests/testPose2.cpp
@@ -15,8 +15,10 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/TestableAssertions.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/lieProxies.h>
 #include <gtsam/base/testLie.h>
 #include <gtsam/geometry/Point2.h>

--- a/gtsam/geometry/tests/testPose3.cpp
+++ b/gtsam/geometry/tests/testPose3.cpp
@@ -14,17 +14,16 @@
  * @brief  Unit tests for Pose3 class
  */
 
-#include <gtsam/geometry/Pose3.h>
-#include <gtsam/geometry/Pose2.h>
-#include <gtsam/base/testLie.h>
-#include <gtsam/base/lieProxies.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/TestableAssertions.h>
 #include <gtsam/base/VectorConstants.h>
+#include <gtsam/base/lieProxies.h>
+#include <gtsam/base/testLie.h>
+#include <gtsam/geometry/Pose2.h>
+#include <gtsam/geometry/Pose3.h>
 #include <gtsam/slam/expressions.h>
 
-
-#include <CppUnitLite/TestHarness.h>
 #include <cmath>
 #include <functional>
 

--- a/gtsam/geometry/tests/testPose3.cpp
+++ b/gtsam/geometry/tests/testPose3.cpp
@@ -18,7 +18,9 @@
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/base/testLie.h>
 #include <gtsam/base/lieProxies.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/TestableAssertions.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/slam/expressions.h>
 
 

--- a/gtsam/geometry/tests/testRot2.cpp
+++ b/gtsam/geometry/tests/testRot2.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/testLie.h>
 #include <gtsam/geometry/Rot2.h>

--- a/gtsam/geometry/tests/testRot3.cpp
+++ b/gtsam/geometry/tests/testRot3.cpp
@@ -17,16 +17,15 @@
  * @author  Varun Agrawal
  */
 
-#include <gtsam/geometry/Point3.h>
-#include <gtsam/geometry/Rot3.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/MatrixConstants.h>
-#include <gtsam/base/testLie.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/VectorConstants.h>
-#include <gtsam/base/numericalDerivative.h>
 #include <gtsam/base/lieProxies.h>
-
-#include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/numericalDerivative.h>
+#include <gtsam/base/testLie.h>
+#include <gtsam/geometry/Point3.h>
+#include <gtsam/geometry/Rot3.h>
 
 #include <array>
 #include <iomanip>

--- a/gtsam/geometry/tests/testRot3.cpp
+++ b/gtsam/geometry/tests/testRot3.cpp
@@ -19,8 +19,10 @@
 
 #include <gtsam/geometry/Point3.h>
 #include <gtsam/geometry/Rot3.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/testLie.h>
 #include <gtsam/base/Testable.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/base/lieProxies.h>
 

--- a/gtsam/geometry/tests/testSL4.cpp
+++ b/gtsam/geometry/tests/testSL4.cpp
@@ -7,6 +7,7 @@
 /* ************************************************************************* */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/TestableAssertions.h>
 #include <gtsam/base/lieProxies.h>
 #include <gtsam/base/numericalDerivative.h>

--- a/gtsam/geometry/tests/testSimilarity3.cpp
+++ b/gtsam/geometry/tests/testSimilarity3.cpp
@@ -18,6 +18,7 @@
 
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/Testable.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/base/testLie.h>
 #include <gtsam/geometry/Pose3.h>

--- a/gtsam/geometry/tests/testUnit3.cpp
+++ b/gtsam/geometry/tests/testUnit3.cpp
@@ -20,6 +20,7 @@
 
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/Testable.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/base/serializationTestHelpers.h>
 #include <gtsam/geometry/Rot3.h>

--- a/gtsam/hybrid/tests/DiscreteFixture.h
+++ b/gtsam/hybrid/tests/DiscreteFixture.h
@@ -15,6 +15,8 @@
  *  @author Varun Agrawal
  */
 
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/discrete/DecisionTreeFactor.h>
 
 #include "Switching.h"

--- a/gtsam/hybrid/tests/Switching.h
+++ b/gtsam/hybrid/tests/Switching.h
@@ -17,6 +17,8 @@
  */
 
 #include <gtsam/base/Matrix.h>
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/discrete/DecisionTreeFactor.h>
 #include <gtsam/discrete/DiscreteDistribution.h>
 #include <gtsam/hybrid/HybridGaussianFactor.h>

--- a/gtsam/hybrid/tests/TinyHybridExample.h
+++ b/gtsam/hybrid/tests/TinyHybridExample.h
@@ -15,6 +15,7 @@
  *  @author Frank Dellaert
  */
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/hybrid/HybridBayesNet.h>
 #include <gtsam/hybrid/HybridGaussianFactorGraph.h>
 #include <gtsam/inference/Symbol.h>

--- a/gtsam/hybrid/tests/testHybridBayesNet.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesNet.cpp
@@ -18,6 +18,7 @@
  * @date    December 2021
  */
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/discrete/DiscreteFactor.h>
 #include <gtsam/discrete/TableDistribution.h>

--- a/gtsam/hybrid/tests/testHybridBayesTree.cpp
+++ b/gtsam/hybrid/tests/testHybridBayesTree.cpp
@@ -16,17 +16,19 @@
  * @date    August 2022
  */
 
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/TestableAssertions.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/serializationTestHelpers.h>
 #include <gtsam/discrete/DiscreteFactorGraph.h>
 #include <gtsam/hybrid/HybridBayesTree.h>
 #include <gtsam/hybrid/HybridGaussianISAM.h>
 #include <gtsam/inference/DotWriter.h>
-#include <gtsam/base/TestableAssertions.h>
 
 #include <numeric>
 
-#include "Switching.h"
 #include "DiscreteFixture.h"
+#include "Switching.h"
 
 // Include for test suite
 #include <CppUnitLite/TestHarness.h>

--- a/gtsam/hybrid/tests/testHybridEstimation.cpp
+++ b/gtsam/hybrid/tests/testHybridEstimation.cpp
@@ -15,6 +15,8 @@
  * @author  Varun Agrawal
  */
 
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/discrete/DiscreteBayesNet.h>
 #include <gtsam/discrete/DiscreteMarginals.h>
 #include <gtsam/discrete/TableDistribution.h>

--- a/gtsam/hybrid/tests/testHybridFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridFactorGraph.cpp
@@ -15,7 +15,9 @@
 
 #include <CppUnitLite/Test.h>
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/TestableAssertions.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/utilities.h>
 #include <gtsam/hybrid/HybridFactorGraph.h>
 #include <gtsam/hybrid/HybridGaussianFactorGraph.h>

--- a/gtsam/hybrid/tests/testHybridGaussianConditional.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianConditional.cpp
@@ -18,6 +18,7 @@
  * @date    December 2021
  */
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/discrete/DecisionTree.h>
 #include <gtsam/discrete/DiscreteKey.h>
 #include <gtsam/discrete/DiscreteValues.h>

--- a/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianFactorGraph.cpp
@@ -19,9 +19,11 @@
 
 #include <CppUnitLite/Test.h>
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/TestableAssertions.h>
 #include <gtsam/base/Vector.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/discrete/DecisionTreeFactor.h>
 #include <gtsam/discrete/DiscreteKey.h>
 #include <gtsam/discrete/DiscreteValues.h>
@@ -43,9 +45,9 @@
 #include <memory>
 #include <vector>
 
+#include "DiscreteFixture.h"
 #include "Switching.h"
 #include "TinyHybridExample.h"
-#include "DiscreteFixture.h"
 
 using namespace std;
 using namespace gtsam;

--- a/gtsam/hybrid/tests/testHybridGaussianProductFactor.cpp
+++ b/gtsam/hybrid/tests/testHybridGaussianProductFactor.cpp
@@ -16,6 +16,7 @@
  * @date    October 2024
  */
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/TestableAssertions.h>
 #include <gtsam/hybrid/HybridGaussianFactor.h>

--- a/gtsam/hybrid/tests/testHybridMotionModel.cpp
+++ b/gtsam/hybrid/tests/testHybridMotionModel.cpp
@@ -18,6 +18,7 @@
  * @date    December 2021
  */
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/TestableAssertions.h>
 #include <gtsam/discrete/DiscreteConditional.h>

--- a/gtsam/linear/NoiseModel.h
+++ b/gtsam/linear/NoiseModel.h
@@ -20,6 +20,7 @@
 
 #include <gtsam/base/Manifold.h>
 #include <gtsam/base/Matrix.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/std_optional_serialization.h>
 #include <gtsam/dllexport.h>

--- a/gtsam/linear/tests/powerMethodExample.h
+++ b/gtsam/linear/tests/powerMethodExample.h
@@ -57,7 +57,7 @@ inline GaussianFactorGraph createDenseGraph() {
   for (size_t j = 0; j < 10; j++) {
     // Each node has an edge with all the others
     for (size_t i = 1; i < 10; i++)
-    fg.add(X(j), -I_1x1, X((j + i) % 10), I_1x1, Z_1x1, model);
+      fg.add(X(j), -I_1x1, X((j + i) % 10), I_1x1, Z_1x1, model);
   }
 
   return fg;

--- a/gtsam/linear/tests/powerMethodExample.h
+++ b/gtsam/linear/tests/powerMethodExample.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/inference/Symbol.h>
 
 #include <iostream>
@@ -38,9 +40,9 @@ inline GaussianFactorGraph createSparseGraph() {
   GaussianFactorGraph fg;
   auto model = noiseModel::Unit::Create(1);
   for (size_t j = 0; j < 3; j++) {
-    fg.add(X(j), -I_1x1, X(j + 1), I_1x1, Vector1::Zero(), model);
+    fg.add(X(j), -I_1x1, X(j + 1), I_1x1, Z_1x1, model);
   }
-  fg.add(X(3), -I_1x1, X(0), I_1x1, Vector1::Zero(), model);  // extra row
+  fg.add(X(3), -I_1x1, X(0), I_1x1, Z_1x1, model);  // extra row
 
   return fg;
 }
@@ -55,7 +57,7 @@ inline GaussianFactorGraph createDenseGraph() {
   for (size_t j = 0; j < 10; j++) {
     // Each node has an edge with all the others
     for (size_t i = 1; i < 10; i++)
-    fg.add(X(j), -I_1x1, X((j + i) % 10), I_1x1, Vector1::Zero(), model);
+    fg.add(X(j), -I_1x1, X((j + i) % 10), I_1x1, Z_1x1, model);
   }
 
   return fg;

--- a/gtsam/linear/tests/testGaussianBayesNet.cpp
+++ b/gtsam/linear/tests/testGaussianBayesNet.cpp
@@ -19,6 +19,7 @@
 #include <gtsam/linear/GaussianDensity.h>
 #include <gtsam/linear/JacobianFactor.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/inference/Symbol.h>

--- a/gtsam/linear/tests/testGaussianBayesNet.cpp
+++ b/gtsam/linear/tests/testGaussianBayesNet.cpp
@@ -15,16 +15,15 @@
  * @author  Frank Dellaert
  */
 
-#include <gtsam/linear/GaussianBayesNet.h>
-#include <gtsam/linear/GaussianDensity.h>
-#include <gtsam/linear/JacobianFactor.h>
-#include <gtsam/linear/GaussianFactorGraph.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/inference/Symbol.h>
-
-#include <CppUnitLite/TestHarness.h>
+#include <gtsam/linear/GaussianBayesNet.h>
+#include <gtsam/linear/GaussianDensity.h>
+#include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/linear/JacobianFactor.h>
 
 // STL/C++
 #include <iostream>

--- a/gtsam/linear/tests/testGaussianBayesTree.cpp
+++ b/gtsam/linear/tests/testGaussianBayesTree.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/debug.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/inference/Symbol.h>

--- a/gtsam/linear/tests/testGaussianConditional.cpp
+++ b/gtsam/linear/tests/testGaussianConditional.cpp
@@ -16,18 +16,16 @@
  **/
 
 #include <CppUnitLite/TestHarness.h>
-#include <gtsam/base/TestableAssertions.h>
-
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/TestableAssertions.h>
 #include <gtsam/base/VerticalBlockMatrix.h>
+#include <gtsam/hybrid/HybridValues.h>
 #include <gtsam/inference/Symbol.h>
-#include <gtsam/linear/JacobianFactor.h>
+#include <gtsam/linear/GaussianBayesNet.h>
 #include <gtsam/linear/GaussianConditional.h>
 #include <gtsam/linear/GaussianDensity.h>
-#include <gtsam/linear/GaussianBayesNet.h>
-#include <gtsam/hybrid/HybridValues.h>
-
+#include <gtsam/linear/JacobianFactor.h>
 
 #include <iostream>
 #include <sstream>

--- a/gtsam/linear/tests/testGaussianConditional.cpp
+++ b/gtsam/linear/tests/testGaussianConditional.cpp
@@ -19,6 +19,7 @@
 #include <gtsam/base/TestableAssertions.h>
 
 #include <gtsam/base/Matrix.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/VerticalBlockMatrix.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/linear/JacobianFactor.h>

--- a/gtsam/linear/tests/testGaussianFactorGraph.cpp
+++ b/gtsam/linear/tests/testGaussianFactorGraph.cpp
@@ -28,6 +28,7 @@
 #include <gtsam/inference/VariableIndex.h>
 #include <gtsam/symbolic/IndexedJunctionTree.h>
 #include <gtsam/base/debug.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/VerticalBlockMatrix.h>
 
 #include <gtsam/base/TestableAssertions.h>

--- a/gtsam/linear/tests/testGaussianFactorGraph.cpp
+++ b/gtsam/linear/tests/testGaussianFactorGraph.cpp
@@ -18,21 +18,20 @@
  *  @author Richard Roberts
  **/
 
-#include <gtsam/linear/GaussianFactorGraph.h>
-#include <gtsam/linear/GaussianConditional.h>
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/TestableAssertions.h>
+#include <gtsam/base/VerticalBlockMatrix.h>
+#include <gtsam/base/debug.h>
+#include <gtsam/inference/Ordering.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/inference/VariableIndex.h>
+#include <gtsam/inference/VariableSlots.h>
 #include <gtsam/linear/GaussianBayesNet.h>
 #include <gtsam/linear/GaussianBayesTree.h>
-#include <gtsam/inference/Symbol.h>
-#include <gtsam/inference/Ordering.h>
-#include <gtsam/inference/VariableSlots.h>
-#include <gtsam/inference/VariableIndex.h>
+#include <gtsam/linear/GaussianConditional.h>
+#include <gtsam/linear/GaussianFactorGraph.h>
 #include <gtsam/symbolic/IndexedJunctionTree.h>
-#include <gtsam/base/debug.h>
-#include <gtsam/base/MatrixConstants.h>
-#include <gtsam/base/VerticalBlockMatrix.h>
-
-#include <gtsam/base/TestableAssertions.h>
-#include <CppUnitLite/TestHarness.h>
 
 using namespace std;
 using namespace gtsam;

--- a/gtsam/linear/tests/testHessianFactor.cpp
+++ b/gtsam/linear/tests/testHessianFactor.cpp
@@ -15,19 +15,18 @@
  * @date    Dec 15, 2010
  */
 
-#include <gtsam/linear/HessianFactor.h>
-#include <gtsam/linear/JacobianFactor.h>
-#include <gtsam/linear/GaussianFactorGraph.h>
-#include <gtsam/linear/GaussianConditional.h>
-#include <gtsam/linear/VectorValues.h>
-#include <gtsam/base/debug.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/TestableAssertions.h>
+#include <gtsam/base/debug.h>
+#include <gtsam/linear/GaussianConditional.h>
+#include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/linear/HessianFactor.h>
+#include <gtsam/linear/JacobianFactor.h>
+#include <gtsam/linear/VectorValues.h>
 
-#include <CppUnitLite/TestHarness.h>
-
-#include <vector>
 #include <utility>
+#include <vector>
 
 using namespace std;
 using namespace gtsam;

--- a/gtsam/linear/tests/testHessianFactor.cpp
+++ b/gtsam/linear/tests/testHessianFactor.cpp
@@ -21,6 +21,7 @@
 #include <gtsam/linear/GaussianConditional.h>
 #include <gtsam/linear/VectorValues.h>
 #include <gtsam/base/debug.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/TestableAssertions.h>
 
 #include <CppUnitLite/TestHarness.h>

--- a/gtsam/linear/tests/testJacobianFactor.cpp
+++ b/gtsam/linear/tests/testJacobianFactor.cpp
@@ -25,6 +25,7 @@
 #include <gtsam/linear/GaussianFactorGraph.h>
 #include <gtsam/linear/GaussianConditional.h>
 #include <gtsam/linear/VectorValues.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/SymmetricBlockMatrix.h>
 
 using namespace std;

--- a/gtsam/linear/tests/testJacobianFactor.cpp
+++ b/gtsam/linear/tests/testJacobianFactor.cpp
@@ -16,17 +16,16 @@
  *  @author Frank Dellaert
  **/
 
-#include <gtsam/base/TestableAssertions.h>
 #include <CppUnitLite/TestHarness.h>
-
-#include <gtsam/inference/VariableSlots.h>
-#include <gtsam/linear/HessianFactor.h>
-#include <gtsam/linear/JacobianFactor.h>
-#include <gtsam/linear/GaussianFactorGraph.h>
-#include <gtsam/linear/GaussianConditional.h>
-#include <gtsam/linear/VectorValues.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/SymmetricBlockMatrix.h>
+#include <gtsam/base/TestableAssertions.h>
+#include <gtsam/inference/VariableSlots.h>
+#include <gtsam/linear/GaussianConditional.h>
+#include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/linear/HessianFactor.h>
+#include <gtsam/linear/JacobianFactor.h>
+#include <gtsam/linear/VectorValues.h>
 
 using namespace std;
 using namespace gtsam;

--- a/gtsam/linear/tests/testKalmanFilter.cpp
+++ b/gtsam/linear/tests/testKalmanFilter.cpp
@@ -17,11 +17,11 @@
  * @author Frank Dellaert
  */
 
-#include <gtsam/linear/KalmanFilter.h>
-#include <gtsam/linear/NoiseModel.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
-#include <CppUnitLite/TestHarness.h>
+#include <gtsam/linear/KalmanFilter.h>
+#include <gtsam/linear/NoiseModel.h>
 
 using namespace std;
 using namespace gtsam;

--- a/gtsam/linear/tests/testKalmanFilter.cpp
+++ b/gtsam/linear/tests/testKalmanFilter.cpp
@@ -19,6 +19,7 @@
 
 #include <gtsam/linear/KalmanFilter.h>
 #include <gtsam/linear/NoiseModel.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <CppUnitLite/TestHarness.h>
 

--- a/gtsam/linear/tests/testMultifrontalSolver.cpp
+++ b/gtsam/linear/tests/testMultifrontalSolver.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/linear/BatchJacobianFactor.h>
 #include <gtsam/linear/GaussianBayesTree.h>

--- a/gtsam/linear/tests/testNoiseModel.cpp
+++ b/gtsam/linear/tests/testNoiseModel.cpp
@@ -17,14 +17,12 @@
  * @author Fan Jiang
  */
 
-
-#include <gtsam/linear/NoiseModel.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/TestableAssertions.h>
 #include <gtsam/geometry/Point2.h>
-
-#include <CppUnitLite/TestHarness.h>
+#include <gtsam/linear/NoiseModel.h>
 
 #include <cmath>
 #include <iostream>

--- a/gtsam/linear/tests/testNoiseModel.cpp
+++ b/gtsam/linear/tests/testNoiseModel.cpp
@@ -20,6 +20,7 @@
 
 #include <gtsam/linear/NoiseModel.h>
 #include <gtsam/base/Matrix.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/TestableAssertions.h>
 #include <gtsam/geometry/Point2.h>
 

--- a/gtsam/linear/tests/testRegularHessianFactor.cpp
+++ b/gtsam/linear/tests/testRegularHessianFactor.cpp
@@ -15,6 +15,7 @@
  * @date    March 4, 2014
  */
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/linear/RegularHessianFactor.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
 #include <gtsam/linear/VectorValues.h>

--- a/gtsam/linear/tests/testRegularHessianFactor.cpp
+++ b/gtsam/linear/tests/testRegularHessianFactor.cpp
@@ -15,12 +15,11 @@
  * @date    March 4, 2014
  */
 
-#include <gtsam/base/MatrixConstants.h>
-#include <gtsam/linear/RegularHessianFactor.h>
-#include <gtsam/linear/GaussianFactorGraph.h>
-#include <gtsam/linear/VectorValues.h>
-
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/linear/RegularHessianFactor.h>
+#include <gtsam/linear/VectorValues.h>
 
 using namespace std;
 using namespace gtsam;

--- a/gtsam/linear/tests/testRegularJacobianFactor.cpp
+++ b/gtsam/linear/tests/testRegularJacobianFactor.cpp
@@ -16,14 +16,13 @@
  * @date    Nov 12, 2014
  */
 
-#include <gtsam/base/MatrixConstants.h>
-#include <gtsam/linear/RegularJacobianFactor.h>
-#include <gtsam/linear/GaussianFactorGraph.h>
-#include <gtsam/linear/GaussianConditional.h>
-#include <gtsam/linear/VectorValues.h>
-#include <gtsam/base/TestableAssertions.h>
-
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/TestableAssertions.h>
+#include <gtsam/linear/GaussianConditional.h>
+#include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/linear/RegularJacobianFactor.h>
+#include <gtsam/linear/VectorValues.h>
 
 using namespace std;
 using namespace gtsam;

--- a/gtsam/linear/tests/testRegularJacobianFactor.cpp
+++ b/gtsam/linear/tests/testRegularJacobianFactor.cpp
@@ -16,6 +16,7 @@
  * @date    Nov 12, 2014
  */
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/linear/RegularJacobianFactor.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
 #include <gtsam/linear/GaussianConditional.h>

--- a/gtsam/linear/tests/testSerializationLinear.cpp
+++ b/gtsam/linear/tests/testSerializationLinear.cpp
@@ -16,6 +16,7 @@
  * @date Feb 7, 2012
  */
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/linear/VectorValues.h>
 #include <gtsam/linear/JacobianFactor.h>
 #include <gtsam/linear/HessianFactor.h>

--- a/gtsam/linear/tests/testSerializationLinear.cpp
+++ b/gtsam/linear/tests/testSerializationLinear.cpp
@@ -16,15 +16,14 @@
  * @date Feb 7, 2012
  */
 
-#include <gtsam/base/MatrixConstants.h>
-#include <gtsam/linear/VectorValues.h>
-#include <gtsam/linear/JacobianFactor.h>
-#include <gtsam/linear/HessianFactor.h>
-#include <gtsam/linear/GaussianISAM.h>
-#include <gtsam/linear/NoiseModel.h>
-
-#include <gtsam/base/serializationTestHelpers.h>
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/serializationTestHelpers.h>
+#include <gtsam/linear/GaussianISAM.h>
+#include <gtsam/linear/HessianFactor.h>
+#include <gtsam/linear/JacobianFactor.h>
+#include <gtsam/linear/NoiseModel.h>
+#include <gtsam/linear/VectorValues.h>
 
 using namespace std;
 using namespace gtsam;

--- a/gtsam/navigation/CarrierPhaseFactor.cpp
+++ b/gtsam/navigation/CarrierPhaseFactor.cpp
@@ -6,6 +6,8 @@
 
 #include "CarrierPhaseFactor.h"
 
+#include <gtsam/base/MatrixConstants.h>
+
 namespace gtsam {
 
 using gnss::C_LIGHT;

--- a/gtsam/navigation/CombinedImuFactor.cpp
+++ b/gtsam/navigation/CombinedImuFactor.cpp
@@ -20,6 +20,7 @@
  *  @author Varun Agrawal
  **/
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/navigation/CombinedImuFactor.h>
 #include <gtsam/navigation/ManifoldPreintegration.h>
 #include <gtsam/navigation/TangentPreintegration.h>

--- a/gtsam/navigation/Gal3ImuEKF.h
+++ b/gtsam/navigation/Gal3ImuEKF.h
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/geometry/Gal3.h>
 #include <gtsam/navigation/InvariantEKF.h>  // Include the base class
 #include <gtsam/navigation/PreintegrationParams.h>

--- a/gtsam/navigation/ImuBias.h
+++ b/gtsam/navigation/ImuBias.h
@@ -20,6 +20,7 @@
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/OptionalJacobian.h>
 #include <gtsam/base/VectorSpace.h>
+
 #include <iosfwd>
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/nvp.hpp>

--- a/gtsam/navigation/ImuBias.h
+++ b/gtsam/navigation/ImuBias.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/OptionalJacobian.h>
 #include <gtsam/base/VectorSpace.h>
 #include <iosfwd>
@@ -177,4 +178,3 @@ struct traits<imuBias::ConstantBias> : public internal::VectorSpace<
 };
 
 } // namespace gtsam
-

--- a/gtsam/navigation/LeggedEstimator.cpp
+++ b/gtsam/navigation/LeggedEstimator.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <gtsam/base/Matrix.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/navigation/LeggedEstimator.h>

--- a/gtsam/navigation/LeggedEstimator.h
+++ b/gtsam/navigation/LeggedEstimator.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/geometry/ExtendedPose3.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/inference/Symbol.h>

--- a/gtsam/navigation/LeggedEstimatorFactors.h
+++ b/gtsam/navigation/LeggedEstimatorFactors.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <gtsam/base/Matrix.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/navigation/LeggedEstimator.h>
 #include <gtsam/nonlinear/NoiseModelFactorN.h>
 

--- a/gtsam/navigation/MagFactor.h
+++ b/gtsam/navigation/MagFactor.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/NoiseModelFactorN.h>
 #include <gtsam/geometry/Rot2.h>
@@ -225,4 +226,3 @@ public:
 };
 
 }
-

--- a/gtsam/navigation/MagFactor.h
+++ b/gtsam/navigation/MagFactor.h
@@ -19,10 +19,10 @@
 #pragma once
 
 #include <gtsam/base/MatrixConstants.h>
-#include <gtsam/nonlinear/NonlinearFactor.h>
-#include <gtsam/nonlinear/NoiseModelFactorN.h>
 #include <gtsam/geometry/Rot2.h>
 #include <gtsam/geometry/Rot3.h>
+#include <gtsam/nonlinear/NoiseModelFactorN.h>
+#include <gtsam/nonlinear/NonlinearFactor.h>
 
 namespace gtsam {
 

--- a/gtsam/navigation/ManifoldPreintegration.cpp
+++ b/gtsam/navigation/ManifoldPreintegration.cpp
@@ -21,6 +21,8 @@
 
 #include "ManifoldPreintegration.h"
 
+#include <gtsam/base/MatrixConstants.h>
+
 using namespace std;
 
 namespace gtsam {

--- a/gtsam/navigation/NavState.cpp
+++ b/gtsam/navigation/NavState.cpp
@@ -16,8 +16,9 @@
  * @date    July 2015
  **/
 
-#include <gtsam/navigation/NavState.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/geometry/Kernel.h>
+#include <gtsam/navigation/NavState.h>
 
 #include <string>
 

--- a/gtsam/navigation/NavState.h
+++ b/gtsam/navigation/NavState.h
@@ -18,12 +18,12 @@
 
 #pragma once
 
+#include <gtsam/base/Manifold.h>
 #include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/Vector.h>
 #include <gtsam/geometry/BearingRange.h>
 #include <gtsam/geometry/ExtendedPose3.h>
 #include <gtsam/geometry/Pose3.h>
-#include <gtsam/base/Vector.h>
-#include <gtsam/base/Manifold.h>
 
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/base_object.hpp>

--- a/gtsam/navigation/NavState.h
+++ b/gtsam/navigation/NavState.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/geometry/BearingRange.h>
 #include <gtsam/geometry/ExtendedPose3.h>
 #include <gtsam/geometry/Pose3.h>

--- a/gtsam/navigation/PlanarGyroFactor.cpp
+++ b/gtsam/navigation/PlanarGyroFactor.cpp
@@ -3,6 +3,8 @@
  * @author joel@truher.org
  * @date May 1, 2026
  */
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/navigation/PlanarGyroFactor.h>
 
 namespace gtsam {

--- a/gtsam/navigation/PreintegratedRotation.cpp
+++ b/gtsam/navigation/PreintegratedRotation.cpp
@@ -21,6 +21,8 @@
 
 #include "PreintegratedRotation.h"
 
+#include <gtsam/base/MatrixConstants.h>
+
 using namespace std;
 
 namespace gtsam {

--- a/gtsam/navigation/PreintegratedRotation.h
+++ b/gtsam/navigation/PreintegratedRotation.h
@@ -25,6 +25,7 @@
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/std_optional_serialization.h>
 #include <gtsam/geometry/Pose3.h>
+
 #include "gtsam/dllexport.h"
 
 namespace gtsam {

--- a/gtsam/navigation/PreintegratedRotation.h
+++ b/gtsam/navigation/PreintegratedRotation.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <gtsam/base/Matrix.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/std_optional_serialization.h>
 #include <gtsam/geometry/Pose3.h>
 #include "gtsam/dllexport.h"

--- a/gtsam/navigation/PreintegrationBase.cpp
+++ b/gtsam/navigation/PreintegrationBase.cpp
@@ -20,6 +20,7 @@
  *  @author Varun Agrawal
  **/
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/navigation/PreintegrationBase.h>
 
 #include <cassert>

--- a/gtsam/navigation/PreintegrationCombinedParams.h
+++ b/gtsam/navigation/PreintegrationCombinedParams.h
@@ -24,6 +24,7 @@
 
 /* GTSAM includes */
 #include <gtsam/base/Matrix.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/navigation/ManifoldPreintegration.h>
 #include <gtsam/navigation/TangentPreintegration.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>

--- a/gtsam/navigation/PreintegrationParams.h
+++ b/gtsam/navigation/PreintegrationParams.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/navigation/PreintegratedRotation.h>
 
 namespace gtsam {

--- a/gtsam/navigation/PseudorangeFactor.cpp
+++ b/gtsam/navigation/PseudorangeFactor.cpp
@@ -7,6 +7,8 @@
 
 #include "PseudorangeFactor.h"
 
+#include <gtsam/base/MatrixConstants.h>
+
 namespace gtsam {
 
 using gnss::C_LIGHT;

--- a/gtsam/navigation/ScenarioRunner.cpp
+++ b/gtsam/navigation/ScenarioRunner.cpp
@@ -15,6 +15,7 @@
  * @author  Frank Dellaert
  */
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/timing.h>
 #include <gtsam/navigation/ScenarioRunner.h>
 

--- a/gtsam/navigation/TangentPreintegration.cpp
+++ b/gtsam/navigation/TangentPreintegration.cpp
@@ -15,6 +15,7 @@
  *  @author Adam Bry
  **/
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/navigation/TangentPreintegration.h>
 
 using namespace std;

--- a/gtsam/navigation/tests/imuFactorTesting.h
+++ b/gtsam/navigation/tests/imuFactorTesting.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/navigation/ImuBias.h>
 

--- a/gtsam/navigation/tests/testAHRSFactor.cpp
+++ b/gtsam/navigation/tests/testAHRSFactor.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/TestableAssertions.h>
 #include <gtsam/base/debug.h>
 #include <gtsam/base/numericalDerivative.h>

--- a/gtsam/navigation/tests/testAttitudeFactor.cpp
+++ b/gtsam/navigation/tests/testAttitudeFactor.cpp
@@ -18,6 +18,7 @@
 
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/Testable.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/navigation/AttitudeFactor.h>
 

--- a/gtsam/navigation/tests/testCombinedImuFactor.cpp
+++ b/gtsam/navigation/tests/testCombinedImuFactor.cpp
@@ -20,7 +20,9 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/TestableAssertions.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/inference/Symbol.h>

--- a/gtsam/navigation/tests/testEquivariantFilter.cpp
+++ b/gtsam/navigation/tests/testEquivariantFilter.cpp
@@ -20,6 +20,7 @@
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/GroupAction.h>
 #include <gtsam/base/Matrix.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Vector.h>
 #include <gtsam/geometry/Rot3.h>
 #include <gtsam/geometry/Unit3.h>

--- a/gtsam/navigation/tests/testGPSFactor.cpp
+++ b/gtsam/navigation/tests/testGPSFactor.cpp
@@ -18,6 +18,7 @@
 
  #include <gtsam/navigation/GPSFactor.h>
  #include <gtsam/base/Testable.h>
+ #include <gtsam/base/VectorConstants.h>
  #include <gtsam/base/numericalDerivative.h>
  
  #include <CppUnitLite/TestHarness.h>

--- a/gtsam/navigation/tests/testGPSFactor.cpp
+++ b/gtsam/navigation/tests/testGPSFactor.cpp
@@ -16,41 +16,40 @@
  * @date   January 22, 2014
  */
 
- #include <gtsam/navigation/GPSFactor.h>
- #include <gtsam/base/Testable.h>
- #include <gtsam/base/VectorConstants.h>
- #include <gtsam/base/numericalDerivative.h>
- 
- #include <CppUnitLite/TestHarness.h>
- 
- #include <GeographicLib/Config.h>
- #include <GeographicLib/LocalCartesian.hpp>
- 
- using namespace std;
- using namespace gtsam;
- using namespace GeographicLib;
- 
- #if GEOGRAPHICLIB_VERSION_MAJOR < 2 && GEOGRAPHICLIB_VERSION_MINOR<37
- static const auto& kWGS84 = Geocentric::WGS84;
- #else
- static const auto& kWGS84 = Geocentric::WGS84();
- #endif
- 
- // *************************************************************************
- namespace example {
- // ENU Origin is where the plane was in hold next to runway
- static constexpr double lat0 = 33.86998, lon0 = -84.30626, h0 = 274;
- 
- // Convert from GPS to ENU
- static const LocalCartesian origin_ENU(lat0, lon0, h0, kWGS84);
- 
- // Dekalb-Peachtree Airport runway 2L
- static constexpr double lat = 33.87071, lon = -84.30482, h = 274;
- 
- // Random lever arm
- static const Point3 leverArm(0.1, 0.2, 0.3);
- }  // namespace example
- 
+#include <CppUnitLite/TestHarness.h>
+#include <GeographicLib/Config.h>
+#include <gtsam/base/Testable.h>
+#include <gtsam/base/VectorConstants.h>
+#include <gtsam/base/numericalDerivative.h>
+#include <gtsam/navigation/GPSFactor.h>
+
+#include <GeographicLib/LocalCartesian.hpp>
+
+using namespace std;
+using namespace gtsam;
+using namespace GeographicLib;
+
+#if GEOGRAPHICLIB_VERSION_MAJOR < 2 && GEOGRAPHICLIB_VERSION_MINOR < 37
+static const auto& kWGS84 = Geocentric::WGS84;
+#else
+static const auto& kWGS84 = Geocentric::WGS84();
+#endif
+
+// *************************************************************************
+namespace example {
+// ENU Origin is where the plane was in hold next to runway
+static constexpr double lat0 = 33.86998, lon0 = -84.30626, h0 = 274;
+
+// Convert from GPS to ENU
+static const LocalCartesian origin_ENU(lat0, lon0, h0, kWGS84);
+
+// Dekalb-Peachtree Airport runway 2L
+static constexpr double lat = 33.87071, lon = -84.30482, h = 274;
+
+// Random lever arm
+static const Point3 leverArm(0.1, 0.2, 0.3);
+}  // namespace example
+
  // *************************************************************************
  TEST( GPSFactor, Constructor ) {
    using namespace example;

--- a/gtsam/navigation/tests/testGal3ImuEKF.cpp
+++ b/gtsam/navigation/tests/testGal3ImuEKF.cpp
@@ -15,7 +15,9 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/geometry/Gal3.h>
 #include <gtsam/inference/Symbol.h>

--- a/gtsam/navigation/tests/testImuFactor.cpp
+++ b/gtsam/navigation/tests/testImuFactor.cpp
@@ -20,18 +20,18 @@
 
 // #define ENABLE_TIMING // uncomment for timing results
 
-#include <gtsam/navigation/ImuFactor.h>
-#include <gtsam/navigation/ScenarioRunner.h>
-#include <gtsam/geometry/Pose3.h>
-#include <gtsam/nonlinear/Values.h>
-#include <gtsam/nonlinear/factorTesting.h>
-#include <gtsam/linear/Sampler.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/TestableAssertions.h>
 #include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
+#include <gtsam/geometry/Pose3.h>
+#include <gtsam/linear/Sampler.h>
+#include <gtsam/navigation/ImuFactor.h>
+#include <gtsam/navigation/ScenarioRunner.h>
+#include <gtsam/nonlinear/Values.h>
+#include <gtsam/nonlinear/factorTesting.h>
 
-#include <CppUnitLite/TestHarness.h>
 #include <list>
 
 #include "imuFactorTesting.h"

--- a/gtsam/navigation/tests/testImuFactor.cpp
+++ b/gtsam/navigation/tests/testImuFactor.cpp
@@ -26,7 +26,9 @@
 #include <gtsam/nonlinear/Values.h>
 #include <gtsam/nonlinear/factorTesting.h>
 #include <gtsam/linear/Sampler.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/TestableAssertions.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 
 #include <CppUnitLite/TestHarness.h>

--- a/gtsam/navigation/tests/testInvariantEKF.cpp
+++ b/gtsam/navigation/tests/testInvariantEKF.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/navigation/InvariantEKF.h>

--- a/gtsam/navigation/tests/testLeftLinearEKF.cpp
+++ b/gtsam/navigation/tests/testLeftLinearEKF.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/geometry/Rot3.h>
 #include <gtsam/navigation/LeftLinearEKF.h>

--- a/gtsam/navigation/tests/testLeggedEstimator.cpp
+++ b/gtsam/navigation/tests/testLeggedEstimator.cpp
@@ -14,6 +14,7 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/TestableAssertions.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/navigation/LeggedEstimator.h>

--- a/gtsam/navigation/tests/testLieGroupEKF.cpp
+++ b/gtsam/navigation/tests/testLieGroupEKF.cpp
@@ -16,6 +16,7 @@
 
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/Matrix.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/OptionalJacobian.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/numericalDerivative.h>

--- a/gtsam/navigation/tests/testMagFactor.cpp
+++ b/gtsam/navigation/tests/testMagFactor.cpp
@@ -16,12 +16,11 @@
  * @date   January 29, 2014
  */
 
-#include <gtsam/navigation/MagFactor.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
-
-#include <CppUnitLite/TestHarness.h>
+#include <gtsam/navigation/MagFactor.h>
 
 #include <GeographicLib/LocalCartesian.hpp>
 

--- a/gtsam/navigation/tests/testMagFactor.cpp
+++ b/gtsam/navigation/tests/testMagFactor.cpp
@@ -18,6 +18,7 @@
 
 #include <gtsam/navigation/MagFactor.h>
 #include <gtsam/base/Testable.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 
 #include <CppUnitLite/TestHarness.h>

--- a/gtsam/navigation/tests/testMagPoseFactor.cpp
+++ b/gtsam/navigation/tests/testMagPoseFactor.cpp
@@ -10,8 +10,9 @@
  * -------------------------------------------------------------------------- */
 
 #include <CppUnitLite/TestHarness.h>
-#include <gtsam/base/numericalDerivative.h>
 #include <gtsam/base/TestableAssertions.h>
+#include <gtsam/base/VectorConstants.h>
+#include <gtsam/base/numericalDerivative.h>
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/inference/Symbol.h>

--- a/gtsam/navigation/tests/testManifoldEKF.cpp
+++ b/gtsam/navigation/tests/testManifoldEKF.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/geometry/Point3.h>
@@ -65,7 +66,7 @@ struct Unit3EKFTest {
                      .finished()),  // Rotate towards +Z axis
         dt(0.1),
         Q(I_2x2 * 0.001),
-        R(Matrix1::Identity() * 0.01) {}
+        R(I_1x1 * 0.01) {}
 };
 
 //==============================================================================

--- a/gtsam/navigation/tests/testManifoldPreintegration.cpp
+++ b/gtsam/navigation/tests/testManifoldPreintegration.cpp
@@ -15,15 +15,14 @@
  * @author  Luca Carlone
  */
 
-#include <gtsam/navigation/ManifoldPreintegration.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
-#include <gtsam/nonlinear/expressions.h>
+#include <gtsam/navigation/ManifoldPreintegration.h>
 #include <gtsam/nonlinear/ExpressionFactor.h>
 #include <gtsam/nonlinear/expressionTesting.h>
-
-#include <CppUnitLite/TestHarness.h>
+#include <gtsam/nonlinear/expressions.h>
 
 #include "imuFactorTesting.h"
 

--- a/gtsam/navigation/tests/testManifoldPreintegration.cpp
+++ b/gtsam/navigation/tests/testManifoldPreintegration.cpp
@@ -16,6 +16,8 @@
  */
 
 #include <gtsam/navigation/ManifoldPreintegration.h>
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/nonlinear/expressions.h>
 #include <gtsam/nonlinear/ExpressionFactor.h>

--- a/gtsam/navigation/tests/testNavState.cpp
+++ b/gtsam/navigation/tests/testNavState.cpp
@@ -16,16 +16,15 @@
  * @date    July 2015
  */
 
-#include <gtsam/navigation/NavState.h>
-
-#include <gtsam/base/lieProxies.h>
-#include <gtsam/base/numericalDerivative.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/TestableAssertions.h>
 #include <gtsam/base/VectorConstants.h>
+#include <gtsam/base/lieProxies.h>
+#include <gtsam/base/numericalDerivative.h>
 #include <gtsam/base/testLie.h>
+#include <gtsam/navigation/NavState.h>
 
-#include <CppUnitLite/TestHarness.h>
 #include <cmath>
 
 using namespace std::placeholders;

--- a/gtsam/navigation/tests/testNavState.cpp
+++ b/gtsam/navigation/tests/testNavState.cpp
@@ -20,7 +20,9 @@
 
 #include <gtsam/base/lieProxies.h>
 #include <gtsam/base/numericalDerivative.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/TestableAssertions.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/testLie.h>
 
 #include <CppUnitLite/TestHarness.h>

--- a/gtsam/navigation/tests/testNavStateImuEKF.cpp
+++ b/gtsam/navigation/tests/testNavStateImuEKF.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/geometry/Gal3.h>

--- a/gtsam/navigation/tests/testScenarioRunner.cpp
+++ b/gtsam/navigation/tests/testScenarioRunner.cpp
@@ -18,6 +18,8 @@
 // #define ENABLE_TIMING // uncomment for timing results
 
 #include <gtsam/navigation/ScenarioRunner.h>
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/timing.h>
 #include <CppUnitLite/TestHarness.h>
 #include <cmath>

--- a/gtsam/navigation/tests/testScenarioRunner.cpp
+++ b/gtsam/navigation/tests/testScenarioRunner.cpp
@@ -17,11 +17,12 @@
 
 // #define ENABLE_TIMING // uncomment for timing results
 
-#include <gtsam/navigation/ScenarioRunner.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/timing.h>
-#include <CppUnitLite/TestHarness.h>
+#include <gtsam/navigation/ScenarioRunner.h>
+
 #include <cmath>
 
 using namespace std;

--- a/gtsam/navigation/tests/testSerializationNavigation.cpp
+++ b/gtsam/navigation/tests/testSerializationNavigation.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/serializationTestHelpers.h>
 #include <gtsam/navigation/AttitudeFactor.h>
 #include <gtsam/navigation/CarrierPhaseFactor.h>

--- a/gtsam/navigation/tests/testTangentPreintegration.cpp
+++ b/gtsam/navigation/tests/testTangentPreintegration.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <gtsam/navigation/TangentPreintegration.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/nonlinear/expressions.h>
 #include <gtsam/nonlinear/ExpressionFactor.h>

--- a/gtsam/navigation/tests/testTangentPreintegration.cpp
+++ b/gtsam/navigation/tests/testTangentPreintegration.cpp
@@ -15,14 +15,13 @@
  * @author  Frank Dellaert
  */
 
-#include <gtsam/navigation/TangentPreintegration.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
-#include <gtsam/nonlinear/expressions.h>
+#include <gtsam/navigation/TangentPreintegration.h>
 #include <gtsam/nonlinear/ExpressionFactor.h>
 #include <gtsam/nonlinear/expressionTesting.h>
-
-#include <CppUnitLite/TestHarness.h>
+#include <gtsam/nonlinear/expressions.h>
 
 #include "imuFactorTesting.h"
 

--- a/gtsam/nonlinear/tests/testExpression.cpp
+++ b/gtsam/nonlinear/tests/testExpression.cpp
@@ -21,6 +21,7 @@
 #include <gtsam/geometry/Cal3_S2.h>
 #include <gtsam/geometry/PinholeCamera.h>
 #include <gtsam/geometry/Point3.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 
 #include <CppUnitLite/TestHarness.h>

--- a/gtsam/nonlinear/tests/testExpression.cpp
+++ b/gtsam/nonlinear/tests/testExpression.cpp
@@ -17,14 +17,13 @@
  * @brief unit tests for Block Automatic Differentiation
  */
 
-#include <gtsam/nonlinear/expressions.h>
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/Testable.h>
 #include <gtsam/geometry/Cal3_S2.h>
 #include <gtsam/geometry/PinholeCamera.h>
 #include <gtsam/geometry/Point3.h>
-#include <gtsam/base/MatrixConstants.h>
-#include <gtsam/base/Testable.h>
-
-#include <CppUnitLite/TestHarness.h>
+#include <gtsam/nonlinear/expressions.h>
 
 using namespace std;
 using namespace gtsam;

--- a/gtsam/nonlinear/tests/testFactorTesting.cpp
+++ b/gtsam/nonlinear/tests/testFactorTesting.cpp
@@ -16,13 +16,12 @@
  * @brief unit tests for testFactorJacobians and testExpressionJacobians
  */
 
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/VectorConstants.h>
 #include <gtsam/geometry/Pose3.h>
-#include <gtsam/nonlinear/expressions.h>
 #include <gtsam/nonlinear/expressionTesting.h>
+#include <gtsam/nonlinear/expressions.h>
 #include <gtsam/slam/expressions.h>
-
-#include <CppUnitLite/TestHarness.h>
 
 using namespace gtsam;
 

--- a/gtsam/nonlinear/tests/testFactorTesting.cpp
+++ b/gtsam/nonlinear/tests/testFactorTesting.cpp
@@ -16,6 +16,7 @@
  * @brief unit tests for testFactorJacobians and testExpressionJacobians
  */
 
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/nonlinear/expressions.h>
 #include <gtsam/nonlinear/expressionTesting.h>

--- a/gtsam/nonlinear/tests/testFunctorizedFactor.cpp
+++ b/gtsam/nonlinear/tests/testFunctorizedFactor.cpp
@@ -21,6 +21,7 @@
 #include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
 #include <gtsam/nonlinear/factorTesting.h>
 #include <gtsam/inference/Symbol.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/TestableAssertions.h>
 

--- a/gtsam/nonlinear/tests/testFunctorizedFactor.cpp
+++ b/gtsam/nonlinear/tests/testFunctorizedFactor.cpp
@@ -17,15 +17,14 @@
  * @brief unit tests for FunctorizedFactor class
  */
 
-#include <gtsam/nonlinear/FunctorizedFactor.h>
-#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
-#include <gtsam/nonlinear/factorTesting.h>
-#include <gtsam/inference/Symbol.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/TestableAssertions.h>
-
-#include <CppUnitLite/TestHarness.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/nonlinear/FunctorizedFactor.h>
+#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
+#include <gtsam/nonlinear/factorTesting.h>
 
 using namespace std;
 using namespace gtsam;

--- a/gtsam/nonlinear/tests/testLinearContainerFactor.cpp
+++ b/gtsam/nonlinear/tests/testLinearContainerFactor.cpp
@@ -6,7 +6,9 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/TestableAssertions.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/geometry/Point3.h>
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/inference/Symbol.h>

--- a/gtsam/precompiled_header.h
+++ b/gtsam/precompiled_header.h
@@ -11,7 +11,7 @@
 
 /**
  * @file    precompiled_header.h>
- * @brief   Include headers that are used heavily, or are heavy to parse 
+ * @brief   Include headers that are used heavily, or are heavy to parse
  * @author  Frank Dellaert
  * @date    November 2018
  */

--- a/gtsam/sfm/tests/testTransferFactor.cpp
+++ b/gtsam/sfm/tests/testTransferFactor.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/geometry/Cal3_S2.h>
 #include <gtsam/geometry/SimpleCamera.h>
 #include <gtsam/nonlinear/factorTesting.h>

--- a/gtsam/slam/GeneralSFMFactor.h
+++ b/gtsam/slam/GeneralSFMFactor.h
@@ -26,6 +26,7 @@
 #include <gtsam/base/SymmetricBlockMatrix.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/Vector.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/concepts.h>
 #include <gtsam/base/timing.h>
 #include <gtsam/base/types.h>

--- a/gtsam/slam/InitializePose3.cpp
+++ b/gtsam/slam/InitializePose3.cpp
@@ -16,18 +16,17 @@
  *  @date   August, 2014
  */
 
-#include <gtsam/slam/InitializePose3.h> 
-
-#include <gtsam/slam/InitializePose.h> 
-#include <gtsam/nonlinear/PriorFactor.h>
-#include <gtsam/slam/BetweenFactor.h>
-#include <gtsam/nonlinear/GaussNewtonOptimizer.h>
-#include <gtsam/inference/Symbol.h>
-#include <gtsam/geometry/Pose2.h>
-#include <gtsam/geometry/Pose3.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/timing.h>
+#include <gtsam/geometry/Pose2.h>
+#include <gtsam/geometry/Pose3.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/nonlinear/GaussNewtonOptimizer.h>
+#include <gtsam/nonlinear/PriorFactor.h>
+#include <gtsam/slam/BetweenFactor.h>
+#include <gtsam/slam/InitializePose.h>
+#include <gtsam/slam/InitializePose3.h>
 
 #include <utility>
 

--- a/gtsam/slam/InitializePose3.cpp
+++ b/gtsam/slam/InitializePose3.cpp
@@ -25,6 +25,8 @@
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/geometry/Pose3.h>
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/timing.h>
 
 #include <utility>

--- a/gtsam/slam/OrientedPlane3Factor.cpp
+++ b/gtsam/slam/OrientedPlane3Factor.cpp
@@ -7,6 +7,8 @@
 
 #include "OrientedPlane3Factor.h"
 
+#include <gtsam/base/VectorConstants.h>
+
 using namespace std;
 
 namespace gtsam {

--- a/gtsam/slam/StereoFactor.h
+++ b/gtsam/slam/StereoFactor.h
@@ -18,11 +18,12 @@
 
 #pragma once
 
-#include <optional>
 #include <gtsam/base/MatrixConstants.h>
-#include <gtsam/nonlinear/NonlinearFactor.h>
-#include <gtsam/nonlinear/NoiseModelFactorN.h>
 #include <gtsam/geometry/StereoCamera.h>
+#include <gtsam/nonlinear/NoiseModelFactorN.h>
+#include <gtsam/nonlinear/NonlinearFactor.h>
+
+#include <optional>
 
 namespace gtsam {
 

--- a/gtsam/slam/StereoFactor.h
+++ b/gtsam/slam/StereoFactor.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <optional>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/NoiseModelFactorN.h>
 #include <gtsam/geometry/StereoCamera.h>

--- a/gtsam/slam/dataset.cpp
+++ b/gtsam/slam/dataset.cpp
@@ -37,6 +37,7 @@
 #include <gtsam/base/GenericValue.h>
 #include <gtsam/base/Lie.h>
 #include <gtsam/base/Matrix.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Value.h>
 #include <gtsam/base/Vector.h>
 #include <gtsam/base/types.h>

--- a/gtsam/slam/dataset.cpp
+++ b/gtsam/slam/dataset.cpp
@@ -18,22 +18,6 @@
  * @brief utility functions for loading datasets
  */
 
-#include <gtsam/sam/BearingRangeFactor.h>
-#include <gtsam/slam/BetweenFactor.h>
-#include <gtsam/slam/dataset.h>
-
-#include <gtsam/geometry/Point3.h>
-#include <gtsam/geometry/Pose2.h>
-#include <gtsam/geometry/Rot3.h>
-
-#include <gtsam/nonlinear/NonlinearFactor.h>
-#include <gtsam/nonlinear/Values-inl.h>
-
-#include <gtsam/linear/Sampler.h>
-
-#include <gtsam/inference/FactorGraph.h>
-#include <gtsam/inference/Symbol.h>
-
 #include <gtsam/base/GenericValue.h>
 #include <gtsam/base/Lie.h>
 #include <gtsam/base/Matrix.h>
@@ -41,13 +25,23 @@
 #include <gtsam/base/Value.h>
 #include <gtsam/base/Vector.h>
 #include <gtsam/base/types.h>
-
-#include <optional>
+#include <gtsam/geometry/Point3.h>
+#include <gtsam/geometry/Pose2.h>
+#include <gtsam/geometry/Rot3.h>
+#include <gtsam/inference/FactorGraph.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/linear/Sampler.h>
+#include <gtsam/nonlinear/NonlinearFactor.h>
+#include <gtsam/nonlinear/Values-inl.h>
+#include <gtsam/sam/BearingRangeFactor.h>
+#include <gtsam/slam/BetweenFactor.h>
+#include <gtsam/slam/dataset.h>
 
 #include <cmath>
 #include <fstream>
 #include <iostream>
 #include <locale>
+#include <optional>
 #include <stdexcept>
 #include <string>
 

--- a/gtsam/slam/lago.cpp
+++ b/gtsam/slam/lago.cpp
@@ -23,6 +23,8 @@
 #include <gtsam/nonlinear/PriorFactor.h>
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/inference/Symbol.h>
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/timing.h>
 #include <gtsam/base/kruskal.h>
 
@@ -191,7 +193,7 @@ GaussianFactorGraph buildLinearOrientationGraph(
     lagoGraph.add(key1, -I_1x1, key2, I_1x1, deltaThetaRegularized, model_deltaTheta);
   }
   // prior on the anchor orientation
-  lagoGraph.add(kAnchorKey, I_1x1, (Vector(1) << 0.0).finished(), priorOrientationNoise);
+  lagoGraph.add(kAnchorKey, I_1x1, Z_1x1, priorOrientationNoise);
   return lagoGraph;
 }
 
@@ -349,7 +351,7 @@ Values computePoses(const NonlinearFactorGraph& pose2graph,
     }
   }
   // add prior
-  linearPose2graph.add(kAnchorKey, I_3x3, Vector3(0.0, 0.0, 0.0), priorPose2Noise);
+  linearPose2graph.add(kAnchorKey, I_3x3, Z_3x1, priorPose2Noise);
 
   // optimize
   VectorValues posesLago = linearPose2graph.optimize();

--- a/gtsam/slam/lago.cpp
+++ b/gtsam/slam/lago.cpp
@@ -16,21 +16,20 @@
  *  @date   May 14, 2014
  */
 
-#include <gtsam/slam/lago.h>
-
-#include <gtsam/slam/InitializePose.h>
-#include <gtsam/slam/BetweenFactor.h>
-#include <gtsam/nonlinear/PriorFactor.h>
-#include <gtsam/geometry/Pose2.h>
-#include <gtsam/inference/Symbol.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/VectorConstants.h>
-#include <gtsam/base/timing.h>
 #include <gtsam/base/kruskal.h>
+#include <gtsam/base/timing.h>
+#include <gtsam/geometry/Pose2.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/nonlinear/PriorFactor.h>
+#include <gtsam/slam/BetweenFactor.h>
+#include <gtsam/slam/InitializePose.h>
+#include <gtsam/slam/lago.h>
 
+#include <cmath>
 #include <iostream>
 #include <stack>
-#include <cmath>
 
 using namespace std;
 

--- a/gtsam/slam/tests/testEssentialMatrixConstraint.cpp
+++ b/gtsam/slam/tests/testEssentialMatrixConstraint.cpp
@@ -17,14 +17,13 @@
  *  @date Jan 5, 2014
  */
 
-#include <gtsam/slam/EssentialMatrixConstraint.h>
-#include <gtsam/nonlinear/Symbol.h>
-#include <gtsam/geometry/Pose3.h>
-#include <gtsam/base/numericalDerivative.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/TestableAssertions.h>
 #include <gtsam/base/VectorConstants.h>
-
-#include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/numericalDerivative.h>
+#include <gtsam/geometry/Pose3.h>
+#include <gtsam/nonlinear/Symbol.h>
+#include <gtsam/slam/EssentialMatrixConstraint.h>
 
 using namespace std::placeholders;
 using namespace std;

--- a/gtsam/slam/tests/testEssentialMatrixConstraint.cpp
+++ b/gtsam/slam/tests/testEssentialMatrixConstraint.cpp
@@ -22,6 +22,7 @@
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/base/TestableAssertions.h>
+#include <gtsam/base/VectorConstants.h>
 
 #include <CppUnitLite/TestHarness.h>
 

--- a/gtsam/slam/tests/testFrobeniusFactor.cpp
+++ b/gtsam/slam/tests/testFrobeniusFactor.cpp
@@ -18,6 +18,7 @@
   * @brief  Check evaluateError for various Frobenius norms
   */
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/lieProxies.h>
 #include <gtsam/base/testLie.h>
 #include <gtsam/geometry/Pose2.h>

--- a/gtsam/slam/tests/testFrobeniusFactor.cpp
+++ b/gtsam/slam/tests/testFrobeniusFactor.cpp
@@ -18,24 +18,23 @@
   * @brief  Check evaluateError for various Frobenius norms
   */
 
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/lieProxies.h>
 #include <gtsam/base/testLie.h>
+#include <gtsam/geometry/Gal3.h>
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/geometry/Rot3.h>
-#include <gtsam/geometry/Similarity2.h>
-#include <gtsam/geometry/Similarity3.h>
+#include <gtsam/geometry/SL4.h>
 #include <gtsam/geometry/SO3.h>
 #include <gtsam/geometry/SO4.h>
-#include <gtsam/geometry/Gal3.h>
-#include <gtsam/geometry/SL4.h>
-#include <gtsam/nonlinear/factorTesting.h>
+#include <gtsam/geometry/Similarity2.h>
+#include <gtsam/geometry/Similarity3.h>
 #include <gtsam/nonlinear/GaussNewtonOptimizer.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <gtsam/nonlinear/factorTesting.h>
 #include <gtsam/slam/FrobeniusFactor.h>
-
-#include <CppUnitLite/TestHarness.h>
 
 using namespace gtsam;
 

--- a/gtsam/slam/tests/testInitializePose3.cpp
+++ b/gtsam/slam/tests/testInitializePose3.cpp
@@ -18,13 +18,13 @@
  *  @date   August, 2014
  */
 
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/geometry/Pose3.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/slam/BetweenFactor.h>
 #include <gtsam/slam/InitializePose3.h>
 #include <gtsam/slam/dataset.h>
-#include <gtsam/slam/BetweenFactor.h>
-#include <gtsam/inference/Symbol.h>
-#include <gtsam/geometry/Pose3.h>
-#include <gtsam/base/MatrixConstants.h>
-#include <CppUnitLite/TestHarness.h>
 
 #include <cmath>
 

--- a/gtsam/slam/tests/testInitializePose3.cpp
+++ b/gtsam/slam/tests/testInitializePose3.cpp
@@ -23,6 +23,7 @@
 #include <gtsam/slam/BetweenFactor.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/geometry/Pose3.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <CppUnitLite/TestHarness.h>
 
 #include <cmath>

--- a/gtsam/slam/tests/testPoseRotationPrior.cpp
+++ b/gtsam/slam/tests/testPoseRotationPrior.cpp
@@ -8,12 +8,11 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
-
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
-
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/geometry/Pose3.h>
-
 #include <gtsam/slam/PoseRotationPrior.h>
 
 using namespace gtsam;

--- a/gtsam/slam/tests/testPoseTranslationPrior.cpp
+++ b/gtsam/slam/tests/testPoseTranslationPrior.cpp
@@ -6,11 +6,10 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
-
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/geometry/Pose3.h>
-
 #include <gtsam/slam/PoseTranslationPrior.h>
 
 using namespace gtsam;

--- a/gtsam/slam/tests/testReferenceFrameFactor.cpp
+++ b/gtsam/slam/tests/testReferenceFrameFactor.cpp
@@ -14,20 +14,18 @@
  * @author Alex Cunningham
  */
 
-#include <iostream>
-
 #include <CppUnitLite/TestHarness.h>
-
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/inference/Symbol.h>
-#include <gtsam/nonlinear/NonlinearFactorGraph.h>
-#include <gtsam/nonlinear/NonlinearEquality.h>
 #include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
-
+#include <gtsam/nonlinear/NonlinearEquality.h>
+#include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/slam/ReferenceFrameFactor.h>
+
+#include <iostream>
 
 using namespace std;
 using namespace boost;

--- a/gtsam/slam/tests/testReferenceFrameFactor.cpp
+++ b/gtsam/slam/tests/testReferenceFrameFactor.cpp
@@ -19,6 +19,7 @@
 #include <CppUnitLite/TestHarness.h>
 
 #include <gtsam/base/Testable.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/inference/Symbol.h>

--- a/gtsam/slam/tests/testRegularImplicitSchurFactor.cpp
+++ b/gtsam/slam/tests/testRegularImplicitSchurFactor.cpp
@@ -25,6 +25,7 @@
 #include <gtsam/linear/VectorValues.h>
 #include <gtsam/linear/NoiseModel.h>
 #include <gtsam/linear/GaussianFactor.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/timing.h>
 
 #include <CppUnitLite/TestHarness.h>

--- a/gtsam/slam/tests/testRegularImplicitSchurFactor.cpp
+++ b/gtsam/slam/tests/testRegularImplicitSchurFactor.cpp
@@ -16,19 +16,17 @@
  * @date    Oct 20, 2013
  */
 
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/timing.h>
+#include <gtsam/geometry/CalibratedCamera.h>
+#include <gtsam/geometry/Point2.h>
+#include <gtsam/linear/GaussianFactor.h>
+#include <gtsam/linear/NoiseModel.h>
+#include <gtsam/linear/VectorValues.h>
 #include <gtsam/slam/JacobianFactorQ.h>
 #include <gtsam/slam/JacobianFactorQR.h>
 #include <gtsam/slam/RegularImplicitSchurFactor.h>
-#include <gtsam/geometry/CalibratedCamera.h>
-#include <gtsam/geometry/Point2.h>
-
-#include <gtsam/linear/VectorValues.h>
-#include <gtsam/linear/NoiseModel.h>
-#include <gtsam/linear/GaussianFactor.h>
-#include <gtsam/base/MatrixConstants.h>
-#include <gtsam/base/timing.h>
-
-#include <CppUnitLite/TestHarness.h>
 
 using namespace std;
 using namespace gtsam;

--- a/gtsam/slam/tests/testRotateFactor.cpp
+++ b/gtsam/slam/tests/testRotateFactor.cpp
@@ -5,13 +5,13 @@
  * @date December 17, 2013
  */
 
-#include <gtsam/slam/RotateFactor.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/VectorConstants.h>
-#include <gtsam/nonlinear/NonlinearFactorGraph.h>
-#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
 #include <gtsam/base/numericalDerivative.h>
-#include <CppUnitLite/TestHarness.h>
+#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
+#include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <gtsam/slam/RotateFactor.h>
 
 #include <vector>
 

--- a/gtsam/slam/tests/testRotateFactor.cpp
+++ b/gtsam/slam/tests/testRotateFactor.cpp
@@ -7,6 +7,7 @@
 
 #include <gtsam/slam/RotateFactor.h>
 #include <gtsam/base/Testable.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
 #include <gtsam/base/numericalDerivative.h>
@@ -233,4 +234,3 @@ int main() {
   return TestRegistry::runAllTests(tr);
 }
 /* ************************************************************************* */
-

--- a/gtsam/slam/tests/testSmartProjectionFactor.cpp
+++ b/gtsam/slam/tests/testSmartProjectionFactor.cpp
@@ -20,6 +20,7 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
 #include <gtsam/sfm/SfmTrack.h>
 #include <gtsam/slam/SmartProjectionFactor.h>

--- a/gtsam/slam/tests/testSmartProjectionPoseFactor.cpp
+++ b/gtsam/slam/tests/testSmartProjectionPoseFactor.cpp
@@ -23,6 +23,7 @@
 #include <gtsam/slam/ProjectionFactor.h>
 #include <gtsam/slam/PoseTranslationPrior.h>
 #include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <CppUnitLite/TestHarness.h>
 #include <iostream>

--- a/gtsam/slam/tests/testSmartProjectionPoseFactor.cpp
+++ b/gtsam/slam/tests/testSmartProjectionPoseFactor.cpp
@@ -19,14 +19,16 @@
  *  @date   Sept 2013
  */
 
-#include "smartFactorScenarios.h"
-#include <gtsam/slam/ProjectionFactor.h>
-#include <gtsam/slam/PoseTranslationPrior.h>
-#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
-#include <CppUnitLite/TestHarness.h>
+#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
+#include <gtsam/slam/PoseTranslationPrior.h>
+#include <gtsam/slam/ProjectionFactor.h>
+
 #include <iostream>
+
+#include "smartFactorScenarios.h"
 
 using namespace std::placeholders;
 

--- a/gtsam/slam/tests/testSmartProjectionRigFactor.cpp
+++ b/gtsam/slam/tests/testSmartProjectionRigFactor.cpp
@@ -20,6 +20,7 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/base/serializationTestHelpers.h>
 #include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>

--- a/gtsam_unstable/dynamics/SimpleHelicopter.h
+++ b/gtsam_unstable/dynamics/SimpleHelicopter.h
@@ -8,10 +8,11 @@
 #pragma once
 
 #include <gtsam/base/MatrixConstants.h>
-#include <gtsam/nonlinear/NonlinearFactor.h>
-#include <gtsam/nonlinear/NoiseModelFactorN.h>
-#include <gtsam/geometry/Pose3.h>
 #include <gtsam/base/numericalDerivative.h>
+#include <gtsam/geometry/Pose3.h>
+#include <gtsam/nonlinear/NoiseModelFactorN.h>
+#include <gtsam/nonlinear/NonlinearFactor.h>
+
 #include <cmath>
 
 namespace gtsam {

--- a/gtsam_unstable/dynamics/SimpleHelicopter.h
+++ b/gtsam_unstable/dynamics/SimpleHelicopter.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/NoiseModelFactorN.h>
 #include <gtsam/geometry/Pose3.h>

--- a/gtsam_unstable/dynamics/tests/testPendulumFactors.cpp
+++ b/gtsam_unstable/dynamics/tests/testPendulumFactors.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam_unstable/dynamics/Pendulum.h>
 

--- a/gtsam_unstable/dynamics/tests/testPoseRTV.cpp
+++ b/gtsam_unstable/dynamics/tests/testPoseRTV.cpp
@@ -4,10 +4,11 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/TestableAssertions.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
-
 #include <gtsam_unstable/dynamics/PoseRTV.h>
 
 using namespace gtsam;

--- a/gtsam_unstable/dynamics/tests/testSimpleHelicopter.cpp
+++ b/gtsam_unstable/dynamics/tests/testSimpleHelicopter.cpp
@@ -5,6 +5,7 @@
 
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/Vector.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/inference/Symbol.h>

--- a/gtsam_unstable/dynamics/tests/testVelocityConstraint.cpp
+++ b/gtsam_unstable/dynamics/tests/testVelocityConstraint.cpp
@@ -4,7 +4,7 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
-
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam_unstable/dynamics/VelocityConstraint.h>
 
 using namespace gtsam;

--- a/gtsam_unstable/dynamics/tests/testVelocityConstraint3.cpp
+++ b/gtsam_unstable/dynamics/tests/testVelocityConstraint3.cpp
@@ -4,7 +4,7 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
-
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam_unstable/dynamics/VelocityConstraint3.h>
 

--- a/gtsam_unstable/examples/ISAM2_SmartFactorStereo_IMU.cpp
+++ b/gtsam_unstable/examples/ISAM2_SmartFactorStereo_IMU.cpp
@@ -8,6 +8,7 @@
  * The data file is at examples/Data/ISAM2_SmartFactorStereo_IMU.txt
  * It contains 5 frames of stereo matches and IMU data.
  */
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/navigation/CombinedImuFactor.h>
 #include <gtsam/nonlinear/ISAM2.h>
 #include <gtsam_unstable/slam/SmartStereoProjectionPoseFactor.h>

--- a/gtsam_unstable/geometry/ABC.h
+++ b/gtsam_unstable/geometry/ABC.h
@@ -36,9 +36,11 @@
 
 #include <gtsam/base/GroupAction.h>
 #include <gtsam/base/Matrix.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/MatrixLieGroup.h>
 #include <gtsam/base/ProductLieGroup.h>
 #include <gtsam/base/Vector.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/geometry/Point3.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/geometry/Rot3.h>

--- a/gtsam_unstable/geometry/ABCEquivariantFilter.h
+++ b/gtsam_unstable/geometry/ABCEquivariantFilter.h
@@ -16,6 +16,7 @@
 
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/Vector.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/geometry/Rot3.h>
 #include <gtsam/geometry/Unit3.h>
 #include <gtsam/navigation/EquivariantFilter.h>

--- a/gtsam_unstable/geometry/InvDepthCamera3.h
+++ b/gtsam_unstable/geometry/InvDepthCamera3.h
@@ -14,6 +14,7 @@
 #include <cmath>
 #include <gtsam/base/Vector.h>
 #include <gtsam/base/Matrix.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/geometry/Point2.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/geometry/PinholeCamera.h>

--- a/gtsam_unstable/geometry/InvDepthCamera3.h
+++ b/gtsam_unstable/geometry/InvDepthCamera3.h
@@ -11,14 +11,15 @@
 
 #pragma once
 
-#include <cmath>
-#include <gtsam/base/Vector.h>
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/Vector.h>
+#include <gtsam/geometry/PinholeCamera.h>
 #include <gtsam/geometry/Point2.h>
 #include <gtsam/geometry/Pose3.h>
-#include <gtsam/geometry/PinholeCamera.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
+
+#include <cmath>
 
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/nvp.hpp>

--- a/gtsam_unstable/geometry/Pose3Upright.cpp
+++ b/gtsam_unstable/geometry/Pose3Upright.cpp
@@ -5,13 +5,13 @@
  * @author Alex Cunningham
  */
 
-#include <iostream>
-#include <cassert>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/OptionalJacobian.h>
 #include <gtsam/base/Vector.h>
-
 #include <gtsam_unstable/geometry/Pose3Upright.h>
+
+#include <cassert>
+#include <iostream>
 
 using namespace std;
 

--- a/gtsam_unstable/geometry/Pose3Upright.cpp
+++ b/gtsam_unstable/geometry/Pose3Upright.cpp
@@ -7,6 +7,7 @@
 
 #include <iostream>
 #include <cassert>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/OptionalJacobian.h>
 #include <gtsam/base/Vector.h>
 

--- a/gtsam_unstable/geometry/tests/testABC.cpp
+++ b/gtsam_unstable/geometry/tests/testABC.cpp
@@ -10,6 +10,8 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/base/testLie.h>
 #include <gtsam/navigation/EquivariantFilter.h>

--- a/gtsam_unstable/geometry/tests/testBearingS2.cpp
+++ b/gtsam_unstable/geometry/tests/testBearingS2.cpp
@@ -8,9 +8,8 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
-
 #include <gtsam/base/TestableAssertions.h>
-
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam_unstable/geometry/BearingS2.h>
 
 using namespace gtsam;

--- a/gtsam_unstable/geometry/tests/testPose3Upright.cpp
+++ b/gtsam_unstable/geometry/tests/testPose3Upright.cpp
@@ -6,10 +6,9 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
-
 #include <gtsam/base/TestableAssertions.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
-
 #include <gtsam_unstable/geometry/Pose3Upright.h>
 
 using namespace gtsam;

--- a/gtsam_unstable/linear/LPInitSolver.cpp
+++ b/gtsam_unstable/linear/LPInitSolver.cpp
@@ -21,6 +21,7 @@
 
 #ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam_unstable/linear/InfeasibleOrUnboundedProblem.h>
 #include <gtsam_unstable/linear/LPInitSolver.h>
 #include <gtsam_unstable/linear/LPSolver.h>

--- a/gtsam_unstable/linear/tests/testLPSolver.cpp
+++ b/gtsam_unstable/linear/tests/testLPSolver.cpp
@@ -21,6 +21,7 @@
 
 #ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/inference/FactorGraph-inst.h>
 #include <gtsam/inference/Symbol.h>

--- a/gtsam_unstable/linear/tests/testLinearEquality.cpp
+++ b/gtsam_unstable/linear/tests/testLinearEquality.cpp
@@ -20,7 +20,9 @@
 
 #ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/TestableAssertions.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/linear/HessianFactor.h>
 #include <gtsam/linear/VectorValues.h>
 #include <gtsam_unstable/linear/LinearEquality.h>

--- a/gtsam_unstable/linear/tests/testQPSolver.cpp
+++ b/gtsam_unstable/linear/tests/testQPSolver.cpp
@@ -22,7 +22,9 @@
 
 #ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam_unstable/linear/QPSolver.h>
 

--- a/gtsam_unstable/navigation/EqVIOCommon.h
+++ b/gtsam_unstable/navigation/EqVIOCommon.h
@@ -21,6 +21,7 @@
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/ProductLieGroup.h>
 #include <gtsam/base/Vector.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/geometry/Cal3_S2.h>
 #include <gtsam/geometry/ExtendedPose3.h>
 #include <gtsam/geometry/PinholeCamera.h>

--- a/gtsam_unstable/navigation/EqVIOState.cpp
+++ b/gtsam_unstable/navigation/EqVIOState.cpp
@@ -15,6 +15,7 @@
  * @author Rohan Bansal
  */
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam_unstable/navigation/EqVIOState.h>
 
 namespace gtsam {

--- a/gtsam_unstable/nonlinear/tests/testParticleFactor.cpp
+++ b/gtsam_unstable/nonlinear/tests/testParticleFactor.cpp
@@ -16,6 +16,7 @@
  * @date    Dec 9, 2013
  */
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/linear/NoiseModel.h>
 
 namespace gtsam {

--- a/gtsam_unstable/slam/AHRS.cpp
+++ b/gtsam_unstable/slam/AHRS.cpp
@@ -6,11 +6,21 @@
  */
 
 #include "AHRS.h"
+
+#include <gtsam/base/VectorConstants.h>
+
 #include <cmath>
 
 using namespace std;
 
 namespace gtsam {
+// Can't use macros because we need to take a pointer to the matrices
+static const Eigen::MatrixBase<Matrix3>::IdentityReturnType I3x3 =
+    Matrix3::Identity();
+static const Eigen::MatrixBase<Matrix9>::IdentityReturnType I9x9 =
+    Matrix9::Identity();
+static const Eigen::MatrixBase<Matrix3>::ConstantReturnType Z3x3 =
+    Matrix3::Constant(0);
 
 /* ************************************************************************* */
 Matrix3 AHRS::Cov(const Vector3s& m) {
@@ -43,8 +53,8 @@ AHRS::AHRS(const Matrix& stationaryU, const Matrix& stationaryF, double g_e,
   double tau_g = 730; // correlation time for gyroscope
   double tau_a = 730; // correlation time for accelerometer
 
-  F_g_ = -I_3x3 / tau_g;
-  F_a_ = -I_3x3 / tau_a;
+  F_g_ = -I3x3 / tau_g;
+  F_a_ = -I3x3 / tau_a;
   Vector3 var_omega_w = 0 * Vector::Ones(3); // TODO
   Vector3 var_omega_g = (0.0034 * 0.0034) * Vector::Ones(3);
   Vector3 var_omega_a = (0.034 * 0.034) * Vector::Ones(3);
@@ -83,22 +93,22 @@ std::pair<Mechanization_bRn2, KalmanFilter::State> AHRS::initialize(double g_e) 
       0.0, 0.0, 0.0).finished();                             // we don't know anything on yaw
 
   // Calculate the initial covariance matrix for the error state dx, Farrell08book eq. 10.66
-  Matrix Pa = 0.025 * 0.025 * I_3x3;
+  Matrix Pa = 0.025 * 0.025 * I3x3;
   Matrix P11 = Omega_T * (H_g * (Pa + Pa_) * trans(H_g)) * trans(Omega_T);
   P11(2, 2) = 0.0001;
   Matrix P12 = -Omega_T * H_g * Pa;
 
   Matrix P_plus_k2 = Matrix(9, 9);
   P_plus_k2.block<3,3>(0, 0) = P11;
-  P_plus_k2.block<3,3>(0, 3) = Z_3x3;
+  P_plus_k2.block<3,3>(0, 3) = Z3x3;
   P_plus_k2.block<3,3>(0, 6) = P12;
 
-  P_plus_k2.block<3,3>(3, 0) = Z_3x3;
+  P_plus_k2.block<3,3>(3, 0) = Z3x3;
   P_plus_k2.block<3,3>(3, 3) = Pg_;
-  P_plus_k2.block<3,3>(3, 6) = Z_3x3;
+  P_plus_k2.block<3,3>(3, 6) = Z3x3;
 
   P_plus_k2.block<3,3>(6, 0) = trans(P12);
-  P_plus_k2.block<3,3>(6, 3) = Z_3x3;
+  P_plus_k2.block<3,3>(6, 3) = Z3x3;
   P_plus_k2.block<3,3>(6, 6) = Pa;
 
   Vector dx = Z_9x1;
@@ -128,17 +138,17 @@ std::pair<Mechanization_bRn2, KalmanFilter::State> AHRS::integrate(
   Matrix9_12 G_k; G_k.setZero();
   G_k.block<3,3>(0, 0) = -bRn;
   G_k.block<3,3>(0, 6) = -bRn;
-  G_k.block<3,3>(3, 3) = I_3x3;
-  G_k.block<3,3>(6, 9) = I_3x3;
+  G_k.block<3,3>(3, 3) = I3x3;
+  G_k.block<3,3>(6, 9) = I3x3;
 
   Matrix9 Q_k = G_k * var_w_.asDiagonal() * G_k.transpose();
-  Matrix9 Psi_k = I_9x9 + dt * F_k; // +dt*dt*F_k*F_k/2; // transition matrix
+  Matrix9 PsIk = I9x9 + dt * F_k; // +dt*dt*F_k*F_k/2; // transition matrix
 
   // This implements update in section 10.6
   Matrix9 B; B.setZero();
   Vector9 u2; u2.setZero();
   // TODO predictQ should be templated to also take fixed size matrices.
-  KalmanFilter::State newState = KF_.predictQ(state, Psi_k,B,u2,dt*Q_k);
+  KalmanFilter::State newState = KF_.predictQ(state, PsIk,B,u2,dt*Q_k);
   return make_pair(newMech, newState);
 }
 
@@ -170,7 +180,7 @@ std::pair<Mechanization_bRn2, KalmanFilter::State> AHRS::aid(
   if (Farrell) {
     // calculate residual gravity measurement
     z = n_g_ - trans(bRn) * measured_b_g;
-    H = collect(3, &n_g_cross_, &Z_3x3, &bRn);
+    H = collect(3, &n_g_cross_, &Z3x3, &bRn);
     R = trans(bRn) * ((Vector3) sigmas_v_a_.array().square()).asDiagonal() * bRn;
   } else {
     // my measurement prediction (in body frame):
@@ -184,7 +194,7 @@ std::pair<Mechanization_bRn2, KalmanFilter::State> AHRS::aid(
     z = bRn * n_g_ - measured_b_g;
     // Now the Jacobian H
     Matrix b_g = bRn * n_g_cross_;
-    H = collect(3, &b_g, &Z_3x3, &I_3x3);
+    H = collect(3, &b_g, &Z3x3, &I3x3);
     // And the measurement noise, TODO: should be created once where sigmas_v_a is given
     R = ((Vector3) sigmas_v_a_.array().square()).asDiagonal();
   }
@@ -214,7 +224,7 @@ std::pair<Mechanization_bRn2, KalmanFilter::State> AHRS::aidGeneral(
   Vector z = f - increment * f_previous;
   //Vector z = increment * f_previous - f;
   Matrix b_g = skewSymmetric(increment* f_previous);
-  Matrix H = collect(3, &b_g, &I_3x3, &Z_3x3);
+  Matrix H = collect(3, &b_g, &I3x3, &Z3x3);
 //  Matrix R = diag(emul(sigmas_v_a_, sigmas_v_a_));
 //  Matrix R = diag(Vector3(1.0, 0.2, 1.0)); // good for L_twice
   Matrix R = Vector3(0.01, 0.0001, 0.01).asDiagonal();

--- a/gtsam_unstable/slam/BiasedGPSFactor.h
+++ b/gtsam_unstable/slam/BiasedGPSFactor.h
@@ -15,12 +15,12 @@
  **/
 #pragma once
 
-#include <ostream>
-
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/geometry/Pose3.h>
-#include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/NoiseModelFactorN.h>
+#include <gtsam/nonlinear/NonlinearFactor.h>
+
+#include <ostream>
 
 namespace gtsam {
 

--- a/gtsam_unstable/slam/BiasedGPSFactor.h
+++ b/gtsam_unstable/slam/BiasedGPSFactor.h
@@ -17,6 +17,7 @@
 
 #include <ostream>
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/NoiseModelFactorN.h>

--- a/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel.h
+++ b/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel.h
@@ -463,8 +463,8 @@ public:
     delta_t += msr_dt;
 
     // Update EquivCov_Overall
-    Matrix Z_3x3 = Z_3x3;
-    Matrix I_3x3 = I_3x3;
+    Matrix Z3x3 = Matrix3::Zero();
+    Matrix I3x3 = Matrix3::Identity();
 
     Matrix H_pos_pos = numericalDerivative11<Vector3, Vector3>(
         std::bind(&PreIntegrateIMUObservations_delta_pos, msr_dt,
@@ -475,7 +475,7 @@ public:
                     delta_pos_in_t0, std::placeholders::_1),
         delta_vel_in_t0);
     Matrix H_pos_angles = Z_3x3;
-    Matrix H_pos_bias = collect(2, &Z_3x3, &Z_3x3);
+    Matrix H_pos_bias = collect(2, &Z3x3, &Z3x3);
 
     Matrix H_vel_vel = numericalDerivative11<Vector3, Vector3>(
         std::bind(&PreIntegrateIMUObservations_delta_vel, msr_gyro_t,
@@ -511,8 +511,8 @@ public:
     Matrix F_angles = collect(4, &H_angles_angles, &H_angles_pos, &H_angles_vel, &H_angles_bias);
     Matrix F_pos    = collect(4, &H_pos_angles, &H_pos_pos, &H_pos_vel, &H_pos_bias);
     Matrix F_vel    = collect(4, &H_vel_angles, &H_vel_pos, &H_vel_vel, &H_vel_bias);
-    Matrix F_bias_a = collect(5, &Z_3x3, &Z_3x3, &Z_3x3, &I_3x3, &Z_3x3);
-    Matrix F_bias_g = collect(5, &Z_3x3, &Z_3x3, &Z_3x3, &Z_3x3, &I_3x3);
+    Matrix F_bias_a = collect(5, &Z3x3, &Z3x3, &Z3x3, &I3x3, &Z3x3);
+    Matrix F_bias_g = collect(5, &Z3x3, &Z3x3, &Z3x3, &Z3x3, &I3x3);
     Matrix F = stack(5, &F_angles, &F_pos, &F_vel, &F_bias_a, &F_bias_g);
 
 

--- a/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel_NoBias.h
+++ b/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel_NoBias.h
@@ -23,6 +23,7 @@
 #include <gtsam/linear/NoiseModel.h>
 #include <gtsam/geometry/Rot3.h>
 #include <gtsam/base/Matrix.h>
+#include <gtsam/base/MatrixConstants.h>
 
 // Using numerical derivative to calculate d(Pose3::Expmap)/dw
 #include <gtsam/base/numericalDerivative.h>
@@ -369,9 +370,6 @@ public:
     delta_t += msr_dt;
 
     // Update EquivCov_Overall
-    Matrix Z_3x3 = Z_3x3;
-    Matrix I_3x3 = I_3x3;
-
     Matrix H_pos_pos = numericalDerivative11<Vector, Vector>(std::bind(&PreIntegrateIMUObservations_delta_pos, msr_dt, _1, delta_vel_in_t0), delta_pos_in_t0);
     Matrix H_pos_vel = numericalDerivative11<Vector, Vector>(std::bind(&PreIntegrateIMUObservations_delta_pos, msr_dt, delta_pos_in_t0, _1), delta_vel_in_t0);
     Matrix H_pos_angles = Z_3x3;

--- a/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel_NoBias.h
+++ b/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel_NoBias.h
@@ -19,11 +19,11 @@
 
 #pragma once
 
-#include <gtsam/nonlinear/NonlinearFactor.h>
-#include <gtsam/linear/NoiseModel.h>
-#include <gtsam/geometry/Rot3.h>
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/MatrixConstants.h>
+#include <gtsam/geometry/Rot3.h>
+#include <gtsam/linear/NoiseModel.h>
+#include <gtsam/nonlinear/NonlinearFactor.h>
 
 // Using numerical derivative to calculate d(Pose3::Expmap)/dw
 #include <gtsam/base/numericalDerivative.h>

--- a/gtsam_unstable/slam/Mechanization_bRn2.h
+++ b/gtsam_unstable/slam/Mechanization_bRn2.h
@@ -9,6 +9,7 @@
 
 #include <gtsam/geometry/Rot3.h>
 #include <gtsam/base/Vector.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam_unstable/dllexport.h>
 #include <list>
 
@@ -85,7 +86,6 @@ public:
     std::cout << s + ".x_g" << x_g_ << std::endl;
     std::cout << s + ".x_a" << x_a_ << std::endl;
   }
-
 };
 
 } // namespace gtsam

--- a/gtsam_unstable/slam/Mechanization_bRn2.h
+++ b/gtsam_unstable/slam/Mechanization_bRn2.h
@@ -7,10 +7,11 @@
 
 #pragma once
 
-#include <gtsam/geometry/Rot3.h>
 #include <gtsam/base/Vector.h>
 #include <gtsam/base/VectorConstants.h>
+#include <gtsam/geometry/Rot3.h>
 #include <gtsam_unstable/dllexport.h>
+
 #include <list>
 
 namespace gtsam {

--- a/gtsam_unstable/slam/PosePriorFactor.h
+++ b/gtsam_unstable/slam/PosePriorFactor.h
@@ -15,6 +15,7 @@
  **/
 #pragma once
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/NoiseModelFactorN.h>
 #include <gtsam/geometry/concepts.h>

--- a/gtsam_unstable/slam/PosePriorFactor.h
+++ b/gtsam_unstable/slam/PosePriorFactor.h
@@ -16,10 +16,10 @@
 #pragma once
 
 #include <gtsam/base/MatrixConstants.h>
-#include <gtsam/nonlinear/NonlinearFactor.h>
-#include <gtsam/nonlinear/NoiseModelFactorN.h>
-#include <gtsam/geometry/concepts.h>
 #include <gtsam/base/Testable.h>
+#include <gtsam/geometry/concepts.h>
+#include <gtsam/nonlinear/NoiseModelFactorN.h>
+#include <gtsam/nonlinear/NonlinearFactor.h>
 
 namespace gtsam {
 

--- a/gtsam_unstable/slam/SmartRangeFactor.h
+++ b/gtsam_unstable/slam/SmartRangeFactor.h
@@ -9,18 +9,18 @@
 
 #pragma once
 
-#include <gtsam_unstable/dllexport.h>
 #include <gtsam/base/MatrixConstants.h>
-#include <gtsam/nonlinear/NonlinearFactor.h>
-#include <gtsam/inference/Key.h>
 #include <gtsam/geometry/Pose2.h>
+#include <gtsam/inference/Key.h>
+#include <gtsam/nonlinear/NonlinearFactor.h>
+#include <gtsam_unstable/dllexport.h>
 
 #include <list>
 #include <map>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
-#include <optional>
 
 namespace gtsam {
 

--- a/gtsam_unstable/slam/SmartRangeFactor.h
+++ b/gtsam_unstable/slam/SmartRangeFactor.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <gtsam_unstable/dllexport.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/inference/Key.h>
 #include <gtsam/geometry/Pose2.h>
@@ -185,4 +186,3 @@ class SmartRangeFactor: public NoiseModelFactor {
   }
 };
 }  // \namespace gtsam
-

--- a/gtsam_unstable/slam/tests/testDummyFactor.cpp
+++ b/gtsam_unstable/slam/tests/testDummyFactor.cpp
@@ -13,7 +13,9 @@
 #include <gtsam_unstable/slam/DummyFactor.h>
 
 #include <gtsam/geometry/Point3.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/TestableAssertions.h>
+#include <gtsam/base/VectorConstants.h>
 
 using namespace gtsam;
 
@@ -47,7 +49,7 @@ TEST( testDummyFactor, basics ) {
   CHECK(actLinearization);
   noiseModel::Diagonal::shared_ptr model3 = noiseModel::Unit::Create(3);
   GaussianFactor::shared_ptr expLinearization(new JacobianFactor(
-      key1, Matrix::Zero(3,3), key2, Matrix::Zero(3,3), Z_3x1, model3));
+      key1, Z_3x3, key2, Z_3x3, Z_3x1, model3));
   EXPECT(assert_equal(*expLinearization, *actLinearization, tol));
 }
 

--- a/gtsam_unstable/slam/tests/testDummyFactor.cpp
+++ b/gtsam_unstable/slam/tests/testDummyFactor.cpp
@@ -9,13 +9,11 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
-
-#include <gtsam_unstable/slam/DummyFactor.h>
-
-#include <gtsam/geometry/Point3.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/TestableAssertions.h>
 #include <gtsam/base/VectorConstants.h>
+#include <gtsam/geometry/Point3.h>
+#include <gtsam_unstable/slam/DummyFactor.h>
 
 using namespace gtsam;
 
@@ -48,8 +46,8 @@ TEST( testDummyFactor, basics ) {
   GaussianFactor::shared_ptr actLinearization = dummyfactor.linearize(c);
   CHECK(actLinearization);
   noiseModel::Diagonal::shared_ptr model3 = noiseModel::Unit::Create(3);
-  GaussianFactor::shared_ptr expLinearization(new JacobianFactor(
-      key1, Z_3x3, key2, Z_3x3, Z_3x1, model3));
+  GaussianFactor::shared_ptr expLinearization(
+      new JacobianFactor(key1, Z_3x3, key2, Z_3x3, Z_3x1, model3));
   EXPECT(assert_equal(*expLinearization, *actLinearization, tol));
 }
 

--- a/gtsam_unstable/slam/tests/testInertialNavFactor_GlobalVelocity.cpp
+++ b/gtsam_unstable/slam/tests/testInertialNavFactor_GlobalVelocity.cpp
@@ -15,16 +15,17 @@
  * @author  Vadim Indelman, Stephen Williams
  */
 
-#include <iostream>
 #include <CppUnitLite/TestHarness.h>
-#include <gtsam/navigation/ImuBias.h>
-#include <gtsam_unstable/slam/InertialNavFactor_GlobalVelocity.h>
-#include <gtsam/geometry/Pose3.h>
-#include <gtsam/nonlinear/Values.h>
-#include <gtsam/inference/Key.h>
-#include <gtsam/base/numericalDerivative.h>
 #include <gtsam/base/TestableAssertions.h>
 #include <gtsam/base/VectorConstants.h>
+#include <gtsam/base/numericalDerivative.h>
+#include <gtsam/geometry/Pose3.h>
+#include <gtsam/inference/Key.h>
+#include <gtsam/navigation/ImuBias.h>
+#include <gtsam/nonlinear/Values.h>
+#include <gtsam_unstable/slam/InertialNavFactor_GlobalVelocity.h>
+
+#include <iostream>
 
 using namespace std::placeholders;
 using namespace std;

--- a/gtsam_unstable/slam/tests/testInertialNavFactor_GlobalVelocity.cpp
+++ b/gtsam_unstable/slam/tests/testInertialNavFactor_GlobalVelocity.cpp
@@ -24,6 +24,7 @@
 #include <gtsam/inference/Key.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/base/TestableAssertions.h>
+#include <gtsam/base/VectorConstants.h>
 
 using namespace std::placeholders;
 using namespace std;

--- a/gtsam_unstable/slam/tests/testRelativeElevationFactor.cpp
+++ b/gtsam_unstable/slam/tests/testRelativeElevationFactor.cpp
@@ -9,6 +9,7 @@
 
 #include <gtsam_unstable/slam/RelativeElevationFactor.h>
 
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 
 using namespace std::placeholders;

--- a/gtsam_unstable/slam/tests/testRelativeElevationFactor.cpp
+++ b/gtsam_unstable/slam/tests/testRelativeElevationFactor.cpp
@@ -6,11 +6,9 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
-
-#include <gtsam_unstable/slam/RelativeElevationFactor.h>
-
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/numericalDerivative.h>
+#include <gtsam_unstable/slam/RelativeElevationFactor.h>
 
 using namespace std::placeholders;
 using namespace gtsam;

--- a/gtsam_unstable/slam/tests/testTransformBtwRobotsUnaryFactor.cpp
+++ b/gtsam_unstable/slam/tests/testTransformBtwRobotsUnaryFactor.cpp
@@ -5,19 +5,15 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
-
-
-#include <gtsam_unstable/slam/TransformBtwRobotsUnaryFactor.h>
-#include <gtsam/geometry/Pose2.h>
-#include <gtsam/nonlinear/Values.h>
 #include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
-
-#include <gtsam/slam/BetweenFactor.h>
-
-#include <gtsam/nonlinear/NonlinearOptimizer.h>
-#include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <gtsam/geometry/Pose2.h>
 #include <gtsam/nonlinear/GaussNewtonOptimizer.h>
+#include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <gtsam/nonlinear/NonlinearOptimizer.h>
+#include <gtsam/nonlinear/Values.h>
+#include <gtsam/slam/BetweenFactor.h>
+#include <gtsam_unstable/slam/TransformBtwRobotsUnaryFactor.h>
 
 using namespace std::placeholders;
 using namespace std;

--- a/gtsam_unstable/slam/tests/testTransformBtwRobotsUnaryFactor.cpp
+++ b/gtsam_unstable/slam/tests/testTransformBtwRobotsUnaryFactor.cpp
@@ -10,6 +10,7 @@
 #include <gtsam_unstable/slam/TransformBtwRobotsUnaryFactor.h>
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/nonlinear/Values.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 
 #include <gtsam/slam/BetweenFactor.h>

--- a/gtsam_unstable/slam/tests/testTransformBtwRobotsUnaryFactorEM.cpp
+++ b/gtsam_unstable/slam/tests/testTransformBtwRobotsUnaryFactorEM.cpp
@@ -10,6 +10,7 @@
 #include <gtsam_unstable/slam/TransformBtwRobotsUnaryFactorEM.h>
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/nonlinear/Values.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 
 #include <gtsam/slam/BetweenFactor.h>

--- a/gtsam_unstable/slam/tests/testTransformBtwRobotsUnaryFactorEM.cpp
+++ b/gtsam_unstable/slam/tests/testTransformBtwRobotsUnaryFactorEM.cpp
@@ -5,19 +5,15 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
-
-
-#include <gtsam_unstable/slam/TransformBtwRobotsUnaryFactorEM.h>
-#include <gtsam/geometry/Pose2.h>
-#include <gtsam/nonlinear/Values.h>
 #include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
-
-#include <gtsam/slam/BetweenFactor.h>
-
-#include <gtsam/nonlinear/NonlinearOptimizer.h>
-#include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <gtsam/geometry/Pose2.h>
 #include <gtsam/nonlinear/GaussNewtonOptimizer.h>
+#include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <gtsam/nonlinear/NonlinearOptimizer.h>
+#include <gtsam/nonlinear/Values.h>
+#include <gtsam/slam/BetweenFactor.h>
+#include <gtsam_unstable/slam/TransformBtwRobotsUnaryFactorEM.h>
 
 using namespace std::placeholders;
 using namespace std;

--- a/tests/simulated2D.h
+++ b/tests/simulated2D.h
@@ -91,7 +91,7 @@ namespace simulated2D {
 
   /// Prior on a single pose, optionally returns derivative
   inline Point2 prior(const Point2& x, OptionalJacobian<2,2> H = OptionalNone) {
-    if (H) *H = I_2x2;
+    if (H) *H = Matrix2::Identity();
     return x;
   }
 
@@ -104,9 +104,9 @@ namespace simulated2D {
   inline Point2 odo(const Point2& x1, const Point2& x2, 
 		  OptionalJacobian<2,2> H1 = OptionalNone, 
 		  OptionalJacobian<2,2> H2 = OptionalNone) {
-      if (H1) *H1 = -I_2x2;
-      if (H2) *H2 = I_2x2;
-      return x2 - x1;
+    if (H1) *H1 = -Matrix2::Identity();
+    if (H2) *H2 = Matrix2::Identity();
+    return x2 - x1;
   }
 
   /// measurement between landmark and pose
@@ -117,9 +117,9 @@ namespace simulated2D {
   /// measurement between landmark and pose, optionally returns derivative
   inline Point2 mea(const Point2& x, const Point2& l, OptionalJacobian<2,2> H1 =
     OptionalNone, OptionalMatrixType H2 = OptionalNone) {
-      if (H1) *H1 = -I_2x2;
-      if (H2) *H2 = I_2x2;
-      return l - x;
+    if (H1) *H1 = -Matrix2::Identity();
+    if (H2) *H2 = Matrix2::Identity();
+    return l - x;
   }
 
   /**

--- a/tests/simulated2DOriented.h
+++ b/tests/simulated2DOriented.h
@@ -64,7 +64,7 @@ namespace simulated2DOriented {
 
   /// Prior on a single pose, optional derivative version
   Pose2 prior(const Pose2& x, OptionalJacobian<3,3> H = OptionalNone) {
-    if (H) *H = I_3x3;
+    if (H) *H = Matrix3::Identity();
     return x;
   }
 

--- a/tests/simulated3D.h
+++ b/tests/simulated3D.h
@@ -41,7 +41,7 @@ namespace simulated3D {
  * Prior on a single pose
  */
 Point3 prior(const Point3& x, OptionalJacobian<3,3> H = OptionalNone) {
-  if (H) *H = I_3x3;
+  if (H) *H = Matrix3::Identity();
   return x;
 }
 
@@ -51,8 +51,8 @@ Point3 prior(const Point3& x, OptionalJacobian<3,3> H = OptionalNone) {
 Point3 odo(const Point3& x1, const Point3& x2,
     OptionalJacobian<3,3> H1 = OptionalNone,
     OptionalJacobian<3,3> H2 = OptionalNone) {
-  if (H1) *H1 = -1 * I_3x3;
-  if (H2) *H2 = I_3x3;
+  if (H1) *H1 = -1 * Matrix3::Identity();
+  if (H2) *H2 = Matrix3::Identity();
   return x2 - x1;
 }
 
@@ -62,8 +62,8 @@ Point3 odo(const Point3& x1, const Point3& x2,
 Point3 mea(const Point3& x, const Point3& l,
     OptionalJacobian<3,3> H1 = OptionalNone,
     OptionalJacobian<3,3> H2 = OptionalNone) {
-  if (H1) *H1 = -1 * I_3x3;
-  if (H2) *H2 = I_3x3;
+  if (H1) *H1 = -1 * Matrix3::Identity();
+  if (H2) *H2 = Matrix3::Identity();
   return l - x;
 }
 

--- a/tests/smallExample.h
+++ b/tests/smallExample.h
@@ -260,9 +260,9 @@ inline VectorValues createZeroDelta() {
   using symbol_shorthand::X;
   using symbol_shorthand::L;
   VectorValues c;
-  c.insert(L(1), Z_2x1);
-  c.insert(X(1), Z_2x1);
-  c.insert(X(2), Z_2x1);
+  c.insert(L(1), Vector2::Zero());
+  c.insert(X(1), Vector2::Zero());
+  c.insert(X(2), Vector2::Zero());
   return c;
 }
 
@@ -274,16 +274,22 @@ inline GaussianFactorGraph createGaussianFactorGraph() {
   GaussianFactorGraph fg;
 
   // linearized prior on x1: c[_x1_]+x1=0 i.e. x1=-c[_x1_]
-  fg.emplace_shared<JacobianFactor>(X(1), 10*I_2x2, -1.0*Vector::Ones(2));
+  fg.emplace_shared<JacobianFactor>(X(1), 10 * Matrix2::Identity(),
+                                    -1.0 * Vector::Ones(2));
 
   // odometry between x1 and x2: x2-x1=[0.2;-0.1]
-  fg.emplace_shared<JacobianFactor>(X(1), -10*I_2x2, X(2), 10*I_2x2, Vector2(2.0, -1.0));
+  fg.emplace_shared<JacobianFactor>(X(1), -10 * Matrix2::Identity(), X(2),
+                                    10 * Matrix2::Identity(),
+                                    Vector2(2.0, -1.0));
 
   // measurement between x1 and l1: l1-x1=[0.0;0.2]
-  fg.emplace_shared<JacobianFactor>(X(1), -5*I_2x2, L(1), 5*I_2x2, Vector2(0.0, 1.0));
+  fg.emplace_shared<JacobianFactor>(X(1), -5 * Matrix2::Identity(), L(1),
+                                    5 * Matrix2::Identity(), Vector2(0.0, 1.0));
 
   // measurement between x2 and l1: l1-x2=[-0.2;0.3]
-  fg.emplace_shared<JacobianFactor>(X(2), -5*I_2x2, L(1), 5*I_2x2, Vector2(-1.0, 1.5));
+  fg.emplace_shared<JacobianFactor>(X(2), -5 * Matrix2::Identity(), L(1),
+                                    5 * Matrix2::Identity(),
+                                    Vector2(-1.0, 1.5));
 
   return fg;
 }
@@ -472,7 +478,7 @@ inline GaussianFactorGraph createSimpleConstraintGraph() {
   using namespace impl;
   // create unary factor
   // prior on _x_, mean = [1,-1], sigma=0.1
-  Matrix Ax = I_2x2;
+  Matrix Ax = Matrix2::Identity();
   Vector b1(2);
   b1(0) = 1.0;
   b1(1) = -1.0;
@@ -482,8 +488,8 @@ inline GaussianFactorGraph createSimpleConstraintGraph() {
   // between _x_ and _y_, that is going to be the only factor on _y_
   // |1 0||x_1| + |-1  0||y_1| = |0|
   // |0 1||x_2|   | 0 -1||y_2|   |0|
-  Matrix Ax1 = I_2x2;
-  Matrix Ay1 = I_2x2 * -1;
+  Matrix Ax1 = Matrix2::Identity();
+  Matrix Ay1 = Matrix2::Identity() * -1;
   Vector b2 = Vector2(0.0, 0.0);
   JacobianFactor::shared_ptr f2(new JacobianFactor(_x_, Ax1, _y_, Ay1, b2,
       kConstrainedModel));
@@ -513,7 +519,7 @@ inline GaussianFactorGraph createSingleConstraintGraph() {
   using namespace impl;
   // create unary factor
   // prior on _x_, mean = [1,-1], sigma=0.1
-  Matrix Ax = I_2x2;
+  Matrix Ax = Matrix2::Identity();
   Vector b1(2);
   b1(0) = 1.0;
   b1(1) = -1.0;
@@ -529,7 +535,7 @@ inline GaussianFactorGraph createSingleConstraintGraph() {
   Ax1(0, 1) = 2.0;
   Ax1(1, 0) = 2.0;
   Ax1(1, 1) = 1.0;
-  Matrix Ay1 = I_2x2 * 10;
+  Matrix Ay1 = Matrix2::Identity() * 10;
   Vector b2 = Vector2(1.0, 2.0);
   JacobianFactor::shared_ptr f2(new JacobianFactor(_x_, Ax1, _y_, Ay1, b2,
       kConstrainedModel));
@@ -553,7 +559,7 @@ inline VectorValues createSingleConstraintValues() {
 inline GaussianFactorGraph createMultiConstraintGraph() {
   using namespace impl;
   // unary factor 1
-  Matrix A = I_2x2;
+  Matrix A = Matrix2::Identity();
   Vector b = Vector2(-2.0, 2.0);
   JacobianFactor::shared_ptr lf1(new JacobianFactor(_x_, A, b, kSigma0_1));
 

--- a/tests/testBoundingConstraint.cpp
+++ b/tests/testBoundingConstraint.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <tests/simulated2DConstraints.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>

--- a/tests/testBoundingConstraint.cpp
+++ b/tests/testBoundingConstraint.cpp
@@ -15,14 +15,13 @@
  * @author Alex Cunningham
  */
 
-#include <tests/simulated2DConstraints.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/inference/Symbol.h>
-#include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
 #include <gtsam/nonlinear/LevenbergMarquardtParams.h>
-
-#include <CppUnitLite/TestHarness.h>
+#include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <tests/simulated2DConstraints.h>
 
 namespace iq2D = simulated2D::inequality_constraints;
 using namespace std;

--- a/tests/testExpressionFactor.cpp
+++ b/tests/testExpressionFactor.cpp
@@ -18,7 +18,9 @@
  */
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/nonlinear/ExpressionFactor.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>

--- a/tests/testGaussianBayesTreeB.cpp
+++ b/tests/testGaussianBayesTreeB.cpp
@@ -15,19 +15,18 @@
  * @author  Michael Kaess
  */
 
-#include <tests/smallExample.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/VectorConstants.h>
+#include <gtsam/geometry/Rot2.h>
 #include <gtsam/inference/Symbol.h>
-#include <gtsam/linear/GaussianBayesTree.h>
 #include <gtsam/linear/GaussianBayesNet.h>
+#include <gtsam/linear/GaussianBayesTree.h>
 #include <gtsam/linear/GaussianConditional.h>
 #include <gtsam/linear/GaussianDensity.h>
 #include <gtsam/linear/HessianFactor.h>
-#include <gtsam/geometry/Rot2.h>
 #include <gtsam/nonlinear/Marginals.h>
-
-#include <CppUnitLite/TestHarness.h>
+#include <tests/smallExample.h>
 
 using namespace std;
 using namespace gtsam;

--- a/tests/testGaussianBayesTreeB.cpp
+++ b/tests/testGaussianBayesTreeB.cpp
@@ -16,6 +16,8 @@
  */
 
 #include <tests/smallExample.h>
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/linear/GaussianBayesTree.h>
 #include <gtsam/linear/GaussianBayesNet.h>

--- a/tests/testGaussianFactorGraphB.cpp
+++ b/tests/testGaussianFactorGraphB.cpp
@@ -15,19 +15,18 @@
  *  @author Christian Potthast
  **/
 
-#include <tests/smallExample.h>
-#include <gtsam/inference/Symbol.h>
-#include <gtsam/linear/GaussianBayesNet.h>
-#include <gtsam/linear/GaussianBayesTree.h>
-#include <gtsam/linear/GaussianFactorGraph.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/VectorConstants.h>
-
-#include <CppUnitLite/TestHarness.h>
-
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/linear/GaussianBayesNet.h>
+#include <gtsam/linear/GaussianBayesTree.h>
+#include <gtsam/linear/GaussianFactorGraph.h>
 #include <string.h>
+#include <tests/smallExample.h>
+
 #include <iostream>
 
 using namespace std;

--- a/tests/testGaussianFactorGraphB.cpp
+++ b/tests/testGaussianFactorGraphB.cpp
@@ -21,7 +21,9 @@
 #include <gtsam/linear/GaussianBayesTree.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
 #include <gtsam/base/Matrix.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
+#include <gtsam/base/VectorConstants.h>
 
 #include <CppUnitLite/TestHarness.h>
 

--- a/tests/testGraph.cpp
+++ b/tests/testGraph.cpp
@@ -16,20 +16,18 @@
  * @brief unit test for graph-inl.h
  */
 
-#include <gtsam/slam/BetweenFactor.h>
-#include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/geometry/Pose2.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/inference/graph.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
 #include <gtsam/linear/JacobianFactor.h>
-#include <gtsam/inference/graph.h>
-#include <gtsam/inference/Symbol.h>
-#include <gtsam/geometry/Pose2.h>
-#include <gtsam/base/MatrixConstants.h>
-
-#include <CppUnitLite/TestHarness.h>
-
-#include <memory>
+#include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <gtsam/slam/BetweenFactor.h>
 
 #include <iostream>
+#include <memory>
 
 using namespace std;
 using namespace gtsam;

--- a/tests/testGraph.cpp
+++ b/tests/testGraph.cpp
@@ -23,6 +23,7 @@
 #include <gtsam/inference/graph.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/geometry/Pose2.h>
+#include <gtsam/base/MatrixConstants.h>
 
 #include <CppUnitLite/TestHarness.h>
 

--- a/tests/testImuPreintegration.cpp
+++ b/tests/testImuPreintegration.cpp
@@ -16,6 +16,7 @@
  **/
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/navigation/CombinedImuFactor.h>
 #include <gtsam/slam/dataset.h>

--- a/tests/testIterative.cpp
+++ b/tests/testIterative.cpp
@@ -15,15 +15,14 @@
  *  @author Frank Dellaert
  **/
 
-#include <tests/smallExample.h>
-#include <gtsam/slam/BetweenFactor.h>
-#include <gtsam/nonlinear/NonlinearEquality.h>
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/VectorConstants.h>
+#include <gtsam/geometry/Pose2.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/linear/iterative.h>
-#include <gtsam/geometry/Pose2.h>
-#include <gtsam/base/VectorConstants.h>
-
-#include <CppUnitLite/TestHarness.h>
+#include <gtsam/nonlinear/NonlinearEquality.h>
+#include <gtsam/slam/BetweenFactor.h>
+#include <tests/smallExample.h>
 
 using namespace std;
 using namespace gtsam;

--- a/tests/testIterative.cpp
+++ b/tests/testIterative.cpp
@@ -21,6 +21,7 @@
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/linear/iterative.h>
 #include <gtsam/geometry/Pose2.h>
+#include <gtsam/base/VectorConstants.h>
 
 #include <CppUnitLite/TestHarness.h>
 

--- a/tests/testManifold.cpp
+++ b/tests/testManifold.cpp
@@ -18,14 +18,14 @@
  */
 
 #include <gtsam/base/Manifold.h>
+#include <gtsam/base/Testable.h>
 #include <gtsam/base/VectorConstants.h>
-#include <gtsam/geometry/PinholeCamera.h>
-#include <gtsam/geometry/Pose2.h>
-#include <gtsam/geometry/Cal3_S2.h>
-#include <gtsam/geometry/Cal3Bundler.h>
 #include <gtsam/base/VectorSpace.h>
 #include <gtsam/base/testLie.h>
-#include <gtsam/base/Testable.h>
+#include <gtsam/geometry/Cal3Bundler.h>
+#include <gtsam/geometry/Cal3_S2.h>
+#include <gtsam/geometry/PinholeCamera.h>
+#include <gtsam/geometry/Pose2.h>
 
 #undef CHECK
 #include <CppUnitLite/TestHarness.h>

--- a/tests/testManifold.cpp
+++ b/tests/testManifold.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <gtsam/base/Manifold.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/geometry/PinholeCamera.h>
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/geometry/Cal3_S2.h>

--- a/tests/testNonlinearEquality.cpp
+++ b/tests/testNonlinearEquality.cpp
@@ -30,6 +30,8 @@
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/geometry/Cal3_S2.h>
 #include <gtsam/geometry/PinholeCamera.h>
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/VectorConstants.h>
 
 #include <CppUnitLite/TestHarness.h>
 

--- a/tests/testNonlinearEquality.cpp
+++ b/tests/testNonlinearEquality.cpp
@@ -14,26 +14,24 @@
  * @author Alex Cunningham
  */
 
-#include <tests/simulated2DConstraints.h>
-
-#include <gtsam/nonlinear/PriorFactor.h>
-#include <gtsam/slam/ProjectionFactor.h>
-#include <gtsam/nonlinear/NonlinearEquality.h>
-#include <gtsam/nonlinear/NonlinearFactorGraph.h>
-#include <gtsam/nonlinear/LevenbergMarquardtParams.h>
-#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
-#include <gtsam/linear/GaussianBayesNet.h>
-#include <gtsam/inference/Symbol.h>
-#include <gtsam/geometry/Point2.h>
-#include <gtsam/geometry/Pose2.h>
-#include <gtsam/geometry/Point3.h>
-#include <gtsam/geometry/Pose3.h>
-#include <gtsam/geometry/Cal3_S2.h>
-#include <gtsam/geometry/PinholeCamera.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/VectorConstants.h>
-
-#include <CppUnitLite/TestHarness.h>
+#include <gtsam/geometry/Cal3_S2.h>
+#include <gtsam/geometry/PinholeCamera.h>
+#include <gtsam/geometry/Point2.h>
+#include <gtsam/geometry/Point3.h>
+#include <gtsam/geometry/Pose2.h>
+#include <gtsam/geometry/Pose3.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/linear/GaussianBayesNet.h>
+#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
+#include <gtsam/nonlinear/LevenbergMarquardtParams.h>
+#include <gtsam/nonlinear/NonlinearEquality.h>
+#include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <gtsam/nonlinear/PriorFactor.h>
+#include <gtsam/slam/ProjectionFactor.h>
+#include <tests/simulated2DConstraints.h>
 
 using namespace std;
 using namespace gtsam;

--- a/tests/testNonlinearOptimizer.cpp
+++ b/tests/testNonlinearOptimizer.cpp
@@ -28,6 +28,7 @@
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/base/Matrix.h>
+#include <gtsam/base/VectorConstants.h>
 
 #include <CppUnitLite/TestHarness.h>
 

--- a/tests/testNonlinearOptimizer.cpp
+++ b/tests/testNonlinearOptimizer.cpp
@@ -15,26 +15,24 @@
  * @author  Frank Dellaert
  */
 
-#include <tests/smallExample.h>
-#include <gtsam/slam/BetweenFactor.h>
-#include <gtsam/nonlinear/NonlinearFactorGraph.h>
-#include <gtsam/nonlinear/Values.h>
-#include <gtsam/nonlinear/NonlinearConjugateGradientOptimizer.h>
-#include <gtsam/nonlinear/GaussNewtonOptimizer.h>
-#include <gtsam/nonlinear/DoglegOptimizer.h>
-#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
-#include <gtsam/linear/GaussianFactorGraph.h>
-#include <gtsam/linear/NoiseModel.h>
-#include <gtsam/inference/Symbol.h>
-#include <gtsam/geometry/Pose2.h>
+#include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/VectorConstants.h>
+#include <gtsam/geometry/Pose2.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/linear/NoiseModel.h>
+#include <gtsam/nonlinear/DoglegOptimizer.h>
+#include <gtsam/nonlinear/GaussNewtonOptimizer.h>
+#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
+#include <gtsam/nonlinear/NonlinearConjugateGradientOptimizer.h>
+#include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <gtsam/nonlinear/Values.h>
+#include <gtsam/slam/BetweenFactor.h>
+#include <tests/smallExample.h>
 
-#include <CppUnitLite/TestHarness.h>
-
-
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <memory>
 
 using namespace std;

--- a/tests/testSubgraphPreconditioner.cpp
+++ b/tests/testSubgraphPreconditioner.cpp
@@ -16,6 +16,8 @@
  **/
 
 #include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/linear/GaussianEliminationTree.h>

--- a/timing/timePose2.cpp
+++ b/timing/timePose2.cpp
@@ -15,10 +15,11 @@
  * @author  Richard Roberts
  */
 
-#include <iostream>
-
+#include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/timing.h>
 #include <gtsam/geometry/Pose2.h>
+
+#include <iostream>
 
 using namespace std;
 using namespace gtsam;

--- a/timing/timeRot2.cpp
+++ b/timing/timeRot2.cpp
@@ -15,11 +15,12 @@
  * @author  Richard Roberts
  */
 
-
-#include <gtsam/geometry/Pose2.h>
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/base/OptionalJacobian.h>
 #include <gtsam/base/timing.h>
+#include <gtsam/geometry/Pose2.h>
+
 #include <iostream>
-#include "gtsam/base/OptionalJacobian.h"
 
 using namespace std;
 using namespace gtsam;


### PR DESCRIPTION
Let's get some stats for this, because some of these changes are pretty invasive, and need a good justification...

On my AMD Ryzen 9 7940HS, I compiled gtsam 12 times, with the first 2 samples dropped to account for laptop warmup, with 3 branches to test different optimizations. I built `all.tests` with Ninja and MSVC on develop (was fc790b0916a81a56077fc197ad8259d5efa63972) and measured the time using a PowerShell script:
```pwsh
function rebuild() {
    cmake --preset default --fresh 2>&1 > $null
    cmake --build build --target clean > $null
    Measure-Command { cmake --build build --target all.tests }
}
function cycle() {
    git switch develop
    rebuild
    git switch optimize-compile-times
    rebuild
    git switch optimize-compile-times-w-matrix-constants
    rebuild
}
cycle
cycle
...
```

I used this CMakeUserPresets.json to configure CMake:
```json
{
  "$schema": "https://cmake.org/cmake/help/latest/_downloads/3e2d73bff478d88a7de0de736ba5e361/schema.json",
  "version": 8,
  "configurePresets": [
    {
      "name": "default",
      "binaryDir": "build",
      "generator": "Ninja",
      "cacheVariables": {
        "GTSAM_BUILD_EXAMPLES_ALWAYS": false,
        "GTSAM_BUILD_WITH_PRECOMPILED_HEADERS": false,
        "GTSAM_ALLOW_DEPRECATED_SINCE_V43": false,
        "GTSAM_ENABLE_BOOST_SERIALIZATION": false,
        "CMAKE_EXPORT_COMPILE_COMMANDS": true,
        "GTSAM_USE_BOOST_FEATURES": false,
        "CMAKE_BUILD_TYPE": "Release"
      }
    }
  ]
}
```
For develop, builds took an average of 873.387 seconds to complete. For the first 5 commits of this PR (various include cleanups only), it took an average of 850.620 seconds to complete. With the addition of `Remove Matrix and Vector constants`, this dropped to an average of 824.932 seconds to complete. In total, it's a 5.55% reduction in compile time, which is less than I would've liked, but I doubt I am able to extract more out without contorting the codebase even more.

As a bonus, I had a hunch that MSVC might not like the extensive use of the comma operator and having to do codegen for all those functions, so I had another batch of runs (14, 2 samples dropped) to remove the use of comma init for matrices and vectors. It was within the noise, and was _really_ invasive, so it's not in this PR (although I personally like the initializer_list syntax more, so that can be done separately if desired).

So that means this PR does two major things: attempting to follow IWYU more closely, and removing those Matrix/Vector constants. As hinted at before, a _lot_ of things broke in the process of cleaning up headers that I had to then patch back up. The loss of `<Eigen/Dense>` meant I had to include Eigen headers in various places in order to get it to compile again, same with a bunch of other headers. The header dependencies here are quite extensive and difficult to untangle, and this could potentially impact downstream users if they are relying on a transitive header include, but that's bad practice, so I think it's fine, and it shouldn't be too bad to fix up. Hopefully downstream users try to follow IWYU.

As for the Matrix/Vector constants, turns out instantiating 21 templates across ~600 files does not make for very good compile times... the cost is that instead of a nice, clean `I_4x4`, it's now `Matrix4::Identity()`, etc, _everywhere_. So it's either accept the verbose syntax, or try to workaround it. Static constant in each TU? Macro in the Matrix/Vector headers? (ew) But I think either way, having all these constants in headers is hard to accept going forward.

<details>
<summary>Raw times in seconds for each build</summary>

Raw times for develop:
```
873.2496393
872.3945005
870.0719114
874.0157575
874.4738764
873.8862947
874.2810931
874.0959795
873.0934347
874.3111212
```

Raw times for first 5 commits:
```
848.4264968
847.1430302
850.0603893
851.6237344
850.326302
851.3154186
852.2742136
851.1269761
853.2655984
850.639124
```

Raw times for the whole PR:
```
815.5565957
825.6354879
828.3017271
826.3272054
828.9986909
824.4908644
824.4115947
824.8515002
825.531017
825.2173939
```
</details>