### PR TITLE
feat(python): expose PriorFactor<EssentialMatrix> to Python wrapper

### DIFF
--- a/gtsam/nonlinear/nonlinear.i
+++ b/gtsam/nonlinear/nonlinear.i
@@ -775,7 +775,8 @@ template <T = {double,
                gtsam::PinholeCamera<gtsam::Cal3Unified>,
                gtsam::SphericalCamera,
                gtsam::NavState,
-               gtsam::imuBias::ConstantBias}>
+               gtsam::imuBias::ConstantBias,
+               gtsam::EssentialMatrix}>
 virtual class PriorFactor : gtsam::NoiseModelFactor {
   PriorFactor(gtsam::Key key, const T& prior,
               const gtsam::noiseModel::Base* noiseModel = nullptr);


### PR DESCRIPTION
### Summary
This PR exposes the `PriorFactor<EssentialMatrix>` template instantiation to the Python wrapper in `gtsam/nonlinear/nonlinear.i`. 

While `gtsam::EssentialMatrix` is a fully defined 5-DoF manifold in the C++ core (`gtsam/geometry/EssentialMatrix.h`), its corresponding prior factor (`PriorFactor`) was previously omitted from the Python interface. Exposing this class allows researchers and engineers working in Python to place a direct prior anchor constraint on an Essential Matrix (representing relative camera rotation and unit translation direction) during non-linear optimization.

### Changes
* Added `gtsam::EssentialMatrix` to the template type parameter list `T` of `PriorFactor` in `gtsam/nonlinear/nonlinear.i`.
* This triggers the auto-generation of the `gtsam.PriorFactorEssentialMatrix` binding class during the build phase.

### How This Was Tested
1. Compiled GTSAM from source locally with Python bindings enabled (`-DGTSAM_BUILD_PYTHON=ON`).
2. Verified that the `PriorFactorEssentialMatrix` class is correctly generated, exposed, and functional inside a Python 3.10 interpreter:

```python
import gtsam

# Create a key
key = 1

# Create an Essential Matrix (Identity rotation, unit translation along X)
rot = gtsam.Rot3()
direction = gtsam.Unit3(1.0, 0.0, 0.0)
essential = gtsam.EssentialMatrix(rot, direction)

# Create a 5-DoF noise model for the Essential Matrix tangent space
noise = gtsam.noiseModel.Isotropic.Precision(5, 100.0)

# Instantiate the newly exposed PriorFactor!
prior = gtsam.PriorFactorEssentialMatrix(key, essential, noise)

print(prior)
# Output:
# PriorFactor on 1
#   prior mean: R:
#  [
# 	1, 0, 0;
# 	0, 1, 0;
# 	0, 0, 1
# ]
# d: :1
# 0
# 0
# isotropic dim=5 sigma=0.1