### PR TITLE
test: fix asymmetric loss zero checks

### DIFF
--- a/gtsam/linear/tests/testNoiseModel.cpp
+++ b/gtsam/linear/tests/testNoiseModel.cpp
@@ -950,11 +950,11 @@ TEST(NoiseModel, lossFunctionAtZero)
   DOUBLES_EQUAL(lsdz->loss(0), 0, 1e-8);
   DOUBLES_EQUAL(lsdz->weight(0), 0, 1e-8);
   auto assy_cauchy = mEstimator::AsymmetricCauchy::Create(k);
-  DOUBLES_EQUAL(lsdz->loss(0), 0, 1e-8);
-  DOUBLES_EQUAL(lsdz->weight(0), 0, 1e-8);
+  DOUBLES_EQUAL(assy_cauchy->loss(0), 0, 1e-8);
+  DOUBLES_EQUAL(assy_cauchy->weight(0), 1, 1e-8);
   auto assy_tukey = mEstimator::AsymmetricTukey::Create(k);
-  DOUBLES_EQUAL(lsdz->loss(0), 0, 1e-8);
-  DOUBLES_EQUAL(lsdz->weight(0), 0, 1e-8);
+  DOUBLES_EQUAL(assy_tukey->loss(0), 0, 1e-8);
+  DOUBLES_EQUAL(assy_tukey->weight(0), 1, 1e-8);
 }
 
 


### PR DESCRIPTION
## Summary
- update the zero-loss test to assert `AsymmetricCauchy` and `AsymmetricTukey` directly instead of reusing the `L2WithDeadZone` instance
- use the expected zero-distance weight of 1 for the asymmetric estimators

Closes #2559

## Verification
- `git diff --check`
- `rg -n "assy_cauchy|assy_tukey|lsdz->loss\(0\)|lsdz->weight\(0\)" gtsam/linear/tests/testNoiseModel.cpp`

Full test binary was not run locally because this checkout is sparse and does not include the complete build tree.