### PR TITLE
Fix/copilot instructions wrap 3rdparty

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,8 @@ For reviewing PRs:
 * If we add a C++ function to a `.i` file to expose it to the wrapper, we must ensure that the parameter names match exactly between the declaration in the header file and the declaration in the `.i`. Similarly, if we change any parameter names in a wrapped function in a header file, or change any parameter names in a `.i` file, we must change the corresponding function in the other file to reflect those changes.
 * For templated classes/factors in wrappers, prefer the normal `.i` template mechanism over hand-writing one wrapper class per instantiation. Let the wrapper generate names such as `AttitudeFactorRot3` from `template<...> class AttitudeFactor`.
 * Do not add or keep C++ `using`/`typedef` aliases solely to manufacture wrapper names. Only keep aliases when they are genuinely useful in the C++ API as well.
-* The top-level `wrap/` directory is a git subtree of `borglab/wrap`, not a submodule. The official way to pull in new upstream versions is `./update_wrap.sh` from the GTSAM repo root, optionally passing a branch or tag as the first argument; it defaults to `master`. This creates GTSAM commits, typically a squash plus a merge commit, so do it on a feature branch and open a PR rather than pushing directly to `master` or `develop`. Make code contributions to wrap in the `borglab/wrap` repository.
+* The top-level `wrap/` directory is a git subtree of `borglab/wrap`, not a submodule. The official way to pull in new upstream versions is `./update_wrap.sh` from the GTSAM repo root, optionally passing a branch or tag as the first argument; it defaults to `master`. This creates GTSAM commits, typically a squash plus a merge commit, so do it on a feature branch and open a PR rather than pushing directly to `master` or `develop`. Make code contributions to wrap in the `borglab/wrap` repository. Do not edit files under `gtsam/wrap/` directly, any fixes must go to `borglab/wrap` first, then be synced in via `update_wrap.sh`.
+* Do not edit files under `gtsam/3rdparty/`. These are third party libraries (e.g. Eigen) vendored into the repository. Modifying them directly causes 'hard to find' issues and breaks the ability to update those dependencies.
 * Classes are Uppercase, methods and functions lowerMixedCase.
 * Public fields in structs keep plain names (no trailing underscore).
 * Apart from those naming conventions, we adopt Google C++ style.
@@ -38,10 +39,3 @@ For reviewing PRs:
   5) imports/setup code cell.
   Use the same `remove-cell` tagging convention as existing notebooks so docs build and Colab behavior stay consistent.
 * After any code change, always run relevant tests via `make -j6 testXXX.run` in the build folder $WORKSPACE/build. If in VS code, ask for escalated permissions if needed.
-* Do not edit files under `gtsam/wrap/` directly. This directory is a git 
-  subtree copy of the `borglab/wrap` repository. Any fixes or changes must 
-  be made via a pull request to `borglab/wrap` first, then synced into GTSAM 
-  using `update_wrap.sh`.
-* Do not edit files under `gtsam/3rdparty/`. These are third party libraries 
-  (e.g. Eigen) vendored into the repository. Modifying them directly causes 
-  'hard to find' issues and breaks the ability to update those dependencies.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,3 +37,10 @@ For reviewing PRs:
   5) imports/setup code cell.
   Use the same `remove-cell` tagging convention as existing notebooks so docs build and Colab behavior stay consistent.
 * After any code change, always run relevant tests via `make -j6 testXXX.run` in the build folder $WORKSPACE/build. If in VS code, ask for escalated permissions if needed.
+* Do not edit files under `gtsam/wrap/` directly. This directory is a git 
+  subtree copy of the `borglab/wrap` repository. Any fixes or changes must 
+  be made via a pull request to `borglab/wrap` first, then synced into GTSAM 
+  using `update_wrap.sh`.
+* Do not edit files under `gtsam/3rdparty/`. These are third party libraries 
+  (e.g. Eigen) vendored into the repository. Modifying them directly causes 
+  'hard to find' issues and breaks the ability to update those dependencies.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,3 +38,10 @@ For reviewing PRs:
   5) imports/setup code cell.
   Use the same `remove-cell` tagging convention as existing notebooks so docs build and Colab behavior stay consistent.
 * After any code change, always run relevant tests via `make -j6 testXXX.run` in the build folder $WORKSPACE/build. If in VS code, ask for escalated permissions if needed.
+* Do not edit files under `gtsam/wrap/` directly. This directory is a git 
+  subtree copy of the `borglab/wrap` repository. Any fixes or changes must 
+  be made via a pull request to `borglab/wrap` first, then synced into GTSAM 
+  using `update_wrap.sh`.
+* Do not edit files under `gtsam/3rdparty/`. These are third party libraries 
+  (e.g. Eigen) vendored into the repository. Modifying them directly causes 
+  'hard to find' issues and breaks the ability to update those dependencies.


### PR DESCRIPTION
**What this changes**
Restructures the wrap-subtree guidance in .github/copilot-instructions.md: folds the "never edit gtsam/wrap/ directly" rule into the existing subtree/update_wrap.sh bullet so the two related points live together, and adds a new explicit rule covering gtsam/3rdparty/ (vendored third-party libraries like Eigen should also never be edited directly).

**Why**
The previous version had the wrap rule split across two separate bullets in different parts of the file, and had no guidance at all for the 3rdparty/ directory, which carries the same "don't edit, it'll break dependency updates" concern.