### PR TITLE
[Python] Add batch triangulateSafe supporting incomplete tracks

### DIFF
--- a/gtsam/geometry/cameras.i
+++ b/gtsam/geometry/cameras.i
@@ -659,6 +659,10 @@ gtsam::TriangulationResult triangulateSafe(
     const gtsam::CameraSetCal3_S2& cameras,
     const gtsam::Point2Vector& measurements,
     const gtsam::TriangulationParameters& params);
+std::vector<gtsam::TriangulationResult> triangulateSafe(
+    const gtsam::CameraSetCal3_S2& cameras,
+    const std::vector<std::map<size_t, gtsam::Point2>>& tracks,
+    const gtsam::TriangulationParameters& params);
 
 // Cal3DS2 versions
 gtsam::Point3 triangulatePoint3(const gtsam::Pose3Vector& poses,
@@ -681,6 +685,10 @@ gtsam::Point3 triangulateNonlinear(const gtsam::CameraSetCal3DS2& cameras,
 gtsam::TriangulationResult triangulateSafe(
     const gtsam::CameraSetCal3DS2& cameras,
     const gtsam::Point2Vector& measurements,
+    const gtsam::TriangulationParameters& params);
+std::vector<gtsam::TriangulationResult> triangulateSafe(
+    const gtsam::CameraSetCal3DS2& cameras,
+    const std::vector<std::map<size_t, gtsam::Point2>>& tracks,
     const gtsam::TriangulationParameters& params);
 
 // Cal3Bundler versions
@@ -705,6 +713,10 @@ gtsam::TriangulationResult triangulateSafe(
     const gtsam::CameraSetCal3Bundler& cameras,
     const gtsam::Point2Vector& measurements,
     const gtsam::TriangulationParameters& params);
+std::vector<gtsam::TriangulationResult> triangulateSafe(
+    const gtsam::CameraSetCal3Bundler& cameras,
+    const std::vector<std::map<size_t, gtsam::Point2>>& tracks,
+    const gtsam::TriangulationParameters& params);
 
 // Cal3Fisheye versions
 gtsam::Point3 triangulatePoint3(const gtsam::Pose3Vector& poses,
@@ -727,6 +739,10 @@ gtsam::Point3 triangulateNonlinear(const gtsam::CameraSetCal3Fisheye& cameras,
 gtsam::TriangulationResult triangulateSafe(
     const gtsam::CameraSetCal3Fisheye& cameras,
     const gtsam::Point2Vector& measurements,
+    const gtsam::TriangulationParameters& params);
+std::vector<gtsam::TriangulationResult> triangulateSafe(
+    const gtsam::CameraSetCal3Fisheye& cameras,
+    const std::vector<std::map<size_t, gtsam::Point2>>& tracks,
     const gtsam::TriangulationParameters& params);
 
 // Cal3Unified versions
@@ -751,6 +767,10 @@ gtsam::TriangulationResult triangulateSafe(
     const gtsam::CameraSetCal3Unified& cameras,
     const gtsam::Point2Vector& measurements,
     const gtsam::TriangulationParameters& params);
+std::vector<gtsam::TriangulationResult> triangulateSafe(
+    const gtsam::CameraSetCal3Unified& cameras,
+    const std::vector<std::map<size_t, gtsam::Point2>>& tracks,
+    const gtsam::TriangulationParameters& params);
 
 // Spherical versions
 gtsam::Point3 triangulatePoint3(
@@ -766,6 +786,10 @@ gtsam::Point3 triangulateNonlinear(
 gtsam::TriangulationResult triangulateSafe(
     const gtsam::CameraSet<gtsam::SphericalCamera>& cameras,
     const gtsam::SphericalCamera::MeasurementVector& measurements,
+    const gtsam::TriangulationParameters& params);
+std::vector<gtsam::TriangulationResult> triangulateSafe(
+    const gtsam::CameraSet<gtsam::SphericalCamera>& cameras,
+    const std::vector<std::map<size_t, gtsam::Unit3>>& tracks,
     const gtsam::TriangulationParameters& params);
 
 }  // namespace gtsam

--- a/gtsam/geometry/triangulation.h
+++ b/gtsam/geometry/triangulation.h
@@ -776,6 +776,10 @@ std::vector<TriangulationResult> triangulateSafe(
     trackCameras.reserve(track.size());
     measurements.reserve(track.size());
     for (const auto& [cameraIndex, measurement] : track) {
+      if (cameraIndex >= cameras.size()) {
+        throw std::out_of_range(
+            "triangulateSafe(batch): cameraIndex out of range for CameraSet");
+      }
       trackCameras.push_back(cameras.at(cameraIndex));
       measurements.push_back(measurement);
     }

--- a/gtsam/geometry/triangulation.h
+++ b/gtsam/geometry/triangulation.h
@@ -34,6 +34,7 @@
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/slam/TriangulationFactor.h>
 
+#include <map>
 #include <optional>
 
 namespace gtsam {
@@ -757,6 +758,28 @@ TriangulationResult triangulateSafe(const CameraSet<CAMERA>& cameras,
       // point is behind one of the cameras: can be the case of close-to-parallel cameras or may depend on outliers
       return TriangulationResult::BehindCamera();
     }
+}
+
+/// Batch triangulation: triangulate multiple (possibly incomplete) tracks.
+/// Each track is a map from camera index to 2D measurement. Cameras missing
+/// from a track are simply skipped, supporting incomplete visibility.
+template <class CAMERA>
+std::vector<TriangulationResult> triangulateSafe(
+    const CameraSet<CAMERA>& cameras,
+    const std::vector<std::map<size_t, typename CAMERA::Measurement>>& tracks,
+    const TriangulationParameters& params) {
+  std::vector<TriangulationResult> results;
+  results.reserve(tracks.size());
+  for (const auto& track : tracks) {
+    CameraSet<CAMERA> track_cameras;
+    typename CAMERA::MeasurementVector measurements;
+    for (const auto& [key, measurement] : track) {
+      track_cameras.push_back(cameras.at(key));
+      measurements.push_back(measurement);
+    }
+    results.push_back(triangulateSafe(track_cameras, measurements, params));
+  }
+  return results;
 }
 
 // Vector of Cameras - used by the Python/MATLAB wrapper

--- a/gtsam/geometry/triangulation.h
+++ b/gtsam/geometry/triangulation.h
@@ -771,13 +771,15 @@ std::vector<TriangulationResult> triangulateSafe(
   std::vector<TriangulationResult> results;
   results.reserve(tracks.size());
   for (const auto& track : tracks) {
-    CameraSet<CAMERA> track_cameras;
+    CameraSet<CAMERA> trackCameras;
     typename CAMERA::MeasurementVector measurements;
-    for (const auto& [key, measurement] : track) {
-      track_cameras.push_back(cameras.at(key));
+    trackCameras.reserve(track.size());
+    measurements.reserve(track.size());
+    for (const auto& [cameraIndex, measurement] : track) {
+      trackCameras.push_back(cameras.at(cameraIndex));
       measurements.push_back(measurement);
     }
-    results.push_back(triangulateSafe(track_cameras, measurements, params));
+    results.push_back(triangulateSafe(trackCameras, measurements, params));
   }
   return results;
 }

--- a/gtsam/geometry/triangulation.h
+++ b/gtsam/geometry/triangulation.h
@@ -36,6 +36,7 @@
 
 #include <map>
 #include <optional>
+#include <stdexcept>
 
 namespace gtsam {
 

--- a/python/gtsam/tests/test_Triangulation.py
+++ b/python/gtsam/tests/test_Triangulation.py
@@ -272,5 +272,69 @@ class TestTriangulationExample(GtsamTestCase):
         self.assertTrue(actual.outlier())
 
 
+    def test_batch_complete_tracks(self) -> None:
+        """Batch triangulateSafe with all cameras seeing all tracks."""
+        K = Cal3_S2(1500, 1200, 0, 640, 480)
+        camera1 = PinholeCameraCal3_S2(self.poses[0], K)
+        camera2 = PinholeCameraCal3_S2(self.poses[1], K)
+
+        cameras = CameraSetCal3_S2()
+        cameras.append(camera1)
+        cameras.append(camera2)
+
+        landmark2 = Point3(3, -1, 0.8)
+
+        tracks = [
+            {0: camera1.project(self.landmark), 1: camera2.project(self.landmark)},
+            {0: camera1.project(landmark2),     1: camera2.project(landmark2)},
+        ]
+
+        params = TriangulationParameters(1.0, False, 10.0)
+        results = gtsam.triangulateSafe(cameras, tracks, params)
+
+        self.assertEqual(len(results), 2)
+        self.assertTrue(results[0].valid())
+        self.gtsamAssertEquals(results[0].get(), self.landmark, 1e-9)
+        self.assertTrue(results[1].valid())
+        self.gtsamAssertEquals(results[1].get(), landmark2, 1e-9)
+
+    def test_batch_incomplete_tracks(self) -> None:
+        """Batch triangulateSafe with incomplete tracks (not all cameras see every point)."""
+        K = Cal3_S2(1500, 1200, 0, 640, 480)
+        pose3 = self.poses[0].compose(Pose3(Rot3(), Point3(0, 1, 0)))
+
+        camera1 = PinholeCameraCal3_S2(self.poses[0], K)
+        camera2 = PinholeCameraCal3_S2(self.poses[1], K)
+        camera3 = PinholeCameraCal3_S2(pose3, K)
+
+        cameras = CameraSetCal3_S2()
+        cameras.append(camera1)   # index 0
+        cameras.append(camera2)   # index 1
+        cameras.append(camera3)   # index 2
+
+        params = TriangulationParameters(1.0, False, 10.0)
+
+        tracks = [
+            # complete: all 3 cameras
+            {0: camera1.project(self.landmark),
+             1: camera2.project(self.landmark),
+             2: camera3.project(self.landmark)},
+            # incomplete: camera 2 missing — still valid with 2 cameras
+            {0: camera1.project(self.landmark),
+             1: camera2.project(self.landmark)},
+            # degenerate: only 1 camera — cannot triangulate
+            {0: camera1.project(self.landmark)},
+        ]
+
+        results = gtsam.triangulateSafe(cameras, tracks, params)
+
+        self.assertEqual(len(results), 3)
+        self.assertTrue(results[0].valid())
+        self.gtsamAssertEquals(results[0].get(), self.landmark, 1e-9)
+        self.assertTrue(results[1].valid())
+        self.gtsamAssertEquals(results[1].get(), self.landmark, 1e-9)
+        self.assertTrue(results[2].degenerate())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/python/gtsam/tests/test_Triangulation.py
+++ b/python/gtsam/tests/test_Triangulation.py
@@ -319,7 +319,7 @@ class TestTriangulationExample(GtsamTestCase):
             {0: camera1.project(self.landmark),
              1: camera2.project(self.landmark),
              2: camera3.project(self.landmark)},
-            # incomplete: camera 2 missing — still valid with 2 cameras
+            # incomplete: camera 3 (index 2) missing — still valid with 2 cameras
             {0: camera1.project(self.landmark),
              1: camera2.project(self.landmark)},
             # degenerate: only 1 camera — cannot triangulate


### PR DESCRIPTION
## Summary

 Closes #919.
  
Adds a new overload of triangulateSafe that accepts a vector of tracks, where each track is a map from camera index to 2D measurement. This lets callers triangulate many 3D points in a single C++ call instead of looping from Python (which is more expensive since it's crossing the Python and C++ boundary continuously), and naturally supports incomplete tracks where some cameras do not observe a given point.

  ## Changes

  - **`gtsam/geometry/triangulation.h`** — new `triangulateSafe` template function that iterates over tracks, builds a per-track sub-`CameraSet` from the map keys, and delegates to the existing
  single-track `triangulateSafe`. Tracks with fewer than 2 cameras return `Degenerate()` via the existing check.
  - **`gtsam/geometry/cameras.i`** — expose the new overload for `Cal3_S2`, `Cal3DS2`, `Cal3Bundler`, `Cal3Fisheye`, `Cal3Unified`, and `SphericalCamera`.
  - **`python/gtsam/tests/test_Triangulation.py`** — two new tests: complete tracks and incomplete tracks (including the single-camera degenerate case).
  
  ## Test Ran

  - [x] `test_batch_complete_tracks` — 2 cameras, 2 landmarks, all valid
  - [x] `test_batch_incomplete_tracks` — 3 cameras: complete / 2-of-3 / 1-of-3 (degenerate)
  - [x] Full Python test suite: 391 passed, 4 skipped, 0 failures