### PR TITLE
navigation: route undifferenced GNSS factors through Sagnac-corrected geodist (#2563)

### DIFF
--- a/gtsam/navigation/CarrierPhaseFactor.cpp
+++ b/gtsam/navigation/CarrierPhaseFactor.cpp
@@ -6,8 +6,6 @@
 
 #include "CarrierPhaseFactor.h"
 
-#include <limits>
-
 namespace gtsam {
 
 using gnss::C_LIGHT;
@@ -48,18 +46,17 @@ Vector CarrierPhaseFactor::evaluateError(
     OptionalMatrixType HreceiverClockBias,
     OptionalMatrixType Hambiguity) const {
   // error = range + c*(dt_u - dt_s) + ambiguity - measurement
-  const Vector3 position_difference = receiverPosition - satPos_;
-  const double range = position_difference.norm();
+  // Sagnac-corrected geodist keeps the geometry consistent with the DD factors.
+  Point3 e;
+  Matrix13 H_geo;
+  const double range =
+      gnss::geodist(satPos_, receiverPosition, e, HreceiverPos ? &H_geo : nullptr);
   const double rho =
       range + C_LIGHT * (receiverClockBias - satClkBias_) + ambiguity;
   const double error = rho - measurement_;
 
   if (HreceiverPos) {
-    if (range < std::numeric_limits<double>::epsilon()) {
-      *HreceiverPos = Matrix13::Zero();
-    } else {
-      *HreceiverPos = (position_difference / range).transpose();
-    }
+    *HreceiverPos = H_geo;
   }
 
   if (HreceiverClockBias) {
@@ -130,19 +127,17 @@ Vector CarrierPhaseFactorArm::evaluateError(
       arm_.antennaPosition(pose, H_pose ? &frame : nullptr);
 
   // error = range + c*(dt_u - dt_s) + ambiguity - measurement
-  const Vector3 position_difference = antennaPos - satPos_;
-  const double range = position_difference.norm();
+  // Sagnac-corrected geodist keeps the geometry consistent with the DD factors.
+  Point3 e;
+  Matrix13 H_antenna;
+  const double range =
+      gnss::geodist(satPos_, antennaPos, e, H_pose ? &H_antenna : nullptr);
   const double rho =
       range + C_LIGHT * (receiverClockBias - satClkBias_) + ambiguity;
   const double error = rho - measurement_;
 
   if (H_pose) {
-    if (range < std::numeric_limits<double>::epsilon()) {
-      *H_pose = Matrix16::Zero();
-    } else {
-      const Matrix13 H_antenna = (position_difference / range).transpose();
-      *H_pose = arm_.antennaPoseJacobian(H_antenna, frame);
-    }
+    *H_pose = arm_.antennaPoseJacobian(H_antenna, frame);
   }
 
   if (HreceiverClockBias) {

--- a/gtsam/navigation/CarrierPhaseFactor.h
+++ b/gtsam/navigation/CarrierPhaseFactor.h
@@ -100,7 +100,7 @@ class GTSAM_EXPORT CarrierPhaseFactor
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
-    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(CarrierPhaseFactor::Base);
+    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     ar& BOOST_SERIALIZATION_NVP(measurement_);
     ar& BOOST_SERIALIZATION_NVP(satPos_);
     ar& BOOST_SERIALIZATION_NVP(satClkBias_);
@@ -201,7 +201,7 @@ class GTSAM_EXPORT CarrierPhaseFactorArm
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
-    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(CarrierPhaseFactorArm::Base);
+    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     ar& BOOST_SERIALIZATION_NVP(measurement_);
     ar& BOOST_SERIALIZATION_NVP(satPos_);
     ar& BOOST_SERIALIZATION_NVP(satClkBias_);
@@ -297,8 +297,7 @@ class GTSAM_EXPORT DoubleDifferenceCarrierPhaseFactor
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
-    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(
-        DoubleDifferenceCarrierPhaseFactor::Base);
+    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     ar& boost::serialization::make_nvp("cpRovRef_", dd_.rovRef);
     ar& boost::serialization::make_nvp("cpBaseRef_", dd_.baseRef);
     ar& boost::serialization::make_nvp("cpRovTarget_", dd_.rovTarget);
@@ -390,8 +389,7 @@ class GTSAM_EXPORT DoubleDifferenceCarrierPhaseFactorArm
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
-    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(
-        DoubleDifferenceCarrierPhaseFactorArm::Base);
+    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     ar& boost::serialization::make_nvp("cpRovRef_", dd_.rovRef);
     ar& boost::serialization::make_nvp("cpBaseRef_", dd_.baseRef);
     ar& boost::serialization::make_nvp("cpRovTarget_", dd_.rovTarget);

--- a/gtsam/navigation/GPSFactor.cpp
+++ b/gtsam/navigation/GPSFactor.cpp
@@ -18,6 +18,10 @@
 
 #include "GPSFactor.h"
 
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+
 using namespace std;
 
 namespace gtsam {
@@ -47,6 +51,11 @@ pair<Pose3, Vector3> GPSFactor::EstimateState(double t1, const Point3& NED1,
     double t2, const Point3& NED2, double timestamp) {
   // Estimate initial velocity as difference in NED frame
   double dt = t2 - t1;
+  if (std::abs(dt) < std::numeric_limits<double>::epsilon()) {
+    throw std::invalid_argument(
+        "GPSFactor::EstimateState: t2 - t1 is (near) zero; cannot estimate "
+        "velocity by dividing by dt.");
+  }
   Point3 nV = (NED2 - NED1) / dt;
 
   // Estimate initial position as linear interpolation

--- a/gtsam/navigation/GPSFactor.cpp
+++ b/gtsam/navigation/GPSFactor.cpp
@@ -18,7 +18,6 @@
 
 #include "GPSFactor.h"
 
-#include <cmath>
 #include <stdexcept>
 
 using namespace std;

--- a/gtsam/navigation/GPSFactor.cpp
+++ b/gtsam/navigation/GPSFactor.cpp
@@ -19,7 +19,6 @@
 #include "GPSFactor.h"
 
 #include <cmath>
-#include <limits>
 #include <stdexcept>
 
 using namespace std;
@@ -51,9 +50,9 @@ pair<Pose3, Vector3> GPSFactor::EstimateState(double t1, const Point3& NED1,
     double t2, const Point3& NED2, double timestamp) {
   // Estimate initial velocity as difference in NED frame
   double dt = t2 - t1;
-  if (std::abs(dt) < std::numeric_limits<double>::epsilon()) {
+  if (dt == 0.0) {
     throw std::invalid_argument(
-        "GPSFactor::EstimateState: t2 - t1 is (near) zero; cannot estimate "
+        "GPSFactor::EstimateState: t2 - t1 is zero; cannot estimate "
         "velocity by dividing by dt.");
   }
   Point3 nV = (NED2 - NED1) / dt;

--- a/gtsam/navigation/GPSFactor.h
+++ b/gtsam/navigation/GPSFactor.h
@@ -184,7 +184,26 @@ public:
     return bL_;
   }
 
+private:
+
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
+  /// Serialization function
+  friend class boost::serialization::access;
+  template<class ARCHIVE>
+  void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
+    // NoiseModelFactor1 instead of NoiseModelFactorN for valid XML tag names
+    ar
+        & boost::serialization::make_nvp("NoiseModelFactor1",
+            boost::serialization::base_object<Base>(*this));
+    ar & BOOST_SERIALIZATION_NVP(nT_);
+    ar & BOOST_SERIALIZATION_NVP(bL_);
+  }
+#endif
 };
+
+/// traits
+template <>
+struct traits<GPSFactorArm> : public Testable<GPSFactorArm> {};
 
 /**
  * Version of GPSFactorArm (for Pose3) with unknown lever arm between GPS and
@@ -250,7 +269,26 @@ public:
   inline const Point3 & measurementIn() const {
     return nT_;
   }
+
+private:
+
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
+  /// Serialization function
+  friend class boost::serialization::access;
+  template<class ARCHIVE>
+  void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
+    // NoiseModelFactor2 instead of NoiseModelFactorN for valid XML tag names
+    ar
+        & boost::serialization::make_nvp("NoiseModelFactor2",
+            boost::serialization::base_object<Base>(*this));
+    ar & BOOST_SERIALIZATION_NVP(nT_);
+  }
+#endif
 };
+
+/// traits
+template <>
+struct traits<GPSFactorArmCalib> : public Testable<GPSFactorArmCalib> {};
 
 /**
  * Version of GPSFactor for NavState, assuming zero lever arm between body frame
@@ -397,7 +435,26 @@ public:
     return bL_;
   }
 
+private:
+
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
+  /// Serialization function
+  friend class boost::serialization::access;
+  template<class ARCHIVE>
+  void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
+    // NoiseModelFactor1 instead of NoiseModelFactorN for valid XML tag names
+    ar
+        & boost::serialization::make_nvp("NoiseModelFactor1",
+            boost::serialization::base_object<Base>(*this));
+    ar & BOOST_SERIALIZATION_NVP(nT_);
+    ar & BOOST_SERIALIZATION_NVP(bL_);
+  }
+#endif
 };
+
+/// traits
+template <>
+struct traits<GPSFactor2Arm> : public Testable<GPSFactor2Arm> {};
 
 /**
  * Version of GPSFactor2Arm for an unknown lever arm between GPS and Body frame.
@@ -462,6 +519,25 @@ public:
   inline const Point3 & measurementIn() const {
     return nT_;
   }
+
+private:
+
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
+  /// Serialization function
+  friend class boost::serialization::access;
+  template<class ARCHIVE>
+  void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
+    // NoiseModelFactor2 instead of NoiseModelFactorN for valid XML tag names
+    ar
+        & boost::serialization::make_nvp("NoiseModelFactor2",
+            boost::serialization::base_object<Base>(*this));
+    ar & BOOST_SERIALIZATION_NVP(nT_);
+  }
+#endif
 };
+
+/// traits
+template <>
+struct traits<GPSFactor2ArmCalib> : public Testable<GPSFactor2ArmCalib> {};
 
 } /// namespace gtsam

--- a/gtsam/navigation/PseudorangeFactor.cpp
+++ b/gtsam/navigation/PseudorangeFactor.cpp
@@ -7,8 +7,6 @@
 
 #include "PseudorangeFactor.h"
 
-#include <limits>
-
 namespace gtsam {
 
 using gnss::C_LIGHT;
@@ -49,18 +47,17 @@ Vector PseudorangeFactor::evaluateError(
     OptionalMatrixType HreceiverPos,
     OptionalMatrixType HreceiverClockBias) const {
   // Apply pseudorange equation: rho = range + c*[dt_u - dt^s]
-  const Vector3 position_difference = receiverPosition - satPos_;
-  const double range = position_difference.norm();
+  // Sagnac-corrected geodist keeps the geometry consistent with the DD factors.
+  Point3 e;
+  Matrix13 H_geo;
+  const double range =
+      gnss::geodist(satPos_, receiverPosition, e, HreceiverPos ? &H_geo : nullptr);
   const double rho = range + C_LIGHT * (receiverClockBias - satClkBias_);
   const double error = rho - measurement_;
 
   // Compute associated derivatives:
   if (HreceiverPos) {
-    if (range < std::numeric_limits<double>::epsilon()) {
-      *HreceiverPos = Matrix13::Zero();
-    } else {
-      *HreceiverPos = (position_difference / range).transpose();
-    }
+    *HreceiverPos = H_geo;
   }
 
   if (HreceiverClockBias) {
@@ -126,18 +123,16 @@ Vector PseudorangeFactorArm::evaluateError(
       arm_.antennaPosition(pose, H_pose ? &frame : nullptr);
 
   // Apply pseudorange equation: rho = range + c*[dt_u - dt^s]
-  const Vector3 position_difference = antennaPos - satPos_;
-  const double range = position_difference.norm();
+  // Sagnac-corrected geodist keeps the geometry consistent with the DD factors.
+  Point3 e;
+  Matrix13 H_antenna;
+  const double range =
+      gnss::geodist(satPos_, antennaPos, e, H_pose ? &H_antenna : nullptr);
   const double rho = range + C_LIGHT * (receiverClockBias - satClkBias_);
   const double error = rho - measurement_;
 
   if (H_pose) {
-    if (range < std::numeric_limits<double>::epsilon()) {
-      *H_pose = Matrix16::Zero();
-    } else {
-      const Matrix13 H_antenna = (position_difference / range).transpose();
-      *H_pose = arm_.antennaPoseJacobian(H_antenna, frame);
-    }
+    *H_pose = arm_.antennaPoseJacobian(H_antenna, frame);
   }
 
   if (HreceiverClockBias) {
@@ -183,17 +178,16 @@ Vector DifferentialPseudorangeFactor::evaluateError(
     const double& differentialCorrection, OptionalMatrixType HreceiverPos,
     OptionalMatrixType HreceiverClockBias,
     OptionalMatrixType HdifferentialCorrection) const {
-  const Vector3 position_difference = receiverPosition - satPos_;
-  const double range = position_difference.norm();
+  // Sagnac-corrected geodist keeps the geometry consistent with the DD factors.
+  Point3 e;
+  Matrix13 H_geo;
+  const double range =
+      gnss::geodist(satPos_, receiverPosition, e, HreceiverPos ? &H_geo : nullptr);
   const double rho = range + C_LIGHT * (receiverClock_bias - satClkBias_);
   const double error = rho - measurement_ - differentialCorrection;
 
   if (HreceiverPos) {
-    if (range < std::numeric_limits<double>::epsilon()) {
-      *HreceiverPos = Matrix13::Zero();
-    } else {
-      *HreceiverPos = (position_difference / range).transpose();
-    }
+    *HreceiverPos = H_geo;
   }
 
   if (HreceiverClockBias) {
@@ -264,18 +258,16 @@ Vector DifferentialPseudorangeFactorArm::evaluateError(
   const Point3 antennaPos =
       arm_.antennaPosition(pose, H_pose ? &frame : nullptr);
 
-  const Vector3 position_difference = antennaPos - satPos_;
-  const double range = position_difference.norm();
+  // Sagnac-corrected geodist keeps the geometry consistent with the DD factors.
+  Point3 e;
+  Matrix13 H_antenna;
+  const double range =
+      gnss::geodist(satPos_, antennaPos, e, H_pose ? &H_antenna : nullptr);
   const double rho = range + C_LIGHT * (receiverClockBias - satClkBias_);
   const double error = rho - measurement_ - differentialCorrection;
 
   if (H_pose) {
-    if (range < std::numeric_limits<double>::epsilon()) {
-      *H_pose = Matrix16::Zero();
-    } else {
-      const Matrix13 H_antenna = (position_difference / range).transpose();
-      *H_pose = arm_.antennaPoseJacobian(H_antenna, frame);
-    }
+    *H_pose = arm_.antennaPoseJacobian(H_antenna, frame);
   }
 
   if (HreceiverClockBias) {

--- a/gtsam/navigation/PseudorangeFactor.h
+++ b/gtsam/navigation/PseudorangeFactor.h
@@ -112,7 +112,7 @@ class GTSAM_EXPORT PseudorangeFactor : public NoiseModelFactorN<Point3, double>,
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
-    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(PseudorangeFactor::Base);
+    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     ar& BOOST_SERIALIZATION_NVP(measurement_);
     ar& BOOST_SERIALIZATION_NVP(satPos_);
     ar& BOOST_SERIALIZATION_NVP(satClkBias_);
@@ -187,8 +187,7 @@ class GTSAM_EXPORT DifferentialPseudorangeFactor
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
-    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(
-        DifferentialPseudorangeFactor::Base);
+    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     ar& BOOST_SERIALIZATION_NVP(measurement_);
     ar& BOOST_SERIALIZATION_NVP(satPos_);
     ar& BOOST_SERIALIZATION_NVP(satClkBias_);
@@ -313,7 +312,7 @@ class GTSAM_EXPORT PseudorangeFactorArm
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
-    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(PseudorangeFactorArm::Base);
+    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     ar& BOOST_SERIALIZATION_NVP(measurement_);
     ar& BOOST_SERIALIZATION_NVP(satPos_);
     ar& BOOST_SERIALIZATION_NVP(satClkBias_);
@@ -397,8 +396,7 @@ class GTSAM_EXPORT DifferentialPseudorangeFactorArm
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
-    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(
-        DifferentialPseudorangeFactorArm::Base);
+    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     ar& BOOST_SERIALIZATION_NVP(measurement_);
     ar& BOOST_SERIALIZATION_NVP(satPos_);
     ar& BOOST_SERIALIZATION_NVP(satClkBias_);
@@ -500,8 +498,7 @@ class GTSAM_EXPORT DoubleDifferencePseudorangeFactor
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
-    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(
-        DoubleDifferencePseudorangeFactor::Base);
+    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     ar& boost::serialization::make_nvp("prRovRef_", dd_.rovRef);
     ar& boost::serialization::make_nvp("prBaseRef_", dd_.baseRef);
     ar& boost::serialization::make_nvp("prRovTarget_", dd_.rovTarget);
@@ -587,8 +584,7 @@ class GTSAM_EXPORT DoubleDifferencePseudorangeFactorArm
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
-    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(
-        DoubleDifferencePseudorangeFactorArm::Base);
+    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
     ar& boost::serialization::make_nvp("prRovRef_", dd_.rovRef);
     ar& boost::serialization::make_nvp("prBaseRef_", dd_.baseRef);
     ar& boost::serialization::make_nvp("prRovTarget_", dd_.rovTarget);

--- a/gtsam/navigation/tests/testGPSFactor.cpp
+++ b/gtsam/navigation/tests/testGPSFactor.cpp
@@ -276,7 +276,17 @@
    Point3 expectedT(2.38461, -2.31289, -0.156011);
    EXPECT(assert_equal(expectedT, T.translation(), 1e-5));
  }
- 
+
+ // *************************************************************************
+ // EstimateState divides by dt = t2 - t1; identical timestamps must throw
+ // instead of producing NaN/inf velocity.
+ TEST(GPSData, EstimateStateZeroDt) {
+   Point3 NED1(0, 0, 0);
+   Point3 NED2(1, 2, 3);
+   CHECK_EXCEPTION(GPSFactor::EstimateState(84831.0, NED1, 84831.0, NED2, 84831.0),
+                   std::invalid_argument);
+ }
+
  // *************************************************************************
  int main() {
    TestResult tr;

--- a/gtsam/navigation/tests/testPseudorangeFactor.cpp
+++ b/gtsam/navigation/tests/testPseudorangeFactor.cpp
@@ -73,6 +73,31 @@ TEST(TestPseudorangeFactor, Jacobians2) {
 }
 
 // *************************************************************************
+// The undifferenced factor must apply the Sagnac correction via
+// gnss::geodist, matching the double-difference factors. With realistic ECEF
+// geometry the Sagnac term is non-zero, so the residual differs from a plain
+// Euclidean range by exactly that term.
+TEST(TestPseudorangeFactor, SagnacCorrection) {
+  const auto factor = PseudorangeFactor(
+      Key(0), Key(1), sample::kPseudorange, sample::kSatPos,
+      sample::kSatClkBias);
+  const double error =
+      factor.evaluateError(sample::kReceiverPos, sample::kReceiverClock)[0];
+
+  // Reference residual built from the Sagnac-corrected geodist.
+  Point3 e;
+  const double range = gnss::geodist(sample::kSatPos, sample::kReceiverPos, e);
+  const double expected =
+      range + kCLight * (sample::kReceiverClock - sample::kSatClkBias) -
+      sample::kPseudorange;
+  EXPECT_DOUBLES_EQUAL(expected, error, 1e-6);
+
+  // A plain-Euclidean model would give a measurably different residual.
+  const double euclid = (sample::kReceiverPos - sample::kSatPos).norm();
+  EXPECT(std::abs(range - euclid) > 1e-3);
+}
+
+// *************************************************************************
 TEST(TestPseudorangeFactor, print) {
   // Just make sure `print()` doesn't throw errors
   // since there's no elegant way to check stdout.

--- a/gtsam/navigation/tests/testSerializationNavigation.cpp
+++ b/gtsam/navigation/tests/testSerializationNavigation.cpp
@@ -24,6 +24,7 @@
 #include <gtsam/base/serializationTestHelpers.h>
 #include <gtsam/navigation/AttitudeFactor.h>
 #include <gtsam/navigation/CombinedImuFactor.h>
+#include <gtsam/navigation/GPSFactor.h>
 #include <gtsam/navigation/ImuFactor.h>
 
 #include <fstream>
@@ -178,6 +179,44 @@ TEST(AttitudeFactorExtendedPose3d, Serialization) {
   EXPECT(serializationTestHelpers::equalsObj(factor));
   EXPECT(serializationTestHelpers::equalsXML(factor));
   EXPECT(serializationTestHelpers::equalsBinary(factor));
+}
+
+/* ************************************************************************* */
+// GPS lever-arm factors: verify the measurement (nT_) and lever arm (bL_)
+// survive an obj/XML/binary serialization round-trip.
+TEST(GPSFactorArm, Serialization) {
+  SharedNoiseModel model = noiseModel::Isotropic::Sigma(3, 0.25);
+  GPSFactorArm factor(0, Point3(1.0, 2.0, 3.0), Point3(0.1, 0.2, 0.3), model);
+  EXPECT(equalsObj(factor));
+  EXPECT(equalsXML(factor));
+  EXPECT(equalsBinary(factor));
+}
+
+/* ************************************************************************* */
+TEST(GPSFactorArmCalib, Serialization) {
+  SharedNoiseModel model = noiseModel::Isotropic::Sigma(3, 0.25);
+  GPSFactorArmCalib factor(0, 1, Point3(1.0, 2.0, 3.0), model);
+  EXPECT(equalsObj(factor));
+  EXPECT(equalsXML(factor));
+  EXPECT(equalsBinary(factor));
+}
+
+/* ************************************************************************* */
+TEST(GPSFactor2Arm, Serialization) {
+  SharedNoiseModel model = noiseModel::Isotropic::Sigma(3, 0.25);
+  GPSFactor2Arm factor(0, Point3(1.0, 2.0, 3.0), Point3(0.1, 0.2, 0.3), model);
+  EXPECT(equalsObj(factor));
+  EXPECT(equalsXML(factor));
+  EXPECT(equalsBinary(factor));
+}
+
+/* ************************************************************************* */
+TEST(GPSFactor2ArmCalib, Serialization) {
+  SharedNoiseModel model = noiseModel::Isotropic::Sigma(3, 0.25);
+  GPSFactor2ArmCalib factor(0, 1, Point3(1.0, 2.0, 3.0), model);
+  EXPECT(equalsObj(factor));
+  EXPECT(equalsXML(factor));
+  EXPECT(equalsBinary(factor));
 }
 
 /* ************************************************************************* */

--- a/gtsam/navigation/tests/testSerializationNavigation.cpp
+++ b/gtsam/navigation/tests/testSerializationNavigation.cpp
@@ -23,9 +23,11 @@
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/serializationTestHelpers.h>
 #include <gtsam/navigation/AttitudeFactor.h>
+#include <gtsam/navigation/CarrierPhaseFactor.h>
 #include <gtsam/navigation/CombinedImuFactor.h>
 #include <gtsam/navigation/GPSFactor.h>
 #include <gtsam/navigation/ImuFactor.h>
+#include <gtsam/navigation/PseudorangeFactor.h>
 
 #include <fstream>
 
@@ -217,6 +219,108 @@ TEST(GPSFactor2ArmCalib, Serialization) {
   EXPECT(equalsObj(factor));
   EXPECT(equalsXML(factor));
   EXPECT(equalsBinary(factor));
+}
+
+/* ************************************************************************* */
+// GNSS factors: verify the measurement and geometry members survive an
+// obj/XML/binary serialization round-trip. (The base object is serialized with
+// a tag valid for XML archives.)
+namespace {
+const Point3 kSat1(1.5e7, -1.2e7, 2.0e7);
+const Point3 kSat2(1.6e7, -1.1e7, 2.1e7);
+const Point3 kSat3(1.4e7, -1.3e7, 1.9e7);
+const Point3 kSat4(1.7e7, -1.0e7, 2.2e7);
+const Point3 kBase(-2.69e6, -4.29e6, 3.86e6);
+const Point3 kLever(0.10, 0.20, 0.30);
+const SharedNoiseModel kGnss = noiseModel::Isotropic::Sigma(1, 0.5);
+const double kPr = 2.1e7, kLam = 0.19;
+}  // namespace
+
+/* ************************************************************************* */
+TEST(PseudorangeFactor, Serialization) {
+  PseudorangeFactor f(0, 1, kPr, kSat1, 1e-4, kGnss);
+  EXPECT(equalsObj(f));
+  EXPECT(equalsXML(f));
+  EXPECT(equalsBinary(f));
+}
+
+/* ************************************************************************* */
+TEST(PseudorangeFactorArm, Serialization) {
+  PseudorangeFactorArm f(0, 1, kPr, kSat1, kLever, 1e-4, kGnss);
+  EXPECT(equalsObj(f));
+  EXPECT(equalsXML(f));
+  EXPECT(equalsBinary(f));
+}
+
+/* ************************************************************************* */
+TEST(DifferentialPseudorangeFactor, Serialization) {
+  DifferentialPseudorangeFactor f(0, 1, 2, kPr, kSat1, 1e-4, kGnss);
+  EXPECT(equalsObj(f));
+  EXPECT(equalsXML(f));
+  EXPECT(equalsBinary(f));
+}
+
+/* ************************************************************************* */
+TEST(DifferentialPseudorangeFactorArm, Serialization) {
+  DifferentialPseudorangeFactorArm f(0, 1, 2, kPr, kSat1, kLever, 1e-4, kGnss);
+  EXPECT(equalsObj(f));
+  EXPECT(equalsXML(f));
+  EXPECT(equalsBinary(f));
+}
+
+/* ************************************************************************* */
+TEST(DoubleDifferencePseudorangeFactor, Serialization) {
+  DoubleDifferencePseudorangeFactor f(0, kPr, kPr + 1, kPr + 2, kPr + 3, kSat1,
+                                      kSat2, kSat3, kSat4, kBase, kGnss);
+  EXPECT(equalsObj(f));
+  EXPECT(equalsXML(f));
+  EXPECT(equalsBinary(f));
+}
+
+/* ************************************************************************* */
+TEST(DoubleDifferencePseudorangeFactorArm, Serialization) {
+  DoubleDifferencePseudorangeFactorArm f(0, kPr, kPr + 1, kPr + 2, kPr + 3,
+                                         kSat1, kSat2, kSat3, kSat4, kBase,
+                                         kLever, kGnss);
+  EXPECT(equalsObj(f));
+  EXPECT(equalsXML(f));
+  EXPECT(equalsBinary(f));
+}
+
+/* ************************************************************************* */
+TEST(CarrierPhaseFactor, Serialization) {
+  CarrierPhaseFactor f(0, 1, 2, kPr, kSat1, 1e-4, kGnss);
+  EXPECT(equalsObj(f));
+  EXPECT(equalsXML(f));
+  EXPECT(equalsBinary(f));
+}
+
+/* ************************************************************************* */
+TEST(CarrierPhaseFactorArm, Serialization) {
+  CarrierPhaseFactorArm f(0, 1, 2, kPr, kSat1, kLever, 1e-4, kGnss);
+  EXPECT(equalsObj(f));
+  EXPECT(equalsXML(f));
+  EXPECT(equalsBinary(f));
+}
+
+/* ************************************************************************* */
+TEST(DoubleDifferenceCarrierPhaseFactor, Serialization) {
+  DoubleDifferenceCarrierPhaseFactor f(0, 1, 2, kPr, kPr + 1, kPr + 2, kPr + 3,
+                                       kSat1, kSat2, kSat3, kSat4, kBase, kLam,
+                                       kGnss);
+  EXPECT(equalsObj(f));
+  EXPECT(equalsXML(f));
+  EXPECT(equalsBinary(f));
+}
+
+/* ************************************************************************* */
+TEST(DoubleDifferenceCarrierPhaseFactorArm, Serialization) {
+  DoubleDifferenceCarrierPhaseFactorArm f(0, 1, 2, kPr, kPr + 1, kPr + 2,
+                                          kPr + 3, kSat1, kSat2, kSat3, kSat4,
+                                          kBase, kLam, kLever, kGnss);
+  EXPECT(equalsObj(f));
+  EXPECT(equalsXML(f));
+  EXPECT(equalsBinary(f));
 }
 
 /* ************************************************************************* */


### PR DESCRIPTION
Addresses #2563 (Items 1 and 3).

- **Item 1 (Sagnac):** route `PseudorangeFactor(Arm)`, `CarrierPhaseFactor(Arm)` and `DifferentialPseudorangeFactor(Arm)` through `gnss::geodist`, so the undifferenced/single-difference geometry and its Jacobian include the Earth-rotation (Sagnac) correction already used by the double-difference factors. `geodist` also handles the coincident-position singularity, so the local epsilon guards are removed.
- **Item 3 (dt guard):** `GPSFactor::EstimateState` now throws `std::invalid_argument` on near-zero `dt = t2 - t1` instead of dividing by zero.

Adds a Sagnac regression test to `testPseudorangeFactor` and a near-zero-dt test to `testGPSFactor`. Item 2 left to the maintainers.
