### PR TITLE
Add compiler hash to vcpkg cache key

### DIFF
--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -78,13 +78,21 @@ jobs:
         env:
           VCPKG_BINARY_SOURCES: default,rw
 
+      - name: Get compiler hash
+        id: hash-compiler
+        shell: bash
+        run: |
+          ./vcpkg/vcpkg install --dry-run
+          cat vcpkg_installed/vcpkg/compiler-file-hash-cache.json
+          echo hash=$(jq '.[].["hash"]' < vcpkg_installed/vcpkg/compiler-file-hash-cache.json) >> $GITHUB_OUTPUT
+
       - name: Restore cache dependencies
         id: cache-restore
         uses: actions/cache/restore@v3
         with:
           path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
-          key: ${{ matrix.os }}-${{ hashFiles('vcpkg.json') }}
-          restore-keys: ${{ matrix.os }}-${{ hashFiles('vcpkg.json') }}
+          key: ${{ matrix.os }}-${{ hashFiles('vcpkg.json') }}-${{ steps.hash-compiler.outputs.hash }}
+          restore-keys: ${{ matrix.os }}-${{ hashFiles('vcpkg.json') }}-${{ steps.hash-compiler.outputs.hash }}
 
       - name: Set Swap Space (Linux)
         if: runner.os == 'Linux'
@@ -131,11 +139,11 @@ jobs:
 
       - name: Cache dependencies
         # Don't save if it's the exact same
-        if: steps.cache-restore.outputs.cache-matched-key != format('{0}-{1}-{2}', matrix.os, hashFiles('vcpkg.json'), hashFiles('vcpkg_installed/**/vcpkg_abi_info.txt'))
+        if: steps.cache-restore.outputs.cache-matched-key != format('{0}-{1}-{2}-{3}', matrix.os, hashFiles('vcpkg.json'), steps.hash-compiler.outputs.hash, hashFiles('vcpkg_installed/**/vcpkg_abi_info.txt'))
         uses: actions/cache/save@v4
         with:
           path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
-          key: ${{ matrix.os }}-${{ hashFiles('vcpkg.json') }}-${{ hashFiles('vcpkg_installed/**/vcpkg_abi_info.txt') }}
+          key: ${{ matrix.os }}-${{ hashFiles('vcpkg.json') }}-${{ steps.hash-compiler.outputs.hash }}-${{ hashFiles('vcpkg_installed/**/vcpkg_abi_info.txt') }}
 
       - name: Install python packages
         shell: bash


### PR DESCRIPTION
After poking around, I realized that the reason why vcpkg caches kept getting invalidated was because the underlying compiler was getting updated. So in order to reliably bust the cache, the cache key must contain the compiler hash. After doing a bit more research, it turns out vcpkg will record compiler hashes in a JSON file, which can be generated by doing a dry run of an install (which avoids unnecessary building). Extracting that hash (or hashes for other platforms) and then incorporating it into the cache key (and not restoring the cache if it's different) is easy enough, and now I believe that the Windows vcpkg cache should stop accumulating dead binaries, which should reduce the amount of cache thrashing.

Test runs:
https://github.com/Gold856/gtsam/actions/runs/27895197804 (first run)
https://github.com/Gold856/gtsam/actions/runs/27917852605 (second run, restored from cache successfully)