### PR TITLE
Fix GCC 15 warnings

### DIFF
--- a/gtsam/constrained/tests/testQpProblem.cpp
+++ b/gtsam/constrained/tests/testQpProblem.cpp
@@ -59,9 +59,9 @@ double DirectTraceCost(const SymmetricBlockMatrix& Q, const Matrix& X0,
 // Verifies affine Hessian factors evaluate direct Vector values.
 TEST(QpCost, HessianVectorError) {
   const Matrix G = (Matrix(2, 2) << 2.0, 0.5, 0.5, 3.0).finished();
-  const Vector g = (Vector(2) << 0.2, -0.3).finished();
+  const Vector2 g{0.2, -0.3};
   const QpCost cost(HessianFactor(x0, G, g, 1.7));
-  const Vector x = (Vector(2) << 1.0, 2.0).finished();
+  const Vector2 x{1.0, 2.0};
   const double expected = 0.5 * (1.7 - 2.0 * x.dot(g) + x.dot(G * x));
 
   EXPECT_DOUBLES_EQUAL(expected, cost.error(VectorValue(x)), 1e-12);
@@ -200,7 +200,7 @@ TEST(QpProblem, Evaluate) {
   QpProblem problem;
 
   const Matrix G = (Matrix(2, 2) << 2.0, 0.5, 0.5, 3.0).finished();
-  const Vector g = (Vector(2) << 0.2, -0.3).finished();
+  const Vector2 g{0.2, -0.3};
   problem.addCost(HessianFactor(x0, G, g, 1.7));
 
   problem.addConstraint(LinearConstraint::Equal(
@@ -210,7 +210,7 @@ TEST(QpProblem, Evaluate) {
 
   const Values values = VectorValue(1.0, 2.0);
   const auto [cost, eqViolation, ineqViolation] = problem.evaluate(values);
-  const Vector x = (Vector(2) << 1.0, 2.0).finished();
+  const Vector2 x{1.0, 2.0};
   const double expectedCost = 0.5 * (1.7 - 2.0 * x.dot(g) + x.dot(G * x));
 
   EXPECT_DOUBLES_EQUAL(expectedCost, cost, 1e-12);

--- a/gtsam/linear/JacobianFactor.cpp
+++ b/gtsam/linear/JacobianFactor.cpp
@@ -239,7 +239,7 @@ std::tuple<FastVector<DenseIndex>, DenseIndex, DenseIndex> _countDims(
   }
 #endif
 
-  return std::make_tuple(varDims, m, n);
+  return std::make_tuple(std::move(varDims), m, n);
 }
 
 /* ************************************************************************* */


### PR DESCRIPTION
Broader question: should we more broadly refactor to trying to use initializer lists instead of comma init? I already did all the work as part of making #2561, and I personally think it's much cleaner. It seems like GCC's analyzers can't see past the comma init and throws up its hands. Note that I changed to the fixed size types, but that's unnecessary to fix the warning. I just think it looks cleaner without the extra pair of braces.