### PR TITLE
Fix Gal3 maybe-uninitialized workaround by initializing Rt unconditionally

### DIFF
--- a/gtsam/geometry/Gal3.cpp
+++ b/gtsam/geometry/Gal3.cpp
@@ -20,12 +20,6 @@
  * refer to the aforementioned paper.
  */
 
-// GCC bug workaround
-#if  defined(__GNUC__) && __GNUC__ == 15
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/geometry/Event.h>
@@ -67,8 +61,7 @@ namespace { // Anonymous namespace for internal linkage
 Gal3 Gal3::Create(const Rot3& R, const Point3& r, const Velocity3& v, double t,
                   OptionalJacobian<10, 3> H1, OptionalJacobian<10, 3> H2,
                   OptionalJacobian<10, 3> H3, OptionalJacobian<10, 1> H4) {
-  Matrix3 Rt;
-  if (H2 || H3 || H4) Rt = R.transpose();
+  const Matrix3 Rt = R.transpose();
   if (H1) {
     H1->setZero();
     H1->block<3, 3>(0, 0) = I_3x3;
@@ -96,8 +89,7 @@ Gal3 Gal3::FromPoseVelocityTime(const Pose3& pose, const Velocity3& v, double t,
                                 OptionalJacobian<10, 1> H3) {
   const Rot3& R = pose.rotation();
   const Point3& r = pose.translation();
-  Matrix3 Rt;
-  if (H2 || H3) Rt = R.transpose();
+  const Matrix3 Rt = R.transpose();
   if (H1) {
     H1->setZero();
     H1->block<3, 3>(0, 0) = I_3x3;
@@ -315,8 +307,7 @@ Gal3 Gal3::Expmap(const TangentVector& xi, OptionalJacobian<10, 10> Hxi) {
 #else
   const Rot3 R(local.expmap());
 #endif
-  Matrix3 Rt;
-  if (Hxi) Rt = R.transpose();
+  const Matrix3 Rt = R.transpose();
 
   // Compute velocity: just apply left SO(3) Jacobian,
   Matrix3 H_v_w;


### PR DESCRIPTION
Fixes #2576.

## Analysis
In `Gal3.cpp`, `Create`, `FromPoseVelocityTime`, and `Expmap` each declared

```cpp
Matrix3 Rt;
if (H2 || H3 || H4) Rt = R.transpose();   // Create; analogous guards elsewhere
```

and then used `Rt` only inside the nested `if (H2)` / `if (H3)` / `if (H4)` (or `if (Hxi)`) blocks. So `Rt` is always assigned before any read, there is no real uninitialized use. GCC 15 cannot prove the correlation between the outer `||` guard and the inner per-handle guards, so it raises a `-Wmaybe-uninitialized` false positive. That warning was silenced by a version-gated pragma:

```cpp
#if defined(__GNUC__) && __GNUC__ == 15
#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
#endif
```

whose `push` had no matching `pop` anywhere in the file, so the suppression leaked to the rest of the translation unit.

## Fix
`R` is always available in all three functions and `R.transpose()` is a trivial 3x3 op, so `Rt` is now computed unconditionally as a `const`:

```cpp
const Matrix3 Rt = R.transpose();
```

This removes the false positive at its source and lets the version-gated pragma block be deleted entirely. No behavior change: the Jacobian blocks are still written only when their handle is non-null. The only difference is the cheap transpose now runs even when no Jacobian is requested.

## Tests
No functional behavior changed, so existing `testGal3` coverage applies. As a follow-up, the analytic Jacobians of `Create` and `FromPoseVelocityTime` (raised in the issue) could get dedicated `numericalDerivative` checks like the existing `RetractJacobians`/`Expmap` tests; happy to add those in a separate PR.