### PR TITLE
Link cephes-gtsam against libm

### DIFF
--- a/gtsam/3rdparty/cephes/CMakeLists.txt
+++ b/gtsam/3rdparty/cephes/CMakeLists.txt
@@ -30,6 +30,20 @@ set(CEPHES_SOURCES
 # Add library source files
 add_library(cephes-gtsam ${GTSAM_LIBRARY_TYPE} ${CEPHES_SOURCES})
 
+# cephes/gamma.c, igam.c, etc. call libm functions (e.g. sin) directly, but
+# nothing here previously linked cephes-gtsam against libm, leaving it to be
+# resolved transitively through whatever else the final binary happens to
+# link. That can crash the dynamic linker while relinking an IFUNC-resolved
+# symbol (e.g. sin) depending on load order; see e.g.
+# https://bugzilla.redhat.com/show_bug.cgi?id=1883501 for the same failure
+# mode in an unrelated project. find_library naturally no-ops on platforms
+# without a separate libm (Windows, and effectively macOS where it's part of
+# libSystem already).
+find_library(MATH_LIBRARY m)
+if(MATH_LIBRARY)
+  target_link_libraries(cephes-gtsam PUBLIC ${MATH_LIBRARY})
+endif()
+
 # Add include directory (aka headers)
 target_include_directories(
   cephes-gtsam BEFORE PUBLIC $<INSTALL_INTERFACE:include/gtsam/3rdparty/cephes/>


### PR DESCRIPTION
## Summary

`cephes-gtsam` calls libm functions directly (e.g. `sin` in `cephes/gamma.c`)
but was never linked against libm itself. It happened to keep working
because the symbol got resolved transitively through whatever else ends up
in the final process, but that's fragile: depending on link order in a
downstream consumer, glibc's dynamic linker can crash while relinking the
IFUNC-resolved `sin` symbol (prints `Relink `libcephes-gtsam.so' with
`libm.so' for IFUNC symbol `sin'` right before segfaulting inside
`_dl_relocate_object`). Same failure mode as
[RHBZ#1883501](https://bugzilla.redhat.com/show_bug.cgi?id=1883501) in an
unrelated project (cp2k/libxc).

I hit this building a downstream Rust FFI binding against GTSAM: a build
that pulled in more of libgtsam's symbol surface shifted link order enough
to trigger the crash reliably. Confirmed the missing dependency directly
(`readelf -d libcephes-gtsam.so` had no `NEEDED` entry for `libm.so`), and
confirmed this fix resolves it.

## Fix

`find_library(MATH_LIBRARY m)` + conditional `target_link_libraries`,
rather than a bare `-lm`, so it naturally no-ops on platforms without a
separate libm (Windows, and effectively macOS where it's already part of
`libSystem`).

Not a duplicate of #2273 (fixed a different issue: duplicate declarations of
libm functions in `cephes.h` conflicting under static linking) or #2371
(trimmed which cephes source files are built); neither touched linking
cephes-gtsam against libm itself.

## Test plan

- [x] `cmake` configure + `make cephes-gtsam` succeeds
- [x] `readelf -d` on the resulting `libcephes-gtsam.so` shows a `NEEDED`
      entry for `libm.so.6` (previously absent)
- [x] Downstream build that previously crashed at dynamic-link time now
      runs cleanly, repeated across multiple rebuilds