### PR TITLE
Clarify JointMarginal::at()/operator() indexing semantics (Key, not position)

### DIFF
--- a/gtsam/linear/JointMarginal.h
+++ b/gtsam/linear/JointMarginal.h
@@ -42,7 +42,14 @@ class GTSAM_EXPORT JointMarginal {
   JointMarginal() {}
 
   /** Access a block, corresponding to a pair of variables, of the joint
-   * marginal. */
+   * marginal. Note: iVariable and jVariable are the actual nonlinear Keys
+   * used to construct this JointMarginal (the keys passed to
+   * jointMarginalCovariance()/jointMarginalInformation()), NOT positional
+   * indices into the block matrix. To retrieve the single variable
+   * marginal for `key` (equivalent to Marginals::marginalCovariance(key)),
+   * call at(key, key), not at(0, key) or any other cross covariance
+   * block, which represents the covariance *between* two different
+   * variables and will generally differ. */
   Matrix operator()(Key iVariable, Key jVariable) const {
     const auto indexI = indices_.at(iVariable);
     const auto indexJ = indices_.at(jVariable);

--- a/gtsam/linear/JointMarginal.h
+++ b/gtsam/linear/JointMarginal.h
@@ -56,7 +56,7 @@ class GTSAM_EXPORT JointMarginal {
     return blockMatrix_.block(indexI, indexJ);
   }
 
-  /** Synonym for operator() */
+  /** Synonym for operator() See operator() for indexing semantics. */
   Matrix at(Key iVariable, Key jVariable) const { return (*this)(iVariable, jVariable); }
 
   /** The full, dense covariance/information matrix of the joint marginal. */


### PR DESCRIPTION
**Summary**
`JointMarginal::at(iVariable, jVariable)` (and its `operator()` equivalent) in `gtsam/linear/JointMarginal.h` takes the actual nonlinear `Keys` used to construct the `JointMarginal`, not positional/row indices into the underlying block matrix. This wasn't documented, and it caused confusion in #1305, where a user compared `joint_covs.at(0, key)` against `marginals.marginalCovariance(key)` expecting them to match. They don't, and `at(0, key)` returns the cross-covariance block between variable 0 and variable key, not the diagonal (self-covariance) block for key. The correct call for that comparison is `at(key, key)`.

This PR is a comment-only clarification of the existing behavior. No functional/behavioral changes, as `operator()`and `at()` are untouched apart from the docstrings.
Fixes https://github.com/borglab/gtsam/issues/1305

**Change**
Updated the doc comments on `JointMarginal::operator()` and `JointMarginal::at()` in `gtsam/linear/JointMarginal.h` to explicitly state that arguments are Keys (not indices), and that `at(key, key)` is the call equivalent to `Marginals::marginalCovariance(key)`.

**Testing**
Documentation-only change, so no code paths affected and no new tests are needed. I also verified the existing unit tests `(testMarginals)` still pass unmodified, confirming no behavioral change.

**Environment**
OS: Windows 11 x64
Compiler: Visual Studio 2026 Community, MSVC 19.51
CMake: 4.2.3