### PR TITLE
fix: remove AmbientDim from QCQP conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ conductor/
 .ccache/
 gtsam_unstable/timing/data/
 timing/results/bayes_tree_covariance/
+_agent/docs*

--- a/gtsam/constrained/tests/testQcqpProblem.cpp
+++ b/gtsam/constrained/tests/testQcqpProblem.cpp
@@ -378,6 +378,45 @@ TEST(QcqpProblem, SingleFrobeniusBetweenFactor) {
                        1e-12);
 }
 
+// Verifies hard Rot2 Frobenius priors become D=1 lifted linear equalities.
+TEST(QcqpProblem, HardFrobeniusPriorRot2D1) {
+  const Rot2 measured = Rot2::fromAngle(0.25);
+  const auto hardNoise = noiseModel::Constrained::All(4);
+
+  NonlinearFactorGraph graph;
+  graph.emplace_shared<FrobeniusPrior<Rot2>>(x0, measured.matrix(), hardNoise);
+
+  const QcqpProblem problem(graph);
+
+  bool foundLinearEquality = false;
+  for (const auto& factor : problem.eConstraints()) {
+    if (dynamic_cast<const LinearEqualityConstraintFactor*>(factor.get())) {
+      foundLinearEquality = true;
+      break;
+    }
+  }
+
+  LONGS_EQUAL(0, problem.costs().size());
+  EXPECT(foundLinearEquality);
+
+  Values qcqpValues;
+  InsertQcqpValue<Rot2, 1>(x0, measured, &qcqpValues);
+  EXPECT_DOUBLES_EQUAL(0.0, problem.eConstraints().violationNorm(qcqpValues),
+                       1e-12);
+}
+
+// Verifies the deferred non-constrained Frobenius prior cost path rejects.
+TEST(QcqpProblem, FrobeniusPriorRot2D1GaussianRejected) {
+  const Rot2 measured = Rot2::fromAngle(0.25);
+  const auto gaussianNoise = noiseModel::Isotropic::Sigma(4, 0.1);
+
+  NonlinearFactorGraph graph;
+  graph.emplace_shared<FrobeniusPrior<Rot2>>(x0, measured.matrix(),
+                                             gaussianNoise);
+
+  CHECK_EXCEPTION({ QcqpProblem problem(graph); }, std::runtime_error);
+}
+
 }  // namespace QcqpSingleFactorFixture
 /* ************************************************************************* */
 namespace QcqpRingFixture {

--- a/gtsam/geometry/Rot2.h
+++ b/gtsam/geometry/Rot2.h
@@ -283,39 +283,50 @@ struct traits<Rot2> : public internal::MatrixLieGroup<Rot2, 2> {
 
   /**
    * Return row-space QCQP equality constraints A, b such that
-   * trace(X' A X) = b. For D=1 these are the vec(R) SO(2) constraints,
-   * including orientation. For D>=2 the same 2-by-2 constraints enforce
+   * trace(X' A X) = b. For D=1 these are the lifted SO(2) constraints in
+   * column-major coordinates. For D>=2 the same 2-by-2 constraints enforce
    * row orthonormality.
    */
   template <int D = 1>
   static std::vector<std::pair<Matrix, double>> QcqpConstraints() {
     if constexpr (D == 1) {
+      // The homogenized Rot2 lifted vector is
+      // x = [1, r00, r10, r01, r11]. The quadratic form x^T A x therefore
+      // stores the quadratic monomials used by the Julia SO(2) prototype.
       std::vector<std::pair<Matrix, double>> constraints;
-      constraints.reserve(4);
+      constraints.reserve(5);
 
-      Matrix A = Matrix::Zero(4, 4);
+      Matrix A = Matrix::Zero(5, 5);
 
+      // Fix the leading-coordinate convention x(0) = 1.
       A(0, 0) = 1.0;
-      A(1, 1) = 1.0;
       constraints.emplace_back(A, 1.0);
 
+      // det(R) = r00*r11 - r10*r01 = 1.
       A.setZero();
-      A(2, 2) = 1.0;
+      A(1, 4) = 0.5;
+      A(4, 1) = 0.5;
+      A(2, 3) = -0.5;
+      A(3, 2) = -0.5;
+      constraints.emplace_back(A, 1.0);
+
+      // RR^T = I supplies the default, non-redundant row-orthonormality
+      // Note the reuse of the A variable for multiple constraints.
+      A.setZero();
+      A(1, 1) = 1.0;
       A(3, 3) = 1.0;
       constraints.emplace_back(A, 1.0);
 
       A.setZero();
-      A(0, 2) = 0.5;
-      A(2, 0) = 0.5;
-      A(1, 3) = 0.5;
-      A(3, 1) = 0.5;
+      A(1, 2) = 0.5;
+      A(2, 1) = 0.5;
+      A(3, 4) = 0.5;
+      A(4, 3) = 0.5;
       constraints.emplace_back(A, 0.0);
 
       A.setZero();
-      A(0, 3) = 0.5;
-      A(3, 0) = 0.5;
-      A(1, 2) = -0.5;
-      A(2, 1) = -0.5;
+      A(2, 2) = 1.0;
+      A(4, 4) = 1.0;
       constraints.emplace_back(A, 1.0);
 
       return constraints;

--- a/gtsam/geometry/Rot2.h
+++ b/gtsam/geometry/Rot2.h
@@ -265,7 +265,7 @@ struct traits<Rot2> : public internal::MatrixLieGroup<Rot2, 2> {
   static Matrix QcqpValue(const Rot2& value) {
     if constexpr (D == 1) {
       const Matrix2 R = value.matrix();
-      Matrix X(5, 1);
+      Vector5 X;
       X(0, 0) = 1.0; // Homogenization entry
       X.bottomRows(4) = Eigen::Map<const Matrix>(R.data(), 4, 1);
       return X;

--- a/gtsam/geometry/Rot2.h
+++ b/gtsam/geometry/Rot2.h
@@ -283,7 +283,7 @@ struct traits<Rot2> : public internal::MatrixLieGroup<Rot2, 2> {
 
   /**
    * Return row-space QCQP equality constraints A, b such that
-   * trace(X' A X) = b. For D=1 these are the lifted SO(2) constraints in
+   * trace(x_i' A x_i) = b[j]. For D=1 these are the lifted SO(2) constraints in
    * column-major coordinates. For D>=2 the same 2-by-2 constraints enforce
    * row orthonormality.
    */
@@ -291,8 +291,7 @@ struct traits<Rot2> : public internal::MatrixLieGroup<Rot2, 2> {
   static std::vector<std::pair<Matrix, double>> QcqpConstraints() {
     if constexpr (D == 1) {
       // The homogenized Rot2 lifted vector is
-      // x = [1, r00, r10, r01, r11]. The quadratic form x^T A x therefore
-      // stores the quadratic monomials used by the Julia SO(2) prototype.
+      // x = [1, r00, r10, r01, r11]. 
       std::vector<std::pair<Matrix, double>> constraints;
       constraints.reserve(5);
 

--- a/gtsam/geometry/Rot2.h
+++ b/gtsam/geometry/Rot2.h
@@ -256,7 +256,8 @@ struct traits<Rot2> : public internal::MatrixLieGroup<Rot2, 2> {
   /**
    * Return a matrix-valued QCQP variable for Rot2.
    *
-   * D=1 is vectorized SO(2) as a 4-by-1 matrix.
+   * D=1 prepends a fixed homogenization coordinate to the existing
+   * column-major SO(2) vectorization, yielding a 5-by-1 matrix.
    * D=2 returns R' as a 2-by-2 row-orthonormal matrix.
    * D>=3 returns [R', 0] as a 2-by-D row-orthonormal matrix.
    */
@@ -264,7 +265,10 @@ struct traits<Rot2> : public internal::MatrixLieGroup<Rot2, 2> {
   static Matrix QcqpValue(const Rot2& value) {
     if constexpr (D == 1) {
       const Matrix2 R = value.matrix();
-      return Eigen::Map<const Matrix>(R.data(), 4, 1);
+      Matrix X(5, 1);
+      X(0, 0) = 1.0; // Homogenization entry
+      X.bottomRows(4) = Eigen::Map<const Matrix>(R.data(), 4, 1);
+      return X;
     } else if constexpr (D == 2) {
       return value.matrix().transpose();
     } else if constexpr (D >= 3) {

--- a/gtsam/slam/FrobeniusFactor.h
+++ b/gtsam/slam/FrobeniusFactor.h
@@ -27,6 +27,7 @@
 #include <gtsam/nonlinear/NoiseModelFactorN.h>
 
 #include <stdexcept>
+#include <type_traits>
 
 namespace gtsam {
 
@@ -319,9 +320,6 @@ class FrobeniusBetweenFactor : public FrobeniusBetweenFactorNL<T> {
             "non-robust quadratic noise model");
       }
 
-      InsertQcqpConstraints<T, 1>(this->key1(), constraints);
-      InsertQcqpConstraints<T, 1>(this->key2(), constraints);
-
       constexpr int AmbientDim = N * N;
       const Matrix measurement = this->T12_.matrix();
       const Matrix A = RightProductMatrix(measurement);
@@ -335,17 +333,29 @@ class FrobeniusBetweenFactor : public FrobeniusBetweenFactorNL<T> {
       const Matrix Q = whitenedB.transpose() * whitenedB;
 
       // From here on we do homogenization and truncation (which may be Lie-group specific): 
-      constexpr int LiftedDim = AmbientDim + 1; // First entry is homogenization
-      Matrix Q_trunc_hom = Matrix::Zero(2 * LiftedDim, 2 * LiftedDim);
-      Q_trunc_hom.block(1, 1, AmbientDim, AmbientDim) = Q.block(0, 0, AmbientDim, AmbientDim);
-      Q_trunc_hom.block(1, LiftedDim + 1, AmbientDim, AmbientDim) = Q.block(0, AmbientDim, AmbientDim, AmbientDim);
-      Q_trunc_hom.block(LiftedDim + 1, 1, AmbientDim, AmbientDim) = Q.block(AmbientDim, 0, AmbientDim, AmbientDim);
-      Q_trunc_hom.block(LiftedDim + 1, LiftedDim + 1, AmbientDim, AmbientDim) = Q.block(AmbientDim, AmbientDim, AmbientDim, AmbientDim);
+      if constexpr (std::is_same_v<T, Rot2>) {
+        constexpr int LiftedDim = AmbientDim + 1; // First entry is homogenization
+        Matrix Q_trunc_hom = Matrix::Zero(2 * LiftedDim, 2 * LiftedDim);
+        Q_trunc_hom.block(1, 1, AmbientDim, AmbientDim) = Q.block(0, 0, AmbientDim, AmbientDim);
+        Q_trunc_hom.block(1, LiftedDim + 1, AmbientDim, AmbientDim) = Q.block(0, AmbientDim, AmbientDim, AmbientDim);
+        Q_trunc_hom.block(LiftedDim + 1, 1, AmbientDim, AmbientDim) = Q.block(AmbientDim, 0, AmbientDim, AmbientDim);
+        Q_trunc_hom.block(LiftedDim + 1, LiftedDim + 1, AmbientDim, AmbientDim) = Q.block(AmbientDim, AmbientDim, AmbientDim, AmbientDim);
 
-      const SymmetricBlockMatrix blockQ(
-          std::vector<DenseIndex>{LiftedDim, LiftedDim}, Q_trunc_hom);
-      costs->push_back(std::make_shared<QpCost>(
-          KeyVector{this->key1(), this->key2()}, blockQ));
+        // Keep constraint insertion inside the type-specific branch so
+        // Q_trunc_hom dimensions agree with the lifted vector, e.g. Rot2.h.
+        InsertQcqpConstraints<T, 1>(this->key1(), constraints);
+        InsertQcqpConstraints<T, 1>(this->key2(), constraints);
+
+        const SymmetricBlockMatrix blockQ(
+            std::vector<DenseIndex>{LiftedDim, LiftedDim}, Q_trunc_hom);
+        costs->push_back(std::make_shared<QpCost>(
+            KeyVector{this->key1(), this->key2()}, blockQ));
+      } else {
+        (void)constraints;
+        throw std::runtime_error(
+            "FrobeniusBetweenFactor::qcqpFactors D=1 lifted Q embedding is "
+            "currently implemented only for Rot2.");
+      }
     }
   }
 

--- a/gtsam/slam/FrobeniusFactor.h
+++ b/gtsam/slam/FrobeniusFactor.h
@@ -149,16 +149,14 @@ class FrobeniusPrior : public NoiseModelFactorN<T> {
       if (this->noiseModel_->isConstrained()) {
         InsertQcqpConstraints<T, 1>(this->key(), constraints);
 
-        constexpr int AmbientDim = N * N;
-        constexpr int LiftedDim = AmbientDim + 1;
-        Matrix B = Matrix::Zero(AmbientDim, LiftedDim);
+        constexpr int LiftedDim = Dim + 1;
+        Matrix B = Matrix::Zero(Dim, LiftedDim);
         B.col(0) = -vecM_;
-        B.block(0, 1, AmbientDim, AmbientDim) =
-            Matrix::Identity(AmbientDim, AmbientDim);
+        B.block(0, 1, Dim, Dim) = Matrix::Identity(Dim, Dim);
 
         constraints->push_back(LinearConstraint::Equal(
                                    JacobianFactor(this->key(), B,
-                                                  Vector::Zero(AmbientDim)))
+                                                  Vector::Zero(Dim)))
                                    .createEqualityFactor());
       } else {
         throw std::runtime_error(

--- a/gtsam/slam/FrobeniusFactor.h
+++ b/gtsam/slam/FrobeniusFactor.h
@@ -111,6 +111,75 @@ class FrobeniusPrior : public NoiseModelFactorN<T> {
     return traits<T>::Vec(g, H) -
            vecM_;  // Jacobian is computed only when needed.
   }
+
+  /** Add this Frobenius prior to the QCQP graph.
+   *  D=1 uses the lifted vector form; higher column dimensions are kept as a
+   *  separate dispatch point for the future matrix-form prior path. */
+  void qcqpFactors(NonlinearFactorGraph* costs,
+                   NonlinearEqualityConstraints* constraints,
+                   size_t columnDimension = 1) const override {
+    if (columnDimension == 0) {
+      throw std::invalid_argument(
+          "FrobeniusPrior::qcqpFactors: columnDimension must be >= 1");
+    }
+    if (columnDimension == 1) {
+      qcqpFactorsForVec(costs, constraints);
+    } else {
+      qcqpFactorsForMatrix(costs, constraints, columnDimension);
+    }
+  }
+
+ private:
+  /// D=1 constrained-noise prior in lifted vector form.
+  /// The stored measurement is vecM_ = vec(M), where M is the matrix passed to
+  /// the FrobeniusPrior constructor. The lifted variable for the current value
+  /// is x = [1, vec(R)]^T, where R is the matrix represented by this key. The
+  /// matrix B = [-vecM_, I] therefore gives B*x = vec(R) - vec(M). A hard prior
+  /// asks for that residual to be zero, so we add the linear equality B*x = 0.
+  void qcqpFactorsForVec(NonlinearFactorGraph* costs,
+                         NonlinearEqualityConstraints* constraints) const {
+    if constexpr (!internal::HasQcqpVariableTraits<T, 1>::value) {
+      (void)costs;
+      (void)constraints;
+      throw std::runtime_error(
+          "FrobeniusPrior::qcqpFactors requires QCQP variable traits for this "
+          "type and column dimension 1.");
+    } else {
+      (void)costs;
+      if (this->noiseModel_->isConstrained()) {
+        InsertQcqpConstraints<T, 1>(this->key(), constraints);
+
+        constexpr int AmbientDim = N * N;
+        constexpr int LiftedDim = AmbientDim + 1;
+        Matrix B = Matrix::Zero(AmbientDim, LiftedDim);
+        B.col(0) = -vecM_;
+        B.block(0, 1, AmbientDim, AmbientDim) =
+            Matrix::Identity(AmbientDim, AmbientDim);
+
+        constraints->push_back(LinearConstraint::Equal(
+                                   JacobianFactor(this->key(), B,
+                                                  Vector::Zero(AmbientDim)))
+                                   .createEqualityFactor());
+      } else {
+        throw std::runtime_error(
+            "FrobeniusPrior::qcqpFactors D=1 non-constrained noise is not yet "
+            "implemented.");
+      }
+    }
+  }
+
+  /// Matrix-form Frobenius priors are deliberately separate from the D=1
+  /// vector path; no QCQP lowering is implemented for this branch yet.
+  void qcqpFactorsForMatrix(NonlinearFactorGraph* costs,
+                            NonlinearEqualityConstraints* constraints,
+                            size_t columnDimension) const {
+    (void)costs;
+    (void)constraints;
+    (void)columnDimension;
+    throw std::runtime_error(
+        "FrobeniusPrior::qcqpFactors with column dimension > 1 is not yet "
+        "implemented.");
+  }
 };
 
 /**

--- a/gtsam/slam/FrobeniusFactor.h
+++ b/gtsam/slam/FrobeniusFactor.h
@@ -297,9 +297,8 @@ class FrobeniusBetweenFactor : public FrobeniusBetweenFactorNL<T> {
     return result;
   }
 
-  /// Vec(R) form (K=1): variable is a homogenized (N*N+1)x1 lift.
-  /// The first N*N residual rows preserve the original Frobenius error and
-  /// the final row ties the fixed homogenization coordinates across the edge.
+  /// Vec(R) form (K=1): build the full (N*N)x1 vec(R) cost first, then
+  /// embed its quadratic matrix in the lifted coordinate layout.
   void qcqpFactorsForVec(NonlinearFactorGraph* costs,
                          NonlinearEqualityConstraints* constraints) const {
     if constexpr (!internal::HasQcqpVariableTraits<T, 1>::value) {
@@ -324,23 +323,31 @@ class FrobeniusBetweenFactor : public FrobeniusBetweenFactorNL<T> {
       InsertQcqpConstraints<T, 1>(this->key2(), constraints);
 
       constexpr int AmbientDim = N * N;
-      constexpr int LiftedDim = AmbientDim + 1; // Add homogenization
       const Matrix measurement = this->T12_.matrix();
       const Matrix A = RightProductMatrix(measurement);
 
-      Matrix B = Matrix::Zero(LiftedDim, 2 * LiftedDim);
-      B.block(0, 1, AmbientDim, AmbientDim) = -A;
-      B.block(0, LiftedDim + 1, AmbientDim, AmbientDim) =
+      Matrix B = Matrix::Zero(AmbientDim, 2 * AmbientDim);
+      B.block(0, 0, AmbientDim, AmbientDim) = -A;
+      B.block(0, AmbientDim, AmbientDim, AmbientDim) =
           Matrix::Identity(AmbientDim, AmbientDim);
-      B(AmbientDim, 0) = -1.0;
-      B(AmbientDim, LiftedDim) = 1.0;
 
-      Matrix whitenedB = B;
-      const Matrix frobeniusRows = B.topRows(AmbientDim);
-      whitenedB.topRows(AmbientDim) = this->noiseModel_->Whiten(frobeniusRows);
+      const Matrix whitenedB = this->noiseModel_->Whiten(B);
       const Matrix Q = whitenedB.transpose() * whitenedB;
+
+      constexpr int LiftedDim = AmbientDim + 1;
+      Matrix Q_trunc_hom = Matrix::Zero(2 * LiftedDim, 2 * LiftedDim);
+      Q_trunc_hom.block(1, 1, AmbientDim, AmbientDim) =
+          Q.block(0, 0, AmbientDim, AmbientDim);
+      Q_trunc_hom.block(1, LiftedDim + 1, AmbientDim, AmbientDim) =
+          Q.block(0, AmbientDim, AmbientDim, AmbientDim);
+      Q_trunc_hom.block(LiftedDim + 1, 1, AmbientDim, AmbientDim) =
+          Q.block(AmbientDim, 0, AmbientDim, AmbientDim);
+      Q_trunc_hom.block(LiftedDim + 1, LiftedDim + 1, AmbientDim,
+                        AmbientDim) =
+          Q.block(AmbientDim, AmbientDim, AmbientDim, AmbientDim);
+
       const SymmetricBlockMatrix blockQ(
-          std::vector<DenseIndex>{LiftedDim, LiftedDim}, Q);
+          std::vector<DenseIndex>{LiftedDim, LiftedDim}, Q_trunc_hom);
       costs->push_back(std::make_shared<QpCost>(
           KeyVector{this->key1(), this->key2()}, blockQ));
     }

--- a/gtsam/slam/FrobeniusFactor.h
+++ b/gtsam/slam/FrobeniusFactor.h
@@ -355,9 +355,8 @@ class FrobeniusBetweenFactor : public FrobeniusBetweenFactorNL<T> {
 
  private:
   static Matrix RightProductMatrix(const Matrix& right) {
-    constexpr int AmbientDim = N * N;
     const Matrix I = Matrix::Identity(N, N);
-    Matrix result = Matrix::Zero(AmbientDim, AmbientDim);
+    Matrix result = Matrix::Zero(Dim, Dim);
     for (int column = 0; column < N; ++column) {
       for (int sourceColumn = 0; sourceColumn < N; ++sourceColumn) {
         result.block(column * N, sourceColumn * N, N, N) =
@@ -386,29 +385,28 @@ class FrobeniusBetweenFactor : public FrobeniusBetweenFactorNL<T> {
           this->noiseModel_->isConstrained()) {
         throw std::runtime_error(
             "FrobeniusBetweenFactor::qcqpFactors requires a "
-            "non-robust quadratic noise model");
+            "non-robust/non-hard quadratic noise model");
       }
 
-      constexpr int AmbientDim = N * N;
       const Matrix measurement = this->T12_.matrix();
       const Matrix A = RightProductMatrix(measurement);
 
-      Matrix B = Matrix::Zero(AmbientDim, 2 * AmbientDim);
-      B.block(0, 0, AmbientDim, AmbientDim) = -A;
-      B.block(0, AmbientDim, AmbientDim, AmbientDim) =
-          Matrix::Identity(AmbientDim, AmbientDim);
+      Matrix B = Matrix::Zero(Dim, 2 * Dim);
+      B.block(0, 0, Dim, Dim) = -A;
+      B.block(0, Dim, Dim, Dim) =
+          Matrix::Identity(Dim, Dim);
 
       const Matrix whitenedB = this->noiseModel_->Whiten(B);
       const Matrix Q = whitenedB.transpose() * whitenedB;
 
       // From here on we do homogenization and truncation (which may be Lie-group specific): 
       if constexpr (std::is_same_v<T, Rot2>) {
-        constexpr int LiftedDim = AmbientDim + 1; // First entry is homogenization
+        constexpr int LiftedDim = Dim + 1; // First entry is homogenization
         Matrix Q_trunc_hom = Matrix::Zero(2 * LiftedDim, 2 * LiftedDim);
-        Q_trunc_hom.block(1, 1, AmbientDim, AmbientDim) = Q.block(0, 0, AmbientDim, AmbientDim);
-        Q_trunc_hom.block(1, LiftedDim + 1, AmbientDim, AmbientDim) = Q.block(0, AmbientDim, AmbientDim, AmbientDim);
-        Q_trunc_hom.block(LiftedDim + 1, 1, AmbientDim, AmbientDim) = Q.block(AmbientDim, 0, AmbientDim, AmbientDim);
-        Q_trunc_hom.block(LiftedDim + 1, LiftedDim + 1, AmbientDim, AmbientDim) = Q.block(AmbientDim, AmbientDim, AmbientDim, AmbientDim);
+        Q_trunc_hom.block(1, 1, Dim, Dim) = Q.block(0, 0, Dim, Dim);
+        Q_trunc_hom.block(1, LiftedDim + 1, Dim, Dim) = Q.block(0, Dim, Dim, Dim);
+        Q_trunc_hom.block(LiftedDim + 1, 1, Dim, Dim) = Q.block(Dim, 0, Dim, Dim);
+        Q_trunc_hom.block(LiftedDim + 1, LiftedDim + 1, Dim, Dim) = Q.block(Dim, Dim, Dim, Dim);
 
         // Keep constraint insertion inside the type-specific branch so
         // Q_trunc_hom dimensions agree with the lifted vector, e.g. Rot2.h.

--- a/gtsam/slam/FrobeniusFactor.h
+++ b/gtsam/slam/FrobeniusFactor.h
@@ -334,17 +334,13 @@ class FrobeniusBetweenFactor : public FrobeniusBetweenFactorNL<T> {
       const Matrix whitenedB = this->noiseModel_->Whiten(B);
       const Matrix Q = whitenedB.transpose() * whitenedB;
 
-      constexpr int LiftedDim = AmbientDim + 1;
+      // From here on we do homogenization and truncation (which may be Lie-group specific): 
+      constexpr int LiftedDim = AmbientDim + 1; // First entry is homogenization
       Matrix Q_trunc_hom = Matrix::Zero(2 * LiftedDim, 2 * LiftedDim);
-      Q_trunc_hom.block(1, 1, AmbientDim, AmbientDim) =
-          Q.block(0, 0, AmbientDim, AmbientDim);
-      Q_trunc_hom.block(1, LiftedDim + 1, AmbientDim, AmbientDim) =
-          Q.block(0, AmbientDim, AmbientDim, AmbientDim);
-      Q_trunc_hom.block(LiftedDim + 1, 1, AmbientDim, AmbientDim) =
-          Q.block(AmbientDim, 0, AmbientDim, AmbientDim);
-      Q_trunc_hom.block(LiftedDim + 1, LiftedDim + 1, AmbientDim,
-                        AmbientDim) =
-          Q.block(AmbientDim, AmbientDim, AmbientDim, AmbientDim);
+      Q_trunc_hom.block(1, 1, AmbientDim, AmbientDim) = Q.block(0, 0, AmbientDim, AmbientDim);
+      Q_trunc_hom.block(1, LiftedDim + 1, AmbientDim, AmbientDim) = Q.block(0, AmbientDim, AmbientDim, AmbientDim);
+      Q_trunc_hom.block(LiftedDim + 1, 1, AmbientDim, AmbientDim) = Q.block(AmbientDim, 0, AmbientDim, AmbientDim);
+      Q_trunc_hom.block(LiftedDim + 1, LiftedDim + 1, AmbientDim, AmbientDim) = Q.block(AmbientDim, AmbientDim, AmbientDim, AmbientDim);
 
       const SymmetricBlockMatrix blockQ(
           std::vector<DenseIndex>{LiftedDim, LiftedDim}, Q_trunc_hom);

--- a/gtsam/slam/FrobeniusFactor.h
+++ b/gtsam/slam/FrobeniusFactor.h
@@ -297,8 +297,9 @@ class FrobeniusBetweenFactor : public FrobeniusBetweenFactorNL<T> {
     return result;
   }
 
-  /// Vec(R) form (K=1): variable is (N*N)x1; accepts any non-robust
-  /// Gaussian noise model.
+  /// Vec(R) form (K=1): variable is a homogenized (N*N+1)x1 lift.
+  /// The first N*N residual rows preserve the original Frobenius error and
+  /// the final row ties the fixed homogenization coordinates across the edge.
   void qcqpFactorsForVec(NonlinearFactorGraph* costs,
                          NonlinearEqualityConstraints* constraints) const {
     if constexpr (!internal::HasQcqpVariableTraits<T, 1>::value) {
@@ -323,18 +324,23 @@ class FrobeniusBetweenFactor : public FrobeniusBetweenFactorNL<T> {
       InsertQcqpConstraints<T, 1>(this->key2(), constraints);
 
       constexpr int AmbientDim = N * N;
+      constexpr int LiftedDim = AmbientDim + 1; // Add homogenization
       const Matrix measurement = this->T12_.matrix();
       const Matrix A = RightProductMatrix(measurement);
 
-      Matrix B = Matrix::Zero(AmbientDim, 2 * AmbientDim);
-      B.block(0, 0, AmbientDim, AmbientDim) = -A;
-      B.block(0, AmbientDim, AmbientDim, AmbientDim) =
+      Matrix B = Matrix::Zero(LiftedDim, 2 * LiftedDim);
+      B.block(0, 1, AmbientDim, AmbientDim) = -A;
+      B.block(0, LiftedDim + 1, AmbientDim, AmbientDim) =
           Matrix::Identity(AmbientDim, AmbientDim);
+      B(AmbientDim, 0) = -1.0;
+      B(AmbientDim, LiftedDim) = 1.0;
 
-      const Matrix whitenedB = this->noiseModel_->Whiten(B);
+      Matrix whitenedB = B;
+      const Matrix frobeniusRows = B.topRows(AmbientDim);
+      whitenedB.topRows(AmbientDim) = this->noiseModel_->Whiten(frobeniusRows);
       const Matrix Q = whitenedB.transpose() * whitenedB;
       const SymmetricBlockMatrix blockQ(
-          std::vector<DenseIndex>{AmbientDim, AmbientDim}, Q);
+          std::vector<DenseIndex>{LiftedDim, LiftedDim}, Q);
       costs->push_back(std::make_shared<QpCost>(
           KeyVector{this->key1(), this->key2()}, blockQ));
     }


### PR DESCRIPTION
This replacement PR is based on Avinash's PR 2549 head (624776d2e) and targets feature/convert_to_QCQP.

It removes the remaining AmbientDim uses from the QCQP Frobenius-prior conversion path and uses the existing Dim constant throughout.

Validation:
- make -j6 testQcqpProblem.run
- make check.constrained
- no AmbientDim occurrences remain in gtsam/slam/FrobeniusFactor.h
