### PR TITLE
Fix PartialPriorFactor instantiation for vector-space types like Point3

### DIFF
--- a/gtsam_unstable/slam/PartialPriorFactor.h
+++ b/gtsam_unstable/slam/PartialPriorFactor.h
@@ -113,18 +113,22 @@ namespace gtsam {
 
     /** Returns a vector of errors for the measured tangent parameters.  */
     Vector evaluateError(const T& p, OptionalMatrixType H) const override {
-      Eigen::Matrix<double, T::dimension, T::dimension> H_local;
+      // Use traits so this also works for types without static members,
+      // e.g. Point3, which is just an alias for Eigen::Vector3d (see #2413).
+      constexpr int Dim = traits<T>::dimension;
+      Eigen::Matrix<double, Dim, Dim> H_local;
 
       // If the Rot3 Cayley map is used, Rot3::LocalCoordinates will throw a runtime error
       // when asked to compute the Jacobian matrix (see Rot3M.cpp).
       #ifdef GTSAM_ROT3_EXPMAP
-      const Vector full_tangent = T::LocalCoordinates(p, H ? &H_local : nullptr);
+      const Vector full_tangent =
+          traits<T>::Local(traits<T>::Identity(), p, {}, H ? &H_local : nullptr);
       #else
-      const Vector full_tangent = T::Logmap(p, H ? &H_local : nullptr);
+      const Vector full_tangent = traits<T>::Logmap(p, H ? &H_local : nullptr);
       #endif
 
       if (H) {
-        (*H) = Matrix::Zero(indices_.size(), T::dimension);
+        (*H) = Matrix::Zero(indices_.size(), Dim);
         for (size_t i = 0; i < indices_.size(); ++i) {
           (*H).row(i) = H_local.row(indices_.at(i));
         }

--- a/gtsam_unstable/slam/tests/testPartialPriorFactor.cpp
+++ b/gtsam_unstable/slam/tests/testPartialPriorFactor.cpp
@@ -11,6 +11,7 @@
 
 #include <gtsam_unstable/slam/PartialPriorFactor.h>
 #include <gtsam/inference/Symbol.h>
+#include <gtsam/geometry/Point3.h>
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/base/numericalDerivative.h>
@@ -34,6 +35,7 @@ static const int kIndexTz = 5;
 
 typedef PartialPriorFactor<Pose2> TestPartialPriorFactor2;
 typedef PartialPriorFactor<Pose3> TestPartialPriorFactor3;
+typedef PartialPriorFactor<Point3> TestPartialPriorFactorPoint3;
 typedef std::vector<size_t> Indices;
 
 /// traits
@@ -43,6 +45,9 @@ struct traits<TestPartialPriorFactor2> : public Testable<TestPartialPriorFactor2
 
 template<>
 struct traits<TestPartialPriorFactor3> : public Testable<TestPartialPriorFactor3> {};
+
+template<>
+struct traits<TestPartialPriorFactorPoint3> : public Testable<TestPartialPriorFactorPoint3> {};
 }
 
 /* ************************************************************************* */
@@ -276,6 +281,31 @@ TEST(PartialPriorFactor, JacobianFullRotation3) {
   // Use the factor to calculate the derivative.
   Matrix actualH1;
   factor.evaluateError(pose, actualH1);
+
+  // Verify we get the expected error.
+  CHECK(assert_equal(expectedH1, actualH1, 1e-5));
+}
+
+/* ************************************************************************* */
+// Vector-space types like Point3 (an Eigen typedef) must also work (see #2413).
+TEST(PartialPriorFactor, JacobianPartialPoint3) {
+  Key pointKey(1);
+  Point3 measurement(1.0, -2.0, 3.0);
+
+  // Prior on z component of the point.
+  TestPartialPriorFactorPoint3 factor(pointKey, 2, measurement.z(), NM::Isotropic::Sigma(1, 0.25));
+
+  Point3 point = measurement; // Zero-error linearization point.
+
+  EXPECT(assert_equal(Vector1::Zero(), factor.evaluateError(point), 1e-9));
+
+  // Calculate numerical derivatives.
+  Matrix expectedH1 = numericalDerivative11<Vector, Point3>(
+      [&factor](const Point3& p) { return factor.evaluateError(p); }, point);
+
+  // Use the factor to calculate the derivative.
+  Matrix actualH1;
+  factor.evaluateError(point, actualH1);
 
   // Verify we get the expected error.
   CHECK(assert_equal(expectedH1, actualH1, 1e-5));


### PR DESCRIPTION
## Summary

`PartialPriorFactor<Point3>` fails to compile: `evaluateError` accesses `T::dimension`, `T::LocalCoordinates`, and `T::Logmap` as direct static members, which don't exist when `T` is an Eigen typedef like `Point3` (`Eigen::Vector3d`):

```
PartialPriorFactor.h:116:57: error: 'dimension' is not a member of 'Eigen::Matrix<double, 3, 1>'
PartialPriorFactor.h:121:54: error: 'LocalCoordinates' is not a member of ... 'Eigen::Matrix<double, 3, 1>'
```

Fixes #2413

## Changes

- `evaluateError` now goes through `traits<T>` (`traits<T>::dimension`, `traits<T>::Logmap`, and `traits<T>::Local(Identity, p)` for the `GTSAM_ROT3_EXPMAP` branch), matching the GTSAM convention for generic code. For Lie-group types these delegate to exactly the same implementations as before, so behavior is unchanged.
- Added a `PartialPriorFactor<Point3>` unit test (zero error at the linearization point + Jacobian vs numerical derivative).

## Testing

`cmake --build build --target testPartialPriorFactor && ./build/gtsam_unstable/slam/tests/testPartialPriorFactor` — no test failures (all existing Pose2/Pose3 Jacobian tests still pass, confirming identical behavior for Lie types).