### PR TITLE
fix: change to direct formulation of FrobeniusPrior to QCQP lift

### DIFF
--- a/gtsam/constrained/tests/testQcqpProblem.cpp
+++ b/gtsam/constrained/tests/testQcqpProblem.cpp
@@ -388,21 +388,36 @@ TEST(QcqpProblem, HardFrobeniusPriorRot2D1) {
 
   const QcqpProblem problem(graph);
 
-  bool foundLinearEquality = false;
+  const LinearEqualityConstraintFactor* priorConstraint = nullptr;
   for (const auto& factor : problem.eConstraints()) {
-    if (dynamic_cast<const LinearEqualityConstraintFactor*>(factor.get())) {
-      foundLinearEquality = true;
+    if (const auto* linear =
+            dynamic_cast<const LinearEqualityConstraintFactor*>(factor.get())) {
+      priorConstraint = linear;
       break;
     }
   }
 
   LONGS_EQUAL(0, problem.costs().size());
-  EXPECT(foundLinearEquality);
+  EXPECT(priorConstraint != nullptr);
+  if (!priorConstraint) return;
+
+  const Vector5 expectedTarget =
+      traits<Rot2>::QcqpValue<1>(measured).col(0);
+  const JacobianFactor& priorJacobian =
+      priorConstraint->linearConstraint().factor();
+  EXPECT(assert_equal(Matrix(Matrix5::Identity()),
+                      Matrix(priorJacobian.getA()), 1e-12));
+  EXPECT(assert_equal(Vector(expectedTarget), Vector(priorJacobian.getb()),
+                      1e-12));
 
   Values qcqpValues;
   InsertQcqpValue<Rot2, 1>(x0, measured, &qcqpValues);
   EXPECT_DOUBLES_EQUAL(0.0, problem.eConstraints().violationNorm(qcqpValues),
                        1e-12);
+
+  Values negatedQcqpValues;
+  negatedQcqpValues.insert(x0, -traits<Rot2>::QcqpValue<1>(measured));
+  EXPECT(problem.eConstraints().violationNorm(negatedQcqpValues) > 1e-12);
 }
 
 // Verifies the deferred non-constrained Frobenius prior cost path rejects.

--- a/gtsam/slam/FrobeniusFactor.h
+++ b/gtsam/slam/FrobeniusFactor.h
@@ -131,9 +131,7 @@ class FrobeniusPrior : public NoiseModelFactorN<T> {
   /// D=1 constrained-noise prior in lifted vector form.
   /// The stored measurement is vecM_ = vec(M), where M is the matrix passed to
   /// the FrobeniusPrior constructor. The lifted variable for the current value
-  /// is x = [1, vec(R)]^T, where R is the matrix represented by this key. The
-  /// matrix B = [-vecM_, I] therefore gives B*x = vec(R) - vec(M). A hard prior
-  /// asks for that residual to be zero, so we add the linear equality B*x = 0.
+  /// is x = [1, vec(R)]^T, where R is the matrix represented by this key.
   void qcqpFactorsForVec(NonlinearFactorGraph* costs,
                          NonlinearEqualityConstraints* constraints) const {
     if constexpr (!internal::HasQcqpVariableTraits<T, 1>::value) {

--- a/gtsam/slam/FrobeniusFactor.h
+++ b/gtsam/slam/FrobeniusFactor.h
@@ -148,13 +148,15 @@ class FrobeniusPrior : public NoiseModelFactorN<T> {
         InsertQcqpConstraints<T, 1>(this->key(), constraints);
 
         constexpr int LiftedDim = Dim + 1;
-        Matrix B = Matrix::Zero(Dim, LiftedDim);
-        B.col(0) = -vecM_;
-        B.block(0, 1, Dim, Dim) = Matrix::Identity(Dim, Dim);
+        Vector target = Vector::Zero(LiftedDim);
+        target(0) = 1.0;
+        target.tail(Dim) = vecM_;
 
         constraints->push_back(LinearConstraint::Equal(
-                                   JacobianFactor(this->key(), B,
-                                                  Vector::Zero(Dim)))
+                                   JacobianFactor(
+                                       this->key(),
+                                       Matrix::Identity(LiftedDim, LiftedDim),
+                                       target))
                                    .createEqualityFactor());
       } else {
         throw std::runtime_error(


### PR DESCRIPTION
some discussion with fable attached to show the motivation for this change. section 6 concerns the D = 2 case which I do not fully understand. 

[negative_rotations.pdf](https://github.com/user-attachments/files/30058063/negative_rotations.pdf)
