### PR TITLE
[Python] Add GPSFactorExample notebook

### DIFF
--- a/python/gtsam/examples/GPSFactorExample.ipynb
+++ b/python/gtsam/examples/GPSFactorExample.ipynb
@@ -1,0 +1,297 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8ff62160",
+   "metadata": {},
+   "source": [
+    "# GPS Factor Example\n",
+    "\n",
+    "A `GPSFactor` ties a 3D position measurement -- for example, a reading from a GPS receiver -- to a `Pose3` variable in a factor graph. Because GPS only observes *position*, a single `GPSFactor` constrains the translation part of a pose but says nothing about orientation.\n",
+    "\n",
+    "This notebook builds the smallest possible example of that idea: one pose, one prior, one GPS measurement. We optimize with Levenberg-Marquardt and see the pose's position pulled toward the GPS reading while its orientation is left to the prior."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b9fc902",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/python/gtsam/examples/GPSFactorExample.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0743d96e",
+   "metadata": {},
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Mandy Xie, Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "187215bf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T06:45:29.202190Z",
+     "iopub.status.busy": "2026-07-22T06:45:29.201991Z",
+     "iopub.status.idle": "2026-07-22T06:45:29.207427Z",
+     "shell.execute_reply": "2026-07-22T06:45:29.206832Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "4542290d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T06:45:29.210037Z",
+     "iopub.status.busy": "2026-07-22T06:45:29.209742Z",
+     "iopub.status.idle": "2026-07-22T06:45:29.379469Z",
+     "shell.execute_reply": "2026-07-22T06:45:29.378994Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import gtsam"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c47d312",
+   "metadata": {},
+   "source": [
+    "## 1. Set up the problem\n",
+    "\n",
+    "`lat0`, `lon0`, `h0` play the role of a single GPS reading -- the ENU origin where the plane was in hold next to the runway. We use two noise models:\n",
+    "\n",
+    "- `GPS_NOISE` is 3-dimensional, since a GPS measurement only observes `x, y, z` position.\n",
+    "- `PRIOR_NOISE` is 6-dimensional, since the prior constrains the full `Pose3` (position **and** orientation)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "01cc459d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T06:45:29.380650Z",
+     "iopub.status.busy": "2026-07-22T06:45:29.380575Z",
+     "iopub.status.idle": "2026-07-22T06:45:29.382232Z",
+     "shell.execute_reply": "2026-07-22T06:45:29.381959Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# ENU origin is where the plane was in hold next to runway\n",
+    "lat0 = 33.86998\n",
+    "lon0 = -84.30626\n",
+    "h0 = 274\n",
+    "\n",
+    "GPS_NOISE = gtsam.noiseModel.Isotropic.Sigma(3, 0.1)\n",
+    "PRIOR_NOISE = gtsam.noiseModel.Isotropic.Sigma(6, 0.25)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4731cba9",
+   "metadata": {},
+   "source": [
+    "## 2. Build the factor graph\n",
+    "\n",
+    "The `PriorFactorPose3` anchors pose key `1` at the identity pose -- deliberately different from the GPS reading, so the optimizer has real work to do. The `GPSFactor` then adds the position-only measurement on the same key."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f44b9f95",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T06:45:29.383128Z",
+     "iopub.status.busy": "2026-07-22T06:45:29.383075Z",
+     "iopub.status.idle": "2026-07-22T06:45:29.385061Z",
+     "shell.execute_reply": "2026-07-22T06:45:29.384801Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NonlinearFactorGraph: size: 2\n",
+      "\n",
+      "Factor 0: PriorFactor on 1\n",
+      "  prior mean:  R: [\n",
+      "\t1, 0, 0;\n",
+      "\t0, 1, 0;\n",
+      "\t0, 0, 1\n",
+      "]\n",
+      "t: 0 0 0\n",
+      "isotropic dim=6 sigma=0.25\n",
+      "\n",
+      "Factor 1:  GPSFactor on 1\n",
+      "  GPS measurement:    33.87\n",
+      "-84.3063\n",
+      "     274\n",
+      "isotropic dim=3 sigma=0.1\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "graph = gtsam.NonlinearFactorGraph()\n",
+    "\n",
+    "# Add a prior on the first pose, setting it to the origin\n",
+    "# A prior factor consists of a mean and a noise model (covariance matrix)\n",
+    "priorMean = gtsam.Pose3()  # prior at origin\n",
+    "graph.add(gtsam.PriorFactorPose3(1, priorMean, PRIOR_NOISE))\n",
+    "\n",
+    "# Add the GPS factor\n",
+    "gps = gtsam.Point3(lat0, lon0, h0)\n",
+    "graph.add(gtsam.GPSFactor(1, gps, GPS_NOISE))\n",
+    "\n",
+    "print(graph)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "addfae54",
+   "metadata": {},
+   "source": [
+    "## 3. Initial estimate\n",
+    "\n",
+    "For illustrative purposes, the initial estimate is deliberately set to the identity pose -- far from the GPS reading -- so we can watch the optimizer correct it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "5d2b7077",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T06:45:29.385929Z",
+     "iopub.status.busy": "2026-07-22T06:45:29.385861Z",
+     "iopub.status.idle": "2026-07-22T06:45:29.387422Z",
+     "shell.execute_reply": "2026-07-22T06:45:29.387162Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Values with 1 values:\n",
+      "Value 1: (gtsam::Pose3)\n",
+      "R: [\n",
+      "\t1, 0, 0;\n",
+      "\t0, 1, 0;\n",
+      "\t0, 0, 1\n",
+      "]\n",
+      "t: 0 0 0\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "initial = gtsam.Values()\n",
+    "initial.insert(1, gtsam.Pose3())\n",
+    "print(initial)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af9a467a",
+   "metadata": {},
+   "source": [
+    "## 4. Optimize\n",
+    "\n",
+    "We solve with `LevenbergMarquardtOptimizer`, the general-purpose nonlinear least-squares solver used throughout GTSAM."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "622dc9e0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T06:45:29.388363Z",
+     "iopub.status.busy": "2026-07-22T06:45:29.388295Z",
+     "iopub.status.idle": "2026-07-22T06:45:29.392325Z",
+     "shell.execute_reply": "2026-07-22T06:45:29.391993Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Values with 1 values:\n",
+      "Value 1: (gtsam::Pose3)\n",
+      "R: [\n",
+      "\t1, 0, 0;\n",
+      "\t0, 1, 0;\n",
+      "\t0, 0, 1\n",
+      "]\n",
+      "t:  29.1983 -72.6778  236.207\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "params = gtsam.LevenbergMarquardtParams()\n",
+    "optimizer = gtsam.LevenbergMarquardtOptimizer(graph, initial, params)\n",
+    "result = optimizer.optimize()\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41543a4f",
+   "metadata": {},
+   "source": [
+    "Notice that the optimized translation lands close to, but not exactly at, the GPS reading `(lat0, lon0, h0)`. It's a noise-weighted compromise between the two factors: the prior pulls it toward `(0, 0, 0)` with `sigma=0.25`, while the GPS factor pulls it toward the measurement with a tighter `sigma=0.1`, so the tighter (more confident) factor dominates. The rotation, meanwhile, stays exactly at the prior's identity value -- a single `GPSFactor` has no way to observe orientation from one position measurement. That information has to come from somewhere else (multiple GPS readings over time, an IMU, a compass, etc.)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/gtsam/examples/README.md
+++ b/python/gtsam/examples/README.md
@@ -59,7 +59,7 @@
 Extra Examples (with no C++ equivalent)
 - [FitBasisExample](FitBasisExample.ipynb)
 - DogLegOptimizerExample
-- GPSFactorExample
+- [GPSFactorExample](GPSFactorExample.ipynb)
 - PlanarManipulatorExample
 - PreintegrationExample
 - SFMData


### PR DESCRIPTION
Adds a notebook counterpart for `GPSFactorExample.py`.

Ran original `python GPSFactorExample.py` and checked values matched.
