### PR TITLE
[Python] Add OdometryExample notebook

### DIFF
--- a/python/gtsam/examples/OdometryExample.ipynb
+++ b/python/gtsam/examples/OdometryExample.ipynb
@@ -1,0 +1,391 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "45df6316",
+   "metadata": {},
+   "source": [
+    "# Odometry Example\n",
+    "\n",
+    "GTSAM models estimation problems as **factor graphs**: a bipartite graph of *variables* (things we want to estimate) and *factors* (measurement constraints between them). This notebook builds the smallest interesting factor graph -- a robot driving in a straight line -- and is a good first look at what a factor graph actually is.\n",
+    "\n",
+    "- **Variables**: three `Pose2` robot poses `(x, y, \\theta)`, at times 1, 2, 3.\n",
+    "- **Factors**: a `PriorFactor` anchoring the first pose at the origin, and two `BetweenFactor`s encoding noisy odometry -- \"the robot believes it moved 2 meters forward\" -- between consecutive poses.\n",
+    "\n",
+    "We build the graph, optimize it with Levenberg-Marquardt, and then look at the marginal covariances to see how uncertainty accumulates as the robot drives."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b8dac26",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/python/gtsam/examples/OdometryExample.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c09df7cc",
+   "metadata": {},
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "eba10674",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T10:15:29.253772Z",
+     "iopub.status.busy": "2026-07-22T10:15:29.253565Z",
+     "iopub.status.idle": "2026-07-22T10:15:29.259282Z",
+     "shell.execute_reply": "2026-07-22T10:15:29.258576Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5fd0279f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T10:15:29.261282Z",
+     "iopub.status.busy": "2026-07-22T10:15:29.261126Z",
+     "iopub.status.idle": "2026-07-22T10:15:29.615820Z",
+     "shell.execute_reply": "2026-07-22T10:15:29.615354Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import gtsam.utils.plot as gtsam_plot\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "885e3afb",
+   "metadata": {},
+   "source": [
+    "## 1. Noise models\n",
+    "\n",
+    "Both factors below use `noiseModel.Diagonal.Sigmas`, which lets us give each dimension of a `Pose2` -- `x`, `y`, `\\theta` -- its own standard deviation, unlike the `Isotropic` model (a single sigma for every dimension) used in the GPS factor example. Here we trust `\\theta` more than `x`/`y`, since the robot's odometry is better at tracking heading than position."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "7e1a111b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T10:15:29.617343Z",
+     "iopub.status.busy": "2026-07-22T10:15:29.617246Z",
+     "iopub.status.idle": "2026-07-22T10:15:29.619097Z",
+     "shell.execute_reply": "2026-07-22T10:15:29.618806Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ODOMETRY_NOISE = gtsam.noiseModel.Diagonal.Sigmas(np.array([0.2, 0.2, 0.1]))\n",
+    "PRIOR_NOISE = gtsam.noiseModel.Diagonal.Sigmas(np.array([0.3, 0.3, 0.1]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7686f23",
+   "metadata": {},
+   "source": [
+    "## 2. Build the factor graph\n",
+    "\n",
+    "The `PriorFactorPose2` pins pose `1` at the origin -- without it, the whole chain of poses could float anywhere, since odometry only measures *relative* motion. Each `BetweenFactorPose2` then says \"the robot believes it moved this `Pose2` -- 2 meters forward, no turn -- between these two poses.\" We reuse the same odometry measurement and noise model for both steps, since the robot drives the same way twice."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "3b892842",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T10:15:29.620048Z",
+     "iopub.status.busy": "2026-07-22T10:15:29.619985Z",
+     "iopub.status.idle": "2026-07-22T10:15:29.622666Z",
+     "shell.execute_reply": "2026-07-22T10:15:29.622334Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NonlinearFactorGraph: size: 3\n",
+      "\n",
+      "Factor 0: PriorFactor on 1\n",
+      "  prior mean:  (0, 0, 0)\n",
+      "  noise model: diagonal sigmas [0.3; 0.3; 0.1];\n",
+      "\n",
+      "Factor 1: BetweenFactor(1,2)\n",
+      "  measured:  (2, 0, 0)\n",
+      "  noise model: diagonal sigmas [0.2; 0.2; 0.1];\n",
+      "\n",
+      "Factor 2: BetweenFactor(2,3)\n",
+      "  measured:  (2, 0, 0)\n",
+      "  noise model: diagonal sigmas [0.2; 0.2; 0.1];\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "graph = gtsam.NonlinearFactorGraph()\n",
+    "\n",
+    "# Add a prior on the first pose, setting it to the origin\n",
+    "# A prior factor consists of a mean and a noise model (covariance matrix)\n",
+    "priorMean = gtsam.Pose2(0.0, 0.0, 0.0)  # prior at origin\n",
+    "graph.add(gtsam.PriorFactorPose2(1, priorMean, PRIOR_NOISE))\n",
+    "\n",
+    "# Add odometry factors\n",
+    "odometry = gtsam.Pose2(2.0, 0.0, 0.0)\n",
+    "# For simplicity, we will use the same noise model for each odometry factor\n",
+    "# Create odometry (Between) factors between consecutive poses\n",
+    "graph.add(gtsam.BetweenFactorPose2(1, 2, odometry, ODOMETRY_NOISE))\n",
+    "graph.add(gtsam.BetweenFactorPose2(2, 3, odometry, ODOMETRY_NOISE))\n",
+    "\n",
+    "print(graph)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "adeabdb2",
+   "metadata": {},
+   "source": [
+    "## 3. Initial estimate\n",
+    "\n",
+    "For illustrative purposes, the initial estimate for each pose is deliberately set to noisy, imprecise values -- not the origin, and not exactly 2 meters apart -- so the optimizer has real work to do."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a6817f6f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T10:15:29.623581Z",
+     "iopub.status.busy": "2026-07-22T10:15:29.623523Z",
+     "iopub.status.idle": "2026-07-22T10:15:29.625177Z",
+     "shell.execute_reply": "2026-07-22T10:15:29.624858Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Values with 3 values:\n",
+      "Value 1: (gtsam::Pose2)\n",
+      "(0.5, 0, 0.2)\n",
+      "\n",
+      "Value 2: (gtsam::Pose2)\n",
+      "(2.3, 0.1, -0.2)\n",
+      "\n",
+      "Value 3: (gtsam::Pose2)\n",
+      "(4.1, 0.1, 0.1)\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "initial = gtsam.Values()\n",
+    "initial.insert(1, gtsam.Pose2(0.5, 0.0, 0.2))\n",
+    "initial.insert(2, gtsam.Pose2(2.3, 0.1, -0.2))\n",
+    "initial.insert(3, gtsam.Pose2(4.1, 0.1, 0.1))\n",
+    "print(initial)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae39f901",
+   "metadata": {},
+   "source": [
+    "## 4. Optimize\n",
+    "\n",
+    "As in the GPS factor example, we solve with `LevenbergMarquardtOptimizer`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ffa74816",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T10:15:29.626000Z",
+     "iopub.status.busy": "2026-07-22T10:15:29.625940Z",
+     "iopub.status.idle": "2026-07-22T10:15:29.631697Z",
+     "shell.execute_reply": "2026-07-22T10:15:29.631332Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Values with 3 values:\n",
+      "Value 1: (gtsam::Pose2)\n",
+      "(7.46978315e-16, -5.34409096e-16, -1.78381863e-16)\n",
+      "\n",
+      "Value 2: (gtsam::Pose2)\n",
+      "(2, -1.09236636e-15, -2.48671179e-16)\n",
+      "\n",
+      "Value 3: (gtsam::Pose2)\n",
+      "(4, -1.70076056e-15, -2.50943863e-16)\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "params = gtsam.LevenbergMarquardtParams()\n",
+    "optimizer = gtsam.LevenbergMarquardtOptimizer(graph, initial, params)\n",
+    "result = optimizer.optimize()\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1b430ae",
+   "metadata": {},
+   "source": [
+    "## 5. Marginal covariances\n",
+    "\n",
+    "Beyond the best-estimate poses, GTSAM can also compute the **marginal covariance** of each variable -- how uncertain we are about it, given every factor in the graph. We'd expect pose 1 to be tightly constrained by its prior, and the uncertainty to grow for poses 2 and 3 as odometry noise accumulates along the direction of travel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9f66573b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T10:15:29.632565Z",
+     "iopub.status.busy": "2026-07-22T10:15:29.632505Z",
+     "iopub.status.idle": "2026-07-22T10:15:29.634945Z",
+     "shell.execute_reply": "2026-07-22T10:15:29.634682Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "X1 covariance:\n",
+      "[[9.00000000e-02 2.92775369e-33 3.54987407e-33]\n",
+      " [2.92775369e-33 9.00000000e-02 2.55795385e-17]\n",
+      " [3.54987407e-33 2.55795385e-17 1.00000000e-02]]\n",
+      "\n",
+      "X2 covariance:\n",
+      "[[1.30000000e-01 1.21229810e-18 6.06149052e-19]\n",
+      " [1.21229810e-18 1.70000000e-01 2.00000000e-02]\n",
+      " [6.06149052e-19 2.00000000e-02 2.00000000e-02]]\n",
+      "\n",
+      "X3 covariance:\n",
+      "[[1.70000000e-01 8.63317033e-18 2.69082498e-18]\n",
+      " [8.63317033e-18 3.70000000e-01 6.00000000e-02]\n",
+      " [2.69082498e-18 6.00000000e-02 3.00000000e-02]]\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "marginals = gtsam.Marginals(graph, result)\n",
+    "for i in range(1, 4):\n",
+    "    print(\"X{} covariance:\\n{}\\n\".format(i, marginals.marginalCovariance(i)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "789733f9",
+   "metadata": {},
+   "source": [
+    "## 6. Visualize\n",
+    "\n",
+    "`gtsam.utils.plot.plot_pose2` draws each pose as an axis triad together with a covariance ellipse, so we can see the growing uncertainty directly instead of just reading numbers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "de5832e4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T10:15:29.635825Z",
+     "iopub.status.busy": "2026-07-22T10:15:29.635770Z",
+     "iopub.status.idle": "2026-07-22T10:15:29.685041Z",
+     "shell.execute_reply": "2026-07-22T10:15:29.684697Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjYAAAGxCAYAAABx6/zIAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAAPYQAAD2EBqD+naQAAUpVJREFUeJzt3Qd4VGWzB/AJvQakgzQpUgQ+qiIdpEhXRBBpSpcOon50FBSlSRNQlCJFkKYC0nuV3nsPvRNqCMne5z/3bm5AElJ297T/73nWAAI5nJzsmTPvvDN+LpfLJUREREQ2EMfoAyAiIiLyFAY2REREZBsMbIiIiMg2GNgQERGRbTCwISIiIttgYENERES2wcCGiIiIbIOBDREREdlGPHGY0NBQuXjxoiRPnlz8/PyMPhwiIiKKAvQTvnv3rmTKlEnixIk4L+O4wAZBTZYsWYw+DCIiIoqBgIAAyZw5c4T/33GBDTI17hPj7+9v9OEQERFRFAQGBmpiwn0fj4jjAhv38hOCGgY2RERE1vKiMhIWDxMREZFtMLAhIiIi22BgQ0RERLbBwIaIiIhsg4ENERER2QYDGyIiIrINBjZERERkGwxsiIiIyDYY2BAREZFtMLAhIiIi22BgQ0RERLbBwIaIiIhsg4ENERER2QYDGyIiIrINBjZERERkGwxsiIiIyDYY2BAREZFtMLAhIiIi22BgQ0RERLZhycAmNDTU6EMgIiIiE7JUYLN48WKpWLGi+Pv7S7JkyaRatWpy4MABow+LiIiITMIygU1ISIiMHz9eBgwYINeuXZOAgABJlSqVVK1aVe7cuWP04REREZEJ+LlcLpdY1Pnz5yVLliyybNkyDXCiIjAwUFKkSKHBEDI/REREZH5RvX9bJmPzPBcuXNCPqVOnNvpQiIiIyATiiUU9fvxYunTpIiVLlpSiRYtG+PuCgoL0FT7iIyIiInuyZMYG9TZNmjSRixcvyuzZs8XPzy/C3zt48GBNXblfWLoiIiIie7JcjQ2CmmbNmsm6dev0lTNnzkh///MyNghuWGNDRERkvxqbeFbrX9O8eXMNaNauXfvCoAYSJkyoLyIiIrI/ywQ2SCy1aNFCVqxYobugMmTIIPfu3dP/lyhRIokXzzL/FCIiInJ6jc3Nmzdl7ty5cv/+fSlTpowGNu7XjBkzjD48IiIiMgHLpDmwpdudoSEiIiKydMaGiIiI6EUY2BAREZFtMLAhIiIi22BgQ0RERLbBwIaIiIhsg4ENERER2QYDGyIiIrINBjZERERkGwxsiIiIyDYY2BAREZFtMLAhIiIi22BgQ0RERLbBwIaIiIhsg4ENERER2QYDGyIiIrINBjZERERkGwxsiIiIyDYY2BAREZFtMLAhIiIi22BgQ0RERLbBwIaIiIhsg4ENERER2QYDGyIiIrINBjZERERkGwxsiIiIyDYY2BAREZFtMLAhIiIi22BgQ0RERLbBwIaIiIhsg4ENERER2QYDGyIiIrINBjZERERkGwxsiIiIyDbiGX0AREREvvL48WM5deqUHD9+XI4dO6Yf8bp586b+P/crTpw4kiBBAn0lTJhQMmXKJK+++qq+cufOrR/xa35+fvzimQwDGyIisqXQ0FDZtWuXLFq0SP755x8NZM6cOaO/DkmSJNEgBa+8efOGBTHx48cXl8ulAU5QUJA8evRIAgIC5I8//tA/HxIS8tSfz5Mnj1SqVElq1qwpmTNnNvhfTX4ufPUcJDAwUFKkSCF37twRf39/ow+HiIg86O7du7JixQpZvHix/P3333L58mV9zy9btqwGL+5sCz7GJOOCYOf06dNPZXz2798vW7du1YCncOHCGuDUqlVLSpQoIXHjxuXX18f3bwY2RERkabdu3ZLp06fLwoULZe3atRIcHCz58uULCzBKlSqlWRhvH8OyZcvCAiosbaVJk0aqV68u7733nh4Hg5zYYWATyxNDRETmdvLkSRk5cqRMmjRJg5mKFStqAIGAJkeOHIYdFzI3WPrCEhheyOjkzJlTunbtKh999JEkS5bMsGOzMgY2sTwxRERkTps3b5bhw4fLggULJHXq1NK+fXt9pU+fXsxox44derxz5szR+07btm2lU6dOuhRGnr9/c7s3ERGZ3pMnTzQwePPNN6V06dJy8OBBGT9+vJw7d06+/PJL0wY1ULx4cfntt990N1aLFi3khx9+kOzZs0uzZs1kz549Rh+e7TCwISIiU9u0aZMULVpUGjRoIIkSJdJamkOHDmnmI3HixGIVWbNmlWHDhsn58+fl22+/lXXr1kmRIkWkadOmcuXKFaMPzzYY2BARkSldv35dWrZsKWXKlNGABnUra9as0Toa9JmxKiyjdO/eXWuEfv75Z1myZIluGR83blzYVnKKOeteGUREZEvoM4MbPm728+fP1yWnLVu2yOuvvy52Ei9ePA3cjh49Ku+//7506NBBl9p27txp9KFZGgMbIiIyjb1792qGpnXr1lK7dm296bdr187WW6VRAD1x4kQtikafHPS/6dixo9y+fdvoQ7MkBjZERGSK4uCePXtKsWLFdNcL6k+mTJki6dKlE6dAtgY7qEaMGCFTp07VhoLoi0PRw8CGiIgMdfXqValataoMHTpUBg4cqDuFypUr58ivCpan0O/myJEjmrlBPRF2fbnHQNCLcVYUEREZZtu2bdqZF0swq1atkvLly/OrISIvv/yy/PnnnzJ48GDp27evbN++XaZNmyYvvfQSz88LMGNDRESGQF0JZjhhcCSGVTKoeRp2fvXu3VtHNKD+Bhmcffv28Wp9AQY2RETkU5iWjeLgNm3a6K4gzHdChoKe7+2339bam+TJk0vJkiVl5syZPFWRYGBDREQ+g+Z0qJ/BssrkyZO1d0vChAn5FXgBzL5Co8L69etL48aNtQ4HBdf0b6yxISIin8BIgUqVKonL5dKbNHZAUdQlSZJEd0uhn0+3bt3k0qVLOtXc25PLrYYZGyIi8roTJ05IhQoV9CbMoCbm/Pz8tMcN5mZhCGijRo208Jr+HwMbIiLyqmPHjmlQg7lO6E+DYmGKnXfeeUfmzZunc7MwQ4vBzf9jYENERF6DfiwIajAfCUXCmTJl4tn2EHRmRtZm6dKlumU+KCiI55aBDRERecvBgwc1qMHIAAyvzJgxI0+2h9WoUUP73axcuVLeffdd3XHmdMzYEBGRx+3fv18qVqwo6dOnl9WrV+tH8o5q1arpkhQyYnXr1pWHDx86+lQzsCEiIq/sfkJvGgQ1adOm5Rn2ssqVK+tcqY0bN+qyVEhIiGPPOQMbIiLymMDAQK39SJEihS6PYBmKfAMZsgULFsjy5cvl888/d+xpZ2BDREQegSwBmsehCR+WRhjU+F7VqlXl+++/1wnhkyZNEidigz4iIvKIXr166VyjRYsWSb58+XhWDdKxY0c5cOCAtGvXTl599VUpU6aMo74WzNgQEVGs/frrrzJkyBAZNmyYVK9enWfU4CZ+Y8aMkVKlSkm9evXk7Nmzjvp6MLAhIqJY2bJliw61bNGihc4wIuMlSJBA5s6dK8mSJZM6derIvXv3xCkY2BARUYwFBARo/xTML8JAS2QLyBzSpEmjtU7Ypda0aVMJDQ0VJ2BgQ0REMYJmcOibguncaO/PKd3m89prr8lvv/2mTfwGDBggTsDAhoiIYqRnz55y6NAhvWmmS5eOZ9GkatWqJQMHDpRBgwbJ+vXrxe4Y2BARUbShR83IkSNl8ODBUrhwYZ5Bk/vvf/+ru6OaNWsmd+7cETtjYENERNFy8+ZN+eijj+Stt96SLl268OxZQNy4cXXnGr52nTt3FjuzXGCDGRhTpkzR6BMFUURE5Fvt27eX+/fv63txnDiWu404Vvbs2WXs2LEa4MyZM0fsylJX5NSpUyVnzpzyxx9/yHfffSfnzp0z+pCIiBwFRcKzZ8/WHVCZM2c2+nAompo2baqzpDp06CDXrl2z5fmLY7Xq7oMHD2rESUREvnXjxg29IWIn1AcffMDTb0F+fn7yww8/6PgLuy4jWmqkQvHixfUjUqBEZD8ul0trAK5cuSJBQUHy5MkTCQ4O1jfj+PHj6ytp0qQ6NTpx4sRGH67jdOvWTb8u7FdjbenTp5dRo0Zp9gYBKhr42YmlApuYwDchXuEnzxKRcdAk7MiRI7Jt2zY5ffq0NngL/3rw4EGUm49lyZLlqVfevHnlzTff5NZjL8AMqGnTpsnkyZMlU6ZM3vgU5EONGzeWWbNm6TypcuXKScqUKW1z/m0f2GAr4pdffmn0YRA5FjKs27dvl02bNsnmzZu1/f6tW7c0C5MhQwYNSLJmzSoFCxYMC1AyZsyozd6QoYkXL55mcpC5QQbn7t27Oj0aQRDq7PBx3bp1+tG9jTVXrlxSunRpnZWDjxjIyCLXmHv8+LHupKlcubI0b97cY9cGGcfPz08mTJig3xvob4MZX3bh58I7hsXgTQ1vfmvWrJEKFSpEO2ODP4s3QH9/fx8cLZHzXL16VXdd4Ilw69atGpDg+w3ZFHfA8cYbb+gcG09CcOMOoPBx7969WkuAp9GaNWtKo0aNpGrVqhowUdRh2aJ79+56PgsUKMBTZyODBg3S5n2HDx+WHDlyiJnh/p0iRYoX3r9tH9jE9MQQUfTge2rBggXavn3VqlX6RIggonbt2hrM5M+fX3tp+BIG/2HJC91WEWihS26qVKmkfv36GuQgBc9MTuSQXUMGDDtpfvrpJx995chXHjx4ILlz59bmfdjtZmZRvX9balcUEZkLnouwDISbHgoSMd0ZGVLsurh06ZIsXrxY1/CxzOTroAaQEapUqZLOyDlw4IBmHNq0aSPLly+XihUr6gPSF198IRcuXPD5sVnF119/rV/Tr776yuhDIS9IkiSJfo1///13XSa2A0tlbHbu3KlPXVhjR1U+nriwNo91X7yighkbotjD28aiRYu0hg1vhlie+Pjjj6Vhw4a6Y8kKx48lMmSX0KwMjT9RO/L5559rdoL+F5qgogajT58+0rdvX54WmwoJCZFixYrpjsONGzeadkK7LTM2CRIk0LVyPGXhDbVQoUL680SJEhl9aESOgFqZmTNnyn/+8x/dIoplHAQ4+/bt0xoMKwQ1gDdu1PuMHj1aC5BRY/DXX39Jnjx5dPsrMjsk0qtXL919hq8t2VfcuHG1eBi1afPnzxers1TGxhOYsSGKPrxNILuBp3Y8xb/99tt60ytbtqxtTqd7XMuQIUPkzJkzWmw8dOhQzVg4ETJaCP4mTZqk2Tiyvxo1asixY8e0Fg2JBLOxZcaGiHwPPWcw7BB9L5Al3bVrlyxZssRWQQ2g4d8nn3wix48fl+nTp8vRo0c1M4UALqq9dewUyPbo0UO/3pgGTc4wdOhQ7S01fvx4sTIGNkT0XLiZ9+7dW29uWK5BMINdT0WKFLH1GUPfHARx+/fv19qSESNG6I6uhQsXilPg64zt8sOHDzek6JuMG1vUqlUrLRTHbjirYmBDRP+Cuhm8yeHGhuAGO4qw/OQkqN3r16+f/tvR0Rg1RZiRdPbsWbF7tgY1R9HZlEH28eWXX2pTTStnbRjYEFEYvKFh6QG9Z1BIi5t6//79HV2gj11SyFbNnTtXd2Yie4PRAnaF/mB79uzRbfDkPBkyZNAdgmPGjHmqua2VMLAhIoXOo6+//rruisCNGzdzbn3+/11U6NWDc9SgQQMN/tAP59GjR7a7erA7BrVFqKsiZ+revbtcvnxZd0BaEQMbItI3sBIlSuiZwFynJk2amLaXhZGSJ0+uQyB/+eUXDf6wa+jkyZNiFwcPHtSA9tNPP+XX38Hy5MmjWVsEuVbcOM3AhsjBkHHATiAUy9arV0/HDzh1e3N0oMMytkNjZEPRokVt0fsDUCiNXkRotEjO1qNHD932vXTpUrEaBjZEDoWRB5gPgwwEZgBNnTpVO49S1GC5ZseOHVKlShVdpkJNihWfbsNfD9jm3qVLF1P2MCHfKlu2rGZxsYHAahjYEDkQGtDhjQvr6Og22rp1ay49xACahWHMC9780dgPW2XRnt6Kxo4dqwENrgUiPz8/XZLEQNvdu3db6oQwsCFyGBTAIlMDmAuDpRSK3Q0AxZaouUHWCyMZrLabxL29F0ENxtQQATKR2bJls1zWhoENkYNguzIyNalSpZINGzZI9uzZjT4k20DB9bx587SRH3reIFiwCixHol09lqGIwjer7Natm8yaNUsCAgLEKhjYEDnE+vXrpWLFipI7d25Zu3atZMyY0ehDsh008Pv777+1a2/VqlXl9u3bYnaoCxo1apS8//77+nRO9GyhPHYD/vDDD2IVDGyIHADr5NWqVdM+NStWrNCMDXlHpUqV9HxjyQ+BpNlb02/ZskVOnDghbdu2NfpQyISSJ08uH374oRaWW6V+jNO96Sl4wrx48aLukAj/Edtag4OD5cmTJ1pTED9+fH2lSZNGMmXKpE//eLl/nDBhQp5ZEy0/VahQQetqMAPIyV2EfQmzpnDeMZpi2bJlOmTTjLDdf/HixVpQHicOn3Xp+cFvqVKlNGBH4G726d4MbBwMQQtueu4Xtq7i18LDRYRABQWFWG/FQDykrhHgPH78WK5du6Z/Bj92w+9B2/lixYrpq3jx4ro11qxv7HaGJ/HSpUvLK6+8om9K3M7t+xsCOvgiW4aRDGYbKInvW7TQR7Zm8ODBRh8OmZTL5ZJXX301rD2EURjYxPLE2BF2amAOzF9//aVPaJjYDKlTpw4LQjDJOXPmzJp5wRtekiRJonTR37x5UwMcvE6dOiW7du3SYGnfvn2a6cEb+htvvKHdLFFYiSZw7GzrXdevX5eSJUtqQIrdT8iukTEDRd955x0NHrCl2kzX/R9//CHvvvuuzgRDZokosuGY6ER85cqVKN0XvIGBTSxPjF3cvXtXlx8QzCAdjiUlPL0jwChfvrwGM1mzZvXamy2CKbxpIhuEz4/XgwcPJGfOnBrg4E0VTwFmerO3A5x3NI47cuSI/PPPP/o1J+NMnDhRZ0uNHj1aOnXqZKrtvKdPn9YHEaIXZX+x8eC3337Tlgamvn+7HObOnTtoDaof7Wz//v2u9u3bu5IlS+by8/NzlSxZ0vX111/rr4eGhhp2XA8fPnQtXrzY1bZtW1emTJn0a5EvXz7XmDFjXLdv3zbsuOwEX99mzZq5EiZM6Nq0aZPRh0P/p3v37q44ceLo9W8GN2/edCVIkMA1YsQIow+FLOLNN9901ahRw/T3bwY2NvL48WPX7NmzXeXKldMvfvr06V19+/Z1nTt3zmXWG/Dq1atd9evXd8WNG9eVNGlSDXj27t1r9KFZ2tixY/XrP2PGDKMPhcJ58uSJq06dOi5/f3/XqVOnDD83P/74owZaFy9eNPpQyCLGjRun79VXrlwx5PMzsInlibGSkJAQ18yZM105c+bUfxsCGwQ4QUFBLqs4f/68a8CAAWFZnHr16rkOHz5s9GFZDjJyyNR07NjR6EOh50BWMnv27K5SpUq5goODDT1HZcqUcVWrVs3QYyBruX79uit+/PiuUaNGGfL5GdjE8sRYATIeS5cudRUpUkT/TbVr13bt2bPHZfWs05QpU1zZsmXTp8mWLVu6AgICjD4sS3jw4IGrQIEC+sKPyZw2btyo1zYCeaMgY4T3jGnTphl2DGRNdevWdZUoUcLU9282LbCovXv3aj+Bt99+W7fwYtcLCoSxrdrK0BunefPmcvToURkxYoT8+eefWrCGyckofKaI4RwdP35cZs6cya31Jobt93379pWvvvpKOxQbAS3y8b6B4n2i6GjatKls375d32vMioGNxaDvBLbdoTfM1atXdS4NWuXjzdJO0OAPc2tOnjypN2xsk8VWdIwCoH9DG/8xY8bI0KFDpWDBgjxFJtenTx/dit+4cWPd4eFraPeAkQ/sa0TRhYdpvD/jPcesGNhYyJ49e7Ql/qBBg6RXr146Sr5WrVq23iqNLX0DBgzQfjhZsmTRFvUdO3Zk9iYc9JX4+OOPpUaNGnpuyPzQW2jGjBk6bqF9+/Y+/dz4nGgciBsUUXQhGC5XrpwsXbpUzIqBjQWgyy+yNCVKlNBmeNu2bdOfJ0iQQJwCfW/QXBB9QND5EtmbdevWGX1YpoBgBsEtzoudg1y7wWT18ePH69Ihek35CjpQh4aGajdkophAUIzs+cOHD8WMGNiYHDr6Vq9eXQYOHCg9e/bUtc0iRYqIE2GODZqbIXuD7shoVY9AB8GeU61evVpb9aMeKV26dEYfDkUThgvi+7t79+4+u0ngSRudvznJm2IT2Dx69EjLIMyIgY2JYTowxhCgK+jy5cu12NBJWZrIsje4oXft2lXrcFq3bq2ddp2YycO/H/VVjRo1MvpwKIa+//57OX/+vAwfPtzr5xAPAQhsuAxFsYHAGKUBZl2OYmBj4vkyCGowiRlZGiMnqpq1RgFzS6ZMmSLTpk3T84NaEyeZMGGCHDx4ULNWXIKyrjx58miAiiGUCHC86dChQ3LhwgUGNhQreL9BcIwROWbEwMaERo4cqXOUcLPevHmz5MiRw+hDMi1sDUetDQZvYqcY3ridMuCyX79+0qpVKylatKjRh0OxhK9l8uTJ5fPPP/fqucQTduLEibX4kyg2ENhgVeHs2bNiNgxsTObrr7+Wbt26yWeffSbz58/XNzuKHLbNIqv10ksvSYUKFbTHj92hDwoKQHG9kD12/yFjgwGDGzZs8Gpgg+8RZIKJYgM1jnHjxjVl1oaBjYlgWzP6W6BQ+LvvvtNiWTPB+vz9x/f1ZbaCXRQTY9eUe0s4tsLbFYqnf/rpJ71e0qZNK3Zm5mvOG9lH7Hzs3LmzBq2edv/+fS325G6oyDnpmosNTNl+8803TVlnY647p4N98803uoX722+/1eDGjB4EP5Bkg5PpCz82m9SpU+tW1ly5ckmVKlXkwIEDYkfI0mCrcIcOHcTuzH7NeRIeZFBAjH5VqLHzNGzPRYNPFg5HzknXXGzhWlq5cqUEBweLmTCwMQF0jO3du7cGNuiySzGXMmVKfYJABqdy5craudhOTpw4odu7sVSJ8RNkL2XLltVdbnjA8XS2ABlNfF+8+uqrHv17ybmqVKkid+/e1Z27ZsLAxmBYn8S2ZfSxQN0ExV6qVKlkxYoVWp+EIuzAwEDbnFbsBEuTJo0uW5A94eEGnYEx/82TduzYoTstuYOOPAWzCfGAhRpHM2FgY6Bjx45Jw4YNNZ03ZMgQvuF4EGpPMBQ0ICBAmjRp4pWaBV+7fPmybm9HIIydLWRPNWvWlNdee03r7DwlJCREdu7cqTU8RJ6CmVEIbhA0mwkDG4Pcvn1bswkZM2bUluqoLifPN5HCLhPUK2A7rdWNGjVKGzR+8sknRh8KebnWBtu+Mahy//79Hvk7jx49qvPVGNiQp+GaYsaG9OkJnWLRUA5ZBVSXk/eeflGvgILbWbNmWfY0YwL0uHHjpF27dlpHRPaG9wfs8EMm1xPcT9TFihXzyN9H5Ib+Yehng1obs2DGxgDY+YDamtmzZ0vu3LmNOARHQaEtZvKgmd3p06fFiiZOnKizWbAMRfaHuoVPP/1UM45YTo0tPFGjwzEfosjT3MOZzVRAzMDGxxDZYlkEb1pVq1b19ad3JBRLYooytoO3bNnScvU2eNPA5O733ntPMmXKZPThkI+0aNFClx6nT5/ukcAGT9ZE3ljyT5IkianqbBjY+HgJ6uOPP9YeJBhoSb7t7Przzz/rltcff/zRUqcefU0wKqJp06ZGHwr5EHb1vfvuuzoLLTZbv9G7BtcQ62vIW3P7ihQpYqo6GwY2Pl6CwhcfT9/c1WJMz4U2bdro0pSVlqRwY0uXLp0ePzkLdvQhyxubTtoYlBoUFMTAhhxTQMzAxkeOHDmiS1DoV4M21GSMoUOH6pIU6m2s0C79yZMnumsOxaR4MiJnQTCbPn16DW5jCjcc7LosXLiwR4+NKHxgg0HEN27cEDNgYOPDpluoj+ASlPFLUhMmTJDVq1frjjSzw4gI7J7jMpQzIZhFUIsiYgS5MQ1s0BcHdRBE3uBe5jRLnQ0DGx/YtGmT3kQHDRrEJSgTQEPESpUqSa9evbTuyczwpJ43b14pWrSo0YdCBi5HIbhFN+2YQC8cZmvIm3LmzClJkyb1WN+l2GJg42VY7vjvf/+r3Rk/+OADb386iuIuKfS2QUFubFL83oZpzAsWLNBsDdvgOxeCWuw8ienuKCwRYDAskTebSubIkUOvNTNgYONlf//9t858GTx4sH7xyTyp0/r162vdE/rDmBGmMT948ECPk5wLQe37778vS5YsiXaGEU3Trl27pk/URN6Ea8wsQ4d5p/Ui9EvBckf58uV1+YPMBUuDFy9e1B43ZrRy5UrJmjUrmziSTqq/detWtHdHuW80DGzI2xjYOAQKP/ft2ydffvkllxJMCJ1YUb8wcuRIU9baILDBDY3LUISp3KhhwDURHQxsyJeBzdmzZ2Nc5O5JzNh4EWb7FCxYUMqVK+fNT0Ox0LFjRzl37pwuGZptkveBAwfYu4YUOhBXqFAh2oENah7Q6A8tDoi8CTU2CGo8MQIkthjYeAlultgJ1aFDBz5xmxjazKPeBkGo2bJ9gN1bRIDsHer1Hj58GK2MDZ6kmfUjb3Mvd5qhzoaBjZf89NNPmjpu3Lixtz4FeUj79u1l6dKlpviGdMOTOXbSoeMwkTuwQQdhtI+IbmBD5G3ZsmXTDTJm2BnlkcAmMDBQZs2aJdu2bfPEX2d5mM2CaczNmzeXZMmSGX049AINGzaUl156SRv3maVFgLu+hsgNTfbQhTg6y1EIbLBEQOSLifTY7GCGB8QYBTZz584N68mCnT8VK1bUFvWlSpXyyCRaq8Mbz9WrV3UuEZkf5nY1a9ZMr10zTP5GAd758+f1+4rIDctJuCbWr18fpZMSHBysS+LM2JDTdkbFiek22b59++qPseaLPgnojIlmYkOGDBGnQ20NvsAFChQw+lAoijBFGQW7O3fuNPycYScdsFssPQvXBIrKozLnDEENdvsxsCFfwbVm2aWoY8eOhX2zYOYObgqoJ8HANjNEa0bCE//ChQulTp06LNizkNKlS+tylBnmR6EtOY4Fs8WIwsMuSzTdQ9ASlcwfZM+enSeRfALX2pkzZ8SSgQ3ecFHAhq1dWJZ666239Nexzevll18WJ9u1a5c2fUNgQ9YaNlizZk3TBDbI9nEnCz3LnQWOykwe96RlbvUmX8G1dvv2bcOX9GMU2HTp0kVvAigUQnBTrVo1/XUUEGMSrZMhW4OnbWQAyFoQjGIZyOgnDty08GRO9KwsWbJIihQpohTYoFMxgmP8fiJfSJUqlS6T3rlzRywX2HTq1EnWrVunHVu3bt0qCRMm1F9HtqZHjx7iZGj0hvEJqBAna0GAjsyNkc36sJ0XS70MbOh5EKggaxPVwCZlypScUUc+g4d697Vnye3eaPHdoEED/cZxa9GihXa5dCoMU9yzZ4+UKVPG6EOhGPD399feMUa2LTh69KhmQVl4ThHBtYEC4hfBzcV9oyHyBff1dvPmTTFSvKj+xilTpujHjz76KOzHEcHvcSI8ReGmhG62ZE3FihWTzZs3G/b53U/iDGwoIsjmTZo0SftlYdRCRBjYkFMzNlEObPr06RMWtLh/HBGnBjbYKoyljEKFChl9KBSLwObnn3+WBw8eSJIkSXx+HrGTBQV44TOhROHlypVLe9SgPQHqHCOCp2bUPBD5ivt6s0xgg4Zhz/sxPR3YoDtookSJeFosCtk2VPTv3btX3nzzTZ9/fjR2RHdZooi4x2zgWokssMHNhTuiyJdQioKxCpassTl06FCE/2/58uXi5MAGT/xkXVgCQnrfqEZ9uFlxPhRFNbCJDJeiyNcQ1CDbbHSNTZyYPtX+8MMP/9rN0a1bN90G7kTY4nbkyBHWRlgcgpo8efLI4cOHDfn86ODNwIYikzZt2rBrJTIMbMioOhtLZmww4LFXr15Sq1YtfWpAwSOCnT/++EO3gTsR9u0/fPjQ8Q0K7QANKC9dumTI52bGhqISfOPmEZWMDWtsyNdwzVkysGncuLFua8bBI3VfokQJ3SaLugQMwnQidBsGtsG3PqMDG9bY0IsgqxdZYIM6MXSA5XZv8jVcc5ZcigLsGEGh0P3793WLc5EiRXzaw8bols3Pct8IM2bMaPShUCzha+gOVH0JAwuvX7/OpSiKdWCD0gD35HoiX8I1h55ulgtsFi9erL0UsPSCupI5c+bI4MGDdQjmhQsXxJvwefBEi86+OAYM4TQD942QgY314WuIrbRRmaDsSXjKQcDurqEgimlggyDZXcxJ5Etx48Y1PPEQo6se07y7du0qa9as0dkl+Dlm7OCbyJs9XCZMmCDffPONzJgxQ2ta6tWrp3U+p0+fFjNkbNC51ojeJ+T5wAbNz3ydTnU/5fAaohfBNYIHyxcFNrjJEPkSrjn39WepwAaTvVE8HP5pAHUJy5Ytk969e4u3jBgxQlq2bCmVK1eWZMmSyYABAyRNmjQa8BgNDd2cPE7CTtxfR3xNfQlLuoAmj0SxuXkwsCEnBzYxegdFsXBEA9q6d+8u3nDjxg05fvy4lC9f/qnPh59v2bJFjIZOoLa/IYVfmrl/XyRYzAlZMz+/GP9x99cRX1NfYmDj3GsuJteo+3p5HvdSADM2McBrzpmBjRtqENBL4dlvsMyZM4unuXs2PFt/gLXmyIYWoojOXUgHgYGB4g04B7YPbMJnMNAd16w3mXv3RJImjfEfd38dI7txeAOfsp17zcXk5hHZ9ckam1jgNRcrWMmx5FIUag+w5RvVz6hHQJ1N+Jc3PVuUhJ8jcxNZsXGKFCnCXt46PjMUTJFnGPW0617a5XVEL4JrJLLCYPd7oq8L4IlcLpfhResxSjH06NFDMyhr167VeTq7d+/WrEnfvn3ls88+8/xRhttt9OxOAPw8Q4YMEf65nj17PrU8hoyNN4KbF6WG7SBJijRyr/P/Zs6SfOrb1Hu0xLKA26glIaMyRWbmlGsuuvBEHNn16Q7KjX5ytiJec7GDa87oJdAYvXMvXbpUNmzYIDlz5tSfYydU4cKFJUeOHBr04OWNpj/58+fXnVj169cPe2rBzz/++OMI/1zChAn15YtuoEbv3fc2vzhxJOlL/zunxs7cS5doKeBLvBk595rz9NI3r6WY4zVn/cAmTky3NiOIASzvoLAX0HXYmzN2vvjiC5k0aZLMmzdP+8YgE3Pv3j355JNPxGio/cF54BOS9bnrubDjzpfcgRS2mhPFZrOC+8bCZU3yNcsGNuHXcJFFmT17tv74r7/+8mo7+GbNmsnw4cN1eSlfvnyyY8cOWbFihVeKlaML293xJvKi+S1kfgjcEdQgC+dL7vb37gcFoojgGkmdOnWE/58ZGzIysLFkjU2xYsXCfoy6GjTo69Onj9y9e/dfU789rX379voyG3cNEG6K7D5sbfgaGjHzC8X46KHD4JheBNeIuxQgsuyfr1sWEAWboPVJjD47MiVu1atXl2PHjsmuXbskT548mklxIveNEEtkRYsWNfpwKBbwNTQqOH1Rq3yiqEyBR2CDQBmDMIl8Cdecu1TFKB4Jq7JmzaovJ8ObDJbnjJoKTZ6Dr2HevHkNOaVYymVgQ5FxL3m/aNkfS5u3bt3iySSfwjVn9FR5TkjzEKTesI38xIkTnvoryaAeDPgaZsuWzZDzz4wNReWJGLuiIsvYAAMbMiqwSZUqlRiJgY0HYQlq586dnvwryccCAgLk+vXrT9WR+RIDG3oRd0aPgQ2Z0S1mbOwFN0PUGrHbp3W5A1MjAxv3dnOi53FfHy8KbPDU7OsJ9eRsDx8+1H5ullqKQlElRQw3Q0Srp0+f5mmyKBTGo5O1EbuiAEXLly9f5m4WitCFCxf0Y2Qd14FLUeRr7pouSwU2BQsWlN9//917R2Nx7qd8LkdZF752RmVr3H2hUD+BSfZEz3PgwAF5+eWXtTlqZBjYkFGBjaVqbNAYD03yPvzwQ1bbPwdSw2gWGNm0cTL3bhNkbIwMbPDwAPv37zfsGMjccG24r5PIMLAhX7NkxgYzoPBEe/ToUf3GQtdfetpbb70lS5Ys4WmxoO3bt2tHV3wNjYJusliOwlM50fPg2ohqYIMaG9b8ka+4a7qMDmyi3cfmtddek61bt8qgQYO0OV/x4sX/1WVw48aN4lR16tSRqVOnyqlTpwxvUkTRg5EgSKFi5pmRcNNixoaeB93dz5w5IwUKFHjhCcK1jLljKOhM4uPp4+RMt6yYsQn/zYWsDbpb5sqV618vJ6tatarOGFq4cKHRh0LRhK9ZzZo1DW8HzsCGIuLO5EU1YwNs0ke+gmsNQXTChAnFSNF+B8cyS8uWLXXXCLY2O3WEQkSSJUumSxl4+u/SpYvRh0NRhJ1syJL069fP8HOGp3EMe8XkelxPRG64RjFgMCrvu+6xIOfPn9diYyJvw7VmhlmJ0crYtGvXTpdaENhs2bKFQU0EateuLevWreOTksWyNci0VatWzehDCXsaP3jwoNGHQiYMbHLnzi2JEiV64e91D8nEsjiRL+Bai2w4qykDmzVr1mj9zMCBA8Omx9K/1a1bVz/+9ttvPD0WgOJK1EVhGRHTtc2QscGNa9OmTUYfCpkMrokSJUpE6ff6+/tLmjRp5OTJk14/LiLAtWa5wGb37t3yxhtveO9obALLdAhuxo0bxx0JFtkNhWXVTz75RMwA69Nly5aVlStXGn0oZCIY9YH34MqVK0f5z+Amw8CGfPWAiGvNDJtmohXYsLI+6tq3b69LCRs2bIj+V4V8CgFo9uzZTbEM5YabF5YzsauFCFavXq0fo9OOADcZLkWRL1y7dk3u379vvYwNRV2lSpUkT548etMk80LfmlmzZmn9WNy4ccVMgc2DBw+0tQIRIIOXN29ebQIaVczYkK+4M4MMbGzMz89PlzbmzZuns3/InCZPnqwp1BYtWoiZFC5cWJv1cTmK3HAtRGcZyn2TwWwp9LIh8kVg88orr4jRmLHxoubNm2sRKLbukvngzX7kyJHSsGFDSZs2rZgJtvRiyYGBDQGWk9CSoEqVKtE6Ie6nZzT1I/L2NYqxQmbYgMHAxotSpkwp3bt3l7Fjx+r+fjIXfF2uXLliit41z4Onc8wdu3PnjtGHQgZDgIul0vLly0frz7kLOVlATE7ZEQUMbLzs008/1SZrX375pbc/FUXD7du3ZfDgwdK6dWvTdsvG03lISIgsW7bM6EMhgy1atEh3pL5oovez0CwNWWMGNuRtZtkRBQxsvAy9JHr37i2TJk2SI0eOePvTURR99913EhQUJH379jXtOcNOLdzMpk+fbvShkMHbvNHx/YMPPojRkiZuNgxsyNuYsXEYFBFnyZJFAxwy3sWLF2XUqFHStWtXU7T/jkzTpk31poatlORMs2fP1o8xCWwAuzMPHTrk4aMienqqNzbJ4FozA2ZsfNRwDdPQ58+frzcpMhZmeCVNmlQ+//xz038pUNgc/uZGzjNt2jR5++23Y1zgXrx4cdmxY4eEhoZ6/NiIYOfOnWHXmhkwsPGRxo0bawM41HSgvoOM8fvvv8vcuXO1cDi69QpGQEv86tWrcznKoY4fPy7//POPNGnSJMZ/B242KEDnchR5s3s7yi7MUq/IwMaHfW0mTpwogYGBWlBMvnf16lXp0KGD1KtXTxo0aGCZLwFuari5HTt2zOhDIR9DfRVuGBg+HFPup2jcfIi8AdcWrjPUdJmBOY7CIVBnM2LECC0k5pKU7yGoQTM+dINGoGmlafG4ubGI2FlwreJrXr9+fUmcOHGM/55UqVLpNlwGNuQtWOqM6nBWX2Bg42MtW7YMW5JCO3/yDUxaxxLUDz/8IOnTp7fUacdN7f3335cpU6ZIcHCw0YdDPrJ27VpteoYC8tjC0zQDG/IGFA2jTxsDGwdzL0lhqzGWQ3ij8r49e/ZIq1atpFGjRpZaggqvc+fOEhAQoDVC5AxDhgyRQoUKRbsp3/PgpoPJ4E+ePPHIsRG5uQNmsxQOAzM2Bi1JIXuwfv161tv4oK6mbt26ug3x559/ttQSVHi4waGIGP13sERB9g/Gly5dKl988YVHrlkENhiqevjwYY8cH1H4ZSjs2MuaNauYBQMbg+ApbMyYMfpCBoc87/Hjx1qf8OjRI/nzzz8lSZIklj7N//3vf2X//v2sz3JItgYNGj2VYSxSpIgGSFyOIk/DNYXA2UwPjQxsDNSuXTtt3oei1g0bNhh5KLaDrEanTp1k69at2j8IWTKrK1u2rJQsWVK+/fZbow+FvAh1NehbhN2T8eLF88jficGE+fLlY2BDHn+fdQc2ZsLAxmDogFu6dGldLkH6mTwDs7l++uknmTBhgp5fO8ATEbI2CII3b95s9OGQlwwfPlx3MrVo0cKjfy9uPszYkCedPXtWR36Yqb4GGNgYLH78+LJgwQKd54KhhwcPHjT6kCwPGQ0ENhhy6embgxm2fuPJG7U2ZM+aMLSDQLG4p5dO33zzTX144rR48hTUieKBC5lkM2FgYwIpU6aU5cuXS6ZMmaRSpUpaR0Exg2CmZ8+e0q9fP81u2A0aYKGg9K+//tKmfWQvX3/9tS4/YXna09BmAtPiV61a5fG/m5xp6dKlUqxYMe2QbiYMbEwCqWe84bz88stSoUIF2bVrl9GHZLm13v79+0uvXr1kwIAB+rIrdCIuXLiwPtVz/o99IFuLPkt9+vTR9wNPQzEydgfiZkQUWwiS8UCOOWZmw8DGRBD1IrjJnTu37prCTh56MfQEQuPDr776SjM2CHDMVKHvaXHjxpXRo0fLtm3b5NdffzX6cMhDgTmGs77yyis6dd5bcBNCYMOWAeSJwZdoMsvAhl7opZde0uAGaeN33nlHU9N8E4q862XFihVl5syZepO34/JTRDukPvjgA/33Yv4YWdsff/yh3/fff/+9JEyY0GufBzchNHpkPxuKLQTIGCT8xhtviNkwY2NCSZMm1Q6zKIBFWho3MDTXon8/MWCnx5kzZ7SIzROt563W6wRBzaBBg4w+FIqFhw8fSvfu3TXoqFmzplfPJTLBiRIl4nIUeSSwwYYXT7Uk8CQGNiYuEkUB7Lx582TRokVSpkwZOXr0qNGHZQrIYGFuErIWGTNm1C2sr7/+ujgNevOgpmjkyJGc/G3x7d2YtYOvo7eXUDF3DMEN62woNm7evKmbF8y4DAUMbEyuXr162rPk7t27WjCKN0EUbTnVxYsXdcvzxx9/LA0bNpR169ZpwbVToYkb/v1oRsglS+s5ffq01oWhvgaFvb6AmxEynMwCU0ytXLlSNy6gZMKMGNhYwH/+8x/Zu3evdir+7LPPpFy5co7L3uCmPXXqVHnttdd0CQqF1ZMnT9YnUCfDv3/8+PG6O2Hs2LFGHw5FAwZSNm7cWNKlS6fZWV9BYIOCezwUEMXEsmXLpECBApI5c2YxIwY2FoFmXSgsxJMWmnghe4MaC8xBsruTJ09qluajjz6SWrVq6bbYOnXqGH1YpoEbFbZ+I+hlDyTrQG0UdrbNmDFD/P39ffZ5kRnKli0bl6Moxg+ZWMo06zIUMLCxGNTaIHuDGVOor8CbFOpN7Lg8hR1PHTt2lLx588ru3bs1SzNt2jSv9PiwOnQifvXVV6VRo0ZajErmtnHjRhk4cKD07dtXSpUq5dPPjToe3JRQu8flS4oudK9GSYBZl6GAgY1FszcjRozQzAWKZlFvguUqdKO1wxsVdvrgDT9Xrlz6NIsn2+PHjzNLEwnsdMGWd2S3kLkh87p9+7Y2WcSIg969extyDJh6j2GbyBgRRQfeZ9KmTatF6GbFwMbCkK2ZM2eOvjmlT59eB2mipwCyGlZcosJANbzRY27WsGHDNFuDN1+MEPD03Bw7wpo3zhu61+JpnMwHDx7Itt66dUumT59u2FZZ9H7CCBe8VxBFFVYGENigBQnmHJqWy2Hu3LmDlIZ+tJPQ0FDXsmXLXFWqVNF/X+rUqV2ff/6569SpUy4zCwkJcS1ZssRVu3ZtV5w4cVz+/v6uTp06uc6fP2/0oVn2OqhVq5YrTZo0rnPnzhl9OPSMX375Rb8/f/vtN8PPTY8ePfR94vHjx0YfClnE8uXL9fr9559/TH3/9sN/xEGwzIFuiZhw68uCPV86duyYTJgwQXcN4d+JtdD33ntPC28zZMhg9OHpNkHMwsLSmXv5BEtp7du3lw8//FCSJUtm9CFa2rVr17RxIYaropaD59McUPhfuXJlXTr+8ccfjT4c2bdvX9gSNorziV6kefPmsnXrVjly5IghY2uiev9mYGNj6FMxa9YsLS7etGmTBhRYqsKOIryRYenCVxcnClrXrFmjb6ILFy7U4jOMj8BxYBs7xt7beb6Trx04cECLUjFQdcGCBTpfioxz4sQJ/d7DbkbsKDFLGh+BDYrzZ8+ebfShkMndv39fSx5QGoAaSCMwsInlibGb69evy99//62BBXoQ3Lt3TwMLjJx3v4oXL64TgGMbYKC+B9uO0W9mx44d+hE3WvTtyJkzp9YCIbgqXbq0Kdtx2wVuoGjRj1olX3S1pYi/93CtA5528X1nFkOHDtWb1JUrV/R9kSgi2MiBonfUPWJYqxEY2MTyxNiZuzkXWmIj6MALLd0hefLkWlSIF8YV4IUf45whCMELmR8EKY8fP9Zlj0uXLmkGBh/dP8b/x+9FQz130IQq+nz58vEG60NYkkSxKrrbOmVAqNmecitVqqQdhtFBHDv9zOTChQs6mmPixInSsmVLow+HTKx69er6QLxhwwbDjoGBTSxPjNPgiQ0BDraQhw9Q3B/xBv0sZADSpEnzryAIb5RFihSRQoUK6TZkMtaAAQN0oOqkSZO0voN8Izg4WDOTqHNau3atBvhmhEGGeBDBUjFRRD3FMLpl3Lhx0rZtWzH7/ZvrAKSwdlqjRg19PQ9qzLHVD2/WGNCJbAzrNqyhf//++sbUqlUr/TmDG+/Dcixmma1atUqXgM0a1EDTpk21KPTcuXOSNWtWow+HTOi3337T9/wGDRqIFbCPDUUJsjO4sDGbKGHChAxqLPa1Q2+b1q1bS4sWLbTehrwHA2vxgLBixQrtlo2dUGb27rvvap+oX3/91ehDIRPP6atZs6ap6sMiw8CGyAGQXcOwTOxo6Natmy5POazTg0/cuHFD3nrrLV3WRZE+6hLMDnV1KApF8Iv6O6LwsETpHuNjFQxsiByUufn222+1kBg1NwhwUAhOnoFaNBTIo1AYN4OyZcta5tTiWsByJZYciMIbPny41kuaPfMYHmtsiBwGu6NQgNehQwctwsOOGG67jx1sgUURLnYKYtcIesNYCY4XPaUwkgP1NmwNQIDNJKgRw1KUla4JZmyIHAhpZcwqwgvbkZFtoJjBGz86PaOoHjugrBbUuH366ad6I8MSGhFg2DJ2umI2lJUwsCFyKIyvWL16tY60wPZ8/JiiDluke/XqpUWVmNSNvlDZsmWz7CksV66c9pvC0gPR5cuX9cGnS5cukiBBAkudEAY2RA6GOpDdu3dLwYIFdSll0KBBrLuJ4ps+ztd3332nNUvo6J0qVSqxMiw19OjRQ1auXCl79uwx+nDIYGPHjtWApk2bNmI1DGyIHC5dunS6/NCnTx/p16+fZiAwBoCeD127keHCIEBkuVCzhGUoO8CwXGSdmLVxtvv372szPvS+wjBdq7HHdyMRxXo7OHZKYb7U9u3bdTji3LlzuSX8mf40yGigJgmjQZDpwi4oO0ERedeuXXV4rnvMCjnP5MmTtcsvlqGsiIENEYWpWrWqLkOg1uL999/XPiyYTO1k6PeDIA/BDJ5isVy3fPlyyZAhg9gRZkYlTZpURo0aZfShkAFCQkLk+++/1+9/DEW2IgY2RPSUzJkza8dcvLDcUqBAAW3ohzEBToOgDl2E8SaPsQiHDh2Snj172np7PBr2tW/fXhs6YlYcOcuvv/6q7QuQnbQqBjZE9FwY4Igbeffu3eWbb77RAGfx4sWOWJ7CFGMszeHffPjw4bBAz6pPsNH12Wef6egU1FyRs2pr+vTpo3POzDzf7EUY2BBRhDBDCEENWqpjQGKtWrV0mWrevHm23D118+ZNDWhQQPv1119rUIfeLgjynAQzgTA8FRPh9+/fb/ThkA/71ly/fl13+lkZAxsieiHUl2BSNWpL0LW4fv36kj9/fi0yRLddq0ODQqTeEbxh7AR6/Bw/flyDOtSbOFG7du0kR44c8vnnnxt9KOQDly5d0vYFnTt3lldeecXS59xygQ3W+dE0COkyzGQhIt/1OUHvFmxx3rJli3bYxbTwXLlyaaEpBkBaCZbU9u3bJ23bttU38p9//ll3gZw9e1bGjBlj6WZ7noAeJrjRYaccAlqyt/79++vyI5pOWp7LQn799VdXpkyZXLVq1cIiv2vNmjXR/jvu3LmjfxYfiSh29u/f72rSpIkrbty4rnjx4rlq1KjhmjZtmiswMNC0p/bEiROugQMHuvLnz6/vBenSpXN9++23rtu3bxt9aKYTGhrqKl26tKtQoUKuJ0+eGH045MXv4zhx4rhGjhxp6nMc1fu3H/4jFrFt2zZNjSJrkyVLFp2gW6FChWj9Hdibj1Q6hv/5+/t77ViJnOTq1asyZ84cnQ69adMmSZw4sdbjNGrUSKpVq6a1OkZCTxb38aFPD5aX3nnnHT0+ZKGs1jLelzAqomTJkvLLL79oho7sp0aNGrr0inoyM38vRPX+banAJvybFAMbInPCUs7s2bM1iEBPHGyNLlq0qJQuXVpKlSqlHzNmzOjVPhx4g0aAtXnzZv2IZWu8YeMNHMEMgi6jgy0rwTlDx2Xc/Jxac2RXK1as0P5V2BBQr149MTMGNv8nKChIX+FPDIIiZmyIvM89dsAdYJw5c0Z/HdumMTgS9Tn4fgz/ikomFTuykCUKCAh46oUdPFu3btXvcwRUGH3gDqiQmbFie3gzQGCImirUX6AWg+whJCREt3UnS5ZMNmzYoHV0dghsDO0yNX/+fNm1a1ekvwfbLWMzXA7b1rB9k4h8DzdDvNDwzb37CEEOXljiQBYAuzHCJ47xhoWMDgoZ48ePry/8/+DgYH2hxwyytvixW6JEibSxYJ48eXR2EwKZEiVKMCvjISiuxqgFvJ9+8MEHep7J+kaNGqUF9HgYMHtQEx2GLkUtXLhQ+2NEpkOHDtpTIaZLUczYEJkbAhQEPO6sy7lz53R6tjuQwQtDJhHgIAuDpRAEMeGzPGnSpLHVG7MZPXjwQGeIpU+fXtavX2+bwZ9OdeLECSlYsKBu68cIBSvgUlQsTwwRET0NAQ0Gf44ePVo6derE02NRoaGhOswVDxLI2Filbiqq92+G3EREFCXlypXTLDqW+zBPiKzpxx9/1GVg9G6ySlATHZbaFbV7926t3L57964+MTRp0kSbaCHyxCsqmLEhIoo51DhhCcNdDhA3blyeTostQRUuXFjvnxMmTBArsWXGBt9AKBJMmzatDBw4UAvY8HM7T9olIjIT7KCZOnWqbNy4UYYNG2b04VA0PHnyRAOaDBky2PprZ6mIoFChQvoiIiJjl6QwQ6pv377aAwXb6sn8vvnmG9mxY4cGpQhQ7cpSS1GewKUoIqLYw/DTN954Qz/iZolu02Tuzv2lSpWS3r17W7YFii2XooiIyBzQyXnGjBlaRIxBog57RraUq1evyvvvv6/N+DBA2u4Y2BARUYzkz59fJk+eLNOmTZOhQ4fyLJpQUFCQjkpAZg2bb9APyu4sVWNDRETmgk7EBw4c0C3g+fLlk9q1axt9SPR/kEX75JNPdKkQ27vR2NIJmLEhIqJY+eqrr6Ru3bry4YcfapBD5vD9999rRg39alAP5RQMbIiIKHY3kjhxdDkqR44cUqdOHbl+/TrPqMGWLFkin332mXzxxRe6xdtJGNgQEVGsYfvwX3/9pQ386tevrzUdZIzDhw/rEmHNmjXl66+/dtyXgYENERF5BDrBz58/X6e3d+zYkTulDHDjxg2tc8qaNavuWnNiZ2gGNkRE5DFlypTRVv0TJ06UQYMG8cz6EMYN1a1bV27fvq3Zs+TJkzvy/HNXFBEReVSLFi3kwoUL0q9fPwkJCZH+/fuLn58fz7KXm9e9/fbbcvDgQVm2bJm88sorjj3fDGyIiMjjMG4Bc/x69eqlwQ12TjG48Q5kaBDUHD16VFauXCklSpQQJ2NgQ0REXtGzZ08NbjBXCgMYMauIwY1n3bp1S+d1nTx5UoOaYsWKidMxsCEiIq/BlmMEN927d9fgZsiQIQxuPFgoXKVKFTl37pysXr1aChcu7Km/2tIY2BARkVd169ZNg5vOnTtrcDNixAgGN7GEXkGVK1eWixcvypo1a6RgwYKe+WLZAAMbIiLyuk6dOmlw0759e3n06JGMHj3aEXOLvCEgIEB71Fy5ckWDmtdee83oQzIVbvcmIiKfwNyiX375RVv8I9tw+fJlnvlowpJT0aJF5c6dO7J27VoGNc/BwIaIiHy6FRxZhmPHjmmh65YtW3j2ozjQctiwYVpTg1qanTt36tBR+jcGNkRE5PMmfrt27dJeK+XLl5fx48ezS/ELGu81bNgwbPbT0qVLJU2aNL77glkMAxsiIvK5jBkz6rJKu3bttO7m448/locPH/Ir8Qz0psFkbgy1nDdvnm6Zd+KYhOhgYENERIZIkCCBFhFjMvjvv/8upUuXltOnT/Or8X8WLFigzfawDLV9+3apV68ez00UMLAhIiJDNWnSRAdnooNugQIFtNdNcHCwY78qGEeBpScEMqip2bZtm+TNm9fow7IMBjZERGQ4FMTu2bNH2rRpox2L8fP169eLk6DHz/fff69BDHY8TZ8+XebOnevYYZYxxcCGiIhMwd/fX2/s2PGTIkUKLSxu3ry5XL16VewOGSvsEvv000/134zamsaNG7ORYQwwsCEiIlNBtmbjxo0yceJEWbRokeTJk0cmTJigwzTtOBahdevWWl+EmiMsO40dO1ZSpkxp9KFZFgMbIiIynThx4kirVq00c4FaEzT3Q0YDyzN2qL9BFqp///7y6quvypw5c2TcuHGydetWKV68uNGHZnkMbIiIyLTQrwXdijdt2iQZMmSQpk2bav8bFBij2NhqDh06pAFb1qxZZfjw4brchOANgRu3cXsGAxsiIjK9UqVKaWO6/fv3S9WqVaVv376SJUsW6dq1q+m3iGO79qpVq6RGjRo6AgE9aQYMGKAzn7DdPX369EYfoq34uXDGHSQwMFCL0jBnA4VqRERkPZgzhVoUdC1G5gbLVQ0aNNCgB+/xZnDq1ClZvHixTJo0SXd8FSpUSIuDP/jgA62nIe/cvxnYEBGRZT148ECmTp2qAQ6yOZggXrZsWalVq5a+UMPiK6j9we4mFDwjoDl8+LAGMAi2kFmqVKkSdznFAgObWJ4YIiKylrNnz2pAgReWfoKCgiRXrlxSs2ZNDSqwuwr1OZ7KluB+cvz4cQ2osEyGF+4tqAXC58QLU8zZh8YzGNjE8sQQEZG1MzmYRYXsCV7o5gso0M2ePbvkzp1bsznuj2nTptWAx/0KDQ2Vx48f6+vRo0daD4OJ5Ahk3B+vXLkS9vmwm8mdJSpSpIju6iLPYmATyxNDRET2gFLSixcv/iswwceTJ09Gefs47h3hg6HwH81S12NnDGxieWKIiMgZYwzOnTsnt27dCsvQYAkLmZ3wGZzMmTPr1nM/Pz+jD9mxAqN4/47n06MiIiIyERQb58iRw+jDIA/iIiARERHZBgMbIiIisg0GNkRERGQbDGyIiIjINhjYEBERkW0wsCEiIiLbYGBDREREtsHAhoiIiGyDgQ0RERHZBgMbIiIisg0GNkRERGQbDGyIiIjINhjYEBERkW0wsCEiIiLbYGBDREREtsHAhoiIiGyDgQ0RERHZBgMbIiIisg0GNkRERGQbDGyIiIjINhjYEBERkW0wsCEiIiLbYGBDREREtsHAhoiIiGyDgQ0RERHZBgMbIiIisg0GNkRERGQbDGyIiIjINhjYEBERkW0wsCEiIiLbYGBDREREtsHAhoiIiGyDgQ0RERHZhqUCm1WrVkn16tUlZcqUkjp1aqlbt64cPXrU6MMiIiIik7BMYBMSEiKDBw+Wrl27ytmzZ+XgwYMSL148qVKlity9e9fowyMiIiIT8HO5XC6xqICAAMmaNassX75cA5yoCAwMlBQpUsidO3fE39/f68dIREREsRfV+7dlMjbPc+XKFf2IpSkiIiKieEaegtDQUH1FBstNzxMcHCzdunWT4sWLS7FixSL880FBQfoKH/ERERGRPRmasWndurUkSpQo0tfJkyf/9ecQDLVo0UL/3+zZsyVOnIj/GajLQerK/cqSJYuX/1VERERkFMvV2OBwW7ZsKUuWLJE1a9ZI3rx5I/39z8vYILhhjQ0REZH9amwMXYqKSVDTqlUr+fvvv6MU1EDChAn1RURERPYXz0pBTbt27WTRokWycuVKyZ07tzx58kT/X9y4ccXPz8/oQyQiIiKDWWZX1M2bN+WXX36RGzduSJEiRZ6qw5k8ebLRh0dEREQmYJmMDToNuzM0RERERJbO2BARERG9CAMbIiIisg0GNkRERGQbDGyIiIjINhjYEBERkW0wsCEiIiLbYGBDREREtsHAhoiIiGyDgQ0RERHZBgMbIiIisg0GNkRERGQbDGyIiIjINhjYEBERkW0wsCEiIiLbYGBDREREtsHAhoiIiGyDgQ0RERHZBgMbIiIisg0GNkRERGQbDGyIiIjINuKJw7hcLv0YGBho9KEQERFRFLnv2+77eEQcF9jcvXtXP2bJksXoQyEiIqIY3MdTpEgR4f/3c70o9LGZ0NBQOXr0qOTPn18CAgLE39/f6EOyXMSMoJDnjueN15y58XuV585u1xzCFQQ1mTJlkjhxIq6kcVzGBifj5Zdf1h/jxDOwiRmeO543X+M1x/PGa84a/L14b40sU+PG4mEiIiKyDQY2REREZBuODGwSJkwo/fv314/Ec8drztz4/crzxmvOGhKa5N7quOJhIiIisi9HZmyIiIjInhjYEBERkW0wsCEiIiLbcFwfm8icPXtWGwsVK1ZMEidObPThmM6DBw/k8OHDkjJlSsmZM6fRh2Mp586d01fRokUlSZIkRh+OZVy7dk3Onz8vr7zyil53FDUonTx58qQ8evRIcuTIwWsuBvbs2SP37t2TMmXK8LJ7gWPHjsnVq1ef+jX0sSlUqJAYAsXDTrd27VpX9erVXalTp0Yhtevw4cNGH5LpzJo1y+Xv7+/KnTu3K3ny5K7y5cu7bt68afRhmd769etdNWvWDLu29u/fb/QhWcLWrVtd5cqVc6VNm9ZVuHBhV+LEiV0tWrRwPX782OhDM72ZM2e6cuTI4cqbN68rT548+v363XffGX1YlrJy5UpXvHjx9Hs2ODjY6MMxvcaNG7vSpUvnKl26dNirTZs2hh0Pl6JEZP/+/dKhQwf5+++/jYkuTe706dPSrFkz+fbbbzUyxxM0nqS7dOli9KFZ4tpq166dLF++3OhDsZTjx4/LoEGD9Clw9+7dsm/fPvnzzz9l8ODBRh+a6d28eVM2btyo2dUjR47IlClT5IsvvpAdO3YYfWiWgGuuRYsW0qlTJ6MPxVKqV6+u15379eOPPxp2LAxsRKRjx45Ss2bNSGdPONn06dN1GaBt27ZhKcbOnTvL77//Lvfv3zf68Eytffv2UqtWLV5b0dSkSRMpW7Zs2M9z5colVapU0TdMihwe0jJmzBj284oVK+rHCxcu8NRFYQmvefPm+n2LZWOKuocPH8rOnTv1QRgzGY3EOzm9EJ6YixQp8tTN+fXXX5egoCA5dOgQzyB5XUhIiF6HCHDoxa5fv65B4MKFC6Vx48ZSrlw5efvtt3nqXmDYsGF6g/7ss894rqJpwYIFmukqUaKEfp+uXr1ajGLL4uGDBw/KrVu3Iv09pUqV4lN0NFLb7sGhbqlTpw77f0Tehm6mWALt1q0bT3YU7N27V8/ZlStX5M6dOzJmzBjDu8Ga3bZt2zSwwZIds/fR884778jo0aMlVapUEhwcrN+n7777rt6LM2fOLL5my8Bm8uTJsnXr1kh/z4oVK7jzKYrix4+vuyvCw1MNJEiQIKZfJqIoGTt2rAwdOlTmz58vuXPn5lmLgrfeektfsGjRIr3xYCoyszaRL39++OGHujsWL9QTwqZNm3QXqBE3aKuoX7/+U/eL4cOHy8SJE2XJkiXSunVrnx+PLQMbRN3kOdmyZZMDBw489Wvu9fqsWbPyVJPXjB8/Xj799FOZM2eO1sFR9KHGK1++fLJ06VIGNpHIkiWLbN++XV+ADRLQu3dv+eSTT3RJj6IG2UHUZRpV12XLwIY8C0Wb2Flx6dKlsKJE7FBBbxH2syFvwa6Krl27apF6nTp1eKKjAMsA7qfm8P2n8L3rXj6m51u1atW/Nk00bdpU1q5dK/Hi8VYZkSdPnmgNXPilTiyFYndZgQIFxAj8aono2v2ZM2fk6NGjelJ27dqlxXcogMqQIYM4HdKMSC3WrVtXevbsqedp3LhxMmPGDKMPzfTwxIJdAidOnNCfowD29u3bGhCG37lC8q+bCp6Se/TooTdk926opEmTaiE7PR9qC6tWrSqtWrWSPHnyaNYB36uJEiUyZEmA7O/+/fvaxBDXXN68efX9Dq0asKsRS6BG4HRvEb1BI+X9LFTG42ZOogWIQ4YMkX/++UdTjC1bttS+BRS5WbNmaY3Is7p37y716tXj6YvAwIEDZdmyZf/6dXTR/fXXX3neIoH6EFxz6KGE1gzYpdKmTRutsaGoQ++pr776StatWydx48blqYsEOvajQB39pvAgUqlSJfnoo48MO28MbIiIiMg22MeGiIiIbIOBDREREdkGAxsiIiKyDQY2REREZBsMbIiIiMg2GNgQERGRbTCwISIiIttgYENEjvT48WNtoIhO0ERkHwxsiMgwJ0+elNmzZ0tQUNC/Zh7h148fP+61zx0YGCiNGjXScSpEZB8MbIjIMGnSpNHRJX379n3q1/Fz/HratGm99rkxtK9hw4by0ksvee1zEJHvcQgmERkG84smT54s1apV04F5pUqVkvXr1+vQVczqwVyyiGDqd2hoqM6jyZYtmw7HDD/Vevv27XLlyhWpVavWU0NJN2zYoHPOEidOrJ8z/AwlZIq2bt2q2Zz//Oc/kjlzZi/+64nIGzgriogM16FDB1mxYoUOHCxZsqQ0aNBAhg4dGumfady4sYSEhMiTJ090+B6CmqVLl0qWLFn0/x88eFCKFy8ukyZN0iUn/F5MHEYW6M8//5Tr16/rjzFxvXDhwnL+/HkpX768JEmSRIdtHjhwQJo3by79+vXz0VkgIk9gYENEhnvw4IFmSFDI+/LLL8u2bdskQYIEUf7zyNwgGEqePLlmgNww5bpPnz6yd+9eDXB++uknDYIQ0Dwb2Hz55ZeaJdq0aVPY37lw4UKpW7euV/7NROQdXIoiIsMhS9K6dWv54osvZMiQIVEOag4dOiSnTp2Se/fuaZCCZazwOnbsqFmcGjVqyLFjx2TRokUR1u1gaerGjRu6XIXgKk6cOAxqiCyIGRsiMlxAQIAUKlRIsmbNKrdu3ZL9+/c/VfvyrIcPH0rt2rU121KiRAn9vfg7sIvq2rVrT/1e/J6iRYtqcLN48eKwX382Y3P37l1p27at/PHHH5I/f36pUqWKBkYIcojIOrgriogM5XK5tJYF9TD//POP+Pv7S9euXSP9M9OmTdMg5uzZs5qRwdbwDz/8UP+uZ//uHj16SL58+XSZCYXBEcEy1syZMzUw+uabb7TGBsd0//59j/1bicj7GNgQkaGGDRumNTBTp06VRIkS6cfp06drfUtELl++rJmUZMmShf3avHnzIvy7V61aJW3atJEmTZrostXzYAkKkiZNKlWrVpXRo0fr50HwRETWwaUoIjIMgo7XX39dZsyYIfXr1w/79f79+2uhL3Y2pUqV6l9/bteuXfLGG2/obqoCBQrIggULZPPmzbr1G0tMsGfPHv096C787rvv6vIVMjD4NRQSP7sUhSLjLVu26JIVtpnjmFBzs3PnTokXj+WIRFbBjA0RGQZZGQQU4YMawK/VqVNHl5meBzUz6EeDrd7YxVSzZk2ZP3++1KtXL+z3/PXXXxogIahxFwdjqQkBDgqOn23QN2jQIG0MeOnSJV2ywp/D52BQQ2QtzNgQERGRbTBjQ0RERLbBwIaIiIhsg4ENERER2QYDGyIiIrINBjZERERkGwxsiIiIyDYY2BAREZFtMLAhIiIi22BgQ0RERLbBwIaIiIhsg4ENERER2QYDGyIiIhK7+B8LsXKrMs4KagAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "for i in range(1, 4):\n",
+    "    gtsam_plot.plot_pose2(0, result.atPose2(i), 0.5, marginals.marginalCovariance(i))\n",
+    "plt.axis('equal')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e28dbbc6",
+   "metadata": {},
+   "source": [
+    "Notice how the covariance ellipse for pose 1 is small and round -- it's pinned only by the prior, whose sigmas are equal in x and y. For poses 2 and 3, the ellipses grow overall, but not evenly: they stretch more *sideways* (perpendicular to the direction of travel) than forward. This is the classic dead-reckoning \"lever-arm\" effect -- heading uncertainty at an earlier pose, carried forward over each 2-meter step, turns into extra lateral position uncertainty at the next pose, on top of the odometry noise itself. It's the same effect behind the \"banana-shaped\" uncertainty regions common in dead-reckoning navigation, and exactly why SLAM systems add loop-closure or absolute measurements (like the GPS factor from the previous notebook) to keep it in check."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/gtsam/examples/README.md
+++ b/python/gtsam/examples/README.md
@@ -19,7 +19,7 @@
 | ISAM2_SmartFactorStereo_IMU                           |        |
 | LocalizationExample                                   | :heavy_check_mark: |
 | METISOrderingExample                                  |        |
-| OdometryExample                                       | :heavy_check_mark: |
+| [OdometryExample](OdometryExample.ipynb) | :heavy_check_mark: |
 | [PlanarSLAMExample](PlanarSLAMExample.ipynb) | :heavy_check_mark: |
 | [Pose2SLAMExample](Pose2SLAMExample.ipynb) | :heavy_check_mark: |
 | Pose2SLAMExampleExpressions                           | ExpressionFactorGraph not yet exposed through Python |


### PR DESCRIPTION
Adds a notebook counterpart for `OdometryExample.py`.

Ran the original `OdometryExample.py` script and compared equivalency.