### PR TITLE
[Python] Add SimpleRotation notebook

### DIFF
--- a/python/gtsam/examples/README.md
+++ b/python/gtsam/examples/README.md
@@ -46,7 +46,7 @@
 | SFMExample_SmartFactor                                |        |
 | SFMExample_SmartFactorPCG                             |        |
 | ShonanAveragingCLI                                    | :heavy_check_mark: |
-| SimpleRotation                                        | :heavy_check_mark: |
+| [SimpleRotation](SimpleRotation.ipynb) | :heavy_check_mark: |
 | SolverComparer                                        |        |
 | [StereoVOExample](StereoVOExample.ipynb) | :heavy_check_mark: |
 | [StereoVOExample_large](StereoVOExample_large.ipynb) | :heavy_check_mark: |

--- a/python/gtsam/examples/SimpleRotation.ipynb
+++ b/python/gtsam/examples/SimpleRotation.ipynb
@@ -1,0 +1,303 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3fdd7d27",
+   "metadata": {},
+   "source": [
+    "# Simple Rotation\n",
+    "\n",
+    "This is the smallest possible GTSAM optimization: a single variable, a single factor. The variable is a 2D rotation (`Rot2`); the factor is a **prior** -- a measurement from a sensor, with a noise model describing how much we trust it.\n",
+    "\n",
+    "The story: a sensor measured a rotation to be close to 30 degrees. We start from a wrong initial guess of 20 degrees, and ask GTSAM to find the best estimate."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3fbed24c",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/python/gtsam/examples/SimpleRotation.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "accd699b",
+   "metadata": {},
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, Alex Cunningham, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "17ccfe63",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T10:24:40.454062Z",
+     "iopub.status.busy": "2026-07-22T10:24:40.453873Z",
+     "iopub.status.idle": "2026-07-22T10:24:40.459726Z",
+     "shell.execute_reply": "2026-07-22T10:24:40.458982Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a32e82a5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T10:24:40.461947Z",
+     "iopub.status.busy": "2026-07-22T10:24:40.461746Z",
+     "iopub.status.idle": "2026-07-22T10:24:40.665633Z",
+     "shell.execute_reply": "2026-07-22T10:24:40.665172Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import gtsam\n",
+    "from gtsam.symbol_shorthand import X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6165fb4",
+   "metadata": {},
+   "source": [
+    "## 1. Keys\n",
+    "\n",
+    "In the previous two notebooks, variables were labeled with plain integer keys (`1`, `2`, `3`, ...). Here we instead use `symbol_shorthand.X`, which packs a character (`'x'`) and an index into the same underlying `Key` type -- a more readable choice once a problem has several kinds of variables (poses, landmarks, calibration, ...) that would otherwise collide under a single integer counter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ca4d4925",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T10:24:40.666825Z",
+     "iopub.status.busy": "2026-07-22T10:24:40.666728Z",
+     "iopub.status.idle": "2026-07-22T10:24:40.668351Z",
+     "shell.execute_reply": "2026-07-22T10:24:40.667973Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "key = X(1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "978b8101",
+   "metadata": {},
+   "source": [
+    "## 2. Create the prior factor\n",
+    "\n",
+    "In general, creating a factor requires:\n",
+    "\n",
+    "- a key or set of keys labeling the variables it acts on,\n",
+    "- a measurement value, and\n",
+    "- a measurement model with the correct dimensionality.\n",
+    "\n",
+    "Here the \"measurement\" is the goal angle of 30 degrees, and the noise model says we trust it to within about 1 degree (`Isotropic.Sigma` since a `Rot2` has a single degree of freedom)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "19bc0234",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T10:24:40.669204Z",
+     "iopub.status.busy": "2026-07-22T10:24:40.669150Z",
+     "iopub.status.idle": "2026-07-22T10:24:40.671001Z",
+     "shell.execute_reply": "2026-07-22T10:24:40.670684Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "theta: 0.523599\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "prior = gtsam.Rot2.fromAngle(np.deg2rad(30))\n",
+    "print(prior)\n",
+    "model = gtsam.noiseModel.Isotropic.Sigma(dim=1, sigma=np.deg2rad(1))\n",
+    "factor = gtsam.PriorFactorRot2(key, prior, model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4bb9d7c2",
+   "metadata": {},
+   "source": [
+    "## 3. Build the graph\n",
+    "\n",
+    "Before optimizing, every factor needs to be added to a graph container. In a practical problem many factors would be added; here there is exactly one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ee02f2a5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T10:24:40.671974Z",
+     "iopub.status.busy": "2026-07-22T10:24:40.671907Z",
+     "iopub.status.idle": "2026-07-22T10:24:40.673540Z",
+     "shell.execute_reply": "2026-07-22T10:24:40.673229Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NonlinearFactorGraph: size: 1\n",
+      "\n",
+      "Factor 0: PriorFactor on x1\n",
+      "  prior mean: : 0.523599\n",
+      "isotropic dim=1 sigma=0.0174533\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "graph = gtsam.NonlinearFactorGraph()\n",
+    "graph.push_back(factor)\n",
+    "print(graph)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07463895",
+   "metadata": {},
+   "source": [
+    "## 4. Initial estimate\n",
+    "\n",
+    "Optimization needs a starting linearization point for every variable in the graph. We deliberately start 10 degrees away from the prior's goal angle, so the optimizer has something to do."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b680567b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T10:24:40.674375Z",
+     "iopub.status.busy": "2026-07-22T10:24:40.674316Z",
+     "iopub.status.idle": "2026-07-22T10:24:40.676032Z",
+     "shell.execute_reply": "2026-07-22T10:24:40.675726Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Values with 1 values:\n",
+      "Value x1: (gtsam::Rot2)\n",
+      ": 0.349066\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "initial = gtsam.Values()\n",
+    "initial.insert(key, gtsam.Rot2.fromAngle(np.deg2rad(20)))\n",
+    "print(initial)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d41edac",
+   "metadata": {},
+   "source": [
+    "## 5. Optimize\n",
+    "\n",
+    "As in the previous notebooks, we solve with `LevenbergMarquardtOptimizer`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "7aa27b9a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T10:24:40.676865Z",
+     "iopub.status.busy": "2026-07-22T10:24:40.676803Z",
+     "iopub.status.idle": "2026-07-22T10:24:40.681902Z",
+     "shell.execute_reply": "2026-07-22T10:24:40.681596Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Values with 1 values:\n",
+      "Value x1: (gtsam::Rot2)\n",
+      ": 0.523599\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "result = gtsam.LevenbergMarquardtOptimizer(graph, initial).optimize()\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3e93e58",
+   "metadata": {},
+   "source": [
+    "With only one factor in the graph, there is nothing else to compromise against, so the optimizer converges exactly to the prior's goal angle of 30 degrees -- unlike the GPS factor notebook, where two competing factors (a prior and a GPS measurement) pulled the result to a noise-weighted blend between them. A single-factor graph like this one just returns that factor's own measurement."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adds a notebook counterpart for `SimpleRotation.py`.

Ran the original `SimpleRotation.py` script and compared outputs.