### PR TITLE
Add pragmas for GCC 16 warnings

### DIFF
--- a/gtsam/geometry/Gal3.cpp
+++ b/gtsam/geometry/Gal3.cpp
@@ -22,7 +22,6 @@
 
 // GCC bug workaround
 #if  defined(__GNUC__) && (__GNUC__ == 15 || __GNUC__ == 16)
-#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 

--- a/gtsam/geometry/Gal3.cpp
+++ b/gtsam/geometry/Gal3.cpp
@@ -21,7 +21,7 @@
  */
 
 // GCC bug workaround
-#if  defined(__GNUC__) && __GNUC__ == 15
+#if  defined(__GNUC__) && (__GNUC__ == 15 || __GNUC__ == 16)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif

--- a/gtsam/geometry/SO4.cpp
+++ b/gtsam/geometry/SO4.cpp
@@ -16,6 +16,12 @@
  * @author  Luca Carlone
  */
 
+// GCC bug workaround
+#if  defined(__GNUC__) && __GNUC__ == 16
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/concepts.h>

--- a/gtsam/geometry/SO4.cpp
+++ b/gtsam/geometry/SO4.cpp
@@ -18,7 +18,6 @@
 
 // GCC bug workaround
 #if  defined(__GNUC__) && __GNUC__ == 16
-#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 

--- a/gtsam/navigation/tests/testPreintegratedRotation.cpp
+++ b/gtsam/navigation/tests/testPreintegratedRotation.cpp
@@ -17,7 +17,6 @@
 
 // GCC bug workaround
 #if  defined(__GNUC__) && __GNUC__ == 16
-#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmismatched-new-delete"
 #endif
 

--- a/gtsam/navigation/tests/testPreintegratedRotation.cpp
+++ b/gtsam/navigation/tests/testPreintegratedRotation.cpp
@@ -15,6 +15,12 @@
  * @author Frank Dellaert
  */
 
+// GCC bug workaround
+#if  defined(__GNUC__) && __GNUC__ == 16
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
+#endif
+
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/navigation/PreintegratedRotation.h>

--- a/gtsam/sfm/ShonanAveraging.cpp
+++ b/gtsam/sfm/ShonanAveraging.cpp
@@ -16,6 +16,12 @@
  * @brief  Shonan Averaging algorithm
  */
 
+// GCC bug workaround
+#if  defined(__GNUC__) && __GNUC__ == 16
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 #include <SymEigsSolver.h>
 #include <gtsam/linear/AcceleratedPowerMethod.h>
 #include <gtsam/linear/PCGSolver.h>

--- a/gtsam/sfm/ShonanAveraging.cpp
+++ b/gtsam/sfm/ShonanAveraging.cpp
@@ -18,7 +18,6 @@
 
 // GCC bug workaround
 #if  defined(__GNUC__) && __GNUC__ == 16
-#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 

--- a/tests/testImuPreintegration.cpp
+++ b/tests/testImuPreintegration.cpp
@@ -17,7 +17,6 @@
 
 // GCC bug workaround
 #if  defined(__GNUC__) && __GNUC__ == 16
-#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 

--- a/tests/testImuPreintegration.cpp
+++ b/tests/testImuPreintegration.cpp
@@ -15,6 +15,12 @@
  * @author Russell Buchanan
  **/
 
+// GCC bug workaround
+#if  defined(__GNUC__) && __GNUC__ == 16
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>


### PR DESCRIPTION
Build fails on rolling release distros due to possibly erroneous GCC 16 warnings. Introduced pragmas to suppress these warnings.

### Changes

Add GCC 16 to current warning suppressions:
- **`-Wmaybe-uninitialized`**: Added to `Gal3.cpp`.

Add new warning suppressions for GCC 16:
- **`-Wmaybe-uninitialized`**: Added to `SO4.cpp`, `ShonanAveraging.cpp`, and `testImuPreintegration.cpp`.
- **`-Wmismatched-new-delete`**: Added to `testPreintegratedRotation.cpp`.
