### PR TITLE
Fix Python 3.14 manylinux wheel builds

### DIFF
--- a/.github/scripts/python_wheels/cibw_before_all.sh
+++ b/.github/scripts/python_wheels/cibw_before_all.sh
@@ -13,7 +13,7 @@ WHEEL_BUILD_JOBS=2
 export PYTHON="python${PYTHON_VERSION}"
 
 if [ "$(uname)" == "Linux" ]; then
-    # manylinux2014 is based on CentOS 7, so use yum to install dependencies
+    # Supported manylinux images use a yum-compatible package manager.
     yum install -y wget doxygen
 elif [ "$(uname)" == "Darwin" ]; then
     brew install doxygen

--- a/.github/workflows/build-cibw.yml
+++ b/.github/workflows/build-cibw.yml
@@ -51,7 +51,7 @@ jobs:
             python_version: "3.14"
             cibw_python_version: 314
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
 
           # Linux aarch64
           - os: ubuntu-24.04-arm
@@ -73,7 +73,7 @@ jobs:
             python_version: "3.14"
             cibw_python_version: 314
             platform_id: manylinux_aarch64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
 
           # MacOS arm64
           - os: macos-latest

--- a/.github/workflows/prod-cibw.yml
+++ b/.github/workflows/prod-cibw.yml
@@ -36,7 +36,7 @@ jobs:
             python_version: "3.14"
             cibw_python_version: 314
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
 
           # Linux aarch64
           - os: ubuntu-24.04-arm
@@ -58,7 +58,7 @@ jobs:
             python_version: "3.14"
             cibw_python_version: 314
             platform_id: manylinux_aarch64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
 
           # MacOS arm64
           - os: macos-latest


### PR DESCRIPTION
## Summary

- build Linux CPython 3.14 wheels with `manylinux_2_28` on x86_64 and aarch64
- apply the same matrix change to both develop and release wheel workflows
- generalize the Linux package-manager comment in the shared pre-build script

## Root cause

The CPython 3.14 jobs used the `manylinux2014` image. NumPy does not provide cp314 wheels compatible with that image's glibc baseline, so `pip install -r python/dev_requirements.txt` fell back to building NumPy from source. That source build requires GCC 10.3 or newer, which the selected image does not provide.

Using `manylinux_2_28` lets pip consume the published cp314 NumPy wheels and supplies a current compiler toolchain. Python 3.11–3.13 remain on `manylinux2014` to preserve their broader glibc compatibility.

## Validation

- `git diff --check`
- `bash -n .github/scripts/python_wheels/cibw_before_all.sh`
- parsed `.github/workflows/build-cibw.yml` and `.github/workflows/prod-cibw.yml` with PyYAML in the `py312` conda environment

The full cibuildwheel jobs require GitHub-hosted Linux runners and will run in CI.