### PR TITLE
Modernize installation and repository guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,41 +1,99 @@
-For reviewing PRs:
-* All functions in header files should have doxygen-style API docs, /** */ style, except small functions like getters which can have single line /// comments, no need for @brief, @params etc
-* Use /// for single-line comments rather than /** */
-* Use meaningful variable names, e.g. `measurement` not `msm`, avoid abbreviations.
-* Flag overly complex or long/functions: break up in smaller functions
-* On Windows it is necessary to explicitly export all functions from the library which should be externally accessible. To do this, include the macro `GTSAM_EXPORT` in your class or function definition.
-* When adding or modifying public classes/methods, always review and follow `Using-GTSAM-EXPORT.md` before finalizing changes, including template specialization/export rules.
-* If we add a C++ function to a `.i` file to expose it to the wrapper, we must ensure that the parameter names match exactly between the declaration in the header file and the declaration in the `.i`. Similarly, if we change any parameter names in a wrapped function in a header file, or change any parameter names in a `.i` file, we must change the corresponding function in the other file to reflect those changes.
-* For templated classes/factors in wrappers, prefer the normal `.i` template mechanism over hand-writing one wrapper class per instantiation. Let the wrapper generate names such as `AttitudeFactorRot3` from `template<...> class AttitudeFactor`.
-* Do not add or keep C++ `using`/`typedef` aliases solely to manufacture wrapper names. Only keep aliases when they are genuinely useful in the C++ API as well.
-* The top-level `wrap/` directory is a git subtree of `borglab/wrap`, not a submodule. The official way to pull in new upstream versions is `./update_wrap.sh` from the GTSAM repo root, optionally passing a branch or tag as the first argument; it defaults to `master`. This creates GTSAM commits, typically a squash plus a merge commit, so do it on a feature branch and open a PR rather than pushing directly to `master` or `develop`. Make code contributions to wrap in the `borglab/wrap` repository. Do not edit files under `gtsam/wrap/` directly, any fixes must go to `borglab/wrap` first, then be synced in via `update_wrap.sh`.
-* Do not edit files under `gtsam/3rdparty/`. These are third party libraries (e.g. Eigen) vendored into the repository. Modifying them directly causes 'hard to find' issues and breaks the ability to update those dependencies.
-* Classes are Uppercase, methods and functions lowerMixedCase.
-* Public fields in structs keep plain names (no trailing underscore).
-* Apart from those naming conventions, we adopt Google C++ style.
-* Prefer concise, elegant examples: use the fewest helpers possible, favor direct construction and small local functors/lambdas over extra adapter functions.
-* In C++ tests, avoid one large anonymous namespace collecting every helper at the top of the file. Prefer small, named fixture-style namespaces that contain both the helper definitions and the tests that use them, so helpers stay local to the relevant test group and the file can evolve toward fixture classes later.
-* In C++ tests, put at least one short `//` comment immediately above each `TEST()` explaining the behavior being verified.
-* When using `/* ************************************************************************* */` dividers in tests, use one divider immediately before each fixture namespace and one divider immediately after it closes. Do not put dividers between tests that belong to the same fixture block. The preferred shape is:
-  ```
+# GTSAM repository guidance
+
+GTSAM is a C++17 library for factor graphs and sensor fusion, with Python and
+MATLAB wrappers. Follow the existing code near your change and keep changes
+focused.
+
+## Public C++ APIs
+
+* All functions in header files should have Doxygen-style API documentation
+  using `/** */`, except small functions such as getters, which can use a
+  single-line `///` comment. There is no need for `@brief`, `@param`, or similar
+  tags when the prose is already clear.
+* Use `///` for single-line documentation comments rather than `/** */`.
+* Use meaningful variable names, for example `measurement` rather than `msm`;
+  avoid abbreviations.
+* On Windows, externally accessible library APIs must be explicitly exported.
+  When adding or modifying public classes or functions, review and follow
+  [`Using-GTSAM-EXPORT.md`](../Using-GTSAM-EXPORT.md), including its template
+  specialization and header-only rules.
+
+## C++ style
+
+* Classes and types are `UpperCamelCase`; methods and functions are
+  `lowerCamelCase`.
+* Public fields in structs use plain names without a trailing underscore.
+* Apart from those naming conventions, follow Google C++ style.
+* Prefer concise, elegant examples. Use the fewest helpers needed and favor
+  direct construction and small local functors or lambdas over adapter
+  functions.
+* When reviewing changes, flag overly complex or long functions and recommend
+  breaking them into smaller functions.
+
+## Wrappers and vendored code
+
+* When a C++ function is exposed in a wrapper `.i` file, parameter names must
+  match exactly between the header declaration and the `.i` declaration.
+  Update both whenever a wrapped parameter name changes.
+* For templated classes and factors in wrappers, prefer the normal `.i`
+  template mechanism over one handwritten wrapper class per instantiation.
+  Let the wrapper generate names such as `AttitudeFactorRot3` from
+  `template<...> class AttitudeFactor`.
+* Do not add or retain C++ `using` or `typedef` aliases solely to manufacture
+  wrapper names. Keep aliases only when they are useful in the C++ API.
+* The top-level `wrap/` directory is a git subtree of `borglab/wrap`, not a
+  submodule. Make wrapper-generator contributions in `borglab/wrap`, then sync
+  them into GTSAM with `./update_wrap.sh [branch-or-tag]`, which defaults to
+  `master`. Run the sync on a feature branch because it creates GTSAM commits,
+  typically a squash followed by a merge commit. Do not edit `wrap/` directly
+  for changes that belong upstream.
+* Do not edit files under `gtsam/3rdparty/`. These are vendored third-party
+  libraries, including Eigen; direct changes make upstream updates difficult.
+
+## Tests
+
+* Run validation relevant to the files changed.
+* Run C++ tests from `build/` with `make -j6 testXXX.run`, replacing `testXXX`
+  with the relevant test target.
+* For Python commands in the standard local development environment, use the
+  `py312` conda environment. Run wrapper tests with
+  `cmake --build build --target python-test` or
+  `cmake --build build --target python-test-unstable`, as appropriate.
+* Documentation-only changes do not require unrelated C++ tests, but should
+  still pass applicable documentation checks and `git diff --check`.
+
+## C++ test organization
+
+* Avoid one large anonymous namespace collecting every helper at the top of a
+  test file. Prefer small, named fixture-style namespaces containing both the
+  helpers and tests that use them.
+* Put at least one short `//` comment immediately above every `TEST()` explaining
+  the behavior being verified.
+* When using `/* ************************************************************************* */`
+  dividers, put one immediately before each fixture namespace and one
+  immediately after it closes. Do not put dividers between tests in the same
+  fixture namespace:
+
+  ```cpp
   /* ************************************************************************* */
   namespace my_fixture {
 
-  // definitions
-
   // Verifies the expected behavior.
   TEST(Suite, Case) {}
-  // Verifies another related behavior.
-  TEST(Suite, AnotherCase) {}
 
   }  // namespace my_fixture
   /* ************************************************************************* */
   ```
-* Notebooks in `*/doc/*.ipynb` and `*/examples/*.ipynb` should follow the standard preamble:
-  1) title/introduction markdown cell,
-  2) copyright markdown cell tagged `remove-cell`,
-  3) Colab badge markdown cell,
-  4) Colab install code cell tagged `remove-cell`,
-  5) imports/setup code cell.
-  Use the same `remove-cell` tagging convention as existing notebooks so docs build and Colab behavior stay consistent.
-* After any code change, always run relevant tests via `make -j6 testXXX.run` in the build folder $WORKSPACE/build. If in VS code, ask for escalated permissions if needed.
+
+## Notebooks
+
+Notebooks in `*/doc/*.ipynb` and `*/examples/*.ipynb` should use this preamble:
+
+1. Title and introductory Markdown cell.
+2. Copyright Markdown cell tagged `remove-cell`.
+3. Colab badge Markdown cell.
+4. Colab installation code cell tagged `remove-cell`.
+5. Imports and setup code cell.
+
+Use the existing `remove-cell` metadata convention so documentation builds and
+Colab behavior stay consistent.

--- a/.github/workflows/build-cibw.yml
+++ b/.github/workflows/build-cibw.yml
@@ -41,12 +41,12 @@ jobs:
             python_version: "3.12"
             cibw_python_version: 312
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
           - os: ubuntu-latest
             python_version: "3.13"
             cibw_python_version: 313
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
           - os: ubuntu-latest
             python_version: "3.14"
             cibw_python_version: 314
@@ -63,12 +63,12 @@ jobs:
             python_version: "3.12"
             cibw_python_version: 312
             platform_id: manylinux_aarch64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
           - os: ubuntu-24.04-arm
             python_version: "3.13"
             cibw_python_version: 313
             platform_id: manylinux_aarch64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
           - os: ubuntu-24.04-arm
             python_version: "3.14"
             cibw_python_version: 314

--- a/.github/workflows/prod-cibw.yml
+++ b/.github/workflows/prod-cibw.yml
@@ -26,12 +26,12 @@ jobs:
             python_version: "3.12"
             cibw_python_version: 312
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
           - os: ubuntu-latest
             python_version: "3.13"
             cibw_python_version: 313
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
           - os: ubuntu-latest
             python_version: "3.14"
             cibw_python_version: 314
@@ -48,12 +48,12 @@ jobs:
             python_version: "3.12"
             cibw_python_version: 312
             platform_id: manylinux_aarch64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
           - os: ubuntu-24.04-arm
             python_version: "3.13"
             cibw_python_version: 313
             platform_id: manylinux_aarch64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
           - os: ubuntu-24.04-arm
             python_version: "3.14"
             cibw_python_version: 314

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ xcode/
 
 # MyST build outputs
 _build
-GEMINI.md
 doc/#*.lyx#
 /cmake-build-debug/
 .venv/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Repository instructions
+
+Before doing any work, read and follow
+`.github/copilot-instructions.md`, the canonical repository guidance.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@.github/copilot-instructions.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+@./.github/copilot-instructions.md

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,9 +15,22 @@ $ cmake --build . --target install
 ## Important Installation Notes
 
 1. GTSAM requires the following libraries to be installed on your system:
-    - BOOST version 1.70 or greater (install through Linux repositories or MacPorts). Please see [Boost Notes](#boost-notes) for version recommendations based on your compiler.
-
     - CMake version 3.16 or higher
+    - A compiler with C++17 support:
+      - Linux: GCC 9 or Clang 11
+      - macOS: Xcode 14.2
+      - Windows: MSVC 14.2
+
+    Boost version 1.70 or greater is required when either
+    `GTSAM_USE_BOOST_FEATURES` or `GTSAM_ENABLE_BOOST_SERIALIZATION` is
+    enabled. Both options are enabled by default outside ROS 2 `colcon` builds.
+    To build without Boost, disable both:
+
+    ```sh
+    $ cmake .. \
+        -DGTSAM_USE_BOOST_FEATURES=OFF \
+        -DGTSAM_ENABLE_BOOST_SERIALIZATION=OFF
+    ```
 
     Optional dependent libraries:
      - If TBB is installed and detectable by CMake GTSAM will use it automatically.
@@ -31,19 +44,6 @@ $ cmake --build . --target install
        achieved with MKL disabled. We therefore advise you to benchmark your problem
        before using MKL.
 
-    Tested compilers:
-
-    - GCC 4.2-7.3
-    - OS X Clang 2.9-10.0
-    - OS X GCC 4.2
-    - MSVC 2010, 2012, 2017
-
-    Tested systems:
-
-    - Ubuntu 16.04 - 18.04
-    - MacOS 10.6 - 10.14
-    - Windows 7, 8, 8.1, 10
-
 2. GTSAM makes extensive use of debug assertions, and we highly recommend you work
 in Debug mode while developing (enabled by default). Likewise, it is imperative
 that you switch to release mode when running finished code and for timing. GTSAM
@@ -51,7 +51,8 @@ will run up to 10x faster in Release mode! See the end of this document for
 additional debugging tips.
 
 3. GTSAM has Doxygen documentation. To generate, run 'make doc' from your
-build directory after setting the `GTSAM_BUILD_DOCS` and `GTSAM_BUILD_[HTML|LATEX]` cmake flags.
+build directory after setting the `GTSAM_BUILD_DOCS` and
+`GTSAM_BUILD_DOC_[HTML|LATEX]` cmake flags.
 
 4. The instructions below install the library to the default system install path and
 build all components. From a terminal, starting in the root library folder,
@@ -73,11 +74,78 @@ execute commands as follows for an out-of-source build:
 Versions of Boost prior to 1.65 have a known bug that prevents proper "deep" serialization of objects, which means that objects encapsulated inside other objects don't get serialized.
 This is particularly seen when using `clang` as the C++ compiler.
 
-For this reason we recommend Boost>=1.65, and recommend installing it through alternative channels when it is not available through your operating system's primary package manager.
+GTSAM's minimum supported Boost version, 1.70, already includes the fix. We
+recommend installing it through alternative channels when it is not available
+through your operating system's primary package manager.
 
-## Known Issues
+## Installing prebuilt packages
 
-- MSVC 2013 is not yet supported because it cannot build the serialization module of Boost 1.55 (or earlier).
+### Ubuntu PPA
+
+GTSAM can also be installed on Ubuntu using the
+[BorgLab PPA repositories](https://launchpad.net/~borglab).
+
+For the current GTSAM 4.2 release:
+
+```sh
+sudo add-apt-repository ppa:borglab/gtsam-release-4.2
+sudo apt update
+sudo apt install libgtsam-dev libgtsam-unstable-dev
+```
+
+For nightly builds from the `develop` branch:
+
+```sh
+sudo add-apt-repository ppa:borglab/gtsam-develop
+sudo apt update
+sudo apt install libgtsam-dev libgtsam-unstable-dev
+```
+
+Package availability depends on the Ubuntu release. Consult the linked PPA
+pages for the currently published packages.
+
+### Arch Linux AUR
+
+GTSAM is available in the Arch User Repository as
+[`gtsam`](https://aur.archlinux.org/packages/gtsam/). Installing GTSAM on
+Arch Linux is not tested by the GTSAM developers.
+
+Install it manually by following the
+[Arch Wiki instructions](https://wiki.archlinux.org/title/Arch_User_Repository)
+or use an AUR helper such as `yay`:
+
+```sh
+yay -S gtsam
+```
+
+An Intel MKL-enabled package is also available:
+
+```sh
+yay -S gtsam-mkl
+```
+
+## Using GTSAM from a CMake project
+
+After installing GTSAM, downstream CMake projects can use its exported target:
+
+```cmake
+find_package(GTSAM REQUIRED)
+
+add_executable(my_program main.cpp)
+target_link_libraries(my_program PRIVATE gtsam)
+```
+
+Linking the `gtsam` target supplies the required include directories and
+transitive build requirements. If GTSAM was installed to a nonstandard prefix,
+point CMake at it when configuring the downstream project:
+
+```sh
+cmake -S . -B build -DCMAKE_PREFIX_PATH=/path/to/gtsam
+```
+
+See the complete
+[`cmake/example_cmake_find_gtsam`](cmake/example_cmake_find_gtsam)
+consumer example.
 
 # Windows Installation
 


### PR DESCRIPTION
## Follow-up

This PR builds on #2610, which moved the Python 3.14 Linux wheel jobs to `manylinux_2_28`. The wheel changes here extend that fix to Python 3.12 and 3.13 after those jobs showed the same NumPy/toolchain incompatibility.

## Summary

- modernize `INSTALL.md` with current compiler, Boost, package-installation, downstream CMake, and platform guidance
- centralize AI-agent instructions in `.github/copilot-instructions.md` and add lightweight entry points for supported assistants
- use `manylinux_2_28` for Python 3.12 and 3.13 Linux wheels on x86_64 and aarch64 in both develop and release workflows

## Details

The installation guide previously documented outdated compiler, operating-system, and Boost support. This update aligns it with the current C++17 build, explains when Boost is required, documents the Ubuntu PPA and Arch AUR packages, and shows the supported downstream CMake target.

Repository-specific agent conventions now live in one canonical file, with `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` directing tools to that guidance.

The wheel matrix extension moves Python 3.12 and 3.13 to the same `manylinux_2_28` baseline introduced for Python 3.14 in #2610. This avoids NumPy/toolchain incompatibilities in the older CentOS 7-based image while retaining `manylinux2014` for Python 3.11.

## Validation

- `git diff --check origin/develop...HEAD`
- parsed `.github/workflows/build-cibw.yml` and `.github/workflows/prod-cibw.yml` with PyYAML in the `py312` conda environment
- reviewed the complete branch diff and confirmed a clean working tree

The documentation and CI configuration changes do not have a relevant local C++ `testXXX.run` target; the wheel builds will be exercised by GitHub Actions.