### PR TITLE
Fix 8-dimensional matrix and vector constants

### DIFF
--- a/gtsam/base/MatrixConstants.h
+++ b/gtsam/base/MatrixConstants.h
@@ -39,8 +39,8 @@
 #define I_7x7 Matrix7::Identity()
 #define Z_7x7 Matrix7::Constant(0.0)
 
-#define I_8x8 Matrix9::Identity()
-#define Z_8x8 Matrix9::Constant(0.0)
+#define I_8x8 Matrix8::Identity()
+#define Z_8x8 Matrix8::Constant(0.0)
 
 #define I_9x9 Matrix9::Identity()
 #define Z_9x9 Matrix9::Constant(0.0)

--- a/gtsam/base/VectorConstants.h
+++ b/gtsam/base/VectorConstants.h
@@ -24,5 +24,5 @@
 #define Z_5x1 Vector5::Constant(0.0)
 #define Z_6x1 Vector6::Constant(0.0)
 #define Z_7x1 Vector7::Constant(0.0)
-#define Z_8x1 Vector7::Constant(0.0)
+#define Z_8x1 Vector8::Constant(0.0)
 #define Z_9x1 Vector9::Constant(0.0)

--- a/gtsam/base/tests/testMatrix.cpp
+++ b/gtsam/base/tests/testMatrix.cpp
@@ -34,6 +34,23 @@ static double inf = std::numeric_limits<double>::infinity();
 static const double tol = 1e-9;
 
 /* ************************************************************************* */
+namespace matrix_constants {
+
+// Verifies the 8x8 constant macros have the correct type and value.
+TEST(MatrixConstants, EightByEight) {
+  const Matrix8 identity = I_8x8;
+  const Matrix8 zero = Z_8x8;
+  const Matrix expectedIdentity = Matrix8::Identity();
+  const Matrix expectedZero = Matrix8::Zero();
+
+  EXPECT(assert_equal(expectedIdentity, identity));
+  EXPECT(assert_equal(expectedZero, zero));
+}
+
+}  // namespace matrix_constants
+/* ************************************************************************* */
+
+/* ************************************************************************* */
 TEST(Matrix, constructor_data )
 {
   Matrix A = (Matrix(2, 2) << -5, 3, 0, -5).finished();

--- a/gtsam/base/tests/testMatrix.cpp
+++ b/gtsam/base/tests/testMatrix.cpp
@@ -34,8 +34,6 @@ static double inf = std::numeric_limits<double>::infinity();
 static const double tol = 1e-9;
 
 /* ************************************************************************* */
-namespace matrix_constants {
-
 // Verifies the 8x8 constant macros have the correct type and value.
 TEST(MatrixConstants, EightByEight) {
   const Matrix8 identity = I_8x8;
@@ -46,9 +44,6 @@ TEST(MatrixConstants, EightByEight) {
   EXPECT(assert_equal(expectedIdentity, identity));
   EXPECT(assert_equal(expectedZero, zero));
 }
-
-}  // namespace matrix_constants
-/* ************************************************************************* */
 
 /* ************************************************************************* */
 TEST(Matrix, constructor_data )

--- a/gtsam/base/tests/testVector.cpp
+++ b/gtsam/base/tests/testVector.cpp
@@ -41,8 +41,6 @@ namespace {
 }
 
 /* ************************************************************************* */
-namespace vector_constants {
-
 // Verifies the 8x1 zero macro has the correct type and value.
 TEST(VectorConstants, EightByOne) {
   const Vector8 zero = Z_8x1;
@@ -50,9 +48,6 @@ TEST(VectorConstants, EightByOne) {
 
   EXPECT(assert_equal(expected, zero));
 }
-
-}  // namespace vector_constants
-/* ************************************************************************* */
 
 /* ************************************************************************* */
 TEST(Vector, special_comma_initializer)

--- a/gtsam/base/tests/testVector.cpp
+++ b/gtsam/base/tests/testVector.cpp
@@ -41,6 +41,20 @@ namespace {
 }
 
 /* ************************************************************************* */
+namespace vector_constants {
+
+// Verifies the 8x1 zero macro has the correct type and value.
+TEST(VectorConstants, EightByOne) {
+  const Vector8 zero = Z_8x1;
+  const Vector expected = Vector8::Zero();
+
+  EXPECT(assert_equal(expected, zero));
+}
+
+}  // namespace vector_constants
+/* ************************************************************************* */
+
+/* ************************************************************************* */
 TEST(Vector, special_comma_initializer)
 {
   Vector expected(3);


### PR DESCRIPTION
## Summary

- correct `Z_8x1` to instantiate `Vector8`
- correct `I_8x8` and `Z_8x8` to instantiate `Matrix8`
- add fixed-size regression coverage for the dimensions and values

## Testing

- `cmake --build build --target testMatrix.run testVector.run -j6`

Fixes #2613
Fixes #2614