### PR TITLE
Speed up geometry

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -164,11 +164,29 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           choco install boost-msvc-14.2 --yes --no-progress
-          $boostRoot = "C:\local\boost_1_72_0"
-          if (!(Test-Path $boostRoot)) {
-            throw "Expected Boost path not found: $boostRoot"
+
+          # Try common Chocolatey install roots for Boost
+          $candidates = @(
+            "C:\local\boost_*",
+            "C:\ProgramData\chocolatey\lib\boost-msvc-14.2\tools\boost_*",
+            "C:\ProgramData\chocolatey\lib\boost-msvc-14.2\**\boost_*"
+          )
+
+          $boostRoot = $null
+          foreach ($pattern in $candidates) {
+            $match = Get-ChildItem -Path $pattern -Directory -ErrorAction SilentlyContinue |
+              Sort-Object FullName -Descending |
+              Select-Object -First 1
+            if ($match) { $boostRoot = $match.FullName; break }
           }
+
+          if (-not $boostRoot) {
+            throw "Boost installed but root directory was not found in expected locations."
+          }
+
           "BOOST_ROOT=$boostRoot" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          Write-Host "Using BOOST_ROOT=$boostRoot"
+    
       - name: Install sccache
         if: runner.os == 'Windows'
         uses: mozilla-actions/sccache-action@v0.0.9

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -4,12 +4,12 @@ name: Python CI
 # instead of under 'pull_request:'. Otherwise, the check is still required but
 # never runs, and a maintainer must bypass the check in order to merge the PR.
 on:
-  workflow_dispatch: 
+  workflow_dispatch:
   pull_request:
     paths-ignore:
-      - '**.md'
-      - '**.ipynb'
-      - 'myst.yml'
+      - "**.md"
+      - "**.ipynb"
+      - "myst.yml"
 
 # Every time you make a push to your PR, it cancel immediately the previous checks,
 # and start a new one. The other runner will be available more quickly to your PR.
@@ -162,22 +162,13 @@ jobs:
         if: runner.os == 'Windows'
         shell: powershell
         run: |
-          # Snippet from: https://github.com/actions/virtual-environments/issues/2667
-          $BOOST_PATH = "C:\hostedtoolcache\windows\Boost\$env:BOOST_VERSION\x86_64"
-
-          # Use the prebuilt binary for Windows
-          $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/$env:BOOST_VERSION/$env:BOOST_EXE-${{matrix.platform}}.exe"
-
-          # Create WebClient with appropriate settings and download Boost exe
-          $wc = New-Object System.Net.Webclient
-          $wc.Headers.Add("User-Agent: Other");
-          $wc.DownloadFile($Url, "$env:TEMP\boost.exe")
-
-          Start-Process -Wait -FilePath "$env:TEMP\boost.exe" "/SILENT","/SP-","/SUPPRESSMSGBOXES","/DIR=$BOOST_PATH"
-
-          # Set the BOOST_ROOT variable
-          echo "BOOST_ROOT=$BOOST_PATH" >> $env:GITHUB_ENV
-
+          $ErrorActionPreference = "Stop"
+          choco install boost-msvc-14.2 --yes --no-progress
+          $boostRoot = "C:\local\boost_1_72_0"
+          if (!(Test-Path $boostRoot)) {
+            throw "Expected Boost path not found: $boostRoot"
+          }
+          "BOOST_ROOT=$boostRoot" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
       - name: Install sccache
         if: runner.os == 'Windows'
         uses: mozilla-actions/sccache-action@v0.0.9

--- a/gtsam/geometry/ExtendedPose3-inl.h
+++ b/gtsam/geometry/ExtendedPose3-inl.h
@@ -157,7 +157,7 @@ typename ExtendedPose3<K, Derived>::This ExtendedPose3<K, Derived>::Expmap(
   // Instantiate functor for Dexp-related operations:
   const so3::DexpFunctor local(w);
 
-  // Compute rotation using Expmap
+// Compute rotation using Expmap
 #ifdef GTSAM_USE_QUATERNIONS
   // Reuse any quaternion-specific validation inside Rot3::Expmap.
   const Rot3 R = Rot3::Expmap(w);
@@ -167,9 +167,7 @@ typename ExtendedPose3<K, Derived>::This ExtendedPose3<K, Derived>::Expmap(
 
   const Eigen::Index k = static_cast<Eigen::Index>(RuntimeK(xi));
 
-  // The translation t = local.Jacobian().left() * v.
-  // Below we call local.Jacobian().applyLeft, which is faster if you don't need
-  // Jacobians, and returns Jacobian of t with respect to w if asked.
+  // The translation block is x = Jl(w) * rho.
   // NOTE(Frank): this does the same as the intuitive formulas:
   //   t_parallel = w * w.dot(v);  // translation parallel to axis
   //   w_cross_v = w.cross(v);     // translation orthogonal to axis
@@ -180,28 +178,27 @@ typename ExtendedPose3<K, Derived>::This ExtendedPose3<K, Derived>::Expmap(
   Matrix3K x;
   if constexpr (K == Eigen::Dynamic) x.resize(3, k);
 
-  const auto J = local.Jacobian();
   if (Hxi) {
     ZeroJacobian(Hxi, 3 + 3 * k);
-    const Matrix3 Jr = J.right();
-    Hxi->block(0, 0, 3, 3) = Jr;  // Jr here *is* the Jacobian of expmap
+    const so3::Kernel jacobian = local.Jacobian();
+    const Matrix3 Jr = jacobian.right();
+    // Jr here is the Jacobian of the rotation exponential map.
+    Hxi->template block<3, 3>(0, 0) = Jr;
     const Matrix3 Rt = R.transpose();
     for (Eigen::Index i = 0; i < k; ++i) {
       Matrix3 H_xi_w;
       const Eigen::Index idx = 3 + 3 * i;
       const Vector3 rho = xi.template segment<3>(idx);
-      x.col(i) = J.applyLeft(rho, &H_xi_w);
-      Hxi->block(idx, 0, 3, 3) = Rt * H_xi_w;
-      Hxi->block(idx, idx, 3, 3) = Jr;
+      x.col(i) = jacobian.applyLeft(rho, &H_xi_w);
+      Hxi->template block<3, 3>(idx, 0) = Rt * H_xi_w;
+      Hxi->template block<3, 3>(idx, idx) = Jr;
       // In the last row, Jr = R^T * Jl, see Barfoot eq. (8.83).
       // Jl is the left Jacobian of SO(3) at w.
     }
-  } else {
-    const Matrix3 Jl = J.left();
+  } else if (k > 0) {
+    const Matrix3 Jl = local.leftJacobian();
     for (Eigen::Index i = 0; i < k; ++i) {
-      const Eigen::Index idx = 3 + 3 * i;
-      const Vector3 rho = xi.template segment<3>(idx);
-      x.col(i) = Jl * rho;
+      x.col(i).noalias() = Jl * xi.template segment<3>(3 + 3 * i);
     }
   }
 

--- a/gtsam/geometry/ExtendedPose3-inl.h
+++ b/gtsam/geometry/ExtendedPose3-inl.h
@@ -180,26 +180,28 @@ typename ExtendedPose3<K, Derived>::This ExtendedPose3<K, Derived>::Expmap(
   Matrix3K x;
   if constexpr (K == Eigen::Dynamic) x.resize(3, k);
 
+  const auto J = local.Jacobian();
   if (Hxi) {
     ZeroJacobian(Hxi, 3 + 3 * k);
-    const Matrix3 Jr = local.Jacobian().right();
+    const Matrix3 Jr = J.right();
     Hxi->block(0, 0, 3, 3) = Jr;  // Jr here *is* the Jacobian of expmap
     const Matrix3 Rt = R.transpose();
     for (Eigen::Index i = 0; i < k; ++i) {
       Matrix3 H_xi_w;
       const Eigen::Index idx = 3 + 3 * i;
       const Vector3 rho = xi.template segment<3>(idx);
-      x.col(i) = local.Jacobian().applyLeft(rho, &H_xi_w);
+      x.col(i) = J.applyLeft(rho, &H_xi_w);
       Hxi->block(idx, 0, 3, 3) = Rt * H_xi_w;
       Hxi->block(idx, idx, 3, 3) = Jr;
       // In the last row, Jr = R^T * Jl, see Barfoot eq. (8.83).
       // Jl is the left Jacobian of SO(3) at w.
     }
   } else {
+    const Matrix3 Jl = J.left();
     for (Eigen::Index i = 0; i < k; ++i) {
       const Eigen::Index idx = 3 + 3 * i;
       const Vector3 rho = xi.template segment<3>(idx);
-      x.col(i) = local.Jacobian().applyLeft(rho);
+      x.col(i) = Jl * rho;
     }
   }
 
@@ -292,25 +294,26 @@ ExtendedPose3<K, Derived>::LogmapDerivative(const TangentVector& xi) {
 
   const Eigen::Index k = static_cast<Eigen::Index>(RuntimeK(xi));
   const Matrix3 Rt = local.expmap().transpose();
-  const Matrix3 Jw = Rot3::LogmapDerivative(w);
+  const Matrix3 Jw = local.InvJacobian().right();  // Rot3::LogmapDerivative(w);
 
-  Jacobian J;
+  Jacobian H;
   if constexpr (dimension == Eigen::Dynamic) {
-    J.setZero(3 + 3 * k, 3 + 3 * k);
+    H.setZero(3 + 3 * k, 3 + 3 * k);
   } else {
-    J.setZero();
+    H.setZero();
   }
 
-  J.block(0, 0, 3, 3) = Jw;
+  H.block(0, 0, 3, 3) = Jw;
+  const auto J = local.Jacobian();
   for (Eigen::Index i = 0; i < k; ++i) {
     Matrix3 H_xi_w;
     const Eigen::Index idx = 3 + 3 * i;
-    local.Jacobian().applyLeft(xi.template segment<3>(idx), H_xi_w);
+    J.applyLeft(xi.template segment<3>(idx), H_xi_w);
     const Matrix3 Q = Rt * H_xi_w;
-    J.block(idx, 0, 3, 3) = -Jw * Q * Jw;
-    J.block(idx, idx, 3, 3) = Jw;
+    H.block(idx, 0, 3, 3) = -Jw * Q * Jw;
+    H.block(idx, idx, 3, 3) = Jw;
   }
-  return J;
+  return H;
 }
 
 template <int K, class Derived>

--- a/gtsam/geometry/ExtendedPose3-inl.h
+++ b/gtsam/geometry/ExtendedPose3-inl.h
@@ -80,7 +80,7 @@ const Rot3& ExtendedPose3<K, Derived>::rotation(ComponentJacobian H) const {
     } else {
       H->setZero();
     }
-    H->block(0, 0, 3, 3) = I_3x3;
+    H->template block<3, 3>(0, 0) = I_3x3;
   }
   return R_;
 }
@@ -95,7 +95,7 @@ Point3 ExtendedPose3<K, Derived>::x(size_t i, ComponentJacobian H) const {
       H->setZero();
     }
     const Eigen::Index idx = 3 + 3 * static_cast<Eigen::Index>(i);
-    H->block(0, idx, 3, 3) = R_.matrix();
+    H->template block<3, 3>(0, idx) = R_.matrix();
   }
   return t_.col(static_cast<Eigen::Index>(i));
 }
@@ -217,10 +217,12 @@ ExtendedPose3<K, Derived>::Logmap(const This& pose, ChartJacobian H) {
     xi.resize(static_cast<Eigen::Index>(poseBase.dim()));
   xi.template head<3>() = w;
   const Eigen::Index k = static_cast<Eigen::Index>(poseBase.k());
-  for (Eigen::Index i = 0; i < k; ++i) {
-    const Eigen::Index idx = 3 + 3 * i;
-    xi.template segment<3>(idx) =
-        local.InvJacobian().applyLeft(poseBase.t_.col(i));
+  if (k > 0) {
+    const Matrix3 JlInv = local.InvJacobian().left();
+    for (Eigen::Index i = 0; i < k; ++i) {
+      const Eigen::Index idx = 3 + 3 * i;
+      xi.template segment<3>(idx).noalias() = JlInv * poseBase.t_.col(i);
+    }
   }
 
   if (H) *H = LogmapDerivative(xi);
@@ -239,12 +241,12 @@ ExtendedPose3<K, Derived>::AdjointMap() const {
     adj.setZero();
   }
 
-  adj.block(0, 0, 3, 3) = R;
+  adj.template block<3, 3>(0, 0) = R;
   const Eigen::Index k = static_cast<Eigen::Index>(this->k());
   for (Eigen::Index i = 0; i < k; ++i) {
     const Eigen::Index idx = 3 + 3 * i;
-    adj.block(idx, 0, 3, 3) = skewSymmetric(t_.col(i)) * R;
-    adj.block(idx, idx, 3, 3) = R;
+    adj.template block<3, 3>(idx, 0) = skewSymmetric(t_.col(i)) * R;
+    adj.template block<3, 3>(idx, idx) = R;
   }
   return adj;
 }
@@ -263,12 +265,12 @@ ExtendedPose3<K, Derived>::adjointMap(const TangentVector& xi) {
     adj.setZero();
   }
 
-  adj.block(0, 0, 3, 3) = w_hat;
+  adj.template block<3, 3>(0, 0) = w_hat;
   for (Eigen::Index i = 0; i < k; ++i) {
     const Eigen::Index idx = 3 + 3 * i;
-    adj.block(idx, 0, 3, 3) =
+    adj.template block<3, 3>(idx, 0) =
         skewSymmetric(xi(idx + 0), xi(idx + 1), xi(idx + 2));
-    adj.block(idx, idx, 3, 3) = w_hat;
+    adj.template block<3, 3>(idx, idx) = w_hat;
   }
   return adj;
 }
@@ -290,8 +292,9 @@ ExtendedPose3<K, Derived>::LogmapDerivative(const TangentVector& xi) {
   const so3::DexpFunctor local(w);
 
   const Eigen::Index k = static_cast<Eigen::Index>(RuntimeK(xi));
-  const Matrix3 Rt = local.expmap().transpose();
-  const Matrix3 Jw = local.InvJacobian().right();  // Rot3::LogmapDerivative(w);
+  const so3::InvJKernel inverseJacobian = local.InvJacobian();
+  const Matrix3 JrInv = inverseJacobian.right();
+  const Matrix3 JlInv = inverseJacobian.left();
 
   Jacobian H;
   if constexpr (dimension == Eigen::Dynamic) {
@@ -300,15 +303,14 @@ ExtendedPose3<K, Derived>::LogmapDerivative(const TangentVector& xi) {
     H.setZero();
   }
 
-  H.block(0, 0, 3, 3) = Jw;
-  const auto J = local.Jacobian();
+  H.template block<3, 3>(0, 0) = JrInv;
+  const so3::Kernel& jacobian = inverseJacobian.J;
   for (Eigen::Index i = 0; i < k; ++i) {
     Matrix3 H_xi_w;
     const Eigen::Index idx = 3 + 3 * i;
-    J.applyLeft(xi.template segment<3>(idx), H_xi_w);
-    const Matrix3 Q = Rt * H_xi_w;
-    H.block(idx, 0, 3, 3) = -Jw * Q * Jw;
-    H.block(idx, idx, 3, 3) = Jw;
+    jacobian.applyLeft(xi.template segment<3>(idx), H_xi_w);
+    H.template block<3, 3>(idx, 0) = -JlInv * H_xi_w * JrInv;
+    H.template block<3, 3>(idx, idx) = JrInv;
   }
   return H;
 }
@@ -359,10 +361,11 @@ typename ExtendedPose3<K, Derived>::LieAlgebra ExtendedPose3<K, Derived>::Hat(
   } else {
     X.setZero();
   }
-  X.block(0, 0, 3, 3) = skewSymmetric(xi(0), xi(1), xi(2));
+  X.template block<3, 3>(0, 0) =
+      skewSymmetric(xi(0), xi(1), xi(2));
   for (Eigen::Index i = 0; i < k; ++i) {
     const Eigen::Index idx = 3 + 3 * i;
-    X.block(0, 3 + i, 3, 1) = xi.template segment<3>(idx);
+    X.template block<3, 1>(0, 3 + i) = xi.template segment<3>(idx);
   }
   return X;
 }

--- a/gtsam/geometry/Gal3.cpp
+++ b/gtsam/geometry/Gal3.cpp
@@ -316,35 +316,37 @@ Gal3 Gal3::Expmap(const TangentVector& xi, OptionalJacobian<10, 10> Hxi) {
 #else
   const Rot3 R(local.expmap());
 #endif
-  Matrix3 Rt;
-  if (Hxi) Rt = R.transpose();
 
-  // Compute velocity: just apply left SO(3) Jacobian,
-  Matrix3 H_v_w;
-  const Velocity3 v = local.Jacobian().applyLeft(nu, Hxi ? &H_v_w : nullptr);
-
-  // Compute position: apply left Jacobian and compute time-dependent part
-  Matrix3 H_p_w, H_delta_w;
-  Point3 p = local.Jacobian().applyLeft(rho, Hxi ? &H_p_w : nullptr);
-  const Point3 delta = local.Gamma().applyLeft(nu, Hxi ? &H_delta_w : nullptr);
-
-  // (*) means: different from Arxiv paper!
+  Velocity3 v;
+  Point3 p;
   if (Hxi) {
-    const Matrix3 Jr = local.Jacobian().right();
-    const Matrix3 Gr = local.Gamma().right();
+    const Matrix3 Rt = R.transpose();
+    const so3::Kernel jacobian = local.Jacobian();
+    Matrix3 H_v_w, H_p_w;
+    v = jacobian.applyLeft(nu, &H_v_w);
+    p = jacobian.applyLeft(rho, &H_p_w);
+
+    const so3::Kernel gamma = local.Gamma();
+    const Matrix3 Jr = jacobian.right();
+    const Matrix3 Gr = gamma.right();
     *Hxi << Jr, Z_3x3, Z_3x3, Z_3x1,      //
         Rt * H_v_w, Jr, Z_3x3, Z_3x1,     //
         Rt * H_p_w, Z_3x3, Jr, -Gr * nu,  // (*)
         Z_9x1.transpose(), 1.0;
-  }
 
-  // if alpha!=0, augment position with time-dependent bit.
-  if (std::abs(alpha) > kSmallTimeThreshold) {
-    p += alpha * delta;
-    if (Hxi) {
-      // Derivative of time-dependent part
+    if (std::abs(alpha) > kSmallTimeThreshold) {
+      Matrix3 H_delta_w;
+      const Point3 delta = gamma.applyLeft(nu, &H_delta_w);
+      p += alpha * delta;
       Hxi->block<3, 3>(6, 0) += alpha * Rt * H_delta_w;
-      Hxi->block<3, 3>(6, 3) = alpha * Rt * local.Gamma().left();  // (*)
+      Hxi->block<3, 3>(6, 3) = alpha * Rt * gamma.left();  // (*)
+    }
+  } else {
+    const Matrix3 Jl = local.leftJacobian();
+    v.noalias() = Jl * nu;
+    p.noalias() = Jl * rho;
+    if (std::abs(alpha) > kSmallTimeThreshold) {
+      p += alpha * local.Gamma().applyLeft(nu);
     }
   }
   return Gal3(R, p, v, alpha);
@@ -368,9 +370,7 @@ Gal3::TangentVector Gal3::Logmap(const Gal3& g, OptionalJacobian<10, 10> Hg) {
     xi_rho(xi) = rho;
     xi_t(xi)(0) = g.t_;
 
-    if (Hg) {
-        *Hg = Gal3::LogmapDerivative(g);
-    }
+    if (Hg) *Hg = Gal3::LogmapDerivative(xi);
 
     return xi;
 }
@@ -439,7 +439,7 @@ Gal3::Jacobian Gal3::LogmapDerivative(const TangentVector& xi) {
   const so3::DexpFunctor local(w);
   const Matrix3 Jr_inv = local.InvJacobian().right();
 
-  const Jacobian J = ExpmapDerivative(xi);  
+  const Jacobian J = ExpmapDerivative(xi);
   const auto L = J.block<7, 3>(3, 0);
   const Matrix7 B = J.block<7, 7>(3, 3);
 

--- a/gtsam/geometry/Pose3.cpp
+++ b/gtsam/geometry/Pose3.cpp
@@ -121,11 +121,12 @@ Pose3 Pose3::Expmap(const Vector6& xi, OptionalJacobian<6, 6> Hxi) {
   // but Local does not need R, deals automatically with the case where theta2
   // is near zero, and also gives us the machinery for the Jacobians.
   Matrix3 H;
-  const Vector3 t = local.Jacobian().applyLeft(v, Hxi ? &H : nullptr);
+  const so3::Kernel jacobian = local.Jacobian();
+  const Vector3 t = jacobian.applyLeft(v, Hxi ? &H : nullptr);
 
   if (Hxi) {
     // The Jacobian of expmap is given by the right Jacobian of SO(3):
-    const Matrix3 Jr = local.Jacobian().right();
+    const Matrix3 Jr = jacobian.right();
     // Chain H with R^T, the Jacobian of Pose3::Create with respect to t.
     const Matrix3 Rt = R.transpose();
     *Hxi << Jr, Z_3x3,  // Jr here *is* the Jacobian of expmap

--- a/gtsam/geometry/Similarity3.cpp
+++ b/gtsam/geometry/Similarity3.cpp
@@ -269,6 +269,20 @@ Matrix7 Similarity3::AdjointMap() const {
   return adj;
 }
 
+Matrix7 Similarity3::adjointMap(const Vector7& xi) {
+  const Vector3 w = xi.head<3>();
+  const Vector3 u = xi.segment<3>(3);
+  const double lambda = xi(6);
+
+  Matrix7 adj = Matrix7::Zero();
+  const Matrix3 W = skewSymmetric(w);
+  adj.block<3, 3>(0, 0) = W;
+  adj.block<3, 3>(3, 0) = skewSymmetric(u);
+  adj.block<3, 3>(3, 3) = W + lambda * I_3x3;
+  adj.block<3, 1>(3, 6) = -u;
+  return adj;
+}
+
 namespace {
 // Functor that implements the Similarity3 V(ω, λ) kernel:
 // See http://www.ethaneade.org/latex2html/lie/node29.html
@@ -304,8 +318,9 @@ struct LocalV : public so3::DexpFunctor {
       mu = 1.0 / 6.0 - lambda / 24.0 + lambda2 / 120.0 - lambda3 / 720.0;
     }
     const double one_minus_alpha = 1.0 - alpha;
-    Q = alpha * beta + one_minus_alpha * (B - lambda * C());
-    R = alpha * mu + one_minus_alpha * (C() - lambda * E());
+    const double C_value = C();
+    Q = alpha * beta + one_minus_alpha * (B - lambda * C_value);
+    R = alpha * mu + one_minus_alpha * (C_value - lambda * E());
   }
 
   Matrix3 V() const { return P * I_3x3 + Q * W + R * WW; }
@@ -314,10 +329,11 @@ struct LocalV : public so3::DexpFunctor {
     const double lambda2 = lambda * lambda;
     const double dalpha =
         (lambda2 > 1e-9) ? (-2.0 * alpha * alpha / lambda2) : 0.0;
-    const double dQ = (beta - (B - lambda * C())) * dalpha +
-                      (1.0 - alpha) * (dB() - lambda * dC());
-    const double dR = (mu - (C() - lambda * E())) * dalpha +
-                      (1.0 - alpha) * (dC() - lambda * dE());
+    const double C_value = C(), dC_value = dC();
+    const double dQ = (beta - (B - lambda * C_value)) * dalpha +
+                      (1.0 - alpha) * (dB() - lambda * dC_value);
+    const double dR = (mu - (C_value - lambda * E())) * dalpha +
+                      (1.0 - alpha) * (dC_value - lambda * dE());
     return so3::Kernel{this, P, Q, R, dQ, dR};
   }
 };
@@ -346,8 +362,14 @@ Similarity3 Similarity3::Expmap(const Vector7& v, OptionalJacobian<7, 7> Hm) {
   if (Hm) {
     throw std::runtime_error("Similarity3::Expmap: derivative not implemented");
   }
-  const Matrix3 V = GetV(w, lambda);
-  return Similarity3(Rot3::Expmap(w), Point3(V * rho), exp(lambda));
+  const LocalV local(w, lambda);
+  const Matrix3 V = local.V();
+#ifdef GTSAM_USE_QUATERNIONS
+  const Rot3 R = Rot3::Expmap(w);
+#else
+  const Rot3 R(local.expmap());
+#endif
+  return Similarity3(R, Point3(V * rho), exp(lambda));
 }
 
 std::ostream &operator<<(std::ostream &os, const Similarity3& p) {

--- a/gtsam/geometry/Similarity3.h
+++ b/gtsam/geometry/Similarity3.h
@@ -176,6 +176,9 @@ class GTSAM_EXPORT Similarity3 : public MatrixLieGroup<Similarity3, 7, 4> {
   /// Project from one tangent space to another
   Matrix7 AdjointMap() const;
 
+  /// Compute the Lie algebra adjoint map associated with a tangent vector.
+  static Matrix7 adjointMap(const Vector7& xi);
+
   /**
    * Hat for Similarity3:
    * @param xi 7-dim twist (w,u,lambda) where

--- a/gtsam/geometry/tests/testSimilarity3.cpp
+++ b/gtsam/geometry/tests/testSimilarity3.cpp
@@ -648,6 +648,11 @@ TEST(Similarity3, AdjointMap) {
 
   // Assert that they are equal
   EXPECT(assert_equal(specialized_Adj, generic_Adj, 1e-9));
+
+  const Vector7 xi(0.2, -0.4, 0.7, -0.1, 0.3, -0.6, 0.5);
+  const Matrix7 specialized_ad = Similarity3::adjointMap(xi);
+  const Matrix7 generic_ad = MatrixLieGroup<Similarity3, 7, 4>::adjointMap(xi);
+  EXPECT(assert_equal(specialized_ad, generic_ad, 1e-9));
 }
 
 //******************************************************************************

--- a/gtsam/navigation/NavState.cpp
+++ b/gtsam/navigation/NavState.cpp
@@ -134,19 +134,22 @@ NavState NavState::retract(const Vector9& xi, //
   const Rot3 nRc = nRb.compose(bRc, H1 ? &D_R_nRb : 0);
   const Point3 t = n_t + nRb.rotate(dP(xi), H1 ? &D_t_nRb : 0);
   const Point3 v = n_v + nRb.rotate(dV(xi), H1 ? &D_v_nRb : 0);
+  Matrix3 bRcTranspose;
+  if (H1 || H2) bRcTranspose = bRc.transpose();
   if (H1) {
-    *H1 << D_R_nRb, Z_3x3, Z_3x3, //
-    // Note(frank): the derivative of n_t with respect to xi is nRb
-    // We pre-multiply with nRc' to account for NavState::Create
-    // Then we make use of the identity nRc' * nRb = bRc'
-    nRc.transpose() * D_t_nRb, bRc.transpose(), Z_3x3,
-    // Similar reasoning for v:
-    nRc.transpose() * D_v_nRb, Z_3x3, bRc.transpose();
+    const Matrix3 nRcTranspose = nRc.transpose();
+    *H1 << D_R_nRb, Z_3x3, Z_3x3,  //
+        // Note(frank): the derivative of n_t with respect to xi is nRb
+        // We pre-multiply with nRc' to account for NavState::Create
+        // Then we make use of the identity nRc' * nRb = bRc'
+        nRcTranspose * D_t_nRb, bRcTranspose, Z_3x3,
+        // Similar reasoning for v:
+        nRcTranspose * D_v_nRb, Z_3x3, bRcTranspose;
   }
   if (H2) {
-    *H2 << D_bRc_xi, Z_3x3, Z_3x3, //
-    Z_3x3, bRc.transpose(), Z_3x3, //
-    Z_3x3, Z_3x3, bRc.transpose();
+    *H2 << D_bRc_xi, Z_3x3, Z_3x3,   //
+        Z_3x3, bRcTranspose, Z_3x3,  //
+        Z_3x3, Z_3x3, bRcTranspose;
   }
   return NavState(nRc, t, v);
 }
@@ -169,9 +172,10 @@ Vector9 NavState::localCoordinates(const NavState& g, //
         D_dv_R, Z_3x3, -I_3x3;
   }
   if (H2) {
-    *H2 << D_xi_R, Z_3x3, Z_3x3,    //
-        Z_3x3, dR.matrix(), Z_3x3,  //
-        Z_3x3, Z_3x3, dR.matrix();
+    const Matrix3 dRMatrix = dR.matrix();
+    *H2 << D_xi_R, Z_3x3, Z_3x3,  //
+        Z_3x3, dRMatrix, Z_3x3,   //
+        Z_3x3, Z_3x3, dRMatrix;
   }
 
   return xi;


### PR DESCRIPTION
Various optimizations in geometry to speed up core geometry ops, inspired by looking into ExtendedPose3 with @ProfFan 

### Performance

Benchmarked against `develop` using Release settings (`-O3 -DNDEBUG`). Values are median nanoseconds per call; **speedup = develop / PR**, so higher is better.

Each result is the median of three alternating process runs. Each process reports the median of nine 300,000-call trials. Outputs were forced to materialize to prevent dead-code elimination.

#### Exponential and logarithmic maps

| Type | `Expmap` | `Expmap(H)` | `Logmap` | `Logmap(H)` | `LogmapDerivative` |
|---|---:|---:|---:|---:|---:|
| `Pose3` | 21.26 → 19.57 ns (**1.09×**) | 51.56 → 51.50 ns (1.00×) | 39.10 → 35.40 ns (**1.10×**) | 119.88 → 95.39 ns (**1.26×**) | 64.91 → 47.75 ns (**1.36×**) |
| `NavState` | 27.21 → 18.84 ns (**1.44×**) | 104.22 → 74.48 ns (**1.40×**) | 52.17 → 35.92 ns (**1.45×**) | 180.92 → 122.47 ns (**1.48×**) | 117.18 → 75.33 ns (**1.56×**) |
| `ExtendedPose3<2>` | 26.83 → 20.02 ns (**1.34×**) | 103.38 → 78.42 ns (**1.32×**) | 52.45 → 36.09 ns (**1.45×**) | 180.66 → 124.46 ns (**1.45×**) | 117.26 → 74.55 ns (**1.57×**) |
| `ExtendedPose3<3>` | 34.70 → 22.95 ns (**1.51×**) | 138.00 → 100.05 ns (**1.38×**) | 61.70 → 36.78 ns (**1.68×**) | 219.46 → 151.90 ns (**1.44×**) | 139.18 → 98.18 ns (**1.42×**) |
| `ExtendedPose3d` (`K=3`) | 64.08 → 55.99 ns (**1.14×**) | 184.46 → 148.23 ns (**1.24×**) | 71.26 → 49.55 ns (**1.44×**) | 241.45 → 160.27 ns (**1.51×**) | 162.02 → 108.25 ns (**1.50×**) |

#### Fixed-size Eigen and algebra operations

| Type | `AdjointMap` | `adjointMap` | `Hat` |
|---|---:|---:|---:|
| `Pose3` | 7.46 → 6.63 ns (**1.12×**) | 6.85 → 4.16 ns (**1.65×**) | 1.39 → 1.39 ns (1.00×) |
| `NavState` | 24.87 → 10.80 ns (**2.30×**) | 22.53 → 8.33 ns (**2.71×**) | 7.04 → 3.30 ns (**2.13×**) |
| `ExtendedPose3<2>` | 25.02 → 10.95 ns (**2.28×**) | 23.45 → 8.52 ns (**2.75×**) | 7.25 → 3.34 ns (**2.17×**) |
| `ExtendedPose3<3>` | 34.23 → 19.08 ns (**1.79×**) | 24.32 → 13.67 ns (**1.78×**) | 3.89 → 3.91 ns (1.00×) |
| `ExtendedPose3d` (`K=3`) | 63.08 → 29.36 ns (**2.15×**) | 57.93 → 28.50 ns (**2.03×**) | 33.06 → 21.71 ns (**1.52×**) |

#### NavState custom manifold chart

| Operation | Develop | PR | Speedup |
|---|---:|---:|---:|
| `retract` | 25.08 ns | 24.03 ns | **1.04×** |
| `retract(H1,H2)` | 76.75 ns | 73.27 ns | **1.05×** |
| `localCoordinates` | 31.80 ns | 32.34 ns | 0.98× |
| `localCoordinates(H1,H2)` | 107.23 ns | 102.96 ns | **1.04×** |

The non-Jacobian `localCoordinates` path was not modified; its approximately 2% difference is measurement noise.

#### Similarity3

| Operation | Develop | PR | Speedup |
|---|---:|---:|---:|
| `Expmap` | 33.00 ns | 22.03 ns | **1.50×** |
| `Logmap` | 42.78 ns | 40.68 ns | **1.05×** |
| `AdjointMap` | 8.71 ns | 8.73 ns | 1.00× |
| `adjointMap` | 129.03 ns | 6.36 ns | **20.28×** |
| `Hat` | 2.84 ns | 2.86 ns | 1.00× |

`Similarity3::adjointMap` now uses a closed-form 7×7 expression instead of the generic matrix-commutator implementation. `Expmap` reuses one SO(3) functor to compute both the rotation and the translation kernel.

`Similarity3` currently throws when an `Expmap` or `Logmap` Jacobian is requested, so those cases are not benchmarked.

#### Gal3

| Operation | Develop | PR | Speedup |
|---|---:|---:|---:|
| `Expmap` | 32.66 ns | 29.33 ns | **1.11×** |
| `Expmap(H)` | 105.84 ns | 102.92 ns | **1.03×** |
| `Logmap` | 44.86 ns | 45.53 ns | 0.99× |
| `Logmap(H)` | 699.05 ns | 624.60 ns | **1.12×** |
| `LogmapDerivative` | 576.48 ns | 549.14 ns | **1.05×** |
| `AdjointMap` | 14.08 ns | 14.09 ns | 1.00× |
| `adjointMap` | 10.73 ns | 10.82 ns | 0.99× |
| `Hat` | 3.09 ns | 3.05 ns | 1.02× |

`Gal3::Expmap` now reuses its SO(3) Jacobian and Gamma kernels, skips unnecessary Gamma work, and shares a specialized evaluator with its derivative paths. `Logmap(g, H)` no longer recomputes `Logmap(g)` while constructing the derivative.