### PR TITLE
Fix Windows Python Boost library discovery

### DIFF
--- a/.github/scripts/python.sh
+++ b/.github/scripts/python.sh
@@ -58,8 +58,16 @@ function build()
   BOOST_CMAKE_ARGS=""
   if [ "${NO_BOOST_BUILD}" != "ON" ] && [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" || "$OSTYPE" == "cygwin" ]]; then
     if [ -n "${BOOST_ROOT}" ]; then
-     BOOST_ROOT_UNIX=$(echo "$BOOST_ROOT" | sed 's/\\/\//g')
-     BOOST_CMAKE_ARGS="-DBOOST_ROOT=${BOOST_ROOT_UNIX} -DBOOST_INCLUDEDIR=${BOOST_ROOT_UNIX}/include -DBOOST_LIBRARYDIR=${BOOST_ROOT_UNIX}/lib"
+      BOOST_ROOT_UNIX=$(echo "$BOOST_ROOT" | sed 's/\\/\//g')
+      BOOST_CMAKE_ARGS="-DBOOST_ROOT=${BOOST_ROOT_UNIX}"
+      if [ -n "${BOOST_INCLUDEDIR}" ]; then
+        BOOST_INCLUDEDIR_UNIX=$(echo "$BOOST_INCLUDEDIR" | sed 's/\\/\//g')
+        BOOST_CMAKE_ARGS="${BOOST_CMAKE_ARGS} -DBOOST_INCLUDEDIR=${BOOST_INCLUDEDIR_UNIX}"
+      fi
+      if [ -n "${BOOST_LIBRARYDIR}" ]; then
+        BOOST_LIBRARYDIR_UNIX=$(echo "$BOOST_LIBRARYDIR" | sed 's/\\/\//g')
+        BOOST_CMAKE_ARGS="${BOOST_CMAKE_ARGS} -DBOOST_LIBRARYDIR=${BOOST_LIBRARYDIR_UNIX}"
+      fi
     fi
   fi
 

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -50,8 +50,6 @@ jobs:
       CTEST_PARALLEL_LEVEL: 2
       CMAKE_BUILD_TYPE: ${{ matrix.build_type }}
       PYTHON_VERSION: ${{ matrix.python_version }}
-      BOOST_VERSION: 1.72.0
-      BOOST_EXE: boost_1_72_0-msvc-14.2
       SCCACHE_GHA_ENABLED: ON
 
     strategy:
@@ -184,8 +182,36 @@ jobs:
             throw "Boost installed but root directory was not found in expected locations."
           }
 
+          $versionHeader = Get-ChildItem -Path $boostRoot -Filter version.hpp -File -Recurse |
+            Where-Object { $_.FullName -match '[\\/]boost[\\/]version\.hpp$' } |
+            Select-Object -First 1
+          if (-not $versionHeader) {
+            throw "Boost version header was not found under $boostRoot."
+          }
+          $boostIncludeDir = Split-Path -Parent (Split-Path -Parent $versionHeader.FullName)
+
+          $timerLibrary = Get-ChildItem -Path $boostRoot -Filter "libboost_timer-*.lib" -File -Recurse |
+            Select-Object -First 1
+          if (-not $timerLibrary) {
+            throw "Boost timer library was not found under $boostRoot."
+          }
+          $boostLibraryDir = $timerLibrary.DirectoryName
+
+          $requiredComponents = @("chrono", "graph", "program_options", "random", "serialization", "timer")
+          foreach ($component in $requiredComponents) {
+            $componentLibrary = Get-ChildItem -Path $boostLibraryDir -Filter "libboost_$component-*.lib" -File |
+              Select-Object -First 1
+            if (-not $componentLibrary) {
+              throw "Boost $component library was not found in $boostLibraryDir."
+            }
+          }
+
           "BOOST_ROOT=$boostRoot" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "BOOST_INCLUDEDIR=$boostIncludeDir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "BOOST_LIBRARYDIR=$boostLibraryDir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           Write-Host "Using BOOST_ROOT=$boostRoot"
+          Write-Host "Using BOOST_INCLUDEDIR=$boostIncludeDir"
+          Write-Host "Using BOOST_LIBRARYDIR=$boostLibraryDir"
     
       - name: Install sccache
         if: runner.os == 'Windows'

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -5,6 +5,15 @@ name: Python CI
 # never runs, and a maintainer must bypass the check in order to merge the PR.
 on:
   workflow_dispatch:
+    inputs:
+      runner:
+        description: Runner selection
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - windows-2022-msvc
   pull_request:
     paths-ignore:
       - "**.md"
@@ -40,7 +49,7 @@ jobs:
   build:
     # Only run build if relevant files have been modified in this PR.
     needs: check-paths
-    if: needs.check-paths.outputs.should_run == 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.check-paths.outputs.should_run == 'true'
 
     name: ${{ matrix.name }} ${{ matrix.build_type }} Python ${{ matrix.python_version }}
     runs-on: ${{ matrix.os }}
@@ -65,6 +74,9 @@ jobs:
             macos-15-xcode-16,
             windows-2022-msvc,
           ]
+
+        runner_selection:
+          - ${{ github.event_name == 'workflow_dispatch' && inputs.runner || 'all' }}
 
         build_type: [Release]
         python_version: [3]
@@ -92,6 +104,16 @@ jobs:
           - name: windows-2022-msvc
             os: windows-2022
             platform: 64
+
+        exclude:
+          - runner_selection: windows-2022-msvc
+            name: ubuntu-22.04-gcc-11
+          - runner_selection: windows-2022-msvc
+            name: ubuntu-22.04-gcc-11-noboost
+          - runner_selection: windows-2022-msvc
+            name: ubuntu-22.04-clang-11
+          - runner_selection: windows-2022-msvc
+            name: macos-15-xcode-16
 
     steps:
       - name: Checkout
@@ -182,33 +204,41 @@ jobs:
             throw "Boost installed but root directory was not found in expected locations."
           }
 
-          $versionHeader = Get-ChildItem -Path $boostRoot -Filter version.hpp -File -Recurse |
-            Where-Object { $_.FullName -match '[\\/]boost[\\/]version\.hpp$' } |
-            Select-Object -First 1
-          if (-not $versionHeader) {
-            throw "Boost version header was not found under $boostRoot."
+          $versionHeaderPath = Join-Path $boostRoot "boost\version.hpp"
+          if (Test-Path $versionHeaderPath -PathType Leaf) {
+            $versionHeader = Get-Item $versionHeaderPath
+          } else {
+            $versionHeaders = @(Get-ChildItem -Path $boostRoot -Filter version.hpp -File -Recurse |
+              Where-Object { $_.FullName -match '[\\/]boost[\\/]version\.hpp$' })
+            if ($versionHeaders.Count -ne 1) {
+              throw "Expected one Boost version header under $boostRoot; found $($versionHeaders.Count)."
+            }
+            $versionHeader = $versionHeaders[0]
           }
           $boostIncludeDir = Split-Path -Parent (Split-Path -Parent $versionHeader.FullName)
 
-          $timerLibrary = Get-ChildItem -Path $boostRoot -Filter "libboost_timer-*.lib" -File -Recurse |
-            Select-Object -First 1
-          if (-not $timerLibrary) {
-            throw "Boost timer library was not found under $boostRoot."
+          $boostLibraryDir = Join-Path $boostRoot "lib64-msvc-14.2"
+          if (-not (Test-Path $boostLibraryDir -PathType Container)) {
+            $libraryDirs = @(Get-ChildItem -Path $boostRoot -Filter "lib64-msvc-*" -Directory)
+            if ($libraryDirs.Count -ne 1) {
+              throw "Expected one x64 MSVC Boost library directory under $boostRoot; found $($libraryDirs.Count)."
+            }
+            $boostLibraryDir = $libraryDirs[0].FullName
           }
-          $boostLibraryDir = $timerLibrary.DirectoryName
 
           $requiredComponents = @("chrono", "graph", "program_options", "random", "serialization", "timer")
           foreach ($component in $requiredComponents) {
-            $componentLibrary = Get-ChildItem -Path $boostLibraryDir -Filter "libboost_$component-*.lib" -File |
+            $componentLibrary = Get-ChildItem -Path $boostLibraryDir -Filter "libboost_$component-*-x64-*.lib" -File |
               Select-Object -First 1
             if (-not $componentLibrary) {
-              throw "Boost $component library was not found in $boostLibraryDir."
+              throw "Boost $component x64 library was not found in $boostLibraryDir."
             }
           }
 
           "BOOST_ROOT=$boostRoot" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           "BOOST_INCLUDEDIR=$boostIncludeDir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           "BOOST_LIBRARYDIR=$boostLibraryDir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "LIB=$boostLibraryDir;$env:LIB" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           Write-Host "Using BOOST_ROOT=$boostRoot"
           Write-Host "Using BOOST_INCLUDEDIR=$boostIncludeDir"
           Write-Host "Using BOOST_LIBRARYDIR=$boostLibraryDir"

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.filter.outputs.relevant_changes }}
+      build_matrix: ${{ steps.matrix.outputs.build_matrix }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -45,6 +46,18 @@ jobs:
               - '!**.md'
               - '!**.ipynb' 
               - '!myst.yml'
+
+      - name: Configure build matrix
+        id: matrix
+        shell: bash
+        env:
+          RUNNER_SELECTION: ${{ inputs.runner || 'all' }}
+        run: |
+          if [ "$RUNNER_SELECTION" = "windows-2022-msvc" ]; then
+            echo 'build_matrix={"include":[{"name":"windows-2022-msvc","build_type":"Release","python_version":3,"os":"windows-2022","platform":64}]}' >> "$GITHUB_OUTPUT"
+          else
+            echo 'build_matrix={"include":[{"name":"ubuntu-22.04-gcc-11","build_type":"Release","python_version":3,"os":"ubuntu-22.04","compiler":"gcc","version":"11"},{"name":"ubuntu-22.04-gcc-11-noboost","build_type":"Release","python_version":3,"os":"ubuntu-22.04","compiler":"gcc","version":"11"},{"name":"ubuntu-22.04-clang-11","build_type":"Release","python_version":3,"os":"ubuntu-22.04","compiler":"clang","version":"11"},{"name":"macos-15-xcode-16","build_type":"Release","python_version":3,"os":"macos-15","compiler":"xcode","version":"16"},{"name":"windows-2022-msvc","build_type":"Release","python_version":3,"os":"windows-2022","platform":64}]}' >> "$GITHUB_OUTPUT"
+          fi
 
   build:
     # Only run build if relevant files have been modified in this PR.
@@ -63,57 +76,7 @@ jobs:
 
     strategy:
       fail-fast: true
-      matrix:
-        # Github Actions requires a single row to be added to the build matrix.
-        # See https://help.github.com/en/articles/workflow-syntax-for-github-actions.
-        name:
-          [
-            ubuntu-22.04-gcc-11,
-            ubuntu-22.04-gcc-11-noboost,
-            ubuntu-22.04-clang-11,
-            macos-15-xcode-16,
-            windows-2022-msvc,
-          ]
-
-        runner_selection:
-          - ${{ github.event_name == 'workflow_dispatch' && inputs.runner || 'all' }}
-
-        build_type: [Release]
-        python_version: [3]
-        include:
-          - name: ubuntu-22.04-gcc-11
-            os: ubuntu-22.04
-            compiler: gcc
-            version: "11"
-
-          - name: ubuntu-22.04-gcc-11-noboost
-            os: ubuntu-22.04
-            compiler: gcc
-            version: "11"
-
-          - name: ubuntu-22.04-clang-11
-            os: ubuntu-22.04
-            compiler: clang
-            version: "11"
-
-          - name: macos-15-xcode-16
-            os: macos-15
-            compiler: xcode
-            version: "16"
-
-          - name: windows-2022-msvc
-            os: windows-2022
-            platform: 64
-
-        exclude:
-          - runner_selection: windows-2022-msvc
-            name: ubuntu-22.04-gcc-11
-          - runner_selection: windows-2022-msvc
-            name: ubuntu-22.04-gcc-11-noboost
-          - runner_selection: windows-2022-msvc
-            name: ubuntu-22.04-clang-11
-          - runner_selection: windows-2022-msvc
-            name: macos-15-xcode-16
+      matrix: ${{ fromJSON(needs.check-paths.outputs.build_matrix) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -201,7 +201,6 @@ jobs:
           "BOOST_ROOT=$boostRoot" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           "BOOST_INCLUDEDIR=$boostIncludeDir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           "BOOST_LIBRARYDIR=$boostLibraryDir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-          "LIB=$boostLibraryDir;$env:LIB" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           Write-Host "Using BOOST_ROOT=$boostRoot"
           Write-Host "Using BOOST_INCLUDEDIR=$boostIncludeDir"
           Write-Host "Using BOOST_LIBRARYDIR=$boostLibraryDir"

--- a/cmake/HandleBoost.cmake
+++ b/cmake/HandleBoost.cmake
@@ -13,8 +13,11 @@
 if(MSVC)
     # By default, Boost pre-compiled binaries for Windows are static libraries.
     set(Boost_USE_STATIC_LIBS ON)
+    # GTSAM links Boost through imported CMake targets, so disable Boost's
+    # pragma-based auto-linking to avoid bare library names on the link line.
+    list_append_cache(GTSAM_COMPILE_DEFINITIONS_PUBLIC BOOST_ALL_NO_LIB)
     if(NOT Boost_USE_STATIC_LIBS)
-        list_append_cache(GTSAM_COMPILE_DEFINITIONS_PUBLIC BOOST_ALL_NO_LIB BOOST_ALL_DYN_LINK)
+        list_append_cache(GTSAM_COMPILE_DEFINITIONS_PUBLIC BOOST_ALL_DYN_LINK)
     endif()
     if(MSVC_VERSION LESS 1910) # older than VS2017
       list_append_cache(GTSAM_COMPILE_OPTIONS_PRIVATE -Zm295)


### PR DESCRIPTION
## Summary

- discover the actual Boost header and MSVC library directories installed by Chocolatey
- validate the required x64 Boost component libraries before configuring GTSAM
- pass the discovered paths through the Python CI build script instead of assuming `include` and `lib` subdirectories
- disable Boost's MSVC pragma auto-linking because CMake's imported Boost targets already supply the correct library paths
- add a `workflow_dispatch` runner selector so the Windows Python lane can be exercised independently
- remove obsolete Boost 1.72 environment variables from the Python workflow

## Root cause

The Windows Python job installed Boost 1.87 at `C:\local\boost_1_87_0`, with compiled libraries in `lib64-msvc-14.2`. After the workflow discovered that directory, MSVC's Boost auto-link pragmas still requested the bare filename `libboost_timer-vc143-mt-x64-1_87.lib`; the Git Bash build step did not preserve the injected `LIB` environment variable. Defining `BOOST_ALL_NO_LIB` makes CMake's imported Boost targets the single source of linker inputs and paths.

This failure is unrelated to the version-only change in #2618.

## Validation

- `git diff --check`
- `bash -n .github/scripts/python.sh`
- parsed the workflow and both generated matrix variants with PyYAML/JSON in the `py312` conda environment
- configured GTSAM locally with CMake
- [focused Windows Python workflow](https://github.com/borglab/gtsam/actions/runs/30959304110) passed, including `gtsam.dll` linking and tests

Commits after the initial PR update use `[skip ci]`, so the full PR workflow suite has intentionally not been started yet.