### PR TITLE
fix(python): reject invalid Rot3 matrix inputs

### DIFF
--- a/gtsam/geometry/Rot3.cpp
+++ b/gtsam/geometry/Rot3.cpp
@@ -32,6 +32,12 @@ using namespace std;
 namespace gtsam {
 
 /* ************************************************************************* */
+bool Rot3::IsValid(const Matrix3& R, double tol) {
+  return (R.transpose() * R - Matrix3::Identity()).norm() <= tol &&
+         R.determinant() > 0;
+}
+
+/* ************************************************************************* */
 void Rot3::print(const std::string& s) const {
   cout << (s.empty() ? "R: " : s + " ");
   gtsam::print(static_cast<Matrix>(matrix()));

--- a/gtsam/geometry/Rot3.h
+++ b/gtsam/geometry/Rot3.h
@@ -141,6 +141,9 @@ class GTSAM_EXPORT Rot3 : public MatrixLieGroup<Rot3, 3, 3> {
     /** Virtual destructor */
     virtual ~Rot3() {}
 
+    /// Check if a 3x3 matrix is a valid rotation (orthonormal with det +1).
+    static bool IsValid(const Matrix3& R, double tol = 1e-9);
+
     /* Static member function to generate some well known rotations */
 
     /// Rotation around X axis as in http://en.wikipedia.org/wiki/Rotation_matrix, counterclockwise when looking from unchanging axis.

--- a/gtsam/geometry/geometry.i
+++ b/gtsam/geometry/geometry.i
@@ -443,6 +443,7 @@ class Rot3 {
   static gtsam::Rot3 Rodrigues(gtsam::Vector v);
   static gtsam::Rot3 Rodrigues(double wx, double wy, double wz);
   static gtsam::Rot3 ClosestTo(const gtsam::Matrix M);
+  static bool IsValid(const gtsam::Matrix& R, double tol);
 
   // Testable
   void print(string s = "") const;

--- a/gtsam/geometry/tests/testRot3.cpp
+++ b/gtsam/geometry/tests/testRot3.cpp
@@ -1083,6 +1083,26 @@ TEST(Rot3, expmapChainRule) {
 }
 
 /* ************************************************************************* */
+TEST(Rot3, IsValid) {
+  // Valid rotation
+  EXPECT(Rot3::IsValid(I_3x3, 1e-9));
+  EXPECT(Rot3::IsValid(Rot3::Rz(0.5).matrix(), 1e-9));
+
+  // Not orthonormal
+  Matrix3 bad = I_3x3;
+  bad(0, 0) = 2.0;
+  EXPECT(!Rot3::IsValid(bad, 1e-9));
+
+  // Reflection (det = -1)
+  Matrix3 reflect = I_3x3;
+  reflect(2, 2) = -1.0;
+  EXPECT(!Rot3::IsValid(reflect, 1e-9));
+
+  // Zero matrix
+  EXPECT(!Rot3::IsValid(Z_3x3, 1e-9));
+}
+
+/* ************************************************************************* */
 int main() {
   TestResult tr;
   return TestRegistry::runAllTests(tr);

--- a/python/gtsam/__init__.py
+++ b/python/gtsam/__init__.py
@@ -77,6 +77,29 @@ def _init():
             return x  # "copy constructor"
         return np.array([x, y, z], dtype=float)
 
+    # Validate rotation matrix input from Python (zero overhead in C++).
+    # The tolerance is deliberately loose (1e-3): the goal is to reject the
+    # degenerate inputs that previously crashed the wrapper (zero, scaled, or
+    # reflected matrices, see issue #2300) while still accepting real-world
+    # rotation matrices rounded to a few decimals. Use Rot3.IsValid(R, tol)
+    # for strict checking, or Rot3.ClosestTo(R) to project onto SO(3).
+    global Rot3
+    _Rot3_orig = gtsam.Rot3
+
+    class Rot3(_Rot3_orig):
+        def __init__(self, *args, **kwargs):
+            if len(args) == 1 and not kwargs:
+                try:
+                    arr = np.asarray(args[0], dtype=float)
+                except (TypeError, ValueError):
+                    arr = None
+                if arr is not None and arr.shape == (3, 3) and not _Rot3_orig.IsValid(arr, 1e-3):
+                    raise ValueError(
+                        "Rot3: matrix is not a valid rotation "
+                        "(must be orthonormal with det +1). "
+                        "Use Rot3.ClosestTo() to project to the nearest rotation.")
+            super().__init__(*args, **kwargs)
+
     # for interactive debugging
     if __name__ == "__main__":
         # we want all definitions accessible

--- a/python/gtsam/tests/test_Rot3.py
+++ b/python/gtsam/tests/test_Rot3.py
@@ -2057,6 +2057,32 @@ class TestRot3(GtsamTestCase):
         np.testing.assert_almost_equal(actual_p, c_p, decimal=6)
         np.testing.assert_almost_equal(actual_u.point3(), c_u.point3(), decimal=6)
 
+    def test_invalid_matrix_raises(self) -> None:
+        """Python wrapper should raise ValueError for degenerate matrix input."""
+        with self.assertRaises(ValueError):
+            Rot3(np.zeros((3, 3)))
+        # Nested lists are validated too, not only ndarrays.
+        with self.assertRaises(ValueError):
+            Rot3([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+        with self.assertRaises(ValueError):
+            Rot3(np.diag([2.0, 1.0, 1.0]))
+        # Reflection (det = -1)
+        with self.assertRaises(ValueError):
+            Rot3(np.diag([1.0, 1.0, -1.0]))
+
+    def test_valid_matrix_no_raise(self) -> None:
+        """Valid and near-valid (rounded) rotation matrices must construct."""
+        Rot3(np.eye(3))
+        Rot3(Rot3.Rz(0.5).matrix())
+        # Real-data rotation rounded to 9 significant digits (orthogonality
+        # error ~6e-7, from test_Sim3's Skydio sequence). The loose validation
+        # tolerance must accept it, as both ndarray and nested lists.
+        R = [[0.692272397, -0.00529704529, -0.721616549],
+             [0.00634689669, 0.999979075, -0.00125157022],
+             [0.721608079, -0.0037136016, 0.692291531]]
+        Rot3(R)
+        Rot3(np.array(R))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Closes #2300

Passing an invalid 3×3 matrix to `gtsam.Rot3` from Python can terminate the interpreter instead of raising a useful exception.

This change:

- adds public `Rot3::IsValid(const Matrix3&, double tol = 1e-9)`
- exposes `Rot3.IsValid(R, tol)` to Python
- validates matrix construction only in the Python `Rot3` shim, using tolerance `1e-3`
- raises `ValueError` for zero, scaled, reflected, or otherwise invalid rotation matrices
- leaves existing C++ constructors unchanged, with no added validation overhead

The relaxed Python tolerance accepts rounded real-world rotation matrices. Call `Rot3.IsValid(R, tol)` for explicit strict validation or `Rot3.ClosestTo(R)` to project onto SO(3).

## Recovery note

This replaces #2517, which was accidentally closed when its former base branch was deleted. The contributor branch and final commit are unchanged. Earlier discussion and approval remain on #2517; GitHub may require fresh approval on this replacement PR.

## Test plan

- invalid NumPy matrices and nested lists raise `ValueError`
- valid and rounded near-valid rotations still construct
- `Rot3.IsValid` independently accepts rotations and rejects scaled, reflected, and zero matrices