### PR TITLE
Avoid redundant system METIS linking

### DIFF
--- a/cmake/HandleMetis.cmake
+++ b/cmake/HandleMetis.cmake
@@ -13,11 +13,14 @@ option(GTSAM_USE_SYSTEM_METIS "Find and use system-installed libmetis. If 'off',
 if(GTSAM_USE_SYSTEM_METIS)
   # Debian package: libmetis-dev
   find_package(METIS CONFIG NAMES metis)
-  if(NOT METIS_FOUND)
+  if(METIS_FOUND)
+    set(GTSAM_METIS_LINK_TARGET metis)
+  else()
     find_path(METIS_INCLUDE_DIR metis.h REQUIRED)
     find_library(METIS_LIBRARY metis REQUIRED)
     if(METIS_INCLUDE_DIR AND METIS_LIBRARY)
       set(METIS_FOUND ON)
+      set(GTSAM_METIS_LINK_TARGET ${METIS_LIBRARY})
     endif()
   endif()
 
@@ -31,7 +34,7 @@ if(GTSAM_USE_SYSTEM_METIS)
       $<BUILD_INTERFACE:${GTSAM_SOURCE_DIR}/gtsam/3rdparty/metis/libmetis>
       $<BUILD_INTERFACE:${GTSAM_SOURCE_DIR}/gtsam/3rdparty/metis/GKlib>
     )
-    target_link_libraries(metis-gtsam-if INTERFACE ${METIS_LIBRARY} metis)
+    target_link_libraries(metis-gtsam-if INTERFACE ${GTSAM_METIS_LINK_TARGET})
   endif()
 else()
   # Bundled version:


### PR DESCRIPTION
## Summary

Link system METIS exactly once, using the result from the successful discovery path.

When a METIS CMake config package is found, GTSAM continues to link its `metis` target. When the fallback `find_library()` path is used, GTSAM now links only the absolute path stored in `METIS_LIBRARY`.

Previously, the fallback added both the absolute library path and a bare `metis` item. This produced link lines containing both `/path/to/libmetis.so` and `-lmetis`. The latter required the system library directory to be discoverable independently, defeating the purpose of the absolute path returned by `find_library()`.

## Verification

Verified with nixpkgs METIS 5.2.1 through the fallback discovery path:

- Configured without temporary executable or shared library linker search flags.
- Confirmed that generated link rules contain the absolute `libmetis.so` path and no bare `-lmetis`.
- Built and ran `testOrdering.run` successfully.
- Built and linked `gtsam_unstable` successfully.