### PR TITLE
METIS: Avoid redundant system linking & use public API for separator partitioning

### DIFF
--- a/cmake/HandleMetis.cmake
+++ b/cmake/HandleMetis.cmake
@@ -13,11 +13,14 @@ option(GTSAM_USE_SYSTEM_METIS "Find and use system-installed libmetis. If 'off',
 if(GTSAM_USE_SYSTEM_METIS)
   # Debian package: libmetis-dev
   find_package(METIS CONFIG NAMES metis)
-  if(NOT METIS_FOUND)
+  if(METIS_FOUND)
+    set(GTSAM_METIS_LINK_TARGET metis)
+  else()
     find_path(METIS_INCLUDE_DIR metis.h REQUIRED)
     find_library(METIS_LIBRARY metis REQUIRED)
     if(METIS_INCLUDE_DIR AND METIS_LIBRARY)
       set(METIS_FOUND ON)
+      set(GTSAM_METIS_LINK_TARGET ${METIS_LIBRARY})
     endif()
   endif()
 
@@ -31,7 +34,7 @@ if(GTSAM_USE_SYSTEM_METIS)
       $<BUILD_INTERFACE:${GTSAM_SOURCE_DIR}/gtsam/3rdparty/metis/libmetis>
       $<BUILD_INTERFACE:${GTSAM_SOURCE_DIR}/gtsam/3rdparty/metis/GKlib>
     )
-    target_link_libraries(metis-gtsam-if INTERFACE ${METIS_LIBRARY} metis)
+    target_link_libraries(metis-gtsam-if INTERFACE ${GTSAM_METIS_LINK_TARGET})
   endif()
 else()
   # Bundled version:

--- a/cmake/HandleMetis.cmake
+++ b/cmake/HandleMetis.cmake
@@ -28,12 +28,7 @@ if(GTSAM_USE_SYSTEM_METIS)
     mark_as_advanced(METIS_INCLUDE_DIR)
     mark_as_advanced(METIS_LIBRARY)
     add_library(metis-gtsam-if INTERFACE)
-    target_include_directories(metis-gtsam-if BEFORE INTERFACE ${METIS_INCLUDE_DIR}
-      # gtsam_unstable/partition/FindSeparator-inl.h uses internal metislib.h API
-      # via extern "C"
-      $<BUILD_INTERFACE:${GTSAM_SOURCE_DIR}/gtsam/3rdparty/metis/libmetis>
-      $<BUILD_INTERFACE:${GTSAM_SOURCE_DIR}/gtsam/3rdparty/metis/GKlib>
-    )
+    target_include_directories(metis-gtsam-if BEFORE INTERFACE ${METIS_INCLUDE_DIR})
     target_link_libraries(metis-gtsam-if INTERFACE ${GTSAM_METIS_LINK_TARGET})
   endif()
 else()
@@ -44,10 +39,6 @@ else()
   target_include_directories(metis-gtsam BEFORE PUBLIC
     $<INSTALL_INTERFACE:include/gtsam/3rdparty/metis/>
     $<BUILD_INTERFACE:${GTSAM_SOURCE_DIR}/gtsam/3rdparty/metis/include>
-    # gtsam_unstable/partition/FindSeparator-inl.h uses internal metislib.h API
-    # via extern "C"
-    $<BUILD_INTERFACE:${GTSAM_SOURCE_DIR}/gtsam/3rdparty/metis/libmetis>
-    $<BUILD_INTERFACE:${GTSAM_SOURCE_DIR}/gtsam/3rdparty/metis/GKlib>
   )
 
   add_library(metis-gtsam-if INTERFACE)

--- a/gtsam_unstable/partition/FindSeparator-inl.h
+++ b/gtsam_unstable/partition/FindSeparator-inl.h
@@ -12,6 +12,7 @@
 
 #include <stdexcept>
 #include <iostream>
+#include <string>
 #include <vector>
 #include <optional>
 #include <cassert>
@@ -22,12 +23,6 @@
 #include "FindSeparator.h"
 
 #include <metis.h>
-
-extern "C" {
-#include <metislib.h>
-}
-
-
 
 namespace gtsam { namespace partition {
 
@@ -79,49 +74,6 @@ namespace gtsam { namespace partition {
   }
 
   /* ************************************************************************* */
-  void modefied_EdgeComputeSeparator(idx_t *nvtxs, idx_t *xadj, idx_t *adjncy, idx_t *vwgt,
-      idx_t *adjwgt, idx_t *options, idx_t *edgecut, idx_t *part)
-  {
-    idx_t i, ncon;
-    graph_t *graph;
-    real_t *tpwgts2;
-    ctrl_t *ctrl;
-    ctrl = SetupCtrl(METIS_OP_OMETIS, options, 1, 3, nullptr, nullptr);
-    ctrl->iptype = METIS_IPTYPE_GROW;
-    //if () == nullptr)
-    //  return METIS_ERROR_INPUT;
-
-    InitRandom(ctrl->seed);
-
-    graph = SetupGraph(ctrl, *nvtxs, 1, xadj, adjncy, vwgt, nullptr, nullptr);
-
-    AllocateWorkSpace(ctrl, graph);
-
-    ncon = graph->ncon;
-    ctrl->ncuts = 1;
-
-    /* determine the weights of the two partitions as a function of the weight of the
-       target partition weights */
-
-    tpwgts2 = rwspacemalloc(ctrl, 2*ncon);
-    for (i=0; i<ncon; i++) {
-      tpwgts2[i]      = rsum((2>>1), ctrl->tpwgts+i, ncon);
-      tpwgts2[ncon+i] = 1.0 - tpwgts2[i];
-    }
-    /* perform the bisection */
-    *edgecut = MultilevelBisect(ctrl, graph, tpwgts2);
-
-    //  ConstructMinCoverSeparator(&ctrl, &graph, 1.05);
-  //  *edgecut = graph->mincut;
-  //  *sepsize = graph.pwgts[2];
-    icopy(*nvtxs, graph->where, part);
-    std::cout << "Finished bisection:" << *edgecut << std::endl;
-    FreeGraph(&graph);
-
-    FreeCtrl(&ctrl);
-  }
-
-  /* ************************************************************************* */
   /**
    * Return the number of edge cuts and the partition indices {part}
    * Part [j] is 0 or 1, depending on
@@ -134,6 +86,9 @@ namespace gtsam { namespace partition {
     std::vector<idx_t> vwgt;                  // the weights of the vertices
     idx_t options[METIS_NOPTIONS];
     METIS_SetDefaultOptions(options);  // use defaults
+    options[METIS_OPTION_IPTYPE] = METIS_IPTYPE_GROW;
+    options[METIS_OPTION_NCUTS] = 1;
+    options[METIS_OPTION_UFACTOR] = 200;
     idx_t edgecut;                      // the number of edge cuts, output
     sharedInts part_(new idx_t[n]);      // the partition of each vertex, output
 
@@ -151,12 +106,21 @@ namespace gtsam { namespace partition {
       //starttimer(TOTALTmr);
     }
 
-    //int wgtflag = 1; // only edge weights
-    //int numflag = 0; // c style numbering starting from 0
-    //int nparts = 2; // partition the graph to 2 submaps
-    modefied_EdgeComputeSeparator(&n, xadj.get(), adjncy.get(), &vwgt[0], adjwgt.get(),
-        options, &edgecut, part_.get());
-
+    idx_t ncon = 1;
+    idx_t nparts = 2;
+    // Deliberately preserve the existing behavior: the private implementation
+    // ignored adjwgt and treated every edge as having uniform weight.
+    static_cast<void>(adjwgt);
+    const int status = METIS_PartGraphRecursive(
+        &n, &ncon, xadj.get(), adjncy.get(), &vwgt[0], nullptr, nullptr,
+        &nparts, nullptr, nullptr, options, &edgecut, part_.get());
+    if (status != METIS_OK) {
+      throw std::runtime_error(
+          "METIS_PartGraphRecursive failed with error code " +
+          std::to_string(status) +
+          "; check the graph inputs and METIS installation");
+    }
+    std::cout << "Finished bisection:" << edgecut << std::endl;
 
     if (verbose) {
       //stoptimer(TOTALTmr);


### PR DESCRIPTION
## 1st commit
### Summary

Link system METIS exactly once, using the result from the successful discovery path.

When a METIS CMake config package is found, GTSAM continues to link its `metis` target. When the fallback `find_library()` path is used, GTSAM now links only the absolute path stored in `METIS_LIBRARY`.

Previously, the fallback added both the absolute library path and a bare `metis` item. This produced link lines containing both `/path/to/libmetis.so` and `-lmetis`. The latter required the system library directory to be discoverable independently, defeating the purpose of the absolute path returned by `find_library()`.

### Verification

Verified with nixpkgs METIS 5.2.1 through the fallback discovery path:

- Configured without temporary executable or shared library linker search flags.
- Confirmed that generated link rules contain the absolute `libmetis.so` path and no bare `-lmetis`.
- Built and ran `testOrdering.run` successfully.
- Built and linked `gtsam_unstable` successfully.

## 2nd commit
### Summary

Replace the separator implementation's use of private METIS internals with the public `METIS_PartGraphRecursive` API.

This removes a private ABI dependency that causes memory corruption when GTSAM is compiled with its bundled METIS 5.1.0 headers but linked against system METIS 5.2.1.

### Background

System METIS support was introduced in [#570](https://github.com/borglab/gtsam/pull/570) as part of the broader system-library work tracked by [#292](https://github.com/borglab/gtsam/issues/292). [#1117](https://github.com/borglab/gtsam/pull/1117) later enabled the unstable separator with system METIS by compiling against GTSAM's bundled private `metislib.h` headers while linking against the system library.

The description of #1117 explicitly identified a possible desynchronization between the bundled private headers and the version used to compile the system library. That risk was accepted because METIS was considered old and stable, with updating GTSAM's bundled copy proposed as the remedy if it occurred.

That risk has now materialized. METIS development resumed and version [5.2.1](https://github.com/KarypisLab/METIS/tree/v5.2.1) was tagged in December 2022. Code compiled from the bundled METIS 5.1.0 private structure declarations is not ABI-compatible with objects created by METIS 5.2.1, resulting in memory corruption and a `testFindSeparator` segmentation fault.

Updating the bundled private headers would only move the problem. It would make the code compatible with one particular system version while retaining the same unsupported private ABI dependency.

### Changes

- Remove the private `metislib.h` include and `modefied_EdgeComputeSeparator`.
- Use the public `METIS_PartGraphRecursive` API with two partitions.
- Select the public controls corresponding to the old behavior where possible:
  - `METIS_IPTYPE_GROW`
  - one cut
  - `METIS_OPTION_UFACTOR = 200`
- Continue passing `nullptr` for edge weights because the previous private implementation also ignored `adjwgt`.
- Check the METIS return code and throw an actionable exception on failure.
- Remove the bundled `libmetis` and `GKlib` directories from GTSAM consumer include paths.
- Retain only the public `metis.h` include path and the existing library-selection behavior.
- This is an internal implementation change and introduces no new public API or build option.

### Partition compatibility

The public recursive API does not expose the private `CoarsenTo = 100` setting used by the old implementation. The remaining public controls have been selected to approximate the previous behavior.

Existing test expectations remain unchanged and pass with both tested METIS versions. Larger graphs may nevertheless receive different, equally valid partitions because the old private coarsening threshold cannot be requested through the public API.

### Verification

Testing was performed from GTSAM commit bc82a2f8a2364a494d5a59ba69d822108eb32406.

The METIS versions were:

- Bundled METIS: 5.1.0
- nixpkgs system METIS: 5.2.1

Before this change:

| Configuration | Result |
| --- | --- |
| Bundled METIS 5.1.0 | 355/355 tests passed |
| System METIS 5.2.1 | 354/355 tests passed |

With system METIS 5.2.1, `testFindSeparator.run` reached the third reduced-camera graph and then exited with a segmentation fault before printing the bisection result. CTest reported `testFindSeparator` as the only failure.

After this change:

| Configuration | Result |
| --- | --- |
| Bundled METIS 5.1.0 | 355/355 tests passed |
| System METIS 5.2.1 | 355/355 tests passed |

Additional checks:

- `testFindSeparator.run` passes with bundled and system METIS.
- `testOrdering.run` passes with bundled and system METIS, covering core `Ordering::Metis`.
- The focused system-METIS `testFindSeparator.run` passes under AddressSanitizer.
- No non-vendored source includes `metislib.h`.
- GTSAM consumer compile rules do not expose the bundled `libmetis` or `GKlib` directories.
- Generated consumer configurations do not export those private directories.

### Deliberately out of scope

- Edge weights remain ignored. This is pre-existing behavior: the private implementation passed `nullptr` to METIS instead of `adjwgt`.