### PR TITLE
Allow using system-installed Spectra

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ endif()
 include(cmake/HandleCCache.cmake)           # ccache
 include(cmake/HandleCPack.cmake)            # CPack
 include(cmake/HandleEigen.cmake)            # Eigen3
+include(cmake/HandleSpectra.cmake)          # Spectra
 include(cmake/HandleMetis.cmake)            # metis
 include(cmake/HandleCephes.cmake)           # cephes
 include(cmake/HandleMKL.cmake)              # MKL

--- a/LICENSE
+++ b/LICENSE
@@ -13,12 +13,12 @@ ordering library
 - ceres: Google's nonlinear least-squares optimization library
     - Includes only auto-diff/jet code, with minor modifications to includes
     - http://ceres-solver.org/license.html
-- Eigen 3.3.7:  General C++ matrix and linear algebra library
+- Eigen 3.4.0:  General C++ matrix and linear algebra library
     - Licenced under MPL2, provided in gtsam/3rdparty/Eigen/COPYING.README
     - Some code that is 3rd-party to Eigen is BSD and LGPL
 - METIS 5.1.0: Graph partitioning and fill-reducing matrix ordering library
     - Included unmodified in gtsam/3rdparty/metis
     - Licenced under Apache License v 2.0, provided in
       gtsam/3rdparty/metis/LICENSE.txt
-- Spectra v0.9.0: Sparse Eigenvalue Computation Toolkit as a Redesigned ARPACK.
+- Spectra v1.1.0: Sparse Eigenvalue Computation Toolkit as a Redesigned ARPACK.
     - Licenced under MPL2, provided at https://github.com/yixuan/spectra

--- a/cmake/HandlePrintConfiguration.cmake
+++ b/cmake/HandlePrintConfiguration.cmake
@@ -38,6 +38,7 @@ print_config("Enable Boost serialization" "${GTSAM_ENABLE_BOOST_SERIALIZATION}")
 print_build_options_for_target(gtsam)
 
 print_config("Use System Eigen" "${GTSAM_USE_SYSTEM_EIGEN} (Using version: ${GTSAM_EIGEN_VERSION})")
+print_config("Use System Spectra" "${GTSAM_USE_SYSTEM_SPECTRA}")
 print_config("Use System Metis" "${GTSAM_USE_SYSTEM_METIS}")
 print_config("Using Boost version" "${Boost_VERSION}")
 

--- a/cmake/HandleSpectra.cmake
+++ b/cmake/HandleSpectra.cmake
@@ -1,0 +1,8 @@
+###############################################################################
+# Option for using system Spectra or GTSAM-bundled Spectra
+option(GTSAM_USE_SYSTEM_SPECTRA "Find and use system-installed Spectra. If 'off', use the one bundled with GTSAM" OFF)
+
+if(GTSAM_USE_SYSTEM_SPECTRA)
+  # GTSAM uses the SortRule API introduced in Spectra 1.0.
+  find_package(Spectra 1.0 CONFIG REQUIRED)
+endif()

--- a/gtsam/CMakeLists.txt
+++ b/gtsam/CMakeLists.txt
@@ -169,6 +169,10 @@ set_target_properties(gtsam PROPERTIES
 # system-eigen, or GTSAM eigen path
 target_link_libraries(gtsam PUBLIC Eigen3::Eigen)
 
+if(GTSAM_USE_SYSTEM_SPECTRA)
+  target_link_libraries(gtsam PRIVATE $<BUILD_INTERFACE:Spectra::Spectra>)
+endif()
+
 # MKL include dir:
 if (GTSAM_USE_EIGEN_MKL)
   target_include_directories(gtsam PUBLIC ${MKL_INCLUDE_DIR})
@@ -193,12 +197,17 @@ target_include_directories(gtsam BEFORE PUBLIC
 # 3rdparty libraries: use the "system" flag so they are included via "-isystem"
 # and warnings (and warnings-considered-errors) in those headers are not
 # reported as warnings/errors in our targets:
+set(gtsam_spectra_include)
+if(NOT GTSAM_USE_SYSTEM_SPECTRA)
+  set(gtsam_spectra_include
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/3rdparty>)
+endif()
 target_include_directories(gtsam SYSTEM BEFORE PUBLIC
   # SuiteSparse_config
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/SuiteSparse_config>
   $<INSTALL_INTERFACE:include/gtsam/3rdparty/SuiteSparse_config>
   # Spectra
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/3rdparty>
+  ${gtsam_spectra_include}
   # CCOLAMD
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/CCOLAMD/Include>
   $<INSTALL_INTERFACE:include/gtsam/3rdparty/CCOLAMD>

--- a/gtsam/CMakeLists.txt
+++ b/gtsam/CMakeLists.txt
@@ -198,7 +198,7 @@ target_include_directories(gtsam SYSTEM BEFORE PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/SuiteSparse_config>
   $<INSTALL_INTERFACE:include/gtsam/3rdparty/SuiteSparse_config>
   # Spectra
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/Spectra>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/3rdparty>
   # CCOLAMD
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/CCOLAMD/Include>
   $<INSTALL_INTERFACE:include/gtsam/3rdparty/CCOLAMD>

--- a/gtsam/certifiable/RiemannianStaircaseOptimizer.cpp
+++ b/gtsam/certifiable/RiemannianStaircaseOptimizer.cpp
@@ -24,8 +24,8 @@
 #include <Eigen/SVD>
 #include <Eigen/SparseCholesky>
 
-#include <MatOp/SparseSymMatProd.h>
-#include <SymEigsSolver.h>
+#include <Spectra/MatOp/SparseSymMatProd.h>
+#include <Spectra/SymEigsSolver.h>
 
 #include <algorithm>
 #include <chrono>

--- a/gtsam/certifiable/RiemannianStaircaseOptimizer.h
+++ b/gtsam/certifiable/RiemannianStaircaseOptimizer.h
@@ -48,7 +48,7 @@ struct RiemannianStaircaseResult;
 
 /// Parameters for the Riemannian Staircase solver.
 struct GTSAM_EXPORT RiemannianStaircaseParams {
-  /// Spectra: sparse Lanczos via gtsam/3rdparty/Spectra.
+  /// Spectra: sparse Lanczos eigensolver.
   /// DenseEigen: full O(n^3) self-adjoint eigensolver, not recommended for large problems.
   enum class VerificationMethod { Spectra, DenseEigen };
 

--- a/gtsam/sfm/ShonanAveraging.cpp
+++ b/gtsam/sfm/ShonanAveraging.cpp
@@ -21,7 +21,7 @@
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 
-#include <SymEigsSolver.h>
+#include <Spectra/SymEigsSolver.h>
 #include <gtsam/linear/AcceleratedPowerMethod.h>
 #include <gtsam/linear/PCGSolver.h>
 #include <gtsam/linear/PowerMethod.h>


### PR DESCRIPTION
## Summary

Add an opt-in `GTSAM_USE_SYSTEM_SPECTRA` CMake option while preserving the bundled Spectra default.

Also use standard `Spectra/...` include paths so the same source works with both GTSAM's vendored copy and normal Spectra installations.

This advances the system-library work tracked by [#292](https://github.com/borglab/gtsam/issues/292) and follows the existing `GTSAM_USE_SYSTEM_EIGEN` and `GTSAM_USE_SYSTEM_METIS` patterns.

A separate documentation only commit also refreshes the stale bundled Eigen and Spectra versions listed in `LICENSE`, noticed while working on the PR.

## Background

GTSAM currently adds `gtsam/3rdparty/Spectra` itself to the include path and includes headers such as `<SymEigsSolver.h>` and `<MatOp/SparseSymMatProd.h>`. Standard Spectra installations place those files below an `include/Spectra` directory, so they cannot satisfy the unprefixed includes.

Adding a system installation's `include/Spectra` directory globally would expose Spectra's internal directory layout and generic names such as `MatOp/...` to every GTSAM source. Using the upstream `Spectra/...` spelling avoids that problem and works unchanged with the bundled copy after moving its include root up to `gtsam/3rdparty`.

Unlike Eigen and METIS, Spectra also had no GTSAM_USE_SYSTEM_* option. GTSAM always added the bundled Spectra headers to the include path, so there was no supported way to build against a system installed Spectra.

## Changes

The changes are split into three commits so the "include normalization" can be reviewed independently:

1. Use prefixed Spectra includes.
   - Change the three include sites to `<Spectra/SymEigsSolver.h>` and `<Spectra/MatOp/SparseSymMatProd.h>`.
   - Change the bundled build include root from `gtsam/3rdparty/Spectra` to `gtsam/3rdparty`.

2. Allow using system Spectra.
   - Add `GTSAM_USE_SYSTEM_SPECTRA`, defaulting to `OFF`.
   - When enabled, require `find_package(Spectra 1.0 CONFIG REQUIRED)` and use the imported `Spectra::Spectra` target.
   - When disabled, continue using the bundled Spectra headers.
   - Report the option in GTSAM's configuration summary.

3. Update bundled Eigen and Spectra versions in LICENSE.
   - The third-party list still named Eigen 3.3.7 and Spectra v0.9.0, while `gtsam/3rdparty` vendors Eigen 3.4.0 and Spectra 1.1.0. Both entries were written when those copies were first added and never updated on the subsequent bumps.

## Version and interface compatibility

GTSAM's vendored Spectra is version 1.1.0. The minimum required system version is set to 1.0 because it provides the APIs used by GTSAM, including the exported Spectra::Spectra CMake target.

The system build was tested with nixpkgs Spectra 1.2.0.

## Verification

Testing was performed from GTSAM commit bc82a2f8a2364a494d5a59ba69d822108eb32406.

| Configuration | Result |
| --- | --- |
| Bundled Spectra baseline on `develop` | 355/355 tests passed |
| Bundled Spectra after this change | 355/355 tests passed |
| nixpkgs system Spectra 1.2.0 after this change | 355/355 tests passed |