### PR TITLE
Preserve joint marginal query key order

### DIFF
--- a/gtsam/inference/BayesTree-inst.h
+++ b/gtsam/inference/BayesTree-inst.h
@@ -433,11 +433,17 @@ namespace gtsam {
   }
 
   /* ************************************************************************* */
+  /** Return unique keys in order of first occurrence. */
   template <class CLIQUE>
   static KeyVector uniqueKeys(const KeyVector& keys) {
-    KeyVector unique = keys;
-    std::sort(unique.begin(), unique.end());
-    unique.erase(std::unique(unique.begin(), unique.end()), unique.end());
+    KeyVector unique;
+    unique.reserve(keys.size());
+    KeySet seen;
+    for (Key key : keys) {
+      if (seen.insert(key).second) {
+        unique.push_back(key);
+      }
+    }
     return unique;
   }
 

--- a/gtsam/inference/BayesTree.h
+++ b/gtsam/inference/BayesTree.h
@@ -191,7 +191,10 @@ namespace gtsam {
      */
     sharedBayesNet jointBayesNet(Key j1, Key j2, const Eliminate& function = EliminationTraitsType::DefaultEliminate) const;
 
-    /** Return a joint marginal on an arbitrary set of variables as a BayesNet. */
+    /**
+     * Return a joint marginal Bayes net whose elimination order follows the
+     * first occurrence of each key.
+     */
     sharedBayesNet jointBayesNet(
         const KeyVector& keys,
         const Eliminate& function = EliminationTraitsType::DefaultEliminate) const;

--- a/gtsam/linear/GaussianBayesTree.h
+++ b/gtsam/linear/GaussianBayesTree.h
@@ -142,19 +142,21 @@ namespace gtsam {
           .fullMatrix();
     }
 
-    /// Return the joint marginal information matrix on the requested keys.
+    /// Return the joint marginal information matrix in `queryKeys` order.
     JointMarginal jointMarginalInformation(const KeyVector& queryKeys) const;
 
-    /// Return the joint marginal covariance matrix on the requested keys.
+    /// Return the joint marginal covariance matrix in `queryKeys` order.
     JointMarginal jointMarginalCovariance(const KeyVector& queryKeys) const;
 
-    /// Return the joint marginal information matrix using a specific elimination rule.
+    /// Return joint marginal information in `queryKeys` order using an
+    /// elimination rule.
     JointMarginal jointMarginalInformation(const KeyVector& queryKeys,
                                           const Eliminate& eliminate) const {
       return internal::jointMarginalInformation(*this, queryKeys, eliminate);
     }
 
-    /// Return the joint marginal covariance matrix using a specific elimination rule.
+    /// Return joint marginal covariance in `queryKeys` order using an
+    /// elimination rule.
     JointMarginal jointMarginalCovariance(const KeyVector& queryKeys,
                                           const Eliminate& eliminate) const {
       return internal::jointMarginalCovariance(*this, queryKeys, eliminate);

--- a/gtsam/linear/GaussianBayesTreeQueries.h
+++ b/gtsam/linear/GaussianBayesTreeQueries.h
@@ -37,6 +37,19 @@ inline KeyVector uniqueSortedKeys(const KeyVector& keys) {
 }
 
 /* ************************************************************************* */
+inline KeyVector uniqueKeysInOrder(const KeyVector& keys) {
+  KeyVector result;
+  result.reserve(keys.size());
+  KeySet seen;
+  for (Key key : keys) {
+    if (seen.insert(key).second) {
+      result.push_back(key);
+    }
+  }
+  return result;
+}
+
+/* ************************************************************************* */
 inline std::vector<size_t> blockOffsets(const std::vector<size_t>& dims) {
   std::vector<size_t> offsets(dims.size() + 1, 0);
   for (size_t i = 0; i < dims.size(); ++i) {
@@ -124,6 +137,26 @@ inline JointMarginal jointMarginalFromMatrix(const Matrix& matrix,
 }
 
 /* ************************************************************************* */
+inline JointMarginal reorderJointMarginal(const JointMarginal& jointMarginal,
+                                          const KeyVector& requestedKeys) {
+  std::vector<size_t> dims;
+  dims.reserve(requestedKeys.size());
+  for (Key key : requestedKeys) {
+    dims.push_back(static_cast<size_t>(jointMarginal(key, key).rows()));
+  }
+
+  const std::vector<size_t> offsets = blockOffsets(dims);
+  Matrix matrix = Matrix::Zero(offsets.back(), offsets.back());
+  for (size_t row = 0; row < requestedKeys.size(); ++row) {
+    for (size_t column = 0; column < requestedKeys.size(); ++column) {
+      matrix.block(offsets[row], offsets[column], dims[row], dims[column]) =
+          jointMarginal(requestedKeys[row], requestedKeys[column]);
+    }
+  }
+  return jointMarginalFromMatrix(matrix, requestedKeys, dims);
+}
+
+/* ************************************************************************* */
 inline JointMarginal emptyJointMarginal() {
   return JointMarginal(Matrix(), Scatter());
 }
@@ -134,20 +167,25 @@ JointMarginal buildJointMarginal(
     const BAYESTREE& bayesTree, const KeyVector& queryKeys,
     const typename BAYESTREE::FactorGraphType::Eliminate& eliminate,
     const SINGLE_BUILDER& singleBuilder, const MULTI_BUILDER& multiBuilder) {
-  const KeyVector orderedKeys = uniqueSortedKeys(queryKeys);
-  if (orderedKeys.empty()) {
+  const KeyVector requestedKeys = uniqueKeysInOrder(queryKeys);
+  if (requestedKeys.empty()) {
     return emptyJointMarginal();
   }
 
-  if (orderedKeys.size() == 1) {
-    const Matrix matrix = singleBuilder(orderedKeys.front());
-    return jointMarginalFromMatrix(matrix, orderedKeys,
+  if (requestedKeys.size() == 1) {
+    const Matrix matrix = singleBuilder(requestedKeys.front());
+    return jointMarginalFromMatrix(matrix, requestedKeys,
                                    {static_cast<size_t>(matrix.rows())});
   }
 
+  const KeyVector sortedKeys = uniqueSortedKeys(requestedKeys);
   const GaussianBayesNet bayesNet =
-      *bayesTree.jointBayesNet(orderedKeys, eliminate);
-  return multiBuilder(bayesNet, orderedKeys);
+      *bayesTree.jointBayesNet(sortedKeys, eliminate);
+  JointMarginal jointMarginal = multiBuilder(bayesNet, sortedKeys);
+  if (requestedKeys == sortedKeys) {
+    return jointMarginal;
+  }
+  return reorderJointMarginal(jointMarginal, requestedKeys);
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/GaussianBayesTreeQueries.h
+++ b/gtsam/linear/GaussianBayesTreeQueries.h
@@ -22,10 +22,23 @@
 #include <gtsam/linear/JointMarginal.h>
 
 #include <Eigen/Cholesky>
-#include <numeric>
 
 namespace gtsam {
 namespace internal {
+
+/* ************************************************************************* */
+/** Return unique keys in their first-occurrence order. */
+inline KeyVector uniqueKeys(const KeyVector& keys) {
+  KeyVector unique;
+  unique.reserve(keys.size());
+  KeySet seen;
+  for (Key key : keys) {
+    if (seen.insert(key).second) {
+      unique.push_back(key);
+    }
+  }
+  return unique;
+}
 
 /* ************************************************************************* */
 /** Return the scalar offsets corresponding to a sequence of block dimensions.
@@ -86,37 +99,58 @@ inline Scatter scatterFromKeysAndDims(const KeyVector& orderedKeys,
 }
 
 /* ************************************************************************* */
-/**
- * Compute selected block columns of covariance from an ordered Bayes net using
- * triangular solves.
+/** Compute covariance blocks in the requested key order using triangular solves
+ * in the Bayes net's elimination order.
  */
 inline Matrix covarianceColumns(const GaussianBayesNet& bayesNet,
                                 const KeyVector& orderedKeys,
-                                const std::vector<size_t>& dims,
-                                const std::vector<size_t>& selectedBlocks) {
-  const auto [R, rhs] = bayesNet.matrix(Ordering(orderedKeys));
+                                const std::vector<size_t>& dims) {
+  const KeyVector factorKeys = bayesNet.ordering();
+  const std::vector<size_t> factorDims = dimsFromBayesNet(bayesNet, factorKeys);
+  const auto [R, rhs] = bayesNet.matrix(Ordering(factorKeys));
   (void)rhs;
 
-  const std::vector<size_t> offsets = blockOffsets(dims);
-  const size_t totalDim = offsets.back();
+  const std::vector<size_t> factorOffsets = blockOffsets(factorDims);
+  const std::vector<size_t> outputOffsets = blockOffsets(dims);
+  const size_t totalDim = factorOffsets.back();
 
-  size_t selectedDim = 0;
-  for (size_t blockIndex : selectedBlocks) {
-    selectedDim += dims.at(blockIndex);
+  FastMap<Key, size_t> factorIndex;
+  for (size_t index = 0; index < factorKeys.size(); ++index) {
+    factorIndex[factorKeys[index]] = index;
   }
 
-  Matrix selectors = Matrix::Zero(totalDim, selectedDim);
-  size_t selectedOffset = 0;
-  for (size_t blockIndex : selectedBlocks) {
-    const size_t begin = offsets[blockIndex];
-    const size_t dim = dims[blockIndex];
-    selectors.block(begin, selectedOffset, dim, dim).setIdentity();
-    selectedOffset += dim;
+  // Solve for covariance columns in elimination order, with output columns
+  // laid out in the requested order.
+  Matrix selectors = Matrix::Zero(totalDim, totalDim);
+  for (size_t outputIndex = 0; outputIndex < orderedKeys.size();
+       ++outputIndex) {
+    const size_t factorIndexForKey = factorIndex.at(orderedKeys[outputIndex]);
+    const size_t dim = dims.at(outputIndex);
+    selectors
+        .block(factorOffsets[factorIndexForKey], outputOffsets[outputIndex],
+               dim, dim)
+        .setIdentity();
   }
 
   R.transpose().triangularView<Eigen::Lower>().solveInPlace(selectors);
   R.triangularView<Eigen::Upper>().solveInPlace(selectors);
-  return selectors;
+
+  // Gather rows in the requested order without changing the factorization
+  // ordering used by the triangular solves above.
+  Matrix covariance = Matrix::Zero(totalDim, totalDim);
+  for (size_t outputRow = 0; outputRow < orderedKeys.size(); ++outputRow) {
+    const size_t factorRow = factorIndex.at(orderedKeys[outputRow]);
+    const size_t rowDim = dims.at(outputRow);
+    for (size_t outputColumn = 0; outputColumn < orderedKeys.size();
+         ++outputColumn) {
+      const size_t columnDim = dims.at(outputColumn);
+      covariance.block(outputOffsets[outputRow], outputOffsets[outputColumn],
+                       rowDim, columnDim) =
+          selectors.block(factorOffsets[factorRow], outputOffsets[outputColumn],
+                          rowDim, columnDim);
+    }
+  }
+  return covariance;
 }
 
 /* ************************************************************************* */
@@ -144,24 +178,19 @@ JointMarginal buildJointMarginal(
     const BAYESTREE& bayesTree, const KeyVector& queryKeys,
     const typename BAYESTREE::FactorGraphType::Eliminate& eliminate,
     const SINGLE_BUILDER& singleBuilder, const MULTI_BUILDER& multiBuilder) {
-  if (queryKeys.empty()) {
+  const KeyVector orderedKeys = uniqueKeys(queryKeys);
+  if (orderedKeys.empty()) {
     return emptyJointMarginal();
   }
 
-  if (queryKeys.size() == 1) {
-    const Matrix matrix = singleBuilder(queryKeys.front());
-    return jointMarginalFromMatrix(matrix, queryKeys,
-                                   {static_cast<size_t>(matrix.rows())});
-  }
-
-  const GaussianBayesNet bayesNet =
-      *bayesTree.jointBayesNet(queryKeys, eliminate);
-  const KeyVector orderedKeys = bayesNet.ordering();
   if (orderedKeys.size() == 1) {
     const Matrix matrix = singleBuilder(orderedKeys.front());
     return jointMarginalFromMatrix(matrix, orderedKeys,
                                    {static_cast<size_t>(matrix.rows())});
   }
+
+  const GaussianBayesNet bayesNet =
+      *bayesTree.jointBayesNet(orderedKeys, eliminate);
   return multiBuilder(bayesNet, orderedKeys);
 }
 
@@ -208,11 +237,8 @@ JointMarginal jointMarginalCovariance(
       [](const GaussianBayesNet& bayesNet, const KeyVector& orderedKeys) {
         const std::vector<size_t> dims =
             dimsFromBayesNet(bayesNet, orderedKeys);
-        std::vector<size_t> allBlocks(orderedKeys.size());
-        std::iota(allBlocks.begin(), allBlocks.end(), 0);
         return jointMarginalFromMatrix(
-            covarianceColumns(bayesNet, orderedKeys, dims, allBlocks),
-            orderedKeys, dims);
+            covarianceColumns(bayesNet, orderedKeys, dims), orderedKeys, dims);
       });
 }
 

--- a/gtsam/linear/GaussianBayesTreeQueries.h
+++ b/gtsam/linear/GaussianBayesTreeQueries.h
@@ -12,7 +12,7 @@
 /**
  * @file    GaussianBayesTreeQueries.h
  * @brief   Internal helpers for Gaussian Bayes-tree covariance queries
- * @author  Codex
+ * @author  Frank Dellaert
  */
 
 #pragma once
@@ -22,34 +22,14 @@
 #include <gtsam/linear/JointMarginal.h>
 
 #include <Eigen/Cholesky>
-#include <algorithm>
 #include <numeric>
 
 namespace gtsam {
 namespace internal {
 
 /* ************************************************************************* */
-inline KeyVector uniqueSortedKeys(const KeyVector& keys) {
-  KeyVector result = keys;
-  std::sort(result.begin(), result.end());
-  result.erase(std::unique(result.begin(), result.end()), result.end());
-  return result;
-}
-
-/* ************************************************************************* */
-inline KeyVector uniqueKeysInOrder(const KeyVector& keys) {
-  KeyVector result;
-  result.reserve(keys.size());
-  KeySet seen;
-  for (Key key : keys) {
-    if (seen.insert(key).second) {
-      result.push_back(key);
-    }
-  }
-  return result;
-}
-
-/* ************************************************************************* */
+/** Return the scalar offsets corresponding to a sequence of block dimensions.
+ */
 inline std::vector<size_t> blockOffsets(const std::vector<size_t>& dims) {
   std::vector<size_t> offsets(dims.size() + 1, 0);
   for (size_t i = 0; i < dims.size(); ++i) {
@@ -59,6 +39,10 @@ inline std::vector<size_t> blockOffsets(const std::vector<size_t>& dims) {
 }
 
 /* ************************************************************************* */
+/**
+ * Convert information to covariance using Cholesky solves, returning zeros
+ * when the information contains non-finite entries.
+ */
 inline Matrix informationToCovariance(const Matrix& information) {
   if (!information.allFinite()) {
     return Matrix::Zero(information.rows(), information.cols());
@@ -71,6 +55,7 @@ inline Matrix informationToCovariance(const Matrix& information) {
 }
 
 /* ************************************************************************* */
+/** Return variable dimensions from a Bayes net in the requested key order. */
 inline std::vector<size_t> dimsFromBayesNet(const GaussianBayesNet& bayesNet,
                                             const KeyVector& orderedKeys) {
   FastMap<Key, size_t> dimsByKey;
@@ -90,6 +75,7 @@ inline std::vector<size_t> dimsFromBayesNet(const GaussianBayesNet& bayesNet,
 }
 
 /* ************************************************************************* */
+/** Construct a scatter with entries in the supplied key and dimension order. */
 inline Scatter scatterFromKeysAndDims(const KeyVector& orderedKeys,
                                       const std::vector<size_t>& dims) {
   Scatter scatter;
@@ -100,6 +86,10 @@ inline Scatter scatterFromKeysAndDims(const KeyVector& orderedKeys,
 }
 
 /* ************************************************************************* */
+/**
+ * Compute selected block columns of covariance from an ordered Bayes net using
+ * triangular solves.
+ */
 inline Matrix covarianceColumns(const GaussianBayesNet& bayesNet,
                                 const KeyVector& orderedKeys,
                                 const std::vector<size_t>& dims,
@@ -130,6 +120,8 @@ inline Matrix covarianceColumns(const GaussianBayesNet& bayesNet,
 }
 
 /* ************************************************************************* */
+/** Construct a joint marginal from a dense matrix and ordered block metadata.
+ */
 inline JointMarginal jointMarginalFromMatrix(const Matrix& matrix,
                                              const KeyVector& orderedKeys,
                                              const std::vector<size_t>& dims) {
@@ -137,58 +129,44 @@ inline JointMarginal jointMarginalFromMatrix(const Matrix& matrix,
 }
 
 /* ************************************************************************* */
-inline JointMarginal reorderJointMarginal(const JointMarginal& jointMarginal,
-                                          const KeyVector& requestedKeys) {
-  std::vector<size_t> dims;
-  dims.reserve(requestedKeys.size());
-  for (Key key : requestedKeys) {
-    dims.push_back(static_cast<size_t>(jointMarginal(key, key).rows()));
-  }
-
-  const std::vector<size_t> offsets = blockOffsets(dims);
-  Matrix matrix = Matrix::Zero(offsets.back(), offsets.back());
-  for (size_t row = 0; row < requestedKeys.size(); ++row) {
-    for (size_t column = 0; column < requestedKeys.size(); ++column) {
-      matrix.block(offsets[row], offsets[column], dims[row], dims[column]) =
-          jointMarginal(requestedKeys[row], requestedKeys[column]);
-    }
-  }
-  return jointMarginalFromMatrix(matrix, requestedKeys, dims);
-}
-
-/* ************************************************************************* */
+/** Construct an empty joint marginal. */
 inline JointMarginal emptyJointMarginal() {
   return JointMarginal(Matrix(), Scatter());
 }
 
 /* ************************************************************************* */
+/**
+ * Build a joint marginal while sharing empty, single-key, and multi-key query
+ * handling between information and covariance calculations.
+ */
 template <class BAYESTREE, class SINGLE_BUILDER, class MULTI_BUILDER>
 JointMarginal buildJointMarginal(
     const BAYESTREE& bayesTree, const KeyVector& queryKeys,
     const typename BAYESTREE::FactorGraphType::Eliminate& eliminate,
     const SINGLE_BUILDER& singleBuilder, const MULTI_BUILDER& multiBuilder) {
-  const KeyVector requestedKeys = uniqueKeysInOrder(queryKeys);
-  if (requestedKeys.empty()) {
+  if (queryKeys.empty()) {
     return emptyJointMarginal();
   }
 
-  if (requestedKeys.size() == 1) {
-    const Matrix matrix = singleBuilder(requestedKeys.front());
-    return jointMarginalFromMatrix(matrix, requestedKeys,
+  if (queryKeys.size() == 1) {
+    const Matrix matrix = singleBuilder(queryKeys.front());
+    return jointMarginalFromMatrix(matrix, queryKeys,
                                    {static_cast<size_t>(matrix.rows())});
   }
 
-  const KeyVector sortedKeys = uniqueSortedKeys(requestedKeys);
   const GaussianBayesNet bayesNet =
-      *bayesTree.jointBayesNet(sortedKeys, eliminate);
-  JointMarginal jointMarginal = multiBuilder(bayesNet, sortedKeys);
-  if (requestedKeys == sortedKeys) {
-    return jointMarginal;
+      *bayesTree.jointBayesNet(queryKeys, eliminate);
+  const KeyVector orderedKeys = bayesNet.ordering();
+  if (orderedKeys.size() == 1) {
+    const Matrix matrix = singleBuilder(orderedKeys.front());
+    return jointMarginalFromMatrix(matrix, orderedKeys,
+                                   {static_cast<size_t>(matrix.rows())});
   }
-  return reorderJointMarginal(jointMarginal, requestedKeys);
+  return multiBuilder(bayesNet, orderedKeys);
 }
 
 /* ************************************************************************* */
+/** Return marginal information for one key using the requested elimination. */
 template <class BAYESTREE>
 Matrix marginalInformation(
     const BAYESTREE& bayesTree, Key key,
@@ -197,6 +175,7 @@ Matrix marginalInformation(
 }
 
 /* ************************************************************************* */
+/** Return joint marginal information with blocks in query-key order. */
 template <class BAYESTREE>
 JointMarginal jointMarginalInformation(
     const BAYESTREE& bayesTree, const KeyVector& queryKeys,
@@ -215,6 +194,7 @@ JointMarginal jointMarginalInformation(
 }
 
 /* ************************************************************************* */
+/** Return joint marginal covariance with blocks in query-key order. */
 template <class BAYESTREE>
 JointMarginal jointMarginalCovariance(
     const BAYESTREE& bayesTree, const KeyVector& queryKeys,

--- a/gtsam/linear/JointMarginal.h
+++ b/gtsam/linear/JointMarginal.h
@@ -59,7 +59,9 @@ class GTSAM_EXPORT JointMarginal {
   /** Synonym for operator() See operator() for indexing semantics. */
   Matrix at(Key iVariable, Key jVariable) const { return (*this)(iVariable, jVariable); }
 
-  /** The full, dense covariance/information matrix of the joint marginal. */
+  /** The full, dense covariance/information matrix of the joint marginal.
+   * Blocks follow the order of the keys in the query that created this object.
+   */
   Matrix fullMatrix() const { return blockMatrix_.selfadjointView(); }
 
   /** Print */

--- a/gtsam/nonlinear/ISAM2.h
+++ b/gtsam/nonlinear/ISAM2.h
@@ -263,10 +263,10 @@ class GTSAM_EXPORT ISAM2 : public BayesTree<ISAM2Clique> {
   /// Return the marginal covariance matrix on any variable.
   Matrix marginalCovariance(Key key) const;
 
-  /// Return the joint marginal covariance on a set of variables.
+  /// Return joint marginal covariance with blocks in `queryKeys` order.
   JointMarginal jointMarginalCovariance(const KeyVector& queryKeys) const;
 
-  /// Return the joint marginal information on a set of variables.
+  /// Return joint marginal information with blocks in `queryKeys` order.
   JointMarginal jointMarginalInformation(const KeyVector& queryKeys) const;
 
   /// @name Public members for non-typical usage

--- a/gtsam/nonlinear/Marginals.h
+++ b/gtsam/nonlinear/Marginals.h
@@ -122,10 +122,10 @@ class GTSAM_EXPORT Marginals {
   /// Compute the marginal covariance of a single variable.
   Matrix marginalCovariance(Key variable) const;
 
-  /// Compute the joint marginal covariance of several variables.
+  /// Compute joint marginal covariance with blocks in `variables` order.
   JointMarginal jointMarginalCovariance(const KeyVector& variables) const;
 
-  /// Compute the joint marginal information of several variables.
+  /// Compute joint marginal information with blocks in `variables` order.
   JointMarginal jointMarginalInformation(const KeyVector& variables) const;
 
   /** Delete cached Bayes tree shortcuts created while computing marginals */

--- a/python/gtsam/tests/test_Marginals.py
+++ b/python/gtsam/tests/test_Marginals.py
@@ -79,7 +79,8 @@ class TestMarginals(GtsamTestCase):
         union_keys = [x1, l1, l2, x3]
         joint = marginals.jointMarginalCovariance(union_keys)
         full = joint.fullMatrix()
-        ordered_keys = sorted(set(union_keys))
+        # JointMarginal preserves the order supplied to the query.
+        ordered_keys = union_keys
         dims = values.dims()
 
         offsets = {}

--- a/tests/testGaussianBayesTreeB.cpp
+++ b/tests/testGaussianBayesTreeB.cpp
@@ -321,6 +321,7 @@ TEST(GaussianBayesTree, shortcut_overlapping_separator)
 }
 
 /* ************************************************************************* */
+// Verifies multi-key joint queries agree with pairwise queries.
 TEST(GaussianBayesTree, multiKeyJointMatchesPairwise) {
   GaussianFactorGraph fg;
   noiseModel::Diagonal::shared_ptr model = noiseModel::Unit::Create(1);
@@ -344,6 +345,7 @@ TEST(GaussianBayesTree, multiKeyJointMatchesPairwise) {
 }
 
 /* ************************************************************************* */
+// Verifies multi-key joints preserve query order and match marginalization.
 TEST(GaussianBayesTree, multiKeyJointMatchesLegacyMarginalization) {
   GaussianFactorGraph fg;
   noiseModel::Diagonal::shared_ptr model = noiseModel::Unit::Create(1);
@@ -360,8 +362,11 @@ TEST(GaussianBayesTree, multiKeyJointMatchesLegacyMarginalization) {
   Ordering ordering(fg.keys());
   GaussianBayesTree bt = *fg.eliminateMultifrontal(ordering);
 
-  const KeyVector query{7, 2, 1};
-  const GaussianFactorGraph actualJoint = *bt.joint(query, EliminateQR);
+  const KeyVector query{7, 2, 1, 2};
+  const GaussianBayesNet actualBayesNet = *bt.jointBayesNet(query, EliminateQR);
+  EXPECT(assert_equal(Ordering{7, 2, 1}, actualBayesNet.ordering()));
+
+  const GaussianFactorGraph actualJoint(actualBayesNet);
   const GaussianFactorGraph legacyJoint =
       GaussianFactorGraph(*fg.marginalMultifrontalBayesTree(KeyVector{1, 2, 7},
                                                             EliminateQR));

--- a/tests/testMarginals.cpp
+++ b/tests/testMarginals.cpp
@@ -92,7 +92,7 @@ Matrix legacyJointCovariance(const GaussianFactorGraph& graph,
 
   const GaussianFactorGraph jointFG =
       legacyJointFactorGraph(graph, ordering, sortedVariables, factorization);
-  const Matrix augmentedInfo = jointFG.augmentedHessian();
+  const Matrix augmentedInfo = jointFG.augmentedHessian(Ordering(variables));
   const Matrix information = augmentedInfo.topLeftCorner(
       augmentedInfo.rows() - 1, augmentedInfo.cols() - 1);
   return information.inverse();
@@ -370,6 +370,7 @@ TEST(Marginals, orderingEquivalence) {
 #endif
 
 /* ************************************************************************* */
+// Verifies joint covariance agrees with the full system in query-key order.
 TEST(Marginals, jointCovarianceMatchesFullHessianInverse) {
   auto dimsForKeys = [](const Values& values, const KeyVector& keys) {
     std::vector<size_t> dims;
@@ -391,7 +392,6 @@ TEST(Marginals, jointCovarianceMatchesFullHessianInverse) {
   auto covarianceBlockFromFullHessian = [&](const GaussianFactorGraph& graph,
                                             const Values& values,
                                             const KeyVector& queryKeys) {
-    const KeyVector orderedQuery = uniqueSortedKeys(queryKeys);
     const KeySet graphKeys = graph.keys();
     KeyVector allKeys(graphKeys.begin(), graphKeys.end());
     const Ordering ordering(allKeys);
@@ -401,7 +401,7 @@ TEST(Marginals, jointCovarianceMatchesFullHessianInverse) {
 
     const std::vector<size_t> allDims = dimsForKeys(values, allKeys);
     const std::vector<size_t> allOffsets = blockOffsets(allDims);
-    const std::vector<size_t> queryDims = dimsForKeys(values, orderedQuery);
+    const std::vector<size_t> queryDims = dimsForKeys(values, queryKeys);
     const std::vector<size_t> queryOffsets = blockOffsets(queryDims);
 
     FastMap<Key, size_t> indexByKey;
@@ -410,11 +410,11 @@ TEST(Marginals, jointCovarianceMatchesFullHessianInverse) {
     }
 
     Matrix result = Matrix::Zero(queryOffsets.back(), queryOffsets.back());
-    for (size_t rowIndex = 0; rowIndex < orderedQuery.size(); ++rowIndex) {
-      const size_t sourceRow = indexByKey.at(orderedQuery[rowIndex]);
+    for (size_t rowIndex = 0; rowIndex < queryKeys.size(); ++rowIndex) {
+      const size_t sourceRow = indexByKey.at(queryKeys[rowIndex]);
       const size_t rowDim = queryDims[rowIndex];
-      for (size_t colIndex = 0; colIndex < orderedQuery.size(); ++colIndex) {
-        const size_t sourceCol = indexByKey.at(orderedQuery[colIndex]);
+      for (size_t colIndex = 0; colIndex < queryKeys.size(); ++colIndex) {
+        const size_t sourceCol = indexByKey.at(queryKeys[colIndex]);
         const size_t colDim = queryDims[colIndex];
         result.block(queryOffsets[rowIndex], queryOffsets[colIndex], rowDim,
                      colDim) =


### PR DESCRIPTION
## Summary

- preserve first-occurrence key order in `BayesTree::jointBayesNet(KeyVector)`
- have joint information and covariance queries consume the ordered Bayes net directly
- document the ordering contract across `Marginals`, `GaussianBayesTree`, `ISAM2`, `JointMarginal`, and `BayesTree`
- document every helper in `GaussianBayesTreeQueries.h` and attribute the file to Frank Dellaert
- add regression coverage for unsorted and duplicate key queries

## Root cause

Both the joint-marginal query helper and `jointBayesNet(KeyVector)` sorted their input keys before constructing the result. Consequently, a query such as `{2, 1}` returned matrix blocks in `{1, 2}` order.

`jointBayesNet` now stably deduplicates its input, so `{7, 2, 1, 2}` produces elimination order `{7, 2, 1}`. The existing ordered marginalization path then creates the Bayes net in that order, and the Gaussian query helpers use its ordering directly. No dense post-processing permutation is required.

## Validation

- `make -j6 testGaussianBayesTreeB.run`
- `make -j6 testMarginals.run`
- `make -j6 testGaussianISAM2.run`
- `make -j6 testSymbolicBayesTree.run`
- `make -j6 testDiscreteBayesTree.run`
- `git diff --check origin/develop...HEAD`
- changed-lines `git clang-format` check

Fixes #2622