### PR TITLE
Build examples in nightly C++ CI

### DIFF
--- a/.github/scripts/unix.sh
+++ b/.github/scripts/unix.sh
@@ -76,15 +76,20 @@ function test ()
 
   configure
 
+  build_targets=(check)
+  if [ "${GTSAM_BUILD_EXAMPLES_ALWAYS:-OFF}" == "ON" ]; then
+    build_targets+=(examples)
+  fi
+
   # Actual testing
   if [ "$(uname)" == "Linux" ]; then
     if (($(nproc) > 2)); then
-      cmake --build build -j$(nproc) --target check
+      cmake --build build -j$(nproc) --target "${build_targets[@]}"
     else
-      cmake --build build -j2 --target check
+      cmake --build build -j2 --target "${build_targets[@]}"
     fi
   elif [ "$(uname)" == "Darwin" ]; then
-    cmake --build build -j$(sysctl -n hw.physicalcpu) --target check
+    cmake --build build -j$(sysctl -n hw.physicalcpu) --target "${build_targets[@]}"
   fi
 
   finish

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -17,6 +17,7 @@ jobs:
       env:
         CMAKE_BUILD_TYPE: ${{ matrix.build_type }}
         GTSAM_BUILD_UNSTABLE: ${{ matrix.build_unstable }}
+        GTSAM_BUILD_EXAMPLES_ALWAYS: ON
       volumes:
         - ${{ github.workspace }}:/gtsam
     strategy:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -18,6 +18,7 @@ jobs:
       CTEST_PARALLEL_LEVEL: 2
       CMAKE_BUILD_TYPE: ${{ matrix.build_type }}
       GTSAM_BUILD_UNSTABLE: ${{ matrix.build_unstable }}
+      GTSAM_BUILD_EXAMPLES_ALWAYS: ON
       GTSAM_ALLOW_DEPRECATED_SINCE_V43: OFF
 
     strategy:

--- a/.github/workflows/build-special.yml
+++ b/.github/workflows/build-special.yml
@@ -16,6 +16,7 @@ jobs:
       image: borglab/gtsam-ci:${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.version }}
       env:
         CMAKE_BUILD_TYPE: ${{ matrix.build_type }}
+        GTSAM_BUILD_EXAMPLES_ALWAYS: ON
       volumes:
         - ${{ github.workspace }}:/gtsam
     strategy:
@@ -32,7 +33,6 @@ jobs:
             ubuntu-clang-cayleymap,
             ubuntu-clang-system-libs,
             ubuntu-no-unstable,
-            ubuntu-build-examples,
           ]
 
         build_type: [Release]
@@ -74,12 +74,6 @@ jobs:
             version: "14"
             flag: no_unstable
 
-          - name: ubuntu-build-examples
-            os: ubuntu-22.04
-            compiler: clang
-            version: "14"
-            flag: build_examples
-
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -108,11 +102,6 @@ jobs:
           echo "GTSAM_POSE3_EXPMAP=OFF" >> $GITHUB_ENV
           echo "GTSAM_ROT3_EXPMAP=OFF" >> $GITHUB_ENV
           echo "GTSAM Uses Cayley map for Rot3"
-
-      - name: Build Examples
-        if: matrix.flag == 'build_examples'
-        run: |
-          echo "GTSAM_BUILD_EXAMPLES_ALWAYS=ON" >> $GITHUB_ENV
 
       - name: Use system versions of 3rd party libraries
         if: matrix.flag == 'system'

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -87,7 +87,7 @@ jobs:
           cmake -E remove_directory build
           if [ "${{ matrix.build_type }}" = "Release" ]; then
             cmake -B build -G Ninja \
-                  -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF \
+                  -DGTSAM_BUILD_EXAMPLES_ALWAYS=ON \
                   -DGTSAM_ALLOW_DEPRECATED_SINCE_V43=OFF \
                   -DGTSAM_USE_BOOST_FEATURES=ON \
                   -DGTSAM_ENABLE_BOOST_SERIALIZATION=ON \
@@ -99,7 +99,7 @@ jobs:
                   -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
           else
             cmake -B build -G Ninja \
-                  -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF \
+                  -DGTSAM_BUILD_EXAMPLES_ALWAYS=ON \
                   -DGTSAM_ALLOW_DEPRECATED_SINCE_V43=OFF \
                   -DGTSAM_ENABLE_CONSISTENCY_CHECKS=ON \
                   -DGTSAM_USE_BOOST_FEATURES=OFF \
@@ -108,7 +108,7 @@ jobs:
 
       - name: Build
         shell: bash
-        run: cmake --build build -j4 --target all.tests
+        run: cmake --build build -j4 --target all.tests examples
 
       - name: Test
         shell: bash


### PR DESCRIPTION
## Summary

Enable example compilation across the nightly/manual Linux, macOS, Windows, and special-case C++ CI matrices.

## Changes

- Build the `examples` target alongside tests in Unix CI.
- Enable `GTSAM_BUILD_EXAMPLES_ALWAYS=ON` in nightly/manual C++ workflows.
- Build Windows `all.tests` and `examples`.
- Remove the dedicated `ubuntu-build-examples` special-case lane.
- Leave PR, Python, wheel, and benchmark workflows examples-off.

## Validation

- `bash -n .github/scripts/unix.sh`
- Changed workflow YAML parsing passed.
- `git diff --check`
- Representative CMake examples build passed: 471/471 targets.
- `actionlint` reported only pre-existing repository-wide warnings.