### PR TITLE
Handle constrained components in ISAM2 gradients

### DIFF
--- a/gtsam/nonlinear/ISAM2.cpp
+++ b/gtsam/nonlinear/ISAM2.cpp
@@ -23,6 +23,7 @@
 #include <gtsam/base/debug.h>
 #include <gtsam/base/timing.h>
 #include <gtsam/inference/BayesTree-inst.h>
+#include <gtsam/linear/NoiseModel.h>
 #include <gtsam/linear/GaussianBayesTreeQueries.h>
 #include <gtsam/nonlinear/LinearContainerFactor.h>
 
@@ -30,6 +31,7 @@
 #include <map>
 #include <utility>
 #include <variant>
+#include <vector>
 #include <cassert>
 
 using namespace std;
@@ -942,9 +944,47 @@ double ISAM2::error(const VectorValues& x) const {
 VectorValues ISAM2::gradientAtZero() const {
   // Create result
   VectorValues g;
+  bool hasConstrainedConditional = false;
 
   // Sum up contributions for each clique
-  for (const auto& root : this->roots()) root->addGradientAtZero(&g);
+  for (const auto& root : this->roots())
+    root->addGradientAtZero(&g, &hasConstrainedConditional);
+
+  if (!hasConstrainedConditional) return g;
+
+  // A constrained conditional makes the corresponding frontal gradient
+  // components undefined. Find those components only for constrained trees.
+  FastMap<Key, std::vector<char>> constrainedComponents;
+  for (const auto& [key, clique] : this->nodes()) {
+    const auto& conditional = clique->conditional();
+    if (key != conditional->firstFrontalKey()) continue;
+
+    const auto& model = conditional->get_model();
+    if (!model || !model->isConstrained()) continue;
+    const auto constrainedModel =
+        std::dynamic_pointer_cast<noiseModel::Constrained>(model);
+    if (!constrainedModel) continue;
+
+    DenseIndex position = 0;
+    for (auto it = conditional->beginFrontals();
+         it != conditional->endFrontals(); ++it) {
+      const DenseIndex dim = conditional->getDim(it);
+      auto& mask = constrainedComponents[*it];
+      if (mask.empty()) mask.assign(static_cast<size_t>(dim), 0);
+      for (DenseIndex i = 0; i < dim; ++i) {
+        mask[static_cast<size_t>(i)] =
+            constrainedModel->constrained(static_cast<size_t>(position + i));
+      }
+      position += dim;
+    }
+  }
+
+  for (const auto& [key, mask] : constrainedComponents) {
+    Vector& gradient = g.at(key);
+    for (size_t i = 0; i < mask.size(); ++i) {
+      if (mask[i]) gradient(static_cast<DenseIndex>(i)) = 0.0;
+    }
+  }
 
   return g;
 }

--- a/gtsam/nonlinear/ISAM2.h
+++ b/gtsam/nonlinear/ISAM2.h
@@ -307,6 +307,9 @@ class GTSAM_EXPORT ISAM2 : public BayesTree<ISAM2Clique> {
    * about zero is \f$ -R^T d \f$.  See also gradient(const GaussianBayesNet&,
    * const VectorValues&).
    *
+   * Components associated with hard constraints are undefined and are
+   * represented as zero in the returned gradient.
+   *
    * @return A VectorValues storing the gradient.
    */
   VectorValues gradientAtZero() const;

--- a/gtsam/nonlinear/ISAM2Clique.cpp
+++ b/gtsam/nonlinear/ISAM2Clique.cpp
@@ -326,6 +326,17 @@ void ISAM2Clique::findAll(const KeySet& markedMask, KeySet* keys) const {
 
 /* ************************************************************************* */
 void ISAM2Clique::addGradientAtZero(VectorValues* g) const {
+  addGradientAtZero(g, nullptr);
+}
+
+/* ************************************************************************* */
+void ISAM2Clique::addGradientAtZero(
+    VectorValues* g, bool* hasConstrainedConditional) const {
+  if (hasConstrainedConditional && conditional_->get_model() &&
+      conditional_->get_model()->isConstrained()) {
+    *hasConstrainedConditional = true;
+  }
+
   // Loop through variables in each clique, adding contributions
   DenseIndex position = 0;
   for (auto it = conditional_->begin(); it != conditional_->end(); ++it) {
@@ -338,7 +349,7 @@ void ISAM2Clique::addGradientAtZero(VectorValues* g) const {
 
   // Recursively add contributions from children
   for (const auto& child : children) {
-    child->addGradientAtZero(g);
+    child->addGradientAtZero(g, hasConstrainedConditional);
   }
 }
 

--- a/gtsam/nonlinear/ISAM2Clique.h
+++ b/gtsam/nonlinear/ISAM2Clique.h
@@ -120,6 +120,12 @@ class GTSAM_EXPORT ISAM2Clique
   void findAll(const KeySet& markedMask, KeySet* keys) const;
 
  private:
+  friend class ISAM2;
+
+  /// Recursively add gradient at zero to g and report constrained conditionals.
+  void addGradientAtZero(VectorValues* g,
+                         bool* hasConstrainedConditional) const;
+
   /**
    * Check if clique was replaced, or if any parents were changed above the
    * threshold or themselves replaced.

--- a/tests/testGaussianISAM2.cpp
+++ b/tests/testGaussianISAM2.cpp
@@ -15,6 +15,7 @@
 #include <gtsam/nonlinear/Values.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/NonlinearEquality.h>
+#include <gtsam/nonlinear/PriorFactor.h>
 #include <gtsam/nonlinear/Marginals.h>
 #include <gtsam/linear/GaussianBayesNet.h>
 #include <gtsam/linear/GaussianBayesTree.h>
@@ -1263,7 +1264,8 @@ TEST(ISAM2, AdaptiveReorder_DisabledByDefault) {
 TEST(ISAM2, constrained_gradient_at_zero) {
   // A hard-constrained variable should not receive gradient contributions from
   // regular factors after the Bayes tree aggregates clique gradients.
-  ISAM2 isam;
+  ISAM2Params params(ISAM2DoglegParams(1.0), 0.0, 0, false);
+  ISAM2 isam(params);
   NonlinearFactorGraph graph;
   Values init;
   const Pose2 origin(0.0, 0.0, 0.0);
@@ -1278,7 +1280,34 @@ TEST(ISAM2, constrained_gradient_at_zero) {
   constrainedKeys.emplace(1, 1);
   isam.update(graph, init, FactorIndices(), constrainedKeys);
 
-  EXPECT(assert_equal(Vector3::Zero(), isam.gradientAtZero().at(1)));
+  const VectorValues gradient = isam.gradientAtZero();
+  EXPECT(assert_equal(Vector3::Zero(), gradient.at(1)));
+  EXPECT(gradient.at(0).norm() > 0.0);
+}
+
+/* ************************************************************************* */
+TEST(ISAM2, constrained_gradient_at_zero_mixed_components) {
+  // Only constrained scalar components should be represented as zero.
+  ISAM2Params params(ISAM2DoglegParams(1.0), 0.0, 0, false);
+  ISAM2 isam(params);
+  NonlinearFactorGraph graph;
+  Values init;
+
+  graph.emplace_shared<PriorFactor<Point2>>(
+      1, Point2(0.0, 0.0),
+      noiseModel::Constrained::MixedSigmas(Vector2(0.0, 1.0)));
+  graph.emplace_shared<BetweenFactor<Point2>>(
+      0, 1, Point2(1.0, 1.0), noiseModel::Isotropic::Sigma(2, 1.0));
+  init.insert(0, Point2(0.0, 0.0));
+  init.insert(1, Point2(0.0, 0.0));
+
+  FastMap<Key, int> constrainedKeys;
+  constrainedKeys.emplace(1, 1);
+  isam.update(graph, init, FactorIndices(), constrainedKeys);
+
+  const VectorValues gradient = isam.gradientAtZero();
+  EXPECT(std::abs(gradient.at(1)(0)) < 1e-9);
+  EXPECT(std::abs(gradient.at(1)(1)) > 1e-9);
 }
 
 /* ************************************************************************* */

--- a/tests/testGaussianISAM2.cpp
+++ b/tests/testGaussianISAM2.cpp
@@ -14,6 +14,7 @@
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/nonlinear/Values.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <gtsam/nonlinear/NonlinearEquality.h>
 #include <gtsam/nonlinear/Marginals.h>
 #include <gtsam/linear/GaussianBayesNet.h>
 #include <gtsam/linear/GaussianBayesTree.h>
@@ -1256,6 +1257,28 @@ TEST(ISAM2, AdaptiveReorder_DisabledByDefault) {
   EXPECT(!result.batchReorderTriggered);
   // treeNnz should still be populated
   EXPECT(result.treeNnz > 0);
+}
+
+/* ************************************************************************* */
+TEST(ISAM2, constrained_gradient_at_zero) {
+  // A hard-constrained variable should not receive gradient contributions from
+  // regular factors after the Bayes tree aggregates clique gradients.
+  ISAM2 isam;
+  NonlinearFactorGraph graph;
+  Values init;
+  const Pose2 origin(0.0, 0.0, 0.0);
+
+  graph.emplace_shared<NonlinearEquality<Pose2>>(1, origin);
+  graph.emplace_shared<BetweenFactor<Pose2>>(
+      0, 1, Pose2(1.0, 0.0, 0.0), odoNoise);
+  init.insert(0, origin);
+  init.insert(1, origin);
+
+  FastMap<Key, int> constrainedKeys;
+  constrainedKeys.emplace(1, 1);
+  isam.update(graph, init, FactorIndices(), constrainedKeys);
+
+  EXPECT(assert_equal(Vector3::Zero(), isam.gradientAtZero().at(1)));
 }
 
 /* ************************************************************************* */


### PR DESCRIPTION
## Summary

Fixes #34 by representing undefined gradient components associated with hard constraints as zero.

- Preserves the existing unconstrained iSAM2 gradient aggregation path.
- Detects constrained conditionals during the existing clique traversal.
- Builds and applies a scalar component mask only when constraints are present.
- Uses conditional noise-model metadata rather than `constrainedKeys`.
- Preserves unconstrained components of mixed constrained variables.
- Adds no public API, serialized state, or persistent per-key metadata.

## Root cause

`ISAM2::gradientAtZero()` aggregated clique gradients without accounting for constrained conditionals. As a result, regular neighboring factors could leave nonzero values in gradient components that are mathematically undefined for hard-constrained variables.

## Validation

- `make -j6 testGaussianISAM2.run`
- `make -j6 testDoglegOptimizer.run`
- `git diff --check`

The tests include the Pose2 Dogleg reproducer and a mixed-component constraint case.