### PR TITLE
Deprecate legacy unstable IMU state APIs

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -117,13 +117,13 @@ jobs:
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
+      # Keep the Windows PR fast-compile gate focused on the stable library.
       - name: Configure
         shell: bash
         run: >-
           cmake -S . -B build -G Ninja
           -DCMAKE_BUILD_TYPE=Release
           -DGTSAM_BUILD_TESTS=OFF
-          # Keep the Windows PR fast-compile gate focused on the stable library.
           -DGTSAM_BUILD_UNSTABLE=${{ runner.os == 'Windows' && 'OFF' || 'ON' }}
           -DGTSAM_USE_QUATERNIONS=OFF
           -DGTSAM_WITH_TBB=OFF

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -123,7 +123,8 @@ jobs:
           cmake -S . -B build -G Ninja
           -DCMAKE_BUILD_TYPE=Release
           -DGTSAM_BUILD_TESTS=OFF
-          -DGTSAM_BUILD_UNSTABLE=ON
+          # Keep the Windows PR fast-compile gate focused on the stable library.
+          -DGTSAM_BUILD_UNSTABLE=${{ runner.os == 'Windows' && 'OFF' || 'ON' }}
           -DGTSAM_USE_QUATERNIONS=OFF
           -DGTSAM_WITH_TBB=OFF
           -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF
@@ -139,7 +140,12 @@ jobs:
           -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
       - name: Compile GTSAM libraries
+        if: runner.os != 'Windows'
         run: cmake --build build --target gtsam gtsam_unstable --parallel 4
+
+      - name: Compile GTSAM library (Windows)
+        if: runner.os == 'Windows'
+        run: cmake --build build --target gtsam --parallel 4
 
       - name: Show sccache statistics
         shell: bash

--- a/gtsam_unstable/dynamics/DynamicsPriors.h
+++ b/gtsam_unstable/dynamics/DynamicsPriors.h
@@ -2,12 +2,17 @@
  * @file DynamicsPriors.h
  *
  * @brief Priors to be used with dynamic systems (Specifically PoseRTV)
+ * @deprecated These priors depend on the deprecated gtsam::PoseRTV state.
  *
  * @date Nov 22, 2011
  * @author Alex Cunningham
  */
 
 #pragma once
+
+#include <gtsam/config.h>
+
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
 
 #include <gtsam_unstable/dynamics/PoseRTV.h>
 #include <gtsam_unstable/slam/PartialPriorFactor.h>
@@ -89,3 +94,5 @@ struct DGroundConstraint : public gtsam::PartialPriorFactor<PoseRTV> {
 };
 
 } // \namespace gtsam
+
+#endif  // GTSAM_ALLOW_DEPRECATED_SINCE_V43

--- a/gtsam_unstable/dynamics/FullIMUFactor.h
+++ b/gtsam_unstable/dynamics/FullIMUFactor.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+#include <gtsam/config.h>
+
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
+
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam_unstable/dynamics/PoseRTV.h>
@@ -15,11 +19,13 @@
 namespace gtsam {
 
 /**
- * Class that represents integrating IMU measurements over time for dynamic systems
+ * Class that represents integrating IMU measurements over time for dynamic systems.
  * This factor has dimension 9, with a built-in constraint for velocity modeling
  *
  * Templated to allow for different key types, but variables all
  * assumed to be PoseRTV
+ *
+ * @deprecated Use gtsam::ImuFactor with gtsam::NavState instead.
  */
 template<class POSE>
 class FullIMUFactor : public NoiseModelFactorN<POSE, POSE> {
@@ -118,3 +124,5 @@ private:
 };
 
 } // \namespace gtsam
+
+#endif  // GTSAM_ALLOW_DEPRECATED_SINCE_V43

--- a/gtsam_unstable/dynamics/IMUFactor.h
+++ b/gtsam_unstable/dynamics/IMUFactor.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+#include <gtsam/config.h>
+
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
+
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam_unstable/dynamics/PoseRTV.h>
@@ -15,9 +19,11 @@
 namespace gtsam {
 
 /**
- * Class that represents integrating IMU measurements over time for dynamic systems
+ * Class that represents integrating IMU measurements over time for dynamic systems.
  * Templated to allow for different key types, but variables all
  * assumed to be PoseRTV
+ *
+ * @deprecated Use gtsam::ImuFactor with gtsam::NavState instead.
  */
 template<class POSE>
 class IMUFactor : public NoiseModelFactorN<POSE, POSE> {
@@ -106,3 +112,5 @@ private:
 };
 
 } // \namespace gtsam
+
+#endif  // GTSAM_ALLOW_DEPRECATED_SINCE_V43

--- a/gtsam_unstable/dynamics/PoseRTV.cpp
+++ b/gtsam_unstable/dynamics/PoseRTV.cpp
@@ -3,6 +3,10 @@
  * @author Alex Cunningham
  */
 
+#include <gtsam/config.h>
+
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
+
 #include <gtsam_unstable/dynamics/PoseRTV.h>
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/base/Vector.h>
@@ -243,3 +247,5 @@ Matrix PoseRTV::RRTMnb(const Rot3& att) {
 
 /* ************************************************************************* */
 } // \namespace gtsam
+
+#endif  // GTSAM_ALLOW_DEPRECATED_SINCE_V43

--- a/gtsam_unstable/dynamics/PoseRTV.h
+++ b/gtsam_unstable/dynamics/PoseRTV.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+#include <gtsam/config.h>
+
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
+
 #include <gtsam_unstable/dllexport.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/base/ProductLieGroup.h>
@@ -16,9 +20,10 @@ namespace gtsam {
 typedef Vector3 Velocity3;
 
 /**
- * Robot state for use with IMU measurements
+ * Robot state for use with IMU measurements.
  * - contains translation, translational velocity and rotation
- * TODO(frank): Alex should deprecate/move to project
+ *
+ * @deprecated Use gtsam::NavState with the stable navigation factors instead.
  */
 class GTSAM_UNSTABLE_EXPORT PoseRTV : public ProductLieGroup<Pose3,Velocity3> {
 protected:
@@ -179,3 +184,5 @@ template<>
 struct Range<PoseRTV, PoseRTV> : HasRange<PoseRTV, PoseRTV, double> {};
 
 } // \namespace gtsam
+
+#endif  // GTSAM_ALLOW_DEPRECATED_SINCE_V43

--- a/gtsam_unstable/dynamics/VelocityConstraint.h
+++ b/gtsam_unstable/dynamics/VelocityConstraint.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+#include <gtsam/config.h>
+
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
+
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/NoiseModelFactorN.h>
@@ -32,6 +36,8 @@ typedef enum {
  *
  * NOTE: this approximation is insufficient for large timesteps, but is accurate
  * if timesteps are small.
+ *
+ * @deprecated This factor depends on the deprecated gtsam::PoseRTV state.
  */
 class VelocityConstraint : public gtsam::NoiseModelFactorN<PoseRTV,PoseRTV> {
 public:
@@ -127,3 +133,5 @@ private:
 };
 
 } // \namespace gtsam
+
+#endif  // GTSAM_ALLOW_DEPRECATED_SINCE_V43

--- a/gtsam_unstable/dynamics/tests/testIMUSystem.cpp
+++ b/gtsam_unstable/dynamics/tests/testIMUSystem.cpp
@@ -3,9 +3,12 @@
  * @author Alex Cunningham
  */
 
-#include <iostream>
-
+#include <gtsam/config.h>
 #include <CppUnitLite/TestHarness.h>
+
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
+
+#include <iostream>
 
 #include <gtsam/slam/BetweenFactor.h>
 #include <gtsam/nonlinear/PriorFactor.h>
@@ -171,6 +174,9 @@ TEST( testIMUSystem, linear_trajectory) {
   }
 //  EXPECT_DOUBLES_EQUAL(0, graph.error(true_traj), 1e-5); // FAIL
 }
+
+/* ************************************************************************* */
+#endif  // GTSAM_ALLOW_DEPRECATED_SINCE_V43
 
 /* ************************************************************************* */
 int main() { TestResult tr; return TestRegistry::runAllTests(tr); }

--- a/gtsam_unstable/dynamics/tests/testPoseRTV.cpp
+++ b/gtsam_unstable/dynamics/tests/testPoseRTV.cpp
@@ -3,7 +3,11 @@
  * @author Alex Cunningham
  */
 
+#include <gtsam/config.h>
 #include <CppUnitLite/TestHarness.h>
+
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
+
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/TestableAssertions.h>
@@ -238,6 +242,9 @@ TEST(testPoseRTV, RRTMnb) {
   EXPECT(assert_equal(I_3x3, PoseRTV::RRTMnb(Rot3())));
   EXPECT(assert_equal(PoseRTV::RRTMnb(Vector3(0.3, 0.2, 0.1)), PoseRTV::RRTMnb(Rot3::Ypr(0.1, 0.2, 0.3))));
 }
+
+/* ************************************************************************* */
+#endif  // GTSAM_ALLOW_DEPRECATED_SINCE_V43
 
 /* ************************************************************************* */
 int main() { TestResult tr; return TestRegistry::runAllTests(tr); }

--- a/gtsam_unstable/dynamics/tests/testVelocityConstraint.cpp
+++ b/gtsam_unstable/dynamics/tests/testVelocityConstraint.cpp
@@ -3,7 +3,11 @@
  * @author Alex Cunningham
  */
 
+#include <gtsam/config.h>
 #include <CppUnitLite/TestHarness.h>
+
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
+
 #include <gtsam/base/VectorConstants.h>
 #include <gtsam_unstable/dynamics/VelocityConstraint.h>
 
@@ -54,6 +58,9 @@ TEST( testEulerVelocityConstraint, euler_end ) {
   EXPECT(assert_equal(Z_3x1, constraint.evaluateError(pose1, pose2), tol));
   EXPECT(assert_equal(Vector::Unit(3,0)*0.5, constraint.evaluateError(origin, pose1a), tol));
 }
+
+/* ************************************************************************* */
+#endif  // GTSAM_ALLOW_DEPRECATED_SINCE_V43
 
 /* ************************************************************************* */
 int main() { TestResult tr; return TestRegistry::runAllTests(tr); }

--- a/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel.h
+++ b/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel.h
@@ -14,10 +14,16 @@
  *  @file   EquivInertialNavFactor_GlobalVel.h
  *  @author Vadim Indelman, Stephen Williams
  *  @brief  Equivalent inertial navigation factor (velocity in the global frame).
+ *  @deprecated This legacy unstable inertial-navigation factor is no longer
+ *  maintained. Use the stable navigation factors where applicable.
  *  @date   Sep. 26, 2012
  **/
 
 #pragma once
+
+#include <gtsam/config.h>
+
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
 
 #include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/NoiseModelFactorN.h>
@@ -718,3 +724,5 @@ private:
 }; // \class EquivInertialNavFactor_GlobalVel
 
 } /// namespace gtsam
+
+#endif  // GTSAM_ALLOW_DEPRECATED_SINCE_V43

--- a/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel_NoBias.h
+++ b/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel_NoBias.h
@@ -14,10 +14,16 @@
  *  @file   EquivInertialNavFactor_GlobalVel_NoBias.h
  *  @author Vadim Indelman, Stephen Williams
  *  @brief  Equivalent inertial navigation factor (velocity in the global frame), without bias state.
+ *  @deprecated This legacy unstable inertial-navigation factor is no longer
+ *  maintained. Use the stable navigation factors where applicable.
  *  @date   May 9, 2013
  **/
 
 #pragma once
+
+#include <gtsam/config.h>
+
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
 
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/MatrixConstants.h>
@@ -584,3 +590,5 @@ private:
 }; // \class EquivInertialNavFactor_GlobalVel_NoBias
 
 } /// namespace gtsam
+
+#endif  // GTSAM_ALLOW_DEPRECATED_SINCE_V43

--- a/gtsam_unstable/slam/InertialNavFactor_GlobalVelocity.h
+++ b/gtsam_unstable/slam/InertialNavFactor_GlobalVelocity.h
@@ -13,10 +13,16 @@
  *  @file   InertialNavFactor_GlobalVelocity.h
  *  @author Vadim Indelman, Stephen Williams
  *  @brief  Inertial navigation factor (velocity in the global frame)
+ *  @deprecated This legacy unstable inertial-navigation factor is no longer
+ *  maintained. Use the stable navigation factors where applicable.
  *  @date   Sept 13, 2012
  **/
 
 #pragma once
+
+#include <gtsam/config.h>
+
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
 
 #include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/NoiseModelFactorN.h>
@@ -429,3 +435,5 @@ struct traits<InertialNavFactor_GlobalVelocity<POSE, VELOCITY, IMUBIAS> > :
 };
 
 } /// namespace aspn
+
+#endif  // GTSAM_ALLOW_DEPRECATED_SINCE_V43

--- a/gtsam_unstable/slam/tests/testEquivInertialNavFactor_GlobalVel.cpp
+++ b/gtsam_unstable/slam/tests/testEquivInertialNavFactor_GlobalVel.cpp
@@ -15,13 +15,17 @@
  * @author  Vadim Indelman, Stephen Williams
  */
 
+#include <gtsam/config.h>
+#include <CppUnitLite/TestHarness.h>
+
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
+
 #include <gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel.h>
 #include <gtsam/navigation/ImuBias.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/nonlinear/Values.h>
 #include <gtsam/inference/Key.h>
 
-#include <CppUnitLite/TestHarness.h>
 #include <iostream>
 
 using namespace std::placeholders;
@@ -61,6 +65,8 @@ TEST( EquivInertialNavFactor_GlobalVel, Constructor)
           g, rho, omega_earth, imu_model, Jacobian_wrt_t0_Overall, bias1);
 
 }
+
+#endif  // GTSAM_ALLOW_DEPRECATED_SINCE_V43
 
 /* ************************************************************************* */
   int main() { TestResult tr; return TestRegistry::runAllTests(tr);}

--- a/gtsam_unstable/slam/tests/testInertialNavFactor_GlobalVelocity.cpp
+++ b/gtsam_unstable/slam/tests/testInertialNavFactor_GlobalVelocity.cpp
@@ -15,7 +15,11 @@
  * @author  Vadim Indelman, Stephen Williams
  */
 
+#include <gtsam/config.h>
 #include <CppUnitLite/TestHarness.h>
+
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
+
 #include <gtsam/base/TestableAssertions.h>
 #include <gtsam/base/VectorConstants.h>
 #include <gtsam/base/numericalDerivative.h>
@@ -704,6 +708,8 @@ Vector predictionErrorVel(const Pose3& p1, const Vector3& v1,
 }
 
 /* ************************************************************************* */
+#endif  // GTSAM_ALLOW_DEPRECATED_SINCE_V43
+
 int main() {
   TestResult tr;
   return TestRegistry::runAllTests(tr);

--- a/gtsam_unstable/timing/CMakeLists.txt
+++ b/gtsam_unstable/timing/CMakeLists.txt
@@ -1,1 +1,6 @@
-gtsamAddTimingGlob("*.cpp" "" "gtsam_unstable" ${GTSAM_BUILD_TIMING_ALWAYS})
+set(excluded_timings "")
+if(NOT GTSAM_ALLOW_DEPRECATED_SINCE_V43)
+  list(APPEND excluded_timings "timeInertialNavFactor_GlobalVelocity.cpp")
+endif()
+
+gtsamAddTimingGlob("*.cpp" "${excluded_timings}" "gtsam_unstable" ${GTSAM_BUILD_TIMING_ALWAYS})

--- a/gtsam_unstable/timing/timeInertialNavFactor_GlobalVelocity.cpp
+++ b/gtsam_unstable/timing/timeInertialNavFactor_GlobalVelocity.cpp
@@ -15,6 +15,10 @@
  * @author  Vadim Indelman, Stephen Williams
  */
 
+#include <gtsam/config.h>
+
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
+
 #include <iostream>
 #include <gtsam/navigation/ImuBias.h>
 #include <gtsam_unstable/slam/InertialNavFactor_GlobalVelocity.h>
@@ -106,3 +110,5 @@ int main() {
 }
 
 /* ************************************************************************* */
+
+#endif  // GTSAM_ALLOW_DEPRECATED_SINCE_V43

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -112,9 +112,36 @@ if(GTSAM_UNSTABLE_INSTALL_MATLAB_TOOLBOX)
     list(APPEND mexFlags -DGTSAM_IMPORT_STATIC)
   endif()
 
+  # PoseRTV and the unstable factors built around it are unavailable when
+  # deprecated APIs are disabled. Keep them out of the optional MATLAB
+  # wrapper in that configuration.
+  set(unstable_ignore ${ignore})
+  if(NOT GTSAM_ALLOW_DEPRECATED_SINCE_V43)
+    list(APPEND unstable_ignore
+         gtsam::PoseRTV
+         gtsam::PriorFactor
+         gtsam::BetweenFactor
+         gtsam::RangeFactor
+         gtsam::RangeFactorRTV
+         gtsam::NonlinearEquality
+         gtsam::IMUFactor
+         gtsam::FullIMUFactor
+         gtsam::DHeightPrior
+         gtsam::DRollPrior
+         gtsam::VelocityPrior
+         gtsam::DGroundConstraint
+         "gtsam::PriorFactor<gtsam::PoseRTV>"
+         "gtsam::BetweenFactor<gtsam::PoseRTV>"
+         "gtsam::RangeFactor<gtsam::PoseRTV,gtsam::PoseRTV>"
+         "gtsam::RangeFactor<gtsam::PoseRTV, gtsam::PoseRTV>"
+         "gtsam::NonlinearEquality<gtsam::PoseRTV>"
+         "gtsam::IMUFactor<gtsam::PoseRTV>"
+         "gtsam::FullIMUFactor<gtsam::PoseRTV>")
+  endif()
+
   # Wrap
   matlab_wrap(${GTSAM_SOURCE_DIR}/gtsam_unstable/gtsam_unstable.i "gtsam_unstable"
-              "${GTSAM_ADDITIONAL_LIBRARIES}" "" "${mexFlags}" "${ignore}" "${GTSAM_ENABLE_BOOST_SERIALIZATION}")
+              "${GTSAM_ADDITIONAL_LIBRARIES}" "" "${mexFlags}" "${unstable_ignore}" "${GTSAM_ENABLE_BOOST_SERIALIZATION}")
   set_target_properties(
     gtsam_unstable_matlab_wrapper
     PROPERTIES BUILD_RPATH

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -270,6 +270,29 @@ if(GTSAM_UNSTABLE_BUILD_PYTHON)
             gtsam::gtsfm::KeypointsVector
             gtsam::gtsfm::SfmTrack2dVector)
 
+    if(NOT GTSAM_ALLOW_DEPRECATED_SINCE_V43)
+        list(APPEND ignore
+             gtsam::PoseRTV
+             gtsam::PriorFactor
+             gtsam::BetweenFactor
+             gtsam::RangeFactor
+             gtsam::RangeFactorRTV
+             gtsam::NonlinearEquality
+             gtsam::IMUFactor
+             gtsam::FullIMUFactor
+             gtsam::DHeightPrior
+             gtsam::DRollPrior
+             gtsam::VelocityPrior
+             gtsam::DGroundConstraint
+             "gtsam::PriorFactor<gtsam::PoseRTV>"
+             "gtsam::BetweenFactor<gtsam::PoseRTV>"
+             "gtsam::RangeFactor<gtsam::PoseRTV,gtsam::PoseRTV>"
+             "gtsam::RangeFactor<gtsam::PoseRTV, gtsam::PoseRTV>"
+             "gtsam::NonlinearEquality<gtsam::PoseRTV>"
+             "gtsam::IMUFactor<gtsam::PoseRTV>"
+             "gtsam::FullIMUFactor<gtsam::PoseRTV>")
+    endif()
+
     pybind_wrap(${GTSAM_PYTHON_UNSTABLE_TARGET} # target
             ${PROJECT_SOURCE_DIR}/gtsam_unstable/gtsam_unstable.i # interface_header
             "gtsam_unstable.cpp" # generated_cpp


### PR DESCRIPTION
## Summary

- Deprecate `PoseRTV`, `IMUFactor`, and `FullIMUFactor` in `gtsam_unstable` using the existing `GTSAM_ALLOW_DEPRECATED_SINCE_V43` policy.
- Deprecate dependent legacy dynamics and global-velocity inertial factors, including `InertialNavFactor_GlobalVelocity`.
- Gate associated tests, timing targets, and MATLAB/Python wrapper generation when deprecated APIs are disabled.
- Disable `gtsam_unstable` in the Windows fast compile job of PR CI; Linux and macOS retain the existing unstable fast-compile coverage.

## Motivation

These old unstable IMU/state APIs are expensive to compile and test and are no longer the preferred interfaces. They remain available by default for compatibility while allowing CI and users to disable them.

## Validation

- Deprecated APIs ON: focused unstable C++ builds and tests pass.
- Deprecated APIs OFF: focused unstable C++ builds and tests pass.
- PR-CI-style no-Boost stable and unstable Python wrapper builds pass with deprecated APIs disabled.
- Deprecated-off timing configuration omits the legacy global-velocity timing target.
- `git diff --check` passes.