### PR TITLE
Fix GenericValue RTTI across shared libraries

### DIFF
--- a/gtsam/base/GenericValue.h
+++ b/gtsam/base/GenericValue.h
@@ -26,8 +26,12 @@
 #include <iostream>
 #include <typeinfo> // operator typeid
 
-#ifdef _WIN32
+// GenericValue's RTTI must remain visible so the C++ ABI can identify a
+// specialization consistently when a Value crosses a shared-library boundary.
+#if defined(_WIN32)
 #define GENERICVALUE_VISIBILITY
+#elif defined(__GNUC__)
+#define GENERICVALUE_VISIBILITY __attribute__((visibility("default")))
 #else
 // This will trigger a LNKxxxx on MSVC, so disable for MSVC build
 // Please refer to https://github.com/borglab/gtsam/blob/develop/Using-GTSAM-EXPORT.md
@@ -37,10 +41,13 @@
 namespace gtsam {
 
 /**
- * Wraps any type T so it can play as a Value
+ * Wraps any type T so it can play as a Value.
+ *
+ * A user-defined T that crosses a shared-library boundary must also have
+ * default visibility so the C++ ABI recognizes GenericValue<T> as one type.
  */
 template<class T>
-class GenericValue: public Value {
+class GENERICVALUE_VISIBILITY GenericValue: public Value {
 
 public:
 

--- a/gtsam/base/GenericValue.h
+++ b/gtsam/base/GenericValue.h
@@ -29,12 +29,10 @@
 // GenericValue's RTTI must remain visible so the C++ ABI can identify a
 // specialization consistently when a Value crosses a shared-library boundary.
 #if defined(_WIN32)
-#define GENERICVALUE_VISIBILITY
-#elif defined(__GNUC__)
-#define GENERICVALUE_VISIBILITY __attribute__((visibility("default")))
-#else
-// This will trigger a LNKxxxx on MSVC, so disable for MSVC build
+// Exporting this header-only template triggers linker errors on MSVC.
 // Please refer to https://github.com/borglab/gtsam/blob/develop/Using-GTSAM-EXPORT.md
+#define GENERICVALUE_VISIBILITY
+#else
 #define GENERICVALUE_VISIBILITY GTSAM_EXPORT
 #endif
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 gtsamAddTestsGlob(tests "test*.cpp" "${excluded_tests}" "gtsam")
 
 # Exercise Values RTTI across a hidden-by-default shared-library boundary.
-if(GTSAM_SHARED_LIB)
+if(GTSAM_BUILD_TESTS AND GTSAM_SHARED_LIB)
   add_library(testValuesCrossLibraryHelper SHARED
               values_cross_library/ValuesCrossLibrary.cpp)
   target_compile_definitions(testValuesCrossLibraryHelper

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,43 @@ endif()
 # Build tests
 gtsamAddTestsGlob(tests "test*.cpp" "${excluded_tests}" "gtsam")
 
+# Exercise Values RTTI across a hidden-by-default shared-library boundary.
+if(GTSAM_SHARED_LIB)
+  add_library(testValuesCrossLibraryHelper SHARED
+              values_cross_library/ValuesCrossLibrary.cpp)
+  target_compile_definitions(testValuesCrossLibraryHelper
+                             PRIVATE VALUES_CROSS_LIBRARY_EXPORTS)
+  target_include_directories(testValuesCrossLibraryHelper
+                             PUBLIC values_cross_library)
+  target_link_libraries(testValuesCrossLibraryHelper PRIVATE gtsam)
+  set_target_properties(testValuesCrossLibraryHelper PROPERTIES
+                        CXX_VISIBILITY_PRESET hidden
+                        VISIBILITY_INLINES_HIDDEN YES
+                        EXCLUDE_FROM_ALL ON)
+  gtsam_apply_build_flags(testValuesCrossLibraryHelper)
+
+  add_executable(testValuesCrossLibrary
+                 values_cross_library/testValuesCrossLibrary.cpp)
+  target_link_libraries(testValuesCrossLibrary PRIVATE CppUnitLite gtsam
+                                                     testValuesCrossLibraryHelper)
+  set_target_properties(testValuesCrossLibrary PROPERTIES
+                        CXX_VISIBILITY_PRESET hidden
+                        VISIBILITY_INLINES_HIDDEN YES
+                        EXCLUDE_FROM_ALL ON)
+  gtsam_apply_build_flags(testValuesCrossLibrary)
+
+  add_test(NAME testValuesCrossLibrary COMMAND testValuesCrossLibrary)
+  add_dependencies(check.tests testValuesCrossLibrary)
+  add_dependencies(check testValuesCrossLibrary)
+  add_dependencies(all.tests testValuesCrossLibrary)
+
+  if(NOT MSVC AND NOT XCODE_VERSION)
+    add_custom_target(testValuesCrossLibrary.run
+                      COMMAND $<TARGET_FILE:testValuesCrossLibrary>
+                      DEPENDS testValuesCrossLibrary)
+  endif()
+endif()
+
 if(MSVC)
 	set_property(SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/testSerializationSlam.cpp"
 		APPEND PROPERTY COMPILE_FLAGS "/bigobj")

--- a/tests/values_cross_library/ValuesCrossLibrary.cpp
+++ b/tests/values_cross_library/ValuesCrossLibrary.cpp
@@ -1,0 +1,43 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+#include "ValuesCrossLibrary.h"
+
+#include <gtsam/base/GenericValue.h>
+
+#include <cmath>
+#include <iostream>
+
+namespace values_cross_library {
+
+void TestValue::print(const std::string& label) const {
+  std::cout << label << value_;
+}
+
+bool TestValue::equals(const TestValue& other, double tolerance) const {
+  return std::abs(value_ - other.value_) <= tolerance;
+}
+
+size_t TestValue::dim() const { return dimension; }
+
+TestValue TestValue::retract(const gtsam::Vector& delta) const {
+  return TestValue(value_ + delta[0]);
+}
+
+gtsam::Vector TestValue::localCoordinates(const TestValue& other) const {
+  return gtsam::Vector1(other.value_ - value_);
+}
+
+gtsam::Value* createValue(double value) {
+  return new gtsam::GenericValue<TestValue>(TestValue(value));
+}
+
+}  // namespace values_cross_library

--- a/tests/values_cross_library/ValuesCrossLibrary.h
+++ b/tests/values_cross_library/ValuesCrossLibrary.h
@@ -1,0 +1,71 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+#pragma once
+
+#include <gtsam/base/Manifold.h>
+#include <gtsam/base/Value.h>
+
+#include <cstddef>
+#include <string>
+
+#if defined(_WIN32)
+#ifdef VALUES_CROSS_LIBRARY_EXPORTS
+#define VALUES_CROSS_LIBRARY_EXPORT __declspec(dllexport)
+#else
+#define VALUES_CROSS_LIBRARY_EXPORT __declspec(dllimport)
+#endif
+#elif defined(__GNUC__)
+#define VALUES_CROSS_LIBRARY_EXPORT __attribute__((visibility("default")))
+#else
+#define VALUES_CROSS_LIBRARY_EXPORT
+#endif
+
+namespace values_cross_library {
+
+/** A small manifold whose RTTI crosses the regression-test library boundary. */
+class VALUES_CROSS_LIBRARY_EXPORT TestValue {
+ public:
+  static constexpr size_t dimension = 1;
+
+  /// Constructs the test value.
+  explicit TestValue(double value = 0.0) : value_(value) {}
+
+  /// Prints the scalar value.
+  void print(const std::string& label = "") const;
+  /// Compares two values within a tolerance.
+  bool equals(const TestValue& other, double tolerance = 1e-9) const;
+  /// Returns the tangent-space dimension.
+  size_t dim() const;
+  /// Retracts by the supplied tangent vector.
+  TestValue retract(const gtsam::Vector& delta) const;
+  /// Computes local coordinates to another value.
+  gtsam::Vector localCoordinates(const TestValue& other) const;
+
+  /// Returns the wrapped scalar.
+  double value() const { return value_; }
+
+ private:
+  double value_;
+};
+
+/** Creates a Value in the helper shared library. */
+VALUES_CROSS_LIBRARY_EXPORT gtsam::Value* createValue(double value);
+
+}  // namespace values_cross_library
+
+namespace gtsam {
+
+template <>
+struct traits<values_cross_library::TestValue>
+    : public internal::Manifold<values_cross_library::TestValue> {};
+
+}  // namespace gtsam

--- a/tests/values_cross_library/testValuesCrossLibrary.cpp
+++ b/tests/values_cross_library/testValuesCrossLibrary.cpp
@@ -29,13 +29,12 @@ TEST(Values, CrossLibraryGenericValue) {
   std::unique_ptr<gtsam::Value> foreignValue(
       values_cross_library::createValue(2.0));
   const gtsam::Value& foreignReference = *foreignValue;
-  CHECK(typeid(foreignReference) == typeid(gtsam::GenericValue<TestValue>));
 
   gtsam::Values values;
   values.insert(key, *foreignValue);
-  DOUBLES_EQUAL(2.0, values.at<TestValue>(key).value(), 1e-9);
-
   values.update(key, TestValue(3.0));
+
+  CHECK(typeid(foreignReference) == typeid(gtsam::GenericValue<TestValue>));
   DOUBLES_EQUAL(3.0, values.at<TestValue>(key).value(), 1e-9);
 
   const gtsam::Vector1 wrongType = gtsam::Vector1::Zero();

--- a/tests/values_cross_library/testValuesCrossLibrary.cpp
+++ b/tests/values_cross_library/testValuesCrossLibrary.cpp
@@ -1,0 +1,53 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+#include "ValuesCrossLibrary.h"
+
+#include <gtsam/nonlinear/Values.h>
+
+#include <CppUnitLite/TestHarness.h>
+
+#include <memory>
+#include <typeinfo>
+
+using values_cross_library::TestValue;
+
+/* ************************************************************************* */
+namespace cross_library_rtti {
+
+// Verifies retrieval and update when GenericValue RTTI originates in a DSO.
+TEST(Values, CrossLibraryGenericValue) {
+  constexpr gtsam::Key key = 1;
+  std::unique_ptr<gtsam::Value> foreignValue(
+      values_cross_library::createValue(2.0));
+  const gtsam::Value& foreignReference = *foreignValue;
+  CHECK(typeid(foreignReference) == typeid(gtsam::GenericValue<TestValue>));
+
+  gtsam::Values values;
+  values.insert(key, *foreignValue);
+  DOUBLES_EQUAL(2.0, values.at<TestValue>(key).value(), 1e-9);
+
+  values.update(key, TestValue(3.0));
+  DOUBLES_EQUAL(3.0, values.at<TestValue>(key).value(), 1e-9);
+
+  const gtsam::Vector1 wrongType = gtsam::Vector1::Zero();
+  CHECK_EXCEPTION(values.update(key, wrongType), gtsam::ValuesIncorrectType);
+}
+
+}  // namespace cross_library_rtti
+/* ************************************************************************* */
+
+/* ************************************************************************* */
+int main() {
+  TestResult result;
+  return TestRegistry::runAllTests(result);
+}
+/* ************************************************************************* */


### PR DESCRIPTION
## Summary

- give `GenericValue<T>` RTTI default visibility so the C++ ABI can identify matching specializations across shared-library boundaries
- document the visibility requirement for user-defined value types crossing DSOs
- add a hidden-by-default helper library regression covering RTTI equality, `Values::at<T>`, `Values::update<T>`, and genuine type mismatch rejection

## Root cause

A `GenericValue<T>` instantiated in one shared library could have a different RTTI identity from the same specialization instantiated in another library. The resulting `type_info::name()` strings were identical, but ABI type equality and `dynamic_cast` failed, causing `ValuesIncorrectType`.

The fix preserves ABI type checks and does not treat matching RTTI names as proof of type identity.

Fixes #254.

## Validation

- C++17 Release shared build with Clang 22.1.7/libc++ and hidden inline visibility
- `make -j6 testValuesCrossLibrary.run`
- `make -j6 testValues.run`
- `ctest -R '^testValuesCrossLibrary$' --output-on-failure`
- `git diff --check`

The new regression was also verified to fail before the visibility fix with the equal-name `ValuesIncorrectType` reported in #254.