### PR TITLE
Rename indeterminate system exception and add debugging guide

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -92,6 +92,29 @@ Matrix23 matrix{{1.0, 2.0, 3.0},
 * Documentation-only changes do not require unrelated C++ tests, but should
   still pass applicable documentation checks and `git diff --check`.
 
+## Debugging indeterminate linear systems
+
+* Use the correctly spelled `IndeterminateSystemException`. The former
+  `IndeterminantLinearSystemException` name is available only through the
+  GTSAM 4.3 deprecation machinery.
+* Treat `nearbyVariable()` as the key where elimination detected the problem,
+  not necessarily its source; the reported key depends on graph structure and
+  elimination ordering.
+* Preserve the failing nonlinear graph, values, and ordering. Linearize at
+  those values, request the Jacobian with an explicit ordering, and inspect its
+  singular spectrum and null space. Prefer Jacobian rank analysis over a
+  determinant or Hessian rank analysis because forming the Hessian squares the
+  condition number.
+* Check for missing gauge constraints, unused or accidental keys, disconnected
+  components, degenerate geometry or motion, lost observability after
+  marginalization, inconsistent units or noise scales, and negative curvature
+  introduced by custom Hessian factors.
+* Use a temporary, physically meaningful prior to test an observability
+  hypothesis, then recompute rank. Do not present damping or a dense solve as a
+  fix unless the model itself becomes observable and well conditioned.
+* See `gtsam/linear/doc/IndeterminateSystemException.ipynb` for a runnable
+  Python example and a full diagnostic checklist.
+
 ## C++ test organization
 
 * Avoid one large anonymous namespace collecting every helper at the top of a

--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -1,3 +1,5 @@
 # User Guide
 
 This section contains documentation and usage instructions for many classes within GTSAM via Markdown files (`*.md`) and interactive Python notebooks (`*.ipynb`). Python notebooks with an <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/> button near the top can be opened in your browser, where you can run the files yourself and make edits to play with and understand GTSAM.
+
+For troubleshooting singular, indefinite, or poorly conditioned factor graphs, see [Debugging an Indeterminate Linear System](../gtsam/linear/doc/IndeterminateSystemException.ipynb).

--- a/gtsam/constrained/ActiveSetSolver.cpp
+++ b/gtsam/constrained/ActiveSetSolver.cpp
@@ -328,7 +328,7 @@ void ActiveSetSolver::initializeDenseQpWorkspace() {
 
   try {
     workspace.costBayesNet = eliminate(regularizedCostGraph);
-  } catch (const IndeterminantLinearSystemException&) {
+  } catch (const IndeterminateSystemException&) {
     if (params_->regularization <= 0.0 ||
         params_->regularization >= kMinimumDenseRegularization) {
       throw std::runtime_error(
@@ -342,7 +342,7 @@ void ActiveSetSolver::initializeDenseQpWorkspace() {
                       kMinimumDenseRegularization);
     try {
       workspace.costBayesNet = eliminate(fallbackCostGraph);
-    } catch (const IndeterminantLinearSystemException&) {
+    } catch (const IndeterminateSystemException&) {
       throw std::runtime_error(
           "ActiveSetSolver: dense QP Hessian factorization failed even after "
           "minimum dense regularization. Increase regularization or use the "

--- a/gtsam/linear/GaussianConditional.cpp
+++ b/gtsam/linear/GaussianConditional.cpp
@@ -226,9 +226,9 @@ namespace gtsam {
     // Solve matrix
     const Vector solution = R().triangularView<Eigen::Upper>().solve(rhs);
 
-    // Check for indeterminant solution
+    // Check for indeterminate solution
     if (solution.hasNaN()) {
-      throw IndeterminantLinearSystemException(keys().front());
+      throw IndeterminateSystemException(keys().front());
     }
 
     // Insert solution into a VectorValues
@@ -277,7 +277,8 @@ namespace gtsam {
     frontalVec = R().transpose().triangularView<Eigen::Lower>().solve(frontalVec);
 
     // Check for indeterminate solution
-    if (frontalVec.hasNaN()) throw IndeterminantLinearSystemException(this->keys().front());
+    if (frontalVec.hasNaN())
+      throw IndeterminateSystemException(this->keys().front());
 
     for (const_iterator it = beginParents(); it!= endParents(); it++)
       gy[*it].noalias() += -1.0 * getA(it).transpose() * frontalVec;

--- a/gtsam/linear/HessianFactor.cpp
+++ b/gtsam/linear/HessianFactor.cpp
@@ -571,7 +571,7 @@ std::shared_ptr<GaussianConditional> HessianFactor::eliminateCholesky(const Orde
     keys.print("Frontal keys ");
     print("HessianFactor:");
 #endif
-    throw IndeterminantLinearSystemException(keys.front());
+    throw IndeterminateSystemException(keys.front());
   }
 
   // Return result

--- a/gtsam/linear/JacobianFactor.cpp
+++ b/gtsam/linear/JacobianFactor.cpp
@@ -148,7 +148,7 @@ JacobianFactor::JacobianFactor(const HessianFactor& factor)
     model_ = SharedDiagonal();  // is equivalent to Unit::Create(maxrank)
   } else {
     // indefinite system
-    throw IndeterminantLinearSystemException(factor.keys().front());
+    throw IndeterminateSystemException(factor.keys().front());
   }
 }
 
@@ -1024,7 +1024,7 @@ GaussianConditional::shared_ptr JacobianFactor::splitConditional(size_t nrFronta
   // Check that the noise model has at least this dimension
   // If this is *not* the case, we do not have enough information on the frontal variables.
   if ((DenseIndex)model_->dim() < frontalDim)
-    throw IndeterminantLinearSystemException(this->keys().front());
+    throw IndeterminateSystemException(this->keys().front());
 
   // Restrict the matrix to be in the first nrFrontals variables and create the conditional
   const DenseIndex originalRowEnd = Ab_.rowEnd();

--- a/gtsam/linear/SubgraphPreconditioner.cpp
+++ b/gtsam/linear/SubgraphPreconditioner.cpp
@@ -238,9 +238,9 @@ void SubgraphPreconditioner::transposeSolve(const Vector &y, Vector &x) const {
         cg->R().transpose().triangularView<Eigen::Lower>().solve(
             rhsFrontal);
 
-    // Check for indeterminant solution
+    // Check for indeterminate solution
     if (solFrontal.hasNaN())
-      throw IndeterminantLinearSystemException(cg->keys().front());
+      throw IndeterminateSystemException(cg->keys().front());
 
     /* assign subvector of sol to the frontal variables */
     setSubvector(solFrontal, keyInfo_, frontalKeys, x);

--- a/gtsam/linear/doc/IndeterminateSystemException.ipynb
+++ b/gtsam/linear/doc/IndeterminateSystemException.ipynb
@@ -1,0 +1,247 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "title",
+   "metadata": {},
+   "source": [
+    "# Debugging an Indeterminate Linear System\n",
+    "\n",
+    "This guide shows how to diagnose `IndeterminateSystemException`, which indicates that a linearized factor graph is underdetermined, indefinite, or too poorly conditioned to solve reliably. We will reproduce a missing-gauge failure, inspect the Jacobian null space, and repair the model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "copyright",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "colab",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/linear/doc/IndeterminateSystemException.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "install",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import X\n",
+    "\n",
+    "POSE2_DIMENSION = 3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "reported-key",
+   "metadata": {},
+   "source": [
+    "## What the exception tells you\n",
+    "\n",
+    "In C++, catch `gtsam::IndeterminateSystemException` and call `nearbyVariable()`. Python currently surfaces the failure as a `RuntimeError` whose message names the nearby key. The reported key is where elimination *detected* the problem; it is not necessarily where the modeling error originated. Its identity can change with the elimination ordering.\n",
+    "\n",
+    "The former C++ spelling, `IndeterminantLinearSystemException`, is available only when the GTSAM 4.3 deprecated API is enabled."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "reproduce",
+   "metadata": {},
+   "source": [
+    "## Reproduce and preserve the failing graph\n",
+    "\n",
+    "This graph constrains the relative pose between `x0` and `x1`, but nothing anchors the global translation or rotation. Preserve both the graph and the exact values that failed; linearization depends on those values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "make-underconstrained-graph",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "odometry_noise = gtsam.noiseModel.Diagonal.Sigmas(\n",
+    "    np.array([0.1, 0.1, 0.1])\n",
+    ")\n",
+    "\n",
+    "graph = gtsam.NonlinearFactorGraph()\n",
+    "graph.add(\n",
+    "    gtsam.BetweenFactorPose2(\n",
+    "        X(0), X(1), gtsam.Pose2(1.0, 0.0, 0.0), odometry_noise\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "values = gtsam.Values()\n",
+    "values.insert(X(0), gtsam.Pose2(0.2, 0.4, 0.1))\n",
+    "values.insert(X(1), gtsam.Pose2(1.5, -0.2, -0.1))\n",
+    "\n",
+    "try:\n",
+    "    gtsam.GaussNewtonOptimizer(graph, values).optimize()\n",
+    "except RuntimeError as exception:\n",
+    "    first_line = next(line for line in str(exception).splitlines() if line)\n",
+    "    print(first_line)\n",
+    "    print(\"Graph keys:\", [gtsam.DefaultKeyFormatter(k) for k in graph.keyVector()])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "linearize",
+   "metadata": {},
+   "source": [
+    "## Inspect the Jacobian before the Hessian\n",
+    "\n",
+    "Linearize at the failing values and choose an explicit ordering so the matrix columns have a known key order. The Jacobian $A$ is preferable for rank tests because forming $A^T A$ squares the condition number. A rank smaller than the number of columns means the system has a null space."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "jacobian-rank",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ordering = gtsam.Ordering()\n",
+    "for key in (X(0), X(1)):\n",
+    "    ordering.push_back(key)\n",
+    "\n",
+    "linear_graph = graph.linearize(values)\n",
+    "A, b = linear_graph.jacobian(ordering)\n",
+    "_, singular_values, Vt = np.linalg.svd(A, full_matrices=True)\n",
+    "tolerance = singular_values[0] * max(A.shape) * np.finfo(A.dtype).eps\n",
+    "rank = int(np.sum(singular_values > tolerance))\n",
+    "nullity = A.shape[1] - rank\n",
+    "\n",
+    "print(f\"Jacobian shape: {A.shape}\")\n",
+    "print(f\"rank: {rank}, nullity: {nullity}\")\n",
+    "print(\"singular values:\", singular_values)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interpret-nullspace",
+   "metadata": {},
+   "source": [
+    "Here the Jacobian has six columns (two `Pose2` variables with three tangent dimensions each) but only rank three. The three null directions are the unconstrained global $x$, $y$, and heading gauges.\n",
+    "\n",
+    "For a mixed graph, map column ranges using each variable's tangent dimension. Large block norms in a null vector identify variables participating in an unobservable direction; they do not by themselves identify a faulty factor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "nullspace-blocks",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "null_space = Vt[rank:]\n",
+    "for direction_index, direction in enumerate(null_space):\n",
+    "    block_norms = {}\n",
+    "    for block_index, key in enumerate((X(0), X(1))):\n",
+    "        start = block_index * POSE2_DIMENSION\n",
+    "        stop = start + POSE2_DIMENSION\n",
+    "        block_norms[gtsam.DefaultKeyFormatter(key)] = np.linalg.norm(\n",
+    "            direction[start:stop]\n",
+    "        )\n",
+    "    print(f\"null direction {direction_index}: {block_norms}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "repair",
+   "metadata": {},
+   "source": [
+    "## Repair the model and verify it\n",
+    "\n",
+    "A prior removes the global gauge in this example. A diagnostic prior can confirm the missing degrees of freedom, but the final constraint must reflect genuine information in the model rather than merely suppressing the exception."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "add-prior",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fixed_graph = gtsam.NonlinearFactorGraph(graph)\n",
+    "prior_noise = gtsam.noiseModel.Diagonal.Sigmas(\n",
+    "    np.array([0.01, 0.01, 0.01])\n",
+    ")\n",
+    "fixed_graph.add(gtsam.PriorFactorPose2(X(0), gtsam.Pose2(), prior_noise))\n",
+    "\n",
+    "fixed_linear_graph = fixed_graph.linearize(values)\n",
+    "fixed_A, _ = fixed_linear_graph.jacobian(ordering)\n",
+    "print(f\"fixed Jacobian rank: {np.linalg.matrix_rank(fixed_A)} / {fixed_A.shape[1]}\")\n",
+    "\n",
+    "result = gtsam.GaussNewtonOptimizer(fixed_graph, values).optimize()\n",
+    "print(\"optimized x0:\", result.atPose2(X(0)))\n",
+    "print(\"optimized x1:\", result.atPose2(X(1)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "checklist",
+   "metadata": {},
+   "source": [
+    "## Checklist for real systems\n",
+    "\n",
+    "1. **Save the exact graph and values at failure.** Also record the elimination ordering and incremental or fixed-lag update that triggered it.\n",
+    "2. **Inspect graph structure.** Look for values absent from every factor, accidental new keys, disconnected components, and missing priors or gauge constraints. Start near the reported key, but trace the whole connected component.\n",
+    "3. **Linearize at the failing values.** Compute the Jacobian singular spectrum and null space with an explicit ordering. Prefer the Jacobian over a determinant or the Hessian for numerical rank diagnosis.\n",
+    "4. **Map weak directions back to variable blocks.** Check whether they represent an expected gauge or a missing observable degree of freedom. Degenerate triangulation, small camera baselines, straight-line or zero-excitation IMU motion, and aggressive marginalization are common causes.\n",
+    "5. **Check numerical scale and curvature.** Very different units or noise sigmas can make a full-rank system unusably ill-conditioned. If custom `HessianFactor`s are present, inspect the symmetric Hessian eigenvalues for unintended negative curvature.\n",
+    "6. **Test one modeling hypothesis at a time.** Temporarily add a physically meaningful prior or remove a suspect measurement block, then recompute rank. Damping or dense optimization may make one solve succeed without restoring observability, so do not treat that alone as a fix.\n",
+    "7. **For incremental estimators, replay updates.** Find the first update that loses rank and inspect factors removed or marginalized at that step. Observability can be lost over time even when every individual measurement is valid."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/linear/linearAlgorithms-inst.h
+++ b/gtsam/linear/linearAlgorithms-inst.h
@@ -95,8 +95,9 @@ namespace gtsam
             // TODO(gareth): Inline instantiation of Eigen::Solve and check flag
             const Vector solution = c.R().triangularView<Eigen::Upper>().solve(rhs);
 
-            // Check for indeterminant solution
-            if(solution.hasNaN()) throw IndeterminantLinearSystemException(c.keys().front());
+            // Check for indeterminate solution
+            if (solution.hasNaN())
+              throw IndeterminateSystemException(c.keys().front());
 
             // Insert solution into a VectorValues
             DenseIndex vectorPosition = 0;

--- a/gtsam/linear/linearExceptions.cpp
+++ b/gtsam/linear/linearExceptions.cpp
@@ -22,19 +22,21 @@
 namespace gtsam {
 
   /* ************************************************************************* */
-  const char* IndeterminantLinearSystemException::what() const noexcept
+  const char* IndeterminateSystemException::what() const noexcept
   {
     if(!description_) {
       description_ = String(
-          "\nIndeterminant linear system detected while working near variable\n"
+          "\nIndeterminate linear system detected while working near variable\n"
           + std::to_string(j_) +
           + " (Symbol: " + gtsam::DefaultKeyFormatter(gtsam::Symbol(j_)) + ").\n"
           "\n\
 Thrown when a linear system is ill-posed.  The most common cause for this\n\
 error is having underconstrained variables.  Mathematically, the system is\n\
-underdetermined.  See the GTSAM Doxygen documentation at\n\
-http://borg.cc.gatech.edu/ on gtsam::IndeterminantLinearSystemException for\n\
-more information.");
+underdetermined.  See the GTSAM Doxygen documentation for\n\
+gtsam::IndeterminateSystemException and the user\n\
+guide at\n\
+https://github.com/borglab/gtsam/blob/develop/gtsam/linear/doc/IndeterminateSystemException.ipynb\n\
+for more information.");
     }
     return description_->c_str();
   }

--- a/gtsam/linear/linearExceptions.h
+++ b/gtsam/linear/linearExceptions.h
@@ -66,7 +66,7 @@ namespace gtsam {
 
   Resolving this problem:
    - This exception contains the variable at which the problem was
-     discovered (IndeterminantLinearSystemException::nearbyVariable()).
+     discovered (IndeterminateSystemException::nearbyVariable()).
      Note, however, that this is not necessarily the variable where the
      problem originates.  For example, in the case that a prior on the
      first camera was forgotten, it may only be another camera or landmark
@@ -91,14 +91,20 @@ namespace gtsam {
      ordered in elimination order and occupy scalars in the same way as
      described for Jacobian columns in the previous bullet.
    */
-  class GTSAM_EXPORT IndeterminantLinearSystemException : public ThreadsafeException<IndeterminantLinearSystemException> {
+  class GTSAM_EXPORT IndeterminateSystemException
+      : public ThreadsafeException<IndeterminateSystemException> {
     Key j_;
   public:
-    IndeterminantLinearSystemException(Key j) noexcept : j_(j) {}
-    ~IndeterminantLinearSystemException() noexcept override {}
+    IndeterminateSystemException(Key j) noexcept : j_(j) {}
+    ~IndeterminateSystemException() noexcept override {}
     Key nearbyVariable() const { return j_; }
     const char* what() const noexcept override;
   };
+
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
+  /// @deprecated Use IndeterminateSystemException.
+  using IndeterminantLinearSystemException = IndeterminateSystemException;
+#endif
 
   /* ************************************************************************* */
   /** An exception indicating that the noise model dimension passed into a

--- a/gtsam/linear/tests/testLinearExceptions.cpp
+++ b/gtsam/linear/tests/testLinearExceptions.cpp
@@ -1,0 +1,58 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file testLinearExceptions.cpp
+ * @brief Tests for exceptions thrown by linear solvers.
+ */
+
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/linear/linearExceptions.h>
+
+#include <string>
+
+using namespace gtsam;
+
+/* ************************************************************************* */
+namespace indeterminate_system_exception {
+
+// Verifies that the correctly named exception reports its nearby variable.
+TEST(IndeterminateSystemException, NearbyVariableAndMessage) {
+  const Key key = Symbol('x', 42);
+  const IndeterminateSystemException exception(key);
+
+  EXPECT_LONGS_EQUAL(key, exception.nearbyVariable());
+  const std::string message = exception.what();
+  CHECK(message.find("Indeterminate linear system") != std::string::npos);
+  CHECK(message.find("Indeterminant linear system") == std::string::npos);
+}
+
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
+// Verifies that the 4.3 compatibility spelling catches the replacement type.
+TEST(IndeterminateSystemException, DeprecatedAlias) {
+  bool caught = false;
+  try {
+    throw IndeterminateSystemException(Symbol('l', 7));
+  } catch (const IndeterminantLinearSystemException& exception) {
+    caught = exception.nearbyVariable() == Symbol('l', 7);
+  }
+  CHECK(caught);
+}
+#endif
+
+}  // namespace indeterminate_system_exception
+/* ************************************************************************* */
+
+int main() {
+  TestResult result;
+  return TestRegistry::runAllTests(result);
+}

--- a/gtsam/nonlinear/ISAM2Clique.cpp
+++ b/gtsam/nonlinear/ISAM2Clique.cpp
@@ -147,9 +147,9 @@ void ISAM2Clique::fastBackSubstitute(VectorValues* delta) const {
     const Vector rhs = c.getb() - c.S() * xS;
     const Vector solution = c.R().triangularView<Eigen::Upper>().solve(rhs);
 
-    // Check for indeterminant solution
+    // Check for indeterminate solution
     if (solution.hasNaN())
-      throw IndeterminantLinearSystemException(c.keys().front());
+      throw IndeterminateSystemException(c.keys().front());
 
     // Insert solution into a VectorValues
     DenseIndex vectorPosition = 0;

--- a/gtsam/nonlinear/LevenbergMarquardtOptimizer.cpp
+++ b/gtsam/nonlinear/LevenbergMarquardtOptimizer.cpp
@@ -152,7 +152,7 @@ bool LevenbergMarquardtOptimizer::tryLambda(const GaussianFactorGraph& linear,
     }
     systemSolvedSuccessfully = true;
     // ========================================================================
-  } catch (const IndeterminantLinearSystemException&) {
+  } catch (const IndeterminateSystemException&) {
     systemSolvedSuccessfully = false;
   }
 

--- a/gtsam/slam/FastSync.h
+++ b/gtsam/slam/FastSync.h
@@ -259,7 +259,7 @@ struct FastSync {
  *
  * @throws std::invalid_argument for invalid noise models, an empty measurement
  * graph, a prior outside the measurement graph, or multiple matching priors.
- * @throws IndeterminantLinearSystemException when the measurement graph is
+ * @throws IndeterminateSystemException when the measurement graph is
  * disconnected or otherwise underconstrained.
  * @throws std::runtime_error if GTSAM was built without METIS support.
  */

--- a/gtsam/slam/doc/FastSync.ipynb
+++ b/gtsam/slam/doc/FastSync.ipynb
@@ -119,7 +119,7 @@
     "| `fastSync<Similarity3>` | `fastSyncSimilarity3` | rotation, translation, and positive scale |\n",
     "| `fastSync<SL4>` | `fastSyncSL4` | orientation-corrected SVD and determinant normalization |\n",
     "\n",
-    "C++ extensions specialize `FastSyncProjection<T>` for another fixed-size matrix Lie group. The input must contain a non-empty, connected set of matching between factors with finite, positive, isotropic Gaussian noise. Robust, constrained, and anisotropic models are rejected, as are multiple matching priors. Disconnected inputs reach QR elimination and raise `IndeterminantLinearSystemException`."
+    "C++ extensions specialize `FastSyncProjection<T>` for another fixed-size matrix Lie group. The input must contain a non-empty, connected set of matching between factors with finite, positive, isotropic Gaussian noise. Robust, constrained, and anisotropic models are rejected, as are multiple matching priors. Disconnected inputs reach QR elimination and raise `IndeterminateSystemException`."
    ]
   },
   {

--- a/gtsam/slam/slam.md
+++ b/gtsam/slam/slam.md
@@ -56,7 +56,7 @@ Helper functions and classes for SLAM tasks.
 
 ### FAST-Sync input and gauge behavior
 
-`fastSync<T>` reads matching `BetweenFactor<T>` measurements and accepts only finite, positive, isotropic Gaussian noise. Anisotropic, constrained, and robust between-factor models are rejected. The measurement graph must be non-empty and connected; disconnected graphs are detected during QR elimination and raise `IndeterminantLinearSystemException`. The graph may contain at most one matching `PriorFactor<T>`.
+`fastSync<T>` reads matching `BetweenFactor<T>` measurements and accepts only finite, positive, isotropic Gaussian noise. Anisotropic, constrained, and robust between-factor models are rejected. The measurement graph must be non-empty and connected; disconnected graphs are detected during QR elimination and raise `IndeterminateSystemException`. The graph may contain at most one matching `PriorFactor<T>`.
 
 The relaxed problem uses fixed-size `N`-by-`N` matrices for measurements, reduced-system blocks, back-substitution, and projection, where `N` is obtained from the matrix representation returned by `T::matrix()`. The complete Gaussian graph retains dynamic sparse storage because its topology is only known at runtime. FAST-Sync uses a METIS nested-dissection ordering and an exact identity gauge at the ordering's final key. Projection to the target group occurs only after the complete ambient-space solve. If a matching prior is present, the rounded solution is subsequently left-aligned to that prior; without a prior, the METIS gauge is retained. Builds without METIS report the nested-dissection error. New fixed-size matrix Lie groups can opt in by specializing `FastSyncProjection<T>`.
 

--- a/gtsam/slam/tests/testFastSync.cpp
+++ b/gtsam/slam/tests/testFastSync.cpp
@@ -276,7 +276,7 @@ TEST(FastSync, InvalidGraphStructure) {
   try {
     solver.solve();
     CHECK(false);
-  } catch (const IndeterminantLinearSystemException&) {
+  } catch (const IndeterminateSystemException&) {
     // The nearby variable is ordering-dependent, but the failure occurs in
     // the linear solve after the constructor accepts both components.
   } catch (...) {

--- a/gtsam/slam/tests/testOrientedPlane3Factor.cpp
+++ b/gtsam/slam/tests/testOrientedPlane3Factor.cpp
@@ -247,7 +247,7 @@ TEST(OrientedPlane3Factor, Issue561Simplified) {
     EXPECT(x0.equals(result.at<Pose3>(X(0))));
     EXPECT(p1.equals(result.at<Plane>(P(1))));
     EXPECT(p2.equals(result.at<Plane>(P(2))));
-  } catch (const IndeterminantLinearSystemException &e) {
+  } catch (const IndeterminateSystemException &e) {
     std::cerr << "CAPTURED THE EXCEPTION: " << DefaultKeyFormatter(e.nearbyVariable()) << std::endl;
     EXPECT(false); // fail if this happens
   }

--- a/gtsam_unstable/slam/tests/testLocalOrientedPlane3Factor.cpp
+++ b/gtsam_unstable/slam/tests/testLocalOrientedPlane3Factor.cpp
@@ -231,7 +231,7 @@ TEST(LocalOrientedPlane3Factor, Issue561Simplified) {
     EXPECT(x0.equals(result.at<Pose3>(X(0))));
     EXPECT(p1_in_x1.equals(result.at<Plane>(P(1))));
     EXPECT(p2_in_x1.equals(result.at<Plane>(P(2))));
-  } catch (const IndeterminantLinearSystemException &e) {
+  } catch (const IndeterminateSystemException &e) {
     cerr << "CAPTURED THE EXCEPTION: "
       << DefaultKeyFormatter(e.nearbyVariable()) << endl;
     EXPECT(false);  // fail if this happens

--- a/gtsam_unstable/slam/tests/testSmartStereoProjectionFactorPP.cpp
+++ b/gtsam_unstable/slam/tests/testSmartStereoProjectionFactorPP.cpp
@@ -863,7 +863,7 @@ TEST( SmartStereoProjectionFactorPP, 3poses_optimization_sameExtrinsicKey ) {
 
   EXPECT_DOUBLES_EQUAL(0, graph.error(result), 1e-5);
 
-  // This passes on my machine but gets and indeterminant linear system exception in CI.
+  // This passes locally but gets an indeterminate system exception in CI.
   // This is a very redundant test, so it's not a problem to omit.
   //  GaussianFactorGraph::shared_ptr GFG = graph.linearize(result);
   //  Matrix H = GFG->hessian().first;

--- a/matlab/+gtsam/cylinderSampleProjectionStereo.m
+++ b/matlab/+gtsam/cylinderSampleProjectionStereo.m
@@ -42,7 +42,7 @@ for i = 1:cylinderNum
             continue;       
         end            
 
-        % too small disparity may call indeterminant system exception
+        % too small disparity may cause an indeterminate system exception
         if Z.du < 0.6
             continue;
         end

--- a/matlab/unstable_examples/+imuSimulator/runConsistencyTests.m
+++ b/matlab/unstable_examples/+imuSimulator/runConsistencyTests.m
@@ -117,7 +117,7 @@ for i = 1:size(testOptions,1)
         imuSimulator.covarianceAnalysisBetween;
     catch
         errorRuns = [errorRuns i];
-        fprintf('\n*****\n   Something went wrong, most likely indeterminant linear system error.\n');
+        fprintf('\n*****\n   Something went wrong, most likely indeterminate linear system error.\n');
         disp('Test Options:\n');
         disp(testOptions(i,:));
         disp('Noises');
@@ -153,7 +153,6 @@ for i = 1:length(errorRuns)
     fprintf('  sigma_gyroBias = %f\n', noises(i,6));
     fprintf('  sigma_gps = %f\n', noises(i,7));
 end
-
 
 
 


### PR DESCRIPTION
## Summary

- introduce the correctly spelled `IndeterminateSystemException` and retain `IndeterminantLinearSystemException` as a GTSAM 4.3-gated deprecated alias
- update internal throw/catch sites, diagnostics, and related documentation to use the corrected name
- add a runnable user-guide notebook for diagnosing rank deficiency, null spaces, conditioning, gauges, and lost observability
- add the same debugging guidance to the repository Copilot instructions

## Why

The public exception name was misspelled, and issue #550 highlighted that users lacked a concrete workflow for finding the modeling or observability problem behind the reported nearby variable.

With deprecated APIs enabled, existing source code remains compatible through the alias. Disabling `GTSAM_ALLOW_DEPRECATED_SINCE_V43` exposes only the corrected API.

Addresses #550.

## Validation

- `make -j6 testLinearExceptions.run` with GTSAM 4.3 deprecated APIs enabled
- `make -j6 testLinearExceptions.run` with `GTSAM_ALLOW_DEPRECATED_SINCE_V43=OFF`
- `make -j6 testFastSync.run testOrientedPlane3Factor.run`
- executed all six code cells in `IndeterminateSystemException.ipynb`
- `git diff --check`