### PR TITLE
Document covariance frames for between and prior factors

### DIFF
--- a/gtsam/nonlinear/PriorFactor.h
+++ b/gtsam/nonlinear/PriorFactor.h
@@ -21,6 +21,15 @@ namespace gtsam {
 
 /**
  * A class for a soft prior on any Value type.
+ *
+ * The noise model applies to `-Local(value, prior)`. For pose types using
+ * GTSAM's right-hand retraction and exponential-map chart, the covariance is
+ * expressed in the local/body frame of the prior pose. For `Pose3`, the
+ * tangent-space order is rotation followed by translation.
+ *
+ * See `gtsam/nonlinear/doc/PriorFactor.ipynb` for a detailed discussion of
+ * coordinate frames and covariance conventions.
+ *
  * @ingroup nonlinear
  **/
 template <class VALUE>

--- a/gtsam/nonlinear/doc/PriorFactor.ipynb
+++ b/gtsam/nonlinear/doc/PriorFactor.ipynb
@@ -19,13 +19,13 @@
         "\n",
         "### Error Calculation\n",
         "\n",
-        "The primary role of the `PriorFactor` is to compute the error between the estimated value of a variable and its prior. You can think of the error as\n",
+        "The primary role of the `PriorFactor` is to compute the local error between the estimated value of a variable and its prior. If $x$ is the estimated value and $\\mu$ is the prior mean, the unwhitened residual is\n",
         "\n",
         "$$\n",
-        "e(x) = x \\ominus \\mu\n",
+        "e(x) = -\\operatorname{Local}(x,\\mu).\n",
         "$$\n",
         "\n",
-        "where $x$ is the estimated value, and $\\mu$ is the prior mean, and $\\ominus$ is like subtraction. The error is then weighted by the noise model to form the contribution of this factor to the overall objective function.\n",
+        "The noise model whitens this vector, and the resulting scalar loss contributes to the graph's objective.\n",
         "\n",
         "### Adding to a Factor Graph\n",
         "\n",
@@ -33,17 +33,9 @@
         "\n",
         "## Usage Considerations\n",
         "\n",
-        "- **Noise Model**: The choice of noise model is critical as it determines how strongly the prior is enforced. A tighter noise model implies a stronger belief in the prior. *Note that very strong priors might make the condition number of the linear systems to be solved very high. In this case consider adding a [NonlinearEqualityFactor](./NonlinearEquality.ipynb)\n",
+        "- **Noise Model**: The choice of noise model is critical as it determines how strongly the prior is enforced. A tighter noise model implies a stronger belief in the prior. Very strong priors can make the linear systems ill-conditioned; in that case, consider using [NonlinearEquality](./NonlinearEquality.ipynb).\n",
         "- **Integration with Other Factors**: The `PriorFactor` is typically used in conjunction with other factors that model the system dynamics and measurements. It helps anchor the solution, especially in scenarios with limited or noisy measurements.\n",
         "- **Applications**: Common applications include SLAM (Simultaneous Localization and Mapping), where priors on initial poses or landmarks can significantly improve map accuracy and convergence speed."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_priorfactor__colab_button",
-      "metadata": {},
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/PriorFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
@@ -65,6 +57,14 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "id": "gtsam_nonlinear_doc_priorfactor__colab_button",
+      "metadata": {},
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/PriorFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
       "cell_type": "code",
       "execution_count": null,
       "id": "gtsam_nonlinear_doc_priorfactor__colab_import",
@@ -80,6 +80,65 @@
         "    %pip install --quiet gtsam-develop\n",
         "except ImportError:\n",
         "    pass"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "gtsam_nonlinear_doc_priorfactor__imports_code",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "\n",
+        "X = gtsam.symbol_shorthand.X"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "gtsam_nonlinear_doc_priorfactor__noise_frame_md",
+      "metadata": {},
+      "source": [
+        "## Noise model and coordinate frame\n",
+        "\n",
+        "The covariance passed to `PriorFactor` is the covariance of its local residual $e(x)=-\\operatorname{Local}(x,\\mu)$. For vector spaces this is simply $x-\\mu$. For Lie groups whose origin chart uses the logarithm map,\n",
+        "\n",
+        "$$ e(x)=\\operatorname{Log}(\\mu^{-1}x), $$\n",
+        "\n",
+        "so a noisy value can be written using GTSAM's right-hand retraction as\n",
+        "\n",
+        "$$ x=\\operatorname{Retract}_{\\mu}(\\eta)=\\mu\\,\\operatorname{Exp}(\\eta), \\qquad \\eta\\sim\\mathcal N(0,\\Sigma). $$\n",
+        "\n",
+        "Consequently, when $\\mu={}^WT_B$ is a `Pose2` or `Pose3` prior, $\\eta$ and $\\Sigma$ are expressed in the local/body axes of the prior pose $B$, not in the world axes $W$. The mean pose itself is still expressed in $W$. Saying that the covariance lives in a tangent space describes its algebraic representation; the right-hand retraction determines its physical coordinate frame.\n",
+        "\n",
+        "For `Pose3`, tangent vectors and covariance matrices use the order $[\\omega_x,\\omega_y,\\omega_z,\\rho_x,\\rho_y,\\rho_z]$: rotation first, then translation. The rotational components are local axis-angle increments, not roll, pitch, and yaw. `Pose2` uses $[\\delta x,\\delta y,\\delta\\theta]$. `noiseModel.Diagonal.Sigmas` expects standard deviations; use `Variances` or `Gaussian.Covariance` for variances or a full covariance matrix.\n",
+        "\n",
+        "For a general manifold, or a type configured with a different origin chart, the literal residual $-\\operatorname{Local}(x,\\mu)$ is authoritative; see the remarks below."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "gtsam_nonlinear_doc_priorfactor__noise_frame_code",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# A right-hand perturbation of a Pose3 prior is recovered as its residual.\n",
+        "prior_mean = gtsam.Pose3(\n",
+        "    gtsam.Rot3.RzRyRx(0.2, -0.1, 0.3), gtsam.Point3(1.0, 0.5, -0.2)\n",
+        ")\n",
+        "delta_b = np.array([0.01, -0.02, 0.03, 0.10, -0.05, 0.02])\n",
+        "perturbed_pose = prior_mean.retract(delta_b)\n",
+        "\n",
+        "unit_noise_6 = gtsam.noiseModel.Unit.Create(6)\n",
+        "prior_factor = gtsam.PriorFactorPose3(X(0), prior_mean, unit_noise_6)\n",
+        "values = gtsam.Values()\n",
+        "values.insert(X(0), perturbed_pose)\n",
+        "\n",
+        "computed_delta_b = prior_factor.unwhitenedError(values)\n",
+        "np.testing.assert_allclose(computed_delta_b, delta_b, atol=1e-9)\n",
+        "print(\"Prior-body perturbation:\", computed_delta_b)"
       ]
     },
     {
@@ -113,11 +172,11 @@
         "$$\n",
         "where `localCoordinates` is the inverse of `retract`. We implement it this way, because the Jacobian at $x$ is identity, which is computationally advantageous.\n",
         "\n",
-        "For Lie groups $\\cal G$ where $\\text{localCoordinates}$ is implemented as $\\text{Log}$, the inverse of the exponential map $\\text{Exp}$, we have\n",
+        "For Lie groups where `localCoordinates` is implemented with the logarithm map, the inverse of the exponential map, we have\n",
         "$$\n",
         "- x.\\text{localCoordinates}(\\mu) = \\text{Log}(\\mu^{-1} x)\n",
         "$$\n",
-        "However, for general manifolds $\\cal M$, it might not be true that\n",
+        "However, for general manifolds, it might not be true that\n",
         "$$\n",
         "- x.\\text{localCoordinates}(\\mu) = \\mu.\\text{localCoordinates}(x)\n",
         "$$\n",

--- a/gtsam/slam/BetweenFactor.h
+++ b/gtsam/slam/BetweenFactor.h
@@ -34,6 +34,15 @@ namespace gtsam {
 
   /**
    * A class for a measurement predicted by "between(config[key1],config[key2])"
+   *
+   * The noise model applies to `Local(measured, between(p1, p2))`. For pose
+   * types using GTSAM's right-hand retraction, this means the covariance is
+   * expressed in the local frame of the second (target) pose. For `Pose3`, the
+   * tangent-space order is rotation followed by translation.
+   *
+   * See `gtsam/slam/doc/BetweenFactor.ipynb` for a detailed discussion of
+   * coordinate frames and covariance conventions.
+   *
    * @tparam VALUE the Value type
    * @ingroup slam
    */

--- a/gtsam/slam/doc/BetweenFactor.ipynb
+++ b/gtsam/slam/doc/BetweenFactor.ipynb
@@ -6,7 +6,19 @@
         "id": "gtsam_slam_doc_betweenfactor__intro_md"
       },
       "source": [
-        "# BetweenFactor"
+        "# BetweenFactor\n",
+        "\n",
+        "`BetweenFactor<VALUE>` represents a measurement of the relative transformation between two variables of the same Lie-group type. Common examples are `BetweenFactorPose2` for 2D odometry and `BetweenFactorPose3` for 3D odometry or relative-pose measurements.\n",
+        "\n",
+        "If the factor connects values $X_1$ and $X_2$ and the measurement is $Z$, its unwhitened residual is\n",
+        "\n",
+        "$$ r(X_1, X_2; Z) = \\operatorname{Local}\\left(Z, \\operatorname{Between}(X_1, X_2)\\right). $$\n",
+        "\n",
+        "Here $\\operatorname{Between}(X_1,X_2)=X_1^{-1}X_2$ is the predicted relative transformation. For a Lie group whose origin chart uses the exponential and logarithm maps, this becomes\n",
+        "\n",
+        "$$ r(X_1, X_2; Z) = \\operatorname{Log}\\left(Z^{-1}X_1^{-1}X_2\\right). $$\n",
+        "\n",
+        "The noise model whitens this residual, and the resulting scalar loss contributes to the graph's objective. `BetweenConstraint<VALUE>` is a derived class that uses a constrained noise model to enforce the relative transformation exactly."
       ]
     },
     {
@@ -19,28 +31,6 @@
       },
       "source": [
         "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_slam_doc_betweenfactor__desc_md"
-      },
-      "source": [
-        "`BetweenFactor<VALUE>` is a fundamental factor in GTSAM used to represent measurements of the relative transformation (motion) between two variables of the same type `VALUE`.\n",
-        "Common examples include:\n",
-        "*   `BetweenFactorPose2`: Represents odometry measurements between 2D robot poses.\n",
-        "*   `BetweenFactorPose3`: Represents odometry or relative pose estimates between 3D poses.\n",
-        "\n",
-        "The `VALUE` type must be a Lie Group (e.g., `Pose2`, `Pose3`, `Rot2`, `Rot3`).\n",
-        "\n",
-        "The factor encodes a constraint based on the measurement `measured_`, such that the error is calculated based on the difference between the predicted relative transformation and the measured one. Specifically, if the factor connects keys $k_1$ and $k_2$ corresponding to values $X_1$ and $X_2$, and the measurement is $Z$, the factor aims to minimize:\n",
-        "\n",
-        "$$ \\text{error}(X_1, X_2) = \\text{Log}(Z^{-1} \\cdot (X_1^{-1} \\cdot X_2)) $$\n",
-        "\n",
-        "where `Log` is the logarithmic map for the Lie group `VALUE`, $X_1^{-1} \\cdot X_2$ is the predicted relative transformation `between(X1, X2)`, and $Z^{-1}$ is the inverse of the measurement. The error vector lives in the tangent space of the identity element of the group.\n",
-        "\n",
-        "`BetweenConstraint<VALUE>` is a derived class that uses a `noiseModel::Constrained` noise model, effectively enforcing the relative transformation to be exactly the measured value."
       ]
     },
     {
@@ -63,7 +53,11 @@
       },
       "outputs": [],
       "source": [
-        "%pip install --quiet gtsam-develop"
+        "try:\n",
+        "    import google.colab\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "except ImportError:\n",
+        "    pass"
       ]
     },
     {
@@ -83,6 +77,63 @@
         "import graphviz\n",
         "\n",
         "X = symbol_shorthand.X"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gtsam_slam_doc_betweenfactor__noise_frame_md"
+      },
+      "source": [
+        "## Noise model and coordinate frame\n",
+        "\n",
+        "Suppose $X_1={}^WT_A$ and $X_2={}^WT_B$ are poses of frames $A$ and $B$ in a world frame $W$. The measured relative pose is\n",
+        "\n",
+        "$$ Z={}^AT_B=X_1^{-1}X_2. $$\n",
+        "\n",
+        "The transform $Z$ is expressed in frame $A$: for example, its translation is the origin of $B$ written in $A$ coordinates. The covariance passed to `BetweenFactor`, however, is the covariance of the local residual $r$, not a covariance of the matrix entries or pose parameters used to construct $Z$.\n",
+        "\n",
+        "GTSAM uses a right-hand retraction. A local perturbation around the measurement is therefore\n",
+        "\n",
+        "$$ \\operatorname{Retract}_Z(\\eta)=Z\\,\\operatorname{Retract}_I(\\eta), $$\n",
+        "\n",
+        "or, for an exponential-map chart, $Z\\operatorname{Exp}(\\eta)$. Consequently, for `Pose2`, `Pose3`, `Rot2`, and `Rot3`, $\\eta$ and its covariance are expressed in the local axes of the second (target) frame $B$. The statement that the residual is represented in the tangent space at the identity describes its algebraic representation; the right-hand retraction determines its physical coordinate frame.\n",
+        "\n",
+        "For `Pose3`, tangent vectors and covariance matrices use the order $[\\omega_x,\\omega_y,\\omega_z,\\rho_x,\\rho_y,\\rho_z]$: rotation first, then translation. The rotational components are local axis-angle increments, not roll, pitch, and yaw. `Pose2` uses $[\\delta x,\\delta y,\\delta\\theta]$. Also note that `noiseModel.Diagonal.Sigmas` expects standard deviations; use `Variances` or `Gaussian.Covariance` when starting from variances or a full covariance matrix.\n",
+        "\n",
+        "If a covariance $\\Sigma_A$ instead describes a left-hand perturbation in the source frame, convert it before constructing the factor:\n",
+        "\n",
+        "$$ \\Sigma_B = \\operatorname{Ad}_{Z^{-1}}\\,\\Sigma_A\\,\\operatorname{Ad}_{Z^{-1}}^T. $$\n",
+        "\n",
+        "Likewise, a covariance expressed in Euler angles or another pose parameterization must be propagated through the Jacobian from those parameters to GTSAM's local coordinates."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "gtsam_slam_doc_betweenfactor__noise_frame_code"
+      },
+      "outputs": [],
+      "source": [
+        "# A right-hand perturbation is recovered directly as the factor residual.\n",
+        "measurement = Pose3(\n",
+        "    Rot3.RzRyRx(0.2, -0.1, 0.3), Point3(1.0, 0.5, -0.2)\n",
+        ")\n",
+        "delta_b = np.array([0.01, -0.02, 0.03, 0.10, -0.05, 0.02])\n",
+        "predicted_relative = measurement.retract(delta_b)\n",
+        "\n",
+        "pose_a = Pose3(Rot3.Yaw(0.4), Point3(2.0, -1.0, 0.5))\n",
+        "pose_b = pose_a.compose(predicted_relative)\n",
+        "unit_noise_6 = gtsam.noiseModel.Unit.Create(6)\n",
+        "frame_factor = BetweenFactorPose3(X(10), X(11), measurement, unit_noise_6)\n",
+        "frame_values = Values()\n",
+        "frame_values.insert(X(10), pose_a)\n",
+        "frame_values.insert(X(11), pose_b)\n",
+        "\n",
+        "computed_delta_b = frame_factor.unwhitenedError(frame_values)\n",
+        "np.testing.assert_allclose(computed_delta_b, delta_b, atol=1e-9)\n",
+        "print(\"Target-frame perturbation:\", computed_delta_b)"
       ]
     },
     {
@@ -165,50 +216,39 @@
         "id": "gtsam_slam_doc_betweenfactor__eval_desc_md"
       },
       "source": [
-        "The `.error(values)` method calculates the error vector based on the current estimates of the variables in the `Values` object."
+        "`unwhitenedError(values)` returns the vector residual defined above. `whitenedError(values)` applies the noise model and also returns a vector. In contrast, `error(values)` returns the scalar loss contributed by the factor; for a Gaussian noise model this is one half of the squared norm of the whitened residual."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": null,
       "metadata": {
         "id": "gtsam_slam_doc_betweenfactor__eval_example_code"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Error vector for BetweenFactorPose2: 0.3750000000000002\n",
-            "Manual unwhitened error calculation: [0.10247917 0.09747917 0.05      ]\n",
-            "Factor unwhitened error: [0.1  0.1  0.05]\n",
-            "Manually whitened error: [0.51239583 0.48739583 0.5       ]\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "values = Values()\n",
         "values.insert(X(0), Pose2(0.0, 0.0, 0.0))\n",
         "values.insert(X(1), Pose2(1.1, 0.1, 0.05)) # Slightly off from measurement\n",
         "\n",
-        "# Evaluate the error for the Pose2 factor\n",
-        "error_vector = between_factor_pose2.error(values)\n",
-        "print(f\"Error vector for BetweenFactorPose2: {error_vector}\")\n",
-        "\n",
-        "# The unwhitened error is Log(Z^-1 * (X1^-1 * X2))\n",
+        "# Reproduce the factor's local-coordinate residual.\n",
         "pose0 = values.atPose2(X(0))\n",
         "pose1 = values.atPose2(X(1))\n",
         "predicted_relative = pose0.between(pose1)\n",
-        "error_pose = measured_pose2.inverse() * predicted_relative\n",
-        "unwhitened_error_expected = Pose2.Logmap(error_pose)\n",
-        "print(f\"Manual unwhitened error calculation: {unwhitened_error_expected}\")\n",
-        "print(f\"Factor unwhitened error: {between_factor_pose2.unwhitenedError(values)}\")\n",
+        "unwhitened_expected = measured_pose2.localCoordinates(predicted_relative)\n",
+        "unwhitened = between_factor_pose2.unwhitenedError(values)\n",
+        "whitened = between_factor_pose2.whitenedError(values)\n",
+        "scalar_loss = between_factor_pose2.error(values)\n",
         "\n",
-        "# The whitened error (returned by error()) applies the noise model\n",
-        "# For diagonal noise model, error_vector = unwhitened_error / sigmas\n",
         "sigmas = odometry_noise.sigmas()\n",
-        "whitened_expected = unwhitened_error_expected / sigmas\n",
-        "print(f\"Manually whitened error: {whitened_expected}\")"
+        "whitened_expected = unwhitened_expected / sigmas\n",
+        "np.testing.assert_allclose(unwhitened, unwhitened_expected)\n",
+        "np.testing.assert_allclose(whitened, whitened_expected)\n",
+        "np.testing.assert_allclose(scalar_loss, 0.5 * whitened @ whitened)\n",
+        "\n",
+        "print(f\"Unwhitened residual: {unwhitened}\")\n",
+        "print(f\"Whitened residual: {whitened}\")\n",
+        "print(f\"Scalar factor loss: {scalar_loss}\")"
       ]
     },
     {


### PR DESCRIPTION
## Summary

- document the exact `Local` residual used by `BetweenFactor`
- clarify that pose-factor covariance uses the target pose's local/body frame under GTSAM's right-hand retraction
- add the analogous local/body-frame clarification to `PriorFactor`
- document `Pose2`/`Pose3` tangent ordering, `Sigmas` semantics, and covariance conversion with the adjoint
- add executable `Pose3` examples and concise API-header pointers to the notebooks

## Motivation

The existing documentation did not say which coordinate frame a `BetweenFactor` covariance is expressed in. This made it easy to confuse the source frame, target frame, and the tangent-space representation, especially when importing covariances from Euler-angle or world-frame parameterizations.

These changes make the implemented residual authoritative and connect its right-hand perturbation convention to the physical frame users need when constructing noise models. The same convention is now explained for pose priors.

## Validation

- executed `BetweenFactor.ipynb` and `PriorFactor.ipynb` successfully in the `py312` environment
- validated notebook JSON and checked the patch with `git diff --check`
- built both pages with the repository MyST configuration; all 258 pages were generated before the sandbox blocked the preview server from binding to port 3100

Closes #504.