### PR TITLE
Fix 32-bit Python bindings for 64-bit GTSAM keys

### DIFF
--- a/gtsam/discrete/discrete.i
+++ b/gtsam/discrete/discrete.i
@@ -207,7 +207,7 @@ virtual class TableDistribution : gtsam::DiscreteConditional {
 
   gtsam::TableFactor table() const;
   double evaluate(const gtsam::DiscreteValues& values) const;
-  size_t nrValues() const;
+  uint64_t nrValues() const;
 };
 
 #include <gtsam/discrete/DiscreteBayesNet.h>
@@ -287,13 +287,13 @@ class DiscreteBayesTree {
 
   size_t size() const;
   bool empty() const;
-  const DiscreteBayesTreeClique* operator[](size_t j) const;
-  const DiscreteBayesTreeClique* clique(size_t j) const;
+  const DiscreteBayesTreeClique* operator[](gtsam::Key j) const;
+  const DiscreteBayesTreeClique* clique(gtsam::Key j) const;
   size_t numCachedSeparatorMarginals() const;
 
   gtsam::DiscreteConditional* marginalFactor(gtsam::Key key) const;
-  gtsam::DiscreteFactorGraph* joint(size_t j1, size_t j2) const;
-  gtsam::DiscreteBayesNet* jointBayesNet(size_t j1, size_t j2) const;
+  gtsam::DiscreteFactorGraph* joint(gtsam::Key j1, gtsam::Key j2) const;
+  gtsam::DiscreteBayesNet* jointBayesNet(gtsam::Key j1, gtsam::Key j2) const;
 
   double evaluate(const gtsam::DiscreteValues& values) const;
   double operator()(const gtsam::DiscreteValues& values) const;

--- a/gtsam/gtsam.i
+++ b/gtsam/gtsam.i
@@ -29,8 +29,8 @@ class KeyList {
   void clear();
 
   // structure specific methods
-  size_t front() const;
-  size_t back() const;
+  gtsam::Key front() const;
+  gtsam::Key back() const;
   void push_back(gtsam::Key key);
   void push_front(gtsam::Key key);
   void pop_back();
@@ -89,9 +89,9 @@ class KeyVector {
   void clear();
 
   // structure specific methods
-  size_t at(size_t i) const;
-  size_t front() const;
-  size_t back() const;
+  gtsam::Key at(size_t i) const;
+  gtsam::Key front() const;
+  gtsam::Key back() const;
   void push_back(gtsam::Key key) const;
 
   void serialize() const;
@@ -114,7 +114,7 @@ class KeyGroupMap {
   void clear();
 
   // structure specific methods
-  size_t at(gtsam::Key key) const;
+  int at(gtsam::Key key) const;
   int erase(gtsam::Key key);
   bool insert2(gtsam::Key key, int val);
 };
@@ -131,9 +131,9 @@ class FactorIndexSet {
   void clear();
 
   // structure specific methods
-  void insert(size_t factorIndex);
-  bool erase(size_t factorIndex);        // returns true if value was removed
-  bool count(size_t factorIndex) const;  // returns true if value exists
+  void insert(gtsam::FactorIndex factorIndex);
+  bool erase(gtsam::FactorIndex factorIndex);        // returns true if value was removed
+  bool count(gtsam::FactorIndex factorIndex) const;  // returns true if value exists
 };
 
 // Actually a vector<FactorIndex>
@@ -148,10 +148,10 @@ class FactorIndices {
   void clear();
 
   // structure specific methods
-  size_t at(size_t i) const;
-  size_t front() const;
-  size_t back() const;
-  void push_back(size_t factorIndex) const;
+  gtsam::FactorIndex at(size_t i) const;
+  gtsam::FactorIndex front() const;
+  gtsam::FactorIndex back() const;
+  void push_back(gtsam::FactorIndex factorIndex) const;
 };
 
 //*************************************************************************
@@ -185,7 +185,7 @@ void insertBackprojections(gtsam::Values& values,
                            const gtsam::Vector& J, gtsam::ConstMatrixView Z,
                            double depth);
 void insertProjectionFactors(
-    gtsam::NonlinearFactorGraph& graph, size_t i, const gtsam::Vector& J,
+    gtsam::NonlinearFactorGraph& graph, gtsam::Key i, const gtsam::Vector& J,
     gtsam::ConstMatrixView Z,
     const gtsam::noiseModel::Base* model, const gtsam::Cal3_S2* K,
     const gtsam::Pose3& body_P_sensor = gtsam::Pose3());

--- a/gtsam/hybrid/hybrid.i
+++ b/gtsam/hybrid/hybrid.i
@@ -202,13 +202,13 @@ class HybridGaussianConditional : gtsam::HybridGaussianFactor {
       const gtsam::DiscreteKey& discreteParent,
       const std::vector<gtsam::GaussianConditional::shared_ptr>& conditionals);
   HybridGaussianConditional(
-      const gtsam::DiscreteKey& discreteParent, size_t key,
-      const gtsam::Matrix& A, size_t parent,
+      const gtsam::DiscreteKey& discreteParent, gtsam::Key key,
+      const gtsam::Matrix& A, gtsam::Key parent,
       const std::vector<std::pair<gtsam::Vector, double>>& parameters);
   HybridGaussianConditional(
-      const gtsam::DiscreteKey& discreteParent, size_t key,  //
-      const gtsam::Matrix& A1, size_t parent1, const gtsam::Matrix& A2,
-      size_t parent2,
+      const gtsam::DiscreteKey& discreteParent, gtsam::Key key,  //
+      const gtsam::Matrix& A1, gtsam::Key parent1, const gtsam::Matrix& A2,
+      gtsam::Key parent2,
       const std::vector<std::pair<gtsam::Vector, double>>& parameters);
 
   // Standard API
@@ -253,7 +253,7 @@ virtual class HybridBayesTree {
 
   size_t size() const;
   bool empty() const;
-  const HybridBayesTreeClique* operator[](size_t j) const;
+  const HybridBayesTreeClique* operator[](gtsam::Key j) const;
 
   gtsam::HybridValues optimize() const;
   gtsam::VectorValues optimize(const gtsam::DiscreteValues& assignment) const;

--- a/gtsam/inference/LabeledSymbol.h
+++ b/gtsam/inference/LabeledSymbol.h
@@ -84,7 +84,7 @@ class GTSAM_EXPORT LabeledSymbol {
   inline unsigned char chr() const { return c_; }
 
   /// Retrieve key index
-  inline size_t index() const { return j_; }
+  inline std::uint64_t index() const { return j_; }
 
   /// Create a string from the key
   operator std::string() const;
@@ -155,7 +155,7 @@ class GTSAM_EXPORT LabeledSymbol {
 };  // \class LabeledSymbol
 
 /// Create a symbol key from a character, label and index, i.e. xA5.
-inline Key mrsymbol(unsigned char c, unsigned char label, size_t j) {
+inline Key mrsymbol(unsigned char c, unsigned char label, std::uint64_t j) {
   return (Key)LabeledSymbol(c, label, j);
 }
 
@@ -168,7 +168,9 @@ inline unsigned char mrsymbolLabel(Key key) {
 }
 
 /// Return the index portion of a symbol key.
-inline size_t mrsymbolIndex(Key key) { return LabeledSymbol(key).index(); }
+inline std::uint64_t mrsymbolIndex(Key key) {
+  return LabeledSymbol(key).index();
+}
 
 /// traits
 template <>

--- a/gtsam/inference/inference.i
+++ b/gtsam/inference/inference.i
@@ -39,49 +39,49 @@ class Symbol {
   string string() const;
 };
 
-gtsam::Key symbol(char chr, size_t index);
+gtsam::Key symbol(char chr, uint64_t index);
 char symbolChr(gtsam::Key key);
-size_t symbolIndex(gtsam::Key key);
+uint64_t symbolIndex(gtsam::Key key);
 
 namespace symbol_shorthand {
-gtsam::Key A(size_t j);
-gtsam::Key B(size_t j);
-gtsam::Key C(size_t j);
-gtsam::Key D(size_t j);
-gtsam::Key E(size_t j);
-gtsam::Key F(size_t j);
-gtsam::Key G(size_t j);
-gtsam::Key H(size_t j);
-gtsam::Key I(size_t j);
-gtsam::Key J(size_t j);
-gtsam::Key K(size_t j);
-gtsam::Key L(size_t j);
-gtsam::Key M(size_t j);
-gtsam::Key N(size_t j);
-gtsam::Key O(size_t j);
-gtsam::Key P(size_t j);
-gtsam::Key Q(size_t j);
-gtsam::Key R(size_t j);
-gtsam::Key S(size_t j);
-gtsam::Key T(size_t j);
-gtsam::Key U(size_t j);
-gtsam::Key V(size_t j);
-gtsam::Key W(size_t j);
-gtsam::Key X(size_t j);
-gtsam::Key Y(size_t j);
-gtsam::Key Z(size_t j);
+gtsam::Key A(uint64_t j);
+gtsam::Key B(uint64_t j);
+gtsam::Key C(uint64_t j);
+gtsam::Key D(uint64_t j);
+gtsam::Key E(uint64_t j);
+gtsam::Key F(uint64_t j);
+gtsam::Key G(uint64_t j);
+gtsam::Key H(uint64_t j);
+gtsam::Key I(uint64_t j);
+gtsam::Key J(uint64_t j);
+gtsam::Key K(uint64_t j);
+gtsam::Key L(uint64_t j);
+gtsam::Key M(uint64_t j);
+gtsam::Key N(uint64_t j);
+gtsam::Key O(uint64_t j);
+gtsam::Key P(uint64_t j);
+gtsam::Key Q(uint64_t j);
+gtsam::Key R(uint64_t j);
+gtsam::Key S(uint64_t j);
+gtsam::Key T(uint64_t j);
+gtsam::Key U(uint64_t j);
+gtsam::Key V(uint64_t j);
+gtsam::Key W(uint64_t j);
+gtsam::Key X(uint64_t j);
+gtsam::Key Y(uint64_t j);
+gtsam::Key Z(uint64_t j);
 }  // namespace symbol_shorthand
 
 #include <gtsam/inference/LabeledSymbol.h>
 class LabeledSymbol {
   LabeledSymbol(gtsam::Key full_key);
   LabeledSymbol(const gtsam::LabeledSymbol& key);
-  LabeledSymbol(unsigned char valType, unsigned char label, size_t j);
+  LabeledSymbol(unsigned char valType, unsigned char label, uint64_t j);
 
   gtsam::Key key() const;
   unsigned char label() const;
   unsigned char chr() const;
-  size_t index() const;
+  uint64_t index() const;
 
   gtsam::LabeledSymbol upper() const;
   gtsam::LabeledSymbol lower() const;
@@ -91,10 +91,10 @@ class LabeledSymbol {
   void print(string s = "") const;
 };
 
-gtsam::Key mrsymbol(unsigned char c, unsigned char label, size_t j);
+gtsam::Key mrsymbol(unsigned char c, unsigned char label, uint64_t j);
 unsigned char mrsymbolChr(gtsam::Key key);
 unsigned char mrsymbolLabel(gtsam::Key key);
-size_t mrsymbolIndex(gtsam::Key key);
+uint64_t mrsymbolIndex(gtsam::Key key);
 
 #include <gtsam/inference/EdgeKey.h>
 class EdgeKey {
@@ -117,7 +117,7 @@ class Ordering {
   // Standard Constructors and Named Constructors
   Ordering();
   Ordering(const gtsam::Ordering& other);
-  Ordering(const std::vector<size_t>& keys);
+  Ordering(const gtsam::KeyVector& keys);
 
   template <
       FACTOR_GRAPH = {gtsam::NonlinearFactorGraph,
@@ -168,7 +168,7 @@ class Ordering {
 
   // Standard interface
   size_t size() const;
-  size_t at(size_t i) const;
+  gtsam::Key at(size_t i) const;
   void push_back(gtsam::Key key);
 
   // enabling serialization functionality

--- a/gtsam/inference/tests/testLabeledSymbol.cpp
+++ b/gtsam/inference/tests/testLabeledSymbol.cpp
@@ -35,7 +35,7 @@ TEST(LabeledSymbol, KeyLabeledSymbolConversion ) {
 /* ************************************************************************* */
 TEST(LabeledSymbol, KeyLabeledSymbolEncoding ) {
 
-  // Test encoding of LabeledSymbol <-> size_t <-> string
+  // Test encoding of LabeledSymbol <-> Key <-> string
   // Encoding scheme:
   // Top 8 bits: variable type (255 possible values) - zero will not process
   // Next 8 high bits: variable type (255 possible values)
@@ -64,6 +64,16 @@ TEST(LabeledSymbol, KeyLabeledSymbolEncoding ) {
     EXPECT(assert_equal(str, MultiRobotKeyFormatter(symbol)));
     EXPECT(assert_equal(symbol, LabeledSymbol(key)));
   }
+}
+
+/* ************************************************************************* */
+// Verifies that labeled-symbol indices are not narrowed on 32-bit platforms.
+TEST(LabeledSymbol, LargeIndex) {
+  const std::uint64_t largeIndex = (std::uint64_t{1} << 32) + 7;
+  const LabeledSymbol symbol('x', 'A', largeIndex);
+
+  EXPECT(largeIndex == symbol.index());
+  EXPECT(largeIndex == mrsymbolIndex(mrsymbol('x', 'A', largeIndex)));
 }
 
 /* ************************************************************************* */
@@ -103,4 +113,3 @@ int main() {
   return TestRegistry::runAllTests(tr);
 }
 /* ************************************************************************* */
-

--- a/gtsam/linear/linear.i
+++ b/gtsam/linear/linear.i
@@ -6,24 +6,24 @@ namespace gtsam {
 #include <gtsam/base/SymmetricBlockMatrix.h>
 class SymmetricBlockMatrix {
   SymmetricBlockMatrix();
-  SymmetricBlockMatrix(const std::vector<size_t>& dimensions,
+  SymmetricBlockMatrix(const std::vector<gtsam::DenseIndex>& dimensions,
                        bool appendOneDimension = false);
-  SymmetricBlockMatrix(const std::vector<size_t>& dimensions,
+  SymmetricBlockMatrix(const std::vector<gtsam::DenseIndex>& dimensions,
                        const gtsam::Matrix& matrix,
                        bool appendOneDimension = false);
 
-  size_t rows() const;
-  size_t cols() const;
-  size_t nBlocks() const;
-  size_t getDim(size_t block) const;
-  gtsam::Matrix block(size_t I, size_t J) const;
+  gtsam::DenseIndex rows() const;
+  gtsam::DenseIndex cols() const;
+  gtsam::DenseIndex nBlocks() const;
+  gtsam::DenseIndex getDim(gtsam::DenseIndex block) const;
+  gtsam::Matrix block(gtsam::DenseIndex I, gtsam::DenseIndex J) const;
   void setZero();
   void setAllZero();
 };
 
 #include <gtsam/linear/JointMarginal.h>
 class JointMarginal {
-  gtsam::Matrix at(size_t iVariable, size_t jVariable) const;
+  gtsam::Matrix at(gtsam::Key iVariable, gtsam::Key jVariable) const;
   gtsam::Matrix fullMatrix() const;
   void print(string s = "", gtsam::KeyFormatter keyFormatter =
                                 gtsam::DefaultKeyFormatter) const;
@@ -321,16 +321,16 @@ class VectorValues {
 
   //Standard Interface
   size_t size() const;
-  size_t dim(size_t j) const;
-  bool exists(size_t j) const;
+  size_t dim(gtsam::Key j) const;
+  bool exists(gtsam::Key j) const;
   void print(string s = "VectorValues",
              const gtsam::KeyFormatter& keyFormatter =
                  gtsam::DefaultKeyFormatter) const;
   bool equals(const gtsam::VectorValues& x, double tol) const;
-  void insert(size_t j, gtsam::Vector value);
+  void insert(gtsam::Key j, gtsam::Vector value);
   gtsam::Vector vector() const;
   gtsam::Vector vector(const gtsam::KeyVector& keys) const;
-  gtsam::Vector at(size_t j) const;
+  gtsam::Vector at(gtsam::Key j) const;
   void insert(const gtsam::VectorValues& values);
   void update(const gtsam::VectorValues& values);
 
@@ -726,7 +726,7 @@ virtual class GaussianBayesTree {
   size_t size() const;
   bool empty() const;
   const gtsam::GaussianBayesTree::Roots& roots() const;
-  const gtsam::GaussianBayesTreeClique* operator[](size_t j) const;
+  const gtsam::GaussianBayesTreeClique* operator[](gtsam::Key j) const;
   size_t numCachedSeparatorMarginals() const;
 
   string dot(const gtsam::KeyFormatter& keyFormatter =
@@ -851,7 +851,7 @@ class KalmanFilter {
   // gtsam::GaussianDensity* init(gtsam::Vector x0, const gtsam::SharedDiagonal& P0);
   gtsam::GaussianDensity* init(gtsam::Vector x0, gtsam::Matrix P0);
   void print(string s = "") const;
-  static size_t step(gtsam::GaussianDensity* p);
+  static gtsam::Key step(gtsam::GaussianDensity* p);
   gtsam::GaussianDensity* predict(gtsam::GaussianDensity* p, gtsam::Matrix F,
       gtsam::Matrix B, gtsam::Vector u, const gtsam::noiseModel::Diagonal* modelQ);
   gtsam::GaussianDensity* predictQ(gtsam::GaussianDensity* p, gtsam::Matrix F,

--- a/gtsam/navigation/navigation.i
+++ b/gtsam/navigation/navigation.i
@@ -941,7 +941,7 @@ virtual class BarometricFactor : gtsam::NonlinearFactor {
 
 #include <gtsam/navigation/ConstantVelocityFactor.h>
 class ConstantVelocityFactor : gtsam::NonlinearFactor {
-  ConstantVelocityFactor(size_t i, size_t j, double dt, const gtsam::noiseModel::Base* model);
+  ConstantVelocityFactor(gtsam::Key i, gtsam::Key j, double dt, const gtsam::noiseModel::Base* model);
   gtsam::Vector evaluateError(const gtsam::NavState &x1, const gtsam::NavState &x2) const;
 };
 

--- a/gtsam/nonlinear/nonlinear.i
+++ b/gtsam/nonlinear/nonlinear.i
@@ -166,8 +166,8 @@ class Marginals {
 
   void print(string s = "Marginals: ", const gtsam::KeyFormatter& keyFormatter =
                                            gtsam::DefaultKeyFormatter) const;
-  gtsam::Matrix marginalCovariance(size_t variable) const;
-  gtsam::Matrix marginalInformation(size_t variable) const;
+  gtsam::Matrix marginalCovariance(gtsam::Key variable) const;
+  gtsam::Matrix marginalInformation(gtsam::Key variable) const;
   gtsam::JointMarginal jointMarginalCovariance(
       const gtsam::KeyVector& variables) const;
   gtsam::JointMarginal jointMarginalInformation(
@@ -904,9 +904,9 @@ template <T = {gtsam::Point2,
                gtsam::imuBias::ConstantBias}>
 virtual class NonlinearEquality : gtsam::NoiseModelFactor {
   // Constructor - forces exact evaluation
-  NonlinearEquality(size_t j, const T& feasible);
+  NonlinearEquality(gtsam::Key j, const T& feasible);
   // Constructor - allows inexact evaluation
-  NonlinearEquality(size_t j, const T& feasible, double error_gain);
+  NonlinearEquality(gtsam::Key j, const T& feasible, double error_gain);
 
   // enabling serialization functionality
   void serialize() const;

--- a/gtsam/symbolic/symbolic.i
+++ b/gtsam/symbolic/symbolic.i
@@ -207,7 +207,7 @@ class SymbolicBayesTree {
   bool empty() const;
   size_t size() const;
   const gtsam::SymbolicBayesTree::Roots& roots() const;
-  const gtsam::SymbolicBayesTreeClique* operator[](size_t j) const;
+  const gtsam::SymbolicBayesTreeClique* operator[](gtsam::Key j) const;
 
   void saveGraph(string s,
                 const gtsam::KeyFormatter& keyFormatter =

--- a/python/gtsam/tests/test_KeyWidth.py
+++ b/python/gtsam/tests/test_KeyWidth.py
@@ -1,0 +1,101 @@
+"""
+GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,
+Atlanta, Georgia 30332-0415
+All Rights Reserved
+
+See LICENSE for the license information.
+
+Regression tests for 64-bit keys on platforms where size_t is 32 bits.
+"""
+
+# pylint: disable=no-member
+
+import unittest
+
+import numpy as np
+
+import gtsam
+from gtsam.symbol_shorthand import X
+
+
+class TestKeyWidth(unittest.TestCase):
+    """Checks that wrapped keys are never narrowed to size_t."""
+
+    def test_large_symbol_indices(self):
+        """Symbol helpers should preserve indices larger than 32 bits."""
+        index = (1 << 32) + 7
+
+        key = gtsam.symbol("x", index)
+        self.assertEqual(gtsam.symbolIndex(key), index)
+        self.assertEqual(X(index), key)
+
+        labeled = gtsam.LabeledSymbol(ord("x"), ord("A"), index)
+        self.assertEqual(labeled.index(), index)
+        labeled_key = gtsam.mrsymbol(ord("x"), ord("A"), index)
+        self.assertEqual(gtsam.mrsymbolIndex(labeled_key), index)
+
+    def test_keyed_collections(self):
+        """Keyed collection APIs should accept an encoded symbolic key."""
+        key = X(0)
+
+        keys = gtsam.KeyList()
+        keys.push_back(key)
+        self.assertEqual(keys.front(), key)
+        self.assertEqual(keys.back(), key)
+
+        ordering = gtsam.Ordering([key])
+        self.assertEqual(ordering.at(0), key)
+
+        values = gtsam.VectorValues()
+        values.insert(key, np.array([1.0, 2.0]))
+        self.assertTrue(values.exists(key))
+        self.assertEqual(values.dim(key), 2)
+        np.testing.assert_array_equal(values.at(key), np.array([1.0, 2.0]))
+
+        groups = gtsam.KeyGroupMap()
+        groups.insert2(key, -1)
+        self.assertEqual(groups.at(key), -1)
+
+        density = gtsam.GaussianDensity.FromMeanAndStddev(
+            key, np.array([0.0]), 1.0
+        )
+        self.assertEqual(gtsam.KalmanFilter.step(density), key)
+
+    def test_keyed_factor_constructors(self):
+        """Factor constructors should retain symbolic keys."""
+        key0, key1, key2 = X(0), X(1), X(2)
+
+        equality = gtsam.NonlinearEqualityPose2(key0, gtsam.Pose2())
+        self.assertEqual(equality.keys(), [key0])
+
+        velocity = gtsam.ConstantVelocityFactor(
+            key0,
+            key1,
+            1.0,
+            gtsam.noiseModel.Isotropic.Sigma(9, 1.0),
+        )
+        self.assertEqual(velocity.keys(), [key0, key1])
+
+        mode = (gtsam.symbol("m", 0), 2)
+        parameters = [(np.array([0.0]), 1.0), (np.array([1.0]), 1.0)]
+        conditional = gtsam.HybridGaussianConditional(
+            mode, key0, np.eye(1), key1, np.eye(1), key2, parameters
+        )
+        self.assertEqual(conditional.keys()[:3], [key0, key1, key2])
+
+    def test_discrete_bayes_tree_key_queries(self):
+        """Bayes-tree lookup and joint queries should take Keys, not indices."""
+        key0, key1 = X(0), X(1)
+        graph = gtsam.DiscreteFactorGraph()
+        graph.add([(key0, 2)], "1 1")
+        graph.add([(key0, 2), (key1, 2)], "1 2 3 4")
+
+        tree = graph.eliminateMultifrontal(gtsam.Ordering([key0, key1]))
+        self.assertIsNotNone(tree[key0])
+        self.assertIsNotNone(tree.clique(key1))
+        self.assertEqual(tree.joint(key0, key1).size(), 2)
+        self.assertEqual(tree.jointBayesNet(key0, key1).size(), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/gtsam/tests/test_Utilities.py
+++ b/python/gtsam/tests/test_Utilities.py
@@ -190,22 +190,24 @@ class TestUtilities(GtsamTestCase):
     def test_insertProjectionFactors(self):
         """Test insertProjectionFactors."""
         pixels = np.asarray([[20, 30], [20, 30]], dtype=float)
+        pose_key = gtsam.symbol("x", 0)
         graph = gtsam.NonlinearFactorGraph()
         gtsam.utilities.insertProjectionFactors(
-            graph, 0, [0, 1], np.array(pixels, order="C"),
+            graph, pose_key, [0, 1], np.array(pixels, order="C"),
             gtsam.noiseModel.Isotropic.Sigma(2, 0.1), gtsam.Cal3_S2())
         self.assertEqual(graph.size(), 2)
+        self.assertEqual(graph.at(0).keys()[0], pose_key)
 
         graph = gtsam.NonlinearFactorGraph()
         gtsam.utilities.insertProjectionFactors(
-            graph, 0, [0, 1], np.array(pixels, order="F"),
+            graph, pose_key, [0, 1], np.array(pixels, order="F"),
             gtsam.noiseModel.Isotropic.Sigma(2, 0.1), gtsam.Cal3_S2(),
             gtsam.Pose3(gtsam.Rot3(), gtsam.Point3(1, 0, 0)))
         self.assertEqual(graph.size(), 2)
 
         with self.assertRaises(TypeError):
             gtsam.utilities.insertProjectionFactors(
-                gtsam.NonlinearFactorGraph(), 0, [0, 1], pixels.tolist(),
+                gtsam.NonlinearFactorGraph(), pose_key, [0, 1], pixels.tolist(),
                 gtsam.noiseModel.Isotropic.Sigma(2, 0.1), gtsam.Cal3_S2())
 
     def test_reprojectionErrors(self):


### PR DESCRIPTION
Fixes #2089.

Several wrapper declarations used size_t where the corresponding C++ APIs use gtsam::Key or other fixed-width types. On i386, size_t is 32-bit while gtsam::Key is always 64-bit, so generated Python bindings rejected or narrowed symbolic keys. This was hidden on 64-bit platforms.

Changes:
- Align wrapper declarations with gtsam::Key, FactorIndex, DenseIndex, and uint64_t.
- Preserve full-width LabeledSymbol indices.
- Add Python and C++ regressions for symbolic keys and indices above 2^32.

Validation:
- Native Python suite: 419 passed, 6 skipped.
- Focused i386 regressions: 5 passed.
- Full i386 suite: 392 passed, 20 skipped; the remaining 13 failures are unrelated minimal-build or i386 numerical baselines.
- No key-conversion TypeErrors remain.