### PR TITLE
Fix gtsam_unstable factor serialization

### DIFF
--- a/python/gtsam_unstable/gtsam_unstable.tpl
+++ b/python/gtsam_unstable/gtsam_unstable.tpl
@@ -20,9 +20,36 @@
 {includes}
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/export.hpp>
+#include <gtsam/linear/NoiseModel.h>
 #endif
 
 {boost_class_export}
+
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
+// Boost export registrations are local to each Python extension. Keep these
+// dependencies synchronized with the serializable noise models in
+// gtsam/linear/linear.i so unstable factors can serialize their polymorphic
+// SharedNoiseModel members.
+BOOST_CLASS_EXPORT(gtsam::noiseModel::Gaussian)
+BOOST_CLASS_EXPORT(gtsam::noiseModel::Diagonal)
+BOOST_CLASS_EXPORT(gtsam::noiseModel::Constrained)
+BOOST_CLASS_EXPORT(gtsam::noiseModel::Isotropic)
+BOOST_CLASS_EXPORT(gtsam::noiseModel::Unit)
+BOOST_CLASS_EXPORT(gtsam::noiseModel::Robust)
+BOOST_CLASS_EXPORT(gtsam::noiseModel::mEstimator::Null)
+BOOST_CLASS_EXPORT(gtsam::noiseModel::mEstimator::Fair)
+BOOST_CLASS_EXPORT(gtsam::noiseModel::mEstimator::Huber)
+BOOST_CLASS_EXPORT(gtsam::noiseModel::mEstimator::Cauchy)
+BOOST_CLASS_EXPORT(gtsam::noiseModel::mEstimator::Tukey)
+BOOST_CLASS_EXPORT(gtsam::noiseModel::mEstimator::Welsch)
+BOOST_CLASS_EXPORT(gtsam::noiseModel::mEstimator::GemanMcClure)
+BOOST_CLASS_EXPORT(gtsam::noiseModel::mEstimator::TruncatedLeastSquares)
+BOOST_CLASS_EXPORT(gtsam::noiseModel::mEstimator::DCS)
+BOOST_CLASS_EXPORT(gtsam::noiseModel::mEstimator::L2WithDeadZone)
+BOOST_CLASS_EXPORT(gtsam::noiseModel::mEstimator::AsymmetricTukey)
+BOOST_CLASS_EXPORT(gtsam::noiseModel::mEstimator::AsymmetricCauchy)
+BOOST_CLASS_EXPORT(gtsam::noiseModel::mEstimator::Custom)
+#endif
 
 #include "python/gtsam_unstable/preamble.h"
 

--- a/python/gtsam_unstable/tests/test_Serialization.py
+++ b/python/gtsam_unstable/tests/test_Serialization.py
@@ -1,0 +1,51 @@
+"""Regression tests for serialization in the unstable Python extension."""
+
+import pickle
+import unittest
+
+import numpy as np
+
+import gtsam
+import gtsam_unstable
+from gtsam.utils.test_case import GtsamTestCase
+
+
+class TestSerialization(GtsamTestCase):
+
+    @staticmethod
+    def _factor(noise_model):
+        return gtsam_unstable.ProjectionFactorPPPCal3_S2(
+            np.ones(2), noise_model, 0, 1, 2, gtsam.Cal3_S2())
+
+    @unittest.skipUnless(
+        hasattr(gtsam_unstable.ProjectionFactorPPPCal3_S2, "serialize"),
+        "Serialization not enabled")
+    def test_projection_factor_noise_models(self):
+        """Unstable factors serialize every supported noise-model family."""
+        noise_models = {
+            # This is the original issue #1173 reproduction. Smart construction
+            # returns a Unit noise model for a vector of unit sigmas.
+            "unit": gtsam.noiseModel.Isotropic.Sigmas(np.ones(2)),
+            "isotropic": gtsam.noiseModel.Isotropic.Sigma(2, 0.5, False),
+            "diagonal": gtsam.noiseModel.Diagonal.Sigmas(
+                np.array([0.5, 1.5]), False),
+            "gaussian": gtsam.noiseModel.Gaussian.SqrtInformation(
+                np.array([[1.0, 0.2], [0.0, 1.0]]), False),
+            "constrained": gtsam.noiseModel.Constrained.MixedSigmas(
+                np.ones(2), np.array([0.0, 0.5])),
+            "robust": gtsam.noiseModel.Robust.Create(
+                gtsam.noiseModel.mEstimator.Huber.Create(1.345),
+                gtsam.noiseModel.Isotropic.Sigma(2, 0.5, False)),
+        }
+
+        for name, noise_model in noise_models.items():
+            with self.subTest(noise_model=name):
+                factor = self._factor(noise_model)
+                self.assertIsInstance(factor.serialize(), str)
+
+                restored = pickle.loads(pickle.dumps(factor))
+                self.assertTrue(factor.equals(restored, 1e-9))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- register stable noise-model and m-estimator serialization types within the `gtsam_unstable` Python extension
- preserve Boost-free builds with `GTSAM_ENABLE_BOOST_SERIALIZATION` guards
- add regression coverage for Unit, Isotropic, Diagonal, Gaussian, Constrained, and Robust/Huber noise models

## Root cause

Boost export registrations are local to each Python extension. Unstable factors serialize a polymorphic `SharedNoiseModel`, but the unstable extension did not register the stable concrete noise-model types. In the original reproduction, unit sigmas are smart-constructed as `noiseModel::Unit`, causing Boost to report an unregistered derived class.

## Validation

- `cmake --build build --target python-test-unstable`: 4 passed, including 6 serialization subtests
- `cmake --build build --target python-test`: 419 passed, 6 skipped
- `git diff --check`

Closes #1173