### PR TITLE
Avoid Rot2 reference-to-value returns on ARM64

### DIFF
--- a/.github/workflows/build-linux-arm64.yml
+++ b/.github/workflows/build-linux-arm64.yml
@@ -3,7 +3,6 @@ name: Linux ARM64 CI
 on:
   workflow_call:
   workflow_dispatch:
-  pull_request:
 
 concurrency:
   group: linux-arm64-ci-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/build-linux-arm64.yml
+++ b/.github/workflows/build-linux-arm64.yml
@@ -1,0 +1,42 @@
+name: Linux ARM64 CI
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  pull_request:
+
+concurrency:
+  group: linux-arm64-ci-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: ubuntu-24.04-arm Release
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libboost-all-dev libtbb-dev ninja-build
+
+      - name: Configure
+        run: |
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_FLAGS="-w" \
+            -DGTSAM_BUILD_TESTS=ON \
+            -DGTSAM_BUILD_UNSTABLE=OFF \
+            -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF \
+            -DGTSAM_BUILD_WITH_MARCH_NATIVE=OFF \
+            -DGTSAM_WITH_TBB=OFF \
+            -DGTSAM_USE_BOOST_FEATURES=OFF \
+            -DGTSAM_ENABLE_BOOST_SERIALIZATION=OFF
+
+      - name: Build and test
+        run: cmake --build build --target check --parallel 2

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -13,6 +13,9 @@ jobs:
   linux:
     uses: ./.github/workflows/build-linux.yml
 
+  linux-arm64:
+    uses: ./.github/workflows/build-linux-arm64.yml
+
   macos:
     uses: ./.github/workflows/build-macos.yml
 
@@ -32,7 +35,7 @@ jobs:
 
   report:
     name: Report nightly status
-    needs: [linux, macos, windows, vcpkg, special, python-extra]
+    needs: [linux, linux-arm64, macos, windows, vcpkg, special, python-extra]
     if: always()
     runs-on: ubuntu-latest
     permissions:
@@ -40,6 +43,7 @@ jobs:
       issues: write
     env:
       LINUX_RESULT: ${{ needs.linux.result }}
+      LINUX_ARM64_RESULT: ${{ needs.linux-arm64.result }}
       MACOS_RESULT: ${{ needs.macos.result }}
       WINDOWS_RESULT: ${{ needs.windows.result }}
       VCPKG_RESULT: ${{ needs.vcpkg.result }}
@@ -54,6 +58,7 @@ jobs:
           script: |
             const results = {
               Linux: process.env.LINUX_RESULT,
+              "Linux ARM64": process.env.LINUX_ARM64_RESULT,
               macOS: process.env.MACOS_RESULT,
               Windows: process.env.WINDOWS_RESULT,
               vcpkg: process.env.VCPKG_RESULT,

--- a/gtsam/constrained/ConstrainedOptimizer.h
+++ b/gtsam/constrained/ConstrainedOptimizer.h
@@ -20,6 +20,8 @@
 #include <gtsam/constrained/ConstrainedOptProblem.h>
 #include <gtsam/nonlinear/NonlinearOptimizer.h>
 
+#include <cmath>
+
 namespace gtsam {
 
 /** Base class for constrained optimization parameters. */
@@ -124,9 +126,10 @@ class GTSAM_EXPORT ConstrainedOptimizer {
       return true;
     }
 
-    if (abs(state.violation() - previousState.violation()) <
+    if (std::abs(state.violation() - previousState.violation()) <
             params.relativeViolationTolerance &&
-        abs(state.cost - previousState.cost) < params.relativeCostTolerance) {
+        std::abs(state.cost - previousState.cost) <
+            params.relativeCostTolerance) {
       return true;
     }
 

--- a/gtsam/geometry/Rot2.cpp
+++ b/gtsam/geometry/Rot2.cpp
@@ -28,14 +28,18 @@ namespace gtsam {
 
 /* ************************************************************************* */
 Rot2 Rot2::fromCosSin(double c, double s) {
-  Rot2 R(c, s);
-  return R.normalize();
+  double squaredNorm = c * c + s * s;
+  if (std::abs(squaredNorm - 1.0) > 1e-10) {
+    const double inverseNorm = 1.0 / std::sqrt(squaredNorm);
+    c *= inverseNorm;
+    s *= inverseNorm;
+  }
+  return Rot2(c, s);
 }
 
 /* ************************************************************************* */
 Rot2 Rot2::atan2(double y, double x) {
-  Rot2 R(x, y);
-  return R.normalize();
+  return fromCosSin(x, y);
 }
 
 /* ************************************************************************* */
@@ -53,17 +57,6 @@ void Rot2::print(const string& s) const {
 /* ************************************************************************* */
 bool Rot2::equals(const Rot2& R, double tol) const {
   return std::abs(c_ - R.c_) <= tol && std::abs(s_ - R.s_) <= tol;
-}
-
-/* ************************************************************************* */
-Rot2& Rot2::normalize() {
-  double scale = c_*c_ + s_*s_;
-  if(std::abs(scale-1.0) > 1e-10) {
-    scale = 1 / sqrt(scale);
-    c_ *= scale;
-    s_ *= scale;
-  }
-  return *this;
 }
 
 /* ************************************************************************* */

--- a/gtsam/geometry/Rot2.h
+++ b/gtsam/geometry/Rot2.h
@@ -41,9 +41,6 @@ namespace gtsam {
     /** we store cos(theta) and sin(theta) */
     double c_, s_;
 
-    /** normalize to make sure cos and sin form unit vector */
-    Rot2& normalize();
-
     /** private constructor from cos/sin */
     inline Rot2(double c, double s) : c_(c), s_(s) {}
 

--- a/gtsam/geometry/tests/testRot2.cpp
+++ b/gtsam/geometry/tests/testRot2.cpp
@@ -30,6 +30,27 @@ Rot2 R(Rot2::fromAngle(0.1));
 Point2 P(0.2, 0.7);
 
 /* ************************************************************************* */
+namespace return_value_tests {
+
+// Verifies that normalized factory results remain valid through copy and group
+// operations.
+TEST(Rot2, NormalizedFactoryReturnValues) {
+  const Rot2 fromCosSin = Rot2::fromCosSin(3.0, 4.0);
+  DOUBLES_EQUAL(0.6, fromCosSin.c(), 1e-12);
+  DOUBLES_EQUAL(0.8, fromCosSin.s(), 1e-12);
+
+  const Rot2 fromAtan2 = Rot2::atan2(4.0, 3.0);
+  CHECK(assert_equal(fromCosSin, fromAtan2, 1e-12));
+
+  const Rot2 copied(fromCosSin);
+  CHECK(assert_equal(fromCosSin, copied, 1e-12));
+  CHECK(assert_equal(Rot2(), copied * copied.inverse(), 1e-12));
+}
+
+}  // namespace return_value_tests
+/* ************************************************************************* */
+
+/* ************************************************************************* */
 TEST( Rot2, constructors_and_angle)
 {
   double c=cos(0.1), s=sin(0.1);

--- a/tests/testNonlinearOptimizer.cpp
+++ b/tests/testNonlinearOptimizer.cpp
@@ -70,6 +70,86 @@ class CountingNonlinearFactorGraph : public NonlinearFactorGraph {
 };
 
 /* ************************************************************************* */
+namespace arm64_return_regression {
+
+class GpsLikePositionFactor : public NoiseModelFactorN<Pose2> {
+  Point2 measurement_;
+
+ public:
+  GpsLikePositionFactor(Key key, const Point2& measurement,
+                        const SharedNoiseModel& model)
+      : NoiseModelFactorN<Pose2>(model, key), measurement_(measurement) {}
+
+  Vector evaluateError(const Pose2& pose,
+                       OptionalMatrixType H) const override {
+    const Rot2& rotation = pose.rotation();
+    if (H) {
+      *H = Matrix23{{rotation.c(), -rotation.s(), 0.0},
+                    {rotation.s(), rotation.c(), 0.0}};
+    }
+    return pose.translation() - measurement_;
+  }
+
+  NonlinearFactor::shared_ptr clone() const override {
+    return std::make_shared<GpsLikePositionFactor>(*this);
+  }
+};
+
+// Verifies BetweenFactor<Pose2> error evaluation with nonzero rotations.
+TEST(NonlinearOptimizer, Arm64Pose2BetweenFactorError) {
+  const SharedNoiseModel model = noiseModel::Isotropic::Sigma(3, 1.0);
+  const BetweenFactor<Pose2> factor(X(0), X(1),
+                                    Pose2(1.0, 0.0, M_PI / 4.0), model);
+  const Pose2 pose1(0.0, 0.0, M_PI / 4.0);
+  const double sqrtTwo = std::sqrt(2.0);
+  const Pose2 pose2(sqrtTwo, sqrtTwo, M_PI / 2.0);
+  const double inverseSqrtTwo = std::sqrt(0.5);
+  const Vector3 expected{inverseSqrtTwo, -inverseSqrtTwo, 0.0};
+
+  EXPECT(assert_equal(expected, factor.evaluateError(pose1, pose2), 1e-9));
+}
+
+// Verifies LM follows strong GPS-like evidence over contradictory diagonal
+// odometry.
+TEST(NonlinearOptimizer, Arm64ConflictingOdometryAndPositionEvidence) {
+  const auto priorModel = noiseModel::Isotropic::Sigma(3, 1e-3);
+  const auto odometryModel = noiseModel::Isotropic::Sigma(3, 1.0);
+  const auto positionModel = noiseModel::Isotropic::Sigma(2, 1e-3);
+
+  NonlinearFactorGraph graph;
+  graph.addPrior(X(0), Pose2(0.0, 0.0, M_PI / 4.0), priorModel);
+  graph.emplace_shared<BetweenFactor<Pose2>>(
+      X(0), X(1), Pose2(1.0, 0.0, 0.0), odometryModel);
+  graph.emplace_shared<BetweenFactor<Pose2>>(
+      X(1), X(2), Pose2(1.0, 0.0, 0.0), odometryModel);
+  graph.emplace_shared<GpsLikePositionFactor>(X(1), Point2(0.0, 1.0),
+                                               positionModel);
+  graph.emplace_shared<GpsLikePositionFactor>(X(2), Point2(0.0, 2.0),
+                                               positionModel);
+
+  const double inverseSqrtTwo = std::sqrt(0.5);
+  Values initial;
+  initial.insert(X(0), Pose2(0.0, 0.0, M_PI / 4.0));
+  initial.insert(X(1), Pose2(inverseSqrtTwo, inverseSqrtTwo, M_PI / 4.0));
+  initial.insert(X(2), Pose2(2.0 * inverseSqrtTwo, 2.0 * inverseSqrtTwo,
+                             M_PI / 4.0));
+
+  const double initialError = graph.error(initial);
+  const Values result = LevenbergMarquardtOptimizer(graph, initial).optimize();
+  const Pose2& pose1 = result.at<Pose2>(X(1));
+  const Pose2& pose2 = result.at<Pose2>(X(2));
+
+  CHECK(graph.error(result) < initialError);
+  DOUBLES_EQUAL(0.0, pose1.x(), 1e-3);
+  DOUBLES_EQUAL(1.0, pose1.y(), 1e-3);
+  DOUBLES_EQUAL(0.0, pose2.x(), 1e-3);
+  DOUBLES_EQUAL(2.0, pose2.y(), 1e-3);
+}
+
+}  // namespace arm64_return_regression
+/* ************************************************************************* */
+
+/* ************************************************************************* */
 TEST( NonlinearOptimizer, paramsEquals )
 {
   // default constructors lead to two identical params


### PR DESCRIPTION
## Summary

- normalize the cosine/sine scalars before constructing the returned `Rot2`
- return direct `Rot2` prvalues from `fromCosSin` and `atan2`
- add regressions for normalized factory returns, `BetweenFactor<Pose2>` error evaluation, and LM optimization with conflicting odometry and GPS-like position evidence

## Rationale

Issue #803 localized the ARM64 failures to functions returning `Rot2` by value. The 2021 workaround in #806 added a user-provided copy constructor, which made the failing tests pass but also changed `Rot2`'s triviality and potentially its calling convention. That constructor was changed back to `= default` in 846c29fa2.

The current factories normalized a local `Rot2` and returned `R.normalize()`. Because `normalize()` returned `Rot2&`, returning it from a function returning `Rot2` required the reference-to-value copy path implicated by the original report.

This change preserves the existing normalization threshold and public behavior while returning `Rot2(c, s)` directly. C++17 guarantees copy elision for that prvalue return, so the fragile copy path is removed without making the copy constructor user-provided or changing the class ABI. `atan2` delegates to the same safe construction path.

Codex believes this will address #803 because it removes the architecture-sensitive return path at the point where the corrupt cosine and sine values were observed, and the regressions exercise the behavior from raw `Rot2` construction through `BetweenFactor<Pose2>` and nonlinear optimization.

I added a separate Ubuntu/ARM workflow to test, fixed one unrelated issue, and it ran in this PR successfully. I moved the workflow to nightly to catch regressions in the future rather than adding another PR run.

## Testing

- `make -j6 testRot2.run`
- `make -j6 testNonlinearOptimizer.run`
- `git diff --check`