### PR TITLE
Fix BetweenFactor Cayley residual test

### DIFF
--- a/gtsam/slam/tests/testBetweenFactor.cpp
+++ b/gtsam/slam/tests/testBetweenFactor.cpp
@@ -34,8 +34,8 @@ TEST(BetweenFactor, Rot3) {
   Matrix actualH1, actualH2;
   Vector actual = factor.evaluateError(R1, R2, actualH1, actualH2);
 
-  Vector expected = Rot3::Logmap(measured.inverse() * R1.between(R2));
-  EXPECT(assert_equal(expected,actual/*, 1e-100*/)); // Uncomment to make unit test fail
+  const Vector3 expected = measured.localCoordinates(R1.between(R2));
+  EXPECT(assert_equal(expected, actual));
 
   Matrix numericalH1 = numericalDerivative21<Vector3, Rot3, Rot3>(
         [&factor](const Rot3& r1, const Rot3& r2) {return factor.evaluateError(r1, r2);},


### PR DESCRIPTION
## Summary

- make the nonzero-residual `BetweenFactor<Rot3>` test derive its expected residual from the active manifold chart
- remove the stale assertion comment from the historical test

## Root cause

#2661 enables the corrected Jacobian path by default and exercises a nonzero residual. The Nightly Cayley configuration sets `GTSAM_ROT3_EXPMAP=OFF` and `GTSAM_POSE3_EXPMAP=OFF`, so `Rot3::localCoordinates` uses the Cayley chart. The test still computed its expected residual with `Rot3::Logmap`, which is only equivalent to the active chart at zero residual.

This produced the reported mismatch:

```text
expected[-0.01; -0.01; -0.01]
actual[-0.01000025; -0.01000025; -0.01000025]
```

The factor behavior is correct; the test expectation was chart-specific.

Nightly failure: https://github.com/borglab/gtsam/actions/runs/31534209964/job/93921316899

## Impact

The test now validates the residual against the configured `Rot3` manifold semantics in both ExpMap and Cayley builds. No production code or public API changes.

## Validation

```text
make -j6 testBetweenFactor.run
There were no test failures
```

Validated with:

- `GTSAM_SLOW_BUT_CORRECT_BETWEENFACTOR=ON`
- `GTSAM_USE_QUATERNIONS=OFF`
- `GTSAM_ROT3_EXPMAP=OFF`
- `GTSAM_POSE3_EXPMAP=OFF`
- Release build