### PR TITLE
Fix projected prior Jacobians

### DIFF
--- a/gtsam/nonlinear/FunctorizedFactor.h
+++ b/gtsam/nonlinear/FunctorizedFactor.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <gtsam/base/Manifold.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/NoiseModelFactorN.h>
@@ -93,6 +94,19 @@ class FunctorizedFactor : public NoiseModelFactorN<T> {
   }
 
   Vector evaluateError(const T &params, OptionalMatrixType H) const override {
+#ifdef GTSAM_SLOW_BUT_CORRECT_BETWEENFACTOR
+    if constexpr (internal::HasLocalJacobians<R>::value) {
+      if (H) {
+        Matrix Hprojection;
+        const R value = func_(params, &Hprojection);
+        typename traits<R>::ChartJacobian::Jacobian Hlocal;
+        const Vector error =
+            traits<R>::Local(measured_, value, OptionalNone, &Hlocal);
+        *H = Hlocal * Hprojection;
+        return error;
+      }
+    }
+#endif
     R x = func_(params, H);
     Vector error = traits<R>::Local(measured_, x);
     return error;
@@ -204,6 +218,22 @@ class FunctorizedFactor2 : public NoiseModelFactorN<T1, T2> {
   Vector evaluateError(
       const T1 &params1, const T2 &params2,
       OptionalMatrixType H1, OptionalMatrixType H2) const override {
+#ifdef GTSAM_SLOW_BUT_CORRECT_BETWEENFACTOR
+    if constexpr (internal::HasLocalJacobians<R>::value) {
+      if (H1 || H2) {
+        Matrix Hprojection1, Hprojection2;
+        const R value = func_(params1, params2,
+                              H1 ? &Hprojection1 : nullptr,
+                              H2 ? &Hprojection2 : nullptr);
+        typename traits<R>::ChartJacobian::Jacobian Hlocal;
+        const Vector error =
+            traits<R>::Local(measured_, value, OptionalNone, &Hlocal);
+        if (H1) *H1 = Hlocal * Hprojection1;
+        if (H2) *H2 = Hlocal * Hprojection2;
+        return error;
+      }
+    }
+#endif
     R x = func_(params1, params2, H1, H2);
     Vector error = traits<R>::Local(measured_, x);
     return error;

--- a/gtsam/nonlinear/tests/testFunctorizedFactor.cpp
+++ b/gtsam/nonlinear/tests/testFunctorizedFactor.cpp
@@ -21,6 +21,7 @@
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/TestableAssertions.h>
+#include <gtsam/geometry/Rot3.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/nonlinear/FunctorizedFactor.h>
 #include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
@@ -268,6 +269,50 @@ TEST(FunctorizedFactor, Lambda2) {
 
   EXPECT(assert_equal(Vector::Zero(3), error, 1e-9));
 }
+
+/* ************************************************************************* */
+namespace manifold_output {
+
+const auto model = noiseModel::Isotropic::Sigma(3, 1.0);
+
+// Verifies the Local Jacobian is chained onto a unary projection Jacobian.
+TEST(FunctorizedFactor, UnaryManifoldOutputJacobian) {
+  const Rot3 measurement = Rot3::Expmap(Vector3(-0.3, 0.1, 0.2));
+  const Rot3 value = Rot3::Expmap(Vector3(0.4, -0.2, 0.1));
+  auto identity = [](const Rot3& rotation,
+                     OptionalJacobian<3, 3> H = {}) {
+    if (H) *H = I_3x3;
+    return rotation;
+  };
+  const auto factor =
+      MakeFunctorizedFactor<Rot3>(key, measurement, model, identity);
+
+  Values values;
+  values.insert<Rot3>(key, value);
+  EXPECT_CORRECT_FACTOR_JACOBIANS(factor, values, 1e-7, 1e-5);
+}
+
+// Verifies the Local Jacobian is chained onto both binary projection Jacobians.
+TEST(FunctorizedFactor, BinaryManifoldOutputJacobians) {
+  const Rot3 measurement = Rot3::Expmap(Vector3(-0.2, 0.3, 0.1));
+  const Rot3 value1 = Rot3::Expmap(Vector3(0.4, -0.1, 0.2));
+  const Rot3 value2 = Rot3::Expmap(Vector3(-0.1, 0.2, -0.3));
+  auto compose = [](const Rot3& rotation1, const Rot3& rotation2,
+                    OptionalJacobian<3, 3> H1 = {},
+                    OptionalJacobian<3, 3> H2 = {}) {
+    return rotation1.compose(rotation2, H1, H2);
+  };
+  const auto factor = MakeFunctorizedFactor2<Rot3, Rot3>(
+      keyA, keyx, measurement, model, compose);
+
+  Values values;
+  values.insert<Rot3>(keyA, value1);
+  values.insert<Rot3>(keyx, value2);
+  EXPECT_CORRECT_FACTOR_JACOBIANS(factor, values, 1e-7, 1e-5);
+}
+
+}  // namespace manifold_output
+/* ************************************************************************* */
 
 /* ************************************************************************* */
 int main() {

--- a/gtsam/slam/PoseRotationPrior.h
+++ b/gtsam/slam/PoseRotationPrior.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <gtsam/base/Manifold.h>
 #include <gtsam/geometry/concepts.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/NoiseModelFactorN.h>
@@ -80,14 +81,22 @@ public:
 
   /** h(x)-z */
   Vector evaluateError(const Pose& pose, OptionalMatrixType H) const override {
-    const Rotation& newR = pose.rotation();
-    if (H) {
-      *H = Matrix::Zero(rDim, xDim);
-      std::pair<size_t, size_t> rotInterval = POSE::rotationInterval();
-      (*H).middleCols(rotInterval.first, rDim).setIdentity(rDim, rDim);
+    Eigen::Matrix<double, rDim, xDim> Hrotation;
+    const Rotation& newR = pose.rotation(H ? &Hrotation : nullptr);
+#ifdef GTSAM_SLOW_BUT_CORRECT_BETWEENFACTOR
+    if constexpr (internal::HasLocalJacobians<Rotation>::value) {
+      if (H) {
+        typename traits<Rotation>::ChartJacobian::Jacobian Hlocal;
+        const Vector error =
+            traits<Rotation>::Local(measured_, newR, OptionalNone, &Hlocal);
+        *H = Hlocal * Hrotation;
+        return error;
+      }
     }
+#endif
+    if (H) *H = Hrotation;
 
-    return measured_.localCoordinates(newR);
+    return traits<Rotation>::Local(measured_, newR);
   }
 
 private:
@@ -106,7 +115,6 @@ private:
 };
 
 } // \namespace gtsam
-
 
 
 

--- a/gtsam/slam/PoseTranslationPrior.h
+++ b/gtsam/slam/PoseTranslationPrior.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <gtsam/base/Manifold.h>
 #include <gtsam/geometry/concepts.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/NoiseModelFactorN.h>
@@ -64,15 +65,20 @@ public:
 
   /** h(x)-z */
   Vector evaluateError(const Pose& pose, OptionalMatrixType H) const override {
-    const Translation& newTrans = pose.translation();
-    const Rotation& R = pose.rotation();
-    const size_t tDim = traits<Translation>::GetDimension(newTrans);
-    const size_t xDim = traits<Pose>::GetDimension(pose);
-    if (H) {
-      *H = Matrix::Zero(tDim, xDim);
-      std::pair<size_t, size_t> transInterval = POSE::translationInterval();
-      (*H).middleCols(transInterval.first, tDim) = R.matrix();
+    Matrix Htranslation;
+    const Translation& newTrans = pose.translation(H ? &Htranslation : nullptr);
+#ifdef GTSAM_SLOW_BUT_CORRECT_BETWEENFACTOR
+    if constexpr (internal::HasLocalJacobians<Translation>::value) {
+      if (H) {
+        typename traits<Translation>::ChartJacobian::Jacobian Hlocal;
+        const Vector error = traits<Translation>::Local(
+            measured_, newTrans, OptionalNone, &Hlocal);
+        *H = Hlocal * Htranslation;
+        return error;
+      }
     }
+#endif
+    if (H) *H = Htranslation;
 
     return traits<Translation>::Local(measured_, newTrans);
   }
@@ -106,6 +112,5 @@ private:
 };
 
 } // \namespace gtsam
-
 
 

--- a/gtsam/slam/tests/testPoseRotationPrior.cpp
+++ b/gtsam/slam/tests/testPoseRotationPrior.cpp
@@ -67,9 +67,7 @@ TEST( testPoseRotationFactor, level3_error ) {
   EXPECT(assert_equal(Vector3(-0.1, -0.2, -0.3), factor.evaluateError(pose1, actH1),1e-2));
 #endif
   Matrix expH1 = numericalDerivative22<Vector3,Pose3RotationPrior,Pose3>(evalFactorError3, factor, pose1, 1e-5);
-  // the derivative is more complex, but is close to the identity for Rot3 around the origin
-  // If not using true expmap will be close, but not exact around the origin
-  // EXPECT(assert_equal(expH1, actH1, tol));
+  EXPECT(assert_equal(expH1, actH1, tol));
 }
 
 /* ************************************************************************* */


### PR DESCRIPTION
## Summary

- Correct unary and binary `FunctorizedFactor` Jacobians to apply the full chain rule
  ```
  D₂ Local(z, h(x)) · Dh(x)
  ```
- Correct `PoseRotationPrior` and `PoseTranslationPrior` by composing the component Jacobian with the second `Local` Jacobian.
- Add nonzero-residual manifold regression coverage and enable the exact numerical Jacobian check for the rotation prior.

## Why

These factors compute residuals as `Local(measurement, projected_value)`. Away from zero residual, returning only the projection Jacobian omits `D₂ Local`, so the analytic Jacobian does not match the derivative of the actual residual.

The implementation follows the exact-Jacobian policy introduced by #2661: use `internal::HasLocalJacobians` under the default-on exact path and retain the existing fallback for result types without `Local` derivatives.

## Relationship to #755

This is the isolated Jacobian commit that is already present on #755. It is intentionally split out so it can merge into `develop` first. The five affected files are identical between this branch and the current #755 head, and a `git merge-tree` simulation confirms that merging updated `develop` back into #755 is conflict-free.

The `PartialPriorFactor` compatibility/deprecation work remains only in #755.

## Validation

From a fresh build:

- `make -j6 testFunctorizedFactor.run`
- `make -j6 testPoseRotationPrior.run`
- `make -j6 testPoseTranslationPrior.run`
- `make -j6 testBasisFactors.run`
- `git diff --check`

All passed.