### PR TITLE
Materialize Shonan certificate product

### DIFF
--- a/gtsam/sfm/ShonanAveraging.cpp
+++ b/gtsam/sfm/ShonanAveraging.cpp
@@ -484,8 +484,8 @@ Sparse ShonanAveraging<d>::computeLambda(const Matrix &S) const {
   std::vector<Eigen::Triplet<double>> triplets;
   triplets.reserve(stride * N);
 
-  // Do sparse-dense multiply to get Q*S'
-  auto QSt = Q_ * S.transpose();
+  // Materialize Q*S' once before extracting a block for each pose.
+  const Matrix QSt = Q_ * S.transpose();
 
   for (size_t j = 0; j < N; j++) {
     // Compute B, the building block for the j^th diagonal block of Lambda


### PR DESCRIPTION
## Summary

- materialize the sparse-dense certificate product `Q_ * S.transpose()` once in `ShonanAveraging::computeLambda`
- avoid reevaluating the full Eigen product while extracting each pose block
- preserve the certificate computation and public behavior

## Root cause

The previous declaration used `auto`:

```cpp
auto QSt = Q_ * S.transpose();
```

Because Eigen products are lazy expressions, each `middleRows` access inside the per-pose loop reevaluated the full sparse-dense multiplication. Materializing the result as a `Matrix` evaluates it once before the loop, removing accidental quadratic scaling with the number of poses.

## Performance

Three-run Release averages for FAST-Sync initialization plus the PCG Shonan solve on the five largest YFCC2 files:

| Dataset | Baseline | Optimized | Speedup |
|---|---:|---:|---:|
| `taj_mahal.g2o` | 1.093 s | 0.478 s | 2.287x |
| `brandenburg_gate.g2o` | 1.191 s | 0.528 s | 2.256x |
| `temple_nara_japan.g2o` | 1.259 s | 0.592 s | 2.125x |
| `st_peters_square.g2o` | 3.115 s | 0.495 s | 6.296x |
| `colosseum_exterior.g2o` | 2.260 s | 0.721 s | 3.135x |

Every optimized trial succeeded at rank 3, and final costs matched the baseline exactly.

## Validation

- `make -j6 testShonanAveraging.run`
- matched AppleClang Release builds for baseline and optimized benchmarks
- three repetitions on each of the five largest YFCC2 datasets
- `git diff --check`
