### PR TITLE
Fix Rot2 prior Jacobian wheel build

### DIFF
--- a/gtsam/nonlinear/ExtendedPriorFactor.h
+++ b/gtsam/nonlinear/ExtendedPriorFactor.h
@@ -150,9 +150,8 @@ class ExtendedPriorFactor : public NoiseModelFactorN<VALUE> {
 #ifdef GTSAM_SLOW_BUT_CORRECT_BETWEENFACTOR
     if constexpr (internal::HasLocalJacobians<T>::value) {
       if (H) {
-        typename traits<T>::ChartJacobian::Jacobian Hlocal;
-        error = -traits<T>::Local(x, origin_, &Hlocal, OptionalNone);
-        *H = -Hlocal;
+        error = -traits<T>::Local(x, origin_, H, OptionalNone);
+        *H *= -1.0;
       } else {
         error = -traits<T>::Local(x, origin_);
       }

--- a/gtsam/nonlinear/tests/testExtendedPriorFactor.cpp
+++ b/gtsam/nonlinear/tests/testExtendedPriorFactor.cpp
@@ -18,6 +18,7 @@
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/geometry/Pose2.h>
+#include <gtsam/geometry/Rot2.h>
 #include <gtsam/nonlinear/ExtendedPriorFactor.h>
 
 using namespace std;
@@ -65,6 +66,21 @@ TEST(ExtendedPriorFactor, ErrorWithMean) {
   Vector expected_error{{0.05463769, -0.038484723, -0.05}};
   Vector actual_error = factor.evaluateError(x);
   EXPECT(assert_equal(expected_error, actual_error, 1e-8));
+}
+
+//******************************************************************************
+// Verifies the fixed-size Rot2 Local Jacobian is written to the dynamic output.
+TEST(ExtendedPriorFactor, Rot2Jacobian) {
+  const Rot2 origin = Rot2::fromAngle(0.3);
+  const auto model = noiseModel::Isotropic::Sigma(1, 0.5);
+  const ExtendedPriorFactor<Rot2> factor(1, origin, model);
+
+  Matrix actualH;
+  const Vector actualError =
+      factor.evaluateError(Rot2::fromAngle(0.5), actualH);
+
+  EXPECT(assert_equal(Vector1{0.2}, actualError, 1e-9));
+  EXPECT(assert_equal(Matrix1::Identity(), actualH, 1e-9));
 }
 
 //******************************************************************************


### PR DESCRIPTION
## Summary

- write the `ExtendedPriorFactor` Local Jacobian directly into the requested dynamic output
- negate the Jacobian in place, avoiding Eigen's fixed-1x1-to-dynamic SIMD assignment path
- add a `Rot2` regression test covering the residual and Jacobian

## Root cause

The GCC 14 manylinux wheel build promoted Eigen's `-Warray-bounds` diagnostic to an error while compiling `*H = -Hlocal` for `ExtendedPriorFactor<Rot2>`. Eigen generated a SIMD-capable assignment path for the fixed 1x1 source, and GCC diagnosed a possible two-double load from the one-double object.

This change preserves the same Jacobian semantics while removing that fixed-to-dynamic expression. It addresses https://github.com/borglab/gtsam/actions/runs/31605679944/job/94143914111.

## Validation

- `make -j6 testExtendedPriorFactor.run`
- `make -j6 testPriorFactor.run`
- `make -j6 testSimilarity2.run`
- `git diff --check`
