### PR TITLE
Use the README infographic for the website splash

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,10 +5,11 @@ on:
   push:
     # Runs on pushes targeting the develop branch
     branches: [develop]
-    # Only trigger redeploy if Markdown files, notebooks, or config changes
+    # Only trigger redeploy if documentation source or config changes
     paths:
       - '**.md'
-      - '**.ipynb' 
+      - '**.ipynb'
+      - '**.css'
       - 'myst.yml'
 env:
   # `BASE_URL` determines the website is served from, including CSS & JS assets

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 [![Docs](https://img.shields.io/badge/Docs-Python%20%7C%20C%2B%2B-green.svg)](https://borglab.github.io/gtsam/)
 
 <p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="doc/images/gtsam-manifold-optimization-dark.png">
-    <source media="(prefers-color-scheme: light)" srcset="doc/images/gtsam-manifold-optimization-light.png">
-    <img alt="GTSAM is a manifold optimization library" src="doc/images/gtsam-manifold-optimization-light.png" width="100%">
-  </picture>
+  <a href="https://borglab.github.io/gtsam/">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="doc/images/gtsam-manifold-optimization-dark.png">
+      <source media="(prefers-color-scheme: light)" srcset="doc/images/gtsam-manifold-optimization-light.png">
+      <img alt="GTSAM manifold optimization workflow: build a factor graph, linearize and solve in tangent spaces, retract to manifolds, and iterate to convergence." src="doc/images/gtsam-manifold-optimization-light.png" width="100%">
+    </picture>
+  </a>
 </p>
 
 **Important Note**

--- a/doc/gtsam-site.css
+++ b/doc/gtsam-site.css
@@ -1,0 +1,17 @@
+/*
+ * MyST flattens the README's <picture> element to its fallback <img>. Replace
+ * that fallback with the matching README artwork for the selected site theme.
+ */
+html.light
+  img[data-canonical-url="doc/images/gtsam-manifold-optimization-light.png"] {
+  content:
+    url("https://github.com/borglab/gtsam/raw/develop/doc/images/gtsam-manifold-optimization-light.png") /
+    "GTSAM manifold optimization workflow: build a factor graph, linearize and solve in tangent spaces, retract to manifolds, and iterate to convergence.";
+}
+
+html.dark
+  img[data-canonical-url="doc/images/gtsam-manifold-optimization-light.png"] {
+  content:
+    url("https://github.com/borglab/gtsam/raw/develop/doc/images/gtsam-manifold-optimization-dark.png") /
+    "GTSAM manifold optimization workflow: build a factor graph, linearize and solve in tangent spaces, retract to manifolds, and iterate to convergence.";
+}

--- a/myst.yml
+++ b/myst.yml
@@ -58,7 +58,8 @@ site:
     - title: C++ reference
       url: https://gtsam.org/doxygen/
   options:
-    logo_text: GTSAM 
+    logo_text: GTSAM
+    style: ./doc/gtsam-site.css
   template: book-theme
 
   # TODO: Graphics for favicon, site logo


### PR DESCRIPTION
## Summary

- link the theme-aware README infographic to the GTSAM website
- give both README variants a descriptive workflow alt text
- replace the MyST homepage splash with the matching light/dark README assets
- trigger Pages deployments when documentation CSS changes

## Why

The GitHub Pages homepage used a different splash image from the README, and MyST flattened the README `<picture>` element to its light fallback. The narrowly scoped stylesheet now switches the homepage image from the site theme class while preserving the existing layout.

## Validation

- `myst build --site --ci`
- verified generated homepage metadata and stylesheet registration
- verified remote light/dark assets match the repository files byte-for-byte
- `git diff --check`

No C++ tests were run because this is documentation-only.
