### PR TITLE
Fix documentation splash rendering

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ on:
       - '**.md'
       - '**.ipynb'
       - '**.css'
+      - 'doc/images/gtsam-manifold-optimization-*.png'
       - 'myst.yml'
 env:
   # `BASE_URL` determines the website is served from, including CSS & JS assets
@@ -43,6 +44,8 @@ jobs:
         run: npm install -g mystmd
       - name: Build HTML Assets
         run: myst build --html
+      - name: Copy theme-aware splash image
+        run: cp doc/images/gtsam-manifold-optimization-dark.png _build/html/
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/doc/gtsam-site.css
+++ b/doc/gtsam-site.css
@@ -2,16 +2,14 @@
  * MyST flattens the README's <picture> element to its fallback <img>. Replace
  * that fallback with the matching README artwork for the selected site theme.
  */
-html.light
-  img[data-canonical-url="doc/images/gtsam-manifold-optimization-light.png"] {
-  content:
-    url("https://github.com/borglab/gtsam/raw/develop/doc/images/gtsam-manifold-optimization-light.png") /
-    "GTSAM manifold optimization workflow: build a factor graph, linearize and solve in tangent spaces, retract to manifolds, and iterate to convergence.";
+img[data-canonical-url="doc/images/gtsam-manifold-optimization-light.png"] {
+  /* MyST treats the linked README image as inline content by default. */
+  max-height: none !important;
 }
 
 html.dark
   img[data-canonical-url="doc/images/gtsam-manifold-optimization-light.png"] {
   content:
-    url("https://github.com/borglab/gtsam/raw/develop/doc/images/gtsam-manifold-optimization-dark.png") /
+    url("gtsam-manifold-optimization-dark.png") /
     "GTSAM manifold optimization workflow: build a factor graph, linearize and solve in tangent spaces, retract to manifolds, and iterate to convergence.";
 }


### PR DESCRIPTION
## Summary

- remove MyST's inline-image height cap for the linked homepage splash
- use MyST's bundled README image directly in light mode
- deploy the dark infographic with the Pages artifact and reference it locally
- redeploy Pages when either theme image changes

## Root cause

Wrapping the README image in a link made MyST classify it as inline content, whose theme CSS limits images to `1.2em` high. The dark-mode override also loaded its image from GitHub Raw, so rate limiting could expose only the alt text.

## Validation

- inspected the deployed light and dark DOM and computed styles
- `myst build --site --ci`
- full `myst build --html --ci --force` rendered all 262 pages; local export then encountered the repository's pre-existing MyST default-favicon fetch failure
- verified the copied dark image is byte-for-byte identical to the README dark asset
- verified generated CSS and homepage alt metadata
- `git diff --check`

No C++ tests were run because this is documentation-only.
