### PR TITLE
Add Frobenius factor support to FastSync

### DIFF
--- a/gtsam/slam/FastSync-inl.h
+++ b/gtsam/slam/FastSync-inl.h
@@ -21,6 +21,7 @@
 #include <gtsam/linear/GaussianFactorGraph.h>
 #include <gtsam/linear/JacobianFactor.h>
 #include <gtsam/linear/NoiseModel.h>
+#include <gtsam/slam/FrobeniusFactor.h>
 
 #include <cmath>
 #include <stdexcept>
@@ -40,32 +41,51 @@ double FastSync<T>::isotropicSigma(const SharedNoiseModel& model) {
 
 template <class T>
 FastSync<T>::FastSync(const NonlinearFactorGraph& graph) {
+  const auto addMeasurement = [this](Key key1, Key key2,
+                                     const T& measurement,
+                                     const SharedNoiseModel& model,
+                                     size_t expectedNoiseDimension) {
+    if (model->dim() != expectedNoiseDimension) {
+      throw std::invalid_argument(
+          "fastSync noise dimension does not match the factor residual");
+    }
+    const double sigma = isotropicSigma(model);
+    if (!std::isfinite(sigma) || sigma <= 0.0) {
+      throw std::invalid_argument(
+          "FastSync requires finite, positive measurement sigmas");
+    }
+    const MatrixN firstBlock = -measurement.matrix().transpose();
+    // Whitening by sigma gives the paper's precision kappa = 1 / sigma^2.
+    reducedGraph_.emplace_shared<JacobianFactor>(
+        key1, firstBlock, key2, MatrixN::Identity(), VectorN::Zero(),
+        noiseModel::Isotropic::Sigma(N, sigma));
+  };
+  const auto addPrior = [this](Key key, const T& value) {
+    if (++priorCount_ > 1) {
+      throw std::invalid_argument(
+          "fastSync supports at most one matching prior");
+    }
+    priorKey_ = key;
+    priorValue_ = value;
+  };
+
   for (const auto& factor : graph) {
     if (const auto between =
             std::dynamic_pointer_cast<BetweenFactor<T>>(factor)) {
-      if (between->noiseModel()->dim() != T::dimension) {
-        throw std::invalid_argument(
-            "fastSync noise dimension must match the group dimension");
-      }
-      const double sigma = isotropicSigma(between->noiseModel());
-      if (!std::isfinite(sigma) || sigma <= 0.0) {
-        throw std::invalid_argument(
-            "FastSync requires finite, positive measurement sigmas");
-      }
-      const Key k1 = between->key1(), k2 = between->key2();
-      const MatrixN firstBlock = -between->measured().matrix().transpose();
-      // Whitening by sigma gives the paper's precision kappa = 1 / sigma^2.
-      reducedGraph_.emplace_shared<JacobianFactor>(
-          k1, firstBlock, k2, MatrixN::Identity(), VectorN::Zero(),
-          noiseModel::Isotropic::Sigma(N, sigma));
+      addMeasurement(between->key1(), between->key2(), between->measured(),
+                     between->noiseModel(), T::dimension);
+    } else if (const auto between =
+                   std::dynamic_pointer_cast<FrobeniusBetweenFactor<T>>(
+                       factor)) {
+      addMeasurement(between->key1(), between->key2(), between->measured(),
+                     between->noiseModel(), N * N);
     } else if (const auto prior =
                    std::dynamic_pointer_cast<PriorFactor<T>>(factor)) {
-      if (++priorCount_ > 1) {
-        throw std::invalid_argument(
-            "fastSync supports at most one matching prior");
-      }
-      priorKey_ = prior->key();
-      priorValue_ = prior->prior();
+      addPrior(prior->key(), prior->prior());
+    } else if (const auto prior =
+                   std::dynamic_pointer_cast<FrobeniusPrior<T>>(factor)) {
+      addPrior(prior->key(),
+               FastSyncProjection<T>::project(prior->priorMatrix()));
     }
   }
   if (reducedGraph_.empty()) {

--- a/gtsam/slam/FastSync.h
+++ b/gtsam/slam/FastSync.h
@@ -188,10 +188,11 @@ struct FastSyncProjection<SL4> {
 /**
  * Solver for the fixed-size ambient linear problem underlying FAST-Sync.
  *
- * The constructor extracts matching between factors and builds the reduced
- * Gaussian graph. `solve()` performs the ordered Cholesky solve and returns
- * ambient matrix estimates; `projectAndAlign()` rounds those estimates to T
- * and applies an optional matching prior.
+ * The constructor extracts matching BetweenFactor or FrobeniusBetweenFactor
+ * measurements and builds the reduced Gaussian graph. `solve()` performs the
+ * ordered Cholesky solve and returns ambient matrix estimates;
+ * `projectAndAlign()` rounds those estimates to T and applies an optional
+ * matching PriorFactor or FrobeniusPrior.
  */
 template <class T>
 struct FastSync {
@@ -263,11 +264,12 @@ struct FastSync {
 /**
  * Initialize a synchronization graph using FAST-Sync.
  *
- * The graph may contain BetweenFactor<T> measurements and at most one matching
- * PriorFactor<T>; factors of other types are ignored. Between-factor noise
- * models must have the tangent dimension of T and be finite, positive,
- * non-robust, unconstrained, diagonal, and isotropic. Arbitrary keys are
- * preserved in the returned Values.
+ * The graph may contain BetweenFactor<T> or FrobeniusBetweenFactor<T>
+ * measurements and at most one matching PriorFactor<T> or FrobeniusPrior<T>;
+ * factors of other types are ignored. Measurement noise models must have the
+ * factor's residual dimension and be finite, positive, non-robust,
+ * unconstrained, diagonal, and isotropic. Arbitrary keys are preserved in the
+ * returned Values.
  *
  * T must be a fixed-size square matrix Lie group with a
  * FastSyncProjection<T> specialization.

--- a/gtsam/slam/FrobeniusFactor.h
+++ b/gtsam/slam/FrobeniusFactor.h
@@ -100,7 +100,11 @@ class FrobeniusPrior : public NoiseModelFactorN<T> {
   GTSAM_CONCEPT_ASSERT(IsMatrixLieGroup<T>);
   inline constexpr static auto N = T::LieAlgebra::RowsAtCompileTime;
   inline constexpr static auto Dim = N * N;
+
+ public:
   using MatrixNN = Eigen::Matrix<double, N, N>;
+
+ private:
   Eigen::Matrix<double, Dim, 1> vecM_;  ///< vectorized matrix to approximate
 
  public:
@@ -112,6 +116,11 @@ class FrobeniusPrior : public NoiseModelFactorN<T> {
                  const SharedNoiseModel& model = nullptr)
       : NoiseModelFactorN<T>(ConvertModel<T, Dim>(model), j) {
     vecM_ << Eigen::Map<const Matrix>(M.data(), Dim, 1);
+  }
+
+  /// Return the fixed ambient matrix targeted by this prior.
+  MatrixNN priorMatrix() const {
+    return Eigen::Map<const MatrixNN>(vecM_.data());
   }
 
   /// Error is just Frobenius norm between T element and vectorized matrix M.
@@ -278,6 +287,9 @@ class FrobeniusBetweenFactorNL
                            const SharedNoiseModel& model = nullptr)
       : Base(ConvertModel<T, Dim>(model), j1, j2),
         T12_(T12) {}
+
+  /// Return the measured transformation from the first key to the second.
+  const T& measured() const { return T12_; }
 
   /// @}
   /// @name Testable

--- a/gtsam/slam/tests/testFastSync.cpp
+++ b/gtsam/slam/tests/testFastSync.cpp
@@ -24,6 +24,7 @@
 #include <gtsam/nonlinear/PriorFactor.h>
 #include <gtsam/slam/BetweenFactor.h>
 #include <gtsam/slam/FastSync.h>
+#include <gtsam/slam/FrobeniusFactor.h>
 
 #include <Eigen/QR>
 #include <cmath>
@@ -73,6 +74,29 @@ TEST(FastSync, Rot3Noiseless) {
   EXPECT(checkTriangle(Rot3::Expmap(Vector3{0.1, -0.2, 0.05}),
                        Rot3::Expmap(Vector3{-0.3, 0.1, 0.2}),
                        Rot3::Expmap(Vector3{0.2, 0.25, -0.1})));
+}
+
+// Verifies Frobenius between/prior factors produce the same aligned Rot3
+// initialization as their tangent-residual counterparts.
+TEST(FastSync, FrobeniusRot3Factors) {
+  const Rot3 value0 = Rot3::Expmap(Vector3{0.1, -0.2, 0.05});
+  const Rot3 value1 = Rot3::Expmap(Vector3{-0.3, 0.1, 0.2});
+  const Rot3 value2 = Rot3::Expmap(Vector3{0.2, 0.25, -0.1});
+  const auto model = noiseModel::Isotropic::Sigma(Rot3::dimension, 0.1);
+
+  NonlinearFactorGraph graph;
+  graph.emplace_shared<FrobeniusBetweenFactor<Rot3>>(
+      k0, k1, value0.between(value1), model);
+  graph.emplace_shared<FrobeniusBetweenFactor<Rot3>>(
+      k1, k2, value1.between(value2), model);
+  graph.emplace_shared<FrobeniusBetweenFactor<Rot3>>(
+      k2, k0, value2.between(value0), model);
+  graph.emplace_shared<FrobeniusPrior<Rot3>>(k0, value0.matrix(), model);
+
+  const Values actual = fastSync<Rot3>(graph);
+  EXPECT(assert_equal(value0, actual.at<Rot3>(k0), 1e-7));
+  EXPECT(assert_equal(value1, actual.at<Rot3>(k1), 1e-7));
+  EXPECT(assert_equal(value2, actual.at<Rot3>(k2), 1e-7));
 }
 
 // Verifies exact synchronization and prior alignment for Pose2.


### PR DESCRIPTION
## Summary

- teach `FastSync` to consume `FrobeniusBetweenFactor` and `FrobeniusPrior` directly
- preserve support for the existing `BetweenFactor` and `PriorFactor` inputs
- expose the small measurement/prior accessors needed by the generic implementation
- add Rot3 coverage for a Frobenius graph with a prior

## Why

Rotation-averaging clients that already construct a Frobenius QCQP graph should not need to build a duplicate graph of conventional between/prior factors solely for FAST-Sync initialization. This keeps FAST-Sync usable as an application-level initializer while allowing the downstream Burer--Monteiro API to remain purely QCQP-based.

## Validation

- `make -j6 testFastSync.run`
- `make -j6 testFrobeniusFactor.run`
- `git diff --check`
