### PR TITLE
Upgrade GitHub Actions for Node 24

### DIFF
--- a/.github/scripts/python_wheels/cibw_before_all.sh
+++ b/.github/scripts/python_wheels/cibw_before_all.sh
@@ -12,8 +12,8 @@ BOOST_BUILD_JOBS=2
 GTSAM_BUILD_JOBS=2
 
 # The generated Python wrapper translation units require substantial memory.
-# Compile them serially on Linux ARM runners to avoid the OOM killer.
-if [ "$(uname)" == "Linux" ] && [ "$(uname -m)" == "aarch64" ]; then
+# Compile them serially in Linux wheel containers to avoid the OOM killer.
+if [ "$(uname)" == "Linux" ]; then
     GTSAM_BUILD_JOBS=1
 fi
 

--- a/.github/workflows/build-cibw.yml
+++ b/.github/workflows/build-cibw.yml
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python_version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
 
@@ -179,7 +179,7 @@ jobs:
           fi
 
       - name: Store artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cibw-wheels-cp${{ matrix.cibw_python_version }}-${{ matrix.platform_id }}
           path: wheelhouse/*.whl
@@ -193,7 +193,7 @@ jobs:
       id-token: write
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: dist/
           merge-multiple: true
@@ -213,7 +213,7 @@ jobs:
       #   uses: actions/checkout@v6
       #
       # - name: Set up Python for cleanup
-      #   uses: actions/setup-python@v5
+      #   uses: actions/setup-python@v6
       #   with:
       #     python-version: "3.12"
       #

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -116,6 +116,8 @@ jobs:
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: "v0.17.0"
 
       # Keep the Windows PR fast-compile gate focused on the stable library.
       - name: Configure
@@ -322,6 +324,8 @@ jobs:
       - name: Install sccache
         if: matrix.use_sccache == true
         uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: "v0.17.0"
 
       - name: Set GTSAM_WITH_TBB Flag
         if: matrix.flag == 'tbb'

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Check modified files
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             relevant_changes:
@@ -115,7 +115,7 @@ jobs:
           toolset: 14.40
 
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       # Keep the Windows PR fast-compile gate focused on the stable library.
       - name: Configure
@@ -250,7 +250,7 @@ jobs:
         run: cl
 
       - name: Setup python (Windows)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         if: runner.os == 'Windows'
         with:
           python-version: ${{ matrix.python_version }}
@@ -321,7 +321,7 @@ jobs:
     
       - name: Install sccache
         if: matrix.use_sccache == true
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Set GTSAM_WITH_TBB Flag
         if: matrix.flag == 'tbb'

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -78,6 +78,8 @@ jobs:
       - name: Install sccache
         if: matrix.build_type == 'Release'
         uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: "v0.17.0"
 
       - name: Configuration
         shell: bash

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Install sccache
         if: matrix.build_type == 'Release'
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Configuration
         shell: bash

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,10 +36,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup Pages
-        uses: actions/configure-pages@v3
-      - uses: actions/setup-node@v4
+        uses: actions/configure-pages@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 18.x
+          node-version: 24.x
       - name: Install MyST Markdown
         run: npm install -g mystmd
       - name: Build HTML Assets
@@ -47,9 +47,9 @@ jobs:
       - name: Copy theme-aware splash image
         run: cp doc/images/gtsam-manifold-optimization-dark.png _build/html/
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './_build/html'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -53,7 +53,7 @@ jobs:
       RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Summarize matrices and manage incident issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const results = {

--- a/.github/workflows/prod-cibw.yml
+++ b/.github/workflows/prod-cibw.yml
@@ -86,7 +86,7 @@ jobs:
           ref: ${{ github.sha }}
 
       - name: Set up Python ${{ matrix.python_version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
 
@@ -158,7 +158,7 @@ jobs:
           fi
 
       - name: Store artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cibw-wheels-cp${{ matrix.cibw_python_version }}-${{ matrix.platform_id }}
           path: wheelhouse/*.whl
@@ -171,7 +171,7 @@ jobs:
       id-token: write
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: dist/
           merge-multiple: true

--- a/.github/workflows/time-sfmbal-benchmark-runner.yml
+++ b/.github/workflows/time-sfmbal-benchmark-runner.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Restore BAL dataset archive cache
         id: dataset_cache_restore
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: examples/Data/problem-135-90642-pre.txt.bz2
           key: bal-problem-135-90642-pre-txt-bz2-v1
@@ -63,7 +63,7 @@ jobs:
 
       - name: Save BAL dataset archive cache
         if: steps.dataset_cache_restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         continue-on-error: true
         with:
           path: examples/Data/problem-135-90642-pre.txt.bz2
@@ -108,7 +108,7 @@ jobs:
           cp benchmark-results-tbbON.json "benchmark-cache/${{ inputs.os_name }}-${{ inputs.arch }}-tbbON-${{ inputs.target_sha }}-${{ inputs.orchestrator_run_id }}.json"
 
       - name: Save benchmark cache (TBB=ON)
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         continue-on-error: true
         with:
           path: benchmark-cache/${{ inputs.os_name }}-${{ inputs.arch }}-tbbON-${{ inputs.target_sha }}-${{ inputs.orchestrator_run_id }}.json
@@ -147,7 +147,7 @@ jobs:
           cp benchmark-results-tbbOFF.json "benchmark-cache/${{ inputs.os_name }}-${{ inputs.arch }}-tbbOFF-${{ inputs.target_sha }}-${{ inputs.orchestrator_run_id }}.json"
 
       - name: Save benchmark cache (TBB=OFF)
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         continue-on-error: true
         with:
           path: benchmark-cache/${{ inputs.os_name }}-${{ inputs.arch }}-tbbOFF-${{ inputs.target_sha }}-${{ inputs.orchestrator_run_id }}.json
@@ -165,7 +165,7 @@ jobs:
 
       - name: Restore BAL dataset archive cache
         id: dataset_cache_restore
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: examples/Data/problem-135-90642-pre.txt.bz2
           key: bal-problem-135-90642-pre-txt-bz2-v1
@@ -179,7 +179,7 @@ jobs:
 
       - name: Save BAL dataset archive cache
         if: steps.dataset_cache_restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         continue-on-error: true
         with:
           path: examples/Data/problem-135-90642-pre.txt.bz2
@@ -224,7 +224,7 @@ jobs:
           cp benchmark-results-tbbON.json "benchmark-cache/${{ inputs.os_name }}-${{ inputs.arch }}-tbbON-${{ inputs.target_sha }}-${{ inputs.orchestrator_run_id }}.json"
 
       - name: Save benchmark cache (TBB=ON)
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         continue-on-error: true
         with:
           path: benchmark-cache/${{ inputs.os_name }}-${{ inputs.arch }}-tbbON-${{ inputs.target_sha }}-${{ inputs.orchestrator_run_id }}.json
@@ -263,7 +263,7 @@ jobs:
           cp benchmark-results-tbbOFF.json "benchmark-cache/${{ inputs.os_name }}-${{ inputs.arch }}-tbbOFF-${{ inputs.target_sha }}-${{ inputs.orchestrator_run_id }}.json"
 
       - name: Save benchmark cache (TBB=OFF)
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         continue-on-error: true
         with:
           path: benchmark-cache/${{ inputs.os_name }}-${{ inputs.arch }}-tbbOFF-${{ inputs.target_sha }}-${{ inputs.orchestrator_run_id }}.json
@@ -281,7 +281,7 @@ jobs:
 
       - name: Restore BAL dataset archive cache
         id: dataset_cache_restore
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: examples/Data/problem-135-90642-pre.txt.bz2
           key: bal-problem-135-90642-pre-txt-bz2-v1
@@ -295,7 +295,7 @@ jobs:
 
       - name: Save BAL dataset archive cache
         if: steps.dataset_cache_restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         continue-on-error: true
         with:
           path: examples/Data/problem-135-90642-pre.txt.bz2
@@ -338,7 +338,7 @@ jobs:
           cp benchmark-results-tbbON.json "benchmark-cache/${{ inputs.os_name }}-${{ inputs.arch }}-tbbON-${{ inputs.target_sha }}-${{ inputs.orchestrator_run_id }}.json"
 
       - name: Save benchmark cache (TBB=ON)
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         continue-on-error: true
         with:
           path: benchmark-cache/${{ inputs.os_name }}-${{ inputs.arch }}-tbbON-${{ inputs.target_sha }}-${{ inputs.orchestrator_run_id }}.json
@@ -377,7 +377,7 @@ jobs:
           cp benchmark-results-tbbOFF.json "benchmark-cache/${{ inputs.os_name }}-${{ inputs.arch }}-tbbOFF-${{ inputs.target_sha }}-${{ inputs.orchestrator_run_id }}.json"
 
       - name: Save benchmark cache (TBB=OFF)
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         continue-on-error: true
         with:
           path: benchmark-cache/${{ inputs.os_name }}-${{ inputs.arch }}-tbbOFF-${{ inputs.target_sha }}-${{ inputs.orchestrator_run_id }}.json

--- a/.github/workflows/time-sfmbal-benchmark-trigger.yml
+++ b/.github/workflows/time-sfmbal-benchmark-trigger.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch benchmark workflow for /benchmark
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const body = context.payload.comment.body.trim();

--- a/.github/workflows/time-sfmbal-benchmark.yml
+++ b/.github/workflows/time-sfmbal-benchmark.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Resolve PR context
         id: resolve
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const eventName = context.eventName;
@@ -82,7 +82,7 @@ jobs:
     steps:
       - name: Dispatch benchmark runner workflows and wait
         id: dispatch
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           WORKFLOW_ID: time-sfmbal-benchmark-runner.yml
         with:
@@ -253,14 +253,14 @@ jobs:
     steps:
       - name: Restore head benchmark cache
         id: restore_head
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: benchmark-cache/${{ matrix.os_name }}-${{ matrix.arch }}-tbb${{ matrix.tbb }}-${{ needs.context.outputs.head_sha }}-${{ github.run_id }}.json
           key: timeSFMBAL-benchmark-v4-${{ matrix.os_name }}-${{ matrix.arch }}-tbb${{ matrix.tbb }}-${{ needs.context.outputs.head_sha }}-${{ github.run_id }}
 
       - name: Restore base benchmark cache
         id: restore_base
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: benchmark-cache/${{ matrix.os_name }}-${{ matrix.arch }}-tbb${{ matrix.tbb }}-${{ needs.context.outputs.base_sha }}-${{ github.run_id }}.json
           key: timeSFMBAL-benchmark-v4-${{ matrix.os_name }}-${{ matrix.arch }}-tbb${{ matrix.tbb }}-${{ needs.context.outputs.base_sha }}-${{ github.run_id }}
@@ -284,7 +284,7 @@ jobs:
           fi
 
       - name: Upload collected files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: time-sfmbal-collected-${{ matrix.id }}
           path: artifact/*
@@ -299,7 +299,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download collected artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: time-sfmbal-collected-*
           path: collected
@@ -354,7 +354,7 @@ jobs:
 
       - name: Post PR comment
         if: needs.context.outputs.should_comment == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require("fs");

--- a/.github/workflows/trigger-packaging.yml
+++ b/.github/workflows/trigger-packaging.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Package Rebuild
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.PACKAGING_REPO_ACCESS_TOKEN }}
           script: |

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: "v0.17.0"
 
       - name: Install mold
         uses: rui314/setup-mold@v1

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -47,7 +47,7 @@ jobs:
           toolset: 14.40
 
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Install mold
         uses: rui314/setup-mold@v1
@@ -71,7 +71,7 @@ jobs:
           brew install autoconf autoconf-archive automake libtool
 
       - name: Set up vcpkg
-        uses: lukka/run-vcpkg@v11.5
+        uses: lukka/run-vcpkg@v11.6
         with:
           vcpkgDirectory: ${{ github.workspace }}/vcpkg
         env:
@@ -87,7 +87,7 @@ jobs:
 
       - name: Restore cache dependencies
         id: cache-restore
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v5
         with:
           path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
           key: ${{ matrix.os }}-${{ hashFiles('vcpkg.json') }}-${{ steps.hash-compiler.outputs.hash }}
@@ -130,7 +130,7 @@ jobs:
 
       - name: On Failure, upload vcpkg logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: logs_${{ matrix.os }}_${{ github.event.pull_request.head.sha }}
           path: vcpkg/buildtrees/**/*.log
@@ -138,7 +138,7 @@ jobs:
       - name: Cache dependencies
         # Don't save if it's the exact same
         if: steps.cache-restore.outputs.cache-matched-key != format('{0}-{1}-{2}-{3}', matrix.os, hashFiles('vcpkg.json'), steps.hash-compiler.outputs.hash, hashFiles('vcpkg_installed/**/vcpkg_abi_info.txt'))
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
           key: ${{ matrix.os }}-${{ hashFiles('vcpkg.json') }}-${{ steps.hash-compiler.outputs.hash }}-${{ hashFiles('vcpkg_installed/**/vcpkg_abi_info.txt') }}


### PR DESCRIPTION
## Summary

- upgrade supported GitHub Actions to Node 24-compatible releases
- update the MyST Pages build from Node 18 to Node 24
- preserve workflow inputs, outputs, permissions, cache keys, and artifact layouts

## Motivation

GitHub has deprecated the Node 20 action runtime and is forcing affected actions to run on Node 24. Updating supported actions removes those warnings and keeps the workflows on maintained runtimes.

`ilammy/msvc-dev-cmd@v1` remains unchanged because its latest release still declares Node 20 and there is no safe upstream Node 24 release yet.

## Validation

- `actionlint -shellcheck= .github/workflows/*.yml`
- `git diff --check origin/develop...HEAD`
- audited all workflow `uses:` references for stale versions
- verified the selected action metadata through the GitHub API; all upgraded JavaScript actions declare Node 24, and `upload-pages-artifact@v5` delegates to `upload-artifact@v7`

The repository's existing ShellCheck diagnostics in unrelated shell steps are unchanged and outside this maintenance update.
