### PR TITLE
Add Pose2 tangent Logmap derivative overload

### DIFF
--- a/gtsam/geometry/Pose2.cpp
+++ b/gtsam/geometry/Pose2.cpp
@@ -190,8 +190,7 @@ Matrix3 Pose2::ExpmapDerivative(const Vector3& v) {
 }
 
 /* ************************************************************************* */
-Matrix3 Pose2::LogmapDerivative(const Pose2& p) {
-  Vector3 v = Logmap(p);
+Matrix3 Pose2::LogmapDerivative(const Vector3& v) {
   double alpha = v[2];
   Matrix3 J;
   if (std::abs(alpha) > 1e-5) {
@@ -209,6 +208,11 @@ Matrix3 Pose2::LogmapDerivative(const Pose2& p) {
         0,0, 1;
   }
   return J;
+}
+
+/* ************************************************************************* */
+Matrix3 Pose2::LogmapDerivative(const Pose2& pose) {
+  return LogmapDerivative(Logmap(pose));
 }
 
 /* ************************************************************************* */

--- a/gtsam/geometry/Pose2.h
+++ b/gtsam/geometry/Pose2.h
@@ -170,8 +170,22 @@ public:
   /// Derivative of Expmap
   static Matrix3 ExpmapDerivative(const Vector3& v);
 
-  /// Derivative of Logmap
-  static Matrix3 LogmapDerivative(const Pose2& v);
+  /**
+   * Inverse right Jacobian of the exponential map evaluated at a pose.
+   *
+   * @param pose Pose whose tangent coordinates determine the evaluation point.
+   * @return The 3-by-3 inverse right Jacobian at Logmap(pose).
+   */
+  static Matrix3 LogmapDerivative(const Pose2& pose);
+
+  /**
+   * Inverse right Jacobian of the exponential map evaluated at tangent
+   * coordinates xi = (dx, dy, dtheta).
+   *
+   * @param xi Tangent coordinates at which to evaluate the Jacobian.
+   * @return The 3-by-3 inverse right Jacobian at xi.
+   */
+  static Matrix3 LogmapDerivative(const Vector3& xi);
 
   // Chart at origin, depends on compile-time flag SLOW_BUT_CORRECT_EXPMAP
   struct GTSAM_EXPORT ChartAtOrigin {

--- a/gtsam/geometry/geometry.i
+++ b/gtsam/geometry/geometry.i
@@ -560,7 +560,8 @@ class Pose2 {
   gtsam::Vector logmap(const gtsam::Pose2& g);
   gtsam::Vector logmap(const gtsam::Pose2& g, Eigen::Ref<Eigen::MatrixXd> H1, Eigen::Ref<Eigen::MatrixXd> H2);
   static gtsam::Matrix ExpmapDerivative(gtsam::Vector v);
-  static gtsam::Matrix LogmapDerivative(const gtsam::Pose2& v);
+  static gtsam::Matrix3 LogmapDerivative(const gtsam::Pose2& pose);
+  static gtsam::Matrix3 LogmapDerivative(const gtsam::Vector3& xi);
 
   // Matrix Lie Group
   gtsam::Matrix AdjointMap() const;

--- a/gtsam/geometry/tests/testPose2.cpp
+++ b/gtsam/geometry/tests/testPose2.cpp
@@ -259,6 +259,34 @@ TEST(Pose2, logmap_full) {
 }
 
 /* ************************************************************************* */
+namespace logmap_derivative {
+
+// Checks the tangent overload against the pose overload and Expmap Jacobian.
+TEST(Pose2, LogmapDerivativeTangent) {
+  const Vector3 xi{0.4, -0.2, 0.3};
+  const Matrix3 actual = Pose2::LogmapDerivative(xi);
+
+  EXPECT(assert_equal(Pose2::LogmapDerivative(Pose2::Expmap(xi)), actual,
+                      1e-12));
+  const Matrix3 identity = actual * Pose2::ExpmapDerivative(xi);
+  EXPECT(assert_equal<Matrix3>(I_3x3, identity, 1e-12));
+}
+
+// Checks that both overloads agree in the small-angle branch.
+TEST(Pose2, LogmapDerivativeTangentNearZero) {
+  const Vector3 xi{0.4, -0.2, 1e-8};
+  const Matrix3 actual = Pose2::LogmapDerivative(xi);
+
+  EXPECT(assert_equal(Pose2::LogmapDerivative(Pose2::Expmap(xi)), actual,
+                      1e-9));
+  const Matrix3 identity = actual * Pose2::ExpmapDerivative(xi);
+  EXPECT(assert_equal<Matrix3>(I_3x3, identity, 1e-12));
+}
+
+}  // namespace logmap_derivative
+/* ************************************************************************* */
+
+/* ************************************************************************* */
 TEST( Pose2, ExpmapDerivative1) {
   Matrix3 actualH;
   Vector3 w(0.1, 0.27, -0.3);

--- a/python/gtsam/tests/test_Pose2.py
+++ b/python/gtsam/tests/test_Pose2.py
@@ -27,6 +27,20 @@ class TestPose2(GtsamTestCase):
         actual = Pose2.adjoint_(xi, xi)
         np.testing.assert_array_equal(actual, expected)
 
+    def test_logmap_derivative_overloads(self) -> None:
+        """The tangent and pose overloads should return the same Jacobian."""
+        for xi in (np.array([0.4, -0.2, 0.3]),
+                   np.array([0.4, -0.2, 1e-8])):
+            with self.subTest(dtheta=xi[2]):
+                from_tangent = Pose2.LogmapDerivative(xi)
+                from_pose = Pose2.LogmapDerivative(Pose2.Expmap(xi))
+
+                np.testing.assert_allclose(from_tangent, from_pose,
+                                           rtol=0, atol=1e-9)
+                np.testing.assert_allclose(
+                    from_tangent @ Pose2.ExpmapDerivative(xi),
+                    np.eye(3), rtol=0, atol=1e-12)
+
     def test_transformTo(self):
         """Test transformTo method."""
         pose = Pose2(2, 4, -math.pi / 2)


### PR DESCRIPTION
## Summary

- Adds `Pose2::LogmapDerivative(const Vector3& xi)` so callers with tangent coordinates can obtain the inverse right Jacobian directly.
- Refactors the existing pose-valued overload to delegate through `Logmap(pose)`, preserving its behavior.
- Exposes both overloads in `geometry.i` and covers C++ and Python overload dispatch, ordinary/small-angle tangents, and inverse consistency with `ExpmapDerivative`.

## API impact and rationale

This is an additive static overload. It avoids an unnecessary `Expmap`/pose construction when tangent coordinates are already available, while keeping the existing `Pose2` overload source-compatible.

## Validation

- `git diff --check`
- `make -j6 testPose2.run`
- `make -j6 python-install`
- `conda run -n py312 python -m pytest -p no:cacheprovider python/gtsam/tests/test_Pose2.py` (5 passed)

## Extraction provenance

Curated from private commit `6170afc40` onto current public `develop`. This PR contains only the Pose2 API, wrapper, and focused tests; it includes no quadrature, LIO, generated artifacts, or unrelated private-repository changes.