### PR TITLE
Add gyroscope integration helpers

### DIFF
--- a/gtsam/navigation/PreintegratedRotation.cpp
+++ b/gtsam/navigation/PreintegratedRotation.cpp
@@ -23,6 +23,8 @@
 
 #include <gtsam/base/MatrixConstants.h>
 
+#include <stdexcept>
+
 using namespace std;
 
 namespace gtsam {
@@ -110,6 +112,77 @@ void PreintegratedRotation::integrateGyroMeasurement(
   // Update Jacobian
   const Matrix3 incrRt = incrR.transpose();
   delRdelBiasOmega_ = incrRt * delRdelBiasOmega_ + H_bias;
+}
+
+namespace {
+
+void validateGyroIntegrationInputs(const Vector& times,
+                                   ConstMatrixView measuredOmegas) {
+  if (times.size() < 2) {
+    throw invalid_argument("Gyro integration requires at least two samples");
+  }
+  if (measuredOmegas.rows() != times.size() || measuredOmegas.cols() != 3) {
+    throw invalid_argument(
+        "Gyro integration requires an Mx3 omega matrix with one row per "
+        "sample time");
+  }
+  for (Eigen::Index index = 0; index + 1 < times.size(); ++index) {
+    if (times(index + 1) <= times(index)) {
+      throw invalid_argument(
+          "Gyro integration requires strictly increasing sample times");
+    }
+  }
+}
+
+Vector3 correctedOmega(ConstMatrixView measuredOmegas, Eigen::Index row,
+                       const Vector3& biasHat, const Rot3& body_R_sensor) {
+  const Vector3 measuredOmega = measuredOmegas.row(row).transpose();
+  return body_R_sensor * (measuredOmega - biasHat);
+}
+
+}  // namespace
+
+Rot3 integrateSequentialRotations(const Vector& times,
+                                  ConstMatrixView measuredOmegas,
+                                  const Vector3& biasHat,
+                                  const Rot3& body_R_sensor) {
+  validateGyroIntegrationInputs(times, measuredOmegas);
+
+  Rot3 rotation;
+  for (Eigen::Index index = 0; index + 1 < times.size(); ++index) {
+    const double deltaTime = times(index + 1) - times(index);
+    const Vector3 omega0 =
+        correctedOmega(measuredOmegas, index, biasHat, body_R_sensor);
+    const Vector3 omega1 =
+        correctedOmega(measuredOmegas, index + 1, biasHat, body_R_sensor);
+    const Vector3 theta = 0.5 * deltaTime * (omega0 + omega1);
+    rotation = rotation.compose(Rot3::Expmap(theta));
+  }
+  return rotation;
+}
+
+Rot3 integrateSingleSpeedConing(const Vector& times,
+                                ConstMatrixView measuredOmegas,
+                                const Vector3& biasHat,
+                                const Rot3& body_R_sensor) {
+  validateGyroIntegrationInputs(times, measuredOmegas);
+
+  Rot3 rotation;
+  Vector3 previousTheta = Vector3::Zero();
+  for (Eigen::Index index = 0; index + 1 < times.size(); ++index) {
+    const double deltaTime = times(index + 1) - times(index);
+    const Vector3 omega0 =
+        correctedOmega(measuredOmegas, index, biasHat, body_R_sensor);
+    const Vector3 omega1 =
+        correctedOmega(measuredOmegas, index + 1, biasHat, body_R_sensor);
+    const Vector3 theta = 0.5 * deltaTime * (omega0 + omega1);
+    const Vector3 correctedTheta =
+        index == 0 ? theta
+                   : theta + (1.0 / 12.0) * previousTheta.cross(theta);
+    rotation = rotation.compose(Rot3::Expmap(correctedTheta));
+    previousTheta = theta;
+  }
+  return rotation;
 }
 
 #ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43

--- a/gtsam/navigation/PreintegratedRotation.h
+++ b/gtsam/navigation/PreintegratedRotation.h
@@ -54,6 +54,48 @@ struct GTSAM_EXPORT IncrementalRotation {
 
 }  // namespace internal
 
+/**
+ * Integrate timed gyroscope samples using sequential trapezoidal rotation
+ * increments. The timestamps must increase strictly, and measuredOmegas must
+ * have one three-axis sample per timestamp.
+ *
+ * The bias is subtracted in the sensor frame before body_R_sensor rotates each
+ * sample into the body frame.
+ *
+ * @param times Strictly increasing sample timestamps.
+ * @param measuredOmegas M-by-3 matrix of sensor-frame angular velocities.
+ * @param biasHat Gyroscope bias expressed in the sensor frame.
+ * @param body_R_sensor Rotation from sensor coordinates to body coordinates.
+ * @return The integrated body rotation.
+ * @throws std::invalid_argument if the sample count, matrix shape, or timestamp
+ * ordering is invalid.
+ */
+GTSAM_EXPORT Rot3 integrateSequentialRotations(
+    const Vector& times, ConstMatrixView measuredOmegas,
+    const Vector3& biasHat = Vector3::Zero(),
+    const Rot3& body_R_sensor = Rot3());
+
+/**
+ * Integrate timed gyroscope samples with a single-speed coning correction.
+ * The timestamps must increase strictly, and measuredOmegas must have one
+ * three-axis sample per timestamp.
+ *
+ * The bias is subtracted in the sensor frame before body_R_sensor rotates each
+ * sample into the body frame.
+ *
+ * @param times Strictly increasing sample timestamps.
+ * @param measuredOmegas M-by-3 matrix of sensor-frame angular velocities.
+ * @param biasHat Gyroscope bias expressed in the sensor frame.
+ * @param body_R_sensor Rotation from sensor coordinates to body coordinates.
+ * @return The integrated body rotation.
+ * @throws std::invalid_argument if the sample count, matrix shape, or timestamp
+ * ordering is invalid.
+ */
+GTSAM_EXPORT Rot3 integrateSingleSpeedConing(
+    const Vector& times, ConstMatrixView measuredOmegas,
+    const Vector3& biasHat = Vector3::Zero(),
+    const Rot3& body_R_sensor = Rot3());
+
 /// Parameters for pre-integration:
 /// Usage: Create just a single Params and pass a shared pointer to the constructor
 struct GTSAM_EXPORT PreintegratedRotationParams {

--- a/gtsam/navigation/navigation.i
+++ b/gtsam/navigation/navigation.i
@@ -151,6 +151,16 @@ class PreintegratedRotation {
   void serialize() const;
 };
 
+gtsam::Rot3 integrateSequentialRotations(
+    const gtsam::Vector& times, gtsam::ConstMatrixView measuredOmegas,
+    const gtsam::Vector3& biasHat = gtsam::Vector3::Zero(),
+    const gtsam::Rot3& body_R_sensor = gtsam::Rot3());
+
+gtsam::Rot3 integrateSingleSpeedConing(
+    const gtsam::Vector& times, gtsam::ConstMatrixView measuredOmegas,
+    const gtsam::Vector3& biasHat = gtsam::Vector3::Zero(),
+    const gtsam::Rot3& body_R_sensor = gtsam::Rot3());
+
 #include <gtsam/navigation/PreintegrationParams.h>
 virtual class PreintegrationParams : gtsam::PreintegratedRotationParams {
   PreintegrationParams(gtsam::Vector n_gravity);

--- a/gtsam/navigation/tests/testPreintegratedRotation.cpp
+++ b/gtsam/navigation/tests/testPreintegratedRotation.cpp
@@ -24,7 +24,9 @@
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/navigation/PreintegratedRotation.h>
 
+#include <initializer_list>
 #include <memory>
+#include <stdexcept>
 
 #include "gtsam/base/Matrix.h"
 #include "gtsam/base/Vector.h"
@@ -92,6 +94,135 @@ TEST(PreintegratedRotation, integrateGyroMeasurement) {
   corrected = pim.biascorrectedDeltaRij(biasOmegaIncr, H);
   EXPECT(assert_equal(expectedH, H));
 }
+
+/* ************************************************************************* */
+namespace gyro_integration_methods {
+
+Vector times(const std::initializer_list<double>& values) {
+  Vector result(values.size());
+  Eigen::Index index = 0;
+  for (const double value : values) result(index++) = value;
+  return result;
+}
+
+Matrix omegas(const std::initializer_list<Vector3>& rows) {
+  Matrix result(rows.size(), 3);
+  Eigen::Index index = 0;
+  for (const Vector3& row : rows) result.row(index++) = row.transpose();
+  return result;
+}
+
+Matrix constantOmegas(const Vector3& omega, size_t count) {
+  Matrix result(count, 3);
+  for (size_t row = 0; row < count; ++row) {
+    result.row(row) = omega.transpose();
+  }
+  return result;
+}
+
+// Checks constant angular velocity for both gyroscope integrators.
+TEST(PreintegratedRotation, GyroIntegrationConstantOmega) {
+  const Vector sampleTimes = times({0.0, 0.25, 0.5, 0.75, 1.0});
+  const Vector3 omega{0.1, -0.2, 0.3};
+  const Matrix measurements = constantOmegas(omega, sampleTimes.size());
+  const Rot3 expected = Rot3::Expmap(omega);
+
+  EXPECT(assert_equal(
+      expected, integrateSequentialRotations(sampleTimes, measurements),
+      1e-12));
+  EXPECT(assert_equal(
+      expected, integrateSingleSpeedConing(sampleTimes, measurements), 1e-12));
+}
+
+// Checks that both functions subtract the supplied gyroscope bias.
+TEST(PreintegratedRotation, GyroIntegrationBiasCorrection) {
+  const Vector sampleTimes = times({0.0, 0.5, 1.0});
+  const Vector3 omega{0.15, 0.0, -0.05};
+  const Vector3 bias{0.3, -0.4, 0.5};
+  const Matrix measurements = constantOmegas(omega + bias, sampleTimes.size());
+  const Rot3 expected = Rot3::Expmap(omega);
+
+  EXPECT(assert_equal(
+      expected, integrateSequentialRotations(sampleTimes, measurements, bias),
+      1e-12));
+  EXPECT(assert_equal(
+      expected, integrateSingleSpeedConing(sampleTimes, measurements, bias),
+      1e-12));
+}
+
+// Checks that samples are rotated from the sensor frame into the body frame.
+TEST(PreintegratedRotation, GyroIntegrationSensorRotation) {
+  const Vector sampleTimes = times({0.0, 0.5, 1.0});
+  const Rot3 body_R_sensor = Rot3::Yaw(M_PI_2);
+  const Vector3 sensorOmega{0.2, 0.0, 0.0};
+  const Vector3 bodyOmega = body_R_sensor * sensorOmega;
+  const Matrix measurements =
+      constantOmegas(sensorOmega, sampleTimes.size());
+  const Rot3 expected = Rot3::Expmap(bodyOmega);
+
+  EXPECT(assert_equal(expected,
+                      integrateSequentialRotations(
+                          sampleTimes, measurements, Vector3::Zero(),
+                          body_R_sensor),
+                      1e-12));
+  EXPECT(assert_equal(expected,
+                      integrateSingleSpeedConing(
+                          sampleTimes, measurements, Vector3::Zero(),
+                          body_R_sensor),
+                      1e-12));
+}
+
+// Checks sequential rotations against explicit trapezoidal composition.
+TEST(PreintegratedRotation, GyroIntegrationSequentialRotations) {
+  const Vector sampleTimes = times({0.0, 1.0, 2.0});
+  const Matrix measurements =
+      omegas({Vector3{1.0, 0.0, 0.0}, Vector3{0.0, 1.0, 0.0},
+              Vector3{0.0, 0.0, 1.0}});
+  const Vector3 theta0{0.5, 0.5, 0.0};
+  const Vector3 theta1{0.0, 0.5, 0.5};
+  const Rot3 expected =
+      Rot3::Expmap(theta0).compose(Rot3::Expmap(theta1));
+
+  EXPECT(assert_equal(
+      expected, integrateSequentialRotations(sampleTimes, measurements),
+      1e-12));
+}
+
+// Checks the single-speed coning correction against its defining formula.
+TEST(PreintegratedRotation, GyroIntegrationSingleSpeedConing) {
+  const Vector sampleTimes = times({0.0, 1.0, 2.0});
+  const Matrix measurements =
+      omegas({Vector3{1.0, 0.0, 0.0}, Vector3{0.0, 1.0, 0.0},
+              Vector3{0.0, 0.0, 1.0}});
+  const Vector3 theta0{0.5, 0.5, 0.0};
+  const Vector3 theta1{0.0, 0.5, 0.5};
+  const Vector3 correctedTheta1 =
+      theta1 + (1.0 / 12.0) * theta0.cross(theta1);
+  const Rot3 expected =
+      Rot3::Expmap(theta0).compose(Rot3::Expmap(correctedTheta1));
+
+  EXPECT(assert_equal(
+      expected, integrateSingleSpeedConing(sampleTimes, measurements), 1e-12));
+}
+
+// Checks that invalid sample layouts and timestamps are rejected.
+TEST(PreintegratedRotation, GyroIntegrationInvalidInputs) {
+  CHECK_EXCEPTION(
+      integrateSequentialRotations(times({0.0}), Matrix::Zero(1, 3)),
+      std::invalid_argument);
+  CHECK_EXCEPTION(integrateSequentialRotations(times({0.0, 1.0}),
+                                               Matrix::Zero(2, 2)),
+                  std::invalid_argument);
+  CHECK_EXCEPTION(integrateSequentialRotations(times({0.0, 0.0}),
+                                               Matrix::Zero(2, 3)),
+                  std::invalid_argument);
+  CHECK_EXCEPTION(integrateSingleSpeedConing(times({0.0, 1.0, 0.5}),
+                                             Matrix::Zero(3, 3)),
+                  std::invalid_argument);
+}
+
+}  // namespace gyro_integration_methods
+/* ************************************************************************* */
 
 //******************************************************************************
 

--- a/python/gtsam/preamble/navigation.h
+++ b/python/gtsam/preamble/navigation.h
@@ -16,3 +16,5 @@
 namespace std {
 using gtsam::operator<<;
 }
+
+#include "python/gtsam/preamble/arg_policies.h"

--- a/python/gtsam/tests/test_PreintegratedRotation.py
+++ b/python/gtsam/tests/test_PreintegratedRotation.py
@@ -1,0 +1,78 @@
+"""
+GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,
+Atlanta, Georgia 30332-0415
+All Rights Reserved
+
+See LICENSE for the license information
+
+Unit tests for the PreintegratedRotation Python bindings.
+"""
+
+import unittest
+
+import gtsam
+import numpy as np
+from gtsam.utils.test_case import GtsamTestCase
+
+
+class TestPreintegratedRotation(GtsamTestCase):
+    """Tests for wrapped rotation preintegration utilities."""
+
+    def test_integrate_sequential_rotations_accepts_numpy_arrays(self):
+        """Sequential rotations accept C- and F-contiguous arrays."""
+        times = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
+        omega = np.array([0.1, -0.2, 0.3])
+        measured_omegas_c = np.tile(omega, (times.size, 1))
+        measured_omegas_f = np.asfortranarray(measured_omegas_c)
+        expected = gtsam.Rot3.Expmap(omega)
+
+        for measured_omegas in (measured_omegas_c, measured_omegas_f):
+            order = "F" if measured_omegas.flags["F_CONTIGUOUS"] else "C"
+            with self.subTest(order=order):
+                actual = gtsam.integrateSequentialRotations(
+                    times, measured_omegas)
+                self.gtsamAssertEquals(expected, actual, tol=1e-12)
+
+        with self.assertRaises(TypeError):
+            gtsam.integrateSequentialRotations(times,
+                                               measured_omegas_c.tolist())
+
+    def test_integrate_single_speed_coning_accepts_numpy_arrays(self):
+        """Single-speed coning accepts C- and F-contiguous arrays."""
+        times = np.array([0.0, 0.5, 1.0])
+        omega = np.array([0.15, 0.0, -0.05])
+        bias = np.array([0.3, -0.4, 0.5])
+        measured_omegas_c = np.tile(omega + bias, (times.size, 1))
+        measured_omegas_f = np.asfortranarray(measured_omegas_c)
+        expected = gtsam.Rot3.Expmap(omega)
+
+        for measured_omegas in (measured_omegas_c, measured_omegas_f):
+            order = "F" if measured_omegas.flags["F_CONTIGUOUS"] else "C"
+            with self.subTest(order=order):
+                actual = gtsam.integrateSingleSpeedConing(
+                    times, measured_omegas, bias)
+                self.gtsamAssertEquals(expected, actual, tol=1e-12)
+
+        with self.assertRaises(TypeError):
+            gtsam.integrateSingleSpeedConing(times,
+                                             measured_omegas_c.tolist(), bias)
+
+    def test_integrators_apply_sensor_rotation(self):
+        """Wrapped utilities rotate sensor samples into the body frame."""
+        times = np.array([0.0, 0.5, 1.0])
+        sensor_omega = np.array([0.2, 0.0, 0.0])
+        measured_omegas = np.tile(sensor_omega, (times.size, 1))
+        body_R_sensor = gtsam.Rot3.Yaw(np.pi / 2.0)
+        expected = gtsam.Rot3.Expmap(body_R_sensor.rotate(sensor_omega))
+
+        sequential = gtsam.integrateSequentialRotations(
+            times, measured_omegas, np.zeros(3), body_R_sensor)
+        single_speed = gtsam.integrateSingleSpeedConing(
+            times, measured_omegas, np.zeros(3), body_R_sensor)
+
+        self.gtsamAssertEquals(expected, sequential, tol=1e-12)
+        self.gtsamAssertEquals(expected, single_speed, tol=1e-12)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds exported `integrateSequentialRotations` and `integrateSingleSpeedConing` gyroscope helpers.
- Validates sample count, matrix shape, and strictly increasing timestamps.
- Applies sensor-frame bias correction, sensor-to-body rotation, trapezoidal increments, and the `1/12 * previousTheta × theta` single-speed coning correction.
- Exposes both functions through `navigation.i` with the `ConstMatrixView` argument policy and matching parameter names.

## API impact and rationale

These are public free functions for integrating timestamped gyroscope batches without constructing a preintegration object. `ConstMatrixView` accepts C- and F-contiguous NumPy arrays without silently accepting Python lists for the matrix argument.

## Validation

- `git diff --check`
- `make -j6 testPreintegratedRotation.run`
- `make -j6 python-install`
- `conda run -n py312 python -m pytest -p no:cacheprovider python/gtsam/tests/test_PreintegratedRotation.py` (3 passed)

C++ coverage includes constant angular velocity, bias correction, sensor rotation, explicit sequential composition, coning correction, and invalid inputs. Python coverage includes C/F layouts, sensor rotation, and list rejection.