### PR TITLE
Upgrade release/4.2 CI actions and stabilize Linux wheels

### DIFF
--- a/.github/scripts/python_wheels/cibw_before_all.sh
+++ b/.github/scripts/python_wheels/cibw_before_all.sh
@@ -5,7 +5,16 @@ set -x
 
 PYTHON_VERSION="$1"
 PROJECT_DIR="$2"
-WHEEL_BUILD_JOBS=2
+BOOST_BUILD_JOBS=2
+GTSAM_BUILD_JOBS=2
+
+# The generated Python wrapper translation units require substantial memory.
+# Compile them serially in Linux wheel containers to avoid the OOM killer.
+if [ "$(uname)" == "Linux" ]; then
+    GTSAM_BUILD_JOBS=1
+fi
+
+echo "Build parallelism: Boost=${BOOST_BUILD_JOBS}, GTSAM=${GTSAM_BUILD_JOBS}"
 
 export PYTHON="python${PYTHON_VERSION}"
 
@@ -27,13 +36,13 @@ BOOST_PREFIX="$HOME/opt/boost"
 ./bootstrap.sh --prefix=${BOOST_PREFIX}
 
 if [ "$(uname)" == "Linux" ]; then
-    ./b2 -j${WHEEL_BUILD_JOBS} install --prefix=${BOOST_PREFIX} -d0 --with-graph \
+    ./b2 -j${BOOST_BUILD_JOBS} install --prefix=${BOOST_PREFIX} -d0 --with-graph \
         --with-move --with-optional --with-program_options --with-random \
         --with-serialization --with-smart_ptr --with-timer --with-chrono \
         --with-filesystem
 elif [ "$(uname)" == "Darwin" ]; then
     BOOST_ARCH="${GTSAM_BOOST_ARCH:-arm}"
-    ./b2 -j${WHEEL_BUILD_JOBS} install --prefix=${BOOST_PREFIX} -d0 --with-graph \
+    ./b2 -j${BOOST_BUILD_JOBS} install --prefix=${BOOST_PREFIX} -d0 --with-graph \
         --with-move --with-optional --with-program_options --with-random \
         --with-serialization --with-smart_ptr --with-timer --with-chrono \
         --with-filesystem \
@@ -79,4 +88,4 @@ cmake $PROJECT_DIR \
     -DCMAKE_INSTALL_PREFIX=$PROJECT_DIR/gtsam_install
 
 cd $PROJECT_DIR/build
-make -j${WHEEL_BUILD_JOBS} install
+make -j${GTSAM_BUILD_JOBS} install

--- a/.github/workflows/prod-cibw.yml
+++ b/.github/workflows/prod-cibw.yml
@@ -106,13 +106,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.sha }}
 
       - name: Set up Python ${{ matrix.python_version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
 
@@ -160,7 +160,7 @@ jobs:
           python3 -c "import platform; print(platform.machine()); import gtsam"
 
       - name: Store artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cibw-wheels-cp${{ matrix.cibw_python_version }}-${{ matrix.platform_id }}
           path: wheelhouse/*.whl
@@ -174,7 +174,7 @@ jobs:
       id-token: write
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: dist/
           merge-multiple: true

--- a/.github/workflows/trigger-packaging.yml
+++ b/.github/workflows/trigger-packaging.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Package Rebuild
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.PACKAGING_REPO_ACCESS_TOKEN }}
           script: |

--- a/.github/workflows/trigger-python.yml
+++ b/.github/workflows/trigger-python.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Repository Dispatch
-        uses: ProfFan/repository-dispatch@master
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.PYTHON_CI_REPO_ACCESS_TOKEN }}
           repository: borglab/gtsam-manylinux-build


### PR DESCRIPTION
## Summary

- upgrade supported GitHub Actions used by the `release/4.2` packaging and dispatch workflows to Node 24-compatible releases
- replace the unmaintained Node 12 `ProfFan/repository-dispatch` action with `peter-evans/repository-dispatch@v4`
- serialize the memory-heavy GTSAM/Python wrapper install in Linux wheel containers while retaining two-job Boost and macOS builds

## Motivation

GitHub-hosted runners are moving JavaScript actions from deprecated Node runtimes to Node 24. The release branch still used several older first-party action releases and one unmaintained Node 12 dispatch action.

The Linux wheel wrapper build also used `-j2` for large generated translation units. That can exceed the memory available in the manylinux container, particularly in the x86_64 Python 3.11 job. Running the wrapper install serially avoids that OOM failure without slowing the separate Boost build.

`ilammy/msvc-dev-cmd@v1` remains unchanged because upstream has no safe Node 24 release; it is the only retained Node 20 action.

## Validation

- `bash -n` passed for all Python wheel shell scripts
- `actionlint -shellcheck= .github/workflows/*.yml` passed
- full `actionlint` reported only pre-existing ShellCheck findings in untouched build workflows
- `git diff --check` passed
- audited every `uses:` declaration: no Node 12 or Node 16 actions remain, and Node 20 remains only for `ilammy/msvc-dev-cmd@v1`
- verified the artifact upload/download and repository-dispatch inputs remain supported by the upgraded actions

No C++ or Python behavior changed; GitHub Actions provides the platform-specific wheel acceptance test.
