### PR TITLE
Add unified ALM update policies with paper-inspired BCL

### DIFF
--- a/examples/CertifiableRotationAveraging.cpp
+++ b/examples/CertifiableRotationAveraging.cpp
@@ -181,21 +181,16 @@ int RunCertifiableRA(const std::string& dataPath,
   if (skipped > 0) std::cout << "  (" << skipped << " non-Between skipped)";
   std::cout << "\n\n";
 
-  // Use the generic QCQP/Burer--Monteiro path with ALM. These globally tuned
-  // parameters are shared with timeShonanInitialization; initialization
-  // remains application-level policy rather than a BM solver backend.
+  // Use the generic QCQP/Burer--Monteiro path with the default BCL policy.
+  // Initialization remains application-level policy rather than a BM solver
+  // backend.
   RiemannianStaircaseParams params;
   params.pMin = IntrinsicDim;
   params.pMax = 10;
   params.eta = 1e-4;
   params.verbose = true;
-  params.almParams->initialMuEq = 1.0;
-  params.almParams->muEqIncreaseRate = 2.0;
   params.almParams->maxIterations = 50;
   params.almParams->absoluteViolationTolerance = 1e-8;
-  params.almParams->relativeViolationTolerance = 1e-8;
-  params.almParams->absoluteCostTolerance = 1e-10;
-  params.almParams->relativeCostTolerance = 1e-10;
   params.almParams->verbose = false;
 
   const auto initializationStart = std::chrono::steady_clock::now();

--- a/gtsam/certifiable/doc/RiemannianStaircaseOptimizer.ipynb
+++ b/gtsam/certifiable/doc/RiemannianStaircaseOptimizer.ipynb
@@ -122,10 +122,7 @@
    "source": [
     "alm = gtsam.AugmentedLagrangianParams()\n",
     "alm.maxIterations = 80\n",
-    "alm.initialMuEq = 10.0\n",
-    "alm.muEqIncreaseRate = 2.0\n",
     "alm.absoluteViolationTolerance = 1e-8\n",
-    "alm.relativeViolationTolerance = 1e-8\n",
     "\n",
     "params = gtsam.RiemannianStaircaseParams()\n",
     "params.pMin = 2\n",

--- a/gtsam/certifiable/doc/RiemannianStaircaseParams.ipynb
+++ b/gtsam/certifiable/doc/RiemannianStaircaseParams.ipynb
@@ -95,8 +95,6 @@
    "source": [
     "alm = gtsam.AugmentedLagrangianParams()\n",
     "alm.maxIterations = 80\n",
-    "alm.initialMuEq = 10.0\n",
-    "alm.muEqIncreaseRate = 2.0\n",
     "alm.absoluteViolationTolerance = 1e-8\n",
     "\n",
     "params = gtsam.RiemannianStaircaseParams()\n",

--- a/gtsam/certifiable/doc/RiemannianStaircaseResult.ipynb
+++ b/gtsam/certifiable/doc/RiemannianStaircaseResult.ipynb
@@ -92,8 +92,6 @@
     "\n",
     "alm = gtsam.AugmentedLagrangianParams()\n",
     "alm.maxIterations = 80\n",
-    "alm.initialMuEq = 10.0\n",
-    "alm.muEqIncreaseRate = 2.0\n",
     "params = gtsam.RiemannianStaircaseParams()\n",
     "params.pMin = 2\n",
     "params.pMax = 4\n",

--- a/gtsam/certifiable/tests/testRiemannianStaircase.cpp
+++ b/gtsam/certifiable/tests/testRiemannianStaircase.cpp
@@ -66,15 +66,12 @@ Values RingQcqpValuesD2(size_t numPoses, double delta, double perturbation) {
   return values;
 }
 
-// Shared ALM tuning used by most tests. Tighter than library defaults so the
-// ring fixture converges to a 1st-order KKT point in <100 iterations.
+// Shared BCL tuning used by most tests. The tighter feasibility tolerance
+// makes the ring fixture suitable for certificate checks.
 AugmentedLagrangianParams::shared_ptr DefaultAlmParams() {
   auto p = std::make_shared<AugmentedLagrangianParams>();
   p->maxIterations = 50;
-  p->initialMuEq = 10.0;
-  p->muEqIncreaseRate = 2.0;
   p->absoluteViolationTolerance = 1e-8;
-  p->relativeViolationTolerance = 1e-8;
   return p;
 }
 

--- a/gtsam/constrained/AugmentedLagrangianOptimizer.cpp
+++ b/gtsam/constrained/AugmentedLagrangianOptimizer.cpp
@@ -12,7 +12,8 @@
 /**
  * @file    AugmentedLagrangianOptimizer.cpp
  * @brief   Augmented Lagrangian method for nonlinear constrained optimization.
- * @author  Yetong Zhang, Frank Dellaert
+ * @author  Yetong Zhang
+ * @author  Frank Dellaert (codex assisted)
  * @date    Aug 3, 2024
  */
 
@@ -30,12 +31,25 @@ using std::cout, std::endl, std::setprecision, std::setw;
 namespace gtsam {
 namespace {
 
-/** Factor adding a constant bias to another factor's unwhitened error. */
+/**
+ * A factor that adds a constant bias term to an original factor's unwhitened
+ * error. The augmented Lagrangian uses this to represent the equality term
+ *
+ *   lambda^T h(x) + (rho / 2) ||h(x)||^2
+ *     = (rho / 2) ||h(x) + lambda / rho||^2
+ *       - ||lambda||^2 / (2 rho).
+ *
+ * The noise model remains attached to both the original factor and this
+ * wrapper. Only this wrapper's noise model is applied to the biased residual;
+ * evaluating originalFactor_->unwhitenedError does not apply the original
+ * factor's noise model a second time.
+ */
 class BiasedFactor : public NoiseModelFactor {
  protected:
   using Base = NoiseModelFactor;
   using This = BiasedFactor;
 
+  // Original factor whose raw error and Jacobians are reused.
   Base::shared_ptr originalFactor_;
   Vector bias_;
 
@@ -45,13 +59,24 @@ class BiasedFactor : public NoiseModelFactor {
   /// Default constructor for I/O only.
   BiasedFactor() = default;
 
-  /// Construct a biased view of an existing factor.
+  /**
+   * Construct a biased view of an existing factor.
+   *
+   * @param originalFactor Original factor on x.
+   * @param bias Constant added to its unwhitened error.
+   */
   BiasedFactor(const Base::shared_ptr& originalFactor, const Vector& bias)
       : Base(originalFactor->noiseModel(), originalFactor->keys()),
         originalFactor_(originalFactor),
         bias_(bias) {}
 
-  /// Evaluate the original error plus the fixed bias.
+  /**
+   * Error function *without* the noise model, conventionally z-h(x). Override
+   * this method to finish implementing an N-way factor. If the optional
+   * argument is specified, it also computes the derivatives in `jacobians`.
+   * Here the result is the original factor's unwhitened error plus the fixed
+   * bias, and the Jacobians are unchanged because the bias is constant.
+   */
   Vector unwhitenedError(
       const Values& values,
       gtsam::OptionalMatrixVecType jacobians = nullptr) const override {
@@ -74,9 +99,18 @@ class BiasedFactor : public NoiseModelFactor {
 };
 
 /**
- * Least-squares factor for the nonconstant part of a scalar PHR term.
- * Its residual is max(0, lambda + rho g(x)) / sqrt(rho), where g is already
- * whitened by the constraint noise model.
+ * Least-squares factor for a scalar Powell--Hestenes--Rockafellar (PHR)
+ * inequality augmented Lagrangian. For a whitened inequality g(x) <= 0,
+ * nonnegative multiplier lambda, and direct penalty rho > 0, the PHR term is
+ *
+ *   [max(0, lambda + rho g(x))^2 - lambda^2] / (2 rho).
+ *
+ * The second term is constant in x, so LM can minimize the equivalent residual
+ *
+ *   r(x) = max(0, lambda + rho g(x)) / sqrt(rho).
+ *
+ * See Nocedal and Wright, Numerical Optimization, 2nd ed., Chapter 17, for the
+ * PHR inequality augmented Lagrangian and projected multiplier update.
  */
 class PhrInequalityFactor : public NoiseModelFactor {
  protected:
@@ -108,12 +142,16 @@ class PhrInequalityFactor : public NoiseModelFactor {
       gtsam::OptionalMatrixVecType jacobians = nullptr) const override {
     Vector expression;
     if (jacobians) {
+      // Convert both g and dg/dx to whitened constraint coordinates so sigma
+      // provides the same fixed scaling in the merit function and diagnostics.
       expression = constraint_->unwhitenedExpr(values, jacobians);
       constraint_->noiseModel()->WhitenSystem(*jacobians, expression);
     } else {
       expression = constraint_->whitenedExpr(values);
     }
 
+    // On the inactive branch lambda + rho*g <= 0, max(0, .) and its selected
+    // boundary derivative are zero.
     const double shifted = lambda_ + penalty_ * expression(0);
     if (shifted <= 0.0) {
       if (jacobians) {
@@ -124,6 +162,8 @@ class PhrInequalityFactor : public NoiseModelFactor {
       return Vector1::Zero();
     }
 
+    // On the active branch r=(lambda+rho*g)/sqrt(rho), hence
+    // dr/dx=sqrt(rho)*dg/dx.
     const double sqrtPenalty = std::sqrt(penalty_);
     if (jacobians) {
       for (Matrix& jacobian : *jacobians) {
@@ -168,6 +208,7 @@ Diagnostics EvaluateDiagnostics(const ConstrainedOptProblem& problem,
                                 const AugmentedLagrangianState& subproblem) {
   Diagnostics diagnostics;
 
+  // Equality feasibility contributes ||h(x)||_inf to theta.
   for (const auto& constraint : problem.eConstraints()) {
     diagnostics.generalizedConstraintViolation =
         std::max(diagnostics.generalizedConstraintViolation,
@@ -178,14 +219,21 @@ Diagnostics EvaluateDiagnostics(const ConstrainedOptProblem& problem,
   for (size_t i = 0; i < inequalities.size(); ++i) {
     const double expression = inequalities.at(i)->whitenedExpr(values)(0);
     const double lambda = subproblem.lambdaIneq.at(i);
+
+    // q=max(g,-lambda/rho) makes the projected multiplier update
+    // lambda^+=max(0,lambda+rho*g)=lambda+rho*q. Thus q=0 encodes primal
+    // feasibility and complementarity, including inactive inequalities.
     const double projectedResidual =
         std::max(expression, -lambda / subproblem.muIneq);
     const double projectedLambda =
         std::max(0.0, lambda + subproblem.muIneq * expression);
 
+    // BCL accepts a multiplier update using
+    // theta=max(||h||_inf,||q||_inf), not merely max(g,0).
     diagnostics.generalizedConstraintViolation =
         std::max(diagnostics.generalizedConstraintViolation,
                  std::abs(projectedResidual));
+    // Report primal violation and complementarity separately for diagnosis.
     diagnostics.primalInequalityViolation = std::max(
         diagnostics.primalInequalityViolation, std::max(0.0, expression));
     diagnostics.complementarity = std::max(
@@ -198,6 +246,8 @@ Diagnostics EvaluateDiagnostics(const ConstrainedOptProblem& problem,
 /* ************************************************************************* */
 void InitializeBclSchedule(const AugmentedLagrangianParams& params,
                            double penalty, AugmentedLagrangianState* state) {
+  // Conn--Gould--Toint use an inverse penalty mu. With rho=1/mu, their
+  // alpha=min(mu,gamma_1) becomes alpha=min(1/rho,gamma_1).
   state->bclAlpha = std::min(1.0 / penalty, params.bclGamma1);
   state->bclOmega =
       params.bclOmega0 * std::pow(state->bclAlpha, params.bclAlphaOmega);
@@ -251,16 +301,26 @@ void AugmentedLagrangianState::initializeLagrangeMultipliers(
 std::tuple<AugmentedLagrangianOptimizer::State, double, double>
 AugmentedLagrangianOptimizer::iterate(const State& state, double muEq,
                                       double muIneq) const {
+  // Validate the fixed-parameter augmented-Lagrangian subproblem.
   validateConfiguration();
   if (muEq <= 0.0 || muIneq <= 0.0) {
     throw std::invalid_argument("ALM direct penalties must be positive");
   }
   if (p_->updatePolicy == AugmentedLagrangianUpdatePolicy::BCL &&
       muEq != muIneq) {
+    // Algorithm 1 of Conn--Gould--Toint has one inverse penalty mu_k for the
+    // complete constraint vector c(x). In direct notation rho_k=1/mu_k, the
+    // same rho must therefore weight h and the PHR inequality terms. Separate
+    // penalties would require a new vector-valued schedule and a new definition
+    // of alpha_k, so it would no longer be the paper's BCL update policy.
+    // Constraint sigmas still provide fixed relative block scaling. The
+    // Aggressive policy remains free to use separate equality/inequality rho.
     throw std::invalid_argument(
-        "BCL requires one common equality/inequality penalty");
+        "BCL Algorithm 1 requires muEq == muIneq (one common direct penalty "
+        "rho)");
   }
 
+  // Hold multipliers and penalties fixed while solving the inner problem.
   State subproblemState = state;
   subproblemState.muEq = muEq;
   subproblemState.muIneq = muIneq;
@@ -276,10 +336,14 @@ AugmentedLagrangianOptimizer::iterate(const State& state, double muEq,
   }
   if (p_->updatePolicy == AugmentedLagrangianUpdatePolicy::BCL &&
       (subproblemState.bclOmega <= 0.0 || subproblemState.bclEta <= 0.0)) {
+    // Initialize omega_k and eta_k when iterate() is called directly.
     InitializeBclSchedule(*p_, muEq, &subproblemState);
   }
 
   const auto start = std::chrono::steady_clock::now();
+
+  // Construct the merit function at (lambda_k,rho_k), then run unconstrained
+  // LM from x_k. Multiplier updates happen only after x_{k+1} is available.
   const NonlinearFactorGraph augmentedLagrangian =
       augmentedLagrangianFunction(subproblemState);
   const SharedOptimizer optimizer =
@@ -288,6 +352,9 @@ AugmentedLagrangianOptimizer::iterate(const State& state, double muEq,
   double stationarity =
       AugmentedLagrangianStationarity(augmentedLagrangian, optimizer->values());
   if (p_->updatePolicy == AugmentedLagrangianUpdatePolicy::BCL) {
+    // The paper stops its projected inner solve when the projected gradient is
+    // at most omega_k. Because this implementation substitutes unconstrained
+    // LM, it uses s_k=||grad_x L_rho(x,lambda_k)||_inf <= omega_k.
     while (stationarity > subproblemState.bclOmega &&
            optimizer->iterations() < p_->lmParams.maxIterations) {
       const size_t previousIterations = optimizer->iterations();
@@ -299,11 +366,15 @@ AugmentedLagrangianOptimizer::iterate(const State& state, double muEq,
       }
     }
   } else {
+    // Preserve the historical Aggressive behavior of letting LM use its own
+    // convergence checks and iteration cap for every outer subproblem.
     optimizer->optimize();
     stationarity = AugmentedLagrangianStationarity(augmentedLagrangian,
                                                    optimizer->values());
   }
 
+  // Evaluate objective and all policy diagnostics at the returned point
+  // x_{k+1}; evaluating at x_k was the old sequencing error.
   State solvedState = subproblemState;
   solvedState.iteration = state.iteration + 1;
   solvedState.setValues(optimizer->values(), problem_);
@@ -323,6 +394,8 @@ AugmentedLagrangianOptimizer::iterate(const State& state, double muEq,
   double nextMuEq = muEq;
   double nextMuIneq = muIneq;
   if (p_->updatePolicy == AugmentedLagrangianUpdatePolicy::Aggressive) {
+    // Aggressive always performs projected dual ascent at x_{k+1}, then grows
+    // each penalty independently if its violation did not decrease enough.
     solvedState.innerConverged = true;
     updateLagrangeMultiplier(subproblemState, &solvedState);
     std::tie(nextMuEq, nextMuIneq) = updatePenaltyParameter(state, solvedState);
@@ -333,9 +406,17 @@ AugmentedLagrangianOptimizer::iterate(const State& state, double muEq,
         CombinedUpdateType(multiplierUpdated, penaltyUpdated);
   } else {
     solvedState.innerConverged = stationarity <= subproblemState.bclOmega;
+
+    // If LM exhausts its cap before s_k<=omega_k, Algorithm 1's inner condition
+    // was not met: keep both lambda and rho unchanged and return the best
+    // point.
     if (solvedState.innerConverged) {
       if (solvedState.generalizedConstraintViolation <=
           subproblemState.bclEta) {
+        // Successful BCL iteration (theta_k<=eta_k):
+        //   lambda_h^+ = lambda_h + rho*h,
+        //   lambda_g^+ = max(0,lambda_g + rho*g),
+        // while rho stays fixed.
         for (size_t i = 0; i < problem_.eConstraints().size(); ++i) {
           solvedState.lambdaEq.at(i) +=
               muEq *
@@ -348,12 +429,17 @@ AugmentedLagrangianOptimizer::iterate(const State& state, double muEq,
               std::max(0.0, solvedState.lambdaIneq.at(i) + muEq * expression);
         }
         solvedState.updateType = AugmentedLagrangianUpdateType::Multiplier;
+
+        // Tighten the next inner and feasibility targets using the unchanged
+        // alpha_k, as in the accepted branch of Algorithm 1.
         solvedState.bclOmega =
             subproblemState.bclOmega *
             std::pow(subproblemState.bclAlpha, p_->bclBetaOmega);
         solvedState.bclEta = subproblemState.bclEta *
                              std::pow(subproblemState.bclAlpha, p_->bclBetaEta);
       } else {
+        // Unsuccessful BCL iteration (theta_k>eta_k): hold lambda fixed,
+        // increase direct rho by 1/tau, recompute alpha, and reset omega/eta.
         nextMuEq = muEq * p_->bclPenaltyIncreaseRate;
         nextMuIneq = nextMuEq;
         solvedState.updateType = AugmentedLagrangianUpdateType::Penalty;
@@ -373,12 +459,15 @@ Values AugmentedLagrangianOptimizer::optimize() const {
   validateConfiguration();
   progress_.clear();
 
+  // Construct the initial primal-dual state with zero multipliers.
   State state(0, initialValues_, problem_);
   state.initializeLagrangeMultipliers(problem_);
 
   double muEq = p_->initialMuEq;
   double muIneq = p_->initialMuIneq;
   if (p_->updatePolicy == AugmentedLagrangianUpdatePolicy::BCL) {
+    // BCL uses one common direct penalty and the paper-derived initial
+    // stationarity/feasibility schedule.
     muEq = p_->bclInitialPenalty;
     muIneq = p_->bclInitialPenalty;
     InitializeBclSchedule(*p_, muEq, &state);
@@ -387,6 +476,7 @@ Values AugmentedLagrangianOptimizer::optimize() const {
   state.muIneq = muIneq;
   logInitialState(state);
 
+  // Solve fixed-parameter subproblems and apply the selected outer policy.
   while (true) {
     const State previousState = state;
     std::tie(state, muEq, muIneq) = iterate(previousState, muEq, muIneq);
@@ -424,8 +514,13 @@ NonlinearFactorGraph AugmentedLagrangianOptimizer::augmentedLagrangianFunction(
         "ALM multiplier dimensions do not match constraints");
   }
 
+  // Initialize the merit graph with the original least-squares costs.
   NonlinearFactorGraph graph = problem_.costs();
 
+  // Add equality factors. Each graph error is
+  // (rho/2)||h+lambda/rho||^2
+  //   = lambda^T h + (rho/2)||h||^2 + ||lambda||^2/(2 rho).
+  // The final term is independent of x and can be omitted during LM.
   const auto& equalities = problem_.eConstraints();
   for (size_t i = 0; i < equalities.size(); ++i) {
     const auto& constraint = equalities.at(i);
@@ -435,6 +530,9 @@ NonlinearFactorGraph AugmentedLagrangianOptimizer::augmentedLagrangianFunction(
                                        bias);
   }
 
+  // Add exact PHR factors for scalar g<=0. Each graph error is
+  // max(0,lambda+rho*g)^2/(2 rho), which differs from the mathematical PHR
+  // term only by the x-independent constant lambda^2/(2 rho).
   const auto& inequalities = problem_.iConstraints();
   for (size_t i = 0; i < inequalities.size(); ++i) {
     graph.emplace_shared<PhrInequalityFactor>(
@@ -447,6 +545,8 @@ NonlinearFactorGraph AugmentedLagrangianOptimizer::augmentedLagrangianFunction(
 /* ************************************************************************* */
 void AugmentedLagrangianOptimizer::updateLagrangeMultiplier(
     const State& subproblemState, State* solvedState) const {
+  // Perform dual ascent on equality multipliers using h(x_{k+1}). Constraint
+  // violation is the gradient of the dual function with respect to lambda.
   const auto& equalities = problem_.eConstraints();
   solvedState->lambdaEq.resize(equalities.size());
   for (size_t i = 0; i < equalities.size(); ++i) {
@@ -458,6 +558,8 @@ void AugmentedLagrangianOptimizer::updateLagrangeMultiplier(
         subproblemState.lambdaEq.at(i) + stepSize * violation;
   }
 
+  // Perform projected dual ascent on inequality multipliers using g(x_{k+1})
+  // and projection onto lambda>=0.
   const auto& inequalities = problem_.iConstraints();
   solvedState->lambdaIneq.resize(inequalities.size());
   for (size_t i = 0; i < inequalities.size(); ++i) {
@@ -474,6 +576,8 @@ void AugmentedLagrangianOptimizer::updateLagrangeMultiplier(
 /* ************************************************************************* */
 std::pair<double, double> AugmentedLagrangianOptimizer::updatePenaltyParameter(
     const State& previousState, const State& solvedState) const {
+  // Aggressive keeps separate penalties and increases a block's rho when its
+  // violation has not contracted by muIncreaseThreshold.
   double muEq = solvedState.muEq;
   if (!problem_.eConstraints().empty() &&
       solvedState.eqConstraintViolation >=
@@ -494,6 +598,7 @@ std::pair<double, double> AugmentedLagrangianOptimizer::updatePenaltyParameter(
 ConstrainedOptimizer::SharedOptimizer
 AugmentedLagrangianOptimizer::createUnconstrainedOptimizer(
     const NonlinearFactorGraph& graph, const Values& values) const {
+  // TODO(yetong): make compatible with all NonlinearOptimizers.
   return std::make_shared<LevenbergMarquardtOptimizer>(graph, values,
                                                        p_->lmParams);
 }
@@ -530,6 +635,7 @@ void AugmentedLagrangianOptimizer::validateConfiguration() const {
 /* ************************************************************************* */
 void AugmentedLagrangianOptimizer::logInitialState(const State& state) const {
   if (p_->verbose) {
+    // Log title line.
     cout << setw(8) << "Iter"
          << "|" << setw(10) << "rhoEq"
          << "|" << setw(10) << "rhoIneq"
@@ -540,6 +646,8 @@ void AugmentedLagrangianOptimizer::logInitialState(const State& state) const {
          << "|" << setw(10) << "theta"
          << "|" << setw(10) << "lm_iters"
          << "|" << endl;
+
+    // Log initial value line.
     cout << setw(8) << state.iteration << "|" << setw(10) << state.muEq << "|"
          << setw(10) << state.muIneq << "|" << setw(10) << setprecision(4)
          << state.cost << "|" << setw(10) << state.eqConstraintViolation << "|"
@@ -548,6 +656,7 @@ void AugmentedLagrangianOptimizer::logInitialState(const State& state) const {
          << "|" << setw(10) << "-"
          << "|" << endl;
   }
+  // Store state.
   if (p_->storeOptProgress) {
     progress_.emplace_back(state);
   }
@@ -564,6 +673,7 @@ void AugmentedLagrangianOptimizer::logIteration(const State& state) const {
          << state.generalizedConstraintViolation << "|" << setw(10)
          << state.unconstrainedIterations << "|" << endl;
   }
+  // Store state.
   if (p_->storeOptProgress) {
     progress_.emplace_back(state);
   }

--- a/gtsam/constrained/AugmentedLagrangianOptimizer.cpp
+++ b/gtsam/constrained/AugmentedLagrangianOptimizer.cpp
@@ -10,175 +10,435 @@
  * -------------------------------------------------------------------------- */
 
 /**
- * @file    AugmentedLagrangianOptimizer.h
+ * @file    AugmentedLagrangianOptimizer.cpp
  * @brief   Augmented Lagrangian method for nonlinear constrained optimization.
- * @author  Yetong Zhang
+ * @author  Yetong Zhang, Frank Dellaert
  * @date    Aug 3, 2024
  */
 
 #include <gtsam/constrained/AugmentedLagrangianOptimizer.h>
-#include <gtsam/slam/AntiFactor.h>
+#include <gtsam/linear/GaussianFactorGraph.h>
 
+#include <algorithm>
+#include <chrono>
+#include <cmath>
 #include <iomanip>
+#include <stdexcept>
 
-using std::setw, std::cout, std::endl, std::setprecision;
+using std::cout, std::endl, std::setprecision, std::setw;
 
 namespace gtsam {
+namespace {
 
-/** A factor that adds a constant bias term to the original factor.
- * This factor is used in augmented Lagrangian optimizer to create biased cost
- * functions.
- * Note that the noise model is stored twice (both in original factor and the
- * noise model of substitute factor. The noise model in the original factor will
- * be ignored. */
-class GTSAM_EXPORT BiasedFactor : public NoiseModelFactor {
+/** Factor adding a constant bias to another factor's unwhitened error. */
+class BiasedFactor : public NoiseModelFactor {
  protected:
-  typedef NoiseModelFactor Base;
-  typedef BiasedFactor This;
+  using Base = NoiseModelFactor;
+  using This = BiasedFactor;
 
-  // original factor
   Base::shared_ptr originalFactor_;
   Vector bias_;
 
  public:
-  typedef std::shared_ptr<This> shared_ptr;
+  using shared_ptr = std::shared_ptr<This>;
 
-  /** Default constructor for I/O only */
-  BiasedFactor() {}
+  /// Default constructor for I/O only.
+  BiasedFactor() = default;
 
-  /** Destructor */
-  ~BiasedFactor() override {}
-
-  /**
-   * Constructor
-   * @param originalFactor   original factor on X
-   * @param bias  the bias term
-   */
+  /// Construct a biased view of an existing factor.
   BiasedFactor(const Base::shared_ptr& originalFactor, const Vector& bias)
       : Base(originalFactor->noiseModel(), originalFactor->keys()),
         originalFactor_(originalFactor),
         bias_(bias) {}
 
-  /**
-   * Error function *without* the NoiseModel, \f$ z-h(x) \f$.
-   * Override this method to finish implementing an N-way factor.
-   * If the optional arguments is specified, it should compute
-   * both the function evaluation and its derivative(s) in H.
-   */
-  virtual Vector unwhitenedError(
-      const Values& x,
-      gtsam::OptionalMatrixVecType H = nullptr) const override {
-    return originalFactor_->unwhitenedError(x, H) + bias_;
+  /// Evaluate the original error plus the fixed bias.
+  Vector unwhitenedError(
+      const Values& values,
+      gtsam::OptionalMatrixVecType jacobians = nullptr) const override {
+    return originalFactor_->unwhitenedError(values, jacobians) + bias_;
   }
 
-  /** print */
-  void print(const std::string& s, const KeyFormatter& keyFormatter =
-                                       DefaultKeyFormatter) const override {
-    std::cout << s << "BiasedFactor " << bias_.transpose()
-              << " version of:" << std::endl;
-    originalFactor_->print(s, keyFormatter);
+  /// Print the biased factor.
+  void print(const std::string& label, const KeyFormatter& keyFormatter =
+                                           DefaultKeyFormatter) const override {
+    cout << label << "BiasedFactor " << bias_.transpose()
+         << " version of:" << endl;
+    originalFactor_->print(label, keyFormatter);
   }
 
-  /** Return a deep copy of this factor. */
-  gtsam::NonlinearFactor::shared_ptr clone() const override {
-    return std::static_pointer_cast<gtsam::NonlinearFactor>(
-        gtsam::NonlinearFactor::shared_ptr(new This(*this)));
+  /// Return a deep copy.
+  NonlinearFactor::shared_ptr clone() const override {
+    return std::static_pointer_cast<NonlinearFactor>(
+        NonlinearFactor::shared_ptr(new This(*this)));
+  }
+};
+
+/**
+ * Least-squares factor for the nonconstant part of a scalar PHR term.
+ * Its residual is max(0, lambda + rho g(x)) / sqrt(rho), where g is already
+ * whitened by the constraint noise model.
+ */
+class PhrInequalityFactor : public NoiseModelFactor {
+ protected:
+  using Base = NoiseModelFactor;
+  using This = PhrInequalityFactor;
+
+  NonlinearInequalityConstraint::shared_ptr constraint_;
+  double lambda_;
+  double penalty_;
+
+ public:
+  /// Construct a scalar PHR factor at fixed multiplier and direct penalty.
+  PhrInequalityFactor(
+      const NonlinearInequalityConstraint::shared_ptr& constraint,
+      double lambda, double penalty)
+      : Base(noiseModel::Unit::Create(1), constraint->keys()),
+        constraint_(constraint),
+        lambda_(lambda),
+        penalty_(penalty) {
+    if (constraint_->dim() != 1) {
+      throw std::invalid_argument(
+          "AugmentedLagrangianOptimizer supports scalar inequalities only");
+    }
   }
 
-};  // \class BiasedFactor
+  /// Evaluate the exact shifted-ramp residual and its piecewise Jacobians.
+  Vector unwhitenedError(
+      const Values& values,
+      gtsam::OptionalMatrixVecType jacobians = nullptr) const override {
+    Vector expression;
+    if (jacobians) {
+      expression = constraint_->unwhitenedExpr(values, jacobians);
+      constraint_->noiseModel()->WhitenSystem(*jacobians, expression);
+    } else {
+      expression = constraint_->whitenedExpr(values);
+    }
+
+    const double shifted = lambda_ + penalty_ * expression(0);
+    if (shifted <= 0.0) {
+      if (jacobians) {
+        for (Matrix& jacobian : *jacobians) {
+          jacobian.setZero();
+        }
+      }
+      return Vector1::Zero();
+    }
+
+    const double sqrtPenalty = std::sqrt(penalty_);
+    if (jacobians) {
+      for (Matrix& jacobian : *jacobians) {
+        jacobian *= sqrtPenalty;
+      }
+    }
+    return Vector1(shifted / sqrtPenalty);
+  }
+
+  /// Return a deep copy.
+  NonlinearFactor::shared_ptr clone() const override {
+    return std::static_pointer_cast<NonlinearFactor>(
+        NonlinearFactor::shared_ptr(new This(*this)));
+  }
+};
+
+struct Diagnostics {
+  double generalizedConstraintViolation = 0.0;
+  double primalInequalityViolation = 0.0;
+  double complementarity = 0.0;
+};
+
+/* ************************************************************************* */
+double InfinityNorm(const Vector& vector) {
+  return vector.size() == 0 ? 0.0 : vector.cwiseAbs().maxCoeff();
+}
+
+/* ************************************************************************* */
+double AugmentedLagrangianStationarity(const NonlinearFactorGraph& graph,
+                                       const Values& values) {
+  const VectorValues gradient = graph.linearize(values)->gradientAtZero();
+  double infinityNorm = 0.0;
+  for (const auto& keyGradient : gradient) {
+    infinityNorm = std::max(infinityNorm, InfinityNorm(keyGradient.second));
+  }
+  return infinityNorm;
+}
+
+/* ************************************************************************* */
+Diagnostics EvaluateDiagnostics(const ConstrainedOptProblem& problem,
+                                const Values& values,
+                                const AugmentedLagrangianState& subproblem) {
+  Diagnostics diagnostics;
+
+  for (const auto& constraint : problem.eConstraints()) {
+    diagnostics.generalizedConstraintViolation =
+        std::max(diagnostics.generalizedConstraintViolation,
+                 InfinityNorm(constraint->whitenedError(values)));
+  }
+
+  const auto& inequalities = problem.iConstraints();
+  for (size_t i = 0; i < inequalities.size(); ++i) {
+    const double expression = inequalities.at(i)->whitenedExpr(values)(0);
+    const double lambda = subproblem.lambdaIneq.at(i);
+    const double projectedResidual =
+        std::max(expression, -lambda / subproblem.muIneq);
+    const double projectedLambda =
+        std::max(0.0, lambda + subproblem.muIneq * expression);
+
+    diagnostics.generalizedConstraintViolation =
+        std::max(diagnostics.generalizedConstraintViolation,
+                 std::abs(projectedResidual));
+    diagnostics.primalInequalityViolation = std::max(
+        diagnostics.primalInequalityViolation, std::max(0.0, expression));
+    diagnostics.complementarity = std::max(
+        diagnostics.complementarity, std::abs(projectedLambda * expression));
+  }
+
+  return diagnostics;
+}
+
+/* ************************************************************************* */
+void InitializeBclSchedule(const AugmentedLagrangianParams& params,
+                           double penalty, AugmentedLagrangianState* state) {
+  state->bclAlpha = std::min(1.0 / penalty, params.bclGamma1);
+  state->bclOmega =
+      params.bclOmega0 * std::pow(state->bclAlpha, params.bclAlphaOmega);
+  state->bclEta =
+      params.bclEta0 * std::pow(state->bclAlpha, params.bclAlphaEta);
+}
+
+/* ************************************************************************* */
+bool AggressiveConverged(const AugmentedLagrangianState& state,
+                         const AugmentedLagrangianState& previousState,
+                         const AugmentedLagrangianParams& params) {
+  if (state.violation() < params.absoluteViolationTolerance &&
+      state.cost < params.absoluteCostTolerance) {
+    return true;
+  }
+  return std::abs(state.violation() - previousState.violation()) <
+             params.relativeViolationTolerance &&
+         std::abs(state.cost - previousState.cost) <
+             params.relativeCostTolerance;
+}
+
+/* ************************************************************************* */
+AugmentedLagrangianUpdateType CombinedUpdateType(bool multiplierUpdated,
+                                                 bool penaltyUpdated) {
+  if (multiplierUpdated && penaltyUpdated) {
+    return AugmentedLagrangianUpdateType::MultiplierAndPenalty;
+  }
+  if (multiplierUpdated) {
+    return AugmentedLagrangianUpdateType::Multiplier;
+  }
+  if (penaltyUpdated) {
+    return AugmentedLagrangianUpdateType::Penalty;
+  }
+  return AugmentedLagrangianUpdateType::None;
+}
+
+}  // namespace
 
 /* ************************************************************************* */
 void AugmentedLagrangianState::initializeLagrangeMultipliers(
     const ConstrainedOptProblem& problem) {
-  lambdaEq = std::vector<Vector>();
+  lambdaEq.clear();
   lambdaEq.reserve(problem.eConstraints().size());
   for (const auto& constraint : problem.eConstraints()) {
     lambdaEq.push_back(Vector::Zero(constraint->dim()));
   }
-  lambdaIneq = std::vector<double>(problem.iConstraints().size(), 0);
+  lambdaIneq.assign(problem.iConstraints().size(), 0.0);
 }
 
 /* ************************************************************************* */
 std::tuple<AugmentedLagrangianOptimizer::State, double, double>
-AugmentedLagrangianOptimizer::iterate(const State& state, const double muEq,
-                                      const double muIneq) const {
-  State newState(state.iteration + 1);
-  newState.muEq = muEq;
-  newState.muIneq = muIneq;
+AugmentedLagrangianOptimizer::iterate(const State& state, double muEq,
+                                      double muIneq) const {
+  validateConfiguration();
+  if (muEq <= 0.0 || muIneq <= 0.0) {
+    throw std::invalid_argument("ALM direct penalties must be positive");
+  }
+  if (p_->updatePolicy == AugmentedLagrangianUpdatePolicy::BCL &&
+      muEq != muIneq) {
+    throw std::invalid_argument(
+        "BCL requires one common equality/inequality penalty");
+  }
 
-  // Update Lagrangian multipliers.
-  updateLagrangeMultiplier(state, &newState);
+  State subproblemState = state;
+  subproblemState.muEq = muEq;
+  subproblemState.muIneq = muIneq;
+  if (subproblemState.lambdaEq.size() != problem_.eConstraints().size() ||
+      subproblemState.lambdaIneq.size() != problem_.iConstraints().size()) {
+    if (subproblemState.lambdaEq.empty() &&
+        subproblemState.lambdaIneq.empty()) {
+      subproblemState.initializeLagrangeMultipliers(problem_);
+    } else {
+      throw std::invalid_argument(
+          "ALM multiplier dimensions do not match constraints");
+    }
+  }
+  if (p_->updatePolicy == AugmentedLagrangianUpdatePolicy::BCL &&
+      (subproblemState.bclOmega <= 0.0 || subproblemState.bclEta <= 0.0)) {
+    InitializeBclSchedule(*p_, muEq, &subproblemState);
+  }
 
-  // Construct merit function.
+  const auto start = std::chrono::steady_clock::now();
   const NonlinearFactorGraph augmentedLagrangian =
-      augmentedLagrangianFunction(newState);
-
-  // Run unconstrained optimization.
-  auto optimizer =
+      augmentedLagrangianFunction(subproblemState);
+  const SharedOptimizer optimizer =
       createUnconstrainedOptimizer(augmentedLagrangian, state.values);
-  newState.setValues(optimizer->optimize(), problem_);
-  newState.unconstrainedIterations = optimizer->iterations();
 
-  // Update penalty parameters for next iteration.
-  double next_muEq, next_muIneq;
-  std::tie(next_muEq, next_muIneq) = updatePenaltyParameter(state, newState);
+  double stationarity =
+      AugmentedLagrangianStationarity(augmentedLagrangian, optimizer->values());
+  if (p_->updatePolicy == AugmentedLagrangianUpdatePolicy::BCL) {
+    while (stationarity > subproblemState.bclOmega &&
+           optimizer->iterations() < p_->lmParams.maxIterations) {
+      const size_t previousIterations = optimizer->iterations();
+      optimizer->iterate();
+      stationarity = AugmentedLagrangianStationarity(augmentedLagrangian,
+                                                     optimizer->values());
+      if (optimizer->iterations() == previousIterations) {
+        break;
+      }
+    }
+  } else {
+    optimizer->optimize();
+    stationarity = AugmentedLagrangianStationarity(augmentedLagrangian,
+                                                   optimizer->values());
+  }
 
-  return {newState, next_muEq, next_muIneq};
+  State solvedState = subproblemState;
+  solvedState.iteration = state.iteration + 1;
+  solvedState.setValues(optimizer->values(), problem_);
+  solvedState.unconstrainedIterations = optimizer->iterations();
+  solvedState.totalUnconstrainedIterations =
+      state.totalUnconstrainedIterations + solvedState.unconstrainedIterations;
+  solvedState.augmentedLagrangianStationarity = stationarity;
+  const Diagnostics diagnostics =
+      EvaluateDiagnostics(problem_, solvedState.values, subproblemState);
+  solvedState.generalizedConstraintViolation =
+      diagnostics.generalizedConstraintViolation;
+  solvedState.primalInequalityViolation = diagnostics.primalInequalityViolation;
+  solvedState.complementarity = diagnostics.complementarity;
+  solvedState.updateType = AugmentedLagrangianUpdateType::None;
+  solvedState.converged = false;
+
+  double nextMuEq = muEq;
+  double nextMuIneq = muIneq;
+  if (p_->updatePolicy == AugmentedLagrangianUpdatePolicy::Aggressive) {
+    solvedState.innerConverged = true;
+    updateLagrangeMultiplier(subproblemState, &solvedState);
+    std::tie(nextMuEq, nextMuIneq) = updatePenaltyParameter(state, solvedState);
+    const bool multiplierUpdated =
+        !problem_.eConstraints().empty() || !problem_.iConstraints().empty();
+    const bool penaltyUpdated = nextMuEq != muEq || nextMuIneq != muIneq;
+    solvedState.updateType =
+        CombinedUpdateType(multiplierUpdated, penaltyUpdated);
+  } else {
+    solvedState.innerConverged = stationarity <= subproblemState.bclOmega;
+    if (solvedState.innerConverged) {
+      if (solvedState.generalizedConstraintViolation <=
+          subproblemState.bclEta) {
+        for (size_t i = 0; i < problem_.eConstraints().size(); ++i) {
+          solvedState.lambdaEq.at(i) +=
+              muEq *
+              problem_.eConstraints().at(i)->whitenedError(solvedState.values);
+        }
+        for (size_t i = 0; i < problem_.iConstraints().size(); ++i) {
+          const double expression = problem_.iConstraints().at(i)->whitenedExpr(
+              solvedState.values)(0);
+          solvedState.lambdaIneq.at(i) =
+              std::max(0.0, solvedState.lambdaIneq.at(i) + muEq * expression);
+        }
+        solvedState.updateType = AugmentedLagrangianUpdateType::Multiplier;
+        solvedState.bclOmega =
+            subproblemState.bclOmega *
+            std::pow(subproblemState.bclAlpha, p_->bclBetaOmega);
+        solvedState.bclEta = subproblemState.bclEta *
+                             std::pow(subproblemState.bclAlpha, p_->bclBetaEta);
+      } else {
+        nextMuEq = muEq * p_->bclPenaltyIncreaseRate;
+        nextMuIneq = nextMuEq;
+        solvedState.updateType = AugmentedLagrangianUpdateType::Penalty;
+        InitializeBclSchedule(*p_, nextMuEq, &solvedState);
+      }
+    }
+  }
+
+  solvedState.time =
+      std::chrono::duration<double>(std::chrono::steady_clock::now() - start)
+          .count();
+  return {solvedState, nextMuEq, nextMuIneq};
 }
 
 /* ************************************************************************* */
 Values AugmentedLagrangianOptimizer::optimize() const {
-  /// Construct initial state
-  State previousState;
+  validateConfiguration();
+  progress_.clear();
+
   State state(0, initialValues_, problem_);
   state.initializeLagrangeMultipliers(problem_);
-  logInitialState(state);
 
-  /// Set penalty parameters for the first iteration.
   double muEq = p_->initialMuEq;
   double muIneq = p_->initialMuIneq;
+  if (p_->updatePolicy == AugmentedLagrangianUpdatePolicy::BCL) {
+    muEq = p_->bclInitialPenalty;
+    muIneq = p_->bclInitialPenalty;
+    InitializeBclSchedule(*p_, muEq, &state);
+  }
+  state.muEq = muEq;
+  state.muIneq = muIneq;
+  logInitialState(state);
 
-  /// iterates
-  do {
-    previousState = std::move(state);
+  while (true) {
+    const State previousState = state;
     std::tie(state, muEq, muIneq) = iterate(previousState, muEq, muIneq);
+
+    if (p_->updatePolicy == AugmentedLagrangianUpdatePolicy::BCL) {
+      state.converged = state.innerConverged &&
+                        state.augmentedLagrangianStationarity <=
+                            p_->absoluteStationarityTolerance &&
+                        state.generalizedConstraintViolation <=
+                            p_->absoluteViolationTolerance;
+    } else {
+      state.converged = AggressiveConverged(state, previousState, *p_);
+    }
     logIteration(state);
-  } while (!checkConvergence(state, previousState, *p_));
+
+    if (state.converged || !state.innerConverged ||
+        state.iteration >= p_->maxIterations) {
+      break;
+    }
+  }
 
   return state.values;
 }
 
 /* ************************************************************************* */
 NonlinearFactorGraph AugmentedLagrangianOptimizer::augmentedLagrangianFunction(
-    const State& state, const double epsilon) const {
-  // Initialize by adding in cost factors.
-  NonlinearFactorGraph graph = problem_.costs();
-
-  // Create factors corresponding to equality constraints.
-  const NonlinearEqualityConstraints& eqConstraints = problem_.eConstraints();
-  const double& muEq = state.muEq;
-  for (size_t i = 0; i < eqConstraints.size(); i++) {
-    const auto& constraint = eqConstraints.at(i);
-    Vector bias = state.lambdaEq[i] / muEq;
-    bias = bias.cwiseProduct(constraint->sigmas());
-    auto penalty_l2 = constraint->penaltyFactor(muEq);
-    graph.emplace_shared<BiasedFactor>(penalty_l2, bias);
+    const State& state, double /*epsilon*/) const {
+  validateConfiguration();
+  if (state.muEq <= 0.0 || state.muIneq <= 0.0) {
+    throw std::invalid_argument("ALM direct penalties must be positive");
+  }
+  if (state.lambdaEq.size() != problem_.eConstraints().size() ||
+      state.lambdaIneq.size() != problem_.iConstraints().size()) {
+    throw std::invalid_argument(
+        "ALM multiplier dimensions do not match constraints");
   }
 
-  // Create factors corresponding to penalty terms of inequality constraints.
-  const NonlinearInequalityConstraints& ineqConstraints =
-      problem_.iConstraints();
-  const double& muIneq = state.muIneq;
-  graph.add(ineqConstraints.penaltyGraphCustom(
-      p_->ineqConstraintPenaltyFunction, muIneq));
+  NonlinearFactorGraph graph = problem_.costs();
 
-  // Create factors corresponding to Lagrange multiplier terms of i-constraints.
-  for (size_t i = 0; i < ineqConstraints.size(); i++) {
-    const auto& constraint = ineqConstraints.at(i);
-    Vector bias = state.lambdaIneq[i] / epsilon * constraint->sigmas();
-    auto penalty_l2 = constraint->penaltyFactorEquality(epsilon);
-    graph.emplace_shared<BiasedFactor>(penalty_l2, bias);
-    graph.emplace_shared<AntiFactor>(penalty_l2);
+  const auto& equalities = problem_.eConstraints();
+  for (size_t i = 0; i < equalities.size(); ++i) {
+    const auto& constraint = equalities.at(i);
+    Vector bias = state.lambdaEq.at(i) / state.muEq;
+    bias = bias.cwiseProduct(constraint->sigmas());
+    graph.emplace_shared<BiasedFactor>(constraint->penaltyFactor(state.muEq),
+                                       bias);
+  }
+
+  const auto& inequalities = problem_.iConstraints();
+  for (size_t i = 0; i < inequalities.size(); ++i) {
+    graph.emplace_shared<PhrInequalityFactor>(
+        inequalities.at(i), state.lambdaIneq.at(i), state.muIneq);
   }
 
   return graph;
@@ -186,48 +446,44 @@ NonlinearFactorGraph AugmentedLagrangianOptimizer::augmentedLagrangianFunction(
 
 /* ************************************************************************* */
 void AugmentedLagrangianOptimizer::updateLagrangeMultiplier(
-    const State& previousState, State* state) const {
-  // Perform dual ascent on Lagrange multipliers for e-constraints.
-  const NonlinearEqualityConstraints& eqConstraints = problem_.eConstraints();
-  state->lambdaEq.resize(eqConstraints.size());
-  for (size_t i = 0; i < eqConstraints.size(); i++) {
-    const auto& constraint = eqConstraints.at(i);
-    // Compute constraint violation as the gradient of the dual function.
-    Vector violation = constraint->whitenedError(previousState.values);
-    double step_size = std::min(p_->maxDualStepSizeEq,
-                                previousState.muEq * p_->dualStepSizeFactorEq);
-    state->lambdaEq[i] = previousState.lambdaEq[i] + step_size * violation;
+    const State& subproblemState, State* solvedState) const {
+  const auto& equalities = problem_.eConstraints();
+  solvedState->lambdaEq.resize(equalities.size());
+  for (size_t i = 0; i < equalities.size(); ++i) {
+    const Vector violation =
+        equalities.at(i)->whitenedError(solvedState->values);
+    const double stepSize = std::min(
+        p_->maxDualStepSizeEq, subproblemState.muEq * p_->dualStepSizeFactorEq);
+    solvedState->lambdaEq.at(i) =
+        subproblemState.lambdaEq.at(i) + stepSize * violation;
   }
 
-  // Perform dual ascent on Lagrange multipliers for i-constraints.
-  const NonlinearInequalityConstraints& ineqConstraints =
-      problem_.iConstraints();
-  state->lambdaIneq.resize(ineqConstraints.size());
-  // Update Lagrangian multipliers.
-  for (size_t i = 0; i < ineqConstraints.size(); i++) {
-    const auto& constraint = ineqConstraints.at(i);
-    double violation = constraint->whitenedExpr(previousState.values)(0);
-    double step_size =
+  const auto& inequalities = problem_.iConstraints();
+  solvedState->lambdaIneq.resize(inequalities.size());
+  for (size_t i = 0; i < inequalities.size(); ++i) {
+    const double violation =
+        inequalities.at(i)->whitenedExpr(solvedState->values)(0);
+    const double stepSize =
         std::min(p_->maxDualStepSizeIneq,
-                 previousState.muIneq * p_->dualStepSizeFactorIneq);
-    state->lambdaIneq[i] =
-        std::max(0.0, previousState.lambdaIneq[i] + step_size * violation);
+                 subproblemState.muIneq * p_->dualStepSizeFactorIneq);
+    solvedState->lambdaIneq.at(i) =
+        std::max(0.0, subproblemState.lambdaIneq.at(i) + stepSize * violation);
   }
 }
 
 /* ************************************************************************* */
 std::pair<double, double> AugmentedLagrangianOptimizer::updatePenaltyParameter(
-    const State& previousState, const State& state) const {
-  double muEq = state.muEq;
-  if (problem_.eConstraints().size() > 0 &&
-      state.eqConstraintViolation >=
+    const State& previousState, const State& solvedState) const {
+  double muEq = solvedState.muEq;
+  if (!problem_.eConstraints().empty() &&
+      solvedState.eqConstraintViolation >=
           p_->muIncreaseThreshold * previousState.eqConstraintViolation) {
     muEq *= p_->muEqIncreaseRate;
   }
 
-  double muIneq = state.muIneq;
-  if (problem_.iConstraints().size() > 0 &&
-      state.ineqConstraintViolation >=
+  double muIneq = solvedState.muIneq;
+  if (!problem_.iConstraints().empty() &&
+      solvedState.ineqConstraintViolation >=
           p_->muIncreaseThreshold * previousState.ineqConstraintViolation) {
     muIneq *= p_->muIneqIncreaseRate;
   }
@@ -238,38 +494,60 @@ std::pair<double, double> AugmentedLagrangianOptimizer::updatePenaltyParameter(
 ConstrainedOptimizer::SharedOptimizer
 AugmentedLagrangianOptimizer::createUnconstrainedOptimizer(
     const NonlinearFactorGraph& graph, const Values& values) const {
-  // TODO(yetong): make compatible with all NonlinearOptimizers.
   return std::make_shared<LevenbergMarquardtOptimizer>(graph, values,
                                                        p_->lmParams);
 }
 
 /* ************************************************************************* */
+void AugmentedLagrangianOptimizer::validateConfiguration() const {
+  if (!p_) {
+    throw std::invalid_argument("AugmentedLagrangianParams must not be null");
+  }
+  if (p_->ineqConstraintPenaltyFunction) {
+    throw std::invalid_argument(
+        "AugmentedLagrangianOptimizer requires exact PHR inequalities; custom "
+        "smoothed inequality penalties are unsupported");
+  }
+  for (const auto& inequality : problem_.iConstraints()) {
+    if (inequality->dim() != 1) {
+      throw std::invalid_argument(
+          "AugmentedLagrangianOptimizer supports scalar inequalities only");
+    }
+  }
+  if (p_->initialMuEq <= 0.0 || p_->initialMuIneq <= 0.0 ||
+      p_->muEqIncreaseRate <= 0.0 || p_->muIneqIncreaseRate <= 0.0 ||
+      p_->absoluteStationarityTolerance < 0.0) {
+    throw std::invalid_argument("Invalid Aggressive ALM parameters");
+  }
+  if (p_->bclInitialPenalty <= 0.0 || p_->bclPenaltyIncreaseRate <= 1.0 ||
+      p_->bclOmega0 <= 0.0 || p_->bclEta0 <= 0.0 || p_->bclGamma1 <= 0.0 ||
+      p_->bclAlphaOmega <= 0.0 || p_->bclBetaOmega <= 0.0 ||
+      p_->bclAlphaEta <= 0.0 || p_->bclBetaEta <= 0.0) {
+    throw std::invalid_argument("Invalid BCL ALM parameters");
+  }
+}
+
+/* ************************************************************************* */
 void AugmentedLagrangianOptimizer::logInitialState(const State& state) const {
   if (p_->verbose) {
-    // Log title line.
-    cout << setw(10) << "Iter"
-         << "|" << setw(10) << "muEq"
-         << "|" << setw(10) << "muIneq"
+    cout << setw(8) << "Iter"
+         << "|" << setw(10) << "rhoEq"
+         << "|" << setw(10) << "rhoIneq"
          << "|" << setw(10) << "cost"
          << "|" << setw(10) << "vio_e"
          << "|" << setw(10) << "vio_i"
-         << "|" << setw(10) << "uopt_iters"
-         << "|" << setw(10) << "time"
+         << "|" << setw(10) << "station"
+         << "|" << setw(10) << "theta"
+         << "|" << setw(10) << "lm_iters"
          << "|" << endl;
-
-    // Log initial value line.
-    cout << setw(10) << state.iteration;
-    cout << "|" << setw(10) << "-";
-    cout << "|" << setw(10) << "-";
-    cout << "|" << setw(10) << setprecision(4) << state.cost;
-    cout << "|" << setw(10) << setprecision(4) << state.eqConstraintViolation;
-    cout << "|" << setw(10) << setprecision(4) << state.ineqConstraintViolation;
-    cout << "|" << setw(10) << "-";
-    cout << "|" << setw(10) << "-";
-    cout << "|" << endl;
+    cout << setw(8) << state.iteration << "|" << setw(10) << state.muEq << "|"
+         << setw(10) << state.muIneq << "|" << setw(10) << setprecision(4)
+         << state.cost << "|" << setw(10) << state.eqConstraintViolation << "|"
+         << setw(10) << state.ineqConstraintViolation << "|" << setw(10) << "-"
+         << "|" << setw(10) << "-"
+         << "|" << setw(10) << "-"
+         << "|" << endl;
   }
-
-  // Store state
   if (p_->storeOptProgress) {
     progress_.emplace_back(state);
   }
@@ -278,18 +556,14 @@ void AugmentedLagrangianOptimizer::logInitialState(const State& state) const {
 /* ************************************************************************* */
 void AugmentedLagrangianOptimizer::logIteration(const State& state) const {
   if (p_->verbose) {
-    cout << setw(10) << state.iteration;
-    cout << "|" << setw(10) << state.muEq;
-    cout << "|" << setw(10) << state.muIneq;
-    cout << "|" << setw(10) << setprecision(4) << state.cost;
-    cout << "|" << setw(10) << setprecision(4) << state.eqConstraintViolation;
-    cout << "|" << setw(10) << setprecision(4) << state.ineqConstraintViolation;
-    cout << "|" << setw(10) << state.unconstrainedIterations;
-    cout << "|" << setw(10) << state.time;
-    cout << "|" << endl;
+    cout << setw(8) << state.iteration << "|" << setw(10) << state.muEq << "|"
+         << setw(10) << state.muIneq << "|" << setw(10) << setprecision(4)
+         << state.cost << "|" << setw(10) << state.eqConstraintViolation << "|"
+         << setw(10) << state.ineqConstraintViolation << "|" << setw(10)
+         << state.augmentedLagrangianStationarity << "|" << setw(10)
+         << state.generalizedConstraintViolation << "|" << setw(10)
+         << state.unconstrainedIterations << "|" << endl;
   }
-
-  // Store state
   if (p_->storeOptProgress) {
     progress_.emplace_back(state);
   }

--- a/gtsam/constrained/AugmentedLagrangianOptimizer.h
+++ b/gtsam/constrained/AugmentedLagrangianOptimizer.h
@@ -44,9 +44,9 @@ class GTSAM_EXPORT AugmentedLagrangianParams : public PenaltyOptimizerParams {
   using This = AugmentedLagrangianParams;
   using shared_ptr = std::shared_ptr<AugmentedLagrangianParams>;
 
-  /// Outer update policy. Aggressive preserves the historical default.
+  /// Outer update policy. BCL is the default; Aggressive remains available.
   AugmentedLagrangianUpdatePolicy updatePolicy =
-      AugmentedLagrangianUpdatePolicy::Aggressive;
+      AugmentedLagrangianUpdatePolicy::BCL;
 
   /// Maximum equality-multiplier step for the Aggressive policy.
   double maxDualStepSizeEq = 10.0;

--- a/gtsam/constrained/AugmentedLagrangianOptimizer.h
+++ b/gtsam/constrained/AugmentedLagrangianOptimizer.h
@@ -12,7 +12,7 @@
 /**
  * @file    AugmentedLagrangianOptimizer.h
  * @brief   Augmented Lagrangian method for nonlinear constrained optimization.
- * @author  Yetong Zhang
+ * @author  Yetong Zhang, Frank Dellaert
  * @date    Aug 3, 2024
  */
 
@@ -21,33 +21,107 @@
 #include <gtsam/constrained/ConstrainedOptimizer.h>
 #include <gtsam/constrained/PenaltyOptimizer.h>
 
+#include <limits>
+
 namespace gtsam {
 
-/// Parameters for Augmented Lagrangian method
+/** Outer update policy used by AugmentedLagrangianOptimizer. */
+enum class AugmentedLagrangianUpdatePolicy { Aggressive, BCL };
+
+/** Update performed after an augmented-Lagrangian subproblem. */
+enum class AugmentedLagrangianUpdateType {
+  None,
+  Multiplier,
+  Penalty,
+  MultiplierAndPenalty
+};
+
+/** Parameters for the augmented Lagrangian method. */
 class GTSAM_EXPORT AugmentedLagrangianParams : public PenaltyOptimizerParams {
  public:
   using Base = PenaltyOptimizerParams;
   using This = AugmentedLagrangianParams;
   using shared_ptr = std::shared_ptr<AugmentedLagrangianParams>;
 
-  double maxDualStepSizeEq = 10;    // maximum step size for dual ascent
-  double maxDualStepSizeIneq = 10;  // maximum step size for dual ascent
+  /// Outer update policy. Aggressive preserves the historical default.
+  AugmentedLagrangianUpdatePolicy updatePolicy =
+      AugmentedLagrangianUpdatePolicy::Aggressive;
+
+  /// Maximum equality-multiplier step for the Aggressive policy.
+  double maxDualStepSizeEq = 10.0;
+  /// Maximum inequality-multiplier step for the Aggressive policy.
+  double maxDualStepSizeIneq = 10.0;
+  /// Equality dual-step factor for the Aggressive policy.
   double dualStepSizeFactorEq = 1.0;
+  /// Inequality dual-step factor for the Aggressive policy.
   double dualStepSizeFactorIneq = 1.0;
+  /// Required violation reduction before Aggressive keeps its penalty fixed.
   double muIncreaseThreshold = 0.25;
+
+  /// Absolute full augmented-Lagrangian gradient tolerance for BCL convergence.
+  double absoluteStationarityTolerance = 1e-5;
+
+  /// Initial common direct penalty rho for BCL (paper default: 1 / mu_0).
+  double bclInitialPenalty = 10.0;
+  /// BCL direct-penalty growth factor (paper default: 1 / tau).
+  double bclPenaltyIncreaseRate = 100.0;
+  /// BCL omega_0 stationarity scale.
+  double bclOmega0 = 1.0;
+  /// BCL eta_0 feasibility scale.
+  double bclEta0 = 1.0;
+  /// BCL gamma_1 cap used to define alpha.
+  double bclGamma1 = 0.1;
+  /// BCL alpha_omega exponent used when resetting omega.
+  double bclAlphaOmega = 1.0;
+  /// BCL beta_omega exponent used when tightening omega.
+  double bclBetaOmega = 1.0;
+  /// BCL alpha_eta exponent used when resetting eta.
+  double bclAlphaEta = 0.1;
+  /// BCL beta_eta exponent used when tightening eta.
+  double bclBetaEta = 0.9;
 
   using Base::Base;
 };
 
-/// Details for each iteration.
+/** Diagnostics and algorithm state for one outer ALM iteration. */
 class GTSAM_EXPORT AugmentedLagrangianState : public PenaltyOptimizerState {
  public:
   using Base = PenaltyOptimizerState;
   using This = AugmentedLagrangianState;
   using shared_ptr = std::shared_ptr<This>;
 
-  std::vector<Vector> lambdaEq;    // Lagrange multipliers for e-constraints
-  std::vector<double> lambdaIneq;  // Lagrange multipliers for i-constraints
+  /// Equality Lagrange multipliers, in whitened constraint coordinates.
+  std::vector<Vector> lambdaEq;
+  /// Nonnegative inequality Lagrange multipliers, one per scalar constraint.
+  std::vector<double> lambdaIneq;
+
+  /// Infinity norm of the full augmented-Lagrangian gradient.
+  double augmentedLagrangianStationarity =
+      std::numeric_limits<double>::infinity();
+  /// max(||h||_inf, ||q||_inf), including inequality complementarity.
+  double generalizedConstraintViolation =
+      std::numeric_limits<double>::infinity();
+  /// Infinity norm of max(g, 0) for whitened inequalities.
+  double primalInequalityViolation = 0.0;
+  /// Infinity norm of lambda^+ times g for whitened inequalities.
+  double complementarity = 0.0;
+
+  /// Total LM iterations accumulated across all outer iterations.
+  size_t totalUnconstrainedIterations = 0;
+  /// Whether LM met the requested BCL stationarity target.
+  bool innerConverged = true;
+  /// Whether the constrained convergence test was met.
+  bool converged = false;
+  /// Outer update performed after solving this subproblem.
+  AugmentedLagrangianUpdateType updateType =
+      AugmentedLagrangianUpdateType::None;
+
+  /// BCL alpha for the next subproblem.
+  double bclAlpha = 0.0;
+  /// BCL stationarity tolerance for the next subproblem.
+  double bclOmega = 0.0;
+  /// BCL generalized-feasibility tolerance for the next subproblem.
+  double bclEta = 0.0;
 
   /** Initialize Lagrange multipliers as zeros. */
   void initializeLagrangeMultipliers(const ConstrainedOptProblem& problem);
@@ -55,21 +129,30 @@ class GTSAM_EXPORT AugmentedLagrangianState : public PenaltyOptimizerState {
   using Base::Base;
 };
 
-/** Augmented Lagrangian method to solve constrained nonlinear least squares
- * problems. The implementation follows
- * https://www.seas.ucla.edu/~vandenbe/133B/lectures/nllseq.pdf for problems
- * with equality constraints only. We further generalize the implementation to
- * incorporate inequality constraints with reference to
- * https://www.stat.cmu.edu/~ryantibs/convexopt/scribes/dual-decomp-scribed.pdf.
- * Example problem:
- * argmin_x  0.5 * ||x1-1||^2 + 0.5 * ||x2-1||^2
- *      s.t.  x1^2 + x2^2 - 1 = 0
- *      s.t.  4*x1^2 + 0.25*x2^2 - 1 <= 0
+/**
+ * Augmented Lagrangian solver for nonlinear least-squares problems with
+ * equalities h(x)=0 and scalar inequalities g(x)<=0. Inequalities use the
+ * Powell--Hestenes--Rockafellar term
+ *
+ *   (max(0, lambda + rho g)^2 - lambda^2) / (2 rho).
+ *
+ * The BCL policy is inspired by Algorithm 1 of Conn, Gould, and Toint,
+ * "A Globally Convergent Augmented Lagrangian Algorithm for Optimization with
+ * General Constraints and Simple Bounds," SIAM J. Numer. Anal. 28(2), 1991,
+ * https://doi.org/10.1137/0728030, but is not entirely faithful. It replaces
+ * the paper's projected bound-constrained inner solve with unconstrained LM
+ * and full augmented-Lagrangian gradient stationarity, and handles
+ * inequalities directly with PHR terms rather than bounded slack variables.
+ * Consequently, the paper's convergence proof does not apply to this
+ * implementation.
+ *
+ * Custom smoothed inequality penalties are intentionally unsupported because
+ * they invalidate the projected PHR multiplier identity.
  */
 class GTSAM_EXPORT AugmentedLagrangianOptimizer : public ConstrainedOptimizer {
  public:
   using Base = ConstrainedOptimizer;
-  using This = PenaltyOptimizer;
+  using This = AugmentedLagrangianOptimizer;
   using shared_ptr = std::shared_ptr<This>;
 
   using Params = AugmentedLagrangianParams;
@@ -81,78 +164,62 @@ class GTSAM_EXPORT AugmentedLagrangianOptimizer : public ConstrainedOptimizer {
   mutable Progress progress_;
 
  public:
-  /// Constructor.
+  /// Construct from a constrained optimization problem.
   AugmentedLagrangianOptimizer(
       const ConstrainedOptProblem& problem, const Values& initialValues,
       Params::shared_ptr p = std::make_shared<Params>())
       : Base(problem, initialValues), p_(p), progress_() {}
 
-  /// Constructor that packs costs and constraints into a single factor graph.
+  /// Construct by unpacking costs and constraints from one factor graph.
   AugmentedLagrangianOptimizer(
       const NonlinearFactorGraph& graph, const Values& initialValues,
       Params::shared_ptr p = std::make_shared<Params>())
       : Base(graph, initialValues), p_(p), progress_() {}
 
-  /// Run optimization with equality constraints only.
+  /// Run the selected augmented-Lagrangian update policy.
   Values optimize() const override;
 
-  std::tuple<State, double, double> iterate(const State& state,
-                                            const double muEq,
-                                            const double muIneq) const;
+  /**
+   * Solve one fixed-multiplier subproblem and perform one outer update.
+   * `muEq` and `muIneq` are the direct penalties used for this subproblem and
+   * the returned pair contains the penalties for the next subproblem. BCL
+   * requires the two supplied penalties to be equal.
+   */
+  std::tuple<State, double, double> iterate(const State& state, double muEq,
+                                            double muIneq) const;
 
-  /// Return progress of iterations.
+  /// Return stored progress; populated when storeOptProgress is true.
   const Progress& progress() const { return progress_; }
 
   /**
-   * Lagrange dual function for equality constraints and inequality constraints
-   *   m(x) = 0.5 * ||f(x)||^2 - lambdaEq * h(x) + 0.5 * muEq * ||h(x)||^2
-   *                           - lambdaIneq * g(x) + 0.5 * muIneq * ||g(x)_-||^2
-   * To express in nonlinear least squares form, it is rewritten as
-   *     m(x)
-   *   = m(x) + 0.5 * epsilon * ||g(x)||^2
-   *   = 0.5 * ||f(x)||^2
-   *     + (0.5 * muEq * ||h(x)||^2 - lambdaEq * h(x))
-   *     + (0.5 * epsilon * ||g(x)||^2 - lambdaIneq * g(x))
-   *     + 0.5 * muIneq * ||g(x)_-||^2
-   *     - 0.5 * epsilon * ||g(x)||^2
-   *   = 0.5 * ||f(x)||^2
-   *     + 0.5 * muEq * ||h(x)- lambdaEq/muEq||^2
-   *     + 0.5 * epsilon * ||g(x)-lambdaIneq/muIneq||^2
-   *     + 0.5 * muIneq * ||g(x)_-||^2
-   *     - 0.5 * epsilon * ||g(x)||^2
-   *     - c
-   * where
-   *   c = ||lambdaEq||^2 / (2 * muEq) + ||lambdaIneq||^2 / (2 * epsilon)
-   * is a constant term,
-   * and epsilon can be any positive scalar value.
-   *
-   * Notice: the purpose of epsilon is to incorporate (-lambdaIneq * g(x)) in
-   * nonlinear least squares form. To do so, we manually create an additional
-   * term (0.5 * epsilon * ||g(x)||^2), which is added and then subtracted in
-   * the merit function. The term (-lambdaIneq * g(x)) and (0.5 * epsilon *
-   * ||g(x)||^2) can be combined as a least-square term, and the subtraction of
-   * (0.5 * epsilon * ||g(x)||^2) can be performed with anti-factor.
-   * @return: factor graph representing m(x) + 0.5d * ||g(x)||^2 + c
+   * Build the least-squares representation of the fixed-parameter augmented
+   * Lagrangian. The represented objective differs from the mathematical PHR
+   * objective only by constants independent of x. `epsilon` is retained for
+   * source compatibility and ignored.
    */
-  NonlinearFactorGraph augmentedLagrangianFunction(
-      const State& state, const double epsilon = 1.0) const;
+  NonlinearFactorGraph augmentedLagrangianFunction(const State& state,
+                                                   double epsilon = 1.0) const;
 
  protected:
-  /// Create an unconstrained optimizer that solves the augmented Lagrangian.
+  /// Create the LM optimizer used for an augmented-Lagrangian subproblem.
   SharedOptimizer createUnconstrainedOptimizer(
       const NonlinearFactorGraph& graph, const Values& values) const;
 
-  /** Update the Lagrange multipliers using dual ascent. */
-  void updateLagrangeMultiplier(const State& prev_state, State* state) const;
+  /// Update Aggressive multipliers from the newly solved point.
+  void updateLagrangeMultiplier(const State& subproblemState,
+                                State* solvedState) const;
 
-  /// Set the penalty parameters for the state using results from prev state.
-  std::pair<double, double> updatePenaltyParameter(const State& prev_state,
-                                                   const State& state) const;
+  /// Compute Aggressive direct penalties for the next subproblem.
+  std::pair<double, double> updatePenaltyParameter(
+      const State& previousState, const State& solvedState) const;
+
+  /// Validate policy parameters and supported inequality constraints.
+  void validateConfiguration() const;
 
   /// Store and log the initial state of the optimization.
   void logInitialState(const State& state) const;
 
-  /// Store and log the state after any iteration of the optimization.
+  /// Store and log the state after an iteration of the optimization.
   void logIteration(const State& state) const;
 };
 

--- a/gtsam/constrained/AugmentedLagrangianOptimizer.h
+++ b/gtsam/constrained/AugmentedLagrangianOptimizer.h
@@ -12,7 +12,8 @@
 /**
  * @file    AugmentedLagrangianOptimizer.h
  * @brief   Augmented Lagrangian method for nonlinear constrained optimization.
- * @author  Yetong Zhang, Frank Dellaert
+ * @author  Yetong Zhang
+ * @author  Frank Dellaert (codex assisted)
  * @date    Aug 3, 2024
  */
 
@@ -61,7 +62,12 @@ class GTSAM_EXPORT AugmentedLagrangianParams : public PenaltyOptimizerParams {
   /// Absolute full augmented-Lagrangian gradient tolerance for BCL convergence.
   double absoluteStationarityTolerance = 1e-5;
 
-  /// Initial common direct penalty rho for BCL (paper default: 1 / mu_0).
+  /**
+   * Initial common direct penalty rho for BCL (paper default: 1 / mu_0).
+   * Algorithm 1 has one penalty for the complete constraint vector, so BCL
+   * applies this rho to both equality and inequality blocks. Constraint sigmas
+   * provide fixed relative scaling. Aggressive may use separate penalties.
+   */
   double bclInitialPenalty = 10.0;
   /// BCL direct-penalty growth factor (paper default: 1 / tau).
   double bclPenaltyIncreaseRate = 100.0;
@@ -183,7 +189,9 @@ class GTSAM_EXPORT AugmentedLagrangianOptimizer : public ConstrainedOptimizer {
    * Solve one fixed-multiplier subproblem and perform one outer update.
    * `muEq` and `muIneq` are the direct penalties used for this subproblem and
    * the returned pair contains the penalties for the next subproblem. BCL
-   * requires the two supplied penalties to be equal.
+   * requires the two supplied penalties to be equal because Algorithm 1 uses
+   * one penalty for the combined constraint vector. Aggressive permits distinct
+   * equality and inequality penalties.
    */
   std::tuple<State, double, double> iterate(const State& state, double muEq,
                                             double muIneq) const;

--- a/gtsam/constrained/constrained.i
+++ b/gtsam/constrained/constrained.i
@@ -193,14 +193,27 @@ class PenaltyOptimizerParams : gtsam::ConstrainedOptimizerParams {
 };
 
 #include <gtsam/constrained/AugmentedLagrangianOptimizer.h>
+enum class AugmentedLagrangianUpdatePolicy { Aggressive, BCL };
+
 class AugmentedLagrangianParams : gtsam::PenaltyOptimizerParams {
   AugmentedLagrangianParams();
 
+  gtsam::AugmentedLagrangianUpdatePolicy updatePolicy;
   double maxDualStepSizeEq;
   double maxDualStepSizeIneq;
   double dualStepSizeFactorEq;
   double dualStepSizeFactorIneq;
   double muIncreaseThreshold;
+  double absoluteStationarityTolerance;
+  double bclInitialPenalty;
+  double bclPenaltyIncreaseRate;
+  double bclOmega0;
+  double bclEta0;
+  double bclGamma1;
+  double bclAlphaOmega;
+  double bclBetaOmega;
+  double bclAlphaEta;
+  double bclBetaEta;
 };
 
 virtual class AugmentedLagrangianOptimizer {

--- a/gtsam/constrained/constrained.md
+++ b/gtsam/constrained/constrained.md
@@ -77,7 +77,10 @@ For a new user, it helps to think in two phases:
 
 Inequality constraints can use different smooth penalty shapes via
 `InequalityPenaltyFunction` (ramp, smooth polynomial ramps, or softplus),
-which controls behavior near the active constraint boundary.
+which controls behavior near the active constraint boundary in
+`PenaltyOptimizer`. `AugmentedLagrangianOptimizer` instead requires exact PHR
+inequality terms and rejects custom smooth penalties so its projected
+multiplier update remains mathematically consistent.
 
 ### 1) Build the Problem
 

--- a/gtsam/constrained/doc/AugmentedLagrangianOptimizer.ipynb
+++ b/gtsam/constrained/doc/AugmentedLagrangianOptimizer.ipynb
@@ -9,7 +9,7 @@
         "\n",
         "## Overview\n",
         "\n",
-        "AugmentedLagrangianOptimizer combines penalty terms with Lagrange multipliers to improve convergence and conditioning on constrained nonlinear problems. It supports the default Aggressive outer update and an opt-in BCL update policy inspired by Conn, Gould, and Toint."
+        "AugmentedLagrangianOptimizer combines penalty terms with Lagrange multipliers to improve convergence and conditioning on constrained nonlinear problems. It uses the BCL update policy inspired by Conn, Gould, and Toint by default, while retaining the earlier Aggressive policy as an explicit option."
       ]
     },
     {
@@ -66,8 +66,8 @@
         "\n",
         "- `AugmentedLagrangianState` stores equality and nonnegative inequality multipliers plus stationarity, generalized-feasibility, primal-feasibility, and complementarity diagnostics.\n",
         "- `augmentedLagrangianFunction` builds a fixed-multiplier subproblem with exact Powell--Hestenes--Rockafellar (PHR) terms for scalar inequalities.\n",
-        "- `Aggressive` is the backward-compatible default and updates multipliers after every solved subproblem.\n",
-        "- `BCL` accepts a multiplier update only when generalized feasibility meets its current target; otherwise it increases the common direct penalty."
+        "- `BCL` is the default. It accepts a multiplier update only when generalized feasibility meets its current target; otherwise it increases the common direct penalty.\n",
+        "- `Aggressive` remains available as an explicit option and updates multipliers after every solved subproblem."
       ]
     },
     {
@@ -117,7 +117,7 @@
         "using namespace gtsam;\n",
         "\n",
         "auto params = std::make_shared<AugmentedLagrangianParams>();\n",
-        "params->updatePolicy = AugmentedLagrangianUpdatePolicy::BCL;\n",
+        "// BCL is the default update policy.\n",
         "params->verbose = true;\n",
         "\n",
         "AugmentedLagrangianOptimizer optimizer(problem, init_values, params);\n",

--- a/gtsam/constrained/doc/AugmentedLagrangianOptimizer.ipynb
+++ b/gtsam/constrained/doc/AugmentedLagrangianOptimizer.ipynb
@@ -9,7 +9,7 @@
         "\n",
         "## Overview\n",
         "\n",
-        "AugmentedLagrangianOptimizer combines penalty terms with Lagrange multipliers to improve convergence and conditioning on constrained nonlinear problems."
+        "AugmentedLagrangianOptimizer combines penalty terms with Lagrange multipliers to improve convergence and conditioning on constrained nonlinear problems. It supports the default Aggressive outer update and an opt-in BCL update policy inspired by Conn, Gould, and Toint."
       ]
     },
     {
@@ -64,10 +64,10 @@
       "source": [
         "## Key Concepts\n",
         "\n",
-        "- AugmentedLagrangianState extends penalty state with equality and inequality multipliers.\n",
-        "- augmentedLagrangianFunction builds the constrained objective used in each outer iteration.\n",
-        "- Multiplier updates are done by dual-ascent style steps.\n",
-        "- Penalty parameters are adapted based on violation reduction."
+        "- `AugmentedLagrangianState` stores equality and nonnegative inequality multipliers plus stationarity, generalized-feasibility, primal-feasibility, and complementarity diagnostics.\n",
+        "- `augmentedLagrangianFunction` builds a fixed-multiplier subproblem with exact Powell--Hestenes--Rockafellar (PHR) terms for scalar inequalities.\n",
+        "- `Aggressive` is the backward-compatible default and updates multipliers after every solved subproblem.\n",
+        "- `BCL` accepts a multiplier update only when generalized feasibility meets its current target; otherwise it increases the common direct penalty."
       ]
     },
     {
@@ -77,15 +77,17 @@
       "source": [
         "## Mathematical Formulation\n",
         "\n",
-        "Augmented Lagrangian combines multipliers and penalties:\n",
+        "For whitened equalities $h(x)=0$, whitened scalar inequalities $g_i(x)\\leq0$, direct penalties $\\rho_e,\\rho_i>0$, and nonnegative inequality multipliers, the fixed-parameter objective is:\n",
         "\n",
         "$$\n",
         "\\mathcal{L}_A(x,\\lambda)=\\frac{1}{2}\\|f(x)\\|^2\n",
-        "-\\lambda_{eq}^T h(x)+\\frac{\\mu_{eq}}{2}\\|h(x)\\|^2\n",
-        "-\\lambda_{ineq}^T g(x)+\\frac{\\mu_{ineq}}{2}\\|g(x)_-\\|^2.\n",
+        "+\\lambda_e^T h(x)+\\frac{\\rho_e}{2}\\|h(x)\\|^2\n",
+        "+\\sum_i\\frac{\\max(0,\\lambda_i+\\rho_i g_i(x))^2-\\lambda_i^2}{2\\rho_i}.\n",
         "$$\n",
         "\n",
-        "The solver alternates between primal minimization (in $x$) and dual-ascent updates (in multipliers), with adaptive penalty updates.\n"
+        "The projected inequality residual $q_i=\\max(g_i,-\\lambda_i/\\rho_i)$ gives $\\lambda_i^+=\\max(0,\\lambda_i+\\rho_i g_i)=\\lambda_i+\\rho_i q_i$. BCL uses the full augmented-Lagrangian gradient infinity norm for inner stationarity and $\\max(\\|h\\|_\\infty,\\|q\\|_\\infty)$ for generalized feasibility.\n",
+        "\n",
+        "The BCL policy follows the update schedule of Conn, Gould, and Toint Algorithm 1 as closely as possible, but it is not entirely faithful: unconstrained LM replaces their projected bound-constrained inner solver, and direct PHR inequalities replace their bounded slack formulation. Their convergence proof therefore does not apply here."
       ]
     },
     {
@@ -98,8 +100,8 @@
         "- `AugmentedLagrangianOptimizer(problem, initialValues, params)`\n",
         "- `optimize()`\n",
         "- `progress()`\n",
-        "- `augmentedLagrangianFunction(state, epsilon)` (advanced inspection)\n",
-        "- `AugmentedLagrangianParams`: dual step sizes and penalty-adaptation settings\n"
+        "- `augmentedLagrangianFunction(state, epsilon)` (advanced inspection; `epsilon` is retained for source compatibility)\n",
+        "- `AugmentedLagrangianParams`: `updatePolicy`, Aggressive controls, and flat BCL schedule parameters\n"
       ]
     },
     {
@@ -115,6 +117,7 @@
         "using namespace gtsam;\n",
         "\n",
         "auto params = std::make_shared<AugmentedLagrangianParams>();\n",
+        "params->updatePolicy = AugmentedLagrangianUpdatePolicy::BCL;\n",
         "params->verbose = true;\n",
         "\n",
         "AugmentedLagrangianOptimizer optimizer(problem, init_values, params);\n",
@@ -132,6 +135,10 @@
         "\n",
         "- [QCQP example notebook](../../../python/gtsam/examples/QcqpProblemExample.ipynb)\n",
         "- [QP example notebook](../../../python/gtsam/examples/QpProblemExample.ipynb)\n",
+        "\n",
+        "### Algorithm reference\n",
+        "\n",
+        "- A. R. Conn, N. I. M. Gould, and Ph. L. Toint, [A Globally Convergent Augmented Lagrangian Algorithm for Optimization with General Constraints and Simple Bounds](https://doi.org/10.1137/0728030), SIAM Journal on Numerical Analysis 28(2), 1991.\n",
         "\n",
         "### Source code\n",
         "\n",

--- a/gtsam/constrained/doc/QcqpProblem.ipynb
+++ b/gtsam/constrained/doc/QcqpProblem.ipynb
@@ -188,8 +188,6 @@
     "problem = gtsam.QcqpProblem(graph)\n",
     "params = gtsam.AugmentedLagrangianParams()\n",
     "params.maxIterations = 10\n",
-    "params.initialMuEq = 10.0\n",
-    "params.muEqIncreaseRate = 5.0\n",
     "params.absoluteViolationTolerance = 1e-6\n",
     "result = gtsam.AugmentedLagrangianOptimizer(problem, initial, params).optimize()\n",
     "recovered = gtsam.extractQcqpValuesPose2(result)\n",

--- a/gtsam/constrained/tests/testAugmentedLagrangianOptimizer.cpp
+++ b/gtsam/constrained/tests/testAugmentedLagrangianOptimizer.cpp
@@ -11,7 +11,10 @@
 
 /**
  * @file  testAugmentedLagrangianOptimizer.cpp
- * @brief Tests for augmented-Lagrangian update policies and PHR inequalities.
+ * @brief Test the augmented Lagrangian optimizer for equality and inequality
+ * constraints, including Aggressive and BCL update policies and PHR terms.
+ * @author Yetong Zhang
+ * @author Frank Dellaert (codex assisted)
  */
 
 #include <CppUnitLite/TestHarness.h>

--- a/gtsam/constrained/tests/testAugmentedLagrangianOptimizer.cpp
+++ b/gtsam/constrained/tests/testAugmentedLagrangianOptimizer.cpp
@@ -11,199 +11,426 @@
 
 /**
  * @file  testAugmentedLagrangianOptimizer.cpp
- * @brief Test augmented Lagrangian method optimizer for equality constrained
- * optimization.
- * @author: Yetong Zhang
+ * @brief Tests for augmented-Lagrangian update policies and PHR inequalities.
  */
 
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/constrained/AugmentedLagrangianOptimizer.h>
 #include <gtsam/inference/Symbol.h>
-#include <gtsam/slam/expressions.h>
+#include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/nonlinear/expressions.h>
+
+#include <cmath>
 
 #include "constrainedExample.h"
-#include "gtsam/constrained/NonlinearEqualityConstraint.h"
 
 using namespace gtsam;
 
 /* ************************************************************************* */
-double EvaluateLagrangeTerm(const std::vector<Vector>& lambdas,
-                            const NonlinearEqualityConstraints& constraints,
-                            const Values& values) {
-  double s = 0;
-  for (size_t i = 0; i < constraints.size(); i++) {
-    const auto& constraint = constraints.at(i);
-    s += lambdas.at(i).dot(constraint->whitenedError(values));
-  }
-  return s;
-}
+namespace scalar_problem {
 
-/* ************************************************************************* */
-double EvaluateLagrangeTerm(const std::vector<double>& lambdas,
-                            const NonlinearInequalityConstraints& constraints,
-                            const Values& values) {
-  double s = 0;
-  for (size_t i = 0; i < constraints.size(); i++) {
-    const auto& constraint = constraints.at(i);
-    s += lambdas.at(i) * constraint->whitenedExpr(values)(0);
-  }
-  return s;
-}
+const Symbol kX('x', 0);
+const Double_ kExpression(kX);
 
-/* ************************************************************************* */
-double ComputeBias(const std::vector<Vector>& lambdas, double mu) {
-  double norm_squared = 0;
-  for (const auto& lambda : lambdas) {
-    norm_squared += pow(lambda.norm(), 2);
-  }
-  return 0.5 / mu * norm_squared;
-}
-
-/* ************************************************************************* */
-double ComputeBias(const std::vector<double>& lambdas, double epsilon) {
-  double norm_squared = 0;
-  for (const auto& lambda : lambdas) {
-    norm_squared += pow(lambda, 2);
-  }
-  return 0.5 / epsilon * norm_squared;
-}
-
-/* ************************************************************************* */
-TEST(AugmentedLagrangian, constrained_example1) {
-  using namespace constrained_example1;
-
-  // Construct optimizer
-  auto params = std::make_shared<AugmentedLagrangianParams>();
-  AugmentedLagrangianOptimizer optimizer(problem, init_values, params);
-
-  AugmentedLagrangianState state;
-  state.lambdaEq.emplace_back(Vector1(0.3));
-  state.muEq = 0.2;
-  NonlinearFactorGraph augmentedLagrangian =
-      optimizer.augmentedLagrangianFunction(state);
-
-  const Values& values = init_values;
-  double expected_cost = costs.error(values);
-  double expected_l2_penalty =
-      eqConstraints.penaltyGraph(state.muEq).error(values);
-  double expected_lagrange_term =
-      EvaluateLagrangeTerm(state.lambdaEq, eqConstraints, values);
-  double bias = ComputeBias(state.lambdaEq, state.muEq);
-  double expected_error =
-      expected_cost + expected_l2_penalty + expected_lagrange_term + bias;
-  EXPECT_DOUBLES_EQUAL(expected_error, augmentedLagrangian.error(values), 1e-6);
-}
-
-/* ************************************************************************* */
-TEST(AugmentedLagrangian, constrained_example2) {
-  using namespace constrained_example2;
-
-  // Construct optimizer
-  auto params = std::make_shared<AugmentedLagrangianParams>();
-  AugmentedLagrangianOptimizer optimizer(problem, init_values, params);
-
-  AugmentedLagrangianState state;
-  state.lambdaEq.emplace_back(Vector1(0.3));
-  state.lambdaIneq.emplace_back(-2.0);
-  state.muEq = 0.2;
-  state.muIneq = 0.3;
-  double epsilon = 1.0;
-  NonlinearFactorGraph augmentedLagrangian =
-      optimizer.augmentedLagrangianFunction(state, epsilon);
-
-  const Values& values = init_values;
-  double expected_cost = costs.error(values);
-  double expected_l2_penalty_e =
-      eqConstraints.penaltyGraph(state.muEq).error(values);
-  double expected_lagrange_term_e =
-      EvaluateLagrangeTerm(state.lambdaEq, eqConstraints, values);
-  double bias_e = ComputeBias(state.lambdaEq, state.muEq);
-  double expected_penalty_i =
-      ineqConstraints.penaltyGraph(state.muIneq).error(values);
-  double expected_lagrange_term_i =
-      EvaluateLagrangeTerm(state.lambdaIneq, ineqConstraints, values);
-  double bias_i = ComputeBias(state.lambdaIneq, epsilon);
-  double expected_error = expected_cost + expected_l2_penalty_e +
-                          expected_penalty_i + expected_lagrange_term_e +
-                          expected_lagrange_term_i + bias_e + bias_i;
-
-  EXPECT_DOUBLES_EQUAL(expected_error, augmentedLagrangian.error(values), 1e-6);
-}
-
-/* ************************************************************************* */
-TEST(AugmentedLagrangianOptimizer, constrained_example1) {
-  using namespace constrained_example1;
-
-  auto params = std::make_shared<AugmentedLagrangianParams>();
-  params->verbose = true;
-  AugmentedLagrangianOptimizer optimizer(problem, init_values, params);
-  Values results = optimizer.optimize();
-
-  /// Check the result is correct within tolerance.
-  EXPECT(assert_equal(optimal_values, results, 1e-4));
-}
-
-/* ************************************************************************* */
-TEST(AugmentedLagrangianOptimizer, constrained_example2) {
-  using namespace constrained_example2;
-
-  auto params = std::make_shared<AugmentedLagrangianParams>();
-  params->verbose = true;
-  AugmentedLagrangianOptimizer optimizer(problem, init_values, params);
-  Values results = optimizer.optimize();
-
-  /// Check the result is correct within tolerance.
-  EXPECT(assert_equal(optimal_values, results, 1e-4));
-}
-
-TEST(AugmentedLagrangian, VectorBiasUsesElementwiseSigmas) {
-  using namespace gtsam;
-
-  const Symbol x_key('x', 0);
-  const Vector3_ x(x_key);
-
-  // Non-uniform sigmas are essential to detect the bug in Release.
-  Vector sigmas{{1.0, 2.0, 4.0}};
-
-  NonlinearEqualityConstraints eq;
-  eq.emplace_shared<ExpressionEqualityConstraint<Vector3>>(x, Vector3::Zero(),
-                                                           sigmas);
-
-  // Empty cost graph keeps the factor indexing simple.
-  NonlinearFactorGraph costs;
-  const auto problem =
-      ConstrainedOptProblem::EqConstrainedOptProblem(costs, eq);
-
+Values ValuesAt(double x) {
   Values values;
-  values.insert<Vector3>(
-      x_key,
-      Vector3::Zero());  // satisfy constraint => penalty factor error is zero
+  values.insert(kX, x);
+  return values;
+}
 
+NonlinearFactorGraph CostTo(double target, double sigma = 1.0) {
+  NonlinearFactorGraph costs;
+  costs.addPrior(kX, target, noiseModel::Isotropic::Sigma(1, sigma));
+  return costs;
+}
+
+NonlinearEqualityConstraints EqualityTo(double target, double sigma = 1.0) {
+  NonlinearEqualityConstraints constraints;
+  constraints.emplace_shared<ExpressionEqualityConstraint<double>>(
+      kExpression, target, Vector1(sigma));
+  return constraints;
+}
+
+NonlinearInequalityConstraints LessEqual(double upperBound,
+                                         double sigma = 1.0) {
+  NonlinearInequalityConstraints constraints;
+  constraints.emplace_shared<ScalarExpressionInequalityConstraint>(
+      kExpression - Double_(upperBound), sigma);
+  return constraints;
+}
+
+ConstrainedOptProblem Problem(
+    const NonlinearFactorGraph& costs,
+    const NonlinearEqualityConstraints& equalities,
+    const NonlinearInequalityConstraints& inequalities) {
+  return ConstrainedOptProblem(costs, equalities, inequalities);
+}
+
+AugmentedLagrangianState StateAt(const ConstrainedOptProblem& problem, double x,
+                                 double penalty) {
+  AugmentedLagrangianState state(0, ValuesAt(x), problem);
+  state.initializeLagrangeMultipliers(problem);
+  state.muEq = penalty;
+  state.muIneq = penalty;
+  return state;
+}
+
+AugmentedLagrangianParams::shared_ptr BclParams() {
   auto params = std::make_shared<AugmentedLagrangianParams>();
-  AugmentedLagrangianOptimizer optimizer(problem, values, params);
+  params->updatePolicy = AugmentedLagrangianUpdatePolicy::BCL;
+  params->maxIterations = 30;
+  params->absoluteViolationTolerance = 1e-7;
+  params->absoluteStationarityTolerance = 1e-7;
+  params->lmParams.maxIterations = 100;
+  params->storeOptProgress = true;
+  return params;
+}
 
-  AugmentedLagrangianState state;
-  state.muEq = 0.2;
-  state.lambdaEq.emplace_back(Vector{{0.3, -0.5, 1.2}});
+double Gradient(const NonlinearFactorGraph& graph, const Values& values) {
+  return graph.linearize(values)->gradientAtZero().at(kX)(0);
+}
 
-  // Buggy code aborts here in Debug (Eigen assert) and gives wrong bias in
-  // Release.
+}  // namespace scalar_problem
+/* ************************************************************************* */
+
+/* ************************************************************************* */
+namespace phr_factor_tests {
+
+// Verifies exact PHR values and gradients on the active shifted-ramp branch.
+TEST(AugmentedLagrangianPHR, ActiveValueAndGradient) {
+  using namespace scalar_problem;
+  const ConstrainedOptProblem problem = Problem({}, {}, LessEqual(0.0));
+  AugmentedLagrangianState state = StateAt(problem, 1.0, 4.0);
+  state.lambdaIneq.at(0) = 2.0;
+
+  const AugmentedLagrangianOptimizer optimizer(problem, state.values);
   const NonlinearFactorGraph graph =
       optimizer.augmentedLagrangianFunction(state);
-  EXPECT_LONGS_EQUAL(1, static_cast<long>(graph.size()));
 
-  auto nf = graph.at(0);
-  auto factor = std::dynamic_pointer_cast<NoiseModelFactor>(nf);
+  // The graph stores max(0, lambda+rho*g)^2/(2*rho); subtracting the fixed
+  // lambda^2/(2*rho) gives the mathematical PHR term.
+  EXPECT_DOUBLES_EQUAL(4.0, graph.error(state.values) - 0.5, 1e-12);
+  EXPECT_DOUBLES_EQUAL(6.0, Gradient(graph, state.values), 1e-12);
+}
+
+// Verifies the inactive PHR branch is constant with zero derivative.
+TEST(AugmentedLagrangianPHR, InactiveValueAndGradient) {
+  using namespace scalar_problem;
+  const ConstrainedOptProblem problem = Problem({}, {}, LessEqual(0.0));
+  AugmentedLagrangianState state = StateAt(problem, -1.0, 4.0);
+  state.lambdaIneq.at(0) = 2.0;
+
+  const AugmentedLagrangianOptimizer optimizer(problem, state.values);
+  const NonlinearFactorGraph graph =
+      optimizer.augmentedLagrangianFunction(state);
+
+  EXPECT_DOUBLES_EQUAL(0.0, graph.error(state.values), 1e-12);
+  EXPECT_DOUBLES_EQUAL(0.0, Gradient(graph, state.values), 1e-12);
+}
+
+// Verifies the chosen derivative at the PHR transition is zero.
+TEST(AugmentedLagrangianPHR, TransitionValueAndGradient) {
+  using namespace scalar_problem;
+  const ConstrainedOptProblem problem = Problem({}, {}, LessEqual(0.0));
+  AugmentedLagrangianState state = StateAt(problem, -0.5, 4.0);
+  state.lambdaIneq.at(0) = 2.0;
+
+  const AugmentedLagrangianOptimizer optimizer(problem, state.values);
+  const NonlinearFactorGraph graph =
+      optimizer.augmentedLagrangianFunction(state);
+
+  EXPECT_DOUBLES_EQUAL(0.0, graph.error(state.values), 1e-12);
+  EXPECT_DOUBLES_EQUAL(0.0, Gradient(graph, state.values), 1e-12);
+}
+
+// Verifies ALM rejects smooth penalties that break the PHR multiplier identity.
+TEST(AugmentedLagrangianPHR, RejectsCustomSmoothedPenalty) {
+  using namespace scalar_problem;
+  const ConstrainedOptProblem problem = Problem({}, {}, LessEqual(0.0));
+  auto params = std::make_shared<AugmentedLagrangianParams>();
+  params->ineqConstraintPenaltyFunction =
+      std::make_shared<SmoothRampPoly2>(1.0);
+
+  CHECK_EXCEPTION(
+      AugmentedLagrangianOptimizer(problem, ValuesAt(0.0), params).optimize(),
+      std::invalid_argument);
+}
+
+}  // namespace phr_factor_tests
+/* ************************************************************************* */
+
+/* ************************************************************************* */
+namespace diagnostic_tests {
+
+// Verifies q drives the projected inequality update on both active branches.
+TEST(AugmentedLagrangianDiagnostics, ProjectedMultiplierAndResidual) {
+  using namespace scalar_problem;
+  const ConstrainedOptProblem problem = Problem({}, {}, LessEqual(0.0));
+  auto params = BclParams();
+  const AugmentedLagrangianOptimizer optimizer(problem, ValuesAt(0.25), params);
+
+  AugmentedLagrangianState active = StateAt(problem, 0.25, 10.0);
+  active.bclAlpha = 0.1;
+  active.bclOmega = 100.0;
+  active.bclEta = 100.0;
+  AugmentedLagrangianState activeResult;
+  double nextEq, nextIneq;
+  std::tie(activeResult, nextEq, nextIneq) =
+      optimizer.iterate(active, 10.0, 10.0);
+  EXPECT_DOUBLES_EQUAL(0.25, activeResult.generalizedConstraintViolation,
+                       1e-12);
+  EXPECT_DOUBLES_EQUAL(2.5, activeResult.lambdaIneq.at(0), 1e-12);
+  EXPECT_DOUBLES_EQUAL(10.0, nextEq, 1e-12);
+
+  AugmentedLagrangianState inactive = StateAt(problem, -1.0, 10.0);
+  inactive.lambdaIneq.at(0) = 2.0;
+  inactive.bclAlpha = 0.1;
+  inactive.bclOmega = 100.0;
+  inactive.bclEta = 100.0;
+  AugmentedLagrangianState inactiveResult;
+  std::tie(inactiveResult, nextEq, nextIneq) =
+      optimizer.iterate(inactive, 10.0, 10.0);
+  EXPECT_DOUBLES_EQUAL(0.2, inactiveResult.generalizedConstraintViolation,
+                       1e-12);
+  EXPECT_DOUBLES_EQUAL(0.0, inactiveResult.primalInequalityViolation, 1e-12);
+  EXPECT_DOUBLES_EQUAL(0.0, inactiveResult.lambdaIneq.at(0), 1e-12);
+  EXPECT_DOUBLES_EQUAL(0.0, inactiveResult.complementarity, 1e-12);
+}
+
+// Verifies mixed diagnostics combine equality feasibility, q, and
+// complementarity.
+TEST(AugmentedLagrangianDiagnostics, MixedConstraints) {
+  using namespace scalar_problem;
+  const ConstrainedOptProblem problem =
+      Problem({}, EqualityTo(1.0), LessEqual(0.25));
+  auto params = BclParams();
+  const AugmentedLagrangianOptimizer optimizer(problem, ValuesAt(0.5), params);
+
+  AugmentedLagrangianState state = StateAt(problem, 0.5, 2.0);
+  state.lambdaIneq.at(0) = 1.0;
+  state.bclAlpha = 0.1;
+  state.bclOmega = 100.0;
+  state.bclEta = 100.0;
+  const auto result = std::get<0>(optimizer.iterate(state, 2.0, 2.0));
+
+  EXPECT_DOUBLES_EQUAL(0.5, result.generalizedConstraintViolation, 1e-12);
+  EXPECT_DOUBLES_EQUAL(0.25, result.primalInequalityViolation, 1e-12);
+  EXPECT_DOUBLES_EQUAL(0.375, result.complementarity, 1e-12);
+  EXPECT(result.augmentedLagrangianStationarity > 0.0);
+}
+
+}  // namespace diagnostic_tests
+/* ************************************************************************* */
+
+/* ************************************************************************* */
+namespace bcl_policy_tests {
+
+// Verifies the translated paper defaults initialize alpha, omega, and eta.
+TEST(AugmentedLagrangianBCL, DefaultInitialization) {
+  using namespace scalar_problem;
+  const ConstrainedOptProblem problem = Problem(CostTo(0.0), {}, {});
+  auto params = BclParams();
+  params->maxIterations = 1;
+  const AugmentedLagrangianOptimizer optimizer(problem, ValuesAt(0.0), params);
+  optimizer.optimize();
+
+  const auto& initial = optimizer.progress().front();
+  EXPECT_DOUBLES_EQUAL(10.0, initial.muEq, 1e-12);
+  EXPECT_DOUBLES_EQUAL(10.0, initial.muIneq, 1e-12);
+  EXPECT_DOUBLES_EQUAL(0.1, initial.bclAlpha, 1e-12);
+  EXPECT_DOUBLES_EQUAL(0.1, initial.bclOmega, 1e-12);
+  EXPECT_DOUBLES_EQUAL(std::pow(0.1, 0.1), initial.bclEta, 1e-12);
+}
+
+// Verifies an accepted BCL iteration updates multipliers and tightens
+// tolerances.
+TEST(AugmentedLagrangianBCL, AcceptedUpdateSchedule) {
+  using namespace scalar_problem;
+  const ConstrainedOptProblem problem = Problem({}, {}, LessEqual(0.0));
+  auto params = BclParams();
+  const AugmentedLagrangianOptimizer optimizer(problem, ValuesAt(0.01), params);
+  AugmentedLagrangianState state = StateAt(problem, 0.01, 10.0);
+  state.bclAlpha = 0.1;
+  state.bclOmega = 1.0;
+  state.bclEta = 1.0;
+
+  double nextEq, nextIneq;
+  AugmentedLagrangianState result;
+  std::tie(result, nextEq, nextIneq) = optimizer.iterate(state, 10.0, 10.0);
+
+  EXPECT(result.innerConverged);
+  EXPECT(result.updateType == AugmentedLagrangianUpdateType::Multiplier);
+  EXPECT_DOUBLES_EQUAL(0.1, result.lambdaIneq.at(0), 1e-12);
+  EXPECT_DOUBLES_EQUAL(0.1, result.bclOmega, 1e-12);
+  EXPECT_DOUBLES_EQUAL(std::pow(0.1, 0.9), result.bclEta, 1e-12);
+  EXPECT_DOUBLES_EQUAL(10.0, nextEq, 1e-12);
+  EXPECT_DOUBLES_EQUAL(10.0, nextIneq, 1e-12);
+}
+
+// Verifies a rejected BCL iteration grows rho and resets both tolerances.
+TEST(AugmentedLagrangianBCL, PenaltyUpdateSchedule) {
+  using namespace scalar_problem;
+  const ConstrainedOptProblem problem = Problem({}, {}, LessEqual(0.0));
+  auto params = BclParams();
+  const AugmentedLagrangianOptimizer optimizer(problem, ValuesAt(1.0), params);
+  AugmentedLagrangianState state = StateAt(problem, 1.0, 10.0);
+  state.bclAlpha = 0.1;
+  state.bclOmega = 100.0;
+  state.bclEta = 0.1;
+
+  double nextEq, nextIneq;
+  AugmentedLagrangianState result;
+  std::tie(result, nextEq, nextIneq) = optimizer.iterate(state, 10.0, 10.0);
+
+  EXPECT(result.innerConverged);
+  EXPECT(result.updateType == AugmentedLagrangianUpdateType::Penalty);
+  EXPECT_DOUBLES_EQUAL(1000.0, nextEq, 1e-12);
+  EXPECT_DOUBLES_EQUAL(1000.0, nextIneq, 1e-12);
+  EXPECT_DOUBLES_EQUAL(0.001, result.bclAlpha, 1e-12);
+  EXPECT_DOUBLES_EQUAL(0.001, result.bclOmega, 1e-12);
+  EXPECT_DOUBLES_EQUAL(std::pow(0.001, 0.1), result.bclEta, 1e-12);
+}
+
+// Verifies an unmet inner stationarity target performs no outer update.
+TEST(AugmentedLagrangianBCL, InnerFailurePerformsNoUpdate) {
+  using namespace scalar_problem;
+  const ConstrainedOptProblem problem = Problem(CostTo(0.0), {}, {});
+  auto params = BclParams();
+  params->lmParams.maxIterations = 0;
+  const AugmentedLagrangianOptimizer optimizer(problem, ValuesAt(1.0), params);
+  AugmentedLagrangianState state = StateAt(problem, 1.0, 10.0);
+  state.bclAlpha = 0.1;
+  state.bclOmega = 1e-12;
+  state.bclEta = 100.0;
+
+  double nextEq, nextIneq;
+  AugmentedLagrangianState result;
+  std::tie(result, nextEq, nextIneq) = optimizer.iterate(state, 10.0, 10.0);
+
+  EXPECT(!result.innerConverged);
+  EXPECT(result.updateType == AugmentedLagrangianUpdateType::None);
+  EXPECT_DOUBLES_EQUAL(10.0, nextEq, 1e-12);
+  EXPECT_DOUBLES_EQUAL(10.0, nextIneq, 1e-12);
+  EXPECT_LONGS_EQUAL(0, static_cast<long>(result.unconstrainedIterations));
+}
+
+}  // namespace bcl_policy_tests
+/* ************************************************************************* */
+
+/* ************************************************************************* */
+namespace sequencing_tests {
+
+// Verifies Aggressive updates its multiplier from x_{k+1}, not x_k.
+TEST(AugmentedLagrangianAggressive, UsesPostLmPoint) {
+  using namespace scalar_problem;
+  const ConstrainedOptProblem problem =
+      Problem(CostTo(2.0), EqualityTo(0.0), {});
+  auto params = std::make_shared<AugmentedLagrangianParams>();
+  params->lmParams.maxIterations = 100;
+  const AugmentedLagrangianOptimizer optimizer(problem, ValuesAt(-4.0), params);
+  AugmentedLagrangianState state = StateAt(problem, -4.0, 1.0);
+
+  const AugmentedLagrangianState result =
+      std::get<0>(optimizer.iterate(state, 1.0, 1.0));
+  const double solvedX = result.values.at<double>(kX);
+
+  EXPECT_DOUBLES_EQUAL(solvedX, result.lambdaEq.at(0)(0), 1e-9);
+  EXPECT(std::abs(result.lambdaEq.at(0)(0) + 4.0) > 1.0);
+}
+
+// Verifies vector equality biases use each constraint sigma independently.
+TEST(AugmentedLagrangian, VectorBiasUsesElementwiseSigmas) {
+  const Symbol xKey('v', 0);
+  const Vector3_ x(xKey);
+  const Vector sigmas{{1.0, 2.0, 4.0}};
+  NonlinearEqualityConstraints equalities;
+  equalities.emplace_shared<ExpressionEqualityConstraint<Vector3>>(
+      x, Vector3::Zero(), sigmas);
+  const ConstrainedOptProblem problem =
+      ConstrainedOptProblem::EqConstrainedOptProblem({}, equalities);
+  Values values;
+  values.insert<Vector3>(xKey, Vector3::Zero());
+
+  AugmentedLagrangianState state(0, values, problem);
+  state.initializeLagrangeMultipliers(problem);
+  state.muEq = 0.2;
+  state.muIneq = 1.0;
+  state.lambdaEq.at(0) = Vector{{0.3, -0.5, 1.2}};
+  const AugmentedLagrangianOptimizer optimizer(problem, values);
+  const NonlinearFactorGraph graph =
+      optimizer.augmentedLagrangianFunction(state);
+  const auto factor = std::dynamic_pointer_cast<NoiseModelFactor>(graph.at(0));
+
   EXPECT(factor);
-
-  const Vector bias_from_factor = factor->unwhitenedError(values);
   const Vector expected =
       (state.lambdaEq.at(0) / state.muEq).cwiseProduct(sigmas);
-  EXPECT(assert_equal(expected, bias_from_factor, 1e-12));
+  EXPECT(assert_equal(expected, factor->unwhitenedError(values), 1e-12));
 }
+
+}  // namespace sequencing_tests
+/* ************************************************************************* */
+
+/* ************************************************************************* */
+namespace optimization_tests {
+
+// Verifies the default remains the historical Aggressive policy.
+TEST(AugmentedLagrangianAggressive, DefaultAndEqualityOptimization) {
+  using namespace constrained_example1;
+  auto params = std::make_shared<AugmentedLagrangianParams>();
+  EXPECT(params->updatePolicy == AugmentedLagrangianUpdatePolicy::Aggressive);
+  const Values result =
+      AugmentedLagrangianOptimizer(problem, init_values, params).optimize();
+  EXPECT(assert_equal(optimal_values, result, 1e-4));
+}
+
+// Verifies BCL solves the equality-only reference problem.
+TEST(AugmentedLagrangianBCL, EqualityOnlyOptimization) {
+  using namespace constrained_example1;
+  auto params = scalar_problem::BclParams();
+  const Values result =
+      AugmentedLagrangianOptimizer(problem, init_values, params).optimize();
+  EXPECT(assert_equal(optimal_values, result, 2e-4));
+}
+
+// Verifies BCL activates an inequality whose unconstrained minimizer is
+// infeasible.
+TEST(AugmentedLagrangianBCL, ActiveInequalityOptimization) {
+  using namespace scalar_problem;
+  const ConstrainedOptProblem problem =
+      Problem(CostTo(2.0), {}, LessEqual(0.0));
+  auto params = BclParams();
+  const Values result =
+      AugmentedLagrangianOptimizer(problem, ValuesAt(2.0), params).optimize();
+  EXPECT_DOUBLES_EQUAL(0.0, result.at<double>(kX), 2e-4);
+}
+
+// Verifies BCL leaves an inactive inequality multiplier at zero.
+TEST(AugmentedLagrangianBCL, InactiveInequalityOptimization) {
+  using namespace scalar_problem;
+  const ConstrainedOptProblem problem =
+      Problem(CostTo(-1.0), {}, LessEqual(0.0));
+  auto params = BclParams();
+  const AugmentedLagrangianOptimizer optimizer(problem, ValuesAt(1.0), params);
+  const Values result = optimizer.optimize();
+  EXPECT_DOUBLES_EQUAL(-1.0, result.at<double>(kX), 2e-4);
+  EXPECT_DOUBLES_EQUAL(0.0, optimizer.progress().back().lambdaIneq.at(0), 1e-9);
+}
+
+// Verifies BCL handles a mixed nonlinear problem whose active set changes.
+TEST(AugmentedLagrangianBCL, MixedChangingActiveSetOptimization) {
+  using namespace constrained_example2;
+  auto params = scalar_problem::BclParams();
+  params->maxIterations = 40;
+  const Values result =
+      AugmentedLagrangianOptimizer(problem, init_values, params).optimize();
+  EXPECT(assert_equal(optimal_values, result, 5e-4));
+}
+
+}  // namespace optimization_tests
+/* ************************************************************************* */
 
 /* ************************************************************************* */
 int main() {
-  TestResult tr;
-  return TestRegistry::runAllTests(tr);
+  TestResult result;
+  return TestRegistry::runAllTests(result);
 }

--- a/gtsam/constrained/tests/testAugmentedLagrangianOptimizer.cpp
+++ b/gtsam/constrained/tests/testAugmentedLagrangianOptimizer.cpp
@@ -329,6 +329,7 @@ TEST(AugmentedLagrangianAggressive, UsesPostLmPoint) {
   const ConstrainedOptProblem problem =
       Problem(CostTo(2.0), EqualityTo(0.0), {});
   auto params = std::make_shared<AugmentedLagrangianParams>();
+  params->updatePolicy = AugmentedLagrangianUpdatePolicy::Aggressive;
   params->lmParams.maxIterations = 100;
   const AugmentedLagrangianOptimizer optimizer(problem, ValuesAt(-4.0), params);
   AugmentedLagrangianState state = StateAt(problem, -4.0, 1.0);
@@ -376,23 +377,24 @@ TEST(AugmentedLagrangian, VectorBiasUsesElementwiseSigmas) {
 /* ************************************************************************* */
 namespace optimization_tests {
 
-// Verifies the default remains the historical Aggressive policy.
-TEST(AugmentedLagrangianAggressive, DefaultAndEqualityOptimization) {
+// Verifies the default BCL policy solves the equality-only reference problem.
+TEST(AugmentedLagrangianBCL, DefaultAndEqualityOptimization) {
   using namespace constrained_example1;
   auto params = std::make_shared<AugmentedLagrangianParams>();
-  EXPECT(params->updatePolicy == AugmentedLagrangianUpdatePolicy::Aggressive);
-  const Values result =
-      AugmentedLagrangianOptimizer(problem, init_values, params).optimize();
-  EXPECT(assert_equal(optimal_values, result, 1e-4));
-}
-
-// Verifies BCL solves the equality-only reference problem.
-TEST(AugmentedLagrangianBCL, EqualityOnlyOptimization) {
-  using namespace constrained_example1;
-  auto params = scalar_problem::BclParams();
+  EXPECT(params->updatePolicy == AugmentedLagrangianUpdatePolicy::BCL);
   const Values result =
       AugmentedLagrangianOptimizer(problem, init_values, params).optimize();
   EXPECT(assert_equal(optimal_values, result, 2e-4));
+}
+
+// Verifies the opt-in Aggressive policy still solves the reference problem.
+TEST(AugmentedLagrangianAggressive, EqualityOnlyOptimization) {
+  using namespace constrained_example1;
+  auto params = std::make_shared<AugmentedLagrangianParams>();
+  params->updatePolicy = AugmentedLagrangianUpdatePolicy::Aggressive;
+  const Values result =
+      AugmentedLagrangianOptimizer(problem, init_values, params).optimize();
+  EXPECT(assert_equal(optimal_values, result, 1e-4));
 }
 
 // Verifies BCL activates an inequality whose unconstrained minimizer is

--- a/gtsam/constrained/tests/testQcqpProblem.cpp
+++ b/gtsam/constrained/tests/testQcqpProblem.cpp
@@ -674,10 +674,7 @@ PoseRingOptimizationResult<T> OptimizePoseRing(
 
   auto params = std::make_shared<AugmentedLagrangianParams>();
   params->maxIterations = 10;
-  params->initialMuEq = 10.0;
-  params->muEqIncreaseRate = 5.0;
   params->absoluteViolationTolerance = 1e-6;
-  params->absoluteCostTolerance = 1e-12;
   params->verbose = false;
 
   const Values result =
@@ -715,10 +712,7 @@ TEST(QcqpProblem, AugmentedLagrangianOptimizerRot2Ring) {
 
   auto params = std::make_shared<AugmentedLagrangianParams>();
   params->maxIterations = 5;
-  params->initialMuEq = 10.0;
-  params->muEqIncreaseRate = 5.0;
   params->absoluteViolationTolerance = 1e-6;
-  params->absoluteCostTolerance = 1e-12;
   params->verbose = false;
 
   const AugmentedLagrangianOptimizer optimizer(problem, initialValues, params);

--- a/python/gtsam/examples/CertifiableRotationAveragingRot2.ipynb
+++ b/python/gtsam/examples/CertifiableRotationAveragingRot2.ipynb
@@ -179,12 +179,7 @@
    "source": [
     "alm_params = gtsam.AugmentedLagrangianParams()\n",
     "alm_params.maxIterations = 100\n",
-    "alm_params.initialMuEq = 10.0\n",
-    "alm_params.muEqIncreaseRate = 2.0\n",
     "alm_params.absoluteViolationTolerance = 1e-8\n",
-    "alm_params.relativeViolationTolerance = 1e-8\n",
-    "alm_params.absoluteCostTolerance = 1e-10\n",
-    "alm_params.relativeCostTolerance = 1e-10\n",
     "\n",
     "params = gtsam.RiemannianStaircaseParams()\n",
     "params.pMin = 2\n",

--- a/python/gtsam/examples/CertifiableRotationAveragingRot3.ipynb
+++ b/python/gtsam/examples/CertifiableRotationAveragingRot3.ipynb
@@ -157,12 +157,7 @@
    "source": [
     "alm_params = gtsam.AugmentedLagrangianParams()\n",
     "alm_params.maxIterations = 100\n",
-    "alm_params.initialMuEq = 10.0\n",
-    "alm_params.muEqIncreaseRate = 2.0\n",
     "alm_params.absoluteViolationTolerance = 1e-8\n",
-    "alm_params.relativeViolationTolerance = 1e-8\n",
-    "alm_params.absoluteCostTolerance = 1e-10\n",
-    "alm_params.relativeCostTolerance = 1e-10\n",
     "\n",
     "params = gtsam.RiemannianStaircaseParams()\n",
     "params.pMin = 3\n",

--- a/python/gtsam/examples/QcqpProblemExample.ipynb
+++ b/python/gtsam/examples/QcqpProblemExample.ipynb
@@ -1217,6 +1217,7 @@
     "initial.insert(rotor_key, initial_rotors)\n",
     "\n",
     "params = gtsam.AugmentedLagrangianParams()\n",
+    "params.updatePolicy = gtsam.AugmentedLagrangianUpdatePolicy.Aggressive\n",
     "params.maxIterations = 2000\n",
     "params.absoluteViolationTolerance = 1e-12\n",
     "params.relativeViolationTolerance = 1e-12\n",

--- a/python/gtsam/tests/test_certifiable.py
+++ b/python/gtsam/tests/test_certifiable.py
@@ -35,12 +35,7 @@ def staircase_params(initial_rank):
     """Return deterministic parameters for the small wrapper test problems."""
     alm_params = gtsam.AugmentedLagrangianParams()
     alm_params.maxIterations = 100
-    alm_params.initialMuEq = 10.0
-    alm_params.muEqIncreaseRate = 2.0
     alm_params.absoluteViolationTolerance = 1e-8
-    alm_params.relativeViolationTolerance = 1e-8
-    alm_params.absoluteCostTolerance = 1e-10
-    alm_params.relativeCostTolerance = 1e-10
 
     params = gtsam.RiemannianStaircaseParams()
     params.pMin = initial_rank

--- a/python/gtsam/tests/test_constrained.py
+++ b/python/gtsam/tests/test_constrained.py
@@ -166,6 +166,17 @@ class TestConstrainedWrappers(unittest.TestCase):
         initial.insert(x, np.array([0.6, 0.2]))
 
         params = gtsam.AugmentedLagrangianParams()
+        self.assertEqual(
+            params.updatePolicy,
+            gtsam.AugmentedLagrangianUpdatePolicy.Aggressive,
+        )
+        params.updatePolicy = gtsam.AugmentedLagrangianUpdatePolicy.BCL
+        self.assertEqual(params.bclInitialPenalty, 10.0)
+        self.assertEqual(params.bclPenaltyIncreaseRate, 100.0)
+        self.assertEqual(params.bclOmega0, 1.0)
+        self.assertEqual(params.bclEta0, 1.0)
+        self.assertEqual(params.bclGamma1, 0.1)
+        params.updatePolicy = gtsam.AugmentedLagrangianUpdatePolicy.Aggressive
         params.maxIterations = 100
         params.absoluteViolationTolerance = 1e-8
         params.relativeViolationTolerance = 1e-8

--- a/python/gtsam/tests/test_constrained.py
+++ b/python/gtsam/tests/test_constrained.py
@@ -168,14 +168,14 @@ class TestConstrainedWrappers(unittest.TestCase):
         params = gtsam.AugmentedLagrangianParams()
         self.assertEqual(
             params.updatePolicy,
-            gtsam.AugmentedLagrangianUpdatePolicy.Aggressive,
+            gtsam.AugmentedLagrangianUpdatePolicy.BCL,
         )
-        params.updatePolicy = gtsam.AugmentedLagrangianUpdatePolicy.BCL
         self.assertEqual(params.bclInitialPenalty, 10.0)
         self.assertEqual(params.bclPenaltyIncreaseRate, 100.0)
         self.assertEqual(params.bclOmega0, 1.0)
         self.assertEqual(params.bclEta0, 1.0)
         self.assertEqual(params.bclGamma1, 0.1)
+        # Aggressive remains selectable through the wrapper.
         params.updatePolicy = gtsam.AugmentedLagrangianUpdatePolicy.Aggressive
         params.maxIterations = 100
         params.absoluteViolationTolerance = 1e-8

--- a/timing/timeAugmentedLagrangianPolicies.cpp
+++ b/timing/timeAugmentedLagrangianPolicies.cpp
@@ -1,0 +1,497 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file timeAugmentedLagrangianPolicies.cpp
+ * @brief Compare Aggressive and BCL augmented-Lagrangian update policies.
+ */
+
+#include <gtsam/constrained/AugmentedLagrangianOptimizer.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/nonlinear/expressions.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "internal/TimingUtils.h"
+
+namespace {
+
+using gtsam::AugmentedLagrangianOptimizer;
+using gtsam::AugmentedLagrangianParams;
+using gtsam::AugmentedLagrangianState;
+using gtsam::AugmentedLagrangianUpdatePolicy;
+using gtsam::AugmentedLagrangianUpdateType;
+using gtsam::ConstrainedOptProblem;
+using gtsam::Double_;
+using gtsam::ExpressionEqualityConstraint;
+using gtsam::NonlinearEqualityConstraints;
+using gtsam::NonlinearFactorGraph;
+using gtsam::NonlinearInequalityConstraints;
+using gtsam::ScalarExpressionInequalityConstraint;
+using gtsam::Symbol;
+using gtsam::Values;
+using gtsam::Vector1;
+
+const Symbol kX('x', 0);
+const Symbol kY('y', 0);
+const Double_ kXExpression(kX);
+const Double_ kYExpression(kY);
+
+struct Options {
+  size_t warmups = 1;
+  size_t repetitions = 5;
+  std::optional<std::string> benchmarkActionJson;
+};
+
+struct Scenario {
+  std::string name;
+  ConstrainedOptProblem problem;
+  Values initial;
+};
+
+struct RunResult {
+  bool success = false;
+  double milliseconds = 0.0;
+  double stationarity = std::numeric_limits<double>::infinity();
+  double generalizedResidual = std::numeric_limits<double>::infinity();
+  double kktResidual = std::numeric_limits<double>::infinity();
+  double objective = std::numeric_limits<double>::infinity();
+  size_t outerIterations = 0;
+  size_t totalLmIterations = 0;
+  size_t multiplierUpdates = 0;
+  size_t penaltyUpdates = 0;
+  double maximumPenalty = 0.0;
+};
+
+struct Summary {
+  double successRate = 0.0;
+  double medianMilliseconds = 0.0;
+  double medianStationarity = 0.0;
+  double medianGeneralizedResidual = 0.0;
+  double medianKktResidual = 0.0;
+  double medianObjective = 0.0;
+  double medianOuterIterations = 0.0;
+  double medianTotalLmIterations = 0.0;
+  double medianMultiplierUpdates = 0.0;
+  double medianPenaltyUpdates = 0.0;
+  double maximumPenalty = 0.0;
+};
+
+struct KktDiagnostics {
+  double stationarity = 0.0;
+  double generalizedResidual = 0.0;
+};
+
+/* ************************************************************************* */
+Values ScalarValues(double x) {
+  Values values;
+  values.insert(kX, x);
+  return values;
+}
+
+/* ************************************************************************* */
+Values PairValues(double x, double y) {
+  Values values;
+  values.insert(kX, x);
+  values.insert(kY, y);
+  return values;
+}
+
+/* ************************************************************************* */
+NonlinearFactorGraph ScalarCost(double target, double sigma = 1.0) {
+  NonlinearFactorGraph costs;
+  costs.addPrior(kX, target, gtsam::noiseModel::Isotropic::Sigma(1, sigma));
+  return costs;
+}
+
+/* ************************************************************************* */
+NonlinearEqualityConstraints Equality(const Double_& expression, double rhs,
+                                      double sigma = 1.0) {
+  NonlinearEqualityConstraints constraints;
+  constraints.emplace_shared<ExpressionEqualityConstraint<double>>(
+      expression, rhs, Vector1(sigma));
+  return constraints;
+}
+
+/* ************************************************************************* */
+NonlinearInequalityConstraints LessEqual(const Double_& expression, double rhs,
+                                         double sigma = 1.0) {
+  NonlinearInequalityConstraints constraints;
+  constraints.emplace_shared<ScalarExpressionInequalityConstraint>(
+      expression - Double_(rhs), sigma);
+  return constraints;
+}
+
+/* ************************************************************************* */
+Scenario EqualityOnlyScenario() {
+  return {
+      "equality_only",
+      ConstrainedOptProblem(ScalarCost(2.0), Equality(kXExpression, 1.0), {}),
+      ScalarValues(-2.0)};
+}
+
+/* ************************************************************************* */
+Scenario ActiveInequalityScenario() {
+  return {
+      "active_inequality",
+      ConstrainedOptProblem(ScalarCost(2.0), {}, LessEqual(kXExpression, 0.0)),
+      ScalarValues(2.0)};
+}
+
+/* ************************************************************************* */
+Scenario InactiveInequalityScenario() {
+  return {
+      "inactive_inequality",
+      ConstrainedOptProblem(ScalarCost(-1.0), {}, LessEqual(kXExpression, 0.0)),
+      ScalarValues(1.0)};
+}
+
+/* ************************************************************************* */
+Scenario MixedScenario(const std::string& name, double equalitySigma,
+                       double inequalitySigma) {
+  NonlinearFactorGraph costs;
+  costs.addPrior(kX, 1.5, gtsam::noiseModel::Isotropic::Sigma(1, 1.0));
+  costs.addPrior(kY, 1.2, gtsam::noiseModel::Isotropic::Sigma(1, 1.0));
+  return {name,
+          ConstrainedOptProblem(
+              costs, Equality(kXExpression + kYExpression, 1.0, equalitySigma),
+              LessEqual(kXExpression, 0.4, inequalitySigma)),
+          PairValues(2.0, -1.0)};
+}
+
+/* ************************************************************************* */
+Scenario DifficultStartScenario() {
+  NonlinearFactorGraph costs;
+  costs.addPrior(kX, 1.0, gtsam::noiseModel::Unit::Create(1));
+  costs.addPrior(kY, 1.0, gtsam::noiseModel::Unit::Create(1));
+  const Double_ circle =
+      kXExpression * kXExpression + kYExpression * kYExpression;
+  const Double_ ellipse =
+      4.0 * kXExpression * kXExpression + 0.25 * kYExpression * kYExpression;
+  return {"difficult_start",
+          ConstrainedOptProblem(costs, Equality(circle, 1.0),
+                                LessEqual(ellipse, 1.0)),
+          PairValues(-3.0, 3.0)};
+}
+
+/* ************************************************************************* */
+std::vector<Scenario> Scenarios() {
+  std::vector<Scenario> scenarios;
+  scenarios.push_back(EqualityOnlyScenario());
+  scenarios.push_back(ActiveInequalityScenario());
+  scenarios.push_back(InactiveInequalityScenario());
+  scenarios.push_back(MixedScenario("mixed", 1.0, 1.0));
+  scenarios.push_back(MixedScenario("poorly_scaled", 0.01, 10.0));
+  scenarios.push_back(DifficultStartScenario());
+  return scenarios;
+}
+
+/* ************************************************************************* */
+AugmentedLagrangianParams::shared_ptr Params(
+    AugmentedLagrangianUpdatePolicy policy) {
+  auto params = std::make_shared<AugmentedLagrangianParams>();
+  params->updatePolicy = policy;
+  params->maxIterations = 40;
+  params->absoluteViolationTolerance = 1e-7;
+  params->relativeViolationTolerance = 1e-9;
+  params->absoluteCostTolerance = 1e-9;
+  params->relativeCostTolerance = 1e-9;
+  params->absoluteStationarityTolerance = 1e-7;
+  params->lmParams.maxIterations = 100;
+  params->storeOptProgress = true;
+  return params;
+}
+
+/* ************************************************************************* */
+void CountUpdate(AugmentedLagrangianUpdateType update, RunResult* result) {
+  if (update == AugmentedLagrangianUpdateType::Multiplier ||
+      update == AugmentedLagrangianUpdateType::MultiplierAndPenalty) {
+    ++result->multiplierUpdates;
+  }
+  if (update == AugmentedLagrangianUpdateType::Penalty ||
+      update == AugmentedLagrangianUpdateType::MultiplierAndPenalty) {
+    ++result->penaltyUpdates;
+  }
+}
+
+/* ************************************************************************* */
+double InfinityNorm(const gtsam::Vector& vector) {
+  return vector.size() == 0 ? 0.0 : vector.cwiseAbs().maxCoeff();
+}
+
+/* ************************************************************************* */
+KktDiagnostics EvaluateFinalKkt(const Scenario& scenario,
+                                const AugmentedLagrangianOptimizer& optimizer,
+                                const AugmentedLagrangianState& final) {
+  KktDiagnostics diagnostics;
+  const auto gradient = optimizer.augmentedLagrangianFunction(final)
+                            .linearize(final.values)
+                            ->gradientAtZero();
+  for (const auto& keyGradient : gradient) {
+    diagnostics.stationarity =
+        std::max(diagnostics.stationarity, InfinityNorm(keyGradient.second));
+  }
+  for (const auto& equality : scenario.problem.eConstraints()) {
+    diagnostics.generalizedResidual =
+        std::max(diagnostics.generalizedResidual,
+                 InfinityNorm(equality->whitenedError(final.values)));
+  }
+  for (size_t i = 0; i < scenario.problem.iConstraints().size(); ++i) {
+    const double expression =
+        scenario.problem.iConstraints().at(i)->whitenedExpr(final.values)(0);
+    const double projectedResidual =
+        std::max(expression, -final.lambdaIneq.at(i) / final.muIneq);
+    diagnostics.generalizedResidual =
+        std::max(diagnostics.generalizedResidual, std::abs(projectedResidual));
+  }
+  return diagnostics;
+}
+
+/* ************************************************************************* */
+RunResult RunOnce(const Scenario& scenario,
+                  AugmentedLagrangianUpdatePolicy policy) {
+  RunResult result;
+  const auto params = Params(policy);
+  const AugmentedLagrangianOptimizer optimizer(scenario.problem,
+                                               scenario.initial, params);
+  const auto start = std::chrono::steady_clock::now();
+  try {
+    optimizer.optimize();
+    result.milliseconds = std::chrono::duration<double, std::milli>(
+                              std::chrono::steady_clock::now() - start)
+                              .count();
+
+    const auto& progress = optimizer.progress();
+    if (progress.size() < 2) {
+      return result;
+    }
+    const AugmentedLagrangianState& final = progress.back();
+    const KktDiagnostics diagnostics =
+        EvaluateFinalKkt(scenario, optimizer, final);
+    result.stationarity = diagnostics.stationarity;
+    result.generalizedResidual = diagnostics.generalizedResidual;
+    result.kktResidual =
+        std::max(result.stationarity, result.generalizedResidual);
+    result.objective = final.cost;
+    result.outerIterations = final.iteration;
+    result.totalLmIterations = final.totalUnconstrainedIterations;
+    for (size_t i = 1; i < progress.size(); ++i) {
+      CountUpdate(progress.at(i).updateType, &result);
+    }
+    for (const AugmentedLagrangianState& state : progress) {
+      result.maximumPenalty =
+          std::max({result.maximumPenalty, state.muEq, state.muIneq});
+    }
+    result.success = std::isfinite(result.kktResidual) &&
+                     result.generalizedResidual <= 1e-5 &&
+                     result.stationarity <= 1e-4;
+  } catch (const std::exception&) {
+    // A failed solve is intentionally retained in the success-rate metric.
+    result.milliseconds = std::chrono::duration<double, std::milli>(
+                              std::chrono::steady_clock::now() - start)
+                              .count();
+  }
+  return result;
+}
+
+/* ************************************************************************* */
+std::vector<double> Values(const std::vector<RunResult>& runs,
+                           double RunResult::* member) {
+  std::vector<double> values;
+  values.reserve(runs.size());
+  for (const RunResult& run : runs) {
+    values.push_back(run.*member);
+  }
+  return values;
+}
+
+/* ************************************************************************* */
+std::vector<double> Counts(const std::vector<RunResult>& runs,
+                           size_t RunResult::* member) {
+  std::vector<double> values;
+  values.reserve(runs.size());
+  for (const RunResult& run : runs) {
+    values.push_back(static_cast<double>(run.*member));
+  }
+  return values;
+}
+
+/* ************************************************************************* */
+double Median(const std::vector<double>& values) {
+  return gtsam::timing::summarizeSamples(
+             values, gtsam::timing::MedianPolicy::kAverageMiddle)
+      .median;
+}
+
+/* ************************************************************************* */
+Summary Summarize(const std::vector<RunResult>& runs) {
+  Summary summary;
+  size_t successes = 0;
+  for (const RunResult& run : runs) {
+    successes += run.success ? 1 : 0;
+    summary.maximumPenalty =
+        std::max(summary.maximumPenalty, run.maximumPenalty);
+  }
+  summary.successRate = 100.0 * static_cast<double>(successes) / runs.size();
+  summary.medianMilliseconds = Median(Values(runs, &RunResult::milliseconds));
+  summary.medianStationarity = Median(Values(runs, &RunResult::stationarity));
+  summary.medianGeneralizedResidual =
+      Median(Values(runs, &RunResult::generalizedResidual));
+  summary.medianKktResidual = Median(Values(runs, &RunResult::kktResidual));
+  summary.medianObjective = Median(Values(runs, &RunResult::objective));
+  summary.medianOuterIterations =
+      Median(Counts(runs, &RunResult::outerIterations));
+  summary.medianTotalLmIterations =
+      Median(Counts(runs, &RunResult::totalLmIterations));
+  summary.medianMultiplierUpdates =
+      Median(Counts(runs, &RunResult::multiplierUpdates));
+  summary.medianPenaltyUpdates =
+      Median(Counts(runs, &RunResult::penaltyUpdates));
+  return summary;
+}
+
+/* ************************************************************************* */
+std::string PolicyName(AugmentedLagrangianUpdatePolicy policy) {
+  return policy == AugmentedLagrangianUpdatePolicy::Aggressive ? "Aggressive"
+                                                               : "BCL";
+}
+
+/* ************************************************************************* */
+void PrintSummary(const Scenario& scenario,
+                  AugmentedLagrangianUpdatePolicy policy,
+                  const Summary& summary) {
+  std::cout << scenario.name << ',' << PolicyName(policy) << ','
+            << summary.successRate << ',' << std::setprecision(9)
+            << summary.medianMilliseconds << ',' << summary.medianStationarity
+            << ',' << summary.medianGeneralizedResidual << ','
+            << summary.medianKktResidual << ',' << summary.medianObjective
+            << ',' << summary.medianOuterIterations << ','
+            << summary.medianTotalLmIterations << ','
+            << summary.medianMultiplierUpdates << ','
+            << summary.medianPenaltyUpdates << ',' << summary.maximumPenalty
+            << '\n';
+}
+
+/* ************************************************************************* */
+void AddMetrics(const Scenario& scenario,
+                AugmentedLagrangianUpdatePolicy policy, const Summary& summary,
+                std::vector<gtsam::timing::BenchmarkMetric>* metrics) {
+  const std::string prefix = scenario.name + "/" + PolicyName(policy) + "/";
+  metrics->push_back({prefix + "success_rate", "percent", summary.successRate});
+  metrics->push_back(
+      {prefix + "median_runtime", "ms", summary.medianMilliseconds});
+  metrics->push_back(
+      {prefix + "stationarity", "residual", summary.medianStationarity});
+  metrics->push_back({prefix + "generalized_residual", "residual",
+                      summary.medianGeneralizedResidual});
+  metrics->push_back(
+      {prefix + "kkt_residual", "residual", summary.medianKktResidual});
+  metrics->push_back({prefix + "objective", "cost", summary.medianObjective});
+  metrics->push_back({prefix + "outer_iterations", "iterations",
+                      summary.medianOuterIterations});
+  metrics->push_back({prefix + "lm_iterations", "iterations",
+                      summary.medianTotalLmIterations});
+  metrics->push_back({prefix + "multiplier_updates", "updates",
+                      summary.medianMultiplierUpdates});
+  metrics->push_back(
+      {prefix + "penalty_updates", "updates", summary.medianPenaltyUpdates});
+  metrics->push_back(
+      {prefix + "maximum_penalty", "rho", summary.maximumPenalty});
+}
+
+/* ************************************************************************* */
+Options ParseOptions(int argc, char** argv) {
+  gtsam::timing::Arguments arguments(argc, argv);
+  if (arguments.helpRequested()) {
+    std::cout << "Usage: timeAugmentedLagrangianPolicies [--warmup N] "
+                 "[--repeats N] [--benchmark-action-json FILE]\n";
+    std::exit(0);
+  }
+  Options options;
+  options.warmups = arguments.sizeValue("--warmup", 1);
+  options.repetitions = arguments.sizeValue("--repeats", 5);
+  options.benchmarkActionJson =
+      arguments.optionalString("--benchmark-action-json");
+  arguments.validateAllConsumed();
+  if (options.repetitions == 0) {
+    throw std::invalid_argument("--repeats must be at least one");
+  }
+  return options;
+}
+
+}  // namespace
+
+/* ************************************************************************* */
+int main(int argc, char** argv) {
+  const Options options = ParseOptions(argc, argv);
+  const std::vector<Scenario> scenarios = Scenarios();
+  const std::vector<AugmentedLagrangianUpdatePolicy> policies{
+      AugmentedLagrangianUpdatePolicy::Aggressive,
+      AugmentedLagrangianUpdatePolicy::BCL};
+  std::vector<gtsam::timing::BenchmarkMetric> metrics;
+
+  std::cout << "scenario,policy,success_percent,median_ms,stationarity,"
+               "generalized_residual,kkt_residual,objective,outer_iterations,"
+               "lm_iterations,multiplier_updates,penalty_updates,max_penalty\n";
+  for (const Scenario& scenario : scenarios) {
+    for (size_t warmup = 0; warmup < options.warmups; ++warmup) {
+      const bool reverse = warmup % 2 == 1;
+      static_cast<void>(RunOnce(scenario, policies.at(reverse ? 1 : 0)));
+      static_cast<void>(RunOnce(scenario, policies.at(reverse ? 0 : 1)));
+    }
+
+    std::vector<RunResult> aggressiveRuns;
+    std::vector<RunResult> bclRuns;
+    aggressiveRuns.reserve(options.repetitions);
+    bclRuns.reserve(options.repetitions);
+    for (size_t repetition = 0; repetition < options.repetitions;
+         ++repetition) {
+      if (repetition % 2 == 0) {
+        aggressiveRuns.push_back(
+            RunOnce(scenario, AugmentedLagrangianUpdatePolicy::Aggressive));
+        bclRuns.push_back(
+            RunOnce(scenario, AugmentedLagrangianUpdatePolicy::BCL));
+      } else {
+        bclRuns.push_back(
+            RunOnce(scenario, AugmentedLagrangianUpdatePolicy::BCL));
+        aggressiveRuns.push_back(
+            RunOnce(scenario, AugmentedLagrangianUpdatePolicy::Aggressive));
+      }
+    }
+
+    const Summary aggressive = Summarize(aggressiveRuns);
+    const Summary bcl = Summarize(bclRuns);
+    PrintSummary(scenario, AugmentedLagrangianUpdatePolicy::Aggressive,
+                 aggressive);
+    PrintSummary(scenario, AugmentedLagrangianUpdatePolicy::BCL, bcl);
+    AddMetrics(scenario, AugmentedLagrangianUpdatePolicy::Aggressive,
+               aggressive, &metrics);
+    AddMetrics(scenario, AugmentedLagrangianUpdatePolicy::BCL, bcl, &metrics);
+  }
+
+  if (options.benchmarkActionJson) {
+    gtsam::timing::writeBenchmarkActionMetrics(*options.benchmarkActionJson,
+                                               metrics);
+  }
+  return 0;
+}

--- a/timing/timeShonanInitialization.cpp
+++ b/timing/timeShonanInitialization.cpp
@@ -80,10 +80,12 @@ const string kAfterPcg = "After/PCG";
 const string kAfterLm = "After/LM";
 const string kBmDefault = "BM/ALM default";
 const string kBmTuned = "BM/ALM tuned";
+const string kBmAggressive = "BM/ALM Aggressive";
+const string kBmBcl = "BM/ALM BCL";
 
 const vector<string>& allBenchmarkMethods() {
-  static const vector<string> methods{kBefore, kAfterPcg, kAfterLm, kBmDefault,
-                                      kBmTuned};
+  static const vector<string> methods{kBefore,       kAfterPcg, kAfterLm,
+                                      kBmAggressive, kBmTuned,  kBmBcl};
   return methods;
 }
 
@@ -91,7 +93,8 @@ const std::map<string, string>& methodTokens() {
   static const std::map<string, string> tokens{
       {"before", kBefore},        {"shonan-pcg", kAfterPcg},
       {"shonan-lm", kAfterLm},    {"bm-alm-default", kBmDefault},
-      {"bm-alm-tuned", kBmTuned},
+      {"bm-alm-tuned", kBmTuned}, {"bm-alm-aggressive", kBmAggressive},
+      {"bm-alm-bcl", kBmBcl},
   };
   return tokens;
 }
@@ -200,7 +203,8 @@ string usage() {
          "  --isotropic-sigma VALUE         Replace all rotation noise; zero "
          "preserves input (default: 0)\n"
          "  --methods LIST                  Comma-separated: before, "
-         "shonan-pcg, shonan-lm, bm-alm-default, bm-alm-tuned\n"
+         "shonan-pcg, shonan-lm, bm-alm-default, bm-alm-tuned, "
+         "bm-alm-aggressive, bm-alm-bcl\n"
          "  --bm-initial-mu VALUE           Tuned ALM initial equality penalty "
          "(default: 1)\n"
          "  --bm-mu-increase VALUE          Tuned ALM penalty growth "
@@ -224,7 +228,12 @@ string usage() {
          "After/PCG: FAST-Sync initialization with PCG.\n"
          "After/LM:  FAST-Sync initialization with direct LM solves.\n"
          "BM/ALM default: FAST-Sync, QCQP conversion, and default ALM.\n"
-         "BM/ALM tuned: FAST-Sync, QCQP conversion, and configured ALM.\n"
+         "BM/ALM tuned: FAST-Sync, QCQP conversion, and configured "
+         "Aggressive ALM.\n"
+         "BM/ALM Aggressive: FAST-Sync, QCQP conversion, and explicit "
+         "Aggressive ALM defaults.\n"
+         "BM/ALM BCL: FAST-Sync, QCQP conversion, and explicit BCL "
+         "defaults.\n"
          "\nExample:\n"
          "  timeShonanInitialization --g2o-directory datasets/yfcc2 "
          "--largest 5 --repeats 1 --csv shonan.csv\n";
@@ -449,7 +458,8 @@ BenchmarkContext buildContext(const Options& options,
 }
 
 bool isBmMethod(const string& method) {
-  return method == kBmDefault || method == kBmTuned;
+  return method == kBmDefault || method == kBmTuned ||
+         method == kBmAggressive || method == kBmBcl;
 }
 
 gtsam::RiemannianStaircaseParams bmParameters(const string& method,
@@ -458,6 +468,13 @@ gtsam::RiemannianStaircaseParams bmParameters(const string& method,
   parameters.pMin = kMinimumRank;
   parameters.pMax = kMaximumRank;
   parameters.eta = -kOptimalityThreshold;
+  if (method == kBmAggressive || method == kBmTuned) {
+    parameters.almParams->updatePolicy =
+        gtsam::AugmentedLagrangianUpdatePolicy::Aggressive;
+  } else if (method == kBmBcl) {
+    parameters.almParams->updatePolicy =
+        gtsam::AugmentedLagrangianUpdatePolicy::BCL;
+  }
   if (method == kBmTuned) {
     parameters.almParams->initialMuEq = options.bmInitialMu;
     parameters.almParams->muEqIncreaseRate = options.bmMuIncrease;


### PR DESCRIPTION
## Summary

- refactor `AugmentedLagrangianOptimizer` around one fixed-parameter PHR subproblem shared by the default `BCL` policy and an opt-in `Aggressive` policy
- evaluate stationarity and constraint diagnostics at the post-LM point, then apply the selected outer update
- use exact direct Powell–Hestenes–Rockafellar terms for scalar inequalities and projected nonnegative multiplier updates
- expose the policy and flat BCL schedule parameters through `constrained.i`
- add focused policy/PHR tests, documentation, `timeAugmentedLagrangianPolicies`, and explicit Aggressive/BCL Burer–Monteiro timing modes

This PR supersedes #2414 and is based directly on the latest `develop` rather than the earlier feature branch.

## Paper relationship

The BCL schedule is inspired by Algorithm 1 of A. R. Conn, N. I. M. Gould, and Ph. L. Toint, “A Globally Convergent Augmented Lagrangian Algorithm for Optimization with General Constraints and Simple Bounds,” *SIAM Journal on Numerical Analysis* 28(2), 1991, [doi:10.1137/0728030](https://doi.org/10.1137/0728030).

It follows the paper's initialization, accepted multiplier-update schedule, rejected penalty-update schedule, and suggested parameter values translated to direct-`rho` notation. It is not entirely faithful: unconstrained LM and full augmented-Lagrangian gradient stationarity replace the projected bound-constrained inner solver, while direct PHR inequalities replace bounded slack variables. The paper's convergence proof therefore does not apply.

## Inequality policy quantities

For whitened `g <= 0`, the implementation uses

```
q = max(g, -lambda / rho)
lambda+ = max(0, lambda + rho g) = lambda + rho q
```

BCL acceptance uses `max(||h||_inf, ||q||_inf)`, so inactive multipliers, primal inequality violation, and complementarity all enter the outer policy.

## Representative policy benchmark

Command: `timeAugmentedLagrangianPolicies --warmup 1 --repeats 5`

Success requires final generalized residual at most `1e-5` and post-update KKT stationarity at most `1e-4`. Timing is a local Release build; no policy win is asserted in CI.

| Scenario | Policy | Success | Median ms | KKT residual | Outer / LM | Penalty updates | Max rho |
|---|---|---:|---:|---:|---:|---:|---:|
| Equality only | Aggressive | 100% | 0.232 | 1.37e-8 | 15 / 19 | 3 | 4 |
| Equality only | BCL | 100% | 0.092 | 5.13e-7 | 7 / 7 | 0 | 10 |
| Active inequality | Aggressive | 100% | 0.184 | 5.46e-8 | 14 / 18 | 3 | 4 |
| Active inequality | BCL | 100% | 0.090 | 9.32e-8 | 8 / 8 | 0 | 10 |
| Inactive inequality | Aggressive | 100% | 0.021 | 5.00e-14 | 1 / 3 | 0 | 1 |
| Inactive inequality | BCL | 100% | 0.044 | 9.09e-12 | 7 / 3 | 0 | 10 |
| Mixed | Aggressive | 100% | 0.522 | 7.04e-9 | 22 / 28 | 21 | 131072 |
| Mixed | BCL | 100% | 0.192 | 1.57e-7 | 9 / 9 | 0 | 10 |
| Poorly scaled | Aggressive | 0% | 0.911 | 3.38e-2 | 37 / 50 | 37 | 3.44e10 |
| Poorly scaled | BCL | 100% | 0.213 | 3.26e-8 | 8 / 9 | 2 | 100000 |
| Difficult start | Aggressive | 100% | 0.426 | 1.33e-8 | 13 / 25 | 6 | 16 |
| Difficult start | BCL | 100% | 0.358 | 5.13e-7 | 7 / 22 | 0 | 10 |

The executable also reports objective, stationarity, generalized residual, multiplier updates, total LM iterations, success rate, and Benchmark Action JSON metrics.

## Burer–Monteiro benchmark

This reruns the two-dataset protocol from #2675, adding explicit Aggressive and BCL methods so the comparison remains stable when the library default changes.

Release build with AppleClang 21.0.0 (`-O3 -DNDEBUG`):

```sh
./timing/timeShonanInitialization \
  --g2o-directory /Users/dellaert/git/shonan-github/datasets/yfcc2 \
  --largest 2 \
  --methods shonan-pcg,bm-alm-aggressive,bm-alm-tuned,bm-alm-bcl \
  --warmup 1 \
  --repeats 3 \
  --csv /tmp/bm-alm-policies-top2.csv \
  --benchmark-action-json /tmp/bm-alm-policies-top2.json
```

Mean times include every attempt. Method order rotates across repetitions.

| Dataset | Method | Certified | BM solve | Local ALM | End-to-end | Speedup vs Aggressive |
|---|---|---:|---:|---:|---:|---:|
| `taj_mahal` | Aggressive | 3/3 | 7.853 s | 5.966 s | 8.523 s | 1.00x |
| `taj_mahal` | tuned Aggressive | 3/3 | 7.423 s | 5.686 s | 7.996 s | 1.07x |
| `taj_mahal` | BCL | 3/3 | 2.644 s | 0.671 s | 3.286 s | **2.59x** |
| `brandenburg_gate` | Aggressive | 3/3 | 19.237 s | 17.223 s | 20.000 s | 1.00x |
| `brandenburg_gate` | tuned Aggressive | 3/3 | 17.963 s | 16.108 s | 18.676 s | 1.07x |
| `brandenburg_gate` | BCL | 3/3 | 2.762 s | 0.650 s | 3.514 s | **5.69x** |

The Shonan/PCG controls were 1.482 s and 1.880 s end-to-end. All BM runs certified at rank 3 and produced the same rounded objectives: `3.712e-07` for `taj_mahal` and `1.649e-06` for `brandenburg_gate`.

BCL accelerates the local ALM phase by **8.89x** and **26.48x**. The timing ranges do not overlap: the fastest Aggressive end-to-end trial was still slower than the slowest BCL trial on both datasets. Because the improvement is large and consistent with no loss of certification or objective quality, this PR now makes BCL the default. Aggressive remains available explicitly.

## Validation

- `make -j6 testAugmentedLagrangianOptimizer.run`
- `make -j6 testQcqpProblem.run`
- `make -j6 testRiemannianStaircase.run`
- complete `gtsam/constrained/tests` C++ suite (11 targets)
- built `CertifiableRotationAveraging`, `timeShonanInitialization`, and `timeAugmentedLagrangianPolicies`
- `conda run -n py312 env PYTHONPATH=$PWD/build/python python -m pytest python/gtsam/tests/test_certifiable.py python/gtsam/tests/test_constrained.py -q` — 10 passed
- five-repeat policy benchmark with 132 valid Benchmark Action metrics
- three-repeat Burer–Monteiro benchmark with all 18 BM attempts certified
- eight edited notebooks validated as JSON
- `git clang-format --diff HEAD`
- `git diff --check`
