### PR TITLE
Suppress GCC 16 Spectra false positive

### DIFF
--- a/gtsam/certifiable/RiemannianStaircaseOptimizer.cpp
+++ b/gtsam/certifiable/RiemannianStaircaseOptimizer.cpp
@@ -24,8 +24,18 @@
 #include <Eigen/SVD>
 #include <Eigen/SparseCholesky>
 
+// Work around a GCC 16 false positive in Spectra's SortEigenvalue comparator.
+#if defined(__GNUC__) && __GNUC__ == 16
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 #include <Spectra/MatOp/SparseSymMatProd.h>
 #include <Spectra/SymEigsSolver.h>
+
+#if defined(__GNUC__) && __GNUC__ == 16
+#pragma GCC diagnostic pop
+#endif
 
 #include <algorithm>
 #include <chrono>


### PR DESCRIPTION
## Summary

- Suppress the GCC 16 false-positive -Wmaybe-uninitialized diagnostic emitted by Spectra SortEigenvalue.
- Scope the diagnostic override to the Spectra includes in RiemannianStaircaseOptimizer.cpp.

## Testing

- cmake --build build -j6
- cmake --build build --target testRiemannianStaircase.run -j6
- git diff --check