### PR TITLE
Avoid recursive BayesTree serialization stack overflow

### DIFF
--- a/gtsam/discrete/DiscreteBayesTree.h
+++ b/gtsam/discrete/DiscreteBayesTree.h
@@ -119,3 +119,7 @@ template <>
 struct traits<DiscreteBayesTree> : public Testable<DiscreteBayesTree> {};
 
 }  // namespace gtsam
+
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
+BOOST_CLASS_VERSION(gtsam::DiscreteBayesTree, 1)
+#endif

--- a/gtsam/inference/BayesTree.h
+++ b/gtsam/inference/BayesTree.h
@@ -19,13 +19,23 @@
 
 #pragma once
 
-#include <memory>
-
 #include <gtsam/inference/Key.h>
 #include <gtsam/base/FastList.h>
 #include <gtsam/base/ConcurrentMap.h>
 #include <gtsam/base/FastVector.h>
 
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
+#include <boost/serialization/shared_ptr.hpp>
+#include <boost/serialization/split_member.hpp>
+#include <boost/serialization/vector.hpp>
+#include <boost/serialization/version.hpp>
+
+#include <stdexcept>
+#include <unordered_map>
+#include <vector>
+#endif
+
+#include <memory>
 #include <string>
 
 namespace gtsam {
@@ -293,13 +303,97 @@ namespace gtsam {
 
    private:
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
-    /** Serialization function */
+    /** Save the tree without recursively serializing clique links. */
     friend class boost::serialization::access;
     template<class ARCHIVE>
-    void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
-      ar & BOOST_SERIALIZATION_NVP(nodes_);
-      ar & BOOST_SERIALIZATION_NVP(roots_);
+    void save(ARCHIVE& ar, const unsigned int version) const {
+      if (version == 0) {
+        ar & BOOST_SERIALIZATION_NVP(nodes_);
+        ar & BOOST_SERIALIZATION_NVP(roots_);
+        return;
+      }
+
+      std::vector<sharedClique> cliques, detached;
+      std::unordered_map<const Clique*, size_t> indices;
+      for (const sharedClique& root : roots_) {
+        if (!indices.emplace(root.get(), cliques.size()).second)
+          throw std::invalid_argument("BayesTree contains duplicate cliques");
+        cliques.push_back(root);
+      }
+
+      std::vector<std::vector<size_t>> children;
+      for (size_t i = 0; i < cliques.size(); ++i) {
+        sharedClique copy = std::make_shared<Clique>(*cliques[i]);
+        copy->parent_.reset();
+        copy->children.clear();
+        copy->is_root = true;
+        detached.push_back(copy);
+        children.emplace_back();
+        for (const sharedClique& child : cliques[i]->children) {
+          if (!indices.emplace(child.get(), cliques.size()).second)
+            throw std::invalid_argument("BayesTree contains duplicate cliques");
+          children.back().push_back(cliques.size());
+          cliques.push_back(child);
+        }
+      }
+
+      const size_t rootCount = roots_.size();
+      ar & BOOST_SERIALIZATION_NVP(rootCount);
+      ar & boost::serialization::make_nvp("cliques", detached);
+      ar & BOOST_SERIALIZATION_NVP(children);
     }
+
+    /** Load either the legacy recursive format or the flat format. */
+    template<class ARCHIVE>
+    void load(ARCHIVE& ar, const unsigned int version) {
+      if (version == 0) {
+        ar & BOOST_SERIALIZATION_NVP(nodes_);
+        ar & BOOST_SERIALIZATION_NVP(roots_);
+        return;
+      }
+
+      size_t rootCount;
+      std::vector<sharedClique> cliques;
+      std::vector<std::vector<size_t>> children;
+      ar & BOOST_SERIALIZATION_NVP(rootCount);
+      ar & BOOST_SERIALIZATION_NVP(cliques);
+      ar & BOOST_SERIALIZATION_NVP(children);
+      if (rootCount > cliques.size() || children.size() != cliques.size())
+        throw std::invalid_argument("Invalid serialized BayesTree structure");
+
+      nodes_.clear();
+      roots_.assign(cliques.begin(), cliques.begin() + rootCount);
+      for (size_t i = 0; i < cliques.size(); ++i) {
+        sharedClique& clique = cliques[i];
+        clique->parent_.reset();
+        clique->children.clear();
+        clique->is_root = i < rootCount;
+      }
+      for (size_t i = 0; i < cliques.size(); ++i) {
+        sharedClique& clique = cliques[i];
+        for (size_t childIndex : children[i]) {
+          if (childIndex >= cliques.size())
+            throw std::invalid_argument("Invalid serialized BayesTree child");
+          sharedClique& child = cliques[childIndex];
+          if (!child->parent_.expired())
+            throw std::invalid_argument("Serialized BayesTree child has multiple parents");
+          clique->children.push_back(child);
+          child->parent_ = clique;
+          child->is_root = false;
+        }
+      }
+
+      for (size_t i = 0; i < cliques.size(); ++i) {
+        if ((i < rootCount) != cliques[i]->isRoot())
+          throw std::invalid_argument("Invalid serialized BayesTree roots");
+        for (Key key : cliques[i]->conditional()->frontals()) {
+          if (!nodes_.insert({key, cliques[i]}).second)
+            throw std::invalid_argument("Serialized BayesTree contains duplicate keys");
+        }
+      }
+    }
+
+    BOOST_SERIALIZATION_SPLIT_MEMBER()
 #endif
 
     /// @}
@@ -339,3 +433,19 @@ namespace gtsam {
   };
 
 } /// namespace gtsam
+
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
+namespace boost {
+namespace serialization {
+
+/** Version of the iterative BayesTree serialization format. */
+template <class CLIQUE>
+struct version<gtsam::BayesTree<CLIQUE>> {
+  typedef mpl::int_<1> type;
+  typedef mpl::integral_c_tag tag;
+  BOOST_STATIC_CONSTANT(int, value = type::value);
+};
+
+}  // namespace serialization
+}  // namespace boost
+#endif

--- a/gtsam/linear/GaussianBayesTree.h
+++ b/gtsam/linear/GaussianBayesTree.h
@@ -169,3 +169,7 @@ namespace gtsam {
   };
 
 } //\ namespace gtsam
+
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
+BOOST_CLASS_VERSION(gtsam::GaussianBayesTree, 1)
+#endif

--- a/gtsam/linear/tests/testSerializationLinear.cpp
+++ b/gtsam/linear/tests/testSerializationLinear.cpp
@@ -247,5 +247,94 @@ TEST (Serialization, gaussian_bayes_tree) {
 }
 
 /* ************************************************************************* */
+namespace bayes_tree_serialization {
+
+using Clique = GaussianBayesTreeClique;
+
+Clique::shared_ptr makeRoot(Key key) {
+  return std::make_shared<Clique>(std::make_shared<GaussianConditional>(
+      key, Vector{{0.0}}, Matrix{{1.0}}));
+}
+
+Clique::shared_ptr makeChild(Key key, Key parent) {
+  return std::make_shared<Clique>(std::make_shared<GaussianConditional>(
+      key, Vector{{0.0}}, Matrix{{1.0}}, parent, Matrix{{-1.0}}));
+}
+
+Key frontal(const Clique::shared_ptr& clique) {
+  return clique->conditional()->frontals().front();
+}
+
+// Verifies that a deep chain round-trips without recursive serialization.
+TEST(Serialization, LargeGaussianBayesTree) {
+  constexpr size_t kCliqueCount = 10000;
+  GaussianBayesTree input;
+  Clique::shared_ptr parent = makeRoot(kCliqueCount - 1);
+  input.insertRoot(parent);
+  for (size_t key = kCliqueCount - 1; key-- > 0;) {
+    Clique::shared_ptr child = makeChild(key, key + 1);
+    input.addClique(child, parent);
+    parent = child;
+  }
+
+  GaussianBayesTree actual;
+  roundtripBinary(input, actual);
+
+  EXPECT_LONGS_EQUAL(kCliqueCount, actual.nodes().size());
+  EXPECT_LONGS_EQUAL(1, actual.roots().size());
+  Clique::shared_ptr previous, clique = actual.roots().front();
+  for (size_t key = kCliqueCount; key-- > 0;) {
+    EXPECT_LONGS_EQUAL(key, frontal(clique));
+    EXPECT(actual[key] == clique);
+    EXPECT(clique->parent() == previous);
+    EXPECT_LONGS_EQUAL(key == 0 ? 0 : 1, clique->nrChildren());
+    previous = clique;
+    if (key != 0) clique = clique->children.front();
+  }
+}
+
+// Verifies that root and child ordering survive a flat round-trip.
+TEST(Serialization, GaussianBayesTreeStructure) {
+  GaussianBayesTree input;
+  Clique::shared_ptr firstRoot = makeRoot(10), secondRoot = makeRoot(20);
+  input.insertRoot(firstRoot);
+  input.addClique(makeChild(11, 10), firstRoot);
+  input.addClique(makeChild(12, 10), firstRoot);
+  input.insertRoot(secondRoot);
+  input.addClique(makeChild(21, 20), secondRoot);
+
+  GaussianBayesTree actual;
+  roundtripBinary(input, actual);
+
+  EXPECT_LONGS_EQUAL(2, actual.roots().size());
+  EXPECT_LONGS_EQUAL(10, frontal(actual.roots()[0]));
+  EXPECT_LONGS_EQUAL(20, frontal(actual.roots()[1]));
+  EXPECT_LONGS_EQUAL(11, frontal(actual.roots()[0]->children[0]));
+  EXPECT_LONGS_EQUAL(12, frontal(actual.roots()[0]->children[1]));
+  EXPECT_LONGS_EQUAL(21, frontal(actual.roots()[1]->children[0]));
+}
+
+// Verifies loading the recursive format written before BayesTree version 1.
+TEST(Serialization, LegacyGaussianBayesTree) {
+  const string legacyArchive =
+      "0 0 0 0 0 0 1 0 0 0 7 0 1 5 1 0\n"
+      "0 1 0 1 7 1 0\n"
+      "1 0 1 0 0 0 0 0 0 1 0 7 0 0 0 0 1 2 "
+      "3.00000000000000000e+00 2.00000000000000000e+00 0 0 3 0 0 1 2 0 1 "
+      "0 1 0 0 1 0 0 0 1 1 1 5 0\n";
+  istringstream stream(legacyArchive);
+  boost::archive::text_iarchive archive(stream, boost::archive::no_header);
+  GaussianBayesTree actual;
+  archive >> actual;
+
+  EXPECT_LONGS_EQUAL(1, actual.nodes().size());
+  EXPECT_LONGS_EQUAL(1, actual.roots().size());
+  EXPECT_LONGS_EQUAL(7, frontal(actual.roots().front()));
+}
+
+}  // namespace bayes_tree_serialization
+/* ************************************************************************* */
+
+/* ************************************************************************* */
 int main() { TestResult tr; return TestRegistry::runAllTests(tr); }
 /* ************************************************************************* */


### PR DESCRIPTION
## Summary

- serialize version-1 Bayes trees as a breadth-first list of detached shallow clique copies plus ordered child IDs
- reconstruct parent/child links, roots, and the frontal-key index iteratively on load
- retain the version-0 `nodes_`/`roots_` path for legacy archives and unversioned external derived trees
- version the built-in Gaussian and discrete trees that directly inherit the base serializer

Boost preserves pointer identity, but the existing clique serializer still recursively follows child links and can exhaust the stack for deep trees. This keeps the flat-ID insight while reusing each clique's existing serialization unchanged: links are cleared only on temporary copies and restored from the child table after loading.

The approach was inspired by @ScottMcMichael's [proposed flat-ID fix](https://github.com/ScottMcMichael/gtsam/tree/fix_large_graph_serialization_stack_overflow) for #1434, while preserving legacy loads and minimizing changes outside `BayesTree`.

## Tests

- `make -j6 testSerializationLinear.run`
- `make -j6 testSerializationNonlinear.run`
- `make -j6 testSerializationHybrid.run`
- `make -j6 testSerializationDiscrete.run`
- `git diff --check`

Closes #1434.
