### PR TITLE
Add NavState Lie-group IMU preintegration

### DIFF
--- a/cmake/HandleGeneralOptions.cmake
+++ b/cmake/HandleGeneralOptions.cmake
@@ -51,6 +51,7 @@ option(GTSAM_INSTALL_MATLAB_TOOLBOX         "Enable/Disable installation of matl
 option(GTSAM_ALLOW_DEPRECATED_SINCE_V43     "Allow use of methods/functions deprecated in GTSAM 4.3" ON)
 option(GTSAM_SUPPORT_NESTED_DISSECTION      "Support Metis-based nested dissection" ON)
 option(GTSAM_TANGENT_PREINTEGRATION         "Use new ImuFactor with integration on tangent space" ON)
+option(GTSAM_LIEGROUP_PREINTEGRATION        "Use NavState SE_2(3) Lie-group IMU preintegration by default (takes precedence over tangent preintegration)" OFF)
 option(GTSAM_SLOW_BUT_CORRECT_BETWEENFACTOR
        "Use Local Jacobians in BetweenFactor and PriorFactor when provided by traits" ON)
 option(GTSAM_SLOW_BUT_CORRECT_EXPMAP        "Use slower but correct expmap for Pose2"  ON)

--- a/cmake/HandlePrintConfiguration.cmake
+++ b/cmake/HandlePrintConfiguration.cmake
@@ -100,7 +100,11 @@ print_enabled_config(${GTSAM_DT_MERGING}                  "Enable branch merging
 print_enabled_config(${GTSAM_ENABLE_TIMING}               "Enable timing machinery")
 print_enabled_config(${GTSAM_ALLOW_DEPRECATED_SINCE_V43}  "Allow features deprecated in GTSAM 4.3")
 print_enabled_config(${GTSAM_SUPPORT_NESTED_DISSECTION}   "Metis-based Nested Dissection   ")
-print_enabled_config(${GTSAM_TANGENT_PREINTEGRATION}      "Use tangent-space preintegration")
+if(GTSAM_LIEGROUP_PREINTEGRATION)
+  print_enabled_config(${GTSAM_LIEGROUP_PREINTEGRATION}   "Use NavState Lie-group preintegration")
+else()
+  print_enabled_config(${GTSAM_TANGENT_PREINTEGRATION}    "Use tangent-space preintegration")
+endif()
 
 message(STATUS "MATLAB toolbox flags")
 print_enabled_config(${GTSAM_INSTALL_MATLAB_TOOLBOX}      "Install MATLAB toolbox          ")

--- a/gtsam/config.h.in
+++ b/gtsam/config.h.in
@@ -92,7 +92,11 @@
 // Support Metis-based nested dissection
 #cmakedefine GTSAM_SUPPORT_NESTED_DISSECTION
 
-// Support Metis-based nested dissection
+// Whether to use NavState SE_2(3) Lie-group IMU preintegration by default.
+// This selection takes precedence over tangent-space preintegration.
+#cmakedefine GTSAM_LIEGROUP_PREINTEGRATION
+
+// Whether to use IMU pre-integration on tangent space
 #cmakedefine GTSAM_TANGENT_PREINTEGRATION
 
 // Whether to use the system installed Metis instead of the provided one

--- a/gtsam/navigation/CombinedImuFactor.cpp
+++ b/gtsam/navigation/CombinedImuFactor.cpp
@@ -22,6 +22,7 @@
 
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/navigation/CombinedImuFactor.h>
+#include <gtsam/navigation/LieGroupPreintegration.h>
 #include <gtsam/navigation/ManifoldPreintegration.h>
 #include <gtsam/navigation/TangentPreintegration.h>
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
@@ -209,14 +210,23 @@ std::ostream& operator<<(std::ostream& os, const CombinedImuFactorT<PIM>& f) {
 //------------------------------------------------------------------------------
 template class GTSAM_EXPORT PreintegratedCombinedMeasurementsT<ManifoldPreintegration>;
 template class GTSAM_EXPORT PreintegratedCombinedMeasurementsT<TangentPreintegration>;
+template class GTSAM_EXPORT
+    PreintegratedCombinedMeasurementsT<LieGroupPreintegration>;
 
 template class GTSAM_EXPORT CombinedImuFactorT<PreintegratedCombinedMeasurementsT<ManifoldPreintegration>>;
 template class GTSAM_EXPORT CombinedImuFactorT<PreintegratedCombinedMeasurementsT<TangentPreintegration>>;
+template class GTSAM_EXPORT CombinedImuFactorT<
+    PreintegratedCombinedMeasurementsT<LieGroupPreintegration>>;
 
 // Instantiate operator<<
 template GTSAM_EXPORT std::ostream& operator<<<PreintegratedCombinedMeasurementsT<ManifoldPreintegration>>(
     std::ostream& os, const CombinedImuFactorT<PreintegratedCombinedMeasurementsT<ManifoldPreintegration>>& f);
 template GTSAM_EXPORT std::ostream& operator<<<PreintegratedCombinedMeasurementsT<TangentPreintegration>>(
     std::ostream& os, const CombinedImuFactorT<PreintegratedCombinedMeasurementsT<TangentPreintegration>>& f);
+template GTSAM_EXPORT std::ostream&
+operator<< <PreintegratedCombinedMeasurementsT<LieGroupPreintegration>>(
+    std::ostream& os,
+    const CombinedImuFactorT<
+        PreintegratedCombinedMeasurementsT<LieGroupPreintegration>>& f);
 
 }  // namespace gtsam

--- a/gtsam/navigation/CombinedImuFactor.h
+++ b/gtsam/navigation/CombinedImuFactor.h
@@ -23,12 +23,15 @@
 #pragma once
 
 /* GTSAM includes */
+#include <gtsam/navigation/LieGroupPreintegration.h>
 #include <gtsam/navigation/PreintegrationCombinedParams.h>
 #include <gtsam/nonlinear/NoiseModelFactorN.h>
 
 namespace gtsam {
 
-#ifdef GTSAM_TANGENT_PREINTEGRATION
+#ifdef GTSAM_LIEGROUP_PREINTEGRATION
+typedef LieGroupPreintegration DefaultPreintegrationType;
+#elif defined(GTSAM_TANGENT_PREINTEGRATION)
 typedef TangentPreintegration DefaultPreintegrationType;
 #else
 typedef ManifoldPreintegration DefaultPreintegrationType;

--- a/gtsam/navigation/CombinedImuFactorWithGravity.cpp
+++ b/gtsam/navigation/CombinedImuFactorWithGravity.cpp
@@ -15,6 +15,7 @@
  **/
 
 #include <gtsam/navigation/CombinedImuFactorWithGravity.h>
+#include <gtsam/navigation/LieGroupPreintegration.h>
 #include <gtsam/navigation/ManifoldPreintegration.h>
 #include <gtsam/navigation/TangentPreintegration.h>
 
@@ -93,16 +94,28 @@ Vector CombinedImuFactorWithGravityT<PIM, GRAVITY>::evaluateError(
 // CombinedImuFactorWithGravityT instantiations
 template class GTSAM_EXPORT CombinedImuFactorWithGravityT<PreintegratedCombinedMeasurementsT<ManifoldPreintegration>, Unit3>;
 template class GTSAM_EXPORT CombinedImuFactorWithGravityT<PreintegratedCombinedMeasurementsT<TangentPreintegration>, Unit3>;
+template class GTSAM_EXPORT CombinedImuFactorWithGravityT<
+    PreintegratedCombinedMeasurementsT<LieGroupPreintegration>, Unit3>;
 template class GTSAM_EXPORT CombinedImuFactorWithGravityT<PreintegratedCombinedMeasurementsT<ManifoldPreintegration>, Point3>;
 template class GTSAM_EXPORT CombinedImuFactorWithGravityT<PreintegratedCombinedMeasurementsT<TangentPreintegration>, Point3>;
+template class GTSAM_EXPORT CombinedImuFactorWithGravityT<
+    PreintegratedCombinedMeasurementsT<LieGroupPreintegration>, Point3>;
 
 template GTSAM_EXPORT std::ostream& operator<<(
     std::ostream& os, const CombinedImuFactorWithGravityT<PreintegratedCombinedMeasurementsT<ManifoldPreintegration>, Unit3>& f);
 template GTSAM_EXPORT std::ostream& operator<<(
     std::ostream& os, const CombinedImuFactorWithGravityT<PreintegratedCombinedMeasurementsT<TangentPreintegration>, Unit3>& f);
 template GTSAM_EXPORT std::ostream& operator<<(
+    std::ostream& os,
+    const CombinedImuFactorWithGravityT<
+        PreintegratedCombinedMeasurementsT<LieGroupPreintegration>, Unit3>& f);
+template GTSAM_EXPORT std::ostream& operator<<(
     std::ostream& os, const CombinedImuFactorWithGravityT<PreintegratedCombinedMeasurementsT<ManifoldPreintegration>, Point3>& f);
 template GTSAM_EXPORT std::ostream& operator<<(
     std::ostream& os, const CombinedImuFactorWithGravityT<PreintegratedCombinedMeasurementsT<TangentPreintegration>, Point3>& f);
+template GTSAM_EXPORT std::ostream& operator<<(
+    std::ostream& os,
+    const CombinedImuFactorWithGravityT<
+        PreintegratedCombinedMeasurementsT<LieGroupPreintegration>, Point3>& f);
 
 }  // namespace gtsam

--- a/gtsam/navigation/ImuFactor.cpp
+++ b/gtsam/navigation/ImuFactor.cpp
@@ -20,6 +20,7 @@
  **/
 
 #include <gtsam/navigation/ImuFactor.h>
+#include <gtsam/navigation/LieGroupPreintegration.h>
 #include <gtsam/navigation/ManifoldPreintegration.h>
 #include <gtsam/navigation/TangentPreintegration.h>
 
@@ -191,25 +192,39 @@ Vector9 ImuFactor2T<PIM>::evaluateError(const NavState& state_i,
 //------------------------------------------------------------------------------
 template class GTSAM_EXPORT PreintegratedImuMeasurementsT<ManifoldPreintegration>;
 template class GTSAM_EXPORT PreintegratedImuMeasurementsT<TangentPreintegration>;
+template class GTSAM_EXPORT
+    PreintegratedImuMeasurementsT<LieGroupPreintegration>;
 
 // ImuFactorT instantiations
 template class GTSAM_EXPORT ImuFactorT<PreintegratedImuMeasurementsT<ManifoldPreintegration>>;
 template class GTSAM_EXPORT ImuFactorT<PreintegratedImuMeasurementsT<TangentPreintegration>>;
+template class GTSAM_EXPORT
+    ImuFactorT<PreintegratedImuMeasurementsT<LieGroupPreintegration>>;
 
 // ImuFactor2T instantiations
 template class GTSAM_EXPORT ImuFactor2T<PreintegratedImuMeasurementsT<ManifoldPreintegration>>;
 template class GTSAM_EXPORT ImuFactor2T<PreintegratedImuMeasurementsT<TangentPreintegration>>;
+template class GTSAM_EXPORT
+    ImuFactor2T<PreintegratedImuMeasurementsT<LieGroupPreintegration>>;
 
 // operator<< instantiations
 template GTSAM_EXPORT std::ostream& operator<<<PreintegratedImuMeasurementsT<ManifoldPreintegration>>(
     std::ostream& os, const ImuFactorT<PreintegratedImuMeasurementsT<ManifoldPreintegration>>& f);
 template GTSAM_EXPORT std::ostream& operator<<<PreintegratedImuMeasurementsT<TangentPreintegration>>(
     std::ostream& os, const ImuFactorT<PreintegratedImuMeasurementsT<TangentPreintegration>>& f);
+template GTSAM_EXPORT std::ostream&
+operator<< <PreintegratedImuMeasurementsT<LieGroupPreintegration>>(
+    std::ostream& os,
+    const ImuFactorT<PreintegratedImuMeasurementsT<LieGroupPreintegration>>& f);
 
 template GTSAM_EXPORT std::ostream& operator<<<PreintegratedImuMeasurementsT<ManifoldPreintegration>>(
     std::ostream& os, const ImuFactor2T<PreintegratedImuMeasurementsT<ManifoldPreintegration>>& f);
 template GTSAM_EXPORT std::ostream& operator<<<PreintegratedImuMeasurementsT<TangentPreintegration>>(
     std::ostream& os, const ImuFactor2T<PreintegratedImuMeasurementsT<TangentPreintegration>>& f);
-
+template GTSAM_EXPORT std::ostream&
+operator<< <PreintegratedImuMeasurementsT<LieGroupPreintegration>>(
+    std::ostream& os,
+    const ImuFactor2T<PreintegratedImuMeasurementsT<LieGroupPreintegration>>&
+        f);
 }
 // namespace gtsam

--- a/gtsam/navigation/ImuFactor.h
+++ b/gtsam/navigation/ImuFactor.h
@@ -22,19 +22,22 @@
 #pragma once
 
 /* GTSAM includes */
+#include <gtsam/base/debug.h>
 #include <gtsam/linear/TernaryJacobianFactor.h>
-#include <gtsam/nonlinear/NonlinearFactor.h>
-#include <gtsam/nonlinear/NoiseModelFactorN.h>
+#include <gtsam/navigation/LieGroupPreintegration.h>
 #include <gtsam/navigation/ManifoldPreintegration.h>
 #include <gtsam/navigation/TangentPreintegration.h>
-#include <gtsam/base/debug.h>
+#include <gtsam/nonlinear/NoiseModelFactorN.h>
+#include <gtsam/nonlinear/NonlinearFactor.h>
 
-#include <type_traits> // For std::is_same, std::enable_if
- 
+#include <type_traits>  // For std::is_same, std::enable_if
+
 namespace gtsam {
 
 // Determine default preintegration backend
-#ifdef GTSAM_TANGENT_PREINTEGRATION
+#ifdef GTSAM_LIEGROUP_PREINTEGRATION
+typedef LieGroupPreintegration DefaultPreintegrationType;
+#elif defined(GTSAM_TANGENT_PREINTEGRATION)
 typedef TangentPreintegration DefaultPreintegrationType;
 #else
 typedef ManifoldPreintegration DefaultPreintegrationType;

--- a/gtsam/navigation/ImuFactorWithGravity.cpp
+++ b/gtsam/navigation/ImuFactorWithGravity.cpp
@@ -15,6 +15,7 @@
  **/
 
 #include <gtsam/navigation/ImuFactorWithGravity.h>
+#include <gtsam/navigation/LieGroupPreintegration.h>
 #include <gtsam/navigation/ManifoldPreintegration.h>
 #include <gtsam/navigation/TangentPreintegration.h>
 
@@ -81,17 +82,28 @@ Vector ImuFactorWithGravityT<PIM, GRAVITY>::evaluateError(const Pose3& pose_i,
 // ImuFactorWithGravityT instantiations
 template class GTSAM_EXPORT ImuFactorWithGravityT<PreintegratedImuMeasurementsT<ManifoldPreintegration>, Unit3>;
 template class GTSAM_EXPORT ImuFactorWithGravityT<PreintegratedImuMeasurementsT<TangentPreintegration>, Unit3>;
+template class GTSAM_EXPORT ImuFactorWithGravityT<
+    PreintegratedImuMeasurementsT<LieGroupPreintegration>, Unit3>;
 template class GTSAM_EXPORT ImuFactorWithGravityT<PreintegratedImuMeasurementsT<ManifoldPreintegration>, Point3>;
 template class GTSAM_EXPORT ImuFactorWithGravityT<PreintegratedImuMeasurementsT<TangentPreintegration>, Point3>;
+template class GTSAM_EXPORT ImuFactorWithGravityT<
+    PreintegratedImuMeasurementsT<LieGroupPreintegration>, Point3>;
 
 template GTSAM_EXPORT std::ostream& operator<<(
     std::ostream& os, const ImuFactorWithGravityT<PreintegratedImuMeasurementsT<ManifoldPreintegration>, Unit3>& f);
 template GTSAM_EXPORT std::ostream& operator<<(
     std::ostream& os, const ImuFactorWithGravityT<PreintegratedImuMeasurementsT<TangentPreintegration>, Unit3>& f);
 template GTSAM_EXPORT std::ostream& operator<<(
+    std::ostream& os,
+    const ImuFactorWithGravityT<
+        PreintegratedImuMeasurementsT<LieGroupPreintegration>, Unit3>& f);
+template GTSAM_EXPORT std::ostream& operator<<(
     std::ostream& os, const ImuFactorWithGravityT<PreintegratedImuMeasurementsT<ManifoldPreintegration>, Point3>& f);
 template GTSAM_EXPORT std::ostream& operator<<(
     std::ostream& os, const ImuFactorWithGravityT<PreintegratedImuMeasurementsT<TangentPreintegration>, Point3>& f);
-
+template GTSAM_EXPORT std::ostream& operator<<(
+    std::ostream& os,
+    const ImuFactorWithGravityT<
+        PreintegratedImuMeasurementsT<LieGroupPreintegration>, Point3>& f);
 
 }  // namespace gtsam

--- a/gtsam/navigation/LieGroupPreintegration.cpp
+++ b/gtsam/navigation/LieGroupPreintegration.cpp
@@ -1,0 +1,148 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved.
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file LieGroupPreintegration.cpp
+ * @brief IMU preintegration using the SE_2(3) group structure of NavState.
+ */
+
+#include <gtsam/base/MatrixConstants.h>
+#include <gtsam/navigation/LieGroupPreintegration.h>
+
+namespace gtsam {
+
+/* ************************************************************************* */
+LieGroupPreintegration::LieGroupPreintegration(
+    const std::shared_ptr<Params>& params, const imuBias::ConstantBias& biasHat)
+    : ManifoldPreintegration(params, biasHat) {}
+
+/* ************************************************************************* */
+void LieGroupPreintegration::updateBiasJacobians(
+    const Rot3& oldRotation, const Vector3& /*bodyAcceleration*/,
+    const Vector3& /*bodyOmega*/, double /*dt*/, const Matrix9& stateTransition,
+    const Matrix93& accelerationJacobian, const Matrix93& omegaJacobian) {
+  const Matrix3 oldRotationTranspose = oldRotation.transpose();
+  Matrix93 oldState_H_biasAcc, oldState_H_biasOmega;
+  oldState_H_biasAcc << Z_3x3, oldRotationTranspose * delPdelBiasAcc_,
+      oldRotationTranspose * delVdelBiasAcc_;
+  oldState_H_biasOmega << delRdelBiasOmega_,
+      oldRotationTranspose * delPdelBiasOmega_,
+      oldRotationTranspose * delVdelBiasOmega_;
+
+  const Matrix93 newState_H_biasAcc =
+      stateTransition * oldState_H_biasAcc - accelerationJacobian;
+  const Matrix93 newState_H_biasOmega =
+      stateTransition * oldState_H_biasOmega - omegaJacobian;
+  const Matrix3 newRotation = deltaXij_.R();
+  delRdelBiasOmega_ = newState_H_biasOmega.topRows<3>();
+  delPdelBiasAcc_ = newRotation * newState_H_biasAcc.middleRows<3>(3);
+  delPdelBiasOmega_ = newRotation * newState_H_biasOmega.middleRows<3>(3);
+  delVdelBiasAcc_ = newRotation * newState_H_biasAcc.bottomRows<3>();
+  delVdelBiasOmega_ = newRotation * newState_H_biasOmega.bottomRows<3>();
+}
+
+/* ************************************************************************* */
+void LieGroupPreintegration::updateFactor(const Vector3& bodyAcceleration,
+                                          const Vector3& bodyOmega, double dt,
+                                          OptionalJacobian<9, 9> F,
+                                          OptionalJacobian<9, 3> G1,
+                                          OptionalJacobian<9, 3> G2) {
+  const bool computeJacobians = F || G1 || G2;
+  Matrix39 bodyVelocity_H_state;
+  const Vector3 bodyVelocity =
+      deltaXij_.bodyVelocity(F ? &bodyVelocity_H_state : nullptr);
+  const double halfDtSquared = 0.5 * dt * dt;
+
+  Matrix3 incrementRotation_H_integratedOmega;
+  const Rot3 incrementRotation = Rot3::Expmap(
+      dt * bodyOmega, G2 ? &incrementRotation_H_integratedOmega : nullptr);
+  Matrix93 increment_H_rotation, increment_H_position, increment_H_velocity;
+  const NavState incrementState = NavState::Create(
+      incrementRotation, dt * bodyVelocity + halfDtSquared * bodyAcceleration,
+      dt * bodyAcceleration, computeJacobians ? &increment_H_rotation : nullptr,
+      computeJacobians ? &increment_H_position : nullptr,
+      computeJacobians ? &increment_H_velocity : nullptr);
+
+  Matrix9 tangent_H_increment;
+  const Vector9 increment = NavState::Logmap(
+      incrementState, computeJacobians ? &tangent_H_increment : nullptr);
+
+  Matrix9 newState_H_increment;
+  deltaXij_ = deltaXij_.expmap(
+      increment, F, computeJacobians ? &newState_H_increment : nullptr);
+
+  if (F) {
+    *F += newState_H_increment * tangent_H_increment * increment_H_position *
+          dt * bodyVelocity_H_state;
+  }
+  if (G1) {
+    *G1 = newState_H_increment * tangent_H_increment *
+          (increment_H_position * halfDtSquared + increment_H_velocity * dt);
+  }
+  if (G2) {
+    *G2 = newState_H_increment * tangent_H_increment * increment_H_rotation *
+          incrementRotation_H_integratedOmega * dt;
+  }
+}
+
+/* ************************************************************************* */
+Vector9 LieGroupPreintegration::biasCorrectedDelta(
+    const imuBias::ConstantBias& bias, OptionalJacobian<9, 6> H) const {
+  const imuBias::ConstantBias biasIncrement = bias - biasHat_;
+  const Vector3 rotationCorrection =
+      delRdelBiasOmega_ * biasIncrement.gyroscope();
+
+  Matrix3 correctedRotation_H_correction;
+  const Rot3 correctedRotation = deltaRij().expmap(
+      rotationCorrection, {}, H ? &correctedRotation_H_correction : nullptr);
+  if (H) correctedRotation_H_correction *= delRdelBiasOmega_;
+
+  Vector9 correctionTangent;
+  NavState::dR(correctionTangent) = rotationCorrection;
+  NavState::dP(correctionTangent) =
+      delPdelBiasAcc_ * biasIncrement.accelerometer() +
+      delPdelBiasOmega_ * biasIncrement.gyroscope();
+  NavState::dV(correctionTangent) =
+      delVdelBiasAcc_ * biasIncrement.accelerometer() +
+      delVdelBiasOmega_ * biasIncrement.gyroscope();
+
+  Matrix9 correction_H_tangent;
+  const NavState correction =
+      NavState::Expmap(correctionTangent, H ? &correction_H_tangent : nullptr);
+
+  Vector9 corrected;
+  Matrix3 logRotation_H_rotation;
+  NavState::dR(corrected) =
+      Rot3::Logmap(correctedRotation, H ? &logRotation_H_rotation : nullptr);
+  NavState::dP(corrected) = deltaPij() + correction.position();
+  NavState::dV(corrected) = deltaVij() + correction.velocity();
+
+  if (H) {
+    const Matrix3 J = correction_H_tangent.block<3, 3>(0, 0);
+    const Matrix3 Qp = correction_H_tangent.block<3, 3>(3, 0);
+    const Matrix3 Qv = correction_H_tangent.block<3, 3>(6, 0);
+
+    Matrix36 rotation_H_bias, position_H_bias, velocity_H_bias;
+    rotation_H_bias << Z_3x3,
+        logRotation_H_rotation * correctedRotation_H_correction;
+    position_H_bias << J * delPdelBiasAcc_,
+        J * delPdelBiasOmega_ + Qp * delRdelBiasOmega_;
+    velocity_H_bias << J * delVdelBiasAcc_,
+        J * delVdelBiasOmega_ + Qv * delRdelBiasOmega_;
+
+    const Matrix3 correctionRotation = correction.attitude().matrix();
+    *H << rotation_H_bias, correctionRotation * position_H_bias,
+        correctionRotation * velocity_H_bias;
+  }
+  return corrected;
+}
+
+}  // namespace gtsam

--- a/gtsam/navigation/LieGroupPreintegration.h
+++ b/gtsam/navigation/LieGroupPreintegration.h
@@ -1,0 +1,72 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved.
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file LieGroupPreintegration.h
+ * @brief IMU preintegration using the SE_2(3) group structure of NavState.
+ * @author Martin Brossard
+ * @author Frank Dellaert
+ */
+
+#pragma once
+
+#include <gtsam/navigation/ManifoldPreintegration.h>
+
+namespace gtsam {
+
+/**
+ * IMU preintegration using the SE_2(3) Lie-group structure of NavState.
+ *
+ * Unlike ManifoldPreintegration, each increment is applied with the group
+ * exponential map. NavState's legacy retract/localCoordinates chart remains
+ * unchanged and is still used by optimization and PreintegrationBase.
+ */
+class GTSAM_EXPORT LieGroupPreintegration : public ManifoldPreintegration {
+ protected:
+  /// Default constructor for serialization.
+  LieGroupPreintegration() = default;
+
+ public:
+  /** Construct an empty preintegrator with parameters and a bias linearization
+   * point. */
+  LieGroupPreintegration(
+      const std::shared_ptr<Params>& params,
+      const imuBias::ConstantBias& biasHat = imuBias::ConstantBias());
+
+  /** Return the bias-corrected delta in NavState's legacy tangent ordering. */
+  Vector9 biasCorrectedDelta(const imuBias::ConstantBias& bias,
+                             OptionalJacobian<9, 6> H = {}) const override;
+
+ protected:
+  /** Apply one unbiased IMU increment with NavState's group exponential. */
+  void updateFactor(const Vector3& bodyAcceleration, const Vector3& bodyOmega,
+                    double dt, OptionalJacobian<9, 9> F = {},
+                    OptionalJacobian<9, 3> G1 = {},
+                    OptionalJacobian<9, 3> G2 = {}) override;
+
+  void updateBiasJacobians(const Rot3& oldRotation,
+                           const Vector3& bodyAcceleration,
+                           const Vector3& bodyOmega, double dt,
+                           const Matrix9& stateTransition,
+                           const Matrix93& accelerationJacobian,
+                           const Matrix93& omegaJacobian) override;
+
+ private:
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
+  friend class boost::serialization::access;
+  template <class Archive>
+  void serialize(Archive& archive, const unsigned int /*version*/) {
+    archive& BOOST_SERIALIZATION_BASE_OBJECT_NVP(ManifoldPreintegration);
+  }
+#endif
+};
+
+}  // namespace gtsam

--- a/gtsam/navigation/ManifoldPreintegration.cpp
+++ b/gtsam/navigation/ManifoldPreintegration.cpp
@@ -60,8 +60,9 @@ bool ManifoldPreintegration::equals(const ManifoldPreintegration& other,
 
 //------------------------------------------------------------------------------
 void ManifoldPreintegration::update(const Vector3& measuredAcc,
-    const Vector3& measuredOmega, const double dt, Matrix9* A, Matrix93* B,
-    Matrix93* C) {
+                                    const Vector3& measuredOmega,
+                                    const double dt, Matrix9* A, Matrix93* B,
+                                    Matrix93* C) {
   // Correct for bias in the sensor frame
   Vector3 acc = biasHat_.correctAccelerometer(measuredAcc);
   Vector3 omega = biasHat_.correctGyroscope(measuredOmega);

--- a/gtsam/navigation/ManifoldPreintegration.cpp
+++ b/gtsam/navigation/ManifoldPreintegration.cpp
@@ -62,7 +62,6 @@ bool ManifoldPreintegration::equals(const ManifoldPreintegration& other,
 void ManifoldPreintegration::update(const Vector3& measuredAcc,
     const Vector3& measuredOmega, const double dt, Matrix9* A, Matrix93* B,
     Matrix93* C) {
-
   // Correct for bias in the sensor frame
   Vector3 acc = biasHat_.correctAccelerometer(measuredAcc);
   Vector3 omega = biasHat_.correctGyroscope(measuredOmega);
@@ -75,39 +74,65 @@ void ManifoldPreintegration::update(const Vector3& measuredAcc,
         D_correctedOmega_omega);
   }
 
-  // Save current rotation for updating Jacobians
-  const Rot3 oldRij = deltaXij_.attitude();
+  const Rot3 oldRotation = deltaXij_.attitude();
 
-  // Do update
+  // Do update. The transition and measurement Jacobians are also needed to
+  // propagate the accumulated bias Jacobians, even if the caller omits them.
+  Matrix9 stateTransition;
+  Matrix93 accelerationJacobian, omegaJacobian;
+  Matrix9* stateTransitionOutput = A ? A : &stateTransition;
+  Matrix93* accelerationOutput = B ? B : &accelerationJacobian;
+  Matrix93* omegaOutput = C ? C : &omegaJacobian;
   deltaTij_ += dt;
-  deltaXij_ = deltaXij_.update(acc, omega, dt, A, B, C); // functional
+  updateFactor(acc, omega, dt, stateTransitionOutput, accelerationOutput,
+               omegaOutput);
 
   if (p().body_P_sensor) {
     // More complicated derivatives in case of non-trivial sensor pose
-    *C *= D_correctedOmega_omega;
+    *omegaOutput *= D_correctedOmega_omega;
     if (!p().body_P_sensor->translation().isZero())
-      *C += *B * D_correctedAcc_omega;
-    *B *= D_correctedAcc_acc; // NOTE(frank): needs to be last
+      *omegaOutput += *accelerationOutput * D_correctedAcc_omega;
+    *accelerationOutput *= D_correctedAcc_acc;  // Must be last.
   }
 
-  // Update Jacobians
-  // TODO(frank): Try same simplification as in new approach
-  Matrix3 D_acc_R;
-  oldRij.rotate(acc, D_acc_R);
-  const Matrix3 D_acc_biasOmega = D_acc_R * delRdelBiasOmega_;
+  updateBiasJacobians(oldRotation, acc, omega, dt, *stateTransitionOutput,
+                      *accelerationOutput, *omegaOutput);
+}
 
-  const Vector3 integratedOmega = omega * dt;
-  Matrix3 D_incrR_integratedOmega;
-  const Rot3 incrR = Rot3::Expmap(integratedOmega, D_incrR_integratedOmega); // expensive !!
-  const Matrix3 incrRt = incrR.transpose();
-  delRdelBiasOmega_ = incrRt * delRdelBiasOmega_ - D_incrR_integratedOmega * dt;
+//------------------------------------------------------------------------------
+void ManifoldPreintegration::updateFactor(const Vector3& bodyAcceleration,
+                                          const Vector3& bodyOmega, double dt,
+                                          OptionalJacobian<9, 9> F,
+                                          OptionalJacobian<9, 3> G1,
+                                          OptionalJacobian<9, 3> G2) {
+  deltaXij_ = deltaXij_.update(bodyAcceleration, bodyOmega, dt, F, G1, G2);
+}
 
-  double dt22 = 0.5 * dt * dt;
-  const Matrix3 dRij = oldRij.matrix(); // expensive
-  delPdelBiasAcc_ += delVdelBiasAcc_ * dt - dt22 * dRij;
-  delPdelBiasOmega_ += dt * delVdelBiasOmega_ + dt22 * D_acc_biasOmega;
-  delVdelBiasAcc_ += -dRij * dt;
-  delVdelBiasOmega_ += D_acc_biasOmega * dt;
+//------------------------------------------------------------------------------
+void ManifoldPreintegration::updateBiasJacobians(
+    const Rot3& oldRotation, const Vector3& bodyAcceleration,
+    const Vector3& bodyOmega, double dt, const Matrix9& /*stateTransition*/,
+    const Matrix93& /*accelerationJacobian*/,
+    const Matrix93& /*omegaJacobian*/) {
+  Matrix3 acceleration_H_rotation;
+  oldRotation.rotate(bodyAcceleration, acceleration_H_rotation);
+  const Matrix3 acceleration_H_biasOmega =
+      acceleration_H_rotation * delRdelBiasOmega_;
+
+  const Vector3 integratedOmega = bodyOmega * dt;
+  Matrix3 incrementRotation_H_integratedOmega;
+  const Rot3 incrementRotation =
+      Rot3::Expmap(integratedOmega, incrementRotation_H_integratedOmega);
+  delRdelBiasOmega_ = incrementRotation.transpose() * delRdelBiasOmega_ -
+                      incrementRotation_H_integratedOmega * dt;
+
+  const double halfDtSquared = 0.5 * dt * dt;
+  const Matrix3 oldR = oldRotation.matrix();
+  delPdelBiasAcc_ += delVdelBiasAcc_ * dt - halfDtSquared * oldR;
+  delPdelBiasOmega_ +=
+      dt * delVdelBiasOmega_ + halfDtSquared * acceleration_H_biasOmega;
+  delVdelBiasAcc_ -= oldR * dt;
+  delVdelBiasOmega_ += acceleration_H_biasOmega * dt;
 }
 
 //------------------------------------------------------------------------------

--- a/gtsam/navigation/ManifoldPreintegration.h
+++ b/gtsam/navigation/ManifoldPreintegration.h
@@ -133,7 +133,7 @@ public:
                                    const Matrix93& accelerationJacobian,
                                    const Matrix93& omegaJacobian);
 
-private:
+ private:
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;

--- a/gtsam/navigation/ManifoldPreintegration.h
+++ b/gtsam/navigation/ManifoldPreintegration.h
@@ -117,6 +117,22 @@ public:
 
   /// @}
 
+ protected:
+  /** Apply one unbiased body-frame IMU increment to deltaXij_. */
+  virtual void updateFactor(const Vector3& bodyAcceleration,
+                            const Vector3& bodyOmega, double dt,
+                            OptionalJacobian<9, 9> F = {},
+                            OptionalJacobian<9, 3> G1 = {},
+                            OptionalJacobian<9, 3> G2 = {});
+
+  /** Update accumulated bias Jacobians after applying one IMU increment. */
+  virtual void updateBiasJacobians(const Rot3& oldRotation,
+                                   const Vector3& bodyAcceleration,
+                                   const Vector3& bodyOmega, double dt,
+                                   const Matrix9& stateTransition,
+                                   const Matrix93& accelerationJacobian,
+                                   const Matrix93& omegaJacobian);
+
 private:
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */

--- a/gtsam/navigation/navigation.md
+++ b/gtsam/navigation/navigation.md
@@ -26,6 +26,9 @@ The `navigation` module in GTSAM provides specialized tools for inertial navigat
 - **[PreintegrationBase](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/PreintegrationBase.h)**: Base class for IMU preintegration classes.
 - **[ManifoldPreintegration](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/ManifoldPreintegration.h)**: Implements IMU preintegration using manifold-based methods as in the Forster et al paper.
 - **[TangentPreintegration](https://github.com/borglab/gtsam/blob/develop/gtsam/navigation/TangentPreintegration.h)**: Implements IMU preintegration using tangent space methods, developed at Skydio.
+- **LieGroupPreintegration**: Integrates IMU increments with the `NavState`
+  $SE_2(3)$ group exponential described by [Brossard, Barrau, and
+  Bonnabel](https://arxiv.org/abs/2007.14097).
 - **[ImuFactor](doc/ImuFactor.ipynb)**: IMU factor.
 - **[CombinedImuFactor](doc/CombinedImuFactor.ipynb)**: IMU factor with built-in bias evolution.
 
@@ -129,17 +132,25 @@ classDiagram
     }
     TangentPreintegration --|> PreintegrationBase : implements
 
+    class LieGroupPreintegration {
+        +NavState deltaXij_
+        +update()
+    }
+    LieGroupPreintegration --|> ManifoldPreintegration : specializes
+
     class PreintegratedImuMeasurements {
         +Matrix9 preintMeasCov_
     }
     PreintegratedImuMeasurements --|> ManifoldPreintegration : inherits
     PreintegratedImuMeasurements --|> TangentPreintegration : inherits
+    PreintegratedImuMeasurements --|> LieGroupPreintegration : inherits
 
     class PreintegratedCombinedMeasurements {
        +Matrix preintMeasCov_ (15x15)
     }
     PreintegratedCombinedMeasurements --|> ManifoldPreintegration : inherits
     PreintegratedCombinedMeasurements --|> TangentPreintegration : inherits
+    PreintegratedCombinedMeasurements --|> LieGroupPreintegration : inherits
 
     class ImuFactor {
         Pose3, Vector3, Pose3, Vector3, ConstantBias
@@ -196,6 +207,10 @@ The key components are:
 3.  **Preintegration Implementations**:
     *   `ManifoldPreintegration`: Concrete implementation of `PreintegrationBase`. Integrates directly on the `NavState` manifold, storing the result as a `NavState`. Corresponds to Forster et al. RSS 2015.
     *   `TangentPreintegration`: Concrete implementation of `PreintegrationBase`. Integrates increments in the 9D tangent space of `NavState`, storing the result as a `Vector9`.
+    *   `LieGroupPreintegration`: Specializes the manifold implementation by
+        applying increments with the `NavState` $SE_2(3)$ exponential and by
+        using the corresponding nonlinear group bias correction. It stores the
+        result as a `NavState`.
 
 4.  **Preintegrated Measurements Containers**:
     *   `PreintegratedImuMeasurements`: Stores the result of standard IMU preintegration along with its 9x9 covariance (`preintMeasCov_`).
@@ -207,9 +222,24 @@ The key components are:
     * [CombinedImuFactor](doc/CombinedImuFactor.ipynb): A 6-way factor connecting previous pose/velocity, current pose/velocity, previous bias, and current bias. *Includes* a model for bias random walk evolution between the two bias states.
 
 ### Important notes
-- Which implementation is used for the `DefaultPreintegrationType` used by `ImuFactor`s and `Preintegrated*Measurements` depends on the compile flag `GTSAM_TANGENT_PREINTEGRATION`, which is true by default.
-    - If false, `ManifoldPreintegration` is used. Please use this setting to get the exact implementation from {cite:t}`https://doi.org/10.1109/TRO.2016.2597321`.
-    - If true, `TangentPreintegration` is used. This does the integration on the tangent space of the NavState manifold.
+- The compiled `DefaultPreintegrationType` used by `ImuFactor`s and
+  `Preintegrated*Measurements` is selected by two CMake options:
+    - `GTSAM_LIEGROUP_PREINTEGRATION=ON` selects `LieGroupPreintegration` and
+      takes precedence if both options are enabled.
+    - Otherwise, `GTSAM_TANGENT_PREINTEGRATION=ON` (the default) selects
+      `TangentPreintegration`.
+    - With both options disabled, `ManifoldPreintegration` is used. Select this
+      backend for the implementation from
+      {cite:t}`https://doi.org/10.1109/TRO.2016.2597321`.
 - If you wish to use any preintegration type other than the default, you must template your PIMs and factors on the desired preintegration type using the template-supporting classes `PreintegratedImuMeasurementsT`, `ImuFactorT`, `ImuFactor2T`, `PreintegratedCombinedMeasurementsT`, or `CombinedImuFactorT`.
+- Named backend selection is a C++ template API. Python and MATLAB expose only
+  the aliases selected when GTSAM is compiled.
+- `NavState` stores tangent blocks in `(R,p,v)` order, whereas Brossard et al.
+  write the $SE_2(3)$ matrix in `(R,v,p)` order. Translate the position and
+  velocity blocks when comparing equations.
+- Lie-group *integration* does not change the chart used by optimization.
+  `LieGroupPreintegration` applies IMU increments with `NavState::expmap`, while
+  `NavState::retract` and `localCoordinates` retain GTSAM's component-wise
+  optimization chart.
 - Using the combined IMU factor is not recommended. Typically biases evolve slowly, and hence a separate, lower frequency Markov chain on the bias is more appropriate.
 - For short-duration experiments it is even recommended to use a single constant bias. Bias estimation is notoriously hard to tune/debug, and also acts as a "sink" for any modeling errors. Hence, starting with a constant bias is a good idea to get the rest of the pipeline working.

--- a/gtsam/navigation/tests/imuFactorTesting.h
+++ b/gtsam/navigation/tests/imuFactorTesting.h
@@ -21,6 +21,7 @@
 #include <gtsam/base/VectorConstants.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/navigation/ImuBias.h>
+#include <gtsam/navigation/LieGroupPreintegration.h>
 
 using namespace std;
 using namespace gtsam;
@@ -88,7 +89,7 @@ struct SomeMeasurements : vector<ImuMeasurement> {
 
 }  // namespace testing
 namespace {
-// Macro to test ImuFactor with both Manifold and Tangent preintegration
+// Macro to test ImuFactor with every supported preintegration backend.
 // In the tests below the selected PreintegratedImuMeasurementsT is available
 // as `PIM`, and the combined version as `CombinedPIM`.
 #define TEST_PIM(testGroup, testName)                          \
@@ -102,8 +103,12 @@ namespace {
     using T = TangentPreintegration;                           \
     using PT = PreintegratedImuMeasurementsT<T>;               \
     using CT = PreintegratedCombinedMeasurementsT<T>;          \
+    using L = LieGroupPreintegration;                          \
+    using PL = PreintegratedImuMeasurementsT<L>;               \
+    using CL = PreintegratedCombinedMeasurementsT<L>;          \
     testGroup##testName##Helper<PM, CM>(result_, this->name_); \
     testGroup##testName##Helper<PT, CT>(result_, this->name_); \
+    testGroup##testName##Helper<PL, CL>(result_, this->name_); \
   }                                                            \
   template <class PIM, class CombinedPIM>                      \
   void testGroup##testName##Helper(TestResult& result_,        \

--- a/gtsam/navigation/tests/testCombinedImuFactor.cpp
+++ b/gtsam/navigation/tests/testCombinedImuFactor.cpp
@@ -141,7 +141,7 @@ TEST(CombinedImuFactor, FirstOrderPreIntegratedMeasurements) {
   testing::SomeMeasurements measurements;
 
   auto preintegrated = [&](const Vector3& a, const Vector3& w) {
-    PreintegratedImuMeasurements pim(p, Bias(a, w));
+    PreintegratedImuMeasurementsT<TangentPreintegration> pim(p, Bias(a, w));
     testing::integrateMeasurements(measurements, &pim);
     return pim.preintegrated();
   };

--- a/gtsam/navigation/tests/testImuFactor.cpp
+++ b/gtsam/navigation/tests/testImuFactor.cpp
@@ -39,6 +39,24 @@
 
 #include "imuFactorTesting.h"
 
+namespace default_backend {
+
+#ifdef GTSAM_LIEGROUP_PREINTEGRATION
+static_assert(
+    std::is_same<DefaultPreintegrationType, LieGroupPreintegration>::value,
+    "Lie-group preintegration must take precedence as the default backend");
+#elif defined(GTSAM_TANGENT_PREINTEGRATION)
+static_assert(
+    std::is_same<DefaultPreintegrationType, TangentPreintegration>::value,
+    "Tangent preintegration must remain the default backend");
+#else
+static_assert(
+    std::is_same<DefaultPreintegrationType, ManifoldPreintegration>::value,
+    "Manifold preintegration must be selected when both options are disabled");
+#endif
+
+}  // namespace default_backend
+
 /* ************************************************************************* */
 TEST_PIM(ImuFactor, PreintegratedMeasurementsConstruction) {
   // Actual pre-integrated values
@@ -927,7 +945,8 @@ TEST_PIM(ImuFactor, bodyPSensorWithBias) {
 }
 
 /* ************************************************************************* */
-#ifdef GTSAM_TANGENT_PREINTEGRATION
+#if defined(GTSAM_TANGENT_PREINTEGRATION) && \
+    !defined(GTSAM_LIEGROUP_PREINTEGRATION)
 static const double kVelocity = 2.0, kAngularVelocity = M_PI / 6;
 
 struct ImuFactorMergeTest {

--- a/gtsam/navigation/tests/testImuFactorWithGravity.cpp
+++ b/gtsam/navigation/tests/testImuFactorWithGravity.cpp
@@ -207,7 +207,8 @@ TEST(ImuFactorWithGravity, RecoverGravityVector) {
 }
 
 /* ************************************************************************* */
-#ifdef GTSAM_TANGENT_PREINTEGRATION
+#if defined(GTSAM_TANGENT_PREINTEGRATION) && \
+    !defined(GTSAM_LIEGROUP_PREINTEGRATION)
 TEST(ImuFactorWithGravity, Merge) {
   using symbol_shorthand::G;
   auto p = testing::Params();

--- a/gtsam/navigation/tests/testLieGroupPreintegration.cpp
+++ b/gtsam/navigation/tests/testLieGroupPreintegration.cpp
@@ -1,0 +1,201 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved.
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file testLieGroupPreintegration.cpp
+ * @brief Tests for NavState SE_2(3) Lie-group IMU preintegration.
+ */
+
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/numericalDerivative.h>
+#include <gtsam/navigation/LieGroupPreintegration.h>
+
+#include "imuFactorTesting.h"
+
+/* ************************************************************************* */
+namespace integration_fixture {
+
+constexpr double kDt = 0.1;
+const Vector3 kAcceleration{0.1, 0.2, 9.8};
+const Vector3 kOmega{0.1, -0.2, 0.3};
+
+class TestableLieGroupPreintegration : public LieGroupPreintegration {
+ public:
+  using LieGroupPreintegration::LieGroupPreintegration;
+  using LieGroupPreintegration::updateFactor;
+
+  void setDeltaXij(const NavState& state) { deltaXij_ = state; }
+};
+
+NavState integrate(const NavState& initial, const Vector3& acceleration,
+                   const Vector3& omega) {
+  TestableLieGroupPreintegration pim(testing::Params());
+  pim.setDeltaXij(initial);
+  pim.updateFactor(acceleration, omega, kDt);
+  return pim.deltaXij();
+}
+
+// Verifies one IMU increment is applied with NavState's group exponential map.
+TEST(LieGroupPreintegration, UsesNavStateExpmap) {
+  const NavState physicalIncrement(Rot3::Expmap(kDt * kOmega),
+                                   0.5 * kDt * kDt * kAcceleration,
+                                   kDt * kAcceleration);
+  const Vector9 groupTangent = NavState::Logmap(physicalIncrement);
+  EXPECT(assert_equal(NavState().expmap(groupTangent),
+                      integrate(NavState(), kAcceleration, kOmega), 1e-12));
+}
+
+// Verifies state, accelerometer, and gyroscope propagation Jacobians.
+TEST(LieGroupPreintegration, UpdateJacobians) {
+  const NavState initial(Rot3::Ypr(0.3, -0.2, 0.1), Point3(1.0, -2.0, 0.5),
+                         Vector3(0.4, 0.2, -0.1));
+  TestableLieGroupPreintegration pim(testing::Params());
+  pim.setDeltaXij(initial);
+  Matrix9 F;
+  Matrix93 G1, G2;
+  pim.updateFactor(kAcceleration, kOmega, kDt, F, G1, G2);
+
+  auto propagate = [](const NavState& state, const Vector3& acceleration,
+                      const Vector3& omega) {
+    return integrate(state, acceleration, omega);
+  };
+
+  EXPECT(assert_equal(
+      numericalDerivative31(propagate, initial, kAcceleration, kOmega), F,
+      1e-8));
+  EXPECT(assert_equal(
+      numericalDerivative32(propagate, initial, kAcceleration, kOmega), G1,
+      1e-8));
+  EXPECT(assert_equal(
+      numericalDerivative33(propagate, initial, kAcceleration, kOmega), G2,
+      1e-8));
+}
+
+}  // namespace integration_fixture
+/* ************************************************************************* */
+namespace bias_fixture {
+
+// Verifies accumulated component Jacobians with respect to the bias hat.
+TEST(LieGroupPreintegration, AccumulatedBiasJacobians) {
+  const testing::SomeMeasurements measurements;
+
+  auto deltaRotation = [&](const Vector3& accelerationBias,
+                           const Vector3& omegaBias) {
+    LieGroupPreintegration pim(testing::Params(),
+                               Bias(accelerationBias, omegaBias));
+    testing::integrateMeasurements(measurements, &pim);
+    return pim.deltaRij();
+  };
+  auto deltaPosition = [&](const Vector3& accelerationBias,
+                           const Vector3& omegaBias) {
+    LieGroupPreintegration pim(testing::Params(),
+                               Bias(accelerationBias, omegaBias));
+    testing::integrateMeasurements(measurements, &pim);
+    return pim.deltaPij();
+  };
+  auto deltaVelocity = [&](const Vector3& accelerationBias,
+                           const Vector3& omegaBias) {
+    LieGroupPreintegration pim(testing::Params(),
+                               Bias(accelerationBias, omegaBias));
+    testing::integrateMeasurements(measurements, &pim);
+    return pim.deltaVij();
+  };
+
+  LieGroupPreintegration pim(testing::Params());
+  testing::integrateMeasurements(measurements, &pim);
+
+  EXPECT(assert_equal(numericalDerivative21(deltaRotation, kZero, kZero),
+                      Matrix3(Z_3x3)));
+  EXPECT(assert_equal(numericalDerivative22(deltaRotation, kZero, kZero),
+                      pim.delRdelBiasOmega(), 1e-3));
+  EXPECT(assert_equal(numericalDerivative21(deltaPosition, kZero, kZero),
+                      pim.delPdelBiasAcc(), 1e-6));
+  EXPECT(assert_equal(numericalDerivative22(deltaPosition, kZero, kZero),
+                      pim.delPdelBiasOmega(), 1e-3));
+  EXPECT(assert_equal(numericalDerivative21(deltaVelocity, kZero, kZero),
+                      pim.delVdelBiasAcc(), 1e-6));
+  EXPECT(assert_equal(numericalDerivative22(deltaVelocity, kZero, kZero),
+                      pim.delVdelBiasOmega(), 1e-3));
+}
+
+// Verifies the nonlinear Lie-group bias correction and its Jacobian.
+TEST(LieGroupPreintegration, BiasCorrectedDeltaJacobian) {
+  LieGroupPreintegration pim(testing::Params());
+  testing::integrateMeasurements(testing::SomeMeasurements(), &pim);
+  const Bias bias(Vector3{1e-3, -2e-3, 3e-3}, Vector3{-4e-4, 5e-4, -6e-4});
+
+  Matrix96 actualJacobian;
+  pim.biasCorrectedDelta(bias, actualJacobian);
+  auto corrected = [&](const Bias& value) {
+    return pim.biasCorrectedDelta(value);
+  };
+  EXPECT(assert_equal(numericalDerivative11(corrected, bias), actualJacobian,
+                      1e-6));
+}
+
+// Verifies bias correction applies the SE_2(3) exponential nonlinearly.
+TEST(LieGroupPreintegration, NonlinearBiasCorrection) {
+  LieGroupPreintegration pim(testing::Params());
+  testing::integrateMeasurements(testing::SomeMeasurements(), &pim);
+  const Bias bias(Vector3{0.02, -0.01, 0.03}, Vector3{-0.015, 0.01, -0.02});
+  const Bias biasIncrement = bias - pim.biasHat();
+
+  Vector9 correctionTangent;
+  NavState::dR(correctionTangent) =
+      pim.delRdelBiasOmega() * biasIncrement.gyroscope();
+  NavState::dP(correctionTangent) =
+      pim.delPdelBiasAcc() * biasIncrement.accelerometer() +
+      pim.delPdelBiasOmega() * biasIncrement.gyroscope();
+  NavState::dV(correctionTangent) =
+      pim.delVdelBiasAcc() * biasIncrement.accelerometer() +
+      pim.delVdelBiasOmega() * biasIncrement.gyroscope();
+  const NavState correction = NavState::Expmap(correctionTangent);
+
+  Vector9 expected;
+  NavState::dR(expected) =
+      Rot3::Logmap(pim.deltaRij().expmap(NavState::dR(correctionTangent)));
+  NavState::dP(expected) = pim.deltaPij() + correction.position();
+  NavState::dV(expected) = pim.deltaVij() + correction.velocity();
+  EXPECT(assert_equal(expected, pim.biasCorrectedDelta(bias), 1e-12));
+}
+
+}  // namespace bias_fixture
+/* ************************************************************************* */
+namespace factor_fixture {
+
+// Verifies PreintegrationBase error Jacobians with this backend.
+TEST(LieGroupPreintegration, ComputeErrorJacobians) {
+  LieGroupPreintegration pim(testing::Params());
+  const NavState x1, x2;
+  const Bias bias;
+  Matrix9 actualH1, actualH2;
+  Matrix96 actualH3;
+  internal::preintegrationError(pim, x1, x2, bias, actualH1, actualH2,
+                                actualH3);
+  auto error = [&](const NavState& a, const NavState& b, const Bias& c) {
+    return internal::preintegrationError(pim, a, b, c);
+  };
+
+  EXPECT(
+      assert_equal(numericalDerivative31(error, x1, x2, bias), actualH1, 1e-9));
+  EXPECT(
+      assert_equal(numericalDerivative32(error, x1, x2, bias), actualH2, 1e-9));
+  EXPECT(
+      assert_equal(numericalDerivative33(error, x1, x2, bias), actualH3, 1e-9));
+}
+
+}  // namespace factor_fixture
+/* ************************************************************************* */
+
+int main() {
+  TestResult result;
+  return TestRegistry::runAllTests(result);
+}

--- a/gtsam/navigation/tests/testSerializationNavigation.cpp
+++ b/gtsam/navigation/tests/testSerializationNavigation.cpp
@@ -170,6 +170,74 @@ TEST(CombinedImuFactorWithGravity, Serialization) {
 }
 
 /* ************************************************************************* */
+namespace lie_group_serialization {
+
+using Pim = PreintegratedImuMeasurementsT<LieGroupPreintegration>;
+using CombinedPim = PreintegratedCombinedMeasurementsT<LieGroupPreintegration>;
+using StandardFactor = ImuFactorT<Pim>;
+using NavStateFactor = ImuFactor2T<Pim>;
+using GravityDirectionFactor = ImuFactorWithGravityT<Pim, Unit3>;
+using GravityVectorFactor = ImuFactorWithGravityT<Pim, Point3>;
+using CombinedFactor = CombinedImuFactorT<CombinedPim>;
+using CombinedGravityDirectionFactor =
+    CombinedImuFactorWithGravityT<CombinedPim, Unit3>;
+using CombinedGravityVectorFactor =
+    CombinedImuFactorWithGravityT<CombinedPim, Point3>;
+
+// Verifies explicit Lie-backed measurements and every factor family round-trip.
+TEST(LieGroupPreintegration, Serialization) {
+  const Pim pim = getPreintegratedMeasurements<Pim>();
+  EXPECT(equalsObj(pim));
+  EXPECT(equalsXML(pim));
+  EXPECT(equalsBinary(pim));
+
+  const StandardFactor standard(1, 2, 3, 4, 5, pim);
+  EXPECT(equalsObj(standard));
+  EXPECT(equalsXML(standard));
+  EXPECT(equalsBinary(standard));
+
+  const NavStateFactor navState(1, 2, 3, pim);
+  EXPECT(equalsObj(navState));
+  EXPECT(equalsXML(navState));
+  EXPECT(equalsBinary(navState));
+
+  const GravityDirectionFactor gravityDirection(1, 2, 3, 4, 5, 6, pim, 9.81);
+  EXPECT(equalsObj(gravityDirection));
+  EXPECT(equalsXML(gravityDirection));
+  EXPECT(equalsBinary(gravityDirection));
+
+  const GravityVectorFactor gravityVector(1, 2, 3, 4, 5, 6, pim);
+  EXPECT(equalsObj(gravityVector));
+  EXPECT(equalsXML(gravityVector));
+  EXPECT(equalsBinary(gravityVector));
+
+  const CombinedPim combinedPim = getPreintegratedMeasurements<CombinedPim>();
+  EXPECT(equalsObj(combinedPim));
+  EXPECT(equalsXML(combinedPim));
+  EXPECT(equalsBinary(combinedPim));
+
+  const CombinedFactor combined(1, 2, 3, 4, 5, 6, combinedPim);
+  EXPECT(equalsObj(combined));
+  EXPECT(equalsXML(combined));
+  EXPECT(equalsBinary(combined));
+
+  const CombinedGravityDirectionFactor combinedGravityDirection(
+      1, 2, 3, 4, 5, 6, 7, combinedPim, 9.81);
+  EXPECT(equalsObj(combinedGravityDirection));
+  EXPECT(equalsXML(combinedGravityDirection));
+  EXPECT(equalsBinary(combinedGravityDirection));
+
+  const CombinedGravityVectorFactor combinedGravityVector(1, 2, 3, 4, 5, 6, 7,
+                                                          combinedPim);
+  EXPECT(equalsObj(combinedGravityVector));
+  EXPECT(equalsXML(combinedGravityVector));
+  EXPECT(equalsBinary(combinedGravityVector));
+}
+
+}  // namespace lie_group_serialization
+/* ************************************************************************* */
+
+/* ************************************************************************* */
 TEST(AttitudeFactorRot3, Serialization) {
   Unit3 nDown(0, 0, -1);
   SharedNoiseModel model = noiseModel::Isotropic::Sigma(2, 0.25);


### PR DESCRIPTION
## Summary

Adds an opt-in IMU preintegration backend that uses the existing `NavState`
SE₂(3) Lie group, without changing `NavState`'s optimization chart or the
default tangent backend.

This supersedes the Lie-group portion of #1916. It deliberately does not copy
that draft's duplicate `ExtendedPose3`, retract switch, or rotating-Earth
patch; exact Earth rotation will follow in a separate stacked PR.

## What changed

- Refactors `ManifoldPreintegration::update` into a shared bias/sensor-pose
  pipeline with protected integration and bias-propagation hooks.
- Adds `LieGroupPreintegration`, which applies physical IMU increments through
  `NavState::expmap`, propagates its actual transition Jacobians, and performs
  nonlinear SE₂(3) bias correction.
- Adds `GTSAM_LIEGROUP_PREINTEGRATION` (default OFF). When enabled it takes
  precedence over `GTSAM_TANGENT_PREINTEGRATION` for compiled aliases.
- Instantiates standard, `ImuFactor2`, combined, and gravity-aware factor
  templates for the Lie backend.
- Expands common fixtures to manifold, tangent, and Lie backends, including
  lever-arm, gravity, Jacobian, and serialization coverage.
- Documents backend selection, `(R,p,v)` ordering, and the distinction between
  group integration and the retained optimization chart.

Named backend selection remains C++-only through templates. Python and MATLAB
continue exposing the aliases selected when GTSAM is compiled.

## Validation

- Full `check.navigation`: 35/35 tests pass with Lie OFF (tangent default).
- Full `check.navigation`: 35/35 tests pass with Lie ON and tangent ON (Lie
  precedence/default).
- Lie-default Python wrapper build/tests: 435 passed, 6 skipped.
- Explicit Lie-backed object/XML/binary serialization round trips for PIMs and
  all factor families.
- `git diff --check` and `git clang-format --diff origin/develop`: clean.
- Release hot-path benchmark, five one-million-sample trials: refactored
  manifold median / legacy median = 0.988 (required <= 1.05).

The local PR analysis HTML and the unrelated Ceres/SuiteSparse workaround are
not included.

## Credit

This work builds on Stefan Gächter's contribution in #1916 and the SE₂(3)
preintegration formulation of Martin Brossard, Axel Barrau, and Silvère
Bonnabel: https://arxiv.org/abs/2007.14097.
