### PR TITLE
Use exact rotating-Earth dynamics in IMU prediction

### DIFF
--- a/gtsam/navigation/AHRSFactor.h
+++ b/gtsam/navigation/AHRSFactor.h
@@ -44,7 +44,7 @@ Rot3 predictAhrs(const PIM& pim, const Rot3& Ri, const Vector3& bias,
 
   // The common case needs no Earth-rotation correction. The compose Jacobian
   // with respect to its second argument is identity, so H2 is already final.
-  if (!pim.p().omegaCoriolis || pim.p().omegaCoriolis->isZero())
+  if (!pim.p().omegaCoriolis || pim.p().omegaCoriolis->isZero(0.0))
     return Ri.compose(biasCorrected, H1);
 
   // Exact rotating-frame attitude transition from Brossard et al.:
@@ -52,11 +52,10 @@ Rot3 predictAhrs(const PIM& pim, const Rot3& Ri, const Vector3& bias,
   const Rot3 gammaRotation =
       Rot3::Expmap(-(*pim.p().omegaCoriolis) * pim.deltaTij());
   Matrix3 D_gammaRi_Ri, D_Rj_gammaRi, D_Rj_delta;
-  const Rot3 gammaRi = gammaRotation.compose(
-      Ri, {}, H1 ? &D_gammaRi_Ri : nullptr);
-  const Rot3 Rj = gammaRi.compose(
-      biasCorrected, H1 ? &D_Rj_gammaRi : nullptr,
-      H2 ? &D_Rj_delta : nullptr);
+  const Rot3 gammaRi =
+      gammaRotation.compose(Ri, {}, H1 ? &D_gammaRi_Ri : nullptr);
+  const Rot3 Rj = gammaRi.compose(biasCorrected, H1 ? &D_Rj_gammaRi : nullptr,
+                                  H2 ? &D_Rj_delta : nullptr);
 
   if (H1) *H1 = D_Rj_gammaRi * D_gammaRi_Ri;
   if (H2) *H2 = D_Rj_delta * (*H2);

--- a/gtsam/navigation/AHRSFactor.h
+++ b/gtsam/navigation/AHRSFactor.h
@@ -42,22 +42,24 @@ Rot3 predictAhrs(const PIM& pim, const Rot3& Ri, const Vector3& bias,
   Rot3 biasCorrected =
       pim.biascorrectedDeltaRij(bias - pim.biasHat(), H2);
 
-  // The common case needs no Coriolis correction. The compose Jacobian with
-  // respect to its second argument is identity, so H2 is already final.
-  if (!pim.p().omegaCoriolis) return Ri.compose(biasCorrected, H1);
+  // The common case needs no Earth-rotation correction. The compose Jacobian
+  // with respect to its second argument is identity, so H2 is already final.
+  if (!pim.p().omegaCoriolis || pim.p().omegaCoriolis->isZero())
+    return Ri.compose(biasCorrected, H1);
 
-  Matrix3 D_coriolis_Ri;
-  const Vector3 coriolis =
-      pim.integrateCoriolis(Ri, H1 ? &D_coriolis_Ri : nullptr);
+  // Exact rotating-frame attitude transition from Brossard et al.:
+  // Rj = Exp(-Omega * dt) * Ri * DeltaR.
+  const Rot3 gammaRotation =
+      Rot3::Expmap(-(*pim.p().omegaCoriolis) * pim.deltaTij());
+  Matrix3 D_gammaRi_Ri, D_Rj_gammaRi, D_Rj_delta;
+  const Rot3 gammaRi = gammaRotation.compose(
+      Ri, {}, H1 ? &D_gammaRi_Ri : nullptr);
+  const Rot3 Rj = gammaRi.compose(
+      biasCorrected, H1 ? &D_Rj_gammaRi : nullptr,
+      H2 ? &D_Rj_delta : nullptr);
 
-  Matrix3 D_delta_bias, D_delta_coriolis;
-  const Rot3 finalDelta = biasCorrected.expmap(
-      -coriolis, H2 ? &D_delta_bias : nullptr,
-      H1 ? &D_delta_coriolis : nullptr);
-  const Rot3 Rj = Ri.compose(finalDelta, H1);
-
-  if (H1) *H1 -= D_delta_coriolis * D_coriolis_Ri;
-  if (H2) *H2 = D_delta_bias * (*H2);
+  if (H1) *H1 = D_Rj_gammaRi * D_gammaRi_Ri;
+  if (H2) *H2 = D_Rj_delta * (*H2);
   return Rj;
 }
 

--- a/gtsam/navigation/LeggedEstimator.cpp
+++ b/gtsam/navigation/LeggedEstimator.cpp
@@ -135,8 +135,6 @@ std::shared_ptr<PreintegrationCombinedParams> combinedPreintegrationParams(
         params.preintegrationParams->accelerometerCovariance;
     combinedParams->integrationCovariance =
         params.preintegrationParams->integrationCovariance;
-    combinedParams->use2ndOrderCoriolis =
-        params.preintegrationParams->use2ndOrderCoriolis;
     combinedParams->omegaCoriolis = params.preintegrationParams->omegaCoriolis;
     combinedParams->body_P_sensor = params.preintegrationParams->body_P_sensor;
   }

--- a/gtsam/navigation/NavState.cpp
+++ b/gtsam/navigation/NavState.cpp
@@ -297,10 +297,13 @@ Vector9 NavState::coriolis(double dt, const Vector3& omega, bool secondOrder,
 
 //------------------------------------------------------------------------------
 Vector9 NavState::correctPIM(const Vector9& pim, double dt,
-    const Vector3& n_gravity, const std::optional<Vector3>& omegaCoriolis,
-    bool use2ndOrderCoriolis, OptionalJacobian<9, 9> H1,
-    OptionalJacobian<9, 9> H2, OptionalJacobian<9, 3> H3) const {
-  if (omegaCoriolis && !omegaCoriolis->isZero()) {
+                             const Vector3& n_gravity,
+                             const std::optional<Vector3>& omegaCoriolis,
+                             bool /*use2ndOrderCoriolis*/,
+                             OptionalJacobian<9, 9> H1,
+                             OptionalJacobian<9, 9> H2,
+                             OptionalJacobian<9, 3> H3) const {
+  if (omegaCoriolis && !omegaCoriolis->isZero(0.0)) {
     const Vector3& omega = *omegaCoriolis;
     const Vector3 earthRotationTangent = -omega * dt;
     const so3::DexpFunctor earthRotation(earthRotationTangent);
@@ -408,15 +411,10 @@ Vector9 NavState::correctPIM(const Vector9& pim, double dt,
       + dt22 * b_gravity;
   dV(xi) = dV(pim) + dt * b_gravity;
 
-  if (omegaCoriolis) {
-    xi += coriolis(dt, *omegaCoriolis, use2ndOrderCoriolis, H1);
-  }
-
   if (H1 || H2 || H3) {
     if (H1) {
       const Matrix3 Ri = nRb.matrix();
-      if (!omegaCoriolis)
-        H1->setZero(); // if coriolis H1 is already initialized
+      H1->setZero();
       D_t_R(H1) += dt * D_dP_Ri1 + dt22 * D_dP_Ri2;
       D_t_v(H1) += dt * D_dP_nv * Ri;
       D_v_R(H1) += dt * D_dP_Ri2;

--- a/gtsam/navigation/NavState.cpp
+++ b/gtsam/navigation/NavState.cpp
@@ -18,6 +18,7 @@
 
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/geometry/Kernel.h>
+#include <gtsam/geometry/SO3.h>
 #include <gtsam/navigation/NavState.h>
 
 #include <string>
@@ -299,6 +300,97 @@ Vector9 NavState::correctPIM(const Vector9& pim, double dt,
     const Vector3& n_gravity, const std::optional<Vector3>& omegaCoriolis,
     bool use2ndOrderCoriolis, OptionalJacobian<9, 9> H1,
     OptionalJacobian<9, 9> H2, OptionalJacobian<9, 3> H3) const {
+  if (omegaCoriolis && !omegaCoriolis->isZero()) {
+    const Vector3& omega = *omegaCoriolis;
+    const Vector3 earthRotationTangent = -omega * dt;
+    const so3::DexpFunctor earthRotation(earthRotationTangent);
+    const Matrix3 gammaRotation = earthRotation.Rodrigues().left();
+    const Matrix3 gammaVelocity = earthRotation.Jacobian().left();
+    // Brossard's Gamma^p integrates Gamma^v - Omega x Gamma^p. In
+    // GTSAM's kernel convention this is J_l(w) - Gamma_2,l(w), not
+    // Gamma_2,l(w) alone.
+    const Matrix3 gammaPosition = gammaVelocity - earthRotation.Gamma().left();
+    const Matrix3 initialRotation = R_.matrix();
+    const Point3 initialPosition = position();
+    const Velocity3 initialVelocity = velocity();
+    Matrix3 deltaRotation_H_pimRotation;
+    const Rot3 deltaRotation =
+        Rot3::Expmap(dR(pim), H2 ? &deltaRotation_H_pimRotation : nullptr);
+    const Matrix3 omegaCross = skewSymmetric(omega);
+
+    const Rot3 predictedRotation(gammaRotation * initialRotation *
+                                 deltaRotation.matrix());
+    const Point3 predictedPosition =
+        gammaPosition * n_gravity * (dt * dt) +
+        gammaRotation * (initialPosition +
+                         (initialVelocity + omegaCross * initialPosition) * dt +
+                         initialRotation * dP(pim));
+    const Velocity3 predictedVelocity =
+        gammaVelocity * n_gravity * dt +
+        gammaRotation * (initialVelocity + omegaCross * initialPosition +
+                         initialRotation * dV(pim)) -
+        omegaCross * predictedPosition;
+    const NavState predicted(predictedRotation, predictedPosition,
+                             predictedVelocity);
+
+    Matrix9 predicted_H_state, predicted_H_pim;
+    Matrix93 predicted_H_gravity;
+    const bool computeJacobians = H1 || H2 || H3;
+    if (computeJacobians) {
+      predicted_H_state.setZero();
+      predicted_H_pim.setZero();
+      predicted_H_gravity.setZero();
+
+      const Matrix3 finalRotationTranspose = predictedRotation.transpose();
+      const Matrix3 initialToFinal =
+          finalRotationTranspose * gammaRotation * initialRotation;
+      const Matrix3 navToFinal = finalRotationTranspose * gammaRotation;
+      const Vector3 pimPositionNav = initialRotation * dP(pim);
+      const Vector3 pimVelocityNav = initialRotation * dV(pim);
+
+      D_R_R(&predicted_H_state) = deltaRotation.transpose();
+      D_t_R(&predicted_H_state) =
+          finalRotationTranspose * gammaRotation *
+          (-skewSymmetric(pimPositionNav) * initialRotation);
+      D_t_t(&predicted_H_state) =
+          navToFinal * (I_3x3 + omegaCross * dt) * initialRotation;
+      D_t_v(&predicted_H_state) = navToFinal * initialRotation * dt;
+      D_v_R(&predicted_H_state) =
+          finalRotationTranspose *
+          (gammaRotation * (-skewSymmetric(pimVelocityNav) * initialRotation) -
+           omegaCross * gammaRotation *
+               (-skewSymmetric(pimPositionNav) * initialRotation));
+      D_v_t(&predicted_H_state) =
+          finalRotationTranspose *
+          ((gammaRotation * omegaCross -
+            omegaCross * gammaRotation * (I_3x3 + omegaCross * dt)) *
+           initialRotation);
+      D_v_v(&predicted_H_state) =
+          finalRotationTranspose *
+          ((gammaRotation - omegaCross * gammaRotation * dt) * initialRotation);
+
+      D_R_R(&predicted_H_pim) = deltaRotation_H_pimRotation;
+      D_t_t(&predicted_H_pim) = initialToFinal;
+      D_v_v(&predicted_H_pim) = initialToFinal;
+      D_v_t(&predicted_H_pim) = -finalRotationTranspose * omegaCross *
+                                gammaRotation * initialRotation;
+
+      predicted_H_gravity.block<3, 3>(3, 0) =
+          finalRotationTranspose * gammaPosition * (dt * dt);
+      predicted_H_gravity.block<3, 3>(6, 0) =
+          finalRotationTranspose *
+          (gammaVelocity * dt - omegaCross * gammaPosition * (dt * dt));
+    }
+
+    Matrix9 chart_H_initial, chart_H_predicted;
+    const Vector9 result =
+        localCoordinates(predicted, H1 ? &chart_H_initial : nullptr,
+                         computeJacobians ? &chart_H_predicted : nullptr);
+    if (H1) *H1 = chart_H_initial + chart_H_predicted * predicted_H_state;
+    if (H2) *H2 = chart_H_predicted * predicted_H_pim;
+    if (H3) *H3 = chart_H_predicted * predicted_H_gravity;
+    return result;
+  }
   const Rot3& nRb = R_;
   const Velocity3 n_v = t_.col(1); // derivative is Ri !
   const double dt22 = 0.5 * dt * dt;

--- a/gtsam/navigation/NavState.h
+++ b/gtsam/navigation/NavState.h
@@ -230,13 +230,15 @@ public:
                   OptionalJacobian<9, 3> G1 = {},
                   OptionalJacobian<9, 3> G2 = {}) const;
 
-  /// Compute tangent space contribution due to Coriolis forces
+  /// Compute the legacy approximate tangent-space Coriolis contribution.
+  [[deprecated("Use correctPIM with omegaCoriolis for exact prediction")]]
   Vector9 coriolis(double dt, const Vector3& omega, bool secondOrder = false,
-      OptionalJacobian<9, 9> H = {}) const;
+                   OptionalJacobian<9, 9> H = {}) const;
 
-  /// Correct a preintegrated tangent vector using the initial state and gravity.
-  /// If omegaCoriolis is present and nonzero, uses the exact rotating-frame
-  /// transition of Brossard et al.; otherwise preserves the inertial fast path.
+  /// Correct a preintegrated tangent vector using the initial state and
+  /// gravity. If omegaCoriolis is present and nonzero, uses the exact
+  /// rotating-frame transition of Brossard et al.; otherwise preserves the
+  /// inertial fast path.
   Vector9 correctPIM(const Vector9& pim, double dt, const Vector3& n_gravity,
       const std::optional<Vector3>& omegaCoriolis, bool use2ndOrderCoriolis =
           false, OptionalJacobian<9, 9> H1 = {},

--- a/gtsam/navigation/NavState.h
+++ b/gtsam/navigation/NavState.h
@@ -234,8 +234,9 @@ public:
   Vector9 coriolis(double dt, const Vector3& omega, bool secondOrder = false,
       OptionalJacobian<9, 9> H = {}) const;
 
-  /// Correct preintegrated tangent vector with our velocity and rotated gravity,
-  /// taking into account Coriolis forces if omegaCoriolis is given.
+  /// Correct a preintegrated tangent vector using the initial state and gravity.
+  /// If omegaCoriolis is present and nonzero, uses the exact rotating-frame
+  /// transition of Brossard et al.; otherwise preserves the inertial fast path.
   Vector9 correctPIM(const Vector9& pim, double dt, const Vector3& n_gravity,
       const std::optional<Vector3>& omegaCoriolis, bool use2ndOrderCoriolis =
           false, OptionalJacobian<9, 9> H1 = {},

--- a/gtsam/navigation/PreintegratedRotation.h
+++ b/gtsam/navigation/PreintegratedRotation.h
@@ -102,7 +102,9 @@ struct GTSAM_EXPORT PreintegratedRotationParams {
   /// Continuous-time "Covariance" of gyroscope measurements
   /// The units for stddev are σ = rad/s/√Hz
   Matrix3 gyroscopeCovariance;
-  std::optional<Vector3> omegaCoriolis;  ///< Coriolis constant
+  /// Navigation-frame angular velocity in radians per second. When present,
+  /// prediction uses the exact rotating-frame transition.
+  std::optional<Vector3> omegaCoriolis;
   std::optional<Pose3> body_P_sensor;    ///< The pose of the sensor in the body frame
 
   PreintegratedRotationParams() : gyroscopeCovariance(I_3x3) {}
@@ -233,7 +235,8 @@ class GTSAM_EXPORT PreintegratedRotation {
   Rot3 biascorrectedDeltaRij(const Vector3& biasOmegaIncr,
                              OptionalJacobian<3, 3> H = {}) const;
 
-  /// Integrate coriolis correction in body frame Ri
+  /// Legacy first-order Coriolis correction in body frame Ri.
+  [[deprecated("Use exact prediction with omegaCoriolis instead")]]
   Vector3 integrateCoriolis(const Rot3& Ri,
                             OptionalJacobian<3, 3> H = {}) const;
 

--- a/gtsam/navigation/PreintegrationParams.cpp
+++ b/gtsam/navigation/PreintegrationParams.cpp
@@ -30,10 +30,8 @@ void PreintegrationParams::print(const string& s) const {
   PreintegratedRotationParams::print(s);
   cout << "accelerometerCovariance:\n[\n" << accelerometerCovariance << "\n]"
        << endl;
-  cout << "integrationCovariance:\n[\n" << integrationCovariance << "\n]"
-       << endl;
-  if (omegaCoriolis && use2ndOrderCoriolis)
-    cout << "Using 2nd-order Coriolis" << endl;
+  cout << "integrationCovariance:\n[\n"
+       << integrationCovariance << "\n]" << endl;
   cout << "n_gravity = (" << n_gravity.transpose() << ")" << endl;
 }
 
@@ -42,7 +40,6 @@ bool PreintegrationParams::equals(const PreintegratedRotationParams& other,
                                   double tol) const {
   auto e = dynamic_cast<const PreintegrationParams*>(&other);
   return e != nullptr && PreintegratedRotationParams::equals(other, tol) &&
-         use2ndOrderCoriolis == e->use2ndOrderCoriolis &&
          equal_with_abs_tol(accelerometerCovariance, e->accelerometerCovariance,
                             tol) &&
          equal_with_abs_tol(integrationCovariance, e->integrationCovariance,

--- a/gtsam/navigation/PreintegrationParams.h
+++ b/gtsam/navigation/PreintegrationParams.h
@@ -28,7 +28,9 @@ struct GTSAM_EXPORT PreintegrationParams: PreintegratedRotationParams {
   /// The units for stddev are σ = m/s²/√Hz
   Matrix3 accelerometerCovariance;
   Matrix3 integrationCovariance; ///< continuous-time "Covariance" describing integration uncertainty
-  bool use2ndOrderCoriolis; ///< Whether to use second order Coriolis integration
+  /// Retained only for source and archive compatibility. Exact rotating-Earth
+  /// dynamics are used whenever omegaCoriolis is set, regardless of this flag.
+  bool use2ndOrderCoriolis;
   Vector3 n_gravity; ///< Gravity vector in nav frame
 
   /// Default constructor for serialization only
@@ -63,12 +65,18 @@ struct GTSAM_EXPORT PreintegrationParams: PreintegratedRotationParams {
 
   void setAccelerometerCovariance(const Matrix3& cov) { accelerometerCovariance = cov; }
   void setIntegrationCovariance(const Matrix3& cov)   { integrationCovariance = cov; }
-  void setUse2ndOrderCoriolis(bool flag)              { use2ndOrderCoriolis = flag; }
+  [[deprecated("Exact rotating-Earth dynamics ignore this compatibility flag")]]
+  void setUse2ndOrderCoriolis(bool flag) {
+    use2ndOrderCoriolis = flag;
+  }
 
   const Matrix3& getAccelerometerCovariance() const { return accelerometerCovariance; }
   const Matrix3& getIntegrationCovariance()   const { return integrationCovariance; }
   const Vector3& getGravity()   const { return n_gravity; }
-  bool           getUse2ndOrderCoriolis()     const { return use2ndOrderCoriolis; }
+  [[deprecated("Exact rotating-Earth dynamics ignore this compatibility flag")]]
+  bool getUse2ndOrderCoriolis() const {
+    return use2ndOrderCoriolis;
+  }
 
 protected:
 

--- a/gtsam/navigation/doc/AHRSFactor.ipynb
+++ b/gtsam/navigation/doc/AHRSFactor.ipynb
@@ -70,7 +70,7 @@
         "e = \\text{Log}\\left(\\hat{R}_j^T R_j\\right) = \\text{Log}\\left((\\Delta \\tilde{R}_{ij}(b_g))^T R_i^T R_j\\right)\n",
         "$$\n",
         "\n",
-        "Note: the reality is a bit more complicated, because the code also takes into account the effects of bias correction Jacobians, and if desired, coriolis forces."
+        "Note: the implementation also accounts for bias-correction Jacobians and, when `omegaCoriolis` is set, the exact rotating-frame attitude transition."
       ]
     },
     {

--- a/gtsam/navigation/doc/PreintegratedRotation.ipynb
+++ b/gtsam/navigation/doc/PreintegratedRotation.ipynb
@@ -102,7 +102,7 @@
         "| Parameter | Description |\n",
         "|-----------|-------------|\n",
         "| `gyroscopeCovariance` | 3×3 continuous-time noise covariance matrix of gyroscope measurements (units: rad²/s²/Hz) |\n",
-        "| `omegaCoriolis` | Optional Coriolis acceleration compensation vector (for earth rotation effects) |\n",
+        "| `omegaCoriolis` | Optional navigation-frame angular velocity in rad/s; enables exact rotating-Earth prediction |\n",
         "| `body_P_sensor` | Optional pose transformation between the IMU sensor frame and body frame |\n",
         "\n",
         "The covariance matrix represents the uncertainty in angular velocity measurements, which propagates into orientation uncertainty during integration. When the IMU is not located at the center of the body frame, the optional body-to-sensor transformation allows for proper handling of lever-arm effects.\n",

--- a/gtsam/navigation/doc/PreintegrationParams.ipynb
+++ b/gtsam/navigation/doc/PreintegrationParams.ipynb
@@ -60,7 +60,7 @@
         "\n",
         "- **`accelerometerCovariance`**: A 3x3 matrix representing the continuous-time noise covariance of the accelerometer. Units: (m/s²)²/Hz.\n",
         "- **`integrationCovariance`**: A 3x3 matrix representing additional uncertainty introduced during the numerical integration process itself (often set to zero). Units: (m²/s⁶)/Hz ? (Consult documentation for precise interpretation).\n",
-        "- **`use2ndOrderCoriolis`**: A boolean flag. If true, enables a more accurate (second-order) correction for Coriolis effects, which arise from the Earth's rotation.\n",
+        "- **`use2ndOrderCoriolis`**: A deprecated compatibility flag retained in serialized archives. It is ignored; whenever `omegaCoriolis` is set, prediction uses the exact rotating-Earth transition.\n",
         "- **`n_gravity`**: A 3D vector specifying the direction and magnitude of gravity in the navigation frame (e.g., [0, 0, -9.81] for ENU, [0, 0, 9.81] for NED). Units: m/s²."
       ]
     },

--- a/gtsam/navigation/navigation.md
+++ b/gtsam/navigation/navigation.md
@@ -241,5 +241,27 @@ The key components are:
   `LieGroupPreintegration` applies IMU increments with `NavState::expmap`, while
   `NavState::retract` and `localCoordinates` retain GTSAM's component-wise
   optimization chart.
+- `omegaCoriolis` is the angular velocity of the navigation frame, expressed
+  in navigation-frame coordinates in radians per second. When it is set,
+  `PreintegrationBase::predict` and AHRS prediction use the exact rotating-Earth
+  transition from Brossard, Barrau, and Bonnabel rather than an additive
+  Coriolis approximation. The covariance recursion is unchanged because Earth
+  rotation changes prediction and residual assembly, not the preintegrated IMU
+  measurement.
+- For $w=-\Omega\Delta t$, GTSAM evaluates the exact transition with stable
+  SO(3) kernels. In GTSAM's kernel conventions, Brossard's position term is
+  $\Gamma^p=(J_l(w)-\Gamma_{2,l}(w))g\Delta t^2$; using
+  `DexpFunctor::Gamma()` alone would have the wrong small-angle coefficients.
+  AHRS uses the corresponding exact attitude law
+  $R_j=\operatorname{Exp}(w)R_i\Delta R_{ij}$.
+- `use2ndOrderCoriolis` remains in `PreintegrationParams` and its serialized
+  layout for compatibility, but it is ignored: the exact model is used for
+  every nonzero `omegaCoriolis`. `NavState::coriolis` and
+  `PreintegratedRotation::integrateCoriolis` are retained as deprecated legacy
+  helpers and are no longer used internally.
+- `n_gravity` must be the gravity vector consistent with the chosen
+  navigation-frame origin. If a local frame is translated, absorb the constant
+  centrifugal contribution associated with that origin shift into
+  `n_gravity`.
 - Using the combined IMU factor is not recommended. Typically biases evolve slowly, and hence a separate, lower frequency Markov chain on the bias is more appropriate.
 - For short-duration experiments it is even recommended to use a single constant bias. Bias estimation is notoriously hard to tune/debug, and also acts as a "sink" for any modeling errors. Hence, starting with a constant bias is a good idea to get the rest of the pipeline working.

--- a/gtsam/navigation/tests/testAHRSFactor.cpp
+++ b/gtsam/navigation/tests/testAHRSFactor.cpp
@@ -472,12 +472,10 @@ TEST_AHRS(AHRSFactor, PIM_predict_and_Jacobians_with_Coriolis) {
 
   // The rotating-frame attitude law is exact, rather than an additive
   // tangent correction.
-  const Rot3 biasCorrected =
-      pim.biascorrectedDeltaRij(bias - pim.biasHat());
-  const Rot3 expected =
-      Rot3::Expmap(-omegaCoriolis * pim.deltaTij())
-          .compose(Ri)
-          .compose(biasCorrected);
+  const Rot3 biasCorrected = pim.biascorrectedDeltaRij(bias - pim.biasHat());
+  const Rot3 expected = Rot3::Expmap(-omegaCoriolis * pim.deltaTij())
+                            .compose(Ri)
+                            .compose(biasCorrected);
   EXPECT(assert_equal(expected, pim.predict(Ri, bias), 1e-12));
 
   // --- Test Jacobians ---

--- a/gtsam/navigation/tests/testAHRSFactor.cpp
+++ b/gtsam/navigation/tests/testAHRSFactor.cpp
@@ -470,6 +470,16 @@ TEST_AHRS(AHRSFactor, PIM_predict_and_Jacobians_with_Coriolis) {
   double deltaT = 0.5;
   pim.integrateMeasurement(measuredOmega, deltaT);
 
+  // The rotating-frame attitude law is exact, rather than an additive
+  // tangent correction.
+  const Rot3 biasCorrected =
+      pim.biascorrectedDeltaRij(bias - pim.biasHat());
+  const Rot3 expected =
+      Rot3::Expmap(-omegaCoriolis * pim.deltaTij())
+          .compose(Ri)
+          .compose(biasCorrected);
+  EXPECT(assert_equal(expected, pim.predict(Ri, bias), 1e-12));
+
   // --- Test Jacobians ---
   // Define a wrapper for numerical derivatives
   auto f = [&pim](const Rot3& r, const Vector3& b) { return pim.predict(r, b); };

--- a/gtsam/navigation/tests/testCombinedImuFactorWithGravity.cpp
+++ b/gtsam/navigation/tests/testCombinedImuFactorWithGravity.cpp
@@ -56,6 +56,7 @@ TEST_PIM(CombinedImuFactorWithGravity, Jacobians) {
   Vector3 v2(0.5, 0.0, 0.0);
 
   auto p = combined::Params();
+  p->omegaCoriolis = kNonZeroOmegaCoriolis;
   CombinedPIM pim(p, Bias(Vector3(0.2, 0.0, 0.0), Vector3(0.0, 0.0, 0.0)));
   const Vector3 measuredAcc =
       x1.rotation().unrotate(-p->n_gravity) + Vector3(0.2, 0.0, 0.0);

--- a/gtsam/navigation/tests/testImuFactor.cpp
+++ b/gtsam/navigation/tests/testImuFactor.cpp
@@ -60,7 +60,9 @@ static_assert(
 /* ************************************************************************* */
 TEST_PIM(ImuFactor, PreintegratedMeasurementsConstruction) {
   // Actual pre-integrated values
-  PIM actual(testing::Params());
+  auto params = testing::Params();
+  params->omegaCoriolis = kNonZeroOmegaCoriolis;
+  PIM actual(params);
   EXPECT(assert_equal(Rot3(), actual.deltaRij()));
   EXPECT(assert_equal(kZero, actual.deltaPij()));
   EXPECT(assert_equal(kZero, actual.deltaVij()));
@@ -329,7 +331,6 @@ TEST_PIM(ImuFactor, PreintegrationBaseMethods) {
   using namespace common;
   auto p = testing::Params();
   p->omegaCoriolis = Vector3(0.02, 0.03, 0.04);
-  p->use2ndOrderCoriolis = true;
 
   PIM pim(p, kZeroBiasHat);
   pim.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
@@ -528,7 +529,7 @@ TEST_PIM(ImuFactor, ErrorAndJacobianWithBiases) {
 }
 
 /* ************************************************************************* */
-TEST_PIM(ImuFactor, ErrorAndJacobianWith2ndOrderCoriolis) {
+TEST_PIM(ImuFactor, ExactCoriolisIgnoresLegacySecondOrderFlag) {
   using common::x1;
   using common::v1;
   using common::v2;
@@ -548,6 +549,14 @@ TEST_PIM(ImuFactor, ErrorAndJacobianWith2ndOrderCoriolis) {
 
   PIM pim(p, Bias(Vector3(0.2, 0.0, 0.0), Vector3(0.0, 0.0, 0.1)));
   pim.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
+
+  auto pWithoutLegacyFlag = testing::Params();
+  pWithoutLegacyFlag->omegaCoriolis = kNonZeroOmegaCoriolis;
+  PIM pimWithoutLegacyFlag(
+      pWithoutLegacyFlag, Bias(Vector3(0.2, 0.0, 0.0), Vector3(0.0, 0.0, 0.1)));
+  pimWithoutLegacyFlag.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
+  EXPECT(assert_equal(pimWithoutLegacyFlag.predict(NavState(x1, v1), bias),
+                      pim.predict(NavState(x1, v1), bias), 1e-12));
 
   // Create factor
   ImuFactorT<PIM> factor(X(1), V(1), X(2), V(2), B(1), pim);

--- a/gtsam/navigation/tests/testImuFactorWithGravity.cpp
+++ b/gtsam/navigation/tests/testImuFactorWithGravity.cpp
@@ -52,7 +52,9 @@ static const Vector3 v2(Vector3(0.5, 0.0, 0.0));
 TEST_PIM(ImuFactorWithGravity, DirectionJacobians) {
   using namespace common;
   using symbol_shorthand::G;
-  PIM pim(testing::Params());
+  auto params = testing::Params();
+  params->omegaCoriolis = kNonZeroOmegaCoriolis;
+  PIM pim(params);
   pim.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
 
   ImuFactorWithGravityT<PIM, Unit3> factor(X(1), V(1), X(2), V(2), B(1), G(0),
@@ -88,7 +90,9 @@ TEST_PIM(ImuFactorWithGravity, DirectionJacobians) {
 TEST_PIM(ImuFactorWithGravity, VectorJacobians) {
   using namespace common;
   using symbol_shorthand::G;
-  PIM pim(testing::Params());
+  auto params = testing::Params();
+  params->omegaCoriolis = kNonZeroOmegaCoriolis;
+  PIM pim(params);
   pim.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
 
   ImuFactorWithGravityT<PIM, Point3> factor(X(1), V(1), X(2), V(2), B(1), G(0),

--- a/gtsam/navigation/tests/testNavState.cpp
+++ b/gtsam/navigation/tests/testNavState.cpp
@@ -352,6 +352,14 @@ TEST(NavState, interpolate) {
 
 /* ************************************************************************* */
 static const double dt = 2.0;
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 auto coriolis = std::bind(&NavState::coriolis, std::placeholders::_1, dt, kOmegaCoriolis,
               std::placeholders::_2, nullptr);
 
@@ -602,6 +610,12 @@ TEST(NavState, ExactRotatingEarthLongDurationReference) {
 
 }  // namespace rotating_earth_fixture
 /* ************************************************************************* */
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 /* ************************************************************************* */
 TEST(NavState, Stream)

--- a/gtsam/navigation/tests/testNavState.cpp
+++ b/gtsam/navigation/tests/testNavState.cpp
@@ -23,6 +23,7 @@
 #include <gtsam/base/lieProxies.h>
 #include <gtsam/base/numericalDerivative.h>
 #include <gtsam/base/testLie.h>
+#include <gtsam/geometry/SO3.h>
 #include <gtsam/navigation/NavState.h>
 
 #include <cmath>
@@ -470,6 +471,137 @@ TEST(NavState, CorrectPIM) {
       numericalDerivative11<Vector9, Vector3>(correctPIMNoCoriolis, kGravity),
       Matrix(aH3NoCoriolis)));
 }
+
+/* ************************************************************************* */
+namespace rotating_earth_fixture {
+
+NavState predict(const NavState& initial, const Vector9& pim, double dt,
+                 const Vector3& gravity, const Vector3& omega,
+                 bool useSecondOrder = false) {
+  return initial.retract(
+      initial.correctPIM(pim, dt, gravity, omega, useSecondOrder));
+}
+
+NavState exactEquation(const NavState& initial, const Vector9& pim, double dt,
+                       const Vector3& gravity, const Vector3& omega) {
+  const so3::DexpFunctor earthRotation(-omega * dt);
+  const Matrix3 gammaRotation = earthRotation.Rodrigues().left();
+  const Matrix3 gammaVelocity = earthRotation.Jacobian().left();
+  const Matrix3 gammaPosition = gammaVelocity - earthRotation.Gamma().left();
+  const Matrix3 initialRotation = initial.R();
+  const Matrix3 omegaCross = skewSymmetric(omega);
+  const Point3 position =
+      gammaPosition * gravity * (dt * dt) +
+      gammaRotation *
+          (initial.position() +
+           (initial.velocity() + omegaCross * initial.position()) * dt +
+           initialRotation * NavState::dP(pim));
+  const Velocity3 velocity =
+      gammaVelocity * gravity * dt +
+      gammaRotation * (initial.velocity() + omegaCross * initial.position() +
+                       initialRotation * NavState::dV(pim)) -
+      omegaCross * position;
+  const Rot3 rotation(gammaRotation * initialRotation *
+                      Rot3::Expmap(NavState::dR(pim)).matrix());
+  return NavState(rotation, position, velocity);
+}
+
+struct PositionVelocity {
+  Point3 position;
+  Velocity3 velocity;
+};
+
+PositionVelocity derivative(const PositionVelocity& state,
+                            const Vector3& gravity, const Vector3& omega) {
+  return {state.velocity, gravity - 2.0 * omega.cross(state.velocity) -
+                              omega.cross(omega.cross(state.position))};
+}
+
+PositionVelocity addScaled(const PositionVelocity& state,
+                           const PositionVelocity& increment, double scale) {
+  return {state.position + scale * increment.position,
+          state.velocity + scale * increment.velocity};
+}
+
+NavState integrateReference(const NavState& initial, double duration,
+                            const Vector3& gravity, const Vector3& omega) {
+  constexpr double kStep = 1e-3;
+  const size_t steps = static_cast<size_t>(std::round(duration / kStep));
+  const double step = duration / static_cast<double>(steps);
+  PositionVelocity state{initial.position(), initial.velocity()};
+  for (size_t index = 0; index < steps; ++index) {
+    const PositionVelocity k1 = derivative(state, gravity, omega);
+    const PositionVelocity k2 =
+        derivative(addScaled(state, k1, 0.5 * step), gravity, omega);
+    const PositionVelocity k3 =
+        derivative(addScaled(state, k2, 0.5 * step), gravity, omega);
+    const PositionVelocity k4 =
+        derivative(addScaled(state, k3, step), gravity, omega);
+    state.position += (step / 6.0) * (k1.position + 2.0 * k2.position +
+                                      2.0 * k3.position + k4.position);
+    state.velocity += (step / 6.0) * (k1.velocity + 2.0 * k2.velocity +
+                                      2.0 * k3.velocity + k4.velocity);
+  }
+  return NavState(Rot3::Expmap(-omega * duration).compose(initial.attitude()),
+                  state.position, state.velocity);
+}
+
+// Verifies Brossard's exact transition for arbitrary state and PIM values.
+TEST(NavState, ExactRotatingEarthEquation) {
+  const NavState initial(Rot3::Ypr(0.4, -0.3, 0.2), Point3(120.0, -35.0, 18.0),
+                         Vector3(12.0, -4.0, 2.0));
+  const Vector9 pim{0.08, -0.04, 0.03, 1.2, -0.7, 0.4, 0.5, -0.2, 0.1};
+  const Vector3 gravity{0.2, -0.1, 9.78};
+  const Vector3 omega{0.002, -0.003, 0.004};
+  EXPECT(assert_equal(exactEquation(initial, pim, 2.5, gravity, omega),
+                      predict(initial, pim, 2.5, gravity, omega), 1e-12));
+}
+
+// Verifies the legacy second-order flag no longer changes rotating prediction.
+TEST(NavState, ExactRotatingEarthIgnoresSecondOrderFlag) {
+  const Vector9 pim{0.08, -0.04, 0.03, 1.2, -0.7, 0.4, 0.5, -0.2, 0.1};
+  EXPECT(assert_equal(
+      predict(kState1, pim, 2.5, kGravity, kOmegaCoriolis),
+      predict(kState1, pim, 2.5, kGravity, kOmegaCoriolis, true), 1e-12));
+}
+
+// Verifies absent and exactly zero Earth rates recover the fast inertial path.
+TEST(NavState, ExactRotatingEarthZeroLimit) {
+  const Vector9 pim{0.08, -0.04, 0.03, 1.2, -0.7, 0.4, 0.5, -0.2, 0.1};
+  const NavState noRotation =
+      kState1.retract(kState1.correctPIM(pim, 2.5, kGravity, {}));
+  EXPECT(assert_equal(noRotation,
+                      predict(kState1, pim, 2.5, kGravity, Vector3::Zero()),
+                      1e-12));
+}
+
+// Verifies the exact transition against an independent long-duration RK4 solve.
+TEST(NavState, ExactRotatingEarthLongDurationReference) {
+  const NavState initial(Rot3::Ypr(0.4, -0.3, 0.2), Point3(120.0, -35.0, 18.0),
+                         Vector3(12.0, -4.0, 2.0));
+  const Vector3 gravity{0.2, -0.1, 9.78};
+  const Vector3 omega{0.01, -0.006, 0.008};
+  constexpr double kDuration = 50.0;
+  const NavState reference =
+      integrateReference(initial, kDuration, gravity, omega);
+  const NavState exact =
+      predict(initial, Vector9::Zero(), kDuration, gravity, omega);
+
+  const Vector9 inertial =
+      initial.correctPIM(Vector9::Zero(), kDuration, gravity, {});
+  const NavState approximate =
+      initial.retract(inertial + initial.coriolis(kDuration, omega, true));
+  const double exactError = (exact.position() - reference.position()).norm() +
+                            (exact.velocity() - reference.velocity()).norm();
+  const double approximateError =
+      (approximate.position() - reference.position()).norm() +
+      (approximate.velocity() - reference.velocity()).norm();
+  EXPECT(exactError < 1e-8);
+  EXPECT(approximateError > 1e-2);
+}
+
+}  // namespace rotating_earth_fixture
+/* ************************************************************************* */
 
 /* ************************************************************************* */
 TEST(NavState, Stream)

--- a/gtsam/navigation/tests/testSerializationNavigation.cpp
+++ b/gtsam/navigation/tests/testSerializationNavigation.cpp
@@ -55,6 +55,21 @@ BOOST_CLASS_EXPORT_GUID(PreintegratedCombinedMeasurements,
                         "gtsam_PreintegratedCombinedMeasurements")
 
 /* ************************************************************************* */
+TEST(PreintegrationParams, LegacySecondOrderFlagSerialization) {
+  PreintegrationParams input(Vector3(0.1, -0.2, -9.8));
+  input.omegaCoriolis = Vector3(1e-5, -2e-5, 7e-5);
+  input.use2ndOrderCoriolis = true;
+
+  PreintegrationParams output;
+  roundtrip(input, output);
+  EXPECT(output.use2ndOrderCoriolis);
+
+  PreintegrationParams semanticallyEquivalent = input;
+  semanticallyEquivalent.use2ndOrderCoriolis = false;
+  EXPECT(input.equals(semanticallyEquivalent, 1e-9));
+}
+
+/* ************************************************************************* */
 TEST(AHRSFactor, Serialization) {
   auto params = std::make_shared<PreintegratedRotationParams>();
   params->gyroscopeCovariance = 1e-8 * I_3x3;


### PR DESCRIPTION
## Summary

This is the rotating-Earth half of the replacement for #1916. It is intentionally stacked on #2687; after #2687 merges, this PR should be rebased and retargeted to `develop`.

- replaces the additive Coriolis/centrifugal approximation with the exact rotating-frame transition from Brossard, Barrau, and Bonnabel;
- applies the transition centrally through `NavState::correctPIM`, so manifold, tangent, Lie-group, standard, combined, and gravity-aware IMU factors share it;
- applies the exact attitude law to AHRS prediction;
- retains the existing no-`omegaCoriolis` fast path and covariance propagation;
- keeps `use2ndOrderCoriolis` in the serialized layout for compatibility while making it behaviorally inert;
- deprecates, but does not remove, the old approximate helper APIs.

## Exact transition

For `w = -omegaCoriolis * deltaT`, the implementation uses `so3::DexpFunctor` for stable zero- and small-rate behavior. One convention detail is important: Brossard's position kernel is

```
GammaP = J_l(w) - Gamma_2,l(w)
```

in GTSAM's kernel naming, not `DexpFunctor::Gamma()` by itself. This follows directly from the paper's equation (84) and gives the required small-angle coefficients `1/2, 1/3, 1/8, ...`. It also agrees with an independent long-duration RK4 integration of the rotating-frame ODE.

The predicted state is converted back through the retained `NavState` optimization chart, with analytic Jacobians with respect to the initial state, preintegrated delta/bias, and gravity.

## Compatibility

- `omegaCoriolis` remains the public/serialized name and is documented as the navigation-frame angular velocity in rad/s.
- `use2ndOrderCoriolis` remains serialized, but no longer affects prediction, semantic equality, or printed configuration.
- `NavState::coriolis` and `PreintegratedRotation::integrateCoriolis` remain callable and are marked deprecated; internal prediction no longer uses them.
- A translated local navigation-frame origin must absorb its constant centrifugal contribution into `n_gravity`.

## Validation

- full navigation suite with tangent default: 35/35 passed;
- full navigation suite with Lie default: 35/35 passed;
- Lie-default Python wrapper suite: 435 passed, 6 skipped;
- exact equation and analytic Jacobians checked numerically for arbitrary state, PIM, bias, and gravity;
- nonzero Earth-rate coverage for `ImuFactor`, `ImuFactor2`, combined, gravity-direction, gravity-vector, AHRS, and all three preintegration backends;
- null and exactly zero Earth-rate recovery, legacy-flag equivalence, serialization round-trip, and independent 50-second RK4 reference;
- changed-lines clang-format and `git diff --check` clean.

Reference: M. Brossard, A. Barrau, P. Chauchat, and S. Bonnabel,
"Associating Uncertainty to Extended Poses for on Lie Group IMU
Preintegration with Rotating Earth," [arXiv:2007.14097](https://arxiv.org/abs/2007.14097).

Supersedes the rotating-Earth portion of #1916. The NavState Lie-group preintegration portion is handled separately by #2687.
