### PR TITLE
Improve batch-factor and LM optimization hot paths

### DIFF
--- a/gtsam/linear/BatchJacobianFactor.h
+++ b/gtsam/linear/BatchJacobianFactor.h
@@ -513,8 +513,9 @@ class BatchJacobianFactor : public BatchJacobianFactorBase {
       const auto& A = std::get<I>(blocks_)[rowIndex];
       const RhsVector& b = rhs_[rowIndex];
       if (weights) {
-        updateOffDiagonalNormalized(
-            targetI, targetJ, A.transpose() * weights->asDiagonal() * b, info);
+        const RhsVector weightedRhs = weights->asDiagonal() * b;
+        updateOffDiagonalNormalized(targetI, targetJ,
+                                    A.transpose() * weightedRhs, info);
       } else {
         updateOffDiagonalNormalized(targetI, targetJ, A.transpose() * b, info);
       }
@@ -635,6 +636,40 @@ class BatchJacobianFactor : public BatchJacobianFactorBase {
     (multiplyRowBlock<Slots>(rowIndex, scalarOffsets, x, residual), ...);
   }
 
+  /// Add one compact block times its keyed value to a row residual.
+  template <size_t Slot>
+  void addVectorValuesRowBlock(size_t rowIndex, const VectorValues& values,
+                               RhsVector* residual) const {
+    const size_t keySlot = static_cast<size_t>(rowSlots_[rowIndex][Slot]);
+    residual->noalias() +=
+        std::get<Slot>(blocks_)[rowIndex] * values.at(keys_[keySlot]);
+  }
+
+  /// Add every compact block times its keyed value to a row residual.
+  template <size_t... Slots>
+  void addVectorValuesRowBlocks(size_t rowIndex, const VectorValues& values,
+                                RhsVector* residual,
+                                std::index_sequence<Slots...>) const {
+    (addVectorValuesRowBlock<Slots>(rowIndex, values, residual), ...);
+  }
+
+  /// Add one compact block's column squared norms to a keyed diagonal.
+  template <size_t Slot>
+  void hessianDiagonalVectorRowAdd(size_t rowIndex,
+                                   VectorValues* diagonal) const {
+    const size_t keySlot = static_cast<size_t>(rowSlots_[rowIndex][Slot]);
+    const auto& block = std::get<Slot>(blocks_)[rowIndex];
+    diagonal->at(keys_[keySlot]).array() +=
+        block.array().square().colwise().sum().transpose();
+  }
+
+  /// Add every compact block's column squared norms to keyed diagonals.
+  template <size_t... Slots>
+  void hessianDiagonalVectorRowAdds(size_t rowIndex, VectorValues* diagonal,
+                                    std::index_sequence<Slots...>) const {
+    (hessianDiagonalVectorRowAdd<Slots>(rowIndex, diagonal), ...);
+  }
+
   /// Scatter one transposed compact block product into a flat vector.
   template <size_t Slot>
   void transposeRowBlockAdd(size_t rowIndex,
@@ -735,6 +770,18 @@ class BatchJacobianFactor : public BatchJacobianFactorBase {
     rhs_.push_back(fixedRhs);
   }
 
+  /** Add one row to a unary compact batch without dynamic block containers. */
+  void addUnaryRow(
+      DenseIndex keySlot,
+      const typename std::tuple_element<0, Blocks>::type::value_type& block,
+      const RhsVector& rhs) {
+    static_assert(NumSlots == 1,
+                  "BatchJacobianFactor::addUnaryRow requires one slot.");
+    rowSlots_.push_back(SlotIndices{keySlot});
+    std::get<0>(blocks_).push_back(block);
+    rhs_.push_back(rhs);
+  }
+
   /// Return the number of scalar rows represented by all row groups.
   size_t rows() const override { return rhs_.size() * ErrorDim; }
 
@@ -748,6 +795,58 @@ class BatchJacobianFactor : public BatchJacobianFactorBase {
 
   /// Return the compact key slot used by each row group and factor slot.
   const std::vector<SlotIndices>& rowSlots() const { return rowSlots_; }
+
+  /// Return one fixed-size Jacobian block from a compact row group.
+  template <size_t Slot>
+  const typename std::tuple_element<Slot, Blocks>::type::value_type& block(
+      size_t rowIndex) const {
+    static_assert(Slot < NumSlots, "BatchJacobianFactor block slot is invalid.");
+    return std::get<Slot>(blocks_).at(rowIndex);
+  }
+
+  /// Return the right-hand side for one compact row group.
+  const RhsVector& rowRhs(size_t rowIndex) const {
+    return rhs_.at(rowIndex);
+  }
+
+  /** Evaluate the linear-model error change directly from compact rows. */
+  double deltaError(const VectorValues& values, double* oldError = nullptr,
+                    double* newError = nullptr) const override {
+    if (model_ && !model_->isUnit()) {
+      return Base::deltaError(values, oldError, newError);
+    }
+
+    double oldValue = 0.0;
+    double newValue = 0.0;
+    for (size_t row = 0; row < rowSlots_.size(); ++row) {
+      const RhsVector& rhs = rhs_[row];
+      RhsVector residual = -rhs;
+      addVectorValuesRowBlocks(row, values, &residual,
+                               std::make_index_sequence<NumSlots>{});
+      oldValue += 0.5 * rhs.squaredNorm();
+      newValue += 0.5 * residual.squaredNorm();
+    }
+    if (oldError) *oldError = oldValue;
+    if (newError) *newError = newValue;
+    return oldValue - newValue;
+  }
+
+  /** Accumulate the Hessian scalar diagonal directly from compact rows. */
+  void hessianDiagonalAdd(VectorValues& diagonal) const override {
+    if (model_ && !model_->isUnit()) {
+      Base::hessianDiagonalAdd(diagonal);
+      return;
+    }
+    for (size_t position = 0; position < keys_.size(); ++position) {
+      auto [entry, inserted] =
+          diagonal.emplace(keys_[position], keyDims_[position]);
+      if (inserted) entry->second.setZero();
+    }
+    for (size_t row = 0; row < rowSlots_.size(); ++row) {
+      hessianDiagonalVectorRowAdds(row, &diagonal,
+                                   std::make_index_sequence<NumSlots>{});
+    }
+  }
 
   /** Add `alpha*A.transpose()*W*A*x` directly to a flat output vector. */
   void multiplyHessianAdd(double alpha,

--- a/gtsam/linear/GaussianFactorGraph.cpp
+++ b/gtsam/linear/GaussianFactorGraph.cpp
@@ -58,6 +58,7 @@ namespace gtsam {
   std::map<Key, size_t> GaussianFactorGraph::getKeyDimMap() const {
     map<Key, size_t> spec;
     for (const GaussianFactor::shared_ptr& gf : *this) {
+      if (!gf) continue;
       for (GaussianFactor::const_iterator it = gf->begin(); it != gf->end(); it++) {
         map<Key,size_t>::iterator it2 = spec.find(*it);
         if ( it2 == spec.end() ) {

--- a/gtsam/linear/tests/testBatchJacobianFactor.cpp
+++ b/gtsam/linear/tests/testBatchJacobianFactor.cpp
@@ -285,6 +285,46 @@ TEST(BatchJacobianFactor, FlatHessianBlockDiagonal) {
   }
 }
 
+// Verifies weighted compact error and diagonal operations preserve the dense
+// compatibility semantics.
+TEST(BatchJacobianFactor, WeightedErrorAndDiagonalUseDenseFallback) {
+  const Factor factor = createWeightedFactor();
+  VectorValues values;
+  values.emplace(0, Vector2{{0.2, -0.4}});
+  values.emplace(1, Vector2{{0.7, 0.1}});
+  values.emplace(2, Vector3{{-0.3, 0.6, 0.9}});
+
+  double actualOld = 0.0, actualNew = 0.0;
+  double expectedOld = 0.0, expectedNew = 0.0;
+  const double actual = factor.deltaError(values, &actualOld, &actualNew);
+  const JacobianFactor dense = factor.toJacobianFactor();
+  const double expected =
+      dense.deltaError(values, &expectedOld, &expectedNew);
+  EXPECT_DOUBLES_EQUAL(expectedOld, actualOld, 1e-12);
+  EXPECT_DOUBLES_EQUAL(expectedNew, actualNew, 1e-12);
+  EXPECT_DOUBLES_EQUAL(expected, actual, 1e-12);
+
+  VectorValues actualDiagonal, expectedDiagonal;
+  factor.hessianDiagonalAdd(actualDiagonal);
+  dense.hessianDiagonalAdd(expectedDiagonal);
+  EXPECT(assert_equal(expectedDiagonal, actualDiagonal, 1e-12));
+}
+
+// Verifies unary-row insertion exposes the original fixed block and right-hand
+// side without converting through a dynamic Jacobian container.
+TEST(BatchJacobianFactor, UnaryRowAccess) {
+  using UnaryFactor = BatchJacobianFactor<3, 3>;
+  UnaryFactor factor(KeyVector{10, 20}, std::vector<size_t>{3, 3});
+  const Matrix3 block = 2.0 * Matrix3::Identity();
+  const Vector3 rhs{{1.0, -2.0, 3.0}};
+  factor.addUnaryRow(1, block, rhs);
+
+  EXPECT_LONGS_EQUAL(3, factor.rows());
+  EXPECT_LONGS_EQUAL(1, factor.rowSlots().at(0).at(0));
+  EXPECT(assert_equal(Matrix(block), Matrix(factor.block<0>(0)), 1e-12));
+  EXPECT(assert_equal(Vector(rhs), Vector(factor.rowRhs(0)), 1e-12));
+}
+
 }  // namespace update_hessian_fixture
 /* ************************************************************************* */
 

--- a/gtsam/nonlinear/LevenbergMarquardtOptimizer.cpp
+++ b/gtsam/nonlinear/LevenbergMarquardtOptimizer.cpp
@@ -100,6 +100,13 @@ GaussianFactorGraph LevenbergMarquardtOptimizer::buildDampedSystem(
 }
 
 /* ************************************************************************* */
+double LevenbergMarquardtOptimizer::linearDeltaError(
+    const GaussianFactorGraph& linear, const VectorValues& delta,
+    double* oldError, double* newError) const {
+  return linear.deltaError(delta, oldError, newError);
+}
+
+/* ************************************************************************* */
 // Log current error/lambda to file
 inline void LevenbergMarquardtOptimizer::writeLogFile(double currentError){
   auto currentState = static_cast<const State*>(state_.get());
@@ -171,8 +178,8 @@ bool LevenbergMarquardtOptimizer::tryLambda(const GaussianFactorGraph& linear,
       linearizedCostChange = nonlinearMultifrontalSolver_->deltaError(
           &oldLinearizedError, &newLinearizedError);
     } else {
-      linearizedCostChange =
-          linear.deltaError(delta, &oldLinearizedError, &newLinearizedError);
+      linearizedCostChange = linearDeltaError(
+          linear, delta, &oldLinearizedError, &newLinearizedError);
     }
 
     // cost change in the linearized system (old - new)

--- a/gtsam/nonlinear/LevenbergMarquardtOptimizer.h
+++ b/gtsam/nonlinear/LevenbergMarquardtOptimizer.h
@@ -115,9 +115,10 @@ public:
   /** linearize, can be overwritten */
   virtual GaussianFactorGraph::shared_ptr linearize() const;
 
-  /** Build a damped system for a specific lambda -- for testing only */
-  GaussianFactorGraph buildDampedSystem(const GaussianFactorGraph& linear,
-                                        const VectorValues& sqrtHessianDiagonal) const;
+  /** Build the damped linear system for the current lambda. */
+  virtual GaussianFactorGraph buildDampedSystem(
+      const GaussianFactorGraph& linear,
+      const VectorValues& sqrtHessianDiagonal) const;
 
   /** Inner loop, changes state, returns true if successful or giving up */
   bool tryLambda(const GaussianFactorGraph& linear, const VectorValues& sqrtHessianDiagonal);
@@ -125,6 +126,12 @@ public:
   /// @}
 
 protected:
+
+  /** Evaluate the linear-model error change used for LM step quality. */
+  virtual double linearDeltaError(const GaussianFactorGraph& linear,
+                                  const VectorValues& delta,
+                                  double* oldError,
+                                  double* newError) const;
 
   /** Access the parameters (base class version) */
   const NonlinearOptimizerParams& _params() const override {

--- a/gtsam/nonlinear/tests/testBatchFactor.cpp
+++ b/gtsam/nonlinear/tests/testBatchFactor.cpp
@@ -112,6 +112,46 @@ TEST(BatchFactor, ConstructorAndLinearize) {
 }
 
 /* ************************************************************************* */
+// Verifies compact delta-error evaluation matches the dense compatibility path.
+TEST(BatchFactor, CompactDeltaErrorMatchesDenseJacobian) {
+  const Key pose = Symbol('x', 0);
+  const Key point1 = Symbol('l', 0);
+  const Key point2 = Symbol('l', 1);
+  const auto noise = noiseModel::Isotropic::Sigma(2, 1.0);
+  std::vector<ProjectionFactor> factors;
+  factors.emplace_back(Point2(0.1, -0.2), noise, pose, point1, sharedK);
+  factors.emplace_back(Point2(-0.3, 0.4), noise, pose, point2, sharedK);
+  BatchFactor<ProjectionFactor, 2> batch(std::move(factors));
+
+  Values values;
+  values.insert(pose, Pose3());
+  values.insert(point1, Point3(0.5, 0.1, 5.0));
+  values.insert(point2, Point3(-0.2, 0.3, 4.0));
+  const auto compact = batch.linearize(values);
+  const JacobianFactor dense = denseJacobian(compact);
+
+  VectorValues delta;
+  delta.insert(pose, Vector6::Constant(0.01));
+  delta.insert(point1, Vector3(0.02, -0.01, 0.03));
+  delta.insert(point2, Vector3(-0.01, 0.04, -0.02));
+  double compactOld = 0.0, compactNew = 0.0;
+  double denseOld = 0.0, denseNew = 0.0;
+  const double compactDelta =
+      compact->deltaError(delta, &compactOld, &compactNew);
+  const double denseDelta = dense.deltaError(delta, &denseOld, &denseNew);
+
+  DOUBLES_EQUAL(denseOld, compactOld, 1e-12);
+  DOUBLES_EQUAL(denseNew, compactNew, 1e-12);
+  DOUBLES_EQUAL(denseDelta, compactDelta, 1e-12);
+
+  VectorValues compactDiagonal;
+  compact->hessianDiagonalAdd(compactDiagonal);
+  VectorValues denseDiagonal;
+  dense.hessianDiagonalAdd(denseDiagonal);
+  EXPECT(assert_equal(denseDiagonal, compactDiagonal, 1e-12));
+}
+
+/* ************************************************************************* */
 // Verifies constrained row semantics are preserved in the dense Jacobian model.
 TEST(BatchFactor, ConstrainedNoiseModel) {
   Key key = Symbol('x', 0);

--- a/tests/testNonlinearOptimizer.cpp
+++ b/tests/testNonlinearOptimizer.cpp
@@ -719,6 +719,60 @@ TEST(NonlinearOptimizer, subclass_solver) {
 }
 
 /* ************************************************************************* */
+namespace lm_extension_hooks_fixture {
+
+class HookedLM final : public LevenbergMarquardtOptimizer {
+  mutable bool builtDampedSystem_ = false;
+  mutable bool evaluatedLinearError_ = false;
+
+ protected:
+  double linearDeltaError(const GaussianFactorGraph& linear,
+                          const VectorValues& delta, double* oldError,
+                          double* newError) const override {
+    evaluatedLinearError_ = true;
+    return LevenbergMarquardtOptimizer::linearDeltaError(
+        linear, delta, oldError, newError);
+  }
+
+ public:
+  using LevenbergMarquardtOptimizer::LevenbergMarquardtOptimizer;
+
+  GaussianFactorGraph buildDampedSystem(
+      const GaussianFactorGraph& linear,
+      const VectorValues& sqrtHessianDiagonal) const override {
+    builtDampedSystem_ = true;
+    return LevenbergMarquardtOptimizer::buildDampedSystem(
+        linear, sqrtHessianDiagonal);
+  }
+
+  bool builtDampedSystem() const { return builtDampedSystem_; }
+  bool evaluatedLinearError() const { return evaluatedLinearError_; }
+};
+
+// Verifies custom damping and linear-model evaluation hooks are dispatched
+// while retaining the default optimizer result.
+TEST(NonlinearOptimizer, LevenbergMarquardtExtensionHooks) {
+  const NonlinearFactorGraph graph =
+      example::createReallyNonlinearFactorGraph();
+  Values initial;
+  initial.insert(X(1), Point2(3, 3));
+  LevenbergMarquardtParams parameters;
+  parameters.linearSolverType =
+      NonlinearOptimizerParams::MULTIFRONTAL_CHOLESKY;
+
+  const Values expected =
+      LevenbergMarquardtOptimizer(graph, initial, parameters).optimize();
+  HookedLM optimizer(graph, initial, parameters);
+  const Values actual = optimizer.optimize();
+
+  CHECK(optimizer.builtDampedSystem());
+  CHECK(optimizer.evaluatedLinearError());
+  EXPECT(assert_equal(expected, actual, 1e-9));
+}
+
+}  // namespace lm_extension_hooks_fixture
+
+/* ************************************************************************* */
 TEST( NonlinearOptimizer, logfile )
 {
   NonlinearFactorGraph fg(example::createReallyNonlinearFactorGraph());

--- a/tests/testPCGSolver.cpp
+++ b/tests/testPCGSolver.cpp
@@ -252,6 +252,21 @@ TEST(PCGSolver, DetailedResult) {
   CHECK(result.solveSeconds >= 0.0);
 }
 
+// Verifies null linear factors are ignored when PCG discovers key dimensions.
+TEST(PCGSolver, DetailedResultWithNullFactor) {
+  const GaussianFactorGraph graph = createTwoDimensionalGraph();
+  GaussianFactorGraph graphWithNull = graph;
+  graphWithNull.push_back(GaussianFactor::shared_ptr());
+
+  const PCGSolverResult expected =
+      PCGSolver(createParameters()).optimizeDetailed(graph, false);
+  const PCGSolverResult actual =
+      PCGSolver(createParameters()).optimizeDetailed(graphWithNull, false);
+
+  EXPECT(assert_equal(expected.solution, actual.solution, 1e-12));
+  CHECK(actual.stats.converged());
+}
+
 // Verifies a fixed one-iteration solve reports the iteration limit.
 TEST(PCGSolver, DetailedMaxIterations) {
   const GaussianFactorGraph graph = createTwoDimensionalGraph();


### PR DESCRIPTION
## Summary

- ignore null Gaussian factors during key-dimension discovery
- evaluate compact batch-factor error changes and Hessian diagonals without materializing dense Jacobians
- expose fixed compact rows for batched damping
- add overridable LM damping and linear-model evaluation hooks while preserving the default behavior

These are classical GTSAM optimizer improvements and do not select a new linear solver backend.

## Validation

- `make -j6 testPCGSolver.run`
- `make -j6 testBatchJacobianFactor.run`
- `make -j6 testBatchFactor.run`
- `make -j6 testNonlinearOptimizer.run`

A separate BAL-88 before/after timing comment will follow.