### PR TITLE
Fix legacy Bayes tree serialization fixture

### DIFF
--- a/gtsam/linear/tests/testSerializationLinear.cpp
+++ b/gtsam/linear/tests/testSerializationLinear.cpp
@@ -319,8 +319,9 @@ TEST(Serialization, LegacyGaussianBayesTree) {
   const string legacyArchive =
       "0 0 0 0 0 0 1 0 0 0 7 0 1 5 1 0\n"
       "0 1 0 1 7 1 0\n"
-      "1 0 1 0 0 0 0 0 0 1 0 7 0 0 0 0 1 2 "
-      "3.00000000000000000e+00 2.00000000000000000e+00 0 0 3 0 0 1 2 0 1 "
+      "1 1 1\n"
+      "2 0 0 0 0 0 0 1 0 7 0 0 0 0 1 2 "
+      "2.00000000000000000e+00 3.00000000000000000e+00 0 0 3 0 0 1 2 0 1 "
       "0 1 0 0 1 0 0 0 1 1 1 5 0\n";
   istringstream stream(legacyArchive);
   boost::archive::text_iarchive archive(stream, boost::archive::no_header);


### PR DESCRIPTION
## Summary

Fix the legacy Gaussian Bayes tree serialization test that caused nightly CI issue #2690.

The previous hard-coded text archive was malformed for the pre-version-1 serializer. Replace it with a valid one-clique archive generated from the pre-regression serialization format.

## Root cause

The fixture failed with Boost.Serialization's "input stream error" across multiple release matrix environments. The new BayesTree implementation was not the failing path; the checked-in legacy archive did not match the recursive serializer's actual output.

Fixes #2690

## Validation

- `make -j6 testSerializationLinear.run`
- `make -j6 testSerializationNonlinear.run testSerializationHybrid.run testSerializationDiscrete.run`
- `git diff --check`