### PR TITLE
Document MultifrontalSolver and the linear module

### DIFF
--- a/gtsam/linear/doc/MultifrontalSolver.ipynb
+++ b/gtsam/linear/doc/MultifrontalSolver.ipynb
@@ -1,0 +1,360 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "title",
+   "metadata": {},
+   "source": [
+    "# MultifrontalSolver\n",
+    "\n",
+    "This guide explains GTSAM's reusable imperative multifrontal solver for Gaussian factor graphs. It covers the solver lifecycle, supported inputs, structural and numerical choices, parallel traversal, diagnostics, and every MultifrontalParameters option with its default."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "copyright",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "colab",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/linear/doc/MultifrontalSolver.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "install",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import X\n",
+    "\n",
+    "SCALAR_IDENTITY = np.eye(1)\n",
+    "UNIT_NOISE = gtsam.noiseModel.Unit.Create(1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "role",
+   "metadata": {},
+   "source": [
+    "## Where the solver fits\n",
+    "\n",
+    "A Gaussian factor graph represents a least-squares objective of the form\n",
+    "\n",
+    "$$\n",
+    "\\frac{1}{2}\\lVert A x-b\\rVert^2.\n",
+    "$$\n",
+    "\n",
+    "Multifrontal elimination uses a variable ordering to construct a symbolic junction tree. Each numerical clique gathers its local factors and child updates, eliminates its frontal variables, and passes a Schur-complement update to its parent. A top-down pass then back-substitutes through the resulting conditionals.\n",
+    "\n",
+    "MultifrontalSolver is the reusable C++ implementation of this process. It separates symbolic setup and memory allocation from repeated numerical loads, factorizations, and solves. The class itself is not currently wrapped in Python, so the executable cells below use the public Python Gaussian-factor APIs to illustrate the same problem and reference solution. The C++ sections show the MultifrontalSolver-specific API."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "example-intro",
+   "metadata": {},
+   "source": [
+    "## A small Gaussian chain\n",
+    "\n",
+    "The first factor anchors $x_0$ at zero. Each binary factor then constrains $x_{i+1}-x_i=1$. Eliminating the graph multifrontally should recover the scalar sequence 0, 1, 2, 3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "gaussian-chain",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graph = gtsam.GaussianFactorGraph()\n",
+    "graph.add(X(0), SCALAR_IDENTITY, np.array([0.0]), UNIT_NOISE)\n",
+    "for index in range(3):\n",
+    "    graph.add(\n",
+    "        X(index),\n",
+    "        -SCALAR_IDENTITY,\n",
+    "        X(index + 1),\n",
+    "        SCALAR_IDENTITY,\n",
+    "        np.array([1.0]),\n",
+    "        UNIT_NOISE,\n",
+    "    )\n",
+    "\n",
+    "ordering = gtsam.Ordering()\n",
+    "for index in range(4):\n",
+    "    ordering.push_back(X(index))\n",
+    "\n",
+    "bayes_tree = graph.eliminateMultifrontal(ordering)\n",
+    "solution = bayes_tree.optimize()\n",
+    "estimated = np.array([solution.at(X(index))[0] for index in range(4)])\n",
+    "np.testing.assert_allclose(estimated, np.arange(4.0), atol=1e-12)\n",
+    "estimated"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "lifecycle",
+   "metadata": {},
+   "source": [
+    "## C++ lifecycle\n",
+    "\n",
+    "A solver instance is reusable while the graph's keys, factor types, factor-to-key structure, dimensions, and ordering remain unchanged. Only the numerical factor values may change between calls to load.\n",
+    "\n",
+    "~~~cpp\n",
+    "#include <gtsam/linear/MultifrontalSolver.h>\n",
+    "\n",
+    "using namespace gtsam;\n",
+    "\n",
+    "MultifrontalSolver::Parameters parameters;\n",
+    "MultifrontalSolver solver(graph, ordering, parameters);\n",
+    "\n",
+    "// Separate load and elimination: useful when timing or inspecting phases.\n",
+    "solver.load(graph);\n",
+    "solver.eliminateInPlace();\n",
+    "const VectorValues& delta = solver.updateSolution();\n",
+    "\n",
+    "// A later graph may reuse the symbolic structure and allocated storage.\n",
+    "solver.load(graphWithUpdatedNumbers);\n",
+    "solver.eliminateInPlace();\n",
+    "const VectorValues& updatedDelta = solver.updateSolution();\n",
+    "~~~\n",
+    "\n",
+    "The overload eliminateInPlace(graph) fuses loading and elimination into one post-order traversal. Use computeBayesTree() after elimination when a persistent GaussianBayesTree is needed. After updateSolution(), deltaError() returns the cached change in linearized error and can optionally return the old and new errors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "precompute",
+   "metadata": {},
+   "source": [
+    "### Reusing symbolic precomputation\n",
+    "\n",
+    "Precompute() separates symbolic analysis from solver construction. This is useful when several solver instances share one graph structure and ordering.\n",
+    "\n",
+    "~~~cpp\n",
+    "auto data = MultifrontalSolver::Precompute(graph, ordering);\n",
+    "MultifrontalSolver solver(std::move(data), ordering, parameters);\n",
+    "solver.load(graph);\n",
+    "solver.eliminateInPlace();\n",
+    "const VectorValues& delta = solver.updateSolution();\n",
+    "~~~\n",
+    "\n",
+    "Calling eliminateInPlace() before load(), computeBayesTree() before elimination, or deltaError() before updateSolution() is an error. The solution returned by updateSolution() is owned by the solver and remains valid only as a reference to its cached storage."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "options-table",
+   "metadata": {},
+   "source": [
+    "## Complete parameter reference\n",
+    "\n",
+    "The following defaults come directly from [MultifrontalParameters.h](../MultifrontalParameters.h).\n",
+    "\n",
+    "| Option | Type | Default | Meaning |\n",
+    "| --- | --- | ---: | --- |\n",
+    "| `leafMergeDimCap` | `size_t` | `256` | Groups sibling leaf cliques that have identical separators into symbolic super-leaves. The running sum uses each leaf's frontal-plus-separator dimension. `0` disables this pass. |\n",
+    "| `mergeDimCap` | `size_t` | `32` | Bottom-up general clique-merge threshold. A child is merged into its parent when the child's frontal dimension plus the parent's total dimension is strictly less than this value. `0` disables this pass. |\n",
+    "| `qrMode` | `QRMode` | `QRMode::Allow` | Chooses whether eligible leaf cliques use QR or Cholesky: `Off`, `Allow`, or `Force`. Details appear below. |\n",
+    "| `qrAspectRatio` | `double` | `2.0` | In `Allow` mode, an eligible leaf uses QR when its total frontal-plus-separator dimension is greater than this value times its frontal dimension. |\n",
+    "| `reportStream` | `std::ostream*` | `nullptr` | Receives symbolic structure summaries during construction. A null pointer disables reporting. The caller owns the stream. |\n",
+    "| `eliminationParallelThreshold` | `int` | `10` | Problem-size threshold used when creating tasks in the bottom-up elimination traversal. Smaller values expose more task parallelism; larger values keep more work in recursive tasks. |\n",
+    "| `solutionParallelThreshold` | `int` | `4096` | Problem-size threshold used when creating tasks in the top-down solution traversal. |\n",
+    "| `numThreads` | `size_t` | `0` | Worker count. Zero selects three quarters of `std::thread::hardware_concurrency()`, rounded down and clamped to at least one worker. A positive value requests exactly that many workers. |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "structural-options",
+   "metadata": {},
+   "source": [
+    "### Structural merge options\n",
+    "\n",
+    "leafMergeDimCap is a specialized first pass. At every symbolic parent it collects direct leaf children, groups only leaves with identical separator key sets, and packs each group until adding another leaf would exceed the cap. A leaf larger than the cap remains a single leaf. Batches containing only one leaf are not merged.\n",
+    "\n",
+    "mergeDimCap is a second, general bottom-up pass. It can merge non-leaf children as well. Increasing either cap generally reduces clique and task overhead but creates larger dense frontal computations and may increase memory use. Setting both values to zero preserves the unmerged symbolic clique structure and is useful as a diagnostic baseline."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qr-options",
+   "metadata": {},
+   "source": [
+    "### QR and Cholesky selection\n",
+    "\n",
+    "QR selection applies only to leaf cliques with at least as many factor rows as frontal scalar dimensions.\n",
+    "\n",
+    "- QRMode::Off always uses Cholesky.\n",
+    "- QRMode::Allow, the default, uses QR for an eligible leaf when\n",
+    "  frontalDim + separatorDim > qrAspectRatio * frontalDim.\n",
+    "- QRMode::Force uses QR for every eligible leaf. A clique that is not an eligible leaf still uses Cholesky.\n",
+    "\n",
+    "QR avoids explicitly forming normal equations for the selected leaves and can be preferable for tall local Jacobians or when numerical conditioning matters. Cholesky is usually cheaper when the clique is not tall. qrAspectRatio has no effect in Off or Force mode."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "parallel-options",
+   "metadata": {},
+   "source": [
+    "### Parallel traversal and reporting\n",
+    "\n",
+    "The two parallel thresholds are scheduling controls, not matrix dimensions or thread counts. Each clique reports a problem size equal to its frontal dimension plus separator dimension. The traversal uses the applicable threshold to decide where additional tasks are worthwhile. Their best values depend on tree shape, clique size, scheduler overhead, and hardware; tune them with representative graphs rather than assuming that more tasks are always faster.\n",
+    "\n",
+    "numThreads controls the solver's worker pool independently of those thresholds. Set it to 1 for deterministic single-worker performance measurements. The default 0 derives the worker count from available hardware.\n",
+    "\n",
+    "When reportStream is non-null, construction prints summaries of the original symbolic cluster structure and the structures after each enabled merge pass. This is useful for confirming whether a parameter actually changed clique count, dimensions, or fan-out."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "configured-example",
+   "metadata": {},
+   "source": [
+    "## Configuring every option\n",
+    "\n",
+    "This example writes every field explicitly. The assigned values are the defaults, so removing any line preserves the same behavior.\n",
+    "\n",
+    "~~~cpp\n",
+    "MultifrontalSolver::Parameters parameters;\n",
+    "parameters.leafMergeDimCap = 256;\n",
+    "parameters.mergeDimCap = 32;\n",
+    "parameters.qrMode = MultifrontalParameters::QRMode::Allow;\n",
+    "parameters.qrAspectRatio = 2.0;\n",
+    "parameters.reportStream = nullptr;\n",
+    "parameters.eliminationParallelThreshold = 10;\n",
+    "parameters.solutionParallelThreshold = 4096;\n",
+    "parameters.numThreads = 0;\n",
+    "\n",
+    "MultifrontalSolver solver(graph, ordering, parameters);\n",
+    "~~~"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "supported-inputs",
+   "metadata": {},
+   "source": [
+    "## Supported factors and constraints\n",
+    "\n",
+    "MultifrontalSolver accepts JacobianFactor and BatchJacobianFactor inputs. Other Gaussian factor types, including HessianFactor, are rejected during precomputation or loading.\n",
+    "\n",
+    "A constrained JacobianFactor is supported only when it is unary, fully constrained, and has a zero residual. Such a factor fixes its key to zero during the linear solve. Mixed-key, partially constrained, or infeasible constrained Jacobian factors are rejected. Constrained BatchJacobianFactor inputs are not supported.\n",
+    "\n",
+    "The graph passed to load() must preserve the structure used during construction: factor positions, factor types, keys, dimensions, and row layout must match. Use a new precomputation and solver if the structure changes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nonlinear-use",
+   "metadata": {},
+   "source": [
+    "## Using it from a nonlinear optimizer\n",
+    "\n",
+    "In C++, Gauss-Newton and Levenberg-Marquardt can select the reusable solver through NonlinearOptimizerParams::MULTIFRONTAL_SOLVER. The multifrontal parameters are stored in the optimizer parameters.\n",
+    "\n",
+    "~~~cpp\n",
+    "GaussNewtonParams parameters;\n",
+    "parameters.linearSolverType =\n",
+    "    NonlinearOptimizerParams::MULTIFRONTAL_SOLVER;\n",
+    "parameters.multifrontalParams.qrMode =\n",
+    "    MultifrontalParameters::QRMode::Allow;\n",
+    "parameters.multifrontalParams.numThreads = 0;\n",
+    "\n",
+    "GaussNewtonOptimizer optimizer(nonlinearGraph, initialValues, parameters);\n",
+    "const Values result = optimizer.optimize();\n",
+    "~~~\n",
+    "\n",
+    "LM damping policy is configured separately through LevenbergMarquardtParams. MultifrontalParameters controls symbolic structure, numerical leaf selection, traversal, worker count, and reporting; it does not choose the LM damping formula."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tuning",
+   "metadata": {},
+   "source": [
+    "## Practical tuning workflow\n",
+    "\n",
+    "Start with the defaults and a representative graph. If performance matters, record end-to-end runtime and peak memory, not elimination time alone. Then change one family of controls at a time:\n",
+    "\n",
+    "1. Set reportStream to std::cout and inspect the symbolic structure.\n",
+    "2. Compare both merge caps at zero with their defaults before increasing them.\n",
+    "3. Compare QRMode::Off, Allow, and Force; tune qrAspectRatio only for Allow.\n",
+    "4. Fix numThreads while tuning traversal thresholds so worker-count changes do not confound the result.\n",
+    "5. Validate every tuned configuration against the untuned solution and linearized error.\n",
+    "\n",
+    "The defaults are general-purpose heuristics, not universal optima. Chains, balanced trees, and bundle-adjustment graphs have very different clique shapes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "summary",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "MultifrontalSolver is most useful when the same symbolic Gaussian graph structure is solved repeatedly with new numerical values. Keep the ordering and graph structure fixed, reuse precomputation and allocated storage, choose QR only where its leaf eligibility rules apply, and treat merge and traversal settings as measurable performance heuristics. For failures caused by rank deficiency or poor conditioning, see [Debugging an Indeterminate Linear System](IndeterminateSystemException.ipynb)."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "gtsam",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/linear/linear.md
+++ b/gtsam/linear/linear.md
@@ -1,0 +1,48 @@
+# Linear
+
+The `linear` module represents and solves Gaussian factor graphs. Nonlinear
+optimizers use these classes after linearizing a nonlinear factor graph around
+the current estimate.
+
+## Gaussian Factors and Graphs
+
+- [GaussianFactor](GaussianFactor.h) is the common interface for linear
+  Gaussian factors.
+- [JacobianFactor](JacobianFactor.h) represents a whitened least-squares term
+  in Jacobian form, $\frac{1}{2}\lVert A x-b\rVert^2$.
+- [HessianFactor](HessianFactor.h) represents the equivalent quadratic term in
+  information form.
+- [GaussianFactorGraph](GaussianFactorGraph.h) stores a collection of Gaussian
+  factors and provides elimination, optimization, gradient, Jacobian, and
+  Hessian operations.
+- [GaussianConditional](GaussianConditional.h) represents a conditional
+  produced by eliminating one or more frontal variables.
+- [VectorValues](VectorValues.h) stores vector-valued assignments such as a
+  linear solution or nonlinear tangent-space update.
+
+## Direct Solvers and Elimination
+
+- [MultifrontalSolver](doc/MultifrontalSolver.ipynb) explains the reusable,
+  imperative multifrontal solver, its lifecycle, supported factors, and every
+  tuning option with its default.
+- [GaussianBayesNet](GaussianBayesNet.h) and
+  [GaussianBayesTree](GaussianBayesTree.h) store the results of sequential and
+  multifrontal elimination. Their graph structure is introduced in the
+  [inference module](../inference/inference.md).
+- [GaussianEliminationTree](GaussianEliminationTree.h) and
+  [GaussianJunctionTree](GaussianJunctionTree.h) organize elimination work from
+  an ordering.
+
+## Iterative Solvers
+
+- [ConjugateGradientSolver](ConjugateGradientSolver.h) implements conjugate
+  gradients for linear systems.
+- [PCGSolver](PCGSolver.h) implements preconditioned conjugate gradients.
+- [Preconditioner](Preconditioner.h) is the interface for iterative-solver
+  preconditioners.
+
+## Diagnostics
+
+- [Debugging an Indeterminate Linear System](doc/IndeterminateSystemException.ipynb)
+  shows how to preserve a failing graph, inspect its Jacobian rank and null
+  space, and repair missing gauge constraints.

--- a/myst.yml
+++ b/myst.yml
@@ -23,6 +23,9 @@ project:
       - file: ./gtsam/inference/inference.md
         children:
         - pattern: ./gtsam/inference/doc/*
+      - file: ./gtsam/linear/linear.md
+        children:
+        - pattern: ./gtsam/linear/doc/*
       - file: ./gtsam/hybrid/hybrid.md
         children:
         - pattern: ./gtsam/hybrid/doc/*


### PR DESCRIPTION
## Summary

- add a landing page for the `linear` module
- add a `MultifrontalSolver` notebook covering the solver lifecycle, reusable symbolic precomputation, supported factor types, and nonlinear optimizer integration
- document every `MultifrontalParameters` option with its type, default, behavior, and tuning implications
- add the linear documentation section to the MyST navigation

## Motivation

The linear module did not have a landing page, and the reusable multifrontal solver API was not represented in the documentation site. This adds a discoverable reference for the current API before subsequent solver changes are integrated.

## Validation

- validated the notebook with `nbformat.validate`
- verified code cells are clean and have no stored execution output
- ran a strict MyST site build for the new landing page and notebook
- ran `git diff --check`
