### PR TITLE
Remove deprecated Coriolis flag usage from examples

### DIFF
--- a/examples/ImuFactorsExample2.cpp
+++ b/examples/ImuFactorsExample2.cpp
@@ -42,7 +42,6 @@ int main(int argc, char* argv[]) {
   params->setAccelerometerCovariance(I_3x3 * 0.1);
   params->setGyroscopeCovariance(I_3x3 * 0.1);
   params->setIntegrationCovariance(I_3x3 * 0.1);
-  params->setUse2ndOrderCoriolis(false);
   params->setOmegaCoriolis(Vector3(0, 0, 0));
 
   Pose3 delta(Rot3::Rodrigues(-0.1, 0.2, 0.25), Point3(0.05, -0.10, 0.20));

--- a/examples/NavStateImuExample.cpp
+++ b/examples/NavStateImuExample.cpp
@@ -53,7 +53,6 @@ int main(int argc, char* argv[]) {
   params->setAccelerometerCovariance(I_3x3 * 0.1);
   params->setGyroscopeCovariance(I_3x3 * 0.1);
   params->setIntegrationCovariance(I_3x3 * 0.1);
-  params->setUse2ndOrderCoriolis(false);
   params->setOmegaCoriolis(Vector3::Zero());
   
   // True biases used to corrupt measurements in ScenarioRunner

--- a/python/gtsam/examples/ImuFactorISAM2Example.py
+++ b/python/gtsam/examples/ImuFactorISAM2Example.py
@@ -39,7 +39,6 @@ def preintegration_parameters():
     PARAMS.setAccelerometerCovariance(I * 0.1)
     PARAMS.setGyroscopeCovariance(I * 0.1)
     PARAMS.setIntegrationCovariance(I * 0.1)
-    PARAMS.setUse2ndOrderCoriolis(False)
     PARAMS.setOmegaCoriolis(vector3(0, 0, 0))
 
     BIAS_COVARIANCE = gtsam.noiseModel.Isotropic.Variance(6, 0.1)


### PR DESCRIPTION
Fixes #2700

## Summary

- Remove obsolete `setUse2ndOrderCoriolis(false)` calls from the C++ and Python IMU examples.
- Keep the supported `omegaCoriolis` configuration unchanged.

## Root cause

The nightly run's Windows Debug and vcpkg builds use `GTSAM_ALLOW_DEPRECATED_SINCE_V43=OFF` and warnings-as-errors. MSVC therefore failed on the deprecated Coriolis compatibility setter with C4996.

## Validation

- Built `ImuFactorsExample2` and `NavStateImuExample` with `GTSAM_ALLOW_DEPRECATED_SINCE_V43=OFF` and `GTSAM_BUILD_WITH_WERROR=ON`.
- Python example syntax check passed in the `py312` environment.
- `git diff --check` passed.