### PR TITLE
Gate IMU Jacobian finite-difference step for quaternions

### DIFF
--- a/gtsam/navigation/tests/testImuFactor.cpp
+++ b/gtsam/navigation/tests/testImuFactor.cpp
@@ -723,8 +723,13 @@ TEST_PIM(ImuFactor, ErrorWithBiasesAndSensorBodyDisplacement) {
   values.insert(V(2), v2);
   values.insert(B(1), bias);
 
-  // Make sure linearization is correct
-  double diffDelta = 1e-8;
+  // Make sure linearization is correct. Quaternion finite differences need a
+  // larger step to avoid roundoff at the strict Jacobian tolerance on Linux.
+#ifdef GTSAM_USE_QUATERNIONS
+  constexpr double diffDelta = 1e-7;
+#else
+  constexpr double diffDelta = 1e-8;
+#endif
   EXPECT_CORRECT_FACTOR_JACOBIANS(factor, values, diffDelta, 1e-3);
 }
 


### PR DESCRIPTION
## Summary

- Gate the IMU factor Jacobian finite-difference step on `GTSAM_USE_QUATERNIONS`.
- Use `1e-7` for quaternion builds and retain `1e-8` for non-quaternion builds.
- Keep the strict `1e-3` Jacobian tolerance unchanged.

## Root cause

The Ubuntu Clang quaternion CI job was failing `testImuFactor` because the `1e-8` central-difference step accumulated enough roundoff to exceed the strict tolerance by roughly `4e-5`. The larger step improves the numerical reference without changing production IMU or quaternion code.

## Validation

- `make -j6 testImuFactor.run` with quaternions enabled: passed.
- `make -j6 testImuFactor.run` with quaternions disabled: passed.
- `git diff --check`: passed.
