### PR TITLE
wrap: declare navigation factors under NoiseModelFactor

### DIFF
--- a/gtsam/navigation/navigation.i
+++ b/gtsam/navigation/navigation.i
@@ -270,7 +270,7 @@ class PreintegratedImuMeasurements {
   void serialize() const;
 };
 
-virtual class ImuFactor: gtsam::NonlinearFactor {
+virtual class ImuFactor: gtsam::NoiseModelFactor {
   ImuFactor(gtsam::Key pose_i, gtsam::Key vel_i, gtsam::Key pose_j, gtsam::Key vel_j,
       gtsam::Key bias,
       const gtsam::PreintegratedImuMeasurements& preintegratedMeasurements);
@@ -286,7 +286,7 @@ virtual class ImuFactor: gtsam::NonlinearFactor {
   void serialize() const;
 };
 
-virtual class ImuFactor2: gtsam::NonlinearFactor {
+virtual class ImuFactor2: gtsam::NoiseModelFactor {
   ImuFactor2();
   ImuFactor2(gtsam::Key state_i, gtsam::Key state_j,
       gtsam::Key bias,
@@ -307,7 +307,7 @@ virtual class ImuFactor2: gtsam::NonlinearFactor {
 
 #include <gtsam/navigation/ImuFactorWithGravity.h>
 template <PIM, GRAVITY>
-virtual class ImuFactorWithGravityT : gtsam::NonlinearFactor {
+virtual class ImuFactorWithGravityT : gtsam::NoiseModelFactor {
   ImuFactorWithGravityT(gtsam::Key pose_i, gtsam::Key vel_i,
       gtsam::Key pose_j, gtsam::Key vel_j, gtsam::Key bias, gtsam::Key gravity,
       const PIM& preintegratedMeasurements);
@@ -485,7 +485,7 @@ class PreintegratedAhrsMeasurements {
   void serialize() const;
 };
 
-virtual class AHRSFactor : gtsam::NonlinearFactor {
+virtual class AHRSFactor : gtsam::NoiseModelFactor {
   AHRSFactor(gtsam::Key rot_i, gtsam::Key rot_j, gtsam::Key bias,
     const gtsam::PreintegratedAhrsMeasurements& preintegratedMeasurements);
 
@@ -517,7 +517,7 @@ virtual class AttitudeFactor : gtsam::NoiseModelFactor {
 };
 
 #include <gtsam/navigation/GPSFactor.h>
-virtual class GPSFactor : gtsam::NonlinearFactor{
+virtual class GPSFactor : gtsam::NoiseModelFactor{
   GPSFactor(gtsam::Key key, const gtsam::Point3& gpsIn,
             const gtsam::noiseModel::Base* model);
 
@@ -531,7 +531,7 @@ virtual class GPSFactor : gtsam::NonlinearFactor{
   void serialize() const;
 };
 
-virtual class GPSFactorArm : gtsam::NonlinearFactor{
+virtual class GPSFactorArm : gtsam::NoiseModelFactor{
   GPSFactorArm(gtsam::Key key, const gtsam::Point3& gpsIn,
             const gtsam::Point3& leverArm, 
             const gtsam::noiseModel::Base* model);
@@ -546,7 +546,7 @@ virtual class GPSFactorArm : gtsam::NonlinearFactor{
   void serialize() const;
 };
 
-virtual class GPSFactorArmCalib : gtsam::NonlinearFactor{
+virtual class GPSFactorArmCalib : gtsam::NoiseModelFactor{
   GPSFactorArmCalib(gtsam::Key key1, gtsam::Key key2, const gtsam::Point3& gpsIn,
             const gtsam::noiseModel::Base* model);
 
@@ -561,7 +561,7 @@ virtual class GPSFactorArmCalib : gtsam::NonlinearFactor{
   void serialize() const;
 };
 
-virtual class GPSFactor2 : gtsam::NonlinearFactor {
+virtual class GPSFactor2 : gtsam::NoiseModelFactor {
   GPSFactor2(gtsam::Key key, const gtsam::Point3& gpsIn,
             const gtsam::noiseModel::Base* model);
 
@@ -575,7 +575,7 @@ virtual class GPSFactor2 : gtsam::NonlinearFactor {
   void serialize() const;
 };
 
-virtual class GPSFactor2Arm : gtsam::NonlinearFactor{
+virtual class GPSFactor2Arm : gtsam::NoiseModelFactor{
   GPSFactor2Arm(gtsam::Key key, const gtsam::Point3& gpsIn,
             const gtsam::Point3& leverArm, 
             const gtsam::noiseModel::Base* model);
@@ -590,7 +590,7 @@ virtual class GPSFactor2Arm : gtsam::NonlinearFactor{
   void serialize() const;
 };
 
-virtual class GPSFactor2ArmCalib : gtsam::NonlinearFactor{
+virtual class GPSFactor2ArmCalib : gtsam::NoiseModelFactor{
   GPSFactor2ArmCalib(gtsam::Key key1, gtsam::Key key2, const gtsam::Point3& gpsIn,
             const gtsam::noiseModel::Base* model);
 
@@ -606,7 +606,7 @@ virtual class GPSFactor2ArmCalib : gtsam::NonlinearFactor{
 };
 
 #include <gtsam/navigation/PseudorangeFactor.h>
-virtual class PseudorangeFactor : gtsam::NonlinearFactor {
+virtual class PseudorangeFactor : gtsam::NoiseModelFactor {
   PseudorangeFactor(gtsam::Key receiverPositionKey,
                     gtsam::Key receiverClockBiasKey, double measuredPseudorange,
                     const gtsam::Point3& satellitePosition,
@@ -623,7 +623,7 @@ virtual class PseudorangeFactor : gtsam::NonlinearFactor {
   void serialize() const;
 };
 
-virtual class UndifferencedPseudorangeFactor : gtsam::NonlinearFactor {
+virtual class UndifferencedPseudorangeFactor : gtsam::NoiseModelFactor {
   UndifferencedPseudorangeFactor(gtsam::Key receiverPositionKey,
                               gtsam::Key receiverClockBiasKey,
                               gtsam::Key tropoZenithWetKey,
@@ -645,7 +645,7 @@ virtual class UndifferencedPseudorangeFactor : gtsam::NonlinearFactor {
   void serialize() const;
 };
 
-virtual class UndifferencedPseudorangeFactorArm : gtsam::NonlinearFactor {
+virtual class UndifferencedPseudorangeFactorArm : gtsam::NoiseModelFactor {
   UndifferencedPseudorangeFactorArm(gtsam::Key poseKey,
                                  gtsam::Key receiverClockBiasKey,
                                  gtsam::Key tropoZenithWetKey,
@@ -680,7 +680,7 @@ virtual class UndifferencedPseudorangeFactorArm : gtsam::NonlinearFactor {
   void serialize() const;
 };
 
-virtual class DifferentialPseudorangeFactor : gtsam::NonlinearFactor {
+virtual class DifferentialPseudorangeFactor : gtsam::NoiseModelFactor {
   DifferentialPseudorangeFactor(gtsam::Key receiverPositionKey,
                                 gtsam::Key receiverClockBiasKey,
                                 gtsam::Key differentialCorrectionKey,
@@ -697,7 +697,7 @@ virtual class DifferentialPseudorangeFactor : gtsam::NonlinearFactor {
   void serialize() const;
 };
 
-virtual class PseudorangeFactorArm : gtsam::NonlinearFactor {
+virtual class PseudorangeFactorArm : gtsam::NoiseModelFactor {
   PseudorangeFactorArm(gtsam::Key poseKey,
                         gtsam::Key receiverClockBiasKey,
                         double measuredPseudorange,
@@ -725,7 +725,7 @@ virtual class PseudorangeFactorArm : gtsam::NonlinearFactor {
   void serialize() const;
 };
 
-virtual class DifferentialPseudorangeFactorArm : gtsam::NonlinearFactor {
+virtual class DifferentialPseudorangeFactorArm : gtsam::NoiseModelFactor {
   DifferentialPseudorangeFactorArm(gtsam::Key poseKey,
                         gtsam::Key receiverClockBiasKey,
                         gtsam::Key differentialCorrectionKey,
@@ -753,7 +753,7 @@ virtual class DifferentialPseudorangeFactorArm : gtsam::NonlinearFactor {
   void serialize() const;
 };
 
-virtual class DoubleDifferencePseudorangeFactor : gtsam::NonlinearFactor {
+virtual class DoubleDifferencePseudorangeFactor : gtsam::NoiseModelFactor {
   DoubleDifferencePseudorangeFactor(gtsam::Key positionKey,
                       double prRovRef, double prBaseRef,
                       double prRovTarget, double prBaseTarget,
@@ -765,7 +765,7 @@ virtual class DoubleDifferencePseudorangeFactor : gtsam::NonlinearFactor {
   void serialize() const;
 };
 
-virtual class DoubleDifferencePseudorangeFactorArm : gtsam::NonlinearFactor {
+virtual class DoubleDifferencePseudorangeFactorArm : gtsam::NoiseModelFactor {
   DoubleDifferencePseudorangeFactorArm(gtsam::Key poseKey,
                          double prRovRef, double prBaseRef,
                          double prRovTarget, double prBaseTarget,
@@ -787,7 +787,7 @@ virtual class DoubleDifferencePseudorangeFactorArm : gtsam::NonlinearFactor {
 };
 
 #include <gtsam/navigation/CarrierPhaseFactor.h>
-virtual class CarrierPhaseFactor : gtsam::NonlinearFactor {
+virtual class CarrierPhaseFactor : gtsam::NoiseModelFactor {
   CarrierPhaseFactor(gtsam::Key receiverPositionKey,
                       gtsam::Key receiverClockBiasKey,
                       gtsam::Key ambiguityKey,
@@ -807,7 +807,7 @@ virtual class CarrierPhaseFactor : gtsam::NonlinearFactor {
   void serialize() const;
 };
 
-virtual class UndifferencedCarrierPhaseFactor : gtsam::NonlinearFactor {
+virtual class UndifferencedCarrierPhaseFactor : gtsam::NoiseModelFactor {
   UndifferencedCarrierPhaseFactor(gtsam::Key receiverPositionKey,
                                gtsam::Key receiverClockBiasKey,
                                gtsam::Key tropoZenithWetKey,
@@ -831,7 +831,7 @@ virtual class UndifferencedCarrierPhaseFactor : gtsam::NonlinearFactor {
   void serialize() const;
 };
 
-virtual class UndifferencedCarrierPhaseFactorArm : gtsam::NonlinearFactor {
+virtual class UndifferencedCarrierPhaseFactorArm : gtsam::NoiseModelFactor {
   UndifferencedCarrierPhaseFactorArm(gtsam::Key poseKey,
                                   gtsam::Key receiverClockBiasKey,
                                   gtsam::Key tropoZenithWetKey,
@@ -870,7 +870,7 @@ virtual class UndifferencedCarrierPhaseFactorArm : gtsam::NonlinearFactor {
   void serialize() const;
 };
 
-virtual class CarrierPhaseFactorArm : gtsam::NonlinearFactor {
+virtual class CarrierPhaseFactorArm : gtsam::NoiseModelFactor {
   CarrierPhaseFactorArm(gtsam::Key poseKey,
                          gtsam::Key receiverClockBiasKey,
                          gtsam::Key ambiguityKey,
@@ -902,7 +902,7 @@ virtual class CarrierPhaseFactorArm : gtsam::NonlinearFactor {
 };
 
 
-virtual class DoubleDifferenceCarrierPhaseFactor : gtsam::NonlinearFactor {
+virtual class DoubleDifferenceCarrierPhaseFactor : gtsam::NoiseModelFactor {
   DoubleDifferenceCarrierPhaseFactor(gtsam::Key positionKey, gtsam::Key ambRefKey,
                        gtsam::Key ambTargetKey,
                        double cpRovRefMeters, double cpBaseRefMeters,
@@ -915,7 +915,7 @@ virtual class DoubleDifferenceCarrierPhaseFactor : gtsam::NonlinearFactor {
   void serialize() const;
 };
 
-virtual class DoubleDifferenceCarrierPhaseFactorArm : gtsam::NonlinearFactor {
+virtual class DoubleDifferenceCarrierPhaseFactorArm : gtsam::NoiseModelFactor {
   DoubleDifferenceCarrierPhaseFactorArm(gtsam::Key poseKey, gtsam::Key ambRefKey, gtsam::Key ambTargetKey,
                           double cpRovRefMeters, double cpBaseRefMeters,
                           double cpRovTargetMeters, double cpBaseTargetMeters,
@@ -938,7 +938,7 @@ virtual class DoubleDifferenceCarrierPhaseFactorArm : gtsam::NonlinearFactor {
 };
 
 #include <gtsam/navigation/DopplerFactor.h>
-virtual class DopplerFactor : gtsam::NonlinearFactor {
+virtual class DopplerFactor : gtsam::NoiseModelFactor {
   DopplerFactor(gtsam::Key velocityKey, gtsam::Key clockBiasPrevKey,
                 gtsam::Key clockBiasCurrKey, double measuredDoppler,
                 double wavelength, const gtsam::Point3& satellitePosition,
@@ -956,7 +956,7 @@ virtual class DopplerFactor : gtsam::NonlinearFactor {
   void serialize() const;
 };
 
-virtual class DopplerFactorArm : gtsam::NonlinearFactor {
+virtual class DopplerFactorArm : gtsam::NoiseModelFactor {
   DopplerFactorArm(gtsam::Key poseKey, gtsam::Key velocityKey,
                    gtsam::Key clockBiasPrevKey, gtsam::Key clockBiasCurrKey,
                    double measuredDoppler, double wavelength,
@@ -990,7 +990,7 @@ virtual class DopplerFactorArm : gtsam::NonlinearFactor {
 };
 
 #include <gtsam/navigation/BarometricFactor.h>
-virtual class BarometricFactor : gtsam::NonlinearFactor {
+virtual class BarometricFactor : gtsam::NoiseModelFactor {
   BarometricFactor();
   BarometricFactor(gtsam::Key key, gtsam::Key baroKey, const double& baroIn,
                    const gtsam::noiseModel::Base* model);
@@ -1008,14 +1008,14 @@ virtual class BarometricFactor : gtsam::NonlinearFactor {
 };
 
 #include <gtsam/navigation/ConstantVelocityFactor.h>
-class ConstantVelocityFactor : gtsam::NonlinearFactor {
+class ConstantVelocityFactor : gtsam::NoiseModelFactor {
   ConstantVelocityFactor(gtsam::Key i, gtsam::Key j, double dt, const gtsam::noiseModel::Base* model);
   gtsam::Vector evaluateError(const gtsam::NavState &x1, const gtsam::NavState &x2) const;
 };
 
 #include <gtsam/navigation/MagFactor.h>
 
-class MagFactor: gtsam::NonlinearFactor {
+class MagFactor: gtsam::NoiseModelFactor {
   MagFactor(gtsam::Key key, const gtsam::Point3& measured, double scale,
       const gtsam::Unit3& direction, const gtsam::Point3& bias,
       const gtsam::noiseModel::Base* model);
@@ -1023,7 +1023,7 @@ class MagFactor: gtsam::NonlinearFactor {
                               gtsam::OptionalMatrixType H = nullptr) const;
 };
 
-class MagFactor1: gtsam::NonlinearFactor {
+class MagFactor1: gtsam::NoiseModelFactor {
   MagFactor1(gtsam::Key key, const gtsam::Point3& measured, double scale,
       const gtsam::Unit3& direction, const gtsam::Point3& bias,
       const gtsam::noiseModel::Base* model);

--- a/gtsam_unstable/gtsam_unstable.i
+++ b/gtsam_unstable/gtsam_unstable.i
@@ -333,7 +333,7 @@ class TimeOfArrival {
 };
 
 #include <gtsam_unstable/slam/TOAFactor.h>
-virtual class TOAFactor : gtsam::NonlinearFactor {
+virtual class TOAFactor : gtsam::NoiseModelFactor {
   // For now, because of overload issues, we only expose constructor with known sensor coordinates:
   TOAFactor(gtsam::Key key1, gtsam::Point3 sensor, double measured,
             const gtsam::noiseModel::Base* noiseModel);
@@ -341,7 +341,7 @@ virtual class TOAFactor : gtsam::NonlinearFactor {
 };
 
 #include <gtsam_unstable/dynamics/VelocityConstraint3.h>
-virtual class VelocityConstraint3 : gtsam::NonlinearFactor {
+virtual class VelocityConstraint3 : gtsam::NoiseModelFactor {
   /** Standard constructor */
   VelocityConstraint3(gtsam::Key key1, gtsam::Key key2, gtsam::Key velKey, double dt);
 
@@ -349,7 +349,7 @@ virtual class VelocityConstraint3 : gtsam::NonlinearFactor {
 };
 
 #include <gtsam_unstable/dynamics/Pendulum.h>
-virtual class PendulumFactor1 : gtsam::NonlinearFactor {
+virtual class PendulumFactor1 : gtsam::NoiseModelFactor {
   /** Standard constructor */
   PendulumFactor1(gtsam::Key k1, gtsam::Key k, gtsam::Key velKey, double dt);
 
@@ -357,21 +357,21 @@ virtual class PendulumFactor1 : gtsam::NonlinearFactor {
 };
 
 #include <gtsam_unstable/dynamics/Pendulum.h>
-virtual class PendulumFactor2 : gtsam::NonlinearFactor {
+virtual class PendulumFactor2 : gtsam::NoiseModelFactor {
   /** Standard constructor */
   PendulumFactor2(gtsam::Key vk1, gtsam::Key vk, gtsam::Key qKey, double dt, double L, double g);
 
   gtsam::Vector evaluateError(const double& vk1, const double& vk, const double& q) const;
 };
 
-virtual class PendulumFactorPk : gtsam::NonlinearFactor {
+virtual class PendulumFactorPk : gtsam::NoiseModelFactor {
   /** Standard constructor */
   PendulumFactorPk(gtsam::Key pk, gtsam::Key qk, gtsam::Key qk1, double h, double m, double r, double g, double alpha);
 
   gtsam::Vector evaluateError(const double& pk, const double& qk, const double& qk1) const;
 };
 
-virtual class PendulumFactorPk1 : gtsam::NonlinearFactor {
+virtual class PendulumFactorPk1 : gtsam::NoiseModelFactor {
   /** Standard constructor */
   PendulumFactorPk1(gtsam::Key pk1, gtsam::Key qk, gtsam::Key qk1, double h, double m, double r, double g, double alpha);
 

--- a/python/gtsam/tests/test_NavigationFactorNoiseModel.py
+++ b/python/gtsam/tests/test_NavigationFactorNoiseModel.py
@@ -1,0 +1,90 @@
+"""
+GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,
+Atlanta, Georgia 30332-0415
+All Rights Reserved
+
+See LICENSE for the license information.
+
+Unit tests confirming navigation factors expose the NoiseModelFactor
+interface (noiseModel, unwhitenedError, whitenedError) in Python.
+"""
+
+# pylint: disable=invalid-name, no-name-in-module, no-member
+
+import unittest
+
+import numpy as np
+
+import gtsam
+from gtsam.symbol_shorthand import B, X
+from gtsam.utils.test_case import GtsamTestCase
+
+
+class TestNavigationFactorNoiseModel(GtsamTestCase):
+    """Navigation factors derive from NoiseModelFactor in C++."""
+
+    def test_gps_factor_exposes_noise_model(self):
+        sigmas = np.array([1.0, 2.0, 3.0])
+        model = gtsam.noiseModel.Diagonal.Sigmas(sigmas)
+        factor = gtsam.GPSFactor(X(1), gtsam.Point3(1.0, 2.0, 3.0), model)
+
+        self.assertIsInstance(factor, gtsam.NoiseModelFactor)
+        np.testing.assert_allclose(factor.noiseModel().sigmas(), sigmas)
+
+    def test_gps_factor_unwhitened_error(self):
+        model = gtsam.noiseModel.Isotropic.Sigma(3, 1.0)
+        measured = gtsam.Point3(1.0, 2.0, 3.0)
+        factor = gtsam.GPSFactor(X(1), measured, model)
+
+        values = gtsam.Values()
+        values.insert(X(1), gtsam.Pose3(gtsam.Rot3(),
+                                        gtsam.Point3(1.0, 2.0, 4.0)))
+
+        error = factor.unwhitenedError(values)
+        np.testing.assert_allclose(error, np.array([0.0, 0.0, 1.0]),
+                                   atol=1e-9)
+
+    def test_barometric_factor_exposes_noise_model(self):
+        model = gtsam.noiseModel.Isotropic.Sigma(1, 0.5)
+        factor = gtsam.BarometricFactor(X(1), B(1), 1013.25, model)
+
+        self.assertIsInstance(factor, gtsam.NoiseModelFactor)
+        self.assertAlmostEqual(factor.noiseModel().sigma(), 0.5)
+
+    def test_whitened_error_scales_by_sigma(self):
+        """whitenedError is unwhitenedError divided through by sigma."""
+        sigma = 2.0
+        model = gtsam.noiseModel.Isotropic.Sigma(3, sigma)
+        factor = gtsam.GPSFactor(X(1), gtsam.Point3(0.0, 0.0, 0.0), model)
+
+        values = gtsam.Values()
+        values.insert(X(1), gtsam.Pose3(gtsam.Rot3(),
+                                        gtsam.Point3(0.0, 0.0, 4.0)))
+
+        np.testing.assert_allclose(factor.whitenedError(values),
+                                   factor.unwhitenedError(values) / sigma,
+                                   atol=1e-9)
+
+    def test_robust_wrapped_factor_still_exposes_raw_error(self):
+        """A robust-wrapped factor exposes its un-whitened residual.
+
+        unwhitenedError is computed before the noise model is applied, so it
+        is unaffected by the m-estimator. This is the residual any outlier
+        gate needs as its input.
+        """
+        base = gtsam.noiseModel.Isotropic.Sigma(3, 1.0)
+        robust = gtsam.noiseModel.Robust.Create(
+            gtsam.noiseModel.mEstimator.Huber.Create(1.345), base)
+        factor = gtsam.GPSFactor(X(1), gtsam.Point3(0.0, 0.0, 0.0), robust)
+
+        values = gtsam.Values()
+        values.insert(X(1), gtsam.Pose3(gtsam.Rot3(),
+                                        gtsam.Point3(0.0, 0.0, 50.0)))
+
+        self.assertIsInstance(factor, gtsam.NoiseModelFactor)
+        np.testing.assert_allclose(factor.unwhitenedError(values),
+                                   np.array([0.0, 0.0, 50.0]), atol=1e-9)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/gtsam/tests/test_NavigationFactorNoiseModel.py
+++ b/python/gtsam/tests/test_NavigationFactorNoiseModel.py
@@ -6,7 +6,7 @@ All Rights Reserved
 See LICENSE for the license information.
 
 Unit tests confirming navigation factors expose the NoiseModelFactor
-interface (noiseModel, unwhitenedError, whitenedError) in Python.
+interface (noiseModel, whitenedError) in Python.
 """
 
 # pylint: disable=invalid-name, no-name-in-module, no-member
@@ -31,7 +31,8 @@ class TestNavigationFactorNoiseModel(GtsamTestCase):
         self.assertIsInstance(factor, gtsam.NoiseModelFactor)
         np.testing.assert_allclose(factor.noiseModel().sigmas(), sigmas)
 
-    def test_gps_factor_unwhitened_error(self):
+    def test_gps_factor_whitened_error(self):
+        """Unit noise, so the whitened residual is the raw residual."""
         model = gtsam.noiseModel.Isotropic.Sigma(3, 1.0)
         measured = gtsam.Point3(1.0, 2.0, 3.0)
         factor = gtsam.GPSFactor(X(1), measured, model)
@@ -40,9 +41,8 @@ class TestNavigationFactorNoiseModel(GtsamTestCase):
         values.insert(X(1), gtsam.Pose3(gtsam.Rot3(),
                                         gtsam.Point3(1.0, 2.0, 4.0)))
 
-        error = factor.unwhitenedError(values)
-        np.testing.assert_allclose(error, np.array([0.0, 0.0, 1.0]),
-                                   atol=1e-9)
+        np.testing.assert_allclose(factor.whitenedError(values),
+                                   np.array([0.0, 0.0, 1.0]), atol=1e-9)
 
     def test_barometric_factor_exposes_noise_model(self):
         model = gtsam.noiseModel.Isotropic.Sigma(1, 0.5)
@@ -52,9 +52,8 @@ class TestNavigationFactorNoiseModel(GtsamTestCase):
         self.assertAlmostEqual(factor.noiseModel().sigma(), 0.5)
 
     def test_whitened_error_scales_by_sigma(self):
-        """whitenedError is unwhitenedError divided through by sigma."""
-        sigma = 2.0
-        model = gtsam.noiseModel.Isotropic.Sigma(3, sigma)
+        """A 4 m residual under a 2 m sigma whitens to 2."""
+        model = gtsam.noiseModel.Isotropic.Sigma(3, 2.0)
         factor = gtsam.GPSFactor(X(1), gtsam.Point3(0.0, 0.0, 0.0), model)
 
         values = gtsam.Values()
@@ -62,15 +61,13 @@ class TestNavigationFactorNoiseModel(GtsamTestCase):
                                         gtsam.Point3(0.0, 0.0, 4.0)))
 
         np.testing.assert_allclose(factor.whitenedError(values),
-                                   factor.unwhitenedError(values) / sigma,
-                                   atol=1e-9)
+                                   np.array([0.0, 0.0, 2.0]), atol=1e-9)
 
-    def test_robust_wrapped_factor_still_exposes_raw_error(self):
-        """A robust-wrapped factor exposes its un-whitened residual.
+    def test_robust_wrapped_factor_reaches_its_noise_model(self):
+        """A robust-wrapped factor still exposes the NoiseModelFactor API.
 
-        unwhitenedError is computed before the noise model is applied, so it
-        is unaffected by the m-estimator. This is the residual any outlier
-        gate needs as its input.
+        The residual is down-weighted by the m-estimator, which is what
+        makes reaching the noise model necessary in the first place.
         """
         base = gtsam.noiseModel.Isotropic.Sigma(3, 1.0)
         robust = gtsam.noiseModel.Robust.Create(
@@ -82,8 +79,12 @@ class TestNavigationFactorNoiseModel(GtsamTestCase):
                                         gtsam.Point3(0.0, 0.0, 50.0)))
 
         self.assertIsInstance(factor, gtsam.NoiseModelFactor)
-        np.testing.assert_allclose(factor.unwhitenedError(values),
-                                   np.array([0.0, 0.0, 50.0]), atol=1e-9)
+        self.assertIsInstance(factor.noiseModel(), gtsam.noiseModel.Robust)
+
+        # 50 sigma, but Huber pulls the whitened residual well below that.
+        whitened = np.linalg.norm(factor.whitenedError(values))
+        self.assertGreater(whitened, 0.0)
+        self.assertLess(whitened, 50.0)
 
 
 if __name__ == "__main__":

--- a/python/gtsam_unstable/tests/test_UnstableFactorNoiseModel.py
+++ b/python/gtsam_unstable/tests/test_UnstableFactorNoiseModel.py
@@ -1,0 +1,71 @@
+"""
+GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,
+Atlanta, Georgia 30332-0415
+All Rights Reserved
+
+See LICENSE for the license information.
+
+Unit tests confirming gtsam_unstable factors that derive from
+NoiseModelFactor in C++ expose that interface in Python.
+"""
+
+# pylint: disable=invalid-name, no-name-in-module, no-member
+
+import unittest
+
+import gtsam
+import gtsam_unstable
+from gtsam.symbol_shorthand import P, Q, T, V, X
+from gtsam.utils.test_case import GtsamTestCase
+
+
+class TestUnstableFactorNoiseModel(GtsamTestCase):
+    """These factors derive from NoiseModelFactorT / ExpressionFactor."""
+
+    def test_pendulum_factor1(self):
+        """Constructed with a Constrained noise model internally."""
+        factor = gtsam_unstable.PendulumFactor1(Q(2), Q(1), V(1), 0.01)
+
+        self.assertIsInstance(factor, gtsam.NoiseModelFactor)
+        self.assertIsInstance(factor.noiseModel(),
+                              gtsam.noiseModel.Constrained)
+
+    def test_pendulum_factor2(self):
+        factor = gtsam_unstable.PendulumFactor2(V(2), V(1), Q(1), 0.01, 1.0,
+                                                9.81)
+
+        self.assertIsInstance(factor, gtsam.NoiseModelFactor)
+        self.assertIsInstance(factor.noiseModel(),
+                              gtsam.noiseModel.Constrained)
+
+    def test_pendulum_factor_pk(self):
+        factor = gtsam_unstable.PendulumFactorPk(P(1), Q(1), Q(2), 0.01, 1.0,
+                                                 1.0, 9.81, 0.0)
+
+        self.assertIsInstance(factor, gtsam.NoiseModelFactor)
+
+    def test_pendulum_factor_pk1(self):
+        factor = gtsam_unstable.PendulumFactorPk1(P(2), Q(1), Q(2), 0.01, 1.0,
+                                                  1.0, 9.81, 0.0)
+
+        self.assertIsInstance(factor, gtsam.NoiseModelFactor)
+
+    def test_velocity_constraint3(self):
+        factor = gtsam_unstable.VelocityConstraint3(X(1), X(2), V(1), 1.0)
+
+        self.assertIsInstance(factor, gtsam.NoiseModelFactor)
+        self.assertIsInstance(factor.noiseModel(),
+                              gtsam.noiseModel.Constrained)
+
+    def test_toa_factor(self):
+        """TOAFactor reaches NoiseModelFactor via ExpressionFactor<double>."""
+        model = gtsam.noiseModel.Isotropic.Sigma(1, 0.05)
+        factor = gtsam_unstable.TOAFactor(T(1), gtsam.Point3(1.0, 0.0, 0.0),
+                                          0.003, model)
+
+        self.assertIsInstance(factor, gtsam.NoiseModelFactor)
+        self.assertAlmostEqual(factor.noiseModel().sigma(), 0.05)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Thirty factors in navigation.i are declared with gtsam::NonlinearFactor as their parent, but every one of them derives from NoiseModelFactorN or NoiseModelFactorT in C++. Because the wrapper registers the shallower parent, the NoiseModelFactor interface -- noiseModel(), unwhitenedError() and whitenedError() -- is unreachable from Python on these factors.

This affects GPSFactor and its five variants, BarometricFactor, ImuFactor, ImuFactor2, ImuFactorWithGravityT, AHRSFactor, ConstantVelocityFactor, MagFactor, MagFactor1, and the sixteen Pseudorange/CarrierPhase/Doppler factors. Only CombinedImuFactor, CombinedImuFactorWithGravityT, AttitudeFactor and MagPoseFactor were declared correctly.

The practical consequence is that no chi-square style gate or residual diagnostic can be computed from a GNSS, barometer or IMU factor in Python, because the noise model cannot be reached. slam.i already uses NoiseModelFactor throughout (25 declarations to 3); this brings navigation.i in line.

The Pseudorange and CarrierPhase factors additionally inherit privately from PseudorangeBase / CarrierPhaseBase, which is not a registered type, so NoiseModelFactor remains the single correct wrapper parent.

Generated the pybind sources before and after: every changed line is a py::class_ parent declaration, with no other delta.