### PR TITLE
wrap: complete targeted single-key calculateEstimate coverage

### DIFF
--- a/gtsam/nonlinear/nonlinear.i
+++ b/gtsam/nonlinear/nonlinear.i
@@ -589,13 +589,15 @@ class ISAM2 {
   const gtsam::Values& getLinearizationPoint() const;
   bool valueExists(gtsam::Key key) const;
   gtsam::Values calculateEstimate() const;
-  template <VALUE = {gtsam::Point2,
+  template <VALUE = {double,
+                     gtsam::Point2,
                      gtsam::Rot2,
                      gtsam::Pose2,
                      gtsam::Point3,
                      gtsam::Gal3,
                      gtsam::Rot3,
                      gtsam::Pose3,
+                     gtsam::NavState,
                      gtsam::SL4,
                      gtsam::Similarity2,
                      gtsam::Similarity3,
@@ -1041,9 +1043,11 @@ virtual class BatchFixedLagSmoother : gtsam::FixedLagSmoother {
 
   const gtsam::NonlinearFactorGraph& getFactors() const;
 
-  template <VALUE = {gtsam::Point2, gtsam::Rot2, gtsam::Pose2, gtsam::Point3,
-                     gtsam::Rot3, gtsam::Pose3, gtsam::SL4, gtsam::Similarity2,
+  template <VALUE = {double, gtsam::Point2, gtsam::Rot2, gtsam::Pose2,
+                     gtsam::Point3, gtsam::Rot3, gtsam::Pose3,
+                     gtsam::NavState, gtsam::SL4, gtsam::Similarity2,
                      gtsam::Similarity3, gtsam::Cal3_S2, gtsam::Cal3DS2,
+                     gtsam::imuBias::ConstantBias,
                      gtsam::Vector, gtsam::Matrix}>
   VALUE calculateEstimate(gtsam::Key key) const;
 };
@@ -1061,6 +1065,35 @@ virtual class IncrementalFixedLagSmoother : gtsam::FixedLagSmoother {
   const gtsam::NonlinearFactorGraph& getFactors() const;
   const gtsam::ISAM2& getISAM2() const;
   const gtsam::ISAM2Result& getISAM2Result() const;
+
+  // Mirrors gtsam::ISAM2::calculateEstimate<VALUE>, which this forwards to.
+  template <VALUE = {double,
+                     gtsam::Point2,
+                     gtsam::Rot2,
+                     gtsam::Pose2,
+                     gtsam::Point3,
+                     gtsam::Gal3,
+                     gtsam::Rot3,
+                     gtsam::Pose3,
+                     gtsam::NavState,
+                     gtsam::SL4,
+                     gtsam::Similarity2,
+                     gtsam::Similarity3,
+                     gtsam::Cal3_S2,
+                     gtsam::Cal3DS2,
+                     gtsam::Cal3f,
+                     gtsam::Cal3Bundler,
+                     gtsam::imuBias::ConstantBias,
+                     gtsam::EssentialMatrix,
+                     gtsam::FundamentalMatrix,
+                     gtsam::SimpleFundamentalMatrix,
+                     gtsam::PinholeCamera<gtsam::Cal3_S2>,
+                     gtsam::PinholeCamera<gtsam::Cal3Bundler>,
+                     gtsam::PinholeCamera<gtsam::Cal3Fisheye>,
+                     gtsam::PinholeCamera<gtsam::Cal3Unified>,
+                     gtsam::Vector,
+                     gtsam::Matrix}>
+  VALUE calculateEstimate(gtsam::Key key) const;
 };
 
 #include <gtsam/nonlinear/ExtendedKalmanFilter.h>

--- a/python/gtsam/tests/test_TargetedEstimate.py
+++ b/python/gtsam/tests/test_TargetedEstimate.py
@@ -1,0 +1,146 @@
+"""
+GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,
+Atlanta, Georgia 30332-0415
+All Rights Reserved
+
+See LICENSE for the license information.
+
+Unit tests for targeted single-key calculateEstimate on ISAM2 and on both
+fixed-lag smoothers.
+"""
+
+# pylint: disable=invalid-name, no-name-in-module, no-member
+
+import unittest
+
+import numpy as np
+
+import gtsam
+from gtsam.symbol_shorthand import B, S, X
+from gtsam.utils.test_case import GtsamTestCase
+
+
+def scalar_problem():
+    """A two-variable scalar chain: prior on s1, between s1 and s2."""
+    graph = gtsam.NonlinearFactorGraph()
+    noise = gtsam.noiseModel.Isotropic.Sigma(1, 0.1)
+
+    graph.add(gtsam.PriorFactorDouble(S(1), 1.0, noise))
+    graph.add(gtsam.BetweenFactorDouble(S(1), S(2), 2.0, noise))
+
+    values = gtsam.Values()
+    values.insert(S(1), 0.9)
+    values.insert(S(2), 3.2)
+    return graph, values
+
+
+def navstate_problem():
+    """A single NavState constrained by a prior."""
+    graph = gtsam.NonlinearFactorGraph()
+    noise = gtsam.noiseModel.Isotropic.Sigma(9, 0.1)
+
+    prior = gtsam.NavState(gtsam.Rot3.Ypr(0.1, 0.0, 0.0),
+                           gtsam.Point3(1.0, 2.0, 3.0),
+                           np.array([0.5, 0.0, 0.0]))
+    graph.add(gtsam.PriorFactorNavState(X(1), prior, noise))
+
+    values = gtsam.Values()
+    values.insert(X(1), gtsam.NavState())
+    return graph, values
+
+
+def timestamps(*pairs):
+    """Build a FixedLagSmootherKeyTimestampMap from (key, time) pairs."""
+    stamps = gtsam.FixedLagSmootherKeyTimestampMap()
+    for key, time in pairs:
+        stamps.insert(gtsam.FixedLagSmootherKeyTimestampMapValue(key, time))
+    return stamps
+
+
+class TestISAM2TargetedEstimate(GtsamTestCase):
+    """ISAM2 gains scalar and NavState extraction."""
+
+    def test_scalar(self):
+        graph, values = scalar_problem()
+        isam = gtsam.ISAM2()
+        isam.update(graph, values)
+
+        expected = isam.calculateEstimate().atDouble(S(2))
+        self.assertAlmostEqual(isam.calculateEstimateDouble(S(2)), expected)
+
+    def test_navstate(self):
+        graph, values = navstate_problem()
+        isam = gtsam.ISAM2()
+        isam.update(graph, values)
+
+        expected = isam.calculateEstimate().atNavState(X(1))
+        actual = isam.calculateEstimateNavState(X(1))
+        self.gtsamAssertEquals(actual, expected, 1e-9)
+
+
+class TestIncrementalFixedLagSmootherTargetedEstimate(GtsamTestCase):
+    """The incremental smoother gains the templated accessor entirely.
+
+    Previously the only way to read a single key from an
+    IncrementalFixedLagSmoother was to go through getISAM2().
+    """
+
+    def test_scalar(self):
+        graph, values = scalar_problem()
+        smoother = gtsam.IncrementalFixedLagSmoother(10.0)
+        smoother.update(graph, values, timestamps((S(1), 0.0), (S(2), 1.0)))
+
+        expected = smoother.calculateEstimate().atDouble(S(2))
+        self.assertAlmostEqual(smoother.calculateEstimateDouble(S(2)), expected)
+
+    def test_navstate(self):
+        graph, values = navstate_problem()
+        smoother = gtsam.IncrementalFixedLagSmoother(10.0)
+        smoother.update(graph, values, timestamps((X(1), 0.0)))
+
+        expected = smoother.calculateEstimate().atNavState(X(1))
+        actual = smoother.calculateEstimateNavState(X(1))
+        self.gtsamAssertEquals(actual, expected, 1e-9)
+
+    def test_matches_isam2_directly(self):
+        """The forwarding accessor agrees with reaching through getISAM2()."""
+        graph, values = scalar_problem()
+        smoother = gtsam.IncrementalFixedLagSmoother(10.0)
+        smoother.update(graph, values, timestamps((S(1), 0.0), (S(2), 1.0)))
+
+        self.assertAlmostEqual(smoother.calculateEstimateDouble(S(2)),
+                               smoother.getISAM2().calculateEstimateDouble(S(2)))
+
+
+class TestBatchFixedLagSmootherTargetedEstimate(GtsamTestCase):
+    """The batch smoother gains scalar, NavState and bias extraction."""
+
+    def test_scalar(self):
+        graph, values = scalar_problem()
+        smoother = gtsam.BatchFixedLagSmoother(10.0)
+        smoother.update(graph, values, timestamps((S(1), 0.0), (S(2), 1.0)))
+
+        expected = smoother.calculateEstimate().atDouble(S(2))
+        self.assertAlmostEqual(smoother.calculateEstimateDouble(S(2)), expected)
+
+    def test_constant_bias(self):
+        bias = gtsam.imuBias.ConstantBias(np.array([0.1, 0.2, 0.3]),
+                                          np.array([0.01, 0.02, 0.03]))
+        noise = gtsam.noiseModel.Isotropic.Sigma(6, 0.1)
+
+        graph = gtsam.NonlinearFactorGraph()
+        graph.add(gtsam.PriorFactorConstantBias(B(1), bias, noise))
+
+        values = gtsam.Values()
+        values.insert(B(1), gtsam.imuBias.ConstantBias())
+
+        smoother = gtsam.BatchFixedLagSmoother(10.0)
+        smoother.update(graph, values, timestamps((B(1), 0.0)))
+
+        expected = smoother.calculateEstimate().atConstantBias(B(1))
+        actual = smoother.calculateEstimateConstantBias(B(1))
+        self.gtsamAssertEquals(actual, expected, 1e-9)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/gtsam/tests/test_TargetedEstimate.py
+++ b/python/gtsam/tests/test_TargetedEstimate.py
@@ -50,11 +50,8 @@ def navstate_problem():
 
 
 def timestamps(*pairs):
-    """Build a FixedLagSmootherKeyTimestampMap from (key, time) pairs."""
-    stamps = gtsam.FixedLagSmootherKeyTimestampMap()
-    for key, time in pairs:
-        stamps.insert(gtsam.FixedLagSmootherKeyTimestampMapValue(key, time))
-    return stamps
+    """Key-timestamp map for the smoothers, which take a plain dict."""
+    return {key: time for key, time in pairs}
 
 
 class TestISAM2TargetedEstimate(GtsamTestCase):


### PR DESCRIPTION
IncrementalFixedLagSmoother::calculateEstimate<VALUE>(Key) exists in C++ and its own doc comment notes it is faster than the no-argument version, but it was never declared in the wrapper. The only way to read a single key from an IncrementalFixedLagSmoother from Python was to reach through getISAM2() and call the accessor on the ISAM2 instance. This declares the templated accessor directly, mirroring the list of the ISAM2 method it forwards to.

Also fills in three missing instantiations:

  - `double` on ISAM2 and BatchFixedLagSmoother. Systems that estimate genuinely scalar states (barometer bias, clock bias) otherwise have to fall back to calculateEstimate() and read the key out of the full Values, which is an O(window) recompute for one scalar. double is already wrappable here: PriorFactor's list starts with it and Values exposes atDouble.

  - `gtsam::NavState` on both. Values already carries NavState in its at<T>, insert and update lists, and ExtendedKalmanFilter already instantiates on it, so no targeted NavState read was available on either smoother despite the type being fully supported elsewhere.

  - `gtsam::imuBias::ConstantBias` on BatchFixedLagSmoother, which ISAM2 already had. No IMU-based system using the batch smoother could pull a single bias by key.