### PR TITLE
wrap: expose noise model introspection and Robust accessors

### DIFF
--- a/gtsam/linear/NoiseModel.cpp
+++ b/gtsam/linear/NoiseModel.cpp
@@ -71,7 +71,7 @@ std::optional<Vector> checkIfDiagonal(const Matrix& M) {
 
 /* ************************************************************************* */
 Vector Base::sigmas() const {
-  throw("Base::sigmas: sigmas() not implemented for this noise model");
+  throw runtime_error("Base::sigmas: sigmas() not implemented for this noise model");
 }
 
 /* ************************************************************************* */

--- a/gtsam/linear/linear.i
+++ b/gtsam/linear/linear.i
@@ -33,12 +33,27 @@ namespace noiseModel {
 #include <gtsam/linear/NoiseModel.h>
 virtual class Base {
   void print(string s = "") const;
-  // Methods below are available for all noise models. However, can't add them
-  // because wrap (incorrectly) thinks robust classes derive from this Base as well.
-  // bool isConstrained() const;
-  // bool isUnit() const;
-  // size_t dim() const;
-  // gtsam::Vector sigmas() const;
+
+  // Introspection, available on every noise model.
+  bool isConstrained() const;
+  bool isUnit() const;
+  size_t dim() const;
+  gtsam::Vector sigmas() const;
+
+  // Whitening operations. Note that for gtsam::noiseModel::Robust these apply
+  // the m-estimator re-weighting; use unweightedWhiten or
+  // squaredMahalanobisDistance for the un-reweighted quantities.
+  gtsam::Vector whiten(const gtsam::Vector& v) const;
+  gtsam::Vector unwhiten(const gtsam::Vector& v) const;
+  gtsam::Matrix Whiten(const gtsam::Matrix& H) const;
+
+  // Error metrics. Robust overrides these to defer to the contained noise
+  // model, so a statistical gate computed here is not silently down-weighted.
+  double squaredMahalanobisDistance(const gtsam::Vector& v) const;
+  double mahalanobisDistance(const gtsam::Vector& v) const;
+  double loss(double squared_distance) const;
+  gtsam::Vector unweightedWhiten(const gtsam::Vector& v) const;
+  double weight(const gtsam::Vector& v) const;
 };
 
 virtual class Gaussian : gtsam::noiseModel::Base {
@@ -393,6 +408,10 @@ virtual class Robust : gtsam::noiseModel::Base {
   static gtsam::noiseModel::Robust* Create(
       const std::shared_ptr<gtsam::noiseModel::mEstimator::Base>& robust,
       const std::shared_ptr<gtsam::noiseModel::Base> noise);
+
+  // Access to the contained models.
+  const std::shared_ptr<gtsam::noiseModel::mEstimator::Base>& robust() const;
+  const std::shared_ptr<gtsam::noiseModel::Base>& noise() const;
 
   // enabling serialization functionality
   void serializable() const;

--- a/python/gtsam/tests/test_NoiseModelIntrospection.py
+++ b/python/gtsam/tests/test_NoiseModelIntrospection.py
@@ -1,0 +1,122 @@
+"""
+GTSAM Copyright 2010-2019, Georgia Tech Research Corporation,
+Atlanta, Georgia 30332-0415
+All Rights Reserved
+
+See LICENSE for the license information
+
+Unit tests for noise model introspection exposed on noiseModel::Base
+and for the accessors on noiseModel::Robust.
+"""
+
+import unittest
+
+import numpy as np
+from gtsam.utils.test_case import GtsamTestCase
+
+import gtsam
+
+
+class TestNoiseModelIntrospection(GtsamTestCase):
+    """Tests for the introspection methods declared on noiseModel::Base."""
+
+    def test_dim_and_flags(self):
+        """dim/isUnit/isConstrained are reachable from any noise model."""
+        diagonal = gtsam.noiseModel.Diagonal.Sigmas(np.array([1.0, 2.0, 3.0]))
+        self.assertEqual(diagonal.dim(), 3)
+        self.assertFalse(diagonal.isUnit())
+        self.assertFalse(diagonal.isConstrained())
+
+        unit = gtsam.noiseModel.Unit.Create(2)
+        self.assertEqual(unit.dim(), 2)
+        self.assertTrue(unit.isUnit())
+
+        constrained = gtsam.noiseModel.Constrained.All(2)
+        self.assertTrue(constrained.isConstrained())
+
+    def test_sigmas_on_base(self):
+        """sigmas() is virtual on Base and resolves to the derived model."""
+        sigmas = np.array([0.5, 4.0])
+        model = gtsam.noiseModel.Diagonal.Sigmas(sigmas)
+        np.testing.assert_allclose(model.sigmas(), sigmas)
+
+    def test_mahalanobis_matches_manual(self):
+        """squaredMahalanobisDistance agrees with the hand computation."""
+        sigmas = np.array([1.0, 2.0])
+        model = gtsam.noiseModel.Diagonal.Sigmas(sigmas)
+        v = np.array([3.0, 4.0])
+        expected = np.sum((v / sigmas) ** 2)
+        self.assertAlmostEqual(model.squaredMahalanobisDistance(v), expected)
+        self.assertAlmostEqual(model.mahalanobisDistance(v), np.sqrt(expected))
+
+    def test_robust_is_not_reweighted(self):
+        """A Robust model reports the *underlying* Mahalanobis distance.
+
+        This is the property that makes chi-square style gating possible on
+        robust factors: whiten() applies the m-estimator weight, but
+        squaredMahalanobisDistance and unweightedWhiten do not.
+        """
+        sigmas = np.array([1.0])
+        base = gtsam.noiseModel.Diagonal.Sigmas(sigmas)
+        robust = gtsam.noiseModel.Robust.Create(
+            gtsam.noiseModel.mEstimator.Huber.Create(1.345), base)
+
+        outlier = np.array([50.0])
+
+        # The un-reweighted quantities match the underlying Gaussian exactly.
+        self.assertAlmostEqual(robust.squaredMahalanobisDistance(outlier),
+                               base.squaredMahalanobisDistance(outlier))
+        np.testing.assert_allclose(robust.unweightedWhiten(outlier),
+                                   base.whiten(outlier))
+
+        # whiten(), by contrast, is down-weighted by the m-estimator.
+        self.assertLess(abs(robust.whiten(outlier)[0]), abs(base.whiten(outlier)[0]))
+
+        # And the weight itself is now observable.
+        self.assertLess(robust.weight(outlier), 1.0)
+        self.assertAlmostEqual(base.weight(outlier), 1.0)
+
+    def test_robust_dim_delegates(self):
+        """Robust reports the dimension of the model it wraps."""
+        base = gtsam.noiseModel.Isotropic.Sigma(3, 2.0)
+        robust = gtsam.noiseModel.Robust.Create(
+            gtsam.noiseModel.mEstimator.Huber.Create(1.345), base)
+        self.assertEqual(robust.dim(), 3)
+
+
+class TestRobustAccessors(GtsamTestCase):
+    """Tests for noiseModel::Robust::robust() and ::noise()."""
+
+    def test_noise_accessor_round_trip(self):
+        """noise() returns the model that was passed to Create()."""
+        sigmas = np.array([0.1, 0.2, 0.3])
+        base = gtsam.noiseModel.Diagonal.Sigmas(sigmas)
+        robust = gtsam.noiseModel.Robust.Create(
+            gtsam.noiseModel.mEstimator.Huber.Create(1.345), base)
+
+        recovered = robust.noise()
+        self.assertEqual(recovered.dim(), 3)
+        np.testing.assert_allclose(recovered.sigmas(), sigmas)
+
+    def test_robust_accessor(self):
+        """robust() returns the contained m-estimator."""
+        loss = gtsam.noiseModel.mEstimator.Huber.Create(1.345)
+        robust = gtsam.noiseModel.Robust.Create(
+            loss, gtsam.noiseModel.Isotropic.Sigma(1, 1.0))
+        self.assertAlmostEqual(robust.robust().weight(0.5), 1.0)
+
+    def test_reachable_from_factor(self):
+        """The chain factor -> noiseModel() -> noise() works end to end."""
+        sigmas = np.array([0.5])
+        base = gtsam.noiseModel.Diagonal.Sigmas(sigmas)
+        robust = gtsam.noiseModel.Robust.Create(
+            gtsam.noiseModel.mEstimator.Huber.Create(1.345), base)
+        factor = gtsam.PriorFactorDouble(0, 1.0, robust)
+
+        model = factor.noiseModel()
+        self.assertEqual(model.dim(), 1)
+        np.testing.assert_allclose(model.noise().sigmas(), sigmas)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/gtsam/tests/test_NoiseModelIntrospection.py
+++ b/python/gtsam/tests/test_NoiseModelIntrospection.py
@@ -83,6 +83,21 @@ class TestNoiseModelIntrospection(GtsamTestCase):
             gtsam.noiseModel.mEstimator.Huber.Create(1.345), base)
         self.assertEqual(robust.dim(), 3)
 
+    def test_sigmas_unsupported_raises_cleanly(self):
+        """Robust has no sigmas of its own, and says so intelligibly.
+
+        Base::sigmas() is the fallback for models that cannot answer. It
+        must surface as a Python exception carrying its message, not as
+        pybind's unknown-exception catch-all.
+        """
+        robust = gtsam.noiseModel.Robust.Create(
+            gtsam.noiseModel.mEstimator.Huber.Create(1.345),
+            gtsam.noiseModel.Isotropic.Sigma(1, 1.0))
+
+        with self.assertRaises(RuntimeError) as ctx:
+            robust.sigmas()
+        self.assertIn("not implemented", str(ctx.exception))
+
 
 class TestRobustAccessors(GtsamTestCase):
     """Tests for noiseModel::Robust::robust() and ::noise()."""


### PR DESCRIPTION
On a stock build the entire Python surface of a robust noise model is:

```python
>>> [x for x in dir(robust) if not x.startswith('_')]
['Create', 'deserialize', 'print', 'serialize']
```

and a `Diagonal` has `sigmas`, `covariance` and `whiten` but no `dim`,
`isUnit` or `isConstrained`. `NoiseModelFactor::noiseModel()` is wrapped, so
from Python you can reach the `Base*` and then go no further.

### The commented-out block

`linear.i` says these methods can't be added "because wrap (incorrectly)
thinks robust classes derive from this Base as well." That comment dates from
`1d6392dc` (Aug 2020, the initial pybind migration) and moved to `linear.i` in
`9bafebb5` without being revisited. It no longer reproduces.

Generated the wrappers with the vendored `wrap`, before and after:

- **pybind**: the only delta is the new `.def` lines on
  `gtsam::noiseModel::Base`. All thirteen `mEstimator` classes still emit as
  `py::class_<gtsam::noiseModel::mEstimator::X, gtsam::noiseModel::mEstimator::Base, ...>`.
- **MATLAB**: `mEstimator` classes still emit
  `classdef X < gtsam.noiseModel.mEstimator.Base`, and the new methods appear
  as `gtsamnoiseModelBase_dim_25` etc. against the correct class.

No contamination on either path. I couldn't find the commit that fixed it —
the comment predates most of `wrap`'s history.

### Why more than the four commented-out methods

`squaredMahalanobisDistance` and `unweightedWhiten` are the two methods
`Robust` overrides specifically to bypass the m-estimator re-weighting.
Exposing them on `Base` means a chi-square style gate can be computed
polymorphically off `NoiseModelFactor::noiseModel()` without the caller
knowing whether a factor is robust-wrapped — including for factors it didn't
construct. `whiten()` on a robust model is silently down-weighted, so a gate
built on it understates a gross fault.

`robust()` and `noise()` are included for introspection. They generate
identically to the existing `Sampler::model()` precedent in the same file:
`-> const auto&` with `return_value_policy::reference_internal`.

Parameter names match the headers exactly, per DEVELOP.md.

### Second commit

`Base::sigmas()` used `throw("...")`, which throws a `const char*` rather than
a `std::exception`. `Robust` doesn't override `sigmas()` — it has none of its
own — so with the method now reachable, the fallback surfaced as
`RuntimeError: Caught an unknown exception!` with the message discarded.

It's the only such throw in the file; the other six use
`throw invalid_argument(...)` and `NoiseModel.h` uses `std::runtime_error` and
`std::invalid_argument`. Split into its own commit so it can be dropped
independently.
