### PR TITLE
Make JacobianVector opaque for every module fragment

### DIFF
--- a/python/gtsam/optional_jacobian_pybind.h
+++ b/python/gtsam/optional_jacobian_pybind.h
@@ -6,6 +6,22 @@
 #include <gtsam/base/OptionalJacobian.h>
 
 #include <memory>
+#include <vector>
+
+/* gtsam::OptionalMatrixVecType is std::vector<gtsam::Matrix>*, an input/output
+ * argument used by NoiseModelFactor::unwhitenedError and by CustomFactor's
+ * error callback. It must be opaque so that mutations on the Python side are
+ * visible to C++, and so that the `= nullptr` default can round-trip through
+ * None during function registration.
+ *
+ * This lives here rather than in a per-module preamble because every .i file is
+ * generated into its own translation unit including only its own preamble,
+ * whereas this header is included by both module templates. pybind11 requires
+ * PYBIND11_MAKE_OPAQUE to be visible in every translation unit of a module that
+ * touches the type; declaring it per-preamble made it opaque in custom.cpp and
+ * transparent everywhere else.
+ */
+PYBIND11_MAKE_OPAQUE(std::vector<gtsam::Matrix>); // JacobianVector
 
 namespace pybind11 {
 namespace detail {

--- a/python/gtsam/preamble/custom.h
+++ b/python/gtsam/preamble/custom.h
@@ -11,5 +11,6 @@
  * mutations on Python side will not be reflected on C++.
  */
 
-// Added so that CustomFactor can pass the JacobianVector to the C++ side
-PYBIND11_MAKE_OPAQUE(std::vector<gtsam::Matrix>); // JacobianVector
+// JacobianVector (std::vector<gtsam::Matrix>) is made opaque in
+// python/gtsam/optional_jacobian_pybind.h, which both module templates include,
+// so that it is opaque in every translation unit rather than only this one.

--- a/python/gtsam/tests/test_OptionalJacobianArgument.py
+++ b/python/gtsam/tests/test_OptionalJacobianArgument.py
@@ -1,0 +1,62 @@
+"""
+GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,
+Atlanta, Georgia 30332-0415
+All Rights Reserved
+
+See LICENSE for the license information.
+
+Unit tests for NoiseModelFactor's optional Jacobian argument.
+"""
+
+# pylint: disable=invalid-name, no-name-in-module, no-member
+
+import unittest
+
+import numpy as np
+
+import gtsam
+from gtsam.symbol_shorthand import X
+from gtsam.utils.test_case import GtsamTestCase
+
+
+class TestUnwhitenedError(GtsamTestCase):
+    """unwhitenedError takes gtsam::OptionalMatrixVecType H = nullptr."""
+
+    @staticmethod
+    def prior_problem():
+        """A single Pose3 prior with a 1 m offset along z."""
+        model = gtsam.noiseModel.Isotropic.Sigma(6, 1.0)
+        factor = gtsam.PriorFactorPose3(X(1), gtsam.Pose3(), model)
+
+        values = gtsam.Values()
+        values.insert(X(1), gtsam.Pose3(gtsam.Rot3(),
+                                        gtsam.Point3(0.0, 0.0, 1.0)))
+        return factor, values
+
+    def test_H_may_be_omitted(self):
+        """The default must round-trip through None."""
+        factor, values = self.prior_problem()
+
+        error = factor.unwhitenedError(values)
+        self.assertEqual(len(error), 6)
+        # A pure 1 m offset with identity rotation, so the tangent vector has
+        # unit norm regardless of sign or tangent-space ordering.
+        self.assertAlmostEqual(np.linalg.norm(error), 1.0)
+
+    def test_H_may_be_passed_explicitly_as_none(self):
+        factor, values = self.prior_problem()
+
+        error = factor.unwhitenedError(values, None)
+        np.testing.assert_allclose(error, factor.unwhitenedError(values),
+                                   atol=1e-12)
+
+    def test_agrees_with_whitened_error(self):
+        """Unit noise, so whitened and unwhitened coincide."""
+        factor, values = self.prior_problem()
+
+        np.testing.assert_allclose(factor.whitenedError(values),
+                                   factor.unwhitenedError(values), atol=1e-12)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Confirmed with a minimal pybind11 module built twice from identical source
with only `PYBIND11_MAKE_OPAQUE` toggled:

    ===== transparent =====
      f.unwhitenedError(1)        -> TypeError: incompatible function arguments
      f.unwhitenedError(1, None)  -> TypeError: incompatible function arguments
      f.whitenedError(1)          -> ok          (no optional arg)

    ===== opaque =====
      f.unwhitenedError(1)        -> no H
      f.unwhitenedError(1, None)  -> no H
      f.whitenedError(1)          -> ok

The opaque build also populates `H` when one is passed. I also compile-tested
the macro in this exact position — global scope, ahead of the
`pybind11::detail` block that follows it in this header.

This moves the declaration rather than adding it to two more preambles,
mirroring how the `OptionalJacobian` caster from #2699 is already handled —
that one lives in this header for the same reason. Happy to do the narrower
version instead (add `PYBIND11_MAKE_OPAQUE` to `preamble/nonlinear.h` and
`gtsam_unstable/preamble.h`, leave `custom.h` alone) if you'd rather not move
a declaration `custom.cpp` currently depends on.

Surfaced by the CI run on #2707.