### PR TITLE
Fix MATLAB CustomFactor destructor chaining

### DIFF
--- a/matlab/+gtsam/CustomFactor.m
+++ b/matlab/+gtsam/CustomFactor.m
@@ -53,7 +53,6 @@ classdef CustomFactor < gtsam.MatlabCustomFactor
           gtsam.customFactorRegistry('remove', obj(i).callbackId);
           obj(i).callbackId = uint64(0);
         end
-        delete@gtsam.MatlabCustomFactor(obj(i));
       end
     end
   end


### PR DESCRIPTION
## Summary

- Remove the explicit MatlabCustomFactor superclass destructor call.
- Rely on handle-class lifecycle dispatch to invoke superclass destructors once.
- Avoid duplicate deletion of the generated native wrapper handle.

## Rationale

MATLAB handle-class destructors augment rather than override superclass destructors. The runtime automatically invokes each superclass destructor after the subclass destructor. Calling the superclass destructor manually can therefore invoke the generated MEX cleanup twice.

Reference: https://www.mathworks.com/help/matlab/matlab_oop/handle-class-destructors.html

## Testing

- Focused CustomFactor callback, Jacobian, optimization, and registry cleanup test under Octave 11.3.0
- Two consecutive focused test runs in one Octave process
- 200 repeated CustomFactor delete/clear lifecycle iterations
- git diff --check

MATLAB is not installed in the local environment; the change follows the documented MATLAB destructor contract.