### PR TITLE
fix: prevent BoundingConstraint1 iSAM2 update segfault

### DIFF
--- a/gtsam/nonlinear/ISAM2.cpp
+++ b/gtsam/nonlinear/ISAM2.cpp
@@ -101,22 +101,23 @@ GaussianFactorGraph ISAM2::relinearizeAffectedFactors(
         useCachedLinear = false;
     }
     if (inside) {
-      if (useCachedLinear) {
+      GaussianFactor::shared_ptr linearFactor;
+      if (useCachedLinear && linearFactors_[idx]) {
 #ifdef GTSAM_EXTRA_CONSISTENCY_CHECKS
-        assert(linearFactors_[idx]);
         assert(linearFactors_[idx]->keys() == nonlinearFactors_[idx]->keys());
 #endif
-        linearized.push_back(linearFactors_[idx]);
+        linearFactor = linearFactors_[idx];
       } else {
-        auto linearFactor = nonlinearFactors_[idx]->linearize(theta_);
-        linearized.push_back(linearFactor);
+        linearFactor = nonlinearFactors_[idx]->linearize(theta_);
         if (params_.cacheLinearizedFactors) {
 #ifdef GTSAM_EXTRA_CONSISTENCY_CHECKS
-          assert(linearFactors_[idx]->keys() == linearFactor->keys());
+          assert(!linearFactor ||
+                 linearFactor->keys() == nonlinearFactors_[idx]->keys());
 #endif
           linearFactors_[idx] = linearFactor;
         }
       }
+      if (linearFactor) linearized.push_back(linearFactor);
     }
   }
   gttoc(check_candidates_and_linearize);

--- a/tests/testBoundingConstraint.cpp
+++ b/tests/testBoundingConstraint.cpp
@@ -18,6 +18,7 @@
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/inference/Symbol.h>
+#include <gtsam/nonlinear/ISAM2.h>
 #include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
 #include <gtsam/nonlinear/LevenbergMarquardtParams.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
@@ -143,6 +144,53 @@ TEST( testBoundingConstraint, unary_linearization_active) {
   EXPECT(assert_equal((const GaussianFactor&)expected1, *actual1, tol));
   EXPECT(assert_equal((const GaussianFactor&)expected2, *actual2, tol));
 }
+
+/* ************************************************************************* */
+namespace isam2_bounding_constraint {
+
+Values updateWithIncrementalOdometry(const Point2& initialPoint) {
+  const Symbol x1('x', 1), x2('x', 2);
+  ISAM2 isam;
+
+  NonlinearFactorGraph initialFactors;
+  initialFactors.emplace_shared<simulated2D::Prior>(initialPoint, soft_model2,
+                                                    x1);
+  initialFactors.emplace_shared<iq2D::PoseXInequality>(x1, 0.0, true);
+  Values initialValues;
+  initialValues.insert(x1, initialPoint);
+  isam.update(initialFactors, initialValues);
+
+  const Point2 odometry(1.0, 0.0);
+  NonlinearFactorGraph incrementalFactors;
+  incrementalFactors.emplace_shared<simulated2D::Odometry>(odometry,
+                                                           soft_model2, x1, x2);
+  Values incrementalValues;
+  const Point2 secondPoint = initialPoint + odometry;
+  incrementalValues.insert(x2, secondPoint);
+  isam.update(incrementalFactors, incrementalValues);
+
+  return isam.calculateEstimate();
+}
+
+// Verifies an inactive cached constraint is safe during a later update.
+TEST(testBoundingConstraint, ISAM2InactiveConstraint) {
+  const Values estimate = updateWithIncrementalOdometry(Point2(1.0, 0.0));
+
+  EXPECT(estimate.at<Point2>(Symbol('x', 1)).allFinite());
+  EXPECT(estimate.at<Point2>(Symbol('x', 2)).allFinite());
+}
+
+// Verifies an active constraint remains in incremental elimination.
+TEST(testBoundingConstraint, ISAM2ActiveConstraint) {
+  const Values estimate = updateWithIncrementalOdometry(Point2(-1.0, 0.0));
+
+  EXPECT(estimate.at<Point2>(Symbol('x', 1)).allFinite());
+  EXPECT(estimate.at<Point2>(Symbol('x', 2)).allFinite());
+  EXPECT(estimate.at<Point2>(Symbol('x', 1)).x() >= -tol);
+}
+
+}  // namespace isam2_bounding_constraint
+/* ************************************************************************* */
 
 /* ************************************************************************* */
 TEST( testBoundingConstraint, unary_simple_optimization1) {


### PR DESCRIPTION
## Summary

Update `ISAM2::relinearizeAffectedFactors` so cached inactive factors are handled as a supported state: do not dereference a null cached or freshly linearized factor, re-evaluate an affected nonlinear factor when its cache cannot safely be reused, and keep the cache synchronized when the factor transitions between active and inactive. Preserve the existing factor-slot and variable-index bookkeeping so active factors still participate in elimination while inactive factors are omitted without introducing a test-only production abstraction. Add a focused regression to `testBoundingConstraint.cpp` using the existing simulated 2D bounding-constraint types and two sequential iSAM2 updates, mirroring the reported incremental workflow rather than changing `BoundingConstraint1`'s public API or its established inactive-linearization semantics.

## Validation

- Run two sequential `ISAM2::update` calls on a graph with an existing bounded variable and newly added incremental data; verify the second update completes and produces a finite estimate instead of crashing.
- Exercise a bounding constraint whose linearization is inactive during an update, then cause its key to be reconsidered by a later update; verify iSAM2 safely skips or refreshes the null cached factor.
- Exercise the complementary active constraint path across the two updates; verify the constraint's Gaussian factor remains in elimination and the estimate respects the configured bound.
- Retain the existing direct tests that inactive bounding constraints linearize to null and active constraints produce the expected constrained Jacobian factor, ensuring the fix does not alter factor-level semantics.

## Motivation

`BoundingConstraint1` can crash incremental optimization on the second `ISAM2::update`, even though the same update sequence works without the constraint. Inequality constraints legitimately become inactive, and `NoiseModelFactor::linearize` represents an inactive factor with a null Gaussian factor. iSAM2 retains linearized factors between updates, so a cached null entry or a factor that changes active state can reach affected-factor relinearization paths that assume a usable Gaussian factor. The issue is open, unassigned, confirmed as a bug by a maintainer, and has no competing or prior closed pull request in the supplied repository evidence.

Fixes #1905
