### PR TITLE
Expose unregistered GaussianFactor subclasses as their registered base

### DIFF
--- a/python/gtsam/gaussian_factor_pybind.h
+++ b/python/gtsam/gaussian_factor_pybind.h
@@ -1,0 +1,83 @@
+#pragma once
+
+/* Surface unregistered GaussianFactor subclasses as their nearest registered
+ * base.
+ *
+ * pybind11 resolves a polymorphic return value by looking up typeid(*src). If
+ * the dynamic type is not registered it does NOT walk up the hierarchy -- it
+ * falls back to the *declared* return type. NonlinearFactor::linearize is
+ * declared to return gtsam::GaussianFactor*, so any concrete factor type that
+ * is not registered surfaces in Python as a bare GaussianFactor, losing the
+ * JacobianFactor interface (getA, getb, jacobian, augmentedJacobian, ...).
+ *
+ * That is what happens to FixedJacobianFactor<M, Ns...>, which is templated on
+ * its dimensions and so cannot practically be registered: every fixed-size
+ * NoiseModelFactorT linearizes to one. gtsam::BetweenFactor names a fixed-size
+ * TangentVector as its error type and is affected; gtsam::PriorFactor goes
+ * through NoiseModelFactorN, whose error type is a dynamic Vector, so it keeps
+ * the generic path and a plain JacobianFactor.
+ *
+ * The hook checks the registry first, so registered subclasses keep their own
+ * identity -- gtsam::GaussianConditional derives from JacobianFactor and must
+ * still arrive in Python as a GaussianConditional.
+ *
+ * This lives in a header included by both module templates rather than in a
+ * per-module preamble: linearize is declared in nonlinear.i while the factor
+ * types are registered from linear.i, and pybind11 needs the hook visible in
+ * every translation unit that casts a GaussianFactor.
+ *
+ * Two limitations worth knowing about:
+ *
+ *  - The list of fallback bases below is hardcoded. C++ RTTI offers no way to
+ *    enumerate base classes, so any hook of this shape has to name them. If a
+ *    further branch is registered under GaussianFactor, add it here.
+ *
+ *  - detail::get_type_info is pybind11 internal API. It is long-stable and
+ *    widely used, but it is not a public guarantee. The alternative -- naming
+ *    the registered subclasses that must keep their identity, currently just
+ *    GaussianConditional -- would be brittle in a different way.
+ */
+
+#include <pybind11/pybind11.h>
+
+#include <gtsam/linear/GaussianFactor.h>
+#include <gtsam/linear/HessianFactor.h>
+#include <gtsam/linear/JacobianFactor.h>
+
+#include <typeinfo>
+
+namespace pybind11 {
+
+template <>
+struct polymorphic_type_hook<gtsam::GaussianFactor> {
+  static const void *get(const gtsam::GaussianFactor *src,
+                         const std::type_info *&type) {
+    if (src == nullptr) {
+      type = nullptr;
+      return nullptr;
+    }
+
+    // A registered dynamic type keeps its own identity.
+    const std::type_info &dynamic_type = typeid(*src);
+    if (detail::get_type_info(dynamic_type) != nullptr) {
+      type = &dynamic_type;
+      return dynamic_cast<const void *>(src);
+    }
+
+    // Otherwise expose the nearest registered base rather than letting
+    // pybind11 fall back to the declared return type.
+    if (const auto *jacobian = dynamic_cast<const gtsam::JacobianFactor *>(src)) {
+      type = &typeid(gtsam::JacobianFactor);
+      return jacobian;
+    }
+    if (const auto *hessian = dynamic_cast<const gtsam::HessianFactor *>(src)) {
+      type = &typeid(gtsam::HessianFactor);
+      return hessian;
+    }
+
+    type = &dynamic_type;
+    return dynamic_cast<const void *>(src);
+  }
+};
+
+}  // namespace pybind11

--- a/python/gtsam/gtsam.tpl
+++ b/python/gtsam/gtsam.tpl
@@ -17,6 +17,7 @@
 #include <pybind11/functional.h>
 #include <pybind11/iostream.h>
 #include "python/gtsam/optional_jacobian_pybind.h"
+#include "python/gtsam/gaussian_factor_pybind.h"
 #include "gtsam/config.h"
 #include "gtsam/base/serialization.h"
 #include "gtsam/base/utilities.h"  // for RedirectCout.

--- a/python/gtsam/tests/test_LinearizeReturnType.py
+++ b/python/gtsam/tests/test_LinearizeReturnType.py
@@ -1,0 +1,103 @@
+"""
+GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,
+Atlanta, Georgia 30332-0415
+All Rights Reserved
+
+See LICENSE for the license information.
+
+Unit tests for the Python type of factors produced by linearization.
+"""
+
+# pylint: disable=invalid-name, no-name-in-module, no-member
+
+import unittest
+
+import gtsam
+from gtsam.symbol_shorthand import X
+from gtsam.utils.test_case import GtsamTestCase
+
+def pose_values():
+    values = gtsam.Values()
+    values.insert(X(1), gtsam.Pose3())
+    values.insert(X(2), gtsam.Pose3(gtsam.Rot3(),
+                                    gtsam.Point3(1.0, 0.0, 0.0)))
+    return values
+
+
+def between_factor():
+    """A fixed-size-error factor: takes the FixedJacobianFactor path."""
+    return gtsam.BetweenFactorPose3(
+        X(1), X(2), gtsam.Pose3(gtsam.Rot3(), gtsam.Point3(1.0, 0.0, 0.0)),
+        gtsam.noiseModel.Isotropic.Sigma(6, 0.1))
+
+
+def prior_factor():
+    """PriorFactor uses NoiseModelFactorN, whose error type is a dynamic
+    Vector, so it retains the generic linearization path."""
+    return gtsam.PriorFactorPose3(X(1), gtsam.Pose3(),
+                                  gtsam.noiseModel.Isotropic.Sigma(6, 0.1))
+
+
+class TestLinearizeReturnType(GtsamTestCase):
+    """linearize() must yield a usable JacobianFactor in Python.
+
+    NonlinearFactor::linearize is declared to return gtsam::GaussianFactor*.
+    When the concrete type is not registered with pybind11, pybind falls back
+    to that declared type rather than walking up to the nearest registered
+    base, so the JacobianFactor interface is lost.
+    """
+
+    def test_between_factor_linearizes_to_jacobian_factor(self):
+        linear = between_factor().linearize(pose_values())
+        self.assertIsInstance(linear, gtsam.JacobianFactor)
+
+    def test_jacobian_interface_is_reachable(self):
+        """Type-checking is not enough: the methods must actually work."""
+        linear = between_factor().linearize(pose_values())
+
+        self.assertEqual(linear.rows(), 6)
+        # Two Pose3 keys of dimension 6 each.
+        self.assertEqual(linear.getA().shape, (6, 12))
+        self.assertEqual(len(linear.getb()), 6)
+
+    def test_prior_factor_linearizes_to_jacobian_factor(self):
+        """Control: this path was never affected."""
+        linear = prior_factor().linearize(pose_values())
+
+        self.assertIsInstance(linear, gtsam.JacobianFactor)
+        self.assertEqual(linear.rows(), 6)
+
+    def test_graph_linearize_yields_jacobian_factors(self):
+        """The same must hold when reached through a linearized graph.
+
+        GaussianFactorGraph::at is also declared to return GaussianFactor*.
+        """
+        graph = gtsam.NonlinearFactorGraph()
+        graph.add(prior_factor())
+        graph.add(between_factor())
+
+        linear_graph = graph.linearize(pose_values())
+        self.assertEqual(linear_graph.size(), 2)
+        for i in range(linear_graph.size()):
+            self.assertIsInstance(linear_graph.at(i), gtsam.JacobianFactor)
+
+    def test_registered_subclasses_keep_their_identity(self):
+        """GaussianConditional derives from JacobianFactor and is registered.
+
+        Reached through GaussianFactorGraph::at, which is declared to return
+        GaussianFactor*, so this exercises the same resolution path. The
+        conditional must not be flattened to a plain JacobianFactor.
+        """
+        graph = gtsam.NonlinearFactorGraph()
+        graph.add(prior_factor())
+        graph.add(between_factor())
+
+        bayes_net = graph.linearize(pose_values()).eliminateSequential()
+        as_graph = gtsam.GaussianFactorGraph(bayes_net)
+
+        self.assertGreater(as_graph.size(), 0)
+        self.assertIsInstance(as_graph.at(0), gtsam.GaussianConditional)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/gtsam_unstable/gtsam_unstable.tpl
+++ b/python/gtsam_unstable/gtsam_unstable.tpl
@@ -14,6 +14,7 @@
 #include <pybind11/functional.h>
 #include <pybind11/iostream.h>
 #include "python/gtsam/optional_jacobian_pybind.h"
+#include "python/gtsam/gaussian_factor_pybind.h"
 #include "gtsam/base/serialization.h"
 #include "gtsam/base/utilities.h"  // for RedirectCout.
 


### PR DESCRIPTION
NonlinearFactor::linearize and GaussianFactorGraph::at are declared to return gtsam::GaussianFactor*. pybind11 resolves a polymorphic return by looking up typeid(*src); when the dynamic type is not registered it does not walk up the hierarchy, it falls back to the declared type. So an unregistered concrete factor arrives in Python as a bare GaussianFactor, whose wrapped surface is only equals, error, clone, negate, augmentedInformation, information, augmentedJacobian and jacobian. getA, getb, rows, jacobianUnweighted and get_model are declared on JacobianFactor and are simply absent.

Since #2710, every NoiseModelFactorT whose error and argument dimensions are all fixed linearizes to FixedJacobianFactor<M, Ns...>. That type is templated on its dimensions, so it cannot practically be registered. BetweenFactor names a fixed-size TangentVector as its error type and is affected; PriorFactor goes through NoiseModelFactorN, whose error type is a dynamic Vector, so it keeps the generic path and a plain JacobianFactor. The declared return type has been GaussianFactor since long before that change, so the behaviour difference comes entirely from the concrete type.

RegularJacobianFactor and RegularHessianFactor are unregistered for the same reason and are covered by the same hook.

Note the object itself is unchanged: FixedJacobianFactor overrides hessianDiagonalAdd, multiplyHessianAdd and updateHessian, and those overrides still run. Only the Python-side wrapper type changes.

The hook consults the registry first, so registered subclasses keep their own identity: GaussianConditional derives from JacobianFactor and must still arrive in Python as a GaussianConditional.

It lives in a header included by both module templates rather than in a per-module preamble, because linearize is declared in nonlinear.i while the factor types are registered from linear.i, and pybind11 needs the hook visible in every translation unit that casts a GaussianFactor -- the same constraint that applies to PYBIND11_MAKE_OPAQUE.

Two limitations, both noted in the header: the list of fallback bases is hardcoded, since C++ RTTI cannot enumerate base classes; and detail::get_type_info is pybind11 internal API. A general fix -- having pybind11 fall back to the nearest registered base rather than the declared type -- would belong upstream in pybind11.