### PR TITLE
Fix GCC 13 warning errors

### DIFF
--- a/gtsam/base/SemidirectLieGroup-inl.h
+++ b/gtsam/base/SemidirectLieGroup-inl.h
@@ -200,7 +200,11 @@ SemidirectLieGroup<G, H, Action> SemidirectLieGroup<G, H, Action>::Expmap(
       const auto phi0Solver = kernels.phi0.lu();
       const H h = kernels.phi1 * v;
       *H1 = Matrix::Zero(d, d1);
-      H1->topRows(d1) = Dg;
+      if constexpr (firstDynamic) {
+        H1->topRows(d1) = Dg;
+      } else {
+        H1->template topLeftCorner<n, n>() = Dg;
+      }
       typename traits<G>::TangentVector ej;
       if constexpr (firstDynamic) ej.resize(d1);
       ej.setZero();
@@ -252,7 +256,11 @@ SemidirectLieGroup<G, H, Action>::Logmap(const SemidirectLieGroup& p,
       const auto solver = kernels.phi1.lu();
       const typename traits<H>::TangentVector v = solver.solve(p.second);
       *D = zeroJacobian(d);
-      D->topLeftCorner(d1, d1) = Dg;
+      if constexpr (firstDynamic) {
+        D->topLeftCorner(d1, d1) = Dg;
+      } else {
+        D->template topLeftCorner<n, n>() = Dg;
+      }
       D->bottomRightCorner(d2, d2) = solver.solve(kernels.phi0);
       for (Eigen::Index j = 0; j < static_cast<Eigen::Index>(d1); ++j) {
         const Jacobian2 B = Action::generator(Dg.col(j));

--- a/gtsam/geometry/PinholeCamera.h
+++ b/gtsam/geometry/PinholeCamera.h
@@ -293,7 +293,7 @@ public:
   double range(const PinholeCamera<CalibrationB>& camera,
       OptionalJacobian<1, dimension> Dcamera = {},
       OptionalJacobian<1, 6 + CalibrationB::dimension> Dother = {}) const {
-    Matrix16 Dcamera_, Dother_;
+    Matrix16 Dcamera_ = Matrix16::Zero(), Dother_ = Matrix16::Zero();
     double result = this->pose().range(camera.pose(), Dcamera ? &Dcamera_ : 0,
         Dother ? &Dother_ : 0);
     if (Dcamera) {

--- a/tests/testGraph.cpp
+++ b/tests/testGraph.cpp
@@ -12,9 +12,14 @@
 /**
  * @file testGraph.cpp
  * @date Jan 12, 2010
- * @author nikai
+ * @author Kai Ni
  * @brief unit test for graph-inl.h
  */
+
+// GCC reports false positives in Boost.Graph adjacency-list copies.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/MatrixConstants.h>

--- a/timing/exportBayesTreeCovarianceVisuals.cpp
+++ b/timing/exportBayesTreeCovarianceVisuals.cpp
@@ -243,7 +243,7 @@ void writeEdgeCsv(const filesystem::path& path,
 string datasetStem(const string& datasetName) {
   filesystem::path path(datasetName);
   string stem = path.filename().string();
-  for (const string& suffix : {".graph", ".txt"}) {
+  for (const string suffix : {".graph", ".txt"}) {
     if (stem.size() >= suffix.size() &&
         stem.compare(stem.size() - suffix.size(), suffix.size(), suffix) == 0) {
       stem.resize(stem.size() - suffix.size());
@@ -318,7 +318,7 @@ int main(int argc, char** argv) {
   writeMatrixCsv(outputDir / "w100_local_covariance.csv", localCovariance);
   writeMatrixCsv(outputDir / "w100_wide_covariance.csv", wideCovariance);
 
-  for (const string& cliqueDatasetName : {"w10000.graph", "w20000.txt"}) {
+  for (const string cliqueDatasetName : {"w10000.graph", "w20000.txt"}) {
     const OptimizedBayesTreeResult optimized =
         optimizeWithBayesTree(cliqueDatasetName);
     writeCliquePoseCsv(


### PR DESCRIPTION
## Summary

- initialize optional PinholeCamera range Jacobians before Eigen assignments
- use compile-time Jacobian blocks for fixed-size semidirect Lie groups
- suppress a GCC false positive in Boost.Graph adjacency-list copies
- avoid temporary string references in the timing visual exporter

## Validation

- `make check` — 376/376 tests passed
- `cmake --build build --target timing -j6` — all configured timing targets built; none were run
- `git diff --check`

Ceres-dependent and CUDA/cuDSS timing targets were not configured in this build.