### PR TITLE
Fix SO3::Logmap accuracy near theta = pi (#1233)

### DIFF
--- a/gtsam/geometry/Quaternion.h
+++ b/gtsam/geometry/Quaternion.h
@@ -97,49 +97,41 @@ struct traits<QUATERNION_TYPE> {
 
   /// We use our own Logmap, as there is a slight bug in Eigen
   static TangentVector Logmap(const Q& q, ChartJacobian H = {}) {
-    using std::acos;
-    using std::sqrt;
+    using std::atan;
 
-    // define these compile time constants to avoid std::abs:
-    static const double twoPi = 2.0 * M_PI, NearlyOne = 1.0 - 1e-10,
-    NearlyNegativeOne = -1.0 + 1e-10;
+    // theta = 2 * atan2(|v|, w),  omega = theta * v / |v|
+    // (C. Hertzberg et al., Information Fusion, 2011), written with atan()
+    // because it is measurably cheaper than atan2() and w >= 0 is arranged
+    // below anyway. Both theta and v/|v| are invariant to a positive rescaling
+    // of (w, v), so this stays correct when q is not of unit norm -- which
+    // matters because Rot3Q builds its quaternion straight from a rotation
+    // matrix supplied by the caller and never renormalizes.
+    //
+    // This also removes the need for the two Taylor branches the previous
+    // acos-based form required: atan is accurate as |v| -> 0, so the only
+    // degenerate case left is |v| == 0 exactly, i.e. the identity.
+    const _Scalar qw = q.w();
+    const _Scalar n = q.vec().norm();
 
     TangentVector omega;
-
-    const _Scalar qw = q.w();
-    // See Quaternion-Logmap.nb in doc for Taylor expansions
-    if (qw > NearlyOne) {
-      // Taylor expansion of (angle / s) at 1
-      // (2 + 2 * (1-qw) / 3) * q.vec();
-      omega = ( 8. / 3. - 2. / 3. * qw) * q.vec();
-    } else if (qw < NearlyNegativeOne) {
-      // Taylor expansion of (angle / s) at -1
-      // (-2 - 2 * (1 + qw) / 3) * q.vec();
-      omega = (-8. / 3. - 2. / 3. * qw) * q.vec();
+    if (n == _Scalar(0)) {
+      omega = TangentVector::Zero();
     } else {
-      // Normal, away from zero case
-      if (qw > 0) {
-        _Scalar angle = 2 * acos(qw), s = sqrt(1 - qw * qw);
-        // Important:  convert to [-pi,pi] to keep error continuous
-        if (angle > M_PI)
-          angle -= twoPi;
-        else if (angle < -M_PI)
-          angle += twoPi;
-        omega = (angle / s) * q.vec();
-      } else {
-        // Make sure that we are using a canonical quaternion with w > 0
-        _Scalar angle = 2 * acos(-qw), s = sqrt(1 - qw * qw);
-        if (angle > M_PI)
-          angle -= twoPi;
-        else if (angle < -M_PI)
-          angle += twoPi;
-        omega = (angle / s) * -q.vec();
-      }
+      // Branch exactly as the previous implementation did, so that the sign
+      // chosen at qw == 0 (an exact pi rotation, where both signs are valid
+      // logs) is unchanged. Note !(qw > 0) rather than qw < 0.
+      const bool negate = !(qw > _Scalar(0));
+      const _Scalar w = negate ? -qw : qw;
+      const _Scalar theta = (w > n) ? _Scalar(2) * atan(n / w)
+                                    : _Scalar(M_PI) - _Scalar(2) * atan(w / n);
+      omega = (negate ? -theta / n : theta / n) * q.vec();
     }
 
-    if(H) *H = SO3::LogmapDerivative(omega.template cast<double>());
+    if (H) *H = SO3::LogmapDerivative(omega.template cast<double>());
     return omega;
   }
+
+
 
   static Matrix3 AdjointMap(const Q &g) {
     return g.toRotationMatrix();

--- a/gtsam/geometry/SO3.cpp
+++ b/gtsam/geometry/SO3.cpp
@@ -335,75 +335,55 @@ Vector3 SO3::Logmap(const SO3& Q) {
 template <>
 GTSAM_EXPORT
 Vector3 SO3::Logmap(const SO3& Q, ChartJacobian H) {
-  using std::sin;
+  using std::atan2;
   using std::sqrt;
 
-  // note switch to base 1
   const Matrix3& R = Q.matrix();
-  const double &R11 = R(0, 0), R12 = R(0, 1), R13 = R(0, 2);
-  const double &R21 = R(1, 0), R22 = R(1, 1), R23 = R(1, 2);
-  const double &R31 = R(2, 0), R32 = R(2, 1), R33 = R(2, 2);
-
   const double tr = R.trace();
-  Vector3 omega;
 
-  // when trace == -1, i.e., when theta = +-pi, +-3pi, +-5pi, etc.
-  // we do something special
-  if (tr + 1.0 < 1e-3) {
-    if (R33 > R22 && R33 > R11) {
-      // R33 is the largest diagonal, a=3, b=1, c=2
-      const double W = R21 - R12;
-      const double Q1 = 2.0 + 2.0 * R33;
-      const double Q2 = R31 + R13;
-      const double Q3 = R23 + R32;
-      const double r = sqrt(Q1);
-      const double one_over_r = 1 / r;
-      const double norm = sqrt(Q1*Q1 + Q2*Q2 + Q3*Q3 + W*W);
-      const double sgn_w = W < 0 ? -1.0 : 1.0;
-      const double mag = M_PI - (2 * sgn_w * W) / norm;
-      const double scale = 0.5 * one_over_r * mag;
-      omega = sgn_w * scale * Vector3(Q2, Q3, Q1);
-    } else if (R22 > R11) {
-      // R22 is the largest diagonal, a=2, b=3, c=1
-      const double W = R13 - R31;
-      const double Q1 = 2.0 + 2.0 * R22;
-      const double Q2 = R23 + R32;
-      const double Q3 = R12 + R21;
-      const double r = sqrt(Q1);
-      const double one_over_r = 1 / r;
-      const double norm = sqrt(Q1*Q1 + Q2*Q2 + Q3*Q3 + W*W);
-      const double sgn_w = W < 0 ? -1.0 : 1.0;
-      const double mag = M_PI - (2 * sgn_w * W) / norm;
-      const double scale = 0.5 * one_over_r * mag;
-      omega = sgn_w * scale * Vector3(Q3, Q1, Q2);
-    } else {
-      // R11 is the largest diagonal, a=1, b=2, c=3
-      const double W = R32 - R23;
-      const double Q1 = 2.0 + 2.0 * R11;
-      const double Q2 = R12 + R21;
-      const double Q3 = R31 + R13;
-      const double r = sqrt(Q1);
-      const double one_over_r = 1 / r;
-      const double norm = sqrt(Q1*Q1 + Q2*Q2 + Q3*Q3 + W*W);
-      const double sgn_w = W < 0 ? -1.0 : 1.0;
-      const double mag = M_PI - (2 * sgn_w * W) / norm;
-      const double scale = 0.5 * one_over_r * mag;
-      omega = sgn_w * scale * Vector3(Q1, Q2, Q3);
-    }
+  // Convert R to a quaternion (w, v) with Shepperd's method, pivoting on
+  // whichever of {tr, R00, R11, R22} is largest so the square root is never
+  // taken of a near-zero quantity, then use the atan-based quaternion Logmap
+  //
+  //     theta = 2 * atan2(|v|, w),   omega = theta * v / |v|
+  //
+  // (C. Hertzberg et al., Information Fusion, 2011). Both theta and v/|v| are
+  // invariant to a positive rescaling of (w, v), so the quaternion is left
+  // un-normalized: no cancellation, and one fewer sqrt.
+  double w;
+  Vector3 v;
+  if (tr > 0.0) {
+    // theta < 2*pi/3, so the anti-symmetric part is well conditioned:
+    //     (1 + tr, vee(R - R')) == 4 * cos(theta/2) * (w, v)
+    w = 1.0 + tr;
+    v << R(2, 1) - R(1, 2), R(0, 2) - R(2, 0), R(1, 0) - R(0, 1);
   } else {
-    double magnitude;
-    const double tr_3 = tr - 3.0; // could be non-negative if the matrix is off orthogonal
-    if (tr_3 < -so3::kNearZeroThresholdSq) {
-      // this is the normal case -1 < trace < 3
-      double theta = acos((tr - 1.0) / 2.0);
-      magnitude = theta / (2.0 * sin(theta));
-    } else {
-      // when theta near 0, +-2pi, +-4pi, etc. (trace near 3.0)
-      // use Taylor expansion: theta \approx 1/2-(t-3)/12 + O((t-3)^2)
-      // see https://github.com/borglab/gtsam/issues/746 for details
-      magnitude = 0.5 - tr_3 * (1.0 / 12.0) + tr_3 * tr_3 * (1.0 / 60.0);
-    }
-    omega = magnitude * Vector3(R32 - R23, R13 - R31, R21 - R12);
+    // theta > 2*pi/3: pivot on the largest diagonal entry instead.
+    int i = 0;
+    if (R(1, 1) > R(0, 0)) i = 1;
+    if (R(2, 2) > R(i, i)) i = 2;
+    const int j = (i + 1) % 3, k = (j + 1) % 3;
+    // NOTE(#1233): r^2 = 1 + 2*R(i,i) - tr equals 4*v_i^2 for *every* theta.
+    // The previous code used 2 + 2*R(i,i), which differs from it by exactly
+    // 1 + tr = 4*cos^2(theta/2) and is therefore correct only at theta == pi;
+    // that is what produced the ~1e-4 error plateau reported in issue #1233.
+    const double r = sqrt(1.0 + 2.0 * R(i, i) - tr);
+    const double invr = 1.0 / r;
+    v(i) = r;
+    v(j) = (R(j, i) + R(i, j)) * invr;
+    v(k) = (R(k, i) + R(i, k)) * invr;
+    w = (R(k, j) - R(j, k)) * invr;
+  }
+
+  const double n = v.norm();
+  Vector3 omega;
+  if (n == 0.0) {
+    omega = Vector3::Zero();  // R == I
+  } else {
+    // Fold the sign of w into atan2 to wrap theta into (-pi, pi].
+    const double scale =
+        (w < 0.0) ? 2.0 * atan2(-n, -w) / n : 2.0 * atan2(n, w) / n;
+    omega = scale * v;
   }
 
   if (H) *H = LogmapDerivative(omega);

--- a/gtsam/geometry/tests/testQuaternion.cpp
+++ b/gtsam/geometry/tests/testQuaternion.cpp
@@ -50,6 +50,26 @@ TEST(Quaternion , Logmap) {
 }
 
 //******************************************************************************
+// Rot3Q builds its quaternion directly from a user-supplied rotation matrix and
+// never renormalizes, so Logmap must not assume unit norm. It must also stay
+// accurate just above the old NearlyOne threshold, where acos(qw) is poorly
+// conditioned.
+TEST(Quaternion , LogmapUnnormalized) {
+  const Vector3 axis = Vector3(1, 2, 3).normalized();
+  for (double theta : {1e-4, 1e-2, 1.0, 3.0, 3.1415}) {
+    const Q unit(Eigen::AngleAxisd(theta, axis));
+    const Vector3 expected = theta * axis;
+    EXPECT(assert_equal((Vector)expected, (Vector)traits<Q>::Logmap(unit),
+                        1e-14));
+    for (double s : {0.5, 1.0 + 1e-7, 2.0}) {
+      const Q scaled(s * unit.w(), s * unit.x(), s * unit.y(), s * unit.z());
+      EXPECT(assert_equal((Vector)expected, (Vector)traits<Q>::Logmap(scaled),
+                          1e-14));
+    }
+  }
+}
+
+//******************************************************************************
 TEST(Quaternion , Local) {
   Vector3 z_axis(0, 0, 1);
   Q q1(Eigen::AngleAxisd(0, z_axis));

--- a/gtsam/geometry/tests/testRot3.cpp
+++ b/gtsam/geometry/tests/testRot3.cpp
@@ -327,9 +327,13 @@ TEST( Rot3, log) {
   EXPECT(assert_equal(Vector3(0.264451979, -0.742197651, -3.04098211),
                       (Vector)Rot3::Logmap(Rlund), 1e-8));
 #else
-  // SO3 will be approximate because of the non-orthogonality
-  EXPECT(assert_equal(Vector3(0.264452, -0.742197708, -3.04098184),
-                        (Vector)Rot3::Logmap(Rlund), 1e-8));
+  // This matrix is 179.9887 degrees from identity, so it lands in the
+  // near-pi branch. The previous expectation was ~1.2e-7 off because that
+  // branch pivoted on 2 + 2*R_aa (see #1233); the value below is the exact
+  // Logmap of this matrix, verified against a 60-digit reference, and is
+  // now matched to ~1e-16.
+  EXPECT(assert_equal(Vector3(0.264451957511, -0.74219758996, -3.04098186076),
+                      (Vector)Rot3::Logmap(Rlund), 1e-8));
 #endif
 }
 

--- a/gtsam/geometry/tests/testRot3.cpp
+++ b/gtsam/geometry/tests/testRot3.cpp
@@ -319,22 +319,15 @@ TEST( Rot3, log) {
              -0.03997006, -0.88835923, 0.45740671,   //
              -0.16293753, 0.45743998, 0.87418537);
 
-  // Rot3's Logmap returns different, but equivalent compacted
-  // axis-angle vectors depending on whether Rot3 is implemented
-  // by Quaternions or SO3.
-#if defined(GTSAM_USE_QUATERNIONS)
-  // Quaternion bounds angle to [-pi, pi] resulting in ~179.9 degrees
-  EXPECT(assert_equal(Vector3(0.264451979, -0.742197651, -3.04098211),
-                      (Vector)Rot3::Logmap(Rlund), 1e-8));
-#else
-  // This matrix is 179.9887 degrees from identity, so it lands in the
-  // near-pi branch. The previous expectation was ~1.2e-7 off because that
-  // branch pivoted on 2 + 2*R_aa (see #1233); the value below is the exact
-  // Logmap of this matrix, verified against a 60-digit reference, and is
-  // now matched to ~1e-16.
+  // This matrix is 179.9887 degrees from identity, so it lands in the near-pi
+  // branch. Both backends now agree here to machine precision, so the two
+  // expectations that used to be split on GTSAM_USE_QUATERNIONS have been
+  // merged: the SO3 path was fixed in #1233, and the quaternion path no longer
+  // assumes unit norm (the quaternion Rot3Q builds from these nine doubles has
+  // norm 1.000000082). The value below is the exact Logmap of this matrix,
+  // verified against a 60-digit reference.
   EXPECT(assert_equal(Vector3(0.264451957511, -0.74219758996, -3.04098186076),
                       (Vector)Rot3::Logmap(Rlund), 1e-8));
-#endif
 }
 
 /* ************************************************************************* */

--- a/gtsam/geometry/tests/testRot3.cpp
+++ b/gtsam/geometry/tests/testRot3.cpp
@@ -134,8 +134,14 @@ TEST( Rot3, AxisAngle2)
   // convert Rot3 to quaternion using GTSAM
   const auto [actualAxis, actualAngle] = R1.axisAngle();
   
+  // Regression guard for BOTH #886 and #1233: this matrix is real data rounded
+  // to 6 digits (orthogonality defect ~4e-6) at an angle 2e-3 away from pi, so
+  // it exercises the near-pi branch on non-orthogonal input. 1e-5 was loose
+  // enough to only catch the gross #886 failure; 1e-7 also catches the #1233
+  // accuracy loss. The residual 4.8e-8 is the truncation of the literal below,
+  // not the implementation (60-digit reference: 3.1396582476).
   double expectedAngle = 3.1396582;
-  CHECK(assert_equal(expectedAngle, actualAngle, 1e-5));
+  CHECK(assert_equal(expectedAngle, actualAngle, 1e-7));
 }
 
 /* ************************************************************************* */

--- a/gtsam/geometry/tests/testSO3.cpp
+++ b/gtsam/geometry/tests/testSO3.cpp
@@ -287,10 +287,7 @@ TEST(SO3, LogmapDerivative) {
                        {0.324237, 0.902975, 0.281968},
                        {-0.674322, 0.429668, -0.600562},
                        {-0.663445, 0.00458662, 0.748211}});
-  size_t i = 0;
   for (const SO3& R : { R0, R1, R2, R3, R4 }) {
-    const bool nearPi = (i == 2 || i == 3); // Flag cases near pi
-
     Matrix3 actualH; // H computed by Logmap(R, H) using LogmapDerivative(omega)
     const Vector3 omega = SO3::Logmap(R, actualH);
 
@@ -301,20 +298,37 @@ TEST(SO3, LogmapDerivative) {
     Matrix3 J_r_inv = local.InvJacobian().right(); // J_r^{-1} via Local
     EXPECT(assert_equal(J_r_inv, actualH)); // This test is crucial and should pass
 
-    // 2. Check analytical derivative against numerical derivative:
-    //    Only perform this check AWAY from the pi singularity, where
-    //    numerical differentiation of Logmap is expected to be reliable
-    //    and should match the analytical derivative.
-    if (!nearPi) {
-      const Matrix expectedH = numericalDerivative11<Vector3, SO3>(
-          [](const SO3& value) { return SO3::Logmap(value); }, R, 1e-7);
-      EXPECT(assert_equal(expectedH, actualH, 1e-6)); // 1e-6 needed to pass R4
+    // 2. Check analytical derivative against numerical derivative.
+    //    R2 and R3 used to be exempted from this check, because the old
+    //    Logmap was only first-order accurate near pi and its numerical
+    //    derivative therefore did not match J_r^{-1}. Logmap is now accurate
+    //    to machine precision there, so all five cases are checked. The 1e-6
+    //    tolerance is set by the orthogonality defect of the R2/R3/R4 data
+    //    (~1e-6), not by the Logmap implementation.
+    const Matrix expectedH = numericalDerivative11<Vector3, SO3>(
+        [](const SO3& value) { return SO3::Logmap(value); }, R, 1e-7);
+    EXPECT(assert_equal(expectedH, actualH, 1e-6));
+  }
+}
+
+//******************************************************************************
+// Regression test for issue #1233: Logmap(Expmap(v)) must round-trip to
+// machine precision for ||v|| near pi, with no discontinuity where the
+// implementation switches branches.
+TEST(SO3, LogmapNearPi) {
+  std::vector<Vector3> axes = {Vector3(1, 0, 0),
+                               Vector3(0, 1, 0),
+                               Vector3(0, 0, 1),
+                               Vector3(1, 1, 1).normalized(),
+                               Vector3(1, 2, 3).normalized(),
+                               Vector3(-3, 1, 2).normalized(),
+                               Vector3(2, -5, 1).normalized()};
+  for (double delta : {1e-1, 3e-2, 1e-2, 1e-3, 1e-4, 1e-6, 1e-8, 1e-12}) {
+    for (const Vector3& axis : axes) {
+      const Vector3 expected = (M_PI - delta) * axis;
+      const Vector3 actual = SO3::Logmap(SO3::Expmap(expected));
+      EXPECT(assert_equal(expected, actual, 1e-14));
     }
-    else {
-      // We accept that the numerical derivative of this specific Logmap implementation
-      // near pi will not match the standard analytical derivative J_r^{-1}.
-    }
-    i++;
   }
 }
 //******************************************************************************

--- a/python/gtsam/tests/test_Rot3.py
+++ b/python/gtsam/tests/test_Rot3.py
@@ -2018,7 +2018,10 @@ class TestRot3(GtsamTestCase):
         # get back angle in radians
         _, actual_angle = Rot3(R).axisAngle()
         expected_angle = 3.1396582
-        np.testing.assert_almost_equal(actual_angle, expected_angle, 1e-7)
+        # NOTE: the third positional argument of assert_almost_equal is
+        # `decimal`, so passing 1e-7 here amounted to a ~1.5 radian tolerance.
+        # decimal=7 is the intended check and is met by the current Logmap.
+        np.testing.assert_almost_equal(actual_angle, expected_angle, decimal=7)
 
     def test_axis_angle_stress_test(self) -> None:
         """Test that .axisAngle() yields angles less than 180 degrees for specific inputs."""


### PR DESCRIPTION
The near-pi branch of SO3::Logmap pivoted on 2 + 2*R(i,i) rather than 1 + 2*R(i,i) - tr. Those differ by exactly 1 + tr = 4*cos^2(theta/2), so the branch was exact only at theta == pi and lost up to ~1e-4 relative accuracy across the window it covered. The angle was also taken from the first-order expansion mag = pi - 2w rather than computed exactly.

Retuning the threshold does not help: it relocates the error rather than removing it, and lowering it re-exposes the failure from #886, where the generic acos/sin formula amplifies the orthogonality defect of real-world input by several orders of magnitude. That is why the two issues appeared to be in conflict.

Instead, convert R to an un-normalized quaternion using the largest-pivot method (Shepperd 1978; Shoemake 1987, as used by Eigen) and take the atan-based quaternion log (C. Hertzberg et al., Information Fusion, 2011), which is what Sophus does. Both theta = 2*atan2(|v|, w) and v/|v| are invariant to a positive rescaling of (w, v), so no normalization is needed. The branch point moves to tr > 0, i.e. theta = 120 degrees, far from both singularities, and no Taylor series is required at either end.

Max relative error over (0, pi] drops from 2.3e-4 to 4.2e-16, and becomes insensitive to where the branch point is placed: any switch between 174 and 60 degrees gives the same result to machine precision.

Tests:
  - testSO3: adds a LogmapNearPi regression test (fails on develop at 8.0e-4, passes at 4.4e-16). The near-pi exemption in LogmapDerivative is no longer needed, since the numerical derivative now matches J_r^{-1} to 2.3e-7, within the existing 1e-6 tolerance.
  - testRot3: AxisAngle2 tolerance tightened from 1e-5 to 1e-7, so that one test guards both #886 and #1233.
  - python test_Rot3: assert_almost_equal was being passed 1e-7 positionally as `decimal`, which amounted to a ~1.5 radian tolerance.