### PR TITLE
Speed up discrete multiplication with generic TableFactor conversion

### DIFF
--- a/gtsam/discrete/DecisionTreeFactor.cpp
+++ b/gtsam/discrete/DecisionTreeFactor.cpp
@@ -69,10 +69,9 @@ namespace gtsam {
       const DiscreteFactor::shared_ptr& f) const {
     DiscreteFactor::shared_ptr result;
     if (auto tf = std::dynamic_pointer_cast<TableFactor>(f)) {
-      // If f is a TableFactor, we convert `this` to a TableFactor since this
-      // conversion is cheaper than converting `f` to a DecisionTreeFactor. We
-      // then return a TableFactor.
-      result = std::make_shared<TableFactor>((*tf) * TableFactor(*this));
+      // If f is a TableFactor, use the virtual conversion so derived decision
+      // tree factors can provide their actual sparse representation.
+      result = std::make_shared<TableFactor>((*tf) * toTableFactor());
 
     } else if (auto dtf = std::dynamic_pointer_cast<DecisionTreeFactor>(f)) {
       // If `f` is a DecisionTreeFactor, simply call operator*.

--- a/gtsam/discrete/DecisionTreeFactor.cpp
+++ b/gtsam/discrete/DecisionTreeFactor.cpp
@@ -89,6 +89,11 @@ namespace gtsam {
   }
 
   /* ************************************************************************ */
+  TableFactor DecisionTreeFactor::toTableFactor() const {
+    return TableFactor(*this);
+  }
+
+  /* ************************************************************************ */
   DiscreteFactor::shared_ptr DecisionTreeFactor::operator/(
       const DiscreteFactor::shared_ptr& f) const {
     if (auto tf = std::dynamic_pointer_cast<TableFactor>(f)) {

--- a/gtsam/discrete/DecisionTreeFactor.h
+++ b/gtsam/discrete/DecisionTreeFactor.h
@@ -193,6 +193,9 @@ namespace gtsam {
     /// Convert into a decision tree
     DecisionTreeFactor toDecisionTreeFactor() const override { return *this; }
 
+    /// Convert directly into a sparse table.
+    TableFactor toTableFactor() const override;
+
     /// Use sum() from AlgebraicDecisionTree
     using ADT::sum;
 

--- a/gtsam/discrete/DiscreteFactor.cpp
+++ b/gtsam/discrete/DiscreteFactor.cpp
@@ -18,7 +18,9 @@
  */
 
 #include <gtsam/base/Vector.h>
+#include <gtsam/discrete/DecisionTreeFactor.h>
 #include <gtsam/discrete/DiscreteFactor.h>
+#include <gtsam/discrete/TableFactor.h>
 #include <gtsam/hybrid/HybridValues.h>
 
 #include <cmath>
@@ -69,6 +71,24 @@ AlgebraicDecisionTree<Key> DiscreteFactor::errorTree() const {
     errors.push_back(error(assignment));
   }
   return AlgebraicDecisionTree<Key>(dkeys, errors);
+}
+
+/* ************************************************************************ */
+DiscreteFactor::shared_ptr DiscreteFactor::multiply(
+    const DiscreteFactor::shared_ptr& factor) const {
+  if (const auto table = std::dynamic_pointer_cast<TableFactor>(factor)) {
+    // The cast and dereference borrow the existing table without copying it.
+    // Only this factor's table representation and the product are materialized;
+    // make_shared moves the temporary product into its owned allocation.
+    return std::make_shared<TableFactor>(*table * toTableFactor());
+  }
+  return std::make_shared<DecisionTreeFactor>(
+      this->operator*(factor->toDecisionTreeFactor()));
+}
+
+/* ************************************************************************ */
+TableFactor DiscreteFactor::toTableFactor() const {
+  return TableFactor(toDecisionTreeFactor());
 }
 
 /* ************************************************************************ */

--- a/gtsam/discrete/DiscreteFactor.h
+++ b/gtsam/discrete/DiscreteFactor.h
@@ -30,6 +30,7 @@ class DecisionTreeFactor;
 class DiscreteConditional;
 class HybridValues;
 class Ordering;
+class TableFactor;
 
 /**
  * Base class for discrete probabilistic factors
@@ -141,13 +142,16 @@ class GTSAM_EXPORT DiscreteFactor : public Factor {
    * @return DiscreteFactor::shared_ptr
    */
   virtual DiscreteFactor::shared_ptr multiply(
-      const DiscreteFactor::shared_ptr& df) const = 0;
+      const DiscreteFactor::shared_ptr& df) const;
 
   /// divide by DiscreteFactor::shared_ptr f (safely)
   virtual DiscreteFactor::shared_ptr operator/(
       const DiscreteFactor::shared_ptr& df) const = 0;
 
   virtual DecisionTreeFactor toDecisionTreeFactor() const = 0;
+
+  /// Convert to a sparse table, falling back through a decision tree.
+  virtual TableFactor toTableFactor() const;
 
   /// Create new factor by summing all values with the same separator values
   virtual DiscreteFactor::shared_ptr sum(size_t nrFrontals) const = 0;

--- a/gtsam/discrete/TableDistribution.h
+++ b/gtsam/discrete/TableDistribution.h
@@ -160,6 +160,9 @@ class GTSAM_EXPORT TableDistribution : public DiscreteConditional {
     return table_.toDecisionTreeFactor();
   }
 
+  /// Get the sparse table representation.
+  TableFactor toTableFactor() const override { return table_; }
+
   /// Get the number of non-zero values.
   uint64_t nrValues() const override { return table_.sparseTable().nonZeros(); }
 

--- a/gtsam/discrete/TableFactor.cpp
+++ b/gtsam/discrete/TableFactor.cpp
@@ -351,9 +351,10 @@ DiscreteFactor::shared_ptr TableFactor::multiply(
     result = std::make_shared<TableFactor>(this->operator*(*tf));
 
   } else if (auto dtf = std::dynamic_pointer_cast<DecisionTreeFactor>(f)) {
-    // If `f` is a DecisionTreeFactor, we convert to a TableFactor which is
-    // cheaper than converting `this` to a DecisionTreeFactor.
-    result = std::make_shared<TableFactor>(this->operator*(TableFactor(*dtf)));
+    // Use the virtual conversion so derived decision tree factors can provide
+    // their actual sparse representation.
+    result =
+        std::make_shared<TableFactor>(this->operator*(dtf->toTableFactor()));
 
   } else {
     // Let the other factor choose its most efficient table representation,

--- a/gtsam/discrete/TableFactor.cpp
+++ b/gtsam/discrete/TableFactor.cpp
@@ -356,14 +356,9 @@ DiscreteFactor::shared_ptr TableFactor::multiply(
     result = std::make_shared<TableFactor>(this->operator*(TableFactor(*dtf)));
 
   } else {
-    // The virtual call dispatches on f's runtime type. Its multiply override
-    // can dynamic-cast the argument back to TableFactor and use a sparse
-    // specialization; otherwise its existing DecisionTreeFactor fallback runs.
-    // The virtual interface accepts an owning shared_ptr. Since this object may
-    // be stack-allocated and TableFactor does not support shared_from_this,
-    // pass an owned copy rather than a potentially dangling non-owning pointer.
-    const auto table = std::make_shared<TableFactor>(*this);
-    result = f->multiply(table);
+    // Let the other factor choose its most efficient table representation,
+    // then multiply it without copying this potentially large sparse table.
+    result = std::make_shared<TableFactor>(this->operator*(f->toTableFactor()));
   }
   return result;
 }

--- a/gtsam/discrete/TableFactor.h
+++ b/gtsam/discrete/TableFactor.h
@@ -213,6 +213,9 @@ class GTSAM_EXPORT TableFactor : public DiscreteFactor {
   /// Convert into a decisiontree
   DecisionTreeFactor toDecisionTreeFactor() const override;
 
+  /// Return this sparse table representation.
+  TableFactor toTableFactor() const override { return *this; }
+
   /// Create a TableFactor that is a subset of this TableFactor
   TableFactor choose(const DiscreteValues parentAssignments,
                      DiscreteKeys parent_keys) const;

--- a/gtsam/discrete/tests/testTableFactor.cpp
+++ b/gtsam/discrete/tests/testTableFactor.cpp
@@ -23,6 +23,7 @@
 #include <gtsam/discrete/DiscreteConditional.h>
 #include <gtsam/discrete/DiscreteDistribution.h>
 #include <gtsam/discrete/Signature.h>
+#include <gtsam/discrete/TableDistribution.h>
 #include <gtsam/discrete/TableFactor.h>
 
 #include <chrono>
@@ -174,6 +175,16 @@ TEST(TableFactor, Conversion) {
   TableFactor tf(dtf.discreteKeys(), dtf);
 
   EXPECT(assert_equal(dtf, tf.toDecisionTreeFactor()));
+  EXPECT(assert_equal(tf,
+                      static_cast<const DiscreteFactor&>(dtf).toTableFactor()));
+  EXPECT(
+      assert_equal(tf, static_cast<const DiscreteFactor&>(tf).toTableFactor()));
+
+  const DiscreteKey distributionKey(3, 2);
+  const TableDistribution distribution(distributionKey, "1 3");
+  EXPECT(assert_equal(
+      distribution.table(),
+      static_cast<const DiscreteFactor&>(distribution).toTableFactor()));
 
   // Test for correct construction when keys are not in reverse order.
   // This is possible in conditionals e.g. P(x1 | x0)

--- a/gtsam/discrete/tests/testTableFactor.cpp
+++ b/gtsam/discrete/tests/testTableFactor.cpp
@@ -203,6 +203,26 @@ TEST(TableFactor, Conversion) {
 }
 
 /* ************************************************************************* */
+// Check multiplication with a TableDistribution in both operand orders.
+TEST(TableFactor, TableDistributionMultiplication) {
+  const DiscreteKey key(0, 3);
+  const auto table =
+      std::make_shared<TableFactor>(key, std::vector<double>{2.0, 3.0, 4.0});
+  const auto distribution = std::make_shared<TableDistribution>(key, "1 2 3");
+  const TableFactor expected(key, std::vector<double>{1.0 / 3.0, 1.0, 2.0});
+
+  const auto tableFirst =
+      std::dynamic_pointer_cast<TableFactor>(table->multiply(distribution));
+  const auto distributionFirst =
+      std::dynamic_pointer_cast<TableFactor>(distribution->multiply(table));
+
+  CHECK(tableFirst);
+  CHECK(distributionFirst);
+  EXPECT(assert_equal(expected, *tableFirst));
+  EXPECT(assert_equal(expected, *distributionFirst));
+}
+
+/* ************************************************************************* */
 TEST(TableFactor, Empty) {
   DiscreteKey X(1, 2);
 

--- a/gtsam/hybrid/HybridBayesTree.cpp
+++ b/gtsam/hybrid/HybridBayesTree.cpp
@@ -47,13 +47,7 @@ DiscreteValues HybridBayesTree::discreteMaxProduct(
     const DiscreteFactorGraph& dfg) const {
   DiscreteFactor::shared_ptr product = dfg.scaledProduct();
 
-  // Check type of product, and get as TableFactor for efficiency.
-  TableFactor p;
-  if (auto tf = std::dynamic_pointer_cast<TableFactor>(product)) {
-    p = *tf;
-  } else {
-    p = TableFactor(product->toDecisionTreeFactor());
-  }
+  TableFactor p = product->toTableFactor();
   DiscreteValues assignment = TableDistribution(p).argmax();
   return assignment;
 }

--- a/gtsam/hybrid/HybridGaussianFactorGraph.cpp
+++ b/gtsam/hybrid/HybridGaussianFactorGraph.cpp
@@ -50,8 +50,6 @@
 #include <utility>
 #include <vector>
 
-#define GTSAM_HYBRID_WITH_TABLEFACTOR 1
-
 namespace gtsam {
 
 /// Specialize EliminateableFactorGraph for HybridGaussianFactorGraph:
@@ -255,11 +253,7 @@ static DiscreteFactor::shared_ptr DiscreteFactorFromErrors(
   double min_log = errors.min();
   AlgebraicDecisionTree<Key> potentials(
       errors, [&min_log](const double x) { return exp(-(x - min_log)); });
-#if GTSAM_HYBRID_WITH_TABLEFACTOR
   return std::make_shared<TableFactor>(discreteKeys, potentials);
-#else
-  return std::make_shared<DecisionTreeFactor>(discreteKeys, potentials);
-#endif
 }
 
 /* ************************************************************************ */
@@ -292,18 +286,7 @@ static DiscreteFactorGraph CollectDiscreteFactors(
 #if GTSAM_HYBRID_TIMING
       gttic_(ConvertConditionalToTableFactor);
 #endif
-      if (auto dtc = std::dynamic_pointer_cast<TableDistribution>(dc)) {
-        /// Get the underlying TableFactor
-        dfg.push_back(dtc->table());
-      } else {
-#if GTSAM_HYBRID_WITH_TABLEFACTOR
-        // Convert DiscreteConditional to TableFactor
-        auto tdc = std::make_shared<TableFactor>(*dc);
-        dfg.push_back(tdc);
-#else
-        dfg.push_back(dc);
-#endif
-      }
+      dfg.push_back(dc->toTableFactor());
 #if GTSAM_HYBRID_TIMING
       gttoc_(ConvertConditionalToTableFactor);
 #endif
@@ -330,7 +313,6 @@ discreteElimination(const HybridGaussianFactorGraph &factors,
 #if GTSAM_HYBRID_TIMING
   gttic_(EliminateDiscrete);
 #endif
-#if GTSAM_HYBRID_WITH_TABLEFACTOR
   // Check if separator is empty.
   // This is the same as checking if the number of frontal variables
   // is the same as the number of variables in the DiscreteFactorGraph.
@@ -340,15 +322,7 @@ discreteElimination(const HybridGaussianFactorGraph &factors,
     // Get product factor
     DiscreteFactor::shared_ptr product = dfg.scaledProduct();
 
-    // Check type of product, and get as TableFactor for efficiency.
-    // Use object instead of pointer since we need it
-    // for the TableDistribution constructor.
-    TableFactor p;
-    if (auto tf = std::dynamic_pointer_cast<TableFactor>(product)) {
-      p = *tf;
-    } else {
-      p = TableFactor(product->toDecisionTreeFactor());
-    }
+    TableFactor p = product->toTableFactor();
     auto conditional = std::make_shared<TableDistribution>(p);
 
     DiscreteFactor::shared_ptr sum = p.sum(frontalKeys);
@@ -356,13 +330,10 @@ discreteElimination(const HybridGaussianFactorGraph &factors,
     return {std::make_shared<HybridConditional>(conditional), sum};
 
   } else {
-#endif
     // Perform sum-product.
     auto result = EliminateDiscrete(dfg, frontalKeys);
     return {std::make_shared<HybridConditional>(result.first), result.second};
-#if GTSAM_HYBRID_WITH_TABLEFACTOR
   }
-#endif
 #if GTSAM_HYBRID_TIMING
   gttoc_(EliminateDiscrete);
 #endif

--- a/gtsam_unstable/discrete/AllDiff.cpp
+++ b/gtsam_unstable/discrete/AllDiff.cpp
@@ -104,15 +104,6 @@ TableFactor AllDiff::toTableFactor() const {
 }
 
 /* ************************************************************************* */
-DiscreteFactor::shared_ptr AllDiff::multiply(
-    const DiscreteFactor::shared_ptr& factor) const {
-  if (const auto table = std::dynamic_pointer_cast<TableFactor>(factor)) {
-    return std::make_shared<TableFactor>(*table * toTableFactor());
-  }
-  return Constraint::multiply(factor);
-}
-
-/* ************************************************************************* */
 DecisionTreeFactor AllDiff::operator*(const DecisionTreeFactor& f) const {
   // TODO: can we do this more efficiently?
   return toDecisionTreeFactor() * f;

--- a/gtsam_unstable/discrete/AllDiff.h
+++ b/gtsam_unstable/discrete/AllDiff.h
@@ -50,11 +50,7 @@ class GTSAM_UNSTABLE_EXPORT AllDiff : public Constraint {
   DecisionTreeFactor toDecisionTreeFactor() const override;
 
   /// Convert directly into a sparse table, enumerating only valid assignments.
-  TableFactor toTableFactor() const;
-
-  /// Multiply factors, preserving TableFactor when possible.
-  DiscreteFactor::shared_ptr multiply(
-      const DiscreteFactor::shared_ptr& factor) const override;
+  TableFactor toTableFactor() const override;
 
   /// Multiply into a decisiontree
   DecisionTreeFactor operator*(const DecisionTreeFactor& f) const override;

--- a/gtsam_unstable/discrete/Constraint.h
+++ b/gtsam_unstable/discrete/Constraint.h
@@ -80,13 +80,6 @@ class GTSAM_UNSTABLE_EXPORT Constraint : public DiscreteFactor {
   /// Partially apply known values, domain version
   virtual shared_ptr partiallyApply(const Domains&) const = 0;
 
-  /// Multiply factors, DiscreteFactor::shared_ptr edition
-  DiscreteFactor::shared_ptr multiply(
-      const DiscreteFactor::shared_ptr& df) const override {
-    return std::make_shared<DecisionTreeFactor>(
-        this->operator*(df->toDecisionTreeFactor()));
-  }
-
   /// Multiply by a scalar
   virtual DiscreteFactor::shared_ptr operator*(double s) const override {
     return this->toDecisionTreeFactor() * s;

--- a/gtsam_unstable/discrete/tests/testHybridAllDiff.cpp
+++ b/gtsam_unstable/discrete/tests/testHybridAllDiff.cpp
@@ -23,6 +23,7 @@
 #include <gtsam/linear/JacobianFactor.h>
 #include <gtsam/linear/NoiseModel.h>
 #include <gtsam_unstable/discrete/AllDiff.h>
+#include <gtsam_unstable/discrete/SingleValue.h>
 
 #include <memory>
 #include <stdexcept>
@@ -99,6 +100,26 @@ TEST(HybridAllDiff, TableMultiplicationAvoidsDecisionTree) {
   EXPECT(assert_equal(expected, *constraintFirst));
   EXPECT(assert_equal(expected, *tableFirst));
   LONGS_EQUAL(6, tableFirst->nrValues());
+}
+
+// Verifies the generic constraint fallback retains TableFactor in both
+// multiplication orders.
+TEST(HybridAllDiff, GenericConstraintTableMultiplication) {
+  const DiscreteKey key(A(0), 3);
+  const auto constraint = std::make_shared<SingleValue>(key, 1);
+  const auto table =
+      std::make_shared<TableFactor>(key, std::vector<double>{1.0, 2.0, 3.0});
+  const TableFactor expected(key, std::vector<double>{0.0, 2.0, 0.0});
+
+  const auto constraintFirst =
+      std::dynamic_pointer_cast<TableFactor>(constraint->multiply(table));
+  const auto tableFirst =
+      std::dynamic_pointer_cast<TableFactor>(table->multiply(constraint));
+
+  CHECK(constraintFirst);
+  CHECK(tableFirst);
+  EXPECT(assert_equal(expected, *constraintFirst));
+  EXPECT(assert_equal(expected, *tableFirst));
 }
 
 // Verifies sequential inference recovers the expected one-to-one association

--- a/gtsam_unstable/timing/CMakeLists.txt
+++ b/gtsam_unstable/timing/CMakeLists.txt
@@ -4,3 +4,5 @@ if(NOT GTSAM_ALLOW_DEPRECATED_SINCE_V43)
 endif()
 
 gtsamAddTimingGlob("*.cpp" "${excluded_timings}" "gtsam_unstable" ${GTSAM_BUILD_TIMING_ALWAYS})
+
+target_link_libraries(timeHybridAllDiff gtsam_timing_utils)

--- a/gtsam_unstable/timing/README.md
+++ b/gtsam_unstable/timing/README.md
@@ -1,0 +1,29 @@
+# Unstable Timing Benchmarks
+
+## Sparse Hybrid AllDiff Multiplication
+
+`timeHybridAllDiff` separates the two performance improvements involved in
+multiplying a `TableFactor` by `AllDiff`:
+
+- `decision_tree` reproduces the original conversion through a
+  `DecisionTreeFactor`;
+- `copied_table` uses sparse `AllDiff` conversion but reproduces the former
+  generic dispatch, including its copy of the input table;
+- `direct_table` uses the current virtual `toTableFactor()` dispatch and
+  borrows the input table by reference.
+
+The benchmark checks that all three products are numerically identical before
+timing them. It reports full-scope and partial-scope multiplication separately,
+including both the speedup over decision-tree conversion and the incremental
+speedup from removing the input-table copy.
+
+Build and run it from the build directory:
+
+```bash
+make -j6 timeHybridAllDiff
+./gtsam_unstable/timing/timeHybridAllDiff \
+  --minimum-objects 3 --maximum-objects 7 --warmup 1 --repeats 5
+```
+
+Use `--output hybrid_all_diff.json` to retain the medians in Benchmark Action
+JSON format.

--- a/gtsam_unstable/timing/timeHybridAllDiff.cpp
+++ b/gtsam_unstable/timing/timeHybridAllDiff.cpp
@@ -1,0 +1,270 @@
+/* ----------------------------------------------------------------------------
+ * GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+ * See LICENSE for the license information
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file timeHybridAllDiff.cpp
+ * @brief Benchmark sparse AllDiff multiplication and table dispatch.
+ */
+
+#include <gtsam/discrete/DecisionTreeFactor.h>
+#include <gtsam/discrete/TableFactor.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam_unstable/discrete/AllDiff.h>
+
+#include <Eigen/Sparse>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "internal/TimingUtils.h"
+
+namespace {
+
+using gtsam::AllDiff;
+using gtsam::DecisionTreeFactor;
+using gtsam::DiscreteFactor;
+using gtsam::DiscreteKey;
+using gtsam::DiscreteKeys;
+using gtsam::TableFactor;
+using gtsam::symbol_shorthand::A;
+using gtsam::timing::BenchmarkMetric;
+using gtsam::timing::MedianPolicy;
+using gtsam::timing::TimingSummary;
+
+volatile uint64_t timingChecksum = 0;
+
+struct BenchmarkOptions {
+  size_t minimumObjects = 3;
+  size_t maximumObjects = 7;
+  size_t warmups = 1;
+  size_t repetitions = 5;
+  std::optional<std::string> outputPath;
+};
+
+struct ProductTimings {
+  std::vector<double> decisionTree;
+  std::vector<double> copiedTable;
+  std::vector<double> directTable;
+};
+
+DiscreteKeys makeKeys(size_t numberObjects) {
+  DiscreteKeys keys;
+  keys.reserve(numberObjects);
+  for (size_t i = 0; i < numberObjects; ++i) {
+    keys.emplace_back(A(i), numberObjects);
+  }
+  return keys;
+}
+
+TableFactor makeDenseTable(const DiscreteKeys& keys) {
+  uint64_t cardinality = 1;
+  for (const DiscreteKey& key : keys) cardinality *= key.second;
+
+  Eigen::SparseVector<double> values(cardinality);
+  values.reserve(cardinality);
+  for (uint64_t index = 0; index < cardinality; ++index) {
+    values.insert(index) = 1.0 + static_cast<double>(index % 17) / 17.0;
+  }
+  return TableFactor(keys, values);
+}
+
+// Reproduce the decision-tree conversion used before sparse AllDiff support.
+DiscreteFactor::shared_ptr decisionTreeProduct(
+    const TableFactor& input, const std::shared_ptr<AllDiff>& constraint) {
+  const DecisionTreeFactor product =
+      constraint->operator*(input.toDecisionTreeFactor());
+  return std::make_shared<TableFactor>(product);
+}
+
+// Reproduce the former generic TableFactor dispatch: copy the input table into
+// an owning shared pointer, then ask the other factor to multiply it.
+DiscreteFactor::shared_ptr copiedTableProduct(
+    const TableFactor& input, const std::shared_ptr<AllDiff>& constraint) {
+  const auto copiedInput = std::make_shared<TableFactor>(input);
+  return constraint->multiply(copiedInput);
+}
+
+// Use the current dispatch, which borrows the input and converts AllDiff.
+DiscreteFactor::shared_ptr directTableProduct(
+    const TableFactor& input, const std::shared_ptr<AllDiff>& constraint) {
+  return input.multiply(constraint);
+}
+
+template <class Callable>
+double timeBatchMicroseconds(Callable&& callable, size_t operations) {
+  const double seconds = gtsam::timing::measureSeconds([&] {
+    for (size_t i = 0; i < operations; ++i) {
+      const DiscreteFactor::shared_ptr product = callable();
+      timingChecksum += product->nrValues();
+    }
+  });
+  return seconds * 1e6 / static_cast<double>(operations);
+}
+
+size_t operationsFor(size_t numberObjects) {
+  if (numberObjects == 3) return 200;
+  if (numberObjects == 4) return 30;
+  if (numberObjects == 5) return 3;
+  return 1;
+}
+
+ProductTimings measureProducts(const TableFactor& input,
+                               const std::shared_ptr<AllDiff>& constraint,
+                               const BenchmarkOptions& options) {
+  const size_t operations = operationsFor(constraint->size());
+  const auto decisionTree = [&] {
+    return decisionTreeProduct(input, constraint);
+  };
+  const auto copiedTable = [&] {
+    return copiedTableProduct(input, constraint);
+  };
+  const auto directTable = [&] {
+    return directTableProduct(input, constraint);
+  };
+
+  for (size_t i = 0; i < options.warmups; ++i) {
+    static_cast<void>(timeBatchMicroseconds(decisionTree, operations));
+    static_cast<void>(timeBatchMicroseconds(copiedTable, operations));
+    static_cast<void>(timeBatchMicroseconds(directTable, operations));
+  }
+
+  ProductTimings timings;
+  timings.decisionTree.reserve(options.repetitions);
+  timings.copiedTable.reserve(options.repetitions);
+  timings.directTable.reserve(options.repetitions);
+  for (size_t repetition = 0; repetition < options.repetitions; ++repetition) {
+    // Rotate the order to reduce systematic CPU-frequency and thermal bias.
+    for (size_t offset = 0; offset < 3; ++offset) {
+      switch ((repetition + offset) % 3) {
+        case 0:
+          timings.decisionTree.push_back(
+              timeBatchMicroseconds(decisionTree, operations));
+          break;
+        case 1:
+          timings.copiedTable.push_back(
+              timeBatchMicroseconds(copiedTable, operations));
+          break;
+        case 2:
+          timings.directTable.push_back(
+              timeBatchMicroseconds(directTable, operations));
+          break;
+      }
+    }
+  }
+  return timings;
+}
+
+TimingSummary summarize(const std::vector<double>& samples) {
+  return gtsam::timing::summarizeSamples(samples, MedianPolicy::kUpperMiddle);
+}
+
+void verifyProducts(const TableFactor& input,
+                    const std::shared_ptr<AllDiff>& constraint) {
+  const TableFactor expected =
+      directTableProduct(input, constraint)->toTableFactor();
+  for (const DiscreteFactor::shared_ptr& product :
+       {decisionTreeProduct(input, constraint),
+        copiedTableProduct(input, constraint)}) {
+    if (!expected.equals(product->toTableFactor(), 1e-9)) {
+      throw std::runtime_error("AllDiff benchmark products disagree");
+    }
+  }
+}
+
+void printUsage() {
+  std::cout << "Usage: timeHybridAllDiff [--minimum-objects N] "
+               "[--maximum-objects N] [--warmup N] [--repeats N] "
+               "[--output FILE]\n";
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  gtsam::timing::Arguments arguments(argc, argv);
+  if (arguments.helpRequested()) {
+    printUsage();
+    return 0;
+  }
+
+  const std::string outputPath = arguments.stringValue("--output", "");
+  const BenchmarkOptions options{
+      arguments.sizeValue("--minimum-objects", 3),
+      arguments.sizeValue("--maximum-objects", 7),
+      arguments.sizeValue("--warmup", 1),
+      arguments.sizeValue("--repeats", 5),
+      outputPath.empty() ? std::optional<std::string>() : outputPath,
+  };
+  arguments.validateAllConsumed();
+  if (options.minimumObjects < 2 ||
+      options.maximumObjects < options.minimumObjects ||
+      options.maximumObjects > 7 || options.repetitions == 0) {
+    throw std::invalid_argument(
+        "require 2 <= minimum <= maximum <= 7 and repeats >= 1");
+  }
+
+  std::cout
+      << "decision_tree: pre-sparse conversion baseline\n"
+      << "copied_table: former generic dispatch, including a copy of the "
+         "input table\n"
+      << "direct_table: current virtual conversion dispatch, borrowing the "
+         "input table\n\n"
+      << "scope objects input_nonzeros result_nonzeros decision_tree_us "
+         "copied_table_us direct_table_us tree_speedup copy_speedup\n";
+
+  std::vector<BenchmarkMetric> metrics;
+  for (const bool partialScope : {false, true}) {
+    const std::string scope = partialScope ? "partial" : "full";
+    for (size_t numberObjects = options.minimumObjects;
+         numberObjects <= options.maximumObjects; ++numberObjects) {
+      const DiscreteKeys constraintKeys = makeKeys(numberObjects);
+      const size_t inputKeyCount =
+          partialScope ? (numberObjects + 1) / 2 : numberObjects;
+      const DiscreteKeys inputKeys(constraintKeys.begin(),
+                                   constraintKeys.begin() + inputKeyCount);
+      const TableFactor input = makeDenseTable(inputKeys);
+      const auto constraint = std::make_shared<AllDiff>(constraintKeys);
+      verifyProducts(input, constraint);
+
+      const uint64_t resultNonzeros =
+          directTableProduct(input, constraint)->nrValues();
+      const ProductTimings samples =
+          measureProducts(input, constraint, options);
+      const double decisionTree = summarize(samples.decisionTree).median;
+      const double copiedTable = summarize(samples.copiedTable).median;
+      const double directTable = summarize(samples.directTable).median;
+
+      std::cout << std::fixed << std::setprecision(2) << scope << ' '
+                << numberObjects << ' ' << input.nrValues() << ' '
+                << resultNonzeros << ' ' << decisionTree << ' ' << copiedTable
+                << ' ' << directTable << ' ' << decisionTree / directTable
+                << ' ' << copiedTable / directTable << '\n';
+
+      const std::string prefix =
+          scope + "_" + std::to_string(numberObjects) + "_objects_";
+      metrics.push_back(
+          {prefix + "decision_tree", "microseconds", decisionTree});
+      metrics.push_back({prefix + "copied_table", "microseconds", copiedTable});
+      metrics.push_back({prefix + "direct_table", "microseconds", directTable});
+      metrics.push_back(
+          {prefix + "tree_speedup", "x", decisionTree / directTable});
+      metrics.push_back(
+          {prefix + "copy_speedup", "x", copiedTable / directTable});
+    }
+  }
+
+  if (options.outputPath) {
+    gtsam::timing::writeBenchmarkActionMetrics(*options.outputPath, metrics);
+  }
+  std::cerr << "timing checksum: " << timingChecksum << '\n';
+  return 0;
+}

--- a/timing/README.md
+++ b/timing/README.md
@@ -22,6 +22,28 @@ These helpers are private to the timing targets and do not add public GTSAM
 API. Legacy `gttic_` microbenchmarks continue to use `gtsam/base/timing` and are
 not candidates for migration to this harness.
 
+## Hybrid Inference Benchmark
+
+`timeHybridInference` constructs a small 2D data-association problem with a
+sparse one-to-one association constraint using only core GTSAM APIs. It times
+the four tutorial-level hybrid inference operations independently: sequential
+Bayes-net creation, Bayes-net optimization, multifrontal Bayes-tree creation,
+and Bayes-tree optimization. Creation performs sum-product elimination, while
+optimization obtains the max-product assignment and its continuous solution.
+The executable verifies that the sequential and multifrontal solutions agree
+before collecting timings.
+
+Build and run it from the build directory:
+
+```bash
+make -j6 timeHybridInference
+./timing/timeHybridInference --objects 3 --warmup 1 --repeats 10 \
+  --iterations 10 --output hybrid_inference.json
+```
+
+The AllDiff-specific table-dispatch comparison lives in
+`gtsam_unstable/timing/timeHybridAllDiff.cpp`.
+
 ## BetweenFactor Jacobian Benchmark
 
 `timeBetweenFactor` measures `BetweenFactor<Rot3>::evaluateError` with both

--- a/timing/timeHybridInference.cpp
+++ b/timing/timeHybridInference.cpp
@@ -1,0 +1,314 @@
+/* ----------------------------------------------------------------------------
+ * GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+ * See LICENSE for the license information
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file timeHybridInference.cpp
+ * @brief Benchmark sequential and multifrontal hybrid inference.
+ */
+
+#include <gtsam/base/Matrix.h>
+#include <gtsam/discrete/TableFactor.h>
+#include <gtsam/hybrid/HybridBayesNet.h>
+#include <gtsam/hybrid/HybridBayesTree.h>
+#include <gtsam/hybrid/HybridGaussianFactor.h>
+#include <gtsam/hybrid/HybridGaussianFactorGraph.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/linear/JacobianFactor.h>
+#include <gtsam/linear/NoiseModel.h>
+
+#include <Eigen/Sparse>
+#include <cmath>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "internal/TimingUtils.h"
+
+namespace {
+
+using gtsam::DiscreteKey;
+using gtsam::DiscreteKeys;
+using gtsam::GaussianFactor;
+using gtsam::HybridBayesNet;
+using gtsam::HybridBayesTree;
+using gtsam::HybridGaussianFactor;
+using gtsam::HybridGaussianFactorGraph;
+using gtsam::HybridValues;
+using gtsam::JacobianFactor;
+using gtsam::Matrix2;
+using gtsam::Ordering;
+using gtsam::TableFactor;
+using gtsam::Vector2;
+using gtsam::noiseModel::Isotropic;
+using gtsam::symbol_shorthand::A;
+using gtsam::symbol_shorthand::X;
+using gtsam::timing::BenchmarkMetric;
+using gtsam::timing::MedianPolicy;
+using gtsam::timing::TimingSummary;
+
+volatile double timingChecksum = 0.0;
+
+struct BenchmarkOptions {
+  size_t numberObjects = 3;
+  size_t warmups = 1;
+  size_t repetitions = 10;
+  size_t iterations = 10;
+  std::optional<std::string> outputPath;
+};
+
+struct InferenceTimings {
+  std::vector<double> sequentialCreate;
+  std::vector<double> sequentialOptimize;
+  std::vector<double> multifrontalCreate;
+  std::vector<double> multifrontalOptimize;
+};
+
+DiscreteKeys makeAssociationKeys(size_t numberObjects) {
+  DiscreteKeys keys;
+  keys.reserve(numberObjects);
+  for (size_t i = 0; i < numberObjects; ++i) {
+    keys.emplace_back(A(i), numberObjects);
+  }
+  return keys;
+}
+
+// Construct a sparse one-to-one association constraint using only core APIs.
+TableFactor makeOneToOneConstraint(size_t numberObjects) {
+  const DiscreteKeys keys = makeAssociationKeys(numberObjects);
+  uint64_t cardinality = 1;
+  uint64_t validAssignments = 1;
+  for (size_t i = 0; i < numberObjects; ++i) {
+    cardinality *= numberObjects;
+    validAssignments *= i + 1;
+  }
+
+  Eigen::SparseVector<double> values(cardinality);
+  values.reserve(validAssignments);
+  std::vector<bool> used(numberObjects, false);
+  const auto addAssignments = [&](const auto& add, size_t depth,
+                                  uint64_t index) -> void {
+    if (depth == numberObjects) {
+      values.insert(index) = 1.0;
+      return;
+    }
+    for (size_t value = 0; value < numberObjects; ++value) {
+      if (used[value]) continue;
+      used[value] = true;
+      add(add, depth + 1, index * numberObjects + value);
+      used[value] = false;
+    }
+  };
+  addAssignments(addAssignments, 0, 0);
+  return TableFactor(keys, values);
+}
+
+std::vector<Vector2> makePredictions(size_t numberObjects) {
+  constexpr double kPi = 3.14159265358979323846;
+  std::vector<Vector2> predictions;
+  predictions.reserve(numberObjects);
+  for (size_t i = 0; i < numberObjects; ++i) {
+    const double angle =
+        2.0 * kPi * static_cast<double>(i) / static_cast<double>(numberObjects);
+    predictions.emplace_back(4.0 * std::cos(angle), 4.0 * std::sin(angle));
+  }
+  return predictions;
+}
+
+HybridGaussianFactorGraph makeGraph(size_t numberObjects) {
+  const std::vector<Vector2> predictions = makePredictions(numberObjects);
+  std::vector<Vector2> measurements;
+  measurements.reserve(numberObjects);
+  for (size_t i = 0; i < numberObjects; ++i) {
+    const Vector2 offset{0.05 * static_cast<double>(i + 1),
+                         -0.03 * static_cast<double>(i + 1)};
+    measurements.push_back(predictions[(i + 1) % numberObjects] + offset);
+  }
+
+  const auto model = Isotropic::Sigma(2, 1.5);
+  HybridGaussianFactorGraph graph;
+  for (size_t i = 0; i < numberObjects; ++i) {
+    graph.emplace_shared<JacobianFactor>(X(i), Matrix2::Identity(),
+                                         predictions[i], model);
+
+    std::vector<GaussianFactor::shared_ptr> components;
+    components.reserve(numberObjects);
+    for (const Vector2& measurement : measurements) {
+      components.emplace_back(std::make_shared<JacobianFactor>(
+          X(i), Matrix2::Identity(), measurement, model));
+    }
+    graph.emplace_shared<HybridGaussianFactor>(DiscreteKey(A(i), numberObjects),
+                                               components);
+  }
+  graph.push_back(
+      std::make_shared<TableFactor>(makeOneToOneConstraint(numberObjects)));
+  return graph;
+}
+
+Ordering makeOrdering(size_t numberObjects) {
+  Ordering ordering;
+  ordering.reserve(2 * numberObjects);
+  for (size_t i = 0; i < numberObjects; ++i) ordering.push_back(X(i));
+  for (size_t i = 0; i < numberObjects; ++i) ordering.push_back(A(i));
+  return ordering;
+}
+
+template <class Callable>
+double timeBatchMicroseconds(Callable&& callable, size_t iterations) {
+  const double seconds = gtsam::timing::measureSeconds([&] {
+    for (size_t i = 0; i < iterations; ++i) callable();
+  });
+  return seconds * 1e6 / static_cast<double>(iterations);
+}
+
+InferenceTimings measureInference(const HybridGaussianFactorGraph& graph,
+                                  const Ordering& ordering,
+                                  const HybridBayesNet::shared_ptr& bayesNet,
+                                  const HybridBayesTree::shared_ptr& bayesTree,
+                                  const BenchmarkOptions& options) {
+  const auto sequentialCreate = [&] {
+    const HybridBayesNet::shared_ptr result =
+        graph.eliminateSequential(ordering);
+    timingChecksum += static_cast<double>(result->size());
+  };
+  const auto sequentialOptimize = [&] {
+    const HybridValues result = bayesNet->optimize();
+    timingChecksum += static_cast<double>(result.discrete().at(A(0)));
+  };
+  const auto multifrontalCreate = [&] {
+    const HybridBayesTree::shared_ptr result =
+        graph.eliminateMultifrontal(ordering);
+    timingChecksum += static_cast<double>(result->size());
+  };
+  const auto multifrontalOptimize = [&] {
+    const HybridValues result = bayesTree->optimize();
+    timingChecksum += static_cast<double>(result.discrete().at(A(0)));
+  };
+
+  for (size_t i = 0; i < options.warmups; ++i) {
+    sequentialCreate();
+    sequentialOptimize();
+    multifrontalCreate();
+    multifrontalOptimize();
+  }
+
+  InferenceTimings timings;
+  timings.sequentialCreate.reserve(options.repetitions);
+  timings.sequentialOptimize.reserve(options.repetitions);
+  timings.multifrontalCreate.reserve(options.repetitions);
+  timings.multifrontalOptimize.reserve(options.repetitions);
+  for (size_t repetition = 0; repetition < options.repetitions; ++repetition) {
+    // Rotate all four operations to reduce systematic thermal bias.
+    for (size_t offset = 0; offset < 4; ++offset) {
+      switch ((repetition + offset) % 4) {
+        case 0:
+          timings.sequentialCreate.push_back(
+              timeBatchMicroseconds(sequentialCreate, options.iterations));
+          break;
+        case 1:
+          timings.sequentialOptimize.push_back(
+              timeBatchMicroseconds(sequentialOptimize, options.iterations));
+          break;
+        case 2:
+          timings.multifrontalCreate.push_back(
+              timeBatchMicroseconds(multifrontalCreate, options.iterations));
+          break;
+        case 3:
+          timings.multifrontalOptimize.push_back(
+              timeBatchMicroseconds(multifrontalOptimize, options.iterations));
+          break;
+      }
+    }
+  }
+  return timings;
+}
+
+TimingSummary summarize(const std::vector<double>& samples) {
+  return gtsam::timing::summarizeSamples(samples, MedianPolicy::kUpperMiddle);
+}
+
+void printUsage() {
+  std::cout << "Usage: timeHybridInference [--objects N] [--warmup N] "
+               "[--repeats N] [--iterations N] [--output FILE]\n";
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  gtsam::timing::Arguments arguments(argc, argv);
+  if (arguments.helpRequested()) {
+    printUsage();
+    return 0;
+  }
+
+  const std::string outputPath = arguments.stringValue("--output", "");
+  const BenchmarkOptions options{
+      arguments.sizeValue("--objects", 3),
+      arguments.sizeValue("--warmup", 1),
+      arguments.sizeValue("--repeats", 10),
+      arguments.sizeValue("--iterations", 10),
+      outputPath.empty() ? std::optional<std::string>() : outputPath,
+  };
+  arguments.validateAllConsumed();
+  if (options.numberObjects < 2 || options.numberObjects > 7 ||
+      options.repetitions == 0 || options.iterations == 0) {
+    throw std::invalid_argument(
+        "require 2 <= objects <= 7, repeats >= 1, and iterations >= 1");
+  }
+
+  const HybridGaussianFactorGraph graph = makeGraph(options.numberObjects);
+  const Ordering ordering = makeOrdering(options.numberObjects);
+  const HybridBayesNet::shared_ptr bayesNet =
+      graph.eliminateSequential(ordering);
+  const HybridBayesTree::shared_ptr bayesTree =
+      graph.eliminateMultifrontal(ordering);
+  const HybridValues sequential = bayesNet->optimize();
+  const HybridValues multifrontal = bayesTree->optimize();
+  if (!sequential.equals(multifrontal, 1e-9)) {
+    throw std::runtime_error(
+        "sequential and multifrontal hybrid solutions disagree");
+  }
+
+  const InferenceTimings samples =
+      measureInference(graph, ordering, bayesNet, bayesTree, options);
+  const double sequentialCreate = summarize(samples.sequentialCreate).median;
+  const double sequentialOptimize =
+      summarize(samples.sequentialOptimize).median;
+  const double multifrontalCreate =
+      summarize(samples.multifrontalCreate).median;
+  const double multifrontalOptimize =
+      summarize(samples.multifrontalOptimize).median;
+
+  const TableFactor constraint = makeOneToOneConstraint(options.numberObjects);
+  std::cout << "Hybrid 2D one-to-one association with " << options.numberObjects
+            << " objects and " << constraint.nrValues()
+            << " feasible assignments\n"
+            << std::fixed << std::setprecision(2)
+            << "sequential_create_us: " << sequentialCreate << '\n'
+            << "sequential_optimize_us: " << sequentialOptimize << '\n'
+            << "multifrontal_create_us: " << multifrontalCreate << '\n'
+            << "multifrontal_optimize_us: " << multifrontalOptimize << '\n';
+
+  if (options.outputPath) {
+    gtsam::timing::writeBenchmarkActionMetrics(
+        *options.outputPath,
+        {BenchmarkMetric{"sequential_create", "microseconds", sequentialCreate},
+         BenchmarkMetric{"sequential_optimize", "microseconds",
+                         sequentialOptimize},
+         BenchmarkMetric{"multifrontal_create", "microseconds",
+                         multifrontalCreate},
+         BenchmarkMetric{"multifrontal_optimize", "microseconds",
+                         multifrontalOptimize}});
+  }
+  std::cerr << "timing checksum: " << timingChecksum << '\n';
+  return 0;
+}


### PR DESCRIPTION
## Core discrete-factor change

This PR speeds up generic multiplication in `gtsam/discrete` by removing an unnecessary copy of the input `TableFactor`.

Previously, when a `TableFactor` encountered another `DiscreteFactor` subclass, core `TableFactor::multiply` made an owning copy of the entire input table solely to obtain a second virtual dispatch:

```cpp
const auto table = std::make_shared<TableFactor>(*this);
return factor->multiply(table);
```

The new core API asks the other factor for its most efficient table representation and multiplies it against the existing input by reference:

```cpp
return std::make_shared<TableFactor>(
    this->operator*(factor->toTableFactor()));
```

The dynamic cast and dereference borrow the existing table. Only the other factor's table representation and the unavoidable product are materialized, and the product is moved into the returned shared allocation.

To support that path generically, this PR adds virtual `DiscreteFactor::toTableFactor()` with direct core overrides for `DecisionTreeFactor`, `TableFactor`, and `TableDistribution`. `DiscreteFactor::multiply` is now a concrete table-aware fallback, while the existing specialized table/table and table/decision-tree paths remain intact.

## Core discrete performance

`AllDiff` is a sparse non-`TableFactor` implementation that exercises the generic core dispatch. The benchmark therefore uses `AllDiff` as the second operand while measuring multiplication and input-table ownership in `gtsam::TableFactor`.

`timeHybridAllDiff` compares three numerically identical routes:

1. conversion through `DecisionTreeFactor`;
2. sparse multiplication using the former core dispatch, including its input-table copy;
3. the new core direct dispatch, borrowing the input table.

Representative Release medians:

| Scope | Objects | Input nonzeros | Decision tree | Copied core table | Direct core table | Tree/direct | Copy/direct |
|---|---:|---:|---:|---:|---:|---:|---:|
| Full | 7 | 823,543 | 3,613,712 us | 68,337 us | 58,587 us | 61.68x | 1.17x |
| Partial | 7 | 2,401 | 2,615,171 us | 3,214 us | 2,997 us | 872.62x | 1.07x |

For the large full-scope core table, removing the copy reduces the median by about 14%. Small tables are close to timing noise, as expected. PR #2728 supplies the much larger decision-tree-to-sparse improvement; this follow-up generalizes that representation through the core API and removes the remaining copy.

## Hybrid inference impact

Hybrid inference consumes the new core API directly:

- discrete-factor collection calls virtual `toTableFactor()` instead of cast-or-convert blocks;
- full-clique sum-product obtains its `TableDistribution` through the same conversion;
- Bayes-tree max-product uses the same sparse conversion path;
- the always-enabled `GTSAM_HYBRID_WITH_TABLEFACTOR` macro and inactive branches are removed.

Consequently, hybrid elimination preserves sparse representations through the discrete product without bespoke knowledge of `AllDiff` or future discrete-factor subclasses. The copy-removal measurements above apply to this discrete multiplication phase when used in hybrid inference.

The core `timeHybridInference` target tracks a complete 2D one-to-one association problem using only `gtsam` APIs. Representative three-object medians were:

| Hybrid operation | Median |
|---|---:|
| Sequential Bayes-net creation (sum-product) | 78.12 us |
| Bayes-net optimization (max-product plus continuous solve) | 54.20 us |
| Multifrontal Bayes-tree creation (sum-product) | 83.72 us |
| Bayes-tree optimization (max-product plus continuous solve) | 16.29 us |

This core benchmark is checked in for continuing hybrid performance regression tracking.

## Stacked PR

This PR is stacked on and depends upon #2728. Its base is `codex/hybrid-all-diff-table`; only the two follow-up commits should be reviewed here.

## Validation

Passed in the existing Release build and in a Release build with `GTSAM_ALLOW_DEPRECATED_SINCE_V43=OFF`:

- `testTableFactor.run`
- `testDiscreteFactorGraph.run`
- `testCSP.run`
- `testHybridAllDiff.run`
- `testHybridGaussianFactorGraph.run`
- `testHybridBayesTree.run`
- `testHybridGaussianISAM.run`
- `testHybridNonlinearISAM.run`

Both timing targets compile and run in both configurations. Benchmark Action JSON output was also validated, and `git diff --check` passes.
