### PR TITLE
Expose ISAM2 update params in ConcurrentIncrementalFilter

### DIFF
--- a/gtsam_unstable/nonlinear/ConcurrentIncrementalFilter.cpp
+++ b/gtsam_unstable/nonlinear/ConcurrentIncrementalFilter.cpp
@@ -45,6 +45,19 @@ bool ConcurrentIncrementalFilter::equals(const ConcurrentFilter& rhs, double tol
 ConcurrentIncrementalFilter::Result ConcurrentIncrementalFilter::update(const NonlinearFactorGraph& newFactors, const Values& newTheta,
     const std::optional<FastList<Key> >& keysToMove, const std::optional< FactorIndices >& removeFactorIndices) {
 
+  ISAM2UpdateParams updateParams;
+  if(removeFactorIndices) {
+    updateParams.removeFactorIndices = *removeFactorIndices;
+  }
+  return update(newFactors, newTheta, updateParams, keysToMove);
+}
+
+/* ************************************************************************* */
+ConcurrentIncrementalFilter::Result ConcurrentIncrementalFilter::update(
+    const NonlinearFactorGraph& newFactors, const Values& newTheta,
+    const ISAM2UpdateParams& updateParams,
+    const std::optional<FastList<Key> >& keysToMove) {
+
   gttic(update);
 
 //  const bool debug = ISDEBUG("ConcurrentIncrementalFilter update");
@@ -55,12 +68,8 @@ ConcurrentIncrementalFilter::Result ConcurrentIncrementalFilter::update(const No
   // Create the return result meta-data
   Result result;
 
-  // We do not need to remove any factors at this time
-  FactorIndices removedFactors;
-
-  if(removeFactorIndices){
-    removedFactors.insert(removedFactors.end(), removeFactorIndices->begin(), removeFactorIndices->end());
-  }
+  // Copy the caller's parameters so filter-specific update controls can be merged in.
+  ISAM2UpdateParams mergedUpdateParams = updateParams;
 
   // Generate ordering constraints that force the 'keys to move' to the end
   std::optional<FastMap<Key,int> > orderingConstraints = {};
@@ -82,11 +91,15 @@ ConcurrentIncrementalFilter::Result ConcurrentIncrementalFilter::update(const No
     for(Key key: *keysToMove){
       orderingConstraints->operator[](key) = 0;
     }
-  }
 
-  // Create the set of linear keys that iSAM2 should hold constant
-  // iSAM2 takes care of this for us; no need to specify additional noRelin keys
-  std::optional<FastList<Key> > noRelinKeys = {};
+    if(!mergedUpdateParams.constrainedKeys) {
+      mergedUpdateParams.constrainedKeys = orderingConstraints;
+    } else {
+      for(const auto& keyAndGroup: *orderingConstraints) {
+        mergedUpdateParams.constrainedKeys->operator[](keyAndGroup.first) = keyAndGroup.second;
+      }
+    }
+  }
 
   // Mark additional keys between the 'keys to move' and the leaves
   std::optional<FastList<Key> > additionalKeys = {};
@@ -106,11 +119,18 @@ ConcurrentIncrementalFilter::Result ConcurrentIncrementalFilter::update(const No
       }
     }
     additionalKeys = FastList<Key>(markedKeys.begin(), markedKeys.end());
+
+    if(!mergedUpdateParams.extraReelimKeys) {
+      mergedUpdateParams.extraReelimKeys = additionalKeys;
+    } else {
+      mergedUpdateParams.extraReelimKeys->insert(
+          mergedUpdateParams.extraReelimKeys->end(), additionalKeys->begin(), additionalKeys->end());
+    }
   }
 
   // Update the system using iSAM2
   gttic(isam2);
-  ISAM2Result isam2Result = isam2_.update(newFactors, newTheta, removedFactors, orderingConstraints, noRelinKeys, additionalKeys);
+  ISAM2Result isam2Result = isam2_.update(newFactors, newTheta, mergedUpdateParams);
   gttoc(isam2);
 
   if(keysToMove && keysToMove->size() > 0) {

--- a/gtsam_unstable/nonlinear/ConcurrentIncrementalFilter.h
+++ b/gtsam_unstable/nonlinear/ConcurrentIncrementalFilter.h
@@ -127,6 +127,21 @@ public:
       const std::optional< FactorIndices >& removeFactorIndices = {});
 
   /**
+   * Add new factors and variables to the filter using additional iSAM2 update parameters.
+   *
+   * This overload preserves the filter-specific key-moving behavior while exposing
+   * parameters such as ISAM2UpdateParams::newAffectedKeys for smart factors.
+   *
+   * @param newFactors The new factors to be added to the filter
+   * @param newTheta Initialization points for new variables to be added to the filter
+   * @param updateParams Additional parameters to control the iSAM2 update
+   * @param keysToMove An optional set of keys to move from the filter to the smoother
+   */
+  Result update(const NonlinearFactorGraph& newFactors,
+      const Values& newTheta, const ISAM2UpdateParams& updateParams,
+      const std::optional<FastList<Key> >& keysToMove = {});
+
+  /**
    * Perform any required operations before the synchronization process starts.
    * Called by 'synchronize'
    */

--- a/gtsam_unstable/nonlinear/tests/testConcurrentIncrementalFilter.cpp
+++ b/gtsam_unstable/nonlinear/tests/testConcurrentIncrementalFilter.cpp
@@ -24,6 +24,7 @@
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/LinearContainerFactor.h>
 #include <gtsam/nonlinear/Values.h>
+#include <gtsam/slam/SmartProjectionPoseFactor.h>
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/inference/Key.h>
 #include <gtsam/inference/JunctionTree.h>
@@ -384,6 +385,67 @@ TEST( ConcurrentIncrementalFilter, update_multiple )
   Values actual3 = filter.calculateEstimate();
   // Check
   CHECK(assert_equal(expected3, actual3, 1e-6));
+}
+
+/* ************************************************************************* */
+// Verify that structured iSAM2 update parameters reach the underlying filter.
+TEST( ConcurrentIncrementalFilter, update_smart_factor_with_new_affected_keys )
+{
+  using SmartFactor = SmartProjectionPoseFactor<Cal3_S2>;
+  using Camera = PinholePose<Cal3_S2>;
+
+  ISAM2Params parameters;
+  parameters.cacheLinearizedFactors = false;
+  parameters.relinearizeSkip = 1;
+  parameters.relinearizeThreshold = 0.01;
+  ConcurrentIncrementalFilter filter(parameters);
+
+  auto calibration = std::make_shared<Cal3_S2>(50.0, 50.0, 0.0, 50.0, 50.0);
+  auto measurementNoise = noiseModel::Isotropic::Sigma(2, 1.0);
+  const auto posePriorNoise = noiseModel::Constrained::All(6);
+  const std::vector<Point3> landmarks{
+      Point3(0.0, 0.0, 5.0), Point3(1.0, 1.0, 6.0), Point3(-1.0, 0.5, 4.0)};
+  const std::vector<Pose3> poses{
+      Pose3::Identity(),
+      Pose3(Rot3::Identity(), Point3(1.0, 0.0, 0.0)),
+      Pose3(Rot3::Identity(), Point3(2.0, 0.0, 0.0))};
+
+  std::vector<SmartFactor::shared_ptr> smartFactors;
+  NonlinearFactorGraph initialFactors;
+  for(const Point3& landmark: landmarks) {
+    auto smartFactor = std::make_shared<SmartFactor>(measurementNoise, calibration);
+    for(Key key: {Key(0), Key(1)}) {
+      smartFactor->add(Camera(poses.at(key), calibration).project(landmark), key);
+    }
+    smartFactors.push_back(smartFactor);
+    initialFactors.push_back(smartFactor);
+  }
+
+  initialFactors.emplace_shared<PriorFactor<Pose3>>(0, poses.at(0), posePriorNoise);
+  initialFactors.emplace_shared<PriorFactor<Pose3>>(1, poses.at(1), posePriorNoise);
+  Values initialValues;
+  initialValues.insert(0, poses.at(0));
+  initialValues.insert(1, poses.at(1));
+  const auto initialResult = filter.update(initialFactors, initialValues);
+
+  for(size_t index = 0; index < smartFactors.size(); ++index) {
+    smartFactors.at(index)->add(
+        Camera(poses.at(2), calibration).project(landmarks.at(index)), 2);
+  }
+  ISAM2UpdateParams updateParams;
+  updateParams.newAffectedKeys = FastMap<FactorIndex, KeySet>();
+  for(size_t index = 0; index < smartFactors.size(); ++index) {
+    (*updateParams.newAffectedKeys)[initialResult.newFactorsIndices.at(index)].insert(2);
+  }
+  Values newValues;
+  newValues.insert(2, poses.at(2));
+  filter.update(NonlinearFactorGraph(), newValues, updateParams);
+
+  const auto& affectedFactorSlots = filter.getISAM2().getVariableIndex().at(2);
+  for(size_t index = 0; index < smartFactors.size(); ++index) {
+    CHECK(std::find(affectedFactorSlots.begin(), affectedFactorSlots.end(),
+                    initialResult.newFactorsIndices.at(index)) != affectedFactorSlots.end());
+  }
 }
 
 /* ************************************************************************* */


### PR DESCRIPTION
## Summary

- Add a source-compatible ConcurrentIncrementalFilter::update overload accepting ISAM2UpdateParams.
- Forward structured update parameters while preserving filter-generated key-moving controls and legacy factor removal.
- Add a smart-factor regression covering newAffectedKeys when an existing factor gains a pose.

## Testing

- make -j6 testConcurrentIncrementalFilter.run
- git diff --check

Closes #1526