### PR TITLE
Declare Python wrapper types before binding methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,38 @@ pybind_wrap(${PROJECT_NAME}_py # target
 
 For more information, please follow our [tutorial](https://github.com/borglab/gtsam-project-python).
 
+### Pybind module templates
+
+Pybind templates use two generated phases so every Python type is registered
+before pybind11 constructs callable signatures. Custom templates must define
+both phase functions and invoke the generated module initializer:
+
+```cpp
+{submodules}
+
+{declaration_module_def} {{
+// Include declaration-only specializations here.
+{wrapped_declarations}
+}}
+
+{binding_module_def} {{
+// Include methods, functions, and property specializations here.
+{wrapped_bindings}
+}}
+
+{module_def} {{
+{module_init}
+}}
+```
+
+Declaration specializations may create modules, classes, or enums but must not
+bind callables. Binding specializations can recover those objects and add their
+constructors, methods, functions, and properties. See
+`templates/pybind_wrapper.tpl.example` for the complete template. Declaration
+calls follow the interface-file list passed to `pybind_wrap`, so an interface
+which declares a base class must still precede interfaces declaring its derived
+classes.
+
 ## Documentation
 
 Documentation for wrapping C++ code can be found [here](https://github.com/borglab/wrap/blob/master/DOCS.md), including the [pybind callable-adapter annotation](https://github.com/borglab/wrap/blob/master/DOCS.md#pybind-callable-adapters).

--- a/gtsam/geometry/cameras.i
+++ b/gtsam/geometry/cameras.i
@@ -500,9 +500,14 @@ typedef gtsam::PinholePose<gtsam::Cal3_S2> PinholePoseCal3_S2;
 typedef gtsam::PinholePose<gtsam::Cal3DS2> PinholePoseCal3DS2;
 typedef gtsam::PinholePose<gtsam::Cal3Unified> PinholePoseCal3Unified;
 typedef gtsam::PinholePose<gtsam::Cal3Bundler> PinholePoseCal3Bundler;
+typedef gtsam::PinholePose<gtsam::Cal3f> PinholePoseCal3f;
 typedef gtsam::PinholePose<gtsam::Cal3Fisheye> PinholePoseCal3Fisheye;
 
 #include <gtsam/geometry/SphericalCamera.h>
+class EmptyCal {
+  EmptyCal();
+};
+
 class SphericalCamera {
   // Standard Constructors
   SphericalCamera();
@@ -551,7 +556,10 @@ class SphericalCamera {
   void serialize() const;
 };
 
-template <T = {gtsam::PinholePoseCal3_S2}>
+template <T = {gtsam::PinholePoseCal3_S2, gtsam::PinholePoseCal3DS2,
+               gtsam::PinholePoseCal3Unified,
+               gtsam::PinholePoseCal3Bundler,
+               gtsam::PinholePoseCal3Fisheye, gtsam::StereoCamera}>
 class CameraSet {
   CameraSet();
 

--- a/gtsam/hybrid/hybrid.i
+++ b/gtsam/hybrid/hybrid.i
@@ -497,6 +497,24 @@ virtual class HybridNonlinearFactorGraph : gtsam::HybridFactorGraph {
 };
 
 #include <gtsam/hybrid/HybridNonlinearFactor.h>
+template<L, Y>
+class DecisionTree {
+  DecisionTree();
+  DecisionTree(
+      const std::vector<std::pair<gtsam::Key, size_t>>& labelCs,
+      const std::vector<Y>& ys);
+  bool empty() const;
+  size_t nrLeaves() const;
+  const Y& operator()(const gtsam::Assignment<gtsam::Key>& x) const;
+};
+
+typedef gtsam::DecisionTree<
+    gtsam::Key, gtsam::GaussianConditional::shared_ptr>
+    HybridGaussianConditionalConditionals;
+
+typedef gtsam::DecisionTree<gtsam::Key, gtsam::NonlinearFactorValuePair>
+    HybridNonlinearFactorValuePairs;
+
 class HybridNonlinearFactor : gtsam::HybridFactor {
   HybridNonlinearFactor(const gtsam::DiscreteKey& discreteKey,
                         const std::vector<gtsam::NoiseModelFactor*>& factors);

--- a/gtsam/linear/linear.i
+++ b/gtsam/linear/linear.i
@@ -485,6 +485,12 @@ virtual class GaussianFactor : gtsam::Factor {
 };
 
 #include <gtsam/linear/JacobianFactor.h>
+class VariableSlots {
+  VariableSlots(const gtsam::GaussianFactorGraph& factorGraph);
+  void print(string str = "VariableSlots: ") const;
+  bool equals(const gtsam::VariableSlots& rhs, double tol = 0.0) const;
+};
+
 virtual class JacobianFactor : gtsam::GaussianFactor {
   //Constructors
   JacobianFactor();
@@ -763,6 +769,15 @@ class GaussianFactorGraph {
 
 #include <gtsam/linear/GaussianConditional.h>
 #include <gtsam/hybrid/HybridValues.h>
+class VerticalBlockMatrix {
+  VerticalBlockMatrix();
+  VerticalBlockMatrix(const std::vector<size_t>& dimensions, size_t height,
+                      bool appendOneDimension = false);
+  VerticalBlockMatrix(const std::vector<size_t>& dimensions,
+                      const gtsam::Matrix& matrix,
+                      bool appendOneDimension = false);
+};
+
 virtual class GaussianConditional : gtsam::JacobianFactor {
   // Constructors
   GaussianConditional(gtsam::Key key, gtsam::Vector d, gtsam::Matrix R,

--- a/gtsam/navigation/CarrierPhaseFactor.cpp
+++ b/gtsam/navigation/CarrierPhaseFactor.cpp
@@ -89,7 +89,7 @@ UndifferencedCarrierPhaseFactor::UndifferencedCarrierPhaseFactor(
     const Key tropoZenithWetKey, const Key slantIonoKey, const Key ambiguityKey,
     const double measuredCarrierPhaseMeters, const Point3& satellitePosition,
     const double tropoWetMapping, const double ionoCoefficient,
-    const double lambda, const double satelliteClockBias,
+    const double lambda_, const double satelliteClockBias,
     const SharedNoiseModel& model)
     : Base(model, receiverPositionKey, receiverClockBiasKey, tropoZenithWetKey,
            slantIonoKey, ambiguityKey),
@@ -97,7 +97,7 @@ UndifferencedCarrierPhaseFactor::UndifferencedCarrierPhaseFactor(
                        satelliteClockBias},
       tropoMap_(tropoWetMapping),
       ionoCoeff_(ionoCoefficient),
-      lambda_(lambda) {}
+      lambda_(lambda_) {}
 
 //***************************************************************************
 void UndifferencedCarrierPhaseFactor::print(
@@ -157,7 +157,7 @@ UndifferencedCarrierPhaseFactorArm::UndifferencedCarrierPhaseFactorArm(
     const Key tropoZenithWetKey, const Key slantIonoKey, const Key ambiguityKey,
     const double measuredCarrierPhaseMeters, const Point3& satellitePosition,
     const Point3& leverArm, const double tropoWetMapping,
-    const double ionoCoefficient, const double lambda,
+    const double ionoCoefficient, const double lambda_,
     const double satelliteClockBias, const SharedNoiseModel& model)
     : Base(model, poseKey, receiverClockBiasKey, tropoZenithWetKey, slantIonoKey,
            ambiguityKey),
@@ -166,7 +166,7 @@ UndifferencedCarrierPhaseFactorArm::UndifferencedCarrierPhaseFactorArm(
       arm_(leverArm),
       tropoMap_(tropoWetMapping),
       ionoCoeff_(ionoCoefficient),
-      lambda_(lambda) {}
+      lambda_(lambda_) {}
 
 //***************************************************************************
 UndifferencedCarrierPhaseFactorArm::UndifferencedCarrierPhaseFactorArm(
@@ -175,7 +175,7 @@ UndifferencedCarrierPhaseFactorArm::UndifferencedCarrierPhaseFactorArm(
     const double measuredCarrierPhaseMeters, const Point3& satellitePosition,
     const Point3& leverArm, const Pose3& ecef_T_nav,
     const double tropoWetMapping, const double ionoCoefficient,
-    const double lambda, const double satelliteClockBias,
+    const double lambda_, const double satelliteClockBias,
     const SharedNoiseModel& model)
     : Base(model, poseKey, receiverClockBiasKey, tropoZenithWetKey, slantIonoKey,
            ambiguityKey),
@@ -184,7 +184,7 @@ UndifferencedCarrierPhaseFactorArm::UndifferencedCarrierPhaseFactorArm(
       arm_(leverArm, ecef_T_nav),
       tropoMap_(tropoWetMapping),
       ionoCoeff_(ionoCoefficient),
-      lambda_(lambda) {}
+      lambda_(lambda_) {}
 
 //***************************************************************************
 void UndifferencedCarrierPhaseFactorArm::print(

--- a/gtsam/navigation/CarrierPhaseFactor.h
+++ b/gtsam/navigation/CarrierPhaseFactor.h
@@ -182,7 +182,7 @@ class GTSAM_EXPORT UndifferencedCarrierPhaseFactor
    * @param satellitePosition    Satellite ECEF position [m].
    * @param tropoWetMapping      Wet mapping function m_w at predicted elevation.
    * @param ionoCoefficient      Ionospheric coefficient mu_f (+1 on L1).
-   * @param lambda               Wavelength [m/cycle].
+   * @param lambda_              Wavelength [m/cycle].
    * @param satelliteClockBias   Satellite clock bias [s].
    * @param model                1-D noise model.
    */
@@ -190,7 +190,7 @@ class GTSAM_EXPORT UndifferencedCarrierPhaseFactor
       Key receiverPositionKey, Key receiverClockBiasKey, Key tropoZenithWetKey,
       Key slantIonoKey, Key ambiguityKey, double measuredCarrierPhaseMeters,
       const Point3& satellitePosition, double tropoWetMapping,
-      double ionoCoefficient, double lambda, double satelliteClockBias = 0.0,
+      double ionoCoefficient, double lambda_, double satelliteClockBias = 0.0,
       const SharedNoiseModel& model = noiseModel::Unit::Create(1));
 
   gtsam::NonlinearFactor::shared_ptr clone() const override {
@@ -270,7 +270,7 @@ class GTSAM_EXPORT UndifferencedCarrierPhaseFactorArm
       Key poseKey, Key receiverClockBiasKey, Key tropoZenithWetKey,
       Key slantIonoKey, Key ambiguityKey, double measuredCarrierPhaseMeters,
       const Point3& satellitePosition, const Point3& leverArm,
-      double tropoWetMapping, double ionoCoefficient, double lambda,
+      double tropoWetMapping, double ionoCoefficient, double lambda_,
       double satelliteClockBias = 0.0,
       const SharedNoiseModel& model = noiseModel::Unit::Create(1));
 
@@ -280,7 +280,7 @@ class GTSAM_EXPORT UndifferencedCarrierPhaseFactorArm
       Key slantIonoKey, Key ambiguityKey, double measuredCarrierPhaseMeters,
       const Point3& satellitePosition, const Point3& leverArm,
       const Pose3& ecef_T_nav, double tropoWetMapping, double ionoCoefficient,
-      double lambda, double satelliteClockBias = 0.0,
+      double lambda_, double satelliteClockBias = 0.0,
       const SharedNoiseModel& model = noiseModel::Unit::Create(1));
 
   gtsam::NonlinearFactor::shared_ptr clone() const override {

--- a/gtsam/navigation/navigation.i
+++ b/gtsam/navigation/navigation.i
@@ -821,7 +821,7 @@ virtual class UndifferencedCarrierPhaseFactor : gtsam::NoiseModelFactor {
                                double measuredCarrierPhaseMeters,
                                const gtsam::Point3& satellitePosition,
                                double tropoWetMapping, double ionoCoefficient,
-                               double lambda, double satelliteClockBias,
+                               double lambda_, double satelliteClockBias,
                                const gtsam::noiseModel::Base* model);
 
 
@@ -847,7 +847,7 @@ virtual class UndifferencedCarrierPhaseFactorArm : gtsam::NoiseModelFactor {
                                   const gtsam::Point3& satellitePosition,
                                   const gtsam::Point3& leverArm,
                                   double tropoWetMapping, double ionoCoefficient,
-                                  double lambda, double satelliteClockBias,
+                                  double lambda_, double satelliteClockBias,
                                   const gtsam::noiseModel::Base* model);
   UndifferencedCarrierPhaseFactorArm(gtsam::Key poseKey,
                                   gtsam::Key receiverClockBiasKey,
@@ -859,7 +859,7 @@ virtual class UndifferencedCarrierPhaseFactorArm : gtsam::NoiseModelFactor {
                                   const gtsam::Point3& leverArm,
                                   const gtsam::Pose3& ecef_T_nav,
                                   double tropoWetMapping, double ionoCoefficient,
-                                  double lambda, double satelliteClockBias,
+                                  double lambda_, double satelliteClockBias,
                                   const gtsam::noiseModel::Base* model);
 
 

--- a/gtsam/nonlinear/nonlinear.i
+++ b/gtsam/nonlinear/nonlinear.i
@@ -543,6 +543,17 @@ class ISAM2Result {
   const gtsam::KeySet& getMarkedKeys() const;
 };
 
+class ISAM2UpdateParams {
+  ISAM2UpdateParams();
+
+  gtsam::FactorIndices removeFactorIndices;
+  std::optional<gtsam::KeyGroupMap> constrainedKeys;
+  std::optional<gtsam::KeyList> noRelinKeys;
+  std::optional<gtsam::KeyList> extraReelimKeys;
+  bool force_relinearize;
+  bool forceFullSolve;
+};
+
 class ISAM2 {
   ISAM2();
   ISAM2(const gtsam::ISAM2Params& params);

--- a/gtsam_unstable/gtsam_unstable.i
+++ b/gtsam_unstable/gtsam_unstable.i
@@ -58,7 +58,7 @@ class Pose3Upright {
   Pose3Upright(double x, double y, double z, double theta);
   Pose3Upright(const gtsam::Pose2& pose, double z);
 
-  void print(string s) const;
+  void print(string s = "") const;
   bool equals(const gtsam::Pose3Upright& pose, double tol) const;
 
   double x() const;
@@ -101,7 +101,7 @@ class SimWall2D {
   SimWall2D(const gtsam::Point2& a, const gtsam::Point2& b);
   SimWall2D(double ax, double ay, double bx, double by);
 
-  void print(string s) const;
+  void print(string s = "") const;
   bool equals(const gtsam::SimWall2D& other, double tol) const;
 
   gtsam::Point2 a() const;
@@ -134,7 +134,7 @@ class SimPolygon2D {
    const gtsam::Point2Vector& vertices() const;
 
    bool equals(const gtsam::SimPolygon2D& p, double tol) const;
-   void print(string s) const;
+   void print(string s = "") const;
 
    gtsam::SimWall2DVector walls() const;
    bool contains(const gtsam::Point2& p) const;
@@ -317,12 +317,12 @@ virtual class TOAFactor : gtsam::NoiseModelFactor {
 
 #include <gtsam_unstable/nonlinear/ConcurrentFilteringAndSmoothing.h>
 virtual class ConcurrentFilter {
-  void print(string s) const;
+  void print(string s = "Concurrent Filter:\n") const;
   bool equals(const gtsam::ConcurrentFilter& rhs, double tol) const;
 };
 
 virtual class ConcurrentSmoother {
-  void print(string s) const;
+  void print(string s = "Concurrent Smoother:\n") const;
   bool equals(const gtsam::ConcurrentSmoother& rhs, double tol) const;
 };
 
@@ -494,7 +494,7 @@ virtual class SmartStereoProjectionFactor : gtsam::NonlinearFactor {
       const gtsam::SmartProjectionParams& params);
   SmartStereoProjectionFactor(const gtsam::noiseModel::Base* sharedNoiseModel);
 
-  void print(string s) const;
+  void print(string s = "") const;
 
   gtsam::TriangulationResult point() const;
   gtsam::TriangulationResult point(const gtsam::Values& values) const;

--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -507,10 +507,13 @@ pybind11::arg py_arg(const char* name) {
         res += ";\n\n"
         return res
 
-    def wrap_enums(self, enums, instantiated_class, prefix=' ' * 4):
+    def wrap_enums(self,
+                   enums,
+                   instantiated_class,
+                   module_var,
+                   prefix=' ' * 4):
         """Wrap multiple enums defined in a class."""
         cpp_class = instantiated_class.to_cpp()
-        module_var = instantiated_class.name.lower()
         res = ''
 
         for enum in enums:
@@ -518,68 +521,94 @@ pybind11::arg py_arg(const char* name) {
                 enum, class_name=cpp_class, module=module_var, prefix=prefix)
         return res
 
-    def wrap_instantiated_class(
+    def _class_binding_type(self, instantiated_class):
+        """Return the complete ``py::class_`` type for a wrapped class."""
+        cpp_class = instantiated_class.to_cpp()
+        if instantiated_class.parent_class:
+            class_parent = f"{instantiated_class.parent_class}, "
+        else:
+            class_parent = ''
+
+        return ('py::class_<{cpp_class}, {class_parent}'
+                'std::shared_ptr<{cpp_class}>>').format(
+                    cpp_class=cpp_class, class_parent=class_parent)
+
+    @staticmethod
+    def _cpp_identifier(value):
+        """Convert a generated name into a valid, deterministic C++ identifier."""
+        identifier = re.sub(r'[^0-9A-Za-z_]', '_', value)
+        if identifier and identifier[0].isdigit():
+            identifier = '_' + identifier
+        return identifier
+
+    def _class_var(self, instantiated_class):
+        """Return a class-handle variable unique within a generated file."""
+        module_var = self._gen_module_var(instantiated_class.namespaces())
+        return self._cpp_identifier(
+            f"gtwrap_class_{module_var}_{instantiated_class.name}")
+
+    def declare_instantiated_class(
             self, instantiated_class: instantiator.InstantiatedClass):
-        """Wrap the class."""
+        """Register a class without binding any of its callables."""
         module_var = self._gen_module_var(instantiated_class.namespaces())
         cpp_class = instantiated_class.to_cpp()
         if cpp_class in self.ignore_classes:
             return ""
-        if instantiated_class.parent_class:
-            class_parent = "{instantiated_class.parent_class}, ".format(
-                instantiated_class=instantiated_class)
-        else:
-            class_parent = ''
+        class_type = self._class_binding_type(instantiated_class)
+        class_var = self._class_var(instantiated_class)
 
+        # Nested enums need the owning Python class object as their scope.
         if instantiated_class.enums:
-            # If class has enums, define an instance and set module_var to the instance
-            instance_name = instantiated_class.name.lower()
-            class_declaration = (
-                '\n    py::class_<{cpp_class}, {class_parent}'
-                'std::shared_ptr<{cpp_class}>> '
-                '{instance_name}({module_var}, "{class_name}");'
-                '\n    {instance_name}').format(
-                    cpp_class=cpp_class,
-                    class_name=instantiated_class.name,
-                    class_parent=class_parent,
-                    instance_name=instance_name,
-                    module_var=module_var)
-            module_var = instance_name
+            declaration = (
+                '\n    {class_type} {class_var}({module_var}, "{class_name}");'
+            ).format(class_type=class_type,
+                     class_var=class_var,
+                     module_var=module_var,
+                     class_name=instantiated_class.name)
+            declaration += self.wrap_enums(instantiated_class.enums,
+                                           instantiated_class, class_var)
+            return declaration
 
-        else:
-            class_declaration = (
-                '\n    py::class_<{cpp_class}, {class_parent}'
-                'std::shared_ptr<{cpp_class}>>({module_var}, "{class_name}")'
-            ).format(cpp_class=cpp_class,
-                     class_name=instantiated_class.name,
-                     class_parent=class_parent,
-                     module_var=module_var)
+        return ('\n    {class_type}({module_var}, "{class_name}");\n').format(
+            class_type=class_type,
+            module_var=module_var,
+            class_name=instantiated_class.name)
 
-        return ('{class_declaration}'
-                '{wrapped_ctors}'
-                '{wrapped_methods}'
-                '{wrapped_static_methods}'
-                '{wrapped_dunder_methods}'
-                '{wrapped_properties}'
-                '{wrapped_operators};\n'.format(
-                    class_declaration=class_declaration,
-                    wrapped_ctors=self.wrap_ctors(instantiated_class),
-                    wrapped_methods=self.wrap_methods(
-                        instantiated_class.methods,
-                        cpp_class),
-                    wrapped_static_methods=self.wrap_methods(
-                        instantiated_class.static_methods,
-                        cpp_class),
-                    wrapped_dunder_methods=self.wrap_dunder_methods(
-                        instantiated_class.dunder_methods, cpp_class),
-                    wrapped_properties=self.wrap_properties(
-                        instantiated_class.properties, cpp_class),
-                    wrapped_operators=self.wrap_operators(
-                        instantiated_class.operators, cpp_class)))
+    def bind_instantiated_class(
+            self, instantiated_class: instantiator.InstantiatedClass):
+        """Bind a class after all generated types have been registered."""
+        module_var = self._gen_module_var(instantiated_class.namespaces())
+        cpp_class = instantiated_class.to_cpp()
+        if cpp_class in self.ignore_classes:
+            return ""
 
-    def wrap_instantiated_declaration(
+        wrapped_members = (
+            self.wrap_ctors(instantiated_class) +
+            self.wrap_methods(instantiated_class.methods, cpp_class) +
+            self.wrap_methods(instantiated_class.static_methods, cpp_class) +
+            self.wrap_dunder_methods(instantiated_class.dunder_methods,
+                                     cpp_class) +
+            self.wrap_properties(instantiated_class.properties, cpp_class) +
+            self.wrap_operators(instantiated_class.operators, cpp_class))
+
+        if not wrapped_members:
+            return ""
+
+        class_type = self._class_binding_type(instantiated_class)
+        class_var = self._class_var(instantiated_class)
+        return (
+            '\n    auto {class_var} = py::reinterpret_borrow<{class_type}>('
+            '{module_var}.attr("{class_name}"));'
+            '\n    {class_var}{wrapped_members};\n').format(
+                class_var=class_var,
+                class_type=class_type,
+                module_var=module_var,
+                class_name=instantiated_class.name,
+                wrapped_members=wrapped_members)
+
+    def declare_instantiated_declaration(
             self, instantiated_decl: instantiator.InstantiatedDeclaration):
-        """Wrap the forward declaration."""
+        """Register an instantiated forward declaration."""
         module_var = self._gen_module_var(instantiated_decl.namespaces())
         cpp_class = instantiated_decl.to_cpp()
         if cpp_class in self.ignore_classes:
@@ -592,34 +621,44 @@ pybind11::arg py_arg(const char* name) {
                         module_var=module_var)
         return res
 
-    def wrap_stl_class(self, stl_class):
-        """Wrap STL containers."""
+    def declare_stl_class(self, stl_class):
+        """Register an STL container class without binding its members."""
         module_var = self._gen_module_var(stl_class.namespaces())
         cpp_class = stl_class.to_cpp()
         if cpp_class in self.ignore_classes:
             return ""
 
-        return ('\n    py::class_<{cpp_class}, {class_parent}'
-                'std::shared_ptr<{cpp_class}>>({module_var}, "{class_name}")'
-                '{wrapped_ctors}'
-                '{wrapped_methods}'
-                '{wrapped_static_methods}'
-                '{wrapped_properties};\n'.format(
-                    cpp_class=cpp_class,
-                    class_name=stl_class.name,
-                    class_parent=str(stl_class.parent_class) +
-                    (', ' if stl_class.parent_class else ''),
-                    module_var=module_var,
-                    wrapped_ctors=self.wrap_ctors(stl_class),
-                    wrapped_methods=self.wrap_methods(
-                        stl_class.methods,
-                        cpp_class),
-                    wrapped_static_methods=self.wrap_methods(
-                        stl_class.static_methods,
-                        cpp_class),
-                    wrapped_properties=self.wrap_properties(
-                        stl_class.properties, cpp_class),
-                ))
+        return ('\n    {class_type}({module_var}, "{class_name}");\n').format(
+            class_type=self._class_binding_type(stl_class),
+            module_var=module_var,
+            class_name=stl_class.name)
+
+    def bind_stl_class(self, stl_class):
+        """Bind an STL container after all generated types are registered."""
+        module_var = self._gen_module_var(stl_class.namespaces())
+        cpp_class = stl_class.to_cpp()
+        if cpp_class in self.ignore_classes:
+            return ""
+
+        wrapped_members = (
+            self.wrap_ctors(stl_class) +
+            self.wrap_methods(stl_class.methods, cpp_class) +
+            self.wrap_methods(stl_class.static_methods, cpp_class) +
+            self.wrap_properties(stl_class.properties, cpp_class))
+        if not wrapped_members:
+            return ""
+
+        class_type = self._class_binding_type(stl_class)
+        class_var = self._class_var(stl_class)
+        return (
+            '\n    auto {class_var} = py::reinterpret_borrow<{class_type}>('
+            '{module_var}.attr("{class_name}"));'
+            '\n    {class_var}{wrapped_members};\n').format(
+                class_var=class_var,
+                class_type=class_type,
+                module_var=module_var,
+                class_name=stl_class.name,
+                wrapped_members=wrapped_members)
 
     def wrap_functions(self,
                        functions,
@@ -703,13 +742,14 @@ pybind11::arg py_arg(const char* name) {
             return name
 
     def wrap_namespace(self, namespace):
-        """Wrap the complete `namespace`."""
-        wrapped = ""
+        """Generate declaration and binding phases for ``namespace``."""
+        declarations = ""
+        bindings = ""
         includes = ""
 
         namespaces = namespace.full_namespaces()
         if not self._partial_match(namespaces, self.top_module_namespaces):
-            return "", ""
+            return "", "", ""
 
         if len(namespaces) < len(self.top_module_namespaces):
             for element in namespace.content:
@@ -720,20 +760,31 @@ pybind11::arg py_arg(const char* name) {
                     includes += include
                 if isinstance(element, parser.Namespace):
                     (
-                        wrapped_namespace,
+                        namespace_declarations,
+                        namespace_bindings,
                         includes_namespace,
                     ) = self.wrap_namespace(  # noqa
                         element)
-                    wrapped += wrapped_namespace
+                    declarations += namespace_declarations
+                    bindings += namespace_bindings
                     includes += includes_namespace
         else:
             module_var = self._gen_module_var(namespaces)
 
             if len(namespaces) > len(self.top_module_namespaces):
-                wrapped += (
-                    ' ' * 4 + 'pybind11::module {module_var} = '
+                declarations += (
+                    '\n' + ' ' * 4 + 'pybind11::module {module_var} = '
                     '{parent_module_var}.def_submodule("{namespace}", "'
                     '{namespace} submodule");\n'.format(
+                        module_var=module_var,
+                        namespace=namespace.name,
+                        parent_module_var=self._gen_module_var(
+                            namespaces[:-1]),
+                    ))
+                bindings += (
+                    '\n' + ' ' * 4 + 'pybind11::module {module_var} = '
+                    'py::reinterpret_borrow<pybind11::module>('
+                    '{parent_module_var}.attr("{namespace}"));\n'.format(
                         module_var=module_var,
                         namespace=namespace.name,
                         parent_module_var=self._gen_module_var(
@@ -748,27 +799,30 @@ pybind11::arg py_arg(const char* name) {
                     include = include.replace('<', '"').replace('>', '"')
                     includes += include
                 elif isinstance(element, parser.Namespace):
-                    wrapped_namespace, includes_namespace = self.wrap_namespace(
-                        element)
-                    wrapped += wrapped_namespace
+                    (namespace_declarations, namespace_bindings,
+                     includes_namespace) = self.wrap_namespace(element)
+                    declarations += namespace_declarations
+                    bindings += namespace_bindings
                     includes += includes_namespace
 
                 elif isinstance(element, instantiator.InstantiatedClass):
-                    wrapped += self.wrap_instantiated_class(element)
-                    wrapped += self.wrap_enums(element.enums, element)
+                    declarations += self.declare_instantiated_class(element)
+                    bindings += self.bind_instantiated_class(element)
 
                 elif isinstance(element, instantiator.InstantiatedDeclaration):
-                    wrapped += self.wrap_instantiated_declaration(element)
+                    declarations += self.declare_instantiated_declaration(
+                        element)
 
                 elif isinstance(element, parser.Variable):
                     variable_namespace = self._add_namespaces('', namespaces)
-                    wrapped += self.wrap_variable(namespace=variable_namespace,
-                                                  module_var=module_var,
-                                                  variable=element,
-                                                  prefix='\n' + ' ' * 4)
+                    bindings += self.wrap_variable(
+                        namespace=variable_namespace,
+                        module_var=module_var,
+                        variable=element,
+                        prefix='\n' + ' ' * 4)
 
                 elif isinstance(element, parser.Enum):
-                    wrapped += self.wrap_enum(element)
+                    declarations += self.wrap_enum(element)
 
             # Global functions.
             all_funcs = [
@@ -776,14 +830,14 @@ pybind11::arg py_arg(const char* name) {
                 if isinstance(func, (parser.GlobalFunction,
                                      instantiator.InstantiatedGlobalFunction))
             ]
-            wrapped += self.wrap_functions(
+            bindings += self.wrap_functions(
                 all_funcs,
                 self._add_namespaces('', namespaces)[:-2],
                 prefix='\n' + ' ' * 4 + module_var,
                 suffix=';',
             )
 
-        return wrapped, includes
+        return declarations, bindings, includes
 
     def wrap_file(self,
                   content,
@@ -799,12 +853,31 @@ pybind11::arg py_arg(const char* name) {
             submodules: List of other interface file names that should be linked to.
             source_name: Name of the interface file for parser diagnostics.
         """
+        required_template_fields = (
+            'module_def',
+            'submodules',
+            'declaration_module_def',
+            'binding_module_def',
+            'wrapped_declarations',
+            'wrapped_bindings',
+            'module_init',
+        )
+        missing_template_fields = [
+            field for field in required_template_fields
+            if '{' + field + '}' not in self.module_template
+        ]
+        if missing_template_fields:
+            raise ValueError(
+                'Pybind module template is missing declare-then-bind fields: '
+                + ', '.join(missing_template_fields))
+
         # Parse the contents of the interface file
         module = parser.Module.parse_string(content, source_name=source_name)
         # Instantiate all templates
         module = instantiator.instantiate_namespace(module)
 
-        wrapped_namespace, includes = self.wrap_namespace(module)
+        wrapped_declarations, wrapped_bindings, includes = self.wrap_namespace(
+            module)
 
         if self.use_boost_serialization:
             includes += "#include <boost/serialization/export.hpp>"
@@ -827,29 +900,58 @@ pybind11::arg py_arg(const char* name) {
         # Reset the serializing classes list
         self._serializing_classes = []
 
-        submodules_init = []
+        phase_name = self._cpp_identifier(module_name)
+        declaration_function = f"gtwrap_declare_{phase_name}"
+        binding_function = f"gtwrap_bind_{phase_name}"
+        declaration_module_def = (
+            f"void {declaration_function}(py::module_ &m_)")
+        binding_module_def = f"void {binding_function}(py::module_ &m_)"
 
         if submodules is not None:
             module_def = "PYBIND11_MODULE({0}, m_)".format(module_name)
+            submodule_declarations = []
+            declare_calls = [f"{declaration_function}(m_);"]
+            bind_calls = [f"{binding_function}(m_);"]
 
-            for idx, submodule in enumerate(submodules):
-                submodules[idx] = "void {0}(py::module_ &);".format(submodule)
-                submodules_init.append("{0}(m_);".format(submodule))
+            for submodule in submodules:
+                submodule_name = self._cpp_identifier(submodule)
+                declare_function = f"gtwrap_declare_{submodule_name}"
+                bind_function = f"gtwrap_bind_{submodule_name}"
+                submodule_declarations.extend([
+                    f"void {declare_function}(py::module_ &);",
+                    f"void {bind_function}(py::module_ &);",
+                ])
+                declare_calls.append(f"{declare_function}(m_);")
+                bind_calls.append(f"{bind_function}(m_);")
+
+            submodules = submodule_declarations
+            module_initialization = "\n".join(declare_calls + bind_calls)
 
         else:
             module_def = "void {0}(py::module_ &m_)".format(module_name)
             submodules = []
+            module_initialization = "\n".join([
+                f"{declaration_function}(m_);",
+                f"{binding_function}(m_);",
+            ])
 
         includes += self.ARG_POLICY_SUPPORT
 
         return self.module_template.format(
             module_def=module_def,
+            declaration_module_def=declaration_module_def,
+            binding_module_def=binding_module_def,
             module_name=module_name,
             includes=includes,
-            wrapped_namespace=wrapped_namespace,
+            wrapped_declarations=wrapped_declarations,
+            wrapped_bindings=wrapped_bindings,
+            module_init=module_initialization,
+            # Alias retained for templates transitioning from the old
+            # single-phase placeholder.
+            wrapped_namespace=module_initialization,
             boost_class_export=boost_class_export,
             submodules="\n".join(submodules),
-            submodules_init="\n".join(submodules_init),
+            submodules_init="",
         )
 
     def wrap_submodule(self, source):

--- a/python/gtsam/gtsam.tpl
+++ b/python/gtsam/gtsam.tpl
@@ -39,14 +39,20 @@ namespace py = pybind11;
 
 {submodules}
 
-{module_def} {{
-    m_.doc() = "pybind11 wrapper of {module_name}";
+{declaration_module_def} {{
+{wrapped_declarations}
+}}
 
+{binding_module_def} {{
 // Specializations for STL classes
 #include "python/gtsam/specializations/{module_name}.h"
 
-{submodules_init}
+{wrapped_bindings}
+}}
 
-{wrapped_namespace}
+{module_def} {{
+    m_.doc() = "pybind11 wrapper of {module_name}";
+
+{module_init}
 
 }}

--- a/python/gtsam/specializations/custom.h
+++ b/python/gtsam/specializations/custom.h
@@ -1,15 +1,2 @@
-/* Please refer to:
- * https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html
- * These are required to save one copy operation on Python calls.
- *
- * NOTES
- * =================
- *
- * `py::bind_vector` and similar machinery gives the std container a Python-like
- * interface, but without the `<pybind11/stl.h>` copying mechanism. Combined
- * with `PYBIND11_MAKE_OPAQUE` this allows the types to be modified with Python,
- * and saves one copy operation.
- */
-
-// Added so that CustomFactor can pass the JacobianVector to the C++ side
-py::bind_vector<std::vector<gtsam::Matrix> >(m_, "JacobianVector");
+// JacobianVector is bound in specializations/nonlinear.h so its Python type is
+// registered before signatures using gtsam::OptionalMatrixVecType are created.

--- a/python/gtsam/specializations/nonlinear.h
+++ b/python/gtsam/specializations/nonlinear.h
@@ -10,3 +10,46 @@
  * with `PYBIND11_MAKE_OPAQUE` this allows the types to be modified with Python,
  * and saves one copy operation.
  */
+
+// Register before NoiseModelFactor::unwhitenedError so pybind11 can use the
+// Python type name in that method's signature. CustomFactor is bound later.
+py::bind_vector<std::vector<gtsam::Matrix>>(
+    m_, "JacobianVector", py::module_local(false));
+
+{
+  using PythonAffectedKeys =
+      std::map<gtsam::FactorIndex, std::set<gtsam::Key>>;
+
+  auto updateParams = py::reinterpret_borrow<
+      py::class_<gtsam::ISAM2UpdateParams,
+                 std::shared_ptr<gtsam::ISAM2UpdateParams>>>(
+      m_.attr("ISAM2UpdateParams"));
+  updateParams.def_property(
+      "newAffectedKeys",
+      [](const gtsam::ISAM2UpdateParams& params)
+          -> std::optional<PythonAffectedKeys> {
+        if (!params.newAffectedKeys) {
+          return std::nullopt;
+        }
+
+        PythonAffectedKeys result;
+        for (const auto& [factorIndex, keys] : *params.newAffectedKeys) {
+          result.emplace(factorIndex,
+                         std::set<gtsam::Key>(keys.begin(), keys.end()));
+        }
+        return result;
+      },
+      [](gtsam::ISAM2UpdateParams& params,
+         const std::optional<PythonAffectedKeys>& affectedKeys) {
+        if (!affectedKeys) {
+          params.newAffectedKeys.reset();
+          return;
+        }
+
+        gtsam::FastMap<gtsam::FactorIndex, gtsam::KeySet> result;
+        for (const auto& [factorIndex, keys] : *affectedKeys) {
+          result.emplace(factorIndex, gtsam::KeySet(keys));
+        }
+        params.newAffectedKeys = std::move(result);
+      });
+}

--- a/python/gtsam/tests/test_OptionalJacobianArgument.py
+++ b/python/gtsam/tests/test_OptionalJacobianArgument.py
@@ -50,6 +50,19 @@ class TestUnwhitenedError(GtsamTestCase):
         np.testing.assert_allclose(error, factor.unwhitenedError(values),
                                    atol=1e-12)
 
+    def test_H_is_populated(self):
+        """A pre-sized JacobianVector receives the output Jacobian."""
+        factor, values = self.prior_problem()
+        jacobians = gtsam.JacobianVector([np.empty((0, 0))])
+
+        error = factor.unwhitenedError(values, jacobians)
+
+        np.testing.assert_allclose(error, factor.unwhitenedError(values),
+                                   atol=1e-12)
+        self.assertEqual(len(jacobians), 1)
+        self.assertEqual(jacobians[0].shape, (6, 6))
+        self.assertTrue(np.all(np.isfinite(jacobians[0])))
+
     def test_agrees_with_whitened_error(self):
         """Unit noise, so whitened and unwhitened coincide."""
         factor, values = self.prior_problem()

--- a/python/gtsam/tests/test_WrapperTypeRegistrations.py
+++ b/python/gtsam/tests/test_WrapperTypeRegistrations.py
@@ -1,0 +1,192 @@
+"""
+GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,
+Atlanta, Georgia 30332-0415
+All Rights Reserved
+
+See LICENSE for the license information.
+
+Tests for C++ types exposed by generated wrapper signatures.
+"""
+
+import unittest
+
+import numpy as np
+
+import gtsam
+from gtsam.utils.test_case import GtsamTestCase
+
+
+class TestWrapperTypeRegistrations(GtsamTestCase):
+    """Checks that every public signature type has a usable Python class."""
+
+    def test_camera_set_instantiations(self):
+        """CameraSet instantiations accept each wrapped camera family."""
+        camera_types = (
+            ("CameraSetPinholePoseCal3DS2", "PinholePoseCal3DS2"),
+            ("CameraSetPinholePoseCal3Unified", "PinholePoseCal3Unified"),
+            ("CameraSetPinholePoseCal3Bundler", "PinholePoseCal3Bundler"),
+            ("CameraSetPinholePoseCal3Fisheye", "PinholePoseCal3Fisheye"),
+            ("CameraSetStereoCamera", "StereoCamera"),
+        )
+
+        for camera_set_name, camera_name in camera_types:
+            with self.subTest(camera_set=camera_set_name):
+                cameras = getattr(gtsam, camera_set_name)()
+                camera = getattr(gtsam, camera_name)()
+                cameras.push_back(camera)
+                self.assertEqual(cameras.at(0).dim(), camera.dim())
+
+    def test_pinhole_pose_cal3f_values_round_trip(self):
+        """The Cal3f PinholePose specialization round-trips through Values."""
+        camera = gtsam.PinholePoseCal3f(gtsam.Pose3())
+        values = gtsam.Values()
+        values.insert(0, camera)
+        self.assertTrue(values.atPinholePoseCal3f(0).equals(camera, 1e-9))
+
+    def test_empty_cal_spherical_camera_constructor(self):
+        """The explicit EmptyCal constructor is callable from Python."""
+        camera = gtsam.SphericalCamera(gtsam.Pose3(), gtsam.EmptyCal())
+        self.gtsamAssertEquals(camera.pose(), gtsam.Pose3())
+
+    def test_variable_slots_jacobian_constructor(self):
+        """VariableSlots can be reused when assembling a JacobianFactor."""
+        model = gtsam.noiseModel.Unit.Create(1)
+        graph = gtsam.GaussianFactorGraph()
+        graph.push_back(
+            gtsam.JacobianFactor(0, np.ones((1, 1)), np.ones(1), model)
+        )
+
+        variable_slots = gtsam.VariableSlots(graph)
+        combined = gtsam.JacobianFactor(graph, variable_slots)
+        self.assertEqual(combined.rows(), 1)
+
+    def test_vertical_block_matrix_constructor(self):
+        """VerticalBlockMatrix can back the corresponding conditional overload."""
+        augmented_matrix = gtsam.VerticalBlockMatrix(
+            [1, 1], np.array([[2.0, 3.0]])
+        )
+        conditional = gtsam.GaussianConditional([0], 1, augmented_matrix)
+        self.assertEqual(conditional.rows(), 1)
+
+    def test_isam2_update_params(self):
+        """ISAM2UpdateParams exposes scalar, container, and optional-map fields."""
+        params = gtsam.ISAM2UpdateParams()
+        self.assertFalse(params.force_relinearize)
+        self.assertFalse(params.forceFullSolve)
+        self.assertIsNone(params.newAffectedKeys)
+
+        params.force_relinearize = True
+        params.newAffectedKeys = {7: {1, 2}}
+        self.assertEqual(params.newAffectedKeys, {7: {1, 2}})
+
+        params.removeFactorIndices = [3]
+        self.assertEqual(params.removeFactorIndices, [3])
+
+        constrained_keys = gtsam.KeyGroupMap()
+        constrained_keys.insert2(1, 2)
+        params.constrainedKeys = constrained_keys
+        self.assertEqual(params.constrainedKeys.at(1), 2)
+
+        no_relin_keys = gtsam.KeyList()
+        no_relin_keys.push_back(4)
+        params.noRelinKeys = no_relin_keys
+        self.assertEqual(params.noRelinKeys.front(), 4)
+
+        extra_reelim_keys = gtsam.KeyList()
+        extra_reelim_keys.push_back(5)
+        params.extraReelimKeys = extra_reelim_keys
+        self.assertEqual(params.extraReelimKeys.front(), 5)
+
+        params.removeFactorIndices = []
+        params.constrainedKeys = None
+        params.noRelinKeys = None
+        params.extraReelimKeys = None
+        params.newAffectedKeys = None
+
+        result = gtsam.ISAM2().update(
+            gtsam.NonlinearFactorGraph(), gtsam.Values(), params
+        )
+        self.assertIsInstance(result, gtsam.ISAM2Result)
+
+    def test_hybrid_gaussian_conditional_conditionals(self):
+        """Conditionals can construct a multi-key hybrid conditional."""
+        first_mode_key = 10
+        second_mode_key = 11
+        continuous_key = 20
+        conditionals = [
+            gtsam.GaussianConditional.FromMeanAndStddev(
+                continuous_key, np.array([mean]), 1.0
+            )
+            for mean in range(4)
+        ]
+        conditional_tree = gtsam.HybridGaussianConditionalConditionals(
+            [(first_mode_key, 2), (second_mode_key, 2)], conditionals
+        )
+
+        self.assertFalse(conditional_tree.empty())
+        self.assertEqual(conditional_tree.nrLeaves(), 4)
+
+        assignment = gtsam.DiscreteValues()
+        assignment[first_mode_key] = 0
+        assignment[second_mode_key] = 0
+        np.testing.assert_allclose(conditional_tree(assignment).d(), [0.0])
+
+        discrete_keys = gtsam.DiscreteKeys()
+        discrete_keys.push_back((first_mode_key, 2))
+        discrete_keys.push_back((second_mode_key, 2))
+        conditional = gtsam.HybridGaussianConditional(
+            discrete_keys, conditional_tree
+        )
+        self.assertEqual(conditional.nrComponents(), 4)
+        np.testing.assert_allclose(conditional.choose(assignment).d(), [0.0])
+
+        assignment[first_mode_key] = 1
+        assignment[second_mode_key] = 1
+        np.testing.assert_allclose(conditional_tree(assignment).d(), [3.0])
+        np.testing.assert_allclose(conditional.choose(assignment).d(), [3.0])
+
+    def test_hybrid_nonlinear_factor_value_pairs(self):
+        """FactorValuePairs can construct a multi-key hybrid factor."""
+        first_mode_key = 10
+        second_mode_key = 11
+        continuous_key = 20
+        prior = gtsam.PriorFactorPose2(
+            continuous_key,
+            gtsam.Pose2(),
+            gtsam.noiseModel.Unit.Create(3),
+        )
+        factor_values = [
+            (prior, 1.25),
+            (prior, 2.5),
+            (prior, 3.75),
+            (prior, 5.0),
+        ]
+        factor_tree = gtsam.HybridNonlinearFactorValuePairs(
+            [(first_mode_key, 2), (second_mode_key, 2)], factor_values
+        )
+
+        self.assertFalse(factor_tree.empty())
+        self.assertEqual(factor_tree.nrLeaves(), 4)
+
+        assignment = gtsam.DiscreteValues()
+        assignment[first_mode_key] = 0
+        assignment[second_mode_key] = 0
+        self.assertEqual(factor_tree(assignment)[1], 1.25)
+
+        discrete_keys = gtsam.DiscreteKeys()
+        discrete_keys.push_back((first_mode_key, 2))
+        discrete_keys.push_back((second_mode_key, 2))
+        factor = gtsam.HybridNonlinearFactor(discrete_keys, factor_tree)
+
+        values = gtsam.Values()
+        values.insert(continuous_key, gtsam.Pose2())
+        self.assertEqual(factor.error(values, assignment), 1.25)
+
+        assignment[first_mode_key] = 1
+        assignment[second_mode_key] = 1
+        self.assertEqual(factor_tree(assignment)[1], 5.0)
+        self.assertEqual(factor.error(values, assignment), 5.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/gtsam_unstable/gtsam_unstable.tpl
+++ b/python/gtsam_unstable/gtsam_unstable.tpl
@@ -58,14 +58,24 @@ using namespace std;
 
 namespace py = pybind11;
 
-PYBIND11_MODULE({module_name}, m_) {{
+{submodules}
+
+{declaration_module_def} {{
+{wrapped_declarations}
+}}
+
+{binding_module_def} {{
+{wrapped_bindings}
+
+#include "python/gtsam_unstable/specializations/gtsam_unstable.h"
+}}
+
+{module_def} {{
     m_.doc() = "pybind11 wrapper of {module_name}";
 
     // Note here we need to import the dependent library
     py::module::import("gtsam");
 
-{wrapped_namespace}
-
-#include "python/gtsam_unstable/specializations/gtsam_unstable.h"
+{module_init}
 
 }}

--- a/python/gtsam_unstable/tests/test_UnstableFactorNoiseModel.py
+++ b/python/gtsam_unstable/tests/test_UnstableFactorNoiseModel.py
@@ -13,6 +13,8 @@ NoiseModelFactor in C++ expose that interface in Python.
 
 import unittest
 
+import numpy as np
+
 import gtsam
 import gtsam_unstable
 from gtsam.symbol_shorthand import T
@@ -30,6 +32,25 @@ class TestUnstableFactorNoiseModel(GtsamTestCase):
 
         self.assertIsInstance(factor, gtsam.NoiseModelFactor)
         self.assertAlmostEqual(factor.noiseModel().sigma(), 0.05)
+
+    def test_jacobian_vector_from_gtsam(self):
+        """Unstable factors accept the globally registered JacobianVector."""
+        model = gtsam.noiseModel.Isotropic.Sigma(3, 1.0)
+        factor = gtsam_unstable.BetweenFactorEMPose2(
+            0, 1, gtsam.Pose2(), model, model, 0.5, 0.5
+        )
+        values = gtsam.Values()
+        values.insert(0, gtsam.Pose2())
+        values.insert(1, gtsam.Pose2())
+        jacobians = gtsam.JacobianVector(
+            [np.empty((0, 0)), np.empty((0, 0))]
+        )
+
+        factor.whitenedError(values, jacobians)
+
+        self.assertEqual(len(jacobians), 2)
+        self.assertEqual(jacobians[0].shape, (6, 3))
+        self.assertEqual(jacobians[1].shape, (6, 3))
 
 
 if __name__ == "__main__":

--- a/templates/pybind_wrapper.tpl.example
+++ b/templates/pybind_wrapper.tpl.example
@@ -19,14 +19,23 @@ namespace py = pybind11;
 
 {submodules}
 
+{declaration_module_def} {{
+// Declaration specializations must only register Python types. Projects can
+// replace this include with their own per-generated-file declaration hook.
+#include "python/declarations/{module_name}.h"
+
+{wrapped_declarations}
+}}
+
+{binding_module_def} {{
+// Callable and property specializations belong in the binding phase.
+#include "python/specializations/{module_name}.h"
+
+{wrapped_bindings}
+}}
+
 {module_def} {{
     m_.doc() = "pybind11 wrapper of {module_name}";
 
-{submodules_init}
-
-{wrapped_namespace}
-
-#include "python/specializations.h"
-
+{module_init}
 }}
-

--- a/tests/expected/python/class_pybind.cpp
+++ b/tests/expected/python/class_pybind.cpp
@@ -31,23 +31,60 @@ using namespace std;
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(class_py, m_) {
-    m_.doc() = "pybind11 wrapper of class_py";
 
 
-    py::class_<FunRange, std::shared_ptr<FunRange>>(m_, "FunRange")
+void gtwrap_declare_class_py(py::module_ &m_) {
+
+    py::class_<FunRange, std::shared_ptr<FunRange>>(m_, "FunRange");
+
+    py::class_<Fun<double>, std::shared_ptr<Fun<double>>>(m_, "FunDouble");
+
+    py::class_<Test, std::shared_ptr<Test>>(m_, "Test");
+
+    py::class_<PrimitiveRef<double>, std::shared_ptr<PrimitiveRef<double>>>(m_, "PrimitiveRefDouble");
+
+    py::class_<MyVector<3>, std::shared_ptr<MyVector<3>>>(m_, "MyVector3");
+
+    py::class_<MyVector<12>, std::shared_ptr<MyVector<12>>>(m_, "MyVector12");
+
+    py::class_<MultipleTemplates<int, double>, std::shared_ptr<MultipleTemplates<int, double>>>(m_, "MultipleTemplatesIntDouble");
+
+    py::class_<MultipleTemplates<int, float>, std::shared_ptr<MultipleTemplates<int, float>>>(m_, "MultipleTemplatesIntFloat");
+
+    py::class_<ForwardKinematics, std::shared_ptr<ForwardKinematics>>(m_, "ForwardKinematics");
+
+    py::class_<TemplatedConstructor, std::shared_ptr<TemplatedConstructor>>(m_, "TemplatedConstructor");
+
+    py::class_<FastSet, std::shared_ptr<FastSet>>(m_, "FastSet");
+
+    py::class_<HessianFactor, gtsam::GaussianFactor, std::shared_ptr<HessianFactor>>(m_, "HessianFactor");
+
+    py::class_<SmartProjectionRigFactor<gtsam::PinholeCamera<gtsam::Cal3_S2>>, gtsam::SmartProjectionFactor<gtsam::PinholeCamera<gtsam::Cal3_S2>>, std::shared_ptr<SmartProjectionRigFactor<gtsam::PinholeCamera<gtsam::Cal3_S2>>>>(m_, "SmartProjectionRigFactorPinholeCameraCal3_S2");
+
+    py::class_<MyFactor<gtsam::Pose2, gtsam::Matrix>, std::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>>>(m_, "MyFactorPosePoint2");
+
+    py::class_<SuperCoolFactor<gtsam::Pose3>, std::shared_ptr<SuperCoolFactor<gtsam::Pose3>>>(m_, "SuperCoolFactorPose3");
+}
+
+void gtwrap_bind_class_py(py::module_ &m_) {
+#include "python/specializations.h"
+
+    auto gtwrap_class_m__FunRange = py::reinterpret_borrow<py::class_<FunRange, std::shared_ptr<FunRange>>>(m_.attr("FunRange"));
+    gtwrap_class_m__FunRange
         .def(py::init<>())
         .def("range",static_cast<FunRange (FunRange::*)(double)>(&FunRange::range), gtwrap::internal::py_arg<double>("d"))
         .def_static("create",static_cast<FunRange (*)()>(&FunRange::create));
 
-    py::class_<Fun<double>, std::shared_ptr<Fun<double>>>(m_, "FunDouble")
+    auto gtwrap_class_m__FunDouble = py::reinterpret_borrow<py::class_<Fun<double>, std::shared_ptr<Fun<double>>>>(m_.attr("FunDouble"));
+    gtwrap_class_m__FunDouble
         .def("templatedMethodString",[](Fun<double>* self, double d, string t){return self->templatedMethod<string>(d, t);}, gtwrap::internal::py_arg<double>("d"), gtwrap::internal::py_arg<string>("t"))
         .def("multiTemplatedMethodStringSize_t",[](Fun<double>* self, double d, string t, size_t u){return self->multiTemplatedMethod<string,size_t>(d, t, u);}, gtwrap::internal::py_arg<double>("d"), gtwrap::internal::py_arg<string>("t"), gtwrap::internal::py_arg<size_t>("u"))
         .def("sets",static_cast<std::map<double, Fun<double>::double> (Fun<double>::*)()>(&Fun<double>::sets))
         .def_static("staticMethodWithThis",static_cast<Fun<double> (*)()>(&Fun<double>::staticMethodWithThis))
         .def_static("templatedStaticMethodInt",[](const int& m){return Fun<double>::templatedStaticMethod<int>(m);}, gtwrap::internal::py_arg<const int&>("m"));
 
-    py::class_<Test, std::shared_ptr<Test>>(m_, "Test")
+    auto gtwrap_class_m__Test = py::reinterpret_borrow<py::class_<Test, std::shared_ptr<Test>>>(m_.attr("Test"));
+    gtwrap_class_m__Test
         .def(py::init<>())
         .def(py::init<double, const gtsam::Matrix&>(), gtwrap::internal::py_arg<double>("a"), gtwrap::internal::py_arg<const gtsam::Matrix&>("b"))
         .def("return_pair",static_cast<std::pair<gtsam::Vector,gtsam::Matrix> (Test::*)(const gtsam::Vector&, const gtsam::Matrix&) const>(&Test::return_pair), gtwrap::internal::py_arg<const gtsam::Vector&>("v"), gtwrap::internal::py_arg<const gtsam::Matrix&>("A"))
@@ -89,42 +126,47 @@ PYBIND11_MODULE(class_py, m_) {
         .def_readwrite("value", &Test::value)
         .def_readwrite("name", &Test::name);
 
-    py::class_<PrimitiveRef<double>, std::shared_ptr<PrimitiveRef<double>>>(m_, "PrimitiveRefDouble")
+    auto gtwrap_class_m__PrimitiveRefDouble = py::reinterpret_borrow<py::class_<PrimitiveRef<double>, std::shared_ptr<PrimitiveRef<double>>>>(m_.attr("PrimitiveRefDouble"));
+    gtwrap_class_m__PrimitiveRefDouble
         .def(py::init<>())
         .def_static("Brutal",static_cast<PrimitiveRef<double> (*)(const double&)>(&PrimitiveRef<double>::Brutal), gtwrap::internal::py_arg<const double&>("t"));
 
-    py::class_<MyVector<3>, std::shared_ptr<MyVector<3>>>(m_, "MyVector3")
+    auto gtwrap_class_m__MyVector3 = py::reinterpret_borrow<py::class_<MyVector<3>, std::shared_ptr<MyVector<3>>>>(m_.attr("MyVector3"));
+    gtwrap_class_m__MyVector3
         .def(py::init<>());
 
-    py::class_<MyVector<12>, std::shared_ptr<MyVector<12>>>(m_, "MyVector12")
+    auto gtwrap_class_m__MyVector12 = py::reinterpret_borrow<py::class_<MyVector<12>, std::shared_ptr<MyVector<12>>>>(m_.attr("MyVector12"));
+    gtwrap_class_m__MyVector12
         .def(py::init<>());
 
-    py::class_<MultipleTemplates<int, double>, std::shared_ptr<MultipleTemplates<int, double>>>(m_, "MultipleTemplatesIntDouble");
-
-    py::class_<MultipleTemplates<int, float>, std::shared_ptr<MultipleTemplates<int, float>>>(m_, "MultipleTemplatesIntFloat");
-
-    py::class_<ForwardKinematics, std::shared_ptr<ForwardKinematics>>(m_, "ForwardKinematics")
+    auto gtwrap_class_m__ForwardKinematics = py::reinterpret_borrow<py::class_<ForwardKinematics, std::shared_ptr<ForwardKinematics>>>(m_.attr("ForwardKinematics"));
+    gtwrap_class_m__ForwardKinematics
         .def(py::init<const gtdynamics::Robot&, const string&, const string&, const gtsam::Values&, const gtsam::Pose3&>(), gtwrap::internal::py_arg<const gtdynamics::Robot&>("robot"), gtwrap::internal::py_arg<const string&>("start_link_name"), gtwrap::internal::py_arg<const string&>("end_link_name"), gtwrap::internal::py_arg<const gtsam::Values&>("joint_angles"), gtwrap::internal::py_arg<const gtsam::Pose3&>("l2Tp") = gtsam::Pose3());
 
-    py::class_<TemplatedConstructor, std::shared_ptr<TemplatedConstructor>>(m_, "TemplatedConstructor")
+    auto gtwrap_class_m__TemplatedConstructor = py::reinterpret_borrow<py::class_<TemplatedConstructor, std::shared_ptr<TemplatedConstructor>>>(m_.attr("TemplatedConstructor"));
+    gtwrap_class_m__TemplatedConstructor
         .def(py::init<>())
         .def(py::init<const string&>(), gtwrap::internal::py_arg<const string&>("arg"))
         .def(py::init<const int&>(), gtwrap::internal::py_arg<const int&>("arg"))
         .def(py::init<const double&>(), gtwrap::internal::py_arg<const double&>("arg"));
 
-    py::class_<FastSet, std::shared_ptr<FastSet>>(m_, "FastSet")
+    auto gtwrap_class_m__FastSet = py::reinterpret_borrow<py::class_<FastSet, std::shared_ptr<FastSet>>>(m_.attr("FastSet"));
+    gtwrap_class_m__FastSet
         .def(py::init<>())
         .def("__len__",[](FastSet* self){return std::distance(self->begin(), self->end());})
         .def("__contains__",[](FastSet* self, size_t key){return std::find(self->begin(), self->end(), key) != self->end();}, gtwrap::internal::py_arg<size_t>("key"))
         .def("__iter__",[](FastSet* self){return py::make_iterator(self->begin(), self->end());});
 
-    py::class_<HessianFactor, gtsam::GaussianFactor, std::shared_ptr<HessianFactor>>(m_, "HessianFactor")
+    auto gtwrap_class_m__HessianFactor = py::reinterpret_borrow<py::class_<HessianFactor, gtsam::GaussianFactor, std::shared_ptr<HessianFactor>>>(m_.attr("HessianFactor"));
+    gtwrap_class_m__HessianFactor
         .def(py::init<const gtsam::KeyVector&, const std::vector<gtsam::Matrix>&, const std::vector<gtsam::Vector>&, double>(), gtwrap::internal::py_arg<const gtsam::KeyVector&>("js"), gtwrap::internal::py_arg<const std::vector<gtsam::Matrix>&>("Gs"), gtwrap::internal::py_arg<const std::vector<gtsam::Vector>&>("gs"), gtwrap::internal::py_arg<double>("f"));
 
-    py::class_<SmartProjectionRigFactor<gtsam::PinholeCamera<gtsam::Cal3_S2>>, gtsam::SmartProjectionFactor<gtsam::PinholeCamera<gtsam::Cal3_S2>>, std::shared_ptr<SmartProjectionRigFactor<gtsam::PinholeCamera<gtsam::Cal3_S2>>>>(m_, "SmartProjectionRigFactorPinholeCameraCal3_S2")
+    auto gtwrap_class_m__SmartProjectionRigFactorPinholeCameraCal3_S2 = py::reinterpret_borrow<py::class_<SmartProjectionRigFactor<gtsam::PinholeCamera<gtsam::Cal3_S2>>, gtsam::SmartProjectionFactor<gtsam::PinholeCamera<gtsam::Cal3_S2>>, std::shared_ptr<SmartProjectionRigFactor<gtsam::PinholeCamera<gtsam::Cal3_S2>>>>>(m_.attr("SmartProjectionRigFactorPinholeCameraCal3_S2"));
+    gtwrap_class_m__SmartProjectionRigFactorPinholeCameraCal3_S2
         .def("add",static_cast<void (SmartProjectionRigFactor<gtsam::PinholeCamera<gtsam::Cal3_S2>>::*)(const gtsam::PinholeCamera<gtsam::Cal3_S2>::Measurement&, const gtsam::Key&, const size_t&)>(&SmartProjectionRigFactor<gtsam::PinholeCamera<gtsam::Cal3_S2>>::add), gtwrap::internal::py_arg<const gtsam::PinholeCamera<gtsam::Cal3_S2>::Measurement&>("measured"), gtwrap::internal::py_arg<const gtsam::Key&>("poseKey"), gtwrap::internal::py_arg<const size_t&>("cameraId") = 0);
 
-    py::class_<MyFactor<gtsam::Pose2, gtsam::Matrix>, std::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>>>(m_, "MyFactorPosePoint2")
+    auto gtwrap_class_m__MyFactorPosePoint2 = py::reinterpret_borrow<py::class_<MyFactor<gtsam::Pose2, gtsam::Matrix>, std::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>>>>(m_.attr("MyFactorPosePoint2"));
+    gtwrap_class_m__MyFactorPosePoint2
         .def(py::init<size_t, size_t, double, const std::shared_ptr<gtsam::noiseModel::Base>>(), gtwrap::internal::py_arg<size_t>("key1"), gtwrap::internal::py_arg<size_t>("key2"), gtwrap::internal::py_arg<double>("measured"), gtwrap::internal::py_arg<const std::shared_ptr<gtsam::noiseModel::Base>>("noiseModel"))
         .def("print",[](MyFactor<gtsam::Pose2, gtsam::Matrix>* self, const string& s, const gtsam::KeyFormatter& keyFormatter){ py::scoped_ostream_redirect output; self->print(s, keyFormatter);}, gtwrap::internal::py_arg<const string&>("s") = "factor: ", gtwrap::internal::py_arg<const gtsam::KeyFormatter&>("keyFormatter") = gtsam::DefaultKeyFormatter)
         .def("__repr__",
@@ -134,9 +176,11 @@ PYBIND11_MODULE(class_py, m_) {
                         return redirect.str();
                     }, gtwrap::internal::py_arg<const string&>("s") = "factor: ", gtwrap::internal::py_arg<const gtsam::KeyFormatter&>("keyFormatter") = gtsam::DefaultKeyFormatter);
 
-    py::class_<SuperCoolFactor<gtsam::Pose3>, std::shared_ptr<SuperCoolFactor<gtsam::Pose3>>>(m_, "SuperCoolFactorPose3");
-
-#include "python/specializations.h"
-
 }
 
+PYBIND11_MODULE(class_py, m_) {
+    m_.doc() = "pybind11 wrapper of class_py";
+
+gtwrap_declare_class_py(m_);
+gtwrap_bind_class_py(m_);
+}

--- a/tests/expected/python/enum_pybind.cpp
+++ b/tests/expected/python/enum_pybind.cpp
@@ -30,26 +30,20 @@ using namespace std;
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(enum_py, m_) {
-    m_.doc() = "pybind11 wrapper of enum_py";
 
+
+void gtwrap_declare_enum_py(py::module_ &m_) {
     py::enum_<Color>(m_, "Color", py::arithmetic())
         .value("Red", Color::Red)
         .value("Green", Color::Green)
         .value("Blue", Color::Blue);
 
 
-    py::class_<Pet, std::shared_ptr<Pet>> pet(m_, "Pet");
-    pet
-        .def(py::init<const string&, Pet::Kind>(), gtwrap::internal::py_arg<const string&>("name"), gtwrap::internal::py_arg<Pet::Kind>("type"))
-        .def("setColor",static_cast<void (Pet::*)(const Color&)>(&Pet::setColor), gtwrap::internal::py_arg<const Color&>("color"))
-        .def("getColor",static_cast<Color (Pet::*)() const>(&Pet::getColor))
-        .def_readwrite("name", &Pet::name)
-        .def_readwrite("type", &Pet::type);
-
-    py::enum_<Pet::Kind>(pet, "Kind", py::arithmetic())
+    py::class_<Pet, std::shared_ptr<Pet>> gtwrap_class_m__Pet(m_, "Pet");
+    py::enum_<Pet::Kind>(gtwrap_class_m__Pet, "Kind", py::arithmetic())
         .value("Dog", Pet::Kind::Dog)
         .value("Cat", Pet::Kind::Cat);
+
 
     pybind11::module m_gtsam = m_.def_submodule("gtsam", "gtsam submodule");
     py::enum_<gtsam::VerbosityLM>(m_gtsam, "VerbosityLM", py::arithmetic())
@@ -63,11 +57,8 @@ PYBIND11_MODULE(enum_py, m_) {
         .value("TRYDELTA", gtsam::VerbosityLM::TRYDELTA);
 
 
-    py::class_<gtsam::MCU, std::shared_ptr<gtsam::MCU>> mcu(m_gtsam, "MCU");
-    mcu
-        .def(py::init<>());
-
-    py::enum_<gtsam::MCU::Avengers>(mcu, "Avengers", py::arithmetic())
+    py::class_<gtsam::MCU, std::shared_ptr<gtsam::MCU>> gtwrap_class_m_gtsam_MCU(m_gtsam, "MCU");
+    py::enum_<gtsam::MCU::Avengers>(gtwrap_class_m_gtsam_MCU, "Avengers", py::arithmetic())
         .value("CaptainAmerica", gtsam::MCU::Avengers::CaptainAmerica)
         .value("IronMan", gtsam::MCU::Avengers::IronMan)
         .value("Hulk", gtsam::MCU::Avengers::Hulk)
@@ -75,7 +66,7 @@ PYBIND11_MODULE(enum_py, m_) {
         .value("Thor", gtsam::MCU::Avengers::Thor);
 
 
-    py::enum_<gtsam::MCU::GotG>(mcu, "GotG", py::arithmetic())
+    py::enum_<gtsam::MCU::GotG>(gtwrap_class_m_gtsam_MCU, "GotG", py::arithmetic())
         .value("Starlord", gtsam::MCU::GotG::Starlord)
         .value("Gamorra", gtsam::MCU::GotG::Gamorra)
         .value("Rocket", gtsam::MCU::GotG::Rocket)
@@ -83,21 +74,44 @@ PYBIND11_MODULE(enum_py, m_) {
         .value("Groot", gtsam::MCU::GotG::Groot);
 
 
-    py::class_<gtsam::Optimizer<gtsam::GaussNewtonParams>, std::shared_ptr<gtsam::Optimizer<gtsam::GaussNewtonParams>>> optimizergaussnewtonparams(m_gtsam, "OptimizerGaussNewtonParams");
-    optimizergaussnewtonparams
-        .def(py::init<const Optimizer<gtsam::GaussNewtonParams>::Verbosity&>(), gtwrap::internal::py_arg<const Optimizer<gtsam::GaussNewtonParams>::Verbosity&>("verbosity"))
-        .def("setVerbosity",static_cast<void (gtsam::Optimizer<gtsam::GaussNewtonParams>::*)(const Optimizer<gtsam::GaussNewtonParams>::Verbosity)>(&gtsam::Optimizer<gtsam::GaussNewtonParams>::setVerbosity), gtwrap::internal::py_arg<const Optimizer<gtsam::GaussNewtonParams>::Verbosity>("value"))
-        .def("getVerbosity",static_cast<gtsam::Optimizer::Verbosity (gtsam::Optimizer<gtsam::GaussNewtonParams>::*)() const>(&gtsam::Optimizer<gtsam::GaussNewtonParams>::getVerbosity))
-        .def("getVerbosity",static_cast<gtsam::VerbosityLM (gtsam::Optimizer<gtsam::GaussNewtonParams>::*)() const>(&gtsam::Optimizer<gtsam::GaussNewtonParams>::getVerbosity));
-
-    py::enum_<gtsam::Optimizer<gtsam::GaussNewtonParams>::Verbosity>(optimizergaussnewtonparams, "Verbosity", py::arithmetic())
+    py::class_<gtsam::Optimizer<gtsam::GaussNewtonParams>, std::shared_ptr<gtsam::Optimizer<gtsam::GaussNewtonParams>>> gtwrap_class_m_gtsam_OptimizerGaussNewtonParams(m_gtsam, "OptimizerGaussNewtonParams");
+    py::enum_<gtsam::Optimizer<gtsam::GaussNewtonParams>::Verbosity>(gtwrap_class_m_gtsam_OptimizerGaussNewtonParams, "Verbosity", py::arithmetic())
         .value("SILENT", gtsam::Optimizer<gtsam::GaussNewtonParams>::Verbosity::SILENT)
         .value("SUMMARY", gtsam::Optimizer<gtsam::GaussNewtonParams>::Verbosity::SUMMARY)
         .value("VERBOSE", gtsam::Optimizer<gtsam::GaussNewtonParams>::Verbosity::VERBOSE);
 
 
+}
 
+void gtwrap_bind_enum_py(py::module_ &m_) {
 #include "python/specializations.h"
+
+    auto gtwrap_class_m__Pet = py::reinterpret_borrow<py::class_<Pet, std::shared_ptr<Pet>>>(m_.attr("Pet"));
+    gtwrap_class_m__Pet
+        .def(py::init<const string&, Pet::Kind>(), gtwrap::internal::py_arg<const string&>("name"), gtwrap::internal::py_arg<Pet::Kind>("type"))
+        .def("setColor",static_cast<void (Pet::*)(const Color&)>(&Pet::setColor), gtwrap::internal::py_arg<const Color&>("color"))
+        .def("getColor",static_cast<Color (Pet::*)() const>(&Pet::getColor))
+        .def_readwrite("name", &Pet::name)
+        .def_readwrite("type", &Pet::type);
+
+    pybind11::module m_gtsam = py::reinterpret_borrow<pybind11::module>(m_.attr("gtsam"));
+
+    auto gtwrap_class_m_gtsam_MCU = py::reinterpret_borrow<py::class_<gtsam::MCU, std::shared_ptr<gtsam::MCU>>>(m_gtsam.attr("MCU"));
+    gtwrap_class_m_gtsam_MCU
+        .def(py::init<>());
+
+    auto gtwrap_class_m_gtsam_OptimizerGaussNewtonParams = py::reinterpret_borrow<py::class_<gtsam::Optimizer<gtsam::GaussNewtonParams>, std::shared_ptr<gtsam::Optimizer<gtsam::GaussNewtonParams>>>>(m_gtsam.attr("OptimizerGaussNewtonParams"));
+    gtwrap_class_m_gtsam_OptimizerGaussNewtonParams
+        .def(py::init<const Optimizer<gtsam::GaussNewtonParams>::Verbosity&>(), gtwrap::internal::py_arg<const Optimizer<gtsam::GaussNewtonParams>::Verbosity&>("verbosity"))
+        .def("setVerbosity",static_cast<void (gtsam::Optimizer<gtsam::GaussNewtonParams>::*)(const Optimizer<gtsam::GaussNewtonParams>::Verbosity)>(&gtsam::Optimizer<gtsam::GaussNewtonParams>::setVerbosity), gtwrap::internal::py_arg<const Optimizer<gtsam::GaussNewtonParams>::Verbosity>("value"))
+        .def("getVerbosity",static_cast<gtsam::Optimizer::Verbosity (gtsam::Optimizer<gtsam::GaussNewtonParams>::*)() const>(&gtsam::Optimizer<gtsam::GaussNewtonParams>::getVerbosity))
+        .def("getVerbosity",static_cast<gtsam::VerbosityLM (gtsam::Optimizer<gtsam::GaussNewtonParams>::*)() const>(&gtsam::Optimizer<gtsam::GaussNewtonParams>::getVerbosity));
 
 }
 
+PYBIND11_MODULE(enum_py, m_) {
+    m_.doc() = "pybind11 wrapper of enum_py";
+
+gtwrap_declare_enum_py(m_);
+gtwrap_bind_enum_py(m_);
+}

--- a/tests/expected/python/functions_pybind.cpp
+++ b/tests/expected/python/functions_pybind.cpp
@@ -30,9 +30,14 @@ using namespace std;
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(functions_py, m_) {
-    m_.doc() = "pybind11 wrapper of functions_py";
 
+
+void gtwrap_declare_functions_py(py::module_ &m_) {
+
+}
+
+void gtwrap_bind_functions_py(py::module_ &m_) {
+#include "python/specializations.h"
 
     m_.def("load2D",static_cast<std::pair<std::shared_ptr<gtsam::NonlinearFactorGraph>,std::shared_ptr<gtsam::Values>> (*)(string, std::shared_ptr<Test>, int, bool, bool)>(&::load2D), gtwrap::internal::py_arg<string>("filename"), gtwrap::internal::py_arg<std::shared_ptr<Test>>("model"), gtwrap::internal::py_arg<int>("maxID"), gtwrap::internal::py_arg<bool>("addNoise"), gtwrap::internal::py_arg<bool>("smart"));
     m_.def("load2D",static_cast<std::pair<std::shared_ptr<gtsam::NonlinearFactorGraph>,std::shared_ptr<gtsam::Values>> (*)(string, const std::shared_ptr<gtsam::noiseModel::Diagonal>, int, bool, bool)>(&::load2D), gtwrap::internal::py_arg<string>("filename"), gtwrap::internal::py_arg<const std::shared_ptr<gtsam::noiseModel::Diagonal>>("model"), gtwrap::internal::py_arg<int>("maxID"), gtwrap::internal::py_arg<bool>("addNoise"), gtwrap::internal::py_arg<bool>("smart"));
@@ -55,8 +60,11 @@ PYBIND11_MODULE(functions_py, m_) {
     m_.def("FindKarcherMeanSO4",[](const std::vector<gtsam::SO4>& elements){return ::FindKarcherMean<gtsam::SO4>(elements);}, gtwrap::internal::py_arg<const std::vector<gtsam::SO4>&>("elements"));
     m_.def("FindKarcherMeanPose3",[](const std::vector<gtsam::Pose3>& elements){return ::FindKarcherMean<gtsam::Pose3>(elements);}, gtwrap::internal::py_arg<const std::vector<gtsam::Pose3>&>("elements"));
     m_.def("TemplatedFunctionRot3",[](const gtsam::Rot3& t){ ::TemplatedFunction<gtsam::Rot3>(t);}, gtwrap::internal::py_arg<const gtsam::Rot3&>("t"));
-
-#include "python/specializations.h"
-
 }
 
+PYBIND11_MODULE(functions_py, m_) {
+    m_.doc() = "pybind11 wrapper of functions_py";
+
+gtwrap_declare_functions_py(m_);
+gtwrap_bind_functions_py(m_);
+}

--- a/tests/expected/python/geometry_pybind.cpp
+++ b/tests/expected/python/geometry_pybind.cpp
@@ -34,12 +34,25 @@ using namespace std;
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(geometry_py, m_) {
-    m_.doc() = "pybind11 wrapper of geometry_py";
+
+
+void gtwrap_declare_geometry_py(py::module_ &m_) {
 
     pybind11::module m_gtsam = m_.def_submodule("gtsam", "gtsam submodule");
 
-    py::class_<gtsam::Point2, std::shared_ptr<gtsam::Point2>>(m_gtsam, "Point2")
+    py::class_<gtsam::Point2, std::shared_ptr<gtsam::Point2>>(m_gtsam, "Point2");
+
+    py::class_<gtsam::Point3, std::shared_ptr<gtsam::Point3>>(m_gtsam, "Point3");
+
+}
+
+void gtwrap_bind_geometry_py(py::module_ &m_) {
+#include "python/specializations.h"
+
+    pybind11::module m_gtsam = py::reinterpret_borrow<pybind11::module>(m_.attr("gtsam"));
+
+    auto gtwrap_class_m_gtsam_Point2 = py::reinterpret_borrow<py::class_<gtsam::Point2, std::shared_ptr<gtsam::Point2>>>(m_gtsam.attr("Point2"));
+    gtwrap_class_m_gtsam_Point2
         .def(py::init<>())
         .def(py::init<double, double>(), gtwrap::internal::py_arg<double>("x"), gtwrap::internal::py_arg<double>("y"))
         .def("x",static_cast<double (gtsam::Point2::*)() const>(&gtsam::Point2::x))
@@ -62,7 +75,8 @@ PYBIND11_MODULE(geometry_py, m_) {
             [](const gtsam::Point2 &a){ /* __getstate__: Returns a string that encodes the state of the object */ return py::make_tuple(gtsam::serialize(a)); },
             [](py::tuple t){ /* __setstate__ */ gtsam::Point2 obj; gtsam::deserialize(t[0].cast<std::string>(), obj); return obj; }));
 
-    py::class_<gtsam::Point3, std::shared_ptr<gtsam::Point3>>(m_gtsam, "Point3")
+    auto gtwrap_class_m_gtsam_Point3 = py::reinterpret_borrow<py::class_<gtsam::Point3, std::shared_ptr<gtsam::Point3>>>(m_gtsam.attr("Point3"));
+    gtwrap_class_m_gtsam_Point3
         .def(py::init<double, double, double>(), gtwrap::internal::py_arg<double>("x"), gtwrap::internal::py_arg<double>("y"), gtwrap::internal::py_arg<double>("z"))
         .def("norm",static_cast<double (gtsam::Point3::*)() const>(&gtsam::Point3::norm))
         .def("serialize", [](gtsam::Point3* self){ return gtsam::serialize(*self); })
@@ -73,8 +87,11 @@ PYBIND11_MODULE(geometry_py, m_) {
         .def_static("staticFunction",static_cast<double (*)()>(&gtsam::Point3::staticFunction))
         .def_static("StaticFunctionRet",static_cast<gtsam::Point3 (*)(double)>(&gtsam::Point3::StaticFunctionRet), gtwrap::internal::py_arg<double>("z"));
 
-
-#include "python/specializations.h"
-
 }
 
+PYBIND11_MODULE(geometry_py, m_) {
+    m_.doc() = "pybind11 wrapper of geometry_py";
+
+gtwrap_declare_geometry_py(m_);
+gtwrap_bind_geometry_py(m_);
+}

--- a/tests/expected/python/inheritance_pybind.cpp
+++ b/tests/expected/python/inheritance_pybind.cpp
@@ -30,13 +30,33 @@ using namespace std;
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(inheritance_py, m_) {
-    m_.doc() = "pybind11 wrapper of inheritance_py";
 
+
+void gtwrap_declare_inheritance_py(py::module_ &m_) {
 
     py::class_<MyBase, std::shared_ptr<MyBase>>(m_, "MyBase");
 
-    py::class_<MyTemplate<gtsam::Point2>, MyBase, std::shared_ptr<MyTemplate<gtsam::Point2>>>(m_, "MyTemplatePoint2")
+    py::class_<MyTemplate<gtsam::Point2>, MyBase, std::shared_ptr<MyTemplate<gtsam::Point2>>>(m_, "MyTemplatePoint2");
+
+    py::class_<MyTemplate<gtsam::Matrix>, MyBase, std::shared_ptr<MyTemplate<gtsam::Matrix>>>(m_, "MyTemplateMatrix");
+
+    py::class_<MyTemplate<A>, MyBase, std::shared_ptr<MyTemplate<A>>>(m_, "MyTemplateA");
+
+    py::class_<ForwardKinematicsFactor, gtsam::BetweenFactor<gtsam::Pose3>, std::shared_ptr<ForwardKinematicsFactor>>(m_, "ForwardKinematicsFactor");
+
+    py::class_<ParentHasTemplate<double>, MyTemplate<double>, std::shared_ptr<ParentHasTemplate<double>>>(m_, "ParentHasTemplateDouble");
+
+    py::class_<Base, std::shared_ptr<Base>>(m_, "Base");
+
+    py::class_<Derived, Base, std::shared_ptr<Derived>>(m_, "Derived");
+
+}
+
+void gtwrap_bind_inheritance_py(py::module_ &m_) {
+#include "python/specializations.h"
+
+    auto gtwrap_class_m__MyTemplatePoint2 = py::reinterpret_borrow<py::class_<MyTemplate<gtsam::Point2>, MyBase, std::shared_ptr<MyTemplate<gtsam::Point2>>>>(m_.attr("MyTemplatePoint2"));
+    gtwrap_class_m__MyTemplatePoint2
         .def(py::init<>())
         .def("templatedMethodPoint2",[](MyTemplate<gtsam::Point2>* self, const gtsam::Point2& t){return self->templatedMethod<gtsam::Point2>(t);}, gtwrap::internal::py_arg<const gtsam::Point2&>("t"))
         .def("templatedMethodPoint3",[](MyTemplate<gtsam::Point2>* self, const gtsam::Point3& t){return self->templatedMethod<gtsam::Point3>(t);}, gtwrap::internal::py_arg<const gtsam::Point3&>("t"))
@@ -51,7 +71,8 @@ PYBIND11_MODULE(inheritance_py, m_) {
         .def("return_ptrs",static_cast<std::pair<std::shared_ptr<gtsam::Point2>,std::shared_ptr<gtsam::Point2>> (MyTemplate<gtsam::Point2>::*)(std::shared_ptr<gtsam::Point2>, std::shared_ptr<gtsam::Point2>) const>(&MyTemplate<gtsam::Point2>::return_ptrs), gtwrap::internal::py_arg<std::shared_ptr<gtsam::Point2>>("p1"), gtwrap::internal::py_arg<std::shared_ptr<gtsam::Point2>>("p2"))
         .def_static("Level",static_cast<MyTemplate<gtsam::Point2> (*)(const gtsam::Point2&)>(&MyTemplate<gtsam::Point2>::Level), gtwrap::internal::py_arg<const gtsam::Point2&>("K"));
 
-    py::class_<MyTemplate<gtsam::Matrix>, MyBase, std::shared_ptr<MyTemplate<gtsam::Matrix>>>(m_, "MyTemplateMatrix")
+    auto gtwrap_class_m__MyTemplateMatrix = py::reinterpret_borrow<py::class_<MyTemplate<gtsam::Matrix>, MyBase, std::shared_ptr<MyTemplate<gtsam::Matrix>>>>(m_.attr("MyTemplateMatrix"));
+    gtwrap_class_m__MyTemplateMatrix
         .def(py::init<>())
         .def("templatedMethodPoint2",[](MyTemplate<gtsam::Matrix>* self, const gtsam::Point2& t){return self->templatedMethod<gtsam::Point2>(t);}, gtwrap::internal::py_arg<const gtsam::Point2&>("t"))
         .def("templatedMethodPoint3",[](MyTemplate<gtsam::Matrix>* self, const gtsam::Point3& t){return self->templatedMethod<gtsam::Point3>(t);}, gtwrap::internal::py_arg<const gtsam::Point3&>("t"))
@@ -66,7 +87,8 @@ PYBIND11_MODULE(inheritance_py, m_) {
         .def("return_ptrs",static_cast<std::pair<std::shared_ptr<gtsam::Matrix>,std::shared_ptr<gtsam::Matrix>> (MyTemplate<gtsam::Matrix>::*)(std::shared_ptr<gtsam::Matrix>, std::shared_ptr<gtsam::Matrix>) const>(&MyTemplate<gtsam::Matrix>::return_ptrs), gtwrap::internal::py_arg<std::shared_ptr<gtsam::Matrix>>("p1"), gtwrap::internal::py_arg<std::shared_ptr<gtsam::Matrix>>("p2"))
         .def_static("Level",static_cast<MyTemplate<gtsam::Matrix> (*)(const gtsam::Matrix&)>(&MyTemplate<gtsam::Matrix>::Level), gtwrap::internal::py_arg<const gtsam::Matrix&>("K"));
 
-    py::class_<MyTemplate<A>, MyBase, std::shared_ptr<MyTemplate<A>>>(m_, "MyTemplateA")
+    auto gtwrap_class_m__MyTemplateA = py::reinterpret_borrow<py::class_<MyTemplate<A>, MyBase, std::shared_ptr<MyTemplate<A>>>>(m_.attr("MyTemplateA"));
+    gtwrap_class_m__MyTemplateA
         .def(py::init<>())
         .def("templatedMethodPoint2",[](MyTemplate<A>* self, const gtsam::Point2& t){return self->templatedMethod<gtsam::Point2>(t);}, gtwrap::internal::py_arg<const gtsam::Point2&>("t"))
         .def("templatedMethodPoint3",[](MyTemplate<A>* self, const gtsam::Point3& t){return self->templatedMethod<gtsam::Point3>(t);}, gtwrap::internal::py_arg<const gtsam::Point3&>("t"))
@@ -81,17 +103,15 @@ PYBIND11_MODULE(inheritance_py, m_) {
         .def("return_ptrs",static_cast<std::pair<std::shared_ptr<A>,std::shared_ptr<A>> (MyTemplate<A>::*)(std::shared_ptr<A>, std::shared_ptr<A>) const>(&MyTemplate<A>::return_ptrs), gtwrap::internal::py_arg<std::shared_ptr<A>>("p1"), gtwrap::internal::py_arg<std::shared_ptr<A>>("p2"))
         .def_static("Level",static_cast<MyTemplate<A> (*)(const A&)>(&MyTemplate<A>::Level), gtwrap::internal::py_arg<const A&>("K"));
 
-    py::class_<ForwardKinematicsFactor, gtsam::BetweenFactor<gtsam::Pose3>, std::shared_ptr<ForwardKinematicsFactor>>(m_, "ForwardKinematicsFactor");
-
-    py::class_<ParentHasTemplate<double>, MyTemplate<double>, std::shared_ptr<ParentHasTemplate<double>>>(m_, "ParentHasTemplateDouble");
-
-    py::class_<Base, std::shared_ptr<Base>>(m_, "Base")
+    auto gtwrap_class_m__Base = py::reinterpret_borrow<py::class_<Base, std::shared_ptr<Base>>>(m_.attr("Base"));
+    gtwrap_class_m__Base
         .def_static("Create",static_cast<std::shared_ptr<gtsam::Base> (*)(double)>(&Base::Create), gtwrap::internal::py_arg<double>("x"));
-
-    py::class_<Derived, Base, std::shared_ptr<Derived>>(m_, "Derived");
-
-
-#include "python/specializations.h"
 
 }
 
+PYBIND11_MODULE(inheritance_py, m_) {
+    m_.doc() = "pybind11 wrapper of inheritance_py";
+
+gtwrap_declare_inheritance_py(m_);
+gtwrap_bind_inheritance_py(m_);
+}

--- a/tests/expected/python/namespaces_pybind.cpp
+++ b/tests/expected/python/namespaces_pybind.cpp
@@ -36,43 +36,81 @@ using namespace std;
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(namespaces_py, m_) {
-    m_.doc() = "pybind11 wrapper of namespaces_py";
+
+
+void gtwrap_declare_namespaces_py(py::module_ &m_) {
 
     pybind11::module m_ns1 = m_.def_submodule("ns1", "ns1 submodule");
 
-    py::class_<ns1::ClassA, std::shared_ptr<ns1::ClassA>>(m_ns1, "ClassA")
+    py::class_<ns1::ClassA, std::shared_ptr<ns1::ClassA>>(m_ns1, "ClassA");
+
+    py::class_<ns1::ClassB, std::shared_ptr<ns1::ClassB>>(m_ns1, "ClassB");
+
+    pybind11::module m_ns2 = m_.def_submodule("ns2", "ns2 submodule");
+
+    py::class_<ns2::ClassA, std::shared_ptr<ns2::ClassA>>(m_ns2, "ClassA");
+
+    pybind11::module m_ns2_ns3 = m_ns2.def_submodule("ns3", "ns3 submodule");
+
+    py::class_<ns2::ns3::ClassB, std::shared_ptr<ns2::ns3::ClassB>>(m_ns2_ns3, "ClassB");
+
+    py::class_<ns2::ClassC, std::shared_ptr<ns2::ClassC>>(m_ns2, "ClassC");
+
+    py::class_<ClassD, std::shared_ptr<ClassD>>(m_, "ClassD");
+
+    pybind11::module m_gtsam = m_.def_submodule("gtsam", "gtsam submodule");
+
+    py::class_<gtsam::Values, std::shared_ptr<gtsam::Values>>(m_gtsam, "Values");
+
+}
+
+void gtwrap_bind_namespaces_py(py::module_ &m_) {
+#include "python/specializations.h"
+
+    pybind11::module m_ns1 = py::reinterpret_borrow<pybind11::module>(m_.attr("ns1"));
+
+    auto gtwrap_class_m_ns1_ClassA = py::reinterpret_borrow<py::class_<ns1::ClassA, std::shared_ptr<ns1::ClassA>>>(m_ns1.attr("ClassA"));
+    gtwrap_class_m_ns1_ClassA
         .def(py::init<>());
 
-    py::class_<ns1::ClassB, std::shared_ptr<ns1::ClassB>>(m_ns1, "ClassB")
+    auto gtwrap_class_m_ns1_ClassB = py::reinterpret_borrow<py::class_<ns1::ClassB, std::shared_ptr<ns1::ClassB>>>(m_ns1.attr("ClassB"));
+    gtwrap_class_m_ns1_ClassB
         .def(py::init<>());
 
-    m_ns1.def("aGlobalFunction",static_cast<gtsam::Vector (*)()>(&ns1::aGlobalFunction));    pybind11::module m_ns2 = m_.def_submodule("ns2", "ns2 submodule");
+    m_ns1.def("aGlobalFunction",static_cast<gtsam::Vector (*)()>(&ns1::aGlobalFunction));
+    pybind11::module m_ns2 = py::reinterpret_borrow<pybind11::module>(m_.attr("ns2"));
 
-    py::class_<ns2::ClassA, std::shared_ptr<ns2::ClassA>>(m_ns2, "ClassA")
+    auto gtwrap_class_m_ns2_ClassA = py::reinterpret_borrow<py::class_<ns2::ClassA, std::shared_ptr<ns2::ClassA>>>(m_ns2.attr("ClassA"));
+    gtwrap_class_m_ns2_ClassA
         .def(py::init<>())
         .def("memberFunction",static_cast<double (ns2::ClassA::*)()>(&ns2::ClassA::memberFunction))
         .def("nsArg",static_cast<int (ns2::ClassA::*)(const ns1::ClassB&)>(&ns2::ClassA::nsArg), gtwrap::internal::py_arg<const ns1::ClassB&>("arg"))
         .def("nsReturn",static_cast<ns2::ns3::ClassB (ns2::ClassA::*)(double)>(&ns2::ClassA::nsReturn), gtwrap::internal::py_arg<double>("q"))
         .def_static("afunction",static_cast<double (*)()>(&ns2::ClassA::afunction));
-    pybind11::module m_ns2_ns3 = m_ns2.def_submodule("ns3", "ns3 submodule");
 
-    py::class_<ns2::ns3::ClassB, std::shared_ptr<ns2::ns3::ClassB>>(m_ns2_ns3, "ClassB")
+    pybind11::module m_ns2_ns3 = py::reinterpret_borrow<pybind11::module>(m_ns2.attr("ns3"));
+
+    auto gtwrap_class_m_ns2_ns3_ClassB = py::reinterpret_borrow<py::class_<ns2::ns3::ClassB, std::shared_ptr<ns2::ns3::ClassB>>>(m_ns2_ns3.attr("ClassB"));
+    gtwrap_class_m_ns2_ns3_ClassB
         .def(py::init<>());
 
-    py::class_<ns2::ClassC, std::shared_ptr<ns2::ClassC>>(m_ns2, "ClassC")
+    auto gtwrap_class_m_ns2_ClassC = py::reinterpret_borrow<py::class_<ns2::ClassC, std::shared_ptr<ns2::ClassC>>>(m_ns2.attr("ClassC"));
+    gtwrap_class_m_ns2_ClassC
         .def(py::init<>());
 
     m_ns2.attr("aNs2Var") = ns2::aNs2Var;
     m_ns2.def("aGlobalFunction",static_cast<gtsam::Vector (*)()>(&ns2::aGlobalFunction));
     m_ns2.def("overloadedGlobalFunction",static_cast<ns1::ClassA (*)(const ns1::ClassA&)>(&ns2::overloadedGlobalFunction), gtwrap::internal::py_arg<const ns1::ClassA&>("a"));
     m_ns2.def("overloadedGlobalFunction",static_cast<ns1::ClassA (*)(const ns1::ClassA&, double)>(&ns2::overloadedGlobalFunction), gtwrap::internal::py_arg<const ns1::ClassA&>("a"), gtwrap::internal::py_arg<double>("b"));
-    py::class_<ClassD, std::shared_ptr<ClassD>>(m_, "ClassD")
+    auto gtwrap_class_m__ClassD = py::reinterpret_borrow<py::class_<ClassD, std::shared_ptr<ClassD>>>(m_.attr("ClassD"));
+    gtwrap_class_m__ClassD
         .def(py::init<>());
 
-    m_.attr("aGlobalVar") = aGlobalVar;    pybind11::module m_gtsam = m_.def_submodule("gtsam", "gtsam submodule");
+    m_.attr("aGlobalVar") = aGlobalVar;
+    pybind11::module m_gtsam = py::reinterpret_borrow<pybind11::module>(m_.attr("gtsam"));
 
-    py::class_<gtsam::Values, std::shared_ptr<gtsam::Values>>(m_gtsam, "Values")
+    auto gtwrap_class_m_gtsam_Values = py::reinterpret_borrow<py::class_<gtsam::Values, std::shared_ptr<gtsam::Values>>>(m_gtsam.attr("Values"));
+    gtwrap_class_m_gtsam_Values
         .def(py::init<>())
         .def(py::init<const gtsam::Values&>(), gtwrap::internal::py_arg<const gtsam::Values&>("other"))
         .def("insert_vector",[](gtsam::Values* self, size_t j, const gtsam::Vector& vector){ self->insert(j, vector);}, gtwrap::internal::py_arg<size_t>("j"), gtwrap::internal::py_arg<const gtsam::Vector&>("vector"))
@@ -80,8 +118,11 @@ PYBIND11_MODULE(namespaces_py, m_) {
         .def("insert_matrix",[](gtsam::Values* self, size_t j, const gtsam::Matrix& matrix){ self->insert(j, matrix);}, gtwrap::internal::py_arg<size_t>("j"), gtwrap::internal::py_arg<const gtsam::Matrix&>("matrix"))
         .def("insert",static_cast<void (gtsam::Values::*)(size_t, const gtsam::Matrix&)>(&gtsam::Values::insert), gtwrap::internal::py_arg<size_t>("j"), gtwrap::internal::py_arg<const gtsam::Matrix&>("matrix"));
 
-
-#include "python/specializations.h"
-
 }
 
+PYBIND11_MODULE(namespaces_py, m_) {
+    m_.doc() = "pybind11 wrapper of namespaces_py";
+
+gtwrap_declare_namespaces_py(m_);
+gtwrap_bind_namespaces_py(m_);
+}

--- a/tests/expected/python/operator_pybind.cpp
+++ b/tests/expected/python/operator_pybind.cpp
@@ -31,22 +31,39 @@ using namespace std;
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(operator_py, m_) {
-    m_.doc() = "pybind11 wrapper of operator_py";
+
+
+void gtwrap_declare_operator_py(py::module_ &m_) {
 
     pybind11::module m_gtsam = m_.def_submodule("gtsam", "gtsam submodule");
 
-    py::class_<gtsam::Pose3, std::shared_ptr<gtsam::Pose3>>(m_gtsam, "Pose3")
+    py::class_<gtsam::Pose3, std::shared_ptr<gtsam::Pose3>>(m_gtsam, "Pose3");
+
+    py::class_<gtsam::Container<gtsam::Matrix>, std::shared_ptr<gtsam::Container<gtsam::Matrix>>>(m_gtsam, "ContainerMatrix");
+
+}
+
+void gtwrap_bind_operator_py(py::module_ &m_) {
+#include "python/specializations.h"
+
+    pybind11::module m_gtsam = py::reinterpret_borrow<pybind11::module>(m_.attr("gtsam"));
+
+    auto gtwrap_class_m_gtsam_Pose3 = py::reinterpret_borrow<py::class_<gtsam::Pose3, std::shared_ptr<gtsam::Pose3>>>(m_gtsam.attr("Pose3"));
+    gtwrap_class_m_gtsam_Pose3
         .def(py::init<>())
         .def(py::init<gtsam::Rot3, gtsam::Point3>(), gtwrap::internal::py_arg<gtsam::Rot3>("R"), gtwrap::internal::py_arg<gtsam::Point3>("t"))
         .def(py::self * py::self);
 
-    py::class_<gtsam::Container<gtsam::Matrix>, std::shared_ptr<gtsam::Container<gtsam::Matrix>>>(m_gtsam, "ContainerMatrix")
+    auto gtwrap_class_m_gtsam_ContainerMatrix = py::reinterpret_borrow<py::class_<gtsam::Container<gtsam::Matrix>, std::shared_ptr<gtsam::Container<gtsam::Matrix>>>>(m_gtsam.attr("ContainerMatrix"));
+    gtwrap_class_m_gtsam_ContainerMatrix
         .def("__call__", &gtsam::Container<gtsam::Matrix>::operator())
         .def("__getitem__", &gtsam::Container<gtsam::Matrix>::operator[]);
 
-
-#include "python/specializations.h"
-
 }
 
+PYBIND11_MODULE(operator_py, m_) {
+    m_.doc() = "pybind11 wrapper of operator_py";
+
+gtwrap_declare_operator_py(m_);
+gtwrap_bind_operator_py(m_);
+}

--- a/tests/expected/python/pybind_lambda_adapters_pybind.cpp
+++ b/tests/expected/python/pybind_lambda_adapters_pybind.cpp
@@ -24,14 +24,29 @@ pybind11::arg py_arg(const char* name) {
 using namespace std;
 namespace py = pybind11;
 
-PYBIND11_MODULE(pybind_lambda_adapters_py, m_) {
+
+
+void gtwrap_declare_pybind_lambda_adapters_py(py::module_ &m_) {
+
     pybind11::module m_adapters = m_.def_submodule("adapters", "adapters submodule");
 
-    py::class_<adapters::BaseAdapter, std::shared_ptr<adapters::BaseAdapter>>(m_adapters, "BaseAdapter")
+    py::class_<adapters::BaseAdapter, std::shared_ptr<adapters::BaseAdapter>>(m_adapters, "BaseAdapter");
+
+    py::class_<adapters::Adapter<int>, adapters::BaseAdapter, std::shared_ptr<adapters::Adapter<int>>>(m_adapters, "AdapterInt");
+
+}
+
+void gtwrap_bind_pybind_lambda_adapters_py(py::module_ &m_) {
+
+    pybind11::module m_adapters = py::reinterpret_borrow<pybind11::module>(m_.attr("adapters"));
+
+    auto gtwrap_class_m_adapters_BaseAdapter = py::reinterpret_borrow<py::class_<adapters::BaseAdapter, std::shared_ptr<adapters::BaseAdapter>>>(m_adapters.attr("BaseAdapter"));
+    gtwrap_class_m_adapters_BaseAdapter
         .def(py::init<>())
         .def("inherited",[](adapters::BaseAdapter* self, int value){return self->inherited(value);}, gtwrap::internal::py_arg<int>("value"));
 
-    py::class_<adapters::Adapter<int>, adapters::BaseAdapter, std::shared_ptr<adapters::Adapter<int>>>(m_adapters, "AdapterInt")
+    auto gtwrap_class_m_adapters_AdapterInt = py::reinterpret_borrow<py::class_<adapters::Adapter<int>, adapters::BaseAdapter, std::shared_ptr<adapters::Adapter<int>>>>(m_adapters.attr("AdapterInt"));
+    gtwrap_class_m_adapters_AdapterInt
         .def(py::init<>())
         .def("exact",static_cast<int (adapters::Adapter<int>::*)(int)>(&adapters::Adapter<int>::exact), gtwrap::internal::py_arg<int>("value"))
         .def("exactConst",static_cast<int (adapters::Adapter<int>::*)(int) const>(&adapters::Adapter<int>::exactConst), gtwrap::internal::py_arg<int>("value"))
@@ -54,4 +69,9 @@ PYBIND11_MODULE(pybind_lambda_adapters_py, m_) {
     m_adapters.def("globalOverload",static_cast<int (*)(int)>(&adapters::globalOverload), gtwrap::internal::py_arg<int>("value"));
     m_adapters.def("globalOverload",static_cast<double (*)(double)>(&adapters::globalOverload), gtwrap::internal::py_arg<double>("value"));
     m_adapters.def("globalTemplatedInt",[](int value){return adapters::globalTemplated<int>(value);}, gtwrap::internal::py_arg<int>("value"));
+}
+
+PYBIND11_MODULE(pybind_lambda_adapters_py, m_) {
+gtwrap_declare_pybind_lambda_adapters_py(m_);
+gtwrap_bind_pybind_lambda_adapters_py(m_);
 }

--- a/tests/expected/python/special_cases_pybind.cpp
+++ b/tests/expected/python/special_cases_pybind.cpp
@@ -31,31 +31,49 @@ using namespace std;
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(special_cases_py, m_) {
-    m_.doc() = "pybind11 wrapper of special_cases_py";
+
+
+void gtwrap_declare_special_cases_py(py::module_ &m_) {
 
     pybind11::module m_gtsam = m_.def_submodule("gtsam", "gtsam submodule");
 
-    py::class_<gtsam::NonlinearFactorGraph, std::shared_ptr<gtsam::NonlinearFactorGraph>>(m_gtsam, "NonlinearFactorGraph")
-        .def("addPriorPinholeCameraCal3Bundler",[](gtsam::NonlinearFactorGraph* self, size_t key, const gtsam::PinholeCamera<gtsam::Cal3Bundler>& prior, const std::shared_ptr<gtsam::noiseModel::Base> noiseModel){ self->addPrior<gtsam::PinholeCamera<gtsam::Cal3Bundler>>(key, prior, noiseModel);}, gtwrap::internal::py_arg<size_t>("key"), gtwrap::internal::py_arg<const gtsam::PinholeCamera<gtsam::Cal3Bundler>&>("prior"), gtwrap::internal::py_arg<const std::shared_ptr<gtsam::noiseModel::Base>>("noiseModel"));
+    py::class_<gtsam::NonlinearFactorGraph, std::shared_ptr<gtsam::NonlinearFactorGraph>>(m_gtsam, "NonlinearFactorGraph");
 
-    py::class_<gtsam::SfmTrack, std::shared_ptr<gtsam::SfmTrack>>(m_gtsam, "SfmTrack")
-        .def_readwrite("measurements", &gtsam::SfmTrack::measurements);
+    py::class_<gtsam::SfmTrack, std::shared_ptr<gtsam::SfmTrack>>(m_gtsam, "SfmTrack");
 
     py::class_<gtsam::PinholeCamera<gtsam::Cal3Bundler>, std::shared_ptr<gtsam::PinholeCamera<gtsam::Cal3Bundler>>>(m_gtsam, "PinholeCameraCal3Bundler");
 
-    py::class_<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>, std::shared_ptr<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>>> generalsfmfactorcal3bundler(m_gtsam, "GeneralSFMFactorCal3Bundler");
-    generalsfmfactorcal3bundler
-        .def_readwrite("verbosity", &gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>::verbosity);
-
-    py::enum_<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>::Verbosity>(generalsfmfactorcal3bundler, "Verbosity", py::arithmetic())
+    py::class_<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>, std::shared_ptr<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>>> gtwrap_class_m_gtsam_GeneralSFMFactorCal3Bundler(m_gtsam, "GeneralSFMFactorCal3Bundler");
+    py::enum_<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>::Verbosity>(gtwrap_class_m_gtsam_GeneralSFMFactorCal3Bundler, "Verbosity", py::arithmetic())
         .value("SILENT", gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>::Verbosity::SILENT)
         .value("SUMMARY", gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>::Verbosity::SUMMARY)
         .value("VALUES", gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>::Verbosity::VALUES);
 
 
+}
 
+void gtwrap_bind_special_cases_py(py::module_ &m_) {
 #include "python/specializations.h"
+
+    pybind11::module m_gtsam = py::reinterpret_borrow<pybind11::module>(m_.attr("gtsam"));
+
+    auto gtwrap_class_m_gtsam_NonlinearFactorGraph = py::reinterpret_borrow<py::class_<gtsam::NonlinearFactorGraph, std::shared_ptr<gtsam::NonlinearFactorGraph>>>(m_gtsam.attr("NonlinearFactorGraph"));
+    gtwrap_class_m_gtsam_NonlinearFactorGraph
+        .def("addPriorPinholeCameraCal3Bundler",[](gtsam::NonlinearFactorGraph* self, size_t key, const gtsam::PinholeCamera<gtsam::Cal3Bundler>& prior, const std::shared_ptr<gtsam::noiseModel::Base> noiseModel){ self->addPrior<gtsam::PinholeCamera<gtsam::Cal3Bundler>>(key, prior, noiseModel);}, gtwrap::internal::py_arg<size_t>("key"), gtwrap::internal::py_arg<const gtsam::PinholeCamera<gtsam::Cal3Bundler>&>("prior"), gtwrap::internal::py_arg<const std::shared_ptr<gtsam::noiseModel::Base>>("noiseModel"));
+
+    auto gtwrap_class_m_gtsam_SfmTrack = py::reinterpret_borrow<py::class_<gtsam::SfmTrack, std::shared_ptr<gtsam::SfmTrack>>>(m_gtsam.attr("SfmTrack"));
+    gtwrap_class_m_gtsam_SfmTrack
+        .def_readwrite("measurements", &gtsam::SfmTrack::measurements);
+
+    auto gtwrap_class_m_gtsam_GeneralSFMFactorCal3Bundler = py::reinterpret_borrow<py::class_<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>, std::shared_ptr<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>>>>(m_gtsam.attr("GeneralSFMFactorCal3Bundler"));
+    gtwrap_class_m_gtsam_GeneralSFMFactorCal3Bundler
+        .def_readwrite("verbosity", &gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>::verbosity);
 
 }
 
+PYBIND11_MODULE(special_cases_py, m_) {
+    m_.doc() = "pybind11 wrapper of special_cases_py";
+
+gtwrap_declare_special_cases_py(m_);
+gtwrap_bind_special_cases_py(m_);
+}

--- a/tests/expected/python/templates_pybind.cpp
+++ b/tests/expected/python/templates_pybind.cpp
@@ -30,21 +30,35 @@ using namespace std;
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(templates_py, m_) {
-    m_.doc() = "pybind11 wrapper of templates_py";
 
 
-    py::class_<TemplatedConstructor, std::shared_ptr<TemplatedConstructor>>(m_, "TemplatedConstructor")
+void gtwrap_declare_templates_py(py::module_ &m_) {
+
+    py::class_<TemplatedConstructor, std::shared_ptr<TemplatedConstructor>>(m_, "TemplatedConstructor");
+
+    py::class_<ScopedTemplate<Result>, std::shared_ptr<ScopedTemplate<Result>>>(m_, "ScopedTemplateResult");
+
+}
+
+void gtwrap_bind_templates_py(py::module_ &m_) {
+#include "python/specializations.h"
+
+    auto gtwrap_class_m__TemplatedConstructor = py::reinterpret_borrow<py::class_<TemplatedConstructor, std::shared_ptr<TemplatedConstructor>>>(m_.attr("TemplatedConstructor"));
+    gtwrap_class_m__TemplatedConstructor
         .def(py::init<>())
         .def(py::init<const string&>(), gtwrap::internal::py_arg<const string&>("arg"))
         .def(py::init<const int&>(), gtwrap::internal::py_arg<const int&>("arg"))
         .def(py::init<const double&>(), gtwrap::internal::py_arg<const double&>("arg"));
 
-    py::class_<ScopedTemplate<Result>, std::shared_ptr<ScopedTemplate<Result>>>(m_, "ScopedTemplateResult")
+    auto gtwrap_class_m__ScopedTemplateResult = py::reinterpret_borrow<py::class_<ScopedTemplate<Result>, std::shared_ptr<ScopedTemplate<Result>>>>(m_.attr("ScopedTemplateResult"));
+    gtwrap_class_m__ScopedTemplateResult
         .def(py::init<const Result::Value&>(), gtwrap::internal::py_arg<const Result::Value&>("arg"));
-
-
-#include "python/specializations.h"
 
 }
 
+PYBIND11_MODULE(templates_py, m_) {
+    m_.doc() = "pybind11 wrapper of templates_py";
+
+gtwrap_declare_templates_py(m_);
+gtwrap_bind_templates_py(m_);
+}

--- a/tests/fixtures/declare_bind_late.i
+++ b/tests/fixtures/declare_bind_late.i
@@ -1,0 +1,7 @@
+namespace testing {
+
+class Later {
+  Later();
+};
+
+}  // namespace testing

--- a/tests/fixtures/declare_bind_main.i
+++ b/tests/fixtures/declare_bind_main.i
@@ -1,0 +1,8 @@
+namespace testing {
+
+class Consumer {
+  Consumer();
+  void consume(const testing::Later& value);
+};
+
+}  // namespace testing

--- a/tests/pybind_wrapper.tpl
+++ b/tests/pybind_wrapper.tpl
@@ -12,12 +12,19 @@ using namespace std;
 
 namespace py = pybind11;
 
-PYBIND11_MODULE({module_name}, m_) {{
-    m_.doc() = "pybind11 wrapper of {module_name}";
+{submodules}
 
-{wrapped_namespace}
-
-#include "python/specializations.h"
-
+{declaration_module_def} {{
+{wrapped_declarations}
 }}
 
+{binding_module_def} {{
+#include "python/specializations.h"
+{wrapped_bindings}
+}}
+
+{module_def} {{
+    m_.doc() = "pybind11 wrapper of {module_name}";
+
+{module_init}
+}}

--- a/tests/test_pybind_wrapper.py
+++ b/tests/test_pybind_wrapper.py
@@ -42,8 +42,18 @@ class TestWrap(unittest.TestCase):
 using namespace std;
 namespace py = pybind11;
 
-PYBIND11_MODULE({module_name}, m_) {{
-{wrapped_namespace}
+{submodules}
+
+{declaration_module_def} {{
+{wrapped_declarations}
+}}
+
+{binding_module_def} {{
+{wrapped_bindings}
+}}
+
+{module_def} {{
+{module_init}
 }}
 """
 
@@ -168,6 +178,72 @@ PYBIND11_MODULE({module_name}, m_) {{
 
         self.compare_and_diff('special_cases_pybind.cpp', output)
 
+        with open(output, 'r', encoding='UTF-8') as output_file:
+            content = output_file.read()
+
+        # Typedef template instantiations are moved to the end by the
+        # instantiator. Their declarations must still precede methods which
+        # use them in generated docstring signatures.
+        class_declaration = (
+            'py::class_<gtsam::PinholeCamera<gtsam::Cal3Bundler>, '
+            'std::shared_ptr<gtsam::PinholeCamera<gtsam::Cal3Bundler>>>'
+            '(m_gtsam, "PinholeCameraCal3Bundler");')
+        self.assertLess(content.index(class_declaration),
+                        content.index('.def("addPriorPinholeCameraCal3Bundler"'))
+
+    def test_module_wide_declare_then_bind_order(self):
+        """Declare every interface file before binding any of them."""
+        main_source = osp.join(self.INTERFACE_DIR, 'declare_bind_main.i')
+        late_source = osp.join(self.INTERFACE_DIR, 'declare_bind_late.i')
+        output = self.wrap_content([main_source, late_source],
+                                   'declare_bind_py',
+                                   self.PYTHON_ACTUAL_DIR)
+
+        with open(output, 'r', encoding='UTF-8') as output_file:
+            module_init = output_file.read().split(
+                'PYBIND11_MODULE(declare_bind_py, m_)', 1)[1]
+
+        ordered_calls = [
+            'gtwrap_declare_declare_bind_py(m_);',
+            'gtwrap_declare_declare_bind_late(m_);',
+            'gtwrap_bind_declare_bind_py(m_);',
+            'gtwrap_bind_declare_bind_late(m_);',
+        ]
+        positions = [module_init.index(call) for call in ordered_calls]
+        self.assertEqual(positions, sorted(positions))
+
+        with open(osp.join(self.TEST_DIR, 'pybind_wrapper.tpl'),
+                  encoding='UTF-8') as template_file:
+            module_template = template_file.read()
+        with open(late_source, encoding='UTF-8') as interface_file:
+            late_content = interface_file.read()
+        wrapper = PybindWrapper(module_name='declare_bind_py',
+                                top_module_namespaces=[''],
+                                ignore_classes=[''],
+                                module_template=module_template)
+        generated_submodule = wrapper.wrap_file(
+            late_content,
+            module_name='declare_bind_late',
+            source_name=late_source)
+        self.assertIn(
+            'void gtwrap_declare_declare_bind_late(py::module_ &m_)',
+            generated_submodule)
+        self.assertIn('void gtwrap_bind_declare_bind_late(py::module_ &m_)',
+                      generated_submodule)
+
+    def test_legacy_template_reports_missing_phase_fields(self):
+        """Reject templates that cannot express module-wide two-phase init."""
+        wrapper = PybindWrapper(module_name='legacy',
+                                top_module_namespaces=[''],
+                                ignore_classes=[''],
+                                module_template=(
+                                    '{module_def} {{\n'
+                                    '{module_init}\n'
+                                    '}}'))
+
+        with self.assertRaisesRegex(ValueError, 'declare-then-bind fields'):
+            wrapper.wrap_file('class Example {};', module_name='legacy')
+
     def test_enum(self):
         """
         Test if enum generation is correct.
@@ -188,10 +264,19 @@ PYBIND11_MODULE({module_name}, m_) {{
 
 namespace py = pybind11;
 
-PYBIND11_MODULE({module_name}, m_) {{
-    m_.doc() = "pybind11 wrapper of {module_name}";
+{submodules}
 
-{wrapped_namespace}
+{declaration_module_def} {{
+{wrapped_declarations}
+}}
+
+{binding_module_def} {{
+{wrapped_bindings}
+}}
+
+{module_def} {{
+    m_.doc() = "pybind11 wrapper of {module_name}";
+{module_init}
 
 }}
 """


### PR DESCRIPTION
## Motivation

The Python wrapper currently registers each class and immediately binds its
constructors, methods, and properties. A method can therefore reference another
wrapped class before pybind11 has registered that class.

When pybind11 constructs the Python-visible signature for such a method, it
cannot resolve the referenced type to its Python name. The resulting docstring
contains a raw C++ expression, such as:

```text
gtsam::BinaryMeasurement<gtsam::Unit3>
```

That expression is not a valid Python type annotation. Tools such as
`pybind11-stubgen` consequently report invalid expressions or generate
incomplete type information.

This is fundamentally a wrapper declaration-order problem rather than a
stub-generator parsing problem. Every wrapped class must be registered with
pybind11 before any constructors or methods using those classes are bound.

## Approach

This PR adopts a declaration-then-bind generation model:

1. Declare every pybind11 class and enum object.
2. Bind constructors, methods, properties, and operators only after all
   declarations exist.
3. Initialize submodules and handwritten specializations after the generated
   declarations are available.

This ensures pybind11 knows the Python name of every wrapped type before it
constructs method signatures and docstrings.

## Changes

### Wrapper generator integration

- Sync the updated `wrap` subtree containing declaration-first pybind
  generation.
- Split generated wrapper output into declaration, binding, and module
  initialization phases.
- Update both the stable and unstable GTSAM Python templates to use these
  phases.
- Preserve the ordering required by handwritten specialization headers.

### Missing type registrations

Several types already appeared in public wrapper signatures but were not
independently registered. This PR adds the required wrapper declarations and
template instantiations for:

- Additional `CameraSet` camera families.
- `PinholePoseCal3f` and `EmptyCal`.
- `VariableSlots` and `VerticalBlockMatrix`.
- Hybrid Gaussian conditional and nonlinear factor decision trees.
- `ISAM2UpdateParams`.

These declarations allow pybind11 to use proper Python type names in signatures
and make the corresponding APIs callable from Python.

### Cross-module and container handling

- Register `JacobianVector` before binding methods whose signatures use
  `OptionalMatrixVecType`.
- Make that registration global so the stable and unstable GTSAM modules share
  the same Python type.
- Add a Python-facing conversion for `ISAM2UpdateParams::newAffectedKeys`,
  bridging GTSAM's internal `FastMap<FactorIndex, KeySet>` representation to
  standard Python-compatible map and set containers.
- Preserve optional semantics, including assigning and retrieving `None`.

### Signature consistency

- Align wrapper parameter names with their C++ declarations for carrier-phase
  factor constructors.
- Rename the wavelength parameter to `lambda_` to avoid Python's reserved
  `lambda` keyword.
- Match wrapper default arguments for unstable `print()` methods with their C++
  declarations.

## Regression coverage

New and extended tests verify that:

- Every newly exposed wrapper type can be constructed and used.
- All supported `CameraSet` instantiations accept their corresponding camera
  types.
- `PinholePoseCal3f` round-trips through `Values`.
- `VariableSlots` and `VerticalBlockMatrix` work with their dependent
  constructors.
- `ISAM2UpdateParams` scalar, container, and optional properties round-trip
  correctly.
- Hybrid decision-tree types construct multi-key hybrid conditionals and
  factors.
- `JacobianVector` receives populated Jacobians from stable factors and works
  across the stable/unstable module boundary.

## Validation

- Built `gtsam_py` and `gtsam_unstable_py` successfully.
- Stable Python suite: **510 passed, 6 skipped**.
- Unstable Python suite: **6 passed**.
- `python-stubs` and `python-unstable-stubs` completed successfully with
  `pybind11-stubgen` 2.5.5.
- Generated `.pyi` files contain no unresolved `gtsam::`, `std::`, or `boost::`
  type spellings.
- Generated and compiled the MATLAB MEX bindings with Octave 11.3.
- MATLAB/Octave suite: **20/20 passed**.
- `git diff --check` passed.

Fixes #1824.
