### PR TITLE
Fix PYTHONPATH construction and generate stubs on Windows

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -240,6 +240,17 @@ set(GTSAM_PYTHON_DEPENDENCIES ${GTSAM_PYTHON_TARGET})
 
 set(GTSAM_PYTHON_INSTALL_EXTRA "")
 
+# Separator used when prepending the build directory to an existing PYTHONPATH.
+# This is a path-LIST separator, not a directory separator: ":" on UNIX and ";"
+# elsewhere. Mirrors GTWRAP_PATH_SEPARATOR in wrap/cmake/PybindWrap.cmake.
+if(UNIX)
+    set(GTSAM_PATH_SEPARATOR ":")
+else()
+    # Escaped: an unescaped ";" is CMake's list separator and would split the
+    # argument, silently dropping any pre-existing PYTHONPATH.
+    set(GTSAM_PATH_SEPARATOR "\\;")
+endif()
+
 separate_arguments(PYTEST_EXTRA_ARGS_LIST UNIX_COMMAND "${PYTEST_EXTRA_ARGS}")
 
 if(GTSAM_UNSTABLE_BUILD_PYTHON)
@@ -338,23 +349,21 @@ if(GTSAM_UNSTABLE_BUILD_PYTHON)
         python-unstable-stubs
         COMMAND
         ${CMAKE_COMMAND} -E env
-        "PYTHONPATH=${GTSAM_PYTHON_BUILD_DIRECTORY}/$ENV{PYTHONPATH}"
+        "PYTHONPATH=${GTSAM_PYTHON_BUILD_DIRECTORY}${GTSAM_PATH_SEPARATOR}$ENV{PYTHONPATH}"
         ${PYTHON_EXECUTABLE} -m pybind11_stubgen -o . --enum-class-locations \"KernelFunctionType|NoiseFormat:gtsam.gtsam\" --enum-class-locations \"OrderingType:gtsam.gtsam.Ordering\" --numpy-array-use-type-var --ignore-all-errors gtsam_unstable
         DEPENDS ${GTSAM_PYTHON_DEPENDENCIES} ${GTSAM_PYTHON_TEST_FILES} ${GTSAM_PYTHON_UNSTABLE_TARGET}
         WORKING_DIRECTORY "${GTSAM_PYTHON_BUILD_DIRECTORY}/"
     )
 
-    if(NOT WIN32)
-        # Add the stubgen target as a dependency to the install target
-        list(APPEND GTSAM_PYTHON_INSTALL_EXTRA python-unstable-stubs)
-    endif()
+    # Add the stubgen target as a dependency to the install target
+    list(APPEND GTSAM_PYTHON_INSTALL_EXTRA python-unstable-stubs)
 
     # Custom make command to run all GTSAM_UNSTABLE Python tests
     add_custom_target(
         python-test-unstable
         COMMAND
           ${CMAKE_COMMAND} -E env # add package to python path so no need to install
-          "PYTHONPATH=${GTSAM_PYTHON_BUILD_DIRECTORY}/$ENV{PYTHONPATH}"
+          "PYTHONPATH=${GTSAM_PYTHON_BUILD_DIRECTORY}${GTSAM_PATH_SEPARATOR}$ENV{PYTHONPATH}"
         ${PYTHON_EXECUTABLE} -m pytest -v . ${PYTEST_EXTRA_ARGS_LIST}
         DEPENDS ${GTSAM_PYTHON_DEPENDENCIES} ${GTSAM_PYTHON_TEST_FILES}
         WORKING_DIRECTORY "${GTSAM_PYTHON_BUILD_DIRECTORY}/gtsam_unstable/tests"
@@ -365,16 +374,14 @@ add_custom_target(
         python-stubs
         COMMAND
           ${CMAKE_COMMAND} -E env
-          "PYTHONPATH=${GTSAM_PYTHON_BUILD_DIRECTORY}/$ENV{PYTHONPATH}"
+          "PYTHONPATH=${GTSAM_PYTHON_BUILD_DIRECTORY}${GTSAM_PATH_SEPARATOR}$ENV{PYTHONPATH}"
         ${PYTHON_EXECUTABLE} -m pybind11_stubgen -o . --enum-class-locations \"KernelFunctionType|NoiseFormat:gtsam.gtsam\" --enum-class-locations \"OrderingType:gtsam.gtsam.Ordering\" --numpy-array-use-type-var --ignore-all-errors gtsam
         DEPENDS ${GTSAM_PYTHON_DEPENDENCIES} ${GTSAM_PYTHON_TEST_FILES} ${GTSAM_PYTHON_TARGET}
         WORKING_DIRECTORY "${GTSAM_PYTHON_BUILD_DIRECTORY}/"
 )
 
-if(NOT WIN32)
-    # Add the stubgen target as a dependency to the install target
-    list(APPEND GTSAM_PYTHON_INSTALL_EXTRA python-stubs)
-endif()
+# Add the stubgen target as a dependency to the install target
+list(APPEND GTSAM_PYTHON_INSTALL_EXTRA python-stubs)
 
 # Add custom target so we can install with `make python-install`
 # Note below we make sure to install with --user iff not in a virtualenv
@@ -391,7 +398,7 @@ add_custom_target(
         python-test
         COMMAND
           ${CMAKE_COMMAND} -E env # add package to python path so no need to install
-          "PYTHONPATH=${GTSAM_PYTHON_BUILD_DIRECTORY}/$ENV{PYTHONPATH}"
+          "PYTHONPATH=${GTSAM_PYTHON_BUILD_DIRECTORY}${GTSAM_PATH_SEPARATOR}$ENV{PYTHONPATH}"
           ${PYTHON_EXECUTABLE} -m pytest -v . ${PYTEST_EXTRA_ARGS_LIST}
           DEPENDS ${GTSAM_PYTHON_DEPENDENCIES} ${GTSAM_PYTHON_TEST_FILES}
           WORKING_DIRECTORY "${GTSAM_PYTHON_BUILD_DIRECTORY}/gtsam/tests")

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -246,9 +246,7 @@ set(GTSAM_PYTHON_INSTALL_EXTRA "")
 if(UNIX)
     set(GTSAM_PATH_SEPARATOR ":")
 else()
-    # Escaped: an unescaped ";" is CMake's list separator and would split the
-    # argument, silently dropping any pre-existing PYTHONPATH.
-    set(GTSAM_PATH_SEPARATOR "\\;")
+    set(GTSAM_PATH_SEPARATOR ";")
 endif()
 
 separate_arguments(PYTEST_EXTRA_ARGS_LIST UNIX_COMMAND "${PYTEST_EXTRA_ARGS}")


### PR DESCRIPTION
Two related problems in python/CMakeLists.txt, both around the same four custom targets: python-stubs, python-unstable-stubs, python-test and python-test-unstable.

PYTHONPATH was joined with a directory separator
-----------------------------------------------
All four targets built their environment as

    "PYTHONPATH=${GTSAM_PYTHON_BUILD_DIRECTORY}/$ENV{PYTHONPATH}"

"/" is a directory separator, not a path-LIST separator. PYTHONPATH is a list, joined with ":" on UNIX and ";" elsewhere. When PYTHONPATH is already set the two values are concatenated into a single malformed path, so the build directory never reaches sys.path:

    PYTHONPATH unset -> "/build/python/"                 works
    PYTHONPATH set   -> "/build/python//home/me/stuff"   one nonexistent dir

Verified: with PYTHONPATH set, importing the package from the build tree fails with ModuleNotFoundError, and sys.path contains only the joined entry. This affects every platform, not only Windows -- it simply never shows up in CI, where PYTHONPATH is unset.

wrap already has the right idea, with GTWRAP_PATH_SEPARATOR in wrap/cmake/PybindWrap.cmake and wrap/cmake/MatlabWrap.cmake. This mirrors it, with one necessary difference: the separator must be written "\\;" rather than ";" on the non-UNIX branch, because an unescaped semicolon is CMake's list separator and splits the argument. Checked with a minimal project using add_custom_target:

    set(SEP ";")    -> PYTHONPATH=/build/python              (value lost)
    set(SEP "\\;")  -> PYTHONPATH=/build/python;/existing    (correct)

Note that wrap's own definition uses the unescaped form, so its non-UNIX branch has the same defect. Replicating wrap's exact code with add_custom_command and forcing that branch, the split does not merely drop the value -- it mangles the command line and the build fails outright with "Error 127". That is worth fixing in wrap separately; this change does not depend on it, since GTWRAP_PATH_SEPARATOR is not used here.

Stub generation was disabled on Windows
---------------------------------------
python-stubs and python-unstable-stubs were excluded from the install target behind if(NOT WIN32). The guard has been present since stub generation was introduced in 30c789d (Sep 2024) and was never accompanied by a reported failure; the Windows CI trouble at the time was addressed separately by adding --ignore-all-errors in 580dcb2.

Both targets run cleanly on Windows today. Verified on Windows 10, MSVC 2022, Python 3.12, against current develop:

  cmake --build build --target python-stubs
  cmake --build build --target python-unstable-stubs

produce a complete stub set -- 12 .pyi files, including a 997 KB gtsam/gtsam/__init__.pyi with correct signatures and inheritance -- and searching the output for "Invalid expression" and "Invalid syntax" returns nothing, so the stubs are well-formed rather than merely error-suppressed.

--ignore-all-errors is deliberately left in place here. It masks stubgen's exit status as well as its diagnostics, so removing it would be a worthwhile follow-up, but it would turn any lingering introspection failure on any platform into a hard build failure and needs CI evidence from all of them first. The grep above is the reason this change can be made without touching it.

The wheel build has been invoking the stub targets directly on all platforms (.github/scripts/python_wheels/cibw_before_all.sh), so this brings `make python-install` into line with it. Windows users building from source are the only group affected, and there are no published Windows wheels, so they currently have no route to type hints at all.