### PR TITLE
Use hybrid TBB gathering for multifrontal parent updates

### DIFF
--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -32,6 +32,9 @@
 #include <tbb/blocked_range.h>
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/parallel_for.h>
+#include <tbb/parallel_reduce.h>
+
+#include <functional>
 #endif
 
 #include <algorithm>
@@ -103,6 +106,45 @@ SymmetricBlockMatrix makeZeroLocalInfo(const std::vector<size_t>& blockDims) {
   local.setZero();
   return local;
 }
+
+#ifdef GTSAM_USE_TBB
+void updateMappedInfoOwnedColumn(
+    const SymmetricBlockMatrix& source, DenseIndex sourceBlockStart,
+    DenseIndex ownedSourceBlock, SymmetricBlockMatrix* target,
+    const std::vector<DenseIndex>& targetIndices,
+    const std::vector<DenseIndex>& targetScalarOffsets) {
+  assert(target && ownedSourceBlock >= 0);
+  const DenseIndex retainedBlocks =
+      static_cast<DenseIndex>(targetIndices.size()) - 1;
+  assert(ownedSourceBlock < retainedBlocks);
+  const DenseIndex targetColumn = targetIndices[ownedSourceBlock];
+  const DenseIndex targetOffset = targetScalarOffsets[ownedSourceBlock];
+  target->updateDiagonalBlockAt(
+      targetOffset, source.diagonalBlock(sourceBlockStart + ownedSourceBlock));
+
+  const DenseIndex sourceRhs = sourceBlockStart + retainedBlocks;
+  target->updateOffDiagonalBlockAt(
+      targetOffset, targetScalarOffsets.back(),
+      source.aboveDiagonalBlock(sourceBlockStart + ownedSourceBlock,
+                                sourceRhs));
+  for (DenseIndex other = 0; other < retainedBlocks; ++other) {
+    if (targetIndices[other] >= targetColumn) continue;
+    if (other < ownedSourceBlock) {
+      target->updateOffDiagonalBlockAt(
+          targetScalarOffsets[other], targetOffset,
+          source.aboveDiagonalBlock(sourceBlockStart + other,
+                                    sourceBlockStart + ownedSourceBlock));
+    } else {
+      target->updateOffDiagonalBlockAt(
+          targetScalarOffsets[other], targetOffset,
+          source
+              .aboveDiagonalBlock(sourceBlockStart + ownedSourceBlock,
+                                  sourceBlockStart + other)
+              .transpose());
+    }
+  }
+}
+#endif
 
 }  // namespace
 
@@ -554,12 +596,12 @@ void MultifrontalClique::resolveLeafSolveMode() {
   }
 
   if (solveMode_ == SolveMode::FusedStarCandidate) {
-    const bool supported =
-        kUseDirectBatchHessianUpdate && hasDirectBatchFactors_ &&
-        std::all_of(loadPlans_.begin(), loadPlans_.end(),
-                    [](const FactorLoadPlan& plan) {
-                      return plan.supportsFusedStarLeaf();
-                    });
+    const bool supported = kUseDirectBatchHessianUpdate &&
+                           hasDirectBatchFactors_ &&
+                           std::all_of(loadPlans_.begin(), loadPlans_.end(),
+                                       [](const FactorLoadPlan& plan) {
+                                         return plan.supportsFusedStarLeaf();
+                                       });
     solveMode_ =
         supported ? SolveMode::FusedStarCholeskyLeaf : starFallbackMode_;
   }
@@ -1129,6 +1171,77 @@ void MultifrontalClique::updateParentInfo(
   }
 }
 
+#ifdef GTSAM_USE_TBB
+void MultifrontalClique::updateParentMaterializedColumn(
+    SymmetricBlockMatrix& parentInfo, DenseIndex sourceSeparatorBlock) const {
+  assert(fullyEliminated() && !useQR() && !useCompactCholesky());
+  assert(info_.nBlocks() > 0 && info_.blockStart() == 0);
+  updateMappedInfoOwnedColumn(info_, static_cast<DenseIndex>(numFrontals()),
+                              sourceSeparatorBlock, &parentInfo, parentIndices_,
+                              parentScalarOffsets_);
+}
+
+void MultifrontalClique::updateParentQrColumnScratch(
+    DenseIndex sourceSeparatorBlock, Matrix* scratch) const {
+  assert(scratch && fullyEliminated() && useQR() && RSdReady_);
+  assert(RSd_.firstBlock() == 0);
+  const DenseIndex frontalBlocks = static_cast<DenseIndex>(numFrontals());
+  const DenseIndex retainedBlocks =
+      static_cast<DenseIndex>(parentIndices_.size()) - 1;
+  assert(sourceSeparatorBlock >= 0 && sourceSeparatorBlock < retainedBlocks);
+
+  const DenseIndex residualRow = static_cast<DenseIndex>(frontalDim);
+  const DenseIndex residualRows =
+      static_cast<DenseIndex>(RSd_.matrix().rows()) - residualRow;
+  const DenseIndex sourceColumn = frontalBlocks + sourceSeparatorBlock;
+  const DenseIndex sourceOffset = RSd_.offset(sourceColumn);
+  const DenseIndex sourceDimension =
+      RSd_.offset(sourceColumn + 1) - sourceOffset;
+  const auto owned = RSd_.matrix().block(residualRow, sourceOffset,
+                                         residualRows, sourceDimension);
+
+  const DenseIndex targetColumn = parentIndices_[sourceSeparatorBlock];
+  const DenseIndex targetOffset = parentScalarOffsets_[sourceSeparatorBlock];
+  assert(scratch->cols() == sourceDimension);
+  assert(scratch->rows() == targetOffset + sourceDimension + 1);
+  scratch->block(targetOffset, 0, sourceDimension, sourceDimension).noalias() +=
+      owned.transpose() * owned;
+
+  const DenseIndex rhsOffset = RSd_.offset(frontalBlocks + retainedBlocks);
+  const auto rhs = RSd_.matrix().block(residualRow, rhsOffset, residualRows, 1);
+  scratch->bottomRows(1).noalias() += (owned.transpose() * rhs).transpose();
+
+  for (DenseIndex other = 0; other < retainedBlocks; ++other) {
+    if (parentIndices_[other] >= targetColumn) continue;
+    const DenseIndex otherColumn = frontalBlocks + other;
+    const DenseIndex otherOffset = RSd_.offset(otherColumn);
+    const DenseIndex otherDimension =
+        RSd_.offset(otherColumn + 1) - otherOffset;
+    const auto otherBlock = RSd_.matrix().block(residualRow, otherOffset,
+                                                residualRows, otherDimension);
+    scratch
+        ->block(parentScalarOffsets_[other], 0, otherDimension, sourceDimension)
+        .noalias() += otherBlock.transpose() * owned;
+  }
+}
+
+double MultifrontalClique::parentMaterializedRhsDiagonal() const {
+  assert(fullyEliminated() && !useQR() && !useCompactCholesky());
+  assert(info_.nBlocks() > 0);
+  return info_.diagonalBlock(info_.nBlocks() - 1).coeff(0, 0);
+}
+
+double MultifrontalClique::parentQrRhsDiagonal() const {
+  assert(fullyEliminated() && useQR() && RSdReady_);
+  const DenseIndex residualRow = static_cast<DenseIndex>(frontalDim);
+  const DenseIndex rhsBlock = RSd_.nBlocks() - 1;
+  return RSd_.matrix()
+      .block(residualRow, RSd_.offset(rhsBlock),
+             RSd_.matrix().rows() - residualRow, 1)
+      .squaredNorm();
+}
+#endif
+
 void MultifrontalClique::updateSeparatorInfo(
     SymmetricBlockMatrix& separatorInfo) const {
   assert(fullyEliminated() && !useQR());
@@ -1160,34 +1273,206 @@ void MultifrontalClique::gatherUpdatesSequential() {
     if (child->fullyEliminated()) child->updateParentInfo(info_);
   }
 }
+#ifdef GTSAM_USE_TBB
+void MultifrontalClique::ParentGatherPlan::build(
+    const MultifrontalClique& parent) {
+  assert(!built);
+  materializedByColumn.resize(parent.blockDims_.size());
+  qrByColumn.resize(parent.blockDims_.size());
+
+  for (size_t childIndex = 0; childIndex < parent.children.size();
+       ++childIndex) {
+    if (!parent.childInSameSeparatorGroup_.empty() &&
+        parent.childInSameSeparatorGroup_[childIndex]) {
+      continue;
+    }
+    const auto& child = parent.children[childIndex];
+    if (!child || !child->fullyEliminated()) continue;
+    assert(!child->deferredSingleFactorAutoQr_);
+    assert(child->solveMode_ != SolveMode::FusedStarCandidate);
+
+    if (child->useCompactCholesky()) {
+      computeOnceChildIndices.push_back(childIndex);
+      continue;
+    }
+
+    const bool qr = child->useQR();
+    auto& childIndices = qr ? qrChildIndices : materializedChildIndices;
+    auto& updatesByColumn = qr ? qrByColumn : materializedByColumn;
+    childIndices.push_back(childIndex);
+    for (size_t sourceBlock = 0; sourceBlock + 1 < child->parentIndices_.size();
+         ++sourceBlock) {
+      const DenseIndex column = child->parentIndices_[sourceBlock];
+      assert(column >= 0 &&
+             column < static_cast<DenseIndex>(parent.blockDims_.size()));
+      updatesByColumn[column].push_back(
+          {childIndex, static_cast<DenseIndex>(sourceBlock)});
+    }
+  }
+
+  constexpr size_t kQrChildrenPerChunk = 128;
+  qrChunkIndicesByColumn.resize(parent.blockDims_.size());
+  for (size_t column = 0; column < qrByColumn.size(); ++column) {
+    const auto& columnUpdates = qrByColumn[column];
+    for (size_t begin = 0; begin < columnUpdates.size();
+         begin += kQrChildrenPerChunk) {
+      const size_t end =
+          std::min(begin + kQrChildrenPerChunk, columnUpdates.size());
+      const size_t scratchRows =
+          static_cast<size_t>(parent.info_.blockScalarOffset(column)) +
+          parent.blockDims_[column] + 1;
+      const size_t chunkIndex = qrChunks.size();
+      qrChunkIndicesByColumn[column].push_back(chunkIndex);
+      qrChunks.push_back(
+          {static_cast<DenseIndex>(column), begin, end,
+           Matrix::Zero(static_cast<DenseIndex>(scratchRows),
+                        static_cast<DenseIndex>(parent.blockDims_[column]))});
+    }
+  }
+  built = true;
+}
+
+void MultifrontalClique::ParentGatherPlan::gather(MultifrontalClique* parent) {
+  assert(parent && built);
+
+  if (!computeOnceChildIndices.empty()) {
+    tbb::enumerable_thread_specific<SymmetricBlockMatrix> locals(
+        [parent]() { return makeZeroLocalInfo(parent->blockDims_); });
+    tbb::parallel_for(
+        tbb::blocked_range<size_t>(0, computeOnceChildIndices.size()),
+        [this, parent, &locals](const tbb::blocked_range<size_t>& range) {
+          auto& local = locals.local();
+          for (size_t index = range.begin(); index < range.end(); ++index) {
+            const auto& child =
+                parent->children[computeOnceChildIndices[index]];
+            assert(child && child->fullyEliminated());
+            child->updateParentInfo(local);
+          }
+        });
+    locals.combine_each([parent](const SymmetricBlockMatrix& local) {
+      parent->info_.addUpperTriangular(local);
+    });
+  }
+
+  // A compact-only parent follows exactly the original compute-once path.
+  if (materializedChildIndices.empty() && qrChildIndices.empty()) return;
+
+  if (!materializedChildIndices.empty()) {
+    tbb::parallel_for(
+        tbb::blocked_range<size_t>(0, materializedByColumn.size(), 1),
+        [this, parent](const tbb::blocked_range<size_t>& range) {
+          for (size_t column = range.begin(); column < range.end(); ++column) {
+            for (const ColumnUpdate& update : materializedByColumn[column]) {
+              const auto& child = parent->children[update.childIndex];
+              assert(child && child->fullyEliminated());
+              child->updateParentMaterializedColumn(
+                  parent->info_, update.sourceSeparatorBlock);
+            }
+          }
+        });
+  }
+
+  if (!qrChildIndices.empty()) {
+    tbb::parallel_for(
+        tbb::blocked_range<size_t>(0, qrChunks.size(), 1),
+        [this, parent](const tbb::blocked_range<size_t>& range) {
+          for (size_t chunkIndex = range.begin(); chunkIndex < range.end();
+               ++chunkIndex) {
+            QrColumnChunk& chunk = qrChunks[chunkIndex];
+            chunk.scratch.setZero();
+            const auto& columnUpdates =
+                qrByColumn[static_cast<size_t>(chunk.column)];
+            for (size_t index = chunk.begin; index < chunk.end; ++index) {
+              const ColumnUpdate& update = columnUpdates[index];
+              parent->children[update.childIndex]->updateParentQrColumnScratch(
+                  update.sourceSeparatorBlock, &chunk.scratch);
+            }
+          }
+        });
+
+    tbb::parallel_for(
+        tbb::blocked_range<size_t>(0, qrChunkIndicesByColumn.size(), 1),
+        [this, parent](const tbb::blocked_range<size_t>& range) {
+          for (size_t column = range.begin(); column < range.end(); ++column) {
+            const auto& chunkIndices = qrChunkIndicesByColumn[column];
+            if (chunkIndices.empty()) continue;
+            Matrix& accumulated = qrChunks[chunkIndices.front()].scratch;
+            for (size_t index = 1; index < chunkIndices.size(); ++index) {
+              accumulated += qrChunks[chunkIndices[index]].scratch;
+            }
+
+            const DenseIndex targetOffset =
+                parent->info_.blockScalarOffset(column);
+            const DenseIndex targetDimension =
+                static_cast<DenseIndex>(parent->blockDims_[column]);
+            for (size_t rowBlock = 0; rowBlock < column; ++rowBlock) {
+              const DenseIndex rowOffset =
+                  parent->info_.blockScalarOffset(rowBlock);
+              const DenseIndex rowDimension =
+                  static_cast<DenseIndex>(parent->blockDims_[rowBlock]);
+              parent->info_.updateOffDiagonalBlockAt(
+                  rowOffset, targetOffset,
+                  accumulated.block(rowOffset, 0, rowDimension,
+                                    targetDimension));
+            }
+            parent->info_.updateDiagonalBlockAt(
+                targetOffset,
+                accumulated.block(targetOffset, 0, targetDimension,
+                                  targetDimension));
+            parent->info_.updateOffDiagonalBlock(
+                static_cast<DenseIndex>(column), parent->info_.nBlocks() - 1,
+                accumulated.bottomRows(1).transpose());
+          }
+        });
+  }
+
+  const double materializedRhs =
+      materializedChildIndices.empty()
+          ? 0.0
+          : tbb::parallel_reduce(
+                tbb::blocked_range<size_t>(0, materializedChildIndices.size()),
+                0.0,
+                [this, parent](const tbb::blocked_range<size_t>& range,
+                               double subtotal) {
+                  for (size_t index = range.begin(); index < range.end();
+                       ++index) {
+                    subtotal +=
+                        parent->children[materializedChildIndices[index]]
+                            ->parentMaterializedRhsDiagonal();
+                  }
+                  return subtotal;
+                },
+                std::plus<double>());
+  const double qrRhs =
+      qrChildIndices.empty()
+          ? 0.0
+          : tbb::parallel_reduce(
+                tbb::blocked_range<size_t>(0, qrChildIndices.size()), 0.0,
+                [this, parent](const tbb::blocked_range<size_t>& range,
+                               double subtotal) {
+                  for (size_t index = range.begin(); index < range.end();
+                       ++index) {
+                    subtotal += parent->children[qrChildIndices[index]]
+                                    ->parentQrRhsDiagonal();
+                  }
+                  return subtotal;
+                },
+                std::plus<double>());
+
+  Eigen::Matrix<double, 1, 1> rhsUpdate;
+  rhsUpdate(0, 0) = materializedRhs + qrRhs;
+  parent->info_.updateDiagonalBlock(parent->info_.nBlocks() - 1, rhsUpdate);
+}
+#endif
 
 void MultifrontalClique::gatherUpdatesParallel(size_t numThreads) {
 #ifdef GTSAM_USE_TBB
-  (void)numThreads;  // TBB controls the effective worker count.
-  tbb::enumerable_thread_specific<SymmetricBlockMatrix> locals([this]() {
-    return makeZeroLocalInfo(blockDims_);
-  });  // Per-thread accumulators.
-  tbb::parallel_for(
-      tbb::blocked_range<size_t>(0, children.size()),
-      [&](const tbb::blocked_range<size_t>& range) {
-        auto& local = locals.local();  // Thread-local info matrix.
-        for (size_t i = range.begin(); i < range.end(); ++i) {
-          const auto& child = children[i];
-          if (!childInSameSeparatorGroup_.empty() &&
-              childInSameSeparatorGroup_[i]) {
-            continue;
-          }
-          assert(child);
-          if (child->fullyEliminated()) {
-            child->updateParentInfo(
-                local);  // No locking: each thread writes its own info matrix.
-          }
-        }
-      });
-  locals.combine_each([this](const SymmetricBlockMatrix& local) {
-    info_.addUpperTriangular(
-        local);  // Merge per-thread partial info matrices into this clique.
-  });
+  (void)numThreads;  // TBB is capped by the enclosing traversal arena.
+  if (!parentGatherPlan_) {
+    parentGatherPlan_ = std::make_unique<ParentGatherPlan>();
+    parentGatherPlan_->build(*this);
+  }
+  parentGatherPlan_->gather(this);
 #else
   std::vector<SymmetricBlockMatrix> locals;
   locals.reserve(numThreads);  // Fixed-size per-thread accumulators.

--- a/gtsam/linear/MultifrontalClique.h
+++ b/gtsam/linear/MultifrontalClique.h
@@ -365,6 +365,22 @@ class GTSAM_EXPORT MultifrontalClique {
   /// contribution.
   void updateParentInfo(SymmetricBlockMatrix& parentInfo) const;
 
+#ifdef GTSAM_USE_TBB
+  /// Accumulate one ordinary separator block into its owned parent column.
+  void updateParentMaterializedColumn(SymmetricBlockMatrix& parentInfo,
+                                      DenseIndex sourceSeparatorBlock) const;
+
+  /// Accumulate one QR separator block into narrow owned-column scratch.
+  void updateParentQrColumnScratch(DenseIndex sourceSeparatorBlock,
+                                   Matrix* scratch) const;
+
+  /// Return the augmented-RHS diagonal from an ordinary child update.
+  double parentMaterializedRhsDiagonal() const;
+
+  /// Return the augmented-RHS diagonal from a QR child update.
+  double parentQrRhsDiagonal() const;
+#endif
+
   /// Update a separator-local information matrix without parent scattering.
   void updateSeparatorInfo(SymmetricBlockMatrix& separatorInfo) const;
 
@@ -468,6 +484,43 @@ class GTSAM_EXPORT MultifrontalClique {
   std::vector<std::vector<DenseIndex>> sameSeparatorParentScalarOffsets_;
   std::vector<SymmetricBlockMatrix> sameSeparatorInfos_;
   std::vector<uint8_t> childInSameSeparatorGroup_;
+
+#ifdef GTSAM_USE_TBB
+  /**
+   * Lazy TBB gather metadata, built after child solve modes are resolved.
+   * Materialized and QR children are bucketed by disjoint parent columns;
+   * compact children remain in the existing compute-once reduction.
+   */
+  struct ParentGatherPlan {
+    struct ColumnUpdate {
+      size_t childIndex = 0;
+      DenseIndex sourceSeparatorBlock = 0;
+    };
+
+    struct QrColumnChunk {
+      DenseIndex column = 0;
+      size_t begin = 0;
+      size_t end = 0;
+      Matrix scratch;
+    };
+
+    bool built = false;
+    std::vector<size_t> materializedChildIndices;
+    std::vector<size_t> qrChildIndices;
+    std::vector<size_t> computeOnceChildIndices;
+    std::vector<std::vector<ColumnUpdate>> materializedByColumn;
+    std::vector<std::vector<ColumnUpdate>> qrByColumn;
+    std::vector<QrColumnChunk> qrChunks;
+    std::vector<std::vector<size_t>> qrChunkIndicesByColumn;
+
+    /// Classify children using their final numerical representation.
+    void build(const MultifrontalClique& parent);
+
+    /// Execute the independent column-owned and compute-once stages.
+    void gather(MultifrontalClique* parent);
+  };
+  std::unique_ptr<ParentGatherPlan> parentGatherPlan_;
+#endif
 
   // Lazily allocated after load-plan construction. Direct batch factors need
   // no rows; QR additionally reserves frontal damping rows.

--- a/gtsam/linear/tests/testMultifrontalSolver.cpp
+++ b/gtsam/linear/tests/testMultifrontalSolver.cpp
@@ -353,6 +353,95 @@ TEST(MultifrontalSolver, AlgebraicLeafMergeNumericsAndReload) {
   EXPECT(assert_equal(partialExpected, actual, 1e-9));
 }
 
+constexpr size_t kParallelChildCount = 1025;
+
+size_t maximumChildren(MultifrontalSolver* solver) {
+  size_t result = 0;
+  solver->runTopDown([&result](MultifrontalClique& clique) {
+    result = std::max(result, clique.children.size());
+  });
+  return result;
+}
+
+MultifrontalSolver::Parameters threadedParams(
+    MultifrontalSolver::Parameters params, size_t threads) {
+  params.numThreads = threads;
+  return params;
+}
+
+// More than 1,024 overlapping ordinary children exercise the parallel gather,
+// including partial elimination and a reload with changed numerical values.
+TEST(MultifrontalSolver, ParallelParentOrdinaryReloadAndPartial) {
+  const Problem problem = createProblem(kParallelChildCount);
+  auto params = noMergeParams();
+  params.qrMode = MultifrontalParameters::QRMode::Off;
+  params.compactCholeskySeparatorDimThreshold =
+      std::numeric_limits<size_t>::max();
+
+  MultifrontalSolver single(problem.graph, problem.fullOrdering,
+                            threadedParams(params, 1));
+  MultifrontalSolver parallel(problem.graph, problem.fullOrdering,
+                              threadedParams(params, 4));
+  EXPECT(maximumChildren(&parallel) > 1024);
+  single.eliminateInPlace(problem.graph);
+  parallel.eliminateInPlace(problem.graph);
+  EXPECT(
+      assert_equal(single.updateSolution(), parallel.updateSolution(), 1e-8));
+
+  const Problem changed = createProblem(kParallelChildCount, false, 0.5);
+  single.eliminateInPlace(changed.graph);
+  parallel.eliminateInPlace(changed.graph);
+  EXPECT(
+      assert_equal(single.updateSolution(), parallel.updateSolution(), 1e-8));
+
+  MultifrontalSolver singlePartial(problem.graph, problem.fullOrdering,
+                                   problem.pointOrdering.size(),
+                                   threadedParams(params, 1));
+  MultifrontalSolver parallelPartial(problem.graph, problem.fullOrdering,
+                                     problem.pointOrdering.size(),
+                                     threadedParams(params, 4));
+  singlePartial.eliminatePartialInPlace(problem.graph);
+  parallelPartial.eliminatePartialInPlace(problem.graph);
+  EXPECT(assert_equal(singlePartial.remainingFactorGraph().augmentedHessian(
+                          problem.cameraOrdering),
+                      parallelPartial.remainingFactorGraph().augmentedHessian(
+                          problem.cameraOrdering),
+                      1e-8));
+}
+
+// Forced QR agrees across thread counts for overlapping siblings.
+TEST(MultifrontalSolver, ParallelParentForcedQr) {
+  const Problem problem = createProblem(kParallelChildCount);
+  auto params = noMergeParams();
+  params.qrMode = MultifrontalParameters::QRMode::Force;
+  MultifrontalSolver single(problem.graph, problem.fullOrdering,
+                            threadedParams(params, 1));
+  MultifrontalSolver parallel(problem.graph, problem.fullOrdering,
+                              threadedParams(params, 4));
+  EXPECT(maximumChildren(&parallel) > 1024);
+  single.eliminateInPlace(problem.graph);
+  parallel.eliminateInPlace(problem.graph);
+  EXPECT(
+      assert_equal(single.updateSolution(), parallel.updateSolution(), 1e-8));
+}
+
+// Compact Cholesky leaves agree across thread counts.
+TEST(MultifrontalSolver, ParallelParentCompactCholesky) {
+  const Problem problem = createProblem(kParallelChildCount);
+  auto params = noMergeParams();
+  params.qrMode = MultifrontalParameters::QRMode::Off;
+  params.compactCholeskySeparatorDimThreshold = 2;
+  MultifrontalSolver single(problem.graph, problem.fullOrdering,
+                            threadedParams(params, 1));
+  MultifrontalSolver parallel(problem.graph, problem.fullOrdering,
+                              threadedParams(params, 4));
+  EXPECT(maximumChildren(&parallel) > 1024);
+  single.eliminateInPlace(problem.graph);
+  parallel.eliminateInPlace(problem.graph);
+  EXPECT(
+      assert_equal(single.updateSolution(), parallel.updateSolution(), 1e-8));
+}
+
 }  // namespace algebraic_leaf_merge_fixture
 /* ************************************************************************* */
 
@@ -461,6 +550,89 @@ Problem createSameSeparatorProblem() {
   return problem;
 }
 
+Problem createLargeFusedProblem(size_t pointCount) {
+  Problem problem;
+  const KeyVector cameras{X(0), X(1), X(2)};
+  problem.cameraOrdering = Ordering(cameras.begin(), cameras.end());
+  problem.fullOrdering.reserve(pointCount + cameras.size());
+  using PointCameraBatch = BatchJacobianFactor<1, 1, 1, 1>;
+  for (size_t index = 0; index < pointCount; ++index) {
+    const Key point = L(index);
+    problem.pointOrdering.push_back(point);
+    problem.fullOrdering.push_back(point);
+    const KeyVector keys{point, cameras[0], cameras[1]};
+    auto observations =
+        std::make_shared<PointCameraBatch>(keys, std::vector<size_t>{1, 1, 1});
+    const double scale = 1.0 + 0.001 * static_cast<double>(index);
+    observations->addRow({0, 1, 2}, {scale * I_1x1, I_1x1, -I_1x1},
+                         Vector1(0.25 * scale));
+    problem.graph.push_back(observations);
+  }
+  problem.fullOrdering.insert(problem.fullOrdering.end(), cameras.begin(),
+                              cameras.end());
+  const auto unit = noiseModel::Unit::Create(1);
+  for (const Key camera : cameras) {
+    problem.graph.emplace_shared<JacobianFactor>(camera, I_1x1, Vector1::Zero(),
+                                                 unit);
+  }
+  for (size_t first = 0; first < cameras.size(); ++first) {
+    for (size_t second = first + 1; second < cameras.size(); ++second) {
+      problem.graph.emplace_shared<JacobianFactor>(cameras[first], I_1x1,
+                                                   cameras[second], -I_1x1,
+                                                   Vector1::Zero(), unit);
+    }
+  }
+  return problem;
+}
+
+Problem createLargeMixedProblem(size_t ordinaryCount, size_t fusedCount,
+                                double rhsScale = 1.0) {
+  Problem problem;
+  const KeyVector cameras{X(0), X(1), X(2)};
+  // Deliberately differ from KeySet order so child-to-parent mappings permute.
+  problem.cameraOrdering = Ordering{cameras[1], cameras[0], cameras[2]};
+  problem.fullOrdering.reserve(ordinaryCount + fusedCount + cameras.size());
+  const auto unit = noiseModel::Unit::Create(1);
+
+  for (size_t index = 0; index < ordinaryCount + fusedCount; ++index) {
+    const Key point = L(index);
+    problem.pointOrdering.push_back(point);
+    problem.fullOrdering.push_back(point);
+    const double scale = 1.0 + 0.001 * static_cast<double>(index);
+    const double rhs = rhsScale * (0.25 + 0.0001 * index);
+    if (index < ordinaryCount) {
+      problem.graph.emplace_shared<JacobianFactor>(
+          point, scale * I_1x1, cameras[0], I_1x1, Vector1(rhs), unit);
+      problem.graph.emplace_shared<JacobianFactor>(
+          point, -scale * I_1x1, cameras[1], I_1x1, Vector1(-2.0 * rhs), unit);
+    } else {
+      using PointCameraBatch = BatchJacobianFactor<1, 1, 1, 1>;
+      auto observations = std::make_shared<PointCameraBatch>(
+          KeyVector{point, cameras[0], cameras[1]},
+          std::vector<size_t>{1, 1, 1});
+      observations->addRow({0, 1, 2}, {scale * I_1x1, I_1x1, -I_1x1},
+                           Vector1(rhs));
+      problem.graph.push_back(observations);
+    }
+  }
+
+  problem.fullOrdering.insert(problem.fullOrdering.end(),
+                              problem.cameraOrdering.begin(),
+                              problem.cameraOrdering.end());
+  for (const Key camera : cameras) {
+    problem.graph.emplace_shared<JacobianFactor>(camera, I_1x1, Vector1::Zero(),
+                                                 unit);
+  }
+  for (size_t first = 0; first < cameras.size(); ++first) {
+    for (size_t second = first + 1; second < cameras.size(); ++second) {
+      problem.graph.emplace_shared<JacobianFactor>(cameras[first], I_1x1,
+                                                   cameras[second], -I_1x1,
+                                                   Vector1::Zero(), unit);
+    }
+  }
+  return problem;
+}
+
 Problem createSingleJacobianProblem() {
   Problem problem = createProblem();
   problem.graph[0] = std::make_shared<JacobianFactor>(
@@ -471,8 +643,8 @@ Problem createSingleJacobianProblem() {
 
 Problem createIneligibleBatchProblem() {
   Problem problem = createProblem();
-  problem.graph.emplace_shared<JacobianFactor>(
-      X(0), I_1x1, Vector1::Zero(), noiseModel::Constrained::All(1));
+  problem.graph.emplace_shared<JacobianFactor>(X(0), I_1x1, Vector1::Zero(),
+                                               noiseModel::Constrained::All(1));
   return problem;
 }
 
@@ -734,6 +906,75 @@ TEST(MultifrontalSolver, FusedStarMultipleBatchFactors) {
       expected,
       solver.remainingFactorGraph().augmentedHessian(problem.cameraOrdering),
       1e-9));
+}
+
+// More than 1,024 deferred auto-QR leaves resolve to fused-star Cholesky and
+// agree across thread counts.
+TEST(MultifrontalSolver, ParallelParentFusedStar) {
+  using namespace compact_leaf_fixture;
+  constexpr size_t kChildren = 1025;
+  const Problem problem = createLargeFusedProblem(kChildren);
+  auto singleParams = fusedStarParams();
+  singleParams.qrMode = MultifrontalParameters::QRMode::Allow;
+  singleParams.numThreads = 1;
+  auto parallelParams = fusedStarParams();
+  parallelParams.qrMode = MultifrontalParameters::QRMode::Allow;
+  parallelParams.numThreads = 4;
+  MultifrontalSolver single(problem.graph, problem.fullOrdering, singleParams);
+  MultifrontalSolver parallel(problem.graph, problem.fullOrdering,
+                              parallelParams);
+  single.eliminateInPlace(problem.graph);
+  parallel.eliminateInPlace(problem.graph);
+  EXPECT_LONGS_EQUAL(kChildren, compactCliqueCount(&parallel));
+  EXPECT(
+      assert_equal(single.updateSolution(), parallel.updateSolution(), 1e-8));
+}
+
+// A single parent can combine column-owned ordinary updates with compute-once
+// fused updates, including permuted mappings, RHS terms, reload, and partial
+// elimination.
+TEST(MultifrontalSolver, ParallelParentMixedRepresentations) {
+  using namespace compact_leaf_fixture;
+  constexpr size_t kOrdinaryChildren = 513;
+  constexpr size_t kFusedChildren = 512;
+  const Problem problem =
+      createLargeMixedProblem(kOrdinaryChildren, kFusedChildren);
+  auto params = fusedStarParams();
+  params.compactCholeskySeparatorDimThreshold =
+      std::numeric_limits<size_t>::max();
+  auto singleParams = params;
+  singleParams.numThreads = 1;
+  auto parallelParams = params;
+  parallelParams.numThreads = 4;
+
+  MultifrontalSolver single(problem.graph, problem.fullOrdering, singleParams);
+  MultifrontalSolver parallel(problem.graph, problem.fullOrdering,
+                              parallelParams);
+  single.eliminateInPlace(problem.graph);
+  parallel.eliminateInPlace(problem.graph);
+  EXPECT_LONGS_EQUAL(kFusedChildren, compactCliqueCount(&parallel));
+  EXPECT(
+      assert_equal(single.updateSolution(), parallel.updateSolution(), 1e-8));
+
+  const Problem changed =
+      createLargeMixedProblem(kOrdinaryChildren, kFusedChildren, 0.5);
+  single.eliminateInPlace(changed.graph);
+  parallel.eliminateInPlace(changed.graph);
+  EXPECT(
+      assert_equal(single.updateSolution(), parallel.updateSolution(), 1e-8));
+
+  MultifrontalSolver singlePartial(problem.graph, problem.fullOrdering,
+                                   problem.pointOrdering.size(), singleParams);
+  MultifrontalSolver parallelPartial(problem.graph, problem.fullOrdering,
+                                     problem.pointOrdering.size(),
+                                     parallelParams);
+  singlePartial.eliminatePartialInPlace(problem.graph);
+  parallelPartial.eliminatePartialInPlace(problem.graph);
+  EXPECT(assert_equal(singlePartial.remainingFactorGraph().augmentedHessian(
+                          problem.cameraOrdering),
+                      parallelPartial.remainingFactorGraph().augmentedHessian(
+                          problem.cameraOrdering),
+                      1e-8));
 }
 
 // Same-separator leaf aggregation accepts fused children and preserves their

--- a/gtsam/sfm/sfm.md
+++ b/gtsam/sfm/sfm.md
@@ -45,7 +45,7 @@ The bespoke CUDA Schur path supports dense Cholesky, cuDSS, and PCG. `Full` is a
 :::{admonition} Fastest tested CPU path
 :class: tip sfm-fast-path
 
-For BAL-style problems, use **point-batched projection factors + `MULTIFRONTAL_SOLVER`** in a Release build with TBB enabled. Construct the complete ordering once with natural points followed by METIS cameras. `Full` was fastest on BAL-16 and BAL-88, while `Schur` was fastest on BAL-135, so these measurements do not identify one universally fastest elimination mode.
+For BAL-style problems, use **point-batched projection factors + `MULTIFRONTAL_SOLVER`** in a Release build with TBB enabled. Construct the complete ordering once with natural points followed by METIS cameras. `Full` and `Schur` were effectively tied on BAL-16, `Full` was fastest on BAL-88, and `Schur` was fastest on BAL-135, so these measurements do not identify one universally fastest elimination mode.
 
 Both modes use one cached, point-first multifrontal factorization. They do not materialize an intermediate reduced graph or invoke a second solver.
 :::
@@ -59,7 +59,7 @@ Both modes use one cached, point-first multifrontal factorization. They do not m
 
 CPU Schur partitioning eliminates active `Point3` and `Unit3` values while retaining every other value type, including poses, camera objects, and shared or per-camera calibrations. This value-based partition supports variable and global calibration without specializing the optimizer for one camera template.
 
-CPU and CUDA defaults reflect their current fast paths and graph support. CPU defaults to `Full`, `MULTIFRONTAL_SOLVER`, and an automatically generated natural-landmark prefix followed by a METIS ordering of the reduced system; that combination won BAL-16 and BAL-88 and was within 0.3% of Schur on BAL-135. CUDA defaults to `Schur` and keeps its existing camera/`Point3` backend assumptions.
+CPU and CUDA defaults reflect their current fast paths and graph support. CPU defaults to `Full`, `MULTIFRONTAL_SOLVER`, and an automatically generated natural-landmark prefix followed by a METIS ordering of the reduced system; that combination was effectively tied on BAL-16, won BAL-88, and was within 0.8% of Schur on BAL-135. CUDA defaults to `Schur` and keeps its existing camera/`Point3` backend assumptions.
 
 | Platform | Full | Schur | Linear solvers |
 | --- | --- | --- | --- |
@@ -151,12 +151,12 @@ CUDA SFM currently supports only its bespoke Schur path; selecting `SfmEliminati
 
 ## Performance at a glance
 
-The primary Release-mode benchmark compares the public CPU and CUDA fast paths on Ubuntu 24.04 with an **Intel Core i7-14700F (20 physical cores, 28 logical CPUs) and 31 GiB RAM**, plus an **NVIDIA GeForce RTX 5060 Ti with 16 GiB VRAM**. Values are median end-to-end optimization times from three runs.
+The primary Release-mode benchmark compares the public CPU and CUDA fast paths on Ubuntu 24.04 with an **Intel Core i7-14700F (20 physical cores, 28 logical CPUs) and 31 GiB RAM**, plus an **NVIDIA GeForce RTX 5060 Ti with 16 GiB VRAM**. CPU values are median end-to-end optimization times from three BAL-16/BAL-88 repetitions and seven separately invoked BAL-135 runs; CUDA values are medians from three runs.
 
 | Public optimizer path | BAL-16 s | BAL-88 s | BAL-135 s |
 | --- | ---: | ---: | ---: |
-| CPU Full + `MULTIFRONTAL_SOLVER` | **0.252** | **1.001** | 1.423 |
-| CPU Schur + `MULTIFRONTAL_SOLVER` | 0.258 | 1.003 | **1.419** |
+| CPU Full + `MULTIFRONTAL_SOLVER` | **0.228** | **0.869** | 1.437 |
+| CPU Schur + `MULTIFRONTAL_SOLVER` | **0.228** | 0.873 | **1.427** |
 | CUDA Schur + dense Cholesky | **0.055** | **0.218** | **0.290** |
 
 An [independent run](https://github.com/borglab/gtsam/pull/2727#issuecomment-5383045325) on a Ryzen 9 5900X (12C/24T) and RTX 5090 produced the following median times; parentheses show speedup relative to CUDA `schur-dense`.
@@ -174,7 +174,7 @@ Absolute times—and even the narrow Full-versus-Schur winner—vary with hardwa
 :::{admonition} Fast-path guidance
 :class: tip
 
-For CPU BAL-style problems, start with point-batched projection factors, the natural-points/METIS-cameras ordering, and `MULTIFRONTAL_SOLVER`. Full is the default and won two datasets; Schur was effectively tied and won the largest by only 0.25%. This benchmark does not measure parallel scaling, so physical core count alone is not a processor-performance prediction.
+For CPU BAL-style problems, start with point-batched projection factors, the natural-points/METIS-cameras ordering, and `MULTIFRONTAL_SOLVER`. Full is the default, tied Schur on BAL-16, and won BAL-88; Schur won BAL-135 by about 0.7%. This benchmark does not measure parallel scaling, so physical core count alone is not a processor-performance prediction.
 
 For CUDA at these problem sizes, use Schur with dense Cholesky. It was about 4.6–4.9× faster than the best CPU result. CUDA Full remains planned and is rejected rather than silently falling back to the CPU.
 :::

--- a/timing/README.md
+++ b/timing/README.md
@@ -178,6 +178,92 @@ spanning-tree builder only uses unary and binary factors, while these graphs
 contain higher-arity factors. Full multifrontal and sequential QR both reached
 the BAL-135 cap.
 
+### Hybrid multifrontal parent-gather acceptance
+
+The August 24, 2026 focused rerun measured the hybrid parent-gather candidate
+on the same i7-14700F host and toolchain. Three detached worktrees used
+identical CPU-only Release builds with TBB enabled:
+
+| Role | Measured commit | Rebased PR commit |
+| --- | --- | --- |
+| Original parent-gather baseline | `dd79e05e9` | not part of the PR |
+| Linear-cleanup reference plus timing harness | `f02e1bcb8` | `fe9a1352c` |
+| Hybrid parent-gather candidate | `bbd2864f9` | `b95413654` |
+
+`git range-diff` reports the cleanup and candidate patches as identical before
+and after the rebase.
+
+All processes were pinned to logical CPUs 0-20. The regular-factor benchmark
+also set `--threads 21` explicitly; the SFM benchmark used the solver's normal
+three-quarter-hardware default, which is 21 threads on this 28-CPU host. The
+build command for each worktree was:
+
+```bash
+cmake -S SOURCE -B BUILD -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  '-DCMAKE_CXX_FLAGS_RELEASE=-O3 -DNDEBUG' \
+  -DGTSAM_WITH_TBB=ON -DGTSAM_ENABLE_CUDA=OFF \
+  -DGTSAM_BUILD_TIMING_ALWAYS=ON -DGTSAM_BUILD_TESTS=OFF \
+  -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF -DGTSAM_BUILD_UNSTABLE=OFF \
+  -DGTSAM_BUILD_PYTHON=OFF
+cmake --build BUILD -j6 --target \
+  timeMultifrontalSolver timeSfmPartialElimination
+```
+
+The regular graph command measures two eliminate-and-solve iterations after
+one untimed warmup:
+
+```bash
+taskset -c 0-20 BUILD/timing/timeMultifrontalSolver \
+  --bal-dataset DATASET --samples SAMPLES --iterations 2 --threads 21
+```
+
+BAL-16 and BAL-88 are three-sample diagnostics. BAL-135 is the formal gate:
+seven separate one-sample baseline/candidate invocations, alternating which
+binary ran first. Negative changes are improvements.
+
+| Dataset | `dd79e05e9` s | `f02e1bcb8` s | `bbd2864f9` s | Candidate vs. original | Result |
+| --- | ---: | ---: | ---: | ---: | --- |
+| BAL-16 | 0.168448 | 0.168262 | 0.058755 | -65.1% | diagnostic pass |
+| BAL-88 | 2.608010 | 2.580410 | 0.942307 | -63.9% | diagnostic pass |
+| BAL-135 | 4.955640 | - | 2.199900 | **-55.6%** | **passes the 5% gate** |
+
+The point-batched public SFM path used one optimizer repetition per BAL-135
+invocation and cycled the baseline, cleanup, and candidate run order. BAL-16
+and BAL-88 used three repetitions per diagnostic invocation:
+
+```bash
+taskset -c 0-20 BUILD/timing/timeSfmPartialElimination \
+  --repetitions REPETITIONS --max-seconds 300 \
+  --configuration 'Full/MultifrontalSolver' examples/Data/DATASET
+# Repeat with Schur/MultifrontalSolver.
+```
+
+The no-regression limit is at most 3% slower than both references. All six
+candidate medians pass; negative percentages are faster.
+
+| Dataset | Mode | `dd79e05e9` s | `f02e1bcb8` s | `bbd2864f9` s | Vs. original | Vs. cleanup |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| BAL-16 | Full | 0.231144 | 0.230305 | 0.228180 | -1.3% | -0.9% |
+| BAL-16 | Schur | 0.230632 | 0.228250 | 0.228183 | -1.1% | -0.03% |
+| BAL-88 | Full | 0.889642 | 0.880253 | 0.868962 | -2.3% | -1.3% |
+| BAL-88 | Schur | 0.893126 | 0.877075 | 0.873318 | -2.2% | -0.4% |
+| BAL-135 | Full | 1.432247 | 1.429569 | 1.436844 | +0.3% | +0.5% |
+| BAL-135 | Schur | 1.421049 | 1.418110 | 1.426606 | +0.4% | +0.6% |
+
+Full and Schur produced identical results in every build: final objectives of
+18,033.914832, 291,581.106404, and 377,782.056028 with respectively 5/5, 4/4,
+and 2/2 LM/inner iterations on BAL-16, BAL-88, and BAL-135.
+
+Peak full-process RSS for the regular BAL-135 command fell from 4,065,540 KiB
+to 3,957,944 KiB, a reduction of 105.1 MiB (2.65%). The process peak includes
+the loaded graph and factorization state, so it understates the scratch-memory
+reduction itself.
+
+These focused results supersede only the two `MultifrontalSolver` rows when
+evaluating the hybrid gather change. The complete solver matrix above remains
+the August 21 record for comparisons with the other solver families.
+
 ### CUDA procedure and results
 
 The CUDA runs used point-batched graphs and Schur elimination. Each command was

--- a/timing/timeMultifrontalSolver.cpp
+++ b/timing/timeMultifrontalSolver.cpp
@@ -21,7 +21,12 @@
 #include <gtsam/linear/MultifrontalSolver.h>
 #include <tests/smallExample.h>
 
+#include <algorithm>
+#include <cstdlib>
 #include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 #include "internal/TimingUtils.h"
 #include "timeSFMBAL.h"
@@ -40,6 +45,65 @@ MultifrontalSolver::Parameters makeDefaultParams() {
   params.mergeDimCap = 32;
   // params.reportStream = &std::cout;
   return params;
+}
+
+struct Options {
+  bool bal135Only = false;
+  size_t balDataset = 0;
+  size_t samples = 1;
+  size_t iterations = 2;
+  size_t threads = 0;
+};
+
+size_t parsePositiveSize(const char* option, const char* value) {
+  size_t consumed = 0;
+  const std::string text(value);
+  const unsigned long long parsed = std::stoull(text, &consumed);
+  if (consumed != text.size() || parsed == 0) {
+    throw std::invalid_argument(std::string(option) +
+                                " requires a positive integer");
+  }
+  return static_cast<size_t>(parsed);
+}
+
+Options parseOptions(int argc, char** argv) {
+  Options options;
+  for (int i = 1; i < argc; ++i) {
+    const std::string option(argv[i]);
+    if (option == "--bal135-only") {
+      options.bal135Only = true;
+    } else if (option == "--bal-dataset" || option == "--samples" ||
+               option == "--iterations" || option == "--threads") {
+      if (++i >= argc) {
+        throw std::invalid_argument(option + " requires a value");
+      }
+      const size_t value = parsePositiveSize(option.c_str(), argv[i]);
+      if (option == "--bal-dataset") {
+        if (value != 16 && value != 88 && value != 135) {
+          throw std::invalid_argument(
+              "--bal-dataset requires one of 16, 88, or 135");
+        }
+        options.balDataset = value;
+      } else if (option == "--samples")
+        options.samples = value;
+      else if (option == "--iterations")
+        options.iterations = value;
+      else
+        options.threads = value;
+    } else if (option == "--help") {
+      cout << "Usage: timeMultifrontalSolver [--bal135-only] "
+              "[--bal-dataset 16|88|135] "
+              "[--samples N] [--iterations N] [--threads N]\n";
+      std::exit(0);
+    } else {
+      throw std::invalid_argument("unknown option: " + option);
+    }
+  }
+  if (options.bal135Only && options.balDataset != 0 &&
+      options.balDataset != 135) {
+    throw std::invalid_argument("--bal135-only conflicts with --bal-dataset");
+  }
+  return options;
 }
 
 }  // namespace
@@ -72,12 +136,28 @@ const string& bal88 = balDatasets[1];
 const string& bal135 = balDatasets[2];
 }  // namespace
 
-void runBAL135Benchmark(MultifrontalSolver::Parameters params) {
-  const size_t iterations = 1;
-  cout << "\nSingle MFS test: " << bal135 << " (iterations=" << iterations
-       << ")" << std::endl;
+const string& sampledBalDataset(size_t cameraCount) {
+  switch (cameraCount) {
+    case 16:
+      return bal16;
+    case 88:
+      return bal88;
+    case 135:
+      return bal135;
+    default:
+      throw std::invalid_argument("unsupported BAL camera count");
+  }
+}
 
-  const SfmData db = bal::loadDataset(bal135);
+void runSampledBALBenchmark(MultifrontalSolver::Parameters params,
+                            size_t cameraCount, size_t samples,
+                            size_t iterations) {
+  const string& filename = sampledBalDataset(cameraCount);
+  cout << "\nBAL-" << cameraCount << " sampled benchmark: " << filename
+       << " (samples=" << samples << ", iterations=" << iterations
+       << ", threads=" << params.numThreads << ")" << std::endl;
+
+  const SfmData db = bal::loadDataset(filename);
   const bal::BalBenchmarkConfig config;
   const NonlinearFactorGraph graph = bal::buildGeneralSfmGraph(db, config, 0.1);
   const Values initial = bal::buildGeneralSfmInitial(db);
@@ -85,10 +165,21 @@ void runBAL135Benchmark(MultifrontalSolver::Parameters params) {
   const Ordering ordering = bal::createSchurOrdering(db, false);
 
   MultifrontalSolver solver(linear, ordering, params);
-  const double imperativeSeconds = gtsam::timing::measureSeconds(
-      [&] { runMultifrontalSolver(solver, linear, iterations); });
-  cout << "  MultifrontalSolver: " << imperativeSeconds << " s" << std::endl;
-  tictoc_print();
+  runMultifrontalSolver(solver, linear, 1);  // Untimed warmup.
+  std::vector<double> timings;
+  timings.reserve(samples);
+  for (size_t sample = 0; sample < samples; ++sample) {
+    const double seconds = gtsam::timing::measureSeconds(
+        [&] { runMultifrontalSolver(solver, linear, iterations); });
+    timings.push_back(seconds);
+    cout << "  Sample " << sample + 1 << ": " << seconds << " s" << std::endl;
+  }
+  std::sort(timings.begin(), timings.end());
+  const size_t middle = timings.size() / 2;
+  const double median = timings.size() % 2 == 0
+                            ? 0.5 * (timings[middle - 1] + timings[middle])
+                            : timings[middle];
+  cout << "  Median: " << median << " s" << std::endl;
 }
 
 void runBALBenchmark(MultifrontalSolver::Parameters params) {
@@ -169,8 +260,7 @@ void tuneMergingBAL(MultifrontalSolver::Parameters params) {
   const size_t iterations = 2;
   const std::vector<std::string> balFiles = {bal16, bal88, bal135};
   cout << "\nTune leaf scheduling aggregation (BAL, iterations=" << iterations
-       << ")"
-       << std::endl;
+       << ")" << std::endl;
 
   const std::vector<size_t> sweep = {0, 64, 128, 256, 512, 1024, 2048};
   std::vector<std::vector<double>> results(
@@ -244,11 +334,18 @@ void tuneMergeChain(MultifrontalSolver::Parameters params) {
   }
 }
 
-int main() {
+int main(int argc, char** argv) {
+  const Options options = parseOptions(argc, argv);
   auto params = makeDefaultParams();
+  if (options.threads > 0) params.numThreads = options.threads;
   cout << "Merging dim parameter " << params.mergeDimCap << std::endl;
 
-  // runBAL135Benchmark(params);
+  const size_t sampledDataset = options.bal135Only ? 135 : options.balDataset;
+  if (sampledDataset != 0) {
+    runSampledBALBenchmark(params, sampledDataset, options.samples,
+                           options.iterations);
+    return 0;
+  }
   runBALBenchmark(params);
   runChainBenchmark(params);
   // runChain5000(params);


### PR DESCRIPTION
## Summary

Reduce TBB parent-update overhead in `MultifrontalSolver` without regressing compact point-batched Full or Schur SFM workloads.

The gather path now selects execution by update representation:

- materialized Cholesky updates use disjoint destination-column ownership;
- QR residual updates use destination-column ownership with bounded narrow scratch;
- compact and fused updates retain child-wise compute-once accumulation.

The stages run additively rather than writing concurrently. Same-separator aggregation, small-clique sequential execution, and the non-TBB implementation are unchanged. There are no public API, solver parameter, or default changes.

## Implementation

- Add a private reusable parent-gather plan after children resolve their final representations.
- Precompute materialized and QR children contributing to each destination column.
- Assign RHS cross-blocks to variable-column owners and reduce only the scalar RHS diagonal for column-owned updates.
- Keep compact and fused children on the existing compute-once reduction path.
- Add stress coverage for ordinary Cholesky, forced QR, compact/fused leaves, mixed representations, reloads, partial elimination, mappings, RHS terms, and more than 1,024 overlapping children.
- Extend `timeMultifrontalSolver` with sampled BAL dataset, iteration, sample, and thread selection while preserving its no-argument behavior.
- Record the full acceptance procedure and update the current CPU SFM guidance.

## Correctness

Full and Schur point-batched runs matched across the original baseline, cleanup reference, and candidate:

| Dataset | Final error | LM iterations | Inner iterations |
| --- | ---: | ---: | ---: |
| BAL-16 | 18,033.914832 | 5 | 5 |
| BAL-88 | 291,581.106404 | 4 | 4 |
| BAL-135 | 377,782.056028 | 2 | 2 |

## Performance

Measured on an Intel Core i7-14700F with CPU affinity fixed to logical CPUs 0-20, a 21-thread budget, GCC 13.3, Release `-O3 -DNDEBUG`, and TBB enabled.

The formal regular-factor BAL-135 gate used seven paired alternating samples, two eliminate-and-solve iterations per sample, and an untimed warmup per invocation:

| Reference | Median s |
| --- | ---: |
| Original parent gather | 4.955640 |
| Hybrid parent gather | 2.199900 |

This is a **55.6% reduction**, exceeding the required 5% improvement. Peak full-process RSS fell from 4,065,540 KiB to 3,957,944 KiB (105.1 MiB, 2.65%).

Point-batched SFM used seven separately invoked BAL-135 samples with cyclic run ordering. The candidate remained within the 3% no-regression limit against both references:

| Mode | Candidate median s | Vs. original | Vs. cleanup |
| --- | ---: | ---: | ---: |
| Full | 1.436844 | +0.3% | +0.5% |
| Schur | 1.426606 | +0.4% | +0.6% |

BAL-16 and BAL-88 regular, Full, and Schur diagnostic medians were all faster than both references. The complete commands, commits, medians, and memory results are recorded in `timing/README.md`.

## Validation

- `testMultifrontalSolver.run`
- `timeMultifrontalSolver` build
- `timeSfmPartialElimination` build
- BAL-16 and BAL-88 diagnostic timing/correctness runs
- BAL-135 seven-sample regular, Full, and Schur acceptance protocol
- `git range-diff` confirmed the multifrontal patches were unchanged by the final rebase onto `develop`
