### PR TITLE
Consolidate multifrontal block update plumbing

### DIFF
--- a/gtsam/base/SymmetricBlockMatrix.cpp
+++ b/gtsam/base/SymmetricBlockMatrix.cpp
@@ -11,7 +11,8 @@
 
 /**
  * @file    SymmetricBlockMatrix.cpp
- * @brief   Access to matrices via blocks of pre-defined sizes.  Used in GaussianFactor and GaussianConditional.
+ * @brief   Access to matrices via blocks of pre-defined sizes.  Used in
+ * GaussianFactor and GaussianConditional.
  * @author  Richard Roberts
  * @date    Sep 18, 2010
  */
@@ -38,8 +39,9 @@ SymmetricBlockMatrix SymmetricBlockMatrix::LikeActiveViewOf(
   SymmetricBlockMatrix result;
   result.variableColOffsets_.resize(other.nBlocks() + 1);
   for (size_t i = 0; i < result.variableColOffsets_.size(); ++i)
-    result.variableColOffsets_[i] = other.variableColOffsets_[other.blockStart_
-        + i] - other.variableColOffsets_[other.blockStart_];
+    result.variableColOffsets_[i] =
+        other.variableColOffsets_[other.blockStart_ + i] -
+        other.variableColOffsets_[other.blockStart_];
   result.matrix_.resize(other.cols(), other.cols());
   result.assertInvariants();
   return result;
@@ -51,8 +53,9 @@ SymmetricBlockMatrix SymmetricBlockMatrix::LikeActiveViewOf(
   SymmetricBlockMatrix result;
   result.variableColOffsets_.resize(other.nBlocks() + 1);
   for (size_t i = 0; i < result.variableColOffsets_.size(); ++i)
-    result.variableColOffsets_[i] = other.variableColOffsets_[other.blockStart_
-        + i] - other.variableColOffsets_[other.blockStart_];
+    result.variableColOffsets_[i] =
+        other.variableColOffsets_[other.blockStart_ + i] -
+        other.variableColOffsets_[other.blockStart_];
   result.matrix_.resize(other.cols(), other.cols());
   result.assertInvariants();
   return result;
@@ -143,16 +146,26 @@ void SymmetricBlockMatrix::updateFromMappedBlocks(
     const SymmetricBlockMatrix& other,
     const std::vector<DenseIndex>& blockIndices,
     const std::vector<DenseIndex>& scalarOffsets) {
-  assert(static_cast<DenseIndex>(blockIndices.size()) == other.nBlocks());
+  updateFromMappedBlocks(other, 0, blockIndices, scalarOffsets);
+}
+
+/* ************************************************************************* */
+void SymmetricBlockMatrix::updateFromMappedBlocks(
+    const SymmetricBlockMatrix& other, DenseIndex sourceBlockStart,
+    const std::vector<DenseIndex>& blockIndices,
+    const std::vector<DenseIndex>& scalarOffsets) {
+  assert(sourceBlockStart >= 0);
+  assert(sourceBlockStart + static_cast<DenseIndex>(blockIndices.size()) <=
+         other.nBlocks());
   assert(scalarOffsets.size() == blockIndices.size());
-  const DenseIndex otherBlocks = other.nBlocks();
+  const DenseIndex otherBlocks = static_cast<DenseIndex>(blockIndices.size());
   for (DenseIndex i = 0; i < otherBlocks; ++i) {
     const DenseIndex I = blockIndices[i];
     if (I < 0) continue;
     assert(I < nBlocks());
     const DenseIndex offsetI = scalarOffsets[i];
     assert(offsetI == blockScalarOffset(I));
-    updateDiagonalBlockAt(offsetI, other.diagonalBlock(i));
+    updateDiagonalBlockAt(offsetI, other.diagonalBlock(sourceBlockStart + i));
     for (DenseIndex j = i + 1; j < otherBlocks; ++j) {
       const DenseIndex J = blockIndices[j];
       if (J < 0) continue;
@@ -160,11 +173,71 @@ void SymmetricBlockMatrix::updateFromMappedBlocks(
       const DenseIndex offsetJ = scalarOffsets[j];
       assert(offsetJ == blockScalarOffset(J));
       if (I < J) {
-        updateOffDiagonalBlockAt(offsetI, offsetJ,
-                                 other.aboveDiagonalBlock(i, j));
+        updateOffDiagonalBlockAt(
+            offsetI, offsetJ,
+            other.aboveDiagonalBlock(sourceBlockStart + i,
+                                     sourceBlockStart + j));
       } else {
-        updateOffDiagonalBlockAt(offsetJ, offsetI,
-                                 other.aboveDiagonalBlock(i, j).transpose());
+        updateOffDiagonalBlockAt(
+            offsetJ, offsetI,
+            other.aboveDiagonalBlock(sourceBlockStart + i, sourceBlockStart + j)
+                .transpose());
+      }
+    }
+  }
+}
+
+/* ************************************************************************* */
+void SymmetricBlockMatrix::updateFromMappedBlockColumn(
+    const SymmetricBlockMatrix& other, DenseIndex sourceBlockStart,
+    DenseIndex ownedSourceBlock, const std::vector<DenseIndex>& blockIndices,
+    const std::vector<DenseIndex>& scalarOffsets, bool ownLastCrossBlock) {
+  assert(sourceBlockStart >= 0 && ownedSourceBlock >= 0);
+  assert(sourceBlockStart + static_cast<DenseIndex>(blockIndices.size()) <=
+         other.nBlocks());
+  assert(scalarOffsets.size() == blockIndices.size());
+  const DenseIndex mappedBlocks = static_cast<DenseIndex>(blockIndices.size());
+  assert(ownedSourceBlock < mappedBlocks);
+  const DenseIndex ownedTarget = blockIndices[ownedSourceBlock];
+  assert(ownedTarget >= 0 && ownedTarget < nBlocks());
+  const DenseIndex ownedOffset = scalarOffsets[ownedSourceBlock];
+  assert(ownedOffset == blockScalarOffset(ownedTarget));
+
+  updateDiagonalBlockAt(
+      ownedOffset, other.diagonalBlock(sourceBlockStart + ownedSourceBlock));
+  const internal::BlockColumnRange ownsColumn{ownedTarget, ownedTarget + 1};
+  for (DenseIndex otherSourceBlock = 0; otherSourceBlock < mappedBlocks;
+       ++otherSourceBlock) {
+    if (otherSourceBlock == ownedSourceBlock) continue;
+    const DenseIndex otherTarget = blockIndices[otherSourceBlock];
+    if (otherTarget < 0) continue;
+    assert(otherTarget < nBlocks());
+    const bool isLastCrossBlock =
+        ownLastCrossBlock && otherSourceBlock == mappedBlocks - 1;
+    if (!isLastCrossBlock && !ownsColumn.owns(ownedTarget, otherTarget)) {
+      continue;
+    }
+    const DenseIndex otherOffset = scalarOffsets[otherSourceBlock];
+    assert(otherOffset == blockScalarOffset(otherTarget));
+    if (otherSourceBlock < ownedSourceBlock) {
+      const auto sourceBlock =
+          other.aboveDiagonalBlock(sourceBlockStart + otherSourceBlock,
+                                   sourceBlockStart + ownedSourceBlock);
+      if (otherTarget < ownedTarget) {
+        updateOffDiagonalBlockAt(otherOffset, ownedOffset, sourceBlock);
+      } else {
+        updateOffDiagonalBlockAt(ownedOffset, otherOffset,
+                                 sourceBlock.transpose());
+      }
+    } else {
+      const auto sourceBlock =
+          other.aboveDiagonalBlock(sourceBlockStart + ownedSourceBlock,
+                                   sourceBlockStart + otherSourceBlock);
+      if (ownedTarget < otherTarget) {
+        updateOffDiagonalBlockAt(ownedOffset, otherOffset, sourceBlock);
+      } else {
+        updateOffDiagonalBlockAt(otherOffset, ownedOffset,
+                                 sourceBlock.transpose());
       }
     }
   }
@@ -193,5 +266,44 @@ void SymmetricBlockMatrix::updateFromOuterProductBlocks(
 }
 
 /* ************************************************************************* */
+void SymmetricBlockMatrix::updateFromOuterProductBlocks(
+    const VerticalBlockMatrix& other, DenseIndex sourceRowBegin,
+    DenseIndex sourceRowEnd, DenseIndex sourceBlockStart,
+    const std::vector<DenseIndex>& blockIndices,
+    const std::vector<DenseIndex>& scalarOffsets, double alpha) {
+  assert(sourceRowBegin >= 0 && sourceRowBegin <= sourceRowEnd);
+  assert(sourceRowEnd <= other.matrix().rows());
+  assert(sourceBlockStart >= 0);
+  assert(sourceBlockStart + static_cast<DenseIndex>(blockIndices.size()) <=
+         other.nBlocks());
+  assert(scalarOffsets.size() == blockIndices.size());
+  const DenseIndex otherBlocks = static_cast<DenseIndex>(blockIndices.size());
+  for (DenseIndex i = 0; i < otherBlocks; ++i) {
+    const DenseIndex I = blockIndices[i];
+    if (I < 0) continue;
+    assert(I < nBlocks());
+    const DenseIndex offsetI = scalarOffsets[i];
+    assert(offsetI == blockScalarOffset(I));
+    const auto Si =
+        other.blockRows(sourceBlockStart + i, sourceRowBegin, sourceRowEnd);
+    updateDiagonalBlockAt(offsetI, alpha * Si.transpose() * Si);
+    for (DenseIndex j = i + 1; j < otherBlocks; ++j) {
+      const DenseIndex J = blockIndices[j];
+      if (J < 0) continue;
+      assert(J < nBlocks());
+      const DenseIndex offsetJ = scalarOffsets[j];
+      assert(offsetJ == blockScalarOffset(J));
+      const auto Sj =
+          other.blockRows(sourceBlockStart + j, sourceRowBegin, sourceRowEnd);
+      if (I < J) {
+        updateOffDiagonalBlockAt(offsetI, offsetJ, alpha * Si.transpose() * Sj);
+      } else {
+        updateOffDiagonalBlockAt(offsetJ, offsetI, alpha * Sj.transpose() * Si);
+      }
+    }
+  }
+}
 
-} //\ namespace gtsam
+/* ************************************************************************* */
+
+}  // namespace gtsam

--- a/gtsam/base/SymmetricBlockMatrix.h
+++ b/gtsam/base/SymmetricBlockMatrix.h
@@ -10,11 +10,12 @@
 * -------------------------------------------------------------------------- */
 
 /**
-* @file    SymmetricBlockMatrix.h
-* @brief   Access to matrices via blocks of pre-defined sizes.  Used in GaussianFactor and GaussianConditional.
-* @author  Richard Roberts
-* @date    Sep 18, 2010
-*/
+ * @file    SymmetricBlockMatrix.h
+ * @brief   Access to matrices via blocks of pre-defined sizes.  Used in
+ * GaussianFactor and GaussianConditional.
+ * @author  Richard Roberts
+ * @date    Sep 18, 2010
+ */
 #pragma once
 
 #include <gtsam/base/FastVector.h>
@@ -24,10 +25,11 @@
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/nvp.hpp>
 #endif
+#include <algorithm>
+#include <array>
 #include <cassert>
 #include <cstring>
 #include <stdexcept>
-#include <array>
 #include <vector>
 
 namespace boost {
@@ -39,520 +41,583 @@ class access;
 namespace gtsam {
 
 namespace internal {
-class CompactLeafSchurKernel;
-}
 
-  // Forward declarations
-  class VerticalBlockMatrix;
+class CompactLeafSchurKernel;
+
+/** Half-open range of physical upper-triangular block columns. */
+struct BlockColumnRange {
+  DenseIndex begin;
+  DenseIndex end;
+
+  /// Return whether this range owns a physical block column.
+  bool operator()(DenseIndex column) const {
+    return column >= begin && column < end;
+  }
+
+  /// Return whether this range owns the stored block for logical indices I,J.
+  bool owns(DenseIndex I, DenseIndex J) const {
+    return (*this)(std::max(I, J));
+  }
+};
+}  // namespace internal
+
+// Forward declarations
+class VerticalBlockMatrix;
+
+/**
+ * This class stores a dense matrix and allows it to be accessed as a collection
+ * of blocks.  When constructed, the caller must provide the dimensions of the
+ * blocks.
+ *
+ * The block structure is symmetric, but the underlying matrix does not
+ * necessarily need to be.
+ *
+ * This class also has a parameter that can be changed after construction to
+ * change the apparent matrix view.  firstBlock() determines the block that
+ * appears to have index 0 for all operations (except re-setting firstBlock()).
+ *
+ * @ingroup base */
+class GTSAM_EXPORT SymmetricBlockMatrix {
+ public:
+  typedef SymmetricBlockMatrix This;
+  typedef Eigen::Block<Matrix> Block;
+  typedef Eigen::Block<const Matrix> constBlock;
+
+ protected:
+  Matrix matrix_;  ///< The full matrix
+  FastVector<DenseIndex>
+      variableColOffsets_;  ///< the starting columns of each block (0-based)
+
+  DenseIndex
+      blockStart_;  ///< Changes apparent matrix view, see main class comment.
+
+ public:
+  /// Construct from an empty matrix (asserts that the matrix is empty)
+  SymmetricBlockMatrix();
+
+  /// Construct from a container of the sizes of each block.
+  template <typename CONTAINER>
+  SymmetricBlockMatrix(const CONTAINER& dimensions,
+                       bool appendOneDimension = false)
+      : blockStart_(0) {
+    fillOffsets(dimensions.begin(), dimensions.end(), appendOneDimension);
+    matrix_.resize(variableColOffsets_.back(), variableColOffsets_.back());
+    assertInvariants();
+  }
+
+  /// Construct from iterator over the sizes of each vertical block.
+  template <typename ITERATOR>
+  SymmetricBlockMatrix(ITERATOR firstBlockDim, ITERATOR lastBlockDim,
+                       bool appendOneDimension = false)
+      : blockStart_(0) {
+    fillOffsets(firstBlockDim, lastBlockDim, appendOneDimension);
+    matrix_.resize(variableColOffsets_.back(), variableColOffsets_.back());
+    assertInvariants();
+  }
+
+  /// Construct from a container of the sizes of each vertical block and a
+  /// pre-prepared matrix.
+  template <typename CONTAINER>
+  SymmetricBlockMatrix(const CONTAINER& dimensions, const Matrix& matrix,
+                       bool appendOneDimension = false)
+      : blockStart_(0) {
+    matrix_.resize(matrix.rows(), matrix.cols());
+    matrix_.triangularView<Eigen::Upper>() =
+        matrix.triangularView<Eigen::Upper>();
+    fillOffsets(dimensions.begin(), dimensions.end(), appendOneDimension);
+    if (matrix_.rows() != matrix_.cols())
+      throw std::invalid_argument(
+          "Requested to create a SymmetricBlockMatrix from a non-square "
+          "matrix.");
+    if (variableColOffsets_.back() != matrix_.cols())
+      throw std::invalid_argument(
+          "Requested to create a SymmetricBlockMatrix with dimensions that do "
+          "not sum to the total size of the provided matrix.");
+    assertInvariants();
+  }
+
+  /// Copy the block structure, but do not copy the matrix data.  If
+  /// blockStart() has been modified, this copies the structure of the
+  /// corresponding matrix view. In the destination SymmetricBlockMatrix,
+  /// blockStart() will be 0.
+  static SymmetricBlockMatrix LikeActiveViewOf(
+      const SymmetricBlockMatrix& other);
+
+  /// Copy the block structure, but do not copy the matrix data. If blockStart()
+  /// has been modified, this copies the structure of the corresponding matrix
+  /// view. In the destination SymmetricBlockMatrix, blockStart() will be 0.
+  static SymmetricBlockMatrix LikeActiveViewOf(
+      const VerticalBlockMatrix& other);
+
+  /// Row size
+  DenseIndex rows() const {
+    assertInvariants();
+    return variableColOffsets_.back() - variableColOffsets_[blockStart_];
+  }
+
+  /// Column size
+  DenseIndex cols() const { return rows(); }
+
+  /// Block count
+  DenseIndex nBlocks() const { return nActualBlocks() - blockStart_; }
+
+  /// Number of dimensions for variable on this diagonal block.
+  DenseIndex getDim(DenseIndex block) const {
+    return calcIndices(block, block, 1, 1)[2];
+  }
+
+  /// Return the scalar offset of a block in the underlying matrix.
+  DenseIndex blockScalarOffset(DenseIndex block) const { return offset(block); }
+
+  /// @name Block getter methods.
+  /// @{
+
+  /// Get a copy of a block (anywhere in the matrix).
+  /// This method makes a copy - use the methods below if performance is
+  /// critical.
+  Matrix block(DenseIndex I, DenseIndex J) const;
+
+  /// Get a block view (anywhere in the matrix) without allocating a copy.
+  /// This method returns a const reference to the block for efficient read
+  /// access.
+  /// @param I The row block index.
+  /// @param J The column block index.
+  /// @return A const block view into the matrix.
+  constBlock blockView(DenseIndex I, DenseIndex J) const {
+    return block_(I, J);
+  }
+
+  /// Return the J'th diagonal block as a self adjoint view.
+  Eigen::SelfAdjointView<Block, Eigen::Upper> diagonalBlock(DenseIndex J) {
+    return block_(J, J).selfadjointView<Eigen::Upper>();
+  }
+
+  /// Return the J'th diagonal block as a self adjoint view.
+  Eigen::SelfAdjointView<constBlock, Eigen::Upper> diagonalBlock(
+      DenseIndex J) const {
+    return block_(J, J).selfadjointView<Eigen::Upper>();
+  }
+
+  /// Get the diagonal of the J'th diagonal block.
+  Vector diagonal(DenseIndex J) const { return block_(J, J).diagonal(); }
+
+  /// Get block above the diagonal (I, J).
+  constBlock aboveDiagonalBlock(DenseIndex I, DenseIndex J) const {
+    assert(I < J);
+    return block_(I, J);
+  }
+
+  /// Return the square sub-matrix that contains blocks(i:j, i:j).
+  Eigen::SelfAdjointView<constBlock, Eigen::Upper> selfadjointView(
+      DenseIndex I, DenseIndex J) const {
+    assert(J > I);
+    return block_(I, I, J - I, J - I).selfadjointView<Eigen::Upper>();
+  }
+
+  /// Return the square sub-matrix that contains blocks(i:j, i:j) as a
+  /// triangular view.
+  Eigen::TriangularView<constBlock, Eigen::Upper> triangularView(
+      DenseIndex I, DenseIndex J) const {
+    assert(J > I);
+    return block_(I, I, J - I, J - I).triangularView<Eigen::Upper>();
+  }
+
+  /// Get a range [i,j) from the matrix. Indices are in block units.
+  constBlock aboveDiagonalRange(DenseIndex i_startBlock, DenseIndex i_endBlock,
+                                DenseIndex j_startBlock,
+                                DenseIndex j_endBlock) const {
+    assert(i_startBlock < j_startBlock);
+    assert(i_endBlock <= j_startBlock);
+    return block_(i_startBlock, j_startBlock, i_endBlock - i_startBlock,
+                  j_endBlock - j_startBlock);
+  }
+
+  /// Get a range [i,j) from the matrix. Indices are in block units.
+  Block aboveDiagonalRange(DenseIndex i_startBlock, DenseIndex i_endBlock,
+                           DenseIndex j_startBlock, DenseIndex j_endBlock) {
+    assert(i_startBlock < j_startBlock);
+    assert(i_endBlock <= j_startBlock);
+    return block_(i_startBlock, j_startBlock, i_endBlock - i_startBlock,
+                  j_endBlock - j_startBlock);
+  }
+
+  /// @}
+  /// @name Block setter methods.
+  /// @{
+
+  /// Set a diagonal block. Only the upper triangular portion of `xpr` is
+  /// evaluated.
+  template <typename XprType>
+  void setDiagonalBlock(DenseIndex I, const XprType& xpr) {
+    block_(I, I).triangularView<Eigen::Upper>() =
+        xpr.template triangularView<Eigen::Upper>();
+  }
+
+  /// Set an off-diagonal block. Only the upper triangular portion of `xpr` is
+  /// evaluated.
+  template <typename XprType>
+  void setOffDiagonalBlock(DenseIndex I, DenseIndex J, const XprType& xpr) {
+    assert(I != J);
+    if (I < J) {
+      block_(I, J) = xpr;
+    } else {
+      block_(J, I) = xpr.transpose();
+    }
+  }
+
+  /// Increment the diagonal block by the values in `xpr`. Only reads the upper
+  /// triangular part of `xpr`.
+  template <typename XprType>
+  void updateDiagonalBlock(DenseIndex I, const XprType& xpr) {
+    // TODO(gareth): Eigen won't let us add triangular or self-adjoint views
+    // here, so we do it manually.
+    auto dest = block_(I, I);
+    assert(dest.rows() == xpr.rows());
+    assert(dest.cols() == xpr.cols());
+    for (DenseIndex col = 0; col < dest.cols(); ++col) {
+      for (DenseIndex row = 0; row <= col; ++row) {
+        dest(row, col) += xpr(row, col);
+      }
+    }
+  }
+
+  /// Increment a diagonal block using its cached scalar offset.
+  template <typename XprType>
+  void updateDiagonalBlockAt(DenseIndex scalarOffset, const XprType& xpr) {
+    auto dest =
+        matrix_.block(scalarOffset, scalarOffset, xpr.rows(), xpr.cols());
+    assert(dest.rows() == dest.cols());
+    for (DenseIndex col = 0; col < dest.cols(); ++col) {
+      for (DenseIndex row = 0; row <= col; ++row) {
+        dest(row, col) += xpr(row, col);
+      }
+    }
+  }
+
+  /// Increment a fixed-size diagonal block using its cached scalar offset.
+  template <int Dimension, typename XprType>
+  void updateFixedDiagonalBlockAt(DenseIndex scalarOffset, const XprType& xpr) {
+    auto dest = matrix_.template block<Dimension, Dimension>(scalarOffset,
+                                                             scalarOffset);
+    for (int col = 0; col < Dimension; ++col) {
+      for (int row = 0; row <= col; ++row) {
+        dest(row, col) += xpr(row, col);
+      }
+    }
+  }
+
+  /// Add a vector to the diagonal entries of block I.
+  void addToDiagonalBlock(DenseIndex I, const Vector& deltaDiag) {
+    auto dest = block_(I, I);
+    assert(dest.rows() == deltaDiag.size());
+    dest.diagonal().array() += deltaDiag.array();
+  }
+
+  /// Add lambda * I to the diagonal block I.
+  void addScaledIdentity(DenseIndex I, double lambda) {
+    auto dest = block_(I, I);
+    dest.diagonal().array() += lambda;
+  }
+
+  /// Update an off diagonal block.
+  /// NOTE(emmett): This assumes noalias().
+  template <typename XprType>
+  void updateOffDiagonalBlock(DenseIndex I, DenseIndex J, const XprType& xpr) {
+    assert(I != J);
+    if constexpr (XprType::SizeAtCompileTime == 1) {
+      if (I < J) {
+        auto destination = block_(I, J);
+        assert(destination.rows() == 1 && destination.cols() == 1);
+        destination(0, 0) += xpr.coeff(0, 0);
+      } else {
+        auto destination = block_(J, I);
+        assert(destination.rows() == 1 && destination.cols() == 1);
+        destination(0, 0) += xpr.coeff(0, 0);
+      }
+    } else {
+      if (I < J) {
+        block_(I, J).noalias() += xpr;
+      } else {
+        block_(J, I).noalias() += xpr.transpose();
+      }
+    }
+  }
+
+  /// Increment an upper off-diagonal block using cached scalar offsets.
+  template <typename XprType>
+  void updateOffDiagonalBlockAt(DenseIndex rowOffset, DenseIndex colOffset,
+                                const XprType& xpr) {
+    assert(rowOffset < colOffset);
+    if constexpr (XprType::SizeAtCompileTime == 1) {
+      matrix_(rowOffset, colOffset) += xpr.coeff(0, 0);
+    } else {
+      matrix_.block(rowOffset, colOffset, xpr.rows(), xpr.cols()) += xpr;
+    }
+  }
+
+  /// Increment a fixed-size upper block using cached scalar offsets.
+  template <int Rows, int Cols, typename XprType>
+  void updateFixedOffDiagonalBlockAt(DenseIndex rowOffset, DenseIndex colOffset,
+                                     const XprType& xpr) {
+    assert(rowOffset < colOffset);
+    if constexpr (Rows == 1 && Cols == 1) {
+      assert(xpr.rows() == 1 && xpr.cols() == 1);
+      matrix_(rowOffset, colOffset) += xpr.coeff(0, 0);
+    } else {
+      matrix_.template block<Rows, Cols>(rowOffset, colOffset) += xpr;
+    }
+  }
+
+  /// Update this matrix with blocks from another block matrix using a mapping.
+  /// Entries with index -1 are skipped.
+  void updateFromMappedBlocks(const SymmetricBlockMatrix& other,
+                              const std::vector<DenseIndex>& blockIndices);
+
+  /// Update mapped blocks using cached scalar offsets in this matrix.
+  void updateFromMappedBlocks(const SymmetricBlockMatrix& other,
+                              const std::vector<DenseIndex>& blockIndices,
+                              const std::vector<DenseIndex>& scalarOffsets);
 
   /**
-  * This class stores a dense matrix and allows it to be accessed as a collection of blocks.  When
-  * constructed, the caller must provide the dimensions of the blocks.
-  *
-  * The block structure is symmetric, but the underlying matrix does not necessarily need to be.
-  *
-  * This class also has a parameter that can be changed after construction to change the apparent
-  * matrix view.  firstBlock() determines the block that appears to have index 0 for all operations
-  * (except re-setting firstBlock()).
-  *
-  * @ingroup base */
-  class GTSAM_EXPORT SymmetricBlockMatrix
-  {
-  public:
-    typedef SymmetricBlockMatrix This;
-    typedef Eigen::Block<Matrix> Block;
-    typedef Eigen::Block<const Matrix> constBlock;
+   * Update mapped blocks from an explicit source-block range.
+   *
+   * This overload does not modify either matrix's active view. `blockIndices`
+   * maps source blocks beginning at `sourceBlockStart`; entries with index -1
+   * are skipped. `scalarOffsets` caches their scalar destinations.
+   */
+  void updateFromMappedBlocks(const SymmetricBlockMatrix& other,
+                              DenseIndex sourceBlockStart,
+                              const std::vector<DenseIndex>& blockIndices,
+                              const std::vector<DenseIndex>& scalarOffsets);
 
-  protected:
-    Matrix matrix_; ///< The full matrix
-    FastVector<DenseIndex> variableColOffsets_; ///< the starting columns of each block (0-based)
+  /**
+   * Update one mapped destination column from an explicit source range.
+   *
+   * The source block selected by `ownedSourceBlock` owns all stored blocks in
+   * its mapped physical column. When `ownLastCrossBlock` is true, it also owns
+   * its cross block with the last mapped block; the last diagonal is omitted
+   * so callers can reduce it separately.
+   */
+  void updateFromMappedBlockColumn(const SymmetricBlockMatrix& other,
+                                   DenseIndex sourceBlockStart,
+                                   DenseIndex ownedSourceBlock,
+                                   const std::vector<DenseIndex>& blockIndices,
+                                   const std::vector<DenseIndex>& scalarOffsets,
+                                   bool ownLastCrossBlock = false);
 
-    DenseIndex blockStart_; ///< Changes apparent matrix view, see main class comment.
+  /// Update this matrix with scaled blockwise outer products from a vertical
+  /// block matrix. Adds alpha * S_i^T S_j into block (I,J), using a block
+  /// mapping; entries with index -1 are skipped. The range to use is controlled
+  /// by other.firstBlock().
+  void updateFromOuterProductBlocks(const VerticalBlockMatrix& other,
+                                    const std::vector<DenseIndex>& blockIndices,
+                                    double alpha = 1.0);
 
-  public:
-    /// Construct from an empty matrix (asserts that the matrix is empty)
-    SymmetricBlockMatrix();
+  /**
+   * Update with mapped blockwise outer products from explicit source rows and
+   * blocks, without changing `other`'s active view.
+   */
+  void updateFromOuterProductBlocks(
+      const VerticalBlockMatrix& other, DenseIndex sourceRowBegin,
+      DenseIndex sourceRowEnd, DenseIndex sourceBlockStart,
+      const std::vector<DenseIndex>& blockIndices,
+      const std::vector<DenseIndex>& scalarOffsets, double alpha = 1.0);
 
-    /// Construct from a container of the sizes of each block.
-    template<typename CONTAINER>
-    SymmetricBlockMatrix(const CONTAINER& dimensions, bool appendOneDimension = false) :
-      blockStart_(0)
-    {
-      fillOffsets(dimensions.begin(), dimensions.end(), appendOneDimension);
-      matrix_.resize(variableColOffsets_.back(), variableColOffsets_.back());
-      assertInvariants();
+  /// Add the upper-triangular part of another symmetric block matrix.
+  void addUpperTriangular(const SymmetricBlockMatrix& other) {
+    assert(nBlocks() == other.nBlocks());
+    full().triangularView<Eigen::Upper>() += other.full();
+  }
+
+  /// @}
+  /// @name Accessing the full matrix.
+  /// @{
+
+  /// Get self adjoint view.
+  Eigen::SelfAdjointView<Block, Eigen::Upper> selfadjointView() {
+    return full().selfadjointView<Eigen::Upper>();
+  }
+
+  /// Get self adjoint view.
+  Eigen::SelfAdjointView<constBlock, Eigen::Upper> selfadjointView() const {
+    return full().selfadjointView<Eigen::Upper>();
+  }
+
+  /// Set the entire active matrix. Only reads the upper triangular part of
+  /// `xpr`.
+  template <typename XprType>
+  void setFullMatrix(const XprType& xpr) {
+    full().triangularView<Eigen::Upper>() =
+        xpr.template triangularView<Eigen::Upper>();
+  }
+
+  /// Set the entire *active* matrix zero.
+  void setZero() { full().triangularView<Eigen::Upper>().setZero(); }
+
+  /// Set entire matrix zero.
+  void setAllZero() { matrix_.setZero(); }
+
+  /// Set the block columns between beginCol (inclusive) and endCol (exclusive)
+  /// to zero.
+  void setZeroColumns(DenseIndex beginCol, DenseIndex endCol) {
+    assert(beginCol < endCol);
+    assert(beginCol >= 0);
+    assert(endCol >= 0);
+    assert(beginCol < nBlocks());
+    assert(endCol <= nBlocks());
+    static_assert(Matrix::IsRowMajor == 0,
+                  "setZeroColumns requires column-major storage.");
+
+    const DenseIndex denseBeginCol = offset(beginCol);
+    const DenseIndex denseEndCol = offset(endCol);
+
+    double* begin = matrix_.data() + denseBeginCol * matrix_.rows();
+    double* end = matrix_.data() + denseEndCol * matrix_.rows();
+
+    // Using memset for maximal compiler optimization.
+    memset(begin, 0, (end - begin) * sizeof(*begin));
+  }
+
+  /// Negate the entire active matrix.
+  void negate();
+
+  /// Invert the entire active matrix in place.
+  void invertInPlace();
+
+  /// @}
+
+  /// Retrieve or modify the first logical block, i.e. the block referenced by
+  /// block index 0. Blocks before it will be inaccessible, except by accessing
+  /// the underlying matrix using matrix().
+  DenseIndex& blockStart() { return blockStart_; }
+
+  /// Retrieve the first logical block, i.e. the block referenced by block index
+  /// 0. Blocks before it will be inaccessible, except by accessing the
+  /// underlying matrix using matrix().
+  DenseIndex blockStart() const { return blockStart_; }
+
+  /**
+   * Given the augmented Hessian [A1'A1 A1'A2 A1'b
+   *                              A2'A1 A2'A2 A2'b
+   *                               b'A1  b'A2  b'b]
+   * on x1 and x2, does partial Cholesky in-place to obtain [R Sd;0 L]  such
+   * that R'R  = A1'A1 R'Sd = [A1'A2 A1'b] L'L is the augmented Hessian on the
+   * the separator x2 R and Sd can be interpreted as a GaussianConditional |R*x1
+   * + S*x2 - d]^2
+   */
+  void choleskyPartial(DenseIndex nFrontals);
+
+  /**
+   * After partial Cholesky, we can optionally split off R and Sd, to be
+   * interpreted as a GaussianConditional |R*x1 + S*x2 - d]^2. We leave the
+   * symmetric lower block L in place, and adjust block_start so now *this
+   * refers to it.
+   */
+  VerticalBlockMatrix split(DenseIndex nFrontals);
+
+  /// I n-place version of split.
+  void split(DenseIndex nFrontals, VerticalBlockMatrix* RSd);
+
+ protected:
+  /// Number of offsets in the full matrix.
+  DenseIndex nOffsets() const { return variableColOffsets_.size(); }
+
+  /// Number of actual blocks in the full matrix.
+  DenseIndex nActualBlocks() const { return nOffsets() - 1; }
+
+  /// Get an offset for a block index (in the active view).
+  DenseIndex offset(DenseIndex block) const {
+    assert(block >= 0);
+    const DenseIndex actual_index = block + blockStart();
+    assert(actual_index < nOffsets());
+    return variableColOffsets_[actual_index];
+  }
+
+  /// Get an arbitrary block from the matrix. Indices are in block units.
+  constBlock block_(DenseIndex iBlock, DenseIndex jBlock,
+                    DenseIndex blockRows = 1, DenseIndex blockCols = 1) const {
+    const std::array<DenseIndex, 4> indices =
+        calcIndices(iBlock, jBlock, blockRows, blockCols);
+    return matrix_.block(indices[0], indices[1], indices[2], indices[3]);
+  }
+
+  /// Get an arbitrary block from the matrix. Indices are in block units.
+  Block block_(DenseIndex iBlock, DenseIndex jBlock, DenseIndex blockRows = 1,
+               DenseIndex blockCols = 1) {
+    const std::array<DenseIndex, 4> indices =
+        calcIndices(iBlock, jBlock, blockRows, blockCols);
+    return matrix_.block(indices[0], indices[1], indices[2], indices[3]);
+  }
+
+  /// Get the full matrix as a block.
+  constBlock full() const { return block_(0, 0, nBlocks(), nBlocks()); }
+
+  /// Get the full matrix as a block.
+  Block full() { return block_(0, 0, nBlocks(), nBlocks()); }
+
+  /// Compute the indices into the underlying matrix for a given block.
+  std::array<DenseIndex, 4> calcIndices(DenseIndex iBlock, DenseIndex jBlock,
+                                        DenseIndex blockRows,
+                                        DenseIndex blockCols) const {
+    assert(blockRows >= 0);
+    assert(blockCols >= 0);
+
+    // adjust indices to account for start and size of blocks
+    const DenseIndex denseI = offset(iBlock);
+    const DenseIndex denseJ = offset(jBlock);
+    const DenseIndex denseRows = offset(iBlock + blockRows) - denseI;
+    const DenseIndex denseCols = offset(jBlock + blockCols) - denseJ;
+    return {{denseI, denseJ, denseRows, denseCols}};
+  }
+
+  void assertInvariants() const {
+    assert(matrix_.rows() == matrix_.cols());
+    assert(matrix_.cols() == variableColOffsets_.back());
+    assert(blockStart_ < (DenseIndex)variableColOffsets_.size());
+  }
+
+  template <typename ITERATOR>
+  void fillOffsets(ITERATOR firstBlockDim, ITERATOR lastBlockDim,
+                   bool appendOneDimension) {
+    variableColOffsets_.resize((lastBlockDim - firstBlockDim) + 1 +
+                               (appendOneDimension ? 1 : 0));
+    variableColOffsets_[0] = 0;
+    DenseIndex j = 0;
+    for (ITERATOR dim = firstBlockDim; dim != lastBlockDim; ++dim) {
+      variableColOffsets_[j + 1] = variableColOffsets_[j] + *dim;
+      ++j;
     }
-
-    /// Construct from iterator over the sizes of each vertical block.
-    template<typename ITERATOR>
-    SymmetricBlockMatrix(ITERATOR firstBlockDim, ITERATOR lastBlockDim, bool appendOneDimension = false) :
-      blockStart_(0)
-    {
-      fillOffsets(firstBlockDim, lastBlockDim, appendOneDimension);
-      matrix_.resize(variableColOffsets_.back(), variableColOffsets_.back());
-      assertInvariants();
+    if (appendOneDimension) {
+      variableColOffsets_[j + 1] = variableColOffsets_[j] + 1;
+      ++j;
     }
-
-    /// Construct from a container of the sizes of each vertical block and a pre-prepared matrix.
-    template<typename CONTAINER>
-    SymmetricBlockMatrix(const CONTAINER& dimensions, const Matrix& matrix, bool appendOneDimension = false) :
-      blockStart_(0)
-    {
-      matrix_.resize(matrix.rows(), matrix.cols());
-      matrix_.triangularView<Eigen::Upper>() = matrix.triangularView<Eigen::Upper>();
-      fillOffsets(dimensions.begin(), dimensions.end(), appendOneDimension);
-      if(matrix_.rows() != matrix_.cols())
-        throw std::invalid_argument("Requested to create a SymmetricBlockMatrix from a non-square matrix.");
-      if(variableColOffsets_.back() != matrix_.cols())
-        throw std::invalid_argument("Requested to create a SymmetricBlockMatrix with dimensions that do not sum to the total size of the provided matrix.");
-      assertInvariants();
-    }
-
-    /// Copy the block structure, but do not copy the matrix data.  If blockStart() has been
-    /// modified, this copies the structure of the corresponding matrix view. In the destination
-    /// SymmetricBlockMatrix, blockStart() will be 0.
-    static SymmetricBlockMatrix LikeActiveViewOf(const SymmetricBlockMatrix& other);
-
-    /// Copy the block structure, but do not copy the matrix data. If blockStart() has been
-    /// modified, this copies the structure of the corresponding matrix view. In the destination
-    /// SymmetricBlockMatrix, blockStart() will be 0.
-    static SymmetricBlockMatrix LikeActiveViewOf(const VerticalBlockMatrix& other);
-
-    /// Row size
-    DenseIndex rows() const { assertInvariants(); return variableColOffsets_.back() - variableColOffsets_[blockStart_]; }
-
-    /// Column size
-    DenseIndex cols() const { return rows(); }
-
-    /// Block count
-    DenseIndex nBlocks() const { return nActualBlocks() - blockStart_; }
-
-    /// Number of dimensions for variable on this diagonal block.
-    DenseIndex getDim(DenseIndex block) const {
-      return calcIndices(block, block, 1, 1)[2];
-    }
-
-    /// Return the scalar offset of a block in the underlying matrix.
-    DenseIndex blockScalarOffset(DenseIndex block) const {
-      return offset(block);
-    }
-
-    /// @name Block getter methods.
-    /// @{
-
-    /// Get a copy of a block (anywhere in the matrix).
-    /// This method makes a copy - use the methods below if performance is critical.
-    Matrix block(DenseIndex I, DenseIndex J) const;
-
-    /// Get a block view (anywhere in the matrix) without allocating a copy.
-    /// This method returns a const reference to the block for efficient read access.
-    /// @param I The row block index.
-    /// @param J The column block index.
-    /// @return A const block view into the matrix.
-    constBlock blockView(DenseIndex I, DenseIndex J) const {
-      return block_(I, J);
-    }
-
-    /// Return the J'th diagonal block as a self adjoint view.
-    Eigen::SelfAdjointView<Block, Eigen::Upper> diagonalBlock(DenseIndex J) {
-      return block_(J, J).selfadjointView<Eigen::Upper>();
-    }
-
-    /// Return the J'th diagonal block as a self adjoint view.
-    Eigen::SelfAdjointView<constBlock, Eigen::Upper> diagonalBlock(DenseIndex J) const {
-      return block_(J, J).selfadjointView<Eigen::Upper>();
-    }
-
-    /// Get the diagonal of the J'th diagonal block.
-    Vector diagonal(DenseIndex J) const {
-      return block_(J, J).diagonal();
-    }
-
-    /// Get block above the diagonal (I, J).
-    constBlock aboveDiagonalBlock(DenseIndex I, DenseIndex J) const {
-      assert(I < J);
-      return block_(I, J);
-    }
-
-    /// Return the square sub-matrix that contains blocks(i:j, i:j).
-    Eigen::SelfAdjointView<constBlock, Eigen::Upper> selfadjointView(
-        DenseIndex I, DenseIndex J) const {
-      assert(J > I);
-      return block_(I, I, J - I, J - I).selfadjointView<Eigen::Upper>();
-    }
-
-    /// Return the square sub-matrix that contains blocks(i:j, i:j) as a triangular view.
-    Eigen::TriangularView<constBlock, Eigen::Upper> triangularView(DenseIndex I,
-                                                                   DenseIndex J) const {
-      assert(J > I);
-      return block_(I, I, J - I, J - I).triangularView<Eigen::Upper>();
-    }
-
-    /// Get a range [i,j) from the matrix. Indices are in block units.
-    constBlock aboveDiagonalRange(DenseIndex i_startBlock,
-                                  DenseIndex i_endBlock,
-                                  DenseIndex j_startBlock,
-                                  DenseIndex j_endBlock) const {
-      assert(i_startBlock < j_startBlock);
-      assert(i_endBlock <= j_startBlock);
-      return block_(i_startBlock, j_startBlock, i_endBlock - i_startBlock,
-                   j_endBlock - j_startBlock);
-    }
-
-    /// Get a range [i,j) from the matrix. Indices are in block units.
-    Block aboveDiagonalRange(DenseIndex i_startBlock, DenseIndex i_endBlock,
-                             DenseIndex j_startBlock, DenseIndex j_endBlock) {
-      assert(i_startBlock < j_startBlock);
-      assert(i_endBlock <= j_startBlock);
-      return block_(i_startBlock, j_startBlock, i_endBlock - i_startBlock,
-                   j_endBlock - j_startBlock);
-    }
-
-    /// @}
-    /// @name Block setter methods.
-    /// @{
-
-    /// Set a diagonal block. Only the upper triangular portion of `xpr` is evaluated.
-    template <typename XprType>
-    void setDiagonalBlock(DenseIndex I, const XprType& xpr) {
-      block_(I, I).triangularView<Eigen::Upper>() = xpr.template triangularView<Eigen::Upper>();
-    }
-
-    /// Set an off-diagonal block. Only the upper triangular portion of `xpr` is evaluated.
-    template <typename XprType>
-    void setOffDiagonalBlock(DenseIndex I, DenseIndex J, const XprType& xpr) {
-      assert(I != J);
-      if (I < J) {
-        block_(I, J) = xpr;
-      } else {
-        block_(J, I) = xpr.transpose();
-      }
-    }
-
-    /// Increment the diagonal block by the values in `xpr`. Only reads the upper triangular part of `xpr`.
-    template <typename XprType>
-    void updateDiagonalBlock(DenseIndex I, const XprType& xpr) {
-      // TODO(gareth): Eigen won't let us add triangular or self-adjoint views
-      // here, so we do it manually.
-      auto dest = block_(I, I);
-      assert(dest.rows() == xpr.rows());
-      assert(dest.cols() == xpr.cols());
-      for (DenseIndex col = 0; col < dest.cols(); ++col) {
-        for (DenseIndex row = 0; row <= col; ++row) {
-          dest(row, col) += xpr(row, col);
-        }
-      }
-    }
-
-    /// Increment a diagonal block using its cached scalar offset.
-    template <typename XprType>
-    void updateDiagonalBlockAt(DenseIndex scalarOffset,
-                               const XprType& xpr) {
-      auto dest = matrix_.block(scalarOffset, scalarOffset, xpr.rows(),
-                                xpr.cols());
-      assert(dest.rows() == dest.cols());
-      for (DenseIndex col = 0; col < dest.cols(); ++col) {
-        for (DenseIndex row = 0; row <= col; ++row) {
-          dest(row, col) += xpr(row, col);
-        }
-      }
-    }
-
-    /// Increment a fixed-size diagonal block using its cached scalar offset.
-    template <int Dimension, typename XprType>
-    void updateFixedDiagonalBlockAt(DenseIndex scalarOffset,
-                                    const XprType& xpr) {
-      auto dest = matrix_.template block<Dimension, Dimension>(scalarOffset,
-                                                               scalarOffset);
-      for (int col = 0; col < Dimension; ++col) {
-        for (int row = 0; row <= col; ++row) {
-          dest(row, col) += xpr(row, col);
-        }
-      }
-    }
-
-    /// Add a vector to the diagonal entries of block I.
-    void addToDiagonalBlock(DenseIndex I, const Vector& deltaDiag) {
-      auto dest = block_(I, I);
-      assert(dest.rows() == deltaDiag.size());
-      dest.diagonal().array() += deltaDiag.array();
-    }
-
-    /// Add lambda * I to the diagonal block I.
-    void addScaledIdentity(DenseIndex I, double lambda) {
-      auto dest = block_(I, I);
-      dest.diagonal().array() += lambda;
-    }
-
-    /// Update an off diagonal block.
-    /// NOTE(emmett): This assumes noalias().
-    template <typename XprType>
-    void updateOffDiagonalBlock(DenseIndex I, DenseIndex J, const XprType& xpr) {
-      assert(I != J);
-      if constexpr (XprType::SizeAtCompileTime == 1) {
-        if (I < J) {
-          auto destination = block_(I, J);
-          assert(destination.rows() == 1 && destination.cols() == 1);
-          destination(0, 0) += xpr.coeff(0, 0);
-        } else {
-          auto destination = block_(J, I);
-          assert(destination.rows() == 1 && destination.cols() == 1);
-          destination(0, 0) += xpr.coeff(0, 0);
-        }
-      } else {
-        if (I < J) {
-          block_(I, J).noalias() += xpr;
-        } else {
-          block_(J, I).noalias() += xpr.transpose();
-        }
-      }
-    }
-
-    /// Increment an upper off-diagonal block using cached scalar offsets.
-    template <typename XprType>
-    void updateOffDiagonalBlockAt(DenseIndex rowOffset, DenseIndex colOffset,
-                                  const XprType& xpr) {
-      assert(rowOffset < colOffset);
-      if constexpr (XprType::SizeAtCompileTime == 1) {
-        matrix_(rowOffset, colOffset) += xpr.coeff(0, 0);
-      } else {
-        matrix_.block(rowOffset, colOffset, xpr.rows(), xpr.cols()) += xpr;
-      }
-    }
-
-    /// Increment a fixed-size upper block using cached scalar offsets.
-    template <int Rows, int Cols, typename XprType>
-    void updateFixedOffDiagonalBlockAt(DenseIndex rowOffset,
-                                       DenseIndex colOffset,
-                                       const XprType& xpr) {
-      assert(rowOffset < colOffset);
-      if constexpr (Rows == 1 && Cols == 1) {
-        assert(xpr.rows() == 1 && xpr.cols() == 1);
-        matrix_(rowOffset, colOffset) += xpr.coeff(0, 0);
-      } else {
-        matrix_.template block<Rows, Cols>(rowOffset, colOffset) += xpr;
-      }
-    }
-
-    /// Update this matrix with blocks from another block matrix using a mapping.
-    /// Entries with index -1 are skipped.
-    void updateFromMappedBlocks(const SymmetricBlockMatrix& other,
-                                const std::vector<DenseIndex>& blockIndices);
-
-    /// Update mapped blocks using cached scalar offsets in this matrix.
-    void updateFromMappedBlocks(
-        const SymmetricBlockMatrix& other,
-        const std::vector<DenseIndex>& blockIndices,
-        const std::vector<DenseIndex>& scalarOffsets);
-
-    /// Update this matrix with scaled blockwise outer products from a vertical block matrix.
-    /// Adds alpha * S_i^T S_j into block (I,J), using a block mapping; entries with index -1 are skipped.
-    /// The range to use is controlled by other.firstBlock().
-    void updateFromOuterProductBlocks(const VerticalBlockMatrix& other,
-                                      const std::vector<DenseIndex>& blockIndices,
-                                      double alpha = 1.0);
-
-    /// Add the upper-triangular part of another symmetric block matrix.
-    void addUpperTriangular(const SymmetricBlockMatrix& other) {
-      assert(nBlocks() == other.nBlocks());
-      full().triangularView<Eigen::Upper>() += other.full();
-    }
-
-    /// @}
-    /// @name Accessing the full matrix.
-    /// @{
-
-    /// Get self adjoint view.
-    Eigen::SelfAdjointView<Block, Eigen::Upper> selfadjointView() {
-      return full().selfadjointView<Eigen::Upper>();
-    }
-
-    /// Get self adjoint view.
-    Eigen::SelfAdjointView<constBlock, Eigen::Upper> selfadjointView() const {
-      return full().selfadjointView<Eigen::Upper>();
-    }
-
-    /// Set the entire active matrix. Only reads the upper triangular part of `xpr`.
-    template <typename XprType>
-    void setFullMatrix(const XprType& xpr) {
-      full().triangularView<Eigen::Upper>() = xpr.template triangularView<Eigen::Upper>();
-    }
-
-    /// Set the entire *active* matrix zero.
-    void setZero() {
-      full().triangularView<Eigen::Upper>().setZero();
-    }
-
-    /// Set entire matrix zero.
-    void setAllZero() {
-      matrix_.setZero();
-    }
-
-    /// Set the block columns between beginCol (inclusive) and endCol (exclusive) to zero. 
-    void setZeroColumns(DenseIndex beginCol, DenseIndex endCol) {
-      assert(beginCol < endCol);
-      assert(beginCol >= 0);
-      assert(endCol >= 0);
-      assert(beginCol < nBlocks());
-      assert(endCol <= nBlocks());
-      static_assert(Matrix::IsRowMajor == 0, "setZeroColumns requires column-major storage.");
-
-      const DenseIndex denseBeginCol = offset(beginCol);
-      const DenseIndex denseEndCol = offset(endCol);
-
-      double *begin = matrix_.data() + denseBeginCol * matrix_.rows();
-      double *end = matrix_.data() + denseEndCol * matrix_.rows();
-
-      // Using memset for maximal compiler optimization.
-      memset(begin, 0, (end - begin) * sizeof(*begin));
-    }
-
-    /// Negate the entire active matrix.
-    void negate();
-
-    /// Invert the entire active matrix in place.
-    void invertInPlace();
-
-    /// @}
-
-    /// Retrieve or modify the first logical block, i.e. the block referenced by block index 0.
-    /// Blocks before it will be inaccessible, except by accessing the underlying matrix using
-    /// matrix().
-    DenseIndex& blockStart() { return blockStart_; }
-
-    /// Retrieve the first logical block, i.e. the block referenced by block index 0. Blocks before
-    /// it will be inaccessible, except by accessing the underlying matrix using matrix().
-    DenseIndex blockStart() const { return blockStart_; }
-
-    /**
-     * Given the augmented Hessian [A1'A1 A1'A2 A1'b
-     *                              A2'A1 A2'A2 A2'b
-     *                               b'A1  b'A2  b'b]
-     * on x1 and x2, does partial Cholesky in-place to obtain [R Sd;0 L]  such that
-     *   R'R  = A1'A1
-     *   R'Sd = [A1'A2 A1'b]
-     *   L'L is the augmented Hessian on the the separator x2
-     * R and Sd can be interpreted as a GaussianConditional |R*x1 + S*x2 - d]^2
-     */
-    void choleskyPartial(DenseIndex nFrontals);
-
-    /**
-     * After partial Cholesky, we can optionally split off R and Sd, to be interpreted as
-     * a GaussianConditional |R*x1 + S*x2 - d]^2. We leave the symmetric lower block L in place,
-     * and adjust block_start so now *this refers to it.
-     */
-    VerticalBlockMatrix split(DenseIndex nFrontals);
-
-    /// I n-place version of split.
-    void split(DenseIndex nFrontals, VerticalBlockMatrix* RSd);
-
-  protected:
-
-    /// Number of offsets in the full matrix.
-    DenseIndex nOffsets() const {
-      return variableColOffsets_.size();
-    }
-
-    /// Number of actual blocks in the full matrix.
-    DenseIndex nActualBlocks() const {
-      return nOffsets() - 1;
-    }
-
-    /// Get an offset for a block index (in the active view).
-    DenseIndex offset(DenseIndex block) const {
-      assert(block >= 0);
-      const DenseIndex actual_index = block + blockStart();
-      assert(actual_index < nOffsets());
-      return variableColOffsets_[actual_index];
-    }
-
-    /// Get an arbitrary block from the matrix. Indices are in block units.
-    constBlock block_(DenseIndex iBlock, DenseIndex jBlock,
-                      DenseIndex blockRows = 1, DenseIndex blockCols = 1) const {
-      const std::array<DenseIndex, 4> indices =
-          calcIndices(iBlock, jBlock, blockRows, blockCols);
-      return matrix_.block(indices[0], indices[1], indices[2], indices[3]);
-    }
-
-    /// Get an arbitrary block from the matrix. Indices are in block units.
-    Block block_(DenseIndex iBlock, DenseIndex jBlock, DenseIndex blockRows = 1,
-                 DenseIndex blockCols = 1) {
-      const std::array<DenseIndex, 4> indices =
-          calcIndices(iBlock, jBlock, blockRows, blockCols);
-      return matrix_.block(indices[0], indices[1], indices[2], indices[3]);
-    }
-
-    /// Get the full matrix as a block.
-    constBlock full() const {
-      return block_(0, 0, nBlocks(), nBlocks());
-    }
-
-    /// Get the full matrix as a block.
-    Block full() {
-      return block_(0, 0, nBlocks(), nBlocks());
-    }
-
-    /// Compute the indices into the underlying matrix for a given block.
-    std::array<DenseIndex, 4> calcIndices(DenseIndex iBlock, DenseIndex jBlock,
-                                          DenseIndex blockRows,
-                                          DenseIndex blockCols) const {
-      assert(blockRows >= 0);
-      assert(blockCols >= 0);
-
-      // adjust indices to account for start and size of blocks
-      const DenseIndex denseI = offset(iBlock);
-      const DenseIndex denseJ = offset(jBlock);
-      const DenseIndex denseRows = offset(iBlock + blockRows) - denseI;
-      const DenseIndex denseCols = offset(jBlock + blockCols) - denseJ;
-      return {{denseI, denseJ, denseRows, denseCols}};
-    }
-
-    void assertInvariants() const
-    {
-      assert(matrix_.rows() == matrix_.cols());
-      assert(matrix_.cols() == variableColOffsets_.back());
-      assert(blockStart_ < (DenseIndex)variableColOffsets_.size());
-    }
-
-    template<typename ITERATOR>
-    void fillOffsets(ITERATOR firstBlockDim, ITERATOR lastBlockDim, bool appendOneDimension)
-    {
-      variableColOffsets_.resize((lastBlockDim-firstBlockDim) + 1 + (appendOneDimension ? 1 : 0));
-      variableColOffsets_[0] = 0;
-      DenseIndex j=0;
-      for(ITERATOR dim=firstBlockDim; dim!=lastBlockDim; ++dim) {
-        variableColOffsets_[j+1] = variableColOffsets_[j] + *dim;
-        ++ j;
-      }
-      if(appendOneDimension)
-      {
-        variableColOffsets_[j+1] = variableColOffsets_[j] + 1;
-        ++ j;
-      }
-    }
+  }
 
     friend class VerticalBlockMatrix;
     friend class internal::CompactLeafSchurKernel;
-    template<typename SymmetricBlockMatrixType> friend class SymmetricBlockMatrixBlockExpr;
+  template <typename SymmetricBlockMatrixType>
+  friend class SymmetricBlockMatrixBlockExpr;
 
-  private:
+ private:
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
-    /** Serialization function */
-    friend class boost::serialization::access;
-    template<class ARCHIVE>
-    void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
-      // Fill in the lower triangle part of the matrix, so boost::serialization won't
-      // complain about uninitialized data with an input_stream_error exception
-      // http://www.boost.org/doc/libs/1_37_0/libs/serialization/doc/exceptions.html#stream_error
-      matrix_.triangularView<Eigen::Lower>() = matrix_.triangularView<Eigen::Upper>().transpose();
-      ar & BOOST_SERIALIZATION_NVP(matrix_);
-      ar & BOOST_SERIALIZATION_NVP(variableColOffsets_);
-      ar & BOOST_SERIALIZATION_NVP(blockStart_);
-    }
+  /** Serialization function */
+  friend class boost::serialization::access;
+  template <class ARCHIVE>
+  void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
+    // Fill in the lower triangle part of the matrix, so boost::serialization
+    // won't complain about uninitialized data with an input_stream_error
+    // exception
+    // http://www.boost.org/doc/libs/1_37_0/libs/serialization/doc/exceptions.html#stream_error
+    matrix_.triangularView<Eigen::Lower>() =
+        matrix_.triangularView<Eigen::Upper>().transpose();
+    ar& BOOST_SERIALIZATION_NVP(matrix_);
+    ar& BOOST_SERIALIZATION_NVP(variableColOffsets_);
+    ar& BOOST_SERIALIZATION_NVP(blockStart_);
+  }
 #endif
-  };
+};
 
-  /// Foward declare exception class
-  class CholeskyFailed;
+/// Foward declare exception class
+class CholeskyFailed;
 
-}
+}  // namespace gtsam

--- a/gtsam/base/VerticalBlockMatrix.h
+++ b/gtsam/base/VerticalBlockMatrix.h
@@ -11,261 +11,319 @@
 
 /**
  * @file    VerticalBlockMatrix.h
- * @brief   A matrix with column blocks of pre-defined sizes.  Used in JacobianFactor and
- *          GaussianConditional.
+ * @brief   A matrix with column blocks of pre-defined sizes.  Used in
+ * JacobianFactor and GaussianConditional.
  * @author  Richard Roberts
  * @date    Sep 18, 2010 */
 #pragma once
 
+#include <gtsam/base/FastVector.h>
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/MatrixSerialization.h>
-#include <gtsam/base/FastVector.h>
 
 #include <cassert>
 
 namespace gtsam {
 
-  // Forward declarations
-  class SymmetricBlockMatrix;
+// Forward declarations
+class SymmetricBlockMatrix;
 
-  /**
-   * This class stores a dense matrix and allows it to be accessed as a collection of vertical
-   * blocks. The dimensions of the blocks are provided when constructing this class.
-   *
-   * This class also has three parameters that can be changed after construction that change the
-   * apparent view of the matrix without any reallocation or data copying.  firstBlock() determines
-   * the block that has index 0 for all operations (except for re-setting firstBlock()).  rowStart()
-   * determines the apparent first row of the matrix for all operations (except for setting
-   * rowStart() and rowEnd()).  rowEnd() determines the apparent exclusive (one-past-the-last) last
-   * row for all operations.  To include all rows, rowEnd() should be set to the number of rows in
-   * the matrix (i.e. one after the last true row index).
-   *
-   * @ingroup base */
-  class GTSAM_EXPORT VerticalBlockMatrix
-  {
-  public:
-    typedef VerticalBlockMatrix This;
-    typedef Eigen::Block<Matrix> Block;
-    typedef Eigen::Block<const Matrix> constBlock;
+/**
+ * This class stores a dense matrix and allows it to be accessed as a collection
+ * of vertical blocks. The dimensions of the blocks are provided when
+ * constructing this class.
+ *
+ * This class also has three parameters that can be changed after construction
+ * that change the apparent view of the matrix without any reallocation or data
+ * copying.  firstBlock() determines the block that has index 0 for all
+ * operations (except for re-setting firstBlock()).  rowStart() determines the
+ * apparent first row of the matrix for all operations (except for setting
+ * rowStart() and rowEnd()).  rowEnd() determines the apparent exclusive
+ * (one-past-the-last) last row for all operations.  To include all rows,
+ * rowEnd() should be set to the number of rows in the matrix (i.e. one after
+ * the last true row index).
+ *
+ * @ingroup base */
+class GTSAM_EXPORT VerticalBlockMatrix {
+ public:
+  typedef VerticalBlockMatrix This;
+  typedef Eigen::Block<Matrix> Block;
+  typedef Eigen::Block<const Matrix> constBlock;
 
-  protected:
-    Matrix matrix_; ///< The full matrix
-    FastVector<DenseIndex> variableColOffsets_; ///< the starting columns of each block (0-based)
+ protected:
+  Matrix matrix_;  ///< The full matrix
+  FastVector<DenseIndex>
+      variableColOffsets_;  ///< the starting columns of each block (0-based)
 
-    DenseIndex rowStart_; ///< Changes apparent matrix view, see main class comment.
-    DenseIndex rowEnd_; ///< Changes apparent matrix view, see main class comment.
-    DenseIndex blockStart_; ///< Changes apparent matrix view, see main class comment.
+  DenseIndex
+      rowStart_;  ///< Changes apparent matrix view, see main class comment.
+  DenseIndex
+      rowEnd_;  ///< Changes apparent matrix view, see main class comment.
+  DenseIndex
+      blockStart_;  ///< Changes apparent matrix view, see main class comment.
 
-  public:
-    /** Construct an empty VerticalBlockMatrix */
-    VerticalBlockMatrix() : rowStart_(0), rowEnd_(0), blockStart_(0) {
-      variableColOffsets_.push_back(0);
-    }
+ public:
+  /** Construct an empty VerticalBlockMatrix */
+  VerticalBlockMatrix() : rowStart_(0), rowEnd_(0), blockStart_(0) {
+    variableColOffsets_.push_back(0);
+  }
 
-    // Destructor
-    ~VerticalBlockMatrix() = default;
+  // Destructor
+  ~VerticalBlockMatrix() = default;
 
-    // Copy constructor (default)
-    VerticalBlockMatrix(const VerticalBlockMatrix& other) = default;
+  // Copy constructor (default)
+  VerticalBlockMatrix(const VerticalBlockMatrix& other) = default;
 
-    // Copy assignment operator (default)
-    VerticalBlockMatrix& operator=(const VerticalBlockMatrix& other) = default;
+  // Copy assignment operator (default)
+  VerticalBlockMatrix& operator=(const VerticalBlockMatrix& other) = default;
 
-    // Move constructor
-    VerticalBlockMatrix(VerticalBlockMatrix&& other) noexcept
+  // Move constructor
+  VerticalBlockMatrix(VerticalBlockMatrix&& other) noexcept
       : matrix_(std::move(other.matrix_)),
         variableColOffsets_(std::move(other.variableColOffsets_)),
         rowStart_(other.rowStart_),
         rowEnd_(other.rowEnd_),
         blockStart_(other.blockStart_) {
+    other.rowStart_ = 0;
+    other.rowEnd_ = 0;
+    other.blockStart_ = 0;
+  }
+
+  // Move assignment operator
+  VerticalBlockMatrix& operator=(VerticalBlockMatrix&& other) noexcept {
+    if (this != &other) {
+      matrix_ = std::move(other.matrix_);
+      variableColOffsets_ = std::move(other.variableColOffsets_);
+      rowStart_ = other.rowStart_;
+      rowEnd_ = other.rowEnd_;
+      blockStart_ = other.blockStart_;
+
       other.rowStart_ = 0;
       other.rowEnd_ = 0;
       other.blockStart_ = 0;
     }
+    return *this;
+  }
 
-    // Move assignment operator
-    VerticalBlockMatrix& operator=(VerticalBlockMatrix&& other) noexcept {
-      if (this != &other) {
-        matrix_ = std::move(other.matrix_);
-        variableColOffsets_ = std::move(other.variableColOffsets_);
-        rowStart_ = other.rowStart_;
-        rowEnd_ = other.rowEnd_;
-        blockStart_ = other.blockStart_;
+  /** Construct from a container of the sizes of each vertical block. */
+  template <typename CONTAINER>
+  VerticalBlockMatrix(const CONTAINER& dimensions, DenseIndex height,
+                      bool appendOneDimension = false)
+      : variableColOffsets_(dimensions.size() + (appendOneDimension ? 2 : 1)),
+        rowStart_(0),
+        rowEnd_(height),
+        blockStart_(0) {
+    fillOffsets(dimensions.begin(), dimensions.end(), appendOneDimension);
+    matrix_.resize(height, variableColOffsets_.back());
+    assertInvariants();
+  }
 
-        other.rowStart_ = 0;
-        other.rowEnd_ = 0;
-        other.blockStart_ = 0;
-      }
-      return *this;
-    }
-
-    /** Construct from a container of the sizes of each vertical block. */
-    template<typename CONTAINER>
-    VerticalBlockMatrix(const CONTAINER& dimensions, DenseIndex height,
-        bool appendOneDimension = false) :
+  /** Construct from a container of the sizes of each vertical block and a
+   * pre-prepared matrix. */
+  template <typename CONTAINER, typename DERIVED>
+  VerticalBlockMatrix(const CONTAINER& dimensions,
+                      const Eigen::MatrixBase<DERIVED>& matrix,
+                      bool appendOneDimension = false)
+      : matrix_(matrix),
         variableColOffsets_(dimensions.size() + (appendOneDimension ? 2 : 1)),
-        rowStart_(0), rowEnd_(height), blockStart_(0) {
-      fillOffsets(dimensions.begin(), dimensions.end(), appendOneDimension);
-      matrix_.resize(height, variableColOffsets_.back());
-      assertInvariants();
+        rowStart_(0),
+        rowEnd_(matrix.rows()),
+        blockStart_(0) {
+    fillOffsets(dimensions.begin(), dimensions.end(), appendOneDimension);
+    if (variableColOffsets_.back() != matrix_.cols())
+      throw std::invalid_argument(
+          "Requested to create a VerticalBlockMatrix with dimensions that do "
+          "not sum to the total columns of the provided matrix.");
+    assertInvariants();
+  }
+
+  /** Construct from iterator over the sizes of each vertical block. */
+  template <typename ITERATOR>
+  VerticalBlockMatrix(ITERATOR firstBlockDim, ITERATOR lastBlockDim,
+                      DenseIndex height, bool appendOneDimension = false)
+      : variableColOffsets_((lastBlockDim - firstBlockDim) +
+                            (appendOneDimension ? 2 : 1)),
+        rowStart_(0),
+        rowEnd_(height),
+        blockStart_(0) {
+    fillOffsets(firstBlockDim, lastBlockDim, appendOneDimension);
+    matrix_.resize(height, variableColOffsets_.back());
+    assertInvariants();
+  }
+
+  /** Copy the block structure and resize the underlying matrix, but do not copy
+   * the matrix data. If blockStart(), rowStart(), and/or rowEnd() have been
+   * modified, this copies the structure of the corresponding matrix view. In
+   * the destination VerticalBlockView, blockStart() and rowStart() will thus be
+   * 0, rowEnd() will be cols() of the source VerticalBlockView, and the
+   *  underlying matrix will be the size of the view of the source matrix.  */
+  static VerticalBlockMatrix LikeActiveViewOf(const VerticalBlockMatrix& rhs);
+
+  /** Copy the block structure, but do not copy the matrix data. If blockStart()
+   * has been modified, this copies the structure of the corresponding matrix
+   * view. In the destination VerticalBlockMatrix, blockStart() will be 0. */
+  static VerticalBlockMatrix LikeActiveViewOf(const SymmetricBlockMatrix& rhs,
+                                              DenseIndex height);
+
+  /// Row size
+  DenseIndex rows() const {
+    assertInvariants();
+    return rowEnd_ - rowStart_;
+  }
+
+  /// Column size
+  DenseIndex cols() const {
+    assertInvariants();
+    return variableColOffsets_.back() - variableColOffsets_[blockStart_];
+  }
+
+  /// Block count
+  DenseIndex nBlocks() const {
+    assertInvariants();
+    return variableColOffsets_.size() - 1 - blockStart_;
+  }
+
+  /** Access a single block in the underlying matrix with read/write access */
+  Block operator()(DenseIndex block) { return range(block, block + 1); }
+
+  /** Access a const block view */
+  const constBlock operator()(DenseIndex block) const {
+    return range(block, block + 1);
+  }
+
+  /** access ranges of blocks at a time */
+  Block range(DenseIndex startBlock, DenseIndex endBlock) {
+    assertInvariants();
+    DenseIndex actualStartBlock = startBlock + blockStart_;
+    DenseIndex actualEndBlock = endBlock + blockStart_;
+    if (startBlock != 0 || endBlock != 0) {
+      checkBlock(actualStartBlock);
+      assert(actualEndBlock < (DenseIndex)variableColOffsets_.size());
     }
+    const DenseIndex startCol = variableColOffsets_[actualStartBlock];
+    const DenseIndex rangeCols = variableColOffsets_[actualEndBlock] - startCol;
+    return matrix_.block(rowStart_, startCol, this->rows(), rangeCols);
+  }
 
-    /** Construct from a container of the sizes of each vertical block and a pre-prepared matrix. */
-    template<typename CONTAINER, typename DERIVED>
-    VerticalBlockMatrix(const CONTAINER& dimensions,
-        const Eigen::MatrixBase<DERIVED>& matrix, bool appendOneDimension = false) :
-        matrix_(matrix), variableColOffsets_(dimensions.size() + (appendOneDimension ? 2 : 1)),
-        rowStart_(0), rowEnd_(matrix.rows()), blockStart_(0) {
-      fillOffsets(dimensions.begin(), dimensions.end(), appendOneDimension);
-      if (variableColOffsets_.back() != matrix_.cols())
-        throw std::invalid_argument(
-            "Requested to create a VerticalBlockMatrix with dimensions that do not sum to the total columns of the provided matrix.");
-      assertInvariants();
+  const constBlock range(DenseIndex startBlock, DenseIndex endBlock) const {
+    assertInvariants();
+    DenseIndex actualStartBlock = startBlock + blockStart_;
+    DenseIndex actualEndBlock = endBlock + blockStart_;
+    if (startBlock != 0 || endBlock != 0) {
+      checkBlock(actualStartBlock);
+      assert(actualEndBlock < (DenseIndex)variableColOffsets_.size());
     }
+    const DenseIndex startCol = variableColOffsets_[actualStartBlock];
+    const DenseIndex rangeCols = variableColOffsets_[actualEndBlock] - startCol;
+    return ((const Matrix&)matrix_)
+        .block(rowStart_, startCol, this->rows(), rangeCols);
+  }
 
-    /** Construct from iterator over the sizes of each vertical block. */
-    template<typename ITERATOR>
-    VerticalBlockMatrix(ITERATOR firstBlockDim, ITERATOR lastBlockDim,
-        DenseIndex height, bool appendOneDimension = false) :
-        variableColOffsets_((lastBlockDim-firstBlockDim) + (appendOneDimension ? 2 : 1)),
-        rowStart_(0), rowEnd_(height), blockStart_(0) {
-      fillOffsets(firstBlockDim, lastBlockDim, appendOneDimension);
-      matrix_.resize(height, variableColOffsets_.back());
-      assertInvariants();
-    }
+  /**
+   * Access one logical block over an explicit underlying row range.
+   *
+   * Unlike operator(), this accessor ignores rowStart() and rowEnd(), making
+   * concurrent const reads independent of mutable active-view state.
+   */
+  constBlock blockRows(DenseIndex block, DenseIndex beginRow,
+                       DenseIndex endRow) const {
+    assertInvariants();
+    assert(beginRow >= 0 && beginRow <= endRow && endRow <= matrix_.rows());
+    const DenseIndex actualBlock = block + blockStart_;
+    checkBlock(actualBlock);
+    const DenseIndex startCol = variableColOffsets_[actualBlock];
+    const DenseIndex blockCols =
+        variableColOffsets_[actualBlock + 1] - startCol;
+    return matrix_.block(beginRow, startCol, endRow - beginRow, blockCols);
+  }
 
-    /** Copy the block structure and resize the underlying matrix, but do not copy the matrix data.
-    *  If blockStart(), rowStart(), and/or rowEnd() have been modified, this copies the structure of
-    *  the corresponding matrix view. In the destination VerticalBlockView, blockStart() and
-    *  rowStart() will thus be 0, rowEnd() will be cols() of the source VerticalBlockView, and the
-    *  underlying matrix will be the size of the view of the source matrix.  */
-    static VerticalBlockMatrix LikeActiveViewOf(const VerticalBlockMatrix& rhs);
+  /** Return the full matrix, *not* including any portions excluded by
+   * rowStart(), rowEnd(), and firstBlock() */
+  Block full() { return range(0, nBlocks()); }
 
-    /** Copy the block structure, but do not copy the matrix data. If blockStart() has been
-    *   modified, this copies the structure of the corresponding matrix view. In the destination
-    *   VerticalBlockMatrix, blockStart() will be 0. */
-    static VerticalBlockMatrix LikeActiveViewOf(const SymmetricBlockMatrix& rhs, DenseIndex height);
+  /** Return the full matrix, *not* including any portions excluded by
+   * rowStart(), rowEnd(), and firstBlock() */
+  const constBlock full() const { return range(0, nBlocks()); }
 
-    /// Row size
-    DenseIndex rows() const { assertInvariants(); return rowEnd_ - rowStart_; }
+  DenseIndex offset(DenseIndex block) const {
+    assertInvariants();
+    DenseIndex actualBlock = block + blockStart_;
+    checkBlock(actualBlock);
+    return variableColOffsets_[actualBlock];
+  }
 
-    /// Column size
-    DenseIndex cols() const { assertInvariants(); return variableColOffsets_.back() - variableColOffsets_[blockStart_]; }
+  /** Get the apparent first row of the underlying matrix for all operations */
+  const DenseIndex& rowStart() const { return rowStart_; }
 
-    /// Block count
-    DenseIndex nBlocks() const { assertInvariants(); return variableColOffsets_.size() - 1 - blockStart_; }
+  /** Get or set the apparent first row of the underlying matrix for all
+   * operations */
+  DenseIndex& rowStart() { return rowStart_; }
 
-    /** Access a single block in the underlying matrix with read/write access */
-    Block operator()(DenseIndex block) { return range(block, block+1); }
+  /** Get the apparent last row (exclusive, i.e. rows() == rowEnd() -
+   * rowStart()) of the underlying matrix for all operations */
+  const DenseIndex& rowEnd() const { return rowEnd_; }
 
-    /** Access a const block view */
-    const constBlock operator()(DenseIndex block) const { return range(block, block+1); }
+  /** Get or set the apparent last row (exclusive, i.e. rows() == rowEnd() -
+   * rowStart()) of the underlying matrix for all operations */
+  DenseIndex& rowEnd() { return rowEnd_; }
 
-    /** access ranges of blocks at a time */
-    Block range(DenseIndex startBlock, DenseIndex endBlock) {
-      assertInvariants();
-      DenseIndex actualStartBlock = startBlock + blockStart_;
-      DenseIndex actualEndBlock = endBlock + blockStart_;
-      if(startBlock != 0 || endBlock != 0) {
-        checkBlock(actualStartBlock);
-        assert(actualEndBlock < (DenseIndex)variableColOffsets_.size());
-      }
-      const DenseIndex startCol = variableColOffsets_[actualStartBlock];
-      const DenseIndex rangeCols = variableColOffsets_[actualEndBlock] - startCol;
-      return matrix_.block(rowStart_, startCol, this->rows(), rangeCols);
-    }
+  /** Get the apparent first block for all operations */
+  const DenseIndex& firstBlock() const { return blockStart_; }
 
-    const constBlock range(DenseIndex startBlock, DenseIndex endBlock) const {
-      assertInvariants();
-      DenseIndex actualStartBlock = startBlock + blockStart_;
-      DenseIndex actualEndBlock = endBlock + blockStart_;
-      if(startBlock != 0 || endBlock != 0) {
-        checkBlock(actualStartBlock);
-        assert(actualEndBlock < (DenseIndex)variableColOffsets_.size());
-      }
-      const DenseIndex startCol = variableColOffsets_[actualStartBlock];
-      const DenseIndex rangeCols = variableColOffsets_[actualEndBlock] - startCol;
-      return ((const Matrix&)matrix_).block(rowStart_, startCol, this->rows(), rangeCols);
-    }
+  /** Get or set the apparent first block for all operations */
+  DenseIndex& firstBlock() { return blockStart_; }
 
-    /** Return the full matrix, *not* including any portions excluded by rowStart(), rowEnd(), and firstBlock() */
-    Block full() { return range(0, nBlocks()); }
+  /** Access to full matrix (*including* any portions excluded by rowStart(),
+   * rowEnd(), and firstBlock()) */
+  const Matrix& matrix() const { return matrix_; }
 
-    /** Return the full matrix, *not* including any portions excluded by rowStart(), rowEnd(), and firstBlock() */
-    const constBlock full() const { return range(0, nBlocks()); }
+  /** Non-const access to full matrix (*including* any portions excluded by
+   * rowStart(), rowEnd(), and firstBlock()) */
+  Matrix& matrix() { return matrix_; }
 
-    DenseIndex offset(DenseIndex block) const {
-      assertInvariants();
-      DenseIndex actualBlock = block + blockStart_;
-      checkBlock(actualBlock);
-      return variableColOffsets_[actualBlock];
-    }
+ protected:
+  void assertInvariants() const {
+    assert(matrix_.cols() == variableColOffsets_.back());
+    assert(blockStart_ < (DenseIndex)variableColOffsets_.size());
+    assert(rowStart_ <= matrix_.rows());
+    assert(rowEnd_ <= matrix_.rows());
+    assert(rowStart_ <= rowEnd_);
+  }
 
-    /** Get the apparent first row of the underlying matrix for all operations */
-    const DenseIndex& rowStart() const { return rowStart_; }
+  void checkBlock(DenseIndex block) const {
+    static_cast<void>(block);  // Disable unused varibale warnings.
+    assert(matrix_.cols() == variableColOffsets_.back());
+    assert(block < (DenseIndex)variableColOffsets_.size() - 1);
+    assert(variableColOffsets_[block] < matrix_.cols() &&
+           variableColOffsets_[block + 1] <= matrix_.cols());
+  }
 
-    /** Get or set the apparent first row of the underlying matrix for all operations */
-    DenseIndex& rowStart() { return rowStart_; }
+  template <typename ITERATOR>
+  void fillOffsets(ITERATOR firstBlockDim, ITERATOR lastBlockDim,
+                   bool appendOneDimension) {
+    variableColOffsets_[0] = 0;
+    DenseIndex j = 0;
+    for (ITERATOR dim = firstBlockDim; dim != lastBlockDim; ++dim, ++j)
+      variableColOffsets_[j + 1] = variableColOffsets_[j] + *dim;
+    if (appendOneDimension)
+      variableColOffsets_[j + 1] = variableColOffsets_[j] + 1;
+  }
 
-    /** Get the apparent last row (exclusive, i.e. rows() == rowEnd() - rowStart()) of the underlying matrix for all operations */
-    const DenseIndex& rowEnd() const { return rowEnd_; }
+  friend class SymmetricBlockMatrix;
 
-    /** Get or set the apparent last row (exclusive, i.e. rows() == rowEnd() - rowStart()) of the underlying matrix for all operations */
-    DenseIndex& rowEnd() { return rowEnd_; }
-
-    /** Get the apparent first block for all operations */
-    const DenseIndex& firstBlock() const { return blockStart_; }
-
-    /** Get or set the apparent first block for all operations */
-    DenseIndex& firstBlock() { return blockStart_; }
-
-    /** Access to full matrix (*including* any portions excluded by rowStart(), rowEnd(), and firstBlock()) */
-    const Matrix& matrix() const { return matrix_; }
-
-    /** Non-const access to full matrix (*including* any portions excluded by rowStart(), rowEnd(), and firstBlock()) */
-    Matrix& matrix() { return matrix_; }
-
-  protected:
-    void assertInvariants() const {
-      assert(matrix_.cols() == variableColOffsets_.back());
-      assert(blockStart_ < (DenseIndex)variableColOffsets_.size());
-      assert(rowStart_ <= matrix_.rows());
-      assert(rowEnd_ <= matrix_.rows());
-      assert(rowStart_ <= rowEnd_);
-    }
-
-    void checkBlock(DenseIndex block) const {
-      static_cast<void>(block); //Disable unused varibale warnings.
-      assert(matrix_.cols() == variableColOffsets_.back());
-      assert(block < (DenseIndex)variableColOffsets_.size() - 1);
-      assert(variableColOffsets_[block] < matrix_.cols() && variableColOffsets_[block+1] <= matrix_.cols());
-    }
-
-    template<typename ITERATOR>
-    void fillOffsets(ITERATOR firstBlockDim, ITERATOR lastBlockDim, bool appendOneDimension) {
-      variableColOffsets_[0] = 0;
-      DenseIndex j=0;
-      for(ITERATOR dim=firstBlockDim; dim!=lastBlockDim; ++dim, ++j)
-        variableColOffsets_[j+1] = variableColOffsets_[j] + *dim;
-      if(appendOneDimension)
-        variableColOffsets_[j+1] = variableColOffsets_[j] + 1;
-    }
-
-    friend class SymmetricBlockMatrix;
-
-  private:
+ private:
 #if GTSAM_ENABLE_BOOST_SERIALIZATION
-    /** Serialization function */
-    friend class boost::serialization::access;
-    template<class ARCHIVE>
-    void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
-      ar & BOOST_SERIALIZATION_NVP(matrix_);
-      ar & BOOST_SERIALIZATION_NVP(variableColOffsets_);
-      ar & BOOST_SERIALIZATION_NVP(rowStart_);
-      ar & BOOST_SERIALIZATION_NVP(rowEnd_);
-      ar & BOOST_SERIALIZATION_NVP(blockStart_);
-    }
+  /** Serialization function */
+  friend class boost::serialization::access;
+  template <class ARCHIVE>
+  void serialize(ARCHIVE& ar, const unsigned int /*version*/) {
+    ar& BOOST_SERIALIZATION_NVP(matrix_);
+    ar& BOOST_SERIALIZATION_NVP(variableColOffsets_);
+    ar& BOOST_SERIALIZATION_NVP(rowStart_);
+    ar& BOOST_SERIALIZATION_NVP(rowEnd_);
+    ar& BOOST_SERIALIZATION_NVP(blockStart_);
+  }
 #endif
-  };
+};
 
-}
+}  // namespace gtsam

--- a/gtsam/base/tests/testSymmetricBlockMatrix.cpp
+++ b/gtsam/base/tests/testSymmetricBlockMatrix.cpp
@@ -10,10 +10,10 @@
 * -------------------------------------------------------------------------- */
 
 /**
-* @file   testSymmetricBlockMatrix.cpp
-* @brief  Unit tests for SymmetricBlockMatrix class
-* @author Richard Roberts
-**/
+ * @file   testSymmetricBlockMatrix.cpp
+ * @brief  Unit tests for SymmetricBlockMatrix class
+ * @author Richard Roberts
+ **/
 
 #include <CppUnitLite/TestHarness.h>
 #include <gtsam/base/SymmetricBlockMatrix.h>
@@ -32,8 +32,7 @@ static SymmetricBlockMatrix testBlockMatrix(std::vector<size_t>{3, 2, 1},
 
 /* ************************************************************************* */
 // Read block accessors.
-TEST(SymmetricBlockMatrix, ReadBlocks)
-{
+TEST(SymmetricBlockMatrix, ReadBlocks) {
   // On the diagonal
   Matrix expected1 = Matrix{{22, 23}, {23, 29}};
   Matrix actual1 = testBlockMatrix.diagonalBlock(1);
@@ -47,11 +46,11 @@ TEST(SymmetricBlockMatrix, ReadBlocks)
 
 /* ************************************************************************* */
 // Write block setters.
-TEST(SymmetricBlockMatrix, WriteBlocks)
-{
+TEST(SymmetricBlockMatrix, WriteBlocks) {
   // On the diagonal
   Matrix expected1 = testBlockMatrix.diagonalBlock(1);
-  SymmetricBlockMatrix bm1 = SymmetricBlockMatrix::LikeActiveViewOf(testBlockMatrix);
+  SymmetricBlockMatrix bm1 =
+      SymmetricBlockMatrix::LikeActiveViewOf(testBlockMatrix);
 
   bm1.setDiagonalBlock(1, expected1);
   Matrix actual1 = bm1.diagonalBlock(1);
@@ -59,14 +58,16 @@ TEST(SymmetricBlockMatrix, WriteBlocks)
 
   // Above the diagonal
   Matrix expected2 = testBlockMatrix.aboveDiagonalBlock(0, 1);
-  SymmetricBlockMatrix bm2 = SymmetricBlockMatrix::LikeActiveViewOf(testBlockMatrix);
+  SymmetricBlockMatrix bm2 =
+      SymmetricBlockMatrix::LikeActiveViewOf(testBlockMatrix);
   bm2.setOffDiagonalBlock(0, 1, expected2);
   Matrix actual2 = bm2.aboveDiagonalBlock(0, 1);
   EXPECT(assert_equal(expected2, actual2));
 
   // Below the diagonal
   Matrix expected3 = testBlockMatrix.aboveDiagonalBlock(0, 1).transpose();
-  SymmetricBlockMatrix bm3 = SymmetricBlockMatrix::LikeActiveViewOf(testBlockMatrix);
+  SymmetricBlockMatrix bm3 =
+      SymmetricBlockMatrix::LikeActiveViewOf(testBlockMatrix);
   bm3.setOffDiagonalBlock(1, 0, expected3);
   Matrix actual3 = bm3.aboveDiagonalBlock(0, 1).transpose();
   EXPECT(assert_equal(expected3, actual3));
@@ -96,8 +97,7 @@ TEST(SymmetricBlockMatrix, setZeroColumns) {
 
 /* ************************************************************************* */
 // Verify block range access.
-TEST(SymmetricBlockMatrix, Ranges)
-{
+TEST(SymmetricBlockMatrix, Ranges) {
   // On the diagonal
   Matrix expected1 = Matrix{//
                             {22, 23, 24},
@@ -117,8 +117,7 @@ TEST(SymmetricBlockMatrix, Ranges)
 
 /* ************************************************************************* */
 // Exercise block expression helpers.
-TEST(SymmetricBlockMatrix, expressions)
-{
+TEST(SymmetricBlockMatrix, expressions) {
   const std::vector<size_t> dimensions{2, 3, 1};
   SymmetricBlockMatrix expected1(dimensions, Matrix{{0, 0, 0, 0, 0, 0},
                                                     {0, 0, 0, 0, 0, 0},
@@ -140,32 +139,39 @@ TEST(SymmetricBlockMatrix, expressions)
   SymmetricBlockMatrix bm1(dimensions);
   bm1.setZero();
   bm1.diagonalBlock(1).rankUpdate(a.transpose());
-  EXPECT(assert_equal(Matrix(expected1.selfadjointView()), bm1.selfadjointView()));
+  EXPECT(
+      assert_equal(Matrix(expected1.selfadjointView()), bm1.selfadjointView()));
 
   SymmetricBlockMatrix bm2(dimensions);
   bm2.setZero();
   bm2.updateOffDiagonalBlock(0, 1, b.transpose() * a);
-  EXPECT(assert_equal(Matrix(expected2.selfadjointView()), bm2.selfadjointView()));
+  EXPECT(
+      assert_equal(Matrix(expected2.selfadjointView()), bm2.selfadjointView()));
 
   SymmetricBlockMatrix bm3(dimensions);
   bm3.setZero();
   bm3.updateOffDiagonalBlock(1, 0, a.transpose() * b);
-  EXPECT(assert_equal(Matrix(expected2.selfadjointView()), bm3.selfadjointView()));
+  EXPECT(
+      assert_equal(Matrix(expected2.selfadjointView()), bm3.selfadjointView()));
 
   SymmetricBlockMatrix bm4(dimensions);
   bm4.setZero();
   bm4.updateDiagonalBlock(1, expected1.diagonalBlock(1));
-  EXPECT(assert_equal(Matrix(expected1.selfadjointView()), bm4.selfadjointView()));
+  EXPECT(
+      assert_equal(Matrix(expected1.selfadjointView()), bm4.selfadjointView()));
 
   SymmetricBlockMatrix bm5(dimensions);
   bm5.setZero();
   bm5.updateOffDiagonalBlock(0, 1, expected2.aboveDiagonalBlock(0, 1));
-  EXPECT(assert_equal(Matrix(expected2.selfadjointView()), bm5.selfadjointView()));
+  EXPECT(
+      assert_equal(Matrix(expected2.selfadjointView()), bm5.selfadjointView()));
 
   SymmetricBlockMatrix bm6(dimensions);
   bm6.setZero();
-  bm6.updateOffDiagonalBlock(1, 0, expected2.aboveDiagonalBlock(0, 1).transpose());
-  EXPECT(assert_equal(Matrix(expected2.selfadjointView()), bm6.selfadjointView()));
+  bm6.updateOffDiagonalBlock(1, 0,
+                             expected2.aboveDiagonalBlock(0, 1).transpose());
+  EXPECT(
+      assert_equal(Matrix(expected2.selfadjointView()), bm6.selfadjointView()));
 }
 
 /* ************************************************************************* */
@@ -194,8 +200,7 @@ TEST(SymmetricBlockMatrix, AddDiagonal) {
 
 /* ************************************************************************* */
 // Update via block mapping.
-TEST(SymmetricBlockMatrix, UpdateFromMappedBlocks)
-{
+TEST(SymmetricBlockMatrix, UpdateFromMappedBlocks) {
   const std::vector<size_t> destDims{1, 3, 2};
   const std::vector<DenseIndex> mapping{1, 2, 0};
 
@@ -233,9 +238,65 @@ TEST(SymmetricBlockMatrix, UpdateFromMappedBlocks)
 }
 
 /* ************************************************************************* */
+// Explicit source ranges and disjoint columns reconstruct a permuted update.
+TEST(SymmetricBlockMatrix, UpdateFromMappedBlockColumns) {
+  const std::vector<size_t> destinationDims{1, 2};
+  const std::vector<DenseIndex> mapping{1, 0};
+  const std::vector<DenseIndex> scalarOffsets{1, 0};
+
+  SymmetricBlockMatrix expected(destinationDims);
+  expected.setZero();
+  expected.updateFromMappedBlocks(testBlockMatrix, 1, mapping, scalarOffsets);
+
+  SymmetricBlockMatrix actual(destinationDims);
+  actual.setZero();
+  actual.updateFromMappedBlockColumn(testBlockMatrix, 1, 0, mapping,
+                                     scalarOffsets);
+  actual.updateFromMappedBlockColumn(testBlockMatrix, 1, 1, mapping,
+                                     scalarOffsets);
+  EXPECT(assert_equal(Matrix(expected.selfadjointView()),
+                      Matrix(actual.selfadjointView())));
+
+  const std::vector<DenseIndex> skippedMapping{1, -1};
+  const std::vector<DenseIndex> skippedOffsets{1, -1};
+  expected.setZero();
+  expected.updateFromMappedBlocks(testBlockMatrix, 1, skippedMapping,
+                                  skippedOffsets);
+  actual.setZero();
+  actual.updateFromMappedBlockColumn(testBlockMatrix, 1, 0, skippedMapping,
+                                     skippedOffsets);
+  EXPECT(assert_equal(Matrix(expected.selfadjointView()),
+                      Matrix(actual.selfadjointView())));
+}
+
+/* ************************************************************************* */
+// Variable-owned RHS cross blocks plus one RHS reduction reconstruct the
+// update.
+TEST(SymmetricBlockMatrix, UpdateFromMappedBlockColumnsVariableOwnsRhs) {
+  const std::vector<DenseIndex> mapping{1, 0, 2};
+  const std::vector<DenseIndex> scalarOffsets{2, 0, 5};
+  const std::vector<size_t> destinationDims{2, 3};
+
+  SymmetricBlockMatrix expected(destinationDims, true);
+  expected.setZero();
+  expected.updateFromMappedBlocks(testBlockMatrix, 0, mapping, scalarOffsets);
+
+  SymmetricBlockMatrix actual(destinationDims, true);
+  actual.setZero();
+  actual.updateFromMappedBlockColumn(testBlockMatrix, 0, 0, mapping,
+                                     scalarOffsets, true);
+  actual.updateFromMappedBlockColumn(testBlockMatrix, 0, 1, mapping,
+                                     scalarOffsets, true);
+  actual.updateDiagonalBlockAt(
+      scalarOffsets.back(),
+      testBlockMatrix.diagonalBlock(testBlockMatrix.nBlocks() - 1));
+  EXPECT(assert_equal(Matrix(expected.selfadjointView()),
+                      Matrix(actual.selfadjointView())));
+}
+
+/* ************************************************************************* */
 // Update via blockwise outer products from a VerticalBlockMatrix view.
-TEST(SymmetricBlockMatrix, UpdateFromOuterProductBlocks)
-{
+TEST(SymmetricBlockMatrix, UpdateFromOuterProductBlocks) {
   const std::vector<size_t> vbmDims{2, 1};
   VerticalBlockMatrix vbm(vbmDims, 4, true);
   vbm.matrix() = Matrix{//
@@ -253,6 +314,33 @@ TEST(SymmetricBlockMatrix, UpdateFromOuterProductBlocks)
   vbm.firstBlock() = 1;
   actual.updateFromOuterProductBlocks(vbm, mapping);
   EXPECT(assert_equal(expected, Matrix(actual.selfadjointView())));
+}
+
+/* ************************************************************************* */
+// Explicit outer-product ranges do not mutate the source active view.
+TEST(SymmetricBlockMatrix, UpdateFromExplicitOuterProductBlocks) {
+  const std::vector<size_t> vbmDims{2, 1};
+  VerticalBlockMatrix vbm(vbmDims, 4, true);
+  vbm.matrix() = Matrix{//
+                        {1, 2, 3, 4},
+                        {5, 6, 7, 8},
+                        {9, 10, 11, 12},
+                        {13, 14, 15, 16}};
+
+  const std::vector<size_t> destinationDims{1};
+  const std::vector<DenseIndex> mapping{0, 1};
+  const std::vector<DenseIndex> scalarOffsets{0, 1};
+  SymmetricBlockMatrix actual(destinationDims, true);
+  actual.setZero();
+  const Matrix S = vbm.matrix().block(1, 2, 3, 2);
+  const Matrix expected = -2.0 * S.transpose() * S;
+
+  actual.updateFromOuterProductBlocks(vbm, 1, 4, 1, mapping, scalarOffsets,
+                                      -2.0);
+  EXPECT(assert_equal(expected, Matrix(actual.selfadjointView())));
+  LONGS_EQUAL(0, vbm.rowStart());
+  LONGS_EQUAL(4, vbm.rowEnd());
+  LONGS_EQUAL(0, vbm.firstBlock());
 }
 
 /* ************************************************************************* */
@@ -275,5 +363,8 @@ TEST(SymmetricBlockMatrix, inverseInPlace) {
 }
 
 /* ************************************************************************* */
-int main() { TestResult tr; return TestRegistry::runAllTests(tr); }
+int main() {
+  TestResult tr;
+  return TestRegistry::runAllTests(tr);
+}
 /* ************************************************************************* */

--- a/gtsam/linear/BatchJacobianFactor.h
+++ b/gtsam/linear/BatchJacobianFactor.h
@@ -22,8 +22,8 @@
 #include <gtsam/base/VerticalBlockMatrix.h>
 #include <gtsam/base/timing.h>
 #include <gtsam/dllexport.h>
-#include <gtsam/linear/GaussianFactor.h>
 #include <gtsam/linear/FlatGaussianFactor.h>
+#include <gtsam/linear/GaussianFactor.h>
 #include <gtsam/linear/JacobianFactor.h>
 #include <gtsam/linear/NoiseModel.h>
 #include <gtsam/linear/VectorValues.h>
@@ -451,7 +451,7 @@ class BatchJacobianFactor : public BatchJacobianFactorBase {
   /// Return whether a block slot lies in the requested Hessian column range.
   static bool slotInRange(DenseIndex slot, DenseIndex beginCol,
                           DenseIndex endCol) {
-    return slot >= beginCol && slot < endCol;
+    return internal::BlockColumnRange{beginCol, endCol}(slot);
   }
 
   /**
@@ -470,9 +470,9 @@ class BatchJacobianFactor : public BatchJacobianFactorBase {
     if constexpr (Slot == NumSlots) {
       const RhsVector& b = rhs_[rowIndex];
       Eigen::Matrix<double, 1, 1> contribution;
-      contribution(0, 0) =
-          weights ? (weights->array() * b.array().square()).sum()
-                  : b.squaredNorm();
+      contribution(0, 0) = weights
+                               ? (weights->array() * b.array().square()).sum()
+                               : b.squaredNorm();
       if (targetScalarOffset >= 0) {
         info->updateFixedDiagonalBlockAt<1>(targetScalarOffset, contribution);
       } else {
@@ -513,8 +513,8 @@ class BatchJacobianFactor : public BatchJacobianFactorBase {
     static_assert(Rows != Eigen::Dynamic && Cols != Eigen::Dynamic);
     if (scalarOffsetI >= 0 && scalarOffsetJ >= 0) {
       if (targetI < targetJ) {
-        info->updateFixedOffDiagonalBlockAt<Rows, Cols>(
-            scalarOffsetI, scalarOffsetJ, block);
+        info->updateFixedOffDiagonalBlockAt<Rows, Cols>(scalarOffsetI,
+                                                        scalarOffsetJ, block);
       } else {
         info->updateFixedOffDiagonalBlockAt<Cols, Rows>(
             scalarOffsetJ, scalarOffsetI, block.transpose());
@@ -568,8 +568,7 @@ class BatchJacobianFactor : public BatchJacobianFactorBase {
       const auto& Aj = std::get<J>(blocks_)[rowIndex];
       Eigen::Matrix<double, BlockDimI, BlockDimJ> contribution;
       if (weights) {
-        contribution.noalias() =
-            Ai.transpose() * weights->asDiagonal() * Aj;
+        contribution.noalias() = Ai.transpose() * weights->asDiagonal() * Aj;
       } else {
         contribution.noalias() = Ai.transpose() * Aj;
       }
@@ -594,15 +593,11 @@ class BatchJacobianFactor : public BatchJacobianFactorBase {
     ((mappedSlots[Is] >= 0 && targetSlot >= 0 &&
               slotInRange(std::max(mappedSlots[Is], targetSlot), beginCol,
                           endCol)
-          ? updateAugmentedOffDiagonal<Is, J>(rowIndex, mappedSlots[Is],
-                                              targetSlot,
-                                              mappedScalarOffsets
-                                                  ? mappedScalarOffsets[Is]
-                                                  : -1,
-                                              mappedScalarOffsets
-                                                  ? mappedScalarOffsets[J]
-                                                  : -1,
-                                              weights, info)
+          ? updateAugmentedOffDiagonal<Is, J>(
+                rowIndex, mappedSlots[Is], targetSlot,
+                mappedScalarOffsets ? mappedScalarOffsets[Is] : -1,
+                mappedScalarOffsets ? mappedScalarOffsets[J] : -1, weights,
+                info)
           : void()),
      ...);
   }
@@ -636,9 +631,8 @@ class BatchJacobianFactor : public BatchJacobianFactorBase {
                                     SymmetricBlockMatrix* info,
                                     DenseIndex beginCol, DenseIndex endCol,
                                     std::index_sequence<Js...>) const {
-    (updateMappedAugmentedColumn<Js>(rowIndex, mappedSlots,
-                                     mappedScalarOffsets, weights, info,
-                                     beginCol, endCol),
+    (updateMappedAugmentedColumn<Js>(rowIndex, mappedSlots, mappedScalarOffsets,
+                                     weights, info, beginCol, endCol),
      ...);
   }
 
@@ -684,16 +678,16 @@ class BatchJacobianFactor : public BatchJacobianFactorBase {
     if constexpr (J == NumSlots) {
       const RhsVector& b = rhs_[rowIndex];
       if (weights) {
-        addFrontalBlock(
-            &destination, Ai.transpose() * weights->asDiagonal() * b);
+        addFrontalBlock(&destination,
+                        Ai.transpose() * weights->asDiagonal() * b);
       } else {
         addFrontalBlock(&destination, Ai.transpose() * b);
       }
     } else {
       const auto& Aj = std::get<J>(blocks_)[rowIndex];
       if (weights) {
-        addFrontalBlock(
-            &destination, Ai.transpose() * weights->asDiagonal() * Aj);
+        addFrontalBlock(&destination,
+                        Ai.transpose() * weights->asDiagonal() * Aj);
       } else {
         addFrontalBlock(&destination, Ai.transpose() * Aj);
       }
@@ -1007,14 +1001,13 @@ class BatchJacobianFactor : public BatchJacobianFactorBase {
   template <size_t Slot>
   const typename std::tuple_element<Slot, Blocks>::type::value_type& block(
       size_t rowIndex) const {
-    static_assert(Slot < NumSlots, "BatchJacobianFactor block slot is invalid.");
+    static_assert(Slot < NumSlots,
+                  "BatchJacobianFactor block slot is invalid.");
     return std::get<Slot>(blocks_).at(rowIndex);
   }
 
   /// Return the right-hand side for one compact row group.
-  const RhsVector& rowRhs(size_t rowIndex) const {
-    return rhs_.at(rowIndex);
-  }
+  const RhsVector& rowRhs(size_t rowIndex) const { return rhs_.at(rowIndex); }
 
   /** Evaluate the linear-model error change directly from compact rows. */
   double deltaError(const VectorValues& values, double* oldError = nullptr,
@@ -1295,12 +1288,11 @@ class BatchJacobianFactor : public BatchJacobianFactorBase {
 
  private:
   /// Update a block-column range of the Hessian from mapped row-slot data.
-  void updateHessianWithMappedSlots(const std::vector<DenseIndex>& mappedSlots,
-                                    const std::vector<DenseIndex>*
-                                        mappedScalarOffsets,
-                                    SymmetricBlockMatrix* info,
-                                    DenseIndex beginCol,
-                                    DenseIndex endCol) const {
+  void updateHessianWithMappedSlots(
+      const std::vector<DenseIndex>& mappedSlots,
+      const std::vector<DenseIndex>* mappedScalarOffsets,
+      SymmetricBlockMatrix* info, DenseIndex beginCol,
+      DenseIndex endCol) const {
     gttic(updateHessian_BatchJacobianFactor);
     if (rows() == 0) return;
     if (model_ && !model_->isUnit() && model_->isConstrained()) {

--- a/gtsam/linear/FixedJacobianFactor.h
+++ b/gtsam/linear/FixedJacobianFactor.h
@@ -302,9 +302,7 @@ struct FixedJacobianFactor : JacobianFactor {
 
     const auto factorSlots = slots(infoKeys, std::make_index_sequence<arity>{});
     const DenseIndex slotB = info->nBlocks() - 1;
-    const auto ownsColumn = [beginCol, endCol](DenseIndex column) {
-      return column >= beginCol && column < endCol;
-    };
+    const internal::BlockColumnRange ownsColumn{beginCol, endCol};
     const internal::FixedJacobianBlock<M, 1> b(Ab_.matrix(), 0, offsets[arity]);
     updateOwnedSelfAndRhsHessians(factorSlots, slotB, b, ownsColumn, info,
                                   std::make_index_sequence<arity>{});

--- a/gtsam/linear/HessianFactor.cpp
+++ b/gtsam/linear/HessianFactor.cpp
@@ -15,31 +15,31 @@
  * @date    Dec 8, 2010
  */
 
-#include <gtsam/linear/HessianFactor.h>
-
+#include <gtsam/base/FastMap.h>
+#include <gtsam/base/Matrix.h>
+#include <gtsam/base/ThreadsafeException.h>
+#include <gtsam/base/Vector.h>
+#include <gtsam/base/cholesky.h>
+#include <gtsam/base/debug.h>
+#include <gtsam/base/timing.h>
 #include <gtsam/linear/GaussianConditional.h>
 #include <gtsam/linear/GaussianFactor.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/linear/HessianFactor.h>
 #include <gtsam/linear/JacobianFactor.h>
 #include <gtsam/linear/linearExceptions.h>
-#include <gtsam/base/cholesky.h>
-#include <gtsam/base/debug.h>
-#include <gtsam/base/FastMap.h>
-#include <gtsam/base/Vector.h>
-#include <gtsam/base/Matrix.h>
-#include <gtsam/base/ThreadsafeException.h>
-#include <gtsam/base/timing.h>
 
-#include <sstream>
 #include <cassert>
 #include <limits>
+#include <sstream>
 
 #ifdef GTSAM_USE_TBB
-  #include <tbb/blocked_range.h>
-  #include <tbb/parallel_for.h>
-  #include <oneapi/tbb/global_control.h>
-  #include <oneapi/tbb/task_arena.h>
-  #include <algorithm>
+#include <oneapi/tbb/global_control.h>
+#include <oneapi/tbb/task_arena.h>
+#include <tbb/blocked_range.h>
+#include <tbb/parallel_for.h>
+
+#include <algorithm>
 #endif
 
 using namespace std;
@@ -53,12 +53,13 @@ using Dims = std::vector<Key>;
 void HessianFactor::Allocate(const Scatter& scatter) {
   gttic(HessianFactor_Allocate);
 
-  // Allocate with dimensions for each variable plus 1 at the end for the information vector
+  // Allocate with dimensions for each variable plus 1 at the end for the
+  // information vector
   const size_t n = scatter.size();
   keys_.resize(n);
   FastVector<DenseIndex> dims(n + 1);
   DenseIndex slot = 0;
-  for(const SlotEntry& slotentry: scatter) {
+  for (const SlotEntry& slotentry : scatter) {
     keys_[slot] = slotentry.key;
     dims[slot] = slotentry.dimension;
     ++slot;
@@ -68,13 +69,10 @@ void HessianFactor::Allocate(const Scatter& scatter) {
 }
 
 /* ************************************************************************* */
-HessianFactor::HessianFactor(const Scatter& scatter) {
-  Allocate(scatter);
-}
+HessianFactor::HessianFactor(const Scatter& scatter) { Allocate(scatter); }
 
 /* ************************************************************************* */
-HessianFactor::HessianFactor() :
-    info_(Dims{1}) {
+HessianFactor::HessianFactor() : info_(Dims{1}) {
   assert(info_.rows() == 1);
   constantTerm() = 0.0;
 }
@@ -84,7 +82,8 @@ HessianFactor::HessianFactor(Key j, const Matrix& G, const Vector& g, double f)
     : GaussianFactor(KeyVector{j}), info_(Dims{static_cast<Key>(G.cols()), 1}) {
   if (G.rows() != G.cols() || G.rows() != g.size())
     throw invalid_argument(
-        "Attempting to construct HessianFactor with inconsistent matrix and/or vector dimensions");
+        "Attempting to construct HessianFactor with inconsistent matrix and/or "
+        "vector dimensions");
   info_.setDiagonalBlock(0, G);
   linearTerm() = g;
   constantTerm() = f;
@@ -94,21 +93,24 @@ HessianFactor::HessianFactor(Key j, const Matrix& G, const Vector& g, double f)
 // error is 0.5*(x-mu)'*inv(Sigma)*(x-mu) = 0.5*(x'*G*x - 2*x'*G*mu + mu'*G*mu)
 // where G = inv(Sigma), g = G*mu, f = mu'*G*mu = mu'*g
 HessianFactor::HessianFactor(Key j, const Vector& mu, const Matrix& Sigma)
-    : GaussianFactor(KeyVector{j}), info_(Dims{static_cast<Key>(Sigma.cols()), 1}) {
+    : GaussianFactor(KeyVector{j}),
+      info_(Dims{static_cast<Key>(Sigma.cols()), 1}) {
   if (Sigma.rows() != Sigma.cols() || Sigma.rows() != mu.size())
     throw invalid_argument(
-        "Attempting to construct HessianFactor with inconsistent matrix and/or vector dimensions");
-  info_.setDiagonalBlock(0, Sigma.inverse()); // G
-  linearTerm() = info_.diagonalBlock(0) * mu; // g
-  constantTerm() = mu.dot(linearTerm().col(0)); // f
+        "Attempting to construct HessianFactor with inconsistent matrix and/or "
+        "vector dimensions");
+  info_.setDiagonalBlock(0, Sigma.inverse());    // G
+  linearTerm() = info_.diagonalBlock(0) * mu;    // g
+  constantTerm() = mu.dot(linearTerm().col(0));  // f
 }
 
 /* ************************************************************************* */
 HessianFactor::HessianFactor(Key j1, Key j2, const Matrix& G11,
-    const Matrix& G12, const Vector& g1, const Matrix& G22, const Vector& g2,
-    double f) :
-    GaussianFactor(KeyVector{j1,j2}), info_(
-        Dims{static_cast<Key>(G11.cols()),static_cast<Key>(G22.cols()),1}) {
+                             const Matrix& G12, const Vector& g1,
+                             const Matrix& G22, const Vector& g2, double f)
+    : GaussianFactor(KeyVector{j1, j2}),
+      info_(
+          Dims{static_cast<Key>(G11.cols()), static_cast<Key>(G22.cols()), 1}) {
   info_.setDiagonalBlock(0, G11);
   info_.setOffDiagonalBlock(0, 1, G12);
   info_.setDiagonalBlock(1, G22);
@@ -118,17 +120,20 @@ HessianFactor::HessianFactor(Key j1, Key j2, const Matrix& G11,
 
 /* ************************************************************************* */
 HessianFactor::HessianFactor(Key j1, Key j2, Key j3, const Matrix& G11,
-    const Matrix& G12, const Matrix& G13, const Vector& g1, const Matrix& G22,
-    const Matrix& G23, const Vector& g2, const Matrix& G33, const Vector& g3,
-    double f) :
-    GaussianFactor(KeyVector{j1,j2,j3}), info_(
-        Dims{static_cast<Key>(G11.cols()),static_cast<Key>(G22.cols()),static_cast<Key>(G33.cols()),1}) {
-  if (G11.rows() != G11.cols() || G11.rows() != G12.rows()
-      || G11.rows() != G13.rows() || G11.rows() != g1.size()
-      || G22.cols() != G12.cols() || G33.cols() != G13.cols()
-      || G22.cols() != g2.size() || G33.cols() != g3.size())
+                             const Matrix& G12, const Matrix& G13,
+                             const Vector& g1, const Matrix& G22,
+                             const Matrix& G23, const Vector& g2,
+                             const Matrix& G33, const Vector& g3, double f)
+    : GaussianFactor(KeyVector{j1, j2, j3}),
+      info_(Dims{static_cast<Key>(G11.cols()), static_cast<Key>(G22.cols()),
+                 static_cast<Key>(G33.cols()), 1}) {
+  if (G11.rows() != G11.cols() || G11.rows() != G12.rows() ||
+      G11.rows() != G13.rows() || G11.rows() != g1.size() ||
+      G22.cols() != G12.cols() || G33.cols() != G13.cols() ||
+      G22.cols() != g2.size() || G33.cols() != g3.size())
     throw invalid_argument(
-        "Inconsistent matrix and/or vector dimensions in HessianFactor constructor");
+        "Inconsistent matrix and/or vector dimensions in HessianFactor "
+        "constructor");
   info_.setDiagonalBlock(0, G11);
   info_.setOffDiagonalBlock(0, 1, G12);
   info_.setOffDiagonalBlock(0, 2, G13);
@@ -151,21 +156,22 @@ static std::vector<DenseIndex> _getSizeHFVec(const std::vector<Vector>& m) {
 }  // namespace
 
 /* ************************************************************************* */
-HessianFactor::HessianFactor(const KeyVector& js,
-    const std::vector<Matrix>& Gs, const std::vector<Vector>& gs, double f) :
-    GaussianFactor(js), info_(_getSizeHFVec(gs), true) {
+HessianFactor::HessianFactor(const KeyVector& js, const std::vector<Matrix>& Gs,
+                             const std::vector<Vector>& gs, double f)
+    : GaussianFactor(js), info_(_getSizeHFVec(gs), true) {
   // Get the number of variables
   size_t variable_count = js.size();
 
   // Verify the provided number of entries in the vectors are consistent
-  if (gs.size() != variable_count
-      || Gs.size() != (variable_count * (variable_count + 1)) / 2)
+  if (gs.size() != variable_count ||
+      Gs.size() != (variable_count * (variable_count + 1)) / 2)
     throw invalid_argument(
         "Inconsistent number of entries between js, Gs, and gs in HessianFactor constructor.\nThe number of keys provided \
         in js must match the number of linear vector pieces in gs. The number of upper-diagonal blocks in Gs must be n*(n+1)/2");
 
   // Verify the dimensions of each provided matrix are consistent
-  // Note: equations for calculating the indices derived from the "sum of an arithmetic sequence" formula
+  // Note: equations for calculating the indices derived from the "sum of an
+  // arithmetic sequence" formula
   for (size_t i = 0; i < variable_count; ++i) {
     DenseIndex block_size = gs[i].size();
     // Check rows
@@ -173,7 +179,8 @@ HessianFactor::HessianFactor(const KeyVector& js,
       size_t index = i * (2 * variable_count - i + 1) / 2 + j;
       if (Gs[index].rows() != block_size) {
         throw invalid_argument(
-            "Inconsistent matrix and/or vector dimensions in HessianFactor constructor");
+            "Inconsistent matrix and/or vector dimensions in HessianFactor "
+            "constructor");
       }
     }
     // Check cols
@@ -181,7 +188,8 @@ HessianFactor::HessianFactor(const KeyVector& js,
       size_t index = j * (2 * variable_count - j + 1) / 2 + (i - j);
       if (Gs[index].cols() != block_size) {
         throw invalid_argument(
-            "Inconsistent matrix and/or vector dimensions in HessianFactor constructor");
+            "Inconsistent matrix and/or vector dimensions in HessianFactor "
+            "constructor");
       }
     }
   }
@@ -211,42 +219,46 @@ void _FromJacobianHelper(const JacobianFactor& jf, SymmetricBlockMatrix& info) {
   if (jfModel) {
     if (jf.get_model()->isConstrained())
       throw invalid_argument(
-          "Cannot construct HessianFactor from JacobianFactor with constrained noise model");
+          "Cannot construct HessianFactor from JacobianFactor with constrained "
+          "noise model");
 
-    auto D = (jfModel->invsigmas().array() * jfModel->invsigmas().array()).matrix().asDiagonal();
+    auto D = (jfModel->invsigmas().array() * jfModel->invsigmas().array())
+                 .matrix()
+                 .asDiagonal();
 
     info.setFullMatrix(A.transpose() * D * A);
   } else {
     info.setFullMatrix(A.transpose() * A);
   }
 }
-}
+}  // namespace
 
 /* ************************************************************************* */
-HessianFactor::HessianFactor(const JacobianFactor& jf) :
-    GaussianFactor(jf), info_(
-        SymmetricBlockMatrix::LikeActiveViewOf(jf.matrixObject())) {
+HessianFactor::HessianFactor(const JacobianFactor& jf)
+    : GaussianFactor(jf),
+      info_(SymmetricBlockMatrix::LikeActiveViewOf(jf.matrixObject())) {
   _FromJacobianHelper(jf, info_);
 }
 
 /* ************************************************************************* */
-HessianFactor::HessianFactor(const GaussianFactor& gf) :
-    GaussianFactor(gf) {
+HessianFactor::HessianFactor(const GaussianFactor& gf) : GaussianFactor(gf) {
   // Copy the matrix data depending on what type of factor we're copying from
   if (const JacobianFactor* jf = dynamic_cast<const JacobianFactor*>(&gf)) {
     info_ = SymmetricBlockMatrix::LikeActiveViewOf(jf->matrixObject());
     _FromJacobianHelper(*jf, info_);
-  } else if (const HessianFactor* hf = dynamic_cast<const HessianFactor*>(&gf)) {
+  } else if (const HessianFactor* hf =
+                 dynamic_cast<const HessianFactor*>(&gf)) {
     info_ = hf->info_;
   } else {
     throw std::invalid_argument(
-        "In HessianFactor(const GaussianFactor& gf), gf is neither a JacobianFactor nor a HessianFactor");
+        "In HessianFactor(const GaussianFactor& gf), gf is neither a "
+        "JacobianFactor nor a HessianFactor");
   }
 }
 
 /* ************************************************************************* */
 HessianFactor::HessianFactor(const GaussianFactorGraph& factors,
-    const Scatter& scatter) {
+                             const Scatter& scatter) {
   gttic(HessianFactor_MergeConstructor);
 
   gttic(Allocate);
@@ -302,26 +314,24 @@ HessianFactor::HessianFactor(const GaussianFactorGraph& factors,
   }
 }
 
-
 /* ************************************************************************* */
 void HessianFactor::print(const std::string& s,
-    const KeyFormatter& formatter) const {
+                          const KeyFormatter& formatter) const {
   cout << s << "\n";
   cout << " keys: ";
   for (const_iterator key = begin(); key != end(); ++key)
     cout << formatter(*key) << "(" << getDim(key) << ") ";
   cout << "\n";
   gtsam::print(Matrix(info_.selfadjointView()),
-      "Augmented information matrix: ");
+               "Augmented information matrix: ");
 }
 
 /* ************************************************************************* */
 bool HessianFactor::equals(const GaussianFactor& lf, double tol) const {
   const HessianFactor* rhs = dynamic_cast<const HessianFactor*>(&lf);
-  if (!rhs || !Factor::equals(lf, tol))
-    return false;
+  if (!rhs || !Factor::equals(lf, tol)) return false;
   return equal_with_abs_tol(augmentedInformation(), rhs->augmentedInformation(),
-      tol);
+                            tol);
 }
 
 /* ************************************************************************* */
@@ -336,16 +346,15 @@ HessianFactor::informationView() const {
 }
 
 /* ************************************************************************* */
-Matrix HessianFactor::information() const {
-  return informationView();
-}
+Matrix HessianFactor::information() const { return informationView(); }
 
 /* ************************************************************************* */
-void HessianFactor::hessianDiagonalAdd(VectorValues &d) const {
+void HessianFactor::hessianDiagonalAdd(VectorValues& d) const {
   for (DenseIndex j = 0; j < (DenseIndex)size(); ++j) {
     auto result = d.emplace(keys_[j], info_.diagonal(j));
-    if(!result.second) {
-      // if emplace fails, it returns an iterator to the existing element, which we add to:
+    if (!result.second) {
+      // if emplace fails, it returns an iterator to the existing element, which
+      // we add to:
       result.first->second += info_.diagonal(j);
     }
   }
@@ -355,14 +364,15 @@ void HessianFactor::hessianDiagonalAdd(VectorValues &d) const {
 // Raw memory access version should be called in Regular Factors only currently
 void HessianFactor::hessianDiagonal(double* d) const {
   throw std::runtime_error(
-      "HessianFactor::hessianDiagonal raw memory access is allowed for Regular Factors only");
+      "HessianFactor::hessianDiagonal raw memory access is allowed for Regular "
+      "Factors only");
 }
 
 /* ************************************************************************* */
 map<Key, Matrix> HessianFactor::hessianBlockDiagonal() const {
   map<Key, Matrix> blocks;
   // Loop over all variables
-  for (DenseIndex j = 0; j < (DenseIndex) size(); ++j) {
+  for (DenseIndex j = 0; j < (DenseIndex)size(); ++j) {
     // Get the diagonal block, and insert it
     blocks.emplace(keys_[j], info_.diagonalBlock(j));
   }
@@ -417,7 +427,7 @@ void HessianFactor::updateHessian(const KeyVector& infoKeys,
   vector<DenseIndex> slots(nrVariablesInThisFactor + 1);
   for (DenseIndex j = 0; j < nrVariablesInThisFactor; ++j)
     slots[j] = Slot(infoKeys, keys_[j]);
-  
+
   slots[nrVariablesInThisFactor] = info->nBlocks() - 1;
   gttoc(slots);
 
@@ -439,26 +449,26 @@ void HessianFactor::updateHessian(const KeyVector& infoKeys,
     slots.push_back(Slot(infoKeys, keys_[j]));
   }
   slots.push_back(info->nBlocks() - 1);
+  const internal::BlockColumnRange ownsColumn{beginCol, endCol};
 
   for (DenseIndex j = 0; j <= nrVariablesInThisFactor; ++j) {
     const DenseIndex J = slots[j];
     // Update diagonal block if J is in range
-    if (J >= beginCol && J < endCol) {
+    if (ownsColumn(J)) {
       info->updateDiagonalBlock(J, info_.diagonalBlock(j));
     }
 
     // Update off-diagonal blocks where column max(I, J) is in range
     // Note: We process all blocks and let the maxCol check filter them,
-    // because I and J may be in different orders (slots are not necessarily sorted)
+    // because I and J may be in different orders (slots are not necessarily
+    // sorted)
     for (DenseIndex i = 0; i < j; ++i) {
       const DenseIndex I = slots[i];
       assert(i < j);
       assert(I != J);
 
       // The physical column index in the symmetric matrix is max(I, J)
-      const DenseIndex maxCol = std::max(I, J);
-
-      if (maxCol >= beginCol && maxCol < endCol) {
+      if (ownsColumn.owns(I, J)) {
         info->updateOffDiagonalBlock(I, J, info_.aboveDiagonalBlock(i, j));
       }
     }
@@ -475,8 +485,7 @@ GaussianFactor::shared_ptr HessianFactor::negate() const {
 
 /* ************************************************************************* */
 void HessianFactor::multiplyHessianAdd(double alpha, const VectorValues& x,
-    VectorValues& yvalues) const {
-
+                                       VectorValues& yvalues) const {
   // Create a vector of temporary y values, corresponding to rows i
   vector<Vector> y;
   y.reserve(size());
@@ -486,27 +495,26 @@ void HessianFactor::multiplyHessianAdd(double alpha, const VectorValues& x,
   // Accessing the VectorValues one by one is expensive
   // So we will loop over columns to access x only once per column
   // And fill the above temporary y values, to be added into yvalues after
-  for (DenseIndex j = 0; j < (DenseIndex) size(); ++j) {
+  for (DenseIndex j = 0; j < (DenseIndex)size(); ++j) {
     // xj is the input vector
     Vector xj = x.at(keys_[j]);
     DenseIndex i = 0;
-    for (; i < j; ++i)
-      y[i] += info_.aboveDiagonalBlock(i, j) * xj;
+    for (; i < j; ++i) y[i] += info_.aboveDiagonalBlock(i, j) * xj;
 
     // blocks on the diagonal are only half
     y[i] += info_.diagonalBlock(j) * xj;
     // for below diagonal, we take transpose block from upper triangular part
-    for (i = j + 1; i < (DenseIndex) size(); ++i)
+    for (i = j + 1; i < (DenseIndex)size(); ++i)
       y[i] += info_.aboveDiagonalBlock(j, i).transpose() * xj;
   }
 
   // copy to yvalues
-  for (DenseIndex i = 0; i < (DenseIndex) size(); ++i) {
+  for (DenseIndex i = 0; i < (DenseIndex)size(); ++i) {
     const auto [it, didNotExist] = yvalues.tryInsert(keys_[i], Vector());
     if (didNotExist)
-      it->second = alpha * y[i]; // init
+      it->second = alpha * y[i];  // init
     else
-      it->second += alpha * y[i]; // add
+      it->second += alpha * y[i];  // add
   }
 }
 
@@ -523,7 +531,8 @@ VectorValues HessianFactor::gradientAtZero() const {
 // Raw memory access version should be called in Regular Factors only currently
 void HessianFactor::gradientAtZero(double* d) const {
   throw std::runtime_error(
-      "HessianFactor::gradientAtZero raw memory access is allowed for Regular Factors only");
+      "HessianFactor::gradientAtZero raw memory access is allowed for Regular "
+      "Factors only");
 }
 
 /* ************************************************************************* */
@@ -537,7 +546,8 @@ Vector HessianFactor::gradient(Key key, const VectorValues& x) const {
     const DenseIndex J = std::distance(begin(), it_j);
 
     // Obtain Gij from the Hessian factor
-    // Hessian factor only stores an upper triangular matrix, so be careful when i>j
+    // Hessian factor only stores an upper triangular matrix, so be careful when
+    // i>j
     const Matrix Gij = info_.block(I, J);
     // Accumulate Gij*xj to gradf
     b += Gij * x.at(*it_j);
@@ -548,7 +558,8 @@ Vector HessianFactor::gradient(Key key, const VectorValues& x) const {
 }
 
 /* ************************************************************************* */
-std::shared_ptr<GaussianConditional> HessianFactor::eliminateCholesky(const Ordering& keys) {
+std::shared_ptr<GaussianConditional> HessianFactor::eliminateCholesky(
+    const Ordering& keys) {
   gttic(HessianFactor_eliminateCholesky);
 
   GaussianConditional::shared_ptr conditional;
@@ -561,7 +572,8 @@ std::shared_ptr<GaussianConditional> HessianFactor::eliminateCholesky(const Orde
 
     // TODO(frank): pre-allocate GaussianConditional and write into it
     VerticalBlockMatrix Ab = info_.split(nFrontals);
-    conditional = std::make_shared<GaussianConditional>(keys_, nFrontals, std::move(Ab));
+    conditional =
+        std::make_shared<GaussianConditional>(keys_, nFrontals, std::move(Ab));
 
     // Erase the eliminated keys in this factor
     keys_.erase(begin(), begin() + nFrontals);
@@ -616,7 +628,8 @@ EliminateCholesky(const GaussianFactorGraph& factors, const Ordering& keys) {
     jointFactor = std::make_shared<HessianFactor>(factors, scatter);
   } catch (std::invalid_argument&) {
     throw InvalidDenseElimination(
-        "EliminateCholesky was called with a request to eliminate variables that are not\n"
+        "EliminateCholesky was called with a request to eliminate variables "
+        "that are not\n"
         "involved in the provided factors.");
   }
 
@@ -629,8 +642,9 @@ EliminateCholesky(const GaussianFactorGraph& factors, const Ordering& keys) {
 
 /* ************************************************************************* */
 std::pair<std::shared_ptr<GaussianConditional>,
-    std::shared_ptr<GaussianFactor> > EliminatePreferCholesky(
-    const GaussianFactorGraph& factors, const Ordering& keys) {
+          std::shared_ptr<GaussianFactor> >
+EliminatePreferCholesky(const GaussianFactorGraph& factors,
+                        const Ordering& keys) {
   gttic(EliminatePreferCholesky);
 
   // If any JacobianFactors have constrained noise models, we have to convert
@@ -643,4 +657,4 @@ std::pair<std::shared_ptr<GaussianConditional>,
     return EliminateCholesky(factors, keys);
 }
 
-} // gtsam
+}  // namespace gtsam

--- a/gtsam/linear/JacobianFactor.cpp
+++ b/gtsam/linear/JacobianFactor.cpp
@@ -17,23 +17,23 @@
  * @date    Dec 8, 2010
  */
 
-#include <gtsam/linear/linearExceptions.h>
-#include <gtsam/linear/GaussianConditional.h>
-#include <gtsam/linear/JacobianFactor.h>
-#include <gtsam/linear/BatchJacobianFactor.h>
-#include <gtsam/linear/Scatter.h>
-#include <gtsam/linear/GaussianFactorGraph.h>
-#include <gtsam/linear/VectorValues.h>
-#include <gtsam/inference/VariableSlots.h>
+#include <gtsam/base/FastMap.h>
+#include <gtsam/base/Matrix.h>
+#include <gtsam/base/cholesky.h>
 #include <gtsam/base/debug.h>
 #include <gtsam/base/timing.h>
-#include <gtsam/base/Matrix.h>
-#include <gtsam/base/FastMap.h>
-#include <gtsam/base/cholesky.h>
+#include <gtsam/inference/VariableSlots.h>
+#include <gtsam/linear/BatchJacobianFactor.h>
+#include <gtsam/linear/GaussianConditional.h>
+#include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/linear/JacobianFactor.h>
+#include <gtsam/linear/Scatter.h>
+#include <gtsam/linear/VectorValues.h>
+#include <gtsam/linear/linearExceptions.h>
 
 #include <array>
-#include <cmath>
 #include <cassert>
+#include <cmath>
 #include <sstream>
 #include <stdexcept>
 
@@ -45,29 +45,28 @@ namespace gtsam {
 using Dims = std::vector<Key>;
 
 /* ************************************************************************* */
-JacobianFactor::JacobianFactor() :
-    Ab_(Dims{1}, 0) {
-  getb().setZero();
-}
+JacobianFactor::JacobianFactor() : Ab_(Dims{1}, 0) { getb().setZero(); }
 
 /* ************************************************************************* */
 JacobianFactor::JacobianFactor(const GaussianFactor& gf) {
   // Copy the matrix data depending on what type of factor we're copying from
-  if (const JacobianFactor* asJacobian = dynamic_cast<const JacobianFactor*>(&gf))
+  if (const JacobianFactor* asJacobian =
+          dynamic_cast<const JacobianFactor*>(&gf))
     *this = JacobianFactor(*asJacobian);
-  else if (const HessianFactor* asHessian = dynamic_cast<const HessianFactor*>(&gf))
+  else if (const HessianFactor* asHessian =
+               dynamic_cast<const HessianFactor*>(&gf))
     *this = JacobianFactor(*asHessian);
   else if (const BatchJacobianFactorBase* asBatch =
                dynamic_cast<const BatchJacobianFactorBase*>(&gf))
     *this = asBatch->toJacobianFactor();
   else
     throw std::invalid_argument(
-        "In JacobianFactor(const GaussianFactor& rhs), rhs is not a supported Jacobian-compatible factor");
+        "In JacobianFactor(const GaussianFactor& rhs), rhs is not a supported "
+        "Jacobian-compatible factor");
 }
 
 /* ************************************************************************* */
-JacobianFactor::JacobianFactor(const Vector& b_in) :
-    Ab_(Dims{1}, b_in.size()) {
+JacobianFactor::JacobianFactor(const Vector& b_in) : Ab_(Dims{1}, b_in.size()) {
   getb() = b_in;
 }
 
@@ -152,7 +151,7 @@ JacobianFactor::JacobianFactor(const HessianFactor& factor)
   }
 }
 
-  /* ************************************************************************* */
+/* ************************************************************************* */
 void JacobianFactor::checkAb(const SharedDiagonal& model,
                              const VerticalBlockMatrix& augmentedMatrix) const {
   // Check noise model dimension
@@ -182,39 +181,42 @@ std::tuple<FastVector<DenseIndex>, DenseIndex, DenseIndex> _countDims(
     const FastVector<VariableSlots::const_iterator>& variableSlots) {
   gttic(countDims);
 #ifdef GTSAM_EXTRA_CONSISTENCY_CHECKS
-  FastVector<DenseIndex> varDims(variableSlots.size(), numeric_limits<DenseIndex>::max());
+  FastVector<DenseIndex> varDims(variableSlots.size(),
+                                 numeric_limits<DenseIndex>::max());
 #else
   FastVector<DenseIndex> varDims(variableSlots.size(),
-      numeric_limits<DenseIndex>::max());
+                                 numeric_limits<DenseIndex>::max());
 #endif
   DenseIndex m = 0;
   DenseIndex n = 0;
   for (size_t jointVarpos = 0; jointVarpos < variableSlots.size();
-      ++jointVarpos) {
+       ++jointVarpos) {
     const VariableSlots::const_iterator& slots = variableSlots[jointVarpos];
 
     assert(slots->second.size() == factors.size());
 
     bool foundVariable = false;
     for (size_t sourceFactorI = 0; sourceFactorI < slots->second.size();
-        ++sourceFactorI) {
+         ++sourceFactorI) {
       const size_t sourceVarpos = slots->second[sourceFactorI];
       if (sourceVarpos != VariableSlots::Empty) {
         const JacobianFactor& sourceFactor = *factors[sourceFactorI];
         if (sourceFactor.cols() > 1) {
           foundVariable = true;
-          DenseIndex vardim = sourceFactor.getDim(
-              sourceFactor.begin() + sourceVarpos);
+          DenseIndex vardim =
+              sourceFactor.getDim(sourceFactor.begin() + sourceVarpos);
 
 #ifdef GTSAM_EXTRA_CONSISTENCY_CHECKS
-          if(varDims[jointVarpos] == numeric_limits<DenseIndex>::max()) {
+          if (varDims[jointVarpos] == numeric_limits<DenseIndex>::max()) {
             varDims[jointVarpos] = vardim;
             n += vardim;
           } else {
-            if(!(varDims[jointVarpos] == vardim)) {
+            if (!(varDims[jointVarpos] == vardim)) {
               std::stringstream ss;
-              ss << "Factor " << sourceFactorI << " variable " << DefaultKeyFormatter(sourceFactor.keys()[sourceVarpos]) <<
-              " has different dimensionality of " << vardim << " instead of " << varDims[jointVarpos];
+              ss << "Factor " << sourceFactorI << " variable "
+                 << DefaultKeyFormatter(sourceFactor.keys()[sourceVarpos])
+                 << " has different dimensionality of " << vardim
+                 << " instead of " << varDims[jointVarpos];
               throw std::runtime_error(ss.str());
             }
           }
@@ -233,12 +235,12 @@ std::tuple<FastVector<DenseIndex>, DenseIndex, DenseIndex> _countDims(
           "Unable to determine dimensionality for all variables");
   }
 
-  for(const JacobianFactor::shared_ptr& factor: factors) {
+  for (const JacobianFactor::shared_ptr& factor : factors) {
     m += factor->rows();
   }
 
 #if !defined(NDEBUG) && defined(GTSAM_EXTRA_CONSISTENCY_CHECKS)
-  for(DenseIndex d: varDims) {
+  for (DenseIndex d : varDims) {
     assert(d != numeric_limits<DenseIndex>::max());
   }
 #endif
@@ -252,10 +254,10 @@ FastVector<JacobianFactor::shared_ptr> _convertOrCastToJacobians(
   gttic(Convert_to_Jacobians);
   FastVector<JacobianFactor::shared_ptr> jacobians;
   jacobians.reserve(factors.size());
-  for(const GaussianFactor::shared_ptr& factor: factors) {
+  for (const GaussianFactor::shared_ptr& factor : factors) {
     if (factor) {
-      if (JacobianFactor::shared_ptr jf = std::dynamic_pointer_cast<
-          JacobianFactor>(factor))
+      if (JacobianFactor::shared_ptr jf =
+              std::dynamic_pointer_cast<JacobianFactor>(factor))
         jacobians.push_back(jf);
       else
         jacobians.push_back(std::make_shared<JacobianFactor>(*factor));
@@ -263,7 +265,7 @@ FastVector<JacobianFactor::shared_ptr> _convertOrCastToJacobians(
   }
   return jacobians;
 }
-}
+}  // namespace
 
 /* ************************************************************************* */
 static std::vector<DenseIndex> _computeRowOffsets(
@@ -281,12 +283,12 @@ static std::vector<DenseIndex> _computeRowOffsets(
   return rowOffsets;
 }
 
-void JacobianFactor::JacobianFactorHelper(const GaussianFactorGraph& graph,
+void JacobianFactor::JacobianFactorHelper(
+    const GaussianFactorGraph& graph,
     const FastVector<VariableSlots::const_iterator>& orderedSlots) {
-
   // Cast or convert to Jacobians
-  FastVector<JacobianFactor::shared_ptr> jacobians = _convertOrCastToJacobians(
-      graph);
+  FastVector<JacobianFactor::shared_ptr> jacobians =
+      _convertOrCastToJacobians(graph);
 
   // Count dimensions
   const auto [varDims, m, n] = _countDims(jacobians, orderedSlots);
@@ -296,18 +298,18 @@ void JacobianFactor::JacobianFactorHelper(const GaussianFactorGraph& graph,
 
   // Allocate matrix and copy keys in order
   gttic(allocate);
-  Ab_ = VerticalBlockMatrix(varDims, m, true); // Allocate augmented matrix
+  Ab_ = VerticalBlockMatrix(varDims, m, true);  // Allocate augmented matrix
   Base::keys_.resize(orderedSlots.size());
   // Copy keys in order
-  std::transform(orderedSlots.begin(), orderedSlots.end(),
-      Base::keys_.begin(),
-      [](const VariableSlots::const_iterator& it) {return it->first;});
+  std::transform(
+      orderedSlots.begin(), orderedSlots.end(), Base::keys_.begin(),
+      [](const VariableSlots::const_iterator& it) { return it->first; });
   gttoc(allocate);
 
   // Loop over slots in combined factor and copy blocks from source factors
   gttic(copy_blocks);
   size_t combinedSlot = 0;
-  for(VariableSlots::const_iterator varslot: orderedSlots) {
+  for (VariableSlots::const_iterator varslot : orderedSlots) {
     JacobianFactor::ABlock destSlot(this->getA(this->begin() + combinedSlot));
     // Loop over source jacobians
     for (size_t factorI = 0; factorI < jacobians.size(); ++factorI) {
@@ -320,8 +322,8 @@ void JacobianFactor::JacobianFactorHelper(const GaussianFactorGraph& graph,
             destSlot.middleRows(nextRow, sourceRows));
         // Copy if exists in source factor, otherwise set zero
         if (sourceSlot != VariableSlots::Empty)
-          destBlock = jacobians[factorI]->getA(
-              jacobians[factorI]->begin() + sourceSlot);
+          destBlock = jacobians[factorI]->getA(jacobians[factorI]->begin() +
+                                               sourceSlot);
         else
           destBlock.setZero();
       }
@@ -341,41 +343,38 @@ void JacobianFactor::JacobianFactorHelper(const GaussianFactorGraph& graph,
       DenseIndex nextRow = rowOffsets[factorI];
       this->getb().segment(nextRow, sourceRows) = jacobians[factorI]->getb();
       if (jacobians[factorI]->get_model()) {
-        // If the factor has a noise model and we haven't yet allocated sigmas, allocate it.
-        if (!sigmas)
-          sigmas = Vector::Constant(m, 1.0);
+        // If the factor has a noise model and we haven't yet allocated sigmas,
+        // allocate it.
+        if (!sigmas) sigmas = Vector::Constant(m, 1.0);
         sigmas->segment(nextRow, sourceRows) =
             jacobians[factorI]->get_model()->sigmasRef();
-        if (jacobians[factorI]->isConstrained())
-          anyConstrained = true;
+        if (jacobians[factorI]->isConstrained()) anyConstrained = true;
       }
     }
   }
   gttoc(copy_vectors);
 
-  if (sigmas)
-    this->setModel(anyConstrained, *sigmas);
+  if (sigmas) this->setModel(anyConstrained, *sigmas);
 }
 
 /* ************************************************************************* */
-// Order variable slots - we maintain the vector of ordered slots, as well as keep a list
-// 'unorderedSlots' of any variables discovered that are not in the ordering.  Those will then
-// be added after all of the ordered variables.
+// Order variable slots - we maintain the vector of ordered slots, as well as
+// keep a list 'unorderedSlots' of any variables discovered that are not in the
+// ordering.  Those will then be added after all of the ordered variables.
 FastVector<VariableSlots::const_iterator> orderedSlotsHelper(
-    const Ordering& ordering,
-    const VariableSlots& variableSlots) {
+    const Ordering& ordering, const VariableSlots& variableSlots) {
   gttic(Order_slots);
-  
+
   FastVector<VariableSlots::const_iterator> orderedSlots;
   orderedSlots.reserve(variableSlots.size());
-  
+
   // If an ordering is provided, arrange the slots first that ordering
   FastList<VariableSlots::const_iterator> unorderedSlots;
   size_t nOrderingSlotsUsed = 0;
   orderedSlots.resize(ordering.size());
   FastMap<Key, size_t> inverseOrdering = ordering.invert();
   for (VariableSlots::const_iterator item = variableSlots.begin();
-      item != variableSlots.end(); ++item) {
+       item != variableSlots.end(); ++item) {
     FastMap<Key, size_t>::const_iterator orderingPosition =
         inverseOrdering.find(item->first);
     if (orderingPosition == inverseOrdering.end()) {
@@ -388,9 +387,10 @@ FastVector<VariableSlots::const_iterator> orderedSlotsHelper(
   if (nOrderingSlotsUsed != ordering.size())
     throw std::invalid_argument(
         "The ordering provided to the JacobianFactor combine constructor\n"
-            "contained extra variables that did not appear in the factors to combine.");
+        "contained extra variables that did not appear in the factors to "
+        "combine.");
   // Add the remaining slots
-  for(VariableSlots::const_iterator item: unorderedSlots) {
+  for (VariableSlots::const_iterator item : unorderedSlots) {
     orderedSlots.push_back(item);
   }
 
@@ -405,19 +405,19 @@ JacobianFactor::JacobianFactor(const GaussianFactorGraph& graph) {
 
   // Compute VariableSlots if one was not provided
   // Binds reference, does not copy VariableSlots
-  const VariableSlots & variableSlots = VariableSlots(graph);
+  const VariableSlots& variableSlots = VariableSlots(graph);
 
   gttic(Order_slots);
-  // Order variable slots - we maintain the vector of ordered slots, as well as keep a list
-  // 'unorderedSlots' of any variables discovered that are not in the ordering.  Those will then
-  // be added after all of the ordered variables.
+  // Order variable slots - we maintain the vector of ordered slots, as well as
+  // keep a list 'unorderedSlots' of any variables discovered that are not in
+  // the ordering.  Those will then be added after all of the ordered variables.
   FastVector<VariableSlots::const_iterator> orderedSlots;
   orderedSlots.reserve(variableSlots.size());
-  
-  // If no ordering is provided, arrange the slots as they were, which will be sorted
-  // numerically since VariableSlots uses a map sorting on Key.
+
+  // If no ordering is provided, arrange the slots as they were, which will be
+  // sorted numerically since VariableSlots uses a map sorting on Key.
   for (VariableSlots::const_iterator item = variableSlots.begin();
-      item != variableSlots.end(); ++item)
+       item != variableSlots.end(); ++item)
     orderedSlots.push_back(item);
   gttoc(Order_slots);
 
@@ -426,23 +426,23 @@ JacobianFactor::JacobianFactor(const GaussianFactorGraph& graph) {
 
 /* ************************************************************************* */
 JacobianFactor::JacobianFactor(const GaussianFactorGraph& graph,
-    const VariableSlots& p_variableSlots) {
+                               const VariableSlots& p_variableSlots) {
   gttic(JacobianFactor_combine_constructor);
 
   // Binds reference, does not copy VariableSlots
-  const VariableSlots & variableSlots = p_variableSlots;
+  const VariableSlots& variableSlots = p_variableSlots;
 
   gttic(Order_slots);
-  // Order variable slots - we maintain the vector of ordered slots, as well as keep a list
-  // 'unorderedSlots' of any variables discovered that are not in the ordering.  Those will then
-  // be added after all of the ordered variables.
+  // Order variable slots - we maintain the vector of ordered slots, as well as
+  // keep a list 'unorderedSlots' of any variables discovered that are not in
+  // the ordering.  Those will then be added after all of the ordered variables.
   FastVector<VariableSlots::const_iterator> orderedSlots;
   orderedSlots.reserve(variableSlots.size());
-  
-  // If no ordering is provided, arrange the slots as they were, which will be sorted
-  // numerically since VariableSlots uses a map sorting on Key.
+
+  // If no ordering is provided, arrange the slots as they were, which will be
+  // sorted numerically since VariableSlots uses a map sorting on Key.
   for (VariableSlots::const_iterator item = variableSlots.begin();
-      item != variableSlots.end(); ++item)
+       item != variableSlots.end(); ++item)
     orderedSlots.push_back(item);
   gttoc(Order_slots);
 
@@ -451,38 +451,37 @@ JacobianFactor::JacobianFactor(const GaussianFactorGraph& graph,
 
 /* ************************************************************************* */
 JacobianFactor::JacobianFactor(const GaussianFactorGraph& graph,
-    const Ordering& ordering) {
+                               const Ordering& ordering) {
   gttic(JacobianFactor_combine_constructor);
-  
+
   // Compute VariableSlots if one was not provided
   // Binds reference, does not copy VariableSlots
-  const VariableSlots & variableSlots = VariableSlots(graph);
+  const VariableSlots& variableSlots = VariableSlots(graph);
 
   // Order variable slots
   FastVector<VariableSlots::const_iterator> orderedSlots =
-    orderedSlotsHelper(ordering, variableSlots);
+      orderedSlotsHelper(ordering, variableSlots);
 
   JacobianFactorHelper(graph, orderedSlots);
 }
 
 /* ************************************************************************* */
 JacobianFactor::JacobianFactor(const GaussianFactorGraph& graph,
-    const Ordering& ordering,
-    const VariableSlots& p_variableSlots) {
+                               const Ordering& ordering,
+                               const VariableSlots& p_variableSlots) {
   gttic(JacobianFactor_combine_constructor);
-  
+
   // Order variable slots
   FastVector<VariableSlots::const_iterator> orderedSlots =
-    orderedSlotsHelper(ordering, p_variableSlots);
+      orderedSlotsHelper(ordering, p_variableSlots);
 
   JacobianFactorHelper(graph, orderedSlots);
 }
 
 /* ************************************************************************* */
 void JacobianFactor::print(const string& s,
-    const KeyFormatter& formatter) const {
-  if (!s.empty())
-    cout << s << "\n";
+                           const KeyFormatter& formatter) const {
+  if (!s.empty()) cout << s << "\n";
   for (const_iterator key = begin(); key != end(); ++key) {
     cout << "  A[" << formatter(*key) << "] = ";
     cout << getA(key).format(matlabFormat()) << endl;
@@ -499,16 +498,14 @@ void JacobianFactor::print(const string& s,
 bool JacobianFactor::equals(const GaussianFactor& f_, double tol) const {
   static const bool verbose = false;
   if (!dynamic_cast<const JacobianFactor*>(&f_)) {
-    if (verbose)
-      cout << "JacobianFactor::equals: Incorrect type" << endl;
+    if (verbose) cout << "JacobianFactor::equals: Incorrect type" << endl;
     return false;
   } else {
     const JacobianFactor& f(static_cast<const JacobianFactor&>(f_));
 
     // Check keys
     if (keys() != f.keys()) {
-      if (verbose)
-        cout << "JacobianFactor::equals: keys do not match" << endl;
+      if (verbose) cout << "JacobianFactor::equals: keys do not match" << endl;
       return false;
     }
 
@@ -534,11 +531,12 @@ bool JacobianFactor::equals(const GaussianFactor& f_, double tol) const {
     // Check matrix contents
     constABlock Ab1(Ab_.range(0, Ab_.nBlocks()));
     constABlock Ab2(f.Ab_.range(0, f.Ab_.nBlocks()));
-    for (size_t row = 0; row < (size_t) Ab1.rows(); ++row)
-      if (!equal_with_abs_tol(Ab1.row(row), Ab2.row(row), tol)
-          && !equal_with_abs_tol(-Ab1.row(row), Ab2.row(row), tol)) {
+    for (size_t row = 0; row < (size_t)Ab1.rows(); ++row)
+      if (!equal_with_abs_tol(Ab1.row(row), Ab2.row(row), tol) &&
+          !equal_with_abs_tol(-Ab1.row(row), Ab2.row(row), tol)) {
         if (verbose)
-          cout << "JacobianFactor::equals: matrix mismatch at row " << row << endl;
+          cout << "JacobianFactor::equals: matrix mismatch at row " << row
+               << endl;
         return false;
       }
 
@@ -571,7 +569,8 @@ Vector JacobianFactor::error_vector(const VectorValues& c) const {
 /* ************************************************************************* */
 double JacobianFactor::error(const VectorValues& c) const {
   Vector e = unweighted_error(c);
-  // Use the noise model distance function to get the correct error if available.
+  // Use the noise model distance function to get the correct error if
+  // available.
   if (model_) return 0.5 * model_->squaredMahalanobisDistance(e);
   return 0.5 * e.dot(e);
 }
@@ -595,7 +594,8 @@ Matrix JacobianFactor::augmentedInformation() const {
   if (model_) {
     Matrix Ab = Ab_.full();
     if (model_->isConstrained()) {
-      auto constrained = std::static_pointer_cast<noiseModel::Constrained>(model_);
+      auto constrained =
+          std::static_pointer_cast<noiseModel::Constrained>(model_);
       return constrained->informationFromA(Ab);
     }
     model_->WhitenInPlace(Ab);
@@ -610,7 +610,8 @@ Matrix JacobianFactor::information() const {
   if (model_) {
     Matrix A = this->getA();
     if (model_->isConstrained()) {
-      auto constrained = std::static_pointer_cast<noiseModel::Constrained>(model_);
+      auto constrained =
+          std::static_pointer_cast<noiseModel::Constrained>(model_);
       return constrained->informationFromA(A);
     }
     model_->WhitenInPlace(A);
@@ -634,7 +635,7 @@ void JacobianFactor::hessianDiagonalAdd(VectorValues& d) const {
       if (model_) {
         Vector column_k_copy = column_k;
         model_->whitenInPlace(column_k_copy);
-        if(!result.second)
+        if (!result.second)
           dj(k) += dot(column_k_copy, column_k_copy);
         else
           dj(k) = dot(column_k_copy, column_k_copy);
@@ -651,7 +652,9 @@ void JacobianFactor::hessianDiagonalAdd(VectorValues& d) const {
 /* ************************************************************************* */
 // Raw memory access version should be called in Regular Factors only currently
 void JacobianFactor::hessianDiagonal(double* d) const {
-  throw std::runtime_error("JacobianFactor::hessianDiagonal raw memory access is allowed for Regular Factors only");
+  throw std::runtime_error(
+      "JacobianFactor::hessianDiagonal raw memory access is allowed for "
+      "Regular Factors only");
 }
 
 /* ************************************************************************* */
@@ -660,8 +663,7 @@ map<Key, Matrix> JacobianFactor::hessianBlockDiagonal() const {
   for (size_t pos = 0; pos < size(); ++pos) {
     Key j = keys_[pos];
     Matrix Aj = Ab_(pos);
-    if (model_)
-      Aj = model_->Whiten(Aj);
+    if (model_) Aj = model_->Whiten(Aj);
     blocks.emplace(j, Aj.transpose() * Aj);
   }
   return blocks;
@@ -709,27 +711,30 @@ void JacobianFactor::updateHessian(const KeyVector& infoKeys,
 }
 
 /* ************************************************************************* */
-static void whitenedUpdateHessian(SymmetricBlockMatrix* info, std::vector<DenseIndex> slots, 
-  const VerticalBlockMatrix& Ab_, DenseIndex beginCol, DenseIndex endCol) {
+static void whitenedUpdateHessian(SymmetricBlockMatrix* info,
+                                  std::vector<DenseIndex> slots,
+                                  const VerticalBlockMatrix& Ab_,
+                                  DenseIndex beginCol, DenseIndex endCol) {
   const DenseIndex n = Ab_.nBlocks() - 1;
+  const internal::BlockColumnRange ownsColumn{beginCol, endCol};
 
   for (DenseIndex j = 0; j <= n; ++j) {
     const DenseIndex J = slots[j];
     Eigen::Block<const Matrix> Ab_j = Ab_(j);
-    
+
     // Update diagonal block if J is in range
-    if (J >= beginCol && J < endCol) {
+    if (ownsColumn(J)) {
       info->diagonalBlock(J).rankUpdate(Ab_j.transpose());
     }
-    
+
     // Fill off-diagonal blocks with Ai'*Aj where column max(I, J) is in range
     for (DenseIndex i = 0; i < j; ++i) {
       const DenseIndex I = slots[i];
-      
+
       // The physical column index in the symmetric matrix is max(I, J)
-      const DenseIndex maxCol = std::max(I, J);
-      if (maxCol >= beginCol && maxCol < endCol) {
-        // Pass original indices - updateOffDiagonalBlock handles swapping internally
+      if (ownsColumn.owns(I, J)) {
+        // Pass original indices - updateOffDiagonalBlock handles swapping
+        // internally
         info->updateOffDiagonalBlock(I, J, Ab_(i).transpose() * Ab_j);
       }
     }
@@ -738,7 +743,8 @@ static void whitenedUpdateHessian(SymmetricBlockMatrix* info, std::vector<DenseI
 
 void JacobianFactor::updateHessian(const KeyVector& infoKeys,
                                    SymmetricBlockMatrix* info,
-                                   DenseIndex beginCol, DenseIndex endCol) const {
+                                   DenseIndex beginCol,
+                                   DenseIndex endCol) const {
   if (rows() == 0) return;
 
   // Ab_ is the augmented Jacobian matrix A, and we perform I += A'*A below.
@@ -768,7 +774,8 @@ void JacobianFactor::updateHessian(const KeyVector& infoKeys,
           "JacobianFactor::updateHessian: cannot update information with "
           "constrained noise model");
     JacobianFactor whitenedFactor = whiten();
-    whitenedUpdateHessian(info, std::move(slots), whitenedFactor.Ab_, beginCol, endCol);
+    whitenedUpdateHessian(info, std::move(slots), whitenedFactor.Ab_, beginCol,
+                          endCol);
   } else {
     whitenedUpdateHessian(info, std::move(slots), Ab_, beginCol, endCol);
   }
@@ -778,8 +785,7 @@ void JacobianFactor::updateHessian(const KeyVector& infoKeys,
 Vector JacobianFactor::operator*(const VectorValues& x) const {
   Vector Ax(Ab_.rows());
   Ax.setZero();
-  if (empty())
-    return Ax;
+  if (empty()) return Ax;
 
   // Just iterate over all A matrices and multiply in correct config part
   for (size_t pos = 0; pos < size(); ++pos) {
@@ -813,7 +819,7 @@ void JacobianFactor::transposeMultiplyAdd(double alpha, const Vector& e,
 
 /* ************************************************************************* */
 void JacobianFactor::multiplyHessianAdd(double alpha, const VectorValues& x,
-    VectorValues& y) const {
+                                        VectorValues& y) const {
   Vector Ax = (*this) * x;
   transposeMultiplyAdd(alpha, Ax, y);
 }
@@ -827,26 +833,27 @@ void JacobianFactor::multiplyHessianAdd(double alpha, const VectorValues& x,
  * NOTE: size of accumulatedDims is size of keys + 1!!
  * TODO Frank asks: why is this here if not regular ????
  */
-void JacobianFactor::multiplyHessianAdd(double alpha, const double* x, double* y,
+void JacobianFactor::multiplyHessianAdd(
+    double alpha, const double* x, double* y,
     const std::vector<size_t>& accumulatedDims) const {
-
   /// Use Eigen magic to access raw memory
   typedef Eigen::Map<Vector> VectorMap;
   typedef Eigen::Map<const Vector> ConstVectorMap;
 
-  if (empty())
-    return;
+  if (empty()) return;
   Vector Ax = Vector::Zero(Ab_.rows());
 
-  /// Just iterate over all A matrices and multiply in correct config part (looping over keys)
-  /// E.g.: Jacobian A = [A0 A1 A2] multiplies x = [x0 x1 x2]'
-  /// Hence: Ax = A0 x0 + A1 x1 + A2 x2 (hence we loop over the keys and accumulate)
+  /// Just iterate over all A matrices and multiply in correct config part
+  /// (looping over keys) E.g.: Jacobian A = [A0 A1 A2] multiplies x = [x0 x1
+  /// x2]' Hence: Ax = A0 x0 + A1 x1 + A2 x2 (hence we loop over the keys and
+  /// accumulate)
   for (size_t pos = 0; pos < size(); ++pos) {
     size_t offset = accumulatedDims[keys_[pos]];
     size_t dim = accumulatedDims[keys_[pos] + 1] - offset;
     Ax += Ab_(pos) * ConstVectorMap(x + offset, dim);
   }
-  /// Deal with noise properly, need to Double* whiten as we are dividing by variance
+  /// Deal with noise properly, need to Double* whiten as we are dividing by
+  /// variance
   if (model_) {
     model_->whitenInPlace(Ax);
     model_->whitenInPlace(Ax);
@@ -870,14 +877,16 @@ VectorValues JacobianFactor::gradientAtZero() const {
   // Gradient is really -A'*b / sigma^2
   // transposeMultiplyAdd will divide by sigma once, so we need one more
   if (model_) model_->whitenInPlace(b);
-  this->transposeMultiplyAdd(-1.0, b, g); // g -= A'*b/sigma^2
+  this->transposeMultiplyAdd(-1.0, b, g);  // g -= A'*b/sigma^2
   return g;
 }
 
 /* ************************************************************************* */
 // Raw memory access version should be called in Regular Factors only currently
 void JacobianFactor::gradientAtZero(double* d) const {
-  throw std::runtime_error("JacobianFactor::gradientAtZero raw memory access is allowed for Regular Factors only");
+  throw std::runtime_error(
+      "JacobianFactor::gradientAtZero raw memory access is allowed for Regular "
+      "Factors only");
 }
 
 /* ************************************************************************* */
@@ -905,8 +914,7 @@ Vector JacobianFactor::gradient(Key key, const VectorValues& x) const {
 pair<Matrix, Vector> JacobianFactor::jacobian() const {
   pair<Matrix, Vector> result = jacobianUnweighted();
   // divide in sigma so error is indeed 0.5*|Ax-b|
-  if (model_)
-    model_->WhitenSystem(result.first, result.second);
+  if (model_) model_->WhitenSystem(result.first, result.second);
   return result;
 }
 
@@ -920,8 +928,7 @@ pair<Matrix, Vector> JacobianFactor::jacobianUnweighted() const {
 /* ************************************************************************* */
 Matrix JacobianFactor::augmentedJacobian() const {
   Matrix Ab = augmentedJacobianUnweighted();
-  if (model_)
-    model_->WhitenInPlace(Ab);
+  if (model_) model_->WhitenInPlace(Ab);
   return Ab;
 }
 
@@ -947,9 +954,8 @@ GaussianFactor::shared_ptr JacobianFactor::negate() const {
 }
 
 /* ************************************************************************* */
-std::pair<GaussianConditional::shared_ptr,
-    JacobianFactor::shared_ptr> JacobianFactor::eliminate(
-    const Ordering& keys) {
+std::pair<GaussianConditional::shared_ptr, JacobianFactor::shared_ptr>
+JacobianFactor::eliminate(const Ordering& keys) {
   GaussianFactorGraph graph;
   graph.add(*this);
   return EliminateQR(graph, keys);
@@ -957,7 +963,7 @@ std::pair<GaussianConditional::shared_ptr,
 
 /* ************************************************************************* */
 void JacobianFactor::setModel(bool anyConstrained, const Vector& sigmas) {
-  if ((size_t) sigmas.size() != this->rows())
+  if ((size_t)sigmas.size() != this->rows())
     throw InvalidNoiseModel(this->rows(), sigmas.size());
   if (anyConstrained)
     model_ = noiseModel::Constrained::MixedSigmas(sigmas);
@@ -966,8 +972,8 @@ void JacobianFactor::setModel(bool anyConstrained, const Vector& sigmas) {
 }
 
 /* ************************************************************************* */
-std::pair<GaussianConditional::shared_ptr, JacobianFactor::shared_ptr> EliminateQR(
-    const GaussianFactorGraph& factors, const Ordering& keys) {
+std::pair<GaussianConditional::shared_ptr, JacobianFactor::shared_ptr>
+EliminateQR(const GaussianFactorGraph& factors, const Ordering& keys) {
   gttic(EliminateQR);
   // Combine and sort variable blocks in elimination order
   JacobianFactor::shared_ptr jointFactor;
@@ -975,7 +981,8 @@ std::pair<GaussianConditional::shared_ptr, JacobianFactor::shared_ptr> Eliminate
     jointFactor = std::make_shared<JacobianFactor>(factors, keys);
   } catch (std::invalid_argument&) {
     throw InvalidDenseElimination(
-        "EliminateQR was called with a request to eliminate variables that are not\n"
+        "EliminateQR was called with a request to eliminate variables that are "
+        "not\n"
         "involved in the provided factors.");
   }
 
@@ -984,9 +991,9 @@ std::pair<GaussianConditional::shared_ptr, JacobianFactor::shared_ptr> Eliminate
   SharedDiagonal noiseModel;
   VerticalBlockMatrix& Ab = jointFactor->Ab_;
   if (jointFactor->model_) {
-    // The noiseModel QR can, in the case of constraints, yield a "staggered" QR where
-    // some rows have more leading zeros than in an upper triangular matrix.
-    // In either case, QR will put zeros below the "diagonal".
+    // The noiseModel QR can, in the case of constraints, yield a "staggered" QR
+    // where some rows have more leading zeros than in an upper triangular
+    // matrix. In either case, QR will put zeros below the "diagonal".
     jointFactor->model_ = jointFactor->model_->QR(Ab.matrix());
   } else {
     // The inplace variant will have no valid rows anymore below m==n
@@ -1005,36 +1012,41 @@ std::pair<GaussianConditional::shared_ptr, JacobianFactor::shared_ptr> Eliminate
 }
 
 /* ************************************************************************* */
-GaussianConditional::shared_ptr JacobianFactor::splitConditional(size_t nrFrontals) {
+GaussianConditional::shared_ptr JacobianFactor::splitConditional(
+    size_t nrFrontals) {
   gttic(JacobianFactor_splitConditional);
 
   if (!model_) {
     throw std::invalid_argument(
-        "JacobianFactor::splitConditional cannot be  given a nullptr noise model");
+        "JacobianFactor::splitConditional cannot be  given a nullptr noise "
+        "model");
   }
 
   if (nrFrontals > size()) {
     throw std::invalid_argument(
-        "JacobianFactor::splitConditional was requested to split off more variables than exist.");
+        "JacobianFactor::splitConditional was requested to split off more "
+        "variables than exist.");
   }
 
   // Convert nr of keys to number of scalar columns
   DenseIndex frontalDim = Ab_.range(0, nrFrontals).cols();
 
   // Check that the noise model has at least this dimension
-  // If this is *not* the case, we do not have enough information on the frontal variables.
+  // If this is *not* the case, we do not have enough information on the frontal
+  // variables.
   if ((DenseIndex)model_->dim() < frontalDim)
     throw IndeterminateSystemException(this->keys().front());
 
-  // Restrict the matrix to be in the first nrFrontals variables and create the conditional
+  // Restrict the matrix to be in the first nrFrontals variables and create the
+  // conditional
   const DenseIndex originalRowEnd = Ab_.rowEnd();
   Ab_.rowEnd() = Ab_.rowStart() + frontalDim;
   SharedDiagonal conditionalNoiseModel;
-  conditionalNoiseModel =
-      noiseModel::Diagonal::Sigmas(
-          model_->sigmasRef().segment(Ab_.rowStart(), Ab_.rows()));
+  conditionalNoiseModel = noiseModel::Diagonal::Sigmas(
+      model_->sigmasRef().segment(Ab_.rowStart(), Ab_.rows()));
   GaussianConditional::shared_ptr conditional =
-      std::make_shared<GaussianConditional>(Base::keys_, nrFrontals, Ab_, conditionalNoiseModel);
+      std::make_shared<GaussianConditional>(Base::keys_, nrFrontals, Ab_,
+                                            conditionalNoiseModel);
 
   const DenseIndex maxRemainingRows =
       std::min(Ab_.cols(), originalRowEnd) - Ab_.rowStart() - frontalDim;
@@ -1051,8 +1063,8 @@ GaussianConditional::shared_ptr JacobianFactor::splitConditional(size_t nrFronta
     model_ = noiseModel::Constrained::MixedSigmas(
         model_->sigmasRef().tail(remainingRows));
   else
-    model_ = noiseModel::Diagonal::Sigmas(
-        model_->sigmasRef().tail(remainingRows));
+    model_ =
+        noiseModel::Diagonal::Sigmas(model_->sigmasRef().tail(remainingRows));
   assert(model_->dim() == (size_t)Ab_.rows());
 
   return conditional;

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -102,49 +102,12 @@ size_t hardwareThreads() {
 }
 
 SymmetricBlockMatrix makeZeroLocalInfo(const std::vector<size_t>& blockDims) {
+  // Partial elimination can leave a smaller active view, while cached child
+  // mappings still address the clique's complete symbolic block layout.
   SymmetricBlockMatrix local(blockDims, true);
   local.setZero();
   return local;
 }
-
-#ifdef GTSAM_USE_TBB
-void updateMappedInfoOwnedColumn(
-    const SymmetricBlockMatrix& source, DenseIndex sourceBlockStart,
-    DenseIndex ownedSourceBlock, SymmetricBlockMatrix* target,
-    const std::vector<DenseIndex>& targetIndices,
-    const std::vector<DenseIndex>& targetScalarOffsets) {
-  assert(target && ownedSourceBlock >= 0);
-  const DenseIndex retainedBlocks =
-      static_cast<DenseIndex>(targetIndices.size()) - 1;
-  assert(ownedSourceBlock < retainedBlocks);
-  const DenseIndex targetColumn = targetIndices[ownedSourceBlock];
-  const DenseIndex targetOffset = targetScalarOffsets[ownedSourceBlock];
-  target->updateDiagonalBlockAt(
-      targetOffset, source.diagonalBlock(sourceBlockStart + ownedSourceBlock));
-
-  const DenseIndex sourceRhs = sourceBlockStart + retainedBlocks;
-  target->updateOffDiagonalBlockAt(
-      targetOffset, targetScalarOffsets.back(),
-      source.aboveDiagonalBlock(sourceBlockStart + ownedSourceBlock,
-                                sourceRhs));
-  for (DenseIndex other = 0; other < retainedBlocks; ++other) {
-    if (targetIndices[other] >= targetColumn) continue;
-    if (other < ownedSourceBlock) {
-      target->updateOffDiagonalBlockAt(
-          targetScalarOffsets[other], targetOffset,
-          source.aboveDiagonalBlock(sourceBlockStart + other,
-                                    sourceBlockStart + ownedSourceBlock));
-    } else {
-      target->updateOffDiagonalBlockAt(
-          targetScalarOffsets[other], targetOffset,
-          source
-              .aboveDiagonalBlock(sourceBlockStart + ownedSourceBlock,
-                                  sourceBlockStart + other)
-              .transpose());
-    }
-  }
-}
-#endif
 
 }  // namespace
 
@@ -213,8 +176,15 @@ MultifrontalClique::MultifrontalClique(
   blockDims_ = this->blockDims(dims, frontals, separatorKeys);
   const size_t numSeparatorBlocks = blockDims_.size() - numFrontals();
   separatorIndices_.reserve(numSeparatorBlocks + 1);
+  separatorScalarOffsets_.reserve(numSeparatorBlocks + 1);
+  DenseIndex separatorScalarOffset = 0;
   for (size_t i = 0; i <= numSeparatorBlocks; ++i) {
     separatorIndices_.push_back(static_cast<DenseIndex>(i));
+    separatorScalarOffsets_.push_back(separatorScalarOffset);
+    if (i < numSeparatorBlocks) {
+      separatorScalarOffset +=
+          static_cast<DenseIndex>(blockDims_[numFrontals() + i]);
+    }
   }
   factorRows_ = vbmRows;
 }
@@ -476,23 +446,12 @@ void MultifrontalClique::FactorLoadPlan::buildSolveMappings(
   assert(clique.parentIndices_.size() ==
          clique.orderedKeys_.size() - clique.numFrontals() + 1);
   const DenseIndex numFrontals = static_cast<DenseIndex>(clique.numFrontals());
-  DenseIndex separatorScalarOffset = 0;
-  std::vector<DenseIndex> localSeparatorScalarOffsets(
-      clique.separatorIndices_.size());
-  for (size_t block = clique.numFrontals(); block < clique.blockDims_.size();
-       ++block) {
-    localSeparatorScalarOffsets[block - clique.numFrontals()] =
-        separatorScalarOffset;
-    separatorScalarOffset +=
-        static_cast<DenseIndex>(clique.blockDims_.at(block));
-  }
-  localSeparatorScalarOffsets.back() = separatorScalarOffset;
 
   parentMapping = buildRetainedMapping(
       factor, numFrontals, clique.parentIndices_, clique.parentScalarOffsets_);
   separatorMapping =
       buildRetainedMapping(factor, numFrontals, clique.separatorIndices_,
-                           localSeparatorScalarOffsets);
+                           clique.separatorScalarOffsets_);
 }
 
 internal::BatchHessianMapping
@@ -621,16 +580,9 @@ void MultifrontalClique::buildFusedStarMappings() {
   parentSchurScalarOffsets_ =
       internal::CompactLeafSchurKernel::expandScalarOffsets(
           retainedDimensions, parentScalarOffsets_);
-
-  std::vector<DenseIndex> separatorBlockOffsets(retainedDimensions.size());
-  DenseIndex offset = 0;
-  for (size_t block = 0; block < retainedDimensions.size(); ++block) {
-    separatorBlockOffsets[block] = offset;
-    offset += static_cast<DenseIndex>(retainedDimensions[block]);
-  }
   separatorSchurScalarOffsets_ =
       internal::CompactLeafSchurKernel::expandScalarOffsets(
-          retainedDimensions, separatorBlockOffsets);
+          retainedDimensions, separatorScalarOffsets_);
 }
 
 void MultifrontalClique::buildLoadPlans(const GaussianFactorGraph& graph) {
@@ -1130,9 +1082,37 @@ void MultifrontalClique::updateFusedStarInfo(
     bool useParentMappedSlots) const {
   assert(RSdReady_ && RSd_.firstBlock() == 0);
   updateDirectFactors(targetInfo, targetIndices, useParentMappedSlots);
+  // Fused point batches have very few frontal rows. Scalar dot products avoid
+  // the dynamic block-product overhead that materially slows this hot path.
   internal::CompactLeafSchurKernel::subtractMappedOuterProduct(
       RSd_, static_cast<DenseIndex>(frontalDim), targetScalarOffsets,
       &targetInfo);
+}
+
+void MultifrontalClique::updateCholeskyInfo(
+    SymmetricBlockMatrix& targetInfo,
+    const std::vector<DenseIndex>& targetIndices,
+    const std::vector<DenseIndex>& targetBlockOffsets,
+    bool useParentMappedSlots) const {
+  assert(fullyEliminated() && !useQR());
+  const DenseIndex frontalBlocks = static_cast<DenseIndex>(numFrontals());
+  if (solveMode_ == SolveMode::FusedStarCholeskyLeaf) {
+    const auto& targetScalarOffsets = useParentMappedSlots
+                                          ? parentSchurScalarOffsets_
+                                          : separatorSchurScalarOffsets_;
+    updateFusedStarInfo(targetInfo, targetIndices, targetScalarOffsets,
+                        useParentMappedSlots);
+  } else if (useCompactCholesky()) {
+    assert(RSdReady_ && RSd_.firstBlock() == 0);
+    updateDirectFactors(targetInfo, targetIndices, useParentMappedSlots);
+    targetInfo.updateFromOuterProductBlocks(
+        RSd_, 0, static_cast<DenseIndex>(frontalDim), frontalBlocks,
+        targetIndices, targetBlockOffsets, -1.0);
+  } else {
+    assert(info_.nBlocks() > 0 && info_.blockStart() == 0);
+    targetInfo.updateFromMappedBlocks(info_, frontalBlocks, targetIndices,
+                                      targetBlockOffsets);
+  }
 }
 
 void MultifrontalClique::updateParentInfo(
@@ -1142,32 +1122,13 @@ void MultifrontalClique::updateParentInfo(
   if (useQR()) {
     // Accumulate separator (and RHS) normal equations from the QR residual.
     assert(RSdReady_ && RSd_.firstBlock() == 0);
-    const DenseIndex nfBlocks = static_cast<DenseIndex>(numFrontals());
-    const DenseIndex rowStart = RSd_.rowStart();
-    const DenseIndex rowEnd = RSd_.rowEnd();
-    RSd_.rowStart() = static_cast<DenseIndex>(frontalDim);
-    RSd_.rowEnd() = static_cast<DenseIndex>(RSd_.matrix().rows());
-    RSd_.firstBlock() = nfBlocks;
-    parentInfo.updateFromOuterProductBlocks(RSd_, parentIndices_);
-    RSd_.firstBlock() = 0;
-    RSd_.rowStart() = rowStart;
-    RSd_.rowEnd() = rowEnd;
-  } else if (solveMode_ == SolveMode::FusedStarCholeskyLeaf) {
-    updateFusedStarInfo(parentInfo, parentIndices_, parentSchurScalarOffsets_,
-                        true);
-  } else if (useCompactCholesky()) {
-    assert(RSdReady_ && RSd_.firstBlock() == 0);
-    updateDirectFactors(parentInfo, parentIndices_, true);
-    RSd_.firstBlock() = static_cast<DenseIndex>(numFrontals());
-    parentInfo.updateFromOuterProductBlocks(RSd_, parentIndices_, -1.0);
-    RSd_.firstBlock() = 0;
+    parentInfo.updateFromOuterProductBlocks(
+        RSd_, static_cast<DenseIndex>(frontalDim),
+        static_cast<DenseIndex>(RSd_.matrix().rows()),
+        static_cast<DenseIndex>(numFrontals()), parentIndices_,
+        parentScalarOffsets_);
   } else {
-    // Accumulate the S^T S part from this clique's info matrix into the parent.
-    assert(info_.nBlocks() > 0 && info_.blockStart() == 0);
-    info_.blockStart() = numFrontals();
-    parentInfo.updateFromMappedBlocks(info_, parentIndices_,
-                                      parentScalarOffsets_);
-    info_.blockStart() = 0;
+    updateCholeskyInfo(parentInfo, parentIndices_, parentScalarOffsets_, true);
   }
 }
 
@@ -1176,9 +1137,9 @@ void MultifrontalClique::updateParentMaterializedColumn(
     SymmetricBlockMatrix& parentInfo, DenseIndex sourceSeparatorBlock) const {
   assert(fullyEliminated() && !useQR() && !useCompactCholesky());
   assert(info_.nBlocks() > 0 && info_.blockStart() == 0);
-  updateMappedInfoOwnedColumn(info_, static_cast<DenseIndex>(numFrontals()),
-                              sourceSeparatorBlock, &parentInfo, parentIndices_,
-                              parentScalarOffsets_);
+  parentInfo.updateFromMappedBlockColumn(
+      info_, static_cast<DenseIndex>(numFrontals()), sourceSeparatorBlock,
+      parentIndices_, parentScalarOffsets_, true);
 }
 
 void MultifrontalClique::updateParentQrColumnScratch(
@@ -1191,14 +1152,10 @@ void MultifrontalClique::updateParentQrColumnScratch(
   assert(sourceSeparatorBlock >= 0 && sourceSeparatorBlock < retainedBlocks);
 
   const DenseIndex residualRow = static_cast<DenseIndex>(frontalDim);
-  const DenseIndex residualRows =
-      static_cast<DenseIndex>(RSd_.matrix().rows()) - residualRow;
   const DenseIndex sourceColumn = frontalBlocks + sourceSeparatorBlock;
-  const DenseIndex sourceOffset = RSd_.offset(sourceColumn);
-  const DenseIndex sourceDimension =
-      RSd_.offset(sourceColumn + 1) - sourceOffset;
-  const auto owned = RSd_.matrix().block(residualRow, sourceOffset,
-                                         residualRows, sourceDimension);
+  const auto owned = RSd_.blockRows(
+      sourceColumn, residualRow, static_cast<DenseIndex>(RSd_.matrix().rows()));
+  const DenseIndex sourceDimension = owned.cols();
 
   const DenseIndex targetColumn = parentIndices_[sourceSeparatorBlock];
   const DenseIndex targetOffset = parentScalarOffsets_[sourceSeparatorBlock];
@@ -1207,37 +1164,34 @@ void MultifrontalClique::updateParentQrColumnScratch(
   scratch->block(targetOffset, 0, sourceDimension, sourceDimension).noalias() +=
       owned.transpose() * owned;
 
-  const DenseIndex rhsOffset = RSd_.offset(frontalBlocks + retainedBlocks);
-  const auto rhs = RSd_.matrix().block(residualRow, rhsOffset, residualRows, 1);
-  scratch->bottomRows(1).noalias() += (owned.transpose() * rhs).transpose();
+  const auto rhs =
+      RSd_.blockRows(frontalBlocks + retainedBlocks, residualRow,
+                     static_cast<DenseIndex>(RSd_.matrix().rows()));
+  scratch->bottomRows(1).noalias() += rhs.transpose() * owned;
 
   for (DenseIndex other = 0; other < retainedBlocks; ++other) {
     if (parentIndices_[other] >= targetColumn) continue;
     const DenseIndex otherColumn = frontalBlocks + other;
-    const DenseIndex otherOffset = RSd_.offset(otherColumn);
-    const DenseIndex otherDimension =
-        RSd_.offset(otherColumn + 1) - otherOffset;
-    const auto otherBlock = RSd_.matrix().block(residualRow, otherOffset,
-                                                residualRows, otherDimension);
+    const auto otherBlock =
+        RSd_.blockRows(otherColumn, residualRow,
+                       static_cast<DenseIndex>(RSd_.matrix().rows()));
+    const DenseIndex otherDimension = otherBlock.cols();
     scratch
         ->block(parentScalarOffsets_[other], 0, otherDimension, sourceDimension)
         .noalias() += otherBlock.transpose() * owned;
   }
 }
 
-double MultifrontalClique::parentMaterializedRhsDiagonal() const {
-  assert(fullyEliminated() && !useQR() && !useCompactCholesky());
-  assert(info_.nBlocks() > 0);
-  return info_.diagonalBlock(info_.nBlocks() - 1).coeff(0, 0);
-}
-
-double MultifrontalClique::parentQrRhsDiagonal() const {
-  assert(fullyEliminated() && useQR() && RSdReady_);
-  const DenseIndex residualRow = static_cast<DenseIndex>(frontalDim);
-  const DenseIndex rhsBlock = RSd_.nBlocks() - 1;
-  return RSd_.matrix()
-      .block(residualRow, RSd_.offset(rhsBlock),
-             RSd_.matrix().rows() - residualRow, 1)
+double MultifrontalClique::parentRhsDiagonal() const {
+  assert(fullyEliminated() && !useCompactCholesky());
+  if (!useQR()) {
+    assert(info_.nBlocks() > 0);
+    return info_.diagonalBlock(info_.nBlocks() - 1).coeff(0, 0);
+  }
+  assert(RSdReady_);
+  return RSd_
+      .blockRows(RSd_.nBlocks() - 1, static_cast<DenseIndex>(frontalDim),
+                 static_cast<DenseIndex>(RSd_.matrix().rows()))
       .squaredNorm();
 }
 #endif
@@ -1246,21 +1200,8 @@ void MultifrontalClique::updateSeparatorInfo(
     SymmetricBlockMatrix& separatorInfo) const {
   assert(fullyEliminated() && !useQR());
   assert(RSd_.rowStart() == 0);
-  if (solveMode_ == SolveMode::FusedStarCholeskyLeaf) {
-    updateFusedStarInfo(separatorInfo, separatorIndices_,
-                        separatorSchurScalarOffsets_, false);
-  } else if (useCompactCholesky()) {
-    assert(RSdReady_ && RSd_.firstBlock() == 0);
-    updateDirectFactors(separatorInfo, separatorIndices_, false);
-    RSd_.firstBlock() = static_cast<DenseIndex>(numFrontals());
-    separatorInfo.updateFromOuterProductBlocks(RSd_, separatorIndices_, -1.0);
-    RSd_.firstBlock() = 0;
-  } else {
-    assert(info_.nBlocks() > 0 && info_.blockStart() == 0);
-    info_.blockStart() = numFrontals();
-    separatorInfo.updateFromMappedBlocks(info_, separatorIndices_);
-    info_.blockStart() = 0;
-  }
+  updateCholeskyInfo(separatorInfo, separatorIndices_, separatorScalarOffsets_,
+                     false);
 }
 
 void MultifrontalClique::gatherUpdatesSequential() {
@@ -1274,9 +1215,44 @@ void MultifrontalClique::gatherUpdatesSequential() {
   }
 }
 #ifdef GTSAM_USE_TBB
-void MultifrontalClique::ParentGatherPlan::build(
+struct MultifrontalClique::ParentGatherPlan {
+  enum class ColumnRepresentation : uint8_t { Materialized, Qr };
+
+  struct ColumnOwnedChild {
+    size_t childIndex;
+    ColumnRepresentation representation;
+  };
+
+  struct ColumnUpdate {
+    size_t childIndex;
+    DenseIndex sourceSeparatorBlock;
+  };
+
+  struct QrColumnChunk {
+    DenseIndex column;
+    size_t begin;
+    size_t end;
+    Matrix scratch;
+  };
+
+  std::vector<ColumnOwnedChild> columnOwnedChildren;
+  std::vector<size_t> computeOnceChildIndices;
+  std::vector<std::vector<ColumnUpdate>> materializedByColumn;
+  std::vector<std::vector<ColumnUpdate>> qrByColumn;
+  std::vector<QrColumnChunk> qrChunks;
+  std::vector<std::vector<size_t>> qrChunkIndicesByColumn;
+  bool hasMaterialized = false;
+  bool hasQr = false;
+
+  /// Classify children using their final numerical representation.
+  explicit ParentGatherPlan(const MultifrontalClique& parent);
+
+  /// Execute the independent column-owned and compute-once stages.
+  void gather(MultifrontalClique* parent);
+};
+
+MultifrontalClique::ParentGatherPlan::ParentGatherPlan(
     const MultifrontalClique& parent) {
-  assert(!built);
   materializedByColumn.resize(parent.blockDims_.size());
   qrByColumn.resize(parent.blockDims_.size());
 
@@ -1297,9 +1273,12 @@ void MultifrontalClique::ParentGatherPlan::build(
     }
 
     const bool qr = child->useQR();
-    auto& childIndices = qr ? qrChildIndices : materializedChildIndices;
+    columnOwnedChildren.push_back(
+        {childIndex,
+         qr ? ColumnRepresentation::Qr : ColumnRepresentation::Materialized});
     auto& updatesByColumn = qr ? qrByColumn : materializedByColumn;
-    childIndices.push_back(childIndex);
+    hasQr |= qr;
+    hasMaterialized |= !qr;
     for (size_t sourceBlock = 0; sourceBlock + 1 < child->parentIndices_.size();
          ++sourceBlock) {
       const DenseIndex column = child->parentIndices_[sourceBlock];
@@ -1329,11 +1308,10 @@ void MultifrontalClique::ParentGatherPlan::build(
                         static_cast<DenseIndex>(parent.blockDims_[column]))});
     }
   }
-  built = true;
 }
 
 void MultifrontalClique::ParentGatherPlan::gather(MultifrontalClique* parent) {
-  assert(parent && built);
+  assert(parent);
 
   if (!computeOnceChildIndices.empty()) {
     tbb::enumerable_thread_specific<SymmetricBlockMatrix> locals(
@@ -1355,9 +1333,9 @@ void MultifrontalClique::ParentGatherPlan::gather(MultifrontalClique* parent) {
   }
 
   // A compact-only parent follows exactly the original compute-once path.
-  if (materializedChildIndices.empty() && qrChildIndices.empty()) return;
+  if (columnOwnedChildren.empty()) return;
 
-  if (!materializedChildIndices.empty()) {
+  if (hasMaterialized) {
     tbb::parallel_for(
         tbb::blocked_range<size_t>(0, materializedByColumn.size(), 1),
         [this, parent](const tbb::blocked_range<size_t>& range) {
@@ -1372,7 +1350,7 @@ void MultifrontalClique::ParentGatherPlan::gather(MultifrontalClique* parent) {
         });
   }
 
-  if (!qrChildIndices.empty()) {
+  if (hasQr) {
     tbb::parallel_for(
         tbb::blocked_range<size_t>(0, qrChunks.size(), 1),
         [this, parent](const tbb::blocked_range<size_t>& range) {
@@ -1426,41 +1404,23 @@ void MultifrontalClique::ParentGatherPlan::gather(MultifrontalClique* parent) {
         });
   }
 
-  const double materializedRhs =
-      materializedChildIndices.empty()
-          ? 0.0
-          : tbb::parallel_reduce(
-                tbb::blocked_range<size_t>(0, materializedChildIndices.size()),
-                0.0,
-                [this, parent](const tbb::blocked_range<size_t>& range,
-                               double subtotal) {
-                  for (size_t index = range.begin(); index < range.end();
-                       ++index) {
-                    subtotal +=
-                        parent->children[materializedChildIndices[index]]
-                            ->parentMaterializedRhsDiagonal();
-                  }
-                  return subtotal;
-                },
-                std::plus<double>());
-  const double qrRhs =
-      qrChildIndices.empty()
-          ? 0.0
-          : tbb::parallel_reduce(
-                tbb::blocked_range<size_t>(0, qrChildIndices.size()), 0.0,
-                [this, parent](const tbb::blocked_range<size_t>& range,
-                               double subtotal) {
-                  for (size_t index = range.begin(); index < range.end();
-                       ++index) {
-                    subtotal += parent->children[qrChildIndices[index]]
-                                    ->parentQrRhsDiagonal();
-                  }
-                  return subtotal;
-                },
-                std::plus<double>());
+  const double rhs = tbb::parallel_reduce(
+      tbb::blocked_range<size_t>(0, columnOwnedChildren.size()), 0.0,
+      [this, parent](const tbb::blocked_range<size_t>& range, double subtotal) {
+        for (size_t index = range.begin(); index < range.end(); ++index) {
+          const ColumnOwnedChild& update = columnOwnedChildren[index];
+          assert(update.representation ==
+                 (parent->children[update.childIndex]->useQR()
+                      ? ColumnRepresentation::Qr
+                      : ColumnRepresentation::Materialized));
+          subtotal += parent->children[update.childIndex]->parentRhsDiagonal();
+        }
+        return subtotal;
+      },
+      std::plus<double>());
 
   Eigen::Matrix<double, 1, 1> rhsUpdate;
-  rhsUpdate(0, 0) = materializedRhs + qrRhs;
+  rhsUpdate(0, 0) = rhs;
   parent->info_.updateDiagonalBlock(parent->info_.nBlocks() - 1, rhsUpdate);
 }
 #endif
@@ -1469,8 +1429,7 @@ void MultifrontalClique::gatherUpdatesParallel(size_t numThreads) {
 #ifdef GTSAM_USE_TBB
   (void)numThreads;  // TBB is capped by the enclosing traversal arena.
   if (!parentGatherPlan_) {
-    parentGatherPlan_ = std::make_unique<ParentGatherPlan>();
-    parentGatherPlan_->build(*this);
+    parentGatherPlan_ = std::make_shared<ParentGatherPlan>(*this);
   }
   parentGatherPlan_->gather(this);
 #else

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -1282,8 +1282,7 @@ MultifrontalClique::ParentGatherPlan::ParentGatherPlan(
     for (size_t sourceBlock = 0; sourceBlock + 1 < child->parentIndices_.size();
          ++sourceBlock) {
       const DenseIndex column = child->parentIndices_[sourceBlock];
-      assert(column >= 0 &&
-             column < static_cast<DenseIndex>(parent.blockDims_.size()));
+      assert(column < static_cast<DenseIndex>(parent.blockDims_.size()));
       updatesByColumn[column].push_back(
           {childIndex, static_cast<DenseIndex>(sourceBlock)});
     }

--- a/gtsam/linear/MultifrontalClique.h
+++ b/gtsam/linear/MultifrontalClique.h
@@ -374,11 +374,8 @@ class GTSAM_EXPORT MultifrontalClique {
   void updateParentQrColumnScratch(DenseIndex sourceSeparatorBlock,
                                    Matrix* scratch) const;
 
-  /// Return the augmented-RHS diagonal from an ordinary child update.
-  double parentMaterializedRhsDiagonal() const;
-
-  /// Return the augmented-RHS diagonal from a QR child update.
-  double parentQrRhsDiagonal() const;
+  /// Return the augmented-RHS diagonal from a column-owned child update.
+  double parentRhsDiagonal() const;
 #endif
 
   /// Update a separator-local information matrix without parent scattering.
@@ -398,6 +395,12 @@ class GTSAM_EXPORT MultifrontalClique {
                            const std::vector<DenseIndex>& targetIndices,
                            const std::vector<DenseIndex>& targetScalarOffsets,
                            bool useParentMappedSlots) const;
+
+  /// Dispatch one Cholesky representation into a mapped destination.
+  void updateCholeskyInfo(SymmetricBlockMatrix& targetInfo,
+                          const std::vector<DenseIndex>& targetIndices,
+                          const std::vector<DenseIndex>& targetBlockOffsets,
+                          bool useParentMappedSlots) const;
 
   /// Add the original separator normal equations directly into the parent.
   void updateDirectFactors(SymmetricBlockMatrix& targetInfo,
@@ -472,6 +475,8 @@ class GTSAM_EXPORT MultifrontalClique {
   std::vector<DenseIndex>
       parentScalarOffsets_;  ///< Cached scalar offsets for parent blocks.
   std::vector<DenseIndex> separatorIndices_;  ///< Identity separator mapping.
+  std::vector<DenseIndex>
+      separatorScalarOffsets_;  ///< Cached separator-local scalar offsets.
   SolveMode solveMode_ = SolveMode::Cholesky;
   SolveMode starFallbackMode_ = SolveMode::Cholesky;
   /// Whether one automatic-QR star awaits inspection of its sole factor.
@@ -486,40 +491,8 @@ class GTSAM_EXPORT MultifrontalClique {
   std::vector<uint8_t> childInSameSeparatorGroup_;
 
 #ifdef GTSAM_USE_TBB
-  /**
-   * Lazy TBB gather metadata, built after child solve modes are resolved.
-   * Materialized and QR children are bucketed by disjoint parent columns;
-   * compact children remain in the existing compute-once reduction.
-   */
-  struct ParentGatherPlan {
-    struct ColumnUpdate {
-      size_t childIndex = 0;
-      DenseIndex sourceSeparatorBlock = 0;
-    };
-
-    struct QrColumnChunk {
-      DenseIndex column = 0;
-      size_t begin = 0;
-      size_t end = 0;
-      Matrix scratch;
-    };
-
-    bool built = false;
-    std::vector<size_t> materializedChildIndices;
-    std::vector<size_t> qrChildIndices;
-    std::vector<size_t> computeOnceChildIndices;
-    std::vector<std::vector<ColumnUpdate>> materializedByColumn;
-    std::vector<std::vector<ColumnUpdate>> qrByColumn;
-    std::vector<QrColumnChunk> qrChunks;
-    std::vector<std::vector<size_t>> qrChunkIndicesByColumn;
-
-    /// Classify children using their final numerical representation.
-    void build(const MultifrontalClique& parent);
-
-    /// Execute the independent column-owned and compute-once stages.
-    void gather(MultifrontalClique* parent);
-  };
-  std::unique_ptr<ParentGatherPlan> parentGatherPlan_;
+  struct ParentGatherPlan;
+  std::shared_ptr<ParentGatherPlan> parentGatherPlan_;
 #endif
 
   // Lazily allocated after load-plan construction. Direct batch factors need


### PR DESCRIPTION
## Summary

- centralize physical block-column ownership and explicit-source mapped updates in the block-matrix layer
- remove temporary active-view mutation from multifrontal parent and separator updates
- simplify and hide the constructor-built TBB parent-gather plan
- consolidate Cholesky representation dispatch while retaining the measured-fast fused scalar Schur kernel

## Design

Materialized Cholesky updates now use mapped block-column primitives, QR reads explicit row and block ranges, and ordinary compact updates use explicit mapped outer products. Compact and fused children remain on the compute-once path.

The fused star path deliberately retains its scalar dot-product scatter: replacing it with general dynamic block products materially regressed BAL-88 Full point-batch timing.

Per-thread compute-once accumulators retain construction from the full symbolic block dimensions. Partial-elimination active views can be smaller than cached child destinations.

## Correctness

Passed with TBB:

- `testSymmetricBlockMatrix`
- `testHessianFactor`
- `testJacobianFactor`
- `testFixedJacobianFactor` (dynamic, binary, and ternary)
- `testBatchJacobianFactor`
- `testMultifrontalSolver`

The multifrontal suite covers ordinary, forced QR, compact and fused, mixed representations, reload, partial elimination, same-separator aggregation, and more than 1,024 children.

A TBB-disabled `testMultifrontalSolver` build and run also passes.

## BAL-88 performance

Release build with TBB, CPUs 0-20, 21 threads for regular timing, and seven alternating paired baseline/candidate samples.

| Path | Baseline median | Candidate median | Change |
| --- | ---: | ---: | ---: |
| Regular factors, 2 iterations | 0.921464 s | 0.930401 s | +0.97% |
| Full point batch | 1.018249 s | 1.011170 s | -0.70% |
| Schur point batch | 0.984561 s | 0.985988 s | +0.15% |

All paths satisfy the 3% no-regression gate. Full and Schur preserve final error 291581.106404 and 4 LM / 4 inner iterations.

Peak RSS on the regular path was effectively flat: 2,454,380 KB baseline versus 2,462,320 KB candidate.
