### PR TITLE
Aggregate non-TBB leaf traversal tasks

### DIFF
--- a/gtsam/base/ForestTraversal.h
+++ b/gtsam/base/ForestTraversal.h
@@ -163,7 +163,6 @@ class ForestTraversal {
   template <typename Fn>
   void runBottomUp(Fn fn, int parallelThreshold = 10,
                    size_t leafAggregationProblemSize = 0) {
-    (void)leafAggregationProblemSize;
     const auto& roots = getRoots();
     if (roots.empty()) return;
     // Create shared traversal state and run from all roots.
@@ -171,7 +170,13 @@ class ForestTraversal {
     state.runTraversal([&]() {
       for (const auto& root : roots) {
         assert(root);
-        Frame<Fn> frame{&scheduler_, *root, 0, fn, parallelThreshold, &state};
+        Frame<Fn> frame{&scheduler_,
+                        *root,
+                        0,
+                        fn,
+                        parallelThreshold,
+                        &state,
+                        leafAggregationProblemSize};
         frame.bottomUpAsync([] {});
       }
     });
@@ -267,6 +272,7 @@ class ForestTraversal {
     const Fn& fn;
     int threshold;
     State* state;
+    size_t leafAggregationProblemSize = 0;
 
     /// Return node children via method or field.
     auto& getChildren() const {
@@ -333,22 +339,123 @@ class ForestTraversal {
       auto&& children = getChildren();
       if (children.empty()) {
         completeBottomUpNode(onDone);
-      } else {
-        auto remaining = std::make_shared<std::atomic<int> >(
-            static_cast<int>(children.size()));
-        std::function<void()> childDone = [frame = *this, remaining,
-                                           onDone]() mutable {
-          if (remaining->fetch_sub(1, std::memory_order_relaxed) == 1) {
-            frame.completeBottomUpNode(onDone);
-          }
-        };
+        return;
+      }
+      if (leafAggregationProblemSize == 0) {
+        bottomUpUnaggregated(children, onDone);
+        return;
+      }
 
-        for (const auto& child : children) {
-          assert(child);
-          Frame childFrame{scheduler, *child, depth + 1, fn, threshold, state};
+      // The sentinel prevents inline child completions from finishing this
+      // node before every sibling unit has been dispatched.
+      auto remaining = std::make_shared<std::atomic<int> >(1);
+      std::function<void()> childDone = [frame = *this, remaining,
+                                         onDone]() mutable {
+        if (remaining->fetch_sub(1, std::memory_order_relaxed) == 1) {
+          frame.completeBottomUpNode(onDone);
+        }
+      };
+
+      for (size_t begin = 0; begin < children.size();) {
+        const auto& child = children[begin];
+        assert(child);
+        Frame childFrame{scheduler,
+                         *child,
+                         depth + 1,
+                         fn,
+                         threshold,
+                         state,
+                         leafAggregationProblemSize};
+        const size_t end = childFrame.getChildren().empty()
+                               ? leafBatchEnd(children, begin)
+                               : begin + 1;
+
+        remaining->fetch_add(1, std::memory_order_relaxed);
+        if (end > begin + 1) {
+          scheduleLeafBatch(begin, end, childDone);
+        } else {
           childFrame.bottomUpAsync(childDone);
         }
+        begin = end;
       }
+
+      childDone();  // Release the dispatch sentinel.
+    }
+
+    /// Preserve one continuation per child when aggregation is disabled.
+    template <typename Children>
+    void bottomUpUnaggregated(Children& children, const DoneFn& onDone) const {
+      auto remaining = std::make_shared<std::atomic<int> >(
+          static_cast<int>(children.size()));
+      std::function<void()> childDone = [frame = *this, remaining,
+                                         onDone]() mutable {
+        if (remaining->fetch_sub(1, std::memory_order_relaxed) == 1) {
+          frame.completeBottomUpNode(onDone);
+        }
+      };
+
+      for (const auto& child : children) {
+        assert(child);
+        Frame childFrame{scheduler, *child, depth + 1, fn, threshold, state, 0};
+        childFrame.bottomUpAsync(childDone);
+      }
+    }
+
+    /// Return the exclusive end of one size-bounded adjacent-leaf batch.
+    template <typename Children>
+    size_t leafBatchEnd(const Children& children, size_t begin) const {
+      size_t end = begin;
+      size_t batchProblemSize = 0;
+      while (end < children.size()) {
+        const auto& child = children[end];
+        assert(child);
+        Frame childFrame{scheduler,
+                         *child,
+                         depth + 1,
+                         fn,
+                         threshold,
+                         state,
+                         leafAggregationProblemSize};
+        if (!childFrame.getChildren().empty()) break;
+
+        const int childProblemSize = child->problemSize();
+        const size_t contribution =
+            childProblemSize > 0 ? static_cast<size_t>(childProblemSize) : 1;
+        if (end > begin &&
+            batchProblemSize + contribution > leafAggregationProblemSize) {
+          break;
+        }
+        batchProblemSize += contribution;
+        ++end;
+      }
+      return end;
+    }
+
+    /// Visit one adjacent range of sibling leaves in a single scheduler task.
+    void scheduleLeafBatch(size_t begin, size_t end,
+                           const DoneFn& onDone) const {
+      auto task = [frame = *this, begin, end, onDone]() mutable {
+        MaybeFinish finish{frame.state};
+        if (!frame.state->hasException.load(std::memory_order_acquire)) {
+          try {
+            auto&& children = frame.getChildren();
+            for (size_t index = begin; index < end; ++index) {
+              if (frame.state->hasException.load(std::memory_order_acquire)) {
+                break;
+              }
+              const auto& child = children[index];
+              assert(child);
+              std::invoke(frame.fn, *child);
+            }
+          } catch (...) {
+            frame.state->recordException(std::current_exception());
+          }
+        }
+        frame.callOnDone(onDone);
+      };
+
+      state->incrementPending();
+      scheduler->enqueueOrRunInline(std::function<void()>(std::move(task)));
     }
 
     /// Execute node work after children; schedule if above threshold.

--- a/gtsam/base/tests/testForestTraversal.cpp
+++ b/gtsam/base/tests/testForestTraversal.cpp
@@ -17,6 +17,8 @@
 #include <gtsam/base/ForestTraversal.h>
 
 #include <memory>
+#include <stdexcept>
+#include <thread>
 #include <vector>
 
 using namespace gtsam;
@@ -108,6 +110,76 @@ TEST(ForestTraversal, BottomUpLeafAggregation) {
 
   EXPECT_LONGS_EQUAL(7, root->subtreeCount);
 }
+
+#ifndef GTSAM_USE_TBB
+namespace {
+
+struct AggregationNode {
+  int problemSize_ = 1;
+  bool throwOnVisit = false;
+  bool visited = false;
+  std::thread::id visitThread;
+  std::vector<std::shared_ptr<AggregationNode>> children;
+
+  int problemSize() const { return problemSize_; }
+
+  void visit() {
+    visited = true;
+    visitThread = std::this_thread::get_id();
+    if (throwOnVisit) throw std::runtime_error("leaf visit failed");
+  }
+};
+
+struct AggregationForest
+    : public ForestTraversal<AggregationForest, AggregationNode> {
+  using Node = AggregationNode;
+  std::vector<std::shared_ptr<AggregationNode>> roots_;
+
+  AggregationForest() : ForestTraversal(2) {}
+
+  const std::vector<std::shared_ptr<AggregationNode>>& roots() const {
+    return roots_;
+  }
+};
+
+std::shared_ptr<AggregationNode> createLeafStar(size_t leafCount) {
+  auto root = std::make_shared<AggregationNode>();
+  for (size_t i = 0; i < leafCount; ++i) {
+    root->children.push_back(std::make_shared<AggregationNode>());
+  }
+  return root;
+}
+
+}  // namespace
+
+// Leaves below the ordinary scheduling threshold still run on scheduler
+// workers when adjacent siblings form a size-bounded batch.
+TEST(ForestTraversal, BottomUpLeafAggregationSchedulesBatches) {
+  const std::thread::id caller = std::this_thread::get_id();
+  auto root = createLeafStar(8);
+  AggregationForest forest;
+  forest.roots_.push_back(root);
+
+  forest.runBottomUp(&AggregationNode::visit, 1000, 4);
+
+  CHECK(root->visited);
+  for (const auto& leaf : root->children) {
+    CHECK(leaf->visited);
+    CHECK(leaf->visitThread != caller);
+  }
+}
+
+// Exceptions raised inside an aggregated leaf task propagate to the caller.
+TEST(ForestTraversal, BottomUpLeafAggregationPropagatesExceptions) {
+  auto root = createLeafStar(4);
+  root->children[1]->throwOnVisit = true;
+  AggregationForest forest;
+  forest.roots_.push_back(root);
+
+  CHECK_EXCEPTION(forest.runBottomUp(&AggregationNode::visit, 1000, 4),
+                  std::runtime_error);
+}
+#endif
 
 /* ************************************************************************* */
 // Test 2: Top-down traversal


### PR DESCRIPTION
## Summary

- honor `leafAggregationProblemSize` in the non-TBB bottom-up traversal
- group adjacent sibling leaves into size-bounded jobs on the existing persistent `TaskScheduler`
- preserve the original one-continuation-per-child path when aggregation is disabled
- propagate exceptions raised within aggregated leaf jobs through the traversal state

No public API, parameter, or default changes are introduced. The TBB implementation is unchanged.

## Design

The non-TBB traversal previously accepted `leafAggregationProblemSize` but ignored it, creating one scheduler task per eligible leaf. This change scans adjacent sibling leaves using the same problem-size accounting as the TBB path and visits each batch in one scheduler job.

A dispatch sentinel prevents inline completions from running a parent before all sibling units have been submitted. Singleton leaves continue through the ordinary threshold-controlled path.

## Correctness

Passed without TBB:

- `testTaskScheduler`
- `testForestTraversal`
- `testMultifrontalSolver`

Passed with TBB:

- `testForestTraversal`
- `testMultifrontalSolver`

Focused tests verify that aggregated leaves run on scheduler workers, every node preserves bottom-up ordering, and exceptions propagate to the caller.

BAL-88 Full and Schur preserve final error `291581.106404` and 4 LM / 4 inner iterations.

## BAL-88 performance

Release build without TBB, CPUs 0-20, 21 workers, and seven paired samples alternating baseline/candidate execution order.

| Path | Baseline median | Candidate median | Change |
| --- | ---: | ---: | ---: |
| Regular factors, 2 iterations | 3.046130 s | 3.018570 s | -0.9% |
| Full point batch | 2.174888 s | 1.795552 s | -17.4% |
| Schur point batch | 2.151441 s | 1.781247 s | -17.2% |
