### PR TITLE
Fix unreferenced values in IncrementalFixedLagSmoother

### DIFF
--- a/gtsam/nonlinear/FixedLagSmoother.cpp
+++ b/gtsam/nonlinear/FixedLagSmoother.cpp
@@ -75,8 +75,13 @@ void FixedLagSmoother::updateKeyTimestampMap(const KeyTimestampMap& timestamps) 
 /* ************************************************************************* */
 void FixedLagSmoother::eraseKeyTimestampMap(const KeyVector& keys) {
   for(Key key: keys) {
+    const KeyTimestampMap::iterator keyIter = keyTimestampMap_.find(key);
+    if (keyIter == keyTimestampMap_.end()) {
+      continue;
+    }
+
     // Erase the key from the Timestamp->Key map
-    double timestamp = keyTimestampMap_.at(key);
+    double timestamp = keyIter->second;
 
     TimestampKeyMap::iterator iter = timestampKeyMap_.lower_bound(timestamp);
     while(iter != timestampKeyMap_.end() && iter->first == timestamp) {
@@ -87,7 +92,7 @@ void FixedLagSmoother::eraseKeyTimestampMap(const KeyVector& keys) {
       }
     }
     // Erase the key from the Key->Timestamp map
-    keyTimestampMap_.erase(key);
+    keyTimestampMap_.erase(keyIter);
   }
 }
 

--- a/gtsam/nonlinear/FixedLagSmoother.cpp
+++ b/gtsam/nonlinear/FixedLagSmoother.cpp
@@ -75,13 +75,8 @@ void FixedLagSmoother::updateKeyTimestampMap(const KeyTimestampMap& timestamps) 
 /* ************************************************************************* */
 void FixedLagSmoother::eraseKeyTimestampMap(const KeyVector& keys) {
   for(Key key: keys) {
-    const KeyTimestampMap::iterator keyIter = keyTimestampMap_.find(key);
-    if (keyIter == keyTimestampMap_.end()) {
-      continue;
-    }
-
     // Erase the key from the Timestamp->Key map
-    double timestamp = keyIter->second;
+    double timestamp = keyTimestampMap_.at(key);
 
     TimestampKeyMap::iterator iter = timestampKeyMap_.lower_bound(timestamp);
     while(iter != timestampKeyMap_.end() && iter->first == timestamp) {
@@ -92,7 +87,7 @@ void FixedLagSmoother::eraseKeyTimestampMap(const KeyVector& keys) {
       }
     }
     // Erase the key from the Key->Timestamp map
-    keyTimestampMap_.erase(keyIter);
+    keyTimestampMap_.erase(key);
   }
 }
 

--- a/gtsam/nonlinear/ISAM2.cpp
+++ b/gtsam/nonlinear/ISAM2.cpp
@@ -413,7 +413,16 @@ void ISAM2::addVariables(const Values& newTheta,
 void ISAM2::removeVariables(const KeySet& unusedKeys) {
   gttic(removeVariables);
 
-  variableIndex_.removeUnusedVariables(unusedKeys.begin(), unusedKeys.end());
+  // Values added before any factor references them have no VariableIndex
+  // entry, but still need the remaining ISAM2 state removed.
+  KeySet indexedUnusedKeys;
+  for (Key key : unusedKeys) {
+    if (variableIndex_.find(key) != variableIndex_.end()) {
+      indexedUnusedKeys.insert(key);
+    }
+  }
+  variableIndex_.removeUnusedVariables(indexedUnusedKeys.begin(),
+                                       indexedUnusedKeys.end());
   for (Key key : unusedKeys) {
     delta_.erase(key);
     deltaNewton_.erase(key);

--- a/gtsam/nonlinear/ISAM2.h
+++ b/gtsam/nonlinear/ISAM2.h
@@ -374,6 +374,8 @@ class GTSAM_EXPORT ISAM2 : public BayesTree<ISAM2Clique> {
    */
   void removeVariables(const KeySet& unusedKeys);
 
+  friend class IncrementalFixedLagSmoother;
+
   void updateDelta(bool forceFullSolve = false) const;
 
  private:

--- a/gtsam/nonlinear/IncrementalFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/IncrementalFixedLagSmoother.cpp
@@ -57,18 +57,14 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
   FastVector<size_t> removedFactors;
   std::optional<FastMap<Key, int> > constrainedKeys = {};
 
-  // ISAM2 requires every new value to occur in a new factor. Treat values
-  // outside that contract as unused instead of leaving them without a
-  // VariableIndex entry, which would make later constrained ordering fail.
   const KeySet newFactorKeys = newFactors.keys();
-  KeySet unreferencedNewKeys;
-  Values referencedNewTheta;
-  for (const auto& keyValue : newTheta) {
-    if (newFactorKeys.find(keyValue.key) != newFactorKeys.end() ||
-        isam_.valueExists(keyValue.key)) {
-      referencedNewTheta.insert(keyValue.key, keyValue.value);
-    } else {
-      unreferencedNewKeys.insert(keyValue.key);
+  for (const auto& keyTimestamp : timestamps) {
+    const Key key = keyTimestamp.first;
+    if (!isam_.valueExists(key) && !newTheta.exists(key)) {
+      throw std::invalid_argument(
+          "IncrementalFixedLagSmoother::update: timestamp provided for key " +
+          DefaultKeyFormatter(key) +
+          ", but no value for that key exists in ISAM2 or newTheta");
     }
   }
 
@@ -85,25 +81,18 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
   KeyVector marginalizableKeys = findKeysBefore(
       current_timestamp - smootherLag_);
 
-  if (not unreferencedNewKeys.empty()) {
-    // The unreferenced values are not forwarded to ISAM2, so remove their
-    // timestamps and keep them out of ordering and marginalization as well.
-    marginalizableKeys.erase(
-        std::remove_if(marginalizableKeys.begin(), marginalizableKeys.end(),
-                       [&](const auto& key) {
-                         return unreferencedNewKeys.find(key) !=
-                                unreferencedNewKeys.end();
-                       }),
-        marginalizableKeys.end());
-
-    KeyVector unreferencedTimestampKeys;
-    for (Key key : unreferencedNewKeys) {
-      if (keyTimestampMap_.find(key) != keyTimestampMap_.end()) {
-        unreferencedTimestampKeys.push_back(key);
-      }
-    }
-    eraseKeyTimestampMap(unreferencedTimestampKeys);
+  // A value can be added before any factor references it. Keep such pending
+  // values and their timestamps, but do not include them in constrained
+  // ordering or marginalization until a factor connects them.
+  KeySet activeKeys = newFactorKeys;
+  const VariableIndex& variableIndex = isam_.getVariableIndex();
+  for (const auto& keyFactors : variableIndex) {
+    activeKeys.insert(keyFactors.first);
   }
+  marginalizableKeys.erase(
+      std::remove_if(marginalizableKeys.begin(), marginalizableKeys.end(),
+                     [&](Key key) { return !activeKeys.exists(key); }),
+      marginalizableKeys.end());
 
   if (debug) {
     std::cout << "Marginalizable Keys: ";
@@ -114,7 +103,7 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
   }
 
   // Force iSAM2 to put the marginalizable variables at the beginning
-  createOrderingConstraints(marginalizableKeys, constrainedKeys);
+  createOrderingConstraints(marginalizableKeys, activeKeys, constrainedKeys);
 
   if (debug) {
     std::cout << "Constrained Keys: ";
@@ -128,17 +117,19 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
     std::cout << std::endl;
   }
 
+  KeyVector existingMarginalizableKeys;
+  std::copy_if(marginalizableKeys.begin(), marginalizableKeys.end(),
+               std::back_inserter(existingMarginalizableKeys), [&](Key key) {
+                 return variableIndex.find(key) != variableIndex.end();
+               });
   std::unordered_set<Key> additionalKeys =
       BayesTreeMarginalizationHelper<ISAM2>::gatherAdditionalKeysToReEliminate(
-          isam_, marginalizableKeys);
+          isam_, existingMarginalizableKeys);
   KeyList additionalMarkedKeys(additionalKeys.begin(), additionalKeys.end());
 
   // Update iSAM2
-  isamResult_ = isam_.update(newFactors, referencedNewTheta, factorsToRemove,
+  isamResult_ = isam_.update(newFactors, newTheta, factorsToRemove,
                              constrainedKeys, {}, additionalMarkedKeys);
-  const KeySet isamUnusedKeys = isamResult_.unusedKeys;
-  isamResult_.unusedKeys.insert(unreferencedNewKeys.begin(),
-                                unreferencedNewKeys.end());
 
   if (debug) {
     std::cout << "Unused Keys After Update: ";
@@ -150,11 +141,11 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
     std::cout << std::endl;
   }
 
-  if (not isamUnusedKeys.empty()) {
+  if (not isamResult_.unusedKeys.empty()) {
     // Remove keys that became unused after update from the key-timestamp
     // database
-    eraseKeyTimestampMap(
-        KeyVector{isamUnusedKeys.begin(), isamUnusedKeys.end()});
+    eraseKeyTimestampMap(KeyVector{isamResult_.unusedKeys.begin(),
+                                   isamResult_.unusedKeys.end()});
 
     if (marginalizableKeys.size() > 0) {
       // Remove keys that became unused after update from the marginalizable
@@ -162,8 +153,8 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
       marginalizableKeys.erase(
           std::remove_if(marginalizableKeys.begin(), marginalizableKeys.end(),
                          [&](const auto& key) {
-                           return isamUnusedKeys.find(key) !=
-                                  isamUnusedKeys.end();
+                           return isamResult_.unusedKeys.find(key) !=
+                                  isamResult_.unusedKeys.end();
                          }),
           marginalizableKeys.end());
     }
@@ -220,14 +211,16 @@ void IncrementalFixedLagSmoother::eraseKeysBefore(double timestamp) {
 
 /* ************************************************************************* */
 void IncrementalFixedLagSmoother::createOrderingConstraints(
-    const KeyVector& marginalizableKeys,
+    const KeyVector& marginalizableKeys, const KeySet& activeKeys,
     std::optional<FastMap<Key, int> >& constrainedKeys) const {
   if (marginalizableKeys.size() > 0) {
     constrainedKeys = FastMap<Key, int>();
     // Generate ordering constraints so that the marginalizable variables will be eliminated first
     // Set all variables to Group1
     for(const TimestampKeyMap::value_type& timestamp_key: timestampKeyMap_) {
-      constrainedKeys->operator[](timestamp_key.second) = 1;
+      if (activeKeys.exists(timestamp_key.second)) {
+        constrainedKeys->operator[](timestamp_key.second) = 1;
+      }
     }
     // Set marginalizable variables to Group0
     for(Key key: marginalizableKeys) {

--- a/gtsam/nonlinear/IncrementalFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/IncrementalFixedLagSmoother.cpp
@@ -57,6 +57,21 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
   FastVector<size_t> removedFactors;
   std::optional<FastMap<Key, int> > constrainedKeys = {};
 
+  // ISAM2 requires every new value to occur in a new factor. Treat values
+  // outside that contract as unused instead of leaving them without a
+  // VariableIndex entry, which would make later constrained ordering fail.
+  const KeySet newFactorKeys = newFactors.keys();
+  KeySet unreferencedNewKeys;
+  Values referencedNewTheta;
+  for (const auto& keyValue : newTheta) {
+    if (newFactorKeys.find(keyValue.key) != newFactorKeys.end() ||
+        isam_.valueExists(keyValue.key)) {
+      referencedNewTheta.insert(keyValue.key, keyValue.value);
+    } else {
+      unreferencedNewKeys.insert(keyValue.key);
+    }
+  }
+
   // Update the Timestamps associated with the factor keys
   updateKeyTimestampMap(timestamps);
 
@@ -69,6 +84,26 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
   // Find the set of variables to be marginalized out
   KeyVector marginalizableKeys = findKeysBefore(
       current_timestamp - smootherLag_);
+
+  if (not unreferencedNewKeys.empty()) {
+    // The unreferenced values are not forwarded to ISAM2, so remove their
+    // timestamps and keep them out of ordering and marginalization as well.
+    marginalizableKeys.erase(
+        std::remove_if(marginalizableKeys.begin(), marginalizableKeys.end(),
+                       [&](const auto& key) {
+                         return unreferencedNewKeys.find(key) !=
+                                unreferencedNewKeys.end();
+                       }),
+        marginalizableKeys.end());
+
+    KeyVector unreferencedTimestampKeys;
+    for (Key key : unreferencedNewKeys) {
+      if (keyTimestampMap_.find(key) != keyTimestampMap_.end()) {
+        unreferencedTimestampKeys.push_back(key);
+      }
+    }
+    eraseKeyTimestampMap(unreferencedTimestampKeys);
+  }
 
   if (debug) {
     std::cout << "Marginalizable Keys: ";
@@ -99,8 +134,11 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
   KeyList additionalMarkedKeys(additionalKeys.begin(), additionalKeys.end());
 
   // Update iSAM2
-  isamResult_ = isam_.update(newFactors, newTheta,
-      factorsToRemove, constrainedKeys, {}, additionalMarkedKeys);
+  isamResult_ = isam_.update(newFactors, referencedNewTheta, factorsToRemove,
+                             constrainedKeys, {}, additionalMarkedKeys);
+  const KeySet isamUnusedKeys = isamResult_.unusedKeys;
+  isamResult_.unusedKeys.insert(unreferencedNewKeys.begin(),
+                                unreferencedNewKeys.end());
 
   if (debug) {
     std::cout << "Unused Keys After Update: ";
@@ -112,11 +150,11 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
     std::cout << std::endl;
   }
 
-  if (not isamResult_.unusedKeys.empty()) {
+  if (not isamUnusedKeys.empty()) {
     // Remove keys that became unused after update from the key-timestamp
     // database
-    eraseKeyTimestampMap(KeyVector{isamResult_.unusedKeys.begin(),
-                                   isamResult_.unusedKeys.end()});
+    eraseKeyTimestampMap(
+        KeyVector{isamUnusedKeys.begin(), isamUnusedKeys.end()});
 
     if (marginalizableKeys.size() > 0) {
       // Remove keys that became unused after update from the marginalizable
@@ -124,8 +162,8 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
       marginalizableKeys.erase(
           std::remove_if(marginalizableKeys.begin(), marginalizableKeys.end(),
                          [&](const auto& key) {
-                           return isamResult_.unusedKeys.find(key) !=
-                                  isamResult_.unusedKeys.end();
+                           return isamUnusedKeys.find(key) !=
+                                  isamUnusedKeys.end();
                          }),
           marginalizableKeys.end());
     }

--- a/gtsam/nonlinear/IncrementalFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/IncrementalFixedLagSmoother.cpp
@@ -58,15 +58,6 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
   std::optional<FastMap<Key, int> > constrainedKeys = {};
 
   const KeySet newFactorKeys = newFactors.keys();
-  for (const auto& keyTimestamp : timestamps) {
-    const Key key = keyTimestamp.first;
-    if (!isam_.valueExists(key) && !newTheta.exists(key)) {
-      throw std::invalid_argument(
-          "IncrementalFixedLagSmoother::update: timestamp provided for key " +
-          DefaultKeyFormatter(key) +
-          ", but no value for that key exists in ISAM2 or newTheta");
-    }
-  }
 
   // Update the Timestamps associated with the factor keys
   updateKeyTimestampMap(timestamps);
@@ -81,17 +72,24 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
   KeyVector marginalizableKeys = findKeysBefore(
       current_timestamp - smootherLag_);
 
-  // A value can be added before any factor references it. Keep such pending
-  // values and their timestamps, but do not include them in constrained
-  // ordering or marginalization until a factor connects them.
+  // Values may arrive before the factors that reference them. Reap pending
+  // values when they age out, without passing them to Bayes-tree
+  // marginalization where they have no clique.
   KeySet activeKeys = newFactorKeys;
   const VariableIndex& variableIndex = isam_.getVariableIndex();
   for (const auto& keyFactors : variableIndex) {
     activeKeys.insert(keyFactors.first);
   }
+  KeyVector expiredPendingKeys;
   marginalizableKeys.erase(
       std::remove_if(marginalizableKeys.begin(), marginalizableKeys.end(),
-                     [&](Key key) { return !activeKeys.exists(key); }),
+                     [&](Key key) {
+                       const bool isPending =
+                           !activeKeys.exists(key) &&
+                           (isam_.valueExists(key) || newTheta.exists(key));
+                       if (isPending) expiredPendingKeys.push_back(key);
+                       return isPending;
+                     }),
       marginalizableKeys.end());
 
   if (debug) {
@@ -160,6 +158,11 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
     }
   }
 
+  if (!expiredPendingKeys.empty()) {
+    isam_.removeVariables(
+        KeySet(expiredPendingKeys.begin(), expiredPendingKeys.end()));
+  }
+
   if (debug) {
     PrintSymbolicTree(isam_,
         "Bayes Tree After Update, Before Marginalization:");
@@ -177,6 +180,7 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
 
   // Remove marginalized keys from the KeyTimestampMap
   eraseKeyTimestampMap(marginalizableKeys);
+  eraseKeyTimestampMap(expiredPendingKeys);
 
   if (debug) {
     PrintSymbolicTree(isam_, "Final Bayes Tree:");

--- a/gtsam/nonlinear/IncrementalFixedLagSmoother.h
+++ b/gtsam/nonlinear/IncrementalFixedLagSmoother.h
@@ -58,7 +58,8 @@ public:
   /**
    * Add new factors, updating the solution and re-linearizing as needed.
    * @param newFactors new factors on old and/or new variables
-   * @param newTheta new values for new variables only
+   * @param newTheta new values for new variables only. Values not referenced
+   * by newFactors are ignored and reported in ISAM2Result::unusedKeys.
    * @param timestamps an (optional) map from keys to real time stamps
    * @param factorsToRemove an (optional) list of factors to remove.
    */

--- a/gtsam/nonlinear/IncrementalFixedLagSmoother.h
+++ b/gtsam/nonlinear/IncrementalFixedLagSmoother.h
@@ -58,8 +58,7 @@ public:
   /**
    * Add new factors, updating the solution and re-linearizing as needed.
    * @param newFactors new factors on old and/or new variables
-   * @param newTheta new values for new variables only. Values not referenced
-   * by newFactors are ignored and reported in ISAM2Result::unusedKeys.
+   * @param newTheta new values for new variables only
    * @param timestamps an (optional) map from keys to real time stamps
    * @param factorsToRemove an (optional) list of factors to remove.
    */
@@ -138,10 +137,11 @@ protected:
   void eraseKeysBefore(double timestamp);
 
   /** Fill in an iSAM2 ConstrainedKeys structure such that the provided keys are eliminated before all others */
-  void createOrderingConstraints(const KeyVector& marginalizableKeys,
+  void createOrderingConstraints(
+      const KeyVector& marginalizableKeys, const KeySet& activeKeys,
       std::optional<FastMap<Key, int> >& constrainedKeys) const;
 
-private:
+ private:
   /** Private methods for printing debug information */
   static void PrintKeySet(const KeySet& keys, const std::string& label =
       "Keys:");

--- a/gtsam/nonlinear/IncrementalFixedLagSmoother.h
+++ b/gtsam/nonlinear/IncrementalFixedLagSmoother.h
@@ -141,7 +141,7 @@ protected:
       const KeyVector& marginalizableKeys, const KeySet& activeKeys,
       std::optional<FastMap<Key, int> >& constrainedKeys) const;
 
- private:
+private:
   /** Private methods for printing debug information */
   static void PrintKeySet(const KeySet& keys, const std::string& label =
       "Keys:");

--- a/gtsam/nonlinear/tests/testIncrementalFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/tests/testIncrementalFixedLagSmoother.cpp
@@ -436,6 +436,51 @@ TEST(IncrementalFixedLagSmoother, Example) {
   }
 }
 
+// A value without a referencing factor used to remain in ISAM2 without a
+// VariableIndex entry and caused a bare map::at failure during a later update.
+TEST(IncrementalFixedLagSmoother, UnreferencedValueIsUnused) {
+  const SharedDiagonal noise = noiseModel::Diagonal::Sigmas(Vector2(0.1, 0.1));
+  IncrementalFixedLagSmoother smoother(1.0);
+
+  NonlinearFactorGraph factors;
+  Values values;
+  FixedLagSmoother::KeyTimestampMap timestamps;
+
+  factors.addPrior(X(0), Point2(0.0, 0.0), noise);
+  values.insert(X(0), Point2(0.0, 0.0));
+  timestamps[X(0)] = 0.0;
+  smoother.update(factors, values, timestamps);
+
+  values.clear();
+  timestamps.clear();
+  values.insert(X(1), Point2(1.0, 0.0));
+  timestamps[X(1)] = 1.0;
+  smoother.update({}, values, timestamps);
+
+  EXPECT(!smoother.getLinearizationPoint().exists(X(1)));
+  EXPECT(smoother.timestamps().find(X(1)) == smoother.timestamps().end());
+  EXPECT_LONGS_EQUAL(1, smoother.getISAM2Result().unusedKeys.size());
+  EXPECT(smoother.getISAM2Result().unusedKeys.exists(X(1)));
+
+  factors.resize(0);
+  values.clear();
+  timestamps.clear();
+  factors.emplace_shared<BetweenPoint2>(X(0), X(2), Point2(2.0, 0.0), noise);
+  values.insert(X(2), Point2(2.0, 0.0));
+  timestamps[X(2)] = 2.0;
+  smoother.update(factors, values, timestamps);
+
+  factors.resize(0);
+  values.clear();
+  timestamps.clear();
+  factors.emplace_shared<BetweenPoint2>(X(2), X(3), Point2(1.0, 0.0), noise);
+  values.insert(X(3), Point2(3.0, 0.0));
+  timestamps[X(3)] = 3.0;
+  smoother.update(factors, values, timestamps);
+
+  EXPECT(smoother.getLinearizationPoint().exists(X(3)));
+}
+
 /* ************************************************************************* */
 TEST( IncrementalFixedLagSmoother, ExampleWithFactorRemoval )
 {

--- a/gtsam/nonlinear/tests/testIncrementalFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/tests/testIncrementalFixedLagSmoother.cpp
@@ -436,9 +436,9 @@ TEST(IncrementalFixedLagSmoother, Example) {
   }
 }
 
-// A value without a referencing factor used to remain in ISAM2 without a
-// VariableIndex entry and caused a bare map::at failure during a later update.
-TEST(IncrementalFixedLagSmoother, UnreferencedValueIsUnused) {
+// Values may arrive before the factors that reference them. They must remain
+// available and must not enter ordering constraints while they are pending.
+TEST(IncrementalFixedLagSmoother, ConnectsPreviouslyUnreferencedValue) {
   const SharedDiagonal noise = noiseModel::Diagonal::Sigmas(Vector2(0.1, 0.1));
   IncrementalFixedLagSmoother smoother(1.0);
 
@@ -448,19 +448,40 @@ TEST(IncrementalFixedLagSmoother, UnreferencedValueIsUnused) {
 
   factors.addPrior(X(0), Point2(0.0, 0.0), noise);
   values.insert(X(0), Point2(0.0, 0.0));
+  values.insert(X(1), Point2(1.0, 0.0));
   timestamps[X(0)] = 0.0;
+  timestamps[X(1)] = 1.0;
   smoother.update(factors, values, timestamps);
 
+  EXPECT(smoother.getLinearizationPoint().exists(X(1)));
+  EXPECT(smoother.timestamps().find(X(1)) != smoother.timestamps().end());
+
+  factors.resize(0);
   values.clear();
   timestamps.clear();
-  values.insert(X(1), Point2(1.0, 0.0));
-  timestamps[X(1)] = 1.0;
-  smoother.update({}, values, timestamps);
+  factors.emplace_shared<BetweenPoint2>(X(0), X(1), Point2(1.0, 0.0), noise);
+  smoother.update(factors, values, timestamps);
 
-  EXPECT(!smoother.getLinearizationPoint().exists(X(1)));
-  EXPECT(smoother.timestamps().find(X(1)) == smoother.timestamps().end());
-  EXPECT_LONGS_EQUAL(1, smoother.getISAM2Result().unusedKeys.size());
-  EXPECT(smoother.getISAM2Result().unusedKeys.exists(X(1)));
+  EXPECT(smoother.getLinearizationPoint().exists(X(1)));
+  EXPECT(!smoother.getISAM2().getVariableIndex().empty(X(1)));
+}
+
+// An unreferenced value may become older than the lag while other variables
+// are marginalized. It must not enter the Bayes-tree-only cleanup path.
+TEST(IncrementalFixedLagSmoother, DefersUnreferencedValueMarginalization) {
+  const SharedDiagonal noise = noiseModel::Diagonal::Sigmas(Vector2(0.1, 0.1));
+  IncrementalFixedLagSmoother smoother(1.0);
+
+  NonlinearFactorGraph factors;
+  Values values;
+  FixedLagSmoother::KeyTimestampMap timestamps;
+
+  factors.addPrior(X(0), Point2(0.0, 0.0), noise);
+  values.insert(X(0), Point2(0.0, 0.0));
+  values.insert(X(1), Point2(1.0, 0.0));
+  timestamps[X(0)] = 0.0;
+  timestamps[X(1)] = 1.0;
+  smoother.update(factors, values, timestamps);
 
   factors.resize(0);
   values.clear();
@@ -479,6 +500,56 @@ TEST(IncrementalFixedLagSmoother, UnreferencedValueIsUnused) {
   smoother.update(factors, values, timestamps);
 
   EXPECT(smoother.getLinearizationPoint().exists(X(3)));
+  EXPECT(smoother.getLinearizationPoint().exists(X(1)));
+  EXPECT(smoother.timestamps().find(X(1)) != smoother.timestamps().end());
+
+  factors.resize(0);
+  values.clear();
+  timestamps.clear();
+  factors.emplace_shared<BetweenPoint2>(X(3), X(1), Point2(-2.0, 0.0), noise);
+  smoother.update(factors, values, timestamps);
+
+  EXPECT(!smoother.getLinearizationPoint().exists(X(1)));
+  EXPECT(smoother.getLinearizationPoint().exists(X(3)));
+  EXPECT(smoother.timestamps().find(X(1)) == smoother.timestamps().end());
+}
+
+// A timestamp without a corresponding value is rejected at the API boundary
+// with the offending key instead of failing later with a bare map::at.
+TEST(IncrementalFixedLagSmoother, RejectsTimestampWithoutValue) {
+  IncrementalFixedLagSmoother smoother(1.0);
+  FixedLagSmoother::KeyTimestampMap timestamps;
+  timestamps[X(0)] = 0.0;
+
+  bool exceptionNamesKey = false;
+  try {
+    smoother.update({}, {}, timestamps);
+  } catch (const std::invalid_argument& error) {
+    exceptionNamesKey =
+        std::string(error.what()).find(DefaultKeyFormatter(X(0))) !=
+        std::string::npos;
+  }
+  CHECK(exceptionNamesKey);
+}
+
+// Removing an untimestamped variable is valid because timestamps are optional.
+// Timestamp cleanup must therefore be a no-op for that key.
+TEST(IncrementalFixedLagSmoother, RemovesUntimestampedUnusedValue) {
+  const SharedDiagonal noise = noiseModel::Diagonal::Sigmas(Vector2(0.1, 0.1));
+  IncrementalFixedLagSmoother smoother(1.0);
+
+  NonlinearFactorGraph factors;
+  factors.addPrior(X(0), Point2(0.0, 0.0), noise);
+  Values values;
+  values.insert(X(0), Point2(0.0, 0.0));
+  smoother.update(factors, values);
+
+  const FactorIndices factorToRemove =
+      smoother.getISAM2Result().newFactorsIndices;
+  smoother.update({}, {}, {}, factorToRemove);
+
+  EXPECT(!smoother.getLinearizationPoint().exists(X(0)));
+  EXPECT(smoother.timestamps().empty());
 }
 
 /* ************************************************************************* */

--- a/gtsam/nonlinear/tests/testIncrementalFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/tests/testIncrementalFixedLagSmoother.cpp
@@ -436,9 +436,8 @@ TEST(IncrementalFixedLagSmoother, Example) {
   }
 }
 
-// Values may arrive before the factors that reference them. They must remain
-// available and must not enter ordering constraints while they are pending.
-TEST(IncrementalFixedLagSmoother, ConnectsPreviouslyUnreferencedValue) {
+// A pending value remains available for a factor that arrives within the lag.
+TEST(IncrementalFixedLagSmoother, ConnectsPendingValueBeforeItAgesOut) {
   const SharedDiagonal noise = noiseModel::Diagonal::Sigmas(Vector2(0.1, 0.1));
   IncrementalFixedLagSmoother smoother(1.0);
 
@@ -466,9 +465,8 @@ TEST(IncrementalFixedLagSmoother, ConnectsPreviouslyUnreferencedValue) {
   EXPECT(!smoother.getISAM2().getVariableIndex().empty(X(1)));
 }
 
-// An unreferenced value may become older than the lag while other variables
-// are marginalized. It must not enter the Bayes-tree-only cleanup path.
-TEST(IncrementalFixedLagSmoother, DefersUnreferencedValueMarginalization) {
+// A pending value with no factor is removed once it leaves the lag window.
+TEST(IncrementalFixedLagSmoother, ReapsPendingValueAfterLag) {
   const SharedDiagonal noise = noiseModel::Diagonal::Sigmas(Vector2(0.1, 0.1));
   IncrementalFixedLagSmoother smoother(1.0);
 
@@ -486,70 +484,14 @@ TEST(IncrementalFixedLagSmoother, DefersUnreferencedValueMarginalization) {
   factors.resize(0);
   values.clear();
   timestamps.clear();
-  factors.emplace_shared<BetweenPoint2>(X(0), X(2), Point2(2.0, 0.0), noise);
+  factors.addPrior(X(2), Point2(2.0, 0.0), noise);
   values.insert(X(2), Point2(2.0, 0.0));
-  timestamps[X(2)] = 2.0;
-  smoother.update(factors, values, timestamps);
-
-  factors.resize(0);
-  values.clear();
-  timestamps.clear();
-  factors.emplace_shared<BetweenPoint2>(X(2), X(3), Point2(1.0, 0.0), noise);
-  values.insert(X(3), Point2(3.0, 0.0));
-  timestamps[X(3)] = 3.0;
-  smoother.update(factors, values, timestamps);
-
-  EXPECT(smoother.getLinearizationPoint().exists(X(3)));
-  EXPECT(smoother.getLinearizationPoint().exists(X(1)));
-  EXPECT(smoother.timestamps().find(X(1)) != smoother.timestamps().end());
-
-  factors.resize(0);
-  values.clear();
-  timestamps.clear();
-  factors.emplace_shared<BetweenPoint2>(X(3), X(1), Point2(-2.0, 0.0), noise);
+  timestamps[X(2)] = 3.0;
   smoother.update(factors, values, timestamps);
 
   EXPECT(!smoother.getLinearizationPoint().exists(X(1)));
-  EXPECT(smoother.getLinearizationPoint().exists(X(3)));
+  EXPECT(smoother.getLinearizationPoint().exists(X(2)));
   EXPECT(smoother.timestamps().find(X(1)) == smoother.timestamps().end());
-}
-
-// A timestamp without a corresponding value is rejected at the API boundary
-// with the offending key instead of failing later with a bare map::at.
-TEST(IncrementalFixedLagSmoother, RejectsTimestampWithoutValue) {
-  IncrementalFixedLagSmoother smoother(1.0);
-  FixedLagSmoother::KeyTimestampMap timestamps;
-  timestamps[X(0)] = 0.0;
-
-  bool exceptionNamesKey = false;
-  try {
-    smoother.update({}, {}, timestamps);
-  } catch (const std::invalid_argument& error) {
-    exceptionNamesKey =
-        std::string(error.what()).find(DefaultKeyFormatter(X(0))) !=
-        std::string::npos;
-  }
-  CHECK(exceptionNamesKey);
-}
-
-// Removing an untimestamped variable is valid because timestamps are optional.
-// Timestamp cleanup must therefore be a no-op for that key.
-TEST(IncrementalFixedLagSmoother, RemovesUntimestampedUnusedValue) {
-  const SharedDiagonal noise = noiseModel::Diagonal::Sigmas(Vector2(0.1, 0.1));
-  IncrementalFixedLagSmoother smoother(1.0);
-
-  NonlinearFactorGraph factors;
-  factors.addPrior(X(0), Point2(0.0, 0.0), noise);
-  Values values;
-  values.insert(X(0), Point2(0.0, 0.0));
-  smoother.update(factors, values);
-
-  const FactorIndices factorToRemove =
-      smoother.getISAM2Result().newFactorsIndices;
-  smoother.update({}, {}, {}, factorToRemove);
-
-  EXPECT(!smoother.getLinearizationPoint().exists(X(0)));
-  EXPECT(smoother.timestamps().empty());
 }
 
 /* ************************************************************************* */


### PR DESCRIPTION
## Summary

Allow `IncrementalFixedLagSmoother` to accept values before their factors arrive, while ensuring that values which remain unconnected are removed once they leave the fixed-lag window.

Fixes #2741.

## Problem

`ISAM2` accepts a value in `newTheta` even when no factor in the same update references it. Such a value remains in the linearization point, but it has no `VariableIndex` entry or Bayes-tree clique until a later factor connects it.

The smoother previously sent every expired timestamped key through ordering and Bayes-tree marginalization. An expired unconnected value therefore reached code that requires a clique and failed instead of being reaped.

## Implementation

The update path separates expired keys into two groups:

- connected keys continue through the existing constrained-ordering and `marginalizeLeaves` path;
- pending values with no factor or clique are removed directly from ISAM2 state once they age out.

A pending value remains available while it is inside the lag window, including when a factor connects it in a later update. Keys referenced by factors in the current update are treated as active, so a newly connected value follows the normal update and marginalization path.

The internal variable cleanup retains the existing unused check for indexed variables while also supporting pending values that never had a `VariableIndex` entry.

The separate timestamp-only `map::at` bookkeeping issue is intentionally left out of this PR.

## Regression coverage

The focused tests cover:

1. adding a value without a factor and connecting it before it ages out;
2. allowing an unconnected value to age out and verifying that both its ISAM2 value and timestamp are removed.

## Validation

- `testIncrementalFixedLagSmoother` — passed
- `testBatchFixedLagSmoother` — passed
- `testGaussianISAM2` — passed
- `testVisualISAM2` — passed
- clang-format check over changed lines — passed
- `git diff --check` — passed
