### PR TITLE
Avoid full parent scratch matrices without TBB

### DIFF
--- a/gtsam/base/tests/testForestTraversal.cpp
+++ b/gtsam/base/tests/testForestTraversal.cpp
@@ -115,13 +115,12 @@ TEST(ForestTraversal, BottomUpLeafAggregation) {
 namespace {
 
 struct AggregationNode {
-  int problemSize_ = 1;
   bool throwOnVisit = false;
   bool visited = false;
   std::thread::id visitThread;
   std::vector<std::shared_ptr<AggregationNode>> children;
 
-  int problemSize() const { return problemSize_; }
+  int problemSize() const { return 1; }
 
   void visit() {
     visited = true;

--- a/gtsam/linear/MultifrontalClique.cpp
+++ b/gtsam/linear/MultifrontalClique.cpp
@@ -40,8 +40,10 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <exception>
 #include <iostream>
 #include <thread>
+#include <utility>
 
 namespace gtsam {
 
@@ -108,6 +110,48 @@ SymmetricBlockMatrix makeZeroLocalInfo(const std::vector<size_t>& blockDims) {
   local.setZero();
   return local;
 }
+
+#ifndef GTSAM_USE_TBB
+std::pair<size_t, size_t> staticRange(size_t itemCount, size_t worker,
+                                      size_t workerCount) {
+  const size_t itemsPerWorker = itemCount / workerCount;
+  const size_t extraItems = itemCount % workerCount;
+  const size_t begin = worker * itemsPerWorker + std::min(worker, extraItems);
+  const size_t end = begin + itemsPerWorker + (worker < extraItems ? 1 : 0);
+  return {begin, end};
+}
+
+template <class Work>
+void runThreadBatch(size_t workerCount, Work&& work) {
+  assert(workerCount > 0);
+  std::vector<std::exception_ptr> failures(workerCount);
+  auto runWorker = [&](size_t worker) {
+    try {
+      work(worker, workerCount);
+    } catch (...) {
+      failures[worker] = std::current_exception();
+    }
+  };
+
+  // This clique is already running on a traversal worker. Count it as worker
+  // zero rather than creating workerCount additional operating-system threads.
+  std::vector<std::thread> threads;
+  threads.reserve(workerCount - 1);
+  try {
+    for (size_t worker = 1; worker < workerCount; ++worker) {
+      threads.emplace_back(runWorker, worker);
+    }
+  } catch (...) {
+    for (std::thread& thread : threads) thread.join();
+    throw;
+  }
+  runWorker(0);
+  for (std::thread& thread : threads) thread.join();
+  for (const std::exception_ptr& failure : failures) {
+    if (failure) std::rethrow_exception(failure);
+  }
+}
+#endif
 
 }  // namespace
 
@@ -258,6 +302,7 @@ void MultifrontalClique::finalize(std::vector<ChildInfo> children,
 
   if (params.leafMode == MultifrontalParameters::LeafMode::SameSeparator &&
       params.leafAggregationProblemSize > 0) {
+    // Equal parent mappings identify siblings that share one local accumulator.
     std::map<std::vector<DenseIndex>, std::vector<size_t>> groups;
     for (size_t i = 0; i < this->children.size(); ++i) {
       const auto& child = this->children[i];
@@ -281,6 +326,7 @@ void MultifrontalClique::finalize(std::vector<ChildInfo> children,
       const size_t numBatches =
           (childIndices.size() + maximumChildrenPerBatch - 1) /
           maximumChildrenPerBatch;
+      // Split evenly so a final singleton is not stranded by a greedy cap.
       const auto firstSeparatorDim =
           child->blockDims_.begin() + child->numFrontals();
       std::vector<size_t> separatorDims(firstSeparatorDim,
@@ -429,6 +475,7 @@ void MultifrontalClique::FactorLoadPlan::buildLocalBatchMapping(
 bool MultifrontalClique::FactorLoadPlan::supportsFusedStarLeaf() const {
   if (kind == FactorLoadKind::Empty) return true;
   if (kind == FactorLoadKind::Batch) return canDirectUpdate;
+  // Fallback rows may touch only the single frontal or fixed variables.
   return std::all_of(blockIndices.begin(), blockIndices.end(),
                      [](DenseIndex index) { return index <= 0; });
 }
@@ -464,6 +511,7 @@ MultifrontalClique::FactorLoadPlan::buildRetainedMapping(
   std::vector<DenseIndex> factorTargetScalarOffsets;
   factorTargetSlots.reserve(blockIndices.size() + 1);
   factorTargetScalarOffsets.reserve(blockIndices.size() + 1);
+  // Preserve factor slot order while excluding eliminated frontal blocks.
   for (const DenseIndex localIndex : blockIndices) {
     if (localIndex < numFrontals) {
       factorTargetSlots.push_back(-1);
@@ -545,6 +593,7 @@ size_t MultifrontalClique::addBatchJacobianFactor(
 }
 
 void MultifrontalClique::resolveLeafSolveMode() {
+  // Auto-QR defers allocation until the sole factor's representation is known.
   const bool needsDeferredStorage = deferredSingleFactorAutoQr_;
   if (deferredSingleFactorAutoQr_) {
     assert(solveMode_ == SolveMode::QrLeaf && loadPlans_.size() == 1);
@@ -555,6 +604,7 @@ void MultifrontalClique::resolveLeafSolveMode() {
   }
 
   if (solveMode_ == SolveMode::FusedStarCandidate) {
+    // Fused-star updates require every retained contribution to stay direct.
     const bool supported = kUseDirectBatchHessianUpdate &&
                            hasDirectBatchFactors_ &&
                            std::all_of(loadPlans_.begin(), loadPlans_.end(),
@@ -614,6 +664,7 @@ void MultifrontalClique::buildLoadPlans(const GaussianFactorGraph& graph) {
     loadPlans_.push_back(std::move(plan));
   }
 
+  // Resolve representation before choosing mappings and packed row storage.
   resolveLeafSolveMode();
   buildFusedStarMappings();
   for (FactorLoadPlan& plan : loadPlans_) {
@@ -635,6 +686,7 @@ void MultifrontalClique::buildLoadPlans(const GaussianFactorGraph& graph) {
 }
 
 void MultifrontalClique::fillAb(const GaussianFactorGraph& graph) {
+  // Direct batch updates retain this graph pointer through elimination.
   activeLoadGraph_ = &graph;
   assert(validateFactorKeys(graph, factorIndices_, orderedKeys_, fixedKeys_));
   RSdReady_ = false;
@@ -729,10 +781,7 @@ void MultifrontalClique::fillAb(const GaussianFactorGraph& graph) {
 
 void MultifrontalClique::eliminateInPlace() {
   prepareForElimination();
-  // There is no damping here and although we do not assert it here, we are
-  // counting on the facts that no damping was *ever* applied during the
-  // existence of this clique, just like we count on the sparsity pattern of
-  // zeros to remain the same.
+  // This path assumes damping has never changed the reusable storage pattern.
   factorize();
 }
 
@@ -768,6 +817,7 @@ void MultifrontalClique::prepareForElimination() {
           *batchFactor, plan.localMapping, &info_);
     }
     if (fillRows_ > 0 && !allBatchFactors_) {
+      // Mixed mode adds only fallback rows after direct batch contributions.
       info_.selfadjointView().rankUpdate(
           Ab_.matrix().topRows(static_cast<DenseIndex>(fillRows_)).transpose());
     }
@@ -784,6 +834,7 @@ void MultifrontalClique::prepareForElimination() {
                                  : static_cast<size_t>(std::count(
                                        childInSameSeparatorGroup_.begin(),
                                        childInSameSeparatorGroup_.end(), 0));
+  // Same-separator groups scatter once and skip the general child gather.
   gatherSameSeparatorUpdates();
   if (numChildren == 0) {
     infoReady_ = true;
@@ -809,6 +860,7 @@ void MultifrontalClique::prepareCompactCholesky() {
   assert(RSd_.matrix().rows() == static_cast<DenseIndex>(frontalDim));
   assert(loadPlans_.size() == factorIndices_.size());
   RSd_.matrix().setZero();
+  // Assemble frontal rows only; retained-retained terms remain implicit.
 
   const DenseIndex nf = static_cast<DenseIndex>(numFrontals());
   const DenseIndex rhsBlock = RSd_.nBlocks() - 1;
@@ -862,6 +914,7 @@ void MultifrontalClique::factorize() {
     factorizeCompactCholesky();
   } else {
     info_.choleskyPartial(numFrontals());
+    // Split exposes [R S d] while info_ retains the separator Schur complement.
     info_.split(numFrontals(), &RSd_);
     info_.blockStart() = 0;
   }
@@ -884,6 +937,7 @@ void MultifrontalClique::factorizeCompactCholesky() {
   Eigen::LLT<Matrix, Eigen::Upper> llt(A);
   if (llt.info() != Eigen::Success) throw CholeskyFailed();
   const Matrix R = llt.matrixU();
+  // Match the scale-normalized pivot guard used by standard Cholesky.
   constexpr double kMinimumNormalizedPivotSquared = 1.0 / (4096.0 * 4096.0);
   for (DenseIndex i = 0; i < n; ++i) {
     const double pivot = R(i, i);
@@ -1105,6 +1159,7 @@ void MultifrontalClique::updateCholeskyInfo(
   } else if (useCompactCholesky()) {
     assert(RSdReady_ && RSd_.firstBlock() == 0);
     updateDirectFactors(targetInfo, targetIndices, useParentMappedSlots);
+    // Compact updates subtract [S d]'[S d] from original retained terms.
     targetInfo.updateFromOuterProductBlocks(
         RSd_, 0, static_cast<DenseIndex>(frontalDim), frontalBlocks,
         targetIndices, targetBlockOffsets, -1.0);
@@ -1132,7 +1187,6 @@ void MultifrontalClique::updateParentInfo(
   }
 }
 
-#ifdef GTSAM_USE_TBB
 void MultifrontalClique::updateParentMaterializedColumn(
     SymmetricBlockMatrix& parentInfo, DenseIndex sourceSeparatorBlock) const {
   assert(fullyEliminated() && !useQR() && !useCompactCholesky());
@@ -1169,6 +1223,7 @@ void MultifrontalClique::updateParentQrColumnScratch(
                      static_cast<DenseIndex>(RSd_.matrix().rows()));
   scratch->bottomRows(1).noalias() += rhs.transpose() * owned;
 
+  // Store each cross-block in its physical upper-triangular owner column.
   for (DenseIndex other = 0; other < retainedBlocks; ++other) {
     if (parentIndices_[other] >= targetColumn) continue;
     const DenseIndex otherColumn = frontalBlocks + other;
@@ -1194,7 +1249,6 @@ double MultifrontalClique::parentRhsDiagonal() const {
                  static_cast<DenseIndex>(RSd_.matrix().rows()))
       .squaredNorm();
 }
-#endif
 
 void MultifrontalClique::updateSeparatorInfo(
     SymmetricBlockMatrix& separatorInfo) const {
@@ -1214,7 +1268,7 @@ void MultifrontalClique::gatherUpdatesSequential() {
     if (child->fullyEliminated()) child->updateParentInfo(info_);
   }
 }
-#ifdef GTSAM_USE_TBB
+
 struct MultifrontalClique::ParentGatherPlan {
   enum class ColumnRepresentation : uint8_t { Materialized, Qr };
 
@@ -1247,15 +1301,32 @@ struct MultifrontalClique::ParentGatherPlan {
   /// Classify children using their final numerical representation.
   explicit ParentGatherPlan(const MultifrontalClique& parent);
 
-  /// Execute the independent column-owned and compute-once stages.
-  void gather(MultifrontalClique* parent);
+  /// Evaluate compact/fused children once into one reduction destination.
+  void gatherComputeOnceRange(MultifrontalClique* parent, size_t begin,
+                              size_t end,
+                              SymmetricBlockMatrix* destination) const;
+
+  /// Add ordinary updates for the owned physical parent columns.
+  void gatherMaterializedRange(MultifrontalClique* parent, size_t begin,
+                               size_t end) const;
+
+  /// Calculate bounded QR scratch without writing the parent matrix.
+  void prepareQrRange(MultifrontalClique* parent, size_t begin, size_t end);
+
+  /// Combine prepared QR scratch into the owned physical parent columns.
+  void combineQrRange(MultifrontalClique* parent, size_t begin, size_t end);
+
+  /// Sum RHS diagonal contributions from column-owned children.
+  double rhsRange(const MultifrontalClique& parent, size_t begin,
+                  size_t end) const;
+
+  /// Execute the shared gather plan with the configured parallel backend.
+  void gather(MultifrontalClique* parent, size_t numThreads);
 };
 
 MultifrontalClique::ParentGatherPlan::ParentGatherPlan(
     const MultifrontalClique& parent) {
-  materializedByColumn.resize(parent.blockDims_.size());
-  qrByColumn.resize(parent.blockDims_.size());
-
+  // Skip same-separator children because their groups are already complete.
   for (size_t childIndex = 0; childIndex < parent.children.size();
        ++childIndex) {
     if (!parent.childInSameSeparatorGroup_.empty() &&
@@ -1277,6 +1348,9 @@ MultifrontalClique::ParentGatherPlan::ParentGatherPlan(
         {childIndex,
          qr ? ColumnRepresentation::Qr : ColumnRepresentation::Materialized});
     auto& updatesByColumn = qr ? qrByColumn : materializedByColumn;
+    if (updatesByColumn.empty()) {
+      updatesByColumn.resize(parent.blockDims_.size());
+    }
     hasQr |= qr;
     hasMaterialized |= !qr;
     for (size_t sourceBlock = 0; sourceBlock + 1 < child->parentIndices_.size();
@@ -1288,7 +1362,10 @@ MultifrontalClique::ParentGatherPlan::ParentGatherPlan(
     }
   }
 
+  if (!hasQr) return;
+
   constexpr size_t kQrChildrenPerChunk = 128;
+  // Chunk busy QR columns so one owner does not serialize all child products.
   qrChunkIndicesByColumn.resize(parent.blockDims_.size());
   for (size_t column = 0; column < qrByColumn.size(); ++column) {
     const auto& columnUpdates = qrByColumn[column];
@@ -1309,166 +1386,221 @@ MultifrontalClique::ParentGatherPlan::ParentGatherPlan(
   }
 }
 
-void MultifrontalClique::ParentGatherPlan::gather(MultifrontalClique* parent) {
+void MultifrontalClique::ParentGatherPlan::gatherComputeOnceRange(
+    MultifrontalClique* parent, size_t begin, size_t end,
+    SymmetricBlockMatrix* destination) const {
+  assert(parent && destination);
+  for (size_t index = begin; index < end; ++index) {
+    const auto& child = parent->children[computeOnceChildIndices[index]];
+    assert(child && child->fullyEliminated());
+    child->updateParentInfo(*destination);
+  }
+}
+
+void MultifrontalClique::ParentGatherPlan::gatherMaterializedRange(
+    MultifrontalClique* parent, size_t begin, size_t end) const {
+  assert(parent);
+  // Every task owns a physical upper-triangular parent column. Mapped blocks
+  // may change logical order, but no other task can write that destination.
+  for (size_t column = begin; column < end; ++column) {
+    for (const ColumnUpdate& update : materializedByColumn[column]) {
+      const auto& child = parent->children[update.childIndex];
+      assert(child && child->fullyEliminated());
+      child->updateParentMaterializedColumn(parent->info_,
+                                            update.sourceSeparatorBlock);
+    }
+  }
+}
+
+void MultifrontalClique::ParentGatherPlan::prepareQrRange(
+    MultifrontalClique* parent, size_t begin, size_t end) {
+  assert(parent);
+  // Multiple QR children can contribute to the same column. Bounded chunks
+  // expose parallel work while keeping every scratch matrix narrow.
+  for (size_t chunkIndex = begin; chunkIndex < end; ++chunkIndex) {
+    QrColumnChunk& chunk = qrChunks[chunkIndex];
+    chunk.scratch.setZero();
+    const auto& columnUpdates = qrByColumn[static_cast<size_t>(chunk.column)];
+    for (size_t index = chunk.begin; index < chunk.end; ++index) {
+      const ColumnUpdate& update = columnUpdates[index];
+      parent->children[update.childIndex]->updateParentQrColumnScratch(
+          update.sourceSeparatorBlock, &chunk.scratch);
+    }
+  }
+}
+
+void MultifrontalClique::ParentGatherPlan::combineQrRange(
+    MultifrontalClique* parent, size_t begin, size_t end) {
+  assert(parent);
+  for (size_t column = begin; column < end; ++column) {
+    const auto& chunkIndices = qrChunkIndicesByColumn[column];
+    if (chunkIndices.empty()) continue;
+    // The first chunk becomes the reusable per-column accumulator.
+    Matrix& accumulated = qrChunks[chunkIndices.front()].scratch;
+    for (size_t index = 1; index < chunkIndices.size(); ++index) {
+      accumulated += qrChunks[chunkIndices[index]].scratch;
+    }
+
+    const DenseIndex targetOffset = parent->info_.blockScalarOffset(column);
+    const DenseIndex targetDimension =
+        static_cast<DenseIndex>(parent->blockDims_[column]);
+    for (size_t rowBlock = 0; rowBlock < column; ++rowBlock) {
+      const DenseIndex rowOffset = parent->info_.blockScalarOffset(rowBlock);
+      const DenseIndex rowDimension =
+          static_cast<DenseIndex>(parent->blockDims_[rowBlock]);
+      parent->info_.updateOffDiagonalBlockAt(
+          rowOffset, targetOffset,
+          accumulated.block(rowOffset, 0, rowDimension, targetDimension));
+    }
+    parent->info_.updateDiagonalBlockAt(
+        targetOffset,
+        accumulated.block(targetOffset, 0, targetDimension, targetDimension));
+    parent->info_.updateOffDiagonalBlock(static_cast<DenseIndex>(column),
+                                         parent->info_.nBlocks() - 1,
+                                         accumulated.bottomRows(1).transpose());
+  }
+}
+
+double MultifrontalClique::ParentGatherPlan::rhsRange(
+    const MultifrontalClique& parent, size_t begin, size_t end) const {
+  double subtotal = 0.0;
+  for (size_t index = begin; index < end; ++index) {
+    const ColumnOwnedChild& update = columnOwnedChildren[index];
+    assert(update.representation == (parent.children[update.childIndex]->useQR()
+                                         ? ColumnRepresentation::Qr
+                                         : ColumnRepresentation::Materialized));
+    subtotal += parent.children[update.childIndex]->parentRhsDiagonal();
+  }
+  return subtotal;
+}
+
+void MultifrontalClique::ParentGatherPlan::gather(MultifrontalClique* parent,
+                                                  size_t numThreads) {
   assert(parent);
 
+  // Compact and fused Schur children stay on a compute-once reduction. Making
+  // them column-owned would repeat their expensive update for every column.
   if (!computeOnceChildIndices.empty()) {
+#ifdef GTSAM_USE_TBB
     tbb::enumerable_thread_specific<SymmetricBlockMatrix> locals(
         [parent]() { return makeZeroLocalInfo(parent->blockDims_); });
     tbb::parallel_for(
         tbb::blocked_range<size_t>(0, computeOnceChildIndices.size()),
         [this, parent, &locals](const tbb::blocked_range<size_t>& range) {
-          auto& local = locals.local();
-          for (size_t index = range.begin(); index < range.end(); ++index) {
-            const auto& child =
-                parent->children[computeOnceChildIndices[index]];
-            assert(child && child->fullyEliminated());
-            child->updateParentInfo(local);
-          }
+          gatherComputeOnceRange(parent, range.begin(), range.end(),
+                                 &locals.local());
         });
     locals.combine_each([parent](const SymmetricBlockMatrix& local) {
       parent->info_.addUpperTriangular(local);
     });
+#else
+    const size_t workerCount =
+        std::min(numThreads, computeOnceChildIndices.size());
+    std::vector<SymmetricBlockMatrix> locals;
+    locals.reserve(workerCount);
+    for (size_t worker = 0; worker < workerCount; ++worker) {
+      locals.push_back(makeZeroLocalInfo(parent->blockDims_));
+    }
+    runThreadBatch(
+        workerCount, [this, parent, &locals](size_t worker, size_t workers) {
+          const auto [begin, end] =
+              staticRange(computeOnceChildIndices.size(), worker, workers);
+          gatherComputeOnceRange(parent, begin, end, &locals[worker]);
+        });
+    for (const SymmetricBlockMatrix& local : locals) {
+      parent->info_.addUpperTriangular(local);
+    }
+#endif
   }
 
   // A compact-only parent follows exactly the original compute-once path.
   if (columnOwnedChildren.empty()) return;
 
+#ifdef GTSAM_USE_TBB
+  (void)numThreads;  // TBB is capped by the enclosing traversal arena.
+  // TBB supplies a persistent arena, task-local storage, and a native scalar
+  // reduction, so its scheduling adapter can express each stage directly.
   if (hasMaterialized) {
     tbb::parallel_for(
         tbb::blocked_range<size_t>(0, materializedByColumn.size(), 1),
         [this, parent](const tbb::blocked_range<size_t>& range) {
-          for (size_t column = range.begin(); column < range.end(); ++column) {
-            for (const ColumnUpdate& update : materializedByColumn[column]) {
-              const auto& child = parent->children[update.childIndex];
-              assert(child && child->fullyEliminated());
-              child->updateParentMaterializedColumn(
-                  parent->info_, update.sourceSeparatorBlock);
-            }
-          }
+          gatherMaterializedRange(parent, range.begin(), range.end());
         });
   }
 
   if (hasQr) {
-    tbb::parallel_for(
-        tbb::blocked_range<size_t>(0, qrChunks.size(), 1),
-        [this, parent](const tbb::blocked_range<size_t>& range) {
-          for (size_t chunkIndex = range.begin(); chunkIndex < range.end();
-               ++chunkIndex) {
-            QrColumnChunk& chunk = qrChunks[chunkIndex];
-            chunk.scratch.setZero();
-            const auto& columnUpdates =
-                qrByColumn[static_cast<size_t>(chunk.column)];
-            for (size_t index = chunk.begin; index < chunk.end; ++index) {
-              const ColumnUpdate& update = columnUpdates[index];
-              parent->children[update.childIndex]->updateParentQrColumnScratch(
-                  update.sourceSeparatorBlock, &chunk.scratch);
-            }
-          }
-        });
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, qrChunks.size(), 1),
+                      [this, parent](const tbb::blocked_range<size_t>& range) {
+                        prepareQrRange(parent, range.begin(), range.end());
+                      });
 
     tbb::parallel_for(
         tbb::blocked_range<size_t>(0, qrChunkIndicesByColumn.size(), 1),
         [this, parent](const tbb::blocked_range<size_t>& range) {
-          for (size_t column = range.begin(); column < range.end(); ++column) {
-            const auto& chunkIndices = qrChunkIndicesByColumn[column];
-            if (chunkIndices.empty()) continue;
-            Matrix& accumulated = qrChunks[chunkIndices.front()].scratch;
-            for (size_t index = 1; index < chunkIndices.size(); ++index) {
-              accumulated += qrChunks[chunkIndices[index]].scratch;
-            }
-
-            const DenseIndex targetOffset =
-                parent->info_.blockScalarOffset(column);
-            const DenseIndex targetDimension =
-                static_cast<DenseIndex>(parent->blockDims_[column]);
-            for (size_t rowBlock = 0; rowBlock < column; ++rowBlock) {
-              const DenseIndex rowOffset =
-                  parent->info_.blockScalarOffset(rowBlock);
-              const DenseIndex rowDimension =
-                  static_cast<DenseIndex>(parent->blockDims_[rowBlock]);
-              parent->info_.updateOffDiagonalBlockAt(
-                  rowOffset, targetOffset,
-                  accumulated.block(rowOffset, 0, rowDimension,
-                                    targetDimension));
-            }
-            parent->info_.updateDiagonalBlockAt(
-                targetOffset,
-                accumulated.block(targetOffset, 0, targetDimension,
-                                  targetDimension));
-            parent->info_.updateOffDiagonalBlock(
-                static_cast<DenseIndex>(column), parent->info_.nBlocks() - 1,
-                accumulated.bottomRows(1).transpose());
-          }
+          combineQrRange(parent, range.begin(), range.end());
         });
   }
 
   const double rhs = tbb::parallel_reduce(
       tbb::blocked_range<size_t>(0, columnOwnedChildren.size()), 0.0,
       [this, parent](const tbb::blocked_range<size_t>& range, double subtotal) {
-        for (size_t index = range.begin(); index < range.end(); ++index) {
-          const ColumnOwnedChild& update = columnOwnedChildren[index];
-          assert(update.representation ==
-                 (parent->children[update.childIndex]->useQR()
-                      ? ColumnRepresentation::Qr
-                      : ColumnRepresentation::Materialized));
-          subtotal += parent->children[update.childIndex]->parentRhsDiagonal();
-        }
-        return subtotal;
+        return subtotal + rhsRange(*parent, range.begin(), range.end());
       },
       std::plus<double>());
+#else
+  // The traversal scheduler cannot safely block for nested tasks: it has no
+  // cooperative task-group wait, while its inline submission path would run
+  // serially. Use a bounded short-lived team for this rare large-parent path.
+  // Independent materialized writes, QR scratch preparation, and scalar RHS
+  // partials share one launch; QR combination waits for that team to finish.
+  const size_t parallelItems = std::max(
+      {hasMaterialized ? materializedByColumn.size() : size_t{0},
+       hasQr ? qrChunks.size() : size_t{0}, columnOwnedChildren.size()});
+  const size_t workerCount = std::min(numThreads, parallelItems);
+  std::vector<double> rhsPartials(workerCount, 0.0);
+  runThreadBatch(workerCount, [this, parent, &rhsPartials](size_t worker,
+                                                           size_t workers) {
+    if (hasMaterialized) {
+      const auto [begin, end] =
+          staticRange(materializedByColumn.size(), worker, workers);
+      gatherMaterializedRange(parent, begin, end);
+    }
+    if (hasQr) {
+      const auto [begin, end] = staticRange(qrChunks.size(), worker, workers);
+      prepareQrRange(parent, begin, end);
+    }
+    const auto [rhsBegin, rhsEnd] =
+        staticRange(columnOwnedChildren.size(), worker, workers);
+    rhsPartials[worker] = rhsRange(*parent, rhsBegin, rhsEnd);
+  });
+
+  if (hasQr) {
+    const size_t combineWorkers =
+        std::min(numThreads, qrChunkIndicesByColumn.size());
+    runThreadBatch(
+        combineWorkers, [this, parent](size_t worker, size_t workers) {
+          const auto [begin, end] =
+              staticRange(qrChunkIndicesByColumn.size(), worker, workers);
+          combineQrRange(parent, begin, end);
+        });
+  }
+
+  double rhs = 0.0;
+  for (double partial : rhsPartials) rhs += partial;
+#endif
 
   Eigen::Matrix<double, 1, 1> rhsUpdate;
   rhsUpdate(0, 0) = rhs;
   parent->info_.updateDiagonalBlock(parent->info_.nBlocks() - 1, rhsUpdate);
 }
-#endif
 
 void MultifrontalClique::gatherUpdatesParallel(size_t numThreads) {
-#ifdef GTSAM_USE_TBB
-  (void)numThreads;  // TBB is capped by the enclosing traversal arena.
+  // Deferred leaf modes are resolved by the first elimination. Build the plan
+  // only after that resolution, then reuse its buckets and scratch on reloads.
   if (!parentGatherPlan_) {
     parentGatherPlan_ = std::make_shared<ParentGatherPlan>(*this);
   }
-  parentGatherPlan_->gather(this);
-#else
-  std::vector<SymmetricBlockMatrix> locals;
-  locals.reserve(numThreads);  // Fixed-size per-thread accumulators.
-  for (size_t i = 0; i < numThreads; ++i) {
-    locals.push_back(makeZeroLocalInfo(blockDims_));
-  }
-  std::vector<std::thread> threads;
-  threads.reserve(numThreads);
-  const size_t chunk =
-      (children.size() + numThreads - 1) / numThreads;  // Static partitioning.
-  for (size_t t = 0; t < numThreads; ++t) {
-    const size_t start = t * chunk;
-    const size_t end = std::min(start + chunk, children.size());
-    if (start >= end) break;
-    threads.emplace_back([this, start, end, &locals, t]() {
-      auto& local = locals[t];
-      for (size_t i = start; i < end; ++i) {
-        if (!childInSameSeparatorGroup_.empty() &&
-            childInSameSeparatorGroup_[i]) {
-          continue;
-        }
-        const auto& child = children[i];
-        assert(child);
-        if (child->fullyEliminated()) {
-          child->updateParentInfo(
-              local);  // No locking: each thread writes its own info matrix.
-        }
-      }
-    });
-  }
-  for (auto& thread : threads) {
-    thread.join();  // Ensure all locals are complete before merge.
-  }
-  for (const auto& local : locals) {
-    info_.addUpperTriangular(
-        local);  // Merge per-thread partial info matrices into this clique.
-  }
-#endif
+  parentGatherPlan_->gather(this, numThreads);
 }
 
 void MultifrontalClique::gatherSameSeparatorUpdates() {
@@ -1494,6 +1626,7 @@ void MultifrontalClique::gatherSameSeparatorUpdates() {
     }
   }
 #endif
+  // Scatter only after disjoint group-local assembly finishes.
   for (size_t group = 0; group < sameSeparatorInfos_.size(); ++group) {
     info_.updateFromMappedBlocks(sameSeparatorInfos_[group],
                                  sameSeparatorParentIndices_[group],
@@ -1581,6 +1714,7 @@ double MultifrontalClique::constantTermError() const {
   if (!RSdReady_) {
     return 0.0;
   }
+  // Only residual QR rows or the active RHS Schur term contribute here.
   double constantError = 0.0;
   if (useQR()) {
     const DenseIndex extraRows =

--- a/gtsam/linear/MultifrontalClique.h
+++ b/gtsam/linear/MultifrontalClique.h
@@ -166,7 +166,7 @@ class GTSAM_EXPORT MultifrontalClique {
   /// @name Read-only methods
   /// @{
 
-  /// Get the cached problem size for traversal scheduling.
+  /// Return the clique dimension used for traversal scheduling.
   int problemSize() const {
     return static_cast<int>(frontalDim + separatorDim);
   }
@@ -365,7 +365,6 @@ class GTSAM_EXPORT MultifrontalClique {
   /// contribution.
   void updateParentInfo(SymmetricBlockMatrix& parentInfo) const;
 
-#ifdef GTSAM_USE_TBB
   /// Accumulate one ordinary separator block into its owned parent column.
   void updateParentMaterializedColumn(SymmetricBlockMatrix& parentInfo,
                                       DenseIndex sourceSeparatorBlock) const;
@@ -376,7 +375,6 @@ class GTSAM_EXPORT MultifrontalClique {
 
   /// Return the augmented-RHS diagonal from a column-owned child update.
   double parentRhsDiagonal() const;
-#endif
 
   /// Update a separator-local information matrix without parent scattering.
   void updateSeparatorInfo(SymmetricBlockMatrix& separatorInfo) const;
@@ -490,16 +488,15 @@ class GTSAM_EXPORT MultifrontalClique {
   std::vector<SymmetricBlockMatrix> sameSeparatorInfos_;
   std::vector<uint8_t> childInSameSeparatorGroup_;
 
-#ifdef GTSAM_USE_TBB
   struct ParentGatherPlan;
+  // Built after deferred modes resolve and reused across numerical reloads.
   std::shared_ptr<ParentGatherPlan> parentGatherPlan_;
-#endif
 
   // Lazily allocated after load-plan construction. Direct batch factors need
   // no rows; QR additionally reserves frontal damping rows.
   VerticalBlockMatrix Ab_;
 
-  // mutable as temporarily updateParentInfo
+  // Cached factorization storage reused by parent updates and result exports.
   mutable VerticalBlockMatrix RSd_;  ///< Cached [R S d] from elimination.
   mutable SymmetricBlockMatrix info_;
 

--- a/gtsam/linear/MultifrontalSolver.cpp
+++ b/gtsam/linear/MultifrontalSolver.cpp
@@ -285,6 +285,7 @@ MergedClusters buildMergedClusters(const std::vector<LeafBatch>& clusters) {
     for (const auto& leaf : batch.leaves) {
       if (leaf) mergedCluster->merge(leaf);
     }
+    // Cluster::merge prepends frontals, so restore the batch's original order.
     std::reverse(mergedCluster->orderedFrontalKeys.begin(),
                  mergedCluster->orderedFrontalKeys.end());
     merged.clusters[i] = mergedCluster;
@@ -418,6 +419,7 @@ void mergeSmallClusters(const SymbolicJunctionTree::sharedNode& cluster,
     const auto& child = cluster->children[i];
     if (!child) continue;
     const size_t childFrontalDim = frontalDimForSymbolicCluster(child, dims);
+    // The child's separator is already contained in the parent's total size.
     if (childFrontalDim + parentTotalDim < mergeDimCap) {
       merge[i] = true;
       any = true;
@@ -507,6 +509,7 @@ struct CliqueBuilder {
 
     // Finalize children metadata and register clique.
     clique->finalize(std::move(childInfos), *params);
+    // Register after recursion so the flat clique list remains in post-order.
     cliques->push_back(clique);
     return {clique, std::move(separatorKeys)};
   }
@@ -618,6 +621,7 @@ MultifrontalSolver::PrecomputedData MultifrontalSolver::Precompute(
 
   Ordering reducedOrdering;
   reducedOrdering.reserve(ordering.size());
+  // Exact unary constraints remove their keys from symbolic elimination.
   for (Key key : ordering) {
     if (!scratch.fixedKeys.count(key)) {
       reducedOrdering.push_back(key);
@@ -768,6 +772,7 @@ GaussianBayesTree MultifrontalSolver::computeBayesTree() const {
   }
 
   if (!fixedKeys_.empty()) {
+    // Reintroduce fixed variables as independent constrained conditionals.
     for (Key key : fixedKeys_) {
       auto dimIt = dims_.find(key);
       if (dimIt == dims_.end()) {
@@ -832,6 +837,7 @@ const VectorValues& MultifrontalSolver::updateSolution(
         "elimination.");
   }
 
+  // Seed retained variables before back-substituting the eliminated prefix.
   for (size_t i = firstPhaseSize_; i < ordering_.size(); ++i) {
     const Key key = ordering_[i];
     if (fixedKeys_.count(key)) {

--- a/gtsam/linear/tests/testMultifrontalSolver.cpp
+++ b/gtsam/linear/tests/testMultifrontalSolver.cpp
@@ -409,7 +409,8 @@ TEST(MultifrontalSolver, ParallelParentOrdinaryReloadAndPartial) {
                       1e-8));
 }
 
-// Forced QR agrees across thread counts for overlapping siblings.
+// Forced QR agrees across thread counts for overlapping siblings, reloads,
+// and partial elimination.
 TEST(MultifrontalSolver, ParallelParentForcedQr) {
   const Problem problem = createProblem(kParallelChildCount);
   auto params = noMergeParams();
@@ -423,6 +424,26 @@ TEST(MultifrontalSolver, ParallelParentForcedQr) {
   parallel.eliminateInPlace(problem.graph);
   EXPECT(
       assert_equal(single.updateSolution(), parallel.updateSolution(), 1e-8));
+
+  const Problem changed = createProblem(kParallelChildCount, false, 0.5);
+  single.eliminateInPlace(changed.graph);
+  parallel.eliminateInPlace(changed.graph);
+  EXPECT(
+      assert_equal(single.updateSolution(), parallel.updateSolution(), 1e-8));
+
+  MultifrontalSolver singlePartial(problem.graph, problem.fullOrdering,
+                                   problem.pointOrdering.size(),
+                                   threadedParams(params, 1));
+  MultifrontalSolver parallelPartial(problem.graph, problem.fullOrdering,
+                                     problem.pointOrdering.size(),
+                                     threadedParams(params, 4));
+  singlePartial.eliminatePartialInPlace(problem.graph);
+  parallelPartial.eliminatePartialInPlace(problem.graph);
+  EXPECT(assert_equal(singlePartial.remainingFactorGraph().augmentedHessian(
+                          problem.cameraOrdering),
+                      parallelPartial.remainingFactorGraph().augmentedHessian(
+                          problem.cameraOrdering),
+                      1e-8));
 }
 
 // Compact Cholesky leaves agree across thread counts.


### PR DESCRIPTION
## Summary

This brings the shared multifrontal parent-gather plan to non-TBB builds. Ordinary Cholesky and QR children now update disjoint physical parent columns instead of allocating and reducing one full parent-sized matrix per worker.

Compact and fused Schur children deliberately remain on the existing compute-once reduction path so their expensive contributions are evaluated only once. The non-TBB backend retains a bounded short-lived thread team because the traversal scheduler does not provide a safe cooperative wait for nested work.

No public API, solver parameter, threshold, or default changes.

## BAL-88 performance

Compared with `9adbeecb5` using seven paired alternating samples, fixed CPU affinity, the same thread budget, and TBB disabled:

| Configuration | Median runtime change | Result |
|---|---:|---|
| Regular | **-66.7%** | **About 3x throughput** |
| Full point-batch | +2.61% | Within 3% gate |
| Schur point-batch | -0.23% | No regression |

The Regular run also reduced peak RSS by **196 MiB**, confirming that ordinary and QR parent gathering no longer creates full parent-sized worker matrices.

A smaller TBB regression check remained stable:

| Configuration | Median runtime change |
|---|---:|
| Regular | -2.23% |
| Full point-batch | +0.97% |
| Schur point-batch | +0.52% |

## Implementation

- Reuse `ParentGatherPlan` and the materialized/QR range operations in both backends.
- Statically partition materialized columns, QR scratch preparation, and RHS reduction over a bounded non-TBB worker batch.
- Count the calling traversal worker toward the requested thread count.
- Join before the QR scratch-combination phase.
- Allocate full parent-sized local matrices only for compact/fused compute-once children.
- Preserve same-separator exclusion, lazy plan reuse across numerical reloads, sequential small-clique behavior, and all numerical representations.
- Extend forced-QR stress coverage to numerical reload and partial elimination.

## Validation

- TBB `testMultifrontalSolver`: passed
- Non-TBB `testMultifrontalSolver`: passed
- BAL-88 paired benchmarks: passed the 3% non-regression gate for Regular, Full, and Schur
- `clang-format` applied to edited C++ files
- `git diff --check`: clean

Fixes #2734 (because tuning, according to report I attached there, yielded no change in defaults).
