### PR TITLE
Fix fixed-size wrapper bindings

### DIFF
--- a/gtsam/slam/slam.i
+++ b/gtsam/slam/slam.i
@@ -638,16 +638,26 @@ class WahbaFactor : gtsam::NoiseModelFactor {
 };
 
 #include <gtsam/slam/RelativeTranslationFactor.h>
-// Relative translation measurement for certifiable SE(d) synchronization,
-// with d = 2 or 3. `measured` is the d-vector translation offset expressed in
-// the body frame of pose i, and `weight` is the translational precision tau.
-template <d = {2, 3}>
-virtual class RelativeTranslationFactor : gtsam::NoiseModelFactor {
-  RelativeTranslationFactor(gtsam::Key rotationKey, gtsam::Key translationKey1,
-                            gtsam::Key translationKey2,
-                            const gtsam::Vector& measured, double weight);
+// Relative translation measurements for certifiable SE(d) synchronization.
+// Concrete declarations let the wrappers use their supported fixed-size Eigen
+// aliases while preserving the templated C++ implementation.
+virtual class RelativeTranslationFactor2 : gtsam::NoiseModelFactor {
+  RelativeTranslationFactor2(gtsam::Key rotationKey,
+                             gtsam::Key translationKey1,
+                             gtsam::Key translationKey2,
+                             const gtsam::Vector2& measured, double weight);
 
-  const Eigen::Matrix<double, d, 1>& measured() const;
+  const gtsam::Vector2& measured() const;
+  double weight() const;
+};
+
+virtual class RelativeTranslationFactor3 : gtsam::NoiseModelFactor {
+  RelativeTranslationFactor3(gtsam::Key rotationKey,
+                             gtsam::Key translationKey1,
+                             gtsam::Key translationKey2,
+                             const gtsam::Vector3& measured, double weight);
+
+  const gtsam::Vector3& measured() const;
   double weight() const;
 };
 

--- a/python/gtsam/specializations/discrete.h
+++ b/python/gtsam/specializations/discrete.h
@@ -15,8 +15,9 @@
 // py::bind_vector<std::vector<gtsam::DiscreteKey>>(m_, "DiscreteKeys");
 
 py::bind_map<gtsam::Assignment<gtsam::Key>>(m_, "AssignmentKey");
-py::bind_map<gtsam::DiscreteValues>(
-    m_, "DiscreteValues", py::base<gtsam::Assignment<gtsam::Key>>());
+py::class_<gtsam::DiscreteValues, gtsam::Assignment<gtsam::Key>>(
+    m_, "DiscreteValues")
+    .def(py::init<>());
 
 #include <gtsam/discrete/DiscreteValues.h>
 /// DiscreteValues print function for wrapper

--- a/python/gtsam/tests/test_RelativeTranslationFactor.py
+++ b/python/gtsam/tests/test_RelativeTranslationFactor.py
@@ -91,6 +91,9 @@ class TestRelativeTranslationFactor2(GtsamTestCase):
         tj = np.array([0.25, 0.75])
 
         factor = gtsam.RelativeTranslationFactor2(R(0), T(0), T(1), measured, weight)
+        np.testing.assert_allclose(factor.measured(), measured)
+        self.assertAlmostEqual(factor.weight(), weight)
+
         values = gtsam.Values()
         values.insert(R(0), rotation)
         values.insert(T(0), gtsam.Point2(ti))


### PR DESCRIPTION
## Summary
- declare the 2D and 3D relative-translation wrappers concretely so MATLAB uses supported fixed-size Eigen aliases
- bind DiscreteValues with pybind11 class-template base syntax, removing the deprecated py::base warning
- cover the 2D measured/weight accessor round trip

## Validation
- make -j6 install with Boost serialization ON (Boost 1.90.0), TBB ON (TBB 2022.3.0), and GTSAM_DEFAULT_ALLOCATOR=TBB
- make -j6 testRelativeTranslationFactor.run
- make -j6 testForestTraversal.run testMultifrontalSolver.run
- conda run -n py312 python -m pytest python/gtsam/tests/test_RelativeTranslationFactor.py python/gtsam/tests/test_DiscreteConditional.py -q (12 passed)
- generated MATLAB wrapper uses wrapFixedSizeEigen for both accessor instantiations
