### PR TITLE
Bring Galilean PIM in line with templated IMU preintegration

### DIFF
--- a/gtsam/navigation/GalileanImuFactor.h
+++ b/gtsam/navigation/GalileanImuFactor.h
@@ -11,109 +11,21 @@
 
 /**
  * @file    GalileanImuFactor.h
- * @brief   Left-invariant Galilean IMU preintegration with bias correction
- *
- * This class implements the Galilean preintegration model described in:
- *
- *   Giulio Delama, Alessandro Fornasier, Robert Mahony, Stephan Weiss,
- *   "Equivariant IMU Preintegration with Biases: a Galilean Group Approach,"
- *   IEEE Robotics and Automation Letters, 2025.
- *
- * Unlike the paper's right-invariant error, this implementation uses GTSAM's
- * right retraction and therefore a left-invariant local error. See
- * navigation/doc/GalileanImuFactor.ipynb for the conventions and derivation.
+ * @brief   Left-invariant Galilean IMU preintegration factor aliases
  */
 
 #pragma once
 
-#include <gtsam/base/Matrix.h>
-#include <gtsam/geometry/Gal3.h>
-#include <gtsam/navigation/ImuBias.h>
+#include <gtsam/navigation/GalileanPreintegration.h>
 #include <gtsam/navigation/ImuFactor.h>
-#include <gtsam/navigation/NavState.h>
-#include <gtsam/navigation/PreintegrationBase.h>
 
 namespace gtsam {
 
-/**
- * IMU preintegration on Gal(3) using GTSAM's left-invariant local error.
- *
- * The internal tangent ordering is `(rotation, velocity, position, time)`. The
- * public factor contract projects this to NavState ordering
- * `(rotation, position, velocity)` and removes deterministic time. Biases use
- * GTSAM's `(accelerometer, gyroscope)` ordering and are corrected on the right.
- */
-class GTSAM_EXPORT PreintegratedImuMeasurementsG : public PreintegrationBase {
- public:
-  using Base = PreintegrationBase;
-  using Params = PreintegrationBase::Params;
-  using Matrix10 = Eigen::Matrix<double, 10, 10>;
-  using Matrix106 = Eigen::Matrix<double, 10, 6>;
-  using Matrix910 = Eigen::Matrix<double, 9, 10>;
+/// Galilean preintegration with generic PIM covariance propagation.
+using PreintegratedImuMeasurementsG =
+    PreintegratedImuMeasurementsT<GalileanPreintegration>;
 
- protected:
-  Gal3 preintMatrix_;       ///< Mean increment in Gal(3).
-  Matrix106 biasJacobian_;  ///< Right correction wrt (accel, gyro) bias.
-  Matrix10 preintMeasCov_;  ///< Covariance in Gal(3) LI local coordinates.
-
-  /** Project Gal(3) tangent order to NavState tangent order. */
-  static Matrix910 NavStateProjector();
-
-  /** Lift GTSAM input order `(acceleration, angular rate)` into Gal(3). */
-  static Matrix106 LiftJacobian();
-
-  /** Update the Gal(3) mean and return its transition and input Jacobian. */
-  void updateGal3(const Vector3& measuredAcc, const Vector3& measuredOmega,
-                  double dt, Matrix10* A, Matrix106* B);
-
- public:
-  /** Construct and reset a Galilean preintegrated measurement. */
-  explicit PreintegratedImuMeasurementsG(
-      const std::shared_ptr<Params>& p = std::make_shared<Params>(),
-      const imuBias::ConstantBias& biasHat = {});
-
-  Rot3 deltaRij() const override { return preintMatrix_.rotation(); }
-  Vector3 deltaPij() const override { return preintMatrix_.translation(); }
-  Vector3 deltaVij() const override { return preintMatrix_.velocity(); }
-  NavState deltaXij() const override {
-    return NavState(preintMatrix_.rotation(), preintMatrix_.translation(),
-                    preintMatrix_.velocity());
-  }
-
-  /** Return covariance in the NavState factor residual chart. */
-  Matrix9 preintMeasCov() const;
-
-  /** Return covariance used by ImuFactorT. */
-  Matrix9 residualCovariance() const { return preintMeasCov(); }
-
-  /** Apply the first-order physical bias correction on the right. */
-  Vector9 biasCorrectedDelta(const imuBias::ConstantBias& bias_i,
-                             OptionalJacobian<9, 6> H = {}) const override;
-
-  /**
-   * Update the mean and bias Jacobian, returning NavState-chart Jacobians.
-   * Covariance propagation is performed by integrateMeasurement().
-   */
-  void update(const Vector3& measuredAcc, const Vector3& measuredOmega,
-              double dt, Matrix9* A, Matrix93* B, Matrix93* C) override;
-
-  /** Integrate one measurement and propagate its conditional covariance. */
-  void integrateMeasurement(const Vector3& measuredAcc,
-                            const Vector3& measuredOmega, double dt) override;
-
-  /** Reset the mean, elapsed time, covariance, and bias Jacobian. */
-  void resetIntegration() override;
-
-  void print(
-      const std::string& s = "PreintegratedImuMeasurementsG") const override;
-  bool equals(const PreintegratedImuMeasurementsG& other,
-              double tol = 1e-9) const;
-};
-
-template <>
-struct traits<PreintegratedImuMeasurementsG>
-    : public Testable<PreintegratedImuMeasurementsG> {};
-
+/// Five-way IMU factor using Galilean preintegration.
 using GalileanImuFactor = ImuFactorT<PreintegratedImuMeasurementsG>;
 
 }  // namespace gtsam

--- a/gtsam/navigation/GalileanPreintegration.cpp
+++ b/gtsam/navigation/GalileanPreintegration.cpp
@@ -22,23 +22,6 @@
 namespace gtsam {
 
 //------------------------------------------------------------------------------
-GalileanPreintegration::Matrix910 GalileanPreintegration::NavStateProjector() {
-  Matrix910 P = Matrix910::Zero();
-  P.block<3, 3>(0, 0) = I_3x3;
-  P.block<3, 3>(3, 6) = I_3x3;
-  P.block<3, 3>(6, 3) = I_3x3;
-  return P;
-}
-
-//------------------------------------------------------------------------------
-GalileanPreintegration::Matrix106 GalileanPreintegration::LiftJacobian() {
-  Matrix106 E = Matrix106::Zero();
-  E.block<3, 3>(0, 3) = I_3x3;
-  E.block<3, 3>(3, 0) = I_3x3;
-  return E;
-}
-
-//------------------------------------------------------------------------------
 GalileanPreintegration::GalileanPreintegration(
     const std::shared_ptr<Params>& p, const imuBias::ConstantBias& biasHat)
     : Base(p, biasHat) {
@@ -59,13 +42,16 @@ void GalileanPreintegration::updateGal3(const Vector3& measuredAcc,
   Vector3 acc = biasHat_.correctAccelerometer(measuredAcc);
   Vector3 omega = biasHat_.correctGyroscope(measuredOmega);
 
-  Matrix3 correctedAcc_H_acc = I_3x3;
-  Matrix3 correctedAcc_H_omega = Z_3x3;
-  Matrix3 correctedOmega_H_omega = I_3x3;
+  Matrix6 correctedInput_H_input;
   if (p().body_P_sensor) {
+    Matrix3 correctedAcc_H_acc, correctedAcc_H_omega, correctedOmega_H_omega;
     std::tie(acc, omega) = correctMeasurementsBySensorPose(
         acc, omega, correctedAcc_H_acc, correctedAcc_H_omega,
         correctedOmega_H_omega);
+    correctedInput_H_input.setZero();
+    correctedInput_H_input.block<3, 3>(0, 0) = correctedAcc_H_acc;
+    correctedInput_H_input.block<3, 3>(0, 3) = correctedAcc_H_omega;
+    correctedInput_H_input.block<3, 3>(3, 3) = correctedOmega_H_omega;
   }
 
   Vector10 integratedInput = Vector10::Zero();
@@ -77,12 +63,15 @@ void GalileanPreintegration::updateGal3(const Vector3& measuredAcc,
   const Gal3 increment = Gal3::Expmap(integratedInput, rightJacobian);
   const Matrix10 transition = increment.inverse().AdjointMap();
 
-  Matrix6 correctedInput_H_input = Matrix6::Zero();
-  correctedInput_H_input.block<3, 3>(0, 0) = correctedAcc_H_acc;
-  correctedInput_H_input.block<3, 3>(0, 3) = correctedAcc_H_omega;
-  correctedInput_H_input.block<3, 3>(3, 3) = correctedOmega_H_omega;
-  const Matrix106 inputJacobian =
-      rightJacobian * LiftJacobian() * correctedInput_H_input * dt;
+  Matrix106 liftedInputJacobian;
+  liftedInputJacobian.leftCols<3>() = rightJacobian.middleCols<3>(3);
+  liftedInputJacobian.rightCols<3>() = rightJacobian.leftCols<3>();
+  Matrix106 inputJacobian;
+  if (p().body_P_sensor) {
+    inputJacobian.noalias() = liftedInputJacobian * correctedInput_H_input * dt;
+  } else {
+    inputJacobian = liftedInputJacobian * dt;
+  }
 
   preintMatrix_ = preintMatrix_.compose(increment);
   deltaTij_ += dt;
@@ -101,16 +90,61 @@ void GalileanPreintegration::update(const Vector3& measuredAcc,
   Matrix106 galInput;
   updateGal3(measuredAcc, measuredOmega, dt, &galTransition, &galInput);
 
-  const Matrix910 P = NavStateProjector();
-  if (A) *A = P * galTransition * P.transpose();
-  if (B) *B = P * galInput.leftCols<3>();
-  if (C) *C = P * galInput.rightCols<3>();
+  constexpr int kGal3BlockForNavState[3] = {0, 6, 3};
+  for (int row = 0; row < 3; ++row) {
+    const int galRow = kGal3BlockForNavState[row];
+    if (B) {
+      B->block<3, 3>(3 * row, 0) = galInput.block<3, 3>(galRow, 0);
+    }
+    if (C) {
+      C->block<3, 3>(3 * row, 0) = galInput.block<3, 3>(galRow, 3);
+    }
+    if (A) {
+      for (int column = 0; column < 3; ++column) {
+        const int galColumn = kGal3BlockForNavState[column];
+        A->block<3, 3>(3 * row, 3 * column) =
+            galTransition.block<3, 3>(galRow, galColumn);
+      }
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+Vector9 GalileanPreintegration::NavStateTangent(const Gal3& galilean,
+                                                OptionalJacobian<9, 10> H) {
+  Matrix3 logRotation_H_rotation;
+  Eigen::Matrix<double, 3, 10> rotation_H_galilean, position_H_galilean,
+      velocity_H_galilean;
+
+  Vector9 result;
+  NavState::dR(result) =
+      Rot3::Logmap(galilean.rotation(H ? &rotation_H_galilean : nullptr),
+                   H ? &logRotation_H_rotation : nullptr);
+  NavState::dP(result) =
+      galilean.translation(H ? &position_H_galilean : nullptr);
+  NavState::dV(result) = galilean.velocity(H ? &velocity_H_galilean : nullptr);
+
+  if (H) {
+    H->setZero();
+    H->block<3, 10>(0, 0) = logRotation_H_rotation * rotation_H_galilean;
+    H->block<3, 10>(3, 0) = position_H_galilean;
+    H->block<3, 10>(6, 0) = velocity_H_galilean;
+  }
+  return result;
 }
 
 //------------------------------------------------------------------------------
 Vector9 GalileanPreintegration::biasCorrectedDelta(
     const imuBias::ConstantBias& bias_i, OptionalJacobian<9, 6> H) const {
   const Vector6 biasIncrement = (bias_i - biasHat_).vector();
+  if (biasIncrement.isZero(0.0)) {
+    Matrix910 result_H_preintegrated;
+    const Vector9 result =
+        NavStateTangent(preintMatrix_, H ? &result_H_preintegrated : nullptr);
+    if (H) *H = result_H_preintegrated * biasJacobian_;
+    return result;
+  }
+
   const Vector10 correction = biasJacobian_ * biasIncrement;
 
   Matrix10 correction_H_vector;
@@ -120,27 +154,15 @@ Vector9 GalileanPreintegration::biasCorrectedDelta(
   const Gal3 corrected = preintMatrix_.compose(
       correctionGroup, {}, H ? &corrected_H_correctionGroup : nullptr);
 
-  Matrix3 logRotation_H_rotation;
-  Eigen::Matrix<double, 3, 10> rotation_H_corrected, position_H_corrected,
-      velocity_H_corrected;
-
-  Vector9 result;
-  NavState::dR(result) =
-      Rot3::Logmap(corrected.rotation(H ? &rotation_H_corrected : nullptr),
-                   H ? &logRotation_H_rotation : nullptr);
-  NavState::dP(result) =
-      corrected.translation(H ? &position_H_corrected : nullptr);
-  NavState::dV(result) =
-      corrected.velocity(H ? &velocity_H_corrected : nullptr);
+  Matrix910 result_H_corrected;
+  const Vector9 result =
+      NavStateTangent(corrected, H ? &result_H_corrected : nullptr);
 
   if (H) {
-    Matrix910 result_H_corrected = Matrix910::Zero();
-    result_H_corrected.block<3, 10>(0, 0) =
-        logRotation_H_rotation * rotation_H_corrected;
-    result_H_corrected.block<3, 10>(3, 0) = position_H_corrected;
-    result_H_corrected.block<3, 10>(6, 0) = velocity_H_corrected;
-    *H = result_H_corrected * corrected_H_correctionGroup *
-         correction_H_vector * biasJacobian_;
+    const Matrix106 correction_H_bias = correction_H_vector * biasJacobian_;
+    const Matrix106 corrected_H_bias =
+        corrected_H_correctionGroup * correction_H_bias;
+    *H = result_H_corrected * corrected_H_bias;
   }
   return result;
 }

--- a/gtsam/navigation/GalileanPreintegration.cpp
+++ b/gtsam/navigation/GalileanPreintegration.cpp
@@ -10,22 +10,19 @@
  * -------------------------------------------------------------------------- */
 
 /**
- * @file    GalileanImuFactor.cpp
+ * @file    GalileanPreintegration.cpp
  * @brief   Left-invariant Galilean IMU preintegration
  * @author  Frank Dellaert
  * @author  Giulio Delama
  */
 
 #include <gtsam/base/MatrixConstants.h>
-#include <gtsam/navigation/GalileanImuFactor.h>
-
-#include <stdexcept>
+#include <gtsam/navigation/GalileanPreintegration.h>
 
 namespace gtsam {
 
 //------------------------------------------------------------------------------
-PreintegratedImuMeasurementsG::Matrix910
-PreintegratedImuMeasurementsG::NavStateProjector() {
+GalileanPreintegration::Matrix910 GalileanPreintegration::NavStateProjector() {
   Matrix910 P = Matrix910::Zero();
   P.block<3, 3>(0, 0) = I_3x3;
   P.block<3, 3>(3, 6) = I_3x3;
@@ -34,8 +31,7 @@ PreintegratedImuMeasurementsG::NavStateProjector() {
 }
 
 //------------------------------------------------------------------------------
-PreintegratedImuMeasurementsG::Matrix106
-PreintegratedImuMeasurementsG::LiftJacobian() {
+GalileanPreintegration::Matrix106 GalileanPreintegration::LiftJacobian() {
   Matrix106 E = Matrix106::Zero();
   E.block<3, 3>(0, 3) = I_3x3;
   E.block<3, 3>(3, 0) = I_3x3;
@@ -43,25 +39,23 @@ PreintegratedImuMeasurementsG::LiftJacobian() {
 }
 
 //------------------------------------------------------------------------------
-PreintegratedImuMeasurementsG::PreintegratedImuMeasurementsG(
+GalileanPreintegration::GalileanPreintegration(
     const std::shared_ptr<Params>& p, const imuBias::ConstantBias& biasHat)
     : Base(p, biasHat) {
   resetIntegration();
 }
 
 //------------------------------------------------------------------------------
-void PreintegratedImuMeasurementsG::resetIntegration() {
+void GalileanPreintegration::resetIntegration() {
   deltaTij_ = 0.0;
   preintMatrix_ = Gal3::Identity();
-  preintMeasCov_.setZero();
   biasJacobian_.setZero();
 }
 
 //------------------------------------------------------------------------------
-void PreintegratedImuMeasurementsG::updateGal3(const Vector3& measuredAcc,
-                                               const Vector3& measuredOmega,
-                                               double dt, Matrix10* A,
-                                               Matrix106* B) {
+void GalileanPreintegration::updateGal3(const Vector3& measuredAcc,
+                                        const Vector3& measuredOmega, double dt,
+                                        Matrix10* A, Matrix106* B) {
   Vector3 acc = biasHat_.correctAccelerometer(measuredAcc);
   Vector3 omega = biasHat_.correctGyroscope(measuredOmega);
 
@@ -100,10 +94,9 @@ void PreintegratedImuMeasurementsG::updateGal3(const Vector3& measuredAcc,
 }
 
 //------------------------------------------------------------------------------
-void PreintegratedImuMeasurementsG::update(const Vector3& measuredAcc,
-                                           const Vector3& measuredOmega,
-                                           double dt, Matrix9* A, Matrix93* B,
-                                           Matrix93* C) {
+void GalileanPreintegration::update(const Vector3& measuredAcc,
+                                    const Vector3& measuredOmega, double dt,
+                                    Matrix9* A, Matrix93* B, Matrix93* C) {
   Matrix10 galTransition;
   Matrix106 galInput;
   updateGal3(measuredAcc, measuredOmega, dt, &galTransition, &galInput);
@@ -115,35 +108,7 @@ void PreintegratedImuMeasurementsG::update(const Vector3& measuredAcc,
 }
 
 //------------------------------------------------------------------------------
-void PreintegratedImuMeasurementsG::integrateMeasurement(
-    const Vector3& measuredAcc, const Vector3& measuredOmega, double dt) {
-  if (dt <= 0) {
-    throw std::runtime_error(
-        "PreintegratedImuMeasurementsG::integrateMeasurement: dt <=0");
-  }
-
-  Matrix10 transition;
-  Matrix106 inputJacobian;
-  updateGal3(measuredAcc, measuredOmega, dt, &transition, &inputJacobian);
-
-  Matrix6 measurementCovariance = Matrix6::Zero();
-  measurementCovariance.block<3, 3>(0, 0) = p().accelerometerCovariance;
-  measurementCovariance.block<3, 3>(3, 3) = p().gyroscopeCovariance;
-
-  preintMeasCov_ = transition * preintMeasCov_ * transition.transpose();
-  preintMeasCov_.noalias() +=
-      inputJacobian * (measurementCovariance / dt) * inputJacobian.transpose();
-  preintMeasCov_.block<3, 3>(6, 6).noalias() += p().integrationCovariance * dt;
-}
-
-//------------------------------------------------------------------------------
-Matrix9 PreintegratedImuMeasurementsG::preintMeasCov() const {
-  const Matrix910 P = NavStateProjector();
-  return P * preintMeasCov_ * P.transpose();
-}
-
-//------------------------------------------------------------------------------
-Vector9 PreintegratedImuMeasurementsG::biasCorrectedDelta(
+Vector9 GalileanPreintegration::biasCorrectedDelta(
     const imuBias::ConstantBias& bias_i, OptionalJacobian<9, 6> H) const {
   const Vector6 biasIncrement = (bias_i - biasHat_).vector();
   const Vector10 correction = biasJacobian_ * biasIncrement;
@@ -181,20 +146,18 @@ Vector9 PreintegratedImuMeasurementsG::biasCorrectedDelta(
 }
 
 //------------------------------------------------------------------------------
-void PreintegratedImuMeasurementsG::print(const std::string& s) const {
+void GalileanPreintegration::print(const std::string& s) const {
   Base::print(s);
   std::cout << "    preintMatrix = " << preintMatrix_ << '\n'
-            << "    preintMeasCov (Gal3) =\n[" << preintMeasCov_ << "]\n"
             << "    biasJacobian =\n[" << biasJacobian_ << "]" << std::endl;
 }
 
 //------------------------------------------------------------------------------
-bool PreintegratedImuMeasurementsG::equals(
-    const PreintegratedImuMeasurementsG& other, double tol) const {
+bool GalileanPreintegration::equals(const GalileanPreintegration& other,
+                                    double tol) const {
   return p().equals(other.p(), tol) && biasHat_.equals(other.biasHat_, tol) &&
          std::abs(deltaTij_ - other.deltaTij_) <= tol &&
          preintMatrix_.equals(other.preintMatrix_, tol) &&
-         equal_with_abs_tol(preintMeasCov_, other.preintMeasCov_, tol) &&
          equal_with_abs_tol(biasJacobian_, other.biasJacobian_, tol);
 }
 

--- a/gtsam/navigation/GalileanPreintegration.h
+++ b/gtsam/navigation/GalileanPreintegration.h
@@ -1,0 +1,116 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file    GalileanPreintegration.h
+ * @brief   Left-invariant Galilean IMU preintegration with bias correction
+ *
+ * This class implements the Galilean preintegration model described in:
+ *
+ *   Giulio Delama, Alessandro Fornasier, Robert Mahony, Stephan Weiss,
+ *   "Equivariant IMU Preintegration with Biases: a Galilean Group Approach,"
+ *   IEEE Robotics and Automation Letters, 2025.
+ *
+ * Unlike the paper's right-invariant error, this implementation uses GTSAM's
+ * right retraction and therefore a left-invariant local error. See
+ * navigation/doc/GalileanImuFactor.ipynb for the conventions and derivation.
+ */
+
+#pragma once
+
+#include <gtsam/base/Matrix.h>
+#include <gtsam/geometry/Gal3.h>
+#include <gtsam/navigation/ImuBias.h>
+#include <gtsam/navigation/NavState.h>
+#include <gtsam/navigation/PreintegrationBase.h>
+
+namespace gtsam {
+
+/**
+ * IMU preintegration on Gal(3) using GTSAM's left-invariant local error.
+ *
+ * The internal tangent ordering is `(rotation, velocity, position, time)`. The
+ * public factor contract projects this to NavState ordering
+ * `(rotation, position, velocity)` and removes deterministic time. Biases use
+ * GTSAM's `(accelerometer, gyroscope)` ordering and are corrected on the right.
+ */
+class GTSAM_EXPORT GalileanPreintegration : public PreintegrationBase {
+ public:
+  using Base = PreintegrationBase;
+  using Params = PreintegrationBase::Params;
+  using Matrix10 = Eigen::Matrix<double, 10, 10>;
+  using Matrix106 = Eigen::Matrix<double, 10, 6>;
+  using Matrix910 = Eigen::Matrix<double, 9, 10>;
+
+ protected:
+  Gal3 preintMatrix_;       ///< Mean increment in Gal(3).
+  Matrix106 biasJacobian_;  ///< Right correction wrt (accel, gyro) bias.
+
+  /** Project Gal(3) tangent order to NavState tangent order. */
+  static Matrix910 NavStateProjector();
+
+  /** Lift GTSAM input order `(acceleration, angular rate)` into Gal(3). */
+  static Matrix106 LiftJacobian();
+
+  /** Update the Gal(3) mean and return its transition and input Jacobian. */
+  void updateGal3(const Vector3& measuredAcc, const Vector3& measuredOmega,
+                  double dt, Matrix10* A, Matrix106* B);
+
+  /// Default constructor for serialization.
+  GalileanPreintegration() { resetIntegration(); }
+
+ public:
+  /** Construct and reset a Galilean preintegrated measurement. */
+  explicit GalileanPreintegration(
+      const std::shared_ptr<Params>& p,
+      const imuBias::ConstantBias& biasHat = {});
+
+  Rot3 deltaRij() const override { return preintMatrix_.rotation(); }
+  Vector3 deltaPij() const override { return preintMatrix_.translation(); }
+  Vector3 deltaVij() const override { return preintMatrix_.velocity(); }
+  NavState deltaXij() const override {
+    return NavState(preintMatrix_.rotation(), preintMatrix_.translation(),
+                    preintMatrix_.velocity());
+  }
+
+  /// Return the Galilean delta in NavState tangent ordering.
+  Vector9 preintegrated() const { return biasCorrectedDelta(biasHat_); }
+
+  /** Apply the first-order physical bias correction on the right. */
+  Vector9 biasCorrectedDelta(const imuBias::ConstantBias& bias_i,
+                             OptionalJacobian<9, 6> H = {}) const override;
+
+  /**
+   * Update the mean and bias Jacobian, returning NavState-chart Jacobians.
+   * Covariance propagation is performed by PreintegratedImuMeasurementsT.
+   */
+  void update(const Vector3& measuredAcc, const Vector3& measuredOmega,
+              double dt, Matrix9* A, Matrix93* B, Matrix93* C) override;
+
+  /** Reset the mean, elapsed time, and bias Jacobian. */
+  void resetIntegration() override;
+
+  void print(const std::string& s = "GalileanPreintegration") const override;
+  bool equals(const GalileanPreintegration& other, double tol = 1e-9) const;
+
+ private:
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
+  friend class boost::serialization::access;
+  template <class Archive>
+  void serialize(Archive& archive, const unsigned int /*version*/) {
+    archive& BOOST_SERIALIZATION_BASE_OBJECT_NVP(PreintegrationBase);
+    archive& BOOST_SERIALIZATION_NVP(preintMatrix_);
+    archive& BOOST_SERIALIZATION_NVP(biasJacobian_);
+  }
+#endif
+};
+
+}  // namespace gtsam

--- a/gtsam/navigation/GalileanPreintegration.h
+++ b/gtsam/navigation/GalileanPreintegration.h
@@ -54,11 +54,9 @@ class GTSAM_EXPORT GalileanPreintegration : public PreintegrationBase {
   Gal3 preintMatrix_;       ///< Mean increment in Gal(3).
   Matrix106 biasJacobian_;  ///< Right correction wrt (accel, gyro) bias.
 
-  /** Project Gal(3) tangent order to NavState tangent order. */
-  static Matrix910 NavStateProjector();
-
-  /** Lift GTSAM input order `(acceleration, angular rate)` into Gal(3). */
-  static Matrix106 LiftJacobian();
+  /** Extract the factor tangent and its Jacobian from a Gal(3) element. */
+  static Vector9 NavStateTangent(const Gal3& galilean,
+                                 OptionalJacobian<9, 10> H = {});
 
   /** Update the Gal(3) mean and return its transition and input Jacobian. */
   void updateGal3(const Vector3& measuredAcc, const Vector3& measuredOmega,

--- a/gtsam/navigation/ImuFactor.cpp
+++ b/gtsam/navigation/ImuFactor.cpp
@@ -179,6 +179,8 @@ template class GTSAM_EXPORT PreintegratedImuMeasurementsT<ManifoldPreintegration
 template class GTSAM_EXPORT PreintegratedImuMeasurementsT<TangentPreintegration>;
 template class GTSAM_EXPORT
     PreintegratedImuMeasurementsT<LieGroupPreintegration>;
+template class GTSAM_EXPORT
+    PreintegratedImuMeasurementsT<GalileanPreintegration>;
 
 // ImuFactorT instantiations
 template class GTSAM_EXPORT ImuFactorT<PreintegratedImuMeasurementsT<ManifoldPreintegration>>;

--- a/gtsam/navigation/ImuFactor.h
+++ b/gtsam/navigation/ImuFactor.h
@@ -155,10 +155,10 @@ public:
    * \qquad \Delta R=\operatorname{Exp}(\theta),
    * \f]
    * where \f$J_r\f$ is the SO(3) right Jacobian. Therefore its covariance is
-   * converted as \f$J P J^T\f$. ManifoldPreintegration and
-   * LieGroupPreintegration already propagate covariance in the residual chart
-   * and return it unchanged. This conversion does not redefine the nonlinear
-   * residual or alter the raw covariance returned by preintMeasCov().
+   * converted as \f$J P J^T\f$. Other backends already propagate covariance
+   * in the residual chart and return it unchanged. This conversion does not
+   * redefine the nonlinear residual or alter the raw covariance returned by
+   * preintMeasCov().
    */
   Matrix9 residualCovariance() const {
     if constexpr (std::is_same_v<PreintegrationType,

--- a/gtsam/navigation/navigation.i
+++ b/gtsam/navigation/navigation.i
@@ -315,6 +315,9 @@ typedef gtsam::PreintegratedImuMeasurementsT<
     gtsam::TangentPreintegration> PreintegratedImuMeasurementsTangent;
 typedef gtsam::PreintegratedImuMeasurementsT<
     gtsam::LieGroupPreintegration> PreintegratedImuMeasurementsLieGroup;
+@serializable
+typedef gtsam::PreintegratedImuMeasurementsT<
+    gtsam::GalileanPreintegration> PreintegratedImuMeasurementsG;
 
 virtual class ImuFactor: gtsam::NoiseModelFactor {
   ImuFactor(gtsam::Key pose_i, gtsam::Key vel_i, gtsam::Key pose_j, gtsam::Key vel_j,
@@ -352,42 +355,6 @@ virtual class ImuFactor2: gtsam::NoiseModelFactor {
 };
 
 #include <gtsam/navigation/GalileanImuFactor.h>
-class PreintegratedImuMeasurementsG {
-  // Constructors
-  PreintegratedImuMeasurementsG(const gtsam::PreintegrationParams* params);
-  PreintegratedImuMeasurementsG(
-      const gtsam::PreintegrationParams* params,
-      const gtsam::imuBias::ConstantBias& bias);
-
-  // Testable
-  void print(string s = "PreintegratedImuMeasurementsG") const;
-  bool equals(const gtsam::PreintegratedImuMeasurementsG& expected,
-              double tol) const;
-
-  // Standard Interface
-  void integrateMeasurement(
-      const gtsam::Vector3& measuredAcc,
-      const gtsam::Vector3& measuredOmega, double deltaT);
-  void resetIntegration();
-  void resetIntegrationAndSetBias(
-      const gtsam::imuBias::ConstantBias& biasHat);
-
-  gtsam::Matrix9 preintMeasCov() const;
-  gtsam::Matrix9 residualCovariance() const;
-  double deltaTij() const;
-  gtsam::Rot3 deltaRij() const;
-  gtsam::Vector3 deltaPij() const;
-  gtsam::Vector3 deltaVij() const;
-  gtsam::NavState deltaXij() const;
-  const gtsam::imuBias::ConstantBias& biasHat() const;
-  gtsam::Vector6 biasHatVector() const;
-  gtsam::NavState predict(
-      const gtsam::NavState& state_i,
-      const gtsam::imuBias::ConstantBias& bias,
-      gtsam::OptionalJacobian<9, 9> H1 = nullptr,
-      gtsam::OptionalJacobian<9, 6> H2 = nullptr) const;
-};
-
 virtual class GalileanImuFactor: gtsam::NoiseModelFactor {
   GalileanImuFactor(
       gtsam::Key pose_i, gtsam::Key vel_i, gtsam::Key pose_j,
@@ -401,6 +368,9 @@ virtual class GalileanImuFactor: gtsam::NoiseModelFactor {
       const gtsam::Pose3& pose_i, const gtsam::Vector3& vel_i,
       const gtsam::Pose3& pose_j, const gtsam::Vector3& vel_j,
       const gtsam::imuBias::ConstantBias& bias) const;
+
+  // enable serialization functionality
+  void serialize() const;
 };
 
 #include <gtsam/navigation/ImuFactorWithGravity.h>

--- a/gtsam/navigation/tests/testGalileanImuFactor.cpp
+++ b/gtsam/navigation/tests/testGalileanImuFactor.cpp
@@ -28,6 +28,10 @@ namespace galilean_imu_factor {
 using PIM = PreintegratedImuMeasurementsG;
 using Bias = imuBias::ConstantBias;
 
+static_assert(
+    std::is_same_v<PIM,
+                   PreintegratedImuMeasurementsT<GalileanPreintegration>>);
+
 class TestPIM : public PIM {
  public:
   using PIM::LiftJacobian;
@@ -36,7 +40,6 @@ class TestPIM : public PIM {
 
   const Gal3& preintegratedGal3() const { return preintMatrix_; }
   const Matrix106& biasJacobian() const { return biasJacobian_; }
-  const Matrix10& gal3Covariance() const { return preintMeasCov_; }
 };
 
 Vector9 Components(const Gal3& g) {
@@ -81,6 +84,7 @@ TEST(GalileanImuFactor, MeanUsesRightComposition) {
   const Gal3 expected = Gal3::Expmap(Input(acc1, omega1, dt1))
                             .compose(Gal3::Expmap(Input(acc2, omega2, dt2)));
   EXPECT(assert_equal(expected, pim.preintegratedGal3(), 1e-12));
+  EXPECT(assert_equal(Components(expected), pim.preintegrated(), 1e-12));
   DOUBLES_EQUAL(dt1 + dt2, pim.deltaTij(), 1e-12);
 }
 
@@ -144,28 +148,37 @@ TEST(GalileanImuFactor, UpdateJacobiansWithSensorPose) {
       1e-7));
 }
 
-// Covariance is propagated in Gal3 order and projected to NavState order.
+// Generic 9D covariance propagation equals full Gal3 propagation followed by
+// removal of deterministic time, including across multiple measurements.
 TEST(GalileanImuFactor, CovarianceProjection) {
   const auto params = PreintegrationParams::MakeSharedU(9.81);
   params->accelerometerCovariance = (Vector3(1e-3, 2e-3, 3e-3)).asDiagonal();
   params->gyroscopeCovariance = (Vector3(4e-4, 5e-4, 6e-4)).asDiagonal();
   params->integrationCovariance = (Vector3(7e-5, 8e-5, 9e-5)).asDiagonal();
-  const Vector3 acc(0.2, -0.1, 0.4), omega(0.1, 0.3, -0.2);
-  const double dt = 0.04;
-
   TestPIM pim(params);
-  pim.integrateMeasurement(acc, omega, dt);
-
-  PIM::Matrix10 Jr;
-  Gal3::Expmap(Input(acc, omega, dt), Jr);
-  const PIM::Matrix106 C = Jr * TestPIM::LiftJacobian() * dt;
   Matrix6 inputCovariance = Matrix6::Zero();
   inputCovariance.block<3, 3>(0, 0) = params->accelerometerCovariance;
   inputCovariance.block<3, 3>(3, 3) = params->gyroscopeCovariance;
-  PIM::Matrix10 expectedGal = C * (inputCovariance / dt) * C.transpose();
-  expectedGal.block<3, 3>(6, 6) += params->integrationCovariance * dt;
+  PIM::Matrix10 expectedGal = PIM::Matrix10::Zero();
 
-  EXPECT(assert_equal(expectedGal, pim.gal3Covariance(), 1e-12));
+  const auto integrate = [&](const Vector3& acc, const Vector3& omega,
+                             double dt) {
+    PIM::Matrix10 rightJacobian;
+    const Gal3 increment =
+        Gal3::Expmap(Input(acc, omega, dt), rightJacobian);
+    const PIM::Matrix10 transition = increment.inverse().AdjointMap();
+    const PIM::Matrix106 inputJacobian =
+        rightJacobian * TestPIM::LiftJacobian() * dt;
+    expectedGal = transition * expectedGal * transition.transpose();
+    expectedGal.noalias() += inputJacobian * (inputCovariance / dt) *
+                             inputJacobian.transpose();
+    expectedGal.block<3, 3>(6, 6) += params->integrationCovariance * dt;
+    pim.integrateMeasurement(acc, omega, dt);
+  };
+
+  integrate(Vector3(0.2, -0.1, 0.4), Vector3(0.1, 0.3, -0.2), 0.04);
+  integrate(Vector3(-0.3, 0.5, 0.1), Vector3(-0.2, 0.1, 0.4), 0.07);
+
   const auto P = TestPIM::NavStateProjector();
   const Matrix9 expectedNav = P * expectedGal * P.transpose();
   EXPECT(assert_equal(expectedNav, pim.preintMeasCov(), 1e-12));

--- a/gtsam/navigation/tests/testGalileanImuFactor.cpp
+++ b/gtsam/navigation/tests/testGalileanImuFactor.cpp
@@ -34,13 +34,26 @@ static_assert(
 
 class TestPIM : public PIM {
  public:
-  using PIM::LiftJacobian;
-  using PIM::NavStateProjector;
   using PIM::PIM;
 
   const Gal3& preintegratedGal3() const { return preintMatrix_; }
   const Matrix106& biasJacobian() const { return biasJacobian_; }
 };
+
+PIM::Matrix106 LiftJacobian() {
+  PIM::Matrix106 lift = PIM::Matrix106::Zero();
+  lift.block<3, 3>(0, 3) = I_3x3;
+  lift.block<3, 3>(3, 0) = I_3x3;
+  return lift;
+}
+
+PIM::Matrix910 NavStateProjector() {
+  PIM::Matrix910 projector = PIM::Matrix910::Zero();
+  projector.block<3, 3>(0, 0) = I_3x3;
+  projector.block<3, 3>(3, 6) = I_3x3;
+  projector.block<3, 3>(6, 3) = I_3x3;
+  return projector;
+}
 
 Vector9 Components(const Gal3& g) {
   Vector9 result;
@@ -66,7 +79,7 @@ TEST(GalileanImuFactor, PhysicalInputLift) {
   Vector10 expected = Vector10::Zero();
   expected.head<3>() = omega;
   expected.segment<3>(3) = acc;
-  const Vector10 actual = TestPIM::LiftJacobian() * input;
+  const Vector10 actual = LiftJacobian() * input;
   EXPECT(assert_equal(expected, actual, 1e-12));
 }
 
@@ -100,7 +113,7 @@ TEST(GalileanImuFactor, PhysicalBiasJacobian) {
 
   PIM::Matrix10 Jr;
   Gal3::Expmap(Input(acc, omega, dt), Jr);
-  const PIM::Matrix106 expected = -Jr * TestPIM::LiftJacobian() * dt;
+  const PIM::Matrix106 expected = -Jr * LiftJacobian() * dt;
   EXPECT(assert_equal(expected, pim.biasJacobian(), 1e-12));
 }
 
@@ -126,7 +139,7 @@ TEST(GalileanImuFactor, UpdateJacobiansWithSensorPose) {
       correctedOmega_H_omega);
   const Gal3 increment =
       Gal3::Expmap(Input(correctedAcc, correctedOmega, dt), Jr);
-  const auto P = TestPIM::NavStateProjector();
+  const auto P = NavStateProjector();
   const Matrix9 expectedA =
       P * increment.inverse().AdjointMap() * P.transpose();
   EXPECT(assert_equal(expectedA, A, 1e-12));
@@ -167,8 +180,7 @@ TEST(GalileanImuFactor, CovarianceProjection) {
     const Gal3 increment =
         Gal3::Expmap(Input(acc, omega, dt), rightJacobian);
     const PIM::Matrix10 transition = increment.inverse().AdjointMap();
-    const PIM::Matrix106 inputJacobian =
-        rightJacobian * TestPIM::LiftJacobian() * dt;
+    const PIM::Matrix106 inputJacobian = rightJacobian * LiftJacobian() * dt;
     expectedGal = transition * expectedGal * transition.transpose();
     expectedGal.noalias() += inputJacobian * (inputCovariance / dt) *
                              inputJacobian.transpose();
@@ -179,7 +191,7 @@ TEST(GalileanImuFactor, CovarianceProjection) {
   integrate(Vector3(0.2, -0.1, 0.4), Vector3(0.1, 0.3, -0.2), 0.04);
   integrate(Vector3(-0.3, 0.5, 0.1), Vector3(-0.2, 0.1, 0.4), 0.07);
 
-  const auto P = TestPIM::NavStateProjector();
+  const auto P = NavStateProjector();
   const Matrix9 expectedNav = P * expectedGal * P.transpose();
   EXPECT(assert_equal(expectedNav, pim.preintMeasCov(), 1e-12));
   EXPECT(assert_equal(pim.preintMeasCov(), pim.residualCovariance(), 1e-12));
@@ -194,6 +206,14 @@ TEST(GalileanImuFactor, RightAppliedBiasCorrection) {
                            0.03);
   pim.integrateMeasurement(Vector3(-0.1, 0.5, 9.6), Vector3(-0.2, 0.1, 0.3),
                            0.06);
+
+  Matrix96 zeroH;
+  const Vector9 zeroCorrected = pim.biasCorrectedDelta(biasHat, zeroH);
+  EXPECT(
+      assert_equal(Components(pim.preintegratedGal3()), zeroCorrected, 1e-12));
+  const Matrix numericalZeroH = numericalDerivative11<Vector9, Bias>(
+      [&](const Bias& b) { return pim.biasCorrectedDelta(b); }, biasHat, 1e-6);
+  EXPECT(assert_equal(numericalZeroH, zeroH, 2e-8));
 
   const Vector6 db =
       (Vector6() << 1e-4, -2e-4, 1.5e-4, -1e-4, 0.5e-4, 2e-4).finished();

--- a/gtsam/navigation/tests/testSerializationNavigation.cpp
+++ b/gtsam/navigation/tests/testSerializationNavigation.cpp
@@ -30,6 +30,7 @@
 #include <gtsam/navigation/CombinedImuFactorWithGravity.h>
 #include <gtsam/navigation/DopplerFactor.h>
 #include <gtsam/navigation/GPSFactor.h>
+#include <gtsam/navigation/GalileanImuFactor.h>
 #include <gtsam/navigation/ImuFactor.h>
 #include <gtsam/navigation/ImuFactorWithGravity.h>
 #include <gtsam/navigation/PseudorangeFactor.h>
@@ -53,6 +54,9 @@ BOOST_CLASS_EXPORT_GUID(PreintegrationCombinedParams,
                         "gtsam_PreintegrationCombinedParams")
 BOOST_CLASS_EXPORT_GUID(PreintegratedCombinedMeasurements,
                         "gtsam_PreintegratedCombinedMeasurements")
+BOOST_CLASS_EXPORT_GUID(PreintegratedImuMeasurementsG,
+                        "gtsam_PreintegratedImuMeasurementsG")
+BOOST_CLASS_EXPORT_GUID(GalileanImuFactor, "gtsam_GalileanImuFactor")
 
 /* ************************************************************************* */
 #ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
@@ -254,6 +258,27 @@ TEST(LieGroupPreintegration, Serialization) {
 }
 
 }  // namespace lie_group_serialization
+/* ************************************************************************* */
+
+/* ************************************************************************* */
+namespace galilean_serialization {
+
+// Verifies the Galilean PIM and its public factor round-trip through every
+// supported archive format.
+TEST(GalileanPreintegration, Serialization) {
+  const PreintegratedImuMeasurementsG pim =
+      getPreintegratedMeasurements<PreintegratedImuMeasurementsG>();
+  EXPECT(equalsObj(pim));
+  EXPECT(equalsXML(pim));
+  EXPECT(equalsBinary(pim));
+
+  const GalileanImuFactor factor(1, 2, 3, 4, 5, pim);
+  EXPECT(equalsObj(factor));
+  EXPECT(equalsXML(factor));
+  EXPECT(equalsBinary(factor));
+}
+
+}  // namespace galilean_serialization
 /* ************************************************************************* */
 
 /* ************************************************************************* */

--- a/python/gtsam/tests/test_GalileanImuFactor.py
+++ b/python/gtsam/tests/test_GalileanImuFactor.py
@@ -27,6 +27,7 @@ class TestGalileanImuFactor(GtsamTestCase):
             gtsam.PreintegratedImuMeasurementsManifold,
             gtsam.PreintegratedImuMeasurementsTangent,
             gtsam.PreintegratedImuMeasurementsLieGroup,
+            gtsam.PreintegratedImuMeasurementsG,
         )
 
         aliases_of_default = [
@@ -44,6 +45,23 @@ class TestGalileanImuFactor(GtsamTestCase):
             self.assertEqual((9, 9), pim.preintMeasCov().shape)
             self.assertEqual((9, 9), pim.residualCovariance().shape)
             self.assertEqual((6,), pim.biasHatVector().shape)
+
+    @unittest.skipUnless(
+        hasattr(gtsam.PreintegratedImuMeasurementsG, "serialize"),
+        "Serialization not enabled")
+    def test_serialization(self):
+        """The Galilean PIM and factor survive Python pickle round trips."""
+        params = gtsam.PreintegrationParams.MakeSharedD(9.81)
+        params.setAccelerometerCovariance(1e-4 * np.eye(3))
+        params.setGyroscopeCovariance(1e-6 * np.eye(3))
+        params.setIntegrationCovariance(1e-8 * np.eye(3))
+        pim = gtsam.PreintegratedImuMeasurementsG(params)
+        pim.integrateMeasurement(np.array([0.2, -0.1, 9.7]),
+                                 np.array([0.03, -0.02, 0.01]), 0.01)
+        self.assertEqualityOnPickleRoundtrip(pim)
+
+        factor = gtsam.GalileanImuFactor(0, 1, 2, 3, 4, pim)
+        self.assertEqualityOnPickleRoundtrip(factor)
 
     def test_preintegrate_predict_and_factor(self):
         """A predicted endpoint has zero Galilean IMU factor error."""

--- a/wrap/DOCS.md
+++ b/wrap/DOCS.md
@@ -168,6 +168,19 @@ The python wrapper supports keyword arguments for functions/methods. Hence, the 
       template<T, U> class Class2 { ... };
       typedef Class2<Type1, Type2> MyInstantiatedClass;
       ```
+    - Serialization can be enabled for one typedef without marking every
+      specialization of the template serializable:
+
+      ```cpp
+      template<T> class Class3 { ... };
+      @serializable
+      typedef Class3<Type1> SerializableClass3;
+      typedef Class3<Type2> PlainClass3;
+      ```
+
+      `@serializable` is wrapper metadata. It generates the same Python pickle
+      and MATLAB save/load support as a `void serialize() const;` marker on a
+      concrete wrapper class, but applies only to the annotated typedef.
     - Templates can also be defined for constructors, methods, properties and static methods.
     - In the class definition, appearances of the template argument(s) will be replaced with their
       instantiated types, e.g. `void setValue(const T& value);`.

--- a/wrap/gtwrap/interface_parser/annotations.py
+++ b/wrap/gtwrap/interface_parser/annotations.py
@@ -1,4 +1,4 @@
-"""Pybind-specific annotations supported by wrapper interface files."""
+"""Annotations supported by wrapper interface files."""
 
 from pyparsing import Regex
 
@@ -12,21 +12,36 @@ PYBIND_LAMBDA = Regex(r"@pybind_lambda(?![A-Za-z0-9_])")
 def _reject_annotation(source, location, tokens):
     """Raise a useful error for unknown or misplaced annotations."""
     annotation = tokens[0]
+    context = "callable annotation"
     if annotation == "@pybind_lambda":
         message = (
             "annotation '@pybind_lambda' can only be applied to a method, "
             "static method, or global function"
         )
+        hint = (
+            "place '@pybind_lambda' after any template declaration and "
+            "immediately before the callable declaration"
+        )
+    elif annotation == "@serializable":
+        context = "typedef annotation"
+        message = (
+            "annotation '@serializable' can only be applied to a template "
+            "typedef"
+        )
+        hint = "place '@serializable' immediately before the typedef declaration"
     else:
         message = f"malformed or unknown annotation '{annotation}'"
+        hint = (
+            "use a supported annotation such as '@pybind_lambda' or "
+            "'@serializable' in its documented position"
+        )
 
     raise semantic_error(
         source,
         location,
-        "callable annotation",
+        context,
         message,
-        "place '@pybind_lambda' after any template declaration and "
-        "immediately before the callable declaration",
+        hint,
     )
 
 

--- a/wrap/gtwrap/interface_parser/template.py
+++ b/wrap/gtwrap/interface_parser/template.py
@@ -12,11 +12,14 @@ Author: Duy Nguyen Ta, Fan Jiang, Matthew Sklar, Varun Agrawal, and Frank Dellae
 
 from typing import List
 
-from pyparsing import Optional, ParseResults, DelimitedList  # type: ignore
+from pyparsing import DelimitedList, Optional, ParseResults, Regex  # type: ignore
 
 from .tokens import (EQUAL, IDENT, LBRACE, LOPBRACK, RBRACE, ROPBRACK,
                      SEMI_COLON, TEMPLATE, TYPEDEF)
 from .type import TemplatedType, Typename
+
+
+SERIALIZABLE = Regex(r"@serializable(?![A-Za-z0-9_])")
 
 
 class Template:
@@ -83,17 +86,20 @@ class TypedefTemplateInstantiation:
     typedef SuperComplexName<Arg1, Arg2, Arg3> EasierName;
     ```
     """
-    rule = (TYPEDEF + TemplatedType.rule("templated_type") +
+    rule = (Optional(SERIALIZABLE("serializable")) +
+            TYPEDEF + TemplatedType.rule("templated_type") +
             IDENT("new_name") +
             SEMI_COLON).set_parse_action(lambda t: TypedefTemplateInstantiation(
-                t.templated_type[0], t.new_name))
+                t.templated_type[0], t.new_name, bool(t.serializable)))
 
     def __init__(self,
                  templated_type: TemplatedType,
                  new_name: str,
+                 serializable: bool = False,
                  parent: str = ''):
         self.typename = templated_type.typename
         self.new_name = new_name
+        self.serializable = serializable
         self.parent = parent
 
     def __repr__(self):

--- a/wrap/gtwrap/template_instantiator/classes.py
+++ b/wrap/gtwrap/template_instantiator/classes.py
@@ -17,13 +17,18 @@ class InstantiatedClass(parser.Class):
     Instantiate the class defined in the interface file.
     """
 
-    def __init__(self, original: parser.Class, instantiations=(), new_name=''):
+    def __init__(self,
+                 original: parser.Class,
+                 instantiations=(),
+                 new_name='',
+                 serializable=False):
         """
         Template <T, U>
         Instantiations: [T1, U1]
         """
         self.original = original
         self.instantiations = instantiations
+        self.serializable = serializable
 
         self.template = None
         self.is_virtual = original.is_virtual
@@ -58,6 +63,12 @@ class InstantiatedClass(parser.Class):
 
         # Instantiate all instance methods
         self.methods = self.instantiate_methods(typenames)
+        if serializable and not any(
+                method.name in ('serialize', 'serializable')
+                for method in self.methods):
+            self.methods.append(
+                parser.Method.rule.parse_string(
+                    "void serialize() const;")[0])
 
         self.dunder_methods = original.dunder_methods
 

--- a/wrap/gtwrap/template_instantiator/namespace.py
+++ b/wrap/gtwrap/template_instantiator/namespace.py
@@ -64,7 +64,8 @@ def instantiate_namespace(namespace):
                 typedef_content.append(
                     InstantiatedClass(original_element,
                                       typedef_inst.typename.instantiations,
-                                      typedef_inst.new_name))
+                                      typedef_inst.new_name,
+                                      typedef_inst.serializable))
             elif isinstance(original_element, parser.GlobalFunction):
                 typedef_content.append(
                     InstantiatedGlobalFunction(

--- a/wrap/tests/fixtures/serializable_typedef.i
+++ b/wrap/tests/fixtures/serializable_typedef.i
@@ -1,0 +1,12 @@
+namespace gtsam {
+
+template<T>
+class SerializableTypedefFixture {
+  SerializableTypedefFixture();
+};
+
+@serializable
+typedef gtsam::SerializableTypedefFixture<int> SerializableFixture;
+typedef gtsam::SerializableTypedefFixture<double> PlainFixture;
+
+}  // namespace gtsam

--- a/wrap/tests/test_interface_parser.py
+++ b/wrap/tests/test_interface_parser.py
@@ -408,6 +408,14 @@ class TestInterfaceParser(unittest.TestCase):
         self.assertEqual("BearingFactor", typedef.typename.name)
         self.assertEqual(["gtsam"], typedef.typename.namespaces)
         self.assertEqual(3, len(typedef.typename.instantiations))
+        self.assertFalse(typedef.serializable)
+
+        serializable = TypedefTemplateInstantiation.rule.parse_string("""
+        @serializable
+        typedef gtsam::BearingFactor<gtsam::Pose2, gtsam::Point2,
+                                     gtsam::Rot2> SerializableBearingFactor2D;
+        """)[0]
+        self.assertTrue(serializable.serializable)
 
     def test_base_class(self):
         """Test a base class."""

--- a/wrap/tests/test_matlab_wrapper.py
+++ b/wrap/tests/test_matlab_wrapper.py
@@ -82,6 +82,36 @@ class TestWrap(unittest.TestCase):
             actual = osp.join(self.MATLAB_ACTUAL_DIR, file)
             self.compare_and_diff(file, actual)
 
+    def test_serializable_template_typedef(self):
+        """Serialization metadata applies to one MATLAB typedef only."""
+        source = osp.join(self.INTERFACE_DIR, 'serializable_typedef.i')
+        wrapper = MatlabWrapper(module_name='serializable_typedef',
+                                top_module_namespace=['gtsam'],
+                                ignore_classes=[''],
+                                use_boost_serialization=True)
+        wrapper.wrap([source], path=self.MATLAB_ACTUAL_DIR)
+
+        with open(osp.join(self.MATLAB_ACTUAL_DIR, '+gtsam',
+                           'SerializableFixture.m'),
+                  'r', encoding='UTF-8') as generated:
+            serializable = generated.read()
+        with open(osp.join(self.MATLAB_ACTUAL_DIR, '+gtsam', 'PlainFixture.m'),
+                  'r', encoding='UTF-8') as generated:
+            plain = generated.read()
+        with open(osp.join(self.MATLAB_ACTUAL_DIR,
+                           'serializable_typedef_wrapper.cpp'),
+                  'r', encoding='UTF-8') as generated:
+            cpp = generated.read()
+
+        self.assertIn('string_serialize', serializable)
+        self.assertIn('string_deserialize', serializable)
+        self.assertNotIn('string_serialize', plain)
+        self.assertNotIn('string_deserialize', plain)
+        self.assertIn(
+            'BOOST_CLASS_EXPORT_GUID(SerializableFixture, '
+            '"gtsamSerializableFixture")', cpp)
+        self.assertNotIn('BOOST_CLASS_EXPORT_GUID(PlainFixture', cpp)
+
     def test_matrix_view_arguments(self):
         """Test that matrix view arguments use MATLAB double arrays directly."""
         file = osp.join(self.INTERFACE_DIR, 'matrix_views.i')

--- a/wrap/tests/test_parser_diagnostics.py
+++ b/wrap/tests/test_parser_diagnostics.py
@@ -124,6 +124,20 @@ class Foo {
         )
         self.assertIn("immediately before the callable", error.hint)
 
+    def test_misplaced_serializable_annotation(self):
+        """The serialization annotation applies only to template typedefs."""
+        error = self.assert_parse_error(
+            "@serializable class Foo {};",
+            line=1,
+            column=1,
+            context="typedef annotation",
+            expected=(
+                "annotation '@serializable' can only be applied to a template "
+                "typedef"
+            ),
+        )
+        self.assertIn("immediately before the typedef", error.hint)
+
     def test_misplaced_annotation_after_template(self):
         self.assert_parse_error(
             "class Foo { template<T> @pybind_lambda Foo(T value); };",

--- a/wrap/tests/test_pybind_wrapper.py
+++ b/wrap/tests/test_pybind_wrapper.py
@@ -114,6 +114,26 @@ namespace py = pybind11;
 
         self.compare_and_diff('geometry_pybind.cpp', output)
 
+    def test_serializable_template_typedef(self):
+        """Serialization metadata applies to one template typedef only."""
+        source = osp.join(self.INTERFACE_DIR, 'serializable_typedef.i')
+        output = self.wrap_content([source],
+                                   'serializable_typedef_py',
+                                   self.PYTHON_ACTUAL_DIR,
+                                   use_boost_serialization=True)
+        with open(output, 'r', encoding='UTF-8') as generated:
+            content = generated.read()
+
+        self.assertEqual(1, content.count('.def("serialize"'))
+        self.assertEqual(1, content.count('.def("deserialize"'))
+        self.assertEqual(1, content.count('.def(py::pickle('))
+        self.assertIn(
+            'BOOST_CLASS_EXPORT(gtsam::SerializableTypedefFixture<int>)',
+            content)
+        self.assertNotIn(
+            'BOOST_CLASS_EXPORT(gtsam::SerializableTypedefFixture<double>)',
+            content)
+
     def test_functions(self):
         """Test interface file with function info."""
         source = osp.join(self.INTERFACE_DIR, 'functions.i')

--- a/wrap/tests/test_template_instantiator.py
+++ b/wrap/tests/test_template_instantiator.py
@@ -645,6 +645,35 @@ class TestTemplateInstantiator(unittest.TestCase):
             if isinstance(item, Class) and item.name == "IntAdapter")
         self.assertTrue(typedef_class.methods[0].force_pybind_lambda)
 
+    def test_serializable_typedef_adds_only_alias_marker(self):
+        """Serialization metadata applies only to the annotated typedef."""
+        module = Module.parse_string("""
+            namespace adapters {
+                template<T>
+                class Adapter {
+                    Adapter();
+                };
+                @serializable
+                typedef adapters::Adapter<int> SerializableAdapter;
+                typedef adapters::Adapter<double> PlainAdapter;
+            }
+        """)
+
+        instantiated = instantiate_namespace(module)
+        namespace = instantiated.content[0]
+        serializable = next(
+            item for item in namespace.content
+            if isinstance(item, Class) and item.name == "SerializableAdapter")
+        plain = next(
+            item for item in namespace.content
+            if isinstance(item, Class) and item.name == "PlainAdapter")
+
+        self.assertTrue(serializable.serializable)
+        self.assertEqual(["serialize"],
+                         [method.name for method in serializable.methods])
+        self.assertFalse(plain.serializable)
+        self.assertEqual([], plain.methods)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

- refactor the Galilean backend into `GalileanPreintegration` and define `PreintegratedImuMeasurementsG` as `PreintegratedImuMeasurementsT<GalileanPreintegration>`
- replace the separately implemented Galilean PIM with the common templated PIM API, including Boost, Python pickle, and MATLAB string serialization
- expose the Galilean PIM through the normal template/typedef wrapper machinery, using the alias-serialization support from borglab/wrap#208
- optimize Galilean integration, bias correction, residual, and Jacobian hot paths

## Performance

The Galilean hot-path microbenchmarks improved approximately as follows:

- integration: `0.99 us` to `0.56 us` per sample
- factor residual: `158 ns` to `115 ns`
- factor residual with Jacobians: `1235 ns` to `954 ns`

Analytical outputs and Jacobians are unchanged.

## Wrapper behavior

Python and MATLAB expose `PreintegratedImuMeasurementsG` through the same template/typedef machinery as the other preintegration backends. The generated wrapper includes the standard PIM methods and serialization without registering a duplicate native type.

## Compatibility

- existing `PreintegratedImuMeasurements`, `ImuFactor`, and `ImuFactor2` construction, serialization, naming, and APIs remain supported
- the NEES notebook was rerun and produced unchanged results, so its output is not included

## Testing

- `testGalileanImuFactor.run`
- `testSerializationNavigation.run`
- targeted Python IMU, Galilean, gravity, and serialization tests in the `py312` environment
- Python extension and stub targets built
- `gtsam_matlab_wrapper` generated and compiled
- wrap test suite: 134 passed
- `git diff --check`

Closes #2756
