### PR TITLE
Remove duplication: Consolidate gravity magnitude resolution and reject PIMs without params

### DIFF
--- a/gtsam/navigation/CombinedImuFactorWithGravity.h
+++ b/gtsam/navigation/CombinedImuFactorWithGravity.h
@@ -84,22 +84,9 @@ class GTSAM_EXPORT CombinedImuFactorWithGravityT
                  preintegratedMeasurements.residualCovariance()),
              pose_i, vel_i, pose_j, vel_j, bias_i, bias_j, gravity),
         pim_(preintegratedMeasurements),
-        gravityMagnitude_(
-            gravityMagnitude
-                ? *gravityMagnitude
-                : preintegratedMeasurements.params()->n_gravity.norm()) {
-    if (internal::GravityParametrization<GRAVITY>::usesMagnitude) {
-      if (!(gravityMagnitude_ > 0.0))
-        throw std::invalid_argument(
-            "CombinedImuFactorWithGravityT: gravityMagnitude must be positive");
-    } else if (gravityMagnitude) {
-      throw std::invalid_argument(
-          "CombinedImuFactorWithGravityT: gravityMagnitude is only used by the "
-          "Unit3 parametrization; the Point3 parametrization optimizes the "
-          "magnitude as part of the gravity variable - to constrain it, add a "
-          "VectorNormFactor<3> on the gravity variable instead");
-    }
-  }
+        gravityMagnitude_(internal::resolveGravityMagnitude<GRAVITY>(
+            "CombinedImuFactorWithGravityT", preintegratedMeasurements,
+            gravityMagnitude)) {}
 
   ~CombinedImuFactorWithGravityT() override {}
 

--- a/gtsam/navigation/ImuFactorWithGravity.h
+++ b/gtsam/navigation/ImuFactorWithGravity.h
@@ -85,21 +85,9 @@ public:
                  preintegratedMeasurements.residualCovariance()),
              pose_i, vel_i, pose_j, vel_j, bias, gravity),
         pim_(preintegratedMeasurements),
-        gravityMagnitude_(gravityMagnitude
-                              ? *gravityMagnitude
-                              : preintegratedMeasurements.params()->n_gravity.norm()) {
-    if (internal::GravityParametrization<GRAVITY>::usesMagnitude) {
-      if (!(gravityMagnitude_ > 0.0))
-        throw std::invalid_argument(
-            "ImuFactorWithGravityT: gravityMagnitude must be positive");
-    } else if (gravityMagnitude) {
-      throw std::invalid_argument(
-          "ImuFactorWithGravityT: gravityMagnitude is only used by the Unit3 "
-          "parametrization; the Point3 parametrization optimizes the magnitude "
-          "as part of the gravity variable - to constrain it, add a "
-          "VectorNormFactor<3> on the gravity variable instead");
-    }
-  }
+        gravityMagnitude_(internal::resolveGravityMagnitude<GRAVITY>(
+            "ImuFactorWithGravityT", preintegratedMeasurements,
+            gravityMagnitude)) {}
 
   ~ImuFactorWithGravityT() override {
   }

--- a/gtsam/navigation/PreintegrationBase.h
+++ b/gtsam/navigation/PreintegrationBase.h
@@ -29,6 +29,8 @@
 #include <gtsam/linear/NoiseModel.h>
 
 #include <iosfwd>
+#include <optional>
+#include <stdexcept>
 #include <string>
 #include <utility>
 
@@ -314,6 +316,40 @@ struct GravityParametrization<Point3> {
     return gravity;
   }
 };
+
+/**
+ * Resolve the gravity magnitude stored by the gravity-aware IMU factors at
+ * construction. For a parametrization with a fixed magnitude (Unit3) this is
+ * the given value, or by default the norm of the gravity vector in the
+ * preintegration params, and it must be positive. For the free-vector
+ * parametrization (Point3) the magnitude is part of the optimized variable,
+ * so none may be given and the stored value is unused. Throws
+ * std::invalid_argument on misuse, including preintegrated measurements
+ * without params when the default is needed.
+ */
+template <class GRAVITY, class PIM>
+double resolveGravityMagnitude(const std::string& factorName, const PIM& pim,
+                               const std::optional<double>& gravityMagnitude) {
+  if (!GravityParametrization<GRAVITY>::usesMagnitude) {
+    if (gravityMagnitude)
+      throw std::invalid_argument(
+          factorName + ": gravityMagnitude is only used by the Unit3 "
+          "parametrization; the Point3 parametrization optimizes the magnitude "
+          "as part of the gravity variable - to constrain it, add a "
+          "VectorNormFactor<3> on the gravity variable instead");
+    return 0.0;
+  }
+  if (!gravityMagnitude && !pim.params())
+    throw std::invalid_argument(
+        factorName + ": the preintegrated measurements have no params to take "
+        "the default gravityMagnitude from");
+  const double magnitude =
+      gravityMagnitude ? *gravityMagnitude : pim.params()->n_gravity.norm();
+  if (!(magnitude > 0.0))
+    throw std::invalid_argument(factorName +
+                                ": gravityMagnitude must be positive");
+  return magnitude;
+}
 
 }  // namespace internal
 

--- a/gtsam/navigation/tests/testCombinedImuFactorWithGravity.cpp
+++ b/gtsam/navigation/tests/testCombinedImuFactorWithGravity.cpp
@@ -129,6 +129,18 @@ TEST(CombinedImuFactorWithGravity, ConstructorValidation) {
   CHECK_EXCEPTION(CombinedImuFactorWithGravityVector(
                       X(1), V(1), X(2), V(2), B(1), B(2), G(0), pim, 9.81),
                   std::invalid_argument);
+  // Without params there is no default magnitude for the Unit3 parametrization
+  // to fall back on; an explicit one still works, and Point3 needs none:
+  const PreintegratedCombinedMeasurements noParams;
+  CHECK_EXCEPTION(CombinedImuFactorWithGravityDirection(
+                      X(1), V(1), X(2), V(2), B(1), B(2), G(0), noParams),
+                  std::invalid_argument);
+  const CombinedImuFactorWithGravityDirection explicitMagnitude(
+      X(1), V(1), X(2), V(2), B(1), B(2), G(0), noParams, 9.81);
+  DOUBLES_EQUAL(9.81, explicitMagnitude.gravityMagnitude(), 1e-9);
+  const CombinedImuFactorWithGravityVector vectorNoParams(
+      X(1), V(1), X(2), V(2), B(1), B(2), G(0), noParams);
+  EXPECT_LONGS_EQUAL(7, vectorNoParams.size());
 }
 
 /* ************************************************************************* */

--- a/gtsam/navigation/tests/testImuFactorWithGravity.cpp
+++ b/gtsam/navigation/tests/testImuFactorWithGravity.cpp
@@ -138,6 +138,18 @@ TEST(ImuFactorWithGravity, ConstructorValidation) {
   CHECK_EXCEPTION(ImuFactorWithGravityVector(X(1), V(1), X(2), V(2), B(1),
                                              G(0), pim, 9.81),
                   std::invalid_argument);
+  // Without params there is no default magnitude for the Unit3 parametrization
+  // to fall back on; an explicit one still works, and Point3 needs none:
+  const PreintegratedImuMeasurements noParams;
+  CHECK_EXCEPTION(ImuFactorWithGravityDirection(X(1), V(1), X(2), V(2), B(1),
+                                                G(0), noParams),
+                  std::invalid_argument);
+  const ImuFactorWithGravityDirection explicitMagnitude(
+      X(1), V(1), X(2), V(2), B(1), G(0), noParams, 9.81);
+  DOUBLES_EQUAL(9.81, explicitMagnitude.gravityMagnitude(), 1e-9);
+  const ImuFactorWithGravityVector vectorNoParams(X(1), V(1), X(2), V(2), B(1),
+                                                  G(0), noParams);
+  EXPECT_LONGS_EQUAL(6, vectorNoParams.size());
 }
 
 /* ************************************************************************* */


### PR DESCRIPTION
The gravity-aware IMU factors repeated the same constructor logic for the stored gravity magnitude: take the given value or default to the params' gravity norm, require it to be positive for the Unit3 parametrization, and reject it for Point3. It now lives once in
internal::resolveGravityMagnitude next to GravityParametrization, which also throws std::invalid_argument instead of dereferencing a null params() when a default magnitude is needed from preintegrated measurements that have no params. 
