### PR TITLE
Add ImuFactor2WithGravity: NavState-based gravity-aware IMU factor

### DIFF
--- a/gtsam/navigation/ImuFactorWithGravity.cpp
+++ b/gtsam/navigation/ImuFactorWithGravity.cpp
@@ -80,6 +80,60 @@ Vector ImuFactorWithGravityT<PIM, GRAVITY>::evaluateError(const Pose3& pose_i,
 }
 
 //------------------------------------------------------------------------------
+// ImuFactor2WithGravityT methods
+//------------------------------------------------------------------------------
+template <class PIM, class GRAVITY>
+std::ostream& operator<<(std::ostream& os,
+                         const ImuFactor2WithGravityT<PIM, GRAVITY>& f) {
+  f.preintegratedMeasurements().print("preintegrated measurements:\n");
+  if (internal::GravityParametrization<GRAVITY>::usesMagnitude)
+    os << "  gravity magnitude: " << f.gravityMagnitude() << "\n";
+  os << "  noise model sigmas: " << f.noiseModel()->sigmas().transpose();
+  return os;
+}
+
+//------------------------------------------------------------------------------
+template <class PIM, class GRAVITY>
+void ImuFactor2WithGravityT<PIM, GRAVITY>::print(const string& s,
+    const KeyFormatter& keyFormatter) const {
+  cout << (s.empty() ? s : s + "\n") << "ImuFactor2WithGravity("
+       << keyFormatter(this->template key<1>()) << ","
+       << keyFormatter(this->template key<2>()) << ","
+       << keyFormatter(this->template key<3>()) << ","
+       << keyFormatter(this->template key<4>()) << ")\n";
+  cout << *this << endl;
+}
+
+//------------------------------------------------------------------------------
+template <class PIM, class GRAVITY>
+bool ImuFactor2WithGravityT<PIM, GRAVITY>::equals(const NonlinearFactor& other,
+    double tol) const {
+  const This *e = dynamic_cast<const This*>(&other);
+  return e != nullptr && Base::equals(*e, tol) && pim_.equals(e->pim_, tol) &&
+         (!internal::GravityParametrization<GRAVITY>::usesMagnitude ||
+          std::abs(gravityMagnitude_ - e->gravityMagnitude_) < tol);
+}
+
+//------------------------------------------------------------------------------
+template <class PIM, class GRAVITY>
+Vector9 ImuFactor2WithGravityT<PIM, GRAVITY>::evaluateError(
+    const NavState& state_i, const NavState& state_j,
+    const imuBias::ConstantBias& bias_i, const GRAVITY& gravity,
+    OptionalMatrixType H1, OptionalMatrixType H2, OptionalMatrixType H3,
+    OptionalMatrixType H4) const {
+  typedef internal::GravityParametrization<GRAVITY> Parametrization;
+  Eigen::Matrix<double, 3, Parametrization::dimension> D_gvec_gravity;
+  const Vector3 n_gravity = Parametrization::vector(
+      gravity, gravityMagnitude_, H4 ? &D_gvec_gravity : nullptr);
+  Matrix93 D_r_gvec;
+  const Vector9 r =
+      internal::preintegrationError(pim_, state_i, state_j, bias_i, n_gravity,
+                                    H1, H2, H3, H4 ? &D_r_gvec : nullptr);
+  if (H4) *H4 = D_r_gvec * D_gvec_gravity;
+  return r;
+}
+
+//------------------------------------------------------------------------------
 // ImuFactorWithGravityT instantiations
 template class GTSAM_EXPORT ImuFactorWithGravityT<PreintegratedImuMeasurementsT<ManifoldPreintegration>, Unit3>;
 template class GTSAM_EXPORT ImuFactorWithGravityT<PreintegratedImuMeasurementsT<TangentPreintegration>, Unit3>;
@@ -116,5 +170,43 @@ template GTSAM_EXPORT std::ostream& operator<<(
 template GTSAM_EXPORT std::ostream& operator<<(
     std::ostream& os,
     const ImuFactorWithGravityT<PreintegratedImuMeasurementsG, Point3>& f);
+
+//------------------------------------------------------------------------------
+// ImuFactor2WithGravityT instantiations
+template class GTSAM_EXPORT ImuFactor2WithGravityT<PreintegratedImuMeasurementsT<ManifoldPreintegration>, Unit3>;
+template class GTSAM_EXPORT ImuFactor2WithGravityT<PreintegratedImuMeasurementsT<TangentPreintegration>, Unit3>;
+template class GTSAM_EXPORT ImuFactor2WithGravityT<
+    PreintegratedImuMeasurementsT<LieGroupPreintegration>, Unit3>;
+template class GTSAM_EXPORT
+    ImuFactor2WithGravityT<PreintegratedImuMeasurementsG, Unit3>;
+template class GTSAM_EXPORT ImuFactor2WithGravityT<PreintegratedImuMeasurementsT<ManifoldPreintegration>, Point3>;
+template class GTSAM_EXPORT ImuFactor2WithGravityT<PreintegratedImuMeasurementsT<TangentPreintegration>, Point3>;
+template class GTSAM_EXPORT ImuFactor2WithGravityT<
+    PreintegratedImuMeasurementsT<LieGroupPreintegration>, Point3>;
+template class GTSAM_EXPORT
+    ImuFactor2WithGravityT<PreintegratedImuMeasurementsG, Point3>;
+
+template GTSAM_EXPORT std::ostream& operator<<(
+    std::ostream& os, const ImuFactor2WithGravityT<PreintegratedImuMeasurementsT<ManifoldPreintegration>, Unit3>& f);
+template GTSAM_EXPORT std::ostream& operator<<(
+    std::ostream& os, const ImuFactor2WithGravityT<PreintegratedImuMeasurementsT<TangentPreintegration>, Unit3>& f);
+template GTSAM_EXPORT std::ostream& operator<<(
+    std::ostream& os,
+    const ImuFactor2WithGravityT<
+        PreintegratedImuMeasurementsT<LieGroupPreintegration>, Unit3>& f);
+template GTSAM_EXPORT std::ostream& operator<<(
+    std::ostream& os,
+    const ImuFactor2WithGravityT<PreintegratedImuMeasurementsG, Unit3>& f);
+template GTSAM_EXPORT std::ostream& operator<<(
+    std::ostream& os, const ImuFactor2WithGravityT<PreintegratedImuMeasurementsT<ManifoldPreintegration>, Point3>& f);
+template GTSAM_EXPORT std::ostream& operator<<(
+    std::ostream& os, const ImuFactor2WithGravityT<PreintegratedImuMeasurementsT<TangentPreintegration>, Point3>& f);
+template GTSAM_EXPORT std::ostream& operator<<(
+    std::ostream& os,
+    const ImuFactor2WithGravityT<
+        PreintegratedImuMeasurementsT<LieGroupPreintegration>, Point3>& f);
+template GTSAM_EXPORT std::ostream& operator<<(
+    std::ostream& os,
+    const ImuFactor2WithGravityT<PreintegratedImuMeasurementsG, Point3>& f);
 
 }  // namespace gtsam

--- a/gtsam/navigation/ImuFactorWithGravity.h
+++ b/gtsam/navigation/ImuFactorWithGravity.h
@@ -216,4 +216,138 @@ template <class PIM, class GRAVITY>
 struct traits<ImuFactorWithGravityT<PIM, GRAVITY>>
     : public Testable<ImuFactorWithGravityT<PIM, GRAVITY>> {};
 
+/**
+ * ImuFactor2WithGravityT is the NavState version of ImuFactorWithGravityT,
+ * just as ImuFactor2T is the NavState version of ImuFactorT: a 4-ways factor
+ * involving the previous and current NavStates, the bias estimate, and a
+ * GRAVITY variable so that gravity can be optimized instead of being fixed by
+ * the preintegration parameters. Two parametrizations are provided, see
+ * ImuFactor2WithGravityDirection and ImuFactor2WithGravityVector.
+ *
+ * The observability caveat of ImuFactorWithGravityT applies here as well:
+ * gravity in the nav frame is entangled with the initial attitude, so a graph
+ * should anchor one of the two.
+ *
+ * @ingroup navigation
+ */
+template <class PIM = PreintegratedImuMeasurements, class GRAVITY = Unit3>
+class GTSAM_EXPORT ImuFactor2WithGravityT
+    : public NoiseModelFactorT<Vector9, NavState, NavState,
+                               imuBias::ConstantBias, GRAVITY> {
+private:
+
+  typedef ImuFactor2WithGravityT<PIM, GRAVITY> This;
+  typedef NoiseModelFactorT<Vector9, NavState, NavState, imuBias::ConstantBias,
+                            GRAVITY>
+      Base;
+
+  PIM pim_;
+  double gravityMagnitude_;  ///< used by the Unit3 parametrization only
+
+public:
+
+  // Provide access to the Matrix& version of evaluateError:
+  using Base::evaluateError;
+
+  /** Default constructor - only use for serialization */
+  ImuFactor2WithGravityT() : gravityMagnitude_(0.0) {}
+
+  /**
+   * Constructor
+   * @param state_i Previous state key
+   * @param state_j Current state key
+   * @param bias    Previous bias key
+   * @param gravity Gravity key
+   * @param preintegratedMeasurements The preintegrated measurements since the
+   * last state
+   * @param gravityMagnitude The known gravity magnitude for the Unit3
+   * parametrization; defaults to the norm of the gravity vector in the
+   * preintegration params. Must not be provided for the Point3
+   * parametrization, where the magnitude is part of the optimized variable;
+   * to constrain it, add a VectorNormFactor<3> on the gravity variable.
+   */
+  ImuFactor2WithGravityT(Key state_i, Key state_j, Key bias, Key gravity,
+      const PIM& preintegratedMeasurements,
+      std::optional<double> gravityMagnitude = {})
+      : Base(noiseModel::Gaussian::Covariance(
+                 preintegratedMeasurements.residualCovariance()),
+             state_i, state_j, bias, gravity),
+        pim_(preintegratedMeasurements),
+        gravityMagnitude_(internal::resolveGravityMagnitude<GRAVITY>(
+            "ImuFactor2WithGravityT", preintegratedMeasurements,
+            gravityMagnitude)) {}
+
+  ~ImuFactor2WithGravityT() override {
+  }
+
+  /// @return a deep copy of this factor
+  gtsam::NonlinearFactor::shared_ptr clone() const override {
+    return std::make_shared<This>(*this);
+  }
+
+  /// @name Testable
+  /// @{
+  void print(const std::string& s = "", const KeyFormatter& keyFormatter =
+                                            DefaultKeyFormatter) const override;
+  bool equals(const NonlinearFactor& expected, double tol = 1e-9) const override;
+  /// @}
+
+  /** Access the preintegrated measurements. */
+  const PIM& preintegratedMeasurements() const {
+    return pim_;
+  }
+
+  /** The gravity magnitude used by the Unit3 parametrization. */
+  double gravityMagnitude() const {
+    return gravityMagnitude_;
+  }
+
+  /** implement functions needed to derive from Factor */
+
+  /// vector of errors
+  Vector9 evaluateError(const NavState& state_i, const NavState& state_j,
+                        const imuBias::ConstantBias& bias_i,
+                        const GRAVITY& gravity, OptionalMatrixType H1,
+                        OptionalMatrixType H2, OptionalMatrixType H3,
+                        OptionalMatrixType H4) const override;
+
+ private:
+#if GTSAM_ENABLE_BOOST_SERIALIZATION
+  /** Serialization function */
+  friend class boost::serialization::access;
+  template<class ARCHIVE>
+  void serialize(ARCHIVE & ar, const unsigned int /*version*/) {
+    // Archive name for the base follows the sibling factors' convention:
+    ar & boost::serialization::make_nvp("NoiseModelFactor4",
+         boost::serialization::base_object<Base>(*this));
+    ar & BOOST_SERIALIZATION_NVP(pim_);
+    ar & BOOST_SERIALIZATION_NVP(gravityMagnitude_);
+  }
+#endif
+};
+// class ImuFactor2WithGravityT
+
+/**
+ * ImuFactor2 variant with the gravity direction as an optimized Unit3 variable
+ * and a fixed, known magnitude; see ImuFactorWithGravityDirection.
+ */
+using ImuFactor2WithGravityDirection =
+    ImuFactor2WithGravityT<PreintegratedImuMeasurements, Unit3>;
+
+/**
+ * ImuFactor2 variant with the gravity vector as a free Point3 variable, ie.
+ * direction and magnitude both optimized; see ImuFactorWithGravityVector.
+ */
+using ImuFactor2WithGravityVector =
+    ImuFactor2WithGravityT<PreintegratedImuMeasurements, Point3>;
+
+// operator<< for ImuFactor2WithGravityT
+template <class PIM, class GRAVITY>
+GTSAM_EXPORT std::ostream& operator<<(std::ostream& os,
+                                      const ImuFactor2WithGravityT<PIM, GRAVITY>& f);
+
+template <class PIM, class GRAVITY>
+struct traits<ImuFactor2WithGravityT<PIM, GRAVITY>>
+    : public Testable<ImuFactor2WithGravityT<PIM, GRAVITY>> {};
+
 } /// namespace gtsam

--- a/gtsam/navigation/doc/ImuFactorWithGravity.ipynb
+++ b/gtsam/navigation/doc/ImuFactorWithGravity.ipynb
@@ -32,6 +32,8 @@
         "`CombinedImuFactorWithGravityDirection` / `...Vector` are the corresponding variants of\n",
         "[CombinedImuFactor](CombinedImuFactor.ipynb), adding gravity as a 7th variable while\n",
         "keeping the bias random walk rows (which have a zero gravity Jacobian).\n",
+        "`ImuFactor2WithGravityDirection` / `...Vector` are the `NavState`-based variants, with\n",
+        "one combined pose+velocity key per state, as `ImuFactor2` is to `ImuFactor`.\n",
         "\n",
         "**Observability**: only the combination $R_i^T g$ is observed by the accelerometer, so\n",
         "nav-frame gravity and initial attitude are entangled: anchor exactly one of them (a\n",
@@ -60,10 +62,10 @@
       "id": "b9b26d2f",
       "metadata": {
         "execution": {
-          "iopub.execute_input": "2026-08-01T10:20:52.382090Z",
-          "iopub.status.busy": "2026-08-01T10:20:52.381908Z",
-          "iopub.status.idle": "2026-08-01T10:20:52.944753Z",
-          "shell.execute_reply": "2026-08-01T10:20:52.944192Z"
+          "iopub.execute_input": "2026-08-29T11:53:48.341199Z",
+          "iopub.status.busy": "2026-08-29T11:53:48.341099Z",
+          "iopub.status.idle": "2026-08-29T11:53:48.436635Z",
+          "shell.execute_reply": "2026-08-29T11:53:48.433250Z"
         }
       },
       "outputs": [],
@@ -135,10 +137,10 @@
       "id": "ec87c70f",
       "metadata": {
         "execution": {
-          "iopub.execute_input": "2026-08-01T10:20:52.949842Z",
-          "iopub.status.busy": "2026-08-01T10:20:52.947469Z",
-          "iopub.status.idle": "2026-08-01T10:20:52.963619Z",
-          "shell.execute_reply": "2026-08-01T10:20:52.962902Z"
+          "iopub.execute_input": "2026-08-29T11:53:48.443970Z",
+          "iopub.status.busy": "2026-08-29T11:53:48.443180Z",
+          "iopub.status.idle": "2026-08-29T11:53:48.454313Z",
+          "shell.execute_reply": "2026-08-29T11:53:48.453414Z"
         }
       },
       "outputs": [
@@ -179,10 +181,10 @@
       "id": "c64ee81a",
       "metadata": {
         "execution": {
-          "iopub.execute_input": "2026-08-01T10:20:52.969144Z",
-          "iopub.status.busy": "2026-08-01T10:20:52.968927Z",
-          "iopub.status.idle": "2026-08-01T10:20:52.978487Z",
-          "shell.execute_reply": "2026-08-01T10:20:52.977203Z"
+          "iopub.execute_input": "2026-08-29T11:53:48.455899Z",
+          "iopub.status.busy": "2026-08-29T11:53:48.455782Z",
+          "iopub.status.idle": "2026-08-29T11:53:48.460262Z",
+          "shell.execute_reply": "2026-08-29T11:53:48.459321Z"
         }
       },
       "outputs": [],
@@ -213,10 +215,10 @@
       "id": "3aec4ecb",
       "metadata": {
         "execution": {
-          "iopub.execute_input": "2026-08-01T10:20:52.980345Z",
-          "iopub.status.busy": "2026-08-01T10:20:52.980152Z",
-          "iopub.status.idle": "2026-08-01T10:20:52.999390Z",
-          "shell.execute_reply": "2026-08-01T10:20:52.998560Z"
+          "iopub.execute_input": "2026-08-29T11:53:48.461535Z",
+          "iopub.status.busy": "2026-08-29T11:53:48.461431Z",
+          "iopub.status.idle": "2026-08-29T11:53:48.467895Z",
+          "shell.execute_reply": "2026-08-29T11:53:48.467266Z"
         }
       },
       "outputs": [
@@ -248,10 +250,10 @@
       "id": "923871a3",
       "metadata": {
         "execution": {
-          "iopub.execute_input": "2026-08-01T10:20:53.005787Z",
-          "iopub.status.busy": "2026-08-01T10:20:53.003620Z",
-          "iopub.status.idle": "2026-08-01T10:20:53.016775Z",
-          "shell.execute_reply": "2026-08-01T10:20:53.015619Z"
+          "iopub.execute_input": "2026-08-29T11:53:48.469001Z",
+          "iopub.status.busy": "2026-08-29T11:53:48.468918Z",
+          "iopub.status.idle": "2026-08-29T11:53:48.472013Z",
+          "shell.execute_reply": "2026-08-29T11:53:48.471519Z"
         }
       },
       "outputs": [
@@ -280,6 +282,50 @@
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": 6,
+      "id": "a7c3f2d9",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-08-29T11:53:48.473026Z",
+          "iopub.status.busy": "2026-08-29T11:53:48.472943Z",
+          "iopub.status.idle": "2026-08-29T11:53:48.476902Z",
+          "shell.execute_reply": "2026-08-29T11:53:48.476587Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "recovered gravity (NavState mode): [ 0.2941  0.4902 -9.7933]\n",
+            "direction error: 1.78e-15\n"
+          ]
+        }
+      ],
+      "source": [
+        "# NavState variant: ImuFactor2WithGravityDirection, one key per state\n",
+        "graph = gtsam.NonlinearFactorGraph()\n",
+        "tight_state = gtsam.noiseModel.Isotropic.Sigma(9, 1e-6)\n",
+        "tight_bias = gtsam.noiseModel.Isotropic.Sigma(6, 1e-6)\n",
+        "graph.add(gtsam.PriorFactorNavState(X(1), gtsam.NavState(), tight_state))\n",
+        "graph.add(gtsam.PriorFactorNavState(X(2), gtsam.NavState(), tight_state))\n",
+        "graph.addPriorConstantBias(B(1), gtsam.imuBias.ConstantBias(), tight_bias)\n",
+        "graph.add(gtsam.ImuFactor2WithGravityDirection(X(1), X(2), B(1), G(0), pim))\n",
+        "\n",
+        "values = gtsam.Values()\n",
+        "values.insert(X(1), gtsam.NavState())\n",
+        "values.insert(X(2), gtsam.NavState())\n",
+        "values.insert(B(1), gtsam.imuBias.ConstantBias())\n",
+        "values.insert(G(0), gtsam.Unit3(np.array([0.0, 0.0, -1.0])))\n",
+        "\n",
+        "result = gtsam.LevenbergMarquardtOptimizer(graph, values).optimize()\n",
+        "recovered = result.atUnit3(G(0)).unitVector() * 9.81\n",
+        "print(f\"recovered gravity (NavState mode): {np.round(recovered, 4)}\")\n",
+        "print(f\"direction error: {np.linalg.norm(recovered - true_gravity):.2e}\")"
+      ]
+    },
+    {
       "cell_type": "markdown",
       "id": "f165b393",
       "metadata": {},
@@ -297,6 +343,9 @@
         "- The Combined variants add the second bias key: `CombinedImuFactorWithGravity*` with\n",
         "  keys `(pose_i, vel_i, pose_j, vel_j, bias_i, bias_j, gravity)` and a 15-dimensional\n",
         "  error whose bias rows have a zero gravity Jacobian.\n",
+        "- `ImuFactor2WithGravityDirection` / `...Vector` are the `NavState`-based variants\n",
+        "  (as `ImuFactor2` is to `ImuFactor`), with keys `(state_i, state_j, bias, gravity)`\n",
+        "  and the same 9-dimensional error; like `ImuFactor2`, they provide no `Merge`.\n",
         "\n",
         "## Source\n",
         "\n",

--- a/gtsam/navigation/navigation.i
+++ b/gtsam/navigation/navigation.i
@@ -432,6 +432,38 @@ typedef gtsam::ImuFactorWithGravityT<gtsam::PreintegratedImuMeasurements,
                                      gtsam::Point3>
     ImuFactorWithGravityVector;
 
+template <PIM, GRAVITY>
+virtual class ImuFactor2WithGravityT : gtsam::NoiseModelFactor {
+  ImuFactor2WithGravityT(gtsam::Key state_i, gtsam::Key state_j,
+      gtsam::Key bias, gtsam::Key gravity, const PIM& preintegratedMeasurements);
+  ImuFactor2WithGravityT(gtsam::Key state_i, gtsam::Key state_j,
+      gtsam::Key bias, gtsam::Key gravity, const PIM& preintegratedMeasurements,
+      double gravityMagnitude);
+
+  // Standard Interface
+  const PIM& preintegratedMeasurements() const;
+  double gravityMagnitude() const;
+  gtsam::Vector9 evaluateError(const gtsam::NavState& state_i,
+      const gtsam::NavState& state_j,
+      const gtsam::imuBias::ConstantBias& bias_i, const GRAVITY& gravity,
+      gtsam::OptionalMatrixType H1 = nullptr,
+      gtsam::OptionalMatrixType H2 = nullptr,
+      gtsam::OptionalMatrixType H3 = nullptr,
+      gtsam::OptionalMatrixType H4 = nullptr) const;
+
+  // enable serialization functionality
+  void serialize() const;
+};
+
+// Gravity direction as an optimized Unit3 with fixed magnitude:
+typedef gtsam::ImuFactor2WithGravityT<gtsam::PreintegratedImuMeasurements,
+                                      gtsam::Unit3>
+    ImuFactor2WithGravityDirection;
+// Gravity as a free Point3 vector, direction and magnitude both optimized:
+typedef gtsam::ImuFactor2WithGravityT<gtsam::PreintegratedImuMeasurements,
+                                      gtsam::Point3>
+    ImuFactor2WithGravityVector;
+
 #include <gtsam/navigation/CombinedImuFactor.h>
 virtual class PreintegrationCombinedParams : gtsam::PreintegrationParams {
   PreintegrationCombinedParams(const gtsam::Vector3& n_gravity);

--- a/gtsam/navigation/tests/testImuFactorWithGravity.cpp
+++ b/gtsam/navigation/tests/testImuFactorWithGravity.cpp
@@ -270,6 +270,196 @@ TEST(ImuFactorWithGravity, Merge) {
 #endif
 
 /* ************************************************************************* */
+// The NavState-based ImuFactor2WithGravity must agree with the
+// Pose3/Vector3-based factor and have correct Jacobians (Unit3 variant).
+TEST_PIM(ImuFactor2WithGravity, DirectionJacobians) {
+  using namespace common;
+  using symbol_shorthand::G;
+  auto params = testing::Params();
+  params->omegaCoriolis = kNonZeroOmegaCoriolis;
+  PIM pim(params);
+  pim.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
+
+  ImuFactor2WithGravityT<PIM, Unit3> factor(X(1), X(2), B(1), G(0), pim);
+  // The default magnitude comes from the params' gravity vector:
+  DOUBLES_EQUAL(testing::Params()->n_gravity.norm(), factor.gravityMagnitude(),
+                1e-9);
+
+  // With the params' gravity direction, the error must match plain ImuFactor2:
+  ImuFactor2T<PIM> plain(X(1), X(2), B(1), pim);
+  EXPECT(assert_equal(
+      plain.evaluateError(NavState(x1, v1), NavState(x2, v2), kZeroBias),
+      factor.evaluateError(NavState(x1, v1), NavState(x2, v2), kZeroBias,
+                           Unit3(testing::Params()->n_gravity))));
+
+  // At a tilted direction, the error must match the Pose3/Vector3-based factor:
+  const Unit3 tilt(0.1, -0.2, -1.0);  // tilted away from params
+  ImuFactorWithGravityT<PIM, Unit3> poseVelFactor(X(1), V(1), X(2), V(2), B(1),
+                                                  G(0), pim);
+  EXPECT(assert_equal(
+      poseVelFactor.evaluateError(x1, v1, x2, v2, kZeroBias, tilt),
+      factor.evaluateError(NavState(x1, v1), NavState(x2, v2), kZeroBias,
+                           tilt)));
+
+  Values values;
+  values.insert(X(1), NavState(x1, v1));
+  values.insert(X(2), NavState(x2, v2));
+  values.insert(B(1), kZeroBias);
+  values.insert(G(0), tilt);
+  EXPECT_CORRECT_FACTOR_JACOBIANS(factor, values, 1e-7, 1e-3);
+
+  // The magnitude scales the gravity Jacobian block; check it at a
+  // deliberately non-default value:
+  ImuFactor2WithGravityT<PIM, Unit3> lunar(X(1), X(2), B(1), G(0), pim, 1.62);
+  EXPECT_CORRECT_FACTOR_JACOBIANS(lunar, values, 1e-7, 1e-3);
+}
+
+/* ************************************************************************* */
+// Jacobians of the free-vector (Point3) parametrization of the NavState-based
+// factor, at a tilted direction and non-standard magnitude.
+TEST_PIM(ImuFactor2WithGravity, VectorJacobians) {
+  using namespace common;
+  using symbol_shorthand::G;
+  auto params = testing::Params();
+  params->omegaCoriolis = kNonZeroOmegaCoriolis;
+  PIM pim(params);
+  pim.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
+
+  ImuFactor2WithGravityT<PIM, Point3> factor(X(1), X(2), B(1), G(0), pim);
+
+  // The error must match the Pose3/Vector3-based factor:
+  const Point3 gravity(0.4, -0.6, -9.5);
+  ImuFactorWithGravityT<PIM, Point3> poseVelFactor(X(1), V(1), X(2), V(2), B(1),
+                                                   G(0), pim);
+  EXPECT(assert_equal(
+      poseVelFactor.evaluateError(x1, v1, x2, v2, kZeroBias, gravity),
+      factor.evaluateError(NavState(x1, v1), NavState(x2, v2), kZeroBias,
+                           gravity)));
+
+  Values values;
+  values.insert(X(1), NavState(x1, v1));
+  values.insert(X(2), NavState(x2, v2));
+  values.insert(B(1), kZeroBias);
+  values.insert(G(0), gravity);
+  EXPECT_CORRECT_FACTOR_JACOBIANS(factor, values, 1e-7, 1e-3);
+}
+
+/* ************************************************************************* */
+// equals() must compare the stored magnitude only for the Unit3
+// parametrization, and must not crash across factor types.
+TEST(ImuFactor2WithGravity, Equals) {
+  using symbol_shorthand::G;
+  auto pim = PreintegratedImuMeasurements(testing::Params());
+  pim.integrateMeasurement(Vector3(0.1, 0.2, -9.81), Vector3(0.1, 0, 0), 0.5);
+  ImuFactor2WithGravityDirection factor1(X(1), X(2), B(1), G(0), pim);
+  ImuFactor2WithGravityDirection factor2(X(1), X(2), B(1), G(0), pim);
+  ImuFactor2WithGravityDirection factor3(X(1), X(2), B(1), G(0), pim,
+                                         1.62);  // lunar gravity
+  EXPECT(factor1.equals(factor2));
+  EXPECT(!factor1.equals(factor3));
+  // clone() must preserve the magnitude:
+  EXPECT(factor3.equals(*factor3.clone()));
+  // The magnitude comparison respects the given tolerance:
+  ImuFactor2WithGravityDirection nearby(X(1), X(2), B(1), G(0), pim, 9.8105);
+  ImuFactor2WithGravityDirection standard(X(1), X(2), B(1), G(0), pim, 9.81);
+  EXPECT(standard.equals(nearby, 1e-3));
+  EXPECT(!standard.equals(nearby, 1e-6));
+  // Comparing against a different factor type must not crash:
+  ImuFactor2WithGravityVector vectorFactor(X(1), X(2), B(1), G(0), pim);
+  EXPECT(!factor1.equals(vectorFactor));
+  EXPECT(!vectorFactor.equals(factor1));
+}
+
+/* ************************************************************************* */
+// The constructor must reject a non-positive magnitude (Unit3) and any
+// magnitude at all for the Point3 parametrization.
+TEST(ImuFactor2WithGravity, ConstructorValidation) {
+  using symbol_shorthand::G;
+  auto pim = PreintegratedImuMeasurements(testing::Params());
+  pim.integrateMeasurement(Vector3(0.1, 0.2, -9.81), Vector3(0.1, 0, 0), 0.5);
+  // The Unit3 parametrization requires a positive magnitude:
+  CHECK_EXCEPTION(ImuFactor2WithGravityDirection(X(1), X(2), B(1), G(0), pim,
+                                                 0.0),
+                  std::invalid_argument);
+  // The Point3 parametrization optimizes the magnitude as part of the gravity
+  // variable, so providing one is rejected (use VectorNormFactor<3> instead):
+  CHECK_EXCEPTION(ImuFactor2WithGravityVector(X(1), X(2), B(1), G(0), pim,
+                                              9.81),
+                  std::invalid_argument);
+  // Without params there is no default magnitude for the Unit3 parametrization
+  // to fall back on; an explicit one still works, and Point3 needs none:
+  const PreintegratedImuMeasurements noParams(
+      std::shared_ptr<PreintegrationParams>{});
+  CHECK_EXCEPTION(ImuFactor2WithGravityDirection(X(1), X(2), B(1), G(0),
+                                                 noParams),
+                  std::invalid_argument);
+  const ImuFactor2WithGravityDirection explicitMagnitude(X(1), X(2), B(1), G(0),
+                                                         noParams, 9.81);
+  DOUBLES_EQUAL(9.81, explicitMagnitude.gravityMagnitude(), 1e-9);
+  const ImuFactor2WithGravityVector vectorNoParams(X(1), X(2), B(1), G(0),
+                                                   noParams);
+  EXPECT_LONGS_EQUAL(4, vectorNoParams.size());
+}
+
+/* ************************************************************************* */
+// NavState counterparts of the tilted-fixture priors and initial values, for
+// the ImuFactor2WithGravity recovery tests below.
+namespace tiltedNavState {
+static void addStationaryPriors(NonlinearFactorGraph* graph) {
+  auto tightState = noiseModel::Isotropic::Sigma(9, 1e-6);
+  auto tightBias = noiseModel::Isotropic::Sigma(6, 1e-6);
+  graph->addPrior(X(1), NavState(), tightState);
+  graph->addPrior(X(2), NavState(), tightState);
+  graph->addPrior(B(1), kZeroBias, tightBias);
+}
+static Values stationaryInitial() {
+  Values initial;
+  initial.insert(X(1), NavState());
+  initial.insert(X(2), NavState());
+  initial.insert(B(1), kZeroBias);
+  return initial;
+}
+}  // namespace tiltedNavState
+/* ************************************************************************* */
+
+// Optimizing NavStates anchored by tight priors recovers the tilted gravity
+// direction, as in the Pose3/Vector3-based RecoverGravityDirection test.
+TEST(ImuFactor2WithGravity, RecoverGravityDirection) {
+  using symbol_shorthand::G;
+  NonlinearFactorGraph graph;
+  // The magnitude is given explicitly since the params' norm is kGravity = 10,
+  // while the data was generated with |g| = 9.81:
+  graph.emplace_shared<ImuFactor2WithGravityDirection>(
+      X(1), X(2), B(1), G(0), tilted::integrateStationary(), 9.81);
+  tiltedNavState::addStationaryPriors(&graph);
+
+  Values initial = tiltedNavState::stationaryInitial();
+  initial.insert(G(0), Unit3(0, 0, -1));
+
+  const Values result = LevenbergMarquardtOptimizer(graph, initial).optimize();
+  EXPECT(assert_equal(Unit3(tilted::trueGravity), result.at<Unit3>(G(0)), 1e-5));
+}
+
+/* ************************************************************************* */
+// Same recovery through the free-vector parametrization, with Lupton's
+// magnitude pseudo-observation on the gravity variable.
+TEST(ImuFactor2WithGravity, RecoverGravityVector) {
+  using symbol_shorthand::G;
+  NonlinearFactorGraph graph;
+  graph.emplace_shared<ImuFactor2WithGravityVector>(
+      X(1), X(2), B(1), G(0), tilted::integrateStationary());
+  graph.emplace_shared<VectorNormFactor<3>>(
+      G(0), 9.81, noiseModel::Isotropic::Sigma(1, 0.03));
+  tiltedNavState::addStationaryPriors(&graph);
+
+  Values initial = tiltedNavState::stationaryInitial();
+  initial.insert(G(0), Point3(0, 0, -9.0));
+
+  const Values result = LevenbergMarquardtOptimizer(graph, initial).optimize();
+  EXPECT(assert_equal(Point3(tilted::trueGravity), result.at<Point3>(G(0)), 1e-4));
+}
+
+/* ************************************************************************* */
 int main() {
   TestResult tr;
   return TestRegistry::runAllTests(tr);

--- a/gtsam/navigation/tests/testSerializationNavigation.cpp
+++ b/gtsam/navigation/tests/testSerializationNavigation.cpp
@@ -167,6 +167,23 @@ TEST(ImuFactorWithGravity, serialization) {
 }
 
 /* ************************************************************************* */
+// Round-trips the NavState-based gravity factors; the non-default magnitude
+// verifies it is restored from the archive, not recomputed from the params.
+TEST(ImuFactor2WithGravity, serialization) {
+  auto pim = getPreintegratedMeasurements<PreintegratedImuMeasurements>();
+
+  ImuFactor2WithGravityDirection direction(1, 2, 3, 4, pim, 1.62);
+  EXPECT(equalsObj<ImuFactor2WithGravityDirection>(direction));
+  EXPECT(equalsXML<ImuFactor2WithGravityDirection>(direction));
+  EXPECT(equalsBinary<ImuFactor2WithGravityDirection>(direction));
+
+  ImuFactor2WithGravityVector vector(1, 2, 3, 4, pim);
+  EXPECT(equalsObj<ImuFactor2WithGravityVector>(vector));
+  EXPECT(equalsXML<ImuFactor2WithGravityVector>(vector));
+  EXPECT(equalsBinary<ImuFactor2WithGravityVector>(vector));
+}
+
+/* ************************************************************************* */
 TEST(CombinedImuFactor, Serialization) {
   auto pim = getPreintegratedMeasurements<PreintegratedCombinedMeasurements>();
 
@@ -205,6 +222,8 @@ using StandardFactor = ImuFactorT<Pim>;
 using NavStateFactor = ImuFactor2T<Pim>;
 using GravityDirectionFactor = ImuFactorWithGravityT<Pim, Unit3>;
 using GravityVectorFactor = ImuFactorWithGravityT<Pim, Point3>;
+using NavStateGravityDirectionFactor = ImuFactor2WithGravityT<Pim, Unit3>;
+using NavStateGravityVectorFactor = ImuFactor2WithGravityT<Pim, Point3>;
 using CombinedFactor = CombinedImuFactorT<CombinedPim>;
 using CombinedGravityDirectionFactor =
     CombinedImuFactorWithGravityT<CombinedPim, Unit3>;
@@ -237,6 +256,17 @@ TEST(LieGroupPreintegration, Serialization) {
   EXPECT(equalsObj(gravityVector));
   EXPECT(equalsXML(gravityVector));
   EXPECT(equalsBinary(gravityVector));
+
+  const NavStateGravityDirectionFactor navStateGravityDirection(1, 2, 3, 4,
+                                                                pim, 9.81);
+  EXPECT(equalsObj(navStateGravityDirection));
+  EXPECT(equalsXML(navStateGravityDirection));
+  EXPECT(equalsBinary(navStateGravityDirection));
+
+  const NavStateGravityVectorFactor navStateGravityVector(1, 2, 3, 4, pim);
+  EXPECT(equalsObj(navStateGravityVector));
+  EXPECT(equalsXML(navStateGravityVector));
+  EXPECT(equalsBinary(navStateGravityVector));
 
   const CombinedPim combinedPim = getPreintegratedMeasurements<CombinedPim>();
   EXPECT(equalsObj(combinedPim));

--- a/python/gtsam/tests/test_ImuFactorWithGravity.py
+++ b/python/gtsam/tests/test_ImuFactorWithGravity.py
@@ -13,7 +13,8 @@ import unittest
 import numpy as np
 
 import gtsam
-from gtsam import ImuFactorWithGravityDirection, ImuFactorWithGravityVector
+from gtsam import (ImuFactor2WithGravityDirection, ImuFactor2WithGravityVector,
+                   ImuFactorWithGravityDirection, ImuFactorWithGravityVector)
 from gtsam.symbol_shorthand import B, G, V, X
 from gtsam.utils.test_case import GtsamTestCase
 
@@ -103,6 +104,37 @@ class TestImuFactorWithGravity(GtsamTestCase):
             gtsam.Pose3(), np.zeros(3), gtsam.Pose3(), np.zeros(3), zb, zb,
             np.array([0.0, 0.0, -9.81]))
         np.testing.assert_allclose(error, np.zeros(15), atol=1e-9)
+
+    def test_navstate_direction_factor(self):
+        pim = stationary_pim()
+        factor = ImuFactor2WithGravityDirection(X(1), X(2), B(1), G(0), pim)
+        self.assertAlmostEqual(factor.gravityMagnitude(), 9.81)
+
+        error = factor.evaluateError(
+            gtsam.NavState(), gtsam.NavState(), gtsam.imuBias.ConstantBias(),
+            gtsam.Unit3(np.array([0.0, 0.0, -1.0])))
+        np.testing.assert_allclose(error, np.zeros(9), atol=1e-9)
+
+    def test_navstate_direction_factor_explicit_magnitude(self):
+        pim = stationary_pim()
+        factor = ImuFactor2WithGravityDirection(
+            X(1), X(2), B(1), G(0), pim, 1.62)
+        self.assertAlmostEqual(factor.gravityMagnitude(), 1.62)
+
+    def test_navstate_vector_factor(self):
+        pim = stationary_pim()
+        factor = ImuFactor2WithGravityVector(X(1), X(2), B(1), G(0), pim)
+        error = factor.evaluateError(
+            gtsam.NavState(), gtsam.NavState(), gtsam.imuBias.ConstantBias(),
+            np.array([0.0, 0.0, -9.81]))
+        np.testing.assert_allclose(error, np.zeros(9), atol=1e-9)
+
+    def test_navstate_vector_factor_rejects_magnitude(self):
+        """The Point3 parametrization optimizes the magnitude with the
+        variable; a magnitude argument is rejected (use VectorNormFactor3)."""
+        pim = stationary_pim()
+        with self.assertRaises(ValueError):
+            ImuFactor2WithGravityVector(X(1), X(2), B(1), G(0), pim, 9.81)
 
     def test_vector_norm_factor(self):
         model = gtsam.noiseModel.Isotropic.Sigma(1, 0.03)


### PR DESCRIPTION
Depends upon #2762. Will rebase once that is merged.

Follow-up to #2020, as promised there: adds `ImuFactor2WithGravityT<PIM, GRAVITY>`, the NavState-based counterpart of `ImuFactorWithGravityT` (exactly as `ImuFactor2` is the NavState-based counterpart of `ImuFactor`). 

Introduces a 4-way factor on `(NavState_i, NavState_j, bias, gravity)` with the same two parametrizations and typedefs as the siblings:  `ImuFactor2WithGravityDirection` (Unit3 direction × fixed magnitude) and `ImuFactor2WithGravityVector` (free Point3 vector).