### PR TITLE
Optimize shared IMU prediction and factor linearization

### DIFF
--- a/gtsam/navigation/ImuFactor.cpp
+++ b/gtsam/navigation/ImuFactor.cpp
@@ -123,10 +123,10 @@ bool ImuFactorT<PIM>::equals(const NonlinearFactor& other, double tol) const {
 
 //------------------------------------------------------------------------------
 template <class PIM>
-Vector ImuFactorT<PIM>::evaluateError(const Pose3& pose_i, const Vector3& vel_i,
-    const Pose3& pose_j, const Vector3& vel_j,
-    const imuBias::ConstantBias& bias_i, OptionalMatrixType H1,
-    OptionalMatrixType H2, OptionalMatrixType H3,
+Vector9 ImuFactorT<PIM>::evaluateError(
+    const Pose3& pose_i, const Vector3& vel_i, const Pose3& pose_j,
+    const Vector3& vel_j, const imuBias::ConstantBias& bias_i,
+    OptionalMatrixType H1, OptionalMatrixType H2, OptionalMatrixType H3,
     OptionalMatrixType H4, OptionalMatrixType H5) const {
   return internal::preintegrationErrorAndJacobians(
       pim_, pose_i, vel_i, pose_j, vel_j, bias_i, H1, H2, H3, H4, H5);

--- a/gtsam/navigation/ImuFactor.h
+++ b/gtsam/navigation/ImuFactor.h
@@ -215,13 +215,15 @@ using PreintegratedImuMeasurements = PreintegratedImuMeasurementsT<DefaultPreint
  * @ingroup navigation
  */
 template <class PIM = PreintegratedImuMeasurements>
-class GTSAM_EXPORT ImuFactorT: public NoiseModelFactorN<Pose3, Vector3, Pose3, Vector3,
-    imuBias::ConstantBias> {
+class GTSAM_EXPORT ImuFactorT
+    : public NoiseModelFactorT<Vector9, Pose3, Vector3, Pose3, Vector3,
+                               imuBias::ConstantBias> {
 private:
 
   typedef ImuFactorT<PIM> This;
-  typedef NoiseModelFactorN<Pose3, Vector3, Pose3, Vector3,
-      imuBias::ConstantBias> Base;
+  typedef NoiseModelFactorT<Vector9, Pose3, Vector3, Pose3, Vector3,
+                            imuBias::ConstantBias>
+      Base;
 
   PIM pim_;
 
@@ -278,10 +280,12 @@ public:
   /** implement functions needed to derive from Factor */
 
   /// vector of errors
-  Vector evaluateError(const Pose3& pose_i, const Vector3& vel_i,
-      const Pose3& pose_j, const Vector3& vel_j,
-      const imuBias::ConstantBias& bias_i, OptionalMatrixType H1, OptionalMatrixType H2,
-      OptionalMatrixType H3, OptionalMatrixType H4, OptionalMatrixType H5) const override;
+  Vector9 evaluateError(const Pose3& pose_i, const Vector3& vel_i,
+                        const Pose3& pose_j, const Vector3& vel_j,
+                        const imuBias::ConstantBias& bias_i,
+                        OptionalMatrixType H1, OptionalMatrixType H2,
+                        OptionalMatrixType H3, OptionalMatrixType H4,
+                        OptionalMatrixType H5) const override;
 
   /// Merge two pre-integrated measurement classes
   template <typename MethodPIMArg = PIM,

--- a/gtsam/navigation/NavState.cpp
+++ b/gtsam/navigation/NavState.cpp
@@ -296,13 +296,12 @@ Vector9 NavState::coriolis(double dt, const Vector3& omega, bool secondOrder,
 }
 
 //------------------------------------------------------------------------------
-Vector9 NavState::correctPIM(const Vector9& pim, double dt,
-                             const Vector3& n_gravity,
-                             const std::optional<Vector3>& omegaCoriolis,
-                             bool /*use2ndOrderCoriolis*/,
-                             OptionalJacobian<9, 9> H1,
-                             OptionalJacobian<9, 9> H2,
-                             OptionalJacobian<9, 3> H3) const {
+NavState NavState::predictPIM(const Vector9& pim, double dt,
+                              const Vector3& n_gravity,
+                              const std::optional<Vector3>& omegaCoriolis,
+                              OptionalJacobian<9, 9> H1,
+                              OptionalJacobian<9, 9> H2,
+                              OptionalJacobian<9, 3> H3) const {
   if (omegaCoriolis && !omegaCoriolis->isZero(0.0)) {
     const Vector3& omega = *omegaCoriolis;
     const Vector3 earthRotationTangent = -omega * dt;
@@ -336,14 +335,7 @@ Vector9 NavState::correctPIM(const Vector9& pim, double dt,
     const NavState predicted(predictedRotation, predictedPosition,
                              predictedVelocity);
 
-    Matrix9 predicted_H_state, predicted_H_pim;
-    Matrix93 predicted_H_gravity;
-    const bool computeJacobians = H1 || H2 || H3;
-    if (computeJacobians) {
-      predicted_H_state.setZero();
-      predicted_H_pim.setZero();
-      predicted_H_gravity.setZero();
-
+    if (H1 || H2 || H3) {
       const Matrix3 finalRotationTranspose = predictedRotation.transpose();
       const Matrix3 initialToFinal =
           finalRotationTranspose * gammaRotation * initialRotation;
@@ -351,39 +343,106 @@ Vector9 NavState::correctPIM(const Vector9& pim, double dt,
       const Vector3 pimPositionNav = initialRotation * dP(pim);
       const Vector3 pimVelocityNav = initialRotation * dV(pim);
 
-      D_R_R(&predicted_H_state) = deltaRotation.transpose();
-      D_t_R(&predicted_H_state) =
-          finalRotationTranspose * gammaRotation *
-          (-skewSymmetric(pimPositionNav) * initialRotation);
-      D_t_t(&predicted_H_state) =
-          navToFinal * (I_3x3 + omegaCross * dt) * initialRotation;
-      D_t_v(&predicted_H_state) = navToFinal * initialRotation * dt;
-      D_v_R(&predicted_H_state) =
-          finalRotationTranspose *
-          (gammaRotation * (-skewSymmetric(pimVelocityNav) * initialRotation) -
-           omegaCross * gammaRotation *
-               (-skewSymmetric(pimPositionNav) * initialRotation));
-      D_v_t(&predicted_H_state) =
-          finalRotationTranspose *
-          ((gammaRotation * omegaCross -
-            omegaCross * gammaRotation * (I_3x3 + omegaCross * dt)) *
-           initialRotation);
-      D_v_v(&predicted_H_state) =
-          finalRotationTranspose *
-          ((gammaRotation - omegaCross * gammaRotation * dt) * initialRotation);
-
-      D_R_R(&predicted_H_pim) = deltaRotation_H_pimRotation;
-      D_t_t(&predicted_H_pim) = initialToFinal;
-      D_v_v(&predicted_H_pim) = initialToFinal;
-      D_v_t(&predicted_H_pim) = -finalRotationTranspose * omegaCross *
-                                gammaRotation * initialRotation;
-
-      predicted_H_gravity.block<3, 3>(3, 0) =
-          finalRotationTranspose * gammaPosition * (dt * dt);
-      predicted_H_gravity.block<3, 3>(6, 0) =
-          finalRotationTranspose *
-          (gammaVelocity * dt - omegaCross * gammaPosition * (dt * dt));
+      if (H1) {
+        H1->setZero();
+        D_R_R(H1) = deltaRotation.transpose();
+        D_t_R(H1) = finalRotationTranspose * gammaRotation *
+                    (-skewSymmetric(pimPositionNav) * initialRotation);
+        D_t_t(H1) = navToFinal * (I_3x3 + omegaCross * dt) * initialRotation;
+        D_t_v(H1) = navToFinal * initialRotation * dt;
+        D_v_R(H1) = finalRotationTranspose *
+                    (gammaRotation *
+                         (-skewSymmetric(pimVelocityNav) * initialRotation) -
+                     omegaCross * gammaRotation *
+                         (-skewSymmetric(pimPositionNav) * initialRotation));
+        D_v_t(H1) = finalRotationTranspose *
+                    ((gammaRotation * omegaCross -
+                      omegaCross * gammaRotation * (I_3x3 + omegaCross * dt)) *
+                     initialRotation);
+        D_v_v(H1) = finalRotationTranspose *
+                    ((gammaRotation - omegaCross * gammaRotation * dt) *
+                     initialRotation);
+      }
+      if (H2) {
+        H2->setZero();
+        D_R_R(H2) = deltaRotation_H_pimRotation;
+        D_t_t(H2) = initialToFinal;
+        D_v_v(H2) = initialToFinal;
+        D_v_t(H2) = -finalRotationTranspose * omegaCross * gammaRotation *
+                    initialRotation;
+      }
+      if (H3) {
+        H3->setZero();
+        H3->block<3, 3>(3, 0) =
+            finalRotationTranspose * gammaPosition * (dt * dt);
+        H3->block<3, 3>(6, 0) =
+            finalRotationTranspose *
+            (gammaVelocity * dt - omegaCross * gammaPosition * (dt * dt));
+      }
     }
+    return predicted;
+  }
+
+  const Matrix3 initialRotation = R_.matrix();
+  Matrix3 deltaRotation_H_pimRotation;
+  const Rot3 deltaRotation =
+      Rot3::Expmap(dR(pim), H2 ? &deltaRotation_H_pimRotation : nullptr);
+  const Rot3 predictedRotation = R_.compose(deltaRotation);
+  const Point3 predictedPosition = position() + velocity() * dt +
+                                   0.5 * n_gravity * (dt * dt) +
+                                   initialRotation * dP(pim);
+  const Velocity3 predictedVelocity =
+      velocity() + n_gravity * dt + initialRotation * dV(pim);
+  const NavState predicted(predictedRotation, predictedPosition,
+                           predictedVelocity);
+
+  if (H1 || H2 || H3) {
+    const Matrix3 finalRotationTranspose = predictedRotation.transpose();
+    const Matrix3 initialToFinal = deltaRotation.transpose();
+
+    if (H1) {
+      const Vector3 pimPositionNav = initialRotation * dP(pim);
+      const Vector3 pimVelocityNav = initialRotation * dV(pim);
+      H1->setZero();
+      D_R_R(H1) = initialToFinal;
+      D_t_R(H1) = finalRotationTranspose *
+                  (-skewSymmetric(pimPositionNav) * initialRotation);
+      D_t_t(H1) = initialToFinal;
+      D_t_v(H1) = initialToFinal * dt;
+      D_v_R(H1) = finalRotationTranspose *
+                  (-skewSymmetric(pimVelocityNav) * initialRotation);
+      D_v_v(H1) = initialToFinal;
+    }
+    if (H2) {
+      H2->setZero();
+      D_R_R(H2) = deltaRotation_H_pimRotation;
+      D_t_t(H2) = initialToFinal;
+      D_v_v(H2) = initialToFinal;
+    }
+    if (H3) {
+      H3->setZero();
+      H3->block<3, 3>(3, 0) = finalRotationTranspose * (0.5 * dt * dt);
+      H3->block<3, 3>(6, 0) = finalRotationTranspose * dt;
+    }
+  }
+  return predicted;
+}
+
+//------------------------------------------------------------------------------
+Vector9 NavState::correctPIM(const Vector9& pim, double dt,
+                             const Vector3& n_gravity,
+                             const std::optional<Vector3>& omegaCoriolis,
+                             bool /*use2ndOrderCoriolis*/,
+                             OptionalJacobian<9, 9> H1,
+                             OptionalJacobian<9, 9> H2,
+                             OptionalJacobian<9, 3> H3) const {
+  if (omegaCoriolis && !omegaCoriolis->isZero(0.0)) {
+    Matrix9 predicted_H_state, predicted_H_pim;
+    Matrix93 predicted_H_gravity;
+    const bool computeJacobians = H1 || H2 || H3;
+    const NavState predicted = predictPIM(
+        pim, dt, n_gravity, omegaCoriolis, H1 ? &predicted_H_state : nullptr,
+        H2 ? &predicted_H_pim : nullptr, H3 ? &predicted_H_gravity : nullptr);
 
     Matrix9 chart_H_initial, chart_H_predicted;
     const Vector9 result =

--- a/gtsam/navigation/NavState.cpp
+++ b/gtsam/navigation/NavState.cpp
@@ -343,11 +343,8 @@ struct PIMPrediction {
 /** PIM prediction in the ordinary inertial navigation frame. */
 struct PIMPredictionInertial : PIMPrediction {
   /** Make the world increment W, which contains only gravity. */
-  NavState makeW(OptionalJacobian<9, 3> D_W = {}) const {
+  NavState makeW() const {
     const double dt2 = dt * dt;
-    if (D_W) {
-      *D_W << Z_3x3, 0.5 * dt2 * I_3x3, dt * I_3x3;
-    }
     return {Rot3(), 0.5 * gravity * dt2, gravity * dt};
   }
 
@@ -359,17 +356,31 @@ struct PIMPredictionInertial : PIMPrediction {
     //                 X_j = W * phi_dt(X_i) * U.
     //
     // W carries world-frame gravity, while U carries the body-frame PIM.
-    Matrix9 D_U, D_Y_W, D_Y_X, D_Y_U;
-    Matrix93 D_W;
-    const NavState W = makeW(H3 ? &D_W : nullptr);
-    const NavState U = makeU(H2 ? &D_U : nullptr);
-    const NavState Y = propagate(W, X, U, H3 ? &D_Y_W : nullptr,
-                                 H1 ? &D_Y_X : nullptr, H2 ? &D_Y_U : nullptr);
+    const NavState W = makeW();
+    const NavState U = makeU(H2);
+    const Point3 X_p = X.position(), U_p = U.position();
+    const Velocity3 X_v = X.velocity(), U_v = U.velocity();
+    const Rot3 Y_R = X.attitude().compose(U.attitude());
+    const Matrix3 X_R = X.R();
+    const NavState Y{Y_R, W.position() + X_p + X_v * dt + X_R * U_p,
+                     W.velocity() + X_v + X_R * U_v};
 
-    // Each line below is the chain rule for one public argument.
-    if (H1) *H1 = D_Y_X;
-    if (H2) *H2 = D_Y_U * D_U;
-    if (H3) *H3 = D_Y_W * D_W;
+    if (H1) {
+      const Matrix3 deltaRt = U.attitude().transpose();
+      H1->setZero();
+      H1->block<3, 3>(0, 0) = deltaRt;
+      H1->block<3, 3>(3, 0) = -deltaRt * skewSymmetric(U_p);
+      H1->block<3, 3>(3, 3) = deltaRt;
+      H1->block<3, 3>(3, 6) = dt * deltaRt;
+      H1->block<3, 3>(6, 0) = -deltaRt * skewSymmetric(U_v);
+      H1->block<3, 3>(6, 6) = deltaRt;
+    }
+    // makeU has already written its own Jacobian directly into H2.
+    if (H3) {
+      const double dt2 = dt * dt;
+      const Matrix3 Y_Rt = Y_R.transpose();
+      *H3 << Z_3x3, 0.5 * dt2 * Y_Rt, dt * Y_Rt;
+    }
     return Y;
   }
 };

--- a/gtsam/navigation/NavState.cpp
+++ b/gtsam/navigation/NavState.cpp
@@ -295,6 +295,161 @@ Vector9 NavState::coriolis(double dt, const Vector3& omega, bool secondOrder,
   return xi;
 }
 
+namespace {
+
+/** Common data and operations for inertial and rotating PIM prediction. */
+struct PIMPrediction {
+  const Vector9& pim;
+  const double dt;
+  const Vector3& gravity;
+
+  /** Make the body-frame PIM increment U = (Delta R, Delta p, Delta v). */
+  NavState makeU(OptionalJacobian<9, 9> D_U = {}) const {
+    Matrix3 D_R;
+    const Rot3 deltaR = Rot3::Expmap(NavState::dR(pim), D_U ? &D_R : nullptr);
+    if (D_U) {
+      const Matrix3 deltaRt = deltaR.transpose();
+      *D_U << D_R, Z_3x3, Z_3x3,  //
+          Z_3x3, deltaRt, Z_3x3,  //
+          Z_3x3, Z_3x3, deltaRt;
+    }
+    return {deltaR, NavState::dP(pim), NavState::dV(pim)};
+  }
+
+  /** Evaluate W * phi_dt(X) * U and differentiate with respect to W, X, U. */
+  NavState propagate(const NavState& W, const NavState& X, const NavState& U,
+                     OptionalJacobian<9, 9> D_Y_W = {},
+                     OptionalJacobian<9, 9> D_Y_X = {},
+                     OptionalJacobian<9, 9> D_Y_U = {}) const {
+    Matrix9 D_F_X, D_Z_F, D_Z_U, D_Y_Z;
+    const NavState::AutonomousFlow phi{dt};
+    if (D_Y_X) D_F_X = phi.dIdentity();
+    const NavState F = phi(X);
+    const NavState Z =
+        F.compose(U, D_Y_X ? &D_Z_F : nullptr, D_Y_U ? &D_Z_U : nullptr);
+    const NavState Y = W.compose(Z, D_Y_W, (D_Y_X || D_Y_U) ? &D_Y_Z : nullptr);
+
+    if (D_Y_X) *D_Y_X = D_Y_Z * D_Z_F * D_F_X;
+    if (D_Y_U) *D_Y_U = D_Y_Z * D_Z_U;
+    return Y;
+  }
+};
+
+/** PIM prediction in the ordinary inertial navigation frame. */
+struct PIMPredictionInertial : PIMPrediction {
+  /** Make the world increment W, which contains only gravity. */
+  NavState makeW(OptionalJacobian<9, 3> D_W = {}) const {
+    const double dt2 = dt * dt;
+    if (D_W) {
+      *D_W << Z_3x3, 0.5 * dt2 * I_3x3, dt * I_3x3;
+    }
+    return {Rot3(), 0.5 * gravity * dt2, gravity * dt};
+  }
+
+  NavState predict(const NavState& X, OptionalJacobian<9, 9> H1 = {},
+                   OptionalJacobian<9, 9> H2 = {},
+                   OptionalJacobian<9, 3> H3 = {}) const {
+    // The ordinary path is deliberately a literal reading of
+    //
+    //                 X_j = W * phi_dt(X_i) * U.
+    //
+    // W carries world-frame gravity, while U carries the body-frame PIM.
+    Matrix9 D_U, D_Y_W, D_Y_X, D_Y_U;
+    Matrix93 D_W;
+    const NavState W = makeW(H3 ? &D_W : nullptr);
+    const NavState U = makeU(H2 ? &D_U : nullptr);
+    const NavState Y = propagate(W, X, U, H3 ? &D_Y_W : nullptr,
+                                 H1 ? &D_Y_X : nullptr, H2 ? &D_Y_U : nullptr);
+
+    // Each line below is the chain rule for one public argument.
+    if (H1) *H1 = D_Y_X;
+    if (H2) *H2 = D_Y_U * D_U;
+    if (H3) *H3 = D_Y_W * D_W;
+    return Y;
+  }
+};
+
+/** PIM prediction in a rotating navigation frame. */
+struct PIMPredictionRotating : PIMPrediction {
+  /** Make the rotating-frame world increment W, including gravity. */
+  NavState makeW(const Vector3& omega, OptionalJacobian<9, 3> D_W = {}) const {
+    const so3::DexpFunctor earthRotation(-omega * dt);
+    const Rot3 A(earthRotation.Rodrigues().left());
+    const Matrix3 gammaVelocity = earthRotation.Jacobian().left();
+
+    // Brossard's Gamma^p is J_l(w) - Gamma_2,l(w) in GTSAM's kernel
+    // convention. Its limit as omega approaches zero is 1/2 I.
+    const Matrix3 gammaPosition = gammaVelocity - earthRotation.Gamma().left();
+
+    const double dt2 = dt * dt;
+    if (D_W) {
+      // NavState uses right-local position and velocity coordinates, hence
+      // the A^T factors in the differential of W.
+      *D_W << Z_3x3,  // rotation does not depend on gravity
+          A.transpose() * gammaPosition * dt2,
+          A.transpose() * gammaVelocity * dt;
+    }
+    return {A, gammaPosition * gravity * dt2, gammaVelocity * gravity * dt};
+  }
+
+  /** Lift physical velocity v to transported velocity v_bar = v + Omega*p. */
+  NavState lift(const NavState& X, const Matrix3& omegaCross,
+                OptionalJacobian<9, 9> D_L_X = {}) const {
+    const Point3 p = X.position();
+    if (D_L_X) {
+      const Matrix3 R = X.attitude().matrix();
+      const Matrix3 omegaBody = R.transpose() * omegaCross * R;
+      *D_L_X << I_3x3, Z_3x3, Z_3x3,  //
+          Z_3x3, I_3x3, Z_3x3,        //
+          Z_3x3, omegaBody, I_3x3;
+    }
+    return {X.attitude(), p, X.velocity() + omegaCross * p};
+  }
+
+  /** Project transported velocity back to physical velocity v. */
+  NavState project(const NavState& Y, const Matrix3& omegaCross,
+                   OptionalJacobian<9, 9> D_P_Y = {}) const {
+    const Point3 p = Y.position();
+    if (D_P_Y) {
+      const Matrix3 R = Y.attitude().matrix();
+      const Matrix3 omegaBody = R.transpose() * omegaCross * R;
+      *D_P_Y << I_3x3, Z_3x3, Z_3x3,  //
+          Z_3x3, I_3x3, Z_3x3,        //
+          Z_3x3, -omegaBody, I_3x3;
+    }
+    return {Y.attitude(), p, Y.velocity() - omegaCross * p};
+  }
+
+  NavState predict(const NavState& X, const Vector3& omega,
+                   OptionalJacobian<9, 9> H1 = {},
+                   OptionalJacobian<9, 9> H2 = {},
+                   OptionalJacobian<9, 3> H3 = {}) const {
+    // The same W * phi(L) * U equation applies after lifting the initial state
+    // to transported velocity. Projection is the only extra operation:
+    //
+    //             X_j = P(W * phi_dt(L(X_i)) * U).
+    Matrix9 D_U, D_L_X, D_Y_W, D_Y_L, D_Y_U, D_P_Y;
+    Matrix93 D_W;
+    const Matrix3 omegaCross = skewSymmetric(omega);
+    const NavState W = makeW(omega, H3 ? &D_W : nullptr);
+    const NavState U = makeU(H2 ? &D_U : nullptr);
+    const NavState L = lift(X, omegaCross, H1 ? &D_L_X : nullptr);
+    const NavState Y = propagate(W, L, U, H3 ? &D_Y_W : nullptr,
+                                 H1 ? &D_Y_L : nullptr, H2 ? &D_Y_U : nullptr);
+    const NavState P =
+        project(Y, omegaCross, (H1 || H2 || H3) ? &D_P_Y : nullptr);
+
+    // The short D_* names keep the complete chain rule visible next to the
+    // equally visible value computation above.
+    if (H1) *H1 = D_P_Y * D_Y_L * D_L_X;
+    if (H2) *H2 = D_P_Y * D_Y_U * D_U;
+    if (H3) *H3 = D_P_Y * D_Y_W * D_W;
+    return P;
+  }
+};
+
+}  // namespace
+
 //------------------------------------------------------------------------------
 NavState NavState::predictPIM(const Vector9& pim, double dt,
                               const Vector3& n_gravity,
@@ -303,123 +458,10 @@ NavState NavState::predictPIM(const Vector9& pim, double dt,
                               OptionalJacobian<9, 9> H2,
                               OptionalJacobian<9, 3> H3) const {
   if (omegaCoriolis && !omegaCoriolis->isZero(0.0)) {
-    const Vector3& omega = *omegaCoriolis;
-    const Vector3 earthRotationTangent = -omega * dt;
-    const so3::DexpFunctor earthRotation(earthRotationTangent);
-    const Matrix3 gammaRotation = earthRotation.Rodrigues().left();
-    const Matrix3 gammaVelocity = earthRotation.Jacobian().left();
-    // Brossard's Gamma^p integrates Gamma^v - Omega x Gamma^p. In
-    // GTSAM's kernel convention this is J_l(w) - Gamma_2,l(w), not
-    // Gamma_2,l(w) alone.
-    const Matrix3 gammaPosition = gammaVelocity - earthRotation.Gamma().left();
-    const Matrix3 initialRotation = R_.matrix();
-    const Point3 initialPosition = position();
-    const Velocity3 initialVelocity = velocity();
-    Matrix3 deltaRotation_H_pimRotation;
-    const Rot3 deltaRotation =
-        Rot3::Expmap(dR(pim), H2 ? &deltaRotation_H_pimRotation : nullptr);
-    const Matrix3 omegaCross = skewSymmetric(omega);
-
-    const Rot3 predictedRotation(gammaRotation * initialRotation *
-                                 deltaRotation.matrix());
-    const Point3 predictedPosition =
-        gammaPosition * n_gravity * (dt * dt) +
-        gammaRotation * (initialPosition +
-                         (initialVelocity + omegaCross * initialPosition) * dt +
-                         initialRotation * dP(pim));
-    const Velocity3 predictedVelocity =
-        gammaVelocity * n_gravity * dt +
-        gammaRotation * (initialVelocity + omegaCross * initialPosition +
-                         initialRotation * dV(pim)) -
-        omegaCross * predictedPosition;
-    const NavState predicted(predictedRotation, predictedPosition,
-                             predictedVelocity);
-
-    if (H1 || H2 || H3) {
-      const Matrix3 finalRotationTranspose = predictedRotation.transpose();
-      if (H1 || H2) {
-        // gammaRotation is a function of omegaCross, so they commute. Reuse
-        // the direct initial-to-final and omega-weighted transformations.
-        const Matrix3 gammaInitial = gammaRotation * initialRotation;
-        const Matrix3 initialToFinal = finalRotationTranspose * gammaInitial;
-        const Matrix3 omegaInitialToFinal =
-            finalRotationTranspose * omegaCross * gammaInitial;
-
-        if (H1) {
-          H1->setZero();
-          D_R_R(H1) = deltaRotation.transpose();
-          D_t_R(H1) = -initialToFinal * skewSymmetric(dP(pim));
-          D_t_t(H1) = initialToFinal + omegaInitialToFinal * dt;
-          D_t_v(H1) = initialToFinal * dt;
-          D_v_R(H1) = -initialToFinal * skewSymmetric(dV(pim)) +
-                      omegaInitialToFinal * skewSymmetric(dP(pim));
-          D_v_t(H1) = -finalRotationTranspose * omegaCross * omegaCross *
-                      gammaInitial * dt;
-          D_v_v(H1) = initialToFinal - omegaInitialToFinal * dt;
-        }
-        if (H2) {
-          H2->setZero();
-          D_R_R(H2) = deltaRotation_H_pimRotation;
-          D_t_t(H2) = initialToFinal;
-          D_v_v(H2) = initialToFinal;
-          D_v_t(H2) = -omegaInitialToFinal;
-        }
-      }
-      if (H3) {
-        H3->setZero();
-        H3->block<3, 3>(3, 0) =
-            finalRotationTranspose * gammaPosition * (dt * dt);
-        H3->block<3, 3>(6, 0) =
-            finalRotationTranspose *
-            (gammaVelocity * dt - omegaCross * gammaPosition * (dt * dt));
-      }
-    }
-    return predicted;
+    return PIMPredictionRotating{{pim, dt, n_gravity}}.predict(
+        *this, *omegaCoriolis, H1, H2, H3);
   }
-
-  const Matrix3 initialRotation = R_.matrix();
-  Matrix3 deltaRotation_H_pimRotation;
-  const Rot3 deltaRotation =
-      Rot3::Expmap(dR(pim), H2 ? &deltaRotation_H_pimRotation : nullptr);
-  const Rot3 predictedRotation = R_.compose(deltaRotation);
-  const Point3 predictedPosition = position() + velocity() * dt +
-                                   0.5 * n_gravity * (dt * dt) +
-                                   initialRotation * dP(pim);
-  const Velocity3 predictedVelocity =
-      velocity() + n_gravity * dt + initialRotation * dV(pim);
-  const NavState predicted(predictedRotation, predictedPosition,
-                           predictedVelocity);
-
-  if (H1 || H2 || H3) {
-    const Matrix3 finalRotationTranspose = predictedRotation.transpose();
-    const Matrix3 initialToFinal = deltaRotation.transpose();
-
-    if (H1) {
-      const Vector3 pimPositionNav = initialRotation * dP(pim);
-      const Vector3 pimVelocityNav = initialRotation * dV(pim);
-      H1->setZero();
-      D_R_R(H1) = initialToFinal;
-      D_t_R(H1) = finalRotationTranspose *
-                  (-skewSymmetric(pimPositionNav) * initialRotation);
-      D_t_t(H1) = initialToFinal;
-      D_t_v(H1) = initialToFinal * dt;
-      D_v_R(H1) = finalRotationTranspose *
-                  (-skewSymmetric(pimVelocityNav) * initialRotation);
-      D_v_v(H1) = initialToFinal;
-    }
-    if (H2) {
-      H2->setZero();
-      D_R_R(H2) = deltaRotation_H_pimRotation;
-      D_t_t(H2) = initialToFinal;
-      D_v_v(H2) = initialToFinal;
-    }
-    if (H3) {
-      H3->setZero();
-      H3->block<3, 3>(3, 0) = finalRotationTranspose * (0.5 * dt * dt);
-      H3->block<3, 3>(6, 0) = finalRotationTranspose * dt;
-    }
-  }
-  return predicted;
+  return PIMPredictionInertial{{pim, dt, n_gravity}}.predict(*this, H1, H2, H3);
 }
 
 //------------------------------------------------------------------------------

--- a/gtsam/navigation/NavState.cpp
+++ b/gtsam/navigation/NavState.cpp
@@ -240,12 +240,16 @@ NavState NavState::update(const Vector3& b_acceleration, const Vector3& b_omega,
 
 //------------------------------------------------------------------------------
 
-// Because our navigation frames are placed on a spinning Earth, we experience two apparent forces on our inertials
-// Let Omega be the Earth's rotation rate in the navigation frame
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
+// Because our navigation frames are placed on a spinning Earth, we experience
+// two apparent forces on our inertials. Let Omega be the Earth's rotation rate
+// in the navigation frame.
 // Coriolis acceleration = -2 * (omega X n_v)
 // Centrifugal acceleration (secondOrder) = -omega X (omega X n_t)
-// We would also experience a rotation of (omega*dt) over time - so, counteract by compensating rotation by (-omega * dt)
-// Integrate centrifugal & coriolis accelerations to yield position, velocity perturbations
+// We would also experience a rotation of (omega*dt) over time - so, counteract
+// by compensating rotation by (-omega * dt).
+// Integrate centrifugal & coriolis accelerations to yield position and velocity
+// perturbations.
 Vector9 NavState::coriolis(double dt, const Vector3& omega, bool secondOrder,
     OptionalJacobian<9, 9> H) const {
   Rot3 nRb = R_;
@@ -294,6 +298,7 @@ Vector9 NavState::coriolis(double dt, const Vector3& omega, bool secondOrder,
   }
   return xi;
 }
+#endif
 
 namespace {
 
@@ -465,6 +470,7 @@ NavState NavState::predictPIM(const Vector9& pim, double dt,
 }
 
 //------------------------------------------------------------------------------
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
 Vector9 NavState::correctPIM(const Vector9& pim, double dt,
                              const Vector3& n_gravity,
                              const std::optional<Vector3>& omegaCoriolis,
@@ -527,6 +533,7 @@ Vector9 NavState::correctPIM(const Vector9& pim, double dt,
 
   return xi;
 }
+#endif
 //------------------------------------------------------------------------------
 
 }/// namespace gtsam

--- a/gtsam/navigation/NavState.cpp
+++ b/gtsam/navigation/NavState.cpp
@@ -337,39 +337,33 @@ NavState NavState::predictPIM(const Vector9& pim, double dt,
 
     if (H1 || H2 || H3) {
       const Matrix3 finalRotationTranspose = predictedRotation.transpose();
-      const Matrix3 initialToFinal =
-          finalRotationTranspose * gammaRotation * initialRotation;
-      const Matrix3 navToFinal = finalRotationTranspose * gammaRotation;
-      const Vector3 pimPositionNav = initialRotation * dP(pim);
-      const Vector3 pimVelocityNav = initialRotation * dV(pim);
+      if (H1 || H2) {
+        // gammaRotation is a function of omegaCross, so they commute. Reuse
+        // the direct initial-to-final and omega-weighted transformations.
+        const Matrix3 gammaInitial = gammaRotation * initialRotation;
+        const Matrix3 initialToFinal = finalRotationTranspose * gammaInitial;
+        const Matrix3 omegaInitialToFinal =
+            finalRotationTranspose * omegaCross * gammaInitial;
 
-      if (H1) {
-        H1->setZero();
-        D_R_R(H1) = deltaRotation.transpose();
-        D_t_R(H1) = finalRotationTranspose * gammaRotation *
-                    (-skewSymmetric(pimPositionNav) * initialRotation);
-        D_t_t(H1) = navToFinal * (I_3x3 + omegaCross * dt) * initialRotation;
-        D_t_v(H1) = navToFinal * initialRotation * dt;
-        D_v_R(H1) = finalRotationTranspose *
-                    (gammaRotation *
-                         (-skewSymmetric(pimVelocityNav) * initialRotation) -
-                     omegaCross * gammaRotation *
-                         (-skewSymmetric(pimPositionNav) * initialRotation));
-        D_v_t(H1) = finalRotationTranspose *
-                    ((gammaRotation * omegaCross -
-                      omegaCross * gammaRotation * (I_3x3 + omegaCross * dt)) *
-                     initialRotation);
-        D_v_v(H1) = finalRotationTranspose *
-                    ((gammaRotation - omegaCross * gammaRotation * dt) *
-                     initialRotation);
-      }
-      if (H2) {
-        H2->setZero();
-        D_R_R(H2) = deltaRotation_H_pimRotation;
-        D_t_t(H2) = initialToFinal;
-        D_v_v(H2) = initialToFinal;
-        D_v_t(H2) = -finalRotationTranspose * omegaCross * gammaRotation *
-                    initialRotation;
+        if (H1) {
+          H1->setZero();
+          D_R_R(H1) = deltaRotation.transpose();
+          D_t_R(H1) = -initialToFinal * skewSymmetric(dP(pim));
+          D_t_t(H1) = initialToFinal + omegaInitialToFinal * dt;
+          D_t_v(H1) = initialToFinal * dt;
+          D_v_R(H1) = -initialToFinal * skewSymmetric(dV(pim)) +
+                      omegaInitialToFinal * skewSymmetric(dP(pim));
+          D_v_t(H1) = -finalRotationTranspose * omegaCross * omegaCross *
+                      gammaInitial * dt;
+          D_v_v(H1) = initialToFinal - omegaInitialToFinal * dt;
+        }
+        if (H2) {
+          H2->setZero();
+          D_R_R(H2) = deltaRotation_H_pimRotation;
+          D_t_t(H2) = initialToFinal;
+          D_v_v(H2) = initialToFinal;
+          D_v_t(H2) = -omegaInitialToFinal;
+        }
       }
       if (H3) {
         H3->setZero();

--- a/gtsam/navigation/NavState.h
+++ b/gtsam/navigation/NavState.h
@@ -230,20 +230,27 @@ public:
                   OptionalJacobian<9, 3> G1 = {},
                   OptionalJacobian<9, 3> G2 = {}) const;
 
-  /// Compute the legacy approximate tangent-space Coriolis contribution.
-  [[deprecated("Use correctPIM with omegaCoriolis for exact prediction")]]
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
+  /**
+   * Compute the legacy approximate tangent-space Coriolis contribution.
+   * @deprecated Configure omegaCoriolis and use a concrete PIM's predict()
+   * method for exact rotating-frame dynamics.
+   */
   Vector9 coriolis(double dt, const Vector3& omega, bool secondOrder = false,
                    OptionalJacobian<9, 9> H = {}) const;
 
-  /// Correct a preintegrated tangent vector using the initial state and
-  /// gravity. If omegaCoriolis is present and nonzero, uses the exact
-  /// rotating-frame transition of Brossard et al.; otherwise preserves the
-  /// inertial fast path.
+  /**
+   * Correct a preintegrated tangent vector using the initial state and gravity.
+   * @deprecated Use a concrete PIM's predict() method, which returns the
+   * predicted NavState directly and supports exact rotating-frame dynamics.
+   */
   Vector9 correctPIM(const Vector9& pim, double dt, const Vector3& n_gravity,
-      const std::optional<Vector3>& omegaCoriolis, bool use2ndOrderCoriolis =
-          false, OptionalJacobian<9, 9> H1 = {},
-      OptionalJacobian<9, 9> H2 = {},
-      OptionalJacobian<9, 3> H3 = {}) const;
+                     const std::optional<Vector3>& omegaCoriolis,
+                     bool use2ndOrderCoriolis = false,
+                     OptionalJacobian<9, 9> H1 = {},
+                     OptionalJacobian<9, 9> H2 = {},
+                     OptionalJacobian<9, 3> H3 = {}) const;
+#endif
 
   /// @}
 

--- a/gtsam/navigation/NavState.h
+++ b/gtsam/navigation/NavState.h
@@ -248,6 +248,16 @@ public:
   /// @}
 
 private:
+  friend class PreintegrationBase;
+
+  // Return the predicted state directly, avoiding a local/retract round-trip.
+  NavState predictPIM(const Vector9& pim, double dt,
+                      const Vector3& n_gravity,
+                      const std::optional<Vector3>& omegaCoriolis,
+                      OptionalJacobian<9, 9> H1 = {},
+                      OptionalJacobian<9, 9> H2 = {},
+                      OptionalJacobian<9, 3> H3 = {}) const;
+
   /// @{
   /// serialization
 #if GTSAM_ENABLE_BOOST_SERIALIZATION  ///

--- a/gtsam/navigation/PreintegrationBase.cpp
+++ b/gtsam/navigation/PreintegrationBase.cpp
@@ -210,25 +210,11 @@ NavState PreintegrationBase::predict(const NavState& state_i,
   Vector9 biasCorrected = biasCorrectedDelta(bias_i,
                                              H2 ? &D_biasCorrected_bias : nullptr);
 
-  // Correct for initial velocity and gravity
-  Matrix9 D_delta_state, D_delta_biasCorrected;
-  Matrix93 D_delta_gravity;
-  Vector9 xi = state_i.correctPIM(biasCorrected, deltaTij_, n_gravity,
-                                  p().omegaCoriolis, p().use2ndOrderCoriolis, H1 ? &D_delta_state : nullptr,
-                                  H2 ? &D_delta_biasCorrected : nullptr,
-                                  H3 ? &D_delta_gravity : nullptr);
-
-  // Use retract to get back to NavState manifold
-  Matrix9 D_predict_state, D_predict_delta;
-  NavState state_j = state_i.retract(xi,
-                                     H1 ? &D_predict_state : nullptr,
-                                     H1 || H2 || H3 ? &D_predict_delta : nullptr);
-  if (H1)
-    *H1 = D_predict_state + D_predict_delta * D_delta_state;
-  if (H2)
-    *H2 = D_predict_delta * D_delta_biasCorrected * D_biasCorrected_bias;
-  if (H3)
-    *H3 = D_predict_delta * D_delta_gravity;
+  Matrix9 D_predict_biasCorrected;
+  NavState state_j =
+      state_i.predictPIM(biasCorrected, deltaTij_, n_gravity, p().omegaCoriolis,
+                         H1, H2 ? &D_predict_biasCorrected : nullptr, H3);
+  if (H2) *H2 = D_predict_biasCorrected * D_biasCorrected_bias;
   return state_j;
 }
 

--- a/gtsam/navigation/PreintegrationBase.cpp
+++ b/gtsam/navigation/PreintegrationBase.cpp
@@ -211,10 +211,27 @@ NavState PreintegrationBase::predict(const NavState& state_i,
                                              H2 ? &D_biasCorrected_bias : nullptr);
 
   Matrix9 D_predict_biasCorrected;
+  const auto& omegaCoriolis = p().omegaCoriolis;
   NavState state_j =
-      state_i.predictPIM(biasCorrected, deltaTij_, n_gravity, p().omegaCoriolis,
+      state_i.predictPIM(biasCorrected, deltaTij_, n_gravity, omegaCoriolis,
                          H1, H2 ? &D_predict_biasCorrected : nullptr, H3);
-  if (H2) *H2 = D_predict_biasCorrected * D_biasCorrected_bias;
+  if (H2) {
+    if (!omegaCoriolis || omegaCoriolis->isZero(0.0)) {
+      // In the inertial path D_predict_biasCorrected is block diagonal. Apply
+      // its three 3x3 blocks without forming a dense 9x9 by 9x6 product.
+      H2->topRows<3>().noalias() =
+          D_predict_biasCorrected.block<3, 3>(0, 0) *
+          D_biasCorrected_bias.topRows<3>();
+      H2->middleRows<3>(3).noalias() =
+          D_predict_biasCorrected.block<3, 3>(3, 3) *
+          D_biasCorrected_bias.middleRows<3>(3);
+      H2->bottomRows<3>().noalias() =
+          D_predict_biasCorrected.block<3, 3>(6, 6) *
+          D_biasCorrected_bias.bottomRows<3>();
+    } else {
+      *H2 = D_predict_biasCorrected * D_biasCorrected_bias;
+    }
+  }
   return state_j;
 }
 

--- a/gtsam/navigation/doc/ImuFactorWithGravity.ipynb
+++ b/gtsam/navigation/doc/ImuFactorWithGravity.ipynb
@@ -83,7 +83,7 @@
         "## Mathematical Formulation\n",
         "\n",
         "Both tangent- and manifold-preintegration accumulate the IMU measurements *without*\n",
-        "gravity; gravity enters only in the correction step `NavState::correctPIM` (the key\n",
+        "gravity; gravity enters only in the PIM's `predict` step (the key\n",
         "insight of Lupton and Sukkarieh: gravity can be changed, or estimated, at correction\n",
         "time without re-integrating). With $R_i$ the attitude of state $i$ and $\\Delta t$ the\n",
         "preintegration interval, the corrected tangent vector is\n",

--- a/gtsam/navigation/navigation.i
+++ b/gtsam/navigation/navigation.i
@@ -326,10 +326,15 @@ virtual class ImuFactor: gtsam::NoiseModelFactor {
 
   // Standard Interface
   const gtsam::PreintegratedImuMeasurements& preintegratedMeasurements() const;
-  gtsam::Vector evaluateError(const gtsam::Pose3& pose_i,
+  gtsam::Vector9 evaluateError(const gtsam::Pose3& pose_i,
       const gtsam::Vector3& vel_i,
       const gtsam::Pose3& pose_j, const gtsam::Vector3& vel_j,
-      const gtsam::imuBias::ConstantBias& bias) const;
+      const gtsam::imuBias::ConstantBias& bias_i,
+      gtsam::OptionalMatrixType H1 = nullptr,
+      gtsam::OptionalMatrixType H2 = nullptr,
+      gtsam::OptionalMatrixType H3 = nullptr,
+      gtsam::OptionalMatrixType H4 = nullptr,
+      gtsam::OptionalMatrixType H5 = nullptr) const;
 
   // enable serialization functionality
   void serialize() const;

--- a/gtsam/navigation/navigation.md
+++ b/gtsam/navigation/navigation.md
@@ -262,9 +262,10 @@ The key components are:
   $R_j=\operatorname{Exp}(w)R_i\Delta R_{ij}$.
 - `use2ndOrderCoriolis` remains in `PreintegrationParams` and its serialized
   layout for compatibility, but it is ignored: the exact model is used for
-  every nonzero `omegaCoriolis`. `NavState::coriolis` and
-  `PreintegratedRotation::integrateCoriolis` are retained as deprecated legacy
-  helpers and are no longer used internally.
+  every nonzero `omegaCoriolis`. `NavState::coriolis`, `NavState::correctPIM`,
+  and `PreintegratedRotation::integrateCoriolis` are retained behind the GTSAM
+  4.3 deprecation guard and are no longer used internally. Use a concrete
+  PIM's `predict` method instead.
 - `n_gravity` must be the gravity vector consistent with the chosen
   navigation-frame origin. If a local frame is translated, absorb the constant
   centrifugal contribution associated with that origin shift into

--- a/gtsam/navigation/tests/testImuFactor.cpp
+++ b/gtsam/navigation/tests/testImuFactor.cpp
@@ -292,7 +292,45 @@ static const NavState state2(x2, v2);
 } // namespace common
 
 /* ************************************************************************* */
-namespace ternary_linearization {
+namespace fixed_linearization {
+
+// Verifies fixed-size five-way IMU linearization changes only the factor type.
+TEST_PIM(ImuFactor, FiveWayLinearizationIsBitwiseIdentical) {
+  using namespace common;
+  PIM pim(testing::Params());
+  pim.integrateMeasurement(measuredAcc, measuredOmega, deltaT);
+
+  const Key pose1Key = 101, velocity1Key = 102, pose2Key = 103;
+  const Key velocity2Key = 104, biasKey = 105;
+  const ImuFactorT<PIM> factor(pose1Key, velocity1Key, pose2Key, velocity2Key,
+                               biasKey, pim);
+  const Values values{{pose1Key, genericValue(x1)},
+                      {velocity1Key, genericValue(v1)},
+                      {pose2Key, genericValue(x2)},
+                      {velocity2Key, genericValue(v2)},
+                      {biasKey, genericValue(kZeroBias)}};
+  const auto expectedBase = factor.NoiseModelFactor::linearize(values);
+  const auto actualBase = factor.linearize(values);
+  const auto expected = std::dynamic_pointer_cast<JacobianFactor>(expectedBase);
+  const auto actual = std::dynamic_pointer_cast<JacobianFactor>(actualBase);
+
+  const bool isFixed = static_cast<bool>(
+      std::dynamic_pointer_cast<FixedJacobianFactor<9, 6, 3, 6, 3, 6>>(
+          actualBase));
+  CHECK(isFixed);
+  CHECK(expected);
+  CHECK(actual);
+  CHECK(expected->keys() == actual->keys());
+  CHECK(expected->get_model() == actual->get_model());
+  CHECK((expected->getb().array() == actual->getb().array()).all());
+  auto expectedBlock = expected->begin();
+  auto actualBlock = actual->begin();
+  for (; expectedBlock != expected->end(); ++expectedBlock, ++actualBlock) {
+    CHECK((expected->getA(expectedBlock).array() ==
+           actual->getA(actualBlock).array())
+              .all());
+  }
+}
 
 // Verifies fixed-size IMU linearization changes only the concrete factor type.
 TEST_PIM(ImuFactor2, TernaryLinearizationIsBitwiseIdentical) {
@@ -327,7 +365,7 @@ TEST_PIM(ImuFactor2, TernaryLinearizationIsBitwiseIdentical) {
   }
 }
 
-}  // namespace ternary_linearization
+}  // namespace fixed_linearization
 /* ************************************************************************* */
 
 /* ************************************************************************* */
@@ -369,6 +407,16 @@ TEST_PIM(ImuFactor, PreintegrationBaseMethods) {
                 pim, state1, std::placeholders::_1, nullptr, nullptr),
       kZeroBias);
   EXPECT(assert_equal(eH2, aH2, derivativeTolerance));
+
+  // Exercise the direct rotating-Earth prediction's gravity Jacobian.
+  Matrix93 aH3;
+  pim.predict(state1, kZeroBias, p->n_gravity, {}, {}, aH3);
+  const Matrix eH3 = numericalDerivative11<NavState, Vector3>(
+      [&](const Vector3& gravity) {
+        return pim.predict(state1, kZeroBias, gravity);
+      },
+      p->n_gravity);
+  EXPECT(assert_equal(eH3, Matrix(aH3)));
 }
 
 /* ************************************************************************* */

--- a/gtsam/navigation/tests/testNavState.cpp
+++ b/gtsam/navigation/tests/testNavState.cpp
@@ -25,6 +25,7 @@
 #include <gtsam/base/testLie.h>
 #include <gtsam/geometry/SO3.h>
 #include <gtsam/navigation/NavState.h>
+#include <gtsam/navigation/TangentPreintegration.h>
 
 #include <cmath>
 
@@ -351,14 +352,8 @@ TEST(NavState, interpolate) {
 }
 
 /* ************************************************************************* */
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
 static const double dt = 2.0;
-#if defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#elif defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
 
 auto coriolis = std::bind(&NavState::coriolis, std::placeholders::_1, dt, kOmegaCoriolis,
               std::placeholders::_2, nullptr);
@@ -479,15 +474,33 @@ TEST(NavState, CorrectPIM) {
       numericalDerivative11<Vector9, Vector3>(correctPIMNoCoriolis, kGravity),
       Matrix(aH3NoCoriolis)));
 }
+#endif
 
 /* ************************************************************************* */
 namespace rotating_earth_fixture {
 
+/** Test adapter that supplies a chosen bias-corrected tangent PIM. */
+class RawTangentPIM : public TangentPreintegration {
+ public:
+  RawTangentPIM(const std::shared_ptr<Params>& params, const Vector9& pim,
+                double dt)
+      : TangentPreintegration(params) {
+    preintegrated_ = pim;
+    deltaTij_ = dt;
+  }
+};
+
 NavState predict(const NavState& initial, const Vector9& pim, double dt,
-                 const Vector3& gravity, const Vector3& omega,
+                 const Vector3& gravity, const std::optional<Vector3>& omega,
                  bool useSecondOrder = false) {
-  return initial.retract(
-      initial.correctPIM(pim, dt, gravity, omega, useSecondOrder));
+  auto params = std::make_shared<PreintegrationParams>(gravity);
+  params->omegaCoriolis = omega;
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
+  params->setUse2ndOrderCoriolis(useSecondOrder);
+#else
+  (void)useSecondOrder;
+#endif
+  return RawTangentPIM(params, pim, dt).predict(initial, {});
 }
 
 NavState exactEquation(const NavState& initial, const Vector9& pim, double dt,
@@ -566,18 +579,19 @@ TEST(NavState, ExactRotatingEarthEquation) {
 }
 
 // Verifies the legacy second-order flag no longer changes rotating prediction.
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
 TEST(NavState, ExactRotatingEarthIgnoresSecondOrderFlag) {
   const Vector9 pim{0.08, -0.04, 0.03, 1.2, -0.7, 0.4, 0.5, -0.2, 0.1};
   EXPECT(assert_equal(
       predict(kState1, pim, 2.5, kGravity, kOmegaCoriolis),
       predict(kState1, pim, 2.5, kGravity, kOmegaCoriolis, true), 1e-12));
 }
+#endif
 
 // Verifies absent and exactly zero Earth rates recover the fast inertial path.
 TEST(NavState, ExactRotatingEarthZeroLimit) {
   const Vector9 pim{0.08, -0.04, 0.03, 1.2, -0.7, 0.4, 0.5, -0.2, 0.1};
-  const NavState noRotation =
-      kState1.retract(kState1.correctPIM(pim, 2.5, kGravity, {}));
+  const NavState noRotation = predict(kState1, pim, 2.5, kGravity, {});
   EXPECT(assert_equal(noRotation,
                       predict(kState1, pim, 2.5, kGravity, Vector3::Zero()),
                       1e-12));
@@ -594,30 +608,27 @@ TEST(NavState, ExactRotatingEarthLongDurationReference) {
       integrateReference(initial, kDuration, gravity, omega);
   const NavState exact =
       predict(initial, Vector9::Zero(), kDuration, gravity, omega);
+  const double exactError = (exact.position() - reference.position()).norm() +
+                            (exact.velocity() - reference.velocity()).norm();
 
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
   const Vector9 inertial =
       initial.correctPIM(Vector9::Zero(), kDuration, gravity, {});
   const NavState approximate =
       initial.retract(inertial + initial.coriolis(kDuration, omega, true));
-  const double exactError = (exact.position() - reference.position()).norm() +
-                            (exact.velocity() - reference.velocity()).norm();
   const double approximateError =
       (approximate.position() - reference.position()).norm() +
       (approximate.velocity() - reference.velocity()).norm();
+#endif
   EXPECT(exactError < 1e-8);
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
   EXPECT(approximateError > 1e-2);
+#endif
 }
 
 }  // namespace rotating_earth_fixture
 /* ************************************************************************* */
 
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#elif defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-
-/* ************************************************************************* */
 TEST(NavState, Stream)
 {
   NavState state;


### PR DESCRIPTION
## Summary

- express shared `NavState` prediction as the exact inertial or rotating-frame transition `X_j = W * phi_dt(X_i) * U`
- specialize the common non-Coriolis path using its sparse block structure, while preserving exact Coriolis and centrifugal dynamics in the rotating path
- optimize the shared PIM bias-Jacobian chain using its inertial 3x3 block structure
- give the five-key `ImuFactor` its fixed `Vector9` output type and fixed-size `FixedJacobianFactor<9, 6, 3, 6, 3, 6>` linearization path, matching `ImuFactor2`
- deprecate the legacy `NavState::coriolis` and `NavState::correctPIM` helpers in favor of concrete PIM `predict()`

## Performance

Measured on top of #2759, the Galilean factor benchmarks improve further:

- factor residual: `115 ns` to `95 ns`
- factor residual with Jacobians: `954 ns` to `650 ns`

A focused benchmark of the shared non-Coriolis prediction path improves from `60.4 ns` to `39.0 ns` for values, from `365.9 ns` to `107.8 ns` with the bias Jacobian, and from `576.4 ns` to `118.6 ns` with both state and bias Jacobians. Rotating-Earth prediction also benefits from the shared refactor. Fixed-size five-key factor linearization is another 2-6% faster than the generic dynamic factor path.

Analytical outputs and Jacobians are unchanged.

## Compatibility

- existing PIM, `ImuFactor`, and `ImuFactor2` construction, serialization, naming, and APIs remain supported
- legacy `NavState::coriolis` and `NavState::correctPIM` remain available behind `GTSAM_ALLOW_DEPRECATED_SINCE_V43`; concrete PIM `predict()` is the supported replacement
- `use2ndOrderCoriolis` remains serialized for compatibility but exact rotating-frame prediction ignores it

## Testing

- `testNavState.run`
- `testImuFactor.run`
- `testImuFactorCovariance.run`
- `testCombinedImuFactor.run`
- `testCombinedImuFactorWithGravity.run`
- `testImuFactorWithGravity.run`
- `testGalileanImuFactor.run`
- `testTangentPreintegration.run`
- `testLieGroupPreintegration.run`
- `testManifoldPreintegration.run`
- `testSerializationNavigation.run`
- focused navigation tests with `GTSAM_ALLOW_DEPRECATED_SINCE_V43` disabled
- numerical prediction Jacobians checked for all four PIM backends, including rotating-Earth gravity derivatives
- `git diff --check`

This PR is intentionally stacked on #2759. After #2759 merges, it can be rebased and retargeted to `develop` without changing its scope.
