### PR TITLE
Optimize IMU measurement integration

### DIFF
--- a/gtsam/navigation/CombinedImuFactor.cpp
+++ b/gtsam/navigation/CombinedImuFactor.cpp
@@ -79,19 +79,130 @@ void PreintegratedCombinedMeasurementsT<PreintegrationType>::resetIntegration() 
   preintMeasCov_.setZero();
 }
 
-//------------------------------------------------------------------------------
-// sugar for derivative blocks
-#define D_R_R(H) (H)->block<3,3>(0,0)
-#define D_R_t(H) (H)->block<3,3>(0,3)
-#define D_R_v(H) (H)->block<3,3>(0,6)
-#define D_t_R(H) (H)->block<3,3>(3,0)
-#define D_t_t(H) (H)->block<3,3>(3,3)
-#define D_t_v(H) (H)->block<3,3>(3,6)
-#define D_v_R(H) (H)->block<3,3>(6,0)
-#define D_v_t(H) (H)->block<3,3>(6,3)
-#define D_v_v(H) (H)->block<3,3>(6,6)
-#define D_a_a(H) (H)->block<3,3>(9,9)
-#define D_g_g(H) (H)->block<3,3>(12,12)
+namespace {
+
+using Matrix15 = Eigen::Matrix<double, 15, 15>;
+
+/** Propagate Combined PIM covariance using its sparse 5-by-5 block form. */
+template <bool kTangentStructure>
+void propagateCombinedCovariance(Matrix15* covariance, const Matrix9& A,
+                                 const Matrix93& B, const Matrix93& C,
+                                 const PreintegrationCombinedParams& params,
+                                 double dt) {
+  // State blocks are ordered R,p,v,b_a,b_g. The Combined transition is
+  //
+  //       [ A00   0    0    0   C0 ]
+  //       [ A10  A11  A12  B1    0 ]
+  //   F = [ A20   0   A22  B2    0 ] .
+  //       [  0    0    0    I    0 ]
+  //       [  0    0    0    0    I ]
+  const auto A00 = A.block<3, 3>(0, 0);
+  const auto A10 = A.block<3, 3>(3, 0);
+  const auto A11 = A.block<3, 3>(3, 3);
+  const auto A12 = A.block<3, 3>(3, 6);
+  const auto A20 = A.block<3, 3>(6, 0);
+  const auto A22 = A.block<3, 3>(6, 6);
+  const auto B1 = B.middleRows<3>(3);
+  const auto B2 = B.bottomRows<3>();
+  const auto C0 = C.topRows<3>();
+
+  const Matrix15 oldCovariance = *covariance;
+  Matrix15 FP;
+  for (int column = 0; column < 5; ++column) {
+    const int offset = 3 * column;
+    FP.block<3, 3>(0, offset).noalias() =
+        A00 * oldCovariance.block<3, 3>(0, offset) +
+        C0 * oldCovariance.block<3, 3>(12, offset);
+    if constexpr (kTangentStructure) {
+      FP.block<3, 3>(3, offset).noalias() =
+          A10 * oldCovariance.block<3, 3>(0, offset) +
+          oldCovariance.block<3, 3>(3, offset) +
+          dt * oldCovariance.block<3, 3>(6, offset) +
+          B1 * oldCovariance.block<3, 3>(9, offset);
+      FP.block<3, 3>(6, offset).noalias() =
+          A20 * oldCovariance.block<3, 3>(0, offset) +
+          oldCovariance.block<3, 3>(6, offset) +
+          B2 * oldCovariance.block<3, 3>(9, offset);
+    } else {
+      FP.block<3, 3>(3, offset).noalias() =
+          A10 * oldCovariance.block<3, 3>(0, offset) +
+          A11 * oldCovariance.block<3, 3>(3, offset) +
+          A12 * oldCovariance.block<3, 3>(6, offset) +
+          B1 * oldCovariance.block<3, 3>(9, offset);
+      FP.block<3, 3>(6, offset).noalias() =
+          A20 * oldCovariance.block<3, 3>(0, offset) +
+          A22 * oldCovariance.block<3, 3>(6, offset) +
+          B2 * oldCovariance.block<3, 3>(9, offset);
+    }
+    FP.block<3, 3>(9, offset) = oldCovariance.block<3, 3>(9, offset);
+    FP.block<3, 3>(12, offset) = oldCovariance.block<3, 3>(12, offset);
+  }
+
+  // Evaluate only the lower blocks of F*P*F'. Each loop corresponds to one
+  // sparse block row of F above.
+  for (int row = 0; row < 5; ++row) {
+    const int offset = 3 * row;
+    covariance->block<3, 3>(offset, 0).noalias() =
+        FP.block<3, 3>(offset, 0) * A00.transpose() +
+        FP.block<3, 3>(offset, 12) * C0.transpose();
+  }
+  for (int row = 1; row < 5; ++row) {
+    const int offset = 3 * row;
+    if constexpr (kTangentStructure) {
+      covariance->block<3, 3>(offset, 3).noalias() =
+          FP.block<3, 3>(offset, 0) * A10.transpose() +
+          FP.block<3, 3>(offset, 3) + dt * FP.block<3, 3>(offset, 6) +
+          FP.block<3, 3>(offset, 9) * B1.transpose();
+    } else {
+      covariance->block<3, 3>(offset, 3).noalias() =
+          FP.block<3, 3>(offset, 0) * A10.transpose() +
+          FP.block<3, 3>(offset, 3) * A11.transpose() +
+          FP.block<3, 3>(offset, 6) * A12.transpose() +
+          FP.block<3, 3>(offset, 9) * B1.transpose();
+    }
+  }
+  for (int row = 2; row < 5; ++row) {
+    const int offset = 3 * row;
+    if constexpr (kTangentStructure) {
+      covariance->block<3, 3>(offset, 6).noalias() =
+          FP.block<3, 3>(offset, 0) * A20.transpose() +
+          FP.block<3, 3>(offset, 6) +
+          FP.block<3, 3>(offset, 9) * B2.transpose();
+    } else {
+      covariance->block<3, 3>(offset, 6).noalias() =
+          FP.block<3, 3>(offset, 0) * A20.transpose() +
+          FP.block<3, 3>(offset, 6) * A22.transpose() +
+          FP.block<3, 3>(offset, 9) * B2.transpose();
+    }
+  }
+  covariance->block<3, 3>(9, 9) = FP.block<3, 3>(9, 9);
+  covariance->block<3, 3>(12, 9) = FP.block<3, 3>(12, 9);
+  covariance->block<3, 3>(12, 12) = FP.block<3, 3>(12, 12);
+
+  // Add continuous-time measurement and bias noise to the affected blocks.
+  const Matrix3 scaledAccelerometerCovariance =
+      params.accelerometerCovariance / dt;
+  const Matrix3 scaledGyroscopeCovariance = params.gyroscopeCovariance / dt;
+  const Matrix3 B1Covariance = B1 * scaledAccelerometerCovariance;
+  const Matrix3 B2Covariance = B2 * scaledAccelerometerCovariance;
+  covariance->block<3, 3>(0, 0).noalias() +=
+      C0 * scaledGyroscopeCovariance * C0.transpose();
+  covariance->block<3, 3>(3, 3).noalias() +=
+      B1Covariance * B1.transpose() + dt * params.integrationCovariance;
+  covariance->block<3, 3>(6, 3).noalias() += B2Covariance * B1.transpose();
+  covariance->block<3, 3>(6, 6).noalias() += B2Covariance * B2.transpose();
+  covariance->block<3, 3>(9, 9).noalias() += dt * params.biasAccCovariance;
+  covariance->block<3, 3>(12, 12).noalias() += dt * params.biasOmegaCovariance;
+
+  for (int row = 1; row < 5; ++row) {
+    for (int column = 0; column < row; ++column) {
+      covariance->block<3, 3>(3 * column, 3 * row) =
+          covariance->block<3, 3>(3 * row, 3 * column).transpose();
+    }
+  }
+}
+
+}  // namespace
 
 //------------------------------------------------------------------------------
 template <class PreintegrationType>
@@ -109,57 +220,10 @@ void PreintegratedCombinedMeasurementsT<
   Matrix93 B, C;  // Jacobian of state wrpt accel bias and omega bias.
   PreintegrationType::update(measuredAcc, measuredOmega, dt, &A, &B, &C);
 
-  // Update preintegrated measurements covariance: as in [2] we consider a first
-  // order propagation that can be seen as a prediction phase in an EKF
-  // framework. In this implementation, in contrast to [2], we consider the
-  // uncertainty of the bias selection and we keep correlation between biases
-  // and preintegrated measurements
-
-  // Single Jacobians to propagate covariance
-  Matrix3 theta_H_omega = C.topRows<3>();
-  Matrix3 pos_H_acc = B.middleRows<3>(3);
-  Matrix3 vel_H_acc = B.bottomRows<3>();
-
-  // overall Jacobian wrt preintegrated measurements (df/dx)
-  Eigen::Matrix<double, 15, 15> F;
-  F.setZero();
-  F.block<9, 9>(0, 0) = A;
-  F.block<3, 3>(0, 12) = theta_H_omega;
-  F.block<3, 3>(3, 9) = pos_H_acc;
-  F.block<3, 3>(6, 9) = vel_H_acc;
-  F.block<6, 6>(9, 9) = I_6x6;
-
-  // Update the uncertainty on the state (matrix F in [4]).
-  preintMeasCov_ = F * preintMeasCov_ * F.transpose();
-
-  // propagate uncertainty
-  // TODO(frank): use noiseModel routine so we can have arbitrary noise models.
-  const Matrix3& aCov = this->p().accelerometerCovariance;
-  const Matrix3& wCov = this->p().gyroscopeCovariance;
-  const Matrix3& iCov = this->p().integrationCovariance;
-
-  // first order uncertainty propagation
-  // Optimized matrix mult: (1/dt) * G * measurementCovariance * G.transpose()
-  Eigen::Matrix<double, 15, 15> G_measCov_Gt;
-  G_measCov_Gt.setZero(15, 15);
-
-  // BLOCK DIAGONAL TERMS
-  D_R_R(&G_measCov_Gt) =
-      (theta_H_omega * (wCov / dt) * theta_H_omega.transpose());
-
-  D_t_t(&G_measCov_Gt) =
-      (pos_H_acc * (aCov / dt) * pos_H_acc.transpose()) + (dt * iCov);
-
-  D_v_v(&G_measCov_Gt) = (vel_H_acc * (aCov / dt) * vel_H_acc.transpose());
-
-  D_a_a(&G_measCov_Gt) = dt * this->p().biasAccCovariance;
-  D_g_g(&G_measCov_Gt) = dt * this->p().biasOmegaCovariance;
-
-  // OFF BLOCK DIAGONAL TERMS
-  D_t_v(&G_measCov_Gt) = (pos_H_acc * (aCov / dt) * vel_H_acc.transpose());
-  D_v_t(&G_measCov_Gt) = (vel_H_acc * (aCov / dt) * pos_H_acc.transpose());
-
-  preintMeasCov_.noalias() += G_measCov_Gt;
+  constexpr bool kTangentStructure =
+      std::is_same_v<PreintegrationType, TangentPreintegration>;
+  propagateCombinedCovariance<kTangentStructure>(&preintMeasCov_, A, B, C,
+                                                 this->p(), dt);
 }
 
 //------------------------------------------------------------------------------

--- a/gtsam/navigation/ImuFactor.cpp
+++ b/gtsam/navigation/ImuFactor.cpp
@@ -33,6 +33,133 @@ namespace gtsam {
 
 using namespace std;
 
+namespace {
+
+/** Propagate the symmetric PIM covariance using its fixed block sparsity. */
+template <bool kTangentStructure>
+void propagatePreintegratedCovariance(Matrix9* covariance, const Matrix9& A,
+                                      const Matrix93& B, const Matrix93& C,
+                                      const Matrix3& accelerometerCovariance,
+                                      const Matrix3& gyroscopeCovariance,
+                                      const Matrix3& integrationCovariance,
+                                      double dt, bool hasSensorPose) {
+  // Every PIM backend has the same transition sparsity in NavState ordering:
+  //
+  //                       [ A00   0    0  ]
+  //                   A = [ A10  A11  A12 ] .
+  //                       [ A20   0   A22 ]
+  //
+  // Form A*P by 3x3 blocks, skipping those structural zeros.
+  Matrix9 AP;
+  const Matrix9 oldCovariance = *covariance;
+  const auto A00 = A.block<3, 3>(0, 0);
+  const auto A10 = A.block<3, 3>(3, 0);
+  const auto A11 = A.block<3, 3>(3, 3);
+  const auto A12 = A.block<3, 3>(3, 6);
+  const auto A20 = A.block<3, 3>(6, 0);
+  const auto A22 = A.block<3, 3>(6, 6);
+  for (int column = 0; column < 3; ++column) {
+    const int offset = 3 * column;
+    AP.block<3, 3>(0, offset).noalias() =
+        A00 * oldCovariance.block<3, 3>(0, offset);
+    if constexpr (kTangentStructure) {
+      // Tangent uses A11=A22=I and A12=dt*I exactly.
+      AP.block<3, 3>(3, offset).noalias() =
+          A10 * oldCovariance.block<3, 3>(0, offset) +
+          oldCovariance.block<3, 3>(3, offset) +
+          dt * oldCovariance.block<3, 3>(6, offset);
+      AP.block<3, 3>(6, offset).noalias() =
+          A20 * oldCovariance.block<3, 3>(0, offset) +
+          oldCovariance.block<3, 3>(6, offset);
+    } else {
+      AP.block<3, 3>(3, offset).noalias() =
+          A10 * oldCovariance.block<3, 3>(0, offset) +
+          A11 * oldCovariance.block<3, 3>(3, offset) +
+          A12 * oldCovariance.block<3, 3>(6, offset);
+      AP.block<3, 3>(6, offset).noalias() =
+          A20 * oldCovariance.block<3, 3>(0, offset) +
+          A22 * oldCovariance.block<3, 3>(6, offset);
+    }
+  }
+
+  // P is symmetric, so evaluate only the six blocks on and below its diagonal.
+  covariance->block<3, 3>(0, 0).noalias() =
+      AP.block<3, 3>(0, 0) * A00.transpose();
+  covariance->block<3, 3>(3, 0).noalias() =
+      AP.block<3, 3>(3, 0) * A00.transpose();
+  covariance->block<3, 3>(6, 0).noalias() =
+      AP.block<3, 3>(6, 0) * A00.transpose();
+  if constexpr (kTangentStructure) {
+    covariance->block<3, 3>(3, 3).noalias() =
+        AP.block<3, 3>(3, 0) * A10.transpose() + AP.block<3, 3>(3, 3) +
+        dt * AP.block<3, 3>(3, 6);
+    covariance->block<3, 3>(6, 3).noalias() =
+        AP.block<3, 3>(6, 0) * A10.transpose() + AP.block<3, 3>(6, 3) +
+        dt * AP.block<3, 3>(6, 6);
+    covariance->block<3, 3>(6, 6).noalias() =
+        AP.block<3, 3>(6, 0) * A20.transpose() + AP.block<3, 3>(6, 6);
+  } else {
+    covariance->block<3, 3>(3, 3).noalias() =
+        AP.block<3, 3>(3, 0) * A10.transpose() +
+        AP.block<3, 3>(3, 3) * A11.transpose() +
+        AP.block<3, 3>(3, 6) * A12.transpose();
+    covariance->block<3, 3>(6, 3).noalias() =
+        AP.block<3, 3>(6, 0) * A10.transpose() +
+        AP.block<3, 3>(6, 3) * A11.transpose() +
+        AP.block<3, 3>(6, 6) * A12.transpose();
+    covariance->block<3, 3>(6, 6).noalias() =
+        AP.block<3, 3>(6, 0) * A20.transpose() +
+        AP.block<3, 3>(6, 6) * A22.transpose();
+  }
+
+  // Acceleration has no direct rotation component, so its measurement noise
+  // only touches the position/velocity covariance blocks.
+  const Matrix3 scaledAccelerometerCovariance = accelerometerCovariance / dt;
+  const auto B1 = B.middleRows<3>(3);
+  const auto B2 = B.bottomRows<3>();
+  Matrix3 B1Covariance, B2Covariance;
+  B1Covariance.noalias() = B1 * scaledAccelerometerCovariance;
+  B2Covariance.noalias() = B2 * scaledAccelerometerCovariance;
+  covariance->block<3, 3>(3, 3).noalias() += B1Covariance * B1.transpose();
+  covariance->block<3, 3>(6, 3).noalias() += B2Covariance * B1.transpose();
+  covariance->block<3, 3>(6, 6).noalias() += B2Covariance * B2.transpose();
+
+  const Matrix3 scaledGyroscopeCovariance = gyroscopeCovariance / dt;
+  const auto C0 = C.topRows<3>();
+  const auto C1 = C.middleRows<3>(3);
+  const auto C2 = C.bottomRows<3>();
+  Matrix3 C0Covariance;
+  C0Covariance.noalias() = C0 * scaledGyroscopeCovariance;
+  covariance->block<3, 3>(0, 0).noalias() += C0Covariance * C0.transpose();
+  const auto addLowerGyroscopeNoise = [&] {
+    Matrix3 C1Covariance, C2Covariance;
+    C1Covariance.noalias() = C1 * scaledGyroscopeCovariance;
+    C2Covariance.noalias() = C2 * scaledGyroscopeCovariance;
+    covariance->block<3, 3>(3, 0).noalias() += C1Covariance * C0.transpose();
+    covariance->block<3, 3>(3, 3).noalias() += C1Covariance * C1.transpose();
+    covariance->block<3, 3>(6, 0).noalias() += C2Covariance * C0.transpose();
+    covariance->block<3, 3>(6, 3).noalias() += C2Covariance * C1.transpose();
+    covariance->block<3, 3>(6, 6).noalias() += C2Covariance * C2.transpose();
+  };
+  if constexpr (kTangentStructure) {
+    // A sensor pose can couple angular velocity into acceleration, making the
+    // lower two gyroscope Jacobian blocks nonzero on this rare path.
+    if (hasSensorPose) addLowerGyroscopeNoise();
+  } else {
+    addLowerGyroscopeNoise();
+  }
+
+  covariance->block<3, 3>(3, 3).noalias() += integrationCovariance * dt;
+
+  // Mirror the computed lower off-diagonal blocks rather than accumulating
+  // cross-block round-off asymmetry over many samples.
+  covariance->block<3, 3>(0, 3) = covariance->block<3, 3>(3, 0).transpose();
+  covariance->block<3, 3>(0, 6) = covariance->block<3, 3>(6, 0).transpose();
+  covariance->block<3, 3>(3, 6) = covariance->block<3, 3>(6, 3).transpose();
+}
+
+}  // namespace
+
 //------------------------------------------------------------------------------
 // Inner class PreintegratedImuMeasurementsT
 //------------------------------------------------------------------------------
@@ -71,25 +198,14 @@ void PreintegratedImuMeasurementsT<PreintegrationType>::integrateMeasurement(
   Matrix93 B, C;  // Jacobian of state wrpt accel bias and omega bias respectively.
   PreintegrationType::update(measuredAcc, measuredOmega, dt, &A, &B, &C);
 
-  // first order covariance propagation:
-  // as in [2] we consider a first order propagation that can be seen as a
-  // prediction phase in EKF
-
-  // propagate uncertainty
-  // TODO(frank): use noiseModel routine so we can have arbitrary noise models.
-  const Matrix3& aCov = this->p().accelerometerCovariance;
-  const Matrix3& wCov = this->p().gyroscopeCovariance;
-  const Matrix3& iCov = this->p().integrationCovariance;
-
-  // (1/dt) allows to pass from continuous time noise to discrete time noise
-  // Update the uncertainty on the state (matrix A in [4]).
-  preintMeasCov_ = A * preintMeasCov_ * A.transpose();
-  // These 2 updates account for uncertainty on the IMU measurement (matrix B in [4]).
-  preintMeasCov_.noalias() += B * (aCov / dt) * B.transpose();
-  preintMeasCov_.noalias() += C * (wCov / dt) * C.transpose();
-
-  // NOTE(frank): (Gi*dt)*(C/dt)*(Gi'*dt), with Gi << Z_3x3, I_3x3, Z_3x3 (9x3 matrix)
-  preintMeasCov_.block<3, 3>(3, 3).noalias() += iCov * dt;
+  // First-order EKF covariance propagation. The fixed NavState block structure
+  // is shared by every backend, even though their nonzero blocks differ.
+  constexpr bool kTangentStructure =
+      std::is_same_v<PreintegrationType, TangentPreintegration>;
+  propagatePreintegratedCovariance<kTangentStructure>(
+      &preintMeasCov_, A, B, C, this->p().accelerometerCovariance,
+      this->p().gyroscopeCovariance, this->p().integrationCovariance, dt,
+      static_cast<bool>(this->p().body_P_sensor));
 }
 
 //------------------------------------------------------------------------------

--- a/gtsam/navigation/LieGroupPreintegration.cpp
+++ b/gtsam/navigation/LieGroupPreintegration.cpp
@@ -78,7 +78,6 @@ void LieGroupPreintegration::updateFactor(const Vector3& bodyAcceleration,
                                           OptionalJacobian<9, 9> F,
                                           OptionalJacobian<9, 3> G1,
                                           OptionalJacobian<9, 3> G2) {
-  const bool computeJacobians = F || G1 || G2;
   Matrix39 bodyVelocity_H_state;
   const Vector3 bodyVelocity =
       deltaXij_.bodyVelocity(F ? &bodyVelocity_H_state : nullptr);
@@ -90,29 +89,27 @@ void LieGroupPreintegration::updateFactor(const Vector3& bodyAcceleration,
   Matrix93 increment_H_rotation, increment_H_position, increment_H_velocity;
   const NavState incrementState = NavState::Create(
       incrementRotation, dt * bodyVelocity + halfDtSquared * bodyAcceleration,
-      dt * bodyAcceleration, computeJacobians ? &increment_H_rotation : nullptr,
-      computeJacobians ? &increment_H_position : nullptr,
-      computeJacobians ? &increment_H_velocity : nullptr);
+      dt * bodyAcceleration, G2 ? &increment_H_rotation : nullptr,
+      (F || G1) ? &increment_H_position : nullptr,
+      G1 ? &increment_H_velocity : nullptr);
 
-  Matrix9 tangent_H_increment;
-  const Vector9 increment = NavState::Logmap(
-      incrementState, computeJacobians ? &tangent_H_increment : nullptr);
-
-  Matrix9 newState_H_increment;
-  deltaXij_ = deltaXij_.expmap(
-      increment, F, computeJacobians ? &newState_H_increment : nullptr);
+  // Applying this increment through the Lie exponential would compute
+  //
+  //   deltaXij_ * Expmap(Logmap(incrementState)),
+  //
+  // which is exactly this composition. Its Jacobian with respect to the
+  // increment is the identity in right-local coordinates, so direct
+  // composition also cancels the corresponding Expmap and Logmap Jacobians.
+  deltaXij_ = deltaXij_.compose(incrementState, F);
 
   if (F) {
-    *F += newState_H_increment * tangent_H_increment * increment_H_position *
-          dt * bodyVelocity_H_state;
+    *F += increment_H_position * dt * bodyVelocity_H_state;
   }
   if (G1) {
-    *G1 = newState_H_increment * tangent_H_increment *
-          (increment_H_position * halfDtSquared + increment_H_velocity * dt);
+    *G1 = increment_H_position * halfDtSquared + increment_H_velocity * dt;
   }
   if (G2) {
-    *G2 = newState_H_increment * tangent_H_increment * increment_H_rotation *
-          incrementRotation_H_integratedOmega * dt;
+    *G2 = increment_H_rotation * incrementRotation_H_integratedOmega * dt;
   }
 }
 

--- a/gtsam/navigation/LieGroupPreintegration.cpp
+++ b/gtsam/navigation/LieGroupPreintegration.cpp
@@ -30,23 +30,46 @@ void LieGroupPreintegration::updateBiasJacobians(
     const Vector3& /*bodyOmega*/, double /*dt*/, const Matrix9& stateTransition,
     const Matrix93& accelerationJacobian, const Matrix93& omegaJacobian) {
   const Matrix3 oldRotationTranspose = oldRotation.transpose();
-  Matrix93 oldState_H_biasAcc, oldState_H_biasOmega;
-  oldState_H_biasAcc << Z_3x3, oldRotationTranspose * delPdelBiasAcc_,
-      oldRotationTranspose * delVdelBiasAcc_;
-  oldState_H_biasOmega << delRdelBiasOmega_,
-      oldRotationTranspose * delPdelBiasOmega_,
+  const Matrix3 oldPosition_H_biasAcc = oldRotationTranspose * delPdelBiasAcc_;
+  const Matrix3 oldVelocity_H_biasAcc = oldRotationTranspose * delVdelBiasAcc_;
+  const Matrix3 oldPosition_H_biasOmega =
+      oldRotationTranspose * delPdelBiasOmega_;
+  const Matrix3 oldVelocity_H_biasOmega =
       oldRotationTranspose * delVdelBiasOmega_;
 
-  const Matrix93 newState_H_biasAcc =
-      stateTransition * oldState_H_biasAcc - accelerationJacobian;
-  const Matrix93 newState_H_biasOmega =
-      stateTransition * oldState_H_biasOmega - omegaJacobian;
+  // The NavState transition has the exact block structure
+  //
+  //                       [ A00   0    0  ]
+  //                   A = [ A10  A11  A12 ] .
+  //                       [ A20   0   A22 ]
+  //
+  // Apply only its nonzero 3x3 blocks to the two bias Jacobians.
+  const auto A00 = stateTransition.block<3, 3>(0, 0);
+  const auto A10 = stateTransition.block<3, 3>(3, 0);
+  const auto A11 = stateTransition.block<3, 3>(3, 3);
+  const auto A12 = stateTransition.block<3, 3>(3, 6);
+  const auto A20 = stateTransition.block<3, 3>(6, 0);
+  const auto A22 = stateTransition.block<3, 3>(6, 6);
+  const Matrix3 newRotation_H_biasOmega =
+      A00 * delRdelBiasOmega_ - omegaJacobian.topRows<3>();
+  const Matrix3 newPosition_H_biasAcc = A11 * oldPosition_H_biasAcc +
+                                        A12 * oldVelocity_H_biasAcc -
+                                        accelerationJacobian.middleRows<3>(3);
+  const Matrix3 newVelocity_H_biasAcc =
+      A22 * oldVelocity_H_biasAcc - accelerationJacobian.bottomRows<3>();
+  const Matrix3 newPosition_H_biasOmega =
+      A10 * delRdelBiasOmega_ + A11 * oldPosition_H_biasOmega +
+      A12 * oldVelocity_H_biasOmega - omegaJacobian.middleRows<3>(3);
+  const Matrix3 newVelocity_H_biasOmega = A20 * delRdelBiasOmega_ +
+                                          A22 * oldVelocity_H_biasOmega -
+                                          omegaJacobian.bottomRows<3>();
+
   const Matrix3 newRotation = deltaXij_.R();
-  delRdelBiasOmega_ = newState_H_biasOmega.topRows<3>();
-  delPdelBiasAcc_ = newRotation * newState_H_biasAcc.middleRows<3>(3);
-  delPdelBiasOmega_ = newRotation * newState_H_biasOmega.middleRows<3>(3);
-  delVdelBiasAcc_ = newRotation * newState_H_biasAcc.bottomRows<3>();
-  delVdelBiasOmega_ = newRotation * newState_H_biasOmega.bottomRows<3>();
+  delRdelBiasOmega_ = newRotation_H_biasOmega;
+  delPdelBiasAcc_ = newRotation * newPosition_H_biasAcc;
+  delPdelBiasOmega_ = newRotation * newPosition_H_biasOmega;
+  delVdelBiasAcc_ = newRotation * newVelocity_H_biasAcc;
+  delVdelBiasOmega_ = newRotation * newVelocity_H_biasOmega;
 }
 
 /* ************************************************************************* */

--- a/gtsam/navigation/TangentPreintegration.cpp
+++ b/gtsam/navigation/TangentPreintegration.cpp
@@ -141,15 +141,31 @@ void TangentPreintegration::update(const Vector3& measuredAcc,
     *B *= D_correctedAcc_acc; // NOTE(frank): needs to be last
   }
 
-  // new_H_biasAcc = new_H_old * old_H_biasAcc + new_H_acc * acc_H_biasAcc
-  // where acc_H_biasAcc = -I_3x3, hence
-  // new_H_biasAcc = new_H_old * old_H_biasAcc - new_H_acc
-  preintegrated_H_biasAcc_ = (*A) * preintegrated_H_biasAcc_ - (*B);
+  // Propagate the two accumulated bias Jacobians using the exact Tangent
+  // transition structure instead of two dense 9x9-by-9x3 products:
+  //
+  //                       [ A00   0    0  ]
+  //                   A = [ A10   I   dtI ] .
+  //                       [ A20   0    I  ]
+  //
+  // Acceleration bias never affects rotation. Its top block therefore remains
+  // zero, while position and velocity need only additions and scaling by dt.
+  const Matrix3 oldAccelerationVelocity =
+      preintegrated_H_biasAcc_.bottomRows<3>();
+  preintegrated_H_biasAcc_.middleRows<3>(3) +=
+      oldAccelerationVelocity * dt - B->middleRows<3>(3);
+  preintegrated_H_biasAcc_.bottomRows<3>() -= B->bottomRows<3>();
 
-  // new_H_biasOmega = new_H_old * old_H_biasOmega + new_H_omega * omega_H_biasOmega
-  // where omega_H_biasOmega = -I_3x3, hence
-  // new_H_biasOmega = new_H_old * old_H_biasOmega - new_H_omega
-  preintegrated_H_biasOmega_ = (*A) * preintegrated_H_biasOmega_ - (*C);
+  // Gyroscope bias affects all three blocks. Save the old rotation block since
+  // the position and velocity updates both use it after rotation is replaced.
+  const Matrix3 oldOmegaRotation = preintegrated_H_biasOmega_.topRows<3>();
+  preintegrated_H_biasOmega_.topRows<3>().noalias() =
+      A->block<3, 3>(0, 0) * oldOmegaRotation - C->topRows<3>();
+  preintegrated_H_biasOmega_.middleRows<3>(3).noalias() +=
+      A->block<3, 3>(3, 0) * oldOmegaRotation +
+      dt * preintegrated_H_biasOmega_.bottomRows<3>() - C->middleRows<3>(3);
+  preintegrated_H_biasOmega_.bottomRows<3>().noalias() +=
+      A->block<3, 3>(6, 0) * oldOmegaRotation - C->bottomRows<3>();
 }
 
 //------------------------------------------------------------------------------

--- a/gtsam/navigation/tests/testImuFactorCovariance.cpp
+++ b/gtsam/navigation/tests/testImuFactorCovariance.cpp
@@ -66,6 +66,56 @@ std::shared_ptr<PreintegrationParams> makeParams() {
   return params;
 }
 
+template <class PIM>
+struct PimBackend;
+
+template <class Backend>
+struct PimBackend<PreintegratedImuMeasurementsT<Backend>> {
+  using Type = Backend;
+};
+
+template <class PIM>
+bool matchesDensePropagation(bool displacedSensor) {
+  auto params = makeParams();
+  const Matrix3 accelerometerRoot{
+      {0.02, 0.00, 0.00}, {0.01, 0.07, 0.00}, {-0.02, 0.03, 0.14}};
+  const Matrix3 gyroscopeRoot{
+      {0.01, 0.00, 0.00}, {-0.002, 0.04, 0.00}, {0.003, -0.01, 0.07}};
+  params->accelerometerCovariance =
+      accelerometerRoot * accelerometerRoot.transpose();
+  params->gyroscopeCovariance = gyroscopeRoot * gyroscopeRoot.transpose();
+  params->integrationCovariance = 1e-5 * I_3x3;
+  if (displacedSensor) {
+    params->body_P_sensor =
+        Pose3(Rot3::RzRyRx(0.1, -0.2, 0.3), Point3(0.2, -0.1, 0.05));
+  }
+
+  using Backend = typename PimBackend<PIM>::Type;
+  const imuBias::ConstantBias bias(Vector3(0.01, -0.02, 0.03),
+                                   Vector3(-0.004, 0.005, -0.006));
+  Backend backend(params, bias);
+  PIM pim(params, bias);
+  Matrix9 expected = Z_9x9;
+  for (size_t sample = 0; sample < 25; ++sample) {
+    const double scale = static_cast<double>(sample);
+    const Vector3 acceleration =
+        kMeasuredAcceleration + scale * Vector3(0.002, -0.001, 0.0005);
+    const Vector3 angularVelocity =
+        kMeasuredAngularVelocity + scale * Vector3(-0.0003, 0.0002, 0.0001);
+    Matrix9 A;
+    Matrix93 B, C;
+    backend.update(acceleration, angularVelocity, kDt, &A, &B, &C);
+    expected = A * expected * A.transpose();
+    expected.noalias() +=
+        B * (params->accelerometerCovariance / kDt) * B.transpose();
+    expected.noalias() +=
+        C * (params->gyroscopeCovariance / kDt) * C.transpose();
+    expected.block<3, 3>(3, 3).noalias() += params->integrationCovariance * kDt;
+    pim.integrateMeasurement(acceleration, angularVelocity, kDt);
+  }
+  return assert_equal(expected, pim.preintMeasCov(), 1e-12);
+}
+
 std::shared_ptr<PreintegrationCombinedParams> makeCombinedParams() {
   auto params = PreintegrationCombinedParams::MakeSharedD(10.0);
   params->accelerometerCovariance =
@@ -82,6 +132,83 @@ std::shared_ptr<PreintegrationCombinedParams> makeCombinedParams() {
           .cwiseProduct(kGyroscopeBiasRandomWalkSigmas)
           .asDiagonal();
   return params;
+}
+
+template <class PIM>
+struct CombinedPimBackend;
+
+template <class Backend>
+struct CombinedPimBackend<PreintegratedCombinedMeasurementsT<Backend>> {
+  using Type = Backend;
+};
+
+template <class PIM>
+bool matchesDenseCombinedPropagation(bool displacedSensor) {
+  auto params = makeCombinedParams();
+  const Matrix3 accelerometerRoot{
+      {0.02, 0.00, 0.00}, {0.01, 0.07, 0.00}, {-0.02, 0.03, 0.14}};
+  const Matrix3 gyroscopeRoot{
+      {0.01, 0.00, 0.00}, {-0.002, 0.04, 0.00}, {0.003, -0.01, 0.07}};
+  params->accelerometerCovariance =
+      accelerometerRoot * accelerometerRoot.transpose();
+  params->gyroscopeCovariance = gyroscopeRoot * gyroscopeRoot.transpose();
+  params->integrationCovariance = 1e-5 * I_3x3;
+  if (displacedSensor) {
+    params->body_P_sensor =
+        Pose3(Rot3::RzRyRx(0.1, -0.2, 0.3), Point3(0.2, -0.1, 0.05));
+  }
+
+  using Backend = typename CombinedPimBackend<PIM>::Type;
+  const imuBias::ConstantBias bias(Vector3(0.01, -0.02, 0.03),
+                                   Vector3(-0.004, 0.005, -0.006));
+  Backend backend(params, bias);
+  PIM pim(params, bias);
+  Matrix15 expected = Matrix15::Zero();
+  for (size_t sample = 0; sample < 25; ++sample) {
+    const double scale = static_cast<double>(sample);
+    const Vector3 acceleration =
+        kMeasuredAcceleration + scale * Vector3(0.002, -0.001, 0.0005);
+    const Vector3 angularVelocity =
+        kMeasuredAngularVelocity + scale * Vector3(-0.0003, 0.0002, 0.0001);
+    Matrix9 A;
+    Matrix93 B, C;
+    backend.update(acceleration, angularVelocity, kDt, &A, &B, &C);
+
+    Matrix15 F = Matrix15::Zero();
+    F.block<9, 9>(0, 0) = A;
+    F.block<3, 3>(0, 12) = C.topRows<3>();
+    F.block<3, 3>(3, 9) = B.middleRows<3>(3);
+    F.block<3, 3>(6, 9) = B.bottomRows<3>();
+    F.block<6, 6>(9, 9) = I_6x6;
+    expected = F * expected * F.transpose();
+
+    const Matrix3 position_H_acceleration = B.middleRows<3>(3);
+    const Matrix3 velocity_H_acceleration = B.bottomRows<3>();
+    const Matrix3 rotation_H_omega = C.topRows<3>();
+    const Matrix3 scaledAccelerometerCovariance =
+        params->accelerometerCovariance / kDt;
+    const Matrix3 scaledGyroscopeCovariance = params->gyroscopeCovariance / kDt;
+    expected.block<3, 3>(0, 0).noalias() += rotation_H_omega *
+                                            scaledGyroscopeCovariance *
+                                            rotation_H_omega.transpose();
+    expected.block<3, 3>(3, 3).noalias() +=
+        position_H_acceleration * scaledAccelerometerCovariance *
+            position_H_acceleration.transpose() +
+        kDt * params->integrationCovariance;
+    expected.block<3, 3>(3, 6).noalias() += position_H_acceleration *
+                                            scaledAccelerometerCovariance *
+                                            velocity_H_acceleration.transpose();
+    expected.block<3, 3>(6, 3).noalias() += velocity_H_acceleration *
+                                            scaledAccelerometerCovariance *
+                                            position_H_acceleration.transpose();
+    expected.block<3, 3>(6, 6).noalias() += velocity_H_acceleration *
+                                            scaledAccelerometerCovariance *
+                                            velocity_H_acceleration.transpose();
+    expected.block<3, 3>(9, 9).noalias() += kDt * params->biasAccCovariance;
+    expected.block<3, 3>(12, 12).noalias() += kDt * params->biasOmegaCovariance;
+    pim.integrateMeasurement(acceleration, angularVelocity, kDt);
+  }
+  return assert_equal(expected, pim.preintMeasCov(), 1e-12);
 }
 
 template <class PIM>
@@ -136,6 +263,19 @@ template <class PIM>
 Matrix9 theoreticalResidualCovariance(const PIM& pim) {
   const Matrix9 jacobian = residualChartJacobian(pim);
   return jacobian * pim.preintMeasCov() * jacobian.transpose();
+}
+
+// Checks optimized propagation against the original dense equation.
+TEST_PIM(ImuFactorCovariance, DensePropagationRegression) {
+  EXPECT(matchesDensePropagation<PIM>(false));
+  EXPECT(matchesDensePropagation<PIM>(true));
+}
+
+// Checks optimized Combined propagation against the original dense equation.
+TEST_PIM_WITH_COMBINED_BACKEND(ImuFactorCovariance,
+                               DenseCombinedPropagationRegression) {
+  EXPECT(matchesDenseCombinedPropagation<CombinedPIM>(false));
+  EXPECT(matchesDenseCombinedPropagation<CombinedPIM>(true));
 }
 
 template <class CombinedPIM>

--- a/timing/timeImuIntegration.cpp
+++ b/timing/timeImuIntegration.cpp
@@ -1,0 +1,185 @@
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file timeImuIntegration.cpp
+ * @brief Benchmark one-sample IMU preintegration for every PIM backend.
+ */
+
+#include <gtsam/navigation/CombinedImuFactor.h>
+#include <gtsam/navigation/GalileanImuFactor.h>
+#include <gtsam/navigation/ImuFactor.h>
+#include <gtsam/navigation/LieGroupPreintegration.h>
+#include <gtsam/navigation/ManifoldPreintegration.h>
+#include <gtsam/navigation/TangentPreintegration.h>
+
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "internal/TimingUtils.h"
+
+namespace {
+
+using gtsam::GalileanPreintegration;
+using gtsam::LieGroupPreintegration;
+using gtsam::ManifoldPreintegration;
+using gtsam::Matrix9;
+using gtsam::Matrix93;
+using gtsam::PreintegratedCombinedMeasurementsT;
+using gtsam::PreintegratedImuMeasurementsG;
+using gtsam::PreintegratedImuMeasurementsT;
+using gtsam::PreintegrationParams;
+using gtsam::TangentPreintegration;
+using gtsam::Vector3;
+using gtsam::imuBias::ConstantBias;
+using gtsam::timing::MedianPolicy;
+using gtsam::timing::TimingSummary;
+
+constexpr double kDt = 0.005;
+const Vector3 kMeasuredAcceleration{0.1, -0.2, 9.7};
+const Vector3 kMeasuredAngularVelocity{0.01, -0.02, 0.015};
+volatile double benchmarkSink = 0.0;
+
+std::shared_ptr<PreintegrationParams> makeParams() {
+  auto params = PreintegrationParams::MakeSharedU(9.81);
+  params->setAccelerometerCovariance(gtsam::I_3x3 * 1e-4);
+  params->setGyroscopeCovariance(gtsam::I_3x3 * 1e-6);
+  params->setIntegrationCovariance(gtsam::I_3x3 * 1e-8);
+  return params;
+}
+
+std::shared_ptr<gtsam::PreintegrationCombinedParams> makeCombinedParams() {
+  auto params = gtsam::PreintegrationCombinedParams::MakeSharedU(9.81);
+  params->setAccelerometerCovariance(gtsam::I_3x3 * 1e-4);
+  params->setGyroscopeCovariance(gtsam::I_3x3 * 1e-6);
+  params->setIntegrationCovariance(gtsam::I_3x3 * 1e-8);
+  params->setBiasAccCovariance(gtsam::I_3x3 * 1e-7);
+  params->setBiasOmegaCovariance(gtsam::I_3x3 * 1e-8);
+  return params;
+}
+
+template <class PreintegrationType>
+double timeBackendUpdate(size_t samples, size_t warmups, size_t repetitions) {
+  const auto params = makeParams();
+  const auto times = gtsam::timing::measureMilliseconds(
+      [&] {
+        PreintegrationType preintegration(params, ConstantBias());
+        Matrix9 A;
+        Matrix93 B, C;
+        for (size_t sample = 0; sample < samples; ++sample) {
+          preintegration.update(kMeasuredAcceleration, kMeasuredAngularVelocity,
+                                kDt, &A, &B, &C);
+        }
+        benchmarkSink +=
+            preintegration.deltaTij() + A(0, 0) + B(3, 0) + C(0, 0);
+      },
+      warmups, repetitions);
+  const TimingSummary summary =
+      gtsam::timing::summarizeSamples(times, MedianPolicy::kUpperMiddle);
+  return 1e6 * summary.median / static_cast<double>(samples);
+}
+
+template <class Pim>
+double timeFullIntegration(size_t samples, size_t warmups, size_t repetitions) {
+  const auto params = makeParams();
+  const auto times = gtsam::timing::measureMilliseconds(
+      [&] {
+        Pim pim(params, ConstantBias());
+        for (size_t sample = 0; sample < samples; ++sample) {
+          pim.integrateMeasurement(kMeasuredAcceleration,
+                                   kMeasuredAngularVelocity, kDt);
+        }
+        benchmarkSink += pim.deltaTij() + pim.preintMeasCov()(0, 0);
+      },
+      warmups, repetitions);
+  const TimingSummary summary =
+      gtsam::timing::summarizeSamples(times, MedianPolicy::kUpperMiddle);
+  return 1e6 * summary.median / static_cast<double>(samples);
+}
+
+template <class PreintegrationType, class Pim>
+void printBackend(const std::string& name, size_t samples, size_t warmups,
+                  size_t repetitions) {
+  const double backend =
+      timeBackendUpdate<PreintegrationType>(samples, warmups, repetitions);
+  const double full = timeFullIntegration<Pim>(samples, warmups, repetitions);
+  std::cout << std::left << std::setw(12) << name << std::right << std::fixed
+            << std::setprecision(1) << std::setw(14) << backend << std::setw(16)
+            << full << std::setw(16) << full - backend << '\n';
+}
+
+template <class Pim>
+void printCombinedBackend(const std::string& name, size_t samples,
+                          size_t warmups, size_t repetitions) {
+  const auto params = makeCombinedParams();
+  const auto times = gtsam::timing::measureMilliseconds(
+      [&] {
+        Pim pim(params, ConstantBias());
+        for (size_t sample = 0; sample < samples; ++sample) {
+          pim.integrateMeasurement(kMeasuredAcceleration,
+                                   kMeasuredAngularVelocity, kDt);
+        }
+        benchmarkSink += pim.deltaTij() + pim.preintMeasCov()(0, 0);
+      },
+      warmups, repetitions);
+  const TimingSummary summary =
+      gtsam::timing::summarizeSamples(times, MedianPolicy::kUpperMiddle);
+  const double full = 1e6 * summary.median / static_cast<double>(samples);
+  std::cout << std::left << std::setw(12) << name << std::right << std::fixed
+            << std::setprecision(1) << std::setw(20) << full << '\n';
+}
+
+}  // namespace
+
+int main(int argc, const char* argv[]) {
+  gtsam::timing::Arguments arguments(argc, argv);
+  if (arguments.helpRequested()) {
+    std::cout << "Usage: timeImuIntegration [--samples N] [--warmups N] "
+                 "[--repetitions N]\n";
+    return 0;
+  }
+  const size_t samples = arguments.sizeValue("--samples", 2000);
+  const size_t warmups = arguments.sizeValue("--warmups", 5);
+  const size_t repetitions = arguments.sizeValue("--repetitions", 21);
+  arguments.validateAllConsumed();
+
+  std::cout << "IMU integration benchmark (nanoseconds per sample)\n"
+            << std::left << std::setw(12) << "backend" << std::right
+            << std::setw(14) << "mean+bias" << std::setw(16) << "full PIM"
+            << std::setw(16) << "PIM overhead" << '\n';
+  printBackend<TangentPreintegration,
+               PreintegratedImuMeasurementsT<TangentPreintegration>>(
+      "Tangent", samples, warmups, repetitions);
+  printBackend<ManifoldPreintegration,
+               PreintegratedImuMeasurementsT<ManifoldPreintegration>>(
+      "Manifold", samples, warmups, repetitions);
+  printBackend<LieGroupPreintegration,
+               PreintegratedImuMeasurementsT<LieGroupPreintegration>>(
+      "LieGroup", samples, warmups, repetitions);
+  printBackend<GalileanPreintegration, PreintegratedImuMeasurementsG>(
+      "Galilean", samples, warmups, repetitions);
+
+  std::cout << "\nCombined IMU integration benchmark (nanoseconds per sample)\n"
+            << std::left << std::setw(12) << "backend" << std::right
+            << std::setw(20) << "full Combined PIM" << '\n';
+  printCombinedBackend<
+      PreintegratedCombinedMeasurementsT<TangentPreintegration>>(
+      "Tangent", samples, warmups, repetitions);
+  printCombinedBackend<
+      PreintegratedCombinedMeasurementsT<ManifoldPreintegration>>(
+      "Manifold", samples, warmups, repetitions);
+  printCombinedBackend<
+      PreintegratedCombinedMeasurementsT<LieGroupPreintegration>>(
+      "LieGroup", samples, warmups, repetitions);
+  return benchmarkSink == 0.0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

- add a focused Release benchmark for one-sample standard and Combined IMU preintegration across every supported backend
- replace dense 9x9 and 15x15 covariance products with their exact sparse 3x3 block equations, evaluating one triangle and mirroring the off-diagonal blocks
- specialize the default Tangent path for its exact identity and `dt * I` transition blocks and its ordinary no-sensor-pose gyro-noise structure
- propagate Tangent and LieGroup bias Jacobians through the same nonzero transition blocks instead of dense products
- replace the LieGroup backend's redundant `X * Expmap(Logmap(U))` update with the exactly equivalent direct composition `X * U`, canceling the corresponding 9x9 Expmap and Logmap Jacobians
- add dense-equation regressions for every standard and Combined backend, including correlated sensor noise and displaced/rotated IMU poses

## Performance

Powered Mac Release-build medians, using `10,000` measurements per trial, `20` warmups, and `41` repetitions:

| Standard PIM backend | Before (ns/sample) | After (ns/sample) | Improvement |
|---|---:|---:|---:|
| Tangent | 502.9 | 151.7 | 69.8% |
| Manifold | 467.4 | 317.4 | 32.1% |
| LieGroup | 1227.5 | 387.9 | 68.4% |
| Galilean | 555.3 | 406.7 | 26.8% |

| Combined PIM backend | Before (ns/sample) | After (ns/sample) | Improvement |
|---|---:|---:|---:|
| Tangent | 882.2 | 444.3 | 49.6% |
| Manifold | 842.8 | 570.5 | 32.3% |
| LieGroup | 1617.1 | 635.8 | 60.7% |

The optimized LieGroup mean-and-bias update takes 240.9 ns/sample, down from approximately 852 ns/sample immediately before the direct-composition change.

## Compatibility and correctness

- no public API or serialization changes
- covariance and bias-Jacobian equations are unchanged apart from floating-point evaluation order
- `Expmap(Logmap(U)) = U`, and its right-local Jacobian product is the identity, so the direct LieGroup composition preserves both the value and analytical derivatives
- dense-reference tests compare 25 sequential updates for all four standard and all three Combined backends, both with and without a nontrivial sensor pose
- an additional 20,000-case randomized comparison against the previous LieGroup implementation found worst errors of `2.0e-14` in state coordinates, `3.6e-14` in `F`, `1.1e-16` in `G1`, and `1.3e-15` in `G2`

## Testing

- `testTangentPreintegration.run`
- `testManifoldPreintegration.run`
- `testLieGroupPreintegration.run`
- `testGalileanImuFactor.run`
- `testImuFactorCovariance.run`
- `testImuFactor.run`
- `testCombinedImuFactor.run`
- `testCombinedImuFactorWithGravity.run`
- `testImuFactorWithGravity.run`
- `testCentripetal.run`
- `testSerializationNavigation.run`
- `git diff --check`

This PR is intentionally stacked on #2764. After #2764 merges, it can be rebased and retargeted without changing its scope.
