### PR TITLE
Add combined Galilean IMU factor

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -2,7 +2,7 @@ name: Nightly CI
 
 on:
   schedule:
-    - cron: "17 3 * * *"
+    - cron: "17 1 * * *"
       timezone: "America/New_York"
   workflow_dispatch:
 

--- a/gtsam/navigation/CombinedImuFactor.cpp
+++ b/gtsam/navigation/CombinedImuFactor.cpp
@@ -22,6 +22,7 @@
 
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/navigation/CombinedImuFactor.h>
+#include <gtsam/navigation/GalileanImuFactor.h>
 #include <gtsam/navigation/LieGroupPreintegration.h>
 #include <gtsam/navigation/ManifoldPreintegration.h>
 #include <gtsam/navigation/TangentPreintegration.h>
@@ -84,18 +85,20 @@ namespace {
 using Matrix15 = Eigen::Matrix<double, 15, 15>;
 
 /** Propagate Combined PIM covariance using its sparse 5-by-5 block form. */
-template <bool kTangentStructure>
+template <bool kTangentStructure, bool kFullGyroscopeStructure>
 void propagateCombinedCovariance(Matrix15* covariance, const Matrix9& A,
                                  const Matrix93& B, const Matrix93& C,
                                  const PreintegrationCombinedParams& params,
-                                 double dt) {
+                                 double dt, bool hasSensorPose) {
   // State blocks are ordered R,p,v,b_a,b_g. The Combined transition is
   //
   //       [ A00   0    0    0   C0 ]
-  //       [ A10  A11  A12  B1    0 ]
-  //   F = [ A20   0   A22  B2    0 ] .
+  //       [ A10  A11  A12  B1   C1 ]
+  //   F = [ A20   0   A22  B2   C2 ] .
   //       [  0    0    0    I    0 ]
   //       [  0    0    0    0    I ]
+  // C1 and C2 are nonzero for Galilean preintegration and when a displaced
+  // sensor couples angular velocity into corrected acceleration.
   const auto A00 = A.block<3, 3>(0, 0);
   const auto A10 = A.block<3, 3>(3, 0);
   const auto A11 = A.block<3, 3>(3, 3);
@@ -105,6 +108,9 @@ void propagateCombinedCovariance(Matrix15* covariance, const Matrix9& A,
   const auto B1 = B.middleRows<3>(3);
   const auto B2 = B.bottomRows<3>();
   const auto C0 = C.topRows<3>();
+  const auto C1 = C.middleRows<3>(3);
+  const auto C2 = C.bottomRows<3>();
+  const bool useFullGyroscope = kFullGyroscopeStructure || hasSensorPose;
 
   const Matrix15 oldCovariance = *covariance;
   Matrix15 FP;
@@ -134,6 +140,12 @@ void propagateCombinedCovariance(Matrix15* covariance, const Matrix9& A,
           A22 * oldCovariance.block<3, 3>(6, offset) +
           B2 * oldCovariance.block<3, 3>(9, offset);
     }
+    if (useFullGyroscope) {
+      FP.block<3, 3>(3, offset).noalias() +=
+          C1 * oldCovariance.block<3, 3>(12, offset);
+      FP.block<3, 3>(6, offset).noalias() +=
+          C2 * oldCovariance.block<3, 3>(12, offset);
+    }
     FP.block<3, 3>(9, offset) = oldCovariance.block<3, 3>(9, offset);
     FP.block<3, 3>(12, offset) = oldCovariance.block<3, 3>(12, offset);
   }
@@ -160,6 +172,10 @@ void propagateCombinedCovariance(Matrix15* covariance, const Matrix9& A,
           FP.block<3, 3>(offset, 6) * A12.transpose() +
           FP.block<3, 3>(offset, 9) * B1.transpose();
     }
+    if (useFullGyroscope) {
+      covariance->block<3, 3>(offset, 3).noalias() +=
+          FP.block<3, 3>(offset, 12) * C1.transpose();
+    }
   }
   for (int row = 2; row < 5; ++row) {
     const int offset = 3 * row;
@@ -173,6 +189,10 @@ void propagateCombinedCovariance(Matrix15* covariance, const Matrix9& A,
           FP.block<3, 3>(offset, 0) * A20.transpose() +
           FP.block<3, 3>(offset, 6) * A22.transpose() +
           FP.block<3, 3>(offset, 9) * B2.transpose();
+    }
+    if (useFullGyroscope) {
+      covariance->block<3, 3>(offset, 6).noalias() +=
+          FP.block<3, 3>(offset, 12) * C2.transpose();
     }
   }
   covariance->block<3, 3>(9, 9) = FP.block<3, 3>(9, 9);
@@ -191,6 +211,16 @@ void propagateCombinedCovariance(Matrix15* covariance, const Matrix9& A,
       B1Covariance * B1.transpose() + dt * params.integrationCovariance;
   covariance->block<3, 3>(6, 3).noalias() += B2Covariance * B1.transpose();
   covariance->block<3, 3>(6, 6).noalias() += B2Covariance * B2.transpose();
+  if (useFullGyroscope) {
+    const Matrix3 C0Covariance = C0 * scaledGyroscopeCovariance;
+    const Matrix3 C1Covariance = C1 * scaledGyroscopeCovariance;
+    const Matrix3 C2Covariance = C2 * scaledGyroscopeCovariance;
+    covariance->block<3, 3>(3, 0).noalias() += C1Covariance * C0.transpose();
+    covariance->block<3, 3>(3, 3).noalias() += C1Covariance * C1.transpose();
+    covariance->block<3, 3>(6, 0).noalias() += C2Covariance * C0.transpose();
+    covariance->block<3, 3>(6, 3).noalias() += C2Covariance * C1.transpose();
+    covariance->block<3, 3>(6, 6).noalias() += C2Covariance * C2.transpose();
+  }
   covariance->block<3, 3>(9, 9).noalias() += dt * params.biasAccCovariance;
   covariance->block<3, 3>(12, 12).noalias() += dt * params.biasOmegaCovariance;
 
@@ -222,8 +252,11 @@ void PreintegratedCombinedMeasurementsT<
 
   constexpr bool kTangentStructure =
       std::is_same_v<PreintegrationType, TangentPreintegration>;
-  propagateCombinedCovariance<kTangentStructure>(&preintMeasCov_, A, B, C,
-                                                 this->p(), dt);
+  constexpr bool kFullGyroscopeStructure =
+      std::is_same_v<PreintegrationType, GalileanPreintegration>;
+  propagateCombinedCovariance<kTangentStructure, kFullGyroscopeStructure>(
+      &preintMeasCov_, A, B, C, this->p(), dt,
+      static_cast<bool>(this->p().body_P_sensor));
 }
 
 //------------------------------------------------------------------------------
@@ -276,11 +309,15 @@ template class GTSAM_EXPORT PreintegratedCombinedMeasurementsT<ManifoldPreintegr
 template class GTSAM_EXPORT PreintegratedCombinedMeasurementsT<TangentPreintegration>;
 template class GTSAM_EXPORT
     PreintegratedCombinedMeasurementsT<LieGroupPreintegration>;
+template class GTSAM_EXPORT
+    PreintegratedCombinedMeasurementsT<GalileanPreintegration>;
 
 template class GTSAM_EXPORT CombinedImuFactorT<PreintegratedCombinedMeasurementsT<ManifoldPreintegration>>;
 template class GTSAM_EXPORT CombinedImuFactorT<PreintegratedCombinedMeasurementsT<TangentPreintegration>>;
 template class GTSAM_EXPORT CombinedImuFactorT<
     PreintegratedCombinedMeasurementsT<LieGroupPreintegration>>;
+template class GTSAM_EXPORT
+    CombinedImuFactorT<PreintegratedCombinedMeasurementsG>;
 
 // Instantiate operator<<
 template GTSAM_EXPORT std::ostream& operator<<<PreintegratedCombinedMeasurementsT<ManifoldPreintegration>>(
@@ -292,5 +329,9 @@ operator<< <PreintegratedCombinedMeasurementsT<LieGroupPreintegration>>(
     std::ostream& os,
     const CombinedImuFactorT<
         PreintegratedCombinedMeasurementsT<LieGroupPreintegration>>& f);
+template GTSAM_EXPORT std::ostream&
+operator<< <PreintegratedCombinedMeasurementsG>(
+    std::ostream& os,
+    const CombinedImuFactorT<PreintegratedCombinedMeasurementsG>& f);
 
 }  // namespace gtsam

--- a/gtsam/navigation/CombinedImuFactor.cpp
+++ b/gtsam/navigation/CombinedImuFactor.cpp
@@ -212,7 +212,6 @@ void propagateCombinedCovariance(Matrix15* covariance, const Matrix9& A,
   covariance->block<3, 3>(6, 3).noalias() += B2Covariance * B1.transpose();
   covariance->block<3, 3>(6, 6).noalias() += B2Covariance * B2.transpose();
   if (useFullGyroscope) {
-    const Matrix3 C0Covariance = C0 * scaledGyroscopeCovariance;
     const Matrix3 C1Covariance = C1 * scaledGyroscopeCovariance;
     const Matrix3 C2Covariance = C2 * scaledGyroscopeCovariance;
     covariance->block<3, 3>(3, 0).noalias() += C1Covariance * C0.transpose();

--- a/gtsam/navigation/CombinedImuFactor.h
+++ b/gtsam/navigation/CombinedImuFactor.h
@@ -151,8 +151,9 @@ class GTSAM_EXPORT PreintegratedCombinedMeasurementsT : public PreintegrationTyp
    * J_9 = \operatorname{diag}
    *       \left(J_r(\theta),\Delta R^T,\Delta R^T\right).
    * \f]
-   * ManifoldPreintegration and LieGroupPreintegration already propagate these
-   * rows in the residual chart, so their \f$J_9\f$ is identity.
+   * ManifoldPreintegration, LieGroupPreintegration, and
+   * GalileanPreintegration already propagate these rows in the residual chart,
+   * so their \f$J_9\f$ is identity.
    *
    * The final six propagated coordinates follow the bias change
    * \f$b_j-b_i\f$, whereas the factor residual is

--- a/gtsam/navigation/CombinedImuFactorWithGravity.cpp
+++ b/gtsam/navigation/CombinedImuFactorWithGravity.cpp
@@ -15,6 +15,7 @@
  **/
 
 #include <gtsam/navigation/CombinedImuFactorWithGravity.h>
+#include <gtsam/navigation/GalileanImuFactor.h>
 #include <gtsam/navigation/LieGroupPreintegration.h>
 #include <gtsam/navigation/ManifoldPreintegration.h>
 #include <gtsam/navigation/TangentPreintegration.h>
@@ -96,10 +97,14 @@ template class GTSAM_EXPORT CombinedImuFactorWithGravityT<PreintegratedCombinedM
 template class GTSAM_EXPORT CombinedImuFactorWithGravityT<PreintegratedCombinedMeasurementsT<TangentPreintegration>, Unit3>;
 template class GTSAM_EXPORT CombinedImuFactorWithGravityT<
     PreintegratedCombinedMeasurementsT<LieGroupPreintegration>, Unit3>;
+template class GTSAM_EXPORT
+    CombinedImuFactorWithGravityT<PreintegratedCombinedMeasurementsG, Unit3>;
 template class GTSAM_EXPORT CombinedImuFactorWithGravityT<PreintegratedCombinedMeasurementsT<ManifoldPreintegration>, Point3>;
 template class GTSAM_EXPORT CombinedImuFactorWithGravityT<PreintegratedCombinedMeasurementsT<TangentPreintegration>, Point3>;
 template class GTSAM_EXPORT CombinedImuFactorWithGravityT<
     PreintegratedCombinedMeasurementsT<LieGroupPreintegration>, Point3>;
+template class GTSAM_EXPORT
+    CombinedImuFactorWithGravityT<PreintegratedCombinedMeasurementsG, Point3>;
 
 template GTSAM_EXPORT std::ostream& operator<<(
     std::ostream& os, const CombinedImuFactorWithGravityT<PreintegratedCombinedMeasurementsT<ManifoldPreintegration>, Unit3>& f);
@@ -110,6 +115,10 @@ template GTSAM_EXPORT std::ostream& operator<<(
     const CombinedImuFactorWithGravityT<
         PreintegratedCombinedMeasurementsT<LieGroupPreintegration>, Unit3>& f);
 template GTSAM_EXPORT std::ostream& operator<<(
+    std::ostream& os,
+    const CombinedImuFactorWithGravityT<PreintegratedCombinedMeasurementsG,
+                                        Unit3>& f);
+template GTSAM_EXPORT std::ostream& operator<<(
     std::ostream& os, const CombinedImuFactorWithGravityT<PreintegratedCombinedMeasurementsT<ManifoldPreintegration>, Point3>& f);
 template GTSAM_EXPORT std::ostream& operator<<(
     std::ostream& os, const CombinedImuFactorWithGravityT<PreintegratedCombinedMeasurementsT<TangentPreintegration>, Point3>& f);
@@ -117,5 +126,9 @@ template GTSAM_EXPORT std::ostream& operator<<(
     std::ostream& os,
     const CombinedImuFactorWithGravityT<
         PreintegratedCombinedMeasurementsT<LieGroupPreintegration>, Point3>& f);
+template GTSAM_EXPORT std::ostream& operator<<(
+    std::ostream& os,
+    const CombinedImuFactorWithGravityT<PreintegratedCombinedMeasurementsG,
+                                        Point3>& f);
 
 }  // namespace gtsam

--- a/gtsam/navigation/GalileanImuFactor.h
+++ b/gtsam/navigation/GalileanImuFactor.h
@@ -29,6 +29,9 @@ using PreintegratedImuMeasurementsG =
 /// Five-way IMU factor using Galilean preintegration.
 using GalileanImuFactor = ImuFactorT<PreintegratedImuMeasurementsG>;
 
+/// Three-way NavState IMU factor using Galilean preintegration.
+using GalileanImuFactor2 = ImuFactor2T<PreintegratedImuMeasurementsG>;
+
 /// Galilean preintegration with combined IMU and bias covariance propagation.
 using PreintegratedCombinedMeasurementsG =
     PreintegratedCombinedMeasurementsT<GalileanPreintegration>;

--- a/gtsam/navigation/GalileanImuFactor.h
+++ b/gtsam/navigation/GalileanImuFactor.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <gtsam/navigation/CombinedImuFactor.h>
 #include <gtsam/navigation/GalileanPreintegration.h>
 #include <gtsam/navigation/ImuFactor.h>
 
@@ -27,5 +28,13 @@ using PreintegratedImuMeasurementsG =
 
 /// Five-way IMU factor using Galilean preintegration.
 using GalileanImuFactor = ImuFactorT<PreintegratedImuMeasurementsG>;
+
+/// Galilean preintegration with combined IMU and bias covariance propagation.
+using PreintegratedCombinedMeasurementsG =
+    PreintegratedCombinedMeasurementsT<GalileanPreintegration>;
+
+/// Six-way Combined IMU factor using Galilean preintegration.
+using GalileanCombinedImuFactor =
+    CombinedImuFactorT<PreintegratedCombinedMeasurementsG>;
 
 }  // namespace gtsam

--- a/gtsam/navigation/ImuFactor.h
+++ b/gtsam/navigation/ImuFactor.h
@@ -86,10 +86,10 @@ protected:
 
 public:
 
-  /// Default constructor for serialization and wrappers
-  PreintegratedImuMeasurementsT() {
-    this->resetIntegration();
-  }
+  /// Default constructor with default preintegration parameters.
+  PreintegratedImuMeasurementsT()
+      : PreintegratedImuMeasurementsT(
+            std::make_shared<PreintegrationParams>()) {}
 
  /**
    *  Constructor, initializes the class with no measurements

--- a/gtsam/navigation/doc/GalileanImuFactor.ipynb
+++ b/gtsam/navigation/doc/GalileanImuFactor.ipynb
@@ -583,7 +583,7 @@
     "\\left(J_k(\\beta-\\hat\\beta)\\right).\n",
     "$$\n",
     "\n",
-    "The six columns of $J_k$ are ordered $(b_a,b_\\omega)$, exactly like `ConstantBias::vector()`. There is no intermediate $10\\times10$ virtual-bias Jacobian and no final column permutation. Bias evolution remains the responsibility of its separate factor."
+    "The six columns of $J_k$ are ordered $(b_a,b_\\omega)$, exactly like `ConstantBias::vector()`. There is no intermediate $10\\times10$ virtual-bias Jacobian and no final column permutation. For the standard Galilean PIM, bias evolution remains the responsibility of a separate factor."
    ]
   },
   {
@@ -645,7 +645,9 @@
     "\n",
     "In the C++ interface this is `NavState::localCoordinates`; the argument order above is intentional because GTSAM's IMU residual asks how the measured state retracts to the prediction.\n",
     "\n",
-    "Conceptually this is a three-variable relation $(X_i,X_j,\\beta_i)$. The current `GalileanImuFactor` alias uses `ImuFactorT`, so each `NavState` is exposed as separate pose and velocity keys and the concrete graph factor has five keys. In both views there is one bias variable for the entire interval. Bias evolution remains a separate factor, exactly as for the standard `ImuFactor`."
+    "Conceptually this is a three-variable relation $(X_i,X_j,\\beta_i)$. The `GalileanImuFactor` alias uses `ImuFactorT`, so each `NavState` is exposed as separate pose and velocity keys and the concrete graph factor has five keys. In both views there is one bias variable for the entire interval. Bias evolution remains a separate factor, exactly as for the standard `ImuFactor`.\n",
+    "\n",
+    "When bias evolution and state--bias correlation should be modeled inside the IMU factor, use `PreintegratedCombinedMeasurementsG` with `GalileanCombinedImuFactor`. The Combined PIM retains the same Galilean mean while propagating a public $15\\times15$ covariance over $(R,p,v,b_a,b_\\omega)$. The Gal(3) clock coordinate is deterministic and is projected out exactly. The resulting six-way factor adds the six bias-random-walk residuals to the nine navigation residuals."
    ]
   },
   {
@@ -660,7 +662,7 @@
     "1. Construct preintegration parameters and a `PreintegratedImuMeasurementsG` at the current bias estimate.\n",
     "2. Integrate each accelerometer/gyroscope sample. The public API and all six-dimensional quantities use GTSAM order $(a,\\omega)$; the lift places them in Gal3 order internally. Each call advances the Galilean mean on the right and propagates its conditional covariance.\n",
     "3. Construct a `GalileanImuFactor` between the two pose/velocity pairs and the interval's bias key. During optimization, use the right-applied first-order bias correction rather than reintegrating immediately.\n",
-    "4. Add a separate factor between consecutive bias keys when bias random-walk evolution is part of the model.\n",
+    "4. Add a separate factor between consecutive bias keys when bias random-walk evolution is part of the model. Alternatively, construct `PreintegratedCombinedMeasurementsG` and a `GalileanCombinedImuFactor` to model the second bias key, its random walk, and state--bias correlation inside one factor.\n",
     "\n",
     "In schematic C++ form:\n",
     "\n",
@@ -672,6 +674,15 @@
     "}\n",
     "graph.emplace_shared<GalileanImuFactor>(\n",
     "    X(i), V(i), X(j), V(j), B(i), pim);\n",
+    "```\n",
+    "\n",
+    "The Combined alternative has the corresponding form:\n",
+    "\n",
+    "```cpp\n",
+    "PreintegratedCombinedMeasurementsG combinedPim(combinedParams, biasHat);\n",
+    "// Integrate the same samples as above.\n",
+    "graph.emplace_shared<GalileanCombinedImuFactor>(\n",
+    "    X(i), V(i), X(j), V(j), B(i), B(j), combinedPim);\n",
     "```\n",
     "\n",
     "The API is deliberately familiar; the essential differences are internal geometric choices. The executable Python example below follows the same sequence. It predicts a consistent endpoint only to demonstrate factor construction; in a real graph, $X_j$ is an optimizer variable rather than the prediction itself."

--- a/gtsam/navigation/navigation.i
+++ b/gtsam/navigation/navigation.i
@@ -380,6 +380,26 @@ virtual class GalileanImuFactor: gtsam::NoiseModelFactor {
   void serialize() const;
 };
 
+virtual class GalileanImuFactor2: gtsam::NoiseModelFactor {
+  GalileanImuFactor2();
+  GalileanImuFactor2(
+      gtsam::Key state_i, gtsam::Key state_j, gtsam::Key bias,
+      const gtsam::PreintegratedImuMeasurementsG& preintegratedMeasurements);
+
+  // Standard Interface
+  const gtsam::PreintegratedImuMeasurementsG&
+  preintegratedMeasurements() const;
+  gtsam::Vector9 evaluateError(
+      const gtsam::NavState& state_i, const gtsam::NavState& state_j,
+      const gtsam::imuBias::ConstantBias& bias_i,
+      gtsam::OptionalMatrixType H1 = nullptr,
+      gtsam::OptionalMatrixType H2 = nullptr,
+      gtsam::OptionalMatrixType H3 = nullptr) const;
+
+  // enable serialization functionality
+  void serialize() const;
+};
+
 #include <gtsam/navigation/ImuFactorWithGravity.h>
 template <PIM, GRAVITY>
 virtual class ImuFactorWithGravityT : gtsam::NoiseModelFactor {

--- a/gtsam/navigation/navigation.i
+++ b/gtsam/navigation/navigation.i
@@ -470,6 +470,49 @@ class PreintegratedCombinedMeasurements {
   void serialize() const;
 };
 
+template<PREINTEGRATION>
+class PreintegratedCombinedMeasurementsT {
+  PreintegratedCombinedMeasurementsT(
+      const gtsam::PreintegrationCombinedParams* p);
+  PreintegratedCombinedMeasurementsT(
+      const gtsam::PreintegrationCombinedParams* p,
+      const gtsam::imuBias::ConstantBias& biasHat);
+
+  void print(string s = "Preintegrated Measurements:") const;
+  bool equals(
+      const gtsam::PreintegratedCombinedMeasurementsT<PREINTEGRATION>& expected,
+      double tol) const;
+
+  @pybind_lambda
+  void integrateMeasurement(
+      const gtsam::Vector3& measuredAcc,
+      const gtsam::Vector3& measuredOmega, double dt);
+  void resetIntegration();
+  void resetIntegrationAndSetBias(
+      const gtsam::imuBias::ConstantBias& biasHat);
+
+  gtsam::Matrix preintMeasCov() const;
+  gtsam::Matrix residualCovariance() const;
+  @pybind_lambda
+  gtsam::Vector9 preintegrated() const;
+  double deltaTij() const;
+  gtsam::Rot3 deltaRij() const;
+  gtsam::Vector3 deltaPij() const;
+  gtsam::Vector3 deltaVij() const;
+  gtsam::Vector3 so3TangentAt(double t) const;
+  gtsam::Matrix deskewPoints(gtsam::ConstMatrixView points,
+      const gtsam::Vector3& velocity_i = gtsam::Vector3::Zero()) const;
+  gtsam::Matrix deskewPointsAtTimes(gtsam::ConstMatrixView points,
+      const gtsam::Vector& times,
+      const gtsam::Vector3& velocity_i = gtsam::Vector3::Zero()) const;
+  const gtsam::imuBias::ConstantBias& biasHat() const;
+  gtsam::Vector6 biasHatVector() const;
+  gtsam::NavState predict(const gtsam::NavState& state_i,
+      const gtsam::imuBias::ConstantBias& bias_i,
+      gtsam::OptionalJacobian<9, 9> H1 = nullptr,
+      gtsam::OptionalJacobian<9, 6> H2 = nullptr) const;
+};
+
 virtual class CombinedImuFactor: gtsam::NoiseModelFactor {
   CombinedImuFactor(gtsam::Key pose_i, gtsam::Key vel_i, gtsam::Key pose_j, gtsam::Key vel_j,
       gtsam::Key bias_i, gtsam::Key bias_j,
@@ -493,6 +536,34 @@ virtual class CombinedImuFactor: gtsam::NoiseModelFactor {
   // enable serialization functionality
   void serialize() const;
 };
+
+template<PIM>
+virtual class CombinedImuFactorT: gtsam::NoiseModelFactor {
+  CombinedImuFactorT(gtsam::Key pose_i, gtsam::Key vel_i,
+      gtsam::Key pose_j, gtsam::Key vel_j, gtsam::Key bias_i,
+      gtsam::Key bias_j, const PIM& preintegratedMeasurements);
+
+  const PIM& preintegratedMeasurements() const;
+  gtsam::Vector evaluateError(const gtsam::Pose3& pose_i,
+      const gtsam::Vector3& vel_i,
+      const gtsam::Pose3& pose_j, const gtsam::Vector3& vel_j,
+      const gtsam::imuBias::ConstantBias& bias_i,
+      const gtsam::imuBias::ConstantBias& bias_j,
+      gtsam::OptionalMatrixType H1 = nullptr,
+      gtsam::OptionalMatrixType H2 = nullptr,
+      gtsam::OptionalMatrixType H3 = nullptr,
+      gtsam::OptionalMatrixType H4 = nullptr,
+      gtsam::OptionalMatrixType H5 = nullptr,
+      gtsam::OptionalMatrixType H6 = nullptr) const;
+
+  void serialize() const;
+};
+
+@serializable
+typedef gtsam::PreintegratedCombinedMeasurementsT<
+    gtsam::GalileanPreintegration> PreintegratedCombinedMeasurementsG;
+typedef gtsam::CombinedImuFactorT<
+    gtsam::PreintegratedCombinedMeasurementsG> GalileanCombinedImuFactor;
 
 #include <gtsam/navigation/CombinedImuFactorWithGravity.h>
 template <PIM, GRAVITY>

--- a/gtsam/navigation/navigation.i
+++ b/gtsam/navigation/navigation.i
@@ -249,6 +249,7 @@ class PreintegratedImuMeasurements {
   gtsam::Rot3 deltaRij() const;
   gtsam::Vector3 deltaPij() const;
   gtsam::Vector3 deltaVij() const;
+  gtsam::NavState deltaXij() const;
   gtsam::Vector3 so3TangentAt(double t) const;
   gtsam::Matrix deskewPoints(gtsam::ConstMatrixView points,
       const gtsam::Vector3& velocity_i = gtsam::Vector3::Zero()) const;
@@ -283,7 +284,7 @@ class PreintegratedImuMeasurementsT {
   @pybind_lambda
   void integrateMeasurement(
       const gtsam::Vector3& measuredAcc,
-      const gtsam::Vector3& measuredOmega, double deltaT);
+      const gtsam::Vector3& measuredOmega, double dt);
   void resetIntegration();
   void resetIntegrationAndSetBias(const gtsam::imuBias::ConstantBias& biasHat);
 
@@ -295,6 +296,7 @@ class PreintegratedImuMeasurementsT {
   gtsam::Rot3 deltaRij() const;
   gtsam::Vector3 deltaPij() const;
   gtsam::Vector3 deltaVij() const;
+  gtsam::NavState deltaXij() const;
   gtsam::Vector3 so3TangentAt(double t) const;
   gtsam::Matrix deskewPoints(gtsam::ConstMatrixView points,
       const gtsam::Vector3& velocity_i = gtsam::Vector3::Zero()) const;

--- a/gtsam/navigation/navigation.md
+++ b/gtsam/navigation/navigation.md
@@ -144,12 +144,19 @@ classDiagram
     }
     LieGroupPreintegration --|> ManifoldPreintegration : specializes
 
+    class GalileanPreintegration {
+        +Gal3 deltaXij_
+        +update()
+    }
+    GalileanPreintegration --|> PreintegrationBase : implements
+
     class PreintegratedImuMeasurements {
         +Matrix9 preintMeasCov_
     }
     PreintegratedImuMeasurements --|> ManifoldPreintegration : inherits
     PreintegratedImuMeasurements --|> TangentPreintegration : inherits
     PreintegratedImuMeasurements --|> LieGroupPreintegration : inherits
+    PreintegratedImuMeasurements --|> GalileanPreintegration : inherits
 
     class PreintegratedCombinedMeasurements {
        +Matrix preintMeasCov_ (15x15)
@@ -157,6 +164,7 @@ classDiagram
     PreintegratedCombinedMeasurements --|> ManifoldPreintegration : inherits
     PreintegratedCombinedMeasurements --|> TangentPreintegration : inherits
     PreintegratedCombinedMeasurements --|> LieGroupPreintegration : inherits
+    PreintegratedCombinedMeasurements --|> GalileanPreintegration : inherits
 
     class ImuFactor {
         Pose3, Vector3, Pose3, Vector3, ConstantBias
@@ -171,7 +179,7 @@ classDiagram
 
 
     class CombinedImuFactor {
-        Pose3, Vector3, Pose3, Vector3, ConstantBias
+        Pose3, Vector3, Pose3, Vector3, ConstantBias, ConstantBias
          +evaluateError(...) Vector (15)
     }
     CombinedImuFactor ..> PreintegratedCombinedMeasurements : uses
@@ -217,15 +225,18 @@ The key components are:
         applying increments with the `NavState` $SE_2(3)$ exponential and by
         using the corresponding nonlinear group bias correction. It stores the
         result as a `NavState`.
+    *   `GalileanPreintegration`: Integrates the IMU mean on `Gal3` and uses a
+        left-invariant Galilean error. The deterministic clock coordinate is
+        projected out when forming the public `(R,p,v)` covariance.
 
 4.  **Preintegrated Measurements Containers**:
-    *   `PreintegratedImuMeasurements`: Stores the result of standard IMU preintegration along with its 9x9 covariance (`preintMeasCov_`).
-    *   `PreintegratedCombinedMeasurements`: Similar, but designed for the `CombinedImuFactor`. Stores the larger 15x15 covariance matrix (`preintMeasCov_`) that includes correlations with the bias terms.
+    *   `PreintegratedImuMeasurements`: Stores the result of standard IMU preintegration along with its 9x9 covariance (`preintMeasCov_`). The named Galilean specialization is `PreintegratedImuMeasurementsG`.
+    *   `PreintegratedCombinedMeasurements`: Similar, but designed for the `CombinedImuFactor`. Stores the larger 15x15 covariance matrix (`preintMeasCov_`) that includes correlations with the bias terms. The named Galilean specialization is `PreintegratedCombinedMeasurementsG`.
 
 5.  **IMU Factors (`...Factor`)**:
     * [ImuFactor](doc/ImuFactor.ipynb): A 5-way factor connecting previous pose/velocity, current pose/velocity, and a single (constant during the interval) bias estimate. Does *not* model bias evolution between factors.
     * [ImuFactor2](doc/ImuFactor.ipynb): A 3-way factor connecting previous `NavState`, current `NavState`, and a single bias estimate. Functionally similar to `ImuFactor` but uses the combined `NavState` type.
-    * [CombinedImuFactor](doc/CombinedImuFactor.ipynb): A 6-way factor connecting previous pose/velocity, current pose/velocity, previous bias, and current bias. *Includes* a model for bias random walk evolution between the two bias states.
+    * [CombinedImuFactor](doc/CombinedImuFactor.ipynb): A 6-way factor connecting previous pose/velocity, current pose/velocity, previous bias, and current bias. *Includes* a model for bias random walk evolution between the two bias states. `GalileanCombinedImuFactor` provides the same model with Galilean preintegration.
 
 ### Important notes
 - The compiled `DefaultPreintegrationType` used by `ImuFactor`s and
@@ -237,9 +248,13 @@ The key components are:
     - With both options disabled, `ManifoldPreintegration` is used. Select this
       backend for the implementation from
       {cite:t}`https://doi.org/10.1109/TRO.2016.2597321`.
-- If you wish to use any preintegration type other than the default, you must template your PIMs and factors on the desired preintegration type using the template-supporting classes `PreintegratedImuMeasurementsT`, `ImuFactorT`, `ImuFactor2T`, `PreintegratedCombinedMeasurementsT`, or `CombinedImuFactorT`.
-- Named backend selection is a C++ template API. Python and MATLAB expose only
-  the aliases selected when GTSAM is compiled.
+- If you wish to use any preintegration type other than the default, you can
+  template your PIMs and factors on the desired preintegration type using the
+  template-supporting classes `PreintegratedImuMeasurementsT`, `ImuFactorT`,
+  `ImuFactor2T`, `PreintegratedCombinedMeasurementsT`, or
+  `CombinedImuFactorT`. Public named specializations are available for the
+  standard PIM backends, and the Galilean standard and Combined types are
+  available in C++, Python, and MATLAB.
 - `NavState` stores tangent blocks in `(R,p,v)` order, whereas Brossard et al.
   write the $SE_2(3)$ matrix in `(R,v,p)` order. Translate the position and
   velocity blocks when comparing equations.

--- a/gtsam/navigation/tests/imuFactorTesting.h
+++ b/gtsam/navigation/tests/imuFactorTesting.h
@@ -116,9 +116,8 @@ namespace {
 
 #define RUN_GALILEAN_PIM_BACKEND(testGroup, testName, name) \
   using PG = PreintegratedImuMeasurementsG;                 \
-  using L = LieGroupPreintegration;                         \
-  using CL = PreintegratedCombinedMeasurementsT<L>;         \
-  testGroup##testName##Helper<PG, CL>(result_, name)
+  using CG = PreintegratedCombinedMeasurementsG;            \
+  testGroup##testName##Helper<PG, CG>(result_, name)
 
 #define TEST_PIM(testGroup, testName)                           \
   TEST_PIM_HELPER_DECLARATION(testGroup, testName);             \
@@ -128,13 +127,12 @@ namespace {
   }                                                             \
   TEST_PIM_HELPER_DECLARATION(testGroup, testName)
 
-// Use for comparisons that require a matching CombinedPIM backend. The
-// three-way Galilean factor deliberately keeps bias evolution separate and
-// therefore has no Galilean CombinedPIM counterpart.
-#define TEST_PIM_WITH_COMBINED_BACKEND(testGroup, testName) \
-  TEST_PIM_HELPER_DECLARATION(testGroup, testName);         \
-  TEST(testGroup, testName) {                               \
-    RUN_ESTABLISHED_PIM_BACKENDS(testGroup, testName);      \
-  }                                                         \
+// Use for comparisons that require a matching CombinedPIM backend.
+#define TEST_PIM_WITH_COMBINED_BACKEND(testGroup, testName)     \
+  TEST_PIM_HELPER_DECLARATION(testGroup, testName);             \
+  TEST(testGroup, testName) {                                   \
+    RUN_ESTABLISHED_PIM_BACKENDS(testGroup, testName);          \
+    RUN_GALILEAN_PIM_BACKEND(testGroup, testName, this->name_); \
+  }                                                             \
   TEST_PIM_HELPER_DECLARATION(testGroup, testName)
 }  // namespace

--- a/gtsam/navigation/tests/testCombinedImuFactor.cpp
+++ b/gtsam/navigation/tests/testCombinedImuFactor.cpp
@@ -217,7 +217,7 @@ TEST_PIM(CombinedImuFactor, PredictRotation) {
 
 /* ************************************************************************* */
 // Testing covariance to check if all the jacobians are accounted for.
-TEST_PIM(CombinedImuFactor, CheckCovariance) {
+TEST(CombinedImuFactor, CheckDefaultCovarianceRegression) {
   auto params = PreintegrationCombinedParams::MakeSharedU(9.81);
 
   params->setAccelerometerCovariance(pow(0.01, 2) * I_3x3);
@@ -227,7 +227,7 @@ TEST_PIM(CombinedImuFactor, CheckCovariance) {
 
   imuBias::ConstantBias currentBias;
 
-  CombinedPIM actual(params, currentBias);
+  PreintegratedCombinedMeasurements actual(params, currentBias);
 
   // Measurements
   Vector3 measuredAcc(0.1577, -0.8251, 9.6111);

--- a/gtsam/navigation/tests/testGalileanImuFactor.cpp
+++ b/gtsam/navigation/tests/testGalileanImuFactor.cpp
@@ -18,7 +18,10 @@
 #include <gtsam/base/MatrixConstants.h>
 #include <gtsam/base/TestableAssertions.h>
 #include <gtsam/base/numericalDerivative.h>
+#include <gtsam/inference/Symbol.h>
 #include <gtsam/navigation/GalileanImuFactor.h>
+#include <gtsam/nonlinear/Values.h>
+#include <gtsam/nonlinear/factorTesting.h>
 
 using namespace gtsam;
 
@@ -26,11 +29,25 @@ using namespace gtsam;
 namespace galilean_imu_factor {
 
 using PIM = PreintegratedImuMeasurementsG;
+using CombinedPIM = PreintegratedCombinedMeasurementsG;
 using Bias = imuBias::ConstantBias;
+using Matrix15 = Eigen::Matrix<double, 15, 15>;
+using Matrix16 = Eigen::Matrix<double, 16, 16>;
+using Matrix1516 = Eigen::Matrix<double, 15, 16>;
+
+using symbol_shorthand::B;
+using symbol_shorthand::V;
+using symbol_shorthand::X;
 
 static_assert(
     std::is_same_v<PIM,
                    PreintegratedImuMeasurementsT<GalileanPreintegration>>);
+static_assert(
+    std::is_same_v<CombinedPIM,
+                   PreintegratedCombinedMeasurementsT<GalileanPreintegration>>);
+static_assert(
+    std::is_same_v<GalileanCombinedImuFactor,
+                   CombinedImuFactorT<PreintegratedCombinedMeasurementsG>>);
 
 class TestPIM : public PIM {
  public:
@@ -52,6 +69,13 @@ PIM::Matrix910 NavStateProjector() {
   projector.block<3, 3>(0, 0) = I_3x3;
   projector.block<3, 3>(3, 6) = I_3x3;
   projector.block<3, 3>(6, 3) = I_3x3;
+  return projector;
+}
+
+Matrix1516 CombinedProjector() {
+  Matrix1516 projector = Matrix1516::Zero();
+  projector.block<9, 10>(0, 0) = NavStateProjector();
+  projector.block<6, 6>(9, 10) = I_6x6;
   return projector;
 }
 
@@ -195,6 +219,100 @@ TEST(GalileanImuFactor, CovarianceProjection) {
   const Matrix9 expectedNav = P * expectedGal * P.transpose();
   EXPECT(assert_equal(expectedNav, pim.preintMeasCov(), 1e-12));
   EXPECT(assert_equal(pim.preintMeasCov(), pim.residualCovariance(), 1e-12));
+}
+
+// Combined propagation equals a full (Gal3,bias) covariance recursion followed
+// by removal of deterministic time, including state-bias cross-covariances.
+TEST(GalileanCombinedImuFactor, CovarianceProjection) {
+  const auto params = PreintegrationCombinedParams::MakeSharedU(9.81);
+  params->accelerometerCovariance = (Vector3(1e-3, 2e-3, 3e-3)).asDiagonal();
+  params->gyroscopeCovariance = (Vector3(4e-4, 5e-4, 6e-4)).asDiagonal();
+  params->integrationCovariance = (Vector3(7e-5, 8e-5, 9e-5)).asDiagonal();
+  params->biasAccCovariance = (Vector3(2e-6, 3e-6, 4e-6)).asDiagonal();
+  params->biasOmegaCovariance = (Vector3(5e-7, 6e-7, 7e-7)).asDiagonal();
+
+  Matrix6 inputCovariance = Matrix6::Zero();
+  inputCovariance.topLeftCorner<3, 3>() = params->accelerometerCovariance;
+  inputCovariance.bottomRightCorner<3, 3>() = params->gyroscopeCovariance;
+
+  CombinedPIM pim(params);
+  Matrix16 expected = Matrix16::Zero();
+  const auto integrate = [&](const Vector3& acc, const Vector3& omega,
+                             double dt) {
+    PIM::Matrix10 rightJacobian;
+    const Gal3 increment = Gal3::Expmap(Input(acc, omega, dt), rightJacobian);
+    const PIM::Matrix10 transition = increment.inverse().AdjointMap();
+    const PIM::Matrix106 inputJacobian = rightJacobian * LiftJacobian() * dt;
+
+    Matrix16 F = Matrix16::Identity();
+    F.topLeftCorner<10, 10>() = transition;
+    F.block<10, 6>(0, 10) = inputJacobian;
+    expected = F * expected * F.transpose();
+    expected.topLeftCorner<10, 10>().noalias() +=
+        inputJacobian * (inputCovariance / dt) * inputJacobian.transpose();
+    expected.block<3, 3>(6, 6).noalias() += params->integrationCovariance * dt;
+    expected.block<3, 3>(10, 10).noalias() += params->biasAccCovariance * dt;
+    expected.block<3, 3>(13, 13).noalias() += params->biasOmegaCovariance * dt;
+    pim.integrateMeasurement(acc, omega, dt);
+  };
+
+  integrate(Vector3(0.2, -0.1, 0.4), Vector3(0.1, 0.3, -0.2), 0.04);
+  integrate(Vector3(-0.3, 0.5, 0.1), Vector3(-0.2, 0.1, 0.4), 0.07);
+
+  const Matrix15 projected =
+      CombinedProjector() * expected * CombinedProjector().transpose();
+  EXPECT(assert_equal(projected, pim.preintMeasCov(), 1e-12));
+  const Matrix15 native = pim.preintMeasCov();
+  const Matrix15 residual = pim.residualCovariance();
+  EXPECT((native.block<9, 6>(0, 9).norm() > 0.0));
+  EXPECT(assert_equal(Matrix9(residual.topLeftCorner<9, 9>()),
+                      Matrix9(native.topLeftCorner<9, 9>()), 1e-12));
+  EXPECT(assert_equal(Matrix6(residual.bottomRightCorner<6, 6>()),
+                      Matrix6(native.bottomRightCorner<6, 6>()), 1e-12));
+  EXPECT(assert_equal(Matrix96(residual.block<9, 6>(0, 9)),
+                      Matrix96(-native.block<9, 6>(0, 9)), 1e-12));
+}
+
+// The public six-way alias gives zero navigation residual at prediction and
+// exposes correct Jacobians for both endpoint states and both biases.
+TEST(GalileanCombinedImuFactor, ErrorAndJacobians) {
+  const auto params = PreintegrationCombinedParams::MakeSharedU(9.81);
+  params->accelerometerCovariance = 1e-4 * I_3x3;
+  params->gyroscopeCovariance = 1e-6 * I_3x3;
+  params->integrationCovariance = 1e-8 * I_3x3;
+  params->biasAccCovariance = 1e-7 * I_3x3;
+  params->biasOmegaCovariance = 1e-8 * I_3x3;
+
+  const Bias bias_i(Vector3(0.01, -0.02, 0.03), Vector3(-0.01, 0.02, 0.01));
+  const Bias bias_j(Vector3(0.011, -0.018, 0.027),
+                    Vector3(-0.012, 0.019, 0.013));
+  CombinedPIM pim(params, bias_i);
+  pim.integrateMeasurement(Vector3(0.2, -0.1, 9.7), Vector3(0.03, -0.02, 0.01),
+                           0.01);
+  pim.integrateMeasurement(Vector3(0.1, 0.2, 9.8), Vector3(-0.01, 0.04, 0.02),
+                           0.02);
+
+  const NavState state_i(Rot3::RzRyRx(0.1, -0.2, 0.3), Point3(1.0, -2.0, 0.5),
+                         Vector3(0.4, -0.1, 0.2));
+  const NavState state_j = pim.predict(state_i, bias_i);
+  const GalileanCombinedImuFactor factor(X(0), V(0), X(1), V(1), B(0), B(1),
+                                         pim);
+
+  const Vector15 error =
+      factor.evaluateError(state_i.pose(), state_i.velocity(), state_j.pose(),
+                           state_j.velocity(), bias_i, bias_j);
+  EXPECT(assert_equal(Vector(Vector9::Zero()), Vector(error.head<9>()), 1e-9));
+  EXPECT(assert_equal(Vector((bias_i - bias_j).vector()),
+                      Vector(error.tail<6>()), 1e-12));
+
+  Values values;
+  values.insert(X(0), state_i.pose());
+  values.insert(V(0), state_i.velocity());
+  values.insert(X(1), state_j.pose());
+  values.insert(V(1), state_j.velocity());
+  values.insert(B(0), bias_i);
+  values.insert(B(1), bias_j);
+  EXPECT_CORRECT_FACTOR_JACOBIANS(factor, values, 1e-6, 1e-5);
 }
 
 // Bias correction is applied on the right and exposes the complete Jacobian.

--- a/gtsam/navigation/tests/testGalileanImuFactor.cpp
+++ b/gtsam/navigation/tests/testGalileanImuFactor.cpp
@@ -95,6 +95,14 @@ Vector10 Input(const Vector3& acc, const Vector3& omega, double dt) {
   return input;
 }
 
+// The historical zero-argument constructor owns usable default parameters.
+TEST(GalileanImuFactor, DefaultConstruction) {
+  PIM pim;
+  EXPECT(pim.params() != nullptr);
+  pim.integrateMeasurement(Vector3::Zero(), Vector3::Zero(), 0.01);
+  DOUBLES_EQUAL(0.01, pim.deltaTij(), 1e-12);
+}
+
 // The physical input lift maps GTSAM (acceleration, angular rate) order into
 // Gal3 (angular rate, acceleration, position rate, clock rate) order.
 TEST(GalileanImuFactor, PhysicalInputLift) {

--- a/gtsam/navigation/tests/testImuFactorCovariance.cpp
+++ b/gtsam/navigation/tests/testImuFactorCovariance.cpp
@@ -176,34 +176,19 @@ bool matchesDenseCombinedPropagation(bool displacedSensor) {
 
     Matrix15 F = Matrix15::Zero();
     F.block<9, 9>(0, 0) = A;
-    F.block<3, 3>(0, 12) = C.topRows<3>();
-    F.block<3, 3>(3, 9) = B.middleRows<3>(3);
-    F.block<3, 3>(6, 9) = B.bottomRows<3>();
+    F.block<9, 3>(0, 9) = B;
+    F.block<9, 3>(0, 12) = C;
     F.block<6, 6>(9, 9) = I_6x6;
     expected = F * expected * F.transpose();
 
-    const Matrix3 position_H_acceleration = B.middleRows<3>(3);
-    const Matrix3 velocity_H_acceleration = B.bottomRows<3>();
-    const Matrix3 rotation_H_omega = C.topRows<3>();
     const Matrix3 scaledAccelerometerCovariance =
         params->accelerometerCovariance / kDt;
     const Matrix3 scaledGyroscopeCovariance = params->gyroscopeCovariance / kDt;
-    expected.block<3, 3>(0, 0).noalias() += rotation_H_omega *
-                                            scaledGyroscopeCovariance *
-                                            rotation_H_omega.transpose();
-    expected.block<3, 3>(3, 3).noalias() +=
-        position_H_acceleration * scaledAccelerometerCovariance *
-            position_H_acceleration.transpose() +
-        kDt * params->integrationCovariance;
-    expected.block<3, 3>(3, 6).noalias() += position_H_acceleration *
-                                            scaledAccelerometerCovariance *
-                                            velocity_H_acceleration.transpose();
-    expected.block<3, 3>(6, 3).noalias() += velocity_H_acceleration *
-                                            scaledAccelerometerCovariance *
-                                            position_H_acceleration.transpose();
-    expected.block<3, 3>(6, 6).noalias() += velocity_H_acceleration *
-                                            scaledAccelerometerCovariance *
-                                            velocity_H_acceleration.transpose();
+    expected.topLeftCorner<9, 9>().noalias() +=
+        B * scaledAccelerometerCovariance * B.transpose();
+    expected.topLeftCorner<9, 9>().noalias() +=
+        C * scaledGyroscopeCovariance * C.transpose();
+    expected.block<3, 3>(3, 3).noalias() += kDt * params->integrationCovariance;
     expected.block<3, 3>(9, 9).noalias() += kDt * params->biasAccCovariance;
     expected.block<3, 3>(12, 12).noalias() += kDt * params->biasOmegaCovariance;
     pim.integrateMeasurement(acceleration, angularVelocity, kDt);
@@ -224,10 +209,12 @@ PIM integrateIdealMeasurements(
 
 template <template <class> class PimTemplate, class PreintegrationType>
 Matrix9 residualChartJacobian(const PimTemplate<PreintegrationType>& pim) {
-  static_assert(std::is_same_v<PreintegrationType, ManifoldPreintegration> ||
-                    std::is_same_v<PreintegrationType, TangentPreintegration> ||
-                    std::is_same_v<PreintegrationType, LieGroupPreintegration>,
-                "Unsupported IMU preintegration backend");
+  static_assert(
+      std::is_same_v<PreintegrationType, ManifoldPreintegration> ||
+          std::is_same_v<PreintegrationType, TangentPreintegration> ||
+          std::is_same_v<PreintegrationType, LieGroupPreintegration> ||
+          std::is_same_v<PreintegrationType, GalileanPreintegration>,
+      "Unsupported IMU preintegration backend");
   if constexpr (std::is_same_v<PreintegrationType, TangentPreintegration>) {
     // Map additive [theta, position, velocity] perturbations into the
     // component-wise NavState chart used by the factor residual.

--- a/gtsam/navigation/tests/testImuFactorWithGravity.cpp
+++ b/gtsam/navigation/tests/testImuFactorWithGravity.cpp
@@ -140,7 +140,8 @@ TEST(ImuFactorWithGravity, ConstructorValidation) {
                   std::invalid_argument);
   // Without params there is no default magnitude for the Unit3 parametrization
   // to fall back on; an explicit one still works, and Point3 needs none:
-  const PreintegratedImuMeasurements noParams;
+  const PreintegratedImuMeasurements noParams(
+      std::shared_ptr<PreintegrationParams>{});
   CHECK_EXCEPTION(ImuFactorWithGravityDirection(X(1), V(1), X(2), V(2), B(1),
                                                 G(0), noParams),
                   std::invalid_argument);

--- a/gtsam/navigation/tests/testSerializationNavigation.cpp
+++ b/gtsam/navigation/tests/testSerializationNavigation.cpp
@@ -57,6 +57,10 @@ BOOST_CLASS_EXPORT_GUID(PreintegratedCombinedMeasurements,
 BOOST_CLASS_EXPORT_GUID(PreintegratedImuMeasurementsG,
                         "gtsam_PreintegratedImuMeasurementsG")
 BOOST_CLASS_EXPORT_GUID(GalileanImuFactor, "gtsam_GalileanImuFactor")
+BOOST_CLASS_EXPORT_GUID(PreintegratedCombinedMeasurementsG,
+                        "gtsam_PreintegratedCombinedMeasurementsG")
+BOOST_CLASS_EXPORT_GUID(GalileanCombinedImuFactor,
+                        "gtsam_GalileanCombinedImuFactor")
 
 /* ************************************************************************* */
 #ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
@@ -276,6 +280,17 @@ TEST(GalileanPreintegration, Serialization) {
   EXPECT(equalsObj(factor));
   EXPECT(equalsXML(factor));
   EXPECT(equalsBinary(factor));
+
+  const PreintegratedCombinedMeasurementsG combinedPim =
+      getPreintegratedMeasurements<PreintegratedCombinedMeasurementsG>();
+  EXPECT(equalsObj(combinedPim));
+  EXPECT(equalsXML(combinedPim));
+  EXPECT(equalsBinary(combinedPim));
+
+  const GalileanCombinedImuFactor combinedFactor(1, 2, 3, 4, 5, 6, combinedPim);
+  EXPECT(equalsObj(combinedFactor));
+  EXPECT(equalsXML(combinedFactor));
+  EXPECT(equalsBinary(combinedFactor));
 }
 
 }  // namespace galilean_serialization

--- a/python/gtsam/tests/test_GalileanImuFactor.py
+++ b/python/gtsam/tests/test_GalileanImuFactor.py
@@ -45,6 +45,7 @@ class TestGalileanImuFactor(GtsamTestCase):
             self.assertEqual((9, 9), pim.preintMeasCov().shape)
             self.assertEqual((9, 9), pim.residualCovariance().shape)
             self.assertEqual((6,), pim.biasHatVector().shape)
+            self.assertIsInstance(pim.deltaXij(), gtsam.NavState)
 
     def test_combined_preintegration(self):
         """The named Combined Galilean PIM exposes its complete 15D state."""
@@ -108,7 +109,8 @@ class TestGalileanImuFactor(GtsamTestCase):
             np.array([0.01, -0.02, 0.03]),
             np.array([-0.01, 0.02, 0.01]),
         )
-        pim = gtsam.PreintegratedImuMeasurementsG(params, bias_hat)
+        pim = gtsam.PreintegratedImuMeasurementsG(p=params,
+                                                   biasHat=bias_hat)
         measurements = (
             (np.array([0.2, -0.1, 9.7]),
              np.array([0.03, -0.02, 0.01]), 0.01),
@@ -116,7 +118,9 @@ class TestGalileanImuFactor(GtsamTestCase):
              np.array([-0.01, 0.04, 0.02]), 0.02),
         )
         for measured_acc, measured_omega, delta_t in measurements:
-            pim.integrateMeasurement(measured_acc, measured_omega, delta_t)
+            pim.integrateMeasurement(measuredAcc=measured_acc,
+                                     measuredOmega=measured_omega,
+                                     dt=delta_t)
 
         self.assertAlmostEqual(0.03, pim.deltaTij())
         self.assertEqual((9, 9), pim.preintMeasCov().shape)

--- a/python/gtsam/tests/test_GalileanImuFactor.py
+++ b/python/gtsam/tests/test_GalileanImuFactor.py
@@ -81,6 +81,9 @@ class TestGalileanImuFactor(GtsamTestCase):
         factor = gtsam.GalileanImuFactor(0, 1, 2, 3, 4, pim)
         self.assertEqualityOnPickleRoundtrip(factor)
 
+        navstate_factor = gtsam.GalileanImuFactor2(0, 1, 2, pim)
+        self.assertEqualityOnPickleRoundtrip(navstate_factor)
+
         combined_params = gtsam.PreintegrationCombinedParams.MakeSharedD(9.81)
         combined_params.setAccelerometerCovariance(1e-4 * np.eye(3))
         combined_params.setGyroscopeCovariance(1e-6 * np.eye(3))
@@ -144,6 +147,15 @@ class TestGalileanImuFactor(GtsamTestCase):
         np.testing.assert_allclose(error, np.zeros(9), atol=1e-9)
         self.assertTrue(
             factor.preintegratedMeasurements().equals(pim, 1e-12))
+
+        navstate_factor = gtsam.GalileanImuFactor2(
+            gtsam.symbol("x", 0), gtsam.symbol("x", 1),
+            gtsam.symbol("b", 0), pim)
+        navstate_error = navstate_factor.evaluateError(
+            state_i, state_j, bias_hat)
+        np.testing.assert_allclose(navstate_error, np.zeros(9), atol=1e-9)
+        self.assertTrue(
+            navstate_factor.preintegratedMeasurements().equals(pim, 1e-12))
 
     def test_combined_factor(self):
         """A predicted endpoint has zero Combined Galilean navigation error."""

--- a/python/gtsam/tests/test_GalileanImuFactor.py
+++ b/python/gtsam/tests/test_GalileanImuFactor.py
@@ -46,6 +46,23 @@ class TestGalileanImuFactor(GtsamTestCase):
             self.assertEqual((9, 9), pim.residualCovariance().shape)
             self.assertEqual((6,), pim.biasHatVector().shape)
 
+    def test_combined_preintegration(self):
+        """The named Combined Galilean PIM exposes its complete 15D state."""
+        params = gtsam.PreintegrationCombinedParams.MakeSharedD(9.81)
+        params.setAccelerometerCovariance(1e-4 * np.eye(3))
+        params.setGyroscopeCovariance(1e-6 * np.eye(3))
+        params.setIntegrationCovariance(1e-8 * np.eye(3))
+        params.setBiasAccCovariance(1e-7 * np.eye(3))
+        params.setBiasOmegaCovariance(1e-8 * np.eye(3))
+        pim = gtsam.PreintegratedCombinedMeasurementsG(params)
+        pim.integrateMeasurement(np.array([0.2, -0.1, 9.7]),
+                                 np.array([0.03, -0.02, 0.01]), 0.01)
+
+        self.assertAlmostEqual(0.01, pim.deltaTij())
+        self.assertEqual((9,), pim.preintegrated().shape)
+        self.assertEqual((15, 15), pim.preintMeasCov().shape)
+        self.assertEqual((15, 15), pim.residualCovariance().shape)
+
     @unittest.skipUnless(
         hasattr(gtsam.PreintegratedImuMeasurementsG, "serialize"),
         "Serialization not enabled")
@@ -62,6 +79,23 @@ class TestGalileanImuFactor(GtsamTestCase):
 
         factor = gtsam.GalileanImuFactor(0, 1, 2, 3, 4, pim)
         self.assertEqualityOnPickleRoundtrip(factor)
+
+        combined_params = gtsam.PreintegrationCombinedParams.MakeSharedD(9.81)
+        combined_params.setAccelerometerCovariance(1e-4 * np.eye(3))
+        combined_params.setGyroscopeCovariance(1e-6 * np.eye(3))
+        combined_params.setIntegrationCovariance(1e-8 * np.eye(3))
+        combined_params.setBiasAccCovariance(1e-7 * np.eye(3))
+        combined_params.setBiasOmegaCovariance(1e-8 * np.eye(3))
+        combined_pim = gtsam.PreintegratedCombinedMeasurementsG(
+            combined_params)
+        combined_pim.integrateMeasurement(np.array([0.2, -0.1, 9.7]),
+                                          np.array([0.03, -0.02, 0.01]),
+                                          0.01)
+        self.assertEqualityOnPickleRoundtrip(combined_pim)
+
+        combined_factor = gtsam.GalileanCombinedImuFactor(
+            0, 1, 2, 3, 4, 5, combined_pim)
+        self.assertEqualityOnPickleRoundtrip(combined_factor)
 
     def test_preintegrate_predict_and_factor(self):
         """A predicted endpoint has zero Galilean IMU factor error."""
@@ -104,6 +138,40 @@ class TestGalileanImuFactor(GtsamTestCase):
             state_i.pose(), state_i.velocity(),
             state_j.pose(), state_j.velocity(), bias_hat)
         np.testing.assert_allclose(error, np.zeros(9), atol=1e-9)
+        self.assertTrue(
+            factor.preintegratedMeasurements().equals(pim, 1e-12))
+
+    def test_combined_factor(self):
+        """A predicted endpoint has zero Combined Galilean navigation error."""
+        params = gtsam.PreintegrationCombinedParams.MakeSharedD(9.81)
+        params.setAccelerometerCovariance(1e-4 * np.eye(3))
+        params.setGyroscopeCovariance(1e-6 * np.eye(3))
+        params.setIntegrationCovariance(1e-8 * np.eye(3))
+        params.setBiasAccCovariance(1e-7 * np.eye(3))
+        params.setBiasOmegaCovariance(1e-8 * np.eye(3))
+        bias = gtsam.imuBias.ConstantBias(
+            np.array([0.01, -0.02, 0.03]),
+            np.array([-0.01, 0.02, 0.01]),
+        )
+        pim = gtsam.PreintegratedCombinedMeasurementsG(params, bias)
+        pim.integrateMeasurement(np.array([0.2, -0.1, 9.7]),
+                                 np.array([0.03, -0.02, 0.01]), 0.01)
+
+        state_i = gtsam.NavState(
+            gtsam.Rot3.RzRyRx(0.1, -0.2, 0.3),
+            np.array([1.0, -2.0, 0.5]),
+            np.array([0.4, -0.1, 0.2]),
+        )
+        state_j = pim.predict(state_i, bias)
+        factor = gtsam.GalileanCombinedImuFactor(
+            gtsam.symbol("x", 0), gtsam.symbol("v", 0),
+            gtsam.symbol("x", 1), gtsam.symbol("v", 1),
+            gtsam.symbol("b", 0), gtsam.symbol("b", 1), pim)
+        error = factor.evaluateError(
+            state_i.pose(), state_i.velocity(), state_j.pose(),
+            state_j.velocity(), bias, bias)
+
+        np.testing.assert_allclose(error, np.zeros(15), atol=1e-9)
         self.assertTrue(
             factor.preintegratedMeasurements().equals(pim, 1e-12))
 

--- a/timing/timeImuIntegration.cpp
+++ b/timing/timeImuIntegration.cpp
@@ -35,6 +35,7 @@ using gtsam::LieGroupPreintegration;
 using gtsam::ManifoldPreintegration;
 using gtsam::Matrix9;
 using gtsam::Matrix93;
+using gtsam::PreintegratedCombinedMeasurementsG;
 using gtsam::PreintegratedCombinedMeasurementsT;
 using gtsam::PreintegratedImuMeasurementsG;
 using gtsam::PreintegratedImuMeasurementsT;
@@ -181,5 +182,7 @@ int main(int argc, const char* argv[]) {
   printCombinedBackend<
       PreintegratedCombinedMeasurementsT<LieGroupPreintegration>>(
       "LieGroup", samples, warmups, repetitions);
+  printCombinedBackend<PreintegratedCombinedMeasurementsG>(
+      "Galilean", samples, warmups, repetitions);
   return benchmarkSink == 0.0 ? 1 : 0;
 }


### PR DESCRIPTION
## Summary

- add the public C++ aliases `PreintegratedCombinedMeasurementsG` and `GalileanCombinedImuFactor`
- reuse the existing Combined PIM and six-way factor templates with `GalileanPreintegration`, retaining the public 15D `(R,p,v,b_a,b_omega)` covariance and residual
- project the deterministic Gal(3) clock coordinate out of the full `(Gal3,bias)` covariance exactly
- complete Combined covariance propagation for gyroscope Jacobians with position and velocity blocks, which occur intrinsically for Galilean preintegration and with displaced IMU sensors
- instantiate the generic Galilean Combined-with-gravity template combinations without adding named gravity-factor aliases
- expose both new named types through the canonical Python and MATLAB template/typedef wrappers, including C++ archive serialization and Python pickle support
- update the Galilean guide and navigation overview with the Combined factor as the alternative for jointly modeling bias evolution and state--bias correlation

## Public behavior

`PreintegratedCombinedMeasurementsG` accepts `PreintegrationCombinedParams`, integrates the same Galilean mean as `PreintegratedImuMeasurementsG`, and propagates a 15x15 covariance. `GalileanCombinedImuFactor` connects pose, velocity, and bias at both endpoints and returns nine Galilean navigation residuals followed by six bias-random-walk residuals.

Existing defaults, standard Combined types, and `GalileanImuFactor` are unchanged.

## Correctness

- compare multi-step Combined propagation against a full dense 16D `(Gal3,bias)` recursion followed by exact projection to the public 15D chart
- verify nonzero state--bias cross-covariances and the residual-chart conversion
- run the shared Combined backend tests with the matching Galilean Combined PIM, including mean agreement, zero-bias-random-walk covariance agreement, dense sparse-propagation regressions, and theoretical and Monte Carlo residual covariance checks
- validate the six-way factor at a predicted endpoint and numerically check all six analytical Jacobians
- round-trip the PIM and factor through text, XML, binary, and Python pickle serialization

## Performance

Powered Mac Release-build medians using 10,000 measurements per trial, 20 warmups, and 41 repetitions. The table reports the median of three benchmark-run medians; the #2765 column is the lower PR's published baseline.

| Combined PIM backend | #2765 (ns/sample) | This PR (ns/sample) |
|---|---:|---:|
| Tangent | 444.3 | 443.6 |
| Manifold | 570.5 | 563.7 |
| LieGroup | 635.8 | 637.1 |
| Galilean | -- | 700.4 |

The existing Combined backends remain within run-to-run noise of #2765.

## Testing

- `testCombinedImuFactor.run`
- `testGalileanImuFactor.run`
- `testImuFactorCovariance.run`
- `testSerializationNavigation.run`
- `testCombinedImuFactorWithGravity.run`
- `testImuFactor.run`
- `testImuFactorWithGravity.run`
- `testCentripetal.run`
- `conda run -n py312 python -m pytest python/gtsam/tests/test_GalileanImuFactor.py -q`
- `python-install` and generated-stub inspection
- `gtsam_matlab_wrapper` plus direct MATLAB construction smoke test
- `git diff --check`

This PR is intentionally stacked on #2765 and should be rebased/retargeted as the lower PR merges.
