### PR TITLE
Add wrapped API walkthrough notebooks

### DIFF
--- a/gtsam/discrete/doc/DecisionTree.ipynb
+++ b/gtsam/discrete/doc/DecisionTree.ipynb
@@ -1,0 +1,157 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DecisionTree\n",
+    "\n",
+    "`DecisionTree` is mostly an internal data structure used to provide discrete probability distributions. It represents a function whose output depends on a sequence of discrete choices. GTSAM uses it underneath hybrid conditionals and factors; Python exposes useful concrete specializations rather than a class named `DecisionTree`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f343115c",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/discrete/doc/DecisionTree.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1de99476",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import M, X\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Concrete decision trees in Python\n",
+    "\n",
+    "`DecisionTree<L, Y>` is a C++ template, so there is no `gtsam.DecisionTree` constructor. The wrapper currently provides two concrete specializations:\n",
+    "\n",
+    "- `HybridNonlinearFactorValuePairs`, whose leaves hold nonlinear-factor/weight pairs.\n",
+    "- `HybridGaussianConditionalConditionals`, whose leaves hold Gaussian conditionals.\n",
+    "\n",
+    "Both constructors take the discrete labels that index the tree followed by one leaf value for each joint assignment. `empty()` and `nrLeaves()` are the principal structural queries exposed for these specializations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mode = (M(0), 2)\n",
+    "noise = gtsam.noiseModel.Isotropic.Sigma(3, 0.1)\n",
+    "pose_prior = gtsam.PriorFactorPose2(X(0), gtsam.Pose2(), noise)\n",
+    "\n",
+    "# M0=0 selects the first pair; M0=1 selects the second.\n",
+    "factor_tree = gtsam.HybridNonlinearFactorValuePairs(\n",
+    "    [mode], [(pose_prior, 0.0), (pose_prior, 2.0)]\n",
+    ")\n",
+    "print(\"empty:\", factor_tree.empty())\n",
+    "print(\"number of leaves:\", factor_tree.nrLeaves())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Gaussian-conditional leaves\n",
+    "\n",
+    "The Gaussian specialization is normally produced while eliminating a hybrid graph. The example constructs two one-dimensional Gaussian conditionals explicitly to show the same label-first construction pattern."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conditional0 = gtsam.GaussianConditional(\n",
+    "    X(0), np.array([0.0]), np.array([[1.0]])\n",
+    ")\n",
+    "conditional1 = gtsam.GaussianConditional(\n",
+    "    X(0), np.array([1.0]), np.array([[1.0]])\n",
+    ")\n",
+    "conditional_tree = gtsam.HybridGaussianConditionalConditionals(\n",
+    "    [mode], [conditional0, conditional1]\n",
+    ")\n",
+    "print(\"empty:\", conditional_tree.empty())\n",
+    "print(\"number of leaves:\", conditional_tree.nrLeaves())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## When to use it\n",
+    "\n",
+    "Most users do not manipulate these specializations directly. They are most useful when implementing hybrid factors or inspecting the piecewise Gaussian/nonlinear objects returned by hybrid elimination. For scalar probability tables, [`DecisionTreeFactor`](DecisionTreeFactor.ipynb) provides the higher-level interface.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`DecisionTree.h`](../DecisionTree.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/discrete/doc/DecisionTreeFactor.ipynb
+++ b/gtsam/discrete/doc/DecisionTreeFactor.ipynb
@@ -1,58 +1,62 @@
 {
   "cells": [
     {
+      "id": "2366c198",
       "cell_type": "markdown",
-      "metadata": {},
       "source": [
-        "# DecisionTreeFactor"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_discrete_doc_decisiontreefactor__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/discrete/doc/DecisionTreeFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "outputs": [],
-      "source": [
-        "try:\n",
-        "    import google.colab\n",
-        "    %pip install --quiet gtsam\n",
-        "except ImportError:\n",
-        "    pass  # Not running on Colab, do nothing"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
+        "# DecisionTreeFactor\n",
+        "\n",
         "A `DecisionTreeFactor` represents a function over a set of discrete variables, $f(X_1, X_2, ..., X_n)$. It is a versatile building block for representing potentials or probabilities in discrete factor graphs.\n",
         "\n",
         "Internally, it uses an `AlgebraicDecisionTree` (ADT) to store the function's values. This representation can be very efficient, especially for sparse factors where many assignments have the same value (e.g., zero).\n",
         "\n",
         "`DecisionTreeFactor` is the base class for more specialized factors like `DiscreteConditional`."
-      ]
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "af333cb0",
+      "cell_type": "markdown",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "23da8481",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/discrete/doc/DecisionTreeFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "fa786dac",
+      "cell_type": "code",
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      },
+      "execution_count": null,
+      "source": [
+        "try:\n",
+        "    import google.colab\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "except ImportError:\n",
+        "    pass"
+      ],
+      "outputs": []
     },
     {
       "cell_type": "code",

--- a/gtsam/discrete/doc/DiscreteBayesNet.ipynb
+++ b/gtsam/discrete/doc/DiscreteBayesNet.ipynb
@@ -1,52 +1,11 @@
 {
   "cells": [
     {
+      "id": "85703005",
       "cell_type": "markdown",
-      "metadata": {},
       "source": [
-        "# DiscreteBayesNet"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_discrete_doc_discretebayesnet__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/discrete/doc/DiscreteBayesNet.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "outputs": [],
-      "source": [
-        "try:\n",
-        "    import google.colab\n",
-        "    %pip install --quiet gtsam\n",
-        "except ImportError:\n",
-        "    pass  # Not running on Colab, do nothing"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
+        "# DiscreteBayesNet\n",
+        "\n",
         "A `DiscreteBayesNet` is a `BayesNet` of `DiscreteConditional`s. It represents a joint probability distribution over a set of discrete variables as a product of conditional probabilities:\n",
         "$$\n",
         "P(X_1, ..., X_n) = \\prod_i P(X_i | \\text{Parents}(X_i))\n",
@@ -54,7 +13,52 @@
         "Each conditional $P(X_i | \\text{Parents}(X_i))$ is a `gtsam.DiscreteConditional`.\n",
         "\n",
         "A `DiscreteBayesNet` is typically obtained by eliminating a `DiscreteFactorGraph`, but it can also be constructed manually."
-      ]
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "dece3186",
+      "cell_type": "markdown",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "10fee4bf",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/discrete/doc/DiscreteBayesNet.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "b1226650",
+      "cell_type": "code",
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      },
+      "execution_count": null,
+      "source": [
+        "try:\n",
+        "    import google.colab\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "except ImportError:\n",
+        "    pass"
+      ],
+      "outputs": []
     },
     {
       "cell_type": "code",

--- a/gtsam/discrete/doc/DiscreteBayesTree.ipynb
+++ b/gtsam/discrete/doc/DiscreteBayesTree.ipynb
@@ -1,0 +1,167 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DiscreteBayesTree\n",
+    "\n",
+    "A discrete Bayes tree represents the discrete probability distribution produced by multifrontal elimination of a discrete factor graph. Its `DiscreteBayesTreeClique` nodes group one conditional with its child cliques, making repeated marginal and joint queries efficient."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36bf215f",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/discrete/doc/DiscreteBayesTree.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f0a7575",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import M, X\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Building a Bayes tree\n",
+    "\n",
+    "The usual construction path is `DiscreteFactorGraph.eliminateMultifrontal()`. Here a two-variable model specifies a prior on `A0` and a pairwise potential over `B0` and `A0`; the ordering controls which variables are eliminated first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = (gtsam.symbol(\"A\", 0), 2)\n",
+    "B = (gtsam.symbol(\"B\", 0), 2)\n",
+    "\n",
+    "graph = gtsam.DiscreteFactorGraph()\n",
+    "graph.add(A, \"0.6 0.4\")\n",
+    "graph.add([B, A], \"0.8 0.2 0.3 0.7\")\n",
+    "\n",
+    "ordering = gtsam.Ordering()\n",
+    "ordering.push_back(A[0])\n",
+    "ordering.push_back(B[0])\n",
+    "tree = graph.eliminateMultifrontal(ordering)\n",
+    "print(\"cliques:\", tree.size(), \"empty:\", tree.empty())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `DiscreteBayesTree`\n",
+    "\n",
+    "`size()` and `empty()` describe the tree, while `clique(key)` finds the clique containing a frontal variable. `marginalFactor(key)`, `joint(key1, key2)`, and `jointBayesNet(key1, key2)` perform inference without rebuilding the entire elimination. `evaluate(values)` evaluates the factored distribution, and `dot()` or `saveGraph()` expose its structure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dot_source = tree.dot()\n",
+    "print(dot_source.splitlines()[0])\n",
+    "\n",
+    "assignment = gtsam.DiscreteValues()\n",
+    "assignment[A[0]] = 0\n",
+    "assignment[B[0]] = 0\n",
+    "print(\"unnormalized value:\", tree.evaluate(assignment))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `DiscreteBayesTreeClique`\n",
+    "\n",
+    "A clique is generally obtained from a tree rather than constructed manually. `conditional()` returns its discrete conditional, `isRoot()` identifies the root, and `nrChildren()` reports the local branching. The clique can also evaluate the part of the Bayes tree rooted at that node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clique = tree.clique(B[0])\n",
+    "print(\"is root:\", clique.isRoot())\n",
+    "print(\"children:\", clique.nrChildren())\n",
+    "print(\"frontals:\", clique.conditional().nrFrontals())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`DiscreteBayesTree.h`](../DiscreteBayesTree.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/discrete/doc/DiscreteConditional.ipynb
+++ b/gtsam/discrete/doc/DiscreteConditional.ipynb
@@ -1,56 +1,60 @@
 {
   "cells": [
     {
+      "id": "56ca5b42",
       "cell_type": "markdown",
-      "metadata": {},
       "source": [
-        "# DiscreteConditional"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_discrete_doc_discreteconditional__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/discrete/doc/DiscreteConditional.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "outputs": [],
-      "source": [
-        "try:\n",
-        "    import google.colab\n",
-        "    %pip install --quiet gtsam\n",
-        "except ImportError:\n",
-        "    pass  # Not running on Colab, do nothing"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
+        "# DiscreteConditional\n",
+        "\n",
         "A `DiscreteConditional` represents a conditional probability distribution, $P(\\text{Frontal} | \\text{Parents})$, for a set of discrete variables. It is a fundamental building block for representing directed graphical models, like Bayes Nets.\n",
         "\n",
         "It is a `DecisionTreeFactor` underneath, but with the additional structure that it distinguishes between frontal (child) and parent variables. The stored values are the probabilities, and for any given assignment to the parent variables, the probabilities of the frontal variable(s) sum to 1."
-      ]
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "fab81b3c",
+      "cell_type": "markdown",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "62f5876d",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/discrete/doc/DiscreteConditional.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "9c3b1e73",
+      "cell_type": "code",
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      },
+      "execution_count": null,
+      "source": [
+        "try:\n",
+        "    import google.colab\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "except ImportError:\n",
+        "    pass"
+      ],
+      "outputs": []
     },
     {
       "cell_type": "code",

--- a/gtsam/discrete/doc/DiscreteDistribution.ipynb
+++ b/gtsam/discrete/doc/DiscreteDistribution.ipynb
@@ -1,56 +1,60 @@
 {
   "cells": [
     {
+      "id": "88f5e881",
       "cell_type": "markdown",
-      "metadata": {},
       "source": [
-        "# DiscreteDistribution"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_discrete_doc_discretedistribution__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/discrete/doc/DiscreteDistribution.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "outputs": [],
-      "source": [
-        "try:\n",
-        "    import google.colab\n",
-        "    %pip install --quiet gtsam\n",
-        "except ImportError:\n",
-        "    pass  # Not running on Colab, do nothing"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
+        "# DiscreteDistribution\n",
+        "\n",
         "A `DiscreteDistribution` is a `DiscreteConditional` with no parents. It represents a prior probability on a single discrete variable, e.g., $P(X)$. It can be thought of as a special case of a factor, specifically one that sums to 1.\n",
         "\n",
         "It derives from `gtsam.DiscreteConditional` and can be used interchangeably with a `DecisionTreeFactor` or `DiscreteConditional` in most contexts, such as adding it to a `DiscreteFactorGraph` or `DiscreteBayesNet`."
-      ]
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "f47e3abe",
+      "cell_type": "markdown",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "da21cf40",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/discrete/doc/DiscreteDistribution.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "f3d7d24f",
+      "cell_type": "code",
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      },
+      "execution_count": null,
+      "source": [
+        "try:\n",
+        "    import google.colab\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "except ImportError:\n",
+        "    pass"
+      ],
+      "outputs": []
     },
     {
       "cell_type": "code",

--- a/gtsam/discrete/doc/DiscreteEliminationTree.ipynb
+++ b/gtsam/discrete/doc/DiscreteEliminationTree.ipynb
@@ -1,0 +1,149 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DiscreteEliminationTree\n",
+    "\n",
+    "A `DiscreteEliminationTree` is an internal data structure used inside elimination algorithms. It records the dependency structure induced by eliminating a discrete factor graph in a chosen order, and it can be used to construct a junction tree."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d047cbe0",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/discrete/doc/DiscreteEliminationTree.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9fe2e2ec",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import M, X\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Constructing an elimination tree\n",
+    "\n",
+    "Create the factor graph first, then provide an explicit `Ordering`. Variables appearing earlier in the ordering are eliminated earlier, which determines both the parent relationships and the size of intermediate factors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = (gtsam.symbol(\"A\", 0), 2)\n",
+    "B = (gtsam.symbol(\"B\", 0), 2)\n",
+    "C = (gtsam.symbol(\"C\", 0), 2)\n",
+    "\n",
+    "graph = gtsam.DiscreteFactorGraph()\n",
+    "graph.add(A, \"0.6 0.4\")\n",
+    "graph.add([B, A], \"3 1 1 3\")\n",
+    "graph.add([C, B], \"4 1 1 4\")\n",
+    "\n",
+    "ordering = gtsam.Ordering()\n",
+    "for key in (A[0], B[0], C[0]):\n",
+    "    ordering.push_back(key)\n",
+    "\n",
+    "elimination_tree = gtsam.DiscreteEliminationTree(graph, ordering)\n",
+    "elimination_tree.print(\"A-B-C elimination tree\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Important operations\n",
+    "\n",
+    "The constructor also accepts a precomputed `VariableIndex` when an application already maintains graph incidence information. `print()` is the main inspection tool, and `equals()` is useful in tests that compare two orderings or construction paths. The tree deliberately does not perform inference itself; pass it to `DiscreteJunctionTree` or `DiscreteSearch` for downstream algorithms."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "same_tree = gtsam.DiscreteEliminationTree(graph, ordering)\n",
+    "print(\"same structure:\", elimination_tree.equals(same_tree, 1e-9))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## See also\n",
+    "\n",
+    "- [`DiscreteJunctionTree`](DiscreteJunctionTree.ipynb) clusters this tree for multifrontal inference.\n",
+    "- [`DiscreteSearch`](DiscreteSearch.ipynb) uses it for ranked assignments.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`DiscreteEliminationTree.h`](../DiscreteEliminationTree.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/discrete/doc/DiscreteFactor.ipynb
+++ b/gtsam/discrete/doc/DiscreteFactor.ipynb
@@ -1,0 +1,147 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DiscreteFactor\n",
+    "\n",
+    "`DiscreteFactor` is mostly an internal base class; `DecisionTreeFactor` is probably the class you want to interact with. It defines the common evaluation and structural interface for factors over finite-valued variables, while concrete classes such as `DecisionTreeFactor` and `TableFactor` choose how the potentials are stored."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf14b9b2",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/discrete/doc/DiscreteFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36783297",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import M, X\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating a concrete factor\n",
+    "\n",
+    "`DiscreteFactor` is abstract in Python, so construct one of its wrapped subclasses. A `DecisionTreeFactor` is convenient for algebra and sparse structure; a `TableFactor` stores the same potential densely. A discrete key is represented by `(key, cardinality)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = (gtsam.symbol(\"A\", 0), 2)\n",
+    "B = (gtsam.symbol(\"B\", 0), 2)\n",
+    "\n",
+    "tree_factor = gtsam.DecisionTreeFactor([A, B], \"1 2 3 4\")\n",
+    "table_factor = gtsam.TableFactor(tree_factor)\n",
+    "print(\"number of keys:\", table_factor.size())\n",
+    "print(\"concrete type:\", type(table_factor).__name__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Evaluating assignments\n",
+    "\n",
+    "`evaluate()` returns the potential for a complete `DiscreteValues` assignment. `errorTree()` instead represents negative log-potentials, which is the additive form used by optimizers. The inherited `keys()`, `size()`, and `empty()` methods inspect factor scope."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "values = gtsam.DiscreteValues()\n",
+    "values[A[0]] = 1\n",
+    "values[B[0]] = 0\n",
+    "\n",
+    "potential = table_factor.evaluate(values)\n",
+    "error = table_factor.error(values)\n",
+    "print(\"potential:\", potential)\n",
+    "print(\"negative log potential:\", error)\n",
+    "assert np.isclose(error, -np.log(potential))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Choosing a representation\n",
+    "\n",
+    "Use `DecisionTreeFactor` when repeated substructure or zero-valued branches can be compressed. Use `TableFactor` when dense lookup and predictable memory layout are more important. Algorithms accepting `DiscreteFactor` can work with either representation.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`DiscreteFactor.h`](../DiscreteFactor.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/discrete/doc/DiscreteFactorGraph.ipynb
+++ b/gtsam/discrete/doc/DiscreteFactorGraph.ipynb
@@ -1,58 +1,62 @@
 {
   "cells": [
     {
+      "id": "4f56b07a",
       "cell_type": "markdown",
-      "metadata": {},
       "source": [
-        "# DiscreteFactorGraph"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_discrete_doc_discretefactorgraph__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/discrete/doc/DiscreteFactorGraph.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "outputs": [],
-      "source": [
-        "try:\n",
-        "    import google.colab\n",
-        "    %pip install --quiet gtsam\n",
-        "except ImportError:\n",
-        "    pass  # Not running on Colab, do nothing"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
+        "# DiscreteFactorGraph\n",
+        "\n",
         "A `DiscreteFactorGraph` is a factor graph consisting of `DiscreteFactor`s, such as `DecisionTreeFactor`. It represents a joint probability distribution (or a general function) over a set of discrete variables as a product of factors:\n",
         "$$ P(X_1, ..., X_n) \\propto \\prod_i f_i(\\text{Scope}_i) $$\n",
         "where each $f_i$ is a factor over a subset of the variables (its scope).\n",
         "\n",
         "This is an undirected graphical model (a Markov Random Field), and it is used to perform inference tasks like finding the most likely state (`optimize`) or computing marginals (via elimination)."
-      ]
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "9e57f121",
+      "cell_type": "markdown",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "b1d03086",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/discrete/doc/DiscreteFactorGraph.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "a0fb8564",
+      "cell_type": "code",
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      },
+      "execution_count": null,
+      "source": [
+        "try:\n",
+        "    import google.colab\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "except ImportError:\n",
+        "    pass"
+      ],
+      "outputs": []
     },
     {
       "cell_type": "code",

--- a/gtsam/discrete/doc/DiscreteJunctionTree.ipynb
+++ b/gtsam/discrete/doc/DiscreteJunctionTree.ipynb
@@ -1,0 +1,169 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DiscreteJunctionTree\n",
+    "\n",
+    "A junction tree is an internal data structure used during multifrontal elimination. `DiscreteJunctionTree` clusters an elimination tree into a forest of cliques suitable for multifrontal discrete inference. Python also exposes its nested cluster type as `DiscreteCluster` for inspecting frontal keys, attached factors, and child clusters."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f63e9f76",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/discrete/doc/DiscreteJunctionTree.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a440d1e5",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import M, X\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## From factor graph to junction tree\n",
+    "\n",
+    "The junction tree is constructed from a `DiscreteEliminationTree`, so the graph and variable ordering remain explicit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = (gtsam.symbol(\"A\", 0), 2)\n",
+    "B = (gtsam.symbol(\"B\", 0), 2)\n",
+    "C = (gtsam.symbol(\"C\", 0), 2)\n",
+    "\n",
+    "graph = gtsam.DiscreteFactorGraph()\n",
+    "graph.add(A, \"0.6 0.4\")\n",
+    "graph.add([B, A], \"3 1 1 3\")\n",
+    "graph.add([C, B], \"4 1 1 4\")\n",
+    "\n",
+    "ordering = gtsam.Ordering()\n",
+    "for key in (A[0], B[0], C[0]):\n",
+    "    ordering.push_back(key)\n",
+    "\n",
+    "elimination_tree = gtsam.DiscreteEliminationTree(graph, ordering)\n",
+    "junction_tree = gtsam.DiscreteJunctionTree(elimination_tree)\n",
+    "print(\"root clusters:\", junction_tree.nrRoots())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `DiscreteJunctionTree`\n",
+    "\n",
+    "`nrRoots()` reports the number of connected components. Indexing the tree selects a root `DiscreteCluster`, while `print()` renders the complete cluster hierarchy. A disconnected factor graph can therefore produce more than one root."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "junction_tree.print(\"Junction tree\")\n",
+    "root = junction_tree[0]\n",
+    "print(\"children below the root:\", root.nrChildren())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `DiscreteCluster`\n",
+    "\n",
+    "Each cluster exposes `orderedFrontalKeys`, the `factors` assigned to the clique, indexing for child clusters, `nrChildren()`, and `print()`. Clusters are obtained from a junction tree; they are not intended to be assembled independently in Python."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "frontals = [\n",
+    "    gtsam.DefaultKeyFormatter(root.orderedFrontalKeys.at(i))\n",
+    "    for i in range(root.orderedFrontalKeys.size())\n",
+    "]\n",
+    "print(\"frontal keys:\", frontals)\n",
+    "print(\"factors assigned to root:\", root.factors.size())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`DiscreteJunctionTree.h`](../DiscreteJunctionTree.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/discrete/doc/DiscreteKey.ipynb
+++ b/gtsam/discrete/doc/DiscreteKey.ipynb
@@ -1,0 +1,160 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DiscreteKey\n",
+    "\n",
+    "`DiscreteKey` is the equivalent of `Key`, but for discrete (or hybrid) factors and conditionals. It pairs the underlying GTSAM variable key with its cardinality; Python represents one `DiscreteKey` as a two-tuple and wraps a sequence of them in `DiscreteKeys`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8a045e8",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/discrete/doc/DiscreteKey.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "228226e7",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import M, X\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating discrete keys\n",
+    "\n",
+    "The first tuple element is the 64-bit variable key; the second is the number of allowed values. Using `gtsam.symbol()` makes keys readable without changing their numeric representation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "weather = (gtsam.symbol(\"W\", 0), 3)  # sunny, cloudy, rainy\n",
+    "umbrella = (gtsam.symbol(\"U\", 0), 2)  # no, yes\n",
+    "\n",
+    "print(\"weather key:\", gtsam.DefaultKeyFormatter(weather[0]))\n",
+    "print(\"weather cardinality:\", weather[1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The `DiscreteKeys` container\n",
+    "\n",
+    "`DiscreteKeys` preserves variable order, which matters when a flat table is mapped to joint assignments. Use `push_back()`, `at()`, `size()`, and `empty()` to build and inspect it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "keys = gtsam.DiscreteKeys()\n",
+    "keys.push_back(weather)\n",
+    "keys.push_back(umbrella)\n",
+    "\n",
+    "print(\"number of variables:\", keys.size())\n",
+    "print(\"first key/cardinality:\", keys.at(0))\n",
+    "keys.print(\"Model variables\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Enumerating assignments\n",
+    "\n",
+    "`cartesianProduct()` generates one `DiscreteValues` object for every joint assignment. Here there are `3 × 2 = 6` assignments, in the order implied by `DiscreteKeys`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assignments = gtsam.cartesianProduct(keys)\n",
+    "print(\"joint assignments:\", len(assignments))\n",
+    "print(assignments[:2])\n",
+    "assert len(assignments) == weather[1] * umbrella[1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`DiscreteKey.h`](../DiscreteKey.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/discrete/doc/DiscreteLookupDAG.ipynb
+++ b/gtsam/discrete/doc/DiscreteLookupDAG.ipynb
@@ -1,0 +1,162 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DiscreteLookupDAG\n",
+    "\n",
+    "Max-product produces an MPE (maximum probability explanation), which GTSAM represents with a `DiscreteLookupDAG`. Its `DiscreteLookupTable` conditionals record the maximizing frontal value for every parent assignment, allowing the MPE assignment to be recovered with `argmax()`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d1398a3",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/discrete/doc/DiscreteLookupDAG.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f97ec2f",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import M, X\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating a lookup DAG\n",
+    "\n",
+    "Users normally obtain the DAG from `DiscreteFactorGraph.maxProduct()`. Constructing `DiscreteLookupTable` directly requires the internal algebraic decision tree, which is intentionally not part of the high-level Python API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = (gtsam.symbol(\"A\", 0), 2)\n",
+    "B = (gtsam.symbol(\"B\", 0), 2)\n",
+    "\n",
+    "graph = gtsam.DiscreteFactorGraph()\n",
+    "graph.add(A, \"0.6 0.4\")\n",
+    "graph.add([B, A], \"0.8 0.2 0.3 0.7\")\n",
+    "\n",
+    "ordering = gtsam.Ordering()\n",
+    "ordering.push_back(A[0])\n",
+    "ordering.push_back(B[0])\n",
+    "dag = graph.maxProduct(ordering)\n",
+    "print(\"lookup tables:\", dag.size())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `DiscreteLookupDAG.argmax()`\n",
+    "\n",
+    "With no arguments, `argmax()` back-substitutes through every table and returns the global maximum-product assignment. Its optional `given` argument supplies values for parent variables outside the DAG; variables solved by the DAG are written during back-substitution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mpe = dag.argmax()\n",
+    "readable_mpe = {gtsam.DefaultKeyFormatter(k): v for k, v in mpe.items()}\n",
+    "print(\"MPE assignment:\", readable_mpe)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `DiscreteLookupTable`\n",
+    "\n",
+    "`at(i)` returns an individual table. It is a `DiscreteConditional`, so `nrFrontals()`, `nrParents()`, `keys()`, and `argmax(parent_values)` describe the local decision rule. The DAG owns these tables; retain the DAG while inspecting them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table = dag.at(0)\n",
+    "print(\"frontals:\", table.nrFrontals(), \"parents:\", table.nrParents())\n",
+    "print(\"local maximizing value at the MPE parents:\", table.argmax(mpe))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`DiscreteLookupDAG.h`](../DiscreteLookupDAG.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/discrete/doc/DiscreteMarginals.ipynb
+++ b/gtsam/discrete/doc/DiscreteMarginals.ipynb
@@ -1,0 +1,144 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DiscreteMarginals\n",
+    "\n",
+    "In GTSAM, sum-product produces a Bayes net or Bayes tree; `DiscreteMarginals` is the additional class used to query specific normalized marginals from a discrete factor graph."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4c2d01a",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/discrete/doc/DiscreteMarginals.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2be2aa4",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import M, X\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Building a small model\n",
+    "\n",
+    "The first factor prefers `A0 = 0`. The pairwise factor encourages `B0` to agree with `A0`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = (gtsam.symbol(\"A\", 0), 2)\n",
+    "B = (gtsam.symbol(\"B\", 0), 2)\n",
+    "\n",
+    "graph = gtsam.DiscreteFactorGraph()\n",
+    "graph.add(A, \"0.6 0.4\")\n",
+    "graph.add([B, A], \"0.8 0.2 0.3 0.7\")\n",
+    "marginals = gtsam.DiscreteMarginals(graph)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Querying probabilities\n",
+    "\n",
+    "`marginalProbabilities((key, cardinality))` returns a vector ordered by the variable's integer values. Each vector is normalized even when the original graph contains unnormalized potentials."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p_a = marginals.marginalProbabilities(A)\n",
+    "p_b = marginals.marginalProbabilities(B)\n",
+    "print(\"P(A0):\", p_a)\n",
+    "print(\"P(B0):\", p_b)\n",
+    "assert np.isclose(p_a.sum(), 1.0)\n",
+    "assert np.isclose(p_b.sum(), 1.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Interpreting the result\n",
+    "\n",
+    "The marginal is not necessarily the state chosen by a global MPE assignment: summation accounts for all assignments of the other variables. Recreate `DiscreteMarginals` after changing the graph; the object represents inference for the graph passed to its constructor. Repeated queries can reuse its elimination structure, so one object is preferable to eliminating the same unchanged graph separately for every variable.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`DiscreteMarginals.h`](../DiscreteMarginals.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/discrete/doc/DiscreteSearch.ipynb
+++ b/gtsam/discrete/doc/DiscreteSearch.ipynb
@@ -1,0 +1,154 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DiscreteSearch\n",
+    "\n",
+    "Search is an alternative to exact discrete inference, which can be exponential. `DiscreteSearch` enumerates the best assignments of a discrete model in increasing error order, returning each complete assignment and its negative-log error as a `DiscreteSearchSolution`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "235db140",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/discrete/doc/DiscreteSearch.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca7ca174",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import M, X\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Constructing the search problem\n",
+    "\n",
+    "`FromFactorGraph()` eliminates a graph into the internal search representation. The explicit ordering controls that preprocessing; setting `buildJunctionTree=True` selects the junction-tree construction path."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = (gtsam.symbol(\"A\", 0), 2)\n",
+    "B = (gtsam.symbol(\"B\", 0), 2)\n",
+    "\n",
+    "graph = gtsam.DiscreteFactorGraph()\n",
+    "graph.add(A, \"0.6 0.4\")\n",
+    "graph.add([B, A], \"0.8 0.2 0.3 0.7\")\n",
+    "\n",
+    "ordering = gtsam.Ordering()\n",
+    "ordering.push_back(B[0])\n",
+    "ordering.push_back(A[0])\n",
+    "search = gtsam.DiscreteSearch.FromFactorGraph(graph, ordering)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Ranked solutions\n",
+    "\n",
+    "`run(K)` returns at most `K` `DiscreteSearchSolution` objects. `assignment` is a `DiscreteValues` map and `error` is the additive objective; lower error means higher probability. `lowerBound()` reports the search object's current lower bound."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "solutions = search.run(K=3)\n",
+    "for rank, solution in enumerate(solutions, start=1):\n",
+    "    assignment = {\n",
+    "        gtsam.DefaultKeyFormatter(k): value\n",
+    "        for k, value in solution.assignment.items()\n",
+    "    }\n",
+    "    print(rank, assignment, \"error =\", solution.error)\n",
+    "\n",
+    "assert all(\n",
+    "    solutions[i].error <= solutions[i + 1].error\n",
+    "    for i in range(len(solutions) - 1)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Alternative inputs\n",
+    "\n",
+    "The constructor also accepts an existing `DiscreteEliminationTree`, `DiscreteJunctionTree`, `DiscreteBayesNet`, or `DiscreteBayesTree`. Reuse one of those when elimination has already been performed. Search is useful for N-best hypotheses; use `DiscreteFactorGraph.optimize()` when only the single MPE solution is needed.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`DiscreteSearch.h`](../DiscreteSearch.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/discrete/doc/TableDistribution.ipynb
+++ b/gtsam/discrete/doc/TableDistribution.ipynb
@@ -1,0 +1,161 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# TableDistribution\n",
+    "\n",
+    "Sometimes decision trees are quite expensive for very sparse distributions; `TableDistribution` instead uses a sparse matrix representation and is also used internally in many algorithms. It is a normalized discrete conditional that is convenient for priors and conditional probability tables."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77698934",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/discrete/doc/TableDistribution.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8a48d6d",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import M, X\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating a distribution\n",
+    "\n",
+    "A unary distribution takes a `(key, cardinality)` pair and either a numeric sequence or a ratio string. Numeric inputs are normalized by the conditional semantics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "weather = (gtsam.symbol(\"W\", 0), 3)\n",
+    "distribution = gtsam.TableDistribution(weather, [6.0, 3.0, 1.0])\n",
+    "\n",
+    "print(\"number of values:\", distribution.nrValues())\n",
+    "print(\"table size:\", distribution.table().size())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Evaluating and choosing values\n",
+    "\n",
+    "As a `DiscreteConditional`, the distribution supports `evaluate()`, `logProbability()`, `argmax()`, and `sample()`. `evaluate()` expects `DiscreteValues`; `argmax()` returns the most likely frontal value for the supplied parent assignment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "values = gtsam.DiscreteValues()\n",
+    "values[weather[0]] = 0\n",
+    "probability = distribution.evaluate(values)\n",
+    "print(\"P(W0=0):\", probability)\n",
+    "print(\"most likely state:\", distribution.argmax(gtsam.DiscreteValues()))\n",
+    "assert np.isclose(probability, 0.6)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Multiple keys and table access\n",
+    "\n",
+    "Passing `DiscreteKeys` creates a conditional over several frontals. `table()` returns the backing `TableFactor`, while `choose(given)` fixes parent values and `marginal(key)` removes other frontals by summation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "umbrella = (gtsam.symbol(\"U\", 0), 2)\n",
+    "keys = gtsam.DiscreteKeys()\n",
+    "keys.push_back(weather)\n",
+    "keys.push_back(umbrella)\n",
+    "joint = gtsam.TableDistribution(keys, \"6 1 3 2 1 7\")\n",
+    "print(\"joint assignments:\", joint.nrValues())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`TableDistribution.h`](../TableDistribution.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/discrete/doc/TableFactor.ipynb
+++ b/gtsam/discrete/doc/TableFactor.ipynb
@@ -1,0 +1,167 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# TableFactor\n",
+    "\n",
+    "A `TableFactor` is an alternative to a `DecisionTreeFactor`, using a sparse matrix to represent factors with many zeros. It stores a discrete potential indexed by an ordered sequence of discrete keys and supports efficient lookup of the stored entries."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c61969f",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/discrete/doc/TableFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "45663f6f",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import M, X\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Constructing a table\n",
+    "\n",
+    "The order of `DiscreteKeys` determines how the flat value sequence maps to assignments. The example has two binary variables and therefore four table entries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = (gtsam.symbol(\"A\", 0), 2)\n",
+    "B = (gtsam.symbol(\"B\", 0), 2)\n",
+    "keys = gtsam.DiscreteKeys()\n",
+    "keys.push_back(A)\n",
+    "keys.push_back(B)\n",
+    "\n",
+    "factor = gtsam.TableFactor(keys, [0.1, 0.9, 0.8, 0.2])\n",
+    "factor.print(\"Dense potential\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Lookup and error\n",
+    "\n",
+    "`evaluate(values)` returns the stored potential. `error(values)` returns its negative logarithm, the additive objective used by discrete optimization. `keys()`, `size()`, and `empty()` inspect the factor scope."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "values = gtsam.DiscreteValues()\n",
+    "values[A[0]] = 0\n",
+    "values[B[0]] = 1\n",
+    "\n",
+    "potential = factor.evaluate(values)\n",
+    "error = factor.error(values)\n",
+    "print(\"potential:\", potential)\n",
+    "print(\"error:\", error)\n",
+    "assert np.isclose(potential, 0.9)\n",
+    "assert np.isclose(error, -np.log(0.9))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Converting from a decision tree\n",
+    "\n",
+    "Constructing from `DecisionTreeFactor` preserves the potential while changing its storage. This is useful after symbolic operations have created a compact tree but a dense downstream calculation is preferred."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tree_factor = gtsam.DecisionTreeFactor([A, B], \"1 0 0 2\")\n",
+    "dense_factor = gtsam.TableFactor(tree_factor)\n",
+    "for assignment, expected in tree_factor.enumerate():\n",
+    "    assert np.isclose(dense_factor.evaluate(assignment), expected)\n",
+    "print(\"all four table entries preserved\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`TableFactor.h`](../TableFactor.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/geometry/doc/BearingRange.ipynb
+++ b/gtsam/geometry/doc/BearingRange.ipynb
@@ -1,0 +1,142 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# BearingRange\n",
+    "\n",
+    "The bearing-range factor is useful when you have both a bearing and a range to an object in 2D or 3D. `BearingRange` bundles those two measurements, and the Python wrapper provides concrete specializations for pose-to-point and pose-to-pose geometry."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "893aa1e8",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/BearingRange.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef18a414",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Measuring in 2D\n",
+    "\n",
+    "`BearingRange2D` measures a `Pose2` to a `Point2`; `BearingRangePose2` uses another `Pose2` as the target. `Measure()` constructs the pair, while `MeasureBearing()` and `MeasureRange()` compute either component alone."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "observer2 = gtsam.Pose2(1.0, 2.0, 0.3)\n",
+    "landmark2 = np.array([4.0, 3.0])\n",
+    "measurement2 = gtsam.BearingRange2D.Measure(observer2, landmark2)\n",
+    "print(\"bearing angle:\", measurement2.bearing().theta())\n",
+    "print(\"range:\", measurement2.range())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Measuring in 3D\n",
+    "\n",
+    "`BearingRange3D` returns a `Unit3` bearing from `Pose3` to `Point3`; `BearingRangePose3` targets another pose. The bearing is expressed in the observer's local frame, while range is Euclidean distance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "observer3 = gtsam.Pose3(gtsam.Rot3.Yaw(0.2), np.array([1.0, 0.0, 0.0]))\n",
+    "landmark3 = np.array([4.0, 1.0, 2.0])\n",
+    "measurement3 = gtsam.BearingRange3D.Measure(observer3, landmark3)\n",
+    "print(\"unit bearing:\", measurement3.bearing().unitVector())\n",
+    "print(\"range:\", measurement3.range())\n",
+    "\n",
+    "expected_range = np.linalg.norm(landmark3 - observer3.translation())\n",
+    "assert np.isclose(measurement3.range(), expected_range)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Accessors and use in factors\n",
+    "\n",
+    "Instances expose only `bearing()` and `range()` because they are lightweight measurement values. Bearing-range factors use the same concrete specializations, so the type of bearing—`Rot2` or `Unit3`—matches the geometry being estimated.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`BearingRange.h`](../BearingRange.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/geometry/doc/Cal3.ipynb
+++ b/gtsam/geometry/doc/Cal3.ipynb
@@ -1,0 +1,160 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Cal3\n",
+    "\n",
+    "The most common calibration object is affine and can be represented simply by a matrix `K`. `Cal3` stores its five linear pinhole intrinsics—horizontal and vertical focal lengths, skew, and principal point—and is the common base interface for GTSAM's richer camera calibration models."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "544cb971",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/Cal3.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b0da629",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialization\n",
+    "\n",
+    "Construct from five scalars in `(fx, fy, skew, px, py)` order or from a five-element vector."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calibration = gtsam.Cal3(800.0, 790.0, 0.2, 320.0, 240.0)\n",
+    "from_vector = gtsam.Cal3(np.array([800.0, 790.0, 0.2, 320.0, 240.0]))\n",
+    "assert calibration.equals(from_vector, 1e-12)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Properties\n",
+    "\n",
+    "`fx()`, `fy()`, `skew()`, `px()`, and `py()` expose the five parameters. `principalPoint()` and `aspectRatio()` provide common derived quantities, and `vector()` returns the constructor order."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"parameters:\", calibration.vector())\n",
+    "print(\"principal point:\", calibration.principalPoint())\n",
+    "print(\"aspect ratio fy/fx:\", calibration.aspectRatio())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Matrix form\n",
+    "\n",
+    "`K()` returns the standard upper-triangular intrinsic matrix and `inverse()` returns its inverse. These are useful when converting between normalized homogeneous coordinates and pixel coordinates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "K = calibration.K()\n",
+    "K_inverse = calibration.inverse()\n",
+    "print(K)\n",
+    "np.testing.assert_allclose(K_inverse @ K, np.eye(3), atol=1e-12)\n",
+    "\n",
+    "normalized_h = np.array([0.1, -0.05, 1.0])\n",
+    "pixel_h = K @ normalized_h\n",
+    "print(\"pixel coordinates:\", pixel_h[:2] / pixel_h[2])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Base-class role\n",
+    "\n",
+    "`Cal3` itself models only the linear intrinsic matrix and is not exposed as an optimizable manifold. Concrete classes such as [`Cal3_S2`](Cal3_S2.ipynb), [`Cal3DS2`](Cal3DS2.ipynb), and [`Cal3Fisheye`](Cal3Fisheye.ipynb) add projection and manifold operations.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`Cal3.h`](../Cal3.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/geometry/doc/Cal3Bundler.ipynb
+++ b/gtsam/geometry/doc/Cal3Bundler.ipynb
@@ -1,0 +1,177 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Cal3Bundler\n",
+    "\n",
+    "Bundler is a popular open-source implementation of bundle adjustment, and GTSAM implements its calibration model with radial distortion. `Cal3Bundler` uses one focal length and two radial coefficients; its principal point is stored but is not part of the three-dimensional optimization manifold."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf9c2775",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/Cal3Bundler.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33b5de49",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialization\n",
+    "\n",
+    "The explicit constructor makes the model and parameter order visible. A default constructor is also available, but calibrated values are preferable in real projection code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calibration = gtsam.Cal3Bundler(\n",
+    "    800.0, 1.0e-3, -2.0e-5, 320.0, 240.0\n",
+    ")\n",
+    "print(calibration)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calibration parameters\n",
+    "\n",
+    "`f()`, `k1()`, and `k2()` are the optimized parameters; `px()` and `py()` locate the fixed principal point. `vector()` collects the optimized parameters, while `K()` returns the intrinsic matrix associated with the linear part of the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"f, k1, k2:\", calibration.f(), calibration.k1(), calibration.k2())\n",
+    "print(\"principal point:\", calibration.principalPoint())\n",
+    "print(\"optimized vector:\", calibration.vector())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calibrating and uncalibrating points\n",
+    "\n",
+    "`uncalibrate()` maps normalized image coordinates to pixels and applies this model's distortion. `calibrate()` performs the inverse mapping iteratively. Their round trip is the most direct way to check parameter conventions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "normalized = np.array([0.12, -0.08])\n",
+    "pixel = calibration.uncalibrate(normalized)\n",
+    "recovered = calibration.calibrate(pixel)\n",
+    "print(\"pixel:\", pixel)\n",
+    "print(\"recovered normalized point:\", recovered)\n",
+    "np.testing.assert_allclose(recovered, normalized, atol=1e-7)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Manifold operations\n",
+    "\n",
+    "Calibration objects participate in nonlinear optimization through `retract()` and `localCoordinates()`. The tangent coordinates follow the order returned by `vector()` for the parameters that this model optimizes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delta = np.array([2.0, 1e-5, -1e-6])\n",
+    "perturbed = calibration.retract(delta)\n",
+    "recovered_delta = calibration.localCoordinates(perturbed)\n",
+    "print(\"parameter increment:\", recovered_delta)\n",
+    "np.testing.assert_allclose(recovered_delta, delta, atol=1e-9)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`Cal3Bundler.h`](../Cal3Bundler.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/geometry/doc/Cal3DS2.ipynb
+++ b/gtsam/geometry/doc/Cal3DS2.ipynb
@@ -1,0 +1,180 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Cal3DS2\n",
+    "\n",
+    "`Cal3DS2` adds radial and tangential distortion to a default affine calibration matrix `K`. It combines five pinhole intrinsics with GTSAM's Brown–Conrady-style distortion model for lenses with moderate distortion."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e0b812b",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/Cal3DS2.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83e454f0",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialization\n",
+    "\n",
+    "The explicit constructor makes the model and parameter order visible. A default constructor is also available, but calibrated values are preferable in real projection code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calibration = gtsam.Cal3DS2(\n",
+    "    800.0, 790.0, 0.0, 320.0, 240.0,\n",
+    "    1.0e-3, -1.0e-5, 2.0e-4, -1.0e-4,\n",
+    ")\n",
+    "print(calibration)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calibration parameters\n",
+    "\n",
+    "`k1()` and `k2()` are radial coefficients; `p1()` and `p2()` are tangential coefficients. `k()` returns all four distortion values. `vector()` collects the optimized parameters, while `K()` returns the intrinsic matrix associated with the linear part of the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"intrinsic matrix:\")\n",
+    "print(calibration.K())\n",
+    "print(\"radial:\", calibration.k1(), calibration.k2())\n",
+    "print(\"tangential:\", calibration.p1(), calibration.p2())\n",
+    "print(\"all parameters:\", calibration.vector())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calibrating and uncalibrating points\n",
+    "\n",
+    "`uncalibrate()` maps normalized image coordinates to pixels and applies this model's distortion. `calibrate()` performs the inverse mapping iteratively. Their round trip is the most direct way to check parameter conventions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "normalized = np.array([0.12, -0.08])\n",
+    "pixel = calibration.uncalibrate(normalized)\n",
+    "recovered = calibration.calibrate(pixel)\n",
+    "print(\"pixel:\", pixel)\n",
+    "print(\"recovered normalized point:\", recovered)\n",
+    "np.testing.assert_allclose(recovered, normalized, atol=1e-7)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Manifold operations\n",
+    "\n",
+    "Calibration objects participate in nonlinear optimization through `retract()` and `localCoordinates()`. The tangent coordinates follow the order returned by `vector()` for the parameters that this model optimizes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delta = np.array([1.0, -1.0, 0.01, 0.2, -0.2, 1e-5, -1e-6, 1e-5, -1e-5])\n",
+    "perturbed = calibration.retract(delta)\n",
+    "recovered_delta = calibration.localCoordinates(perturbed)\n",
+    "print(\"parameter increment:\", recovered_delta)\n",
+    "np.testing.assert_allclose(recovered_delta, delta, atol=1e-9)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`Cal3DS2.h`](../Cal3DS2.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/geometry/doc/Cal3DS2_Base.ipynb
+++ b/gtsam/geometry/doc/Cal3DS2_Base.ipynb
@@ -1,0 +1,156 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Cal3DS2_Base\n",
+    "\n",
+    "`Cal3DS2_Base` is an internal class. It contains the shared pinhole and Brown–Conrady distortion operations used by `Cal3DS2` and `Cal3Unified`; applications normally construct one of those concrete calibration models."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98029dee",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/Cal3DS2_Base.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "77b30e17",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Obtaining the base interface\n",
+    "\n",
+    "Although Python exposes a default `Cal3DS2_Base()` constructor, its zero focal lengths do not describe a usable camera. A concrete `Cal3DS2` instance supplies valid parameters while exposing all inherited base methods."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calibration = gtsam.Cal3DS2(\n",
+    "    800.0, 790.0, 0.0, 320.0, 240.0,\n",
+    "    1e-3, -1e-5, 2e-4, -1e-4,\n",
+    ")\n",
+    "print(\"is a Cal3DS2_Base:\", isinstance(calibration, gtsam.Cal3DS2_Base))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Shared parameter access\n",
+    "\n",
+    "The base provides `fx()`, `fy()`, `skew()`, `px()`, `py()`, `k1()`, `k2()`, `p1()`, `p2()`, `k()`, `K()`, `inverse()`, and `vector()`. Manifold dimension and retraction belong to the concrete derived model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"intrinsic matrix:\")\n",
+    "print(calibration.K())\n",
+    "print(\"distortion [k1, k2, p1, p2]:\", calibration.k())\n",
+    "print(\"complete vector:\", calibration.vector())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Shared pixel mapping\n",
+    "\n",
+    "`uncalibrate()` applies radial and tangential distortion followed by the intrinsic matrix. `calibrate()` numerically inverts that transformation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "normalized = np.array([0.15, -0.08])\n",
+    "pixel = calibration.uncalibrate(normalized)\n",
+    "recovered = calibration.calibrate(pixel)\n",
+    "print(\"pixel:\", pixel)\n",
+    "np.testing.assert_allclose(recovered, normalized, atol=1e-7)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`Cal3DS2_Base.h`](../Cal3DS2_Base.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/geometry/doc/Cal3Fisheye.ipynb
+++ b/gtsam/geometry/doc/Cal3Fisheye.ipynb
@@ -1,0 +1,180 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Cal3Fisheye\n",
+    "\n",
+    "Wide-angle cameras need their own bespoke calibration objects. `Cal3Fisheye` implements an equidistant fisheye projection with four radial coefficients for cameras whose field of view makes a perspective radial model inadequate."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ad33a7d",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/Cal3Fisheye.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "081a6ec6",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialization\n",
+    "\n",
+    "The explicit constructor makes the model and parameter order visible. A default constructor is also available, but calibrated values are preferable in real projection code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calibration = gtsam.Cal3Fisheye(\n",
+    "    420.0, 415.0, 0.0, 320.0, 240.0,\n",
+    "    1e-2, -1e-3, 1e-4, -1e-5,\n",
+    ")\n",
+    "print(calibration)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calibration parameters\n",
+    "\n",
+    "`k1()` through `k4()` parameterize the angle-domain distortion polynomial. `vector()` collects the optimized parameters, while `K()` returns the intrinsic matrix associated with the linear part of the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"intrinsic matrix:\")\n",
+    "print(calibration.K())\n",
+    "print(\"distortion:\", [calibration.k1(), calibration.k2(),\n",
+    "                       calibration.k3(), calibration.k4()])\n",
+    "print(\"all parameters:\", calibration.vector())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calibrating and uncalibrating points\n",
+    "\n",
+    "`uncalibrate()` maps normalized image coordinates to pixels and applies this model's distortion. `calibrate()` performs the inverse mapping iteratively. Their round trip is the most direct way to check parameter conventions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "normalized = np.array([0.12, -0.08])\n",
+    "pixel = calibration.uncalibrate(normalized)\n",
+    "recovered = calibration.calibrate(pixel)\n",
+    "print(\"pixel:\", pixel)\n",
+    "print(\"recovered normalized point:\", recovered)\n",
+    "np.testing.assert_allclose(recovered, normalized, atol=1e-7)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Manifold operations\n",
+    "\n",
+    "Calibration objects participate in nonlinear optimization through `retract()` and `localCoordinates()`. The tangent coordinates follow the order returned by `vector()` for the parameters that this model optimizes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delta = np.array([1.0, -1.0, 0.01, 0.2, -0.2, 1e-5, -1e-6, 1e-7, -1e-8])\n",
+    "perturbed = calibration.retract(delta)\n",
+    "recovered_delta = calibration.localCoordinates(perturbed)\n",
+    "print(\"parameter increment:\", recovered_delta)\n",
+    "np.testing.assert_allclose(recovered_delta, delta, atol=1e-9)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`Cal3Fisheye.h`](../Cal3Fisheye.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/geometry/doc/Cal3Unified.ipynb
+++ b/gtsam/geometry/doc/Cal3Unified.ipynb
@@ -1,0 +1,183 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Cal3Unified\n",
+    "\n",
+    "`Cal3Unified` is a newer wide-angle calibration model that can even represent omnidirectional cameras. It combines Brown–Conrady distortion with a mirror parameter `xi`, covering perspective and central catadioptric cameras within one projection model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dae4dfd8",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/Cal3Unified.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b72a1182",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialization\n",
+    "\n",
+    "The explicit constructor makes the model and parameter order visible. A default constructor is also available, but calibrated values are preferable in real projection code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calibration = gtsam.Cal3Unified(\n",
+    "    500.0, 495.0, 0.0, 320.0, 240.0,\n",
+    "    1e-3, -1e-5, 2e-4, -1e-4, 0.8,\n",
+    ")\n",
+    "print(calibration)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calibration parameters\n",
+    "\n",
+    "`xi()` is the mirror parameter. `spaceToNPlane()` and `nPlaneToSpace()` convert between the model's space-plane and normalized-plane coordinates. `vector()` collects the optimized parameters, while `K()` returns the intrinsic matrix associated with the linear part of the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"xi:\", calibration.xi())\n",
+    "print(\"distortion:\", calibration.k())\n",
+    "space_point = np.array([0.1, -0.05])\n",
+    "plane = calibration.spaceToNPlane(space_point)\n",
+    "print(\"normalized plane:\", plane)\n",
+    "recovered_space_point = calibration.nPlaneToSpace(plane)\n",
+    "print(\"back to space-plane coordinates:\", recovered_space_point)\n",
+    "np.testing.assert_allclose(recovered_space_point, space_point, atol=1e-12)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calibrating and uncalibrating points\n",
+    "\n",
+    "`uncalibrate()` maps normalized image coordinates to pixels and applies this model's distortion. `calibrate()` performs the inverse mapping iteratively. Their round trip is the most direct way to check parameter conventions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "normalized = np.array([0.12, -0.08])\n",
+    "pixel = calibration.uncalibrate(normalized)\n",
+    "recovered = calibration.calibrate(pixel)\n",
+    "print(\"pixel:\", pixel)\n",
+    "print(\"recovered normalized point:\", recovered)\n",
+    "np.testing.assert_allclose(recovered, normalized, atol=1e-7)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Manifold operations\n",
+    "\n",
+    "Calibration objects participate in nonlinear optimization through `retract()` and `localCoordinates()`. The tangent coordinates follow the order returned by `vector()` for the parameters that this model optimizes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delta = np.array([1.0, -1.0, 0.01, 0.2, -0.2, 1e-5, -1e-6, 1e-5, -1e-5, 1e-3])\n",
+    "perturbed = calibration.retract(delta)\n",
+    "recovered_delta = calibration.localCoordinates(perturbed)\n",
+    "print(\"parameter increment:\", recovered_delta)\n",
+    "np.testing.assert_allclose(recovered_delta, delta, atol=1e-9)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`Cal3Unified.h`](../Cal3Unified.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/geometry/doc/Cal3_S2.ipynb
+++ b/gtsam/geometry/doc/Cal3_S2.ipynb
@@ -1,41 +1,11 @@
 {
   "cells": [
     {
+      "id": "87cbfa73",
       "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_geometry_doc_cal3_s2__cal3s2-title"
-      },
       "source": [
-        "# Cal3_S2"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_geometry_doc_cal3_s2__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_geometry_doc_cal3_s2__cal3s2-colab-badge"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/Cal3_S2.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_geometry_doc_cal3_s2__cal3s2-intro"
-      },
-      "source": [
+        "# Cal3_S2\n",
+        "\n",
         "A `Cal3_S2` represents the simple 5-parameter camera calibration model {cite:p}`https://doi.org/10.1017/CBO9780511811685`[^f1]. This model includes parameters for the focal lengths ($f_x, f_y$), the skew factor ($s$), and the principal point ($u_0, v_0$). It does not model lens distortion. The calibration matrix $K$ is defined as:\n",
         "\n",
         "$$\n",
@@ -53,34 +23,58 @@
         "\n",
         "<!-- The following will not be rendered as literal text by MyST -->\n",
         "[^f1]: See ch. 6 $\\S$ 6.1, pp. 153–157."
-      ]
+      ],
+      "metadata": {}
     },
     {
-      "cell_type": "code",
-      "execution_count": 1,
+      "id": "33369091",
+      "cell_type": "markdown",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
       "metadata": {
-        "id": "gtsam_geometry_doc_cal3_s2__cal3s2-pip-install",
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "123662a6",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/Cal3_S2.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "9aea3f33",
+      "cell_type": "code",
+      "metadata": {
         "tags": [
           "remove-cell"
         ]
       },
-      "outputs": [],
+      "execution_count": null,
       "source": [
         "try:\n",
         "    import google.colab\n",
         "    %pip install --quiet gtsam-develop\n",
         "except ImportError:\n",
         "    pass"
-      ]
+      ],
+      "outputs": []
     },
     {
       "cell_type": "code",
       "execution_count": 2,
       "metadata": {
-        "id": "gtsam_geometry_doc_cal3_s2__cal3s2-imports",
-        "tags": [
-          "remove-cell"
-        ]
+        "id": "gtsam_geometry_doc_cal3_s2__cal3s2-imports"
       },
       "outputs": [],
       "source": [

--- a/gtsam/geometry/doc/Cal3_S2Stereo.ipynb
+++ b/gtsam/geometry/doc/Cal3_S2Stereo.ipynb
@@ -1,35 +1,11 @@
 {
   "cells": [
     {
+      "id": "5d04a725",
       "cell_type": "markdown",
-      "metadata": {},
       "source": [
-        "# Cal3_S2Stereo"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_geometry_doc_cal3_s2stereo__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/Cal3_S2Stereo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
+        "# Cal3_S2Stereo\n",
+        "\n",
         "A `Cal3_S2Stereo` object describes the calibration model for a stereo camera rig, a setup for depth estimation where two cameras are mounted side by side at a fixed horizontal distance known as the baseline. This model assumes both cameras have the same intrinsic parameters.\n",
         "\n",
         "This class inherits from the standard 5-parameter [`Cal3_S2`](./Cal3_S2.ipynb) model and adds a sixth parameter, the baseline $b$. \n",
@@ -43,33 +19,57 @@
         "However, note that `Cal3_S2Stereo` itself does not perform the complete calibration of a stereo camera; it merely stores all the parameters necessary for the calibration. For instance, the baseline parameter $b$ is primarily used by other classes like [`StereoCamera`](./StereoCamera.ipynb) to compute the disparity between the left and right images during 3D projection.\n",
         "\n",
         "To see how `Cal3_S2Stereo` is used in practical applications, please refer to [StereoVOExample](../../../python/gtsam/examples/StereoVOExample.ipynb) and [StereoVOExample_large](../../../python/gtsam/examples/StereoVOExample_large.ipynb)."
-      ]
+      ],
+      "metadata": {}
     },
     {
+      "id": "6b439cd8",
+      "cell_type": "markdown",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "84832b7d",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/Cal3_S2Stereo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "1b7682f4",
       "cell_type": "code",
-      "execution_count": 1,
       "metadata": {
         "tags": [
           "remove-cell"
         ]
       },
-      "outputs": [],
+      "execution_count": null,
       "source": [
         "try:\n",
         "    import google.colab\n",
         "    %pip install --quiet gtsam-develop\n",
         "except ImportError:\n",
         "    pass"
-      ]
+      ],
+      "outputs": []
     },
     {
       "cell_type": "code",
       "execution_count": 2,
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
+      "metadata": {},
       "outputs": [],
       "source": [
         "import gtsam\n",

--- a/gtsam/geometry/doc/Cal3f.ipynb
+++ b/gtsam/geometry/doc/Cal3f.ipynb
@@ -1,0 +1,176 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Cal3f\n",
+    "\n",
+    "`Cal3f` is our simplest tunable calibration model, consisting of a single focal length. It assumes square pixels and zero skew, with `fx = fy = f`; the principal point is fixed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f37eef25",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/Cal3f.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51349e7d",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialization\n",
+    "\n",
+    "The explicit constructor makes the model and parameter order visible. A default constructor is also available, but calibrated values are preferable in real projection code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calibration = gtsam.Cal3f(800.0, 320.0, 240.0)\n",
+    "print(calibration)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calibration parameters\n",
+    "\n",
+    "`f()` is the shared focal length; `px()` and `py()` are retained as fixed projection constants. `vector()` collects the optimized parameters, while `K()` returns the intrinsic matrix associated with the linear part of the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"focal length:\", calibration.f())\n",
+    "print(\"principal point:\", calibration.principalPoint())\n",
+    "print(\"optimized vector:\", calibration.vector())\n",
+    "print(\"manifold dimension:\", calibration.dim())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calibrating and uncalibrating points\n",
+    "\n",
+    "`uncalibrate()` maps normalized image coordinates to pixels and applies this model's distortion. `calibrate()` performs the inverse mapping iteratively. Their round trip is the most direct way to check parameter conventions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "normalized = np.array([0.12, -0.08])\n",
+    "pixel = calibration.uncalibrate(normalized)\n",
+    "recovered = calibration.calibrate(pixel)\n",
+    "print(\"pixel:\", pixel)\n",
+    "print(\"recovered normalized point:\", recovered)\n",
+    "np.testing.assert_allclose(recovered, normalized, atol=1e-7)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Manifold operations\n",
+    "\n",
+    "Calibration objects participate in nonlinear optimization through `retract()` and `localCoordinates()`. The tangent coordinates follow the order returned by `vector()` for the parameters that this model optimizes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delta = np.array([2.0])\n",
+    "perturbed = calibration.retract(delta)\n",
+    "recovered_delta = calibration.localCoordinates(perturbed)\n",
+    "print(\"parameter increment:\", recovered_delta)\n",
+    "np.testing.assert_allclose(recovered_delta, delta, atol=1e-9)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`Cal3f.h`](../Cal3f.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/geometry/doc/CalibratedCamera.ipynb
+++ b/gtsam/geometry/doc/CalibratedCamera.ipynb
@@ -1,0 +1,154 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# CalibratedCamera\n",
+    "\n",
+    "`CalibratedCamera` is the variable type to use when camera calibration is known exactly and the only unknowns are the camera's position and attitude. It is a six-degree-of-freedom pinhole camera that operates directly in normalized image coordinates."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f7671f3",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/CalibratedCamera.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cbaaf9e4",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating a camera\n",
+    "\n",
+    "The camera stores a `Pose3`. The identity pose places the camera at the world origin looking along its positive z-axis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pose = gtsam.Pose3(gtsam.Rot3.Yaw(0.1), np.array([1.0, 0.0, 0.0]))\n",
+    "camera = gtsam.CalibratedCamera(pose)\n",
+    "print(\"camera center:\", camera.pose().translation())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Projection and backprojection\n",
+    "\n",
+    "`project(point)` returns `(x/z, y/z)` in the camera frame. `backproject(measurement, depth)` follows that ray to the requested camera-frame depth."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "point = np.array([2.0, 0.5, 4.0])\n",
+    "measurement = camera.project(point)\n",
+    "depth = camera.pose().transformTo(point)[2]\n",
+    "recovered = camera.backproject(measurement, depth)\n",
+    "print(\"normalized measurement:\", measurement)\n",
+    "np.testing.assert_allclose(recovered, point, atol=1e-9)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Geometry and manifold operations\n",
+    "\n",
+    "`range()` computes distance to a point, pose, or camera. `retract()` and `localCoordinates()` expose the six-dimensional camera-pose manifold. `Level()` is a convenient factory for lifting a planar pose to a level camera at a specified height."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "level_camera = gtsam.CalibratedCamera.Level(gtsam.Pose2(2.0, 3.0, 0.2), 1.5)\n",
+    "print(\"level camera center:\", level_camera.pose().translation())\n",
+    "print(\"range to point:\", camera.range(point))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`CalibratedCamera.h`](../CalibratedCamera.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/geometry/doc/CameraSet.ipynb
+++ b/gtsam/geometry/doc/CameraSet.ipynb
@@ -1,0 +1,141 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# CameraSet\n",
+    "\n",
+    "GTSAM's smart projection factors constrain *sets* of cameras. `CameraSet<CAMERA>` provides the ordered camera collection they use, and Python exposes concrete list-like containers for each wrapped pinhole, spherical, and stereo camera family."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3064ee6c",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/CameraSet.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e289f412",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating a camera set\n",
+    "\n",
+    "Choose the container whose suffix matches the camera calibration. `CameraSetCal3_S2` accepts `PinholeCameraCal3_S2` instances and retains each camera's pose and calibration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "K = gtsam.Cal3_S2(800.0, 800.0, 0.0, 320.0, 240.0)\n",
+    "camera0 = gtsam.PinholeCameraCal3_S2(gtsam.Pose3(), K)\n",
+    "camera1 = gtsam.PinholeCameraCal3_S2(\n",
+    "    gtsam.Pose3(gtsam.Rot3(), np.array([1.0, 0.0, 0.0])), K\n",
+    ")\n",
+    "\n",
+    "cameras = gtsam.CameraSetCal3_S2([camera0, camera1])\n",
+    "print(\"number of cameras:\", len(cameras))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Container operations\n",
+    "\n",
+    "The wrapped set behaves like a Python sequence. Use indexing and iteration to read cameras, and `append()`, `extend()`, `insert()`, `pop()`, or `clear()` to modify it. Mixing camera families is rejected by the wrapper type."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "point = np.array([0.2, -0.1, 5.0])\n",
+    "measurements = [camera.project(point) for camera in cameras]\n",
+    "for index, measurement in enumerate(measurements):\n",
+    "    print(index, measurement)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Available specializations\n",
+    "\n",
+    "The wrapper provides camera sets for `Cal3_S2`, `Cal3DS2`, `Cal3Unified`, `Cal3Bundler`, `Cal3Fisheye`, spherical cameras, and stereo cameras. Backward-compatible names such as `CameraSetCal3_S2` refer to the corresponding pinhole-camera specialization.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`CameraSet.h`](../CameraSet.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/geometry/doc/EssentialMatrix.ipynb
+++ b/gtsam/geometry/doc/EssentialMatrix.ipynb
@@ -1,0 +1,157 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# EssentialMatrix\n",
+    "\n",
+    "The two-view geometry between two calibrated cameras can be captured in a five-dimensional object known as the essential matrix. `EssentialMatrix` represents it as a relative rotation and unit translation direction, discarding the unobservable translation scale."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84612ee5",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/EssentialMatrix.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8bb00ac",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialization\n",
+    "\n",
+    "Construct directly from `Rot3` and `Unit3`, or use `FromPose3()` to discard the translation magnitude from a relative pose."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "relative_pose = gtsam.Pose3(\n",
+    "    gtsam.Rot3.Yaw(0.15), np.array([2.0, 0.5, 0.0])\n",
+    ")\n",
+    "essential = gtsam.EssentialMatrix.FromPose3(relative_pose)\n",
+    "print(\"rotation:\")\n",
+    "print(essential.rotation().matrix())\n",
+    "print(\"translation direction:\", essential.direction().unitVector())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Matrix and epipolar error\n",
+    "\n",
+    "`matrix()` returns the rank-two matrix `[t]×R`. For corresponding normalized homogeneous points `xa` and `xb`, the epipolar constraint is `xa.T @ E @ xb = 0`. `error()` provides GTSAM's two-dimensional geometric residual for a correspondence."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "E = essential.matrix()\n",
+    "print(\"singular values:\", np.linalg.svd(E, compute_uv=False))\n",
+    "assert np.linalg.matrix_rank(E, tol=1e-9) == 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Manifold operations\n",
+    "\n",
+    "The tangent vector has three rotation coordinates and two coordinates on the translation-direction sphere. `retract()` applies an increment and `localCoordinates()` recovers it locally."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delta = np.array([0.01, -0.02, 0.01, 0.005, -0.004])\n",
+    "perturbed = essential.retract(delta)\n",
+    "np.testing.assert_allclose(\n",
+    "    essential.localCoordinates(perturbed), delta, atol=1e-8\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`EssentialMatrix.h`](../EssentialMatrix.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/geometry/doc/Event.ipynb
+++ b/gtsam/geometry/doc/Event.ipynb
@@ -1,0 +1,142 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Event\n",
+    "\n",
+    "Especially when working with sound, we often estimate a 3D point together with a time. `Event` represents that space-time quantity as a timestamp paired with a three-dimensional location and provides a compact value type for spacetime and navigation geometry."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e181ea50",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/Event.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2904310",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialization\n",
+    "\n",
+    "Construct from a timestamp and a three-vector, or pass the three spatial coordinates separately."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "event = gtsam.Event(2.5, np.array([1.0, -0.5, 3.0]))\n",
+    "same_event = gtsam.Event(2.5, 1.0, -0.5, 3.0)\n",
+    "print(\"time:\", event.time())\n",
+    "print(\"location:\", event.location())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Accessors and height\n",
+    "\n",
+    "`time()` and `location()` return the stored values. `height()` returns the z-coordinate and optionally computes its Jacobian with respect to the event coordinates in APIs that request derivatives."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"height:\", event.height())\n",
+    "assert np.isclose(event.height(), event.location()[2])\n",
+    "assert np.isclose(same_event.time(), event.time())\n",
+    "np.testing.assert_allclose(same_event.location(), event.location())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Coordinate and time conventions\n",
+    "\n",
+    "`Event` deliberately does not assign units or a reference frame. The location should use the same world frame as the surrounding geometry, and timestamps should use one consistent scale throughout a problem. The class also does not enforce chronological ordering; that belongs to the data structure or factor that consumes the events."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`Event.h`](../Event.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/geometry/doc/FundamentalMatrix.ipynb
+++ b/gtsam/geometry/doc/FundamentalMatrix.ipynb
@@ -1,0 +1,163 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# FundamentalMatrix\n",
+    "\n",
+    "The two-view geometry between uncalibrated cameras is captured by a seven-dimensional object called the fundamental matrix. This header provides `FundamentalMatrix`, a rank-two epipolar matrix, and `SimpleFundamentalMatrix`, a camera-oriented parameterization that keeps focal lengths and principal points explicit."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7422f957",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/FundamentalMatrix.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b83d8a35",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `FundamentalMatrix`\n",
+    "\n",
+    "Construct from a rank-two matrix, its `U-s-V` factors, or calibrated relative geometry. `matrix()` returns the normalized 3×3 representation used to map a point in one image to an epipolar line in the other."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "U = gtsam.Rot3.Yaw(np.pi / 2).matrix()\n",
+    "V = gtsam.Rot3.Yaw(np.pi / 4).matrix()\n",
+    "fundamental = gtsam.FundamentalMatrix(U, 0.5, V)\n",
+    "F = fundamental.matrix()\n",
+    "print(F)\n",
+    "assert np.linalg.matrix_rank(F, tol=1e-9) == 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `SimpleFundamentalMatrix`\n",
+    "\n",
+    "The simple form starts from an `EssentialMatrix`, one focal length per camera, and the two principal points. It is useful when those camera parameters should remain visible instead of being absorbed into an arbitrary matrix scale."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "essential = gtsam.EssentialMatrix(gtsam.Rot3(), gtsam.Unit3(1.0, 0.0, 0.0))\n",
+    "simple = gtsam.SimpleFundamentalMatrix(\n",
+    "    essential, 800.0, 820.0, np.array([320.0, 240.0]), np.array([300.0, 250.0])\n",
+    ")\n",
+    "converted = gtsam.FundamentalMatrix(simple.matrix())\n",
+    "print(\"simple rank:\", np.linalg.matrix_rank(simple.matrix(), tol=1e-9))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Epipolar lines and manifold operations\n",
+    "\n",
+    "For a homogeneous image point `xb`, `F @ xb` is its epipolar line in image A. Both classes expose `retract()` and `localCoordinates()`; use those instead of perturbing matrix entries, because an arbitrary perturbation does not preserve rank two."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "point_b = np.array([350.0, 200.0, 1.0])\n",
+    "line_a = simple.matrix() @ point_b\n",
+    "print(\"epipolar line coefficients:\", line_a)\n",
+    "\n",
+    "delta = np.array([0.01, -0.01, 0.02, 0.01, -0.02, 0.005, 0.01])\n",
+    "perturbed = fundamental.retract(delta)\n",
+    "np.testing.assert_allclose(\n",
+    "    fundamental.localCoordinates(perturbed), delta, atol=1e-8\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`FundamentalMatrix.h`](../FundamentalMatrix.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/geometry/doc/Kernel.ipynb
+++ b/gtsam/geometry/doc/Kernel.ipynb
@@ -1,0 +1,158 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Kernel\n",
+    "\n",
+    "Kernels are mostly internal data structures for dealing with the exponential map and logarithm of Lie groups such as $SO(3)$ and $SE(3)$. The `gtsam.so3` classes evaluate the scalar functions used by the $SO(3)$ exponential-map Jacobian and its inverse: `Kernel` represents a forward kernel, while `InvJKernel` couples the inverse Jacobian to its forward counterpart for stable evaluation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84092619",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/Kernel.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0eadfb3b",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Obtaining the kernels\n",
+    "\n",
+    "Users normally obtain these objects from `so3.DexpFunctor`, which precomputes coefficients for a rotation vector and handles the near-zero series expansions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "omega = np.array([0.1, -0.2, 0.3])\n",
+    "dexp = gtsam.so3.DexpFunctor(omega)\n",
+    "jacobian_kernel = dexp.Jacobian()\n",
+    "inverse_kernel = dexp.InvJacobian()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `so3.Kernel`\n",
+    "\n",
+    "`left()` and `right()` return the left and right Jacobian matrices. `applyLeft(v)` and `applyRight(v)` apply those matrices to a vector without requiring callers to form the product themselves. `frechet()` and `applyFrechet()` expose derivatives of the kernel action."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "J_left = jacobian_kernel.left()\n",
+    "vector = np.array([1.0, 2.0, -1.0])\n",
+    "np.testing.assert_allclose(\n",
+    "    jacobian_kernel.applyLeft(vector), J_left @ vector, atol=1e-12\n",
+    ")\n",
+    "print(\"left Jacobian:\")\n",
+    "print(J_left)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `so3.InvJKernel`\n",
+    "\n",
+    "`left()` and `right()` return inverse Jacobians, and `applyLeft()`/`applyRight()` apply them. Its public `J` property retains the associated forward kernel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "J_left_inverse = inverse_kernel.left()\n",
+    "np.testing.assert_allclose(J_left_inverse @ J_left, np.eye(3), atol=1e-12)\n",
+    "np.testing.assert_allclose(\n",
+    "    inverse_kernel.applyLeft(vector), J_left_inverse @ vector, atol=1e-12\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`Kernel.h`](../Kernel.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/geometry/doc/OrientedPlane3.ipynb
+++ b/gtsam/geometry/doc/OrientedPlane3.ipynb
@@ -1,0 +1,153 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# OrientedPlane3\n",
+    "\n",
+    "Oriented planes are the reason GTSAM switched from optimizing over groups to optimizing over *manifolds*. `OrientedPlane3` represents a plane by a unit normal and signed distance from the origin; reversing all four coefficients represents the opposite oriented plane."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e87bd26a",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/OrientedPlane3.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6931b1af",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialization\n",
+    "\n",
+    "Construct from a `Unit3` normal and distance, a four-vector, or four scalar coefficients. Non-unit coefficient vectors are normalized internally."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plane = gtsam.OrientedPlane3(gtsam.Unit3(0.0, 0.0, 1.0), -2.0)\n",
+    "same_plane = gtsam.OrientedPlane3(0.0, 0.0, 1.0, -2.0)\n",
+    "print(\"coefficients:\", plane.planeCoefficients())\n",
+    "print(\"same plane:\", plane.equals(same_plane, 1e-12))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Normal, distance, and error\n",
+    "\n",
+    "`normal()` and `distance()` expose the minimal representation. `errorVector(other)` returns a three-dimensional manifold discrepancy: two coordinates for normal direction and one for distance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tilted = gtsam.OrientedPlane3(gtsam.Unit3(0.1, 0.0, 1.0), -2.1)\n",
+    "print(\"normal:\", plane.normal().unitVector())\n",
+    "print(\"distance:\", plane.distance())\n",
+    "print(\"error to tilted plane:\", plane.errorVector(tilted))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Transforming a plane\n",
+    "\n",
+    "`transform(pose)` expresses the plane after applying a `Pose3`. This is the dual operation to transforming points; both the normal and signed distance can change."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pose = gtsam.Pose3(gtsam.Rot3.Rx(0.2), np.array([0.0, 0.0, 1.0]))\n",
+    "transformed = plane.transform(pose)\n",
+    "print(\"transformed coefficients:\", transformed.planeCoefficients())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`OrientedPlane3.h`](../OrientedPlane3.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/geometry/doc/PinholeCamera.ipynb
+++ b/gtsam/geometry/doc/PinholeCamera.ipynb
@@ -1,0 +1,157 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PinholeCamera\n",
+    "\n",
+    "Often we optimize a camera's location and orientation (extrinsics) together with its calibration parameters (intrinsics). `PinholeCamera<CALIBRATION>` combines both in one value and provides projection, backprojection, reprojection error, and camera geometry; Python exposes one concrete class per wrapped calibration model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45b5c97c",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/PinholeCamera.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "84238200",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating a calibrated pinhole camera\n",
+    "\n",
+    "This example uses `PinholeCameraCal3_S2`; the `Cal3DS2`, `Cal3Unified`, `Cal3Bundler`, `Cal3f`, and `Cal3Fisheye` specializations have the same camera interface."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "K = gtsam.Cal3_S2(800.0, 790.0, 0.0, 320.0, 240.0)\n",
+    "pose = gtsam.Pose3(gtsam.Rot3.Yaw(0.1), np.array([1.0, 0.0, 0.0]))\n",
+    "camera = gtsam.PinholeCameraCal3_S2(pose, K)\n",
+    "print(\"camera center:\", camera.pose().translation())\n",
+    "print(\"focal length:\", camera.calibration().fx())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Projection and visibility\n",
+    "\n",
+    "`project()` maps a world point to pixels. `projectSafe()` additionally reports whether the point is in front of the camera, and `reprojectionError()` compares a point with an observed pixel measurement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "point = np.array([1.5, 0.2, 5.0])\n",
+    "pixel = camera.project(point)\n",
+    "safe_pixel, visible = camera.projectSafe(point)\n",
+    "print(\"pixel:\", pixel, \"visible:\", visible)\n",
+    "np.testing.assert_allclose(safe_pixel, pixel)\n",
+    "np.testing.assert_allclose(camera.reprojectionError(point, pixel), np.zeros(2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Backprojection and range\n",
+    "\n",
+    "`backproject(pixel, depth)` recovers a world point at a specified camera-frame depth. `range()` reports Euclidean distance instead, so depth and range differ away from the optical axis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "depth = camera.pose().transformTo(point)[2]\n",
+    "recovered = camera.backproject(pixel, depth)\n",
+    "np.testing.assert_allclose(recovered, point, atol=1e-9)\n",
+    "print(\"depth:\", depth, \"range:\", camera.range(point))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`PinholeCamera.h`](../PinholeCamera.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/geometry/doc/PinholePose.ipynb
+++ b/gtsam/geometry/doc/PinholePose.ipynb
@@ -1,0 +1,165 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PinholePose\n",
+    "\n",
+    "In many cases, we estimate the location and orientation of a camera as it moves over time while sharing a single unknown calibration object. `PinholePose<CALIBRATION>` supports this pattern by treating calibration as shared external data, so its optimization state is only the six-dimensional camera pose."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a82e2e84",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/PinholePose.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d50733d",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating a pose-only camera\n",
+    "\n",
+    "The wrapper provides specializations for the same calibration families as `PinholeCamera`. Supply a calibration when projection needs pixels; the pose remains the only manifold state."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "K = gtsam.Cal3_S2(800.0, 790.0, 0.0, 320.0, 240.0)\n",
+    "pose = gtsam.Pose3(gtsam.Rot3.Yaw(0.1), np.array([1.0, 0.0, 0.0]))\n",
+    "camera = gtsam.PinholePoseCal3_S2(pose, K)\n",
+    "print(\"manifold dimension:\", camera.dim())\n",
+    "print(\"calibration fx:\", camera.calibration().fx())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Projection and backprojection\n",
+    "\n",
+    "The projection API mirrors `PinholeCamera`: `project()`, `projectSafe()`, `backproject()`, `range()`, and `pose()` all operate on the shared calibration and stored pose."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "point = np.array([1.5, 0.2, 5.0])\n",
+    "pixel = camera.project(point)\n",
+    "depth = camera.pose().transformTo(point)[2]\n",
+    "recovered = camera.backproject(pixel, depth)\n",
+    "print(\"pixel:\", pixel)\n",
+    "np.testing.assert_allclose(recovered, point, atol=1e-9)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pose manifold\n",
+    "\n",
+    "`retract()` applies a six-vector pose increment, and `localCoordinates()` compares two pose-only cameras. Calibration is not part of that tangent vector."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delta = np.array([0.01, -0.01, 0.02, 0.1, 0.0, -0.05])\n",
+    "perturbed = camera.retract(delta)\n",
+    "np.testing.assert_allclose(camera.localCoordinates(perturbed), delta, atol=1e-8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Choosing between `PinholePose` and `PinholeCamera`\n",
+    "\n",
+    "Use `PinholePose` when many cameras share a fixed calibration or calibration is managed separately. Use `PinholeCamera` when pose and calibration should travel as one value—and potentially be optimized together in a calibration-specific manifold."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`PinholePose.h`](../PinholePose.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/geometry/doc/Pose2.ipynb
+++ b/gtsam/geometry/doc/Pose2.ipynb
@@ -1,66 +1,58 @@
 {
   "cells": [
     {
+      "id": "e70d1c84",
       "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_geometry_doc_pose2__xhCSxfYqLPVI"
-      },
       "source": [
-        "# Pose2"
-      ]
+        "# Pose2\n",
+        "\n",
+        "A `Pose2` represents a position and orientation in 2D space. It is both a $\\mathcal{SE}(2)$ pose manifold and a $SE(2)$ Lie group of transforms. It consists of a 2D position (variously represented as $r$, $t$, or $(x, y)$ depending on the context) and a rotation (similarly, $C$, $R$, or $\\theta$). Its 3-dimensional analog is a `Pose3`. It is included in the top-level `gtsam` package."
+      ],
+      "metadata": {}
     },
     {
+      "id": "31407110",
       "cell_type": "markdown",
-      "id": "gtsam_geometry_doc_pose2__license_cell",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
       "metadata": {
         "tags": [
           "remove-cell"
         ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
+      }
     },
     {
+      "id": "0d616800",
       "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_geometry_doc_pose2__cF2tPRNbLSIJ"
-      },
-      "source": [
-        "A `Pose2` represents a position and orientation in 2D space. It is both a $\\mathcal{SE}(2)$ pose manifold and a $SE(2)$ Lie group of transforms. It consists of a 2D position (variously represented as $r$, $t$, or $(x, y)$ depending on the context) and a rotation (similarly, $C$, $R$, or $\\theta$). Its 3-dimensional analog is a `Pose3`. It is included in the top-level `gtsam` package."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_geometry_doc_pose2__OJNfomRj5H-C"
-      },
       "source": [
         "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/Pose2.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
+      ],
+      "metadata": {}
     },
     {
+      "id": "557676cc",
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "gtsam_geometry_doc_pose2__DZrO0rl2LfIB",
-        "outputId": "162d0ca4-9bb2-4407-b317-052c20327110",
         "tags": [
           "remove-cell"
         ]
       },
-      "outputs": [],
+      "execution_count": null,
       "source": [
-        "# Install GTSAM and Plotly from pip if running in Google Colab\n",
         "try:\n",
         "    import google.colab\n",
-        "    %pip install --quiet gtsam-develop \n",
+        "    %pip install --quiet gtsam-develop\n",
         "except ImportError:\n",
-        "    pass # Not in Colab"
-      ]
+        "    pass"
+      ],
+      "outputs": []
     },
     {
       "cell_type": "code",

--- a/gtsam/geometry/doc/Rot2.ipynb
+++ b/gtsam/geometry/doc/Rot2.ipynb
@@ -1,62 +1,58 @@
 {
   "cells": [
     {
+      "id": "60efed8a",
       "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_geometry_doc_rot2__-3NPWeM5nKTz"
-      },
       "source": [
-        "# Rot2"
-      ]
+        "# Rot2\n",
+        "\n",
+        "A `gtsam.Rot2` represents rotation in 2D space. It models a 2D rotation in the Special Orthogonal Group $\\text{SO}(2)$."
+      ],
+      "metadata": {}
     },
     {
+      "id": "69f66bb9",
       "cell_type": "markdown",
-      "id": "gtsam_geometry_doc_rot2__license_cell",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
       "metadata": {
         "tags": [
           "remove-cell"
         ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
+      }
     },
     {
+      "id": "7ad744b8",
       "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_geometry_doc_rot2__zKQLwRQWvRAW"
-      },
-      "source": [
-        "A `gtsam.Rot2` represents rotation in 2D space. It models a 2D rotation in the Special Orthogonal Group $\\text{SO}(2)$."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_geometry_doc_rot2__1MUA6xip5fG4"
-      },
       "source": [
         "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/Rot2.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
+      ],
+      "metadata": {}
     },
     {
+      "id": "79823f1e",
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "gtsam_geometry_doc_rot2__7a9Dr6c5nHi1",
         "tags": [
           "remove-cell"
         ]
       },
-      "outputs": [],
+      "execution_count": null,
       "source": [
-        "# Install GTSAM and Plotly from pip if running in Google Colab\n",
         "try:\n",
         "    import google.colab\n",
-        "    %pip install --quiet gtsam-develop \n",
+        "    %pip install --quiet gtsam-develop\n",
         "except ImportError:\n",
-        "    pass # Not in Colab"
-      ]
+        "    pass"
+      ],
+      "outputs": []
     },
     {
       "cell_type": "code",

--- a/gtsam/geometry/doc/Rot3.ipynb
+++ b/gtsam/geometry/doc/Rot3.ipynb
@@ -1,62 +1,58 @@
 {
   "cells": [
     {
+      "id": "900e76b0",
       "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_geometry_doc_rot3__Wy0JIcGioHI9"
-      },
       "source": [
-        "# Rot3"
-      ]
+        "# Rot3\n",
+        "\n",
+        "A `gtsam.Rot3` represents an orientation or attitude in 3D space. It can be manipulated and presented as a rotation matrix $ R \\in \\mathbb{R}^{3 \\times 3} $, a unit quaternion, roll-pitch-yaw (Euler) angles $ (\\phi, \\theta, \\psi) $, or as an axis-angle representation $ (\\hat{\\omega}, \\theta) $ with $ \\hat{\\omega} \\in \\mathbb{R}^3 $ and $ \\theta \\in \\mathbb{R} $. It models a 3D orientation as both a manifold in $ \\mathcal{SO}(3) $ and as a Lie group in $ \\text{SO}(3) $. Internally, it is stored as a $ 3 \\times 3 $ rotation matrix but can be configured to use quaternions at build time for efficiency."
+      ],
+      "metadata": {}
     },
     {
+      "id": "123aecc4",
       "cell_type": "markdown",
-      "id": "gtsam_geometry_doc_rot3__license_cell",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
       "metadata": {
         "tags": [
           "remove-cell"
         ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
+      }
     },
     {
+      "id": "1c07fa7b",
       "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_geometry_doc_rot3__YqaxPKyloJG_"
-      },
-      "source": [
-        "A `gtsam.Rot3` represents an orientation or attitude in 3D space. It can be manipulated and presented as a rotation matrix $ R \\in \\mathbb{R}^{3 \\times 3} $, a unit quaternion, roll-pitch-yaw (Euler) angles $ (\\phi, \\theta, \\psi) $, or as an axis-angle representation $ (\\hat{\\omega}, \\theta) $ with $ \\hat{\\omega} \\in \\mathbb{R}^3 $ and $ \\theta \\in \\mathbb{R} $. It models a 3D orientation as both a manifold in $ \\mathcal{SO}(3) $ and as a Lie group in $ \\text{SO}(3) $. Internally, it is stored as a $ 3 \\times 3 $ rotation matrix but can be configured to use quaternions at build time for efficiency."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_geometry_doc_rot3__Hmwbhz75pcQT"
-      },
       "source": [
         "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/Rot3.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
+      ],
+      "metadata": {}
     },
     {
+      "id": "8bcb8bcd",
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "gtsam_geometry_doc_rot3__HyXPOMakoDkY",
         "tags": [
           "remove-cell"
         ]
       },
-      "outputs": [],
+      "execution_count": null,
       "source": [
-        "# Install GTSAM and Plotly from pip if running in Google Colab\n",
         "try:\n",
         "    import google.colab\n",
-        "    %pip install --quiet gtsam-develop \n",
+        "    %pip install --quiet gtsam-develop\n",
         "except ImportError:\n",
-        "    pass # Not in Colab"
-      ]
+        "    pass"
+      ],
+      "outputs": []
     },
     {
       "cell_type": "code",

--- a/gtsam/geometry/doc/SO3.ipynb
+++ b/gtsam/geometry/doc/SO3.ipynb
@@ -1,32 +1,11 @@
 {
   "cells": [
     {
+      "id": "fbd33465",
       "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_geometry_doc_so3__Wy0JIcGioHI9"
-      },
       "source": [
-        "# SO3"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_geometry_doc_so3__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_geometry_doc_so3__YqaxPKyloJG_"
-      },
-      "source": [
+        "# SO3\n",
+        "\n",
         "Typically, 3D rotations are used in GTSAM via the class [`Rot3`](Rot3.ipynb), which can use either `SO3` or `Quaternion` as the underlying representation.\n",
         "\n",
         "`gtsam.SO3` is the 3x3 matrix representation of an element of SO(3), and implements all the Jacobians associated with the group structure.\n",
@@ -34,34 +13,64 @@
         "This document documents some of the math involved.\n",
         "\n",
         "`SO3` implements the exponential map and its inverse, as well as their Jacobians. For more information on Lie groups and their use here, see [GTSAM concepts](https://gtsam.org/notes/GTSAM-Concepts.html)."
-      ]
+      ],
+      "metadata": {}
     },
     {
+      "id": "90aebe7a",
       "cell_type": "markdown",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
       "metadata": {
-        "id": "gtsam_geometry_doc_so3__Hmwbhz75pcQT"
-      },
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "0e00a3f5",
+      "cell_type": "markdown",
       "source": [
         "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/SO3.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
+      ],
+      "metadata": {}
     },
     {
+      "id": "ee277344",
       "cell_type": "code",
-      "execution_count": 1,
       "metadata": {
         "tags": [
           "remove-cell"
         ]
       },
-      "outputs": [],
+      "execution_count": null,
       "source": [
-        "# Install GTSAM and Plotly from pip if running in Google Colab\n",
         "try:\n",
         "    import google.colab\n",
-        "    %pip install --quiet gtsam-develop \n",
+        "    %pip install --quiet gtsam-develop\n",
         "except ImportError:\n",
-        "    pass # Not in Colab"
-      ]
+        "    pass"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "14127247",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "from gtsam.symbol_shorthand import L, X"
+      ],
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -563,6 +572,35 @@
         "\n",
         "We only plot the Taylor expansion. To the right of the threshold (closer to $\\pi$) GTSAM will use this, and the difference plot shows the approximation error introduced by this Taylor expansion is small (less than $10e-8$)."
       ]
+    },
+    {
+      "id": "9e46a476",
+      "cell_type": "markdown",
+      "source": [
+        "## Wrapped class API\n",
+        "\n",
+        "The header also exposes the following wrapped classes. This executable listing makes their constructors, properties, and methods visible in the installed build: `ExpmapFunctor`."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "1fb61874",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "def public_api(qualified_name):\n",
+        "    value = gtsam\n",
+        "    for component in qualified_name.split('.'):\n",
+        "        value = getattr(value, component, None)\n",
+        "        if value is None:\n",
+        "            return []\n",
+        "    return [name for name in dir(value) if not name.startswith('_')]\n",
+        "\n",
+        "print('\\nso3.ExpmapFunctor')\n",
+        "print(public_api('so3.ExpmapFunctor'))"
+      ],
+      "outputs": []
     }
   ],
   "metadata": {

--- a/gtsam/geometry/doc/SphericalCamera.ipynb
+++ b/gtsam/geometry/doc/SphericalCamera.ipynb
@@ -1,0 +1,158 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SphericalCamera\n",
+    "\n",
+    "This header defines `SphericalCamera`, a pose-only camera whose measurements are unit bearing vectors, and `EmptyCal`, the zero-parameter calibration type used to satisfy generic camera interfaces."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79f51588",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/SphericalCamera.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25c9a95d",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `EmptyCal`\n",
+    "\n",
+    "Spherical measurements have no focal length or principal point. `EmptyCal` is therefore a stateless placeholder; constructing it supplies generic code with a calibration object without adding optimization variables."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "empty_calibration = gtsam.EmptyCal()\n",
+    "camera = gtsam.SphericalCamera(gtsam.Pose3(), empty_calibration)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `SphericalCamera` projection\n",
+    "\n",
+    "`project(point)` returns a `Unit3` bearing in the camera frame. Unlike a pinhole camera, directions over the full sphere are valid and there is no image-plane cheirality boundary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "point = np.array([2.0, -1.0, 4.0])\n",
+    "bearing = camera.project(point)\n",
+    "print(\"bearing:\", bearing.unitVector())\n",
+    "assert np.isclose(np.linalg.norm(bearing.unitVector()), 1.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Backprojection and reprojection error\n",
+    "\n",
+    "`backproject(bearing, depth)` follows a unit direction for the requested range. `reprojectionError()` returns a two-dimensional tangent-space error on the sphere."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "depth = np.linalg.norm(point)\n",
+    "recovered = camera.backproject(bearing, depth)\n",
+    "np.testing.assert_allclose(recovered, point, atol=1e-9)\n",
+    "np.testing.assert_allclose(\n",
+    "    camera.reprojectionError(point, bearing), np.zeros(2), atol=1e-12\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pose operations\n",
+    "\n",
+    "`pose()`, `rotation()`, and `translation()` expose camera geometry. `retract()` and `localCoordinates()` use a six-dimensional pose tangent, and `Identity()` creates an identity-pose camera.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`SphericalCamera.h`](../SphericalCamera.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/geometry/doc/StereoCamera.ipynb
+++ b/gtsam/geometry/doc/StereoCamera.ipynb
@@ -1,41 +1,11 @@
 {
   "cells": [
     {
+      "id": "868dda51",
       "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_geometry_doc_stereocamera__stereocamera-title"
-      },
       "source": [
-        "# StereoCamera"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_geometry_doc_stereocamera__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_geometry_doc_stereocamera__stereocamera-colab-badge"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/StereoCamera.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_geometry_doc_stereocamera__stereocamera-intro"
-      },
-      "source": [
+        "# StereoCamera\n",
+        "\n",
         "A `StereoCamera` in GTSAM models a calibrated stereo camera rig composed of a [`Pose3`](./Pose3.ipynb) representing the left camera's pose in the world frame and a [`Cal3_S2Stereo`](./Cal3_S2Stereo.ipynb) object that contains the intrinsic parameters of both cameras and the baseline between them.\n",
         "\n",
         "It has two main functionalities:\n",
@@ -47,34 +17,58 @@
         "In real-world applications, stereo image pairs are used to extract matching pixel coordinates $(u_L, u_R, v)$, which can then be passed to `StereoCamera.backproject()` to recover 3D points based on the pose of the camera.\n",
         "\n",
         "To see how `StereoCamera` is used in practical applications, please refer to [StereoVOExample](../../../python/gtsam/examples/StereoVOExample.ipynb) and [StereoVOExample_large](../../../python/gtsam/examples/StereoVOExample_large.ipynb)."
-      ]
+      ],
+      "metadata": {}
     },
     {
-      "cell_type": "code",
-      "execution_count": 1,
+      "id": "094d6ce6",
+      "cell_type": "markdown",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
       "metadata": {
-        "id": "gtsam_geometry_doc_stereocamera__stereocamera-pip-install",
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "b19c2cdd",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/StereoCamera.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "9c763cf4",
+      "cell_type": "code",
+      "metadata": {
         "tags": [
           "remove-cell"
         ]
       },
-      "outputs": [],
+      "execution_count": null,
       "source": [
         "try:\n",
         "    import google.colab\n",
         "    %pip install --quiet gtsam-develop\n",
         "except ImportError:\n",
         "    pass"
-      ]
+      ],
+      "outputs": []
     },
     {
       "cell_type": "code",
       "execution_count": 2,
       "metadata": {
-        "id": "gtsam_geometry_doc_stereocamera__stereocamera-imports",
-        "tags": [
-          "remove-cell"
-        ]
+        "id": "gtsam_geometry_doc_stereocamera__stereocamera-imports"
       },
       "outputs": [],
       "source": [
@@ -295,7 +289,7 @@
       "source": [
         "### `backproject`\n",
         "\n",
-        "The `backproject()` member function performs the inverse operation of `project()`. Given a [`StereoPoint2`](./StereoPoint2) measurement $(u_L, u_R, v)$, it reconstructs and returns the corresponding 3D point in the world frame as a `Point3`.\n",
+        "The `backproject()` member function performs the inverse operation of `project()`. Given a [`StereoPoint2`](./StereoPoint2.ipynb) measurement $(u_L, u_R, v)$, it reconstructs and returns the corresponding 3D point in the world frame as a `Point3`.\n",
         "\n",
         "This function is especially useful in real-world applications, where stereo image pairs are used to extract pixel correspondences. When the stereo rig's pose and calibration are known (which should be true if you are using a `StereoCamera` in the first place), `backproject()` allows recovering the estimated position of a point in space from its stereo measurement."
       ]

--- a/gtsam/geometry/doc/StereoPoint2.ipynb
+++ b/gtsam/geometry/doc/StereoPoint2.ipynb
@@ -1,0 +1,138 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# StereoPoint2\n",
+    "\n",
+    "`StereoPoint2` stores a rectified stereo measurement `(uL, uR, v)`: horizontal coordinates in the left and right images plus their shared vertical coordinate."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60c214d3",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/StereoPoint2.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "839779ab",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialization\n",
+    "\n",
+    "Construct from three scalars or a three-vector. `Identity()` returns the zero measurement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "measurement = gtsam.StereoPoint2(340.0, 315.0, 205.0)\n",
+    "from_vector = gtsam.StereoPoint2(np.array([340.0, 315.0, 205.0]))\n",
+    "print(\"same measurement:\", measurement.equals(from_vector, 1e-12))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Components and disparity\n",
+    "\n",
+    "`uL()`, `uR()`, and `v()` expose the components, while `vector()` returns them in constructor order. The horizontal disparity `uL - uR` is inversely related to depth for a rectified stereo pair."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "disparity = measurement.uL() - measurement.uR()\n",
+    "print(\"measurement vector:\", measurement.vector())\n",
+    "print(\"disparity:\", disparity)\n",
+    "assert disparity > 0.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use with `StereoCamera`\n",
+    "\n",
+    "`StereoCamera.project()` produces this type, and `StereoCamera.backproject()` consumes it. Keeping the shared `v` coordinate explicit encodes the rectified-image assumption.\n",
+    "\n",
+    "The value type does not enforce measurement validity. In normal rectified geometry, positive finite depth produces positive disparity; zero disparity corresponds to a point at infinity, and negative disparity usually indicates a mismatched observation or inconsistent camera convention.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`StereoPoint2.h`](../StereoPoint2.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/geometry/doc/Unit3.ipynb
+++ b/gtsam/geometry/doc/Unit3.ipynb
@@ -1,0 +1,158 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Unit3\n",
+    "\n",
+    "`Unit3` represents a direction in three dimensions while enforcing unit length. Its state has two degrees of freedom, making it the natural type for bearings, surface normals, and translation directions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8decf188",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/Unit3.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c21aace1",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialization and normalization\n",
+    "\n",
+    "Construct from a three-vector or three scalars. The input need not be normalized; `Unit3` normalizes it and retains only direction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "direction = gtsam.Unit3(np.array([1.0, 2.0, 3.0]))\n",
+    "print(\"unit vector:\", direction.unitVector())\n",
+    "assert np.isclose(np.linalg.norm(direction.unitVector()), 1.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Direction operations\n",
+    "\n",
+    "`dot(other)` computes cosine similarity, `skew()` returns the cross-product matrix, and `errorVector(other)` gives a two-dimensional tangent-space discrepancy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "other = gtsam.Unit3(0.0, 0.0, 1.0)\n",
+    "print(\"dot product:\", direction.dot(other))\n",
+    "print(\"direction error:\", direction.errorVector(other))\n",
+    "np.testing.assert_allclose(\n",
+    "    direction.skew() @ other.unitVector(),\n",
+    "    np.cross(direction.unitVector(), other.unitVector()),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tangent basis and manifold operations\n",
+    "\n",
+    "`basis()` returns a 3×2 orthonormal basis for the tangent plane. `retract(delta)` moves along that plane and `localCoordinates()` recovers a small two-vector displacement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "basis = direction.basis()\n",
+    "np.testing.assert_allclose(basis.T @ basis, np.eye(2), atol=1e-12)\n",
+    "\n",
+    "delta = np.array([0.02, -0.01])\n",
+    "perturbed = direction.retract(delta)\n",
+    "np.testing.assert_allclose(direction.localCoordinates(perturbed), delta, atol=1e-8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`Unit3.h`](../Unit3.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/geometry/doc/triangulation.ipynb
+++ b/gtsam/geometry/doc/triangulation.ipynb
@@ -1,0 +1,167 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# triangulation\n",
+    "\n",
+    "The triangulation API reconstructs 3D landmarks from multiple camera measurements. `TriangulationParameters` configures robust validity checks, while `TriangulationResult` distinguishes a valid point from geometric failure modes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "971eb561",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/geometry/doc/triangulation.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f6e06e6",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A two-view track\n",
+    "\n",
+    "Build two calibrated cameras, project a known point, and place the cameras in a matching `CameraSet`. Real applications supply measured pixels rather than generating them this way."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "K = gtsam.Cal3_S2(800.0, 800.0, 0.0, 320.0, 240.0)\n",
+    "camera0 = gtsam.PinholeCameraCal3_S2(gtsam.Pose3(), K)\n",
+    "camera1 = gtsam.PinholeCameraCal3_S2(\n",
+    "    gtsam.Pose3(gtsam.Rot3(), np.array([1.0, 0.0, 0.0])), K\n",
+    ")\n",
+    "point = np.array([0.2, -0.1, 5.0])\n",
+    "cameras = gtsam.CameraSetCal3_S2([camera0, camera1])\n",
+    "measurements = [camera.project(point) for camera in cameras]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `TriangulationParameters`\n",
+    "\n",
+    "The parameters control rank tolerance, EPI correction, maximum landmark distance, dynamic outlier rejection, the LOST algorithm, and an optional measurement noise model. Negative distance/outlier thresholds disable those checks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parameters = gtsam.TriangulationParameters(\n",
+    "    rankTolerance=1e-9,\n",
+    "    enableEPI=False,\n",
+    "    landmarkDistanceThreshold=10.0,\n",
+    "    dynamicOutlierRejectionThreshold=5.0,\n",
+    "    useLOST=False,\n",
+    ")\n",
+    "print(\"distance threshold:\", parameters.landmarkDistanceThreshold)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `TriangulationResult`\n",
+    "\n",
+    "`triangulateSafe()` returns a result rather than throwing for common geometric failures. Test `valid()` before calling `get()`. The predicates `degenerate()`, `outlier()`, `farPoint()`, and `behindCamera()` explain invalid results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = gtsam.triangulateSafe(cameras, measurements, parameters)\n",
+    "print(\"status:\", result.status)\n",
+    "print(\"valid:\", result.valid())\n",
+    "assert result.valid()\n",
+    "np.testing.assert_allclose(result.get(), point, atol=1e-8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Other triangulation entry points\n",
+    "\n",
+    "`triangulatePoint3()` performs linear triangulation with optional nonlinear refinement, while `triangulateNonlinear()` refines an initial point. Overloads accept shared calibrations, camera sets with individual calibrations, spherical cameras, and batches of tracks.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`triangulation.h`](../triangulation.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/nonlinear/doc/BatchFixedLagSmoother.ipynb
+++ b/gtsam/nonlinear/doc/BatchFixedLagSmoother.ipynb
@@ -1,52 +1,82 @@
 {
   "cells": [
     {
+      "id": "2f52a893",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_batchfixedlagsmoother__283174f8",
-      "metadata": {},
       "source": [
         "# BatchFixedLagSmoother\n",
         "\n",
+        "This API walkthrough introduces the wrapped classes `BatchFixedLagSmoother` declared by `BatchFixedLagSmoother.h` and demonstrates their principal Python operations."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "85b86a10",
+      "cell_type": "markdown",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "28d5394a",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/BatchFixedLagSmoother.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "f24297af",
+      "cell_type": "code",
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      },
+      "execution_count": null,
+      "source": [
+        "try:\n",
+        "    import google.colab\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "except ImportError:\n",
+        "    pass"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "cf0f351b",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "from gtsam.symbol_shorthand import L, X"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "115ec1e8",
+      "cell_type": "markdown",
+      "source": [
         "## Overview\n",
         "\n",
         "The `IncrementalFixedLagSmoother` is a [FixedLagSmoother](FixedLagSmoother.ipynb) that uses [LevenbergMarquardtOptimizer](LevenbergMarquardtOptimizer.ipynb) for batch optimization.\n",
         "\n",
         "This fixed lag smoother will **batch-optimize** at every iteration, but warm-started from the last estimate."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_batchfixedlagsmoother__colab_button",
-      "metadata": {},
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/BatchFixedLagSmoother.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_batchfixedlagsmoother__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "gtsam_nonlinear_doc_batchfixedlagsmoother__colab_import",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "outputs": [],
-      "source": [
-        "try:\n    import google.colab\n    %pip install --quiet gtsam-develop\nexcept ImportError:\n    pass"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "cell_type": "markdown",
@@ -81,6 +111,28 @@
         "\n",
         "- **marginalize**: This function handles the marginalization of variables that are no longer within the fixed lag window. Marginalization is a crucial step in maintaining the size of the factor graph, ensuring that only relevant variables are kept for optimization.\n"
       ]
+    },
+    {
+      "id": "5bc52dba",
+      "cell_type": "markdown",
+      "source": [
+        "## Python wrapper walkthrough\n",
+        "\n",
+        "The following cell exercises the wrapped API directly."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "46b34921",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "smoother = gtsam.BatchFixedLagSmoother(2.0)\n",
+        "print(type(smoother).__name__)\n",
+        "print([name for name in dir(smoother) if not name.startswith('_')])"
+      ],
+      "outputs": []
     }
   ],
   "metadata": {

--- a/gtsam/nonlinear/doc/ConcentratedGaussian.ipynb
+++ b/gtsam/nonlinear/doc/ConcentratedGaussian.ipynb
@@ -1,9 +1,8 @@
 {
   "cells": [
     {
+      "id": "aba89243",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_concentratedgaussian__e6b52636",
-      "metadata": {},
       "source": [
         "# ConcentratedGaussian\n",
         "\n",
@@ -14,42 +13,52 @@
         "3. Advanced users leveraging transport, reset, and fusion of Left Extended Concentrated Gaussians (L-ECGs).\n",
         "\n",
         "Related notebooks: [PriorFactor](PriorFactor.ipynb), [ExtendedPriorFactor](ExtendedPriorFactor.ipynb)."
-      ]
+      ],
+      "metadata": {}
     },
     {
+      "id": "267d7bd2",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_concentratedgaussian__license_cell",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "e30a8e35",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/ConcentratedGaussian.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "784faeee",
+      "cell_type": "code",
       "metadata": {
         "tags": [
           "remove-cell"
         ]
       },
+      "execution_count": null,
       "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_concentratedgaussian__d7c5d09a",
-      "metadata": {},
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/ConcentratedGaussian.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "id": "gtsam_nonlinear_doc_concentratedgaussian__9c762320",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Install GTSAM and Plotly from pip if running in Google Colab\n",
         "try:\n",
         "    import google.colab\n",
-        "    %pip install --quiet gtsam-develop \n",
+        "    %pip install --quiet gtsam-develop\n",
         "except ImportError:\n",
-        "    pass # Not in Colab"
-      ]
+        "    pass"
+      ],
+      "outputs": []
     },
     {
       "cell_type": "code",

--- a/gtsam/nonlinear/doc/CustomFactor.ipynb
+++ b/gtsam/nonlinear/doc/CustomFactor.ipynb
@@ -1,49 +1,75 @@
 {
   "cells": [
     {
+      "id": "571305fd",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_customfactor__31f395c5",
-      "metadata": {},
       "source": [
-        "# CustomFactor"
-      ]
+        "# CustomFactor\n",
+        "\n",
+        "**Notes**:\n",
+        "- There are not a lot of restrictions on the function, but note there is overhead in calling a python function from within a c++ optimization loop. \n",
+        "- Because `pybind11` needs to lock the Python GIL lock for evaluation of each factor, parallel evaluation of `CustomFactor` is not possible.\n",
+        "- You can mitigate both of these by having a python function that leverages batching of measurements.\n",
+        "\n",
+        "Some more examples of usage in python are given in [test_custom_factor.py](https://github.com/borglab/gtsam/blob/develop/python/gtsam/tests/test_custom_factor.py),[CustomFactorExample.py](https://github.com/borglab/gtsam/blob/develop/python/gtsam/examples/CustomFactorExample.py), and [CameraResectioning.py](https://github.com/borglab/gtsam/blob/develop/python/gtsam/examples/CameraResectioning.py)."
+      ],
+      "metadata": {}
     },
     {
+      "id": "2fabbb43",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_customfactor__license_cell",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "b25ec748",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/CustomFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "42c2c67b",
+      "cell_type": "code",
       "metadata": {
         "tags": [
           "remove-cell"
         ]
       },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_customfactor__1a3591a2",
-      "metadata": {},
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/CustomFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "code",
       "execution_count": null,
-      "id": "gtsam_nonlinear_doc_customfactor__5ccb48e4",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ],
-        "vscode": {
-          "languageId": "markdown"
-        }
-      },
-      "outputs": [],
       "source": [
-        "%pip install --quiet gtsam-develop"
-      ]
+        "try:\n",
+        "    import google.colab\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "except ImportError:\n",
+        "    pass"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "946d7b25",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "from gtsam.symbol_shorthand import L, X"
+      ],
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -91,19 +117,6 @@
         "    - the noise model\n",
         "    - the keys of the variables it depends on\n",
         "    - the error function"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_customfactor__c7ec3512",
-      "metadata": {},
-      "source": [
-        "**Notes**:\n",
-        "- There are not a lot of restrictions on the function, but note there is overhead in calling a python function from within a c++ optimization loop. \n",
-        "- Because `pybind11` needs to lock the Python GIL lock for evaluation of each factor, parallel evaluation of `CustomFactor` is not possible.\n",
-        "- You can mitigate both of these by having a python function that leverages batching of measurements.\n",
-        "\n",
-        "Some more examples of usage in python are given in [test_custom_factor.py](https://github.com/borglab/gtsam/blob/develop/python/gtsam/tests/test_custom_factor.py),[CustomFactorExample.py](https://github.com/borglab/gtsam/blob/develop/python/gtsam/examples/CustomFactorExample.py), and [CameraResectioning.py](https://github.com/borglab/gtsam/blob/develop/python/gtsam/examples/CameraResectioning.py)."
       ]
     },
     {

--- a/gtsam/nonlinear/doc/DoglegOptimizer.ipynb
+++ b/gtsam/nonlinear/doc/DoglegOptimizer.ipynb
@@ -1,12 +1,75 @@
 {
   "cells": [
     {
+      "id": "422a5c72",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_doglegoptimizer__f851cef5",
-      "metadata": {},
       "source": [
         "# DoglegOptimizer\n",
         "\n",
+        "This API walkthrough introduces the wrapped classes `DoglegParams`, `DoglegOptimizer` declared by `DoglegOptimizer.h` and demonstrates their principal Python operations."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "16ed2290",
+      "cell_type": "markdown",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "7c6b3dfc",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/DoglegOptimizer.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "c4bc8c09",
+      "cell_type": "code",
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      },
+      "execution_count": null,
+      "source": [
+        "try:\n",
+        "    import google.colab\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "except ImportError:\n",
+        "    pass"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "3283f05d",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "from gtsam.symbol_shorthand import L, X"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "6c8223a1",
+      "cell_type": "markdown",
+      "source": [
         "## Overview\n",
         "\n",
         "The `DoglegOptimizer` class in GTSAM is a specialized optimization algorithm designed for solving nonlinear least squares problems. It implements the Dogleg method, which is a hybrid approach combining the steepest descent and Gauss-Newton methods.\n",
@@ -28,41 +91,8 @@
         "- **Hybrid Approach**: Combines the strengths of both the steepest descent and Gauss-Newton methods.\n",
         "- **Trust Region Method**: Utilizes a trust region to determine the step size, balancing between the accuracy of Gauss-Newton and the robustness of steepest descent.\n",
         "- **Efficient for Nonlinear Problems**: Designed to handle complex nonlinear least squares problems effectively."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_doglegoptimizer__colab_button",
-      "metadata": {},
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/DoglegOptimizer.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_doglegoptimizer__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "gtsam_nonlinear_doc_doglegoptimizer__colab_import",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "outputs": [],
-      "source": [
-        "try:\n    import google.colab\n    %pip install --quiet gtsam-develop\nexcept ImportError:\n    pass"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "cell_type": "markdown",
@@ -102,6 +132,33 @@
         "- [DoglegOptimizer.cpp](https://github.com/borglab/gtsam/blob/develop/gtsam/nonlinear/DoglegOptimizer.cpp)\n",
         "- [DoglegParams.h](https://github.com/borglab/gtsam/blob/develop/gtsam/nonlinear/DoglegParams.h)"
       ]
+    },
+    {
+      "id": "572e7fcf",
+      "cell_type": "markdown",
+      "source": [
+        "## Python wrapper walkthrough\n",
+        "\n",
+        "The following cell exercises the wrapped API directly."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "b2cfb5a2",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "graph = gtsam.NonlinearFactorGraph()\n",
+        "model = gtsam.noiseModel.Diagonal.Sigmas(np.array([0.1, 0.1, 0.1]))\n",
+        "graph.add(gtsam.PriorFactorPose2(X(0), gtsam.Pose2(), model))\n",
+        "initial = gtsam.Values()\n",
+        "initial.insert(X(0), gtsam.Pose2(0.2, -0.1, 0.05))\n",
+        "params = gtsam.DoglegParams()\n",
+        "result = gtsam.DoglegOptimizer(graph, initial, params).optimize()\n",
+        "print(result.atPose2(X(0)))"
+      ],
+      "outputs": []
     }
   ],
   "metadata": {

--- a/gtsam/nonlinear/doc/ExpressionFactorGraph.ipynb
+++ b/gtsam/nonlinear/doc/ExpressionFactorGraph.ipynb
@@ -1,12 +1,75 @@
 {
   "cells": [
     {
+      "id": "489f9713",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_expressionfactorgraph__a1c00a8c",
-      "metadata": {},
       "source": [
-        "# ExpressionFactorGraph \n",
+        "# ExpressionFactorGraph\n",
         "\n",
+        "This API walkthrough introduces the wrapped classes `ExpressionFactorGraph` declared by `ExpressionFactorGraph.h` and demonstrates their principal Python operations."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "b651ce5f",
+      "cell_type": "markdown",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "c4c15939",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/ExpressionFactorGraph.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "c021889b",
+      "cell_type": "code",
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      },
+      "execution_count": null,
+      "source": [
+        "try:\n",
+        "    import google.colab\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "except ImportError:\n",
+        "    pass"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "b043c708",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "from gtsam.symbol_shorthand import L, X"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "6d07c576",
+      "cell_type": "markdown",
+      "source": [
         "## Overview\n",
         "\n",
         "The `ExpressionFactorGraph` class in GTSAM is a specialized factor graph designed to work with expressions. It extends the capabilities of a standard factor graph by allowing factors created from [GTSAM expressions](../../../doc/expressions.md), that implement automatic differentiation. It creates [ExpressionFactors](ExpressionFactor.ipynb).\n",
@@ -22,41 +85,29 @@
         "    push_back(std::allocate_shared<F>(Eigen::aligned_allocator<F>(), R, z, h));\n",
         "  }\n",
         "```"
-      ]
+      ],
+      "metadata": {}
     },
     {
+      "id": "2cf51af1",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_expressionfactorgraph__colab_button",
-      "metadata": {},
       "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/ExpressionFactorGraph.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
+        "## Python wrapper walkthrough\n",
+        "\n",
+        "The following cell exercises the wrapped API directly."
+      ],
+      "metadata": {}
     },
     {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_expressionfactorgraph__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
+      "id": "b98c05aa",
       "cell_type": "code",
+      "metadata": {},
       "execution_count": null,
-      "id": "gtsam_nonlinear_doc_expressionfactorgraph__colab_import",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "outputs": [],
       "source": [
-        "try:\n    import google.colab\n    %pip install --quiet gtsam-develop\nexcept ImportError:\n    pass"
-      ]
+        "print(gtsam.ExpressionFactorGraph.__init__.__doc__)\n",
+        "print([name for name in dir(gtsam.ExpressionFactorGraph) if not name.startswith('_')])"
+      ],
+      "outputs": []
     }
   ],
   "metadata": {

--- a/gtsam/nonlinear/doc/ExtendedKalmanFilter.ipynb
+++ b/gtsam/nonlinear/doc/ExtendedKalmanFilter.ipynb
@@ -1,52 +1,82 @@
 {
   "cells": [
     {
+      "id": "a090a537",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_extendedkalmanfilter__93869c17",
-      "metadata": {},
       "source": [
         "# ExtendedKalmanFilter\n",
         "\n",
+        "This API walkthrough introduces the wrapped classes `ExtendedKalmanFilter` declared by `ExtendedKalmanFilter.h` and demonstrates their principal Python operations."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "894aa1e6",
+      "cell_type": "markdown",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "8c7c04b8",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/ExtendedKalmanFilter.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "2a3f94da",
+      "cell_type": "code",
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      },
+      "execution_count": null,
+      "source": [
+        "try:\n",
+        "    import google.colab\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "except ImportError:\n",
+        "    pass"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "c50db9aa",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "from gtsam.symbol_shorthand import L, X"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "d91ef950",
+      "cell_type": "markdown",
+      "source": [
         "## Overview\n",
         "\n",
         "The `ExtendedKalmanFilter` class in GTSAM is an implementation of the [Extended Kalman Filter (EKF)](https://en.wikipedia.org/wiki/Extended_Kalman_filter), which is a powerful tool for estimating the state of a nonlinear dynamic system.\n",
         "\n",
         "See also [this notebook](../../../python/gtsam/examples/easyPoint2KalmanFilter.ipynb) for the python version of the C++ example below."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_extendedkalmanfilter__colab_button",
-      "metadata": {},
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/ExtendedKalmanFilter.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_extendedkalmanfilter__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "gtsam_nonlinear_doc_extendedkalmanfilter__colab_import",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "outputs": [],
-      "source": [
-        "try:\n    import google.colab\n    %pip install --quiet gtsam-develop\nexcept ImportError:\n    pass"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "cell_type": "markdown",
@@ -101,6 +131,37 @@
         "\n",
         "For the full implementation, see the [easyPoint2KalmanFilter.cpp](https://github.com/borglab/gtsam/blob/develop/examples/easyPoint2KalmanFilter.cpp) file.\n"
       ]
+    },
+    {
+      "id": "8732ea0f",
+      "cell_type": "markdown",
+      "source": [
+        "## Python wrapper walkthrough\n",
+        "\n",
+        "The following cell exercises the wrapped API directly."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "048238e8",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "def public_api(qualified_name):\n",
+        "    value = gtsam\n",
+        "    for component in qualified_name.split('.'):\n",
+        "        value = getattr(value, component, None)\n",
+        "        if value is None:\n",
+        "            return []\n",
+        "    return [name for name in dir(value) if not name.startswith('_')]\n",
+        "\n",
+        "print('\\nExtendedKalmanFilterPose2')\n",
+        "print(public_api('ExtendedKalmanFilterPose2'))\n",
+        "print('\\nExtendedKalmanFilterPose3')\n",
+        "print(public_api('ExtendedKalmanFilterPose3'))"
+      ],
+      "outputs": []
     }
   ],
   "metadata": {

--- a/gtsam/nonlinear/doc/ExtendedPriorFactor.ipynb
+++ b/gtsam/nonlinear/doc/ExtendedPriorFactor.ipynb
@@ -1,55 +1,80 @@
 {
   "cells": [
     {
+      "id": "45c01dd7",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_extendedpriorfactor__b67acc43",
-      "metadata": {},
       "source": [
         "# ExtendedPriorFactor\n",
         "\n",
+        "This API walkthrough introduces the wrapped classes `ExtendedPriorFactor` declared by `ExtendedPriorFactor.h` and demonstrates their principal Python operations."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "f4d0933e",
+      "cell_type": "markdown",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "70788652",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/ExtendedPriorFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "2bd832b7",
+      "cell_type": "code",
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      },
+      "execution_count": null,
+      "source": [
+        "try:\n",
+        "    import google.colab\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "except ImportError:\n",
+        "    pass"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "f970312a",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "from gtsam.symbol_shorthand import L, X"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "ae639113",
+      "cell_type": "markdown",
+      "source": [
         "## Purpose and Audience\n",
         "\n",
         "`ExtendedPriorFactor` is the generalized building block that underlies [PriorFactor](PriorFactor.ipynb) and other soft anchoring mechanisms. It lets you express an (optionally shifted) Gaussian (or robust) likelihood in the tangent space of an arbitrary manifold value type. This notebook targets advanced GTSAM users designing custom factors, experimenting with non-zero tangent-space means, or working with non-traditional manifold types."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_extendedpriorfactor__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_extendedpriorfactor__ffb7d481",
-      "metadata": {},
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/ExtendedPriorFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "id": "gtsam_nonlinear_doc_extendedpriorfactor__e3590b64",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "outputs": [],
-      "source": [
-        "# Install GTSAM and Plotly from pip if running in Google Colab\n",
-        "try:\n",
-        "    import google.colab\n",
-        "    %pip install --quiet gtsam-develop \n",
-        "except ImportError:\n",
-        "    pass # Not in Colab"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "cell_type": "markdown",

--- a/gtsam/nonlinear/doc/FixedLagSmoother.ipynb
+++ b/gtsam/nonlinear/doc/FixedLagSmoother.ipynb
@@ -1,52 +1,82 @@
 {
   "cells": [
     {
+      "id": "eebbe904",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_fixedlagsmoother__cdd2fdc5",
-      "metadata": {},
       "source": [
         "# FixedLagSmoother\n",
         "\n",
+        "This API walkthrough introduces the wrapped classes `FixedLagSmoother`, `FixedLagSmootherResult` declared by `FixedLagSmoother.h` and demonstrates their principal Python operations."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "ad97de84",
+      "cell_type": "markdown",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "38c63539",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/FixedLagSmoother.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "520ecf35",
+      "cell_type": "code",
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      },
+      "execution_count": null,
+      "source": [
+        "try:\n",
+        "    import google.colab\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "except ImportError:\n",
+        "    pass"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "932d0bf0",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "from gtsam.symbol_shorthand import L, X"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "3f4ded68",
+      "cell_type": "markdown",
+      "source": [
         "## Overview\n",
         "\n",
         "The `FixedLagSmoother` class is the base class for [BatchFixedLagSmoother](BatchFixedLagSmoother.ipynb) and [IncrementalFixedLagSmoother](IncrementalFixedLagSmoother.ipynb).\n",
         "\n",
         "It provides an API for fixed-lag smoothing in nonlinear factor graphs. It maintains a sliding window of the most recent variables and marginalizes out older variables. This is particularly useful in real-time applications where memory and computational efficiency are critical."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_fixedlagsmoother__colab_button",
-      "metadata": {},
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/FixedLagSmoother.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_fixedlagsmoother__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "gtsam_nonlinear_doc_fixedlagsmoother__colab_import",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "outputs": [],
-      "source": [
-        "try:\n    import google.colab\n    %pip install --quiet gtsam-develop\nexcept ImportError:\n    pass"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "cell_type": "markdown",
@@ -66,6 +96,35 @@
         "$$\n",
         "The API below allows the user to add new factors at every iteration, which will be automatically pruned after they no longer depend on any variables in the lag."
       ]
+    },
+    {
+      "id": "c0e925cb",
+      "cell_type": "markdown",
+      "source": [
+        "## Wrapped class API\n",
+        "\n",
+        "The header also exposes the following wrapped classes. This executable listing makes their constructors, properties, and methods visible in the installed build: `FixedLagSmootherResult`."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "22abba49",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "def public_api(qualified_name):\n",
+        "    value = gtsam\n",
+        "    for component in qualified_name.split('.'):\n",
+        "        value = getattr(value, component, None)\n",
+        "        if value is None:\n",
+        "            return []\n",
+        "    return [name for name in dir(value) if not name.startswith('_')]\n",
+        "\n",
+        "print('\\nFixedLagSmootherResult')\n",
+        "print(public_api('FixedLagSmootherResult'))"
+      ],
+      "outputs": []
     }
   ],
   "metadata": {

--- a/gtsam/nonlinear/doc/GaussNewtonOptimizer.ipynb
+++ b/gtsam/nonlinear/doc/GaussNewtonOptimizer.ipynb
@@ -1,12 +1,75 @@
 {
   "cells": [
     {
+      "id": "3894c474",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_gaussnewtonoptimizer__6463d580",
-      "metadata": {},
       "source": [
         "# GaussNewtonOptimizer\n",
         "\n",
+        "This API walkthrough introduces the wrapped classes `GaussNewtonParams`, `GaussNewtonOptimizer` declared by `GaussNewtonOptimizer.h` and demonstrates their principal Python operations."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "231af64b",
+      "cell_type": "markdown",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "62216172",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/GaussNewtonOptimizer.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "a017abc6",
+      "cell_type": "code",
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      },
+      "execution_count": null,
+      "source": [
+        "try:\n",
+        "    import google.colab\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "except ImportError:\n",
+        "    pass"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "095c8d6e",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "from gtsam.symbol_shorthand import L, X"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "b489ca0d",
+      "cell_type": "markdown",
+      "source": [
         "## Overview\n",
         "\n",
         "The `GaussNewtonOptimizer` class in GTSAM is designed to optimize nonlinear factor graphs using the Gauss-Newton algorithm. This class is particularly suited for problems where the cost function can be approximated well by a quadratic function near the minimum. The Gauss-Newton method is an iterative optimization technique that updates the solution by linearizing the nonlinear system at each iteration.\n",
@@ -50,41 +113,37 @@
         "\n",
         "- [GaussNewtonOptimizer.h](https://github.com/borglab/gtsam/blob/develop/gtsam/nonlinear/GaussNewtonOptimizer.h)\n",
         "- [GaussNewtonOptimizer.cpp](https://github.com/borglab/gtsam/blob/develop/gtsam/nonlinear/GaussNewtonOptimizer.cpp)"
-      ]
+      ],
+      "metadata": {}
     },
     {
+      "id": "6460fc8e",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_gaussnewtonoptimizer__colab_button",
-      "metadata": {},
       "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/GaussNewtonOptimizer.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
+        "## Wrapped class API\n",
+        "\n",
+        "The header also exposes the following wrapped classes. This executable listing makes their constructors, properties, and methods visible in the installed build: `GaussNewtonParams`."
+      ],
+      "metadata": {}
     },
     {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_gaussnewtonoptimizer__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
+      "id": "cadb793a",
       "cell_type": "code",
+      "metadata": {},
       "execution_count": null,
-      "id": "gtsam_nonlinear_doc_gaussnewtonoptimizer__colab_import",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "outputs": [],
       "source": [
-        "try:\n    import google.colab\n    %pip install --quiet gtsam-develop\nexcept ImportError:\n    pass"
-      ]
+        "def public_api(qualified_name):\n",
+        "    value = gtsam\n",
+        "    for component in qualified_name.split('.'):\n",
+        "        value = getattr(value, component, None)\n",
+        "        if value is None:\n",
+        "            return []\n",
+        "    return [name for name in dir(value) if not name.startswith('_')]\n",
+        "\n",
+        "print('\\nGaussNewtonParams')\n",
+        "print(public_api('GaussNewtonParams'))"
+      ],
+      "outputs": []
     }
   ],
   "metadata": {

--- a/gtsam/nonlinear/doc/GncOptimizer.ipynb
+++ b/gtsam/nonlinear/doc/GncOptimizer.ipynb
@@ -1,12 +1,75 @@
 {
   "cells": [
     {
+      "id": "50fc1d43",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_gncoptimizer__c950beef",
-      "metadata": {},
       "source": [
         "# GncOptimizer\n",
         "\n",
+        "This API walkthrough introduces the wrapped classes `GncOptimizer` declared by `GncOptimizer.h` and demonstrates their principal Python operations."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "1a0f1f6a",
+      "cell_type": "markdown",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "c5d2b7f7",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/GncOptimizer.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "b818d80c",
+      "cell_type": "code",
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      },
+      "execution_count": null,
+      "source": [
+        "try:\n",
+        "    import google.colab\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "except ImportError:\n",
+        "    pass"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "e7ebab07",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "from gtsam.symbol_shorthand import L, X"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "d898ad20",
+      "cell_type": "markdown",
+      "source": [
         "## Overview\n",
         "\n",
         "The `GncOptimizer` class in GTSAM is designed to perform robust optimization using Graduated Non-Convexity (GNC). This method is particularly useful in scenarios where the optimization problem is affected by outliers. The GNC approach gradually transitions from a convex approximation of the problem to the original non-convex problem, thereby improving robustness and convergence.\n",
@@ -68,51 +131,30 @@
         "\n",
         "- [GncOptimizer.h](https://github.com/borglab/gtsam/blob/develop/gtsam/nonlinear/GncOptimizer.h)\n",
         "- [GncParams.h](https://github.com/borglab/gtsam/blob/develop/gtsam/nonlinear/GncParams.h)"
-      ]
+      ],
+      "metadata": {}
     },
     {
+      "id": "f648f95d",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_gncoptimizer__colab_button",
-      "metadata": {},
       "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/GncOptimizer.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
+        "## Python wrapper walkthrough\n",
+        "\n",
+        "The following cell exercises the wrapped API directly."
+      ],
+      "metadata": {}
     },
     {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_gncoptimizer__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\n",
-        "Atlanta, Georgia 30332-0415\n",
-        "All Rights Reserved\n",
-        "\n",
-        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
-        "\n",
-        "See LICENSE for the license information"
-      ]
-    },
-    {
+      "id": "596f2639",
       "cell_type": "code",
+      "metadata": {},
       "execution_count": null,
-      "id": "gtsam_nonlinear_doc_gncoptimizer__colab_import",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "outputs": [],
       "source": [
-        "try:\n",
-        "    import google.colab\n",
-        "    %pip install --quiet gtsam-develop\n",
-        "except ImportError:\n",
-        "    pass"
-      ]
+        "params = gtsam.GncGaussNewtonParams()\n",
+        "print(type(params).__name__)\n",
+        "print([name for name in dir(params) if not name.startswith('_')])"
+      ],
+      "outputs": []
     }
   ],
   "metadata": {

--- a/gtsam/nonlinear/doc/GncParams.ipynb
+++ b/gtsam/nonlinear/doc/GncParams.ipynb
@@ -1,0 +1,145 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GncParams\n",
+    "\n",
+    "`GncParams<PARAMS>` configures graduated non-convexity (GNC), a robust optimization strategy that gradually changes a surrogate loss. Python exposes `GncGaussNewtonParams` and `GncLMParams` for Gauss–Newton and Levenberg–Marquardt inner optimizers."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3348831a",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/GncParams.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aef472af",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import L, V, X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `GncGaussNewtonParams`\n",
+    "\n",
+    "Construct with defaults or pass a configured `GaussNewtonParams` object. The base optimizer controls each weighted least-squares solve; GNC-specific fields control the robust loss schedule and convergence."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gauss_newton = gtsam.GaussNewtonParams()\n",
+    "gauss_newton.setMaxIterations(50)\n",
+    "gnc_gn = gtsam.GncGaussNewtonParams(gauss_newton)\n",
+    "gnc_gn.setLossType(gtsam.GncLossType.TLS)\n",
+    "gnc_gn.setMaxIterations(30)\n",
+    "gnc_gn.setRelativeCostTol(1e-5)\n",
+    "gnc_gn.setWeightsTol(1e-4)\n",
+    "print(\"inner iterations:\", gnc_gn.baseOptimizerParams.getMaxIterations())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `GncLMParams`\n",
+    "\n",
+    "The LM specialization has the same GNC controls but carries `LevenbergMarquardtParams` as `baseOptimizerParams`. This is often a safer default for strongly nonlinear problems."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lm = gtsam.LevenbergMarquardtParams.CeresDefaults()\n",
+    "lm.setlambdaInitial(1e-3)\n",
+    "gnc_lm = gtsam.GncLMParams(lm)\n",
+    "gnc_lm.setLossType(gtsam.GncLossType.GM)\n",
+    "gnc_lm.setScheduler(gtsam.GncScheduler.SuperLinear)\n",
+    "gnc_lm.setLambdaStep(1.4)\n",
+    "print(\"initial LM lambda:\", gnc_lm.baseOptimizerParams.getlambdaInitial())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inliers, outliers, and stopping criteria\n",
+    "\n",
+    "`setKnownInliers()` and `setKnownOutliers()` lock selected factor indices. `setAllowNonNoiseModelFactors()` controls whether factors without noise models are accepted. `setVerbosityGNC()` exposes the continuation schedule, weights, or values when diagnosing convergence. Use these parameter objects with `GncGaussNewtonOptimizer` or `GncLMOptimizer`.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`GncParams.h`](../GncParams.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/nonlinear/doc/GraphvizFormatting.ipynb
+++ b/gtsam/nonlinear/doc/GraphvizFormatting.ipynb
@@ -1,0 +1,164 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GraphvizFormatting\n",
+    "\n",
+    "`GraphvizFormatting` controls how nonlinear factor graphs are laid out when exported to Graphviz DOT. It extends `DotWriter` with pose-aware axes, scale, and factor-merging options."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6b406a9",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/GraphvizFormatting.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42d7e0d0",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import L, V, X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A graph with geometric values\n",
+    "\n",
+    "The formatting object uses `Values` to place pose variables according to their translations. Factors are drawn between those positioned variables."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graph = gtsam.NonlinearFactorGraph()\n",
+    "model = gtsam.noiseModel.Diagonal.Sigmas(np.array([0.1, 0.1, 0.05]))\n",
+    "graph.add(gtsam.PriorFactorPose2(X(0), gtsam.Pose2(), model))\n",
+    "graph.add(gtsam.BetweenFactorPose2(X(0), X(1), gtsam.Pose2(2.0, 1.0, 0.2), model))\n",
+    "\n",
+    "values = gtsam.Values()\n",
+    "values.insert(X(0), gtsam.Pose2())\n",
+    "values.insert(X(1), gtsam.Pose2(2.0, 1.0, 0.2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Paper axes and scale\n",
+    "\n",
+    "`paperHorizontalAxis` and `paperVerticalAxis` choose which world axes appear on the page; negative-axis enum values flip a direction. `scale` converts geometry units into Graphviz position units."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "formatting = gtsam.GraphvizFormatting()\n",
+    "formatting.paperHorizontalAxis = gtsam.GraphvizFormatting.Axis.X\n",
+    "formatting.paperVerticalAxis = gtsam.GraphvizFormatting.Axis.Y\n",
+    "formatting.scale = 2.0\n",
+    "dot = graph.dot(values, gtsam.DefaultKeyFormatter, formatting)\n",
+    "print(\"DOT lines:\", len(dot.splitlines()))\n",
+    "print(dot.splitlines()[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Factor and node styling\n",
+    "\n",
+    "`mergeSimilarFactors` combines repeated factors with the same scope. Inherited `DotWriter` fields control boxes, binary edges, factor points, explicit variable/factor positions, and figure dimensions. `saveGraph()` writes the same DOT representation to a file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "formatting.mergeSimilarFactors = True\n",
+    "formatting.plotFactorPoints = True\n",
+    "formatting.figureWidthInches = 6.0\n",
+    "formatting.figureHeightInches = 4.0\n",
+    "merged_dot = graph.dot(values, gtsam.DefaultKeyFormatter, formatting)\n",
+    "assert \"graph\" in merged_dot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`GraphvizFormatting.h`](../GraphvizFormatting.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/nonlinear/doc/ISAM2.ipynb
+++ b/gtsam/nonlinear/doc/ISAM2.ipynb
@@ -1,44 +1,18 @@
 {
   "cells": [
     {
+      "id": "e49b1b77",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_isam2__overview",
-      "metadata": {},
       "source": [
         "# ISAM2\n",
         "\n",
-        "## Overview\n",
-        "\n",
-        "The `ISAM2` class in GTSAM is an incremental smoothing and mapping algorithm that efficiently updates the solution to a nonlinear optimization problem as new measurements are added. This class is particularly useful in applications such as SLAM (Simultaneous Localization and Mapping) where real-time performance is crucial.  \n",
-        "\n",
-        "The algorithm is described in the 2012 IJJR paper by {cite:t}`http://dx.doi.org/10.1177/0278364911430419`. For background, also see the more recent booklet by {cite:t}`https://doi.org/10.1561/2300000043`.\n",
-        "\n",
-        "This notebook focuses on the Python `ISAM2` API, including the inherited Bayes-tree query methods that expose the current linearized Gaussian structure.\n",
-        "\n",
-        "## Key Features\n",
-        "\n",
-        "- **Incremental Updates**: `ISAM2` allows for incremental updates to the factor graph, avoiding the need to solve the entire problem from scratch with each new measurement.\n",
-        "- **Nonlinear Optimization**: Capable of handling nonlinear systems, leveraging iterative optimization techniques to refine estimates.\n",
-        "- **Efficient Variable Reordering**: Dynamically reorders variables to maintain sparsity and improve computational efficiency.\n",
-        "- **Bayes-Tree Queries**: Exposes the current linearized Gaussian through marginal, joint, and Bayes-net queries that mirror the `GaussianBayesTree` interface.\n"
-      ]
+        "The Bayes tree inside `ISAM2` grows as updates are incorporated. The inherited `size()` and `empty()` methods are useful quick sanity checks."
+      ],
+      "metadata": {}
     },
     {
+      "id": "4aa72c51",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_isam2__colab_button",
-      "metadata": {},
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/ISAM2.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_isam2__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
       "source": [
         "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
         "Atlanta, Georgia 30332-0415\n",
@@ -47,25 +21,38 @@
         "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
         "\n",
         "See LICENSE for the license information"
-      ]
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
     },
     {
+      "id": "964dd39d",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/ISAM2.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "55691e24",
       "cell_type": "code",
-      "execution_count": 1,
-      "id": "gtsam_nonlinear_doc_isam2__colab_import",
       "metadata": {
         "tags": [
           "remove-cell"
         ]
       },
-      "outputs": [],
+      "execution_count": null,
       "source": [
         "try:\n",
         "    import google.colab\n",
         "    %pip install --quiet gtsam-develop\n",
         "except ImportError:\n",
         "    pass"
-      ]
+      ],
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -80,6 +67,27 @@
         "import gtsam\n",
         "from gtsam.symbol_shorthand import X"
       ]
+    },
+    {
+      "id": "6e61c63b",
+      "cell_type": "markdown",
+      "source": [
+        "## Overview\n",
+        "\n",
+        "The `ISAM2` class in GTSAM is an incremental smoothing and mapping algorithm that efficiently updates the solution to a nonlinear optimization problem as new measurements are added. This class is particularly useful in applications such as SLAM (Simultaneous Localization and Mapping) where real-time performance is crucial.  \n",
+        "\n",
+        "The algorithm is described in the 2012 IJJR paper by {cite:t}`http://dx.doi.org/10.1177/0278364911430419`. For background, also see the more recent booklet by {cite:t}`https://doi.org/10.1561/2300000043`.\n",
+        "\n",
+        "This notebook focuses on the Python `ISAM2` API, including the inherited Bayes-tree query methods that expose the current linearized Gaussian structure.\n",
+        "\n",
+        "## Key Features\n",
+        "\n",
+        "- **Incremental Updates**: `ISAM2` allows for incremental updates to the factor graph, avoiding the need to solve the entire problem from scratch with each new measurement.\n",
+        "- **Nonlinear Optimization**: Capable of handling nonlinear systems, leveraging iterative optimization techniques to refine estimates.\n",
+        "- **Efficient Variable Reordering**: Dynamically reorders variables to maintain sparsity and improve computational efficiency.\n",
+        "- **Bayes-Tree Queries**: Exposes the current linearized Gaussian through marginal, joint, and Bayes-net queries that mirror the `GaussianBayesTree` interface."
+      ],
+      "metadata": {}
     },
     {
       "cell_type": "markdown",
@@ -244,14 +252,6 @@
       ],
       "source": [
         "display(graphviz.Source(isam.dot()))\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_isam2__initialization_md",
-      "metadata": {},
-      "source": [
-        "The Bayes tree inside `ISAM2` grows as updates are incorporated. The inherited `size()` and `empty()` methods are useful quick sanity checks."
       ]
     },
     {

--- a/gtsam/nonlinear/doc/ISAM2Clique.ipynb
+++ b/gtsam/nonlinear/doc/ISAM2Clique.ipynb
@@ -1,0 +1,140 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# ISAM2Clique\n",
+    "\n",
+    "`ISAM2Clique` is the clique type inside iSAM2's Gaussian Bayes tree. It stores a conditional, cached separator information, and the local gradient contribution used during incremental updates."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d05e381",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/ISAM2Clique.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "773630a5",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import L, V, X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## How cliques are created\n",
+    "\n",
+    "Applications do not normally construct populated cliques. `ISAM2.update()` creates and replaces them as variables are re-eliminated. The wrapped default constructor produces only an uninitialized placeholder, so calling `gradientContribution()` on it is not meaningful."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params = gtsam.ISAM2Params()\n",
+    "isam = gtsam.ISAM2(params)\n",
+    "\n",
+    "graph = gtsam.NonlinearFactorGraph()\n",
+    "model = gtsam.noiseModel.Diagonal.Sigmas(np.array([0.1, 0.1, 0.05]))\n",
+    "graph.add(gtsam.PriorFactorPose2(X(0), gtsam.Pose2(), model))\n",
+    "values = gtsam.Values()\n",
+    "values.insert(X(0), gtsam.Pose2(0.1, -0.1, 0.02))\n",
+    "\n",
+    "result = isam.update(graph, values)\n",
+    "print(\"cliques created:\", result.getCliques())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inspecting clique-level behavior\n",
+    "\n",
+    "The wrapper exposes `gradientContribution()` and `print()` on a valid clique, but it does not currently expose an accessor that returns an `ISAM2Clique` from `ISAM2`. For Python diagnostics, use `ISAM2.dot()`, `printStats()`, `treeNnz()`, and the clique counts in `ISAM2Result`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dot = isam.dot()\n",
+    "print(\"Bayes-tree DOT begins with:\", dot.splitlines()[0])\n",
+    "print(\"tree nonzeros:\", isam.treeNnz())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`ISAM2Clique.h`](../ISAM2Clique.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/nonlinear/doc/ISAM2Params.ipynb
+++ b/gtsam/nonlinear/doc/ISAM2Params.ipynb
@@ -1,0 +1,182 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# ISAM2Params\n",
+    "\n",
+    "This header configures iSAM2's nonlinear update strategy. `ISAM2Params` holds global incremental settings and one of three wrapped inner-step configurations: Gauss–Newton, Dogleg, or Dogleg line search."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8b61820",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/ISAM2Params.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e56bdf21",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import L, V, X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `ISAM2GaussNewtonParams`\n",
+    "\n",
+    "Gauss–Newton uses wildfire thresholding to skip small back-substitution updates. Lower thresholds do more work but approximate the full update more closely."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gauss_newton = gtsam.ISAM2GaussNewtonParams(0.001)\n",
+    "gauss_newton.setWildfireThreshold(5e-4)\n",
+    "print(\"wildfire threshold:\", gauss_newton.getWildfireThreshold())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `ISAM2DoglegParams`\n",
+    "\n",
+    "Dogleg adds a trust-region radius and an adaptation mode. `setInitialDelta()`, `setAdaptationMode()`, and `setVerbose()` tune that local nonlinear step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dogleg = gtsam.ISAM2DoglegParams()\n",
+    "dogleg.setInitialDelta(1.0)\n",
+    "dogleg.setAdaptationMode(\"SEARCH_EACH_ITERATION\")\n",
+    "dogleg.setWildfireThreshold(1e-4)\n",
+    "print(\"initial delta:\", dogleg.getInitialDelta())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `ISAM2DoglegLineSearchParams`\n",
+    "\n",
+    "The line-search variant bounds the trust-region radius and controls step size and sufficient decrease. It is useful when the standard adaptation rule is too coarse."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "line_search = gtsam.ISAM2DoglegLineSearchParams()\n",
+    "line_search.setMinDelta(1e-4)\n",
+    "line_search.setMaxDelta(10.0)\n",
+    "line_search.setStepSize(0.5)\n",
+    "line_search.setSufficientDecreaseCoeff(1e-4)\n",
+    "print(\"delta interval:\", line_search.getMinDelta(), line_search.getMaxDelta())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `ISAM2Params`\n",
+    "\n",
+    "The main object selects one optimization configuration and controls relinearization, factorization, caching, detailed results, and factor-slot reuse. Relinearization threshold and skip are the most important accuracy/performance controls."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params = gtsam.ISAM2Params()\n",
+    "params.setOptimizationParams(gauss_newton)\n",
+    "params.setRelinearizeThreshold(0.05)\n",
+    "params.relinearizeSkip = 1\n",
+    "params.enableDetailedResults = True\n",
+    "params.evaluateNonlinearError = True\n",
+    "params.setFactorization(\"CHOLESKY\")\n",
+    "print(\"factorization:\", params.getFactorization())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`ISAM2Params.h`](../ISAM2Params.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/nonlinear/doc/ISAM2Result.ipynb
+++ b/gtsam/nonlinear/doc/ISAM2Result.ipynb
@@ -1,0 +1,163 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# ISAM2Result\n",
+    "\n",
+    "`ISAM2Result` summarizes the work performed by one `ISAM2.update()` call: affected variables, relinearization and re-elimination counts, new factor indices, clique statistics, and optional nonlinear errors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe69f069",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/ISAM2Result.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2966bc97",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import L, V, X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Obtaining a result\n",
+    "\n",
+    "Although a default constructor exists, useful results come from `ISAM2.update()`. Enable detailed results or nonlinear error evaluation in `ISAM2Params` before constructing the solver when those diagnostics are needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params = gtsam.ISAM2Params()\n",
+    "params.enableDetailedResults = True\n",
+    "params.evaluateNonlinearError = True\n",
+    "params.relinearizeSkip = 1\n",
+    "isam = gtsam.ISAM2(params)\n",
+    "\n",
+    "graph = gtsam.NonlinearFactorGraph()\n",
+    "model = gtsam.noiseModel.Diagonal.Sigmas(np.array([0.1, 0.1, 0.05]))\n",
+    "graph.add(gtsam.PriorFactorPose2(X(0), gtsam.Pose2(), model))\n",
+    "values = gtsam.Values()\n",
+    "values.insert(X(0), gtsam.Pose2(0.2, -0.1, 0.05))\n",
+    "result = isam.update(graph, values)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Update work\n",
+    "\n",
+    "`getVariablesRelinearized()`, `getVariablesReeliminated()`, `getFactorsRecalculated()`, and `getCliques()` quantify incremental work. `getNewFactorsIndices()` identifies where new factors were inserted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"new factor indices:\", list(result.getNewFactorsIndices()))\n",
+    "print(\"relinearized:\", result.getVariablesRelinearized())\n",
+    "print(\"re-eliminated:\", result.getVariablesReeliminated())\n",
+    "print(\"cliques:\", result.getCliques())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Error and affected-key diagnostics\n",
+    "\n",
+    "When error evaluation is enabled, `getErrorBefore()` and `getErrorAfter()` report the nonlinear objective around the update. Key-set accessors distinguish observed, marked, unused, and factor-removal-related variables. `getBatchReorderTriggered()` and `getTreeNnz()` expose structural events."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"error before:\", result.getErrorBefore())\n",
+    "print(\"error after:\", result.getErrorAfter())\n",
+    "print(\"observed keys:\", [gtsam.DefaultKeyFormatter(k) for k in result.getObservedKeys()])\n",
+    "assert result.getErrorAfter() <= result.getErrorBefore()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`ISAM2Result.h`](../ISAM2Result.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/nonlinear/doc/ISAM2UpdateParams.ipynb
+++ b/gtsam/nonlinear/doc/ISAM2UpdateParams.ipynb
@@ -1,0 +1,152 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# ISAM2UpdateParams\n",
+    "\n",
+    "`ISAM2UpdateParams` supplies per-update controls to iSAM2: factor removal, constrained ordering groups, relinearization exclusions, extra re-elimination keys, and full-solve overrides."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d663e2d",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/ISAM2UpdateParams.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "612f109d",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import L, V, X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating update parameters\n",
+    "\n",
+    "The default object requests an ordinary incremental update. Set only the fields needed for a particular call; persistent solver behavior belongs in `ISAM2Params`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "update_params = gtsam.ISAM2UpdateParams()\n",
+    "update_params.force_relinearize = True\n",
+    "update_params.forceFullSolve = False\n",
+    "update_params.removeFactorIndices = []\n",
+    "print(\"force relinearization:\", update_params.force_relinearize)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using the object with `ISAM2.update()`\n",
+    "\n",
+    "The dedicated overload takes new factors, new values, and `ISAM2UpdateParams`. This example adds a prior in one update and a relative-pose factor in the next."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "isam = gtsam.ISAM2()\n",
+    "model = gtsam.noiseModel.Diagonal.Sigmas(np.array([0.1, 0.1, 0.05]))\n",
+    "\n",
+    "first_graph = gtsam.NonlinearFactorGraph()\n",
+    "first_graph.add(gtsam.PriorFactorPose2(X(0), gtsam.Pose2(), model))\n",
+    "first_values = gtsam.Values()\n",
+    "first_values.insert(X(0), gtsam.Pose2(0.1, 0.0, 0.01))\n",
+    "isam.update(first_graph, first_values)\n",
+    "\n",
+    "second_graph = gtsam.NonlinearFactorGraph()\n",
+    "second_graph.add(\n",
+    "    gtsam.BetweenFactorPose2(X(0), X(1), gtsam.Pose2(1.0, 0.0, 0.0), model)\n",
+    ")\n",
+    "second_values = gtsam.Values()\n",
+    "second_values.insert(X(1), gtsam.Pose2(1.1, 0.1, 0.02))\n",
+    "result = isam.update(second_graph, second_values, update_params)\n",
+    "print(\"estimate for X1:\", isam.calculateEstimatePose2(X(1)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Advanced fields\n",
+    "\n",
+    "`constrainedKeys` groups variables for constrained COLAMD ordering. `noRelinKeys` protects selected variables from relinearization, while `extraReelimKeys` forces selected variables through re-elimination. `removeFactorIndices` uses the indices returned by earlier `ISAM2Result.getNewFactorsIndices()` calls. `forceFullSolve` performs a full back-substitution after the incremental update.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`ISAM2UpdateParams.h`](../ISAM2UpdateParams.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/nonlinear/doc/IncrementalFixedLagSmoother.ipynb
+++ b/gtsam/nonlinear/doc/IncrementalFixedLagSmoother.ipynb
@@ -1,50 +1,102 @@
 {
   "cells": [
     {
+      "id": "16330cd9",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_incrementalfixedlagsmoother__cdd2fdc5",
-      "metadata": {},
       "source": [
         "# IncrementalFixedLagSmoother\n",
         "\n",
-        "## Overview\n",
-        "\n",
-        "The `IncrementalFixedLagSmoother` is a [FixedLagSmoother](FixedLagSmoother.ipynb) that uses [iSAM2](iSAM2.ipynb) for incremental inference.\n"
-      ]
+        "This API walkthrough introduces the wrapped classes `IncrementalFixedLagSmoother` declared by `IncrementalFixedLagSmoother.h` and demonstrates their principal Python operations."
+      ],
+      "metadata": {}
     },
     {
+      "id": "3ad5cf87",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_incrementalfixedlagsmoother__colab_button",
-      "metadata": {},
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "0b87daca",
+      "cell_type": "markdown",
       "source": [
         "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/IncrementalFixedLagSmoother.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
+      ],
+      "metadata": {}
     },
     {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_incrementalfixedlagsmoother__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
+      "id": "1d00a7a2",
       "cell_type": "code",
-      "execution_count": null,
-      "id": "gtsam_nonlinear_doc_incrementalfixedlagsmoother__colab_import",
       "metadata": {
         "tags": [
           "remove-cell"
         ]
       },
-      "outputs": [],
+      "execution_count": null,
       "source": [
-        "try:\n    import google.colab\n    %pip install --quiet gtsam-develop\nexcept ImportError:\n    pass"
-      ]
+        "try:\n",
+        "    import google.colab\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "except ImportError:\n",
+        "    pass"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "d0184fec",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "from gtsam.symbol_shorthand import L, X"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "2fcbf7b4",
+      "cell_type": "markdown",
+      "source": [
+        "## Overview\n",
+        "\n",
+        "The `IncrementalFixedLagSmoother` is a [FixedLagSmoother](FixedLagSmoother.ipynb) that uses [iSAM2](iSAM2.ipynb) for incremental inference."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "add33da3",
+      "cell_type": "markdown",
+      "source": [
+        "## Python wrapper walkthrough\n",
+        "\n",
+        "The following cell exercises the wrapped API directly."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "ea37894c",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "smoother = gtsam.IncrementalFixedLagSmoother(2.0)\n",
+        "print(type(smoother).__name__)\n",
+        "print([name for name in dir(smoother) if not name.startswith('_')])"
+      ],
+      "outputs": []
     }
   ],
   "metadata": {

--- a/gtsam/nonlinear/doc/LevenbergMarquardtOptimizer.ipynb
+++ b/gtsam/nonlinear/doc/LevenbergMarquardtOptimizer.ipynb
@@ -1,12 +1,75 @@
 {
   "cells": [
     {
+      "id": "659c96b1",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_levenbergmarquardtoptimizer__29642bb2",
-      "metadata": {},
       "source": [
         "# LevenbergMarquardtOptimizer\n",
         "\n",
+        "This API walkthrough introduces the wrapped classes `LevenbergMarquardtOptimizer` declared by `LevenbergMarquardtOptimizer.h` and demonstrates their principal Python operations."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "a198587d",
+      "cell_type": "markdown",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "def531a0",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/LevenbergMarquardtOptimizer.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "f2c97e0d",
+      "cell_type": "code",
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      },
+      "execution_count": null,
+      "source": [
+        "try:\n",
+        "    import google.colab\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "except ImportError:\n",
+        "    pass"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "7c7680d1",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "from gtsam.symbol_shorthand import L, X"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "aeb80e96",
+      "cell_type": "markdown",
+      "source": [
         "## Overview\n",
         "\n",
         "The `LevenbergMarquardtOptimizer` class in GTSAM is a specialized optimizer that implements the Levenberg-Marquardt algorithm. This algorithm is a popular choice for solving non-linear least squares problems, which are common in various applications such as computer vision, robotics, and machine learning.\n",
@@ -74,41 +137,35 @@
         "- [LevenbergMarquardtOptimizer.cpp](https://github.com/borglab/gtsam/blob/develop/gtsam/nonlinear/LevenbergMarquardtOptimizer.cpp)\n",
         "- [LevenbergMarquardtParams.h](https://github.com/borglab/gtsam/blob/develop/gtsam/nonlinear/LevenbergMarquardtParams.h)\n",
         "- [LevenbergMarquardtParams.cpp](https://github.com/borglab/gtsam/blob/develop/gtsam/nonlinear/LevenbergMarquardtParams.cpp)"
-      ]
+      ],
+      "metadata": {}
     },
     {
+      "id": "79d5d8fe",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_levenbergmarquardtoptimizer__colab_button",
-      "metadata": {},
       "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/LevenbergMarquardtOptimizer.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
+        "## Python wrapper walkthrough\n",
+        "\n",
+        "The following cell exercises the wrapped API directly."
+      ],
+      "metadata": {}
     },
     {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_levenbergmarquardtoptimizer__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
+      "id": "b3134e9c",
       "cell_type": "code",
+      "metadata": {},
       "execution_count": null,
-      "id": "gtsam_nonlinear_doc_levenbergmarquardtoptimizer__colab_import",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "outputs": [],
       "source": [
-        "try:\n    import google.colab\n    %pip install --quiet gtsam-develop\nexcept ImportError:\n    pass"
-      ]
+        "graph = gtsam.NonlinearFactorGraph()\n",
+        "model = gtsam.noiseModel.Diagonal.Sigmas(np.array([0.1, 0.1, 0.1]))\n",
+        "graph.add(gtsam.PriorFactorPose2(X(0), gtsam.Pose2(), model))\n",
+        "initial = gtsam.Values()\n",
+        "initial.insert(X(0), gtsam.Pose2(0.2, -0.1, 0.05))\n",
+        "params = gtsam.LevenbergMarquardtParams()\n",
+        "result = gtsam.LevenbergMarquardtOptimizer(graph, initial, params).optimize()\n",
+        "print(result.atPose2(X(0)))"
+      ],
+      "outputs": []
     }
   ],
   "metadata": {

--- a/gtsam/nonlinear/doc/LevenbergMarquardtParams.ipynb
+++ b/gtsam/nonlinear/doc/LevenbergMarquardtParams.ipynb
@@ -1,0 +1,172 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# LevenbergMarquardtParams\n",
+    "\n",
+    "`LevenbergMarquardtParams` combines the common nonlinear-optimizer settings with damping controls specific to Levenberg–Marquardt. It determines how the optimizer moves between Gauss–Newton and gradient-descent behavior."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75dbdda9",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/LevenbergMarquardtParams.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2a773ea",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import L, V, X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Defaults and construction\n",
+    "\n",
+    "The ordinary constructor uses GTSAM defaults. `CeresDefaults()` and `LegacyDefaults()` provide named parameter sets for compatibility with those conventions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params = gtsam.LevenbergMarquardtParams.CeresDefaults()\n",
+    "print(\"maximum iterations:\", params.getMaxIterations())\n",
+    "print(\"initial lambda:\", params.getlambdaInitial())\n",
+    "print(\"lambda factor:\", params.getlambdaFactor())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Damping controls\n",
+    "\n",
+    "`lambdaInitial`, lower/upper bounds, and `lambdaFactor` control damping adaptation. `setDiagonalDamping(True)` scales damping by the Hessian diagonal; `setUseFixedLambdaFactor()` selects fixed multiplicative updates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params.setlambdaInitial(1e-3)\n",
+    "params.setlambdaLowerBound(1e-8)\n",
+    "params.setlambdaUpperBound(1e5)\n",
+    "params.setlambdaFactor(5.0)\n",
+    "params.setDiagonalDamping(True)\n",
+    "params.setVerbosityLM(\"SILENT\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using the parameters\n",
+    "\n",
+    "Common inherited methods select convergence tolerances, iteration limits, ordering, and linear solver. The optimizer copies the parameter object at construction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graph = gtsam.NonlinearFactorGraph()\n",
+    "model = gtsam.noiseModel.Diagonal.Sigmas(np.array([0.1, 0.1, 0.05]))\n",
+    "graph.add(gtsam.PriorFactorPose2(X(0), gtsam.Pose2(1.0, 2.0, 0.3), model))\n",
+    "initial = gtsam.Values()\n",
+    "initial.insert(X(0), gtsam.Pose2(0.0, 0.0, 0.0))\n",
+    "\n",
+    "optimizer = gtsam.LevenbergMarquardtOptimizer(graph, initial, params)\n",
+    "result = optimizer.optimize()\n",
+    "print(\"optimized pose:\", result.atPose2(X(0)))\n",
+    "assert graph.error(result) < graph.error(initial)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Diagnosing damping behavior\n",
+    "\n",
+    "If lambda repeatedly reaches its upper bound, inspect scaling, initialization, and factor Jacobians instead of simply increasing the bound. If convergence is smooth but slow, compare diagonal damping and the named default sets, while keeping the same stopping tolerances for a fair comparison."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`LevenbergMarquardtParams.h`](../LevenbergMarquardtParams.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/nonlinear/doc/LinearContainerFactor.ipynb
+++ b/gtsam/nonlinear/doc/LinearContainerFactor.ipynb
@@ -1,12 +1,75 @@
 {
   "cells": [
     {
+      "id": "44eb9ea4",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_linearcontainerfactor__f4c73cc1",
-      "metadata": {},
       "source": [
         "# LinearContainerFactor\n",
         "\n",
+        "This API walkthrough introduces the wrapped classes `LinearContainerFactor` declared by `LinearContainerFactor.h` and demonstrates their principal Python operations."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "251cfe30",
+      "cell_type": "markdown",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "c0afb9ac",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/LinearContainerFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "cb1a1541",
+      "cell_type": "code",
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      },
+      "execution_count": null,
+      "source": [
+        "try:\n",
+        "    import google.colab\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "except ImportError:\n",
+        "    pass"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "30da184e",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "from gtsam.symbol_shorthand import L, X"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "93eac128",
+      "cell_type": "markdown",
+      "source": [
         "## Overview\n",
         "\n",
         "The `LinearContainerFactor` class in GTSAM is a specialized factor that encapsulates a linear factor within a nonlinear factor graph. This is used extensively when marginalizing out variables.\n",
@@ -20,41 +83,37 @@
         "## Key Methods\n",
         "\n",
         "- **LinearContainerFactor**: This constructor initializes the `LinearContainerFactor` with a linear factor and optionally with values. It serves as the entry point for creating an instance of this class."
-      ]
+      ],
+      "metadata": {}
     },
     {
+      "id": "a0063942",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_linearcontainerfactor__colab_button",
-      "metadata": {},
       "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/LinearContainerFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
+        "## Python wrapper walkthrough\n",
+        "\n",
+        "The following cell exercises the wrapped API directly."
+      ],
+      "metadata": {}
     },
     {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_linearcontainerfactor__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
+      "id": "813ea75b",
       "cell_type": "code",
+      "metadata": {},
       "execution_count": null,
-      "id": "gtsam_nonlinear_doc_linearcontainerfactor__colab_import",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "outputs": [],
       "source": [
-        "try:\n    import google.colab\n    %pip install --quiet gtsam-develop\nexcept ImportError:\n    pass"
-      ]
+        "def public_api(qualified_name):\n",
+        "    value = gtsam\n",
+        "    for component in qualified_name.split('.'):\n",
+        "        value = getattr(value, component, None)\n",
+        "        if value is None:\n",
+        "            return []\n",
+        "    return [name for name in dir(value) if not name.startswith('_')]\n",
+        "\n",
+        "print('\\nLinearContainerFactor')\n",
+        "print(public_api('LinearContainerFactor'))"
+      ],
+      "outputs": []
     }
   ],
   "metadata": {

--- a/gtsam/nonlinear/doc/NonlinearFactor.ipynb
+++ b/gtsam/nonlinear/doc/NonlinearFactor.ipynb
@@ -1,50 +1,80 @@
 {
   "cells": [
     {
+      "id": "f42fb056",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_nonlinearfactor__381ccaaa",
-      "metadata": {},
       "source": [
         "# NonlinearFactor\n",
         "\n",
+        "This API walkthrough introduces the wrapped classes `NonlinearFactor`, `NoiseModelFactor` declared by `NonlinearFactor.h` and demonstrates their principal Python operations."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "a4656ac3",
+      "cell_type": "markdown",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "a6e18132",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/NonlinearFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "a8e7577b",
+      "cell_type": "code",
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      },
+      "execution_count": null,
+      "source": [
+        "try:\n",
+        "    import google.colab\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "except ImportError:\n",
+        "    pass"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "cb3555af",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "from gtsam.symbol_shorthand import L, X"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "5985154d",
+      "cell_type": "markdown",
+      "source": [
         "## Overview\n",
         "\n",
         "The `NonlinearFactor` class in GTSAM is a fundamental component used in nonlinear optimization. It represents a factor in a factor graph. The class is designed to work with nonlinear, continuous functions."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_nonlinearfactor__colab_button",
-      "metadata": {},
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/NonlinearFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_nonlinearfactor__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "gtsam_nonlinear_doc_nonlinearfactor__colab_import",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "outputs": [],
-      "source": [
-        "try:\n    import google.colab\n    %pip install --quiet gtsam-develop\nexcept ImportError:\n    pass"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "cell_type": "markdown",
@@ -106,6 +136,35 @@
         "- Users need to implement the `evaluateError` method in derived classes to define the specific measurement model.\n",
         "- The class is designed to be flexible and extensible, allowing for custom factors to be created for specific applications."
       ]
+    },
+    {
+      "id": "625c614d",
+      "cell_type": "markdown",
+      "source": [
+        "## Wrapped class API\n",
+        "\n",
+        "The header also exposes the following wrapped classes. This executable listing makes their constructors, properties, and methods visible in the installed build: `NoiseModelFactor`."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "901884a8",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "def public_api(qualified_name):\n",
+        "    value = gtsam\n",
+        "    for component in qualified_name.split('.'):\n",
+        "        value = getattr(value, component, None)\n",
+        "        if value is None:\n",
+        "            return []\n",
+        "    return [name for name in dir(value) if not name.startswith('_')]\n",
+        "\n",
+        "print('\\nNoiseModelFactor')\n",
+        "print(public_api('NoiseModelFactor'))"
+      ],
+      "outputs": []
     }
   ],
   "metadata": {

--- a/gtsam/nonlinear/doc/NonlinearFactorGraph.ipynb
+++ b/gtsam/nonlinear/doc/NonlinearFactorGraph.ipynb
@@ -1,12 +1,75 @@
 {
   "cells": [
     {
+      "id": "a4d7948d",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_nonlinearfactorgraph__a58d890a",
-      "metadata": {},
       "source": [
         "# NonlinearFactorGraph\n",
         "\n",
+        "This API walkthrough introduces the wrapped classes `NonlinearFactorGraph` declared by `NonlinearFactorGraph.h` and demonstrates their principal Python operations."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "cb1f4f1f",
+      "cell_type": "markdown",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "71db7129",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/NonlinearFactorGraph.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "390aae67",
+      "cell_type": "code",
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      },
+      "execution_count": null,
+      "source": [
+        "try:\n",
+        "    import google.colab\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "except ImportError:\n",
+        "    pass"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "76e8e44a",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "from gtsam.symbol_shorthand import L, X"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "9ca0f4cd",
+      "cell_type": "markdown",
+      "source": [
         "## Overview\n",
         "\n",
         "The `NonlinearFactorGraph` class in GTSAM is a key component for representing and solving nonlinear factor graphs. A factor graph is a bipartite graph that represents the factorization of a function, commonly used in probabilistic graphical models. In the context of GTSAM, it is used to represent the structure of optimization problems, e.g., in the domain of simultaneous localization and mapping (SLAM) or structure from motion (SfM).\n",
@@ -34,41 +97,8 @@
         "- **at**: Accesses a specific factor by its index.\n",
         "- **back**: Retrieves the last factor in the graph.\n",
         "- **front**: Retrieves the first factor in the graph."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_nonlinearfactorgraph__colab_button",
-      "metadata": {},
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/NonlinearFactorGraph.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_nonlinearfactorgraph__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "gtsam_nonlinear_doc_nonlinearfactorgraph__colab_import",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "outputs": [],
-      "source": [
-        "try:\n    import google.colab\n    %pip install --quiet gtsam-develop\nexcept ImportError:\n    pass"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "cell_type": "markdown",
@@ -85,6 +115,29 @@
         "  \n",
         "  where $A$ is the Jacobian matrix evaluated at the point $x_0$."
       ]
+    },
+    {
+      "id": "ddfd52b9",
+      "cell_type": "markdown",
+      "source": [
+        "## Python wrapper walkthrough\n",
+        "\n",
+        "The following cell exercises the wrapped API directly."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "3ba129bb",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "graph = gtsam.NonlinearFactorGraph()\n",
+        "model = gtsam.noiseModel.Diagonal.Sigmas(np.array([0.1, 0.1, 0.1]))\n",
+        "graph.add(gtsam.PriorFactorPose2(X(0), gtsam.Pose2(), model))\n",
+        "print('size:', graph.size(), 'keys:', list(graph.keyVector()))"
+      ],
+      "outputs": []
     }
   ],
   "metadata": {

--- a/gtsam/nonlinear/doc/NonlinearISAM.ipynb
+++ b/gtsam/nonlinear/doc/NonlinearISAM.ipynb
@@ -1,50 +1,102 @@
 {
   "cells": [
     {
+      "id": "70ca0708",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_nonlinearisam__2b6fc012",
-      "metadata": {},
       "source": [
         "# NonlinearISAM\n",
         "\n",
-        "## Overview\n",
-        "\n",
-        "The `NonlinearISAM` class wraps the incremental factorization version of iSAM {cite:p}`http://dx.doi.org/10.1109/TRO.2008.2006706`. It is largely superseded by [iSAM2](./ISAM2.ipynb) but it is a simpler class, with less bells and whistles, that might be easier to debug. For background, also see the more recent booklet by {cite:t}`https://doi.org/10.1561/2300000043`.\n"
-      ]
+        "This API walkthrough introduces the wrapped classes `NonlinearISAM` declared by `NonlinearISAM.h` and demonstrates their principal Python operations."
+      ],
+      "metadata": {}
     },
     {
+      "id": "fd2b62b2",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_nonlinearisam__colab_button",
-      "metadata": {},
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "1f425256",
+      "cell_type": "markdown",
       "source": [
         "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/NonlinearISAM.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
+      ],
+      "metadata": {}
     },
     {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_nonlinearisam__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
+      "id": "a6e8bb24",
       "cell_type": "code",
-      "execution_count": null,
-      "id": "gtsam_nonlinear_doc_nonlinearisam__colab_import",
       "metadata": {
         "tags": [
           "remove-cell"
         ]
       },
-      "outputs": [],
+      "execution_count": null,
       "source": [
-        "try:\n    import google.colab\n    %pip install --quiet gtsam-develop\nexcept ImportError:\n    pass"
-      ]
+        "try:\n",
+        "    import google.colab\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "except ImportError:\n",
+        "    pass"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "16e5d8a3",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "from gtsam.symbol_shorthand import L, X"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "214a16e7",
+      "cell_type": "markdown",
+      "source": [
+        "## Overview\n",
+        "\n",
+        "The `NonlinearISAM` class wraps the incremental factorization version of iSAM {cite:p}`http://dx.doi.org/10.1109/TRO.2008.2006706`. It is largely superseded by [iSAM2](./ISAM2.ipynb) but it is a simpler class, with less bells and whistles, that might be easier to debug. For background, also see the more recent booklet by {cite:t}`https://doi.org/10.1561/2300000043`."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "fef73a47",
+      "cell_type": "markdown",
+      "source": [
+        "## Python wrapper walkthrough\n",
+        "\n",
+        "The following cell exercises the wrapped API directly."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "af30e459",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "isam = gtsam.NonlinearISAM(reorderInterval=10)\n",
+        "print(type(isam).__name__)\n",
+        "print([name for name in dir(isam) if not name.startswith('_')])"
+      ],
+      "outputs": []
     }
   ],
   "metadata": {

--- a/gtsam/nonlinear/doc/NonlinearOptimizer.ipynb
+++ b/gtsam/nonlinear/doc/NonlinearOptimizer.ipynb
@@ -1,12 +1,75 @@
 {
   "cells": [
     {
+      "id": "eda2f1d5",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_nonlinearoptimizer__2e4812da",
-      "metadata": {},
       "source": [
         "# NonlinearOptimizer\n",
         "\n",
+        "This API walkthrough introduces the wrapped classes `NonlinearOptimizer` declared by `NonlinearOptimizer.h` and demonstrates their principal Python operations."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "83f2e056",
+      "cell_type": "markdown",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
+        "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "d1894d88",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/NonlinearOptimizer.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "f3c9b941",
+      "cell_type": "code",
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      },
+      "execution_count": null,
+      "source": [
+        "try:\n",
+        "    import google.colab\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "except ImportError:\n",
+        "    pass"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "05ed537d",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "from gtsam.symbol_shorthand import L, X"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "0004d7a4",
+      "cell_type": "markdown",
+      "source": [
         "## Overview\n",
         "\n",
         "The `NonlinearOptimizer` class in GTSAM is a the base class for (batch) nonlinear optimization solvers. It provides the basic API for optimizing nonlinear factor graphs, commonly used in robotics and computer vision applications.\n",
@@ -66,41 +129,37 @@
         "- [NonlinearOptimizer.cpp](https://github.com/borglab/gtsam/blob/develop/gtsam/nonlinear/NonlinearOptimizer.cpp)\n",
         "- [NonlinearOptimizerParams.h](https://github.com/borglab/gtsam/blob/develop/gtsam/nonlinear/NonlinearOptimizerParams.h)\n",
         "- [NonlinearOptimizerParams.cpp](https://github.com/borglab/gtsam/blob/develop/gtsam/nonlinear/NonlinearOptimizerParams.cpp)"
-      ]
+      ],
+      "metadata": {}
     },
     {
+      "id": "a98d4a86",
       "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_nonlinearoptimizer__colab_button",
-      "metadata": {},
       "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/NonlinearOptimizer.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
+        "## Python wrapper walkthrough\n",
+        "\n",
+        "The following cell exercises the wrapped API directly."
+      ],
+      "metadata": {}
     },
     {
-      "cell_type": "markdown",
-      "id": "gtsam_nonlinear_doc_nonlinearoptimizer__license_cell",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
+      "id": "5bed7403",
       "cell_type": "code",
+      "metadata": {},
       "execution_count": null,
-      "id": "gtsam_nonlinear_doc_nonlinearoptimizer__colab_import",
-      "metadata": {
-        "tags": [
-          "remove-cell"
-        ]
-      },
-      "outputs": [],
       "source": [
-        "try:\n    import google.colab\n    %pip install --quiet gtsam-develop\nexcept ImportError:\n    pass"
-      ]
+        "def public_api(qualified_name):\n",
+        "    value = gtsam\n",
+        "    for component in qualified_name.split('.'):\n",
+        "        value = getattr(value, component, None)\n",
+        "        if value is None:\n",
+        "            return []\n",
+        "    return [name for name in dir(value) if not name.startswith('_')]\n",
+        "\n",
+        "print('\\nNonlinearOptimizer')\n",
+        "print(public_api('NonlinearOptimizer'))"
+      ],
+      "outputs": []
     }
   ],
   "metadata": {

--- a/gtsam/nonlinear/doc/NonlinearOptimizerParams.ipynb
+++ b/gtsam/nonlinear/doc/NonlinearOptimizerParams.ipynb
@@ -1,0 +1,168 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# NonlinearOptimizerParams\n",
+    "\n",
+    "`NonlinearOptimizerParams` holds convergence, iteration, ordering, verbosity, and linear-solver settings shared by GTSAM's batch nonlinear optimizers. Concrete optimizer parameter classes inherit this interface."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16c97efb",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/NonlinearOptimizerParams.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8de9e065",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import L, V, X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating and configuring the common parameters\n",
+    "\n",
+    "The base object is constructible for inspection, but applications normally create `GaussNewtonParams`, `DoglegParams`, or `LevenbergMarquardtParams` and use the inherited setters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params = gtsam.GaussNewtonParams()\n",
+    "params.setMaxIterations(50)\n",
+    "params.setRelativeErrorTol(1e-6)\n",
+    "params.setAbsoluteErrorTol(1e-8)\n",
+    "params.setErrorTol(0.0)\n",
+    "params.setVerbosity(\"SILENT\")\n",
+    "print(\"maximum iterations:\", params.getMaxIterations())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Linear solver and ordering\n",
+    "\n",
+    "`setLinearSolverType()` accepts names such as `MULTIFRONTAL_CHOLESKY` and `SEQUENTIAL_QR`. Query methods identify the selected solver family. An explicit `Ordering` can override the automatic ordering for reproducibility or known sparsity structure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params.setLinearSolverType(\"MULTIFRONTAL_CHOLESKY\")\n",
+    "ordering = gtsam.Ordering()\n",
+    "ordering.push_back(X(0))\n",
+    "params.setOrdering(ordering)\n",
+    "print(\"solver:\", params.getLinearSolverType())\n",
+    "print(\"is multifrontal:\", params.isMultifrontal())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Iteration hooks\n",
+    "\n",
+    "Python can assign `iterationHook` to receive `(iteration, error_before, error_after)` after each iteration. This is useful for logging without increasing optimizer verbosity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "history = []\n",
+    "params.iterationHook = lambda iteration, before, after: history.append(\n",
+    "    (iteration, before, after)\n",
+    ")\n",
+    "\n",
+    "graph = gtsam.NonlinearFactorGraph()\n",
+    "model = gtsam.noiseModel.Diagonal.Sigmas(np.array([0.1, 0.1, 0.05]))\n",
+    "graph.add(gtsam.PriorFactorPose2(X(0), gtsam.Pose2(1.0, 0.0, 0.2), model))\n",
+    "initial = gtsam.Values()\n",
+    "initial.insert(X(0), gtsam.Pose2())\n",
+    "gtsam.GaussNewtonOptimizer(graph, initial, params).optimize()\n",
+    "print(\"iterations recorded:\", len(history))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`NonlinearOptimizerParams.h`](../NonlinearOptimizerParams.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/nonlinear/doc/Values.ipynb
+++ b/gtsam/nonlinear/doc/Values.ipynb
@@ -1,0 +1,171 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Values\n",
+    "\n",
+    "`Values` is GTSAM's heterogeneous, key-indexed container for nonlinear variable assignments. It stores typed manifold values while providing uniform insertion, update, retraction, and local-coordinate operations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9785a285",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/Values.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83be476b",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import L, V, X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inserting values\n",
+    "\n",
+    "Each key may appear once and has a fixed stored type. `insert()` rejects duplicate keys; use `update()` or `insert_or_assign()` when replacement is intended."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "values = gtsam.Values()\n",
+    "values.insert(X(0), gtsam.Pose2(1.0, 2.0, 0.1))\n",
+    "values.insert(L(0), np.array([4.0, 5.0]))\n",
+    "values.insert(gtsam.symbol(\"d\", 0), 2.5)\n",
+    "print(\"size:\", values.size(), \"dimension:\", values.dim())\n",
+    "print(\"keys:\", [gtsam.DefaultKeyFormatter(k) for k in values.keys()])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Typed retrieval and updates\n",
+    "\n",
+    "Python exposes typed accessors such as `atPose2()`, `atPoint2()`, and `atDouble()`. `exists()` checks a key before retrieval, and `erase()` removes it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"pose:\", values.atPose2(X(0)))\n",
+    "print(\"landmark:\", values.atPoint2(L(0)))\n",
+    "\n",
+    "values.update(X(0), gtsam.Pose2(1.1, 2.0, 0.1))\n",
+    "assert values.exists(X(0))\n",
+    "print(\"updated pose:\", values.atPose2(X(0)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Retraction and local coordinates\n",
+    "\n",
+    "`zeroVectors()` creates a zero `VectorValues` tangent with the correct dimensions. To specify an increment, insert one tangent vector per key. `retract(delta)` applies it, while `localCoordinates(other)` computes the displacement between compatible containers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zero = values.zeroVectors()\n",
+    "print(\"zero tangent norm:\", zero.norm())\n",
+    "\n",
+    "delta = gtsam.VectorValues()\n",
+    "delta.insert(X(0), np.array([0.01, -0.02, 0.03]))\n",
+    "delta.insert(L(0), np.array([0.1, -0.1]))\n",
+    "delta.insert(gtsam.symbol(\"d\", 0), np.array([0.2]))\n",
+    "\n",
+    "perturbed = values.retract(delta)\n",
+    "recovered = values.localCoordinates(perturbed)\n",
+    "for key in values.keys():\n",
+    "    np.testing.assert_allclose(recovered.at(key), delta.at(key), atol=1e-8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Combining containers\n",
+    "\n",
+    "`insert(other_values)` merges disjoint keys, `swap()` exchanges contents, and `clear()` removes everything. Container equality is manifold-aware through `equals()`; it is not just Python object identity.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`Values.h`](../Values.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/nonlinear/doc/VectorNormFactor.ipynb
+++ b/gtsam/nonlinear/doc/VectorNormFactor.ipynb
@@ -1,14 +1,75 @@
 {
   "cells": [
     {
+      "id": "d7787e3a",
       "cell_type": "markdown",
-      "id": "ed487bc4",
-      "metadata": {},
       "source": [
         "# VectorNormFactor\n",
         "\n",
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/VectorNormFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+        "This API walkthrough introduces the wrapped classes `VectorNormFactor` declared by `VectorNormFactor.h` and demonstrates their principal Python operations."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "ad5957db",
+      "cell_type": "markdown",
+      "source": [
+        "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+        "Atlanta, Georgia 30332-0415\n",
+        "All Rights Reserved\n",
         "\n",
+        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+        "\n",
+        "See LICENSE for the license information"
+      ],
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      }
+    },
+    {
+      "id": "88d58082",
+      "cell_type": "markdown",
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/VectorNormFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "f0cde534",
+      "cell_type": "code",
+      "metadata": {
+        "tags": [
+          "remove-cell"
+        ]
+      },
+      "execution_count": null,
+      "source": [
+        "try:\n",
+        "    import google.colab\n",
+        "    %pip install --quiet gtsam-develop\n",
+        "except ImportError:\n",
+        "    pass"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "475b64dd",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "from gtsam.symbol_shorthand import L, X"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "e596d667",
+      "cell_type": "markdown",
+      "source": [
         "## Overview\n",
         "\n",
         "`VectorNormFactor<N>` is a unary factor constraining the norm of an N-dimensional\n",
@@ -35,42 +96,8 @@
         "**Warning**: the error is not differentiable at $\\lVert v \\rVert = 0$; the Jacobian\n",
         "is zero there, so a variable initialized at exactly zero receives no gradient from this\n",
         "factor and will not move. Always initialize with a non-zero guess."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "4fa7ea59",
-      "metadata": {},
-      "source": [
-        "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\n",
-        "Atlanta, Georgia 30332-0415\n",
-        "All Rights Reserved\n",
-        "\n",
-        "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
-        "\n",
-        "See LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "id": "d796072b",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-08-01T10:20:56.326366Z",
-          "iopub.status.busy": "2026-08-01T10:20:56.326254Z",
-          "iopub.status.idle": "2026-08-01T10:20:56.526270Z",
-          "shell.execute_reply": "2026-08-01T10:20:56.525643Z"
-        }
-      },
-      "outputs": [],
-      "source": [
-        "# Install gtsam-develop if not installed\n",
-        "try:\n",
-        "    import gtsam\n",
-        "except ImportError:\n",
-        "    %pip install --quiet gtsam-develop"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "cell_type": "markdown",

--- a/gtsam/nonlinear/doc/WnoaFactor.ipynb
+++ b/gtsam/nonlinear/doc/WnoaFactor.ipynb
@@ -1,0 +1,144 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# WnoaFactor\n",
+    "\n",
+    "`WnoaMotionFactor<POSE>` imposes a white-noise-on-acceleration prior between two time-stamped pose/velocity states. Python provides concrete factors for `Point1`, `Point2`, `Point3`, `Pose2`, and `Pose3` trajectories."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37399759",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/WnoaFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a97a6ba3",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import L, V, X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating state metadata\n",
+    "\n",
+    "Each factor connects pose and velocity keys at two times. `StateData` keeps those keys and timestamps together, while `q_psd_diag` specifies acceleration power spectral density per tangent dimension."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "state0 = gtsam.StateData(X(0), V(0), 0.0)\n",
+    "state1 = gtsam.StateData(X(1), V(1), 1.0)\n",
+    "q_psd_diag = np.array([0.1, 0.1])\n",
+    "\n",
+    "factor = gtsam.WnoaMotionFactorPoint2(state0, state1, q_psd_diag)\n",
+    "print(\"connected keys:\", [gtsam.DefaultKeyFormatter(k) for k in factor.keys()])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Motion residual\n",
+    "\n",
+    "`evaluateError(p0, v0, p1, v1)` compares endpoint states with the constant-velocity trajectory implied by WNOA. A one-second unit-x motion with equal endpoint velocities has zero residual."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "error = factor.evaluateError(\n",
+    "    np.array([0.0, 0.0]),\n",
+    "    np.array([1.0, 0.0]),\n",
+    "    np.array([1.0, 0.0]),\n",
+    "    np.array([1.0, 0.0]),\n",
+    ")\n",
+    "print(\"motion error:\", error)\n",
+    "np.testing.assert_allclose(error, np.zeros(4), atol=1e-12)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Other wrapped state spaces\n",
+    "\n",
+    "Choose `WnoaMotionFactorPoint1`, `WnoaMotionFactorPoint2`, `WnoaMotionFactorPoint3`, `WnoaMotionFactorPose2`, or `WnoaMotionFactorPose3` to match the stored pose type. The velocity dimension matches that pose's tangent dimension. Insert the factor into a `NonlinearFactorGraph` like any other noise-model factor.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`WnoaFactor.h`](../WnoaFactor.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/nonlinear/doc/WnoaFactorGraph.ipynb
+++ b/gtsam/nonlinear/doc/WnoaFactorGraph.ipynb
@@ -1,0 +1,149 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# WnoaFactorGraph\n",
+    "\n",
+    "`WnoaFactorGraph<POSE>` is the expression-factor graph produced when factors on interpolated states are rewritten in terms of neighboring estimated WNOA states. Python exposes one specialization for each wrapped point or pose trajectory type."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "615a95db",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/WnoaFactorGraph.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07eca44b",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import L, V, X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Estimated and interpolated states\n",
+    "\n",
+    "The estimated states are optimization variables. An interpolated state lies between them in time and is mapped to its left and right borders."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "left = gtsam.StateData(X(0), V(0), 0.0)\n",
+    "middle = gtsam.StateData(X(1), V(1), 0.5)\n",
+    "right = gtsam.StateData(X(2), V(2), 1.0)\n",
+    "q_psd_diag = np.array([0.1, 0.1])\n",
+    "\n",
+    "interp_map = {middle: (left, right)}\n",
+    "empty_wnoa_graph = gtsam.WnoaFactorGraphPoint2(interp_map, q_psd_diag)\n",
+    "print(\"initial factors:\", empty_wnoa_graph.size())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Rewriting a factor graph\n",
+    "\n",
+    "`interpolateWnoaFactorGraphPoint2()` replaces factors involving interpolated poses with `WnoaInterpFactorPoint2` objects and adds the required WNOA motion prior. The returned specialized graph remains a `NonlinearFactorGraph`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "measurement_graph = gtsam.NonlinearFactorGraph()\n",
+    "model = gtsam.noiseModel.Isotropic.Sigma(2, 0.1)\n",
+    "measurement_graph.add(\n",
+    "    gtsam.PriorFactorPoint2(X(1), np.array([0.5, 0.0]), model)\n",
+    ")\n",
+    "\n",
+    "wnoa_graph = gtsam.interpolateWnoaFactorGraphPoint2(\n",
+    "    measurement_graph, {left, right}, {middle}, q_psd_diag\n",
+    ")\n",
+    "print(\"rewritten factors:\", wnoa_graph.size())\n",
+    "assert wnoa_graph.size() == 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Related utilities and specializations\n",
+    "\n",
+    "`interpolateFactorGraph*` returns a plain nonlinear graph, while `updateInterpValues*` reconstructs interpolated values after solving and `updateInterpValuesWithCovariance*` also returns conditional covariances. The graph classes are `WnoaFactorGraphPoint1`, `WnoaFactorGraphPoint2`, `WnoaFactorGraphPoint3`, `WnoaFactorGraphPose2`, and `WnoaFactorGraphPose3`.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`WnoaFactorGraph.h`](../WnoaFactorGraph.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/nonlinear/doc/WnoaInterpFactor.ipynb
+++ b/gtsam/nonlinear/doc/WnoaInterpFactor.ipynb
@@ -1,0 +1,153 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# WnoaInterpFactor\n",
+    "\n",
+    "`WnoaInterpFactor<POSE>` wraps a measurement factor on an interpolated state and expresses its error using the neighboring estimated WNOA states. This avoids adding every measurement time as a full optimization state."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7569edc6",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/WnoaInterpFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "44af6d30",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import L, V, X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating an interpolation factor\n",
+    "\n",
+    "Supply the original factor, ordered estimated/interpolated `StateData` sets, and acceleration PSD. The wrapped `Point2` example turns a prior at `t=0.5` into a four-key factor on the bordering pose/velocity states."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "left = gtsam.StateData(X(0), V(0), 0.0)\n",
+    "middle = gtsam.StateData(X(1), V(1), 0.5)\n",
+    "right = gtsam.StateData(X(2), V(2), 1.0)\n",
+    "\n",
+    "model = gtsam.noiseModel.Isotropic.Sigma(2, 0.1)\n",
+    "inner_factor = gtsam.PriorFactorPoint2(X(1), np.array([0.5, 0.0]), model)\n",
+    "factor = gtsam.WnoaInterpFactorPoint2(\n",
+    "    inner_factor,\n",
+    "    {left, right},\n",
+    "    {middle},\n",
+    "    np.array([0.1, 0.1]),\n",
+    ")\n",
+    "print(\"factor dimension:\", factor.dim())\n",
+    "print(\"border-state keys:\", [gtsam.DefaultKeyFormatter(k) for k in factor.keys()])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Noise and interpolation options\n",
+    "\n",
+    "`fixed_noise_model=False` augments measurement uncertainty with interpolation uncertainty. Set it to `True` when the original factor's noise model should remain fixed. `precomp_interp_mats=True` caches interpolation matrices for repeated evaluations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fixed_noise_factor = gtsam.WnoaInterpFactorPoint2(\n",
+    "    inner_factor,\n",
+    "    {left, right},\n",
+    "    {middle},\n",
+    "    np.array([0.1, 0.1]),\n",
+    "    fixed_noise_model=True,\n",
+    "    precomp_interp_mats=True,\n",
+    ")\n",
+    "print(\"fixed-noise dimension:\", fixed_noise_factor.dim())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Other wrapped state spaces\n",
+    "\n",
+    "`WnoaInterpFactorPoint1`, `WnoaInterpFactorPoint2`, `WnoaInterpFactorPoint3`, `WnoaInterpFactorPose2`, and `WnoaInterpFactorPose3` share the same construction pattern. In most applications, [`WnoaFactorGraph`](WnoaFactorGraph.ipynb) utilities create these factors automatically from an ordinary measurement graph.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`WnoaInterpFactor.h`](../WnoaInterpFactor.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/nonlinear/doc/WnoaStateData.ipynb
+++ b/gtsam/nonlinear/doc/WnoaStateData.ipynb
@@ -1,0 +1,157 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# WnoaStateData\n",
+    "\n",
+    "`StateData` identifies one continuous-time trajectory state by its pose key, velocity key, and timestamp. WNOA factors use it to keep temporal ordering and variable identities consistent."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "387341db",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/nonlinear/doc/WnoaStateData.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f3bbd1aa",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "from gtsam.symbol_shorthand import L, V, X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating state descriptors\n",
+    "\n",
+    "Pose and velocity keys must be distinct GTSAM keys. Time is a floating-point value in the application's chosen unit, used consistently with acceleration PSD."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "state0 = gtsam.StateData(X(0), V(0), 0.0)\n",
+    "state1 = gtsam.StateData(X(1), V(1), 0.5)\n",
+    "print(\"pose key:\", gtsam.DefaultKeyFormatter(state1.pose))\n",
+    "print(\"velocity key:\", gtsam.DefaultKeyFormatter(state1.velocity))\n",
+    "print(\"time:\", state1.time)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Ordering and sets\n",
+    "\n",
+    "`StateData` is hashable, so Python sets can be passed directly to WNOA wrapper functions. The C++ conversion orders those sets by time, with keys providing deterministic tie-breaking; Python code can sort explicitly with a time key when it needs to display that order."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "states = {state1, state0}\n",
+    "ordered_states = sorted(states, key=lambda state: state.time)\n",
+    "print(\"ordered times:\", [state.time for state in ordered_states])\n",
+    "assert [state.time for state in ordered_states] == [0.0, 0.5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using descriptors in a motion factor\n",
+    "\n",
+    "The descriptor does not store pose or velocity values. Those live in a `Values` object under the referenced keys; `StateData` only tells WNOA factors where and when to find them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "values = gtsam.Values()\n",
+    "values.insert(state0.pose, np.array([0.0, 0.0]))\n",
+    "values.insert(state0.velocity, np.array([1.0, 0.0]))\n",
+    "print(\"pose value:\", values.atPoint2(state0.pose))\n",
+    "print(\"velocity value:\", values.atVector(state0.velocity))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source\n",
+    "\n",
+    "[`WnoaStateData.h`](../WnoaStateData.h)\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

- add 45 API walkthrough notebooks for wrapper-exposed classes in discrete, geometry, and nonlinear
- give every added page the prescribed five-cell preamble, curated examples, related links, and an AI-assistance caveat
- normalize existing user guides in the same modules while preserving their authored content

## Validation

- validated every changed notebook as JSON in the py312 environment
- parsed the Python cells in all 76 changed notebooks
- ran `git diff --check origin/develop..HEAD`