### PR TITLE
fix cmake ceres cudss dependency issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,9 @@ add_subdirectory(CppUnitLite)
 # Build GTSAM library
 add_subdirectory(gtsam)
 
+# Find ceres for tests and timing dependencies
+find_package(Ceres CONFIG QUIET)
+
 # Build Tests
 add_subdirectory(tests)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,7 +26,6 @@ endif()
 gtsamAddTestsGlob(tests "test*.cpp" "${excluded_tests}" "gtsam")
 
 if(GTSAM_BUILD_TESTS)
-  find_package(Ceres CONFIG QUIET)
   if(Ceres_FOUND)
     message(STATUS "Found Ceres ${CERES_VERSION}; enabling testAdaptAutoDiff")
     gtsamAddTestsGlob(ceres_autodiff "testAdaptAutoDiff.cpp" ""

--- a/timing/CMakeLists.txt
+++ b/timing/CMakeLists.txt
@@ -1,4 +1,3 @@
-find_package(Ceres CONFIG QUIET)
 if(Ceres_FOUND)
   message(STATUS "Found Ceres ${CERES_VERSION}")
 else()


### PR DESCRIPTION
When building with ceres with a cuda dependency, the following error is seen:
```
 Found Ceres 2.3.0; enabling testAdaptAutoDiff
 CMake Error at /usr/lib/x86_64-linux-gnu/cmake/cudss/cudss-config.cmake:176 (set_target_properties):
   Attempt to promote imported target "cudss" to global scope (by setting
   IMPORTED_GLOBAL) which is not built in this directory.
 Call Stack (most recent call first):
   /usr/share/cmake-3.28/Modules/CMakeFindDependencyMacro.cmake:76 (find_package)
   /usr/local/lib/cmake/Ceres/CeresConfig.cmake:129 (find_dependency)
   timing/CMakeLists.txt:1 (find_package)

 CMake Error at /usr/lib/x86_64-linux-gnu/cmake/cudss/cudss-config.cmake:178 (set_target_properties):
   Attempt to promote imported target "cudss_static" to global scope (by
   setting IMPORTED_GLOBAL) which is not built in this directory.
 Call Stack (most recent call first):
   /usr/share/cmake-3.28/Modules/CMakeFindDependencyMacro.cmake:76 (find_package)
   /usr/local/lib/cmake/Ceres/CeresConfig.cmake:129 (find_dependency)
   timing/CMakeLists.txt:1 (find_package)

 Found Ceres 2.3.0
```

This fixes the issue by finding ceres in cmake a single time. 

This was tested on Ubuntu 24.04 with ceres built with cuda and cudss.