### PR TITLE
Handle a timestamp supplied for a key with no value and no factor

### DIFF
--- a/gtsam/nonlinear/BayesTreeMarginalizationHelper.h
+++ b/gtsam/nonlinear/BayesTreeMarginalizationHelper.h
@@ -27,6 +27,8 @@
 #include <gtsam/inference/BayesTreeCliqueBase.h>
 #include <gtsam/base/debug.h>
 #include "gtsam/dllexport.h"
+#include <stdexcept>
+#include <string>
 
 namespace gtsam {
 
@@ -136,7 +138,17 @@ public:
       const BayesTree& bayesTree,
       const std::unordered_set<Key>& keysOfInterest) {
     std::unordered_set<const Clique*> cliques;
+    const auto& nodes = bayesTree.nodes();
     for (const Key& key : keysOfInterest) {
+      if (!nodes.exists(key)) {
+        // Otherwise the lookup fails inside bayesTree[key], naming neither the
+        // key nor this helper, with text that varies by build: "map::at"
+        // without TBB, "Index out of requested size range" with it. A variable
+        // that no factor references is never eliminated, so it has no clique.
+        throw std::out_of_range(
+            "BayesTreeMarginalizationHelper: key '" + DefaultKeyFormatter(key) +
+            "' has no clique in the Bayes tree.");
+      }
       cliques.insert(bayesTree[key].get());
     }
     return cliques;

--- a/gtsam/nonlinear/BayesTreeMarginalizationHelper.h
+++ b/gtsam/nonlinear/BayesTreeMarginalizationHelper.h
@@ -140,7 +140,12 @@ public:
     std::unordered_set<const Clique*> cliques;
     const auto& nodes = bayesTree.nodes();
     for (const Key& key : keysOfInterest) {
-      if (!nodes.exists(key)) {
+      // One lookup, reused for both the check and the insert. exists() is a
+      // count() and bayesTree[key] is an at(), so testing then indexing would
+      // search the node map twice per key; bayesTree[key] also returns the
+      // shared_ptr by value, which costs a reference count round trip.
+      const auto node = nodes.find(key);
+      if (node == nodes.end()) {
         // Otherwise the lookup fails inside bayesTree[key], naming neither the
         // key nor this helper, with text that varies by build: "map::at"
         // without TBB, "Index out of requested size range" with it. A variable
@@ -149,7 +154,7 @@ public:
             "BayesTreeMarginalizationHelper: key '" + DefaultKeyFormatter(key) +
             "' has no clique in the Bayes tree.");
       }
-      cliques.insert(bayesTree[key].get());
+      cliques.insert(node->second.get());
     }
     return cliques;
   }

--- a/gtsam/nonlinear/IncrementalFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/IncrementalFixedLagSmoother.cpp
@@ -80,15 +80,28 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
   for (const auto& keyFactors : variableIndex) {
     activeKeys.insert(keyFactors.first);
   }
+  //
+  // An inactive key has no factor referencing it, so after isam_.update() it
+  // still has no clique and marginalizeLeaves, which does nodes_[j], has no
+  // node for it. Two cases, told apart by whether a value exists:
+  //
+  //  - a value exists (pending): reap it below, once ISAM2 has been updated.
+  //  - no value exists: the caller supplied a timestamp for a key that has
+  //    neither a value nor a factor. Nothing in ISAM2 to remove; only the
+  //    timestamp has to go.
+  //
+  // Both leave marginalizableKeys; only the first needs removeVariables.
   KeyVector expiredPendingKeys;
+  KeyVector staleTimestampKeys;
   marginalizableKeys.erase(
       std::remove_if(marginalizableKeys.begin(), marginalizableKeys.end(),
                      [&](Key key) {
-                       const bool isPending =
-                           !activeKeys.exists(key) &&
-                           (isam_.valueExists(key) || newTheta.exists(key));
-                       if (isPending) expiredPendingKeys.push_back(key);
-                       return isPending;
+                       if (activeKeys.exists(key)) return false;
+                       if (isam_.valueExists(key) || newTheta.exists(key))
+                         expiredPendingKeys.push_back(key);
+                       else
+                         staleTimestampKeys.push_back(key);
+                       return true;
                      }),
       marginalizableKeys.end());
 
@@ -181,6 +194,7 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
   // Remove marginalized keys from the KeyTimestampMap
   eraseKeyTimestampMap(marginalizableKeys);
   eraseKeyTimestampMap(expiredPendingKeys);
+  eraseKeyTimestampMap(staleTimestampKeys);
 
   if (debug) {
     PrintSymbolicTree(isam_, "Final Bayes Tree:");

--- a/gtsam/nonlinear/IncrementalFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/IncrementalFixedLagSmoother.cpp
@@ -75,11 +75,18 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
   // Values may arrive before the factors that reference them. Reap pending
   // values when they age out, without passing them to Bayes-tree
   // marginalization where they have no clique.
-  KeySet activeKeys = newFactorKeys;
+  //
+  // A key is active when some factor references it, either one already in the
+  // system or one arriving now. Asking the variable index directly avoids
+  // materialising that set: it is a KeySet, so building it costs an ordered
+  // insert and an allocation per variable in the whole window, on every
+  // update, and both users below are skipped entirely when nothing is
+  // marginalizable.
   const VariableIndex& variableIndex = isam_.getVariableIndex();
-  for (const auto& keyFactors : variableIndex) {
-    activeKeys.insert(keyFactors.first);
-  }
+  const auto isActive = [&](Key key) {
+    return newFactorKeys.exists(key) ||
+           variableIndex.find(key) != variableIndex.end();
+  };
   //
   // An inactive key has no factor referencing it, so after isam_.update() it
   // still has no clique and marginalizeLeaves, which does nodes_[j], has no
@@ -96,7 +103,7 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
   marginalizableKeys.erase(
       std::remove_if(marginalizableKeys.begin(), marginalizableKeys.end(),
                      [&](Key key) {
-                       if (activeKeys.exists(key)) return false;
+                       if (isActive(key)) return false;
                        if (isam_.valueExists(key) || newTheta.exists(key))
                          expiredPendingKeys.push_back(key);
                        else
@@ -114,7 +121,7 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
   }
 
   // Force iSAM2 to put the marginalizable variables at the beginning
-  createOrderingConstraints(marginalizableKeys, activeKeys, constrainedKeys);
+  createOrderingConstraints(marginalizableKeys, isActive, constrainedKeys);
 
   if (debug) {
     std::cout << "Constrained Keys: ";
@@ -229,14 +236,15 @@ void IncrementalFixedLagSmoother::eraseKeysBefore(double timestamp) {
 
 /* ************************************************************************* */
 void IncrementalFixedLagSmoother::createOrderingConstraints(
-    const KeyVector& marginalizableKeys, const KeySet& activeKeys,
+    const KeyVector& marginalizableKeys,
+    const std::function<bool(Key)>& isActive,
     std::optional<FastMap<Key, int> >& constrainedKeys) const {
   if (marginalizableKeys.size() > 0) {
     constrainedKeys = FastMap<Key, int>();
     // Generate ordering constraints so that the marginalizable variables will be eliminated first
     // Set all variables to Group1
     for(const TimestampKeyMap::value_type& timestamp_key: timestampKeyMap_) {
-      if (activeKeys.exists(timestamp_key.second)) {
+      if (isActive(timestamp_key.second)) {
         constrainedKeys->operator[](timestamp_key.second) = 1;
       }
     }

--- a/gtsam/nonlinear/IncrementalFixedLagSmoother.h
+++ b/gtsam/nonlinear/IncrementalFixedLagSmoother.h
@@ -24,6 +24,8 @@
 #include <gtsam/nonlinear/ISAM2.h>
 #include "gtsam/dllexport.h"
 
+#include <functional>
+
 namespace gtsam {
 
 /**
@@ -138,7 +140,8 @@ protected:
 
   /** Fill in an iSAM2 ConstrainedKeys structure such that the provided keys are eliminated before all others */
   void createOrderingConstraints(
-      const KeyVector& marginalizableKeys, const KeySet& activeKeys,
+      const KeyVector& marginalizableKeys,
+      const std::function<bool(Key)>& isActive,
       std::optional<FastMap<Key, int> >& constrainedKeys) const;
 
 private:

--- a/gtsam/nonlinear/tests/testIncrementalFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/tests/testIncrementalFixedLagSmoother.cpp
@@ -29,6 +29,7 @@
 #include <gtsam/slam/BetweenFactor.h>
 #include <gtsam/slam/PriorFactor.h>
 #include <gtsam/slam/dataset.h>  // For writeG2o
+#include <gtsam/nonlinear/BayesTreeMarginalizationHelper.h>
 #include <gtsam/nonlinear/IncrementalFixedLagSmoother.h>
 
 #include <CppUnitLite/TestHarness.h>
@@ -492,6 +493,129 @@ TEST(IncrementalFixedLagSmoother, ReapsPendingValueAfterLag) {
   EXPECT(!smoother.getLinearizationPoint().exists(X(1)));
   EXPECT(smoother.getLinearizationPoint().exists(X(2)));
   EXPECT(smoother.timestamps().find(X(1)) == smoother.timestamps().end());
+}
+
+// A timestamp may be supplied for a key that has neither a value nor a factor.
+// Such a key is not "pending" -- there is no value for it -- so it survives the
+// pending-value partition, ages out, and reaches marginalizeLeaves with no
+// clique. The variableIndex filter guards only the marginalization helper.
+TEST(IncrementalFixedLagSmoother, TimestampWithoutValueOrFactor) {
+  const SharedDiagonal noise = noiseModel::Diagonal::Sigmas(Vector2(0.1, 0.1));
+  IncrementalFixedLagSmoother smoother(1.0);
+  const Key phantom = Symbol('p', 0);
+
+  NonlinearFactorGraph factors;
+  Values values;
+  FixedLagSmoother::KeyTimestampMap timestamps;
+
+  factors.addPrior(X(0), Point2(0.0, 0.0), noise);
+  values.insert(X(0), Point2(0.0, 0.0));
+  timestamps[X(0)] = 0.0;
+  timestamps[phantom] = 0.0;  // no value, no factor
+  smoother.update(factors, values, timestamps);
+  EXPECT(smoother.timestamps().find(phantom) != smoother.timestamps().end());
+
+  // X(1) is joined to X(0), so marginalizing X(0) leaves a marginal factor.
+  factors.resize(0);
+  values.clear();
+  timestamps.clear();
+  factors.emplace_shared<BetweenPoint2>(X(0), X(1), Point2(1.0, 0.0), noise);
+  values.insert(X(1), Point2(1.0, 0.0));
+  timestamps[X(1)] = 5.0;
+  smoother.update(factors, values, timestamps);
+
+  EXPECT(smoother.timestamps().find(phantom) == smoother.timestamps().end());
+  EXPECT(!smoother.getLinearizationPoint().exists(phantom));
+  EXPECT(smoother.getLinearizationPoint().exists(X(1)));
+  EXPECT(!smoother.getLinearizationPoint().exists(X(0)));  // marginalized
+}
+
+// The same phantom key, but the following variable is in its own connected
+// component. This reached a different failure from the connected case above,
+// so both graph shapes are covered.
+TEST(IncrementalFixedLagSmoother, TimestampWithoutValueOrFactorDisconnected) {
+  const SharedDiagonal noise = noiseModel::Diagonal::Sigmas(Vector2(0.1, 0.1));
+  IncrementalFixedLagSmoother smoother(1.0);
+  const Key phantom = Symbol('p', 0);
+
+  NonlinearFactorGraph factors;
+  Values values;
+  FixedLagSmoother::KeyTimestampMap timestamps;
+
+  factors.addPrior(X(0), Point2(0.0, 0.0), noise);
+  values.insert(X(0), Point2(0.0, 0.0));
+  timestamps[X(0)] = 0.0;
+  timestamps[phantom] = 0.0;
+  smoother.update(factors, values, timestamps);
+
+  // No factor links X(1) to X(0).
+  factors.resize(0);
+  values.clear();
+  timestamps.clear();
+  factors.addPrior(X(1), Point2(1.0, 0.0), noise);
+  values.insert(X(1), Point2(1.0, 0.0));
+  timestamps[X(1)] = 5.0;
+  smoother.update(factors, values, timestamps);
+
+  EXPECT(smoother.timestamps().find(phantom) == smoother.timestamps().end());
+  EXPECT(smoother.getLinearizationPoint().exists(X(1)));
+}
+
+// A key with a value but no factor is still reaped, not treated as stale.
+// Guards the partition split added alongside the two tests above.
+TEST(IncrementalFixedLagSmoother, PendingValueStillReapedAlongsideStaleKey) {
+  const SharedDiagonal noise = noiseModel::Diagonal::Sigmas(Vector2(0.1, 0.1));
+  IncrementalFixedLagSmoother smoother(1.0);
+  const Key phantom = Symbol('p', 0);
+
+  NonlinearFactorGraph factors;
+  Values values;
+  FixedLagSmoother::KeyTimestampMap timestamps;
+
+  factors.addPrior(X(0), Point2(0.0, 0.0), noise);
+  values.insert(X(0), Point2(0.0, 0.0));
+  values.insert(X(1), Point2(1.0, 0.0));  // value, no factor -> pending
+  timestamps[X(0)] = 0.0;
+  timestamps[X(1)] = 0.0;
+  timestamps[phantom] = 0.0;              // no value, no factor -> stale
+  smoother.update(factors, values, timestamps);
+  EXPECT(smoother.getLinearizationPoint().exists(X(1)));
+
+  factors.resize(0);
+  values.clear();
+  timestamps.clear();
+  factors.addPrior(X(2), Point2(2.0, 0.0), noise);
+  values.insert(X(2), Point2(2.0, 0.0));
+  timestamps[X(2)] = 5.0;
+  smoother.update(factors, values, timestamps);
+
+  EXPECT(!smoother.getLinearizationPoint().exists(X(1)));  // reaped
+  EXPECT(smoother.timestamps().find(X(1)) == smoother.timestamps().end());
+  EXPECT(smoother.timestamps().find(phantom) == smoother.timestamps().end());
+}
+
+// A clique-less key should be named rather than failing inside the Bayes tree
+// with a message that identifies neither the key nor the caller.
+TEST(BayesTreeMarginalizationHelper, MissingCliqueNamesTheKey) {
+  const SharedDiagonal noise = noiseModel::Diagonal::Sigmas(Vector2(0.1, 0.1));
+  IncrementalFixedLagSmoother smoother(10.0);
+  NonlinearFactorGraph factors;
+  Values values;
+  FixedLagSmoother::KeyTimestampMap timestamps;
+  factors.addPrior(X(0), Point2(0.0, 0.0), noise);
+  values.insert(X(0), Point2(0.0, 0.0));
+  timestamps[X(0)] = 0.0;
+  smoother.update(factors, values, timestamps);
+
+  const KeyVector absent{Symbol('z', 9)};
+  bool named = false;
+  try {
+    BayesTreeMarginalizationHelper<ISAM2>::gatherAdditionalKeysToReEliminate(
+        smoother.getISAM2(), absent);
+  } catch (const std::out_of_range& e) {
+    named = std::string(e.what()).find("z9") != std::string::npos;
+  }
+  EXPECT(named);
 }
 
 /* ************************************************************************* */


### PR DESCRIPTION
Follow-up to #2749. The pending-value partition added there treats a marginalizable key as pending only when a value exists for it:

    !activeKeys.exists(key) && (isam_.valueExists(key) || newTheta.exists(key))

A caller can supply a timestamp for a key that has neither a value nor a factor. It is not active and has no value, so it is not pending and stays in marginalizableKeys. The variableIndex filter added in #2749 keeps it out of the copy passed to BayesTreeMarginalizationHelper, but marginalizableKeys itself is unfiltered and goes on to marginalizeLeaves, which does nodes_[j] and has no node for the key.

Before #2749 the same input threw from getCliquesContainingKeys, which runs before isam_.update(). It now reaches further and the process segfaults. Reproduced with published wheels: gtsam-develop 4.3a2.dev202608252015 raises "map::at", 4.3a2.dev202608300315 dies.

Partition on activity first, then on whether a value exists. Keys with a value are reaped exactly as before; keys without one have nothing in ISAM2 to remove, so only the timestamp is dropped. Both leave marginalizableKeys.

Also names the key in BayesTreeMarginalizationHelper rather than failing inside the Bayes tree, where the message identifies neither the key nor the caller and varies by build -- "map::at" without TBB, "Index out of requested size range" with it. This was one of the asks in #2741.

Tests cover both graph shapes, a stale key alongside a pending one to pin the partition split, and the new diagnostic.