### PR TITLE
Tolerate a missing timestamp in FixedLagSmoother::eraseKeyTimestampMap

### DIFF
--- a/gtsam/nonlinear/FixedLagSmoother.cpp
+++ b/gtsam/nonlinear/FixedLagSmoother.cpp
@@ -76,7 +76,17 @@ void FixedLagSmoother::updateKeyTimestampMap(const KeyTimestampMap& timestamps) 
 void FixedLagSmoother::eraseKeyTimestampMap(const KeyVector& keys) {
   for(Key key: keys) {
     // Erase the key from the Timestamp->Key map
-    double timestamp = keyTimestampMap_.at(key);
+    const auto entry = keyTimestampMap_.find(key);
+    if (entry == keyTimestampMap_.end()) {
+      // Not every caller can guarantee the key has a timestamp.
+      // IncrementalFixedLagSmoother::update() passes ISAM2Result::unusedKeys
+      // here directly, and ISAM2 derives those from the variable index, which
+      // says nothing about timestamps. There is no entry to erase, which is
+      // not an error; failing here throws a bare "map::at" that names neither
+      // the key nor the map.
+      continue;
+    }
+    const double timestamp = entry->second;
 
     TimestampKeyMap::iterator iter = timestampKeyMap_.lower_bound(timestamp);
     while(iter != timestampKeyMap_.end() && iter->first == timestamp) {
@@ -86,8 +96,10 @@ void FixedLagSmoother::eraseKeyTimestampMap(const KeyVector& keys) {
         ++iter;
       }
     }
-    // Erase the key from the Key->Timestamp map
-    keyTimestampMap_.erase(key);
+    // Erase the key from the Key->Timestamp map. The loop above touches only
+    // timestampKeyMap_, so entry is still valid; erasing through it saves the
+    // second lookup that erase(key) would do.
+    keyTimestampMap_.erase(entry);
   }
 }
 

--- a/gtsam/nonlinear/tests/testIncrementalFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/tests/testIncrementalFixedLagSmoother.cpp
@@ -654,6 +654,69 @@ TEST( IncrementalFixedLagSmoother, ExampleWithFactorRemoval )
   add_x_check_keep_every_y(1, 1);
 }
 
+/* ************************************************************************* */
+// A key can become unused without ever having had a timestamp: give it a value
+// and a factor but no timestamp, then remove the factor. ISAM2 reports it in
+// unusedKeys, which update() passes straight to eraseKeyTimestampMap. There is
+// no timestamp to erase and that is not an error.
+//
+// The two arms differ only in whether a timestamp is supplied, which isolates
+// the missing entry as the cause; the second arm threw "map::at" before this
+// was handled.
+TEST(FixedLagSmoother, EraseKeyTimestampMapWithoutTimestamp) {
+  const SharedDiagonal noise = noiseModel::Diagonal::Sigmas(Vector2(0.1, 0.1));
+
+  for (bool giveTimestamp : {true, false}) {
+    IncrementalFixedLagSmoother smoother(10.0);
+    NonlinearFactorGraph factors;
+    Values values;
+    FixedLagSmoother::KeyTimestampMap timestamps;
+
+    factors.addPrior(X(1), Point2(0.0, 0.0), noise);
+    values.insert(X(1), Point2(0.0, 0.0));
+    if (giveTimestamp) timestamps[X(1)] = 0.0;
+    smoother.update(factors, values, timestamps);
+    EXPECT(smoother.getLinearizationPoint().exists(X(1)));
+
+    // Remove the only factor touching X(1); ISAM2 now reports it in unusedKeys.
+    const FactorIndices toRemove{0};
+    smoother.update(NonlinearFactorGraph(), Values(),
+                    FixedLagSmoother::KeyTimestampMap(), toRemove);
+
+    EXPECT(smoother.timestamps().find(X(1)) == smoother.timestamps().end());
+    EXPECT(!smoother.getLinearizationPoint().exists(X(1)));
+  }
+}
+
+/* ************************************************************************* */
+// The other callers pass keys obtained from findKeysBefore, which are in the
+// map by construction. Marginalization must still erase their timestamps.
+TEST(FixedLagSmoother, EraseKeyTimestampMapStillErasesPresentKeys) {
+  const SharedDiagonal noise = noiseModel::Diagonal::Sigmas(Vector2(0.1, 0.1));
+  IncrementalFixedLagSmoother smoother(1.0);
+
+  NonlinearFactorGraph factors;
+  Values values;
+  FixedLagSmoother::KeyTimestampMap timestamps;
+  factors.addPrior(X(0), Point2(0.0, 0.0), noise);
+  values.insert(X(0), Point2(0.0, 0.0));
+  timestamps[X(0)] = 0.0;
+  smoother.update(factors, values, timestamps);
+  EXPECT(smoother.timestamps().find(X(0)) != smoother.timestamps().end());
+
+  factors.resize(0);
+  values.clear();
+  timestamps.clear();
+  factors.emplace_shared<BetweenPoint2>(X(0), X(1), Point2(1.0, 0.0), noise);
+  values.insert(X(1), Point2(1.0, 0.0));
+  timestamps[X(1)] = 5.0;
+  smoother.update(factors, values, timestamps);
+
+  EXPECT(smoother.timestamps().find(X(0)) == smoother.timestamps().end());
+  EXPECT(!smoother.getLinearizationPoint().exists(X(0)));
+  EXPECT(smoother.getLinearizationPoint().exists(X(1)));
+}
+
 int main() {
   TestResult tr;
   return TestRegistry::runAllTests(tr);


### PR DESCRIPTION
eraseKeyTimestampMap does a bare keyTimestampMap_.at(key), but not every caller can guarantee the key has a timestamp.

IncrementalFixedLagSmoother::update() passes ISAM2Result::unusedKeys straight to it. ISAM2 derives those from the variable index, which says nothing about timestamps, so a key given a value and a factor but no timestamp, whose factor is later removed, arrives here with no entry. std::map::at then throws "map::at", naming neither the key nor the map.

Erasing a key that is not present is a no-op rather than an error, as it is for std::map::erase, so skip it. The other caller in IncrementalFixedLagSmoother and the one in BatchFixedLagSmoother pass keys obtained from findKeysBefore, which are in the map by construction, so their behaviour is unchanged. A second test covers that path.

This is a second, independent cause of the "map::at" reported in #2741, which was closed by #2749. That fix addressed a value with no referencing factor reaching Bayes tree marginalization without a clique; this one needs factorsToRemove instead and involves no clique at all, so it is still reachable. Also independent of #2769.

Since the lookup now yields an iterator, the trailing erase goes through it rather than repeating the search by key. The intervening loop touches only timestampKeyMap_, so the iterator remains valid.