### PR TITLE
Update Galilean IMU factor notebooks

### DIFF
--- a/gtsam/navigation/doc/GalileanImuFactor.ipynb
+++ b/gtsam/navigation/doc/GalileanImuFactor.ipynb
@@ -7,9 +7,9 @@
    "source": [
     "# Galilean IMU preintegration with a left-invariant error\n",
     "\n",
-    "This guide develops IMU preintegration on the Galilean group $\\mathrm{Gal}(3)$ using the terminology of GTSAM's `EquivariantFilter`: a physical state manifold, a symmetry group, compatible state and input actions, a lift, and the equivariant error induced by those choices. The resulting formulation follows GTSAM's manifold convention: tangent increments update a group element on the right, and local coordinates define a left-invariant error.\n",
+    "This guide develops the left-invariant Galilean IMU preintegration used by GTSAM: a direct-product symmetry, compatible left actions, exact zero-order-held Galilean increments, adjoint covariance transport, right-applied bias correction, and exact constant-rate rotating-frame prediction.\n",
     "\n",
-    "The construction is adapted from Delama, Fornasier, Mahony, and Weiss, [*Equivariant IMU Preintegration with Biases: a Galilean Group Approach*](https://arxiv.org/abs/2411.05548). The paper pairs a semidirect-product symmetry with right state and input actions, producing a right-invariant error and a left-applied bias correction. This guide instead pairs a direct-product symmetry with left state and input actions. It uses only the physical six-dimensional IMU input and bias, both in GTSAM's accelerometer-then-gyroscope order. That coherent change of symmetry makes the induced equivariant error exactly GTSAM's left-invariant local error and makes the bias correction act on the right.\n",
+    "The construction is motivated by Delama, Fornasier, Mahony, and Weiss, [*Equivariant IMU Preintegration with Biases: a Galilean Group Approach*](https://arxiv.org/abs/2411.05548), but deliberately uses a different symmetry and perturbation convention. It closes on the physical six-dimensional IMU input and bias in accelerometer-then-gyroscope order, and it induces the same left-invariant, component-wise right-retracted endpoint error used by GTSAM.\n",
     "\n",
     "For background, see the [`EquivariantFilter` guide](EKF-variants.md#equivariantfilter), the [`Gal3` guide](../../geometry/doc/Gal3.ipynb), the [`Gal3ImuEKF` guide](Gal3ImuEKF.ipynb), the [`NavState` guide](NavState.ipynb), and the standard [`ImuFactor` guide](ImuFactor.ipynb). The companion [`NEES comparison`](GalileanImuFactorNEES.ipynb) evaluates all four GTSAM preintegration backends under identical high-dynamic IMU samples."
    ]
@@ -45,6 +45,12 @@
    "execution_count": 1,
    "id": "gtsam_navigation_doc_galileanimufactor__colab_install",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T17:20:24.398258Z",
+     "iopub.status.busy": "2026-08-30T17:20:24.398110Z",
+     "iopub.status.idle": "2026-08-30T17:20:24.402038Z",
+     "shell.execute_reply": "2026-08-30T17:20:24.401327Z"
+    },
     "tags": [
      "remove-cell"
     ]
@@ -63,7 +69,14 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "gtsam_navigation_doc_galileanimufactor__imports",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T17:20:24.403648Z",
+     "iopub.status.busy": "2026-08-30T17:20:24.403504Z",
+     "iopub.status.idle": "2026-08-30T17:20:24.779477Z",
+     "shell.execute_reply": "2026-08-30T17:20:24.778912Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -87,7 +100,7 @@
     "\n",
     "The group error $\\hat X^{-1}X$ is **left-invariant**: replacing both arguments by $AX$ and $A\\hat X$ leaves it unchanged. Thus, throughout this guide, *left-invariant error* and *right perturbation* describe the same convention.\n",
     "\n",
-    "The paper instead uses the navigation error $\\Upsilon\\hat\\Upsilon^{-1}$, which is right-invariant, and its first-order correction multiplies $\\hat\\Upsilon$ on the left. Merely replacing that error by $\\hat\\Upsilon^{-1}\\Upsilon$ while retaining the paper's right action would produce a valid coordinate chart, but not an invariant EqF error. We therefore change the symmetry action as well: the direct-product left action introduced in Section 5 induces $\\hat\\Upsilon^{-1}\\Upsilon$ as its equivariant error.\n",
+    "Delama et al.'s motivating construction instead uses the navigation error $\\Upsilon\\hat\\Upsilon^{-1}$, which is right-invariant, together with a left-applied first-order correction. Reversing only the error while retaining their right action would not produce an invariant EqF error; the direct-product left action introduced in Section 5 is what induces $\\hat\\Upsilon^{-1}\\Upsilon$.\n",
     "\n",
     "> **Do not conflate multiplication sides.** `ActionType::Left` below describes how the symmetry moves the physical state and input. GTSAM's `EquivariantFilter` prediction still composes the lifted increment on the right, while its measurement update composes the innovation on the left. The side of a symmetry action, the side of a group increment, and the invariance of an error are related choices, but they are not synonyms."
    ]
@@ -253,15 +266,26 @@
     "\n",
     "The group law automatically performs all four component updates. In particular, old velocity advances position by $h\\,\\Delta v_{ik}$, while the exponential contributes the rotation-aware acceleration integral. No separate Euler position update is needed.\n",
     "\n",
-    "For navigation states $T_i,T_j\\in\\mathrm{Gal}(3)$ at keyframes, gravity and the passage of time are collected in a known left increment $\\Gamma_{ij}$, giving\n",
+    "Gal(3) is internal to preintegration; the optimized keyframe states remain $X_i,X_j\\in\\mathrm{SE}_2(3)$. `NavState` stores and retracts it as $(R,p,v)$, and we define\n",
     "\n",
     "$$\n",
-    "T_j=\\Gamma_{ij}T_i\\Upsilon_{ij},\n",
-    "\\qquad\n",
-    "\\Upsilon_{ij}=T_i^{-1}\\Gamma_{ij}^{-1}T_j.\n",
+    "W_{ij}=\\operatorname{NavState}\\!\\left(I,\\tfrac12g\\Delta t_{ij}^2,g\\Delta t_{ij}\\right),\\qquad\n",
+    "\\phi_{\\Delta t}(R,p,v)=(R,p+v\\Delta t,v),\n",
     "$$\n",
     "\n",
-    "This separation is important: gravity acts in the navigation frame on the left, while bias-corrected IMU increments act in the body/local frame on the right."
+    "and project the corrected $\\Upsilon_{ij}$ to the body-frame increment\n",
+    "\n",
+    "$$\n",
+    "U_{ij}(\\beta_i)=\\operatorname{NavState}(\\Delta R_{ij},\\Delta p_{ij},\\Delta v_{ij}).\n",
+    "$$\n",
+    "\n",
+    "The inertial endpoint prediction is exactly\n",
+    "\n",
+    "$$\n",
+    "\\boxed{X_j=W_{ij}\\,\\phi_{\\Delta t_{ij}}(X_i)\\,U_{ij}(\\beta_i)}.\n",
+    "$$\n",
+    "\n",
+    "This $W\\phi(X)U$ separation is important: gravity acts in the navigation frame on the left, autonomous coasting advances the existing position, and bias-corrected IMU motion acts in the body/local frame on the right."
    ]
   },
   {
@@ -405,7 +429,7 @@
     "=\\lambda_L(\\xi,u).\n",
     "$$\n",
     "\n",
-    "> **Relation to the paper.** The paper closes its model over the full Galilean algebra: its input and bias coordinates lie in $\\mathfrak{gal}(3)$, including virtual coordinates, and its symmetry is the semidirect product $\\mathcal G_R=\\mathrm{Gal}(3)\\ltimes\\mathfrak{gal}(3)$. It uses the right actions\n",
+    "> **Relation to Delama et al.** Their construction closes its model over the full Galilean algebra: its input and bias coordinates lie in $\\mathfrak{gal}(3)$, including virtual coordinates, and its symmetry is the semidirect product $\\mathcal G_R=\\mathrm{Gal}(3)\\ltimes\\mathfrak{gal}(3)$. It uses the right actions\n",
     ">\n",
     "> $$\n",
     "> \\phi_R((\\Upsilon,b),(C,\\gamma))\n",
@@ -414,7 +438,7 @@
     "> =(\\operatorname{Ad}_{C^{-1}}(w-\\gamma),\\operatorname{Ad}_{C^{-1}}\\tau).\n",
     "> $$\n",
     ">\n",
-    "> That coherent pairing induces the invariant error $X\\hat X^{-1}$. The adjoint in the paper's input action does not preserve the six-dimensional physical IMU subspace by itself, which motivates completing the input and bias to the full algebra. Here the direct-product action needs no adjoint transport: it is closed on the physical $\\mathbb R^6$ input and bias spaces, while the lift supplies the fixed Gal3 coordinates. Thus this guide changes the group and both actions together; it does not retain the paper's semidirect group while merely reversing the error."
+    "> That coherent pairing induces the invariant error $X\\hat X^{-1}$. The adjoint in their input action does not preserve the six-dimensional physical IMU subspace by itself, which motivates completing the input and bias to the full algebra. The direct-product construction used here needs no adjoint transport: it is closed on the physical $\\mathbb R^6$ input and bias spaces, while the lift supplies the fixed Gal3 coordinates. The group and both actions change together; this is not merely a reversal of the error."
    ]
   },
   {
@@ -440,7 +464,6 @@
     "$$\n",
     "\n",
     "These are exactly the error coordinates in which `EquivariantFilter::errorCovariance()` is interpreted: a tangent vector at the fixed reference $\\xi^\\circ$. The navigation component is also exactly GTSAM's right-retracted local coordinate.\n",
-    "\n",
     "### Exact discrete linearization\n",
     "\n",
     "Adopt the six-dimensional measurement convention\n",
@@ -549,7 +572,7 @@
     "\n",
     "The deterministic $10\\times6$ bias sensitivity derived next accounts for changing the optimizer's bias away from its linearization value; it is not part of this conditional covariance. A combined-bias factor could extend the input with a physical six-dimensional bias random walk and retain the full augmented covariance, without introducing virtual coordinates.\n",
     "\n",
-    "The augmented covariance above belongs to the direct-product, left-action EqF error. It must not be identified directly with the paper's semidirect-product covariance, whose navigation and bias components use different frames and coordinates. For the conditioned navigation covariance consumed by this three-way factor, the two descriptions agree after the corresponding frame conversion."
+    "The augmented covariance above belongs to the direct-product, left-action EqF error used in GTSAM. It must not be identified directly with Delama et al.'s semidirect-product covariance, whose navigation and bias components use different frames and coordinates. For the conditioned navigation covariance consumed by the ordinary factor, the descriptions agree after the corresponding frame conversion."
    ]
   },
   {
@@ -652,14 +675,74 @@
   },
   {
    "cell_type": "markdown",
+   "id": "gtsam_navigation_doc_galileanimufactor__rotating_frame",
+   "metadata": {},
+   "source": [
+    "## 9. Exact prediction in a rotating navigation frame\n",
+    "\n",
+    "Let $\\omega_n$ be the constant angular velocity of the navigation frame, expressed in navigation-frame coordinates, and let $\\Omega=[\\omega_n]_\\times$. In the $(R,v,p)$ display order, the continuous dynamics are\n",
+    "\n",
+    "$$\n",
+    "\\dot R=-\\Omega R+R[\\omega]_\\times,\\qquad\n",
+    "\\dot v=g+Ra-2\\Omega v-\\Omega^2p,\\qquad\n",
+    "\\dot p=v.\n",
+    "$$\n",
+    "\n",
+    "GTSAM stores the same state as `NavState(R,p,v)`. Define the mutually inverse transported-velocity maps in that order by\n",
+    "\n",
+    "$$\n",
+    "\\mathcal L_\\Omega(R,p,v)=(R,p,\\bar v),\\quad \\bar v=v+\\Omega p,\\qquad\n",
+    "\\mathcal P_\\Omega(R,p,\\bar v)=(R,p,v),\\quad v=\\bar v-\\Omega p.\n",
+    "$$\n",
+    "\n",
+    "For $\\theta_{ij}=-\\omega_n\\Delta t_{ij}$, form the exact $SO(3)$ kernels\n",
+    "\n",
+    "$$\n",
+    "A_{ij}=\\operatorname{Exp}(\\theta_{ij}),\\qquad\n",
+    "G^v_{ij}=J_L(\\theta_{ij}),\\qquad\n",
+    "G^p_{ij}=J_L(\\theta_{ij})-\\Gamma_2(\\theta_{ij}),\n",
+    "$$\n",
+    "\n",
+    "and the rotating-frame world increment, now written directly in `NavState` order,\n",
+    "\n",
+    "$$\n",
+    "W^\\Omega_{ij}=\\operatorname{NavState}\\left(\n",
+    "A_{ij},G^p_{ij}g\\Delta t_{ij}^2,G^v_{ij}g\\Delta t_{ij}\n",
+    "\\right).\n",
+    "$$\n",
+    "\n",
+    "The complete endpoint prediction preserves the same left-linear backbone:\n",
+    "\n",
+    "$$\n",
+    "\\boxed{X_j=\\mathcal P_\\Omega\\!\\left(\n",
+    "W^\\Omega_{ij}\\,\\phi_{\\Delta t_{ij}}(\\mathcal L_\\Omega(X_i))\\,U_{ij}(\\beta_i)\n",
+    "\\right)}.\n",
+    "$$\n",
+    "\n",
+    "Writing $U_{ij}=(\\Delta R,\\Delta p,\\Delta v)$ and $W^\\Omega_{ij}=(A,p_W,v_W)$ in GTSAM order makes the implementation explicit:\n",
+    "\n",
+    "$$\n",
+    "R_j=AR_i\\Delta R,\\qquad\n",
+    "p_j=p_W+A(p_i+\\bar v_i\\Delta t+R_i\\Delta p),\n",
+    "$$\n",
+    "$$\n",
+    "\\bar v_j=v_W+A(\\bar v_i+R_i\\Delta v),\\qquad\n",
+    "v_j=\\bar v_j-\\Omega p_j.\n",
+    "$$\n",
+    "\n",
+    "This is an exact constant-rate rotating-frame transition: Coriolis and centrifugal terms arise from the lift, group composition, and projection rather than an appended acceleration correction. The body-frame increment $U_{ij}$, its covariance, and its bias correction are unchanged; only endpoint prediction and its Jacobians depend on $\\omega_n$. In Python, enable this path with `params.setOmegaCoriolis(omega_n)`. Omitting it (or setting exactly zero) selects the inertial prediction."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "gtsam_navigation_doc_galileanimufactor__usage",
    "metadata": {},
    "source": [
-    "## 9. Intended use\n",
+    "## 10. Intended use\n",
     "\n",
     "A user-facing workflow mirrors the existing IMU factors:\n",
     "\n",
-    "1. Construct preintegration parameters and a `PreintegratedImuMeasurementsG` at the current bias estimate.\n",
+    "1. Construct preintegration parameters and a `PreintegratedImuMeasurementsG` at the current bias estimate. When the navigation frame rotates, call `setOmegaCoriolis` with its constant angular velocity in navigation-frame coordinates.\n",
     "2. Integrate each accelerometer/gyroscope sample. The public API and all six-dimensional quantities use GTSAM order $(a,\\omega)$; the lift places them in Gal3 order internally. Each call advances the Galilean mean on the right and propagates its conditional covariance.\n",
     "3. Construct a `GalileanImuFactor` between the two pose/velocity pairs and the interval's bias key. During optimization, use the right-applied first-order bias correction rather than reintegrating immediately.\n",
     "4. Add a separate factor between consecutive bias keys when bias random-walk evolution is part of the model. Alternatively, construct `PreintegratedCombinedMeasurementsG` and a `GalileanCombinedImuFactor` to model the second bias key, its random walk, and state--bias correlation inside one factor.\n",
@@ -692,7 +775,14 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "gtsam_navigation_doc_galileanimufactor__python_preintegration",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T17:20:24.780939Z",
+     "iopub.status.busy": "2026-08-30T17:20:24.780847Z",
+     "iopub.status.idle": "2026-08-30T17:20:24.783798Z",
+     "shell.execute_reply": "2026-08-30T17:20:24.783386Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -730,7 +820,14 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "gtsam_navigation_doc_galileanimufactor__python_factor",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T17:20:24.784914Z",
+     "iopub.status.busy": "2026-08-30T17:20:24.784855Z",
+     "iopub.status.idle": "2026-08-30T17:20:24.787767Z",
+     "shell.execute_reply": "2026-08-30T17:20:24.787433Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -769,7 +866,7 @@
    "id": "gtsam_navigation_doc_galileanimufactor__invariants",
    "metadata": {},
    "source": [
-    "## 10. Consistency checks for the formulation\n",
+    "## 11. Consistency checks for the formulation\n",
     "\n",
     "The following statements should all remain true together:\n",
     "\n",
@@ -786,6 +883,8 @@
     "- Measurement covariance and bias-Jacobian columns therefore remain in GTSAM order throughout.\n",
     "- The 10D-to-9D covariance conversion removes time and swaps the velocity and position blocks.\n",
     "- The preintegration interval is accumulated alongside the Galilean mean; time is not an uncertain optimized coordinate.\n",
+    "- `NavState` orders its value and tangent blocks as $(R,p,v)$; every equation imported from an $(R,v,p)$ matrix convention swaps the position and velocity blocks explicitly.\n",
+    "- A nonzero `omegaCoriolis` changes the exact endpoint prediction and Jacobians, but not the preintegrated body increment, covariance recursion, or bias correction.\n",
     "\n",
     "Changing any one of these conventions requires rederiving the associated Jacobians and covariance transport."
    ]

--- a/gtsam/navigation/doc/GalileanImuFactor.ipynb
+++ b/gtsam/navigation/doc/GalileanImuFactor.ipynb
@@ -863,34 +863,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "gtsam_navigation_doc_galileanimufactor__invariants",
-   "metadata": {},
-   "source": [
-    "## 11. Consistency checks for the formulation\n",
-    "\n",
-    "The following statements should all remain true together:\n",
-    "\n",
-    "- The physical state is $\\xi=(\\Upsilon,\\beta)\\in\\mathrm{Gal}(3)\\times\\mathbb R^6$, while the symmetry element is $Y=(\\Gamma,c)\\in\\mathrm{Gal}(3)\\times(\\mathbb R^6,+)$; state and symmetry are different EqF roles even though their coordinates have the same dimensions.\n",
-    "- Both $\\phi_L$ and $\\psi_L$ are left actions, and together they make $F_h$ equivariant.\n",
-    "- The input action is closed on the physical $\\mathbb R^6$ IMU space; the lift supplies the fixed Gal3 position-rate and clock coordinates.\n",
-    "- The EqF error induced by the left action is $(\\hat\\Upsilon^{-1}\\Upsilon,\\beta-\\hat\\beta)\\in\\mathbb R^{16}$.\n",
-    "- The mean update is $\\Upsilon^+=\\Upsilon\\operatorname{Exp}(x)$, never $\\operatorname{Exp}(x)\\Upsilon$.\n",
-    "- The lift reconstructs the mean by right-composing the lifted group estimate and then applying the reference orbit; `ActionType::Left` does not change that prediction side.\n",
-    "- Transport through an increment uses $\\operatorname{Ad}_{V^{-1}}$. Consequently the left-invariant transition is not generally the identity.\n",
-    "- Input perturbations use the complete Galilean right Jacobian $J_R(x)$.\n",
-    "- Bias correction is $\\hat\\Upsilon\\operatorname{Exp}(J\\delta\\beta)$, not $\\operatorname{Exp}(J\\delta\\beta)\\hat\\Upsilon$.\n",
-    "- Every physical six-vector uses GTSAM ordering $(a,\\omega)$ or $(b_a,b_\\omega)$; the lift Jacobian $E$ handles Gal3's internal $(\\omega,a)$ order.\n",
-    "- Measurement covariance and bias-Jacobian columns therefore remain in GTSAM order throughout.\n",
-    "- The 10D-to-9D covariance conversion removes time and swaps the velocity and position blocks.\n",
-    "- The preintegration interval is accumulated alongside the Galilean mean; time is not an uncertain optimized coordinate.\n",
-    "- `NavState` orders its value and tangent blocks as $(R,p,v)$; every equation imported from an $(R,v,p)$ matrix convention swaps the position and velocity blocks explicitly.\n",
-    "- A nonzero `omegaCoriolis` changes the exact endpoint prediction and Jacobians, but not the preintegrated body increment, covariance recursion, or bias correction.\n",
-    "\n",
-    "Changing any one of these conventions requires rederiving the associated Jacobians and covariance transport."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "gtsam_navigation_doc_galileanimufactor__references",
    "metadata": {},
    "source": [

--- a/gtsam/navigation/doc/GalileanImuFactorNEES.ipynb
+++ b/gtsam/navigation/doc/GalileanImuFactorNEES.ipynb
@@ -5,9 +5,9 @@
    "id": "gtsam_navigation_doc_galileanimufactornees__title",
    "metadata": {},
    "source": [
-    "# Galilean IMU preintegration: a four-backend NEES comparison\n",
+    "# Galilean IMU preintegration: NEES in inertial and rotating frames\n",
     "\n",
-    "This notebook compares GTSAM's Manifold, Tangent, Lie-group, and Galilean IMU preintegration backends under identical measurements and noise samples. The stress test uses simultaneous body-frame acceleration and rotation with a zero-order-held IMU signal. That is the regime in which the Galilean exponential integrates the coupled rotation, velocity, position, and time dynamics exactly.\n",
+    "This notebook compares GTSAM's Manifold, Tangent, Lie-group, and Galilean IMU preintegration backends under identical measurements and noise samples. Sections 2--6 retain the inertial-frame stress test with simultaneous body-frame acceleration and rotation. Section 7 adds a realistic powered-ascent benchmark in a rotating Earth frame and evaluates every backend both with `omegaCoriolis` specified and with it omitted.\n",
     "\n",
     "The word *better* has two testable meanings here: smaller deterministic endpoint error at a fixed sample period, and statistical consistency measured by 9D Normalized Estimation Error Squared (NEES). This experiment does not claim universal dominance, lower runtime, or an advantage when the assumed held-input model is a poor description of the sensor signal. See the companion [`GalileanImuFactor` guide](GalileanImuFactor.ipynb) for the complete left-invariant derivation."
    ]
@@ -43,6 +43,12 @@
    "execution_count": 1,
    "id": "gtsam_navigation_doc_galileanimufactornees__colab_install",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T17:35:01.865254Z",
+     "iopub.status.busy": "2026-08-30T17:35:01.865113Z",
+     "iopub.status.idle": "2026-08-30T17:35:01.868817Z",
+     "shell.execute_reply": "2026-08-30T17:35:01.868329Z"
+    },
     "tags": [
      "remove-cell"
     ]
@@ -61,7 +67,14 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "gtsam_navigation_doc_galileanimufactornees__imports",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T17:35:01.870575Z",
+     "iopub.status.busy": "2026-08-30T17:35:01.870418Z",
+     "iopub.status.idle": "2026-08-30T17:35:02.536650Z",
+     "shell.execute_reply": "2026-08-30T17:35:02.536271Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -102,7 +115,14 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "gtsam_navigation_doc_galileanimufactornees__configuration",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T17:35:02.537982Z",
+     "iopub.status.busy": "2026-08-30T17:35:02.537894Z",
+     "iopub.status.idle": "2026-08-30T17:35:02.540266Z",
+     "shell.execute_reply": "2026-08-30T17:35:02.539950Z"
+    }
+   },
    "outputs": [],
    "source": [
     "DURATION = 1.0\n",
@@ -154,7 +174,14 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "gtsam_navigation_doc_galileanimufactornees__truth_code",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T17:35:02.541219Z",
+     "iopub.status.busy": "2026-08-30T17:35:02.541160Z",
+     "iopub.status.idle": "2026-08-30T17:35:02.543454Z",
+     "shell.execute_reply": "2026-08-30T17:35:02.543064Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def exact_held_input_state(acceleration, angular_velocity, duration):\n",
@@ -173,8 +200,10 @@
     ")\n",
     "\n",
     "\n",
-    "def integrate(backend_type, accelerations, angular_velocities, dt):\n",
-    "    pim = backend_type(PARAMS, BIAS)\n",
+    "def integrate(\n",
+    "    backend_type, accelerations, angular_velocities, dt, params=PARAMS\n",
+    "):\n",
+    "    pim = backend_type(params, BIAS)\n",
     "    for acceleration, angular_velocity in zip(\n",
     "        accelerations, angular_velocities\n",
     "    ):\n",
@@ -196,7 +225,14 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "gtsam_navigation_doc_galileanimufactornees__deterministic_code",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T17:35:02.544298Z",
+     "iopub.status.busy": "2026-08-30T17:35:02.544237Z",
+     "iopub.status.idle": "2026-08-30T17:35:02.551340Z",
+     "shell.execute_reply": "2026-08-30T17:35:02.550887Z"
+    }
+   },
    "outputs": [],
    "source": [
     "SAMPLE_PERIODS = np.array([0.1, 0.05, 0.025, 0.0125])\n",
@@ -232,17 +268,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 6,
    "id": "gtsam_navigation_doc_galileanimufactornees__deterministic_plot",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T17:35:02.552591Z",
+     "iopub.status.busy": "2026-08-30T17:35:02.552525Z",
+     "iopub.status.idle": "2026-08-30T17:35:02.648053Z",
+     "shell.execute_reply": "2026-08-30T17:35:02.647507Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/html": [
+       "        <script type=\"text/javascript\">\n",
+       "        window.PlotlyConfig = {MathJaxConfig: 'local'};\n",
+       "        if (window.MathJax && window.MathJax.Hub && window.MathJax.Hub.Config) {window.MathJax.Hub.Config({SVG: {font: \"STIX-Web\"}});}\n",
+       "        </script>\n",
+       "        <script type=\"module\">import \"https://cdn.plot.ly/plotly-3.1.1.min\"</script>\n",
+       "        "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
        "<div>            <script src=\"https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_SVG\"></script><script type=\"text/javascript\">if (window.MathJax && window.MathJax.Hub && window.MathJax.Hub.Config) {window.MathJax.Hub.Config({SVG: {font: \"STIX-Web\"}});}</script>                <script type=\"text/javascript\">window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n",
-       "        <script charset=\"utf-8\" src=\"https://cdn.plot.ly/plotly-3.1.1.min.js\" integrity=\"sha256-HUEFyfiTnZJxCxur99FjbKYTvKSzwDaD3/x5TqHpFu4=\" crossorigin=\"anonymous\"></script>                <div id=\"c688ced1-5d70-4cf1-bf0d-986a57034d99\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                window.PLOTLYENV=window.PLOTLYENV || {};                                if (document.getElementById(\"c688ced1-5d70-4cf1-bf0d-986a57034d99\")) {                    Plotly.newPlot(                        \"c688ced1-5d70-4cf1-bf0d-986a57034d99\",                        [{\"line\":{\"color\":\"#777777\",\"dash\":\"solid\"},\"mode\":\"lines+markers\",\"name\":\"Manifold\",\"x\":{\"dtype\":\"f8\",\"bdata\":\"mpmZmZmZuT+amZmZmZmpP5qZmZmZmZk\\u002fmpmZmZmZiT8=\"},\"y\":[0.14470970212904335,0.07230897306815333,0.03614876041163706,0.01807366470967831],\"type\":\"scatter\"},{\"line\":{\"color\":\"#999999\",\"dash\":\"dash\"},\"mode\":\"lines+markers\",\"name\":\"Tangent\",\"x\":{\"dtype\":\"f8\",\"bdata\":\"mpmZmZmZuT+amZmZmZmpP5qZmZmZmZk\\u002fmpmZmZmZiT8=\"},\"y\":[0.1447097021290434,0.07230897306815298,0.036148760411636095,0.018073664709679912],\"type\":\"scatter\"},{\"line\":{\"color\":\"#bbbbbb\",\"dash\":\"dot\"},\"mode\":\"lines+markers\",\"name\":\"Lie group\",\"x\":{\"dtype\":\"f8\",\"bdata\":\"mpmZmZmZuT+amZmZmZmpP5qZmZmZmZk\\u002fmpmZmZmZiT8=\"},\"y\":[0.14470970212904338,0.07230897306815338,0.03614876041163674,0.018073664709678278],\"type\":\"scatter\"},{\"line\":{\"color\":\"#14866d\",\"dash\":\"solid\"},\"mode\":\"lines+markers\",\"name\":\"Galilean\",\"x\":{\"dtype\":\"f8\",\"bdata\":\"mpmZmZmZuT+amZmZmZmpP5qZmZmZmZk\\u002fmpmZmZmZiT8=\"},\"y\":[4.191000011072726e-16,2.288783399261118e-16,7.043575467574347e-16,3.1796795178217615e-15],\"type\":\"scatter\"}],                        {\"template\":{\"data\":{\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"white\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"white\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"#C8D4E3\",\"linecolor\":\"#C8D4E3\",\"minorgridcolor\":\"#C8D4E3\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"#C8D4E3\",\"linecolor\":\"#C8D4E3\",\"minorgridcolor\":\"#C8D4E3\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scattermap\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermap\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatter\":[{\"fillpattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2},\"type\":\"scatter\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"white\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"#C8D4E3\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"white\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\"},\"bgcolor\":\"white\",\"radialaxis\":{\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"},\"yaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"},\"zaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"},\"bgcolor\":\"white\",\"caxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"#EBF0F8\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"#EBF0F8\",\"zerolinewidth\":2}}},\"xaxis\":{\"type\":\"log\",\"title\":{\"text\":\"IMU sample period (s)\"}},\"yaxis\":{\"type\":\"log\",\"title\":{\"text\":\"Velocity error norm (m\\u002fs)\"}},\"legend\":{\"title\":{\"text\":\"Backend\"}},\"title\":{\"text\":\"Held-input discretization error\"}},                        {\"responsive\": true}                    ).then(function(){\n",
+       "        <script charset=\"utf-8\" src=\"https://cdn.plot.ly/plotly-3.1.1.min.js\" integrity=\"sha256-HUEFyfiTnZJxCxur99FjbKYTvKSzwDaD3/x5TqHpFu4=\" crossorigin=\"anonymous\"></script>                <div id=\"53c4f05c-edaa-40a9-b3dc-0e6b9ed22288\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                window.PLOTLYENV=window.PLOTLYENV || {};                                if (document.getElementById(\"53c4f05c-edaa-40a9-b3dc-0e6b9ed22288\")) {                    Plotly.newPlot(                        \"53c4f05c-edaa-40a9-b3dc-0e6b9ed22288\",                        [{\"line\":{\"color\":\"#777777\",\"dash\":\"solid\"},\"mode\":\"lines+markers\",\"name\":\"Manifold\",\"x\":{\"dtype\":\"f8\",\"bdata\":\"mpmZmZmZuT+amZmZmZmpP5qZmZmZmZk\\u002fmpmZmZmZiT8=\"},\"y\":[0.14470970212904335,0.07230897306815333,0.03614876041163706,0.01807366470967831],\"type\":\"scatter\"},{\"line\":{\"color\":\"#999999\",\"dash\":\"dash\"},\"mode\":\"lines+markers\",\"name\":\"Tangent\",\"x\":{\"dtype\":\"f8\",\"bdata\":\"mpmZmZmZuT+amZmZmZmpP5qZmZmZmZk\\u002fmpmZmZmZiT8=\"},\"y\":[0.1447097021290434,0.07230897306815298,0.036148760411636095,0.018073664709679912],\"type\":\"scatter\"},{\"line\":{\"color\":\"#bbbbbb\",\"dash\":\"dot\"},\"mode\":\"lines+markers\",\"name\":\"Lie group\",\"x\":{\"dtype\":\"f8\",\"bdata\":\"mpmZmZmZuT+amZmZmZmpP5qZmZmZmZk\\u002fmpmZmZmZiT8=\"},\"y\":[0.14470970212904335,0.07230897306815333,0.03614876041163706,0.01807366470967831],\"type\":\"scatter\"},{\"line\":{\"color\":\"#14866d\",\"dash\":\"solid\"},\"mode\":\"lines+markers\",\"name\":\"Galilean\",\"x\":{\"dtype\":\"f8\",\"bdata\":\"mpmZmZmZuT+amZmZmZmpP5qZmZmZmZk\\u002fmpmZmZmZiT8=\"},\"y\":[4.191000011072726e-16,2.288783399261118e-16,7.043575467574347e-16,3.1796795178217615e-15],\"type\":\"scatter\"}],                        {\"template\":{\"data\":{\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"white\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"white\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"#C8D4E3\",\"linecolor\":\"#C8D4E3\",\"minorgridcolor\":\"#C8D4E3\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"#C8D4E3\",\"linecolor\":\"#C8D4E3\",\"minorgridcolor\":\"#C8D4E3\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scattermap\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermap\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatter\":[{\"fillpattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2},\"type\":\"scatter\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"white\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"#C8D4E3\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"white\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\"},\"bgcolor\":\"white\",\"radialaxis\":{\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"},\"yaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"},\"zaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"},\"bgcolor\":\"white\",\"caxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"#EBF0F8\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"#EBF0F8\",\"zerolinewidth\":2}}},\"xaxis\":{\"type\":\"log\",\"title\":{\"text\":\"IMU sample period (s)\"}},\"yaxis\":{\"type\":\"log\",\"title\":{\"text\":\"Velocity error norm (m\\u002fs)\"}},\"legend\":{\"title\":{\"text\":\"Backend\"}},\"title\":{\"text\":\"Held-input discretization error\"}},                        {\"responsive\": true}                    ).then(function(){\n",
        "                            \n",
-       "var gd = document.getElementById('c688ced1-5d70-4cf1-bf0d-986a57034d99');\n",
+       "var gd = document.getElementById('53c4f05c-edaa-40a9-b3dc-0e6b9ed22288');\n",
        "var x = new MutationObserver(function (mutations, observer) {{\n",
        "        var display = window.getComputedStyle(gd).display;\n",
        "        if (!display || display === 'none') {{\n",
@@ -312,7 +369,14 @@
    "cell_type": "code",
    "execution_count": 7,
    "id": "gtsam_navigation_doc_galileanimufactornees__monte_carlo_code",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T17:35:02.650333Z",
+     "iopub.status.busy": "2026-08-30T17:35:02.650119Z",
+     "iopub.status.idle": "2026-08-30T17:35:03.031036Z",
+     "shell.execute_reply": "2026-08-30T17:35:03.030621Z"
+    }
+   },
    "outputs": [],
    "source": [
     "DT = 0.05\n",
@@ -360,7 +424,14 @@
    "cell_type": "code",
    "execution_count": 8,
    "id": "gtsam_navigation_doc_galileanimufactornees__statistics",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T17:35:03.032256Z",
+     "iopub.status.busy": "2026-08-30T17:35:03.032182Z",
+     "iopub.status.idle": "2026-08-30T17:35:03.037471Z",
+     "shell.execute_reply": "2026-08-30T17:35:03.036998Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -436,7 +507,14 @@
    "cell_type": "code",
    "execution_count": 9,
    "id": "gtsam_navigation_doc_galileanimufactornees__assertions",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T17:35:03.038657Z",
+     "iopub.status.busy": "2026-08-30T17:35:03.038581Z",
+     "iopub.status.idle": "2026-08-30T17:35:03.040456Z",
+     "shell.execute_reply": "2026-08-30T17:35:03.040140Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Executable statistical claims for this deterministic experiment.\n",
@@ -459,15 +537,22 @@
    "cell_type": "code",
    "execution_count": 10,
    "id": "gtsam_navigation_doc_galileanimufactornees__nees_plot",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T17:35:03.041260Z",
+     "iopub.status.busy": "2026-08-30T17:35:03.041203Z",
+     "iopub.status.idle": "2026-08-30T17:35:03.060752Z",
+     "shell.execute_reply": "2026-08-30T17:35:03.060436Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/html": [
        "<div>            <script src=\"https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_SVG\"></script><script type=\"text/javascript\">if (window.MathJax && window.MathJax.Hub && window.MathJax.Hub.Config) {window.MathJax.Hub.Config({SVG: {font: \"STIX-Web\"}});}</script>                <script type=\"text/javascript\">window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n",
-       "        <script charset=\"utf-8\" src=\"https://cdn.plot.ly/plotly-3.1.1.min.js\" integrity=\"sha256-HUEFyfiTnZJxCxur99FjbKYTvKSzwDaD3/x5TqHpFu4=\" crossorigin=\"anonymous\"></script>                <div id=\"44f3d81c-8b82-4c39-9efe-b2eb53ee4602\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                window.PLOTLYENV=window.PLOTLYENV || {};                                if (document.getElementById(\"44f3d81c-8b82-4c39-9efe-b2eb53ee4602\")) {                    Plotly.newPlot(                        \"44f3d81c-8b82-4c39-9efe-b2eb53ee4602\",                        [{\"error_y\":{\"array\":[0.2270039603499084,0.2270806714719236,0.22700396034990838,0.15391831133705505],\"type\":\"data\",\"visible\":true},\"hovertemplate\":\"%{x}: mean NEES %{y:.3f}\\u003cextra\\u003e\\u003c\\u002fextra\\u003e\",\"marker\":{\"color\":[\"#888888\",\"#999999\",\"#aaaaaa\",\"#14866d\"],\"size\":11},\"mode\":\"markers\",\"x\":[\"Manifold\",\"Tangent\",\"Lie group\",\"Galilean\"],\"y\":[14.506300017104186,14.511308623506503,14.506300017104186,8.957909312634683],\"type\":\"scatter\"}],                        {\"template\":{\"data\":{\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"white\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"white\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"#C8D4E3\",\"linecolor\":\"#C8D4E3\",\"minorgridcolor\":\"#C8D4E3\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"#C8D4E3\",\"linecolor\":\"#C8D4E3\",\"minorgridcolor\":\"#C8D4E3\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scattermap\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermap\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatter\":[{\"fillpattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2},\"type\":\"scatter\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"white\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"#C8D4E3\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"white\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\"},\"bgcolor\":\"white\",\"radialaxis\":{\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"},\"yaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"},\"zaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"},\"bgcolor\":\"white\",\"caxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"#EBF0F8\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"#EBF0F8\",\"zerolinewidth\":2}}},\"shapes\":[{\"fillcolor\":\"#14866d\",\"line\":{\"width\":0},\"opacity\":0.14,\"type\":\"rect\",\"x0\":0,\"x1\":1,\"xref\":\"x domain\",\"y0\":8.848814261164716,\"y1\":9.1524486026962,\"yref\":\"y\"},{\"line\":{\"color\":\"#333333\",\"dash\":\"dash\"},\"type\":\"line\",\"x0\":0,\"x1\":1,\"xref\":\"x domain\",\"y0\":9,\"y1\":9,\"yref\":\"y\"}],\"annotations\":[{\"showarrow\":false,\"text\":\"95% consistency band\",\"x\":0,\"xanchor\":\"left\",\"xref\":\"x domain\",\"y\":9.1524486026962,\"yanchor\":\"top\",\"yref\":\"y\"}],\"yaxis\":{\"title\":{\"text\":\"Mean NEES\"},\"range\":[0,16.0113086235065]},\"title\":{\"text\":\"Average 9D NEES under identical high-dynamic IMU samples\"},\"xaxis\":{\"title\":{\"text\":\"Preintegration backend\"}},\"showlegend\":false},                        {\"responsive\": true}                    ).then(function(){\n",
+       "        <script charset=\"utf-8\" src=\"https://cdn.plot.ly/plotly-3.1.1.min.js\" integrity=\"sha256-HUEFyfiTnZJxCxur99FjbKYTvKSzwDaD3/x5TqHpFu4=\" crossorigin=\"anonymous\"></script>                <div id=\"d4f67958-6f3b-40b8-8a45-23c11b8f1ec3\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                window.PLOTLYENV=window.PLOTLYENV || {};                                if (document.getElementById(\"d4f67958-6f3b-40b8-8a45-23c11b8f1ec3\")) {                    Plotly.newPlot(                        \"d4f67958-6f3b-40b8-8a45-23c11b8f1ec3\",                        [{\"error_y\":{\"array\":[0.22700396034990827,0.2270806714719236,0.22700396034990833,0.153918311337055],\"type\":\"data\",\"visible\":true},\"hovertemplate\":\"%{x}: mean NEES %{y:.3f}\\u003cextra\\u003e\\u003c\\u002fextra\\u003e\",\"marker\":{\"color\":[\"#888888\",\"#999999\",\"#aaaaaa\",\"#14866d\"],\"size\":11},\"mode\":\"markers\",\"x\":[\"Manifold\",\"Tangent\",\"Lie group\",\"Galilean\"],\"y\":[14.506300017104174,14.511308623506503,14.506300017104174,8.957909312634683],\"type\":\"scatter\"}],                        {\"template\":{\"data\":{\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"white\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"white\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"#C8D4E3\",\"linecolor\":\"#C8D4E3\",\"minorgridcolor\":\"#C8D4E3\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"#C8D4E3\",\"linecolor\":\"#C8D4E3\",\"minorgridcolor\":\"#C8D4E3\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scattermap\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermap\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatter\":[{\"fillpattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2},\"type\":\"scatter\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"white\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"#C8D4E3\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"white\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\"},\"bgcolor\":\"white\",\"radialaxis\":{\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"},\"yaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"},\"zaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"},\"bgcolor\":\"white\",\"caxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"#EBF0F8\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"#EBF0F8\",\"zerolinewidth\":2}}},\"shapes\":[{\"fillcolor\":\"#14866d\",\"line\":{\"width\":0},\"opacity\":0.14,\"type\":\"rect\",\"x0\":0,\"x1\":1,\"xref\":\"x domain\",\"y0\":8.848814261164716,\"y1\":9.1524486026962,\"yref\":\"y\"},{\"line\":{\"color\":\"#333333\",\"dash\":\"dash\"},\"type\":\"line\",\"x0\":0,\"x1\":1,\"xref\":\"x domain\",\"y0\":9,\"y1\":9,\"yref\":\"y\"}],\"annotations\":[{\"showarrow\":false,\"text\":\"95% consistency band\",\"x\":0,\"xanchor\":\"left\",\"xref\":\"x domain\",\"y\":9.1524486026962,\"yanchor\":\"top\",\"yref\":\"y\"}],\"yaxis\":{\"title\":{\"text\":\"Mean NEES\"},\"range\":[0,16.0113086235065]},\"title\":{\"text\":\"Average 9D NEES under identical high-dynamic IMU samples\"},\"xaxis\":{\"title\":{\"text\":\"Preintegration backend\"}},\"showlegend\":false},                        {\"responsive\": true}                    ).then(function(){\n",
        "                            \n",
-       "var gd = document.getElementById('44f3d81c-8b82-4c39-9efe-b2eb53ee4602');\n",
+       "var gd = document.getElementById('d4f67958-6f3b-40b8-8a45-23c11b8f1ec3');\n",
        "var x = new MutationObserver(function (mutations, observer) {{\n",
        "        var display = window.getComputedStyle(gd).display;\n",
        "        if (!display || display === 'none') {{\n",
@@ -546,6 +631,500 @@
     "The endpoint table also separates consistency from accuracy: Galilean preintegration reduces both position and velocity RMS error, while all four backends have essentially the same rotation RMS error. The timestep sweep identifies the cause. The three established variants converge as the sampling interval shrinks, whereas the Galilean group law and exponential integrate the coupled held input exactly at every tested interval.\n",
     "\n",
     "This result is deliberately scoped. At very high IMU rates the standard discretization error becomes negligible; with time-varying input inside a sample, all zero-order-hold methods inherit model error; and this notebook does not compare runtime, bias random walks, sensor-pose corrections, or full graph optimization. It shows that for simultaneous rotation and acceleration at a finite sampling rate, the left-invariant Galilean formulation provides the most accurate mean and the only statistically consistent covariance among the four tested GTSAM backends."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gtsam_navigation_doc_galileanimufactornees__rotating_setup",
+   "metadata": {},
+   "source": [
+    "## 7. Powered ascent in a rotating Earth frame\n",
+    "\n",
+    "We now model the first four seconds of a high-power sounding-rocket ascent. This scale is grounded in a [Georgia Tech Experimental Rocketry flight](https://ae.gatech.edu/news/2024/07/ramblin-rocket-club-swarms-desert-annual-rocket-launch) that reached roughly 8,000 ft in six to seven seconds and Mach 1.8. The benchmark starts from rest, uses a constant 12 g measured specific force along the body vertical, and applies a modest $-0.04$ rad/s pitch rate. Its exact endpoint is about 861 m above the pad, traveling at 431 m/s with 9.2 degrees of pitch: a plausible early powered-ascent segment rather than an artificially high initial speed.\n",
+    "\n",
+    "The local navigation frame is east-north-up at Spaceport America latitude, so the physical Earth-rate vector contains north and up components. For every backend we run two otherwise identical predictions: `Specified` supplies that vector through `omegaCoriolis`, while `Not specified` leaves the parameter absent. Each paired Monte Carlo trial uses the same IMU noise sequence in all eight cases. The preintegrated body increment and covariance recursion are unchanged by Earth rotation; only endpoint prediction and residual assembly use the rotating-frame model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "gtsam_navigation_doc_galileanimufactornees__rotating_constants",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T17:35:03.061801Z",
+     "iopub.status.busy": "2026-08-30T17:35:03.061738Z",
+     "iopub.status.idle": "2026-08-30T17:35:03.064490Z",
+     "shell.execute_reply": "2026-08-30T17:35:03.064056Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "EARTH_ANGULAR_SPEED = 7.292115e-5\n",
+    "SPACEPORT_LATITUDE = np.deg2rad(32.99)\n",
+    "EARTH_RATE = EARTH_ANGULAR_SPEED * np.array([\n",
+    "    0.0, np.cos(SPACEPORT_LATITUDE), np.sin(SPACEPORT_LATITUDE)\n",
+    "])\n",
+    "STANDARD_GRAVITY = 9.80665\n",
+    "ROTATING_GRAVITY = np.array([0.0, 0.0, -STANDARD_GRAVITY])\n",
+    "ROTATING_ACCELERATION = np.array([\n",
+    "    0.0, 0.0, 12.0 * STANDARD_GRAVITY\n",
+    "])\n",
+    "PITCH_RATE = -0.04\n",
+    "ROTATING_ANGULAR_VELOCITY = (\n",
+    "    EARTH_RATE + np.array([0.0, PITCH_RATE, 0.0])\n",
+    ")\n",
+    "ROTATING_DURATION = 4.0\n",
+    "ROTATING_DT = 0.05\n",
+    "ROTATING_STEPS = round(ROTATING_DURATION / ROTATING_DT)\n",
+    "ROTATING_TRIALS = 3_000\n",
+    "ROTATING_SEED = 2232\n",
+    "ROTATING_STATE_I = gtsam.NavState()\n",
+    "ROCKET_ACCELEROMETER_SIGMAS = ACCELEROMETER_SIGMAS.copy()\n",
+    "ROCKET_GYROSCOPE_SIGMAS = np.array([5e-4, 7.5e-4, 1e-3])\n",
+    "\n",
+    "\n",
+    "def make_rotating_params(with_coriolis):\n",
+    "    params = gtsam.PreintegrationParams(ROTATING_GRAVITY)\n",
+    "    params.setAccelerometerCovariance(\n",
+    "        np.diag(ROCKET_ACCELEROMETER_SIGMAS**2)\n",
+    "    )\n",
+    "    params.setGyroscopeCovariance(\n",
+    "        np.diag(ROCKET_GYROSCOPE_SIGMAS**2)\n",
+    "    )\n",
+    "    params.setIntegrationCovariance(np.zeros((3, 3)))\n",
+    "    if with_coriolis:\n",
+    "        params.setOmegaCoriolis(EARTH_RATE)\n",
+    "    return params\n",
+    "\n",
+    "\n",
+    "CORIOLIS_CONDITIONS = {\n",
+    "    \"Not specified\": False,\n",
+    "    \"Specified\": True,\n",
+    "}\n",
+    "ROTATING_PARAMS = {\n",
+    "    condition: make_rotating_params(enabled)\n",
+    "    for condition, enabled in CORIOLIS_CONDITIONS.items()\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gtsam_navigation_doc_galileanimufactornees__rotating_truth_text",
+   "metadata": {},
+   "source": [
+    "### Independent exact endpoint\n",
+    "\n",
+    "The truth calculation below is a direct transcription of the paper's closed-form rotating-frame equation, not a call to a PIM's `predict`. It first evaluates the held body increment $U=(\\Delta R,\\Delta p,\\Delta v)$ with the Galilean exponential. For $\\theta=-\\omega_E T$, it then forms $A=\\operatorname{Exp}(\\theta)$, $G^v=J_L(\\theta)$, and $G^p=J_L(\\theta)-\\Gamma_2(\\theta)$. In GTSAM's `NavState(R,p,v)` order,\n",
+    "\n",
+    "$$\n",
+    "p_j=G^pgT^2+A(p_i+\\bar v_iT+R_i\\Delta p),\\qquad\n",
+    "\\bar v_j=G^vgT+A(\\bar v_i+R_i\\Delta v),\n",
+    "$$\n",
+    "\n",
+    "with $\\bar v_i=v_i+[\\omega_E]_\\times p_i$, $v_j=\\bar v_j-[\\omega_E]_\\times p_j$, and $R_j=AR_i\\Delta R$. This explicit block order is the only change from the paper's displayed $(R,v,p)$ convention."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "gtsam_navigation_doc_galileanimufactornees__rotating_truth",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T17:35:03.065400Z",
+     "iopub.status.busy": "2026-08-30T17:35:03.065335Z",
+     "iopub.status.idle": "2026-08-30T17:35:03.071376Z",
+     "shell.execute_reply": "2026-08-30T17:35:03.070998Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exact endpoint: altitude 861.0 m, speed 431.1 m/s, pitch -9.2 deg\n"
+     ]
+    }
+   ],
+   "source": [
+    "def skew(vector):\n",
+    "    x, y, z = vector\n",
+    "    return np.array([[0.0, -z, y], [z, 0.0, -x], [-y, x, 0.0]])\n",
+    "\n",
+    "\n",
+    "def exact_rotating_state(\n",
+    "    state_i, acceleration, angular_velocity, duration, gravity, omega\n",
+    "):\n",
+    "    tangent = np.zeros(10)\n",
+    "    tangent[:3] = angular_velocity * duration\n",
+    "    tangent[3:6] = acceleration * duration\n",
+    "    tangent[9] = duration\n",
+    "    delta = gtsam.Gal3.Expmap(tangent)\n",
+    "\n",
+    "    theta = -omega * duration\n",
+    "    kernels = gtsam.so3.DexpFunctor(theta)\n",
+    "    A = gtsam.Rot3.Expmap(theta).matrix()\n",
+    "    gamma_velocity = kernels.leftJacobian()\n",
+    "    gamma_position = gamma_velocity - kernels.Gamma().left()\n",
+    "\n",
+    "    omega_cross = skew(omega)\n",
+    "    R_i = state_i.attitude().matrix()\n",
+    "    p_i = state_i.position()\n",
+    "    v_bar_i = state_i.velocity() + omega_cross @ p_i\n",
+    "    p_j = gamma_position @ gravity * duration**2 + A @ (\n",
+    "        p_i + v_bar_i * duration + R_i @ delta.translation()\n",
+    "    )\n",
+    "    v_bar_j = gamma_velocity @ gravity * duration + A @ (\n",
+    "        v_bar_i + R_i @ delta.velocity()\n",
+    "    )\n",
+    "    v_j = v_bar_j - omega_cross @ p_j\n",
+    "    R_j = A @ R_i @ delta.rotation().matrix()\n",
+    "    return gtsam.NavState(gtsam.Rot3(R_j), p_j, v_j)\n",
+    "\n",
+    "\n",
+    "ROTATING_TRUTH = exact_rotating_state(\n",
+    "    ROTATING_STATE_I,\n",
+    "    ROTATING_ACCELERATION,\n",
+    "    ROTATING_ANGULAR_VELOCITY,\n",
+    "    ROTATING_DURATION,\n",
+    "    ROTATING_GRAVITY,\n",
+    "    EARTH_RATE,\n",
+    ")\n",
+    "\n",
+    "rotating_deterministic = {name: {} for name in BACKENDS}\n",
+    "nominal_accelerations = np.tile(\n",
+    "    ROTATING_ACCELERATION, (ROTATING_STEPS, 1)\n",
+    ")\n",
+    "nominal_angular_velocities = np.tile(\n",
+    "    ROTATING_ANGULAR_VELOCITY, (ROTATING_STEPS, 1)\n",
+    ")\n",
+    "for name, backend_type in BACKENDS.items():\n",
+    "    for condition, params in ROTATING_PARAMS.items():\n",
+    "        pim = integrate(\n",
+    "            backend_type,\n",
+    "            nominal_accelerations,\n",
+    "            nominal_angular_velocities,\n",
+    "            ROTATING_DT,\n",
+    "            params,\n",
+    "        )\n",
+    "        error = np.asarray(\n",
+    "            ROTATING_TRUTH.localCoordinates(\n",
+    "                pim.predict(ROTATING_STATE_I, BIAS)\n",
+    "            )\n",
+    "        )\n",
+    "        rotating_deterministic[name][condition] = error\n",
+    "\n",
+    "final_speed = np.linalg.norm(ROTATING_TRUTH.velocity())\n",
+    "final_altitude = ROTATING_TRUTH.position()[2]\n",
+    "final_pitch = np.rad2deg(ROTATING_TRUTH.attitude().rpy()[1])\n",
+    "print(\n",
+    "    f\"Exact endpoint: altitude {final_altitude:.1f} m, \"\n",
+    "    f\"speed {final_speed:.1f} m/s, pitch {final_pitch:.1f} deg\"\n",
+    ")\n",
+    "\n",
+    "galilean_specified = rotating_deterministic[\"Galilean\"][\n",
+    "    \"Specified\"\n",
+    "]\n",
+    "assert np.linalg.norm(galilean_specified) < 1e-8\n",
+    "assert np.linalg.norm(\n",
+    "    rotating_deterministic[\"Galilean\"][\"Not specified\"]\n",
+    ") > 0.2\n",
+    "for name in (\"Manifold\", \"Tangent\", \"Lie group\"):\n",
+    "    specified_norm = np.linalg.norm(\n",
+    "        rotating_deterministic[name][\"Specified\"]\n",
+    "    )\n",
+    "    omitted_norm = np.linalg.norm(\n",
+    "        rotating_deterministic[name][\"Not specified\"]\n",
+    "    )\n",
+    "    assert specified_norm > 1.0\n",
+    "    assert omitted_norm > specified_norm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gtsam_navigation_doc_galileanimufactornees__rotating_mc_text",
+   "metadata": {},
+   "source": [
+    "### Paired rotating-frame NEES\n",
+    "\n",
+    "The deterministic checks separate the two errors. With Earth rate specified, the Galilean backend recovers the closed-form powered-ascent endpoint to floating-point precision, while the three established backends retain finite-rate position and velocity error from simultaneous thrust and pitch. Omitting Earth rate adds rotating-frame error to every backend. We then use a plausible lower-noise rocket IMU model and repeat 3,000 paired trials."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "gtsam_navigation_doc_galileanimufactornees__rotating_mc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T17:35:03.072346Z",
+     "iopub.status.busy": "2026-08-30T17:35:03.072282Z",
+     "iopub.status.idle": "2026-08-30T17:35:05.394626Z",
+     "shell.execute_reply": "2026-08-30T17:35:05.394176Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "rotating_rng = np.random.default_rng(ROTATING_SEED)\n",
+    "rotating_errors = {\n",
+    "    name: {\n",
+    "        condition: np.empty((ROTATING_TRIALS, 9))\n",
+    "        for condition in CORIOLIS_CONDITIONS\n",
+    "    }\n",
+    "    for name in BACKENDS\n",
+    "}\n",
+    "rotating_nees = {\n",
+    "    name: {\n",
+    "        condition: np.empty(ROTATING_TRIALS)\n",
+    "        for condition in CORIOLIS_CONDITIONS\n",
+    "    }\n",
+    "    for name in BACKENDS\n",
+    "}\n",
+    "\n",
+    "for trial in range(ROTATING_TRIALS):\n",
+    "    accelerometer_noise = rotating_rng.normal(\n",
+    "        size=(ROTATING_STEPS, 3)\n",
+    "    ) * (ROCKET_ACCELEROMETER_SIGMAS / np.sqrt(ROTATING_DT))\n",
+    "    gyroscope_noise = rotating_rng.normal(\n",
+    "        size=(ROTATING_STEPS, 3)\n",
+    "    ) * (ROCKET_GYROSCOPE_SIGMAS / np.sqrt(ROTATING_DT))\n",
+    "    accelerations = ROTATING_ACCELERATION + accelerometer_noise\n",
+    "    angular_velocities = (\n",
+    "        ROTATING_ANGULAR_VELOCITY + gyroscope_noise\n",
+    "    )\n",
+    "\n",
+    "    for name, backend_type in BACKENDS.items():\n",
+    "        for condition, params in ROTATING_PARAMS.items():\n",
+    "            pim = integrate(\n",
+    "                backend_type,\n",
+    "                accelerations,\n",
+    "                angular_velocities,\n",
+    "                ROTATING_DT,\n",
+    "                params,\n",
+    "            )\n",
+    "            error = np.asarray(\n",
+    "                ROTATING_TRUTH.localCoordinates(\n",
+    "                    pim.predict(ROTATING_STATE_I, BIAS)\n",
+    "                )\n",
+    "            )\n",
+    "            covariance = np.asarray(pim.residualCovariance())\n",
+    "            rotating_errors[name][condition][trial] = error\n",
+    "            rotating_nees[name][condition][trial] = (\n",
+    "                error @ np.linalg.solve(covariance, error)\n",
+    "            )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "gtsam_navigation_doc_galileanimufactornees__rotating_results",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T17:35:05.395947Z",
+     "iopub.status.busy": "2026-08-30T17:35:05.395861Z",
+     "iopub.status.idle": "2026-08-30T17:35:05.401859Z",
+     "shell.execute_reply": "2026-08-30T17:35:05.401347Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "| Backend | Coriolis | Mean NEES | Position RMS (m) | Velocity RMS (m/s) |\n",
+       "|---|---|---:|---:|---:|\n",
+       "| Manifold | Not specified | 16.716 | 1.4079 | 0.8057 |\n",
+       "| Manifold | Specified | 14.011 | 1.2364 | 0.6859 |\n",
+       "| Tangent | Not specified | 16.716 | 1.4079 | 0.8057 |\n",
+       "| Tangent | Specified | 14.011 | 1.2364 | 0.6859 |\n",
+       "| Lie group | Not specified | 16.716 | 1.4079 | 0.8057 |\n",
+       "| Lie group | Specified | 14.011 | 1.2364 | 0.6859 |\n",
+       "| Galilean | Not specified | 9.664 | 0.8491 | 0.5317 |\n",
+       "| Galilean | Specified | 9.090 | 0.8213 | 0.5070 |"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Expected 95% interval for mean NEES: [8.849, 9.152]\n"
+     ]
+    }
+   ],
+   "source": [
+    "rotating_expected_interval = chi2.ppf(\n",
+    "    [0.025, 0.975], ROTATING_TRIALS * DIMENSION\n",
+    ") / ROTATING_TRIALS\n",
+    "\n",
+    "rotating_summary = {name: {} for name in BACKENDS}\n",
+    "rotating_rows = [\n",
+    "    \"| Backend | Coriolis | Mean NEES | Position RMS (m) | \"\n",
+    "    \"Velocity RMS (m/s) |\",\n",
+    "    \"|---|---|---:|---:|---:|\",\n",
+    "]\n",
+    "for name in BACKENDS:\n",
+    "    for condition in CORIOLIS_CONDITIONS:\n",
+    "        backend_errors = rotating_errors[name][condition]\n",
+    "        values = rotating_nees[name][condition]\n",
+    "        mean = values.mean()\n",
+    "        half_width = 1.96 * values.std(ddof=1) / np.sqrt(\n",
+    "            ROTATING_TRIALS\n",
+    "        )\n",
+    "        rotating_summary[name][condition] = {\n",
+    "            \"mean_nees\": mean,\n",
+    "            \"mean_half_width\": half_width,\n",
+    "            \"position_rmse\": np.sqrt(\n",
+    "                np.mean(np.sum(backend_errors[:, 3:6] ** 2, axis=1))\n",
+    "            ),\n",
+    "            \"velocity_rmse\": np.sqrt(\n",
+    "                np.mean(np.sum(backend_errors[:, 6:9] ** 2, axis=1))\n",
+    "            ),\n",
+    "        }\n",
+    "        result = rotating_summary[name][condition]\n",
+    "        rotating_rows.append(\n",
+    "            f\"| {name} | {condition} | {mean:.3f} | \"\n",
+    "            f\"{result['position_rmse']:.4f} | \"\n",
+    "            f\"{result['velocity_rmse']:.4f} |\"\n",
+    "        )\n",
+    "\n",
+    "display(Markdown(\"\\n\".join(rotating_rows)))\n",
+    "print(\n",
+    "    \"Expected 95% interval for mean NEES: \"\n",
+    "    f\"[{rotating_expected_interval[0]:.3f}, \"\n",
+    "    f\"{rotating_expected_interval[1]:.3f}]\"\n",
+    ")\n",
+    "\n",
+    "galilean_with_coriolis = rotating_summary[\"Galilean\"][\n",
+    "    \"Specified\"\n",
+    "][\"mean_nees\"]\n",
+    "galilean_without_coriolis = rotating_summary[\"Galilean\"][\n",
+    "    \"Not specified\"\n",
+    "][\"mean_nees\"]\n",
+    "assert (\n",
+    "    rotating_expected_interval[0]\n",
+    "    <= galilean_with_coriolis\n",
+    "    <= rotating_expected_interval[1]\n",
+    ")\n",
+    "assert galilean_without_coriolis > rotating_expected_interval[1]\n",
+    "assert galilean_with_coriolis < galilean_without_coriolis\n",
+    "\n",
+    "for name in (\"Manifold\", \"Tangent\", \"Lie group\"):\n",
+    "    specified = rotating_summary[name][\"Specified\"][\"mean_nees\"]\n",
+    "    omitted = rotating_summary[name][\"Not specified\"][\"mean_nees\"]\n",
+    "    assert specified > rotating_expected_interval[1]\n",
+    "    assert omitted > specified"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "gtsam_navigation_doc_galileanimufactornees__rotating_plot",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T17:35:05.403014Z",
+     "iopub.status.busy": "2026-08-30T17:35:05.402925Z",
+     "iopub.status.idle": "2026-08-30T17:35:05.420124Z",
+     "shell.execute_reply": "2026-08-30T17:35:05.419780Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>            <script src=\"https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_SVG\"></script><script type=\"text/javascript\">if (window.MathJax && window.MathJax.Hub && window.MathJax.Hub.Config) {window.MathJax.Hub.Config({SVG: {font: \"STIX-Web\"}});}</script>                <script type=\"text/javascript\">window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n",
+       "        <script charset=\"utf-8\" src=\"https://cdn.plot.ly/plotly-3.1.1.min.js\" integrity=\"sha256-HUEFyfiTnZJxCxur99FjbKYTvKSzwDaD3/x5TqHpFu4=\" crossorigin=\"anonymous\"></script>                <div id=\"1f3994c0-e5d0-40fb-b908-5a04766c11a9\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                window.PLOTLYENV=window.PLOTLYENV || {};                                if (document.getElementById(\"1f3994c0-e5d0-40fb-b908-5a04766c11a9\")) {                    Plotly.newPlot(                        \"1f3994c0-e5d0-40fb-b908-5a04766c11a9\",                        [{\"error_y\":{\"array\":[0.25046595758720963,0.250466529684016,0.2504659575872097,0.1618219001732203],\"type\":\"data\",\"visible\":true},\"hovertemplate\":\"Not specified\\u003cbr\\u003e%{x}: mean NEES %{y:.3f}\\u003cextra\\u003e\\u003c\\u002fextra\\u003e\",\"marker\":{\"color\":\"#b44b4b\",\"size\":11,\"symbol\":\"x\"},\"mode\":\"markers\",\"name\":\"Not specified\",\"x\":[\"Manifold\",\"Tangent\",\"Lie group\",\"Galilean\"],\"y\":[16.715602989499892,16.71566034865431,16.715602989499892,9.663712462223891],\"type\":\"scatter\"},{\"error_y\":{\"array\":[0.22171796076434708,0.22171853428214705,0.22171796076434716,0.15278730547198266],\"type\":\"data\",\"visible\":true},\"hovertemplate\":\"Specified\\u003cbr\\u003e%{x}: mean NEES %{y:.3f}\\u003cextra\\u003e\\u003c\\u002fextra\\u003e\",\"marker\":{\"color\":\"#14866d\",\"size\":11,\"symbol\":\"circle\"},\"mode\":\"markers\",\"name\":\"Specified\",\"x\":[\"Manifold\",\"Tangent\",\"Lie group\",\"Galilean\"],\"y\":[14.01118912559349,14.011241648794801,14.01118912559349,9.089900833738204],\"type\":\"scatter\"}],                        {\"template\":{\"data\":{\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"white\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"white\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"#C8D4E3\",\"linecolor\":\"#C8D4E3\",\"minorgridcolor\":\"#C8D4E3\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"#C8D4E3\",\"linecolor\":\"#C8D4E3\",\"minorgridcolor\":\"#C8D4E3\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scattermap\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermap\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatter\":[{\"fillpattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2},\"type\":\"scatter\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"white\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"#C8D4E3\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"white\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\"},\"bgcolor\":\"white\",\"radialaxis\":{\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"},\"yaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"},\"zaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"},\"bgcolor\":\"white\",\"caxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"#EBF0F8\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"#EBF0F8\",\"zerolinewidth\":2}}},\"shapes\":[{\"fillcolor\":\"#14866d\",\"line\":{\"width\":0},\"opacity\":0.14,\"type\":\"rect\",\"x0\":0,\"x1\":1,\"xref\":\"x domain\",\"y0\":8.848814261164716,\"y1\":9.1524486026962,\"yref\":\"y\"},{\"line\":{\"color\":\"#333333\",\"dash\":\"dash\"},\"type\":\"line\",\"x0\":0,\"x1\":1,\"xref\":\"x domain\",\"y0\":9,\"y1\":9,\"yref\":\"y\"}],\"annotations\":[{\"showarrow\":false,\"text\":\"95% consistency band\",\"x\":0,\"xanchor\":\"left\",\"xref\":\"x domain\",\"y\":9.1524486026962,\"yanchor\":\"top\",\"yref\":\"y\"}],\"legend\":{\"title\":{\"text\":\"omegaCoriolis\"}},\"title\":{\"text\":\"Powered-ascent NEES with and without Coriolis\"},\"xaxis\":{\"title\":{\"text\":\"Preintegration backend\"}},\"yaxis\":{\"title\":{\"text\":\"Mean NEES\"}}},                        {\"responsive\": true}                    ).then(function(){\n",
+       "                            \n",
+       "var gd = document.getElementById('1f3994c0-e5d0-40fb-b908-5a04766c11a9');\n",
+       "var x = new MutationObserver(function (mutations, observer) {{\n",
+       "        var display = window.getComputedStyle(gd).display;\n",
+       "        if (!display || display === 'none') {{\n",
+       "            console.log([gd, 'removed!']);\n",
+       "            Plotly.purge(gd);\n",
+       "            observer.disconnect();\n",
+       "        }}\n",
+       "}});\n",
+       "\n",
+       "// Listen for the removal of the full notebook cells\n",
+       "var notebookContainer = gd.closest('#notebook-container');\n",
+       "if (notebookContainer) {{\n",
+       "    x.observe(notebookContainer, {childList: true});\n",
+       "}}\n",
+       "\n",
+       "// Listen for the clearing of the current output cell\n",
+       "var outputEl = gd.closest('.output');\n",
+       "if (outputEl) {{\n",
+       "    x.observe(outputEl, {childList: true});\n",
+       "}}\n",
+       "\n",
+       "                        })                };            </script>        </div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig = go.Figure()\n",
+    "fig.add_hrect(\n",
+    "    y0=rotating_expected_interval[0],\n",
+    "    y1=rotating_expected_interval[1],\n",
+    "    fillcolor=\"#14866d\",\n",
+    "    opacity=0.14,\n",
+    "    line_width=0,\n",
+    "    annotation_text=\"95% consistency band\",\n",
+    "    annotation_position=\"top left\",\n",
+    ")\n",
+    "condition_styles = {\n",
+    "    \"Not specified\": (\"#b44b4b\", \"x\"),\n",
+    "    \"Specified\": (\"#14866d\", \"circle\"),\n",
+    "}\n",
+    "for condition, (color, symbol) in condition_styles.items():\n",
+    "    fig.add_scatter(\n",
+    "        x=list(BACKENDS),\n",
+    "        y=[\n",
+    "            rotating_summary[name][condition][\"mean_nees\"]\n",
+    "            for name in BACKENDS\n",
+    "        ],\n",
+    "        mode=\"markers\",\n",
+    "        name=condition,\n",
+    "        marker=dict(size=11, color=color, symbol=symbol),\n",
+    "        error_y=dict(\n",
+    "            type=\"data\",\n",
+    "            array=[\n",
+    "                rotating_summary[name][condition][\"mean_half_width\"]\n",
+    "                for name in BACKENDS\n",
+    "            ],\n",
+    "            visible=True,\n",
+    "        ),\n",
+    "        hovertemplate=(\n",
+    "            f\"{condition}<br>%{{x}}: mean NEES %{{y:.3f}}\"\n",
+    "            \"<extra></extra>\"\n",
+    "        ),\n",
+    "    )\n",
+    "fig.add_hline(y=DIMENSION, line_dash=\"dash\", line_color=\"#333333\")\n",
+    "fig.update_layout(\n",
+    "    title=\"Powered-ascent NEES with and without Coriolis\",\n",
+    "    xaxis_title=\"Preintegration backend\",\n",
+    "    yaxis_title=\"Mean NEES\",\n",
+    "    template=\"plotly_white\",\n",
+    "    legend_title_text=\"omegaCoriolis\",\n",
+    ")\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gtsam_navigation_doc_galileanimufactornees__rotating_notes",
+   "metadata": {},
+   "source": [
+    "### Powered-ascent interpretation\n",
+    "\n",
+    "With the fixed seed, Galilean preintegration with the physical Earth rate specified has mean NEES close to nine and inside the exact 95% consistency interval. The three established methods remain above the interval even with Coriolis enabled because their mean recursion incurs finite-rate error while the rocket pitches under thrust. Omitting `omegaCoriolis` worsens every backend; it adds deterministic rotating-frame error that the sensor-noise covariance does not model.\n",
+    "\n",
+    "This powered-ascent experiment exercises both effects together. Galilean composition removes held-input discretization error from simultaneous thrust and pitch, while `omegaCoriolis` supplies the exact rotating-frame lift, gravity kernels, and projection. The result is not obtained by amplifying Earth's rate or seeding an extreme initial velocity: the vehicle starts on the pad and reaches a flight state consistent with the early portion of a Georgia Tech high-power sounding-rocket launch."
    ]
   }
  ],


### PR DESCRIPTION
## Summary

- align the Galilean IMU factor guide with the left-invariant paper derivation
- translate the paper equations explicitly into NavState R, p, v convention
- document exact constant-rate rotating-frame prediction and Coriolis configuration
- retain the existing inertial NEES study and add a powered-ascent rotating-Earth comparison
- compare Manifold, Tangent, Lie-group, and Galilean backends with and without Coriolis

## Powered-ascent result

The four-second, 20 Hz benchmark starts from rest, uses 12 g specific force and a modest pitch program, and reaches 861 m altitude at 431 m/s. Mean 9D NEES is 9.090 for Galilean preintegration with Coriolis, inside the exact 95% interval [8.849, 9.152]. Established backends remain near 14.011 with Coriolis and 16.716 without it.

## Validation

- executed both notebooks end-to-end in the py312 environment
- validated notebook schemas
- confirmed no notebook error outputs
- git diff --check
