### PR TITLE
Add sam, sfm, and slam API walkthrough notebooks

### DIFF
--- a/gtsam/sam/doc/BearingFactor.ipynb
+++ b/gtsam/sam/doc/BearingFactor.ipynb
@@ -1,0 +1,157 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "bearingfactor-intro",
+   "metadata": {},
+   "source": [
+    "# BearingFactor\n",
+    "\n",
+    "A `BearingFactor` constrains the direction from a pose to a landmark, or between two poses, without measuring distance."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bearingfactor-copyright",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bearingfactor-colab-badge",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/sam/doc/BearingFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "bearingfactor-colab-install",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "bearingfactor-imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "\n",
+    "from gtsam.symbol_shorthand import L, X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bearingfactor-model",
+   "metadata": {},
+   "source": [
+    "## Create a bearing factor\n",
+    "\n",
+    "The example starts from a planar pose and landmark, uses `Pose2.bearing()` to create the direction measurement, and constructs a `BearingFactor2D`. In two dimensions the stored bearing is a `Rot2`, so its angle is easy to inspect after construction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "bearingfactor-example",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "bearing angle: 0.4853981633974484\n",
+      "factor keys: [8646911284551352320, 7782220156096217088]\n"
+     ]
+    }
+   ],
+   "source": [
+    "pose_key, landmark_key = X(0), L(0)\n",
+    "pose = gtsam.Pose2(1.0, 2.0, 0.3)\n",
+    "landmark = np.array([4.0, 5.0])\n",
+    "measured_bearing = pose.bearing(landmark)\n",
+    "bearing_noise = gtsam.noiseModel.Isotropic.Sigma(1, 0.01)\n",
+    "\n",
+    "factor = gtsam.BearingFactor2D(\n",
+    "    pose_key, landmark_key, measured_bearing, bearing_noise\n",
+    ")\n",
+    "values = gtsam.Values()\n",
+    "values.insert(pose_key, pose)\n",
+    "values.insert(landmark_key, landmark)\n",
+    "\n",
+    "assert np.allclose(factor.unwhitenedError(values), 0.0)\n",
+    "print(\"bearing angle:\", factor.measured().theta())\n",
+    "print(\"factor keys:\", factor.keys())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bearingfactor-variants",
+   "metadata": {},
+   "source": [
+    "## When to use it\n",
+    "\n",
+    "Use a `BearingFactor` when a sensor observes direction but not distance. Several such factors from different poses can triangulate a landmark. `BearingFactor3D` follows the same workflow with a `Unit3` measurement, while `BearingFactorPose2` applies it between planar poses.\n",
+    "\n",
+    "Use [`BearingRangeFactor`](BearingRangeFactor.ipynb) when the same observation includes distance, or [`RangeFactor`](RangeFactor.ipynb) for distance alone.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`BearingFactor.h`](../BearingFactor.h)\n",
+    "\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/sam/doc/BearingRangeFactor.ipynb
+++ b/gtsam/sam/doc/BearingRangeFactor.ipynb
@@ -1,0 +1,203 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "bearingrangefactor-intro",
+   "metadata": {},
+   "source": [
+    "# BearingRangeFactor\n",
+    "\n",
+    "A `BearingRangeFactor` combines a direction and distance observation in one binary factor for landmark or relative-pose estimation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bearingrangefactor-copyright",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bearingrangefactor-colab-badge",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/sam/doc/BearingRangeFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "bearingrangefactor-colab-install",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "bearingrangefactor-imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "\n",
+    "from gtsam.symbol_shorthand import L, X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bearingrangefactor-model",
+   "metadata": {},
+   "source": [
+    "## Create a bearing-range factor\n",
+    "\n",
+    "Start with a pose and landmark, then compute the direction and distance that the pose would observe. `BearingRangeFactor2D` stores both values in one measurement. Its two-dimensional noise model is ordered as bearing uncertainty followed by range uncertainty."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "bearingrangefactor-example",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "bearing: 0.4853981633974484\n",
+      "range: 4.242640687119285\n"
+     ]
+    }
+   ],
+   "source": [
+    "pose_key, landmark_key = X(0), L(0)\n",
+    "pose = gtsam.Pose2(1.0, 2.0, 0.3)\n",
+    "landmark = np.array([4.0, 5.0])\n",
+    "bearing = pose.bearing(landmark)\n",
+    "distance = pose.range(landmark)\n",
+    "measurement_noise = gtsam.noiseModel.Diagonal.Sigmas(\n",
+    "    np.array([0.01, 0.1])\n",
+    ")\n",
+    "\n",
+    "factor = gtsam.BearingRangeFactor2D(\n",
+    "    pose_key, landmark_key, bearing, distance, measurement_noise\n",
+    ")\n",
+    "values = gtsam.Values()\n",
+    "values.insert(pose_key, pose)\n",
+    "values.insert(landmark_key, landmark)\n",
+    "\n",
+    "measurement = factor.measured()\n",
+    "assert np.allclose(factor.unwhitenedError(values), 0.0)\n",
+    "print(\"bearing:\", measurement.bearing().theta())\n",
+    "print(\"range:\", measurement.range())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bearingrangefactor-optimization",
+   "metadata": {},
+   "source": [
+    "## Estimate a landmark\n",
+    "\n",
+    "With the pose fixed by a prior, one bearing-range observation determines the landmark. We add the factor to a small nonlinear graph, perturb the landmark's initial value, and let Levenberg–Marquardt recover the measured location."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "bearingrangefactor-optimization-example",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "estimated landmark: [4. 5.]\n"
+     ]
+    }
+   ],
+   "source": [
+    "graph = gtsam.NonlinearFactorGraph()\n",
+    "graph.addPriorPose2(\n",
+    "    pose_key,\n",
+    "    pose,\n",
+    "    gtsam.noiseModel.Diagonal.Sigmas(np.array([1e-4, 1e-4, 1e-4])),\n",
+    ")\n",
+    "graph.add(factor)\n",
+    "\n",
+    "initial = gtsam.Values()\n",
+    "initial.insert(pose_key, pose)\n",
+    "initial.insert(landmark_key, landmark + np.array([0.4, -0.2]))\n",
+    "result = gtsam.LevenbergMarquardtOptimizer(graph, initial).optimize()\n",
+    "\n",
+    "assert np.allclose(result.atPoint2(landmark_key), landmark, atol=1e-6)\n",
+    "print(\"estimated landmark:\", result.atPoint2(landmark_key))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bearingrangefactor-variants",
+   "metadata": {},
+   "source": [
+    "## When to use it\n",
+    "\n",
+    "Use a `BearingRangeFactor` when one sensor observation supplies both direction and distance. `BearingRangeFactor3D` uses a `Unit3` bearing for spatial landmarks; the pose-to-pose variants use the same constructor and optimization workflow.\n",
+    "\n",
+    "The separate [`BearingFactor`](BearingFactor.ipynb) and [`RangeFactor`](RangeFactor.ipynb) pages show how to model the two measurements independently.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`BearingRangeFactor.h`](../BearingRangeFactor.h)\n",
+    "\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/sam/doc/QuadraticRangeFactor.ipynb
+++ b/gtsam/sam/doc/QuadraticRangeFactor.ipynb
@@ -1,0 +1,199 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "quadraticrangefactor-intro",
+   "metadata": {},
+   "source": [
+    "# QuadraticRangeFactor\n",
+    "\n",
+    "A `QuadraticRangeFactor` expresses a range measurement as a weighted quadratic residual using an auxiliary unit direction, as used in certifiable range-aided SLAM."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "quadraticrangefactor-copyright",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "quadraticrangefactor-colab-badge",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/sam/doc/QuadraticRangeFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "quadraticrangefactor-colab-install",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "quadraticrangefactor-imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "\n",
+    "from gtsam.symbol_shorthand import L, T, U"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "quadraticrangefactor-model",
+   "metadata": {},
+   "source": [
+    "## Create a lifted range factor\n",
+    "\n",
+    "For a translation $t$, target $l$, measured range $r$, and auxiliary unit direction $u$, a `QuadraticRangeFactor` penalizes\n",
+    "\n",
+    "$$\n",
+    "\\frac{\\nu}{2}\\lVert l-t-r u\\rVert^2,\n",
+    "$$\n",
+    "\n",
+    "where `weight` is the precision $\\nu$. The example uses the 3D specialization, constructs a consistent target from a `Unit3` direction, and confirms that the resulting cost is zero."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "quadraticrangefactor-example",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "range: 1.4\n",
+      "weight: 2.25\n"
+     ]
+    }
+   ],
+   "source": [
+    "measured_range, weight = 1.4, 2.25\n",
+    "factor = gtsam.QuadraticRangeFactor3(\n",
+    "    T(0), L(0), U(0), measured_range, weight\n",
+    ")\n",
+    "\n",
+    "translation = np.array([0.3, -0.2, 0.1])\n",
+    "direction = gtsam.Unit3(np.array([0.0, 0.0, 1.0]))\n",
+    "target = translation + measured_range * direction.unitVector()\n",
+    "\n",
+    "values = gtsam.Values()\n",
+    "values.insert(T(0), translation)\n",
+    "values.insert(L(0), target)\n",
+    "values.insert(U(0), direction)\n",
+    "\n",
+    "assert np.isclose(factor.error(values), 0.0)\n",
+    "print(\"range:\", factor.range())\n",
+    "print(\"weight:\", factor.weight())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "quadraticrangefactor-error",
+   "metadata": {},
+   "source": [
+    "## Evaluate the quadratic cost\n",
+    "\n",
+    "After perturbing the target, `error()` returns one half of the weighted squared vector residual. Computing that expression explicitly makes the meaning of `range()` and `weight()` concrete."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "quadraticrangefactor-error-example",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "perturbed cost: 0.059062500000000025\n"
+     ]
+    }
+   ],
+   "source": [
+    "perturbed_target = target + np.array([0.1, -0.2, 0.05])\n",
+    "values.update(L(0), perturbed_target)\n",
+    "residual = (\n",
+    "    perturbed_target\n",
+    "    - translation\n",
+    "    - measured_range * direction.unitVector()\n",
+    ")\n",
+    "expected_cost = 0.5 * weight * float(residual @ residual)\n",
+    "assert np.isclose(factor.error(values), expected_cost)\n",
+    "print(\"perturbed cost:\", factor.error(values))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "quadraticrangefactor-variants",
+   "metadata": {},
+   "source": [
+    "## When to use it\n",
+    "\n",
+    "Use a `QuadraticRangeFactor` when a range-aided problem is being lifted for a certifiable quadratic solver. `QuadraticRangeFactor3` uses a `Unit3` auxiliary; `QuadraticRangeFactor2` uses the first column of a `Rot2`. For ordinary nonlinear least squares without an auxiliary direction, [`RangeFactor`](RangeFactor.ipynb) is simpler.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`QuadraticRangeFactor.h`](../QuadraticRangeFactor.h)\n",
+    "\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/sam/doc/RangeFactor.ipynb
+++ b/gtsam/sam/doc/RangeFactor.ipynb
@@ -1,0 +1,207 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "rangefactor-intro",
+   "metadata": {},
+   "source": [
+    "# RangeFactor\n",
+    "\n",
+    "A `RangeFactor` models scalar distance measurements between points, poses, and cameras. The related `RangeFactorWithTransform` and `RangeFactorWithTransformBias` classes account for sensor offsets and additive range bias."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "rangefactor-copyright",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "rangefactor-colab-badge",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/sam/doc/RangeFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "rangefactor-colab-install",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "rangefactor-imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "\n",
+    "from gtsam.symbol_shorthand import B, L, X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "rangefactor-direct",
+   "metadata": {},
+   "source": [
+    "## Create a direct range factor\n",
+    "\n",
+    "Start with a planar pose, a landmark, and the distance between them. A `RangeFactor2D` stores that scalar measurement and connects the two keys. The inherited `unwhitenedError()` method lets us verify that the measurement agrees with a set of values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "rangefactor-direct-example",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "stored measurement: 4.242640687119285\n",
+      "factor keys: [8646911284551352320, 7782220156096217088]\n"
+     ]
+    }
+   ],
+   "source": [
+    "pose_key, landmark_key = X(0), L(0)\n",
+    "pose = gtsam.Pose2(1.0, 2.0, 0.3)\n",
+    "landmark = np.array([4.0, 5.0])\n",
+    "measured_range = pose.range(landmark)\n",
+    "range_noise = gtsam.noiseModel.Isotropic.Sigma(1, 0.1)\n",
+    "\n",
+    "factor = gtsam.RangeFactor2D(\n",
+    "    pose_key, landmark_key, measured_range, range_noise\n",
+    ")\n",
+    "values = gtsam.Values()\n",
+    "values.insert(pose_key, pose)\n",
+    "values.insert(landmark_key, landmark)\n",
+    "\n",
+    "assert np.allclose(factor.unwhitenedError(values), 0.0)\n",
+    "print(\"stored measurement:\", factor.measured())\n",
+    "print(\"factor keys:\", factor.keys())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "rangefactor-offsets",
+   "metadata": {},
+   "source": [
+    "## Add a sensor transform and bias\n",
+    "\n",
+    "Often the range sensor is not located at the body-frame origin. `RangeFactorWithTransform2D` accepts the fixed body-to-sensor transform and predicts distance from that sensor pose. If the sensor also has an estimated additive offset, `RangeFactorWithTransformBias2D` connects a third key containing the scalar bias."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "rangefactor-offsets-example",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "offset measurement: 4.066813490320851\n",
+      "biased measurement: 4.316813490320851\n"
+     ]
+    }
+   ],
+   "source": [
+    "body_T_sensor = gtsam.Pose2(0.2, 0.0, 0.1)\n",
+    "sensor_pose = pose.compose(body_T_sensor)\n",
+    "sensor_range = sensor_pose.range(landmark)\n",
+    "\n",
+    "offset_factor = gtsam.RangeFactorWithTransform2D(\n",
+    "    pose_key, landmark_key, sensor_range, range_noise, body_T_sensor\n",
+    ")\n",
+    "assert np.allclose(offset_factor.unwhitenedError(values), 0.0)\n",
+    "\n",
+    "bias_key, bias = B(0), 0.25\n",
+    "bias_factor = gtsam.RangeFactorWithTransformBias2D(\n",
+    "    pose_key,\n",
+    "    landmark_key,\n",
+    "    bias_key,\n",
+    "    sensor_range + bias,\n",
+    "    range_noise,\n",
+    "    body_T_sensor,\n",
+    ")\n",
+    "values.insert(bias_key, bias)\n",
+    "assert np.allclose(bias_factor.unwhitenedError(values), 0.0)\n",
+    "print(\"offset measurement:\", offset_factor.measured())\n",
+    "print(\"biased measurement:\", bias_factor.measured())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "rangefactor-selection",
+   "metadata": {},
+   "source": [
+    "## When to use it\n",
+    "\n",
+    "Use a direct `RangeFactor` when the measurement origin coincides with the estimated pose or point. Use `RangeFactorWithTransform` for a known sensor offset, and `RangeFactorWithTransformBias` when the graph should estimate an additive range bias. The 3D and camera variants follow the same construction pattern shown above.\n",
+    "\n",
+    "For direction-only or combined measurements, continue with [`BearingFactor`](BearingFactor.ipynb) and [`BearingRangeFactor`](BearingRangeFactor.ipynb). [`QuadraticRangeFactor`](QuadraticRangeFactor.ipynb) presents the lifted formulation used by certifiable solvers.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`RangeFactor.h`](../RangeFactor.h)\n",
+    "\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/sfm/doc/BinaryMeasurement.ipynb
+++ b/gtsam/sfm/doc/BinaryMeasurement.ipynb
@@ -39,22 +39,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "d56e1db7",
-   "metadata": {},
-   "source": [
-    "## Mathematical idea\n",
-    "\n",
-    "A binary measurement record packages an observation $z_{ab}$ and covariance $\\Sigma_{ab}$ with its ordered endpoint keys $(a,b)$:\n",
-    "\n",
-    "$$\n",
-    "(a,b,z_{ab},\\Sigma_{ab}).\n",
-    "$$\n",
-    "\n",
-    "It deliberately does not define a prediction $h(x_a,x_b)$ or residual $h(x_a,x_b)-z_{ab}$; an algorithm consuming the record chooses that model."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "binarymeasurement-colab-install",
@@ -102,6 +86,22 @@
     "P = symbol_shorthand.P\n",
     "S = symbol_shorthand.S\n",
     "X = symbol_shorthand.X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d56e1db7",
+   "metadata": {},
+   "source": [
+    "## Mathematical idea\n",
+    "\n",
+    "A binary measurement record packages an observation $z_{ab}$ and covariance $\\Sigma_{ab}$ with its ordered endpoint keys $(a,b)$:\n",
+    "\n",
+    "$$\n",
+    "(a,b,z_{ab},\\Sigma_{ab}).\n",
+    "$$\n",
+    "\n",
+    "It deliberately does not define a prediction $h(x_a,x_b)$ or residual $h(x_a,x_b)-z_{ab}$; an algorithm consuming the record chooses that model."
    ]
   },
   {

--- a/gtsam/sfm/doc/DsfTrackGenerator.ipynb
+++ b/gtsam/sfm/doc/DsfTrackGenerator.ipynb
@@ -1,0 +1,180 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "dsftrackgenerator-intro",
+   "metadata": {},
+   "source": [
+    "# DsfTrackGenerator\n",
+    "\n",
+    "The `Keypoints` class and `tracksFromPairwiseMatches` helper are internal GTSFM data structures for feature matching. They turn pairwise image matches into multi-view feature tracks using a disjoint-set forest."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dsftrackgenerator-copyright",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dsftrackgenerator-colab-badge",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/sfm/doc/DsfTrackGenerator.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dsftrackgenerator-colab-install",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "dsftrackgenerator-imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dsftrackgenerator-inputs",
+   "metadata": {},
+   "source": [
+    "## Build the feature-matching inputs\n",
+    "\n",
+    "GTSFM represents each image's detections with a `Keypoints` object containing an $N \times 2$ coordinate matrix. Pairwise matches map an `IndexPair` to rows of corresponding keypoint indices. Ordinary Python lists and dictionaries are converted to the internal `KeypointsVector` and `MatchIndicesMap` types by the wrapper."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "dsftrackgenerator-example",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "track count: 3\n",
+      "[0 1] -> [[10.0, 20.0], [50.0, 60.0]]\n",
+      "[0 1 2] -> [[30.0, 40.0], [70.0, 80.0], [130.0, 140.0]]\n",
+      "[1 2] -> [[90.0, 100.0], [110.0, 120.0]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "keypoints = [\n",
+    "    gtsam.gtsfm.Keypoints(np.array([[10.0, 20.0], [30.0, 40.0]])),\n",
+    "    gtsam.gtsfm.Keypoints(\n",
+    "        np.array([[50.0, 60.0], [70.0, 80.0], [90.0, 100.0]])\n",
+    "    ),\n",
+    "    gtsam.gtsfm.Keypoints(np.array([[110.0, 120.0], [130.0, 140.0]])),\n",
+    "]\n",
+    "matches = {\n",
+    "    gtsam.IndexPair(0, 1): np.array([[0, 0], [1, 1]], dtype=np.int32),\n",
+    "    gtsam.IndexPair(1, 2): np.array([[2, 0], [1, 1]], dtype=np.int32),\n",
+    "}\n",
+    "\n",
+    "tracks = gtsam.gtsfm.tracksFromPairwiseMatches(matches, keypoints)\n",
+    "assert len(tracks) == 3\n",
+    "print(\"track count:\", len(tracks))\n",
+    "for track in tracks:\n",
+    "    print(track.indexVector(), \"->\", track.measurementMatrix().tolist())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dsftrackgenerator-output",
+   "metadata": {},
+   "source": [
+    "## Inspect the generated tracks\n",
+    "\n",
+    "`tracksFromPairwiseMatches()` merges pairwise correspondences with a disjoint-set forest and returns `SfmTrack2d` objects. For each track, `indexVector()` lists the participating cameras and `measurementMatrix()` contains the image coordinates in the same order."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "dsftrackgenerator-inspect",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert all(track.hasUniqueCameras() for track in tracks)\n",
+    "assert tracks[1].numberMeasurements() == 3\n",
+    "np.testing.assert_allclose(tracks[1].indexVector(), [0, 1, 2])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dsftrackgenerator-links",
+   "metadata": {},
+   "source": [
+    "## When to use it\n",
+    "\n",
+    "This is internal feature-matching infrastructure used by GTSFM. It is useful when converting pairwise matcher output into tracks before triangulation or bundle adjustment. A valid track contains at most one keypoint per camera, so check `hasUniqueCameras()` before using the result downstream.\n",
+    "\n",
+    "[`SfmTrack`](SfmTrack.ipynb) explains the returned track objects. The focused [`Keypoints`](Keypoints.ipynb) page gives additional coordinate-convention details.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`DsfTrackGenerator.h`](../DsfTrackGenerator.h)\n",
+    "\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/sfm/doc/EssentialMatrixConstraint.ipynb
+++ b/gtsam/sfm/doc/EssentialMatrixConstraint.ipynb
@@ -24,24 +24,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "gtsam_slam_doc_essentialmatrixconstraint__desc_md"
-      },
-      "source": [
-        "`EssentialMatrixConstraint` is a binary factor connecting two `Pose3` variables.\n",
-        "It represents a constraint derived from a measured Essential matrix ($E$) between the two camera views corresponding to the poses.\n",
-        "The Essential matrix $E$ encapsulates the relative rotation $R$ and translation direction $t$ between two *calibrated* cameras according to the epipolar constraint:\n",
-        "$$ p_2^T E p_1 = 0 $$\n",
-        "where $p_1$ and $p_2$ are the homogeneous coordinates of corresponding points in the *normalized (calibrated)* image planes.\n",
-        "\n",
-        "This factor takes the measured $E_{12}$ (from pose 1 to pose 2) and compares it to the Essential matrix predicted from the estimated poses $P_1$ and $P_2$.\n",
-        "The error is computed in the 5-dimensional tangent space of the Essential matrix manifold.\n",
-        "\n",
-        "**Note:** This factor requires known camera calibration, as the Essential matrix operates on normalized image coordinates."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "gtsam_slam_doc_essentialmatrixconstraint__colab_badge_md"
       },
       "source": [
@@ -76,6 +58,24 @@
         "from gtsam import symbol_shorthand\n",
         "\n",
         "X = symbol_shorthand.X"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gtsam_slam_doc_essentialmatrixconstraint__desc_md"
+      },
+      "source": [
+        "`EssentialMatrixConstraint` is a binary factor connecting two `Pose3` variables.\n",
+        "It represents a constraint derived from a measured Essential matrix ($E$) between the two camera views corresponding to the poses.\n",
+        "The Essential matrix $E$ encapsulates the relative rotation $R$ and translation direction $t$ between two *calibrated* cameras according to the epipolar constraint:\n",
+        "$$ p_2^T E p_1 = 0 $$\n",
+        "where $p_1$ and $p_2$ are the homogeneous coordinates of corresponding points in the *normalized (calibrated)* image planes.\n",
+        "\n",
+        "This factor takes the measured $E_{12}$ (from pose 1 to pose 2) and compares it to the Essential matrix predicted from the estimated poses $P_1$ and $P_2$.\n",
+        "The error is computed in the 5-dimensional tangent space of the Essential matrix manifold.\n",
+        "\n",
+        "**Note:** This factor requires known camera calibration, as the Essential matrix operates on normalized image coordinates."
       ]
     },
     {

--- a/gtsam/sfm/doc/EssentialMatrixFactor.ipynb
+++ b/gtsam/sfm/doc/EssentialMatrixFactor.ipynb
@@ -6,7 +6,7 @@
         "id": "gtsam_slam_doc_essentialmatrixfactor__intro_md"
       },
       "source": [
-        "# EssentialMatrixFactor Variants"
+        "# EssentialMatrixFactor\n"
       ]
     },
     {
@@ -19,25 +19,6 @@
       },
       "source": [
         "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_slam_doc_essentialmatrixfactor__desc_md"
-      },
-      "source": [
-        "This header defines several factors related to the Essential matrix ($E$), which encodes the relative rotation and translation direction between two *calibrated* cameras.\n",
-        "They are primarily used in Structure from Motion (SfM) problems where point correspondences between views are available but the 3D structure and/or camera poses/calibration are unknown.\n",
-        "\n",
-        "The core constraint is the epipolar constraint: $p_2^T E p_1 = 0$, where $p_1$ and $p_2$ are corresponding points in *normalized (calibrated)* image coordinates.\n",
-        "\n",
-        "Factors defined here:\n",
-        "*   `EssentialMatrixFactor`: Constrains an unknown `EssentialMatrix` variable using a single point correspondence $(p_1, p_2)$.\n",
-        "*   `EssentialMatrixFactor2`: Constrains an `EssentialMatrix` and an unknown inverse depth variable using a point correspondence.\n",
-        "*   `EssentialMatrixFactor3`: Like Factor2, but incorporates an additional fixed extrinsic rotation (useful for camera rigs).\n",
-        "*   `EssentialMatrixFactor4<CALIBRATION>`: Constrains an `EssentialMatrix` and a *shared* `CALIBRATION` variable using a point correspondence given in *pixel* coordinates.\n",
-        "*   `EssentialMatrixFactor5<CALIBRATION>`: Constrains an `EssentialMatrix` and *two* unknown `CALIBRATION` variables (one for each camera) using a point correspondence given in *pixel* coordinates."
       ]
     },
     {
@@ -81,6 +62,25 @@
         "E = symbol_shorthand.E\n",
         "K = symbol_shorthand.K\n",
         "D = symbol_shorthand.D # For inverse depth"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gtsam_slam_doc_essentialmatrixfactor__desc_md"
+      },
+      "source": [
+        "This header defines several factors related to the Essential matrix ($E$), which encodes the relative rotation and translation direction between two *calibrated* cameras.\n",
+        "They are primarily used in Structure from Motion (SfM) problems where point correspondences between views are available but the 3D structure and/or camera poses/calibration are unknown.\n",
+        "\n",
+        "The core constraint is the epipolar constraint: $p_2^T E p_1 = 0$, where $p_1$ and $p_2$ are corresponding points in *normalized (calibrated)* image coordinates.\n",
+        "\n",
+        "Factors defined here:\n",
+        "*   `EssentialMatrixFactor`: Constrains an unknown `EssentialMatrix` variable using a single point correspondence $(p_1, p_2)$.\n",
+        "*   `EssentialMatrixFactor2`: Constrains an `EssentialMatrix` and an unknown inverse depth variable using a point correspondence.\n",
+        "*   `EssentialMatrixFactor3`: Like Factor2, but incorporates an additional fixed extrinsic rotation (useful for camera rigs).\n",
+        "*   `EssentialMatrixFactor4<CALIBRATION>`: Constrains an `EssentialMatrix` and a *shared* `CALIBRATION` variable using a point correspondence given in *pixel* coordinates.\n",
+        "*   `EssentialMatrixFactor5<CALIBRATION>`: Constrains an `EssentialMatrix` and *two* unknown `CALIBRATION` variables (one for each camera) using a point correspondence given in *pixel* coordinates."
       ]
     },
     {

--- a/gtsam/sfm/doc/GlobalPositioner.ipynb
+++ b/gtsam/sfm/doc/GlobalPositioner.ipynb
@@ -39,22 +39,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "1524e38a",
-   "metadata": {},
-   "source": [
-    "## Mathematical idea\n",
-    "\n",
-    "For camera position $C_i$, landmark position $P_j$, and world-frame unit bearing $u_{ij}$, each observation contributes the BATA residual\n",
-    "\n",
-    "$$\n",
-    "r_{ij}=|s_{ij}|(P_j-C_i)-u_{ij}.\n",
-    "$$\n",
-    "\n",
-    "One scale $s_{ij}$ is optimized per observation. BATA means **Bilinear Angle-based Translation Averaging**; see [Zhuang, Cheong, and Lee, *Baseline Desensitizing in Translation Averaging*, IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR), 2018](https://openaccess.thecvf.com/content_cvpr_2018/html/Zhuang_Baseline_Desensitizing_in_CVPR_2018_paper.html). Direction-only data leaves global translation and scale gauges, so anchoring and metric information remain essential."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "globalpositioner-colab-install",
@@ -102,6 +86,22 @@
     "P = symbol_shorthand.P\n",
     "S = symbol_shorthand.S\n",
     "X = symbol_shorthand.X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1524e38a",
+   "metadata": {},
+   "source": [
+    "## Mathematical idea\n",
+    "\n",
+    "For camera position $C_i$, landmark position $P_j$, and world-frame unit bearing $u_{ij}$, each observation contributes the BATA residual\n",
+    "\n",
+    "$$\n",
+    "r_{ij}=|s_{ij}|(P_j-C_i)-u_{ij}.\n",
+    "$$\n",
+    "\n",
+    "One scale $s_{ij}$ is optimized per observation. BATA means **Bilinear Angle-based Translation Averaging**; see [Zhuang, Cheong, and Lee, *Baseline Desensitizing in Translation Averaging*, IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR), 2018](https://openaccess.thecvf.com/content_cvpr_2018/html/Zhuang_Baseline_Desensitizing_in_CVPR_2018_paper.html). Direction-only data leaves global translation and scale gauges, so anchoring and metric information remain essential."
    ]
   },
   {

--- a/gtsam/sfm/doc/LocationRecovery.ipynb
+++ b/gtsam/sfm/doc/LocationRecovery.ipynb
@@ -39,22 +39,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "a0bbd3da",
-   "metadata": {},
-   "source": [
-    "## Mathematical idea\n",
-    "\n",
-    "Given a measured direction $u_{ab}$, location recovery can use either the normalized chordal residual\n",
-    "\n",
-    "$$\n",
-    "r_{ab}^{\\mathrm{chordal}}=\\frac{T_b-T_a}{\\lVert T_b-T_a\\rVert}-u_{ab},\n",
-    "$$\n",
-    "\n",
-    "or the Bilinear Angle-based Translation Averaging (**BATA**) residual $r_{ab}^{\\mathrm{BATA}}=|s_{ab}|(T_b-T_a)-u_{ab}$. The latter adds one scale variable per edge. Both models require gauge constraints because directions alone determine neither global translation nor metric scale."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "locationrecovery-colab-install",
@@ -102,6 +86,22 @@
     "P = symbol_shorthand.P\n",
     "S = symbol_shorthand.S\n",
     "X = symbol_shorthand.X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0bbd3da",
+   "metadata": {},
+   "source": [
+    "## Mathematical idea\n",
+    "\n",
+    "Given a measured direction $u_{ab}$, location recovery can use either the normalized chordal residual\n",
+    "\n",
+    "$$\n",
+    "r_{ab}^{\\mathrm{chordal}}=\\frac{T_b-T_a}{\\lVert T_b-T_a\\rVert}-u_{ab},\n",
+    "$$\n",
+    "\n",
+    "or the Bilinear Angle-based Translation Averaging (**BATA**) residual $r_{ab}^{\\mathrm{BATA}}=|s_{ab}|(T_b-T_a)-u_{ab}$. The latter adds one scale variable per edge. Both models require gauge constraints because directions alone determine neither global translation nor metric scale."
    ]
   },
   {

--- a/gtsam/sfm/doc/MFAS.ipynb
+++ b/gtsam/sfm/doc/MFAS.ipynb
@@ -39,22 +39,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "5df8011a",
-   "metadata": {},
-   "source": [
-    "## Mathematical idea\n",
-    "\n",
-    "**MFAS** means **Minimum Feedback Arc Set**. For an ordering $\\pi$ of graph vertices, an edge $(i,j)$ is backward when $\\pi(i)>\\pi(j)$; the weighted objective is\n",
-    "\n",
-    "$$\n",
-    "\\min_{\\pi}\\sum_{(i,j):\\,\\pi(i)>\\pi(j)} w_{ij}.\n",
-    "$$\n",
-    "\n",
-    "The one-dimensional structure-from-motion (**1DSfM**) procedure projects translation directions onto a line, uses this ordering problem to expose inconsistent edges, and repeats over projection directions for robust outlier evidence."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "mfas-colab-install",
@@ -102,6 +86,22 @@
     "P = symbol_shorthand.P\n",
     "S = symbol_shorthand.S\n",
     "X = symbol_shorthand.X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5df8011a",
+   "metadata": {},
+   "source": [
+    "## Mathematical idea\n",
+    "\n",
+    "**MFAS** means **Minimum Feedback Arc Set**. For an ordering $\\pi$ of graph vertices, an edge $(i,j)$ is backward when $\\pi(i)>\\pi(j)$; the weighted objective is\n",
+    "\n",
+    "$$\n",
+    "\\min_{\\pi}\\sum_{(i,j):\\,\\pi(i)>\\pi(j)} w_{ij}.\n",
+    "$$\n",
+    "\n",
+    "The one-dimensional structure-from-motion (**1DSfM**) procedure projects translation directions onto a line, uses this ordering problem to expose inconsistent edges, and repeats over projection directions for robust outlier evidence."
    ]
   },
   {

--- a/gtsam/sfm/doc/SelfCalibrationFactor.ipynb
+++ b/gtsam/sfm/doc/SelfCalibrationFactor.ipynb
@@ -39,22 +39,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "67d8f1a2",
-   "metadata": {},
-   "source": [
-    "## Mathematical idea\n",
-    "\n",
-    "For fundamental matrix $F$ and calibration matrices $K_i(f_i),K_j(f_j)$, the induced essential matrix is\n",
-    "\n",
-    "$$\n",
-    "E(f_i,f_j)=K_j(f_j)^{\\mathsf T}F K_i(f_i).\n",
-    "$$\n",
-    "\n",
-    "A valid essential matrix has singular values $(\\sigma,\\sigma,0)$. The factor penalizes departure from the two equal nonzero singular-value constraints, thereby estimating the focal lengths. **SVD** means singular value decomposition."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "selfcalibrationfactor-colab-install",
@@ -102,6 +86,22 @@
     "P = symbol_shorthand.P\n",
     "S = symbol_shorthand.S\n",
     "X = symbol_shorthand.X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67d8f1a2",
+   "metadata": {},
+   "source": [
+    "## Mathematical idea\n",
+    "\n",
+    "For fundamental matrix $F$ and calibration matrices $K_i(f_i),K_j(f_j)$, the induced essential matrix is\n",
+    "\n",
+    "$$\n",
+    "E(f_i,f_j)=K_j(f_j)^{\\mathsf T}F K_i(f_i).\n",
+    "$$\n",
+    "\n",
+    "A valid essential matrix has singular values $(\\sigma,\\sigma,0)$. The factor penalizes departure from the two equal nonzero singular-value constraints, thereby estimating the focal lengths. **SVD** means singular value decomposition."
    ]
   },
   {

--- a/gtsam/sfm/doc/SfmData.ipynb
+++ b/gtsam/sfm/doc/SfmData.ipynb
@@ -39,23 +39,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "2e01971a",
-   "metadata": {},
-   "source": [
-    "## Mathematical idea\n",
-    "\n",
-    "Bundle adjustment estimates cameras $C_i$ and landmarks $P_j$ by minimizing reprojection error,\n",
-    "\n",
-    "$$\n",
-    "\\min_{\\{C_i\\},\\{P_j\\}}\\sum_{(i,j)\\in\\mathcal O}\n",
-    "\\left\\lVert z_{ij}-\\pi(C_i,P_j)\\right\\rVert_{\\Sigma_{ij}}^2,\n",
-    "$$\n",
-    "\n",
-    "where $\\mathcal O$ is the observation set. `SfmData` stores exactly the cameras, points, and observations needed to construct this graph. **BAL** means **Bundle Adjustment in the Large**, a standard dataset and file format used by these examples."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "sfmdata-colab-install",
@@ -103,6 +86,23 @@
     "P = symbol_shorthand.P\n",
     "S = symbol_shorthand.S\n",
     "X = symbol_shorthand.X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e01971a",
+   "metadata": {},
+   "source": [
+    "## Mathematical idea\n",
+    "\n",
+    "Bundle adjustment estimates cameras $C_i$ and landmarks $P_j$ by minimizing reprojection error,\n",
+    "\n",
+    "$$\n",
+    "\\min_{\\{C_i\\},\\{P_j\\}}\\sum_{(i,j)\\in\\mathcal O}\n",
+    "\\left\\lVert z_{ij}-\\pi(C_i,P_j)\\right\\rVert_{\\Sigma_{ij}}^2,\n",
+    "$$\n",
+    "\n",
+    "where $\\mathcal O$ is the observation set. `SfmData` stores exactly the cameras, points, and observations needed to construct this graph. **BAL** means **Bundle Adjustment in the Large**, a standard dataset and file format used by these examples."
    ]
   },
   {

--- a/gtsam/sfm/doc/SfmLevenbergMarquardt.ipynb
+++ b/gtsam/sfm/doc/SfmLevenbergMarquardt.ipynb
@@ -1,0 +1,229 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "sfmlevenbergmarquardt-intro",
+   "metadata": {},
+   "source": [
+    "# SfmLevenbergMarquardt\n",
+    "\n",
+    "The `SfmLevenbergMarquardtOptimizer` class is an easy entry point for structure from motion. Together with `SfmLevenbergMarquardtParams`, it runs CPU Levenberg–Marquardt and lets users choose whether landmarks are eliminated through a Schur complement."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sfmlevenbergmarquardt-copyright",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sfmlevenbergmarquardt-colab-badge",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/sfm/doc/SfmLevenbergMarquardt.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "sfmlevenbergmarquardt-colab-install",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "sfmlevenbergmarquardt-imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "\n",
+    "from gtsam.symbol_shorthand import K, L, X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sfmlm-role",
+   "metadata": {},
+   "source": [
+    "## Build a small structure-from-motion problem\n",
+    "\n",
+    "We first create two cameras, four landmarks, and their image measurements. The graph stores poses, points, and a shared calibration as separate variables. Priors fix the gauge, while deliberately perturbed initial values give the optimizer something to improve."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "sfmlm-graph",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "poses = [\n",
+    "    gtsam.Pose3(),\n",
+    "    gtsam.Pose3(gtsam.Rot3.Ypr(0.02, -0.01, 0.01), np.array([1.0, 0.0, 0.0])),\n",
+    "]\n",
+    "points = [\n",
+    "    np.array([-1.0, -0.5, 5.0]),\n",
+    "    np.array([0.8, -0.6, 4.5]),\n",
+    "    np.array([-0.7, 0.9, 5.5]),\n",
+    "    np.array([1.1, 0.8, 6.0]),\n",
+    "]\n",
+    "calibration = gtsam.Cal3_S2(500.0, 505.0, 0.0, 320.0, 240.0)\n",
+    "pixel_noise = gtsam.noiseModel.Isotropic.Sigma(2, 1.0)\n",
+    "\n",
+    "graph = gtsam.NonlinearFactorGraph()\n",
+    "for i, pose in enumerate(poses):\n",
+    "    camera = gtsam.PinholeCameraCal3_S2(pose, calibration)\n",
+    "    for j, point in enumerate(points):\n",
+    "        graph.add(\n",
+    "            gtsam.GeneralSFMFactor2Cal3_S2(\n",
+    "                camera.project(point), pixel_noise, X(i), L(j), K(0)\n",
+    "            )\n",
+    "        )\n",
+    "graph.addPriorPose3(\n",
+    "    X(0), poses[0], gtsam.noiseModel.Isotropic.Sigma(6, 1e-3)\n",
+    ")\n",
+    "graph.addPriorPoint3(\n",
+    "    L(0), points[0], gtsam.noiseModel.Isotropic.Sigma(3, 1e-3)\n",
+    ")\n",
+    "graph.addPriorCal3_S2(\n",
+    "    K(0),\n",
+    "    calibration,\n",
+    "    gtsam.noiseModel.Diagonal.Sigmas(\n",
+    "        np.array([50.0, 50.0, 0.1, 10.0, 10.0])\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "initial = gtsam.Values()\n",
+    "for i, pose in enumerate(poses):\n",
+    "    initial.insert(\n",
+    "        X(i),\n",
+    "        pose.retract(np.array([0.01, -0.01, 0.01, 0.02, 0.0, -0.01])),\n",
+    "    )\n",
+    "for j, point in enumerate(points):\n",
+    "    initial.insert(L(j), point + np.array([0.01, -0.02, 0.01]))\n",
+    "initial.insert(K(0), gtsam.Cal3_S2(510.0, 495.0, 0.0, 318.0, 242.0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sfmlm-optimize",
+   "metadata": {},
+   "source": [
+    "## Configure and run the optimizer\n",
+    "\n",
+    "`SfmLevenbergMarquardtParams` extends the usual LM parameters with a landmark-elimination mode. Here we select Schur elimination, ask `CreateReducedOrdering()` for the non-landmark ordering expected by that mode, and pass the parameters to `SfmLevenbergMarquardtOptimizer`. The final graph error confirms that the optimization improved the initial estimate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "sfmlm-optimize-example",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "reduced variables: 7\n",
+      "error: 845.7689790759512 -> 3.236514773600142e-27\n"
+     ]
+    }
+   ],
+   "source": [
+    "params = gtsam.SfmLevenbergMarquardtParams.ceresDefaults()\n",
+    "params.setEliminationMode(gtsam.SfmEliminationMode.Schur)\n",
+    "params.setLinearSolver(\n",
+    "    gtsam.NonlinearOptimizerParams.LinearSolverType.MULTIFRONTAL_SOLVER\n",
+    ")\n",
+    "reduced_ordering = (\n",
+    "    gtsam.SfmLevenbergMarquardtOptimizer.CreateReducedOrdering(graph, initial)\n",
+    ")\n",
+    "complete_ordering = (\n",
+    "    gtsam.SfmLevenbergMarquardtOptimizer.CreateSchurOrdering(\n",
+    "        graph, reduced_ordering\n",
+    "    )\n",
+    ")\n",
+    "params.setOrdering(reduced_ordering)\n",
+    "\n",
+    "initial_error = graph.error(initial)\n",
+    "optimizer = gtsam.SfmLevenbergMarquardtOptimizer(graph, initial, params)\n",
+    "result = optimizer.optimize()\n",
+    "final_error = graph.error(result)\n",
+    "\n",
+    "assert final_error < initial_error\n",
+    "assert complete_ordering.size() == initial.size()\n",
+    "print(\"reduced variables:\", reduced_ordering.size())\n",
+    "print(\"error:\", initial_error, \"->\", final_error)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sfmlm-guidance",
+   "metadata": {},
+   "source": [
+    "## When to use it\n",
+    "\n",
+    "Use `SfmLevenbergMarquardtOptimizer` as a direct entry point for bundle adjustment when the graph contains explicit `Point3` or `Unit3` landmarks. Full mode solves the joint system; Schur mode removes those landmarks before solving the reduced camera system. Shared calibration remains in the reduced system.\n",
+    "\n",
+    "[`SfmData`](SfmData.ipynb) can build standard SFM graphs, and [`GeneralSFMFactor`](../../slam/doc/GeneralSFMFactor.ipynb) explains the reprojection factor used in this example.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`SfmLevenbergMarquardt.h`](../SfmLevenbergMarquardt.h)\n",
+    "\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/sfm/doc/SfmTrack.ipynb
+++ b/gtsam/sfm/doc/SfmTrack.ipynb
@@ -39,22 +39,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "0624570f",
-   "metadata": {},
-   "source": [
-    "## Mathematical idea\n",
-    "\n",
-    "A reconstructed landmark $P_j$ and its observations form the track\n",
-    "\n",
-    "$$\n",
-    "\\mathcal T_j=\\{(i,z_{ij})\\mid z_{ij}\\approx\\pi(C_i,P_j)\\}.\n",
-    "$$\n",
-    "\n",
-    "The point $P_j$ participates in bundle adjustment, while its red–green–blue (**RGB**) color is optional display metadata and does not enter the objective."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "sfmtrack-colab-install",
@@ -106,38 +90,45 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0624570f",
+   "metadata": {},
+   "source": [
+    "## Mathematical idea\n",
+    "\n",
+    "A reconstructed landmark $P_j$ and its observations form the track\n",
+    "\n",
+    "$$\n",
+    "\\mathcal T_j=\\{(i,z_{ij})\\mid z_{ij}\\approx\\pi(C_i,P_j)\\}.\n",
+    "$$\n",
+    "\n",
+    "The point $P_j$ participates in bundle adjustment, while its red–green–blue (**RGB**) color is optional display metadata and does not enter the objective."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "sfmtrack-guide-1",
    "metadata": {},
    "source": [
     "## Relationship to `SfmTrack2d`\n",
     "\n",
-    "`SfmTrack` inherits the observation list from `SfmTrack2d` and adds the current landmark estimate `p`. The color fields `r`, `g`, and `b` are floating-point metadata and do not affect optimization."
+    "`SfmTrack2d` stores image measurements and camera indices before a landmark has been reconstructed. `SfmTrack` inherits that observation list and adds the current landmark estimate `p`. The color fields `r`, `g`, and `b` are floating-point metadata and do not affect optimization."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "sfmtrack-guide-2",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-21T17:16:49.025386Z",
-     "iopub.status.busy": "2026-08-21T17:16:49.024142Z",
-     "iopub.status.idle": "2026-08-21T17:16:49.030046Z",
-     "shell.execute_reply": "2026-08-21T17:16:49.028853Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "point: [ 0.5 -0.2  4. ]\n",
-      "RGB: (0.800000011920929, 0.4000000059604645, 0.10000000149011612)\n",
-      "observed by cameras: [0 1]\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
+    "measurements = [\n",
+    "    (0, np.array([382.5, 215.0])),\n",
+    "    (1, np.array([350.1, 214.8])),\n",
+    "]\n",
+    "observations = gtsam.SfmTrack2d(measurements)\n",
+    "assert observations.numberMeasurements() == 2\n",
+    "print(\"2D measurements:\\n\", observations.measurementMatrix())\n",
+    "\n",
     "track = gtsam.SfmTrack(np.array([0.5, -0.2, 4.0]), 0.8, 0.4, 0.1)\n",
     "track.addMeasurement(0, np.array([382.5, 215.0]))\n",
     "track.addMeasurement(1, np.array([350.1, 214.8]))\n",

--- a/gtsam/sfm/doc/ShonanAveraging.ipynb
+++ b/gtsam/sfm/doc/ShonanAveraging.ipynb
@@ -39,23 +39,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "243445de",
-   "metadata": {},
-   "source": [
-    "## Mathematical idea\n",
-    "\n",
-    "Rotation averaging seeks absolute rotations whose relative rotations agree with measurements:\n",
-    "\n",
-    "$$\n",
-    "\\min_{R_i\\in\\mathrm{SO}(d)}\\sum_{(i,j)}\n",
-    "\\left\\lVert R_iR_{ij}-R_j\\right\\rVert_F^2.\n",
-    "$$\n",
-    "\n",
-    "$\\mathrm{SO}(d)$ is the special orthogonal group. Shonan averaging lifts the problem from $\\mathrm{SO}(d)$ to successively larger $\\mathrm{SO}(p)$ manifolds, searches for a certifiable optimum, and rounds the lifted solution back to dimension $d$."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "shonanaveraging-colab-install",
@@ -107,6 +90,23 @@
   },
   {
    "cell_type": "markdown",
+   "id": "243445de",
+   "metadata": {},
+   "source": [
+    "## Mathematical idea\n",
+    "\n",
+    "Rotation averaging seeks absolute rotations whose relative rotations agree with measurements:\n",
+    "\n",
+    "$$\n",
+    "\\min_{R_i\\in\\mathrm{SO}(d)}\\sum_{(i,j)}\n",
+    "\\left\\lVert R_iR_{ij}-R_j\\right\\rVert_F^2.\n",
+    "$$\n",
+    "\n",
+    "$\\mathrm{SO}(d)$ is the special orthogonal group. Shonan averaging lifts the problem from $\\mathrm{SO}(d)$ to successively larger $\\mathrm{SO}(p)$ manifolds, searches for a certifiable optimum, and rounds the lifted solution back to dimension $d$."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "shonanaveraging-guide-1",
    "metadata": {},
    "source": [
@@ -122,22 +122,98 @@
    "id": "shonanaveraging-guide-2",
    "metadata": {},
    "source": [
-    "## C++ sketch\n",
+    "## Configure the staircase\n",
     "\n",
-    "~~~cpp\n",
-    "#include <gtsam/sfm/ShonanAveraging.h>\n",
+    "Python exposes dimension-specific parameter classes. Both wrap ordinary `LevenbergMarquardtParams` and add anchoring, robust-loss, and optimality-certificate controls. Robust loss and optimality certification are alternative modes: disable Huber loss before requesting a certificate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "shonanaveraging-parameters",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lm = gtsam.LevenbergMarquardtParams()\n",
+    "lm.setMaxIterations(100)\n",
     "\n",
-    "using namespace gtsam;\n",
+    "parameters2 = gtsam.ShonanAveragingParameters2(lm)\n",
+    "parameters3 = gtsam.ShonanAveragingParameters3(lm)\n",
+    "parameters3.setAnchor(0, gtsam.Rot3())\n",
+    "parameters3.setUseHuber(True)\n",
+    "assert parameters3.getAnchor()[0] == 0\n",
+    "assert parameters3.getUseHuber()\n",
+    "parameters3.setUseHuber(False)\n",
+    "parameters3.setCertifyOptimality(True)\n",
+    "print(\"3D certification enabled:\", parameters3.getCertifyOptimality())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "shonanaveraging-2d-heading",
+   "metadata": {},
+   "source": [
+    "## Planar rotation averaging\n",
     "\n",
-    "ShonanAveragingParameters<3> parameters;\n",
-    "ShonanAveraging<3>::Measurements measurements = /* relative Rot3 edges */;\n",
-    "ShonanAveraging<3> shonan(measurements, parameters);\n",
+    "`ShonanAveraging2` accepts planar pose-between factors and returns `Rot2` values at the original keys. Only the rotational part of each pose measurement contributes to the objective."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "shonanaveraging-2d-example",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pose_noise = gtsam.noiseModel.Diagonal.Sigmas(np.array([0.1, 0.1, 0.05]))\n",
+    "planar_measurements = [\n",
+    "    gtsam.BetweenFactorPose2(0, 1, gtsam.Pose2(1.0, 0.0, 0.2), pose_noise),\n",
+    "    gtsam.BetweenFactorPose2(1, 2, gtsam.Pose2(1.0, 0.0, -0.1), pose_noise),\n",
+    "    gtsam.BetweenFactorPose2(0, 2, gtsam.Pose2(2.0, 0.0, 0.1), pose_noise),\n",
+    "]\n",
+    "shonan2 = gtsam.ShonanAveraging2(planar_measurements, parameters2)\n",
+    "rotations2, certificate2 = shonan2.run(2, 5)\n",
     "\n",
-    "auto [rotations, certificate] = shonan.run(/* minP = */ 3,\n",
-    "                                           /* maxP = */ 10);\n",
-    "~~~\n",
+    "assert shonan2.numberMeasurements() == 3\n",
+    "print(\"R(2) angle:\", rotations2.atRot2(2).theta())\n",
+    "print(\"2D certificate:\", certificate2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "shonanaveraging-3d-heading",
+   "metadata": {},
+   "source": [
+    "## Spatial rotation averaging\n",
     "\n",
-    "In ordinary code prefer `ShonanAveraging3`, which provides the same main API and stable explicit template instantiation."
+    "`ShonanAveraging3` accepts `BinaryMeasurementRot3` or `BetweenFactorPose3` measurements. The returned `Values` contains `Rot3` estimates; the scalar reports the staircase certificate quantity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "shonanaveraging-3d-example",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rotation_noise = gtsam.noiseModel.Isotropic.Sigma(3, 0.05)\n",
+    "spatial_measurements = [\n",
+    "    gtsam.BinaryMeasurementRot3(\n",
+    "        0, 1, gtsam.Rot3.RzRyRx(0.1, 0.0, 0.0), rotation_noise\n",
+    "    ),\n",
+    "    gtsam.BinaryMeasurementRot3(\n",
+    "        1, 2, gtsam.Rot3.RzRyRx(0.0, -0.1, 0.0), rotation_noise\n",
+    "    ),\n",
+    "    gtsam.BinaryMeasurementRot3(\n",
+    "        0, 2, gtsam.Rot3.RzRyRx(0.1, -0.1, 0.0), rotation_noise\n",
+    "    ),\n",
+    "]\n",
+    "shonan3 = gtsam.ShonanAveraging3(spatial_measurements, parameters3)\n",
+    "rotations3, certificate3 = shonan3.run(3, 6)\n",
+    "\n",
+    "assert shonan3.numberMeasurements() == 3\n",
+    "print(\"R(2):\\n\", rotations3.atRot3(2).matrix())\n",
+    "print(\"3D certificate:\", certificate3)"
    ]
   },
   {

--- a/gtsam/sfm/doc/ShonanFactor.ipynb
+++ b/gtsam/sfm/doc/ShonanFactor.ipynb
@@ -39,22 +39,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "9059e377",
-   "metadata": {},
-   "source": [
-    "## Mathematical idea\n",
-    "\n",
-    "At relaxation level $p$, each variable $Q_i\\in\\mathrm{SO}(p)$ projects to its first $d$ columns, $Y_i=Q_i[:,1\\!:\\!d]$. A relative rotation $R_{ij}\\in\\mathrm{SO}(d)$ gives the lifted residual\n",
-    "\n",
-    "$$\n",
-    "r_{ij}=\\operatorname{vec}(Y_iR_{ij}-Y_j).\n",
-    "$$\n",
-    "\n",
-    "Here $\\mathrm{SO}(p)$ is the special orthogonal group and the projected matrices $Y_i$ lie on a Stiefel manifold."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "shonanfactor-colab-install",
@@ -102,6 +86,22 @@
     "P = symbol_shorthand.P\n",
     "S = symbol_shorthand.S\n",
     "X = symbol_shorthand.X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9059e377",
+   "metadata": {},
+   "source": [
+    "## Mathematical idea\n",
+    "\n",
+    "At relaxation level $p$, each variable $Q_i\\in\\mathrm{SO}(p)$ projects to its first $d$ columns, $Y_i=Q_i[:,1\\!:\\!d]$. A relative rotation $R_{ij}\\in\\mathrm{SO}(d)$ gives the lifted residual\n",
+    "\n",
+    "$$\n",
+    "r_{ij}=\\operatorname{vec}(Y_iR_{ij}-Y_j).\n",
+    "$$\n",
+    "\n",
+    "Here $\\mathrm{SO}(p)$ is the special orthogonal group and the projected matrices $Y_i$ lie on a Stiefel manifold."
    ]
   },
   {

--- a/gtsam/sfm/doc/TrajectoryAlignerSim3.ipynb
+++ b/gtsam/sfm/doc/TrajectoryAlignerSim3.ipynb
@@ -39,22 +39,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "6abc29a9",
-   "metadata": {},
-   "source": [
-    "## Mathematical idea\n",
-    "\n",
-    "A three-dimensional similarity transform $S=(s,R,t)\\in\\mathrm{Sim}(3)$ maps a child position $p_k^c$ to its parent frame by\n",
-    "\n",
-    "$$\n",
-    "p_k^p\\approx sRp_k^c+t.\n",
-    "$$\n",
-    "\n",
-    "$\\mathrm{Sim}(3)$ denotes rotation, translation, and uniform scale. Pose orientation residuals additionally compare the rotated child orientation with the parent orientation. Graduated Non-Convexity (**GNC**) can down-weight mismatched correspondences."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "trajectoryalignersim3-colab-install",
@@ -102,6 +86,22 @@
     "P = symbol_shorthand.P\n",
     "S = symbol_shorthand.S\n",
     "X = symbol_shorthand.X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6abc29a9",
+   "metadata": {},
+   "source": [
+    "## Mathematical idea\n",
+    "\n",
+    "A three-dimensional similarity transform $S=(s,R,t)\\in\\mathrm{Sim}(3)$ maps a child position $p_k^c$ to its parent frame by\n",
+    "\n",
+    "$$\n",
+    "p_k^p\\approx sRp_k^c+t.\n",
+    "$$\n",
+    "\n",
+    "$\\mathrm{Sim}(3)$ denotes rotation, translation, and uniform scale. Pose orientation residuals additionally compare the rotated child orientation with the parent orientation. Graduated Non-Convexity (**GNC**) can down-weight mismatched correspondences."
    ]
   },
   {

--- a/gtsam/sfm/doc/TransferFactor.ipynb
+++ b/gtsam/sfm/doc/TransferFactor.ipynb
@@ -39,24 +39,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "59088215",
-   "metadata": {},
-   "source": [
-    "## Mathematical idea\n",
-    "\n",
-    "Two observations predict epipolar lines in their shared target view,\n",
-    "\n",
-    "$$\n",
-    "\\ell_c^{(a)}=F_{ca}\\tilde p_a,\n",
-    "\\qquad\n",
-    "\\ell_c^{(b)}=F_{cb}\\tilde p_b.\n",
-    "$$\n",
-    "\n",
-    "Their homogeneous intersection is $\\hat p_c\\propto\\ell_c^{(a)}\\times\\ell_c^{(b)}$. After dehomogenization, the factor returns $\\hat p_c-p_c$; stacking $N$ triplets produces a $2N$-dimensional residual."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "transferfactor-colab-install",
@@ -108,6 +90,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "59088215",
+   "metadata": {},
+   "source": [
+    "## Mathematical idea\n",
+    "\n",
+    "Two observations predict epipolar lines in their shared target view,\n",
+    "\n",
+    "$$\n",
+    "\\ell_c^{(a)}=F_{ca}\\tilde p_a,\n",
+    "\\qquad\n",
+    "\\ell_c^{(b)}=F_{cb}\\tilde p_b.\n",
+    "$$\n",
+    "\n",
+    "Their homogeneous intersection is $\\hat p_c\\propto\\ell_c^{(a)}\\times\\ell_c^{(b)}$. After dehomogenization, the factor returns $\\hat p_c-p_c$; stacking $N$ triplets produces a $2N$-dimensional residual."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "transferfactor-guide-1",
    "metadata": {},
    "source": [
@@ -115,31 +115,15 @@
     "\n",
     "For each `(p_a, p_b, p_c)` triplet, the factor intersects the two epipolar lines transferred from views `a` and `b` into their shared view `c`, then compares the result with observed `p_c`. The residual dimension is `2N` for `N` triplets; the noise model must have the same dimension.\n",
     "\n",
-    "Python exposes `TransferFactorFundamentalMatrix` and `TransferFactorSimpleFundamentalMatrix`."
+    "Python exposes `TransferFactorFundamentalMatrix` and `TransferFactorSimpleFundamentalMatrix`. When intrinsics are known, `EssentialTransferFactor` stores a fixed calibration with the factor. `EssentialTransferFactorK` instead treats calibration as an optimized variable. The calibration template has concrete `Cal3_S2`, `Cal3f`, and `Cal3Bundler` variants; the example uses the representative `Cal3_S2` forms."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "transferfactor-guide-2",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-21T17:16:58.911734Z",
-     "iopub.status.busy": "2026-08-21T17:16:58.911455Z",
-     "iopub.status.idle": "2026-08-21T17:16:58.915360Z",
-     "shell.execute_reply": "2026-08-21T17:16:58.914730Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "factor keys: [2, 4294967298]\n",
-      "residual dimension: 2\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "edge_ac = gtsam.EdgeKey(0, 2)\n",
     "edge_bc = gtsam.EdgeKey(1, 2)\n",
@@ -152,7 +136,18 @@
     "    edge_ac, edge_bc, triplets, model\n",
     ")\n",
     "print(\"factor keys:\", factor.keys())\n",
-    "print(\"residual dimension:\", factor.dim())"
+    "print(\"residual dimension:\", factor.dim())\n",
+    "\n",
+    "calibration = gtsam.Cal3_S2(500.0, 500.0, 0.0, 320.0, 240.0)\n",
+    "fixed_calibration = gtsam.EssentialTransferFactorCal3_S2(\n",
+    "    edge_ac, edge_bc, triplets, calibration, model\n",
+    ")\n",
+    "variable_calibration = gtsam.EssentialTransferFactorKCal3_S2(\n",
+    "    edge_ac, edge_bc, K(0), triplets, model\n",
+    ")\n",
+    "assert fixed_calibration.dim() == variable_calibration.dim() == 2\n",
+    "print(\"fixed-calibration keys:\", fixed_calibration.keys())\n",
+    "print(\"variable-calibration keys:\", variable_calibration.keys())"
    ]
   },
   {

--- a/gtsam/sfm/doc/TranslationRecovery.ipynb
+++ b/gtsam/sfm/doc/TranslationRecovery.ipynb
@@ -39,22 +39,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "ba957749",
-   "metadata": {},
-   "source": [
-    "## Mathematical idea\n",
-    "\n",
-    "Translation recovery minimizes direction residuals over positions $T_i$. With the Bilinear Angle-based Translation Averaging (**BATA**) option, each edge contributes\n",
-    "\n",
-    "$$\n",
-    "r_{ij}=|s_{ij}|(T_j-T_i)-u_{ij};\n",
-    "$$\n",
-    "\n",
-    "the chordal option instead normalizes $T_j-T_i$. Fixing one position removes the translation gauge, while a known baseline or metric measurement fixes global scale."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "translationrecovery-colab-install",
@@ -102,6 +86,22 @@
     "P = symbol_shorthand.P\n",
     "S = symbol_shorthand.S\n",
     "X = symbol_shorthand.X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba957749",
+   "metadata": {},
+   "source": [
+    "## Mathematical idea\n",
+    "\n",
+    "Translation recovery minimizes direction residuals over positions $T_i$. With the Bilinear Angle-based Translation Averaging (**BATA**) option, each edge contributes\n",
+    "\n",
+    "$$\n",
+    "r_{ij}=|s_{ij}|(T_j-T_i)-u_{ij};\n",
+    "$$\n",
+    "\n",
+    "the chordal option instead normalizes $T_j-T_i$. Fixing one position removes the translation gauge, while a known baseline or metric measurement fixes global scale."
    ]
   },
   {

--- a/gtsam/sfm/doc/UnaryMeasurement.ipynb
+++ b/gtsam/sfm/doc/UnaryMeasurement.ipynb
@@ -39,22 +39,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "cafdd716",
-   "metadata": {},
-   "source": [
-    "## Mathematical idea\n",
-    "\n",
-    "A unary measurement record packages a key, typed observation, and covariance,\n",
-    "\n",
-    "$$\n",
-    "(i,z_i,\\Sigma_i).\n",
-    "$$\n",
-    "\n",
-    "It is intentionally model-free: a consumer may later define a residual such as $h(x_i)-z_i$, but the record itself stores no prediction function and contributes no optimization error."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "unarymeasurement-colab-install",
@@ -102,6 +86,22 @@
     "P = symbol_shorthand.P\n",
     "S = symbol_shorthand.S\n",
     "X = symbol_shorthand.X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cafdd716",
+   "metadata": {},
+   "source": [
+    "## Mathematical idea\n",
+    "\n",
+    "A unary measurement record packages a key, typed observation, and covariance,\n",
+    "\n",
+    "$$\n",
+    "(i,z_i,\\Sigma_i).\n",
+    "$$\n",
+    "\n",
+    "It is intentionally model-free: a consumer may later define a residual such as $h(x_i)-z_i$, but the record itself stores no prediction function and contributes no optimization error."
    ]
   },
   {

--- a/gtsam/slam/doc/FrobeniusFactor.ipynb
+++ b/gtsam/slam/doc/FrobeniusFactor.ipynb
@@ -6,7 +6,7 @@
         "id": "gtsam_slam_doc_frobeniusfactor__intro_md"
       },
       "source": [
-        "# Frobenius Norm Factors"
+        "# FrobeniusFactor\n"
       ]
     },
     {
@@ -19,28 +19,6 @@
       },
       "source": [
         "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_slam_doc_frobeniusfactor__desc_md"
-      },
-      "source": [
-        "This header defines factors that operate directly on the entries of rotation matrices (`Rot3` or generally `SO(n)`) rather than using their Lie algebra representation (log map). They minimize the Frobenius norm of the difference between rotation matrices.\n",
-        "\n",
-        "These factors can sometimes be useful in specific optimization contexts, particularly in rotation averaging problems or as alternatives to standard `BetweenFactor` or `PriorFactor` on rotations.\n",
-        "\n",
-        "* `FrobeniusPrior<T>`: Penalizes the Frobenius norm difference between a variable rotation `T` and a fixed target matrix `M`. Error is $||T - M||_F^2$.\n",
-        "* `FrobeniusFactor<T>`: Penalizes the Frobenius norm difference between two variable rotations `T1` and `T2`. Error is $||T_1 - T_2||_F^2$.\n",
-        "* `FrobeniusBetweenFactorNL<T>`: Penalizes the Frobenius norm difference between the predicted measurement `T2^{-1} * T1` and the actual measurement `T12_measured`. Error is $||I - T_2^{-1} T_1 \\cdot \\tilde T_{12}||_F^2$. Use this with *any* Matrix Lie group.\n",
-        "* `FrobeniusBetweenFactor<T>`: Penalizes the Frobenius norm difference between the predicted rotation `T2` and the expected rotation `T1 * T12_measured`. Error is $||T_1 \\cdot \\tilde T_{12} - T_2||_F^2$. Uses this - easier to optimize factor - if the norm is invariant to multiplying with T2, as is the case for `Rot3`, `Pose3`, etc, but not, say, `Similarity3`. \n",
-        "* `FrobeniusLeftBetweenFactor<T>`: Penalizes $||T^i_w-T^i_j T^j_w||_F^2$ for inverse states and a measured left-composed transform `iTj`. It provides the exact D=1 QCQP relative-pose cost used by certifiable localization.\n",
-        "\n",
-        "The helper function function `ConvertModel` ensures the noise model used by the various Frobenius factors has the correct dimension. You can either provide:\n",
-        "  - an isotropic noise model of the manifold dimension of the type T (e.g., 3 for Rot3)\n",
-        "  - any noise model of the full vectorized matrix dimension (N*N, where N is the matrix size, e.g., 9 for Rot3).\n",
-        "  -  If you provide an isotropic model of the manifold dimension, ConvertModel will automatically convert it to the correct dimension for the Frobenius factor."
       ]
     },
     {
@@ -89,6 +67,28 @@
         "\n",
         "X = symbol_shorthand.X\n",
         "R = symbol_shorthand.R # Using 'R' for Rot3 keys"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gtsam_slam_doc_frobeniusfactor__desc_md"
+      },
+      "source": [
+        "This header defines factors that operate directly on the entries of rotation matrices (`Rot3` or generally `SO(n)`) rather than using their Lie algebra representation (log map). They minimize the Frobenius norm of the difference between rotation matrices.\n",
+        "\n",
+        "These factors can sometimes be useful in specific optimization contexts, particularly in rotation averaging problems or as alternatives to standard `BetweenFactor` or `PriorFactor` on rotations.\n",
+        "\n",
+        "* `FrobeniusPrior<T>`: Penalizes the Frobenius norm difference between a variable rotation `T` and a fixed target matrix `M`. Error is $||T - M||_F^2$.\n",
+        "* `FrobeniusFactor<T>`: Penalizes the Frobenius norm difference between two variable rotations `T1` and `T2`. Error is $||T_1 - T_2||_F^2$.\n",
+        "* `FrobeniusBetweenFactorNL<T>`: Penalizes the Frobenius norm difference between the predicted measurement `T2^{-1} * T1` and the actual measurement `T12_measured`. Error is $||I - T_2^{-1} T_1 \\cdot \\tilde T_{12}||_F^2$. Use this with *any* Matrix Lie group.\n",
+        "* `FrobeniusBetweenFactor<T>`: Penalizes the Frobenius norm difference between the predicted rotation `T2` and the expected rotation `T1 * T12_measured`. Error is $||T_1 \\cdot \\tilde T_{12} - T_2||_F^2$. Uses this - easier to optimize factor - if the norm is invariant to multiplying with T2, as is the case for `Rot3`, `Pose3`, etc, but not, say, `Similarity3`. \n",
+        "* `FrobeniusLeftBetweenFactor<T>`: Penalizes $||T^i_w-T^i_j T^j_w||_F^2$ for inverse states and a measured left-composed transform `iTj`. It provides the exact D=1 QCQP relative-pose cost used by certifiable localization.\n",
+        "\n",
+        "The helper function function `ConvertModel` ensures the noise model used by the various Frobenius factors has the correct dimension. You can either provide:\n",
+        "  - an isotropic noise model of the manifold dimension of the type T (e.g., 3 for Rot3)\n",
+        "  - any noise model of the full vectorized matrix dimension (N*N, where N is the matrix size, e.g., 9 for Rot3).\n",
+        "  -  If you provide an isotropic model of the manifold dimension, ConvertModel will automatically convert it to the correct dimension for the Frobenius factor."
       ]
     },
     {

--- a/gtsam/slam/doc/GeneralSFMFactor.ipynb
+++ b/gtsam/slam/doc/GeneralSFMFactor.ipynb
@@ -24,28 +24,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "gtsam_slam_doc_generalsfmfactor__desc_md"
-      },
-      "source": [
-        "This header defines factors for Structure from Motion (SfM) problems where camera calibration might be unknown or optimized alongside pose and structure.\n",
-        "\n",
-        "`GeneralSFMFactor<CAMERA, LANDMARK>`:\n",
-        "- A binary factor connecting a `CAMERA` variable and a `LANDMARK` variable.\n",
-        "- Represents the reprojection error of the `LANDMARK` into the `CAMERA` view, compared to a 2D `measured_` pixel coordinate.\n",
-        "- The `CAMERA` type encapsulates both pose and calibration (e.g., `PinholeCamera<Cal3Bundler>`).\n",
-        "- Error: `camera.project(landmark) - measured`\n",
-        "\n",
-        "`GeneralSFMFactor2<CALIBRATION>`:\n",
-        "- A ternary factor connecting a `Pose3` variable, a `Point3` landmark variable, and a `CALIBRATION` variable.\n",
-        "- This explicitly separates the camera pose and calibration into different variables.\n",
-        "- Error: `PinholeCamera<CALIBRATION>(pose, calibration).project(landmark) - measured`\n",
-        "\n",
-        "These factors are core components for visual SLAM or SfM systems where calibration is refined or initially unknown."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "gtsam_slam_doc_generalsfmfactor__colab_badge_md"
       },
       "source": [
@@ -84,6 +62,28 @@
         "L = symbol_shorthand.L\n",
         "K = symbol_shorthand.K\n",
         "C = symbol_shorthand.C # For Camera variable"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gtsam_slam_doc_generalsfmfactor__desc_md"
+      },
+      "source": [
+        "This header defines factors for Structure from Motion (SfM) problems where camera calibration might be unknown or optimized alongside pose and structure.\n",
+        "\n",
+        "`GeneralSFMFactor<CAMERA, LANDMARK>`:\n",
+        "- A binary factor connecting a `CAMERA` variable and a `LANDMARK` variable.\n",
+        "- Represents the reprojection error of the `LANDMARK` into the `CAMERA` view, compared to a 2D `measured_` pixel coordinate.\n",
+        "- The `CAMERA` type encapsulates both pose and calibration (e.g., `PinholeCamera<Cal3Bundler>`).\n",
+        "- Error: `camera.project(landmark) - measured`\n",
+        "\n",
+        "`GeneralSFMFactor2<CALIBRATION>`:\n",
+        "- A ternary factor connecting a `Pose3` variable, a `Point3` landmark variable, and a `CALIBRATION` variable.\n",
+        "- This explicitly separates the camera pose and calibration into different variables.\n",
+        "- Error: `PinholeCamera<CALIBRATION>(pose, calibration).project(landmark) - measured`\n",
+        "\n",
+        "These factors are core components for visual SLAM or SfM systems where calibration is refined or initially unknown."
       ]
     },
     {

--- a/gtsam/slam/doc/InitializePose3.ipynb
+++ b/gtsam/slam/doc/InitializePose3.ipynb
@@ -24,25 +24,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "gtsam_slam_doc_initializepose3__desc_md"
-      },
-      "source": [
-        "The `InitializePose3` structure provides static methods for computing an initial estimate for 3D poses (`Pose3`) in a factor graph, particularly useful for Structure from Motion (SfM) or SLAM problems.\n",
-        "The core idea is to first estimate the orientations (`Rot3`) independently and then use these estimates to initialize a linear system for the translations.\n",
-        "\n",
-        "Key static methods:\n",
-        "*   `buildPose3graph(graph)`: Extracts the subgraph containing only `Pose3` `BetweenFactor` and `PriorFactor` constraints from a larger `NonlinearFactorGraph`.\n",
-        "*   `computeOrientationsChordal(pose3Graph)`: Estimates rotations using chordal relaxation on the rotation constraints.\n",
-        "*   `computeOrientationsGradient(pose3Graph, initialGuess)`: Estimates rotations using gradient descent on the manifold.\n",
-        "*   `initializeOrientations(graph)`: Convenience function combining `buildPose3graph` and `computeOrientationsChordal`.\n",
-        "*   `computePoses(initialRot, poseGraph)`: Computes translations given estimated rotations by solving a linear system (performing one Gauss-Newton iteration on poses).\n",
-        "*   `initialize(graph)`: Performs the full initialization pipeline (extract graph, estimate rotations via chordal, compute translations).\n",
-        "*   `initialize(graph, givenGuess, useGradient)`: Full pipeline allowing specification of an initial guess and choosing between chordal or gradient descent for rotations."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "gtsam_slam_doc_initializepose3__colab_badge_md"
       },
       "source": [
@@ -78,6 +59,25 @@
         "from gtsam import symbol_shorthand\n",
         "\n",
         "X = symbol_shorthand.X"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gtsam_slam_doc_initializepose3__desc_md"
+      },
+      "source": [
+        "The `InitializePose3` structure provides static methods for computing an initial estimate for 3D poses (`Pose3`) in a factor graph, particularly useful for Structure from Motion (SfM) or SLAM problems.\n",
+        "The core idea is to first estimate the orientations (`Rot3`) independently and then use these estimates to initialize a linear system for the translations.\n",
+        "\n",
+        "Key static methods:\n",
+        "*   `buildPose3graph(graph)`: Extracts the subgraph containing only `Pose3` `BetweenFactor` and `PriorFactor` constraints from a larger `NonlinearFactorGraph`.\n",
+        "*   `computeOrientationsChordal(pose3Graph)`: Estimates rotations using chordal relaxation on the rotation constraints.\n",
+        "*   `computeOrientationsGradient(pose3Graph, initialGuess)`: Estimates rotations using gradient descent on the manifold.\n",
+        "*   `initializeOrientations(graph)`: Convenience function combining `buildPose3graph` and `computeOrientationsChordal`.\n",
+        "*   `computePoses(initialRot, poseGraph)`: Computes translations given estimated rotations by solving a linear system (performing one Gauss-Newton iteration on poses).\n",
+        "*   `initialize(graph)`: Performs the full initialization pipeline (extract graph, estimate rotations via chordal, compute translations).\n",
+        "*   `initialize(graph, givenGuess, useGradient)`: Full pipeline allowing specification of an initial guess and choosing between chordal or gradient descent for rotations."
       ]
     },
     {

--- a/gtsam/slam/doc/JacobianFactorQ.ipynb
+++ b/gtsam/slam/doc/JacobianFactorQ.ipynb
@@ -1,0 +1,186 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "jacobianfactorq-intro",
+   "metadata": {},
+   "source": [
+    "# JacobianFactorQ\n",
+    "\n",
+    "A `JacobianFactorQ` is one of the specialized Jacobian factor classes used internally by smart factors. It represents the orthogonal null-space projection produced when a smart projection factor eliminates its landmark."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "jacobianfactorq-copyright",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "jacobianfactorq-colab-badge",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/slam/doc/JacobianFactorQ.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "jacobianfactorq-colab-install",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "jacobianfactorq-imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "\n",
+    "from gtsam.symbol_shorthand import X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "jacobianfactorq-role",
+   "metadata": {},
+   "source": [
+    "## Obtain one from a smart factor\n",
+    "\n",
+    "A `JacobianFactorQ` is normally returned by smart-factor linearization rather than constructed directly. We create two calibrated cameras, add their measurements of one landmark to a smart projection factor, and call `createJacobianQFactor()` to eliminate the landmark. Because each camera has an 11-dimensional tangent vector, this example returns `JacobianFactorQ112`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "jacobianfactorq-example",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "type: JacobianFactorQ112\n",
+      "keys: [8646911284551352320, 8646911284551352321]\n",
+      "A shape: (4, 22)\n",
+      "b shape: (4,)\n"
+     ]
+    }
+   ],
+   "source": [
+    "calibration = gtsam.Cal3_S2(500.0, 500.0, 0.0, 320.0, 240.0)\n",
+    "cameras = [\n",
+    "    gtsam.PinholeCameraCal3_S2(gtsam.Pose3(), calibration),\n",
+    "    gtsam.PinholeCameraCal3_S2(\n",
+    "        gtsam.Pose3(gtsam.Rot3(), np.array([1.0, 0.0, 0.0])),\n",
+    "        calibration,\n",
+    "    ),\n",
+    "]\n",
+    "landmark = np.array([0.0, 0.0, 5.0])\n",
+    "factor = gtsam.SmartProjectionFactorPinholeCameraCal3_S2(\n",
+    "    gtsam.noiseModel.Isotropic.Sigma(2, 1.0)\n",
+    ")\n",
+    "values = gtsam.Values()\n",
+    "for index, camera in enumerate(cameras):\n",
+    "    factor.add(camera.project(landmark), X(index))\n",
+    "    values.insert(X(index), camera)\n",
+    "\n",
+    "jacobian = factor.createJacobianQFactor(values, 0.0)\n",
+    "assert isinstance(jacobian, gtsam.JacobianFactorQ112)\n",
+    "print(\"type:\", type(jacobian).__name__)\n",
+    "print(\"keys:\", jacobian.keys())\n",
+    "print(\"A shape:\", jacobian.getA().shape)\n",
+    "print(\"b shape:\", jacobian.getb().shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "jacobianfactorq-methods",
+   "metadata": {},
+   "source": [
+    "## Inspect the projected linear system\n",
+    "\n",
+    "The returned object behaves like any other `JacobianFactor`. `keys()` identifies the camera variables, while `getA()` and `getb()` expose the whitened linear system. The dimension checks below show how the two camera blocks appear in the matrix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "jacobianfactorq-dimensions",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert jacobian.rows() == jacobian.getA().shape[0]\n",
+    "assert jacobian.getA().shape[1] == 11 * len(cameras)\n",
+    "assert jacobian.getb().shape == (jacobian.rows(),)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "jacobianfactorq-links",
+   "metadata": {},
+   "source": [
+    "## When to use it\n",
+    "\n",
+    "`JacobianFactorQ` is an internal linear factor for smart factors. Most applications select the Jacobian-Q mode through [`SmartFactorParams`](SmartFactorParams.ipynb) and pass the returned factor to a Gaussian solver rather than manipulating it directly. [`SmartProjectionFactor`](SmartProjectionFactor.ipynb) shows the higher-level nonlinear factor.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`JacobianFactorQ.h`](../JacobianFactorQ.h)\n",
+    "\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/slam/doc/KarcherMeanFactor.ipynb
+++ b/gtsam/slam/doc/KarcherMeanFactor.ipynb
@@ -6,7 +6,7 @@
         "id": "gtsam_slam_doc_karchermeanfactor__intro_md"
       },
       "source": [
-        "# Karcher Mean Factors"
+        "# KarcherMeanFactor\n"
       ]
     },
     {
@@ -19,21 +19,6 @@
       },
       "source": [
         "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_slam_doc_karchermeanfactor__desc_md"
-      },
-      "source": [
-        "The [KarcherMeanFactor.h](https://github.com/borglab/gtsam/blob/develop/gtsam/slam/KarcherMeanFactor.h) header provides functionality related to computing and constraining the Karcher mean (or Fréchet mean) of a set of rotations or other manifold values.\n",
-        "The Karcher mean $\\bar{R}$ of a set of rotations $\\{R_i\\}$ is the rotation that minimizes the sum of squared geodesic distances on the manifold:\n",
-        "$$ \\bar{R} = \\arg \\min_R \\sum_i d^2(R, R_i) = \\arg \\min_R \\sum_i || \\text{Log}(R_i^{-1} R) ||^2 $$\n",
-        "\n",
-        "Functions/Classes:\n",
-        "*   `FindKarcherMean`: Computes the Karcher mean of a `std::vector` of rotations (or other suitable manifold type `T`). It solves the minimization problem above using a small internal optimization.\n",
-        "*   `KarcherMeanFactor<T>`: A factor that enforces a constraint related to the Karcher mean. It does *not* constrain the mean to a specific value. Instead, it acts as a gauge fixing constraint by ensuring that the *sum of tangent space updates* applied to the variables involved sums to zero. This effectively removes the rotational degree of freedom corresponding to simultaneously rotating all variables."
       ]
     },
     {
@@ -75,6 +60,21 @@
         "import numpy as np\n",
         "from gtsam import Rot3, FindKarcherMeanRot3, KarcherMeanFactorRot3, Values\n",
         "from gtsam.symbol_shorthand import R"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gtsam_slam_doc_karchermeanfactor__desc_md"
+      },
+      "source": [
+        "The [KarcherMeanFactor.h](https://github.com/borglab/gtsam/blob/develop/gtsam/slam/KarcherMeanFactor.h) header provides functionality related to computing and constraining the Karcher mean (or Fréchet mean) of a set of rotations or other manifold values.\n",
+        "The Karcher mean $\\bar{R}$ of a set of rotations $\\{R_i\\}$ is the rotation that minimizes the sum of squared geodesic distances on the manifold:\n",
+        "$$ \\bar{R} = \\arg \\min_R \\sum_i d^2(R, R_i) = \\arg \\min_R \\sum_i || \\text{Log}(R_i^{-1} R) ||^2 $$\n",
+        "\n",
+        "Functions/Classes:\n",
+        "*   `FindKarcherMean`: Computes the Karcher mean of a `std::vector` of rotations (or other suitable manifold type `T`). It solves the minimization problem above using a small internal optimization.\n",
+        "*   `KarcherMeanFactor<T>`: A factor that enforces a constraint related to the Karcher mean. It does *not* constrain the mean to a specific value. Instead, it acts as a gauge fixing constraint by ensuring that the *sum of tangent space updates* applied to the variables involved sums to zero. This effectively removes the rotational degree of freedom corresponding to simultaneously rotating all variables."
       ]
     },
     {

--- a/gtsam/slam/doc/KnownLandmarkFactor.ipynb
+++ b/gtsam/slam/doc/KnownLandmarkFactor.ipynb
@@ -5,7 +5,7 @@
    "id": "title",
    "metadata": {},
    "source": [
-    "# Known landmark factors\n",
+    "# KnownLandmarkFactor\n",
     "\n",
     "This guide explains how to use `KnownLandmarkFactor` and `KnownLandmarkFactor2` for localization against fixed landmarks. **Prefer `KnownLandmarkFactor` for normal GTSAM use.** It follows the conventional pose direction used throughout GTSAM. `KnownLandmarkFactor2` accepts the same physical measurement in the opposite state direction and is intended specifically for exact QCQP and certifiable optimization."
    ]

--- a/gtsam/slam/doc/OrientedPlane3Factor.ipynb
+++ b/gtsam/slam/doc/OrientedPlane3Factor.ipynb
@@ -6,7 +6,7 @@
         "id": "gtsam_slam_doc_orientedplane3factor__intro_md"
       },
       "source": [
-        "# OrientedPlane3 Factors"
+        "# OrientedPlane3Factor\n"
       ]
     },
     {
@@ -19,20 +19,6 @@
       },
       "source": [
         "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_slam_doc_orientedplane3factor__desc_md"
-      },
-      "source": [
-        "This header defines factors for working with planar landmarks represented by `gtsam.OrientedPlane3`.\n",
-        "`OrientedPlane3` represents a plane using normalized coefficients $(n_x, n_y, n_z, d)$, where $(n_x, n_y, n_z)$ is the unit normal vector and $d$ is the distance from the origin along the normal.\n",
-        "\n",
-        "Factors defined:\n",
-        "*   `OrientedPlane3Factor`: A binary factor connecting a `Pose3` and an `OrientedPlane3`. It measures the difference between the plane parameters as observed from the given pose and a measured plane.\n",
-        "*   `OrientedPlane3DirectionPrior`: A unary factor on an `OrientedPlane3`. It penalizes the difference between the plane's normal direction and a measured direction (represented by the normal of a measured `OrientedPlane3`). **Note:** The factor error is 3D, but only constrains 2 degrees of freedom (direction). Consider using a more specific direction factor if only direction is measured."
       ]
     },
     {
@@ -75,6 +61,20 @@
         "from gtsam import Pose3, OrientedPlane3, Point3, Rot3, Values\n",
         "from gtsam import OrientedPlane3Factor, OrientedPlane3DirectionPrior\n",
         "from gtsam.symbol_shorthand import X, P"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gtsam_slam_doc_orientedplane3factor__desc_md"
+      },
+      "source": [
+        "This header defines factors for working with planar landmarks represented by `gtsam.OrientedPlane3`.\n",
+        "`OrientedPlane3` represents a plane using normalized coefficients $(n_x, n_y, n_z, d)$, where $(n_x, n_y, n_z)$ is the unit normal vector and $d$ is the distance from the origin along the normal.\n",
+        "\n",
+        "Factors defined:\n",
+        "*   `OrientedPlane3Factor`: A binary factor connecting a `Pose3` and an `OrientedPlane3`. It measures the difference between the plane parameters as observed from the given pose and a measured plane.\n",
+        "*   `OrientedPlane3DirectionPrior`: A unary factor on an `OrientedPlane3`. It penalizes the difference between the plane's normal direction and a measured direction (represented by the normal of a measured `OrientedPlane3`). **Note:** The factor error is 3D, but only constrains 2 degrees of freedom (direction). Consider using a more specific direction factor if only direction is measured."
       ]
     },
     {

--- a/gtsam/slam/doc/PlanarProjectionFactor.ipynb
+++ b/gtsam/slam/doc/PlanarProjectionFactor.ipynb
@@ -24,27 +24,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "gtsam_slam_doc_planarprojectionfactor__desc_md"
-      },
-      "source": [
-        "The `PlanarProjectionFactor` variants provide camera projection factors specifically designed for scenarios where **the robot or camera moves primarily on a 2D plane** (e.g., ground robots with cameras).\n",
-        "They relate a 3D landmark point to a 2D pixel measurement observed by a camera, considering:\n",
-        "*   The robot's 2D pose (`Pose2` `wTb`: body in world frame) in the ground plane.\n",
-        "*   The camera's fixed 3D pose relative to the robot's body frame (`Pose3` `bTc`: body-to-camera).\n",
-        "*   The camera's intrinsic calibration (including distortion, typically `Cal3DS2` or similar).\n",
-        "*   The 3D landmark position in the world frame.\n",
-        "\n",
-        "The core projection logic involves converting the `Pose2` `wTb` to a `Pose3` assuming z=0 and yaw=theta, composing it with `bTc` to get the world-to-camera pose `wTc`, and then using a standard `PinholeCamera` model to project the landmark.\n",
-        "\n",
-        "Variants:\n",
-        "*   `PlanarProjectionFactor1`: Unknown is robot `Pose2` (`wTb`). Landmark, `bTc`, and calibration are fixed. Useful for localization.\n",
-        "*   `PlanarProjectionFactor2`: Unknowns are robot `Pose2` (`wTb`) and `Point3` landmark. `bTc` and calibration are fixed. Useful for planar SLAM.\n",
-        "*   `PlanarProjectionFactor3`: Unknowns are robot `Pose2` (`wTb`), camera offset `Pose3` (`bTc`), and `Cal3DS2` calibration. Landmark is fixed. Useful for calibration."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "gtsam_slam_doc_planarprojectionfactor__colab_badge_md"
       },
       "source": [
@@ -82,6 +61,27 @@
         "from gtsam import (Pose2, Pose3, Point3, Point2, Rot3, Cal3DS2, Values,\n",
         "                   PlanarProjectionFactor1, PlanarProjectionFactor2, PlanarProjectionFactor3)\n",
         "from gtsam.symbol_shorthand import X, L, C, O"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gtsam_slam_doc_planarprojectionfactor__desc_md"
+      },
+      "source": [
+        "The `PlanarProjectionFactor` variants provide camera projection factors specifically designed for scenarios where **the robot or camera moves primarily on a 2D plane** (e.g., ground robots with cameras).\n",
+        "They relate a 3D landmark point to a 2D pixel measurement observed by a camera, considering:\n",
+        "*   The robot's 2D pose (`Pose2` `wTb`: body in world frame) in the ground plane.\n",
+        "*   The camera's fixed 3D pose relative to the robot's body frame (`Pose3` `bTc`: body-to-camera).\n",
+        "*   The camera's intrinsic calibration (including distortion, typically `Cal3DS2` or similar).\n",
+        "*   The 3D landmark position in the world frame.\n",
+        "\n",
+        "The core projection logic involves converting the `Pose2` `wTb` to a `Pose3` assuming z=0 and yaw=theta, composing it with `bTc` to get the world-to-camera pose `wTc`, and then using a standard `PinholeCamera` model to project the landmark.\n",
+        "\n",
+        "Variants:\n",
+        "*   `PlanarProjectionFactor1`: Unknown is robot `Pose2` (`wTb`). Landmark, `bTc`, and calibration are fixed. Useful for localization.\n",
+        "*   `PlanarProjectionFactor2`: Unknowns are robot `Pose2` (`wTb`) and `Point3` landmark. `bTc` and calibration are fixed. Useful for planar SLAM.\n",
+        "*   `PlanarProjectionFactor3`: Unknowns are robot `Pose2` (`wTb`), camera offset `Pose3` (`bTc`), and `Cal3DS2` calibration. Landmark is fixed. Useful for calibration."
       ]
     },
     {

--- a/gtsam/slam/doc/PoseRotationPrior.ipynb
+++ b/gtsam/slam/doc/PoseRotationPrior.ipynb
@@ -24,21 +24,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "gtsam_slam_doc_poserotationprior__desc_md"
-      },
-      "source": [
-        "`PoseRotationPrior<POSE>` is a unary factor that applies a prior constraint only to the **rotation** component of a `POSE` variable (e.g., `Pose2` or `Pose3`).\n",
-        "It ignores the translation component of the pose variable during error calculation.\n",
-        "The error is calculated as the difference between the rotation component of the pose variable and the measured prior rotation, expressed in the tangent space of the rotation group.\n",
-        "\n",
-        "Error: $ \\text{Log}(\\text{measured}^{-1} \\cdot \\text{pose.rotation}()) $\n",
-        "\n",
-        "This is useful when you have information about the absolute orientation of a pose but little or no information about its translation."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "gtsam_slam_doc_poserotationprior__colab_badge_md"
       },
       "source": [
@@ -73,6 +58,21 @@
         "from gtsam import symbol_shorthand\n",
         "\n",
         "X = symbol_shorthand.X"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gtsam_slam_doc_poserotationprior__desc_md"
+      },
+      "source": [
+        "`PoseRotationPrior<POSE>` is a unary factor that applies a prior constraint only to the **rotation** component of a `POSE` variable (e.g., `Pose2` or `Pose3`).\n",
+        "It ignores the translation component of the pose variable during error calculation.\n",
+        "The error is calculated as the difference between the rotation component of the pose variable and the measured prior rotation, expressed in the tangent space of the rotation group.\n",
+        "\n",
+        "Error: $ \\text{Log}(\\text{measured}^{-1} \\cdot \\text{pose.rotation}()) $\n",
+        "\n",
+        "This is useful when you have information about the absolute orientation of a pose but little or no information about its translation."
       ]
     },
     {

--- a/gtsam/slam/doc/PoseTranslationPrior.ipynb
+++ b/gtsam/slam/doc/PoseTranslationPrior.ipynb
@@ -24,19 +24,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "gtsam_slam_doc_posetranslationprior__desc_md"
-      },
-      "source": [
-        "`PoseTranslationPrior<POSE>` is a unary factor that applies a prior constraint only to the **translation** component of a `POSE` variable (e.g., `Pose2` or `Pose3`).\n",
-        "It ignores the rotation component of the pose variable during error calculation.\n",
-        "The error is calculated as the difference between the translation component of the pose variable and the measured prior translation, expressed in the tangent space (which is typically just vector subtraction for `Point2` or `Point3`).\n",
-        "\n",
-        "This is useful when you have information about the absolute position of a pose but little or no information about its orientation (e.g., GPS measurement)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "gtsam_slam_doc_posetranslationprior__colab_badge_md"
       },
       "source": [
@@ -71,6 +58,19 @@
         "from gtsam import symbol_shorthand\n",
         "\n",
         "X = symbol_shorthand.X"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gtsam_slam_doc_posetranslationprior__desc_md"
+      },
+      "source": [
+        "`PoseTranslationPrior<POSE>` is a unary factor that applies a prior constraint only to the **translation** component of a `POSE` variable (e.g., `Pose2` or `Pose3`).\n",
+        "It ignores the rotation component of the pose variable during error calculation.\n",
+        "The error is calculated as the difference between the translation component of the pose variable and the measured prior translation, expressed in the tangent space (which is typically just vector subtraction for `Point2` or `Point3`).\n",
+        "\n",
+        "This is useful when you have information about the absolute position of a pose but little or no information about its orientation (e.g., GPS measurement)."
       ]
     },
     {

--- a/gtsam/slam/doc/ProjectionFactor.ipynb
+++ b/gtsam/slam/doc/ProjectionFactor.ipynb
@@ -6,7 +6,7 @@
         "id": "gtsam_slam_doc_projectionfactor__intro_md"
       },
       "source": [
-        "# GenericProjectionFactor"
+        "# ProjectionFactor\n"
       ]
     },
     {
@@ -19,26 +19,6 @@
       },
       "source": [
         "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_slam_doc_projectionfactor__desc_md"
-      },
-      "source": [
-        "`GenericProjectionFactor<POSE, LANDMARK, CALIBRATION>` is a versatile factor for monocular camera measurements.\n",
-        "It models the reprojection error between the predicted projection of a 3D `LANDMARK` (usually `Point3`) onto the image plane of a camera defined by `POSE` (usually `Pose3`) and `CALIBRATION` (e.g., `Cal3_S2`, `Cal3Bundler`, `Cal3DS2`), and a measured 2D pixel coordinate `measured_`.\n",
-        "\n",
-        "Key features:\n",
-        "- **Templated:** Works with different pose, landmark, and calibration types.\n",
-        "- **Fixed Calibration:** Assumes the `CALIBRATION` object (`K_`) is known and fixed (passed as a shared pointer).\n",
-        "- **Sensor Offset:** Optionally handles a fixed `body_P_sensor_` (`Pose3`) transform between the pose variable's frame (body) and the camera's sensor frame.\n",
-        "- **Cheirality Handling:** Can be configured to throw an exception or return a large error if the landmark projects behind the camera.\n",
-        "\n",
-        "The error is the 2D vector difference:\n",
-        "$$ \\text{error}(P, L) = \\text{project}(P \\cdot S, L) - z $$\n",
-        "where $P$ is the pose variable, $L$ is the landmark variable, $S$ is the optional `body_P_sensor` transform, `project` is the camera projection function including calibration, and $z$ is the `measured_` point."
       ]
     },
     {
@@ -81,6 +61,26 @@
         "\n",
         "X = symbol_shorthand.X\n",
         "L = symbol_shorthand.L"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gtsam_slam_doc_projectionfactor__desc_md"
+      },
+      "source": [
+        "`GenericProjectionFactor<POSE, LANDMARK, CALIBRATION>` is a versatile factor for monocular camera measurements.\n",
+        "It models the reprojection error between the predicted projection of a 3D `LANDMARK` (usually `Point3`) onto the image plane of a camera defined by `POSE` (usually `Pose3`) and `CALIBRATION` (e.g., `Cal3_S2`, `Cal3Bundler`, `Cal3DS2`), and a measured 2D pixel coordinate `measured_`.\n",
+        "\n",
+        "Key features:\n",
+        "- **Templated:** Works with different pose, landmark, and calibration types.\n",
+        "- **Fixed Calibration:** Assumes the `CALIBRATION` object (`K_`) is known and fixed (passed as a shared pointer).\n",
+        "- **Sensor Offset:** Optionally handles a fixed `body_P_sensor_` (`Pose3`) transform between the pose variable's frame (body) and the camera's sensor frame.\n",
+        "- **Cheirality Handling:** Can be configured to throw an exception or return a large error if the landmark projects behind the camera.\n",
+        "\n",
+        "The error is the 2D vector difference:\n",
+        "$$ \\text{error}(P, L) = \\text{project}(P \\cdot S, L) - z $$\n",
+        "where $P$ is the pose variable, $L$ is the landmark variable, $S$ is the optional `body_P_sensor` transform, `project` is the camera projection function including calibration, and $z$ is the `measured_` point."
       ]
     },
     {

--- a/gtsam/slam/doc/ReferenceFrameFactor.ipynb
+++ b/gtsam/slam/doc/ReferenceFrameFactor.ipynb
@@ -24,26 +24,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "gtsam_slam_doc_referenceframefactor__desc_md"
-      },
-      "source": [
-        "`ReferenceFrameFactor<POINT, TRANSFORM>` is a ternary factor used to relate landmark observations made in two different reference frames (e.g., from two different robots or two distinct SLAM sessions).\n",
-        "It connects:\n",
-        "1.  A landmark (`POINT`) expressed in a 'global' or common reference frame (`globalKey`).\n",
-        "2.  A transform (`TRANSFORM`) representing the pose of a 'local' frame relative to the 'global' frame (`transKey`). Typically `TRANSFORM = global_T_local`.\n",
-        "3.  The *same* landmark (`POINT`) expressed in the 'local' reference frame (`localKey`).\n",
-        "\n",
-        "The factor enforces the constraint that the globally expressed landmark, when transformed by the `global_T_local` transform, should match the locally expressed landmark.\n",
-        "The transformation logic depends on the specific `POINT` and `TRANSFORM` types and is handled by the `transform_point` helper function (which usually calls `Transform::transformFrom`).\n",
-        "\n",
-        "Error: $ \\text{Log}(\\text{local}^{-1} \\cdot \\text{transform\\_point}(\\text{trans}, \\text{global})) $\n",
-        "\n",
-        "This factor is crucial for multi-robot map merging or combining results from different SLAM sessions where common landmarks have been observed."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "gtsam_slam_doc_referenceframefactor__colab_badge_md"
       },
       "source": [
@@ -80,6 +60,26 @@
       "source": [
         "import gtsam\n",
         "print([k for k in gtsam.__dict__.keys() if \"ReferenceFrame\" in k])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gtsam_slam_doc_referenceframefactor__desc_md"
+      },
+      "source": [
+        "`ReferenceFrameFactor<POINT, TRANSFORM>` is a ternary factor used to relate landmark observations made in two different reference frames (e.g., from two different robots or two distinct SLAM sessions).\n",
+        "It connects:\n",
+        "1.  A landmark (`POINT`) expressed in a 'global' or common reference frame (`globalKey`).\n",
+        "2.  A transform (`TRANSFORM`) representing the pose of a 'local' frame relative to the 'global' frame (`transKey`). Typically `TRANSFORM = global_T_local`.\n",
+        "3.  The *same* landmark (`POINT`) expressed in the 'local' reference frame (`localKey`).\n",
+        "\n",
+        "The factor enforces the constraint that the globally expressed landmark, when transformed by the `global_T_local` transform, should match the locally expressed landmark.\n",
+        "The transformation logic depends on the specific `POINT` and `TRANSFORM` types and is handled by the `transform_point` helper function (which usually calls `Transform::transformFrom`).\n",
+        "\n",
+        "Error: $ \\text{Log}(\\text{local}^{-1} \\cdot \\text{transform\\_point}(\\text{trans}, \\text{global})) $\n",
+        "\n",
+        "This factor is crucial for multi-robot map merging or combining results from different SLAM sessions where common landmarks have been observed."
       ]
     },
     {

--- a/gtsam/slam/doc/RotateFactor.ipynb
+++ b/gtsam/slam/doc/RotateFactor.ipynb
@@ -6,7 +6,7 @@
         "id": "gtsam_slam_doc_rotatefactor__intro_md"
       },
       "source": [
-        "# Rotate Factors"
+        "# RotateFactor\n"
       ]
     },
     {
@@ -19,18 +19,6 @@
       },
       "source": [
         "GTSAM Copyright 2010-2022, Georgia Tech Research Corporation,\nAtlanta, Georgia 30332-0415\nAll Rights Reserved\n\nAuthors: Frank Dellaert, et al. (see THANKS for the full author list)\n\nSee LICENSE for the license information"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_slam_doc_rotatefactor__desc_md"
-      },
-      "source": [
-        "This header defines factors that constrain an unknown rotation (`Rot3`) based on how it transforms either full rotations or directions.\n",
-        "\n",
-        "*   `RotateFactor`: Relates two *incremental* rotations measured in different frames using an unknown rotation relating the frames. If $Z = R \\cdot P \\cdot R^T$, where $P = e^{[p]}$ and $Z = e^{[z]}$ are measured incremental rotations (expressed as angular velocity vectors $p$ and $z$), this factor constrains the unknown rotation $R$ such that $p = R z$. The error is $Rz - p$.\n",
-        "*   `RotateDirectionsFactor`: Relates two *directions* (unit vectors, `Unit3`) measured in different frames using an unknown rotation $R$ relating the frames. If $p_{world} = R \\cdot z_{body}$, this factor constrains $R$. The error is the angular difference between the predicted $R z_{body}$ and the measured $p_{world}$."
       ]
     },
     {
@@ -71,6 +59,18 @@
         "from gtsam import symbol_shorthand\n",
         "\n",
         "R = symbol_shorthand.R # For Rotation key"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gtsam_slam_doc_rotatefactor__desc_md"
+      },
+      "source": [
+        "This header defines factors that constrain an unknown rotation (`Rot3`) based on how it transforms either full rotations or directions.\n",
+        "\n",
+        "*   `RotateFactor`: Relates two *incremental* rotations measured in different frames using an unknown rotation relating the frames. If $Z = R \\cdot P \\cdot R^T$, where $P = e^{[p]}$ and $Z = e^{[z]}$ are measured incremental rotations (expressed as angular velocity vectors $p$ and $z$), this factor constrains the unknown rotation $R$ such that $p = R z$. The error is $Rz - p$.\n",
+        "*   `RotateDirectionsFactor`: Relates two *directions* (unit vectors, `Unit3`) measured in different frames using an unknown rotation $R$ relating the frames. If $p_{world} = R \\cdot z_{body}$, this factor constrains $R$. The error is the angular difference between the predicted $R z_{body}$ and the measured $p_{world}$."
       ]
     },
     {

--- a/gtsam/slam/doc/SmartFactorBase.ipynb
+++ b/gtsam/slam/doc/SmartFactorBase.ipynb
@@ -1,0 +1,194 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "smartfactorbase-intro",
+   "metadata": {},
+   "source": [
+    "# SmartFactorBase\n",
+    "\n",
+    "The `SmartFactorBase` class is an internal base class for wrapped smart projection factors. It provides their shared measurement and camera workflow."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "smartfactorbase-copyright",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "smartfactorbase-colab-badge",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/slam/doc/SmartFactorBase.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "smartfactorbase-colab-install",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "smartfactorbase-imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "\n",
+    "from gtsam.symbol_shorthand import X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "smartfactorbase-role",
+   "metadata": {},
+   "source": [
+    "## Use the base API through a concrete smart factor\n",
+    "\n",
+    "`SmartFactorBase` is not constructed directly. We use `SmartProjectionFactorPinholeCameraCal3_S2`, which inherits the base API, and add two image measurements of one landmark. The base class stores the measurement vector and the corresponding camera keys while leaving the landmark implicit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "smartfactorbase-example",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "measurements: [array([320., 240.]), array([220., 240.])]\n",
+      "camera keys: [8646911284551352320, 8646911284551352321]\n"
+     ]
+    }
+   ],
+   "source": [
+    "calibration = gtsam.Cal3_S2(500.0, 500.0, 0.0, 320.0, 240.0)\n",
+    "cameras = [\n",
+    "    gtsam.PinholeCameraCal3_S2(gtsam.Pose3(), calibration),\n",
+    "    gtsam.PinholeCameraCal3_S2(\n",
+    "        gtsam.Pose3(gtsam.Rot3(), np.array([1.0, 0.0, 0.0])),\n",
+    "        calibration,\n",
+    "    ),\n",
+    "]\n",
+    "landmark = np.array([0.0, 0.0, 5.0])\n",
+    "factor = gtsam.SmartProjectionFactorPinholeCameraCal3_S2(\n",
+    "    gtsam.noiseModel.Isotropic.Sigma(2, 1.0)\n",
+    ")\n",
+    "values = gtsam.Values()\n",
+    "for index, camera in enumerate(cameras):\n",
+    "    factor.add(camera.project(landmark), X(index))\n",
+    "    values.insert(X(index), camera)\n",
+    "\n",
+    "assert len(factor.measured()) == 2\n",
+    "print(\"measurements:\", factor.measured())\n",
+    "print(\"camera keys:\", factor.keys())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "smartfactorbase-cameras",
+   "metadata": {},
+   "source": [
+    "## Recover the cameras and triangulate\n",
+    "\n",
+    "`cameras(values)` follows the stored keys and assembles the typed camera set used by the derived factor. With consistent measurements, the factor triangulates the landmark and reports zero total reprojection error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "smartfactorbase-cameras-example",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "camera set type: CameraSetCal3_S2\n",
+      "triangulation valid: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "camera_set = factor.cameras(values)\n",
+    "assert len(camera_set) == 2\n",
+    "assert np.isclose(factor.totalReprojectionError(camera_set), 0.0)\n",
+    "print(\"camera set type:\", type(camera_set).__name__)\n",
+    "print(\"triangulation valid:\", bool(factor.point(values)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "smartfactorbase-specializations",
+   "metadata": {},
+   "source": [
+    "## When to use it\n",
+    "\n",
+    "`SmartFactorBase` is internal shared machinery for smart projection factors. Application code should construct a derived factor matching the camera type stored in `Values`; the wrapper supplies the corresponding base specialization automatically. The base API is most useful when adding measurements or inspecting how a smart factor resolves its cameras.\n",
+    "\n",
+    "Continue with [`SmartProjectionFactor`](SmartProjectionFactor.ipynb) for the nonlinear factor, [`SmartFactorParams`](SmartFactorParams.ipynb) for configuration, and [`JacobianFactorQ`](JacobianFactorQ.ipynb) for one possible linearization result.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`SmartFactorBase.h`](../SmartFactorBase.h)\n",
+    "\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/slam/doc/SmartFactorParams.ipynb
+++ b/gtsam/slam/doc/SmartFactorParams.ipynb
@@ -1,0 +1,244 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "smartfactorparams-intro",
+   "metadata": {},
+   "source": [
+    "# SmartFactorParams\n",
+    "\n",
+    "The `SmartProjectionParams` class configures smart projection factors. It controls their linearization, triangulation, and degeneracy behavior."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "smartfactorparams-copyright",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "GTSAM Copyright 2010-2026, Georgia Tech Research Corporation,\n",
+    "Atlanta, Georgia 30332-0415\n",
+    "All Rights Reserved\n",
+    "\n",
+    "Authors: Frank Dellaert, et al. (see THANKS for the full author list)\n",
+    "\n",
+    "See LICENSE for the license information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "smartfactorparams-colab-badge",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/slam/doc/SmartFactorParams.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "smartfactorparams-colab-install",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    %pip install --quiet gtsam-develop\n",
+    "except ImportError:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "smartfactorparams-imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gtsam\n",
+    "import numpy as np\n",
+    "\n",
+    "from gtsam.symbol_shorthand import X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "smartfactorparams-modes",
+   "metadata": {},
+   "source": [
+    "## Configure SmartProjectionParams\n",
+    "\n",
+    "We construct `SmartProjectionParams` with Jacobian-Q linearization and zero-information handling for degenerate triangulation. The setter methods then tune rank, epipolar-initialization, landmark-distance, and dynamic-outlier thresholds for the intended scene."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "smartfactorparams-example",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "linearizationMode: 2\n",
+      "   degeneracyMode: 1\n",
+      "rankTolerance = 1e-08\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "enableEPI = 0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "landmarkDistanceThreshold = 10000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dynamicOutlierRejectionThreshold = 3\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "useLOST = 0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "noise model\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "params = gtsam.SmartProjectionParams(\n",
+    "    gtsam.LinearizationMode.JACOBIAN_Q,\n",
+    "    gtsam.DegeneracyMode.ZERO_ON_DEGENERACY,\n",
+    "    False,\n",
+    "    False,\n",
+    "    1e-5,\n",
+    ")\n",
+    "params.setRankTolerance(1e-8)\n",
+    "params.setEnableEPI(False)\n",
+    "params.setLandmarkDistanceThreshold(1e4)\n",
+    "params.setDynamicOutlierRejectionThreshold(3.0)\n",
+    "params.print(\"configured smart-factor parameters\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "smartfactorparams-use",
+   "metadata": {},
+   "source": [
+    "## Apply the parameters to a smart factor\n",
+    "\n",
+    "Pass the configured object to a smart projection factor constructor. After adding two consistent camera observations, `linearizeToJacobian()` returns a `JacobianFactorQ`, confirming that the selected linearization mode took effect."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "smartfactorparams-use-example",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "linear factor: JacobianFactorQ112\n"
+     ]
+    }
+   ],
+   "source": [
+    "calibration = gtsam.Cal3_S2(500.0, 500.0, 0.0, 320.0, 240.0)\n",
+    "cameras = [\n",
+    "    gtsam.PinholeCameraCal3_S2(gtsam.Pose3(), calibration),\n",
+    "    gtsam.PinholeCameraCal3_S2(\n",
+    "        gtsam.Pose3(gtsam.Rot3(), np.array([1.0, 0.0, 0.0])),\n",
+    "        calibration,\n",
+    "    ),\n",
+    "]\n",
+    "landmark = np.array([0.0, 0.0, 5.0])\n",
+    "factor = gtsam.SmartProjectionFactorPinholeCameraCal3_S2(\n",
+    "    gtsam.noiseModel.Isotropic.Sigma(2, 1.0), params\n",
+    ")\n",
+    "values = gtsam.Values()\n",
+    "for index, camera in enumerate(cameras):\n",
+    "    factor.add(camera.project(landmark), X(index))\n",
+    "    values.insert(X(index), camera)\n",
+    "\n",
+    "linear_factor = factor.linearizeToJacobian(values)\n",
+    "assert isinstance(linear_factor, gtsam.JacobianFactorQ112)\n",
+    "assert np.isclose(factor.totalReprojectionError(factor.cameras(values)), 0.0)\n",
+    "print(\"linear factor:\", type(linear_factor).__name__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "smartfactorparams-guidance",
+   "metadata": {},
+   "source": [
+    "## When to use it\n",
+    "\n",
+    "Use `SmartProjectionParams` whenever a smart projection factor needs non-default triangulation, degeneracy, outlier, or linearization behavior. Start with the default Hessian mode unless the downstream solver specifically consumes Jacobian factors, and choose thresholds in the same scale as the scene and measurement noise.\n",
+    "\n",
+    "[`SmartProjectionFactor`](SmartProjectionFactor.ipynb) shows the factor itself, while [`JacobianFactorQ`](JacobianFactorQ.ipynb) explains the linear factor returned by this example.\n",
+    "\n",
+    "## Source\n",
+    "\n",
+    "[`SmartFactorParams.h`](../SmartFactorParams.h)\n",
+    "\n",
+    "\n",
+    "## AI assistance caveat\n",
+    "\n",
+    "AI was used to help draft this documentation, and inaccuracies could be present."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtsam/slam/doc/SmartProjectionFactor.ipynb
+++ b/gtsam/slam/doc/SmartProjectionFactor.ipynb
@@ -24,29 +24,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "gtsam_slam_doc_smartprojectionfactor__desc_md"
-      },
-      "source": [
-        "`SmartProjectionFactor<CAMERA>` is a \"smart\" factor designed for Structure from Motion (SfM) or visual SLAM problems where **both camera poses and calibration are being optimized**.\n",
-        "It implicitly represents a 3D point landmark that has been observed by multiple cameras.\n",
-        "\n",
-        "Key characteristics:\n",
-        "- **Implicit Point:** The 3D point is not an explicit variable in the factor graph. Instead, the factor internally triangulates the point based on the current camera estimates whenever needed (e.g., during linearization or error calculation).\n",
-        "- **Marginalization:** When linearized (e.g., to a Hessian factor), it effectively marginalizes out the 3D point, creating a dense factor connecting only the cameras that observed the point.\n",
-        "- **`CAMERA` Template:** This template parameter must represent a camera model that includes *both* pose and calibration (e.g., `PinholeCameraCal3_S2`, `PinholeCameraBundler`).\n",
-        "- **`Values` Requirement:** When using this factor, the `Values` object passed to methods like `error` or `linearize` must contain `CAMERA` objects (not separate `Pose3` and `Calib` objects) associated with the factor's keys.\n",
-        "- **Configuration:** Its behavior (linearization method, handling of degenerate triangulations) is controlled by `SmartProjectionParams`.\n",
-        "\n",
-        "**Use Case:** Suitable for Bundle Adjustment or SfM problems where calibration parameters are unknown or need refinement along with camera poses.\n",
-        "**Alternative:** If calibration is known and fixed, use `SmartProjectionPoseFactor` for better efficiency.\n",
-        "\n",
-        "If you are using the factor, please cite:\n",
-        "> **L. Carlone, Z. Kira, C. Beall, V. Indelman, F. Dellaert**, \"Eliminating conditionally independent sets in factor graphs: a unifying perspective based on smart factors\", Int. Conf. on Robotics and Automation (ICRA), 2014."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "gtsam_slam_doc_smartprojectionfactor__colab_badge_md"
       },
       "source": [
@@ -94,6 +71,29 @@
         "    Cal3_S2,\n",
         ")\n",
         "from gtsam.symbol_shorthand import C"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gtsam_slam_doc_smartprojectionfactor__desc_md"
+      },
+      "source": [
+        "`SmartProjectionFactor<CAMERA>` is a \"smart\" factor designed for Structure from Motion (SfM) or visual SLAM problems where **both camera poses and calibration are being optimized**.\n",
+        "It implicitly represents a 3D point landmark that has been observed by multiple cameras.\n",
+        "\n",
+        "Key characteristics:\n",
+        "- **Implicit Point:** The 3D point is not an explicit variable in the factor graph. Instead, the factor internally triangulates the point based on the current camera estimates whenever needed (e.g., during linearization or error calculation).\n",
+        "- **Marginalization:** When linearized (e.g., to a Hessian factor), it effectively marginalizes out the 3D point, creating a dense factor connecting only the cameras that observed the point.\n",
+        "- **`CAMERA` Template:** This template parameter must represent a camera model that includes *both* pose and calibration (e.g., `PinholeCameraCal3_S2`, `PinholeCameraBundler`).\n",
+        "- **`Values` Requirement:** When using this factor, the `Values` object passed to methods like `error` or `linearize` must contain `CAMERA` objects (not separate `Pose3` and `Calib` objects) associated with the factor's keys.\n",
+        "- **Configuration:** Its behavior (linearization method, handling of degenerate triangulations) is controlled by `SmartProjectionParams`.\n",
+        "\n",
+        "**Use Case:** Suitable for Bundle Adjustment or SfM problems where calibration parameters are unknown or need refinement along with camera poses.\n",
+        "**Alternative:** If calibration is known and fixed, use `SmartProjectionPoseFactor` for better efficiency.\n",
+        "\n",
+        "If you are using the factor, please cite:\n",
+        "> **L. Carlone, Z. Kira, C. Beall, V. Indelman, F. Dellaert**, \"Eliminating conditionally independent sets in factor graphs: a unifying perspective based on smart factors\", Int. Conf. on Robotics and Automation (ICRA), 2014."
       ]
     },
     {

--- a/gtsam/slam/doc/SmartProjectionPoseFactor.ipynb
+++ b/gtsam/slam/doc/SmartProjectionPoseFactor.ipynb
@@ -24,29 +24,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "gtsam_slam_doc_smartprojectionposefactor__desc_md"
-      },
-      "source": [
-        "`SmartProjectionPoseFactor<CALIBRATION>` is a \"smart\" factor optimized for visual SLAM problems where the **camera calibration is known and fixed**, and only the camera **poses** are being optimized.\n",
-        "It inherits from `SmartProjectionFactor` but simplifies the setup by taking a single shared `CALIBRATION` object (e.g., `Cal3_S2`, `Cal3Bundler`) assumed to be used by all cameras observing the landmark.\n",
-        "\n",
-        "Key characteristics:\n",
-        "- **Implicit Point:** Like its base class, the 3D point is not an explicit variable.\n",
-        "- **Fixed Calibration:** Assumes a single, known calibration `K` for all measurements.\n",
-        "- **Pose Variables:** The factor connects `Pose3` variables directly.\n",
-        "- **`Values` Requirement:** Requires `Pose3` objects in the `Values` container for its keys.\n",
-        "- **Configuration:** Behavior is controlled by `SmartProjectionParams`.\n",
-        "\n",
-        "**Use Case:** Ideal for visual SLAM or SfM when camera intrinsics are pre-calibrated and assumed constant.\n",
-        "**Alternative:** If calibration also needs optimization, use `SmartProjectionFactor`.\n",
-        "\n",
-        "If you are using the factor, please cite:\n",
-        "> **L. Carlone, Z. Kira, C. Beall, V. Indelman, F. Dellaert**, \"Eliminating conditionally independent sets in factor graphs: a unifying perspective based on smart factors\", Int. Conf. on Robotics and Automation (ICRA), 2014."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "gtsam_slam_doc_smartprojectionposefactor__colab_badge_md"
       },
       "source": [
@@ -92,6 +69,29 @@
         "    Cal3_S2,\n",
         ")\n",
         "from gtsam.symbol_shorthand import X  # Key for Pose3 variable"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gtsam_slam_doc_smartprojectionposefactor__desc_md"
+      },
+      "source": [
+        "`SmartProjectionPoseFactor<CALIBRATION>` is a \"smart\" factor optimized for visual SLAM problems where the **camera calibration is known and fixed**, and only the camera **poses** are being optimized.\n",
+        "It inherits from `SmartProjectionFactor` but simplifies the setup by taking a single shared `CALIBRATION` object (e.g., `Cal3_S2`, `Cal3Bundler`) assumed to be used by all cameras observing the landmark.\n",
+        "\n",
+        "Key characteristics:\n",
+        "- **Implicit Point:** Like its base class, the 3D point is not an explicit variable.\n",
+        "- **Fixed Calibration:** Assumes a single, known calibration `K` for all measurements.\n",
+        "- **Pose Variables:** The factor connects `Pose3` variables directly.\n",
+        "- **`Values` Requirement:** Requires `Pose3` objects in the `Values` container for its keys.\n",
+        "- **Configuration:** Behavior is controlled by `SmartProjectionParams`.\n",
+        "\n",
+        "**Use Case:** Ideal for visual SLAM or SfM when camera intrinsics are pre-calibrated and assumed constant.\n",
+        "**Alternative:** If calibration also needs optimization, use `SmartProjectionFactor`.\n",
+        "\n",
+        "If you are using the factor, please cite:\n",
+        "> **L. Carlone, Z. Kira, C. Beall, V. Indelman, F. Dellaert**, \"Eliminating conditionally independent sets in factor graphs: a unifying perspective based on smart factors\", Int. Conf. on Robotics and Automation (ICRA), 2014."
       ]
     },
     {

--- a/gtsam/slam/doc/SmartProjectionRigFactor.ipynb
+++ b/gtsam/slam/doc/SmartProjectionRigFactor.ipynb
@@ -24,38 +24,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "gtsam_slam_doc_smartprojectionrigfactor__desc_md"
-      },
-      "source": [
-        "`SmartProjectionRigFactor<CAMERA>` is a generalization of `SmartProjectionPoseFactor` designed for multi-camera systems (rigs).\n",
-        "Like other smart factors, it implicitly represents a 3D point landmark observed by multiple cameras.\n",
-        "\n",
-        "Key differences/features:\n",
-        "- **Multi-Camera Rig:** Assumes a fixed rig configuration, where multiple cameras (`CAMERA` instances, which include fixed intrinsics and fixed extrinsics *relative to the rig's body frame*) are defined.\n",
-        "- **Pose Variables:** Connects `Pose3` variables representing the pose of the **rig's body frame** in the world.\n",
-        "- **Multiple Observations per Pose:** Allows multiple measurements associated with the *same* body pose key, but originating from different cameras within the rig.\n",
-        "- **Camera Indexing:** Each measurement must be associated with both a body pose key and a `cameraId` (index) specifying which camera in the rig took the measurement.\n",
-        "- **Fixed Calibration/Extrinsics:** The intrinsics and relative extrinsics of the cameras within the rig are assumed fixed.\n",
-        "- **`CAMERA` Template:** Can be templated on various camera models (e.g., `PinholePose`, `SphericalCamera`), provided they adhere to the expected GTSAM camera concepts. **Important Note:** See the **Note on Template Parameter `CAMERA`** below.\n",
-        "- **`Values` Requirement:** Requires `Pose3` objects (representing the body frame) in the `Values` container.\n",
-        "- **Configuration:** Behavior controlled by `SmartProjectionParams`. **Note:** Currently (as of C++ header comment), only supports `HESSIAN` linearization mode and `ZERO_ON_DEGENERACY` mode.\n",
-        "\n",
-        "**Use Case:** Ideal for visual SLAM with a calibrated multi-camera rig (e.g., stereo rig, multi-fisheye system) where only the rig's pose is optimized.\n",
-        "\n",
-        "**Note on Template Parameter `CAMERA`:**\n",
-        "While this factor is templated on `CAMERA` for generality, the current internal implementation for linearization has limitations. It implicitly assumes that `traits<CAMERA>::dimension` matches the optimized variable dimension (`Pose3::dimension`, which is 6).\n",
-        "Consequently:\n",
-        "- It works correctly with `CAMERA` types where `dimension == 6`, such as `PinholePose<CALIBRATION>` or `SphericalCamera`.\n",
-        "- Using `CAMERA` types where `dimension != 6`, such as `PinholeCamera<CALIBRATION>` (dim = 6 + CalDim), **will cause compilation errors**.\n",
-        "- **Recommendation:** For standard pinhole cameras in a fixed rig, **use `PinholePose<CALIBRATION>`** as the `CAMERA` type when defining the `CameraSet` for this factor.\n",
-        "\n",
-        "If you are using the factor, please cite:\n",
-        "> **L. Carlone, Z. Kira, C. Beall, V. Indelman, F. Dellaert**, \"Eliminating conditionally independent sets in factor graphs: a unifying perspective based on smart factors\", Int. Conf. on Robotics and Automation (ICRA), 2014.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "gtsam_slam_doc_smartprojectionrigfactor__colab_badge_md"
       },
       "source": [
@@ -104,6 +72,38 @@
         "    Cal3_S2,\n",
         ")\n",
         "from gtsam.symbol_shorthand import X  # Key for Pose3 variable (Body Pose)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gtsam_slam_doc_smartprojectionrigfactor__desc_md"
+      },
+      "source": [
+        "`SmartProjectionRigFactor<CAMERA>` is a generalization of `SmartProjectionPoseFactor` designed for multi-camera systems (rigs).\n",
+        "Like other smart factors, it implicitly represents a 3D point landmark observed by multiple cameras.\n",
+        "\n",
+        "Key differences/features:\n",
+        "- **Multi-Camera Rig:** Assumes a fixed rig configuration, where multiple cameras (`CAMERA` instances, which include fixed intrinsics and fixed extrinsics *relative to the rig's body frame*) are defined.\n",
+        "- **Pose Variables:** Connects `Pose3` variables representing the pose of the **rig's body frame** in the world.\n",
+        "- **Multiple Observations per Pose:** Allows multiple measurements associated with the *same* body pose key, but originating from different cameras within the rig.\n",
+        "- **Camera Indexing:** Each measurement must be associated with both a body pose key and a `cameraId` (index) specifying which camera in the rig took the measurement.\n",
+        "- **Fixed Calibration/Extrinsics:** The intrinsics and relative extrinsics of the cameras within the rig are assumed fixed.\n",
+        "- **`CAMERA` Template:** Can be templated on various camera models (e.g., `PinholePose`, `SphericalCamera`), provided they adhere to the expected GTSAM camera concepts. **Important Note:** See the **Note on Template Parameter `CAMERA`** below.\n",
+        "- **`Values` Requirement:** Requires `Pose3` objects (representing the body frame) in the `Values` container.\n",
+        "- **Configuration:** Behavior controlled by `SmartProjectionParams`. **Note:** Currently (as of C++ header comment), only supports `HESSIAN` linearization mode and `ZERO_ON_DEGENERACY` mode.\n",
+        "\n",
+        "**Use Case:** Ideal for visual SLAM with a calibrated multi-camera rig (e.g., stereo rig, multi-fisheye system) where only the rig's pose is optimized.\n",
+        "\n",
+        "**Note on Template Parameter `CAMERA`:**\n",
+        "While this factor is templated on `CAMERA` for generality, the current internal implementation for linearization has limitations. It implicitly assumes that `traits<CAMERA>::dimension` matches the optimized variable dimension (`Pose3::dimension`, which is 6).\n",
+        "Consequently:\n",
+        "- It works correctly with `CAMERA` types where `dimension == 6`, such as `PinholePose<CALIBRATION>` or `SphericalCamera`.\n",
+        "- Using `CAMERA` types where `dimension != 6`, such as `PinholeCamera<CALIBRATION>` (dim = 6 + CalDim), **will cause compilation errors**.\n",
+        "- **Recommendation:** For standard pinhole cameras in a fixed rig, **use `PinholePose<CALIBRATION>`** as the `CAMERA` type when defining the `CameraSet` for this factor.\n",
+        "\n",
+        "If you are using the factor, please cite:\n",
+        "> **L. Carlone, Z. Kira, C. Beall, V. Indelman, F. Dellaert**, \"Eliminating conditionally independent sets in factor graphs: a unifying perspective based on smart factors\", Int. Conf. on Robotics and Automation (ICRA), 2014.\n"
       ]
     },
     {

--- a/gtsam/slam/doc/StereoFactor.ipynb
+++ b/gtsam/slam/doc/StereoFactor.ipynb
@@ -6,7 +6,7 @@
         "id": "gtsam_slam_doc_stereofactor__intro_md"
       },
       "source": [
-        "# GenericStereoFactor"
+        "# StereoFactor\n"
       ]
     },
     {
@@ -22,6 +22,15 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gtsam_slam_doc_stereofactor__colab_badge_md"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/slam/doc/StereoFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
       "cell_type": "code",
       "execution_count": null,
       "id": "gtsam_slam_doc_stereofactor__colab_import",
@@ -33,6 +42,27 @@
       "outputs": [],
       "source": [
         "try:\n    import google.colab\n    %pip install --quiet gtsam-develop\nexcept ImportError:\n    pass"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "id": "gtsam_slam_doc_stereofactor__imports_code"
+      },
+      "outputs": [],
+      "source": [
+        "import gtsam\n",
+        "import numpy as np\n",
+        "from gtsam import Pose3, Point3, StereoPoint2, Rot3, Cal3_S2Stereo, Values\n",
+        "# Need StereoCamera for backprojection/triangulation\n",
+        "from gtsam import StereoCamera \n",
+        "# The Python wrapper often creates specific instantiations\n",
+        "from gtsam import GenericStereoFactor3D\n",
+        "from gtsam import symbol_shorthand\n",
+        "\n",
+        "X = symbol_shorthand.X\n",
+        "L = symbol_shorthand.L"
       ]
     },
     {
@@ -59,15 +89,6 @@
       ]
     },
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gtsam_slam_doc_stereofactor__colab_badge_md"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/borglab/gtsam/blob/develop/gtsam/slam/doc/StereoFactor.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
@@ -79,27 +100,6 @@
       "outputs": [],
       "source": [
         "%pip install --quiet gtsam"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "id": "gtsam_slam_doc_stereofactor__imports_code"
-      },
-      "outputs": [],
-      "source": [
-        "import gtsam\n",
-        "import numpy as np\n",
-        "from gtsam import Pose3, Point3, StereoPoint2, Rot3, Cal3_S2Stereo, Values\n",
-        "# Need StereoCamera for backprojection/triangulation\n",
-        "from gtsam import StereoCamera \n",
-        "# The Python wrapper often creates specific instantiations\n",
-        "from gtsam import GenericStereoFactor3D\n",
-        "from gtsam import symbol_shorthand\n",
-        "\n",
-        "X = symbol_shorthand.X\n",
-        "L = symbol_shorthand.L"
       ]
     },
     {

--- a/gtsam/slam/doc/TriangulationFactor.ipynb
+++ b/gtsam/slam/doc/TriangulationFactor.ipynb
@@ -24,24 +24,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "gtsam_slam_doc_triangulationfactor__desc_md"
-      },
-      "source": [
-        "`TriangulationFactor<CAMERA>` is a unary factor that constrains a single unknown 3D point (`Point3`) based on a 2D measurement from a **known** camera.\n",
-        "It's essentially the inverse of a projection factor where the camera pose and calibration are fixed, and only the 3D point is variable.\n",
-        "\n",
-        "Key characteristics:\n",
-        "- **Unary Factor:** Connects only to a `Point3` variable key.\n",
-        "- **Known Camera:** The `CAMERA` object (e.g., `PinholeCameraCal3_S2`, `StereoCamera`) containing the fixed pose and calibration is provided during factor construction.\n",
-        "- **Measurement:** Takes a 2D measurement (`Point2` for monocular, `StereoPoint2` for stereo).\n",
-        "- **Error:** Calculates the reprojection error: $ \\text{error}(L) = \\text{camera.project}(L) - z $\n",
-        "\n",
-        "**Use Case:** Useful in triangulation scenarios where multiple camera views with known poses observe an unknown landmark. A `NonlinearFactorGraph` containing only `TriangulationFactor`s (one for each view) can be optimized to find the maximum likelihood estimate of the 3D landmark position."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "gtsam_slam_doc_triangulationfactor__colab_badge_md"
       },
       "source": [
@@ -78,6 +60,24 @@
         "from gtsam import symbol_shorthand\n",
         "\n",
         "L = symbol_shorthand.L"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gtsam_slam_doc_triangulationfactor__desc_md"
+      },
+      "source": [
+        "`TriangulationFactor<CAMERA>` is a unary factor that constrains a single unknown 3D point (`Point3`) based on a 2D measurement from a **known** camera.\n",
+        "It's essentially the inverse of a projection factor where the camera pose and calibration are fixed, and only the 3D point is variable.\n",
+        "\n",
+        "Key characteristics:\n",
+        "- **Unary Factor:** Connects only to a `Point3` variable key.\n",
+        "- **Known Camera:** The `CAMERA` object (e.g., `PinholeCameraCal3_S2`, `StereoCamera`) containing the fixed pose and calibration is provided during factor construction.\n",
+        "- **Measurement:** Takes a 2D measurement (`Point2` for monocular, `StereoPoint2` for stereo).\n",
+        "- **Error:** Calculates the reprojection error: $ \\text{error}(L) = \\text{camera.project}(L) - z $\n",
+        "\n",
+        "**Use Case:** Useful in triangulation scenarios where multiple camera views with known poses observe an unknown landmark. A `NonlinearFactorGraph` containing only `TriangulationFactor`s (one for each view) can be optimized to find the maximum likelihood estimate of the 3D landmark position."
       ]
     },
     {

--- a/gtsam/slam/doc/WahbaFactor.ipynb
+++ b/gtsam/slam/doc/WahbaFactor.ipynb
@@ -5,7 +5,7 @@
    "id": "title",
    "metadata": {},
    "source": [
-    "# `WahbaFactor`\n",
+    "# WahbaFactor\n",
     "\n",
     "`WahbaFactor` estimates a `Rot3` from a direction correspondence using the classical three-dimensional chordal Wahba residual. The factor stores both directions as `Unit3`, supports full three-dimensional Gaussian weighting, and provides an exact D=1 QCQP conversion."
    ]


### PR DESCRIPTION
## Summary

- normalize 33 existing SFM and SLAM notebooks to the prescribed preamble and exact header titles while preserving their authored content
- expand SfmTrack, TransferFactor, and ShonanAveraging to cover every wrapped class in their headers
- add nine example-led API walkthroughs for the missing SAM, SFM, and SLAM wrapped-class headers
- commit executed py312 outputs for all nine new notebooks so MyST renders the results

This completes notebook coverage for all 44 wrapped-class headers in sam, sfm, and slam. Internal types are identified explicitly and demonstrated through the higher-level workflow that creates or returns them.

## Validation

- executed the 33 normalized notebooks independently in the py312 environment
- executed all nine added notebooks through the py312 Jupyter kernel and committed their outputs
- verified exact titles, five-cell preambles, class coverage, notebook/header links, and absence of generic API inventories
- verified no notebook contains saved error outputs
- ran git diff --check

Documentation-only change; no unrelated C++ tests were run.