### PR TITLE
fix sagnac term in doppler factor

### DIFF
--- a/gtsam/navigation/DopplerFactor.cpp
+++ b/gtsam/navigation/DopplerFactor.cpp
@@ -48,12 +48,12 @@ DopplerFactor::DopplerFactor(const Key velocityKey, const Key clockBiasPrevKey,
   los_ = e;
 
   // Earth-rotation (Sagnac) rate term:
-  //   (OMGE/c) * (v_s.y*r_r.x + r_s.y*v_r.x - v_s.x*r_r.y - r_s.x*v_r.y)
+  //   (OMGE/c) * (v_s.x*r_r.y + r_s.x*v_r.y - v_s.y*r_r.x - r_s.y*v_r.x)
   // Split into the v_r-independent offset and the linear coefficient on v_r.
   const double k = OMGE / C_LIGHT;
-  sagnacOffset_ = k * (satelliteVelocity.y() * receiverPosition.x() -
-                       satelliteVelocity.x() * receiverPosition.y());
-  velSagnac_ = Point3(k * satellitePosition.y(), -k * satellitePosition.x(), 0.0);
+  sagnacOffset_ = k * (satelliteVelocity.x() * receiverPosition.y() -
+                       satelliteVelocity.y() * receiverPosition.x());
+  velSagnac_ = Point3(-k * satellitePosition.y(), k * satellitePosition.x(), 0.0);
 }
 
 //***************************************************************************
@@ -126,9 +126,9 @@ void initDopplerArmGeometry(const Point3& satellitePosition,
                             double& sagnacOffset, Point3& leverVel) {
   gnss::geodist(satellitePosition, receiverPosition, los);
   const double k = OMGE / C_LIGHT;
-  sagnacOffset = k * (satelliteVelocity.y() * receiverPosition.x() -
-                      satelliteVelocity.x() * receiverPosition.y());
-  velSagnac = Point3(k * satellitePosition.y(), -k * satellitePosition.x(), 0.0);
+  sagnacOffset = k * (satelliteVelocity.x() * receiverPosition.y() -
+                      satelliteVelocity.y() * receiverPosition.x());
+  velSagnac = Point3(-k * satellitePosition.y(), k * satellitePosition.x(), 0.0);
   leverVel = angularVelocity.cross(leverArm);
 }
 }  // namespace

--- a/gtsam/navigation/tests/testDopplerFactor.cpp
+++ b/gtsam/navigation/tests/testDopplerFactor.cpp
@@ -52,10 +52,10 @@ TEST(TestDopplerFactor, Model) {
   gnss::geodist(sample::kSatPos, sample::kReceiverPos, e);
   const double kSag = gnss::OMGE / kCLight;
   const double sagnacRate =
-      kSag * (satVel.y() * sample::kReceiverPos.x() +
-              sample::kSatPos.y() * rcvVel.x() -
-              satVel.x() * sample::kReceiverPos.y() -
-              sample::kSatPos.x() * rcvVel.y());
+      kSag * (satVel.x() * sample::kReceiverPos.y() +
+              sample::kSatPos.x() * rcvVel.y() -
+              satVel.y() * sample::kReceiverPos.x() -
+              sample::kSatPos.y() * rcvVel.x());
   const double rangeRate = e.dot(satVel - rcvVel) +
                            kCLight * (rcvClkDrift - satClkDrift) + sagnacRate;
   const double expected = rangeRate - (-kLambdaL1 * measDoppler);
@@ -178,10 +178,10 @@ TEST(TestDopplerFactorArm, Model) {
   const Vector3 vAnt = (Vector3)rcvVel + pose.rotation().rotate(omega.cross(lever));
   const double kSag = gnss::OMGE / kCLight;
   const double sagnac =
-      kSag * (satVel.y() * sample::kReceiverPos.x() +
-              sample::kSatPos.y() * vAnt.x() -
-              satVel.x() * sample::kReceiverPos.y() -
-              sample::kSatPos.x() * vAnt.y());
+      kSag * (satVel.x() * sample::kReceiverPos.y() +
+              sample::kSatPos.x() * vAnt.y() -
+              satVel.y() * sample::kReceiverPos.x() -
+              sample::kSatPos.y() * vAnt.x());
   const double rangeRate = e.dot(satVel - Point3(vAnt)) +
                            kCLight * (rcvClkDrift - satClkDrift) + sagnac;
   const double expected = rangeRate - (-kLambdaL1 * measDoppler);
@@ -223,10 +223,10 @@ TEST(TestDopplerFactorArm, NavFrame) {
   const Vector3 vAnt = ecef_T_nav.rotation().rotate(Point3(vAntNav));
   const double kSag = gnss::OMGE / kCLight;
   const double sagnac =
-      kSag * (satVel.y() * sample::kReceiverPos.x() +
-              sample::kSatPos.y() * vAnt.x() -
-              satVel.x() * sample::kReceiverPos.y() -
-              sample::kSatPos.x() * vAnt.y());
+      kSag * (satVel.x() * sample::kReceiverPos.y() +
+              sample::kSatPos.x() * vAnt.y() -
+              satVel.y() * sample::kReceiverPos.x() -
+              sample::kSatPos.y() * vAnt.x());
   const double rangeRate = e.dot(satVel - Point3(vAnt)) +
                            kCLight * (rcvClkDrift - satClkDrift) + sagnac;
   const double expected = rangeRate - (-kLambdaL1 * measDoppler);
@@ -271,6 +271,53 @@ TEST(TestDopplerFactorArm, InvalidDtThrows) {
                        sample::kReceiverPos, lever, omega, -1.0),
       std::invalid_argument);
 }
+
+/* ************************************************************************* */
+namespace sagnac_rate {
+
+TEST(TestDopplerFactor, SagnacRateMatchesGeodistDerivative) {
+  const Point3 satVel(-1500.0, 900.0, 2300.0);
+  const Point3 rcvVel(7.0, -5.0, 3.0);
+
+  // Zero Doppler and equal clock biases, so the error is the modelled rate.
+  DopplerFactor factor(0, 1, 2, /*measuredDoppler=*/0.0, kLambdaL1,
+                       sample::kSatPos, satVel, sample::kReceiverPos,
+                       /*dt=*/1.0);
+  const double modelled = factor.evaluateError((Vector3)rcvVel, 0.0, 0.0)[0];
+
+  const double h = 0.1;
+  Point3 e;
+  const double rangePlus = gnss::geodist(sample::kSatPos + satVel * h,
+                                         sample::kReceiverPos + rcvVel * h, e);
+  const double rangeMinus = gnss::geodist(sample::kSatPos - satVel * h,
+                                          sample::kReceiverPos - rcvVel * h, e);
+  EXPECT_DOUBLES_EQUAL((rangePlus - rangeMinus) / (2.0 * h), modelled, 1e-6);
+}
+
+TEST(TestDopplerFactor, SagnacRateSignMatchesRangeDomain) {
+  const Point3 satVel(-1500.0, 900.0, 2300.0);
+  const Point3 rcvVel(7.0, -5.0, 3.0);
+  const double kSag = gnss::OMGE / kCLight;
+
+  DopplerFactor factor(0, 1, 2, 0.0, kLambdaL1, sample::kSatPos, satVel,
+                       sample::kReceiverPos, 1.0);
+  Point3 e;
+  gnss::geodist(sample::kSatPos, sample::kReceiverPos, e);
+  const double applied =
+      factor.evaluateError((Vector3)rcvVel, 0.0, 0.0)[0] - e.dot(satVel - rcvVel);
+
+  const double expected =
+      kSag * (satVel.x() * sample::kReceiverPos.y() +
+              sample::kSatPos.x() * rcvVel.y() -
+              satVel.y() * sample::kReceiverPos.x() -
+              sample::kSatPos.y() * rcvVel.x());
+
+  EXPECT_DOUBLES_EQUAL(expected, applied, 1e-9);
+  CHECK(expected * applied > 0.0);
+}
+
+}  // namespace sagnac_rate
+/* ************************************************************************* */
 
 // *************************************************************************
 int main() {

--- a/python/gtsam/tests/test_DopplerFactor.py
+++ b/python/gtsam/tests/test_DopplerFactor.py
@@ -33,10 +33,14 @@ def line_of_sight(sat_pos, rcv_pos):
 
 
 def sagnac_rate(sat_pos, sat_vel, rcv_pos, rcv_vel):
-    """Earth-rotation (Sagnac) range-rate term."""
+    """Earth-rotation (Sagnac) range-rate term.
+
+    The time derivative of the Sagnac term gnss::geodist adds to the range,
+    k * (sat.x * rcv.y - sat.y * rcv.x).
+    """
     k = OMGE / C_LIGHT
-    return k * (sat_vel[1] * rcv_pos[0] + sat_pos[1] * rcv_vel[0] -
-                sat_vel[0] * rcv_pos[1] - sat_pos[0] * rcv_vel[1])
+    return k * (sat_vel[0] * rcv_pos[1] + sat_pos[0] * rcv_vel[1] -
+                sat_vel[1] * rcv_pos[0] - sat_pos[1] * rcv_vel[0])
 
 
 def expected_error(sat_vel, rcv_vel, meas_doppler, dt, bias_prev, bias_curr,


### PR DESCRIPTION
Old code was not consistent; used $r_s \times r_r$ but defined derivative w respect to $r_r \times r_s$. This was pulled directly from RTKLIB() which uses a different definition of Sagnac term. 
Existing code would end up returning 2x the error instead of compensating for the Sagnac term correctly

New code is defined consistently with geodist() in the rest of GTSAM.

