### PR TITLE
Reuse matrix-vector products in PowerMethod::compute()

### DIFF
--- a/gtsam/linear/PowerMethod.h
+++ b/gtsam/linear/PowerMethod.h
@@ -130,14 +130,21 @@ class PowerMethod {
   bool compute(size_t maxIterations, double tol) {
     // Starting
     bool isConverged = false;
+    if (maxIterations == 0) return isConverged;
+
+    Vector product = A_ * ritzVector_;
 
     for (size_t i = 0; i < maxIterations && !isConverged; i++) {
       ++nrIterations_;
       // update the ritzVector after power iteration
-      ritzVector_ = powerIteration();
-      // update the ritzValue 
-      ritzValue_ = ritzVector_.dot(A_ * ritzVector_);
-      isConverged = converged(tol);
+      ritzVector_ = product;
+      ritzVector_.normalize();
+
+      // Reuse this product for the Ritz value, residual, and next iteration.
+      product = A_ * ritzVector_;
+      ritzValue_ = ritzVector_.dot(product);
+      const double error = (product - ritzValue_ * ritzVector_).norm();
+      isConverged = error < tol;
     }
 
     return isConverged;

--- a/gtsam/linear/tests/testPowerMethod.cpp
+++ b/gtsam/linear/tests/testPowerMethod.cpp
@@ -35,6 +35,47 @@ using namespace std;
 using namespace gtsam;
 
 /* ************************************************************************* */
+namespace multiplication_reuse {
+
+class CountingOperator {
+ public:
+  explicit CountingOperator(const Matrix& matrix) : matrix_(matrix) {}
+
+  DenseIndex rows() const { return matrix_.rows(); }
+
+  Vector operator*(const Vector& vector) const {
+    ++multiplicationCount_;
+    return matrix_ * vector;
+  }
+
+  void resetCount() const { multiplicationCount_ = 0; }
+
+  size_t multiplicationCount() const { return multiplicationCount_; }
+
+ private:
+  Matrix matrix_;
+  mutable size_t multiplicationCount_ = 0;
+};
+
+// Verifies that compute reuses each matrix-vector product across iterations.
+TEST(PowerMethod, reusesMatrixVectorProducts) {
+  Matrix matrix = Matrix::Zero(3, 3);
+  matrix.diagonal() << 3.0, 2.0, 1.0;
+  const Vector initial = Vector3(1.0, 1.0, 1.0);
+  CountingOperator countingOperator(matrix);
+  PowerMethod<CountingOperator> powerMethod(countingOperator, initial);
+  countingOperator.resetCount();
+
+  EXPECT(!powerMethod.compute(3, -1.0));
+
+  EXPECT_LONGS_EQUAL(3, powerMethod.nrIterations());
+  EXPECT_LONGS_EQUAL(4, countingOperator.multiplicationCount());
+}
+
+}  // namespace multiplication_reuse
+/* ************************************************************************* */
+
+/* ************************************************************************* */
 TEST(PowerMethod, powerIteration) {
   // test power iteration, beta is set to 0
   Sparse A(6, 6);


### PR DESCRIPTION
## Summary

- carry each evaluated matrix-vector product forward across the Ritz value, convergence residual, and next iteration
- reduce operator evaluations from four per iteration to one per iteration after the initial product
- preserve zero-iteration behavior and add a counting-operator regression test

This optimization was found using Zynoptes, the AI Performance Engineer for Robotics.

## Performance

Linux GCC 12.2 Release, with two warm-up pairs and 20 measured baseline/candidate pairs in balanced alternating order. The timing columns are marginal medians; improvement and its 95% paired-bootstrap confidence interval are computed from paired samples.

| Workload | Before | After | Paired improvement |
|---|---:|---:|---:|
| 64 dimensions, 8 iterations x 1,024 calls | 16.6121 ms | 5.6713 ms | 65.85% [65.66%, 66.01%] |
| 512 dimensions, 12 iterations x 120 calls | 288.8913 ms | 84.1805 ms | 71.22% [70.24%, 72.00%] |
| 1,024 dimensions, 16 iterations x 32 calls | 652.1025 ms | 180.0367 ms | 72.16% [71.84%, 72.56%] |

All paired outputs produced identical checksums. These timings cover only `PowerMethod::compute()` and do not claim a whole-GTSAM or application speedup.

## Correctness and compatibility

- GCC 12.2 and Clang 16 Release full `check`: 367/367 tests passed with examples built
- focused tests passed under GCC AddressSanitizer and UndefinedBehaviorSanitizer builds
- state, convergence, and repeated-call outputs matched the baseline digest exactly
- dense and sparse repository cases passed without candidate-added failures
- the exact source patch applies to the current `develop` tip, where the focused `testPowerMethod.run` target passes

## Testing

- GCC 12.2 Release full `check` and examples
- Clang 16 Release full `check` and examples
- GCC AddressSanitizer and UndefinedBehaviorSanitizer focused tests
- state/convergence differential harness
- dense and sparse repository cases
- current-`develop` `testPowerMethod.run`
