### PR TITLE
CustomFactor: make the jacobian argument optional in its own type

### DIFF
--- a/gtsam/nonlinear/CustomFactor.cpp
+++ b/gtsam/nonlinear/CustomFactor.cpp
@@ -27,7 +27,7 @@ Vector CustomFactor::unwhitenedError(const Values& x, OptionalMatrixVecType H) c
 
     if(H) {
       /*
-       * In this case, we pass the raw pointer to the `std::vector<Matrix>` object directly to pybind.
+       * In this case, we pass a reference to the `std::vector<Matrix>` object directly to pybind.
        * As the type `std::vector<Matrix>` has been marked as opaque in `preamble/custom.h`, any changes in
        * Python will be immediately reflected on the C++ side.
        *
@@ -43,13 +43,13 @@ Vector CustomFactor::unwhitenedError(const Values& x, OptionalMatrixVecType H) c
        *    return error
        * ```
        */
-      return this->error_function_(*this, x, H);
+      return this->error_function_(*this, x, std::ref(*H));
     } else {
       /*
-       * In this case, we pass the a `nullptr` to pybind, and it will translate to `None` in Python.
+       * In this case, we pass `std::nullopt` to pybind, and it will translate to `None` in Python.
        * Users can check for `None` in their callback to determine if the Jacobian is requested.
        */
-      return this->error_function_(*this, x, nullptr);
+      return this->error_function_(*this, x, std::nullopt);
     }
   } else {
     return Vector::Zero(this->dim());

--- a/gtsam/nonlinear/CustomFactor.h
+++ b/gtsam/nonlinear/CustomFactor.h
@@ -19,21 +19,30 @@
 
 #include <gtsam/nonlinear/NonlinearFactor.h>
 
+#include <functional>
+#include <optional>
+
 namespace gtsam {
 
 using JacobianVector = std::vector<Matrix>;
 
 class CustomFactor;
 
+/// Jacobians handed to the Python callback, absent when only the error is wanted.
+using OptionalJacobianVector = std::optional<std::reference_wrapper<JacobianVector>>;
+
 /*
  * NOTE
  * ==========
  * pybind11 will invoke a copy if this is `JacobianVector &`, and modifications in Python will not be reflected.
  *
- * This is safe because this is passing a const pointer, and pybind11 will maintain the `std::vector` memory layout.
- * Thus the pointer will never be invalidated.
+ * A `std::optional<std::reference_wrapper<JacobianVector>>` keeps reference semantics -- `JacobianVector` is
+ * opaque (see `preamble/custom.h`), so pybind11 maintains the `std::vector` memory layout and Python's writes
+ * are visible in C++ -- while also telling pybind11 that the argument is nullable. A bare pointer does not:
+ * pybind11 renders pointer arguments without `Optional`, so the generated stub claims the callback always
+ * receives a `JacobianVector`, and a correct `if H is not None` guard gets reported as unreachable.
  */
-using CustomErrorFunction = std::function<Vector(const CustomFactor &, const Values &, const JacobianVector *)>;
+using CustomErrorFunction = std::function<Vector(const CustomFactor &, const Values &, OptionalJacobianVector)>;
 
 /**
  * @brief Custom factor that takes a std::function as the error

--- a/gtsam/nonlinear/doc/CustomFactor.ipynb
+++ b/gtsam/nonlinear/doc/CustomFactor.ipynb
@@ -87,7 +87,7 @@
         "\n",
         "```cpp\n",
         "using JacobianVector = std::vector<Matrix>;\n",
-        "using CustomErrorFunction = std::function<Vector(const CustomFactor &, const Values &, const JacobianVector *)>;\n",
+        "using CustomErrorFunction = std::function<Vector(const CustomFactor &, const Values &, OptionalJacobianVector)>;\n",
         "```\n",
         "\n",
         "The function will be passed a reference to the factor itself so the keys can be accessed, a `Values` reference, and a writeable vector of Jacobians.\n",
@@ -301,7 +301,7 @@
         " * and pybind11 will maintain the `std::vector` memory layout.\n",
         " * Thus the pointer will never be invalidated.\n",
         " */\n",
-        "using CustomErrorFunction = std::function<Vector(const CustomFactor&, const Values&, const JacobianVector*)>;\n",
+        "using CustomErrorFunction = std::function<Vector(const CustomFactor&, const Values&, OptionalJacobianVector)>;\n",
         "```\n",
         "which is not documented in `pybind11` docs. One needs to be aware of this if they wanted to implement similar \"mutable\" arguments going across the Python-C++ boundary.\n"
       ]

--- a/gtsam/nonlinear/tests/testCudaSparseLevenbergMarquardt.cpp
+++ b/gtsam/nonlinear/tests/testCudaSparseLevenbergMarquardt.cpp
@@ -1193,15 +1193,14 @@ TEST(SparseLevenbergMarquardt,
   const CustomErrorFunction callback = [callbackState](
                                            const CustomFactor&,
                                            const Values& values,
-                                           const JacobianVector* jacobians) {
+                                           OptionalJacobianVector jacobians) {
     if (jacobians) {
       callbackState->jacobianCalls.fetch_add(1);
       {
         std::lock_guard<std::mutex> lock(callbackState->mutex);
         callbackState->jacobianThreads.push_back(std::this_thread::get_id());
       }
-      auto& mutableJacobians = *const_cast<JacobianVector*>(jacobians);
-      mutableJacobians[0] = Matrix::Identity(1, 1);
+      jacobians->get()[0] = Matrix::Identity(1, 1);
     } else {
       callbackState->errorCalls.fetch_add(1);
     }

--- a/gtsam/nonlinear/tests/testCustomFactor.cpp
+++ b/gtsam/nonlinear/tests/testCustomFactor.cpp
@@ -46,17 +46,17 @@ class Residual {
       : measurements_(std::move(measurements)) {}
 
   Vector operator()(const CustomFactor& factor, const Values& values,
-                    const JacobianVector* jacobians) const {
+                    OptionalJacobianVector jacobians) const {
     const Pose2& pose = values.at<Pose2>(factor.keys()[0]);
     const size_t measurementCount = measurements_.size();
     Vector error = Vector::Zero(2 * measurementCount);
     Matrix* H = nullptr;
 
     if (jacobians) {
-      // CustomFactor exposes a const JacobianVector* so wrapped languages can
-      // mutate the shared storage directly. Native C++ callbacks still need to
-      // fill the same storage when derivatives are requested.
-      auto& mutableJacobians = *const_cast<JacobianVector*>(jacobians);
+      // CustomFactor hands the callback a reference to the shared storage so
+      // wrapped languages can mutate it directly. Native C++ callbacks still
+      // need to fill the same storage when derivatives are requested.
+      auto& mutableJacobians = jacobians->get();
       H = &mutableJacobians[0];
       H->resize(2 * measurementCount, 3);
     }

--- a/matlab/MatlabCustomFactor.h
+++ b/matlab/MatlabCustomFactor.h
@@ -163,11 +163,11 @@ class MatlabCustomFactor : public CustomFactor {
       : CustomFactor(
             noiseModel, keys,
             [callbackId](const CustomFactor& factor, const Values& values,
-                         const JacobianVector* jacobians) {
+                         OptionalJacobianVector jacobians) {
               const auto& matlabFactor =
                   static_cast<const MatlabCustomFactor&>(factor);
               return matlabFactor.invokeCallback(
-                  values, const_cast<JacobianVector*>(jacobians));
+                  values, jacobians ? &jacobians->get() : nullptr);
             }),
         callback_id_(callbackId)
 #ifdef GTSAM_USE_TBB


### PR DESCRIPTION
The Python callback receives None for its jacobians whenever only the error is requested -- python/gtsam/tests/test_custom_factor.py asserts exactly that -- but the generated stub says otherwise:

    errorFunction: Callable[[CustomFactor, Values, JacobianVector], ...]

pybind11 renders pointer arguments without Optional, so the nullability that CustomErrorFunction expresses with 'const JacobianVector *' is lost on the way to Python. Callers who follow the stub omit the None check and get a TypeError at runtime; callers who annotate H as JacobianVector have their correct 'if H is not None' guard reported as unreachable.

Express the nullability in a form pybind11 understands. A std::optional<std::reference_wrapper<JacobianVector>> keeps the reference semantics the raw pointer was chosen for -- JacobianVector is opaque, so pybind11 preserves the std::vector memory layout and Python's writes are still visible in C++ -- and pybind11 renders it as 'JacobianVector | None'.

Verified against pybind11 3.0.4 with an isolated module: passing std::ref(v) delivers the bound vector and in-place writes propagate back to C++, passing std::nullopt delivers None, and the generated signature is Callable[[VecInt | None], ...].

As a side effect the const_cast in each native C++ callback goes away, since the reference is already non-const.

Updates the two C++ tests, the MATLAB wrapper callback, and the CustomFactor notebook.