### PR TITLE
python: remove the Rot3 validation shim and fix wrapper matrix shape checks

### DIFF
--- a/gtsam/geometry/Pose2.h
+++ b/gtsam/geometry/Pose2.h
@@ -100,11 +100,6 @@ public:
   /// @name Advanced Constructors
   /// @{
 
-  /** Construct from canonical coordinates \f$ [T_x,T_y,\theta] \f$ (Lie algebra) */
-  Pose2(const Vector& v) : Pose2() {
-    *this = Expmap(v);
-  }
-
   /**
    *  Create Pose2 by aligning two point pairs
    *  A pose aTb is estimated between pairs (a_point, b_point) such that 
@@ -340,6 +335,12 @@ public:
   /// @deprecated: use Hat
   static inline Matrix3 wedge(double vx, double vy, double w) {
     return Hat(TangentVector(vx, vy, w));
+  }
+
+  /// @deprecated: use Expmap. This is the exponential map, not componentwise
+  /// construction: use Pose2(x, y, theta) for that.
+  Pose2(const Vector& v) : Pose2() {
+    *this = Expmap(v);
   }
 #endif
   /// @}

--- a/gtsam/geometry/cameras.i
+++ b/gtsam/geometry/cameras.i
@@ -326,7 +326,7 @@ class CalibratedCamera {
   // Standard Constructors and Named Constructors
   CalibratedCamera();
   CalibratedCamera(const gtsam::Pose3& pose);
-  CalibratedCamera(const gtsam::Vector& v);
+  CalibratedCamera(const gtsam::Vector6& v);
   static gtsam::CalibratedCamera Level(const gtsam::Pose2& pose2,
                                        double height);
 
@@ -514,7 +514,7 @@ class SphericalCamera {
   SphericalCamera(const gtsam::Pose3& pose);
   SphericalCamera(const gtsam::Pose3& pose,
                   const gtsam::EmptyCal::shared_ptr& cal);
-  SphericalCamera(const gtsam::Vector& v);
+  SphericalCamera(const gtsam::Vector6& v);
 
   // Testable
   bool equals(const gtsam::SphericalCamera& camera, double tol = 1e-9) const;

--- a/gtsam/geometry/geometry.i
+++ b/gtsam/geometry/geometry.i
@@ -511,7 +511,7 @@ class Quaternion {
 class Rot3 {
   // Standard Constructors and Named Constructors
   Rot3();
-  Rot3(gtsam::Matrix R);
+  Rot3(gtsam::Matrix3 R);
   Rot3(const gtsam::Point3& col1, const gtsam::Point3& col2,
        const gtsam::Point3& col3);
   Rot3(double R11, double R12, double R13, double R21, double R22, double R23,
@@ -651,7 +651,7 @@ class Pose2 {
   Pose2(double x, double y, double theta);
   Pose2(double theta, const gtsam::Point2& t);
   Pose2(const gtsam::Rot2& r, const gtsam::Point2& t);
-  Pose2(gtsam::Vector v);
+  Pose2(gtsam::Vector3 v);
 
   static std::optional<gtsam::Pose2> Align(const gtsam::Point2Pairs& abPointPairs);
   static std::optional<gtsam::Pose2> Align(gtsam::ConstMatrixView a, gtsam::ConstMatrixView b);
@@ -770,7 +770,7 @@ class Pose3 {
   Pose3(const gtsam::Pose3& other);
   Pose3(const gtsam::Rot3& r, const gtsam::Point3& t);
   Pose3(const gtsam::Pose2& pose2);
-  Pose3(gtsam::Matrix mat);
+  Pose3(gtsam::Matrix4 mat);
 
   static std::optional<gtsam::Pose3> Align(const gtsam::Point3Pairs& abPointPairs);
   static std::optional<gtsam::Pose3> Align(gtsam::ConstMatrixView a, gtsam::ConstMatrixView b);
@@ -1205,7 +1205,7 @@ class OrientedPlane3 {
   // Standard constructors
   OrientedPlane3();
   OrientedPlane3(const gtsam::Unit3& n, double d);
-  OrientedPlane3(const gtsam::Vector& vec);
+  OrientedPlane3(const gtsam::Vector4& vec);
   OrientedPlane3(double a, double b, double c, double d);
 
   // Testable

--- a/gtsam/geometry/geometry.i
+++ b/gtsam/geometry/geometry.i
@@ -651,7 +651,12 @@ class Pose2 {
   Pose2(double x, double y, double theta);
   Pose2(double theta, const gtsam::Point2& t);
   Pose2(const gtsam::Rot2& r, const gtsam::Point2& t);
-  Pose2(gtsam::Vector3 v);
+  // NOTE: stays dynamic. Pose2 declares both Pose2(const Matrix&) and
+  // Pose2(const Vector&), and a fixed-size Vector3 converts to both, so
+  // py::init<gtsam::Vector3> is ambiguous. Passing the wrong length here
+  // is still unchecked; fixing it needs a disambiguating adapter, which
+  // wrap_ctors does not currently support.
+  Pose2(gtsam::Vector v);
 
   static std::optional<gtsam::Pose2> Align(const gtsam::Point2Pairs& abPointPairs);
   static std::optional<gtsam::Pose2> Align(gtsam::ConstMatrixView a, gtsam::ConstMatrixView b);

--- a/gtsam/geometry/geometry.i
+++ b/gtsam/geometry/geometry.i
@@ -651,12 +651,6 @@ class Pose2 {
   Pose2(double x, double y, double theta);
   Pose2(double theta, const gtsam::Point2& t);
   Pose2(const gtsam::Rot2& r, const gtsam::Point2& t);
-  // NOTE: stays dynamic. Pose2 declares both Pose2(const Matrix&) and
-  // Pose2(const Vector&), and a fixed-size Vector3 converts to both, so
-  // py::init<gtsam::Vector3> is ambiguous. Passing the wrong length here
-  // is still unchecked; fixing it needs a disambiguating adapter, which
-  // wrap_ctors does not currently support.
-  Pose2(gtsam::Vector v);
 
   static std::optional<gtsam::Pose2> Align(const gtsam::Point2Pairs& abPointPairs);
   static std::optional<gtsam::Pose2> Align(gtsam::ConstMatrixView a, gtsam::ConstMatrixView b);

--- a/gtsam/geometry/tests/testPose2.cpp
+++ b/gtsam/geometry/tests/testPose2.cpp
@@ -120,8 +120,11 @@ TEST(Pose2, expmap3) {
 
   Vector v = Vector3(0.01, -0.015, 0.99);
   Pose2 pose = Pose2::Expmap(v);
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
+  // The deprecated Vector constructor is Expmap.
   Pose2 pose2(v);
   EXPECT(assert_equal(pose, pose2));
+#endif
   Matrix actual = pose.matrix();
   //EXPECT(assert_equal(expected, actual));
 }

--- a/gtsam/slam/slam.i
+++ b/gtsam/slam/slam.i
@@ -387,7 +387,7 @@ class RotateDirectionsFactor : gtsam::NoiseModelFactor {
 #include <gtsam/slam/OrientedPlane3Factor.h>
 class OrientedPlane3Factor : gtsam::NoiseModelFactor {
   OrientedPlane3Factor();
-  OrientedPlane3Factor(const gtsam::Vector& z, const gtsam::noiseModel::Gaussian* noiseModel,
+  OrientedPlane3Factor(const gtsam::Vector4& z, const gtsam::noiseModel::Gaussian* noiseModel,
       gtsam::Key poseKey, gtsam::Key landmarkKey);
 
   gtsam::Vector evaluateError(
@@ -396,7 +396,7 @@ class OrientedPlane3Factor : gtsam::NoiseModelFactor {
 
 class OrientedPlane3DirectionPrior : gtsam::NoiseModelFactor {
   OrientedPlane3DirectionPrior();
-  OrientedPlane3DirectionPrior(gtsam::Key key, const gtsam::Vector& z,
+  OrientedPlane3DirectionPrior(gtsam::Key key, const gtsam::Vector4& z,
                                const gtsam::noiseModel::Gaussian* noiseModel);
 
   gtsam::Vector evaluateError(const gtsam::OrientedPlane3& plane) const;

--- a/python/gtsam/__init__.py
+++ b/python/gtsam/__init__.py
@@ -77,29 +77,6 @@ def _init():
             return x  # "copy constructor"
         return np.array([x, y, z], dtype=float)
 
-    # Validate rotation matrix input from Python (zero overhead in C++).
-    # The tolerance is deliberately loose (1e-3): the goal is to reject the
-    # degenerate inputs that previously crashed the wrapper (zero, scaled, or
-    # reflected matrices, see issue #2300) while still accepting real-world
-    # rotation matrices rounded to a few decimals. Use Rot3.IsValid(R, tol)
-    # for strict checking, or Rot3.ClosestTo(R) to project onto SO(3).
-    global Rot3
-    _Rot3_orig = gtsam.Rot3
-
-    class Rot3(_Rot3_orig):
-        def __init__(self, *args, **kwargs):
-            if len(args) == 1 and not kwargs:
-                try:
-                    arr = np.asarray(args[0], dtype=float)
-                except (TypeError, ValueError):
-                    arr = None
-                if arr is not None and arr.shape == (3, 3) and not _Rot3_orig.IsValid(arr, 1e-3):
-                    raise ValueError(
-                        "Rot3: matrix is not a valid rotation "
-                        "(must be orthonormal with det +1). "
-                        "Use Rot3.ClosestTo() to project to the nearest rotation.")
-            super().__init__(*args, **kwargs)
-
     # for interactive debugging
     if __name__ == "__main__":
         # we want all definitions accessible

--- a/python/gtsam/tests/test_Rot3.py
+++ b/python/gtsam/tests/test_Rot3.py
@@ -2060,32 +2060,37 @@ class TestRot3(GtsamTestCase):
         np.testing.assert_almost_equal(actual_p, c_p, decimal=6)
         np.testing.assert_almost_equal(actual_u.point3(), c_u.point3(), decimal=6)
 
-    def test_invalid_matrix_raises(self) -> None:
-        """Python wrapper should raise ValueError for degenerate matrix input."""
-        with self.assertRaises(ValueError):
-            Rot3(np.zeros((3, 3)))
-        # Nested lists are validated too, not only ndarrays.
-        with self.assertRaises(ValueError):
-            Rot3([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
-        with self.assertRaises(ValueError):
-            Rot3(np.diag([2.0, 1.0, 1.0]))
+    def test_is_valid(self) -> None:
+        """Rot3.IsValid accepts rotations and rejects degenerate matrices."""
+        self.assertTrue(Rot3.IsValid(np.eye(3), 1e-9))
+        self.assertTrue(Rot3.IsValid(Rot3.Rz(0.5).matrix(), 1e-9))
+        self.assertFalse(Rot3.IsValid(np.zeros((3, 3)), 1e-9))
+        self.assertFalse(Rot3.IsValid(np.diag([2.0, 1.0, 1.0]), 1e-9))
         # Reflection (det = -1)
-        with self.assertRaises(ValueError):
-            Rot3(np.diag([1.0, 1.0, -1.0]))
-
-    def test_valid_matrix_no_raise(self) -> None:
-        """Valid and near-valid (rounded) rotation matrices must construct."""
-        Rot3(np.eye(3))
-        Rot3(Rot3.Rz(0.5).matrix())
+        self.assertFalse(Rot3.IsValid(np.diag([1.0, 1.0, -1.0]), 1e-9))
         # Real-data rotation rounded to 9 significant digits (orthogonality
-        # error ~6e-7, from test_Sim3's Skydio sequence). The loose validation
-        # tolerance must accept it, as both ndarray and nested lists.
-        R = [[0.692272397, -0.00529704529, -0.721616549],
-             [0.00634689669, 0.999979075, -0.00125157022],
-             [0.721608079, -0.0037136016, 0.692291531]]
-        Rot3(R)
-        Rot3(np.array(R))
+        # error ~6e-7, from test_Sim3's Skydio sequence): rejected strictly,
+        # accepted at a loose tolerance.
+        R = np.array([[0.692272397, -0.00529704529, -0.721616549],
+                      [0.00634689669, 0.999979075, -0.00125157022],
+                      [0.721608079, -0.0037136016, 0.692291531]])
+        self.assertFalse(Rot3.IsValid(R, 1e-9))
+        self.assertTrue(Rot3.IsValid(R, 1e-3))
 
+    def test_type_identity(self) -> None:
+        """gtsam.Rot3 must be the extension type itself, not a subclass.
+
+        Every inherited factory and every C++ method returning a rotation
+        hands back gtsam.gtsam.Rot3, so a Python subclass would silently
+        break isinstance checks and split the type in the generated stubs,
+        making type checkers reject `r: Rot3 = Rot3.Ypr(...)`.
+        """
+        self.assertIs(gtsam.Rot3, gtsam.gtsam.Rot3)
+        self.assertIsInstance(Rot3.Ypr(0.1, 0.2, 0.3), gtsam.Rot3)
+        self.assertIsInstance(Rot3.Rz(0.5), gtsam.Rot3)
+        self.assertIsInstance(Rot3().inverse(), gtsam.Rot3)
+        self.assertIsInstance(
+            gtsam.Pose3(Rot3(), np.zeros(3)).rotation(), gtsam.Rot3)
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/gtsam/tests/test_matrix_shape_checks.py
+++ b/python/gtsam/tests/test_matrix_shape_checks.py
@@ -1,0 +1,65 @@
+"""
+GTSAM Copyright 2010-2025, Georgia Tech Research Corporation,
+Atlanta, Georgia 30332-0415
+All Rights Reserved
+
+See LICENSE for the license information
+
+Wrapped constructors must reject wrong-shaped Eigen input.
+
+Author: GTSAM contributors
+"""
+
+import unittest
+
+import numpy as np
+
+import gtsam
+from gtsam.utils.test_case import GtsamTestCase
+
+
+class TestMatrixShapeChecks(GtsamTestCase):
+    """Fixed-size Eigen parameters must be enforced at the pybind11 boundary.
+
+    Declaring a wrapper parameter as the dynamic gtsam::Matrix / gtsam::Vector
+    when the C++ signature takes a fixed-size type lets any shape through, and
+    the dynamic-to-fixed Eigen conversion is undefined behaviour once NDEBUG is
+    set. gtsam.Rot3(np.eye(2)) used to segfault, and gtsam.Pose3(np.eye(2))
+    used to return a garbage transform.
+    """
+
+    def test_rot3_rejects_wrong_shape(self) -> None:
+        for bad in (np.eye(2), np.eye(4), np.zeros((3, 4)), np.zeros((1, 3))):
+            with self.subTest(shape=bad.shape), self.assertRaises(TypeError):
+                gtsam.Rot3(bad)
+        gtsam.Rot3(np.eye(3))  # still accepted
+
+    def test_pose3_rejects_wrong_shape(self) -> None:
+        for bad in (np.eye(2), np.eye(3), np.zeros((4, 3))):
+            with self.subTest(shape=bad.shape), self.assertRaises(TypeError):
+                gtsam.Pose3(bad)
+        gtsam.Pose3(np.eye(4))
+
+    def test_pose2_rejects_wrong_length(self) -> None:
+        for bad in (np.zeros(2), np.zeros(4)):
+            with self.subTest(size=bad.size), self.assertRaises(TypeError):
+                gtsam.Pose2(bad)
+        gtsam.Pose2(np.zeros(3))
+
+    def test_oriented_plane3_rejects_wrong_length(self) -> None:
+        for bad in (np.zeros(2), np.zeros(3), np.zeros(5)):
+            with self.subTest(size=bad.size), self.assertRaises(TypeError):
+                gtsam.OrientedPlane3(bad)
+        gtsam.OrientedPlane3(np.array([0.0, 0.0, 1.0, 1.0]))
+
+    def test_cameras_reject_wrong_length(self) -> None:
+        for ctor in (gtsam.CalibratedCamera, gtsam.SphericalCamera):
+            for bad in (np.zeros(2), np.zeros(7)):
+                with self.subTest(ctor=ctor.__name__, size=bad.size), \
+                        self.assertRaises(TypeError):
+                    ctor(bad)
+            ctor(np.zeros(6))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/gtsam/tests/test_matrix_shape_checks.py
+++ b/python/gtsam/tests/test_matrix_shape_checks.py
@@ -40,12 +40,6 @@ class TestMatrixShapeChecks(GtsamTestCase):
                 gtsam.Pose3(bad)
         gtsam.Pose3(np.eye(4))
 
-    def test_pose2_rejects_wrong_length(self) -> None:
-        for bad in (np.zeros(2), np.zeros(4)):
-            with self.subTest(size=bad.size), self.assertRaises(TypeError):
-                gtsam.Pose2(bad)
-        gtsam.Pose2(np.zeros(3))
-
     def test_oriented_plane3_rejects_wrong_length(self) -> None:
         for bad in (np.zeros(2), np.zeros(3), np.zeros(5)):
             with self.subTest(size=bad.size), self.assertRaises(TypeError):

--- a/python/gtsam/tests/test_matrix_shape_checks.py
+++ b/python/gtsam/tests/test_matrix_shape_checks.py
@@ -40,6 +40,22 @@ class TestMatrixShapeChecks(GtsamTestCase):
                 gtsam.Pose3(bad)
         gtsam.Pose3(np.eye(4))
 
+    def test_pose2_vector_constructor_is_gone(self) -> None:
+        """Pose2(vector) was Expmap in disguise; use Pose2.Expmap instead."""
+        with self.assertRaises(TypeError):
+            gtsam.Pose2(np.array([1.0, 2.0, 3.0]))
+        # The replacement is explicit about being the exponential map, and is
+        # declared Vector3 so it rejects wrong lengths.
+        pose = gtsam.Pose2.Expmap(np.array([1.0, 2.0, 3.0]))
+        self.assertAlmostEqual(pose.theta(), 3.0)
+        for bad in (np.zeros(2), np.zeros(4)):
+            with self.subTest(size=bad.size), self.assertRaises(TypeError):
+                gtsam.Pose2.Expmap(bad)
+        # Componentwise construction is a different thing, and still works.
+        p = gtsam.Pose2(1.0, 2.0, 3.0)
+        self.assertAlmostEqual(p.x(), 1.0)
+        self.assertAlmostEqual(p.y(), 2.0)
+
     def test_oriented_plane3_rejects_wrong_length(self) -> None:
         for bad in (np.zeros(2), np.zeros(3), np.zeros(5)):
             with self.subTest(size=bad.size), self.assertRaises(TypeError):


### PR DESCRIPTION
f8469b12 of #2621 added matrix validation by deriving a Python subclass:

    class Rot3(_Rot3_orig):
        def __init__(self, *args, **kwargs): ...

That makes gtsam.Rot3 a *different* type from gtsam.gtsam.Rot3, while every inherited factory and every C++ method returning a rotation keeps returning the extension base:

    gtsam.Rot3 is gtsam.gtsam.Rot3            -> False
    isinstance(Rot3.Ypr(.1,.2,.3), gtsam.Rot3) -> False
    isinstance(Pose3(...).rotation(), gtsam.Rot3) -> False

So any user code doing isinstance(x, gtsam.Rot3) silently stops matching rotations produced by Ypr/Rz/ClosestTo/inverse, Pose3.rotation(), Values.atRot3(), and optimizer results.

pybind11-stubgen faithfully records the split. The re-export

    from gtsam.gtsam import Rot3

disappears from gtsam/__init__.pyi and is replaced by a second class, so type checkers reject ordinary code:

    error: Type "gtsam.gtsam.Rot3" is not assignable to declared type
    "gtsam.Rot3" (reportAssignmentType)
    error: Argument of type "Rot3" cannot be assigned to parameter "r"
    of type "Rot3" (reportArgumentType)

**Review of #2621 established that the validation itself is unnecessary, so remove it rather than repair it.** #2300 reproduces, but not for the reason given: on gtsam 4.2 (cp38–cp311 wheels only, which is why the reporter mentions switching interpreters) every matrix constructor segfaults, including gtsam.Rot3(np.eye(3)) — a valid rotation. It's a numpy 2.x ABI break; 4.2 was built in 2023, before numpy 2.0. With numpy<2 the exact matrix from the issue constructs cleanly, and gtsam.Pose3(np.eye(4)) crashes identically under numpy 2. 4.3a0 onward, built against numpy 2, don't crash on any of it.

Rot3::IsValid, its wrapper exposure and its C++ test are kept — useful independent of the shim, along with Rot3.ClosestTo. A regression test pins gtsam.Rot3 is gtsam.gtsam.Rot3 so the split cannot return.

**The second commit fixes the crash that is real.** It is shape, not values:

```
gtsam.Rot3(np.eye(2))        -> SIGSEGV   on 4.2.2, 4.3a0/a1/a2 and develop
gtsam.Pose3(np.eye(2))       -> a garbage 4x4 transform
gtsam.Rot3(np.zeros((3,4)))  -> an all-zero rotation
```

geometry.i:514 declared Rot3(gtsam::Matrix R) while the C++ ctor is explicit Rot3(const Matrix3&); pybind11 accepts any shape and the dynamic-to-fixed Eigen conversion is UB under NDEBUG. SO3 at :315 is already declared Matrix3 and correctly raises TypeError. Eight declarations fixed across geometry.i, cameras.i, slam.i; genuinely variable-length parameters left alone.

**Behaviour changes.** Wrong-shaped arrays now raise TypeError instead of returning garbage. A correctly-shaped but invalid 3×3 constructs silently again, as before #2621 and as in C++ — the shim only ever covered one entry point, since gtsam.gtsam.Rot3(M) and gtsam.SO3(M) accept it even with the shim in place.