### PR TITLE
ci: generate gtsam_unstable stubs when building wheels

### DIFF
--- a/.github/scripts/python_wheels/cibw_before_all.sh
+++ b/.github/scripts/python_wheels/cibw_before_all.sh
@@ -115,3 +115,6 @@ doxygen build/doc/Doxyfile.xml
 cd $PROJECT_DIR/build/python
 make -j${GTSAM_BUILD_JOBS} install
 make -j${GTSAM_BUILD_JOBS} python-stubs
+if [ "${GTSAM_BUILD_UNSTABLE:-ON}" != "OFF" ]; then
+    make -j${GTSAM_BUILD_JOBS} python-unstable-stubs
+fi


### PR DESCRIPTION
The published wheels contain gtsam_unstable/gtsam_unstable*.so but not a single .pyi, so gtsam_unstable is entirely untyped even though the stable package ships ~1.1 MB of stubs.

The target exists and is wired up correctly for local builds: python/CMakeLists.txt defines python-unstable-stubs and appends it to GTSAM_PYTHON_INSTALL_EXTRA, which the python-install target depends on. The wheel pipeline never goes through python-install. cibw_before_all.sh runs 'make install' followed by 'make python-stubs' and stops, so GTSAM_PYTHON_INSTALL_EXTRA is never consumed and the unstable stubs are never generated. python-unstable-stubs appears nowhere under .github/.

Invoke it explicitly, guarded by the same GTSAM_BUILD_UNSTABLE variable that already decides whether the unstable module is built at all a few lines above.