### PR TITLE
Reject timestamps without corresponding values in IncrementalFixedLagSmoother

### DIFF
--- a/gtsam/nonlinear/IncrementalFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/IncrementalFixedLagSmoother.cpp
@@ -23,6 +23,8 @@
 #include <gtsam/nonlinear/BayesTreeMarginalizationHelper.h>
 #include <gtsam/base/debug.h>
 
+#include <stdexcept>
+
 namespace gtsam {
 
 /* ************************************************************************* */
@@ -58,6 +60,23 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
   std::optional<FastMap<Key, int> > constrainedKeys = {};
 
   const KeySet newFactorKeys = newFactors.keys();
+
+  // Every supplied timestamp must name a value the smoother already holds or
+  // one arriving in this update. A timestamp for any other key describes
+  // nothing the smoother estimates, yet it would enter the map that
+  // getCurrentTimestamp() -- the maximum over all entries -- derives the clock
+  // from, and could silently expire every established state. Validate before
+  // updateKeyTimestampMap(), the first state mutation, so a rejected update
+  // leaves the smoother unchanged.
+  for (const auto& keyTimestamp : timestamps) {
+    const Key key = keyTimestamp.first;
+    if (!isam_.valueExists(key) && !newTheta.exists(key)) {
+      throw std::invalid_argument(
+          "IncrementalFixedLagSmoother::update: timestamp supplied for key '" +
+          DefaultKeyFormatter(key) +
+          "', but no value exists in the smoother or newTheta.");
+    }
+  }
 
   // Update the Timestamps associated with the factor keys
   updateKeyTimestampMap(timestamps);

--- a/gtsam/nonlinear/IncrementalFixedLagSmoother.h
+++ b/gtsam/nonlinear/IncrementalFixedLagSmoother.h
@@ -63,6 +63,22 @@ public:
    * @param newTheta new values for new variables only
    * @param timestamps an (optional) map from keys to real time stamps
    * @param factorsToRemove an (optional) list of factors to remove.
+   *
+   * Every key in @p timestamps must name a value the smoother already holds or
+   * one supplied in @p newTheta in this update; otherwise the update throws
+   * std::invalid_argument identifying the key, before any state is mutated, so
+   * a rejected update leaves the smoother unchanged. Timestamp-before-value is
+   * not supported. A timestamp for an existing value is accepted whether or
+   * not a factor references the key yet, and participates in the smoother
+   * clock normally.
+   *
+   * If this validation fails, no timestamp is retained and no part of the
+   * update is applied. A caller that later supplies the value must supply its
+   * timestamp again; until timestamped, that value is not eligible for
+   * fixed-lag expiration.
+   *
+   * @throws std::invalid_argument if a key in @p timestamps has no value in
+   * the smoother or in @p newTheta.
    */
   Result update(const NonlinearFactorGraph& newFactors = NonlinearFactorGraph(),
                 const Values& newTheta = Values(), //

--- a/gtsam/nonlinear/tests/testIncrementalFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/tests/testIncrementalFixedLagSmoother.cpp
@@ -36,6 +36,7 @@
 
 // #include <algorithm>
 #include <iostream>
+#include <stdexcept>
 #include <string>
 
 using namespace std;
@@ -495,13 +496,86 @@ TEST(IncrementalFixedLagSmoother, ReapsPendingValueAfterLag) {
   EXPECT(smoother.timestamps().find(X(1)) == smoother.timestamps().end());
 }
 
-// A timestamp may be supplied for a key that has neither a value nor a factor.
-// Such a key is not "pending" -- there is no value for it -- so it survives the
-// pending-value partition, ages out, and reaches marginalizeLeaves with no
-// clique. The variableIndex filter guards only the marginalization helper.
+// A timestamp naming no value -- neither an existing one nor one supplied in
+// this update -- is rejected with an error identifying the key, before any
+// state is mutated. The invalid entry arrives mixed with valid factors, values
+// and timestamps, and sorts after them, so a partially mutating implementation
+// cannot pass; rejection must be atomic. No timestamp is retained, so the
+// retry supplies the value together with the same timestamp.
 TEST(IncrementalFixedLagSmoother, TimestampWithoutValueOrFactor) {
   const SharedDiagonal noise = noiseModel::Diagonal::Sigmas(Vector2(0.1, 0.1));
   IncrementalFixedLagSmoother smoother(1.0);
+  const Key invalid = Symbol('z', 0);  // sorts after X(1) in the map
+
+  NonlinearFactorGraph factors;
+  Values values;
+  FixedLagSmoother::KeyTimestampMap timestamps;
+
+  factors.addPrior(X(0), Point2(0.0, 0.0), noise);
+  values.insert(X(0), Point2(0.0, 0.0));
+  timestamps[X(0)] = 0.0;
+  smoother.update(factors, values, timestamps);
+
+  const Values before = smoother.calculateEstimate();
+  const NonlinearFactorGraph factorsBefore = smoother.getFactors();
+  const FixedLagSmoother::KeyTimestampMap timestampsBefore =
+      smoother.timestamps();
+
+  // Valid input for X(1) plus one timestamp with no value anywhere.
+  factors.resize(0);
+  values.clear();
+  timestamps.clear();
+  factors.emplace_shared<BetweenPoint2>(X(0), X(1), Point2(1.0, 0.0), noise);
+  values.insert(X(1), Point2(1.0, 0.0));
+  timestamps[X(1)] = 0.5;
+  timestamps[invalid] = 0.75;  // no value, no factor
+  bool rejectedNamingTheKey = false;
+  try {
+    smoother.update(factors, values, timestamps);
+  } catch (const std::invalid_argument& e) {
+    rejectedNamingTheKey =
+        std::string(e.what()).find(DefaultKeyFormatter(invalid)) !=
+        std::string::npos;
+  }
+  EXPECT(rejectedNamingTheKey);
+
+  // Atomic: the valid parts of the rejected update must not have landed.
+  EXPECT(assert_equal(before, smoother.calculateEstimate(), 0.0));
+  EXPECT(assert_equal(factorsBefore, smoother.getFactors(), 0.0));
+  EXPECT(timestampsBefore == smoother.timestamps());
+  EXPECT(!smoother.getLinearizationPoint().exists(X(1)));
+
+  // The corrected retry supplies the missing value, with the previously
+  // rejected timestamp still present: both must be accepted together.
+  values.insert(invalid, Point2(9.0, 9.0));
+  smoother.update(factors, values, timestamps);
+  EXPECT(smoother.getLinearizationPoint().exists(X(1)));
+  EXPECT(smoother.getLinearizationPoint().exists(invalid));
+  DOUBLES_EQUAL(0.75, smoother.timestamps().at(invalid), 0.0);
+  DOUBLES_EQUAL(0.5, smoother.timestamps().at(X(1)), 0.0);
+}
+
+/* ************************************************************************* */
+namespace seeded_cleanup {
+
+// Timestamps naming no value are rejected at admission, so #2769's cleanup
+// branch is publicly unreachable. This subclass seeds that state directly, for
+// the tests that exercise the cleanup itself.
+class TestableIncrementalFixedLagSmoother : public IncrementalFixedLagSmoother {
+ public:
+  using IncrementalFixedLagSmoother::IncrementalFixedLagSmoother;
+  void injectTimestampForTest(Key key, double timestamp) {
+    KeyTimestampMap timestamps{{key, timestamp}};
+    updateKeyTimestampMap(timestamps);
+  }
+};
+
+// #2769's cleanup of an aged timestamp-only key, in the connected graph shape.
+// Admission now rejects such input, so the state is seeded directly and
+// asserted present before ageing, keeping the test non-vacuous.
+TEST(IncrementalFixedLagSmoother, SeededTimestampWithoutValueIsCleanedUp) {
+  const SharedDiagonal noise = noiseModel::Diagonal::Sigmas(Vector2(0.1, 0.1));
+  TestableIncrementalFixedLagSmoother smoother(1.0);
   const Key phantom = Symbol('p', 0);
 
   NonlinearFactorGraph factors;
@@ -511,8 +585,9 @@ TEST(IncrementalFixedLagSmoother, TimestampWithoutValueOrFactor) {
   factors.addPrior(X(0), Point2(0.0, 0.0), noise);
   values.insert(X(0), Point2(0.0, 0.0));
   timestamps[X(0)] = 0.0;
-  timestamps[phantom] = 0.0;  // no value, no factor
   smoother.update(factors, values, timestamps);
+
+  smoother.injectTimestampForTest(phantom, 0.0);
   EXPECT(smoother.timestamps().find(phantom) != smoother.timestamps().end());
 
   // X(1) is joined to X(0), so marginalizing X(0) leaves a marginal factor.
@@ -530,12 +605,13 @@ TEST(IncrementalFixedLagSmoother, TimestampWithoutValueOrFactor) {
   EXPECT(!smoother.getLinearizationPoint().exists(X(0)));  // marginalized
 }
 
-// The same phantom key, but the following variable is in its own connected
-// component. This reached a different failure from the connected case above,
-// so both graph shapes are covered.
+// The same seeded phantom key, but the following variable is in its own
+// connected component. The cleanup reached a different failure from the
+// connected case, so both graph shapes stay covered. Seeded and asserted
+// present before ageing, since admission now rejects this input.
 TEST(IncrementalFixedLagSmoother, TimestampWithoutValueOrFactorDisconnected) {
   const SharedDiagonal noise = noiseModel::Diagonal::Sigmas(Vector2(0.1, 0.1));
-  IncrementalFixedLagSmoother smoother(1.0);
+  TestableIncrementalFixedLagSmoother smoother(1.0);
   const Key phantom = Symbol('p', 0);
 
   NonlinearFactorGraph factors;
@@ -545,8 +621,10 @@ TEST(IncrementalFixedLagSmoother, TimestampWithoutValueOrFactorDisconnected) {
   factors.addPrior(X(0), Point2(0.0, 0.0), noise);
   values.insert(X(0), Point2(0.0, 0.0));
   timestamps[X(0)] = 0.0;
-  timestamps[phantom] = 0.0;
   smoother.update(factors, values, timestamps);
+
+  smoother.injectTimestampForTest(phantom, 0.0);
+  EXPECT(smoother.timestamps().find(phantom) != smoother.timestamps().end());
 
   // No factor links X(1) to X(0).
   factors.resize(0);
@@ -561,11 +639,12 @@ TEST(IncrementalFixedLagSmoother, TimestampWithoutValueOrFactorDisconnected) {
   EXPECT(smoother.getLinearizationPoint().exists(X(1)));
 }
 
-// A key with a value but no factor is still reaped, not treated as stale.
-// Guards the partition split added alongside the two tests above.
+// A key with a value but no factor is still reaped, not treated as stale, and
+// both partition arms are exercised in the same update. The stale entry is
+// seeded and asserted present before ageing, since admission now rejects it.
 TEST(IncrementalFixedLagSmoother, PendingValueStillReapedAlongsideStaleKey) {
   const SharedDiagonal noise = noiseModel::Diagonal::Sigmas(Vector2(0.1, 0.1));
-  IncrementalFixedLagSmoother smoother(1.0);
+  TestableIncrementalFixedLagSmoother smoother(1.0);
   const Key phantom = Symbol('p', 0);
 
   NonlinearFactorGraph factors;
@@ -577,9 +656,13 @@ TEST(IncrementalFixedLagSmoother, PendingValueStillReapedAlongsideStaleKey) {
   values.insert(X(1), Point2(1.0, 0.0));  // value, no factor -> pending
   timestamps[X(0)] = 0.0;
   timestamps[X(1)] = 0.0;
-  timestamps[phantom] = 0.0;              // no value, no factor -> stale
   smoother.update(factors, values, timestamps);
+
+  smoother.injectTimestampForTest(phantom,
+                                  0.0);  // no value, no factor -> stale
   EXPECT(smoother.getLinearizationPoint().exists(X(1)));
+  EXPECT(smoother.timestamps().find(X(1)) != smoother.timestamps().end());
+  EXPECT(smoother.timestamps().find(phantom) != smoother.timestamps().end());
 
   factors.resize(0);
   values.clear();
@@ -593,6 +676,9 @@ TEST(IncrementalFixedLagSmoother, PendingValueStillReapedAlongsideStaleKey) {
   EXPECT(smoother.timestamps().find(X(1)) == smoother.timestamps().end());
   EXPECT(smoother.timestamps().find(phantom) == smoother.timestamps().end());
 }
+
+}  // namespace seeded_cleanup
+/* ************************************************************************* */
 
 // A clique-less key should be named rather than failing inside the Bayes tree
 // with a message that identifies neither the key nor the caller.
@@ -840,6 +926,110 @@ TEST(FixedLagSmoother, EraseKeyTimestampMapStillErasesPresentKeys) {
   EXPECT(!smoother.getLinearizationPoint().exists(X(0)));
   EXPECT(smoother.getLinearizationPoint().exists(X(1)));
 }
+
+/* ************************************************************************* */
+namespace timestamp_validation {
+
+// Timestamps for keys the smoother can account for are accepted: an existing
+// active value, a previously supplied pending value, and a value arriving in
+// the same update. None of these may be rejected by the validation.
+TEST(IncrementalFixedLagSmoother, AcceptsTimestampsForValuedKeys) {
+  const SharedDiagonal noise = noiseModel::Diagonal::Sigmas(Vector2(0.1, 0.1));
+  IncrementalFixedLagSmoother smoother(10.0);
+  const Key pending = Symbol('p', 0);
+
+  // Same-update value with no factor: accepted.
+  NonlinearFactorGraph factors;
+  Values values;
+  FixedLagSmoother::KeyTimestampMap timestamps;
+  factors.addPrior(X(0), Point2(0.0, 0.0), noise);
+  values.insert(X(0), Point2(0.0, 0.0));
+  values.insert(pending, Point2(1.0, 0.0));  // value + timestamp, no factor
+  timestamps[X(0)] = 0.0;
+  timestamps[pending] = 0.5;
+  smoother.update(factors, values, timestamps);
+  EXPECT(smoother.getLinearizationPoint().exists(pending));
+
+  // Existing active value (X(0)) and previously pending value: both accepted
+  // in a timestamps-only update.
+  timestamps.clear();
+  timestamps[X(0)] = 1.0;
+  timestamps[pending] = 1.5;
+  smoother.update(NonlinearFactorGraph(), Values(), timestamps);
+  DOUBLES_EQUAL(1.0, smoother.timestamps().at(X(0)), 0.0);
+  DOUBLES_EQUAL(1.5, smoother.timestamps().at(pending), 0.0);
+}
+
+// A pending value's timestamp participates in the smoother clock normally: it
+// may advance the window and expire established states. A timestamp on such a
+// key that is wildly inconsistent with the stream is caller error, outside the
+// validation's protection.
+TEST(IncrementalFixedLagSmoother, PendingValueTimestampAdvancesClock) {
+  const SharedDiagonal noise = noiseModel::Diagonal::Sigmas(Vector2(0.1, 0.1));
+  IncrementalFixedLagSmoother smoother(1.0);
+  const Key pending = Symbol('p', 0);
+
+  NonlinearFactorGraph factors;
+  Values values;
+  FixedLagSmoother::KeyTimestampMap timestamps;
+  factors.addPrior(X(0), Point2(0.0, 0.0), noise);
+  values.insert(X(0), Point2(0.0, 0.0));
+  timestamps[X(0)] = 0.0;
+  smoother.update(factors, values, timestamps);
+
+  values.clear();
+  timestamps.clear();
+  values.insert(pending, Point2(1.0, 0.0));  // value, no factor
+  timestamps[pending] = 5.0;
+  smoother.update(NonlinearFactorGraph(), values, timestamps);
+
+  EXPECT(!smoother.getLinearizationPoint().exists(X(0)));  // 5.0 - 1.0 > 0.0
+  EXPECT(smoother.timestamps().find(X(0)) == smoother.timestamps().end());
+  EXPECT(smoother.getLinearizationPoint().exists(pending));
+}
+
+// A value and its timestamp may arrive before the factor that constrains
+// them, with the connecting factor landing in a later update and the timestamp
+// not resent. The key becomes active and keeps the timestamp it was given.
+TEST(IncrementalFixedLagSmoother, PendingValueKeepsTimestampWhenFactorArrives) {
+  const SharedDiagonal noise = noiseModel::Diagonal::Sigmas(Vector2(0.1, 0.1));
+  IncrementalFixedLagSmoother smoother(10.0);
+  const Key pending = Symbol('p', 0);
+
+  NonlinearFactorGraph factors;
+  Values values;
+  FixedLagSmoother::KeyTimestampMap timestamps;
+  factors.addPrior(X(0), Point2(0.0, 0.0), noise);
+  values.insert(X(0), Point2(0.0, 0.0));
+  timestamps[X(0)] = 0.0;
+  smoother.update(factors, values, timestamps);
+
+  values.clear();
+  timestamps.clear();
+  values.insert(pending, Point2(1.0, 0.0));  // value + timestamp, no factor
+  timestamps[pending] = 0.5;
+  smoother.update(NonlinearFactorGraph(), values, timestamps);
+
+  factors.resize(0);
+  values.clear();
+  timestamps.clear();  // the timestamp is not resent
+  factors.emplace_shared<BetweenPoint2>(X(0), pending, Point2(1.0, 0.0), noise);
+  smoother.update(factors, values, timestamps);
+
+  EXPECT(smoother.getLinearizationPoint().exists(pending));
+  bool connected = false;
+  for (const auto& factor : smoother.getFactors()) {
+    if (FactorInvolvesKey(factor, X(0)) && FactorInvolvesKey(factor, pending)) {
+      connected = true;
+      break;
+    }
+  }
+  EXPECT(connected);
+  DOUBLES_EQUAL(0.5, smoother.timestamps().at(pending), 0.0);
+}
+
+}  // namespace timestamp_validation
+/* ************************************************************************* */
 
 int main() {
   TestResult tr;


### PR DESCRIPTION
## Summary

This PR validates timestamp keys passed to `IncrementalFixedLagSmoother::update()`.

Every key in `timestamps` must either already have a value in the smoother or have a value supplied through `newTheta` in the same update:

```cpp
isam_.valueExists(key) || newTheta.exists(key)
```

Otherwise, the update throws `std::invalid_argument` with an error identifying the key. Validation occurs before modifying the timestamp map or ISAM2 state, so a rejected update leaves the smoother unchanged.

An earlier revision derived the clock only from active keys in response to [this counterexample](https://github.com/borglab/gtsam/pull/2781#issuecomment-5497700365), as described in [this follow-up](https://github.com/borglab/gtsam/pull/2781#issuecomment-5510246504). That approach has been removed. This revision preserves the existing clock behavior and narrows the change to input validation.

## Problem

The smoother clock is derived from the largest stored timestamp. A timestamp for a key with no corresponding value can therefore move the fixed-lag cutoff forward and silently marginalize established states, even though the timestamped key does not exist in ISAM2.

For example, with a lag of `5.0`:

```text
update 1: X0, value and prior factor, t = 10.0
update 2: X1, value and between factor, t = 11.0
update 3: no values or factors, only P0 timestamped at 16.1
```

The third update moves the cutoff to `11.1`, marginalizes the established states, and leaves the nonexistent `P0` as the newest timestamp.

In our application this input came from a caller-side bookkeeping bug. Rejecting it immediately provides a useful diagnostic instead of silently changing the estimator state.

## Contract

* A timestamp for an existing value is accepted, even if no factor currently references it, and may advance the smoother's time.
* A timestamp and its value may be supplied together in the same update.
* A timestamp for a key with neither an existing nor a same-update value is rejected before any state mutation.
* Timestamp-before-value is not supported.
* A far-future timestamp attached to an existing or same-update value remains invalid caller input and is outside this PR's protection.
* Existing clock and marginalization semantics are unchanged.
* `BatchFixedLagSmoother` is unchanged.

## Tests

Regression tests verify that:

* A timestamp without a corresponding value is rejected and the error identifies the key.
* A rejected update leaves the smoother unchanged.
* Timestamps for existing and same-update values remain accepted, including values not yet referenced by a factor.
* Existing #2769 cleanup tests seed their otherwise unreachable timestamp state through a test fixture, ensuring those tests remain non-vacuous.

Follow-up to #2769. Related: #2741, #2749, and #2770.
