### PR TITLE
Fix nonlinear symbolic cache invalidation

### DIFF
--- a/gtsam/inference/EliminationTree-inst.h
+++ b/gtsam/inference/EliminationTree-inst.h
@@ -98,7 +98,7 @@ namespace gtsam {
       for (size_t j = 0; j < n; j++)
       {
         // Retrieve the factors involving this variable and create the current node
-        const FactorIndices& factors = structure[order[j]];
+        const FactorIndices& factors = structure.at(order[j]);
         const sharedNode node = std::make_shared<Node>();
         node->key = order[j];
 
@@ -135,7 +135,7 @@ namespace gtsam {
         nodes[j] = node;
       }
     } catch(std::invalid_argument& e) {
-      // If this is thrown from structure[order[j]] above, it means that it was requested to
+      // If this is thrown from structure.at(order[j]) above, it means that it was requested to
       // eliminate a variable not present in the graph, so throw a more informative error message.
       (void)e; // Prevent unused variable warning
       throw std::invalid_argument("EliminationTree: given ordering contains variables that are not involved in the factor graph");

--- a/gtsam/nonlinear/NonlinearOptimizer.cpp
+++ b/gtsam/nonlinear/NonlinearOptimizer.cpp
@@ -34,10 +34,44 @@
 #include <stdexcept>
 #include <iostream>
 #include <iomanip>
+#include <vector>
 
 using namespace std;
 
 namespace gtsam {
+
+/// Cache only the symbolic inputs; numerical factors are read at each solve.
+struct NonlinearOptimizer::IndexedJunctionTreeCache {
+  Ordering ordering;
+  std::vector<KeyVector> factorKeys;
+  IndexedJunctionTree tree;
+
+  /// Snapshot the factor slots and ordering used to build the tree.
+  IndexedJunctionTreeCache(const GaussianFactorGraph& graph,
+                           const Ordering& ordering)
+      : ordering(ordering), tree(graph.buildIndexedJunctionTree(ordering)) {
+    factorKeys.reserve(graph.size());
+    for (const auto& factor : graph) {
+      factorKeys.push_back(factor ? factor->keys() : KeyVector{});
+    }
+  }
+
+  /// Compare exact symbolic inputs without allocating or checking numeric data.
+  bool matches(const GaussianFactorGraph& graph,
+               const Ordering& requestedOrdering) const {
+    if (ordering != requestedOrdering || factorKeys.size() != graph.size()) {
+      return false;
+    }
+    for (size_t i = 0; i < graph.size(); ++i) {
+      if (graph[i]) {
+        if (factorKeys[i] != graph[i]->keys()) return false;
+      } else if (!factorKeys[i].empty()) {
+        return false;
+      }
+    }
+    return true;
+  }
+};
 
 /* ************************************************************************* */
 // NOTE(frank): unique_ptr by-value takes ownership, as discussed in
@@ -142,15 +176,16 @@ VectorValues NonlinearOptimizer::solve(const GaussianFactorGraph& gfg,
   if (params.isMultifrontal()) {
     // Multifrontal QR or Cholesky (decided by params.getEliminationFunction())
     if (params.ordering) {
-      if (!indexedJunctionTreeCache_.has_value()) {
-        indexedJunctionTreeCache_ = gfg.buildIndexedJunctionTree(*params.ordering);
+      if (!indexedJunctionTreeCache_ ||
+          !indexedJunctionTreeCache_->matches(gfg, *params.ordering)) {
+        indexedJunctionTreeCache_ =
+            std::make_unique<IndexedJunctionTreeCache>(gfg, *params.ordering);
       }
 
-      delta = gfg.eliminateMultifrontal(*indexedJunctionTreeCache_,
+      delta = gfg.eliminateMultifrontal(indexedJunctionTreeCache_->tree,
                                         params.getEliminationFunction())
                   ->optimize();
-    }
-    else
+    } else
       delta = gfg.optimize(params.getEliminationFunction());
   } else if (params.isSequential()) {
     // Sequential QR or Cholesky (decided by params.getEliminationFunction())

--- a/gtsam/nonlinear/NonlinearOptimizer.h
+++ b/gtsam/nonlinear/NonlinearOptimizer.h
@@ -20,10 +20,8 @@
 
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/NonlinearOptimizerParams.h>
-#include <gtsam/symbolic/IndexedJunctionTree.h>
 
 #include <memory>
-#include <optional>
 
 namespace gtsam {
 
@@ -97,9 +95,9 @@ class GTSAM_EXPORT NonlinearOptimizer {
   mutable std::unique_ptr<internal::CholmodSolver> cholmodSolver_;
 
  private:
-  /// Cached indexed junction tree used to avoid rebuilding the symbolic structure
-  /// across iterations when the ordering remains constant.
-  mutable std::optional<IndexedJunctionTree> indexedJunctionTreeCache_;
+  /// Symbolic tree and the ordering and per-factor keys that permit its reuse.
+  struct IndexedJunctionTreeCache;
+  mutable std::unique_ptr<IndexedJunctionTreeCache> indexedJunctionTreeCache_;
 
  public:
   /** A shared pointer to this class */

--- a/gtsam/symbolic/tests/testSymbolicEliminationTree.cpp
+++ b/gtsam/symbolic/tests/testSymbolicEliminationTree.cpp
@@ -103,6 +103,15 @@ TEST(EliminationTree, Create) {
 }
 
 /* ************************************************************************* */
+// Missing ordering keys must throw before accessing their factor indices.
+TEST(EliminationTree, RejectsMissingOrderingKey) {
+  SymbolicFactorGraph graph;
+  graph.emplace_shared<SymbolicFactor>(0);
+  CHECK_EXCEPTION(SymbolicEliminationTree(graph, Ordering{1}),
+                  std::invalid_argument);
+}
+
+/* ************************************************************************* */
 TEST(EliminationTree, Create2) {
   //        l1                  l2
   //    /    |                /  |

--- a/tests/testNonlinearOptimizer.cpp
+++ b/tests/testNonlinearOptimizer.cpp
@@ -221,7 +221,7 @@ TEST(NonlinearOptimizer, SymbolicCacheTracksOrdering) {
   bool rejected = false;
   try {
     optimizer.solve(graph, params);
-  } catch (const std::runtime_error&) {
+  } catch (const std::invalid_argument&) {
     rejected = true;
   }
   CHECK(rejected);

--- a/tests/testNonlinearOptimizer.cpp
+++ b/tests/testNonlinearOptimizer.cpp
@@ -115,6 +115,147 @@ class CountingNonlinearFactorGraph : public NonlinearFactorGraph {
 };
 
 /* ************************************************************************* */
+namespace symbolic_cache_regression {
+
+/// A continuous squared hinge penalty that activates above x = 0.5.
+class HingeFactor : public NoiseModelFactor1<double> {
+ public:
+  /// Construct a unit-noise upper-bound penalty.
+  HingeFactor() : NoiseModelFactor1<double>(noiseModel::Unit::Create(1), 0) {}
+
+  /// Determine activity from the current estimate, without external mutation.
+  bool active(const Values& values) const override {
+    return values.at<double>(0) > 0.5;
+  }
+
+  /// Evaluate the active residual and its tangent derivative.
+  Vector evaluateError(const double& x, OptionalMatrixType H) const override {
+    if (H) *H = Matrix11::Identity();
+    return Vector1{x - 0.5};
+  }
+};
+
+// Both GN and LM must include a factor activated by their own state updates.
+TEST(NonlinearOptimizer, ActivatesFactorDuringOptimization) {
+  NonlinearFactorGraph graph;
+  graph.addPrior(0, 2.0);
+  graph.emplace_shared<HingeFactor>();
+  Values initial;
+  initial.insert(0, 0.0);
+  for (auto solver : {NonlinearOptimizerParams::MULTIFRONTAL_CHOLESKY,
+                      NonlinearOptimizerParams::MULTIFRONTAL_QR}) {
+    GaussNewtonParams gnParams;
+    gnParams.setLinearSolver(solver);
+    GaussNewtonOptimizer gn(graph, initial, gnParams);
+    DOUBLES_EQUAL(1.25, gn.optimize().at<double>(0), 1e-8);
+    DOUBLES_EQUAL(0.5625, gn.error(), 1e-8);
+
+    LevenbergMarquardtParams lmParams;
+    lmParams.setLinearSolver(solver);
+    LevenbergMarquardtOptimizer lm(graph, initial, lmParams);
+    DOUBLES_EQUAL(1.25, lm.optimize().at<double>(0), 1e-8);
+    DOUBLES_EQUAL(0.5625, lm.error(), 1e-8);
+  }
+}
+
+// Factor slots can become active, disappear, or be appended between solves.
+TEST(NonlinearOptimizer, SymbolicCacheTracksFactorSlots) {
+  GaussNewtonOptimizer optimizer(NonlinearFactorGraph{}, Values{});
+  NonlinearOptimizerParams params;
+  params.setOrdering(Ordering{0});
+  for (auto solver : {NonlinearOptimizerParams::MULTIFRONTAL_CHOLESKY,
+                      NonlinearOptimizerParams::MULTIFRONTAL_QR}) {
+    params.setLinearSolver(solver);
+    GaussianFactorGraph graph;
+    graph.emplace_shared<JacobianFactor>(0, Matrix11::Identity(), Vector1{0.0});
+    graph.push_back(GaussianFactor::shared_ptr{});
+    DOUBLES_EQUAL(0.0, optimizer.solve(graph, params).at(0)(0), 1e-9);
+
+    graph[1] =
+        std::make_shared<JacobianFactor>(0, Matrix11::Identity(), Vector1{2.0});
+    DOUBLES_EQUAL(1.0, optimizer.solve(graph, params).at(0)(0), 1e-9);
+
+    graph[1].reset();
+    DOUBLES_EQUAL(0.0, optimizer.solve(graph, params).at(0)(0), 1e-9);
+
+    graph.emplace_shared<JacobianFactor>(0, Matrix11::Identity(), Vector1{4.0});
+    DOUBLES_EQUAL(2.0, optimizer.solve(graph, params).at(0)(0), 1e-9);
+
+    graph.resize(1);
+    DOUBLES_EQUAL(0.0, optimizer.solve(graph, params).at(0)(0), 1e-9);
+  }
+}
+
+// A factor's support can change in place without changing its address or arity.
+TEST(NonlinearOptimizer, SymbolicCacheTracksFactorKeys) {
+  GaussNewtonOptimizer optimizer(NonlinearFactorGraph{}, Values{});
+  NonlinearOptimizerParams params;
+  params.setOrdering(Ordering{0, 1});
+  GaussianFactorGraph graph;
+  graph.emplace_shared<JacobianFactor>(0, Matrix11::Identity(), Vector1{0.0});
+  graph.emplace_shared<JacobianFactor>(1, Matrix11::Identity(), Vector1{4.0});
+  auto changingFactor =
+      std::make_shared<JacobianFactor>(0, Matrix11::Identity(), Vector1{2.0});
+  graph.push_back(changingFactor);
+  DOUBLES_EQUAL(1.0, optimizer.solve(graph, params).at(0)(0), 1e-9);
+
+  *changingFactor = JacobianFactor(1, Matrix11::Identity(), Vector1{2.0});
+  const VectorValues result = optimizer.solve(graph, params);
+  DOUBLES_EQUAL(0.0, result.at(0)(0), 1e-9);
+  DOUBLES_EQUAL(3.0, result.at(1)(0), 1e-9);
+}
+
+// A changed ordering must be validated instead of silently reusing the old one.
+TEST(NonlinearOptimizer, SymbolicCacheTracksOrdering) {
+  GaussNewtonOptimizer optimizer(NonlinearFactorGraph{}, Values{});
+  NonlinearOptimizerParams params;
+  params.setOrdering(Ordering{0, 1});
+  GaussianFactorGraph graph;
+  graph.emplace_shared<JacobianFactor>(0, Matrix11::Identity(), Vector1{1.0});
+  graph.emplace_shared<JacobianFactor>(1, Matrix11::Identity(), Vector1{2.0});
+  const VectorValues expected = optimizer.solve(graph, params);
+  params.setOrdering(Ordering{1, 0});
+  EXPECT(assert_equal(expected, optimizer.solve(graph, params), 1e-9));
+
+  params.setOrdering(Ordering{0, 2});
+  bool rejected = false;
+  try {
+    optimizer.solve(graph, params);
+  } catch (const std::runtime_error&) {
+    rejected = true;
+  }
+  CHECK(rejected);
+
+  // Failed rebuilding must not corrupt the previously valid cache.
+  params.setOrdering(Ordering{1, 0});
+  EXPECT(assert_equal(expected, optimizer.solve(graph, params), 1e-9));
+}
+
+// The symbolic tree contains keys, not numerical blocks or variable dimensions.
+TEST(NonlinearOptimizer, SymbolicCacheAllowsNumericalChanges) {
+  GaussNewtonOptimizer optimizer(NonlinearFactorGraph{}, Values{});
+  NonlinearOptimizerParams params;
+  params.setOrdering(Ordering{0});
+  GaussianFactorGraph graph;
+  graph.emplace_shared<JacobianFactor>(0, Matrix11::Identity(), Vector1{1.0});
+  DOUBLES_EQUAL(1.0, optimizer.solve(graph, params).at(0)(0), 1e-9);
+
+  graph[0] = std::make_shared<HessianFactor>(0, Matrix22::Identity(),
+                                             Vector2{2.0, 3.0}, 13.0);
+  EXPECT(assert_equal(Vector2{2.0, 3.0}, optimizer.solve(graph, params).at(0),
+                      1e-9));
+  graph[0] = std::make_shared<JacobianFactor>(
+      0, Matrix22::Identity(), Vector2{4.0, 5.0},
+      noiseModel::Isotropic::Sigma(2, 2.0));
+  EXPECT(assert_equal(Vector2{4.0, 5.0}, optimizer.solve(graph, params).at(0),
+                      1e-9));
+
+  params.setOrdering(Ordering{});
+  LONGS_EQUAL(0, optimizer.solve(GaussianFactorGraph{}, params).size());
+}
+
+}  // namespace symbolic_cache_regression
+/* ************************************************************************* */
 namespace arm64_return_regression {
 
 class GpsLikePositionFactor : public NoiseModelFactorN<Pose2> {

--- a/timing/timeNonlinearOptimizerCache.cpp
+++ b/timing/timeNonlinearOptimizerCache.cpp
@@ -8,12 +8,14 @@
 
 /**
  * @file timeNonlinearOptimizerCache.cpp
- * @brief Compare repeated optimizer solves with fresh symbolic elimination.
+ * @brief Compare validated cache reuse, unchecked reuse, and fresh elimination.
  */
 
+#include <gtsam/linear/GaussianBayesTree.h>
 #include <gtsam/linear/GaussianFactorGraph.h>
 #include <gtsam/nonlinear/GaussNewtonOptimizer.h>
 #include <gtsam/slam/BetweenFactor.h>
+#include <gtsam/symbolic/IndexedJunctionTree.h>
 
 #include <algorithm>
 #include <chrono>
@@ -23,6 +25,24 @@
 #include <vector>
 
 using namespace gtsam;
+
+/// Reproduce the old cache policy for fixed-structure benchmark inputs only.
+class UncheckedCacheOptimizer : public GaussNewtonOptimizer {
+  mutable std::optional<IndexedJunctionTree> tree_;
+
+ public:
+  using GaussNewtonOptimizer::GaussNewtonOptimizer;
+
+  /// Reuse the first tree without validating subsequent symbolic inputs.
+  VectorValues solve(const GaussianFactorGraph& graph,
+                     const NonlinearOptimizerParams& params) const override {
+    if (!tree_) {
+      tree_ = graph.buildIndexedJunctionTree(*params.ordering);
+    }
+    return graph.eliminateMultifrontal(*tree_, params.getEliminationFunction())
+        ->optimize();
+  }
+};
 
 /// Return median microseconds per operation after an untimed warmup.
 template <class Operation>
@@ -57,15 +77,19 @@ void benchmarkLinear(size_t variables, size_t dimension, size_t repetitions) {
   NonlinearOptimizerParams params;
   params.setOrdering(Ordering::Colamd(graph));
   GaussNewtonOptimizer optimizer(NonlinearFactorGraph{}, Values{});
+  UncheckedCacheOptimizer uncheckedOptimizer(NonlinearFactorGraph{}, Values{});
   double checksum = 0.0;
   const double cached = medianTime(repetitions, [&] {
     checksum += optimizer.solve(graph, params).at(0)(0);
+  });
+  const double unchecked = medianTime(repetitions, [&] {
+    checksum += uncheckedOptimizer.solve(graph, params).at(0)(0);
   });
   const double rebuilt = medianTime(repetitions, [&] {
     checksum += graph.optimize(*params.ordering).at(0)(0);
   });
   std::cout << "linear," << variables << ',' << dimension << ',' << cached
-            << ',' << rebuilt << ',' << checksum << '\n';
+            << ',' << unchecked << ',' << rebuilt << ',' << checksum << '\n';
 }
 
 /// Include linearization, error evaluation, and retraction in the measurement.
@@ -83,8 +107,11 @@ void benchmarkNonlinear(size_t variables, size_t repetitions) {
     }
   }
   GaussNewtonOptimizer optimizer(graph, initial);
+  UncheckedCacheOptimizer uncheckedOptimizer(graph, initial);
   const double time = medianTime(repetitions, [&] { optimizer.iterate(); });
-  std::cout << "nonlinear," << variables << ",3," << time << ",,"
+  const double unchecked =
+      medianTime(repetitions, [&] { uncheckedOptimizer.iterate(); });
+  std::cout << "nonlinear," << variables << ",3," << time << ',' << unchecked << ",,"
             << optimizer.error() << '\n';
 }
 
@@ -97,7 +124,7 @@ int main(int argc, char** argv) {
     return 1;
   }
   std::cout << std::fixed << std::setprecision(3)
-            << "case,variables,dimension,cached_us,rebuilt_us,checksum\n";
+            << "case,variables,dimension,cached_us,unchecked_us,rebuilt_us,checksum\n";
   benchmarkLinear(variables, 1, repetitions);
   benchmarkLinear(variables, 6, repetitions);
   benchmarkNonlinear(variables, repetitions);

--- a/timing/timeNonlinearOptimizerCache.cpp
+++ b/timing/timeNonlinearOptimizerCache.cpp
@@ -1,0 +1,105 @@
+/* ----------------------------------------------------------------------------
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+ * See LICENSE for the license information
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file timeNonlinearOptimizerCache.cpp
+ * @brief Compare repeated optimizer solves with fresh symbolic elimination.
+ */
+
+#include <gtsam/linear/GaussianFactorGraph.h>
+#include <gtsam/nonlinear/GaussNewtonOptimizer.h>
+#include <gtsam/slam/BetweenFactor.h>
+
+#include <algorithm>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace gtsam;
+
+/// Return median microseconds per operation after an untimed warmup.
+template <class Operation>
+double medianTime(size_t repetitions, Operation operation) {
+  using Clock = std::chrono::steady_clock;
+  operation();
+  std::vector<double> samples;
+  for (size_t sample = 0; sample < 7; ++sample) {
+    const auto start = Clock::now();
+    for (size_t i = 0; i < repetitions; ++i) operation();
+    samples.push_back(
+        std::chrono::duration<double, std::micro>(Clock::now() - start)
+            .count() /
+        repetitions);
+  }
+  std::sort(samples.begin(), samples.end());
+  return samples[samples.size() / 2];
+}
+
+/// Benchmark a fixed graph with scalar or six-dimensional variable blocks.
+void benchmarkLinear(size_t variables, size_t dimension, size_t repetitions) {
+  GaussianFactorGraph graph;
+  const Matrix identity = Matrix::Identity(dimension, dimension);
+  const Vector measurement = Vector::Ones(dimension);
+  for (Key key = 0; key < variables; ++key) {
+    graph.emplace_shared<JacobianFactor>(key, identity, measurement);
+    if (key > 0) {
+      graph.emplace_shared<JacobianFactor>(key - 1, -identity, key, identity,
+                                           measurement);
+    }
+  }
+  NonlinearOptimizerParams params;
+  params.setOrdering(Ordering::Colamd(graph));
+  GaussNewtonOptimizer optimizer(NonlinearFactorGraph{}, Values{});
+  double checksum = 0.0;
+  const double cached = medianTime(repetitions, [&] {
+    checksum += optimizer.solve(graph, params).at(0)(0);
+  });
+  const double rebuilt = medianTime(repetitions, [&] {
+    checksum += graph.optimize(*params.ordering).at(0)(0);
+  });
+  std::cout << "linear," << variables << ',' << dimension << ',' << cached
+            << ',' << rebuilt << ',' << checksum << '\n';
+}
+
+/// Include linearization, error evaluation, and retraction in the measurement.
+void benchmarkNonlinear(size_t variables, size_t repetitions) {
+  NonlinearFactorGraph graph;
+  Values initial;
+  const Vector3 measurement{1.0, 0.5, -0.25};
+  const auto model = noiseModel::Unit::Create(3);
+  for (Key key = 0; key < variables; ++key) {
+    initial.insert(key, Vector3::Zero().eval());
+    graph.addPrior(key, measurement, model);
+    if (key > 0) {
+      graph.emplace_shared<BetweenFactor<Vector3>>(key - 1, key, measurement,
+                                                   model);
+    }
+  }
+  GaussNewtonOptimizer optimizer(graph, initial);
+  const double time = medianTime(repetitions, [&] { optimizer.iterate(); });
+  std::cout << "nonlinear," << variables << ",3," << time << ",,"
+            << optimizer.error() << '\n';
+}
+
+/// Usage: timeNonlinearOptimizerCache [variables=1000] [repetitions=30].
+int main(int argc, char** argv) {
+  const size_t variables = argc > 1 ? std::stoul(argv[1]) : 1000;
+  const size_t repetitions = argc > 2 ? std::stoul(argv[2]) : 30;
+  if (variables == 0 || repetitions == 0) {
+    std::cerr << "variables and repetitions must be positive\n";
+    return 1;
+  }
+  std::cout << std::fixed << std::setprecision(3)
+            << "case,variables,dimension,cached_us,rebuilt_us,checksum\n";
+  benchmarkLinear(variables, 1, repetitions);
+  benchmarkLinear(variables, 6, repetitions);
+  benchmarkNonlinear(variables, repetitions);
+  return 0;
+}

--- a/timing/timeNonlinearOptimizerCache.cpp
+++ b/timing/timeNonlinearOptimizerCache.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <functional>
 #include <iomanip>
 #include <iostream>
 #include <string>
@@ -44,22 +45,29 @@ class UncheckedCacheOptimizer : public GaussNewtonOptimizer {
   }
 };
 
-/// Return median microseconds per operation after an untimed warmup.
-template <class Operation>
-double medianTime(size_t repetitions, Operation operation) {
+/// Interleave alternatives, reversing their order to limit timing drift.
+std::vector<double> medianTimes(
+    size_t repetitions, const std::vector<std::function<void()>>& operations) {
   using Clock = std::chrono::steady_clock;
-  operation();
-  std::vector<double> samples;
+  for (const auto& operation : operations) operation();
+  std::vector<std::vector<double>> samples(operations.size());
   for (size_t sample = 0; sample < 7; ++sample) {
-    const auto start = Clock::now();
-    for (size_t i = 0; i < repetitions; ++i) operation();
-    samples.push_back(
-        std::chrono::duration<double, std::micro>(Clock::now() - start)
-            .count() /
-        repetitions);
+    for (size_t j = 0; j < operations.size(); ++j) {
+      const size_t index = sample % 2 ? operations.size() - 1 - j : j;
+      const auto start = Clock::now();
+      for (size_t i = 0; i < repetitions; ++i) operations[index]();
+      samples[index].push_back(
+          std::chrono::duration<double, std::micro>(Clock::now() - start)
+              .count() /
+          repetitions);
+    }
   }
-  std::sort(samples.begin(), samples.end());
-  return samples[samples.size() / 2];
+  std::vector<double> medians;
+  for (auto& times : samples) {
+    std::sort(times.begin(), times.end());
+    medians.push_back(times[times.size() / 2]);
+  }
+  return medians;
 }
 
 /// Benchmark a fixed graph with scalar or six-dimensional variable blocks.
@@ -79,17 +87,12 @@ void benchmarkLinear(size_t variables, size_t dimension, size_t repetitions) {
   GaussNewtonOptimizer optimizer(NonlinearFactorGraph{}, Values{});
   UncheckedCacheOptimizer uncheckedOptimizer(NonlinearFactorGraph{}, Values{});
   double checksum = 0.0;
-  const double cached = medianTime(repetitions, [&] {
-    checksum += optimizer.solve(graph, params).at(0)(0);
-  });
-  const double unchecked = medianTime(repetitions, [&] {
-    checksum += uncheckedOptimizer.solve(graph, params).at(0)(0);
-  });
-  const double rebuilt = medianTime(repetitions, [&] {
-    checksum += graph.optimize(*params.ordering).at(0)(0);
-  });
-  std::cout << "linear," << variables << ',' << dimension << ',' << cached
-            << ',' << unchecked << ',' << rebuilt << ',' << checksum << '\n';
+  const auto times = medianTimes(repetitions, {
+      [&] { checksum += optimizer.solve(graph, params).at(0)(0); },
+      [&] { checksum += uncheckedOptimizer.solve(graph, params).at(0)(0); },
+      [&] { checksum += graph.optimize(*params.ordering).at(0)(0); }});
+  std::cout << "linear," << variables << ',' << dimension << ',' << times[0]
+            << ',' << times[1] << ',' << times[2] << ',' << checksum << '\n';
 }
 
 /// Include linearization, error evaluation, and retraction in the measurement.
@@ -108,10 +111,9 @@ void benchmarkNonlinear(size_t variables, size_t repetitions) {
   }
   GaussNewtonOptimizer optimizer(graph, initial);
   UncheckedCacheOptimizer uncheckedOptimizer(graph, initial);
-  const double time = medianTime(repetitions, [&] { optimizer.iterate(); });
-  const double unchecked =
-      medianTime(repetitions, [&] { uncheckedOptimizer.iterate(); });
-  std::cout << "nonlinear," << variables << ",3," << time << ',' << unchecked << ",,"
+  const auto times = medianTimes(repetitions, {
+      [&] { optimizer.iterate(); }, [&] { uncheckedOptimizer.iterate(); }});
+  std::cout << "nonlinear," << variables << ",3," << times[0] << ',' << times[1] << ",,"
             << optimizer.error() << '\n';
 }
 


### PR DESCRIPTION
A factor can become active after an optimizer updates its estimate, but the cached indexed junction tree still reflects the first linearization. The nonlinear error then includes a factor that the linear solve omits. The regression starts at `x = 0` with a prior at `2` and a hinge penalty above `0.5`: the original Gauss-Newton solve stops at `2`, while the corrected solve reaches the minimum at `1.25`.

Cache the ordering and keys in each Gaussian factor slot alongside the tree, and rebuild when those symbolic inputs change. Exact comparisons also handle deactivation, graph resizing, in-place key changes, and ordering changes. Numerical coefficients, noise models, and variable dimensions can change while reusing the tree. The private cache keeps replacement exception-safe without adding public methods.

Validation used Clang 22.1.8 in Release mode with deprecated APIs and TBB disabled:

- Five added regression tests fail against the original library and pass with the fix. Coverage includes automatic activation in GN and LM with multifrontal Cholesky and QR, factor-slot and key changes, ordering validation and failed-rebuild recovery, numerical changes, and an empty graph.
- `testNonlinearOptimizer.run`, `testGaussianFactorGraph.run`, `testDoglegOptimizer.run`, `testNonlinearConjugateGradientOptimizer.run`, and `testNonlinearMultifrontalSolver.run` all pass.
- The new `timeNonlinearOptimizerCache` benchmark builds and runs. `git diff --check` passes.

The documentation directory cleanup is tracked separately in #2788.
