### PR TITLE
Reset adaptive LM rejection multiplier after accepted steps

### DIFF
--- a/gtsam/nonlinear/internal/LevenbergMarquardtPolicy.h
+++ b/gtsam/nonlinear/internal/LevenbergMarquardtPolicy.h
@@ -35,7 +35,10 @@ inline void increaseLevenbergMarquardtLambda(
   }
 }
 
-/** Decrease LM damping after accepting a step with the given fidelity. */
+/**
+ * Update LM damping after accepting a step with the given fidelity.
+ * The adaptive Nielsen policy resets the rejection multiplier to two.
+ */
 inline void decreaseLevenbergMarquardtLambda(
     const LevenbergMarquardtParams& params, double modelFidelity,
     double* lambda, double* currentFactor) {
@@ -45,7 +48,7 @@ inline void decreaseLevenbergMarquardtLambda(
     *lambda *= std::max(
         1.0 / 3.0,
         1.0 - std::pow(2.0 * modelFidelity - 1.0, 3));
-    *currentFactor *= 2.0;
+    *currentFactor = 2.0;
   }
   *lambda = std::max(params.lambdaLowerBound, *lambda);
 }

--- a/tests/testNonlinearOptimizer.cpp
+++ b/tests/testNonlinearOptimizer.cpp
@@ -47,31 +47,96 @@ using symbol_shorthand::X;
 using symbol_shorthand::L;
 
 /* ************************************************************************* */
-// Verifies LevenbergMarquardtPolicy::AppliesAdaptiveLambdaUpdates.
+namespace lm_policy_fixture {
+
+// A smooth residual whose first two LM steps from x = 2 succeed, then overshoot.
+class CubicFactor : public NoiseModelFactorN<double> {
+ public:
+  CubicFactor() : NoiseModelFactorN<double>(noiseModel::Unit::Create(1), 0) {}
+
+  Vector evaluateError(const double& value,
+                       OptionalMatrixType derivative) const override {
+    if (derivative) *derivative = Matrix11{3.0 * value * value - 2.0};
+    return Vector1{value * value * value - 2.0 * value + 2.0};
+  }
+};
+
+// A custom initial multiplier applies before the first acceptance, then resets.
 TEST(LevenbergMarquardtPolicy, AppliesAdaptiveLambdaUpdates) {
   LevenbergMarquardtParams params;
   params.useFixedLambdaFactor = false;
-  params.lambdaLowerBound = 1e-6;
+  params.lambdaFactor = 10.0;
 
   double lambda = 9e-3;
-  double factor = 10.0;
+  double factor = params.lambdaFactor;
   internal::increaseLevenbergMarquardtLambda(params, &lambda, &factor);
   DOUBLES_EQUAL(9e-2, lambda, 1e-15);
   DOUBLES_EQUAL(20.0, factor, 1e-15);
 
   internal::decreaseLevenbergMarquardtLambda(params, 1.0, &lambda, &factor);
   DOUBLES_EQUAL(3e-2, lambda, 1e-15);
-  DOUBLES_EQUAL(40.0, factor, 1e-15);
+  DOUBLES_EQUAL(2.0, factor, 1e-15);
 
-  lambda = 1e-7;
-  factor = 10.0;
-  internal::decreaseLevenbergMarquardtLambda(params, 1.0, &lambda, &factor);
-  DOUBLES_EQUAL(params.lambdaLowerBound, lambda, 1e-15);
-  DOUBLES_EQUAL(20.0, factor, 1e-15);
+  internal::increaseLevenbergMarquardtLambda(params, &lambda, &factor);
+  DOUBLES_EQUAL(6e-2, lambda, 1e-15);
+  DOUBLES_EQUAL(4.0, factor, 1e-15);
 }
 
-/* ************************************************************************* */
-// Verifies LevenbergMarquardtPolicy::AppliesFixedLambdaUpdates.
+// Consecutive accepted steps must not amplify the next rejected step's damping.
+TEST(LevenbergMarquardtPolicy, AcceptAcceptReject) {
+  const auto params = LevenbergMarquardtParams::CeresDefaults();
+  double lambda = 9e-3;
+  double factor = params.lambdaFactor;
+
+  internal::decreaseLevenbergMarquardtLambda(params, 1.0, &lambda, &factor);
+  internal::decreaseLevenbergMarquardtLambda(params, 1.0, &lambda, &factor);
+  DOUBLES_EQUAL(1e-3, lambda, 1e-15);
+  DOUBLES_EQUAL(2.0, factor, 1e-15);
+
+  internal::increaseLevenbergMarquardtLambda(params, &lambda, &factor);
+  DOUBLES_EQUAL(2e-3, lambda, 1e-15);
+  DOUBLES_EQUAL(4.0, factor, 1e-15);
+}
+
+// Acceptance clears the multiplier accumulated by consecutive rejections.
+TEST(LevenbergMarquardtPolicy, RejectRejectAcceptReject) {
+  const auto params = LevenbergMarquardtParams::CeresDefaults();
+  double lambda = 1e-3;
+  double factor = params.lambdaFactor;
+
+  internal::increaseLevenbergMarquardtLambda(params, &lambda, &factor);
+  DOUBLES_EQUAL(2e-3, lambda, 1e-15);
+  DOUBLES_EQUAL(4.0, factor, 1e-15);
+  internal::increaseLevenbergMarquardtLambda(params, &lambda, &factor);
+  DOUBLES_EQUAL(8e-3, lambda, 1e-15);
+  DOUBLES_EQUAL(8.0, factor, 1e-15);
+
+  internal::decreaseLevenbergMarquardtLambda(params, 0.75, &lambda, &factor);
+  DOUBLES_EQUAL(7e-3, lambda, 1e-15);
+  DOUBLES_EQUAL(2.0, factor, 1e-15);
+  internal::increaseLevenbergMarquardtLambda(params, &lambda, &factor);
+  DOUBLES_EQUAL(14e-3, lambda, 1e-15);
+  DOUBLES_EQUAL(4.0, factor, 1e-15);
+}
+
+// Long success sequences stay bounded, including when lambda reaches its floor.
+TEST(LevenbergMarquardtPolicy, RepeatedAcceptancesAtLowerBound) {
+  auto params = LevenbergMarquardtParams::CeresDefaults();
+  params.lambdaLowerBound = 1e-6;
+  double lambda = 1e-7;
+  double factor = params.lambdaFactor;
+
+  for (size_t iteration = 0; iteration < 2048; ++iteration) {
+    internal::decreaseLevenbergMarquardtLambda(params, 1.0, &lambda, &factor);
+  }
+  DOUBLES_EQUAL(params.lambdaLowerBound, lambda, 1e-15);
+  DOUBLES_EQUAL(2.0, factor, 1e-15);
+  internal::increaseLevenbergMarquardtLambda(params, &lambda, &factor);
+  DOUBLES_EQUAL(2e-6, lambda, 1e-15);
+  DOUBLES_EQUAL(4.0, factor, 1e-15);
+}
+
+// Fixed damping keeps the configured multiplier across rejections and successes.
 TEST(LevenbergMarquardtPolicy, AppliesFixedLambdaUpdates) {
   LevenbergMarquardtParams params;
   params.useFixedLambdaFactor = true;
@@ -86,7 +151,48 @@ TEST(LevenbergMarquardtPolicy, AppliesFixedLambdaUpdates) {
   DOUBLES_EQUAL(1e-3, lambda, 1e-15);
   DOUBLES_EQUAL(10.0, factor, 1e-15);
 
+  params.lambdaLowerBound = 5e-4;
+  internal::decreaseLevenbergMarquardtLambda(params, 1.0, &lambda, &factor);
+  DOUBLES_EQUAL(params.lambdaLowerBound, lambda, 1e-15);
+  DOUBLES_EQUAL(10.0, factor, 1e-15);
 }
+
+// Real LM acceptances reset the next rejection multiplier with Cholesky and QR.
+TEST(NonlinearOptimizer, AdaptiveLambdaAfterAcceptedSteps) {
+  NonlinearFactorGraph graph;
+  graph.emplace_shared<CubicFactor>();
+  Values initial;
+  initial.insert(0, 2.0);
+
+  for (const auto solver : {NonlinearOptimizerParams::MULTIFRONTAL_CHOLESKY,
+                            NonlinearOptimizerParams::MULTIFRONTAL_QR}) {
+    LevenbergMarquardtParams params;
+    params.useFixedLambdaFactor = false;
+    params.lambdaInitial = 1e-2;
+    params.lambdaFactor = 2.0;
+    params.relativeErrorTol = 0.0;
+    params.linearSolverType = solver;
+    LevenbergMarquardtOptimizer optimizer(graph, initial, params);
+
+    optimizer.iterate();
+    optimizer.iterate();
+    LONGS_EQUAL(2, optimizer.iterations());
+    LONGS_EQUAL(2, optimizer.getInnerIterations());
+    const Values acceptedValues = optimizer.values();
+    const double acceptedError = optimizer.error();
+    const double lambdaBeforeRejection = optimizer.lambda();
+
+    EXPECT(!optimizer.tryLambda(*optimizer.linearize(), VectorValues()));
+    EXPECT(assert_equal(acceptedValues, optimizer.values()));
+    DOUBLES_EQUAL(acceptedError, optimizer.error(), 1e-15);
+    LONGS_EQUAL(2, optimizer.iterations());
+    LONGS_EQUAL(3, optimizer.getInnerIterations());
+    DOUBLES_EQUAL(2.0 * lambdaBeforeRejection, optimizer.lambda(), 1e-12);
+  }
+}
+
+}  // namespace lm_policy_fixture
+/* ************************************************************************* */
 
 class CountingNonlinearFactorGraph : public NonlinearFactorGraph {
  public:

--- a/timing/timeSFMBAL.cpp
+++ b/timing/timeSFMBAL.cpp
@@ -24,6 +24,7 @@
 #include <gtsam/linear/JacobianFactor.h>
 #include <gtsam/nonlinear/BatchFactor.h>
 #include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
+#include <gtsam/nonlinear/internal/LevenbergMarquardtPolicy.h>
 #include <gtsam/sfm/SfmLevenbergMarquardt.h>
 #include <gtsam/symbolic/IndexedJunctionTree.h>
 
@@ -410,19 +411,13 @@ PointCholeskyProfileRow profilePointFirstCholeskyVariant(
       stopSearchingLambda = std::abs(costChange) < minAbsoluteTolerance;
 
       if (stepSuccessful) {
-        if (params.useFixedLambdaFactor) {
-          lambda /= currentFactor;
-        } else {
-          lambda *=
-              std::max(1.0 / 3.0, 1.0 - std::pow(2.0 * modelFidelity - 1.0, 3));
-          currentFactor = 2.0 * currentFactor;
-        }
-        lambda = std::max(params.lambdaLowerBound, lambda);
+        internal::decreaseLevenbergMarquardtLambda(
+            params, modelFidelity, &lambda, &currentFactor);
         acceptedValues = std::move(newValues);
         acceptedError = newError;
       } else if (!stopSearchingLambda) {
-        lambda *= currentFactor;
-        if (!params.useFixedLambdaFactor) currentFactor *= 2.0;
+        internal::increaseLevenbergMarquardtLambda(params, &lambda,
+                                                 &currentFactor);
         if (lambda >= params.lambdaUpperBound) {
           stopSearchingLambda = true;
         }


### PR DESCRIPTION
In adaptive LM (`useFixedLambdaFactor=false`), accepted steps were doubling `currentFactor`, the multiplier used to increase damping after a rejection. Starting at `2`, two accepted steps leave it at `8`, so the next rejection increases lambda eightfold. This accumulation can cause premature termination at `lambdaUpperBound` and eventually overflow the multiplier.

The fix resets `currentFactor` to `2.0` after acceptance and doubles it only after rejection. This follows **Nielsen's update rule**, given in [Madsen, Nielsen & Tingleff (2004), Eq. (2.21), page 14](https://www2.imm.dtu.dk/pubdb/edoc/imm3215.pdf#page=8). [Ceres implements the same reset](https://ceres-solver.googlesource.com/ceres-solver/+/master/internal/ceres/levenberg_marquardt_strategy.cc) in `StepAccepted()`. A custom `lambdaFactor` still controls the initial rejection sequence.

The correction lives in the shared CPU/CUDA policy. The BAL profiling loop now uses that helper too, removing a duplicate implementation. The update remains constant-time and allocation-free.

Validation:

- Five regression cases fail with the original policy and pass with the fix, covering acceptance/rejection sequences, custom initial factors, the damping floor, overflow, and actual LM steps with Cholesky and QR.
- Nonlinear optimizer, multifrontal solver, and SFM optimizer suites pass.
- CUDA sparse PCG and SFM PCG/dense Cholesky validation passed on an RTX 5090. cuDSS was not tested because it is not installed.
