### PR TITLE
python: wrapper fixes for AttitudeFactor noise model

### DIFF
--- a/gtsam/navigation/navigation.i
+++ b/gtsam/navigation/navigation.i
@@ -717,10 +717,10 @@ template<VALUE = {gtsam::Rot3, gtsam::Pose3, gtsam::NavState, gtsam::Gal3,
                   gtsam::Se23, gtsam::ExtendedPose3d}>
 virtual class AttitudeFactor : gtsam::NoiseModelFactor {
   AttitudeFactor(gtsam::Key key, const gtsam::Unit3& nRef,
-                 const gtsam::noiseModel::Diagonal* model,
+                 const gtsam::noiseModel::Base* model,
                  const gtsam::Unit3& bMeasured);
   AttitudeFactor(gtsam::Key key, const gtsam::Unit3& nRef,
-                 const gtsam::noiseModel::Diagonal* model);
+                 const gtsam::noiseModel::Base* model);
   AttitudeFactor();
   const gtsam::Unit3& nRef() const;
   const gtsam::Unit3& bMeasured() const;

--- a/python/gtsam/tests/test_AttitudeFactor.py
+++ b/python/gtsam/tests/test_AttitudeFactor.py
@@ -40,6 +40,25 @@ class TestAttitudeFactor(GtsamTestCase):
         values.insert(0, state)
         self.assertAlmostEqual(factor.error(values), 0.0, places=9)
 
+    def test_accepts_any_noise_model(self):
+        """The constructor takes a noiseModel.Base, not only a Diagonal.
+
+        Regression test: the wrapper used to declare the model as a
+        Diagonal, which rejected robust and full-covariance models.
+        """
+        gaussian = gtsam.noiseModel.Gaussian.Covariance(
+            np.array([[0.1, 0.02], [0.02, 0.2]]))
+        robust = gtsam.noiseModel.Robust.Create(
+            gtsam.noiseModel.mEstimator.Huber.Create(1.345), self.model())
+        for model in (gaussian, robust):
+            factor = gtsam.AttitudeFactorRot3(0, self.n_down(), model)
+            values = gtsam.Values()
+            values.insert(0, gtsam.Rot3())
+            self.assertAlmostEqual(factor.error(values), 0.0, places=9)
+            # a rotated state gives a non-zero, finite error under both models
+            values.update(0, gtsam.Rot3.Roll(0.5))
+            self.assertGreater(factor.error(values), 0.0)
+
     def test_navstate_attitude_factor(self):
         state = gtsam.NavState(
             gtsam.Rot3(),


### PR DESCRIPTION
Two unrelated defects in the Python wrapper, one commit each.

1. `gtsam.DefaultKeyFormatter` is the wrapper's only module-level variable. wrap
   emits it as `m_.attr(...) = gtsam::DefaultKeyFormatter`, and pybind11 gives that
   std::function value no `__module__` or `__name__`, so pybind11-stubgen cannot
   resolve it and drops it from the stubs; type checkers then reject a symbol that
   works at runtime and that gtsam's own Python files use (hidden today by
   --ignore-all-errors on the stub targets). ~~Fix: re-register it once in gtsam.tpl,
   after the generated bindings, as a real function. Behaviour is unchanged.
   Declaring it as a function in gtsam.i instead would also make the MATLAB wrapper
   emit a new binding (verified by running it on both declarations), so the fix
   stays pybind-only. The template block runs exactly once and pybind11 replaces
   the attribute rather than chaining an overload; verified on a minimal module,
   where the symbol then appears in the stub. Adds test_DefaultKeyFormatter.py.~~
   Fixed by borglab/wrap#209 (when merged and squashed).


2. `AttitudeFactor`'s C++ constructor takes a SharedNoiseModel, but navigation.i
   declared it as `noiseModel::Diagonal*`, rejecting Robust and full-covariance
   Gaussian models from Python. Declare it as `Base*`, as the sibling navigation
   factors do, for all VALUE instantiations. An audit of every interface file
   found no other declaration narrower than its C++ signature. Adds a regression
   test with a robust and a full-covariance model.