### PR TITLE
Add Values::extract(keys) and calculateEstimate(keys) for subset extraction

### DIFF
--- a/gtsam/nonlinear/BatchFixedLagSmoother.h
+++ b/gtsam/nonlinear/BatchFixedLagSmoother.h
@@ -69,6 +69,14 @@ public:
     return theta_.retract(delta_);
   }
 
+  /** Compute estimates for a set of variables only, one retract per key. */
+  Values calculateEstimate(const KeyVector& keys) const override {
+    Values result;
+    for (Key key : keys)
+      result.insert(key, *theta_.at(key).retract_(delta_[key]));
+    return result;
+  }
+
   /** Compute an estimate for a single variable using its incomplete linear delta computed
    * during the last update.  This is faster than calling the no-argument version of
    * calculateEstimate, which operates on all variables.

--- a/gtsam/nonlinear/BatchFixedLagSmoother.h
+++ b/gtsam/nonlinear/BatchFixedLagSmoother.h
@@ -71,10 +71,7 @@ public:
 
   /** Compute estimates for a set of variables only, one retract per key. */
   Values calculateEstimate(const KeyVector& keys) const override {
-    Values result;
-    for (Key key : keys)
-      result.insert(key, *theta_.at(key).retract_(delta_[key]));
-    return result;
+    return theta_.retract(delta_, keys);
   }
 
   /** Compute an estimate for a single variable using its incomplete linear delta computed

--- a/gtsam/nonlinear/FixedLagSmoother.h
+++ b/gtsam/nonlinear/FixedLagSmoother.h
@@ -114,6 +114,16 @@ public:
    */
   virtual Values calculateEstimate() const  = 0;
 
+  /** Compute estimates for a set of variables only, as a Values holding those
+   * keys, whatever their types. The default retracts the whole window and
+   * extracts; subclasses override it with a per-key path.
+   * @param keys The keys to estimate; must be unique.
+   * @throws ValuesKeyDoesNotExist if a key is not in the smoother.
+   */
+  virtual Values calculateEstimate(const KeyVector& keys) const {
+    return calculateEstimate().extract(keys);
+  }
+
 
 protected:
 

--- a/gtsam/nonlinear/ISAM2.cpp
+++ b/gtsam/nonlinear/ISAM2.cpp
@@ -900,11 +900,13 @@ Values ISAM2::calculateEstimate() const {
   gttoc(Expmap);
 }
 
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
 /* ************************************************************************* */
 const Value& ISAM2::calculateEstimate(Key key) const {
   const Vector& delta = getDelta()[key];
   return *theta_.at(key).retract_(delta);
 }
+#endif
 
 /* ************************************************************************* */
 Values ISAM2::calculateEstimate(const KeyVector& keys) const {

--- a/gtsam/nonlinear/ISAM2.cpp
+++ b/gtsam/nonlinear/ISAM2.cpp
@@ -907,6 +907,14 @@ const Value& ISAM2::calculateEstimate(Key key) const {
 }
 
 /* ************************************************************************* */
+Values ISAM2::calculateEstimate(const KeyVector& keys) const {
+  const VectorValues& delta = getDelta();
+  Values result;
+  for (Key key : keys) result.insert(key, *theta_.at(key).retract_(delta[key]));
+  return result;
+}
+
+/* ************************************************************************* */
 Values ISAM2::calculateBestEstimate() const {
   updateDelta(true);  // Force full solve when updating delta_
   return theta_.retract(delta_);

--- a/gtsam/nonlinear/ISAM2.cpp
+++ b/gtsam/nonlinear/ISAM2.cpp
@@ -908,10 +908,7 @@ const Value& ISAM2::calculateEstimate(Key key) const {
 
 /* ************************************************************************* */
 Values ISAM2::calculateEstimate(const KeyVector& keys) const {
-  const VectorValues& delta = getDelta();
-  Values result;
-  for (Key key : keys) result.insert(key, *theta_.at(key).retract_(delta[key]));
-  return result;
+  return theta_.retract(getDelta(), keys);
 }
 
 /* ************************************************************************* */

--- a/gtsam/nonlinear/ISAM2.h
+++ b/gtsam/nonlinear/ISAM2.h
@@ -257,6 +257,15 @@ class GTSAM_EXPORT ISAM2 : public BayesTree<ISAM2Clique> {
    */
   const Value& calculateEstimate(Key key) const;
 
+  /** Compute estimates for a set of variables from the incomplete linear
+   * delta computed during the last update, as a Values holding only those
+   * keys, whatever their types. Costs one retract per requested key, unlike
+   * the no-argument calculateEstimate(), which retracts every variable.
+   * @param keys The keys to estimate; must be unique.
+   * @throws ValuesKeyDoesNotExist if a key is not in the linearization point.
+   */
+  Values calculateEstimate(const KeyVector& keys) const;
+
   /// Return the marginal information matrix on any variable.
   Matrix marginalInformation(Key key) const;
 

--- a/gtsam/nonlinear/ISAM2.h
+++ b/gtsam/nonlinear/ISAM2.h
@@ -247,15 +247,23 @@ class GTSAM_EXPORT ISAM2 : public BayesTree<ISAM2Clique> {
     return traits<VALUE>::Retract(theta_.at<VALUE>(key), delta);
   }
 
+#ifdef GTSAM_ALLOW_DEPRECATED_SINCE_V43
   /** Compute an estimate for a single variable using its incomplete linear
-   * delta computed during the last update.  This is faster than calling the
-   * no-argument version of calculateEstimate, which operates on all variables.
-   * This is a non-templated version that returns a Value base class for use
-   * with the MATLAB wrapper.
+   * delta computed during the last update.
+   *
+   * @deprecated: use calculateEstimate<VALUE>(key) when the type is known, or
+   * calculateEstimate(KeyVector{key}) for a type-erased result. This overload
+   * returns a reference to a Value allocated by Value::retract_(), which no
+   * one owns, so every call leaks. It cannot be repaired in place: Value is
+   * abstract, so the estimate cannot be returned by value. It was introduced
+   * as a non-templated form "for use with the MATLAB wrapper", but the MATLAB
+   * and Python wrappers are generated from the interface files, which declare
+   * only the templated overload, so neither ever reached it.
    * @param key
    * @return
    */
   const Value& calculateEstimate(Key key) const;
+#endif
 
   /** Compute estimates for a set of variables from the incomplete linear
    * delta computed during the last update, as a Values holding only those

--- a/gtsam/nonlinear/IncrementalFixedLagSmoother.h
+++ b/gtsam/nonlinear/IncrementalFixedLagSmoother.h
@@ -93,6 +93,11 @@ public:
     return isam_.calculateEstimate();
   }
 
+  /** Compute estimates for a set of variables only, one retract per key. */
+  Values calculateEstimate(const KeyVector& keys) const override {
+    return isam_.calculateEstimate(keys);
+  }
+
   /** Compute an estimate for a single variable using its incomplete linear delta computed
    * during the last update.  This is faster than calling the no-argument version of
    * calculateEstimate, which operates on all variables.

--- a/gtsam/nonlinear/Values.cpp
+++ b/gtsam/nonlinear/Values.cpp
@@ -230,6 +230,13 @@ namespace gtsam {
   }
 
   /* ************************************************************************* */
+  Values Values::extract(const KeyVector& keys) const {
+    Values result;
+    for (Key key : keys) result.insert(key, at(key));
+    return result;
+  }
+
+  /* ************************************************************************* */
   Values& Values::operator=(const Values& rhs) {
     this->clear();
     this->insert(rhs);

--- a/gtsam/nonlinear/Values.cpp
+++ b/gtsam/nonlinear/Values.cpp
@@ -102,6 +102,20 @@ namespace gtsam {
   }
 
   /* ************************************************************************* */
+  Values Values::retract(const VectorValues& delta,
+                         const KeyVector& keys) const {
+    Values result;
+    for (Key key : keys) {
+      // retract_() returns an owning raw pointer; adopt it immediately.
+      auto value = std::unique_ptr<Value>(at(key).retract_(delta[key]));
+      const bool inserted =
+          result.values_.try_emplace(key, std::move(value)).second;
+      if (!inserted) throw ValuesKeyAlreadyExists(key);
+    }
+    return result;
+  }
+
+  /* ************************************************************************* */
   void Values::retractMasked(const VectorValues& delta, const KeySet& mask) {
     gttic(retractMasked);
     assert(this->size() == delta.size());

--- a/gtsam/nonlinear/Values.cpp
+++ b/gtsam/nonlinear/Values.cpp
@@ -106,10 +106,15 @@ namespace gtsam {
                          const KeyVector& keys) const {
     Values result;
     for (Key key : keys) {
-      // retract_() returns an owning raw pointer; adopt it immediately.
-      auto value = std::unique_ptr<Value>(at(key).retract_(delta[key]));
+      const Value& value = at(key);
+      // Match retract(delta): a value with no delta is copied unchanged.
+      // retract_() and clone_() both return owning raw pointers; adopt them
+      // immediately.
+      VectorValues::const_iterator it = delta.find(key);
+      auto retracted = std::unique_ptr<Value>(
+          it != delta.end() ? value.retract_(it->second) : value.clone_());
       const bool inserted =
-          result.values_.try_emplace(key, std::move(value)).second;
+          result.values_.try_emplace(key, std::move(retracted)).second;
       if (!inserted) throw ValuesKeyAlreadyExists(key);
     }
     return result;

--- a/gtsam/nonlinear/Values.h
+++ b/gtsam/nonlinear/Values.h
@@ -235,9 +235,11 @@ namespace gtsam {
     /**
      * Retract only the named keys, returning a Values holding just those.
      * Complements retract(delta), which retracts every variable.
+     * As in retract(delta), a requested key with no entry in @p delta is
+     * copied unchanged rather than treated as an error.
      * @param delta The delta vector in the tangent space of this Values.
      * @param keys The keys to retract; must be unique.
-     * @throws ValuesKeyDoesNotExist if a key is not present.
+     * @throws ValuesKeyDoesNotExist if a key is not in this Values.
      * @throws ValuesKeyAlreadyExists if a key is repeated.
      */
     Values retract(const VectorValues& delta, const KeyVector& keys) const;

--- a/gtsam/nonlinear/Values.h
+++ b/gtsam/nonlinear/Values.h
@@ -233,6 +233,16 @@ namespace gtsam {
     Values retract(const VectorValues& delta) const;
 
     /**
+     * Retract only the named keys, returning a Values holding just those.
+     * Complements retract(delta), which retracts every variable.
+     * @param delta The delta vector in the tangent space of this Values.
+     * @param keys The keys to retract; must be unique.
+     * @throws ValuesKeyDoesNotExist if a key is not present.
+     * @throws ValuesKeyAlreadyExists if a key is repeated.
+     */
+    Values retract(const VectorValues& delta, const KeyVector& keys) const;
+
+    /**
      * Retract, but only for Keys appearing in \c mask. In-place.
      * \param mask Mask on Keys where to apply retract.
      */

--- a/gtsam/nonlinear/Values.h
+++ b/gtsam/nonlinear/Values.h
@@ -352,6 +352,16 @@ namespace gtsam {
      */
     KeySet keySet() const;
 
+    /**
+     * Returns a new Values holding copies of the values at the given keys,
+     * whatever their types. Complements the typed extract<ValueType>(), which
+     * returns a map of one type; this one keeps the result a Values, so it can
+     * be fed straight back into a factor graph, optimizer, or smoother.
+     * @param keys The keys to copy; must be unique.
+     * @throws ValuesKeyDoesNotExist if a key is not present.
+     */
+    Values extract(const KeyVector& keys) const;
+
     /** Replace all keys and variables */
     Values& operator=(const Values& rhs);
 

--- a/gtsam/nonlinear/nonlinear.i
+++ b/gtsam/nonlinear/nonlinear.i
@@ -622,6 +622,7 @@ class ISAM2 {
   const gtsam::Values& getLinearizationPoint() const;
   bool valueExists(gtsam::Key key) const;
   gtsam::Values calculateEstimate() const;
+  gtsam::Values calculateEstimate(const gtsam::KeyVector& keys) const;
   template <VALUE = {double,
                      gtsam::Point2,
                      gtsam::Rot2,
@@ -1004,6 +1005,7 @@ virtual class FixedLagSmoother {
           gtsam::FixedLagSmootherKeyTimestampMap(),
       const gtsam::FactorIndices& factorsToRemove = gtsam::FactorIndices());
   gtsam::Values calculateEstimate() const;
+  gtsam::Values calculateEstimate(const gtsam::KeyVector& keys) const;
 };
 
 #include <gtsam/nonlinear/BatchFixedLagSmoother.h>

--- a/gtsam/nonlinear/tests/testBatchFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/tests/testBatchFixedLagSmoother.cpp
@@ -426,9 +426,11 @@ TEST(BatchFixedLagSmoother, CalculateEstimateForKeys) {
   }
   smoother.update(factors, values, timestamps);
 
-  const Values full = smoother.calculateEstimate();
+  // Request the subset first, so the full estimate cannot have warmed
+  // anything the subset path depends on.
   const Values subset =
       smoother.calculateEstimate(KeyVector{Symbol('x', 3), Symbol('x', 1)});
+  const Values full = smoother.calculateEstimate();
   LONGS_EQUAL(2, subset.size());
   EXPECT(!subset.exists(Symbol('x', 0)));
   EXPECT(assert_equal(full.at<Point2>(Symbol('x', 1)),

--- a/gtsam/nonlinear/tests/testBatchFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/tests/testBatchFixedLagSmoother.cpp
@@ -21,6 +21,7 @@
 #include <gtsam/nonlinear/Marginals.h>
 #include <gtsam/base/debug.h>
 #include <gtsam/inference/Key.h>
+#include <gtsam/inference/Symbol.h>
 #include <gtsam/geometry/Point2.h>
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/linear/GaussianBayesNet.h>
@@ -402,6 +403,38 @@ TEST( BatchFixedLagSmoother, NEES )
   EXPECT(neesCount > 0);
   EXPECT(avgNees_on > 0.0);
   EXPECT(avgNees_off > 0.0);
+}
+
+/* ************************************************************************* */
+// calculateEstimate(keys) retracts only the requested keys and matches the
+// full estimate there.
+TEST(BatchFixedLagSmoother, CalculateEstimateForKeys) {
+  const SharedDiagonal noise = noiseModel::Diagonal::Sigmas(Vector2(0.1, 0.1));
+  BatchFixedLagSmoother smoother(10.0, LevenbergMarquardtParams());
+
+  NonlinearFactorGraph factors;
+  Values values;
+  FixedLagSmoother::KeyTimestampMap timestamps;
+  factors.addPrior(Symbol('x', 0), Point2(0.0, 0.0), noise);
+  values.insert(Symbol('x', 0), Point2(0.1, -0.1));
+  timestamps[Symbol('x', 0)] = 0.0;
+  for (size_t i = 1; i < 4; ++i) {
+    factors.emplace_shared<BetweenFactor<Point2>>(
+        Symbol('x', i - 1), Symbol('x', i), Point2(1.0, 0.0), noise);
+    values.insert(Symbol('x', i), Point2(double(i) + 0.1, -0.1));
+    timestamps[Symbol('x', i)] = double(i);
+  }
+  smoother.update(factors, values, timestamps);
+
+  const Values full = smoother.calculateEstimate();
+  const Values subset =
+      smoother.calculateEstimate(KeyVector{Symbol('x', 3), Symbol('x', 1)});
+  LONGS_EQUAL(2, subset.size());
+  EXPECT(!subset.exists(Symbol('x', 0)));
+  EXPECT(assert_equal(full.at<Point2>(Symbol('x', 1)),
+                      subset.at<Point2>(Symbol('x', 1))));
+  EXPECT(assert_equal(full.at<Point2>(Symbol('x', 3)),
+                      subset.at<Point2>(Symbol('x', 3))));
 }
 
 /* ************************************************************************* */

--- a/gtsam/nonlinear/tests/testIncrementalFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/tests/testIncrementalFixedLagSmoother.cpp
@@ -1031,6 +1031,37 @@ TEST(IncrementalFixedLagSmoother, PendingValueKeepsTimestampWhenFactorArrives) {
 }  // namespace timestamp_validation
 /* ************************************************************************* */
 
+/* ************************************************************************* */
+// calculateEstimate(keys) returns only the requested keys, equal to the full
+// estimate at those keys, and rejects keys the smoother does not hold.
+TEST(IncrementalFixedLagSmoother, CalculateEstimateForKeys) {
+  const SharedDiagonal noise = noiseModel::Diagonal::Sigmas(Vector2(0.1, 0.1));
+  IncrementalFixedLagSmoother smoother(10.0);
+
+  NonlinearFactorGraph factors;
+  Values values;
+  FixedLagSmoother::KeyTimestampMap timestamps;
+  factors.addPrior(X(0), Point2(0.0, 0.0), noise);
+  values.insert(X(0), Point2(0.1, -0.1));
+  timestamps[X(0)] = 0.0;
+  for (size_t i = 1; i < 4; ++i) {
+    factors.emplace_shared<BetweenFactor<Point2>>(X(i - 1), X(i),
+                                                  Point2(1.0, 0.0), noise);
+    values.insert(X(i), Point2(double(i) + 0.1, -0.1));
+    timestamps[X(i)] = double(i);
+  }
+  smoother.update(factors, values, timestamps);
+
+  const Values full = smoother.calculateEstimate();
+  const Values subset = smoother.calculateEstimate(KeyVector{X(3), X(1)});
+  LONGS_EQUAL(2, subset.size());
+  EXPECT(!subset.exists(X(0)));
+  EXPECT(assert_equal(full.at<Point2>(X(1)), subset.at<Point2>(X(1))));
+  EXPECT(assert_equal(full.at<Point2>(X(3)), subset.at<Point2>(X(3))));
+  CHECK_EXCEPTION(smoother.calculateEstimate(KeyVector{X(9)}),
+                  ValuesKeyDoesNotExist);
+}
+
 int main() {
   TestResult tr;
   return TestRegistry::runAllTests(tr);

--- a/gtsam/nonlinear/tests/testIncrementalFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/tests/testIncrementalFixedLagSmoother.cpp
@@ -1052,8 +1052,10 @@ TEST(IncrementalFixedLagSmoother, CalculateEstimateForKeys) {
   }
   smoother.update(factors, values, timestamps);
 
-  const Values full = smoother.calculateEstimate();
+  // Request the subset first, so the full estimate cannot have warmed
+  // anything the subset path depends on.
   const Values subset = smoother.calculateEstimate(KeyVector{X(3), X(1)});
+  const Values full = smoother.calculateEstimate();
   LONGS_EQUAL(2, subset.size());
   EXPECT(!subset.exists(X(0)));
   EXPECT(assert_equal(full.at<Point2>(X(1)), subset.at<Point2>(X(1))));

--- a/gtsam/nonlinear/tests/testValues.cpp
+++ b/gtsam/nonlinear/tests/testValues.cpp
@@ -381,6 +381,35 @@ TEST(Values, localCoordinates)
 }
 
 /* ************************************************************************* */
+// retract(delta, keys) retracts only the named keys, and owns what retract_()
+// allocates: no leak on success or when a later key throws.
+TEST(Values, retract_by_keys)
+{
+  Values values;
+  values.insert(key1, Pose2(1.0, 2.0, 0.3));
+  values.insert(key2, Point3(1.0, 2.0, 3.0));
+  values.insert(key3, Vector3(4.0, 5.0, 6.0));
+
+  VectorValues delta;
+  delta.insert(key1, Vector3(0.1, 0.2, 0.05));
+  delta.insert(key2, Vector3(0.1, 0.1, 0.1));
+  delta.insert(key3, Vector3(1.0, 1.0, 1.0));
+
+  const Values full = values.retract(delta);
+  const Values subset = values.retract(delta, KeyVector{key3, key1});
+  LONGS_EQUAL(2, subset.size());
+  EXPECT(!subset.exists(key2));
+  EXPECT(assert_equal(full.at<Pose2>(key1), subset.at<Pose2>(key1)));
+  EXPECT(assert_equal(full.at<Vector3>(key3), subset.at<Vector3>(key3)));
+
+  EXPECT(values.retract(delta, KeyVector{}).empty());
+  CHECK_EXCEPTION(values.retract(delta, KeyVector{key1, key1}),
+                  ValuesKeyAlreadyExists);
+  CHECK_EXCEPTION(values.retract(delta, KeyVector{key1, Symbol('z', 9)}),
+                  ValuesKeyDoesNotExist);
+}
+
+/* ************************************************************************* */
 // extract(keys) copies the named values of any type into a new Values.
 TEST(Values, extract_by_keys)
 {

--- a/gtsam/nonlinear/tests/testValues.cpp
+++ b/gtsam/nonlinear/tests/testValues.cpp
@@ -402,6 +402,20 @@ TEST(Values, retract_by_keys)
   EXPECT(assert_equal(full.at<Pose2>(key1), subset.at<Pose2>(key1)));
   EXPECT(assert_equal(full.at<Vector3>(key3), subset.at<Vector3>(key3)));
 
+  // A requested key with no delta is copied unchanged, as retract(delta) does.
+  VectorValues partial;
+  partial.insert(key1, Vector3(0.1, 0.2, 0.05));
+  const Values partialFull = values.retract(partial);
+  const Values partialSubset = values.retract(partial, KeyVector{key3, key1});
+  EXPECT(assert_equal(values.at<Vector3>(key3),
+                      partialSubset.at<Vector3>(key3)));
+  EXPECT(assert_equal(partialFull.at<Vector3>(key3),
+                      partialSubset.at<Vector3>(key3)));
+  EXPECT(assert_equal(partialFull.at<Pose2>(key1),
+                      partialSubset.at<Pose2>(key1)));
+  EXPECT(values.retract(VectorValues(), KeyVector{key1}).at<Pose2>(key1).equals(
+      values.at<Pose2>(key1)));
+
   EXPECT(values.retract(delta, KeyVector{}).empty());
   CHECK_EXCEPTION(values.retract(delta, KeyVector{key1, key1}),
                   ValuesKeyAlreadyExists);

--- a/gtsam/nonlinear/tests/testValues.cpp
+++ b/gtsam/nonlinear/tests/testValues.cpp
@@ -381,6 +381,35 @@ TEST(Values, localCoordinates)
 }
 
 /* ************************************************************************* */
+// extract(keys) copies the named values of any type into a new Values.
+TEST(Values, extract_by_keys)
+{
+  Values values;
+  values.insert(key1, Pose2(1.0, 2.0, 0.3));
+  values.insert(key2, Point3(1.0, 2.0, 3.0));
+  values.insert(key3, Vector3(4.0, 5.0, 6.0));
+  values.insert(key4, Pose3());
+
+  const Values subset = values.extract(KeyVector{key3, key1});
+  LONGS_EQUAL(2, subset.size());
+  EXPECT(subset.exists(key1));
+  EXPECT(subset.exists(key3));
+  EXPECT(!subset.exists(key2));
+  EXPECT(assert_equal(Pose2(1.0, 2.0, 0.3), subset.at<Pose2>(key1)));
+  EXPECT(assert_equal(Vector3(4.0, 5.0, 6.0), subset.at<Vector3>(key3)));
+
+  // Copies, not references: the source is untouched by edits to the subset.
+  Values edited = subset;
+  edited.update(key1, Pose2());
+  EXPECT(assert_equal(Pose2(1.0, 2.0, 0.3), values.at<Pose2>(key1)));
+
+  // Empty request, and a missing key.
+  EXPECT(values.extract(KeyVector{}).empty());
+  CHECK_EXCEPTION(values.extract(KeyVector{key1, Symbol('z', 9)}),
+                  ValuesKeyDoesNotExist);
+}
+
+/* ************************************************************************* */
 TEST(Values, extract_keys)
 {
   Values config;

--- a/gtsam/nonlinear/values.i
+++ b/gtsam/nonlinear/values.i
@@ -59,6 +59,7 @@ class Values {
 
   bool exists(gtsam::Key j) const;
   gtsam::KeyVector keys() const;
+  gtsam::Values extract(const gtsam::KeyVector& keys) const;
 
   std::map<gtsam::Key,size_t> dims() const;
   gtsam::VectorValues zeroVectors() const;

--- a/python/gtsam/tests/test_Values.py
+++ b/python/gtsam/tests/test_Values.py
@@ -80,6 +80,31 @@ class TestValues(GtsamTestCase):
         actualMatrix2 = values.atMatrix(13)
         np.testing.assert_allclose(mat2, actualMatrix2, tol)
 
+    def test_extract_by_keys(self):
+        """extract(keys) returns a Values with copies of the named values,
+        of any type, without the caller knowing each key's type."""
+        values = gtsam.Values()
+        values.insert(0, Point2(1.0, 2.0))
+        values.insert(1, Pose3())
+        values.insert(2, np.array([4.0, 5.0, 6.0]))
+        values.insert(3, Rot3())
+
+        subset = values.extract([2, 0])
+        self.assertEqual(subset.size(), 2)
+        self.assertTrue(subset.exists(0))
+        self.assertTrue(subset.exists(2))
+        self.assertFalse(subset.exists(1))
+        np.testing.assert_allclose(subset.atPoint2(0), Point2(1.0, 2.0))
+        np.testing.assert_allclose(subset.atVector(2), np.array([4.0, 5.0, 6.0]))
+
+        # copies, not references
+        subset.update(0, Point2(9.0, 9.0))
+        np.testing.assert_allclose(values.atPoint2(0), Point2(1.0, 2.0))
+
+        self.assertEqual(values.extract([]).size(), 0)
+        with self.assertRaises(RuntimeError):
+            values.extract([0, 99])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/gtsam/tests/test_Values.py
+++ b/python/gtsam/tests/test_Values.py
@@ -106,5 +106,75 @@ class TestValues(GtsamTestCase):
             values.extract([0, 99])
 
 
+class TestCalculateEstimateForKeys(GtsamTestCase):
+    """calculateEstimate(keys) on ISAM2 and both fixed-lag smoothers."""
+
+    X, V, B, S = 0, 100, 200, 300
+
+    def _graph(self):
+        """A Pose3 / velocity / bias / double set, so the subset spans types."""
+        graph = gtsam.NonlinearFactorGraph()
+        values = gtsam.Values()
+        graph.push_back(gtsam.PriorFactorPose3(
+            self.X, Pose3(), gtsam.noiseModel.Isotropic.Sigma(6, 0.1)))
+        values.insert(self.X, Pose3(Rot3.Rz(0.05), Point3(0.1, 0.0, 0.0)))
+        graph.push_back(gtsam.PriorFactorPoint3(
+            self.V, Point3(1.0, 0.0, 0.0), gtsam.noiseModel.Isotropic.Sigma(3, 0.1)))
+        values.insert(self.V, Point3(0.9, 0.1, 0.0))
+        graph.push_back(gtsam.PriorFactorConstantBias(
+            self.B, gtsam.imuBias.ConstantBias(),
+            gtsam.noiseModel.Isotropic.Sigma(6, 0.1)))
+        values.insert(self.B, gtsam.imuBias.ConstantBias())
+        graph.push_back(gtsam.PriorFactorDouble(
+            self.S, 2.0, gtsam.noiseModel.Isotropic.Sigma(1, 0.1)))
+        values.insert(self.S, 1.9)
+        return graph, values
+
+    def _check(self, subset, full):
+        """The subset holds exactly the requested keys, equal to the full estimate."""
+        self.assertEqual(subset.size(), 3)
+        self.assertFalse(subset.exists(self.B))
+        self.gtsamAssertEquals(subset.atPose3(self.X), full.atPose3(self.X), 1e-9)
+        np.testing.assert_allclose(subset.atPoint3(self.V),
+                                   full.atPoint3(self.V), atol=1e-9)
+        self.assertAlmostEqual(subset.atDouble(self.S), full.atDouble(self.S),
+                               places=9)
+
+    def _requested(self):
+        return [self.X, self.V, self.S]
+
+    def test_isam2(self):
+        graph, values = self._graph()
+        isam = gtsam.ISAM2()
+        isam.update(graph, values)
+        # Request the subset first, so the full estimate cannot have warmed
+        # anything the subset path depends on.
+        subset = isam.calculateEstimate(self._requested())
+        self._check(subset, isam.calculateEstimate())
+
+    def test_incremental_fixed_lag_smoother(self):
+        graph, values = self._graph()
+        smoother = gtsam.IncrementalFixedLagSmoother(10.0)
+        smoother.update(graph, values, {k: 0.0 for k in
+                                        [self.X, self.V, self.B, self.S]})
+        subset = smoother.calculateEstimate(self._requested())
+        self._check(subset, smoother.calculateEstimate())
+
+    def test_batch_fixed_lag_smoother(self):
+        graph, values = self._graph()
+        smoother = gtsam.BatchFixedLagSmoother(10.0)
+        smoother.update(graph, values, {k: 0.0 for k in
+                                        [self.X, self.V, self.B, self.S]})
+        subset = smoother.calculateEstimate(self._requested())
+        self._check(subset, smoother.calculateEstimate())
+
+    def test_missing_key_raises(self):
+        graph, values = self._graph()
+        isam = gtsam.ISAM2()
+        isam.update(graph, values)
+        with self.assertRaises(RuntimeError):
+            isam.calculateEstimate([999])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Two commits, the second building on the first.

1. `Values Values::extract(const KeyVector& keys) const`: copies the named values,
   whatever their types, into a new Values. The typed `extract<ValueType>()`
   returns a std::map of one type and is not wrapped; from Python there is no way
   to build a subset at all, since the type-erased `at(Key)` is not wrapped either.
   Missing keys throw ValuesKeyDoesNotExist, as `at()` does; keys must be unique.
   Wrapped as `Values.extract(keys)`. I overloaded the existing verb (the template
   needs an explicit type, so there is no ambiguity); happy to rename to `subset`
   if preferred.

2. `Values calculateEstimate(const KeyVector& keys) const` on ISAM2,
   IncrementalFixedLagSmoother (via ISAM2) and BatchFixedLagSmoother (via its own
   theta_/delta_), retracting only the requested keys with the type-erased
   `Value::retract_()`. `calculateEstimate()` retracts and copies the whole window,
   and the per-key `calculateEstimate<VALUE>(key)` needs the type and a call per
   key; a front-end consuming a few states per update paid O(N) plus a round trip
   per key. `FixedLagSmoother` declares it virtual with a correct default (full
   estimate, then `extract`) so external subclasses keep working. Wrapped on ISAM2
   and FixedLagSmoother.

Verification: testValues built and run locally with the new test (a mutant dropping
one key fails it).