### PR TITLE
Report expired pending keys in FixedLagSmoother::Result

### DIFF
--- a/gtsam/nonlinear/FixedLagSmoother.cpp
+++ b/gtsam/nonlinear/FixedLagSmoother.cpp
@@ -27,7 +27,10 @@ void FixedLagSmoother::Result::print() const {
             << "Nr intermediateSteps: " << intermediateSteps << '\n'
             << "Nr nonlinear variables: " << nonlinearVariables << '\n'
             << "Nr linear variables: " << linearVariables << '\n'
-            << "error: " << error << std::endl;
+            << "error: " << error << '\n'
+            << "Nr keys of deleted nodes: " << keysOfDeletedNodes.size() << '\n'
+            << "Nr expired pending keys: " << expiredPendingKeys.size()
+            << std::endl;
 }
 
 /* ************************************************************************* */

--- a/gtsam/nonlinear/FixedLagSmoother.h
+++ b/gtsam/nonlinear/FixedLagSmoother.h
@@ -54,6 +54,9 @@ public:
     FactorIndices marginalFactorIndices; ///< Indices added during the marginalizeLeaves step
     FactorIndices deletedFactorIndices; ///< Indices removed during the marginalizeLeaves step
     KeySet keysOfDeletedNodes; ///< Keys of nodes removed during the marginalizeLeaves step
+    KeySet expiredPendingKeys;  ///< Keys of values that left the lag window
+                                ///< before any factor referenced them, and were
+                                ///< removed without marginalization
     Result() : iterations(0), intermediateSteps(0), nonlinearVariables(0), linearVariables(0), error(0) {}
 
     /// Getter methods
@@ -65,6 +68,7 @@ public:
     FactorIndices getMarginalFactorIndices() const { return marginalFactorIndices; }
     FactorIndices getDeletedFactorIndices() const { return deletedFactorIndices; }
     KeySet getKeysOfDeletedNodes() const { return keysOfDeletedNodes; }
+    KeySet getExpiredPendingKeys() const { return expiredPendingKeys; }
     GTSAM_EXPORT void print() const;
   };
 

--- a/gtsam/nonlinear/IncrementalFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/IncrementalFixedLagSmoother.cpp
@@ -236,6 +236,7 @@ FixedLagSmoother::Result IncrementalFixedLagSmoother::update(
   result.marginalFactorIndices = marginalFactorIndices;
   result.deletedFactorIndices = deletedFactorIndices;
   result.keysOfDeletedNodes = KeySet(marginalizableKeys);
+  result.expiredPendingKeys = KeySet(expiredPendingKeys);
 
   if (debug)
     std::cout << "IncrementalFixedLagSmoother::update() Finish" << std::endl;

--- a/gtsam/nonlinear/nonlinear.i
+++ b/gtsam/nonlinear/nonlinear.i
@@ -982,6 +982,7 @@ class FixedLagSmootherResult {
   gtsam::FactorIndices getMarginalFactorIndices() const;
   gtsam::FactorIndices getDeletedFactorIndices() const;
   gtsam::KeySet getKeysOfDeletedNodes() const;
+  gtsam::KeySet getExpiredPendingKeys() const;
   void print() const;
 };
 

--- a/gtsam/nonlinear/tests/testIncrementalFixedLagSmoother.cpp
+++ b/gtsam/nonlinear/tests/testIncrementalFixedLagSmoother.cpp
@@ -142,6 +142,9 @@ TEST(IncrementalFixedLagSmoother, UpdateResultMarginalizationMetadata) {
   LONGS_EQUAL(1, result.keysOfDeletedNodes.size());
   EXPECT(result.keysOfDeletedNodes.exists(X(0)));
   EXPECT(result.getKeysOfDeletedNodes().exists(X(0)));
+  // every expired key had a factor here, so nothing was reaped as pending
+  EXPECT(result.expiredPendingKeys.empty());
+  EXPECT(result.getExpiredPendingKeys().empty());
 
   // Marginalized key removed from the smoother state
   EXPECT(!smoother.getLinearizationPoint().exists(X(0)));
@@ -489,11 +492,21 @@ TEST(IncrementalFixedLagSmoother, ReapsPendingValueAfterLag) {
   factors.addPrior(X(2), Point2(2.0, 0.0), noise);
   values.insert(X(2), Point2(2.0, 0.0));
   timestamps[X(2)] = 3.0;
-  smoother.update(factors, values, timestamps);
+  const FixedLagSmoother::Result result =
+      smoother.update(factors, values, timestamps);
 
   EXPECT(!smoother.getLinearizationPoint().exists(X(1)));
   EXPECT(smoother.getLinearizationPoint().exists(X(2)));
   EXPECT(smoother.timestamps().find(X(1)) == smoother.timestamps().end());
+
+  // The result reports the reaped pending key, so a caller holding queued
+  // measurements for X(1) can drop them without diffing the estimate. X(0)
+  // had a factor and was marginalized instead, so it is reported separately.
+  LONGS_EQUAL(1, result.expiredPendingKeys.size());
+  EXPECT(result.expiredPendingKeys.exists(X(1)));
+  EXPECT(result.getExpiredPendingKeys().exists(X(1)));
+  EXPECT(!result.keysOfDeletedNodes.exists(X(1)));
+  EXPECT(result.keysOfDeletedNodes.exists(X(0)));
 }
 
 // A timestamp naming no value -- neither an existing one nor one supplied in


### PR DESCRIPTION
`IncrementalFixedLagSmoother::update()` removes values that leave the lag window
before any factor references them (via `removeVariables()`, erasing their
timestamps) but does not report which keys it reaped. `Result::keysOfDeletedNodes`
only lists the keys marginalized through `marginalizeLeaves()`. A front-end holding
queued measurements for a pending state can only discover its removal by diffing
the linearization point or timestamps, or by catching the exception from the next
update that references it.

Add `Result::expiredPendingKeys` (KeySet) with `getExpiredPendingKeys()`, populated
from the vector `update()` already builds, exposed in the Python wrapper, and
counted in `Result::print()`. It is deliberately a separate field: the documented
meaning of `keysOfDeletedNodes` is unchanged. `BatchFixedLagSmoother` has no
pending-value path and leaves it empty.

Tests: extends ReapsPendingValueAfterLag to check the result (and its disjointness
from keysOfDeletedNodes) and UpdateResultMarginalizationMetadata to check it is
empty when every expired key had a factor. 