### PR TITLE
Fix nightly Cayley-map smart PCG test failure

### DIFF
--- a/timing/tests/testSfmBalBenchmark.cpp
+++ b/timing/tests/testSfmBalBenchmark.cpp
@@ -63,8 +63,16 @@ namespace smart_pcg_tests {
 bal::PcgOptimizationResult optimize(const SfmData& data,
                                     LinearizationMode mode) {
   bal::BalBenchmarkConfig config;
-  const NonlinearFactorGraph graph = bal::buildSmartSfmGraph(
+  NonlinearFactorGraph graph = bal::buildSmartSfmGraph(
       data, config, SmartProjectionParams(mode));
+  // This tiny dataset is underconstrained even beyond the similarity gauge.
+  // Soft priors on every camera's pose and calibration make the comparison
+  // observable, so roundoff does not send the two modes along different paths.
+  const auto cameraPriorNoise = noiseModel::Unit::Create(9);
+  for (size_t i = 0; i < data.numberCameras(); ++i) {
+    graph.addPrior<bal::Camera>(symbol_shorthand::C(i), data.cameras[i],
+                               cameraPriorNoise);
+  }
   const Values initial = bal::buildSmartSfmInitial(data);
   const Ordering ordering = bal::createCameraOrdering(data);
   LevenbergMarquardtParams parameters =
@@ -82,9 +90,8 @@ TEST(SfmBalBenchmark, SmartPcgLinearizationsAgree) {
 
   CHECK(hessian.finalError < hessian.initialError);
   CHECK(implicit.finalError < implicit.initialError);
-  // This tiny, gauge-sensitive problem can follow slightly different
-  // nonlinear trajectories after mathematically equivalent flat reductions.
-  DOUBLES_EQUAL(hessian.finalError, implicit.finalError, 3e-3);
+  DOUBLES_EQUAL(hessian.initialError, implicit.initialError, 1e-9);
+  DOUBLES_EQUAL(hessian.finalError, implicit.finalError, 1e-6);
   CHECK(hessian.linearSolves > 0);
   CHECK(implicit.linearSolves > 0);
   LONGS_EQUAL(0, hessian.nonConvergedLinearSolves);


### PR DESCRIPTION
The Cayley-map nightly fails `SmartPcgLinearizationsAgree` because the tiny BAL fixture is underconstrained beyond the similarity gauge. The explicit-Hessian and implicit-Schur optimizations consequently follow different nonlinear trajectories, producing final errors around 0.02146 and 0.03611.

Add soft priors on each camera's pose and calibration within the test fixture, and tighten the final-error comparison from 3e-3 to 1e-6. Also check that both modes start at the same error. Production solvers and benchmark graph builders are unchanged.

Validation:
- Reproduced the original failure locally with `GTSAM_ROT3_EXPMAP=OFF` and `GTSAM_POSE3_EXPMAP=OFF`.
- `make -j6 testSfmBalBenchmark.run` passes with the fix under both Cayley-map and default exponential-map configurations.
- `git diff --check` passes.

Fixes #2792
