### PR TITLE
Anchor smart PCG regression camera and baseline

### DIFF
--- a/timing/tests/testSfmBalBenchmark.cpp
+++ b/timing/tests/testSfmBalBenchmark.cpp
@@ -19,6 +19,7 @@
 
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/nonlinear/LevenbergMarquardtParams.h>
+#include <gtsam/sam/RangeFactor.h>
 #include <gtsam/slam/dataset.h>
 
 #include <cstddef>
@@ -63,8 +64,15 @@ namespace smart_pcg_tests {
 bal::PcgOptimizationResult optimize(const SfmData& data,
                                     LinearizationMode mode) {
   bal::BalBenchmarkConfig config;
-  const NonlinearFactorGraph graph = bal::buildSmartSfmGraph(
+  NonlinearFactorGraph graph = bal::buildSmartSfmGraph(
       data, config, SmartProjectionParams(mode));
+  // Anchor the first camera's pose and calibration, and the baseline to the
+  // second camera to remove the remaining monocular scale ambiguity.
+  graph.addPrior<bal::Camera>(symbol_shorthand::C(0), data.cameras[0],
+                             noiseModel::Unit::Create(9));
+  graph.emplace_shared<RangeFactor<bal::Camera>>(
+      symbol_shorthand::C(0), symbol_shorthand::C(1),
+      data.cameras[0].range(data.cameras[1]), noiseModel::Unit::Create(1));
   const Values initial = bal::buildSmartSfmInitial(data);
   const Ordering ordering = bal::createCameraOrdering(data);
   LevenbergMarquardtParams parameters =
@@ -82,8 +90,7 @@ TEST(SfmBalBenchmark, SmartPcgLinearizationsAgree) {
 
   CHECK(hessian.finalError < hessian.initialError);
   CHECK(implicit.finalError < implicit.initialError);
-  // This tiny, gauge-sensitive problem can follow slightly different
-  // nonlinear trajectories after mathematically equivalent flat reductions.
+  // Allow small differences in nonlinear trajectories from the PCG solves.
   DOUBLES_EQUAL(hessian.finalError, implicit.finalError, 3e-3);
   CHECK(hessian.linearSolves > 0);
   CHECK(implicit.linearSolves > 0);


### PR DESCRIPTION
The Cayley-map nightly fails `SmartPcgLinearizationsAgree` because the unanchored BAL fixture gives explicit-Hessian and implicit-Schur PCG different nonlinear trajectories: final errors are approximately 0.02146 and 0.03611, exceeding the existing 0.003 tolerance.

Add unit-noise soft priors on the first camera's pose and calibration and on the distance between the first two cameras. The camera prior leaves the monocular scale ambiguity; the baseline prior removes it. Keep all existing assertions and solver settings unchanged. Only the regression fixture changes.

Validation:
- Reproduced the unanchored Cayley failure locally.
- Diagnostic Jacobian rank increased from 38/48 unanchored to 47/48 with one camera prior and 48/48 with the camera and baseline priors.
- With both priors, Cayley final errors are 0.0289431 and 0.0299299, within the unchanged tolerance.
- `make -j6 testSfmBalBenchmark.run` passes on macOS in both Cayley (`GTSAM_POSE3_EXPMAP=OFF`, `GTSAM_ROT3_EXPMAP=OFF`) and default exponential-map configurations, with deprecated APIs disabled.
- `git diff --check` passes.

Failing nightly: https://github.com/borglab/gtsam/actions/runs/34462214518/job/102822435024
