### PR TITLE
Add opt-in chordal SDP null-space reduction

### DIFF
--- a/examples/CertifiableMosek.h
+++ b/examples/CertifiableMosek.h
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <cstdlib>
 #include <iostream>
 #include <map>
 #include <stdexcept>
@@ -175,8 +176,11 @@ inline MosekExampleResult solveMosek(const QcqpProblem& problem,
     MosekMonolithicSDP sdp(problem);
     result = solveMosek(&sdp);
   } else if (solver == CertifiableSolver::MosekChordal) {
+    // Opt-in experiment: keep baseline runs available without changing inputs.
+    const char* reduction = std::getenv("GTSAM_MOSEK_ELIMINATE_NULLS");
     std::cout << "Chordal ordering: COLAMD" << std::endl;
-    MosekChordalSDP sdp(problem, ChordalOrderingType::Colamd);
+    MosekChordalSDP sdp(problem, ChordalOrderingType::Colamd,
+                        reduction && std::string(reduction) == "1");
     result = solveMosek(&sdp);
   } else {
     throw std::invalid_argument("solveMosek requires a MOSEK solver mode.");

--- a/gtsam/certifiable/LiftedSDPProblem.cpp
+++ b/gtsam/certifiable/LiftedSDPProblem.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <gtsam/certifiable/LiftedSDPProblem.h>
+#include <gtsam/certifiable/SDPNullspaceReduction.h>
 #include <gtsam/symbolic/SymbolicFactorGraph.h>
 
 #include <Eigen/Eigenvalues>
@@ -42,9 +43,26 @@ namespace gtsam {
 // Keep MOSEK-specific helpers private to this translation unit.
 namespace {
 
-// Maps each pair of QCQP keys to its block in an SDP variable.
+// A view in original QCQP coordinates, optionally backed by a smaller cone.
+struct SDPBlockView {
+  mf::Variable::t variable;
+  mf::Expression::t expression;
+  Matrix rowBasis, columnBasis;
+
+  explicit SDPBlockView(const mf::Variable::t& view)
+      : variable(view), expression(view->asExpr()) {}
+  SDPBlockView(const mf::Variable::t& cone, const Matrix& rows,
+               const Matrix& columns);
+  mf::Expression::t asExpr() const { return expression; }
+  mf::Expression::t index(int row, int col) const {
+    return expression->index(monty::new_array_ptr<int, 1>({row, col}));
+  }
+  Matrix matrix() const;
+};
+
+// Maps each pair of QCQP keys to its original-coordinate SDP block.
 using LiftedVariableXijToSDPVariableViewMap =
-    std::map<std::pair<Key, Key>, mf::Variable::t>;
+    std::map<std::pair<Key, Key>, std::shared_ptr<SDPBlockView>>;
 
 // Stores the solver information exposed by the public result accessors.
 struct MosekSolveSummary {
@@ -274,20 +292,34 @@ Matrix ConvertFromMosekLevelColMajor(
   return Matrix(view);
 }
 
-// Extract and validate a square SDP block from a solved Fusion variable.
-Matrix ExtractSolvedMatrixBlock(const mf::Variable::t& blockView,
+// Express original QCQP rows through the post-processing substitution basis.
+SDPBlockView::SDPBlockView(const mf::Variable::t& cone, const Matrix& rows,
+                         const Matrix& columns)
+    : variable(cone), rowBasis(rows), columnBasis(columns) {
+  expression = mf::Expr::mul(
+      mf::Expr::mul(convertToMosekDenseMatrix(rows), cone->asExpr()),
+      convertToMosekDenseMatrix(Matrix(columns.transpose())));
+}
+
+// Lift the solved reduced cone back before running the existing recovery code.
+Matrix SDPBlockView::matrix() const {
+  Matrix result = ConvertFromMosekLevelColMajor(
+      variable->level(), variable->getDim(0), variable->getDim(1));
+  if (rowBasis.size()) result = rowBasis * result * columnBasis.transpose();
+  return result;
+}
+
+// Extract and validate a square block in the original QCQP coordinates.
+Matrix ExtractSolvedMatrixBlock(const std::shared_ptr<SDPBlockView>& blockView,
                                 DenseIndex expectedDim) {
-  const auto level = blockView->level();
-  const size_t numel = static_cast<size_t>(level->size(0));
-  const size_t expectedSize = static_cast<size_t>(expectedDim);
-  if (numel != expectedSize * expectedSize) {
+  const Matrix result = blockView->matrix();
+  if (result.rows() != expectedDim || result.cols() != expectedDim) {
     throw std::runtime_error(
         "ExtractSolvedMatrixBlock: solved block size does not match the QCQP "
         "variable dimension.");
   }
 
-  return ConvertFromMosekLevelColMajor(level, static_cast<int>(expectedDim),
-                                       static_cast<int>(expectedDim));
+  return result;
 }
 
 // Compute the dominant-to-second eigenvalue ratio used as a rank-one metric.
@@ -433,10 +465,6 @@ void AddLinearEqualityConstraint(
     const Key key = *it;
     const auto Xii = xijMap.at({key, key});
     const DenseIndex dim = J.getDim(it);
-
-    auto first = monty::new_array_ptr<int, 1>({0, 0});
-    auto last = monty::new_array_ptr<int, 1>({static_cast<int>(dim), 1});
-    const auto xi = Xii->slice(first, last)->asExpr();
     const Matrix A = J.getA(it);
     const Vector b = J.getb();
 
@@ -444,9 +472,8 @@ void AddLinearEqualityConstraint(
     // Since x is the first column of X and x(0)=1, x'=X(0,:).
     // Enforcing only A*X(:,0)=b leaves unconstrained PSD slack in X.
     const auto xTranspose =
-        Xii->slice(monty::new_array_ptr<int, 1>({0, 0}),
-                   monty::new_array_ptr<int, 1>({1, static_cast<int>(dim)}))
-            ->asExpr();
+        Xii->asExpr()->slice(monty::new_array_ptr<int, 1>({0, 0}),
+                            monty::new_array_ptr<int, 1>({1, static_cast<int>(dim)}));
     const auto lhs = mf::Expr::mul(convertToMosekDenseMatrix(A), Xii->asExpr());
     const auto rhs = mf::Expr::mul(convertToMosekDenseMatrix(b), xTranspose);
     M->constraint(mf::Expr::sub(lhs, rhs), mf::Domain::equalsTo(0.0));
@@ -598,7 +625,8 @@ struct LiftedSDPProblem<MonolithicSDP, MosekSDPSolver>::Impl {
             {static_cast<int>(i_end), static_cast<int>(j_end)});
 
         liftedVariableXijToSDPVariableViewMap.emplace(
-            std::make_pair(key_i, key_j), Y->slice(first, last));
+            std::make_pair(key_i, key_j),
+            std::make_shared<SDPBlockView>(Y->slice(first, last)));
       }
     }
   }
@@ -610,6 +638,7 @@ struct LiftedSDPProblem<ChordalSDP, MosekSDPSolver>::Impl {
   KeyVector orderedKeys;
   std::map<Key, DenseIndex> orderedKeyDims;
   SymbolicBayesTree bayesTree_;
+  std::map<KeyVector, Matrix> cliqueBases;
   LiftedVariableXijToSDPVariableViewMap liftedVariableXijToSDPVariableViewMap;
 
   ~Impl() {
@@ -629,10 +658,11 @@ struct LiftedSDPProblem<ChordalSDP, MosekSDPSolver>::Impl {
 
   // Constrain duplicate clique views to agree on their shared entries.
   void addChordalOverlapEquality(const std::pair<Key, Key>& key,
-                                 const mf::Variable::t& owner,
-                                 const mf::Variable::t& duplicate) {
+                                 const std::shared_ptr<SDPBlockView>& owner,
+                                 const std::shared_ptr<SDPBlockView>& duplicate) {
     if (key.first < key.second) {
-      M->constraint(mf::Expr::sub(owner, duplicate), mf::Domain::equalsTo(0.0));
+      M->constraint(mf::Expr::sub(owner->asExpr(), duplicate->asExpr()),
+                    mf::Domain::equalsTo(0.0));
       return;
     }
 
@@ -649,6 +679,34 @@ struct LiftedSDPProblem<ChordalSDP, MosekSDPSolver>::Impl {
       }
       return;
     }
+  }
+
+  // Collect completed layouts for the separate numerical post-processing pass.
+  static void collectCliques(const SymbolicBayesTree::sharedClique& clique,
+                            std::vector<KeyVector>* layouts) {
+    KeyVector keys = clique->conditional()->keys();
+    std::sort(keys.begin(), keys.end());
+    layouts->push_back(keys);
+    for (const auto& child : clique->children) collectCliques(child, layouts);
+  }
+
+  // Register one original-coordinate block, regardless of its backing cone size.
+  void registerBlock(const mf::Variable::t& cone, const Matrix* basis,
+                     const std::pair<Key, Key>& key,
+                     DenseIndex rowStart, DenseIndex rowEnd,
+                     DenseIndex colStart, DenseIndex colEnd) {
+    std::shared_ptr<SDPBlockView> view;
+    if (basis) {
+      view = std::make_shared<SDPBlockView>(
+          cone, basis->middleRows(rowStart, rowEnd - rowStart),
+          basis->middleRows(colStart, colEnd - colStart));
+    } else {
+      view = std::make_shared<SDPBlockView>(cone->slice(
+          monty::new_array_ptr<int, 1>({int(rowStart), int(colStart)}),
+          monty::new_array_ptr<int, 1>({int(rowEnd), int(colEnd)})));
+    }
+    auto [owner, inserted] = liftedVariableXijToSDPVariableViewMap.emplace(key, view);
+    if (!inserted) addChordalOverlapEquality(key, owner->second, view);
   }
 
   // Allocate clique variables and register their block views recursively.
@@ -670,26 +728,19 @@ struct LiftedSDPProblem<ChordalSDP, MosekSDPSolver>::Impl {
     }
 
     if (!indices.empty()) {
+      const auto found = cliqueBases.find(indices);
+      const Matrix* basis = found == cliqueBases.end() ? nullptr : &found->second;
+      const DenseIndex coneDimension = basis ? basis->cols() : cliqueDimension;
       auto cliqueY =
           M->variable(makeCliqueVariableName(indices),
-                      mf::Domain::inPSDCone(static_cast<int>(cliqueDimension)));
+                      mf::Domain::inPSDCone(static_cast<int>(coneDimension)));
 
       for (Key key_i : indices) {
         for (Key key_j : indices) {
           const auto [i_start, i_end] = keyToCliqueSlice.at(key_i);
           const auto [j_start, j_end] = keyToCliqueSlice.at(key_j);
-          auto blockView = cliqueY->slice(
-              monty::new_array_ptr<int, 1>(
-                  {static_cast<int>(i_start), static_cast<int>(j_start)}),
-              monty::new_array_ptr<int, 1>(
-                  {static_cast<int>(i_end), static_cast<int>(j_end)}));
-
-          const std::pair<Key, Key> key(key_i, key_j);
-          auto [it, inserted] =
-              liftedVariableXijToSDPVariableViewMap.emplace(key, blockView);
-          if (!inserted) {
-            addChordalOverlapEquality(key, it->second, blockView);
-          }
+          registerBlock(cliqueY, basis, {key_i, key_j},
+                        i_start, i_end, j_start, j_end);
         }
       }
     }
@@ -795,12 +846,24 @@ LiftedSDPProblem<MonolithicSDP, MosekSDPSolver>::orderedKeyDims() const {
 }
 
 LiftedSDPProblem<ChordalSDP, MosekSDPSolver>::LiftedSDPProblem(
-    const QcqpProblem& problem, ChordalOrderingType orderingType)
+    const QcqpProblem& problem, ChordalOrderingType orderingType,
+    bool eliminateKnownNullDirections)
     : impl_(std::make_unique<Impl>()) {
   CollectOrderedKeysAndDims(problem, &impl_->orderedKeys,
                             &impl_->orderedKeyDims);
   impl_->M = new mf::Model("ChordalSDP_MosekSDPSolver");
   impl_->bayesTree_ = BuildSymbolicBayesTree(problem, orderingType);
+
+  // POST-PROCESSING PASS: reduce the numerical cone coordinates only.
+  // The QCQP, clique membership, and original-coordinate constraints are intact.
+  if (eliminateKnownNullDirections) {
+    std::vector<KeyVector> layouts;
+    for (const auto& root : impl_->bayesTree_.roots()) {
+      Impl::collectCliques(root, &layouts);
+    }
+    impl_->cliqueBases = internal::EliminateKnownNullDirections(
+        problem, impl_->orderedKeyDims, layouts);
+  }
 
   // Use one positive semidefinite variable per symbolic clique.
   impl_->populateXijMap();

--- a/gtsam/certifiable/LiftedSDPProblem.h
+++ b/gtsam/certifiable/LiftedSDPProblem.h
@@ -131,9 +131,14 @@ class GTSAM_EXPORT LiftedSDPProblem<ChordalSDP, MosekSDPSolver> {
    *
    * @param problem QCQP to relax.
    * @param orderingType Ordering used for symbolic elimination.
+   * @param eliminateKnownNullDirections Experimental, disabled by default.
+   * Post-process clique layouts to remove duplicate homogeneous coordinates
+   * and individually fixed coordinates. Smaller cones do not guarantee better
+   * convergence or certification.
    */
   LiftedSDPProblem(const QcqpProblem& problem,
-                   ChordalOrderingType orderingType);
+                   ChordalOrderingType orderingType,
+                   bool eliminateKnownNullDirections = false);
 
   /// Dispose of the owned MOSEK model.
   ~LiftedSDPProblem();

--- a/gtsam/certifiable/SDPNullspaceReduction.cpp
+++ b/gtsam/certifiable/SDPNullspaceReduction.cpp
@@ -1,0 +1,105 @@
+/* Copyright 2026, Georgia Tech Research Corporation. See LICENSE. */
+#include <gtsam/certifiable/SDPNullspaceReduction.h>
+
+#include <cmath>
+#include <limits>
+
+namespace gtsam::internal {
+namespace {
+
+// Require an explicit h^2=1 equality, not an assumption about a key's type.
+KeySet UnitHomogeneousKeys(const QcqpProblem& problem) {
+  KeySet keys;
+  for (const auto& factor : problem.eConstraints()) {
+    const auto* quadratic =
+        dynamic_cast<const QuadraticEqualityConstraintFactor*>(factor.get());
+    if (!quadratic) continue;
+    const auto& constraint = quadratic->quadraticConstraint();
+    Matrix expected =
+        Matrix::Zero(constraint.A().rows(), constraint.A().cols());
+    if (expected.size() == 0 || constraint.b() == 0.0) continue;
+    expected(0, 0) = constraint.b();
+    if ((constraint.A().array() == expected.array()).all()) {
+      keys.insert(constraint.key());
+    }
+  }
+  return keys;
+}
+
+// Recognize only a*x_r + a0*h = b: in Gram coordinates x_r=(b-a0)*h/a.
+// Coupled linear equations are deliberately left untouched in this first pass.
+std::map<Key, Vector> FixedCoordinates(
+    const QcqpProblem& problem, const std::map<Key, DenseIndex>& dimensions) {
+  std::map<Key, Vector> fixed;
+  for (const auto& [key, dimension] : dimensions) {
+    fixed[key] =
+        Vector::Constant(dimension, std::numeric_limits<double>::quiet_NaN());
+  }
+  for (const auto& factor : problem.eConstraints()) {
+    const auto* linear =
+        dynamic_cast<const LinearEqualityConstraintFactor*>(factor.get());
+    if (!linear) continue;
+    const auto& jacobian = linear->linearConstraint().factor();
+    if (jacobian.size() != 1) continue;
+    const Matrix A = jacobian.getA(jacobian.begin());
+    for (DenseIndex row = 0; row < A.rows(); ++row) {
+      DenseIndex coordinate = 0;
+      size_t count = 0;
+      for (DenseIndex col = 1; col < A.cols(); ++col) {
+        if (A(row, col) != 0.0) {
+          coordinate = col;
+          ++count;
+        }
+      }
+      if (count == 1) {
+        fixed.at(*jacobian.begin())(coordinate) =
+            (jacobian.getb()(row) - A(row, 0)) / A(row, coordinate);
+      }
+    }
+  }
+  return fixed;
+}
+
+// A sparse substitution basis preserves the physical coordinate scaling.
+Matrix CliqueBasis(const KeyVector& keys, const KeySet& homogeneous,
+                   const std::map<Key, Vector>& fixed) {
+  DenseIndex dimension = 0, reduced = 1;
+  bool supported = true;
+  for (Key key : keys) {
+    dimension += fixed.at(key).size();
+    supported = supported && homogeneous.count(key);
+    for (DenseIndex row = 1; row < fixed.at(key).size(); ++row) {
+      if (!std::isfinite(fixed.at(key)(row))) ++reduced;
+    }
+  }
+  if (!supported || keys.empty()) return Matrix::Identity(dimension, dimension);
+  Matrix basis = Matrix::Zero(dimension, reduced);
+  DenseIndex offset = 0, column = 1;
+  for (Key key : keys) {
+    basis(offset++, 0) = 1.0;
+    for (DenseIndex row = 1; row < fixed.at(key).size(); ++row) {
+      const double value = fixed.at(key)(row);
+      if (std::isfinite(value))
+        basis(offset++, 0) = value;
+      else
+        basis(offset++, column++) = 1.0;
+    }
+  }
+  return basis;
+}
+
+}  // namespace
+
+std::map<KeyVector, Matrix> EliminateKnownNullDirections(
+    const QcqpProblem& problem, const std::map<Key, DenseIndex>& dimensions,
+    const std::vector<KeyVector>& cliques) {
+  const KeySet homogeneous = UnitHomogeneousKeys(problem);
+  const auto fixed = FixedCoordinates(problem, dimensions);
+  std::map<KeyVector, Matrix> bases;
+  for (const auto& keys : cliques) {
+    bases.emplace(keys, CliqueBasis(keys, homogeneous, fixed));
+  }
+  return bases;
+}
+
+}  // namespace gtsam::internal

--- a/gtsam/certifiable/SDPNullspaceReduction.h
+++ b/gtsam/certifiable/SDPNullspaceReduction.h
@@ -1,0 +1,21 @@
+/* Copyright 2026, Georgia Tech Research Corporation. See LICENSE. */
+#pragma once
+
+#include <gtsam/constrained/QcqpProblem.h>
+
+#include <map>
+#include <vector>
+
+namespace gtsam::internal {
+
+/**
+ * Post-process completed clique layouts, leaving the QCQP unchanged.
+ * Each returned B represents the original clique moment matrix as B Z B'.
+ * Only proven duplicate homogeneous rows and individually fixed coordinates
+ * are eliminated; other constraints remain for the solver to enforce.
+ */
+GTSAM_EXPORT std::map<KeyVector, Matrix> EliminateKnownNullDirections(
+    const QcqpProblem& problem, const std::map<Key, DenseIndex>& dimensions,
+    const std::vector<KeyVector>& cliques);
+
+}  // namespace gtsam::internal

--- a/gtsam/certifiable/certifiable_mosek.i
+++ b/gtsam/certifiable/certifiable_mosek.i
@@ -25,7 +25,8 @@ enum class ChordalOrderingType { Metis, Colamd };
 
 class MosekChordalSDP {
   MosekChordalSDP(const gtsam::QcqpProblem& problem,
-                  gtsam::ChordalOrderingType orderingType);
+                  gtsam::ChordalOrderingType orderingType,
+                  bool eliminateKnownNullDirections = false);
 
   bool solve(
       const std::map<std::string, double>& mosekParams =

--- a/gtsam/certifiable/tests/testLiftedSDPs.cpp
+++ b/gtsam/certifiable/tests/testLiftedSDPs.cpp
@@ -450,14 +450,39 @@ TEST(LiftedSDPs, Pr2713ApplicationFactorsMonolithicAndChordal) {
   MosekChordalSDP chordal(problem, ChordalOrderingType::Metis);
   const ApplicationSolution monolithicResult = SolveApplication(&monolithic);
   const ApplicationSolution chordalResult = SolveApplication(&chordal);
+  MosekChordalSDP reduced(problem, ChordalOrderingType::Metis, true);
+  const ApplicationSolution reducedResult = SolveApplication(&reduced);
   for (const ApplicationSolution* result :
-       {&monolithicResult, &chordalResult}) {
+       {&monolithicResult, &chordalResult, &reducedResult}) {
     EXPECT(result->solved);
     EXPECT(result->objective < 1e-5);
     EXPECT_LONGS_EQUAL(6, result->valueCount);
     EXPECT_LONGS_EQUAL(6, result->evrs.size());
     EXPECT(std::all_of(result->evrs.begin(), result->evrs.end(),
                        [](double evr) { return evr > 1e3; }));
+  }
+}
+
+// Reduction preserves a nonzero optimum and original-coordinate recovery.
+TEST(LiftedSDPs, ReducedNoisyRot2Ring) {
+  NonlinearFactorGraph graph = lifted_sdp_tests::Rot2RingGraph(4, 0.2);
+  QcqpProblem problem(graph, 1);
+  const Matrix selector{{0, 1, 0}, {0, 0, 1}};
+  problem.addConstraint(LinearConstraint::Equal(JacobianFactor(
+      Symbol('x', 0), selector, Vector2(0.6, 0.8))));
+  MosekMonolithicSDP monolithic(problem);
+  const auto reference = SolveApplication(&monolithic);
+  EXPECT(reference.objective > 0.01);
+  for (const auto ordering :
+       {ChordalOrderingType::Metis, ChordalOrderingType::Colamd}) {
+    MosekChordalSDP reduced(problem, ordering, true);
+    const auto result = SolveApplication(&reduced);
+    EXPECT(result.solved);
+    EXPECT_DOUBLES_EQUAL(reference.objective, result.objective, 1e-6);
+    EXPECT_DOUBLES_EQUAL(result.objective,
+                         problem.costs().error(reduced.qcqpValues()), 1e-6);
+    EXPECT(assert_equal(Vector3(1, 0.6, 0.8),
+                        Vector(reduced.qcqpValues().at<Matrix>(Symbol('x', 0)).col(0)), 1e-7));
   }
 }
 

--- a/gtsam/certifiable/tests/testSDPNullspaceReduction.cpp
+++ b/gtsam/certifiable/tests/testSDPNullspaceReduction.cpp
@@ -1,0 +1,60 @@
+/* Copyright 2026, Georgia Tech Research Corporation. See LICENSE. */
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/TestableAssertions.h>
+#include <gtsam/certifiable/SDPNullspaceReduction.h>
+
+using namespace gtsam;
+
+/* ************************************************************************* */
+namespace nullspace_fixture {
+
+const std::map<Key, DenseIndex> dimensions{{0, 3}, {1, 3}};
+
+QcqpProblem Problem(bool bothHomogeneous, bool coupledAnchor = false) {
+  NonlinearEqualityConstraints constraints;
+  InsertQcqpConstraints<Vector2, 1>(0, &constraints);
+  if (bothHomogeneous) InsertQcqpConstraints<Vector2, 1>(1, &constraints);
+  Matrix A{{1, 2, 0}, {0, 0, 1}};
+  if (coupledAnchor) A(0, 2) = 1;
+  constraints.push_back(
+      LinearConstraint::Equal(JacobianFactor(0, A, Vector2(5, -3)))
+          .createEqualityFactor());
+  return QcqpProblem(NonlinearFactorGraph(), constraints);
+}
+
+// Duplicate h rows and nonzero fixed coordinates are exact substitutions.
+TEST(SDPNullspaceReduction, SubstitutionAndObjectiveParity) {
+  const auto bases = internal::EliminateKnownNullDirections(
+      Problem(true), dimensions, {{0, 1}});
+  const Matrix B = bases.at({0, 1});
+  const Matrix expected{{1, 0, 0}, {2, 0, 0}, {-3, 0, 0},
+                        {1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
+  EXPECT(assert_equal(expected, B));
+  const Matrix Z{{2, 1, 0}, {1, 3, 1}, {0, 1, 2}};
+  const Matrix Q = Matrix::Identity(6, 6) + Matrix::Ones(6, 6);
+  EXPECT_DOUBLES_EQUAL((Q * B * Z * B.transpose()).trace(),
+                       (B.transpose() * Q * B * Z).trace(), 1e-12);
+}
+
+// No homogeneous-coordinate reduction is inferred without h^2=1 constraints.
+TEST(SDPNullspaceReduction, MissingNormalizationLeavesCliqueUnchanged) {
+  const auto bases = internal::EliminateKnownNullDirections(
+      Problem(false), dimensions, {{0, 1}});
+  EXPECT(assert_equal(Matrix(Matrix::Identity(6, 6)), bases.at({0, 1})));
+}
+
+// A coupled anchor is retained; only its separate fixed coordinate is removed.
+TEST(SDPNullspaceReduction, CoupledEquationIsNotGuessed) {
+  const auto bases = internal::EliminateKnownNullDirections(
+      Problem(true, true), dimensions, {{0, 1}, {1}});
+  EXPECT_LONGS_EQUAL(4, bases.at({0, 1}).cols());
+  EXPECT(assert_equal(Matrix(Matrix::Identity(3, 3)), bases.at({1})));
+}
+
+}  // namespace nullspace_fixture
+/* ************************************************************************* */
+
+int main() {
+  TestResult result;
+  return TestRegistry::runAllTests(result);
+}


### PR DESCRIPTION
## Summary

Stacked on #2784: this PR targets `codex/new-mosek-applications`, so its diff contains only the eight-file null-space-reduction commit, `9d0a1ba66`.

- Add an explicit post-processing pass that removes known forced-null directions from chordal SDP clique matrices: duplicate homogeneous coordinates and individually fixed coordinates.
- Transcribe the objective, original constraints, and full overlap equations through the reconstruction bases, then reconstruct original-coordinate blocks for recovery and rank diagnostics.
- Add an opt-in constructor argument, matching wrapper declaration, and the example switch `GTSAM_MOSEK_ELIMINATE_NULLS=1`. Reduction remains disabled by default.
- Add focused substitution and solver-equivalence tests. Monolithic reduction is not implemented here.

## Review and merge order

Merge #2784 first; **do not merge this PR into its current feature-branch base**. After #2784 merges, rebase/replay only the null-reduction commit onto the actual merged `develop` (including after a squash merge), retarget this PR to `develop`, and rerun the focused tests and rotation-ring comparison.

[Avinash's concern about changes to the SDP's core representation](https://github.com/borglab/gtsam/pull/2784#discussion_r3962866658) is an explicit design-review topic here. In particular, review the boundary between the small basis-construction pass and the original-coordinate expression/recovery adapter. The separate example-helper review comments remain with #2784.

## Experimental evidence

The noisy 100-rotation ring was numerically tight with monolithic, vanilla chordal, and null-reduced chordal formulations, matching the independently known optimum of approximately `0.0099999166669`.

Across six runs, null reduction lowered median MOSEK solver time from **60.34 to 44.69 ms (26%)**, but construction-through-recovery time increased from **87.76 to 94.15 ms (7%)**. This is a solver-only saving, not an end-to-end speedup over vanilla chordal. Full goats16 still failed to certify; smaller cones do not guarantee convergence or tighten the mathematical relaxation.

The existing HTML report remains attached to #2784 and has not been modified as part of this split. Earlier null-reduction results describe the work now isolated here.

## Validation

- Previously passed `make -j6 testSDPNullspaceReduction.run` and `make -j6 testLiftedSDPs.run` on the preserved implementation; six affected certifiable examples were also built.
- The rotation-ring experiment checked objective agreement, reconstructed rank-one blocks, and independent primal/dual diagnostics.
- Verified that the stacked diff contains exactly one commit and eight files. No implementation changes or fresh null-reduction test runs were made while creating this PR.
- The trimmed #2784 baseline separately passed all six agreed test suites and rebuilt all six affected examples after the split.
