### PR TITLE
Reduce iSAM2 update overhead and make tree statistics opt-in

### DIFF
--- a/gtsam/inference/Ordering.cpp
+++ b/gtsam/inference/Ordering.cpp
@@ -119,7 +119,7 @@ Ordering Ordering::ColamdConstrained(const VariableIndex& variableIndex,
   int count = 0;
   KeyVector keys(nVars); // Array to store the keys in the order we add them so we can retrieve them in permuted order
   size_t index = 0;
-  for (auto key_factors: variableIndex) {
+  for (const auto& key_factors: variableIndex) {
     // Arrange factor indices into COLAMD format
     const FactorIndices& column = key_factors.second;
     for(size_t factorIndex: column) {
@@ -181,7 +181,7 @@ Ordering Ordering::ColamdConstrainedLast(const VariableIndex& variableIndex,
   // TODO(frank): think of a way to not build this
   FastMap<Key, size_t> keyIndices;
   size_t j = 0;
-  for (auto key_factors: variableIndex)
+  for (const auto& key_factors: variableIndex)
     keyIndices.insert(keyIndices.end(), make_pair(key_factors.first, j++));
 
   // If at least some variables are not constrained to be last, constrain the
@@ -208,7 +208,7 @@ Ordering Ordering::ColamdConstrainedFirst(const VariableIndex& variableIndex,
   // Build a mapping to look up sorted Key indices by Key
   FastMap<Key, size_t> keyIndices;
   size_t j = 0;
-  for (auto key_factors: variableIndex)
+  for (const auto& key_factors: variableIndex)
     keyIndices.insert(keyIndices.end(), make_pair(key_factors.first, j++));
 
   // If at least some variables are not constrained to be last, constrain the
@@ -239,7 +239,7 @@ Ordering Ordering::ColamdConstrained(const VariableIndex& variableIndex,
   // Build a mapping to look up sorted Key indices by Key
   FastMap<Key, size_t> keyIndices;
   size_t j = 0;
-  for (auto key_factors: variableIndex)
+  for (const auto& key_factors: variableIndex)
     keyIndices.insert(keyIndices.end(), make_pair(key_factors.first, j++));
 
   // Assign groups

--- a/gtsam/nonlinear/ISAM2-impl.h
+++ b/gtsam/nonlinear/ISAM2-impl.h
@@ -177,6 +177,8 @@ struct GTSAM_EXPORT UpdateImpl {
                          const KeySet& keysWithRemovedFactors,
                          KeySet* unusedKeys) const {
     gttic(computeUnusedKeys);
+    // Most incremental updates remove no factors, so no key can become unused.
+    if (keysWithRemovedFactors.empty()) return;
     KeySet removedAndEmpty;
     for (Key key : keysWithRemovedFactors) {
       if (variableIndex.empty(key))

--- a/gtsam/nonlinear/ISAM2.cpp
+++ b/gtsam/nonlinear/ISAM2.cpp
@@ -198,11 +198,16 @@ void ISAM2::recalculateBatch(const ISAM2UpdateParams& updateParams,
   for (const auto& [key, _] : variableIndex_) {
     affectedKeysSet->insert(key);
   }
-  // Removed unused keys:
-  VariableIndex affectedFactorsVarIndex = variableIndex_;
-
-  affectedFactorsVarIndex.removeUnusedVariables(result->unusedKeys.begin(),
-                                                result->unusedKeys.end());
+  // Reuse the index unless removal requires a filtered copy. Batch reorders
+  // without factor removal need no duplicate of the entire variable index.
+  std::optional<VariableIndex> filteredVariableIndex;
+  if (!result->unusedKeys.empty()) {
+    filteredVariableIndex.emplace(variableIndex_);
+    filteredVariableIndex->removeUnusedVariables(result->unusedKeys.begin(),
+                                                  result->unusedKeys.end());
+  }
+  const VariableIndex& affectedFactorsVarIndex =
+      filteredVariableIndex ? *filteredVariableIndex : variableIndex_;
 
   for (const Key key : result->unusedKeys) {
     affectedKeysSet->erase(key);
@@ -393,6 +398,7 @@ void ISAM2::recalculateIncremental(const ISAM2UpdateParams& updateParams,
 void ISAM2::addVariables(const Values& newTheta,
                          ISAM2Result::DetailedResults* detail) {
   gttic(addNewVariables);
+  if (newTheta.empty()) return;
 
   theta_.insert(newTheta);
   if (ISDEBUG("ISAM2 AddVariables")) newTheta.print("The new variables are: ");
@@ -530,12 +536,15 @@ ISAM2Result ISAM2::update(const NonlinearFactorGraph& newFactors,
   if (!result.unusedKeys.empty()) removeVariables(result.unusedKeys);
   result.cliques = this->nodes().size();
 
-  // 10. Track fill-in: record nnz and update baseline after batch reorders.
-  result.treeNnz = treeNnz();
-  // Update baseline on first update or after any batch reorder (adaptive or
-  // the existing 65% affected-variables threshold).
-  if (nnzAfterLastReorder_ == 0 || result.batchReorderTriggered) {
-    nnzAfterLastReorder_ = result.treeNnz;
+  // Counting nonzeros traverses every clique. Keep this global work out of
+  // ordinary incremental updates unless the caller requests it.
+  if (params_.enableAdaptiveReorder || params_.enableDetailedResults) {
+    result.treeNnz = treeNnz();
+    // Update baseline on first update or after any batch reorder (adaptive or
+    // the existing 65% affected-variables threshold).
+    if (nnzAfterLastReorder_ == 0 || result.batchReorderTriggered) {
+      nnzAfterLastReorder_ = result.treeNnz;
+    }
   }
 
   if (params_.evaluateNonlinearError)

--- a/gtsam/nonlinear/ISAM2.h
+++ b/gtsam/nonlinear/ISAM2.h
@@ -313,7 +313,9 @@ class GTSAM_EXPORT ISAM2 : public BayesTree<ISAM2Clique> {
 
   const ISAM2Params& params() const { return params_; }
 
-  /** Compute the total number of nonzeros in the Bayes tree. */
+  /** Compute the total number of nonzeros by traversing the entire Bayes tree.
+   * Available regardless of whether update() computes ISAM2Result::treeNnz.
+   */
   size_t treeNnz() const;
 
   /** prints out clique statistics */

--- a/gtsam/nonlinear/ISAM2Params.h
+++ b/gtsam/nonlinear/ISAM2Params.h
@@ -270,9 +270,10 @@ struct GTSAM_EXPORT ISAM2Params {
       keyFormatter;  ///< A KeyFormatter for when keys are printed during
                      ///< debugging (default: DefaultKeyFormatter)
 
-  bool enableDetailedResults;  ///< Whether to compute and return
-                               ///< ISAM2Result::detailedResults, this can
-                               ///< increase running time (default: false)
+  /** Compute per-variable details and ISAM2Result::treeNnz. The latter visits
+   * every clique, so enabling this can increase update time (default: false).
+   */
+  bool enableDetailedResults;
 
   /** Check variables for relinearization in tree-order, stopping the check once
    * a variable does not need to be relinearized (default: false). This can

--- a/gtsam/nonlinear/ISAM2Result.h
+++ b/gtsam/nonlinear/ISAM2Result.h
@@ -90,7 +90,9 @@ struct ISAM2Result {
 
   /** Total number of nonzero entries in the Bayes tree (upper-triangular R and
    *  rectangular S blocks of every clique conditional).  Useful for monitoring
-   *  fill-in growth over long incremental sessions. */
+   *  fill-in growth over long incremental sessions. Computed only when
+   *  ISAM2Params::enableAdaptiveReorder or ISAM2Params::enableDetailedResults
+   *  is enabled; otherwise zero. Use ISAM2::treeNnz() for an explicit query. */
   size_t treeNnz;
 
   /** Whether a full batch reorder was triggered during this update, either by

--- a/python/gtsam/tests/test_ISAM2FillIn.py
+++ b/python/gtsam/tests/test_ISAM2FillIn.py
@@ -74,15 +74,19 @@ class TestTreeNnz(GtsamTestCase):
 
     def test_result_reports_nnz(self):
         graph, values = pose_chain(5)
-        isam = gtsam.ISAM2()
+        params = gtsam.ISAM2Params()
+        params.enableDetailedResults = True
+        isam = gtsam.ISAM2(params)
         result = isam.update(graph, values)
 
         self.assertGreater(result.getTreeNnz(), 0)
 
     def test_isam_accessor_matches_result(self):
-        """ISAM2.treeNnz() agrees with the value recorded in the result."""
+        """The explicit accessor agrees with an opt-in recorded value."""
         graph, values = pose_chain(5)
-        isam = gtsam.ISAM2()
+        params = gtsam.ISAM2Params()
+        params.enableDetailedResults = True
+        isam = gtsam.ISAM2(params)
         result = isam.update(graph, values)
 
         self.assertEqual(isam.treeNnz(), result.getTreeNnz())

--- a/tests/testGaussianISAM2.cpp
+++ b/tests/testGaussianISAM2.cpp
@@ -1244,6 +1244,7 @@ TEST(ISAM2, AdaptiveReorder_Triggered) {
 }
 
 /* ************************************************************************* */
+// Default updates leave full-tree statistics to an explicit query.
 TEST(ISAM2, AdaptiveReorder_DisabledByDefault) {
   // With default params, adaptive reorder should never trigger
   ISAM2 isam;
@@ -1256,10 +1257,114 @@ TEST(ISAM2, AdaptiveReorder_DisabledByDefault) {
   ISAM2Result result = isam.update(graph, init);
 
   EXPECT(!result.batchReorderTriggered);
-  // treeNnz should still be populated
-  EXPECT(result.treeNnz > 0);
+  EXPECT_LONGS_EQUAL(0, result.treeNnz);
+  EXPECT_LONGS_EQUAL(6, isam.treeNnz());
 }
 
+/* ************************************************************************* */
+namespace optional_tree_statistics {
+
+// Requested statistics remain exact across incremental and batch updates.
+TEST(ISAM2, OptionalTreeStatistics) {
+  for (bool adaptive : {false, true}) {
+    for (bool detailed : {false, true}) {
+      ISAM2Params params;
+      params.enableAdaptiveReorder = adaptive;
+      params.enableDetailedResults = detailed;
+      params.adaptiveReorderThreshold = 1.01;
+      ISAM2 isam(params);
+      const auto checkStatistics = [&](const ISAM2Result& result) {
+        EXPECT_LONGS_EQUAL(adaptive || detailed ? isam.treeNnz() : 0,
+                          result.treeNnz);
+      };
+      for (Key key = 0; key < 8; ++key) {
+        NonlinearFactorGraph graph;
+        Values initial;
+        initial.insert(key, double(key));
+        if (key == 0)
+          graph.addPrior(0, 0.0, noiseModel::Unit::Create(1));
+        else
+          graph.emplace_shared<BetweenFactor<double>>(
+              key - 1, key, 1.0, noiseModel::Unit::Create(1));
+        checkStatistics(isam.update(graph, initial));
+        EXPECT_DOUBLES_EQUAL(double(key), isam.calculateEstimate<double>(key), 1e-9);
+      }
+      NonlinearFactorGraph loop;
+      loop.emplace_shared<BetweenFactor<double>>(
+          0, 7, 7.0, noiseModel::Unit::Create(1));
+      const auto loopResult = isam.update(loop);
+      checkStatistics(loopResult);
+      checkStatistics(isam.update());
+      checkStatistics(isam.update({}, {}, loopResult.newFactorsIndices));
+      EXPECT_DOUBLES_EQUAL(7.0, isam.calculateEstimate<double>(7), 1e-9);
+    }
+  }
+}
+
+// Statistics reflect marginalization immediately, including copied solvers.
+TEST(ISAM2, TreeStatisticsAfterMarginalization) {
+  ISAM2Params params;
+  params.enableDetailedResults = true;
+  ISAM2 isam(params);
+  NonlinearFactorGraph graph;
+  graph.addPrior(0, 0.0, noiseModel::Unit::Create(1));
+  graph.emplace_shared<BetweenFactor<double>>(
+      0, 1, 1.0, noiseModel::Unit::Create(1));
+  graph.emplace_shared<BetweenFactor<double>>(
+      1, 2, 1.0, noiseModel::Unit::Create(1));
+  Values initial;
+  for (Key key = 0; key < 3; ++key) initial.insert(key, double(key));
+  FastMap<Key, int> constraints;
+  for (Key key = 0; key < 3; ++key) constraints[key] = int(key);
+  const auto before = isam.update(graph, initial, {}, constraints);
+  isam.marginalizeLeaves({0});
+  EXPECT(isam.treeNnz() < before.treeNnz);
+  EXPECT_LONGS_EQUAL(isam.treeNnz(), isam.update().treeNnz);
+  ISAM2 copy(isam);
+  EXPECT_LONGS_EQUAL(isam.treeNnz(), copy.update().treeNnz);
+  EXPECT_DOUBLES_EQUAL(2.0, copy.calculateEstimate<double>(2), 1e-9);
+}
+
+}  // namespace optional_tree_statistics
+/* ************************************************************************* */
+namespace batch_factor_removal {
+
+// Batch reordering preserves live variables when removing most of the graph.
+TEST(ISAM2, BatchReorderWithUnusedKeys) {
+  for (bool cache : {false, true}) {
+    for (bool reuseSlots : {false, true}) {
+      ISAM2Params params;
+      params.cacheLinearizedFactors = cache;
+      params.findUnusedFactorSlots = reuseSlots;
+      ISAM2 isam(params);
+      NonlinearFactorGraph graph;
+      Values initial;
+      for (Key key = 0; key < 10; ++key) {
+        graph.addPrior(key, double(key), noiseModel::Unit::Create(1));
+        initial.insert(key, double(key) + 0.1);
+      }
+      const auto added = isam.update(graph, initial);
+      const FactorIndices removed(added.newFactorsIndices.begin(),
+                                  added.newFactorsIndices.begin() + 8);
+      const auto result = isam.update({}, {}, removed);
+      EXPECT(result.batchReorderTriggered);
+      EXPECT_LONGS_EQUAL(8, result.unusedKeys.size());
+      EXPECT_LONGS_EQUAL(2, isam.getLinearizationPoint().size());
+      EXPECT_DOUBLES_EQUAL(8.0, isam.calculateEstimate<double>(8), 1e-9);
+      EXPECT_DOUBLES_EQUAL(9.0, isam.calculateEstimate<double>(9), 1e-9);
+
+      NonlinearFactorGraph next;
+      next.addPrior(10, 10.0, noiseModel::Unit::Create(1));
+      Values nextInitial;
+      nextInitial.insert(10, 10.1);
+      isam.update(next, nextInitial);
+      EXPECT_LONGS_EQUAL(3, isam.getLinearizationPoint().size());
+      EXPECT_DOUBLES_EQUAL(10.0, isam.calculateEstimate<double>(10), 1e-9);
+    }
+  }
+}
+
+}  // namespace batch_factor_removal
 /* ************************************************************************* */
 TEST(ISAM2, constrained_gradient_at_zero) {
   // A hard-constrained variable should not receive gradient contributions from


### PR DESCRIPTION
iSAM2 currently traverses the entire Bayes tree to count structural nonzeros after every update, even when neither detailed results nor adaptive reordering is enabled. This adds global bookkeeping to otherwise local incremental updates.

This change computes `ISAM2Result::treeNnz` only when `enableDetailedResults` or `enableAdaptiveReorder` is enabled. **Otherwise, the result field is zero.** Callers can still obtain the exact count explicitly through `ISAM2::treeNnz()`. Adaptive-reordering policy is unchanged.

It also avoids factor-index vector copies in four COLAMD loops, reuses the variable index during batch reordering unless unused keys require a filtered copy, and skips empty new-variable initialization and unused-key discovery when no factors were removed. Relinearization, wildfire thresholds, factor ordering, and numerical solves retain their existing policies.

### Before/after timing

Medians from five measured trials after one warmup per variant, with variant order rotated:

| Workload | Before | After | Time reduction |
| --- | ---: | ---: | ---: |
| W10000, default TBB concurrency, full replay | 19.462 s | 19.137 s | 1.7% |
| W10000, default TBB concurrency, updates only | 13.363 s | 12.989 s | 2.8% |
| W10000, TBB limited to one thread, full replay | 16.136 s | 16.044 s | 0.6% |
| Stationary 10,000-pose chain, default settings | 1.183 s | 0.608 s | 48.6% |
| Stationary chain, relinearization disabled | 1.102 s | 0.524 s | 52.5% |
| 1,000 empty updates after that chain | 101.969 ms | 0.0625 ms | 99.94% |

W10000 contains 10,000 poses and 64,312 factors including the origin prior. Replay includes updates, latest-pose estimate queries (lazy back-substitution), and per-step Values construction; loading, final validation, output, and solver destruction are excluded. The stationary chain isolates bookkeeping overhead and is not a moving-SLAM accuracy benchmark.

**The W10000 differences are small relative to variability.** Default-thread replay ranges overlap: 17.525–24.814 s before and 17.089–20.559 s after. Single-thread ranges also overlap: 16.021–16.327 s and 15.896–16.211 s. These results do not establish a general SLAM speedup. A statistics-only control accounted for most of the stationary-chain improvement (1.183 → 0.636 s, versus 0.608 s for the full patch).

Environment: Apple M5, 24 GiB, macOS 26.6.2, Clang 22.1.7, C++17 Release `-O3`, TBB, bundled Eigen 3.4, system CCOLAMD/CHOLMOD, deprecated APIs and timing instrumentation disabled. Separate builds used identical configuration; their loaded libraries were verified. Benchmarks ran without competing build jobs; CPU frequencies were not pinned. Both measured variants included baseline commit `5d0988413` from #2799; this PR independently targets `develop` and does not include that unrelated scalar-robustness change. The benchmark uses ordinary Gaussian factors.

### Correctness and validation

Every exported final pose component and every per-step relinearization, re-elimination, recalculated-factor, and batch-reorder counter matched exactly across variants and trials. W10000 ended with error `144.88440054426417`, 1,378,221 explicitly queried nonzeros, and 89 batch reorders.

Regression tests cover optional statistics, marginalization and copying, and batch factor removal with caching and factor-slot reuse independently enabled or disabled. The following targets pass, including after rebasing onto `develop`:

```sh
make -j6 testGaussianISAM2.run testOrdering.run \
  testIncrementalFixedLagSmoother.run testGaussianISAM.run \
  testSerializationNonlinear.run
```

Timing scripts, reports, and raw measurements remain local and are intentionally excluded from this PR. Windows and Python/MATLAB wrapper builds were not part of this evaluation.
